### PR TITLE
Only pull python-auth if you dont have it already

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ build-app-image:
 run:
 	# Make sure IP is correct for mac etc.
 	$(eval docker_ip := `hash boot2docker 2> /dev/null && echo "\`boot2docker ip\`" || echo "127.0.0.1"`)
-	docker pull ubuntudesign/python-auth
+	if [[ -z "`docker images -q ubuntudesign/python-auth`" ]]; then docker pull ubuntudesign/python-auth; fi
 	@cat docker-compose.yml | sed 's/8001/${PORT}/g' | docker-compose --file=- up -d web # Run Django
 	@echo ""
 	@echo "== Running server on http://${docker_ip}:${PORT} =="


### PR DESCRIPTION
## QA

``` bash
docker rmi ubuntudesign/python-auth
make run  # Should pull python-auth
make run  # Second time, shouldn't even try to pull
```
