### PR TITLE
Remove external heading class

### DIFF
--- a/static/css/section/_local.scss
+++ b/static/css/section/_local.scss
@@ -594,12 +594,6 @@ html.no-svg {
   }
 }
 
-h3.external span {
-    background: url("../img/external-link-cool-grey.svg") left center no-repeat;
-    background-size: 20px;
-    padding-left: 26px;   
-}
-
 footer.global ul.inline li:after {
   content: "•";
 }

--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -36,32 +36,32 @@
         <p>BitTorrent is a peer-to-peer download network that sometimes enables higher download speeds and more reliable downloads of large files. You will need to install a BitTorrent client on your computer in order to enable this download method.</p>
     </div>
      <div class="four-col">
-        <h3 class="external"><span>Ubuntu 15.04</span></h3>
+        <h3>Ubuntu 15.04</h3>
         <ul class="no-bullets list">
-            <li><a href="http://releases.ubuntu.com/15.04/ubuntu-15.04-desktop-amd64.iso.torrent">Ubuntu 15.04 Desktop (64-bit)&nbsp;&rsaquo;</a></li>
-            <li><a href="http://releases.ubuntu.com/15.04/ubuntu-15.04-desktop-i386.iso.torrent">Ubuntu 15.04 Desktop (32-bit)&nbsp;&rsaquo;</a></li>
-            <li><a href="http://releases.ubuntu.com/15.04/ubuntu-15.04-server-amd64.iso.torrent">Ubuntu 15.04 Server (64-bit)&nbsp;&rsaquo;</a></li>
-            <li><a href="http://releases.ubuntu.com/15.04/ubuntu-15.04-server-i386.iso.torrent">Ubuntu 15.04 Server (32-bit)&nbsp;&rsaquo;</a></li>
+            <li><a class="external" href="http://releases.ubuntu.com/15.04/ubuntu-15.04-desktop-amd64.iso.torrent">Ubuntu 15.04 Desktop (64-bit)&nbsp;&rsaquo;</a></li>
+            <li><a class="external" href="http://releases.ubuntu.com/15.04/ubuntu-15.04-desktop-i386.iso.torrent">Ubuntu 15.04 Desktop (32-bit)&nbsp;&rsaquo;</a></li>
+            <li><a class="external" href="http://releases.ubuntu.com/15.04/ubuntu-15.04-server-amd64.iso.torrent">Ubuntu 15.04 Server (64-bit)&nbsp;&rsaquo;</a></li>
+            <li><a class="external" href="http://releases.ubuntu.com/15.04/ubuntu-15.04-server-i386.iso.torrent">Ubuntu 15.04 Server (32-bit)&nbsp;&rsaquo;</a></li>
         </ul>
     </div><!-- /.four-col -->
     <div class="four-col">
-        <h3 class="external"><span>Ubuntu 14.04.2 LTS</span></h3>
+        <h3>Ubuntu 14.04.2 LTS</h3>
         <ul class="no-bullets list">
-            <li><a href="http://releases.ubuntu.com/14.04.2/ubuntu-14.04.2-desktop-amd64.iso.torrent">Ubuntu 14.04.2 LTS Desktop (64-bit)&nbsp;&rsaquo;</a></li>
-            <li><a href="http://releases.ubuntu.com/14.04.2/ubuntu-14.04.2-desktop-i386.iso.torrent">Ubuntu 14.04.2 LTS Desktop (32-bit)&nbsp;&rsaquo;</a></li>
-            <li><a href="http://releases.ubuntu.com/14.04.2/ubuntu-14.04.2-server-amd64.iso.torrent">Ubuntu 14.04.2 LTS Server (64-bit)&nbsp;&rsaquo;</a></li>
-            <li><a href="http://releases.ubuntu.com/14.04.2/ubuntu-14.04.2-server-i386.iso.torrent">Ubuntu 14.04.2 LTS Server (32-bit)&nbsp;&rsaquo;</a></li>
+            <li><a class="external" href="http://releases.ubuntu.com/14.04.2/ubuntu-14.04.2-desktop-amd64.iso.torrent">Ubuntu 14.04.2 LTS Desktop (64-bit)&nbsp;&rsaquo;</a></li>
+            <li><a class="external" href="http://releases.ubuntu.com/14.04.2/ubuntu-14.04.2-desktop-i386.iso.torrent">Ubuntu 14.04.2 LTS Desktop (32-bit)&nbsp;&rsaquo;</a></li>
+            <li><a class="external" href="http://releases.ubuntu.com/14.04.2/ubuntu-14.04.2-server-amd64.iso.torrent">Ubuntu 14.04.2 LTS Server (64-bit)&nbsp;&rsaquo;</a></li>
+            <li><a class="external" href="http://releases.ubuntu.com/14.04.2/ubuntu-14.04.2-server-i386.iso.torrent">Ubuntu 14.04.2 LTS Server (32-bit)&nbsp;&rsaquo;</a></li>
         </ul>
     </div><!-- /.four-col -->
     <div class="four-col last-col">
