### PR TITLE
Increment version number of Ubuntu vanilla theme

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
   "author": "Canonical webteam",
   "license": "LGPL v3",
   "dependencies": {
-    "ubuntu-vanilla-theme": "0.0.1"
+    "ubuntu-vanilla-theme": "0.0.9"
   }
 }


### PR DESCRIPTION
# Done

Increment version number from 0.0.1 to 0.0.9 of Ubuntu vanilla theme
# QA

Not required
