### PR TITLE
Remove 'first' class form first item in secondary nav

### DIFF
--- a/templates/cloud/_nav_secondary.html
+++ b/templates/cloud/_nav_secondary.html
@@ -1,5 +1,5 @@
 	<ul{% if list_class %} class="{{ list_class }}"{% endif %} class="second-level-nav">
-		<li class="first"><a{% if level_1 == 'cloud' and not level_2 %} class="active"{% endif %} href="/cloud">Overview</a></li>
+		<li><a{% if level_1 == 'cloud' and not level_2 %} class="active"{% endif %} href="/cloud">Overview</a></li>
 		<li><a{% if level_2 == 'ubuntu-openstack' %} class="active"{% endif %} href="/cloud/ubuntu-openstack">Ubuntu OpenStack</a></li>
 		<li><a{% if level_2 == 'managed-cloud' %} class="active"{% endif %} href="/cloud/managed-cloud">Managed cloud</a></li>
 		<li><a{% if level_2 == 'training' %} class="active"{% endif %} href="/cloud/training">Training</a></li>

--- a/templates/desktop/_nav_secondary.html
+++ b/templates/desktop/_nav_secondary.html
@@ -1,8 +1,8 @@
 	<ul{% if list_class %} class="{{ list_class }}"{% endif %} class="second-level-nav">
-		<li class="first"><a{% if level_1 == 'desktop' and not level_2 %} class="active"{% endif %} href="/desktop">Overview</a></li>
+		<li><a{% if level_1 == 'desktop' and not level_2 %} class="active"{% endif %} href="/desktop">Overview</a></li>
 		<li><a{% if level_2 == 'features' %} class="active"{% endif %} href="/desktop/features">Features</a></li>
 		<li><a{% if level_2 == 'enterprise' %} class="active"{% endif %} href="/desktop/enterprise">For enterprise</a></li>
-		<li><a{% if level_2 == 'education' %} class="active"{% endif %} href="/desktop/education">For education	</a></li>
+		<li><a{% if level_2 == 'education' %} class="active"{% endif %} href="/desktop/education">For education</a></li>
 		<li><a{% if level_2 == 'government' %} class="active"{% endif %} href="/desktop/government">For government</a></li>
 		<li><a{% if level_2 == 'developers' %} class="active"{% endif %} href="/desktop/developers">For developers</a></li>
 		<li><a{% if level_2 == 'ubuntu-kylin' %} class="active"{% endif %} href="/desktop/ubuntukylin">For China</a></li>

--- a/templates/download/_nav_secondary.html
+++ b/templates/download/_nav_secondary.html
@@ -1,5 +1,5 @@
 	<ul{% if list_class %} class="{{ list_class }}"{% endif %} class="second-level-nav">
-		<li class="first"><a{% if level_1 == 'download' and not level_2 %} class="active"{% endif %} href="/download">Overview</a></li>
+		<li><a{% if level_1 == 'download' and not level_2 %} class="active"{% endif %} href="/download">Overview</a></li>
 		<li><a{% if level_2 == 'cloud' %} class="active"{% endif %} href="/download/cloud">Cloud</a></li>
 		<li><a{% if level_2 == 'server' %} class="active"{% endif %} href="/download/server">Server</a></li>
 		<li><a{% if level_2 == 'desktop' %} class="active"{% endif %} href="/download/desktop">Desktop</a></li>

--- a/templates/legal/_nav_secondary.html
+++ b/templates/legal/_nav_secondary.html
@@ -1,5 +1,5 @@
 	<ul{% if list_class %} class="{{ list_class }}"{% endif %} class="second-level-nav">
-		<li class="first"><a{% if level_1 == 'legal' and not level_2 %} class="active"{% endif %} href="/legal">Overview</a></li>
+		<li><a{% if level_1 == 'legal' and not level_2 %} class="active"{% endif %} href="/legal">Overview</a></li>
 		<li{% if level_2 == 'terms-and-policies' %} class="active" {% endif %}><a href="/legal/terms-and-policies">Terms and policies</a></li>
 		<li{% if level_2 == 'ubuntu-advantage' %} class="active" {% endif %}><a href="/legal/ubuntu-advantage">Ubuntu Advantage</a></li>
 		<li{% if level_2 == 'bootstack' %} class="active" {% endif %}><a href="/legal/bootstack">BootStack</a></li>

--- a/templates/management/_nav_secondary.html
+++ b/templates/management/_nav_secondary.html
@@ -1,5 +1,5 @@
 	<ul{% if list_class %} class="{{ list_class }}"{% endif %} class="second-level-nav">
