### PR TITLE
Add vanilla theme import back in

### DIFF
--- a/static/css/section/homepage.scss
+++ b/static/css/section/homepage.scss
@@ -23,8 +23,9 @@
   body.homepage-1310 - 13.10 launch
 
 -------------------------------------------------------------- */
-@import "core-constants";
-@import "core-mixins";
+@import "../core-constants";
+@import "../core-mixins";
+
 body.homepage {
 
   .lang-switch {

--- a/static/css/styles.scss
+++ b/static/css/styles.scss
@@ -92,6 +92,11 @@
 import all the scss and css files in the order they should be combined.
 core scss files are in /sites/core/static/css
 -------------------------------------------------------------- */
+
+// import vanilla themes
+@import "../../node_modules/ubuntu-vanilla-theme/scss/theme";
+@include ubuntu-vanilla-theme;
+
 @import "core-constants";
 @import "core-mixins";
 


### PR DESCRIPTION
## Done

Add vanilla theme import back into styles.sss
Add required imports to homepage.scss
## QA

Pull, refresh browser to make sure vanilla is being included. homepage.scss should no longer error (I may need to do what the same to all the other section files, this is an exploritory change atm)