-        <h3 class="external"><span>Ubuntu 12.04.5 LTS</span></h3>
+        <h3>Ubuntu 12.04.5 LTS</h3>
         <ul class="no-bullets list">
-            <li><a href="http://releases.ubuntu.com/12.04/ubuntu-12.04.5-alternate-amd64.iso.torrent">Ubuntu 12.04.5 alternate (64-bit)&nbsp;&rsaquo;</a></li>
-            <li><a href="http://releases.ubuntu.com/12.04/ubuntu-12.04.5-alternate-i386.iso.torrent">Ubuntu 12.04.5 alternate (32-bit)&nbsp;&rsaquo;</a></li>
-            <li><a href="http://releases.ubuntu.com/12.04/ubuntu-12.04.5-desktop-amd64.iso.torrent">Ubuntu 12.04.5 Desktop (64-bit)&nbsp;&rsaquo;</a></li>
-            <li><a href="http://releases.ubuntu.com/12.04/ubuntu-12.04.5-desktop-i386.iso.torrent">Ubuntu 12.04.5 Desktop (32-bit)&nbsp;&rsaquo;</a></li>
-            <li><a href="http://releases.ubuntu.com/12.04/ubuntu-12.04.5-server-amd64.iso.torrent">Ubuntu 12.04.5 Server (64-bit)&nbsp;&rsaquo;</a></li>
-            <li><a href="http://releases.ubuntu.com/12.04/ubuntu-12.04.5-server-i386.iso.torrent">Ubuntu 12.04.5 Server (32-bit)&nbsp;&rsaquo;</a></li>
+            <li><a class="external" href="http://releases.ubuntu.com/12.04/ubuntu-12.04.5-alternate-amd64.iso.torrent">Ubuntu 12.04.5 alternate (64-bit)&nbsp;&rsaquo;</a></li>
+            <li><a class="external" href="http://releases.ubuntu.com/12.04/ubuntu-12.04.5-alternate-i386.iso.torrent">Ubuntu 12.04.5 alternate (32-bit)&nbsp;&rsaquo;</a></li>
+            <li><a class="external" href="http://releases.ubuntu.com/12.04/ubuntu-12.04.5-desktop-amd64.iso.torrent">Ubuntu 12.04.5 Desktop (64-bit)&nbsp;&rsaquo;</a></li>
+            <li><a class="external" href="http://releases.ubuntu.com/12.04/ubuntu-12.04.5-desktop-i386.iso.torrent">Ubuntu 12.04.5 Desktop (32-bit)&nbsp;&rsaquo;</a></li>
+            <li><a class="external" href="http://releases.ubuntu.com/12.04/ubuntu-12.04.5-server-amd64.iso.torrent">Ubuntu 12.04.5 Server (64-bit)&nbsp;&rsaquo;</a></li>
+            <li><a class="external" href="http://releases.ubuntu.com/12.04/ubuntu-12.04.5-server-i386.iso.torrent">Ubuntu 12.04.5 Server (32-bit)&nbsp;&rsaquo;</a></li>
         </ul>
     </div><!-- /.four-col -->
 </div><!-- /.row -->
@@ -71,22 +71,22 @@
         <h2>Other images</h2>
         <p>For other versions of the Ubuntu installer please select your nearest mirror; however, we recommend you use  the <a href="/download">standard installer</a> as all other packages are available in the Software Centre.</p>
     </div>
-    <h3 class="external"><span>Select the nearest mirror</span></h3>
+    <h3>Select the nearest mirror</h3>
     <ul class="twelve-col no-bullets list">
