### PR TITLE
Add src folder (the Fenchurch folder) to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ node_modules
 etc/mirrors-rss.xml
 django-error.log
 node_modules/
+src/


### PR DESCRIPTION
# Details
## Done

Add the Fenchurch ‘src’ folder to git ignore. This folder is created on 'make setup'.
### QA

No QA required.
