### PR TITLE
force a rebuild of scss on run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ help:
 run:
 	${MAKE} build-app-image
 	${MAKE} node_modules
+	${MAKE} compile-sass
 	${MAKE} watch-sass &
 	${MAKE} run-app-image
 


### PR DESCRIPTION
# About

As @nottrobin pointed out, just watching scss all the time doesn't rebuild it in every case, and in my experience can keep errors hidden until a full rebuild is done.

This PR just runs a compile of sass the first time on each run.
# QA

```
make clean
make run
```
# Fixes
#14