-      <li class="four-col"><a href="http://mirror.eftel.com/ubuntu-dvd ">Australia &rsaquo;</a></li>
-      <li class="four-col"><a href="http://ftp.funet.fi/pub/Linux/INSTALL/Ubuntu/dvd-releases/releases">Finland &rsaquo;</a></li>
-      <li class="four-col last-col"><a href="ftp://ftp.free.fr/mirrors/ftp.ubuntu.com/releases/">France &rsaquo;</a></li>
-      <li class="four-col"><a href="http://de.releases.ubuntu.com/">Germany &rsaquo;</a></li>
-      <li class="four-col"><a href="http://ftp.ntua.gr/pub/linux/ubuntu-releases-dvd">Greece &rsaquo;</a></li>
-      <li class="four-col last-col"><a href="http://ftp.heanet.ie/pub/ubuntu-cdimage/releases">Ireland &rsaquo;</a></li>
-      <li class="four-col"><a href="http://nl.archive.ubuntu.com/ubuntu-cdimages">Netherlands (1) &rsaquo;</a></li>
-      <li class="four-col"><a href="http://nginyang.uvt.nl/">Netherlands (2) &rsaquo;</a></li>
-      <li class="four-col last-col"><a href="http://mirror.yandex.ru/ubuntu-cdimage/releases">Russian Federation &rsaquo;</a></li>
-      <li class="four-col"><a href="http://es.archive.ubuntu.com/cdimage/releases">Spain</a></li>
-      <li class="four-col"><a href="http://ftp.acc.umu.se/mirror/cdimage.ubuntu.com/releases">Sweden &rsaquo;</a></li>
-      <li class="four-col last-col"><a href="http://tw.archive.ubuntu.com/ubuntu-dvd-releases/releases">Taiwan</a></li>
-      <li class="four-col last-item"><a href="http://www.mirrorservice.org/sites/cdimage.ubuntu.com/cdimage/releases">United Kingdom &rsaquo;</a></li>
-      <li class="four-col"><a href="http://mirror.anl.gov/pub/ubuntu-iso/DVDs/ubuntu">United States &rsaquo;</a></li>
+      <li class="four-col"><a class="external" href="http://mirror.eftel.com/ubuntu-dvd ">Australia &rsaquo;</a></li>
+      <li class="four-col"><a class="external" href="http://ftp.funet.fi/pub/Linux/INSTALL/Ubuntu/dvd-releases/releases">Finland &rsaquo;</a></li>
+      <li class="four-col last-col"><a class="external" href="ftp://ftp.free.fr/mirrors/ftp.ubuntu.com/releases/">France &rsaquo;</a></li>
+      <li class="four-col"><a class="external" href="http://de.releases.ubuntu.com/">Germany &rsaquo;</a></li>
+      <li class="four-col"><a class="external" href="http://ftp.ntua.gr/pub/linux/ubuntu-releases-dvd">Greece &rsaquo;</a></li>
+      <li class="four-col last-col"><a class="external" href="http://ftp.heanet.ie/pub/ubuntu-cdimage/releases">Ireland &rsaquo;</a></li>
+      <li class="four-col"><a class="external" href="http://nl.archive.ubuntu.com/ubuntu-cdimages">Netherlands (1) &rsaquo;</a></li>
+      <li class="four-col"><a class="external" href="http://nginyang.uvt.nl/">Netherlands (2) &rsaquo;</a></li>
+      <li class="four-col last-col"><a class="external" href="http://mirror.yandex.ru/ubuntu-cdimage/releases">Russian Federation &rsaquo;</a></li>
+      <li class="four-col"><a class="external" href="http://es.archive.ubuntu.com/cdimage/releases">Spain</a></li>
+      <li class="four-col"><a class="external" href="http://ftp.acc.umu.se/mirror/cdimage.ubuntu.com/releases">Sweden &rsaquo;</a></li>
+      <li class="four-col last-col"><a class="external" href="http://tw.archive.ubuntu.com/ubuntu-dvd-releases/releases">Taiwan</a></li>
+      <li class="four-col last-item"><a class="external" href="http://www.mirrorservice.org/sites/cdimage.ubuntu.com/cdimage/releases">United Kingdom &rsaquo;</a></li>
+      <li class="four-col"><a class="external" href="http://mirror.anl.gov/pub/ubuntu-iso/DVDs/ubuntu">United States &rsaquo;</a></li>
     </ul>
 </div><!-- /.row -->
 

