### PR TITLE
Fix UTF-8 errors in sass compilation using Docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,6 @@ clean:
 it:
 so: run
 
-#Phony targets (don't correspond to files or directories)
+# Phony targets (don't correspond to files or directories)
 all: help build run run-app-image watch-sass compile-sass stop-sass-watcher rebuild-app-image it so
 .PHONY: all


### PR DESCRIPTION
Something about the docker env causes sass to be sad when compiling files with unicode files. Fixed it simply by adding the default encoding of UTF-8 to the sass command.
# QA

```
make clean
make run
make clean
make compile-sass
```

site should run with compiled css.
