### PR TITLE
Remove 'Works with all your hardware and software' partners box

### DIFF
--- a/templates/server/hyperscale.html
+++ b/templates/server/hyperscale.html
@@ -163,35 +163,6 @@
 		</li>
 	</ul>
 </div>
-
 {% include "shared/_ubuntu_advantage_whats_inlcuded.html" %}
-
-<div class="row no-border">
-	<div class="twelve-col clearfix">
-		<div class="box-padded-feature">
-			<h3>Works with all your hardware and software</h3>
-				<div>
-					<div class="six-col">
-						<ul class="inline-icons clearfix">
-							<li><img src="{{ STATIC_URL }}img/third-party-logos/logo-dell-45x45.png" width="45" height="45" alt="Dell" /></li>
-							<li><img src="{{ STATIC_URL }}img/third-party-logos/logo-ibm-46x45.png" width="46" height="45" alt="IBM" /></li>
-							<li><img src="{{ STATIC_URL }}img/third-party-logos/logo-hp-41x45.png" width="41" height="45" alt="HP" /></li>
-							<li><img src="{{ STATIC_URL }}img/third-party-logos/logo-intel-50x45.png" width="50" height="45" alt="Intel" /></li>
-						</ul>
-						<p><a href="/certification">View all certified hardware&nbsp;&rsaquo;</a></p>
-					</div><!-- /.six-col -->
-					<div class="six-col last-col">
-						<ul class="inline-icons clearfix">
-							<li><img src="{{ STATIC_URL }}img/third-party-logos/logo-centrify-94x45.png" width="94" height="45" alt="Centrify" /></li>
-							<li><img src="{{ STATIC_URL }}img/third-party-logos/logo-likewise-100x45.png" width="100" height="45" alt="Likewise" /></li>
-							<li><img src="{{ STATIC_URL }}img/third-party-logos/logo-openstack-45x45.png" width="45" height="45" alt="OpenStack" /></li>
-							<li><img src="{{ STATIC_URL }}img/third-party-logos/logo-openbravo-112x45.png" width="112" height="45" alt="Openbravo" /></li>
-						</ul>
-						<p><a href="/partners/certified-software">View all certified software&nbsp;&rsaquo;</a></p>
-					</div><!-- /.six-col -->
-				</div><!-- /.vertical-divider -->
-		</div><!-- /.box-padded-feature -->
-	</div><!-- /.twelve-col -->
-</div><!-- /.row -->
 {% endblock content %}
 {% block footer_extra %}{{ marketo }}{% endblock footer_extra %}


### PR DESCRIPTION
# Done

Remove 'Works with all your hardware and software' partners box on /server/hyperscale page
## QA

Possibly a visual only, or make run/develop, navigate to server/hyperscale and note that the section has gone. I’ve also update the copy doc.
## Notes

Copy doc: https://docs.google.com/document/d/1f56CCzH519lIVa4KvxDt0QpxYFMK-bMdVlKo4TvPSIk/edit#
Card: https://canonical.leankit.com/Boards/View/111185042/115594991