--- a/templates/download/shared/_contextual_footer.html
+++ b/templates/download/shared/_contextual_footer.html
@@ -146,9 +146,9 @@
 		<p><a href="https://help.ubuntu.com/community/UbuntuHashes" class="external">View Ubuntu&rsquo;s md5 hashes</a></p>
 	</div>
 	<div class="feature-three four-col">
-		<h3 class="external"><span>Detailed documentation</span></h3>
-		<p><a href="https://help.ubuntu.com/lts/serverguide/index.html ">Ubuntu Server Guide&nbsp;&rsaquo;</a></p>
-		<p><a href="https://help.ubuntu.com/14.04/index.html">Ubuntu 14.04 LTS documentation&nbsp;&rsaquo;</a></p>
+		<h3>Detailed documentation</h3>
+		<p><a class="external" href="https://help.ubuntu.com/lts/serverguide/index.html ">Ubuntu Server Guide&nbsp;&rsaquo;</a></p>
+		<p><a class="external" href="https://help.ubuntu.com/14.04/index.html">Ubuntu 14.04 LTS documentation&nbsp;&rsaquo;</a></p>
 	</div><!-- /.feature-two -->
 {% else %}
 {% if level_2 == 'server' and not level_3 %}
@@ -161,9 +161,9 @@
 		</ul>
 	</div>
 	<div class="feature-three four-col">
-		<h3 class="external"><span>Detailed documentation</span></h3>
-		<p><a href="https://help.ubuntu.com/lts/serverguide/index.html">Ubuntu Server Guide&nbsp;&rsaquo;</a></p>
-		<p><a href="https://help.ubuntu.com/14.04/index.html">Ubuntu 14.04 LTS documentation&nbsp;&rsaquo;</a></p>
+		<h3>Detailed documentation</h3>
+		<p><a class="external" href="https://help.ubuntu.com/lts/serverguide/index.html">Ubuntu Server Guide&nbsp;&rsaquo;</a></p>
+		<p><a class="external" href="https://help.ubuntu.com/14.04/index.html">Ubuntu 14.04 LTS documentation&nbsp;&rsaquo;</a></p>
 	</div><!-- /.feature-two -->
 {% else %}
 {% if level_2 == 'ubuntu-kylin' %}
@@ -206,13 +206,13 @@
 {% endif %}{% endif %}{% endif %}{% endif %}{% endif %}{% endif %}{% endif %}{% endif %}{% endif %}{% endif %}{% endif %}{% endif %}{% endif %}{% endif %}
 {% if level_2 != 'ubuntu-kylin-zh-CN' %}
 	<div class="feature-four four-col">
-		<h3 class="external"><span>Helping hands</span></h3>
+		<h3>Helping hands</h3>
 		<p>If you get stuck, help is always at hand.</p>
 		<ul class="no-bullets">
-			<li><a href="http://askubuntu.com/">Ask Ubuntu&nbsp;&rsaquo;</a></li>
-			<li><a href="http://ubuntuforums.org/">Ubuntu Forums&nbsp;&rsaquo;</a></li>
-			<li><a href="http://discourse.ubuntu.com">Ubuntu Discourse&nbsp;&rsaquo;</a></li>
-			<li><a href="https://help.ubuntu.com/community/InternetRelayChat">Live Support Chat&nbsp;&rsaquo;</a></li>
+			<li><a class="external" href="http://askubuntu.com/">Ask Ubuntu&nbsp;&rsaquo;</a></li>
+			<li><a class="external" href="http://ubuntuforums.org/">Ubuntu Forums&nbsp;&rsaquo;</a></li>
+			<li><a class="external" href="http://discourse.ubuntu.com">Ubuntu Discourse&nbsp;&rsaquo;</a></li>
+			<li><a class="external" href="https://help.ubuntu.com/community/InternetRelayChat">Live Support Chat&nbsp;&rsaquo;</a></li>
 		</ul>
 	</div>
 {% endif %}


### PR DESCRIPTION
# Done

Remove the 'external' class from headings and add the class to the list item links. 
Remove external heading CSS.
## QA

Run make develop or make run. Notice that the ‘external' class has been removed from all headings and the links relating to the section have been given the external class.
Run gulp check and note that there are no errors caused by the removal of the CSS.