-		<li class="first"><a{% if level_1 == 'management' and not level_2 %} class="active"{% endif %} href="/management">Overview</a></li>
+		<li><a{% if level_1 == 'management' and not level_2 %} class="active"{% endif %} href="/management">Overview</a></li>
 		<li><a{% if level_2 == 'landscape-features' %} class="active"{% endif %} href="/management/landscape-features">Landscape features</a></li>
 		<li><a{% if level_2 == 'working-with-landscape' %} class="active"{% endif %} href="/management/working-with-landscape">Working with Landscape</a></li>
 		<li><a{% if level_2 == 'return-on-investment' %} class="active"{% endif %} href="/management/return-on-investment">Return on investment</a></li>

--- a/templates/phone/_nav_secondary.html
+++ b/templates/phone/_nav_secondary.html
@@ -1,5 +1,5 @@
 	<ul{% if list_class %} class="{{ list_class }}"{% endif %} class="second-level-nav">
-		<li class="first"><a{% if level_1 == 'phone' and not level_2 %} class="active"{% endif %} href="/phone">Overview</a></li>
+		<li><a{% if level_1 == 'phone' and not level_2 %} class="active"{% endif %} href="/phone">Overview</a></li>
 		<li><a{% if level_2 == 'features' %} class="active"{% endif %} href="/phone/features" >Features</a></li>
 		<li><a{% if level_2 == 'devices' %} class="active"{% endif %} href="/phone/devices" >Devices</a></li>
 		<li><a{% if level_2 == 'developers' %} class="active"{% endif %} href="/phone/developers" >For developers</a></li>

--- a/templates/tablet/_nav_secondary.html
+++ b/templates/tablet/_nav_secondary.html
@@ -1,5 +1,5 @@
 	<ul{% if list_class %} class="{{ list_class }}"{% endif %} class="second-level-nav">
-		<li class="first"><a{% if level_1 == 'tablet' and not level_2 %} class="active"{% endif %} href="/tablet">Design</a></li>
+		<li><a{% if level_1 == 'tablet' and not level_2 %} class="active"{% endif %} href="/tablet">Design</a></li>
 		<li><a{% if level_2 == 'operators-and-oems' %} class="active"{% endif %} href="/tablet/operators-and-oems">Operators and OEMs</a></li>
 		<li><a{% if level_2 == 'backed-by-canonical' %} class="last-item"{% endif %}{% if level_2 == 'app-ecosystem' %} class="active"{% endif %} href="/tablet/app-ecosystem">App ecosystem</a></li>
 	</ul>

--- a/templates/things/_nav_secondary.html
+++ b/templates/things/_nav_secondary.html
@@ -1,5 +1,5 @@
 	<ul{% if list_class %} class="{{ list_class }}"{% endif %} class="second-level-nav">
-		<li class="first"><a{% if level_1 == 'things' and not level_2 %} class="active"{% endif %} href="/cloud">Overview</a></li>
+		<li><a{% if level_1 == 'things' and not level_2 %} class="active"{% endif %} href="/cloud">Overview</a></li>
 		<li><a{% if level_2 == 'openstack' %} class="active"{% endif %} href="/cloud/openstack">OpenStack</a></li>
 		<li><a{% if level_2 == 'bootstack' %} class="active"{% endif %} href="/cloud/bootstack">BootStack</a></li>
 		<li><a{% if level_2 == 'training' %} class="active"{% endif %} href="/cloud/training">Training</a></li>

--- a/templates/tv/_nav_secondary.html
+++ b/templates/tv/_nav_secondary.html
@@ -1,5 +1,5 @@
 	<ul{% if list_class %} class="{{ list_class }}"{% endif %} class="second-level-nav">
-		<li class="first"><a{% if level_1 == 'tv' and not level_2 %} class="active"{% endif %} href="/tv">Overview</a></li>
+		<li><a{% if level_1 == 'tv' and not level_2 %} class="active"{% endif %} href="/tv">Overview</a></li>
 		<li><a{% if level_2 == 'experience' %} class="active"{% endif %} href="/tv/experience">Experience</a></li>
 		<li><a{% if level_2 == 'industry' %} class="active"{% endif %} href="/tv/industry">Industry</a></li>
 		<li><a{% if level_2 == 'contributors' %} class="active"{% endif %} href="/tv/contributors">Contributors</a></li>


### PR DESCRIPTION
# Done

Remove 'first' class form first item in secondary nav
## QA

Make sure class=“first” has been removed from all secondary navs
## Details

Card: https://canonical.leankit.com/Boards/View/111185042/119338984
