### PR TITLE
Bring inline-logos inline with Vanilla framework

### DIFF
--- a/static/js/scratch.js
+++ b/static/js/scratch.js
@@ -461,7 +461,7 @@ YUI().use('node','gallery-carousel','gallery-carousel-anim','substitute', 'galle
         var numberToDisplay = numberPartners < 10 ? numberPartners : 10;
 
         for (var i = 0; i < numberToDisplay; i++) {
-            Y.one(id).append(Y.Node.create('<li><img onload="this.style.opacity=\'1\';" src="'+JSON[i].logo+'" alt="'+JSON[i].name+'"></li>'));
+            Y.one(id).append(Y.Node.create('<li class="inline-logos__item"><img class="inline-logos__image"  onload="this.style.opacity=\'1\';" src="'+JSON[i].logo+'" alt="'+JSON[i].name+'"></li>'));
         }
     };
 

--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -84,23 +84,47 @@
 	</div>
 
 	<h3 class="muted-heading">Works with all your hardware and software</h3>
-	<ul class="inline-logos no-bullets">
-		<li><img src="{{ STATIC_URL }}img/logos/logo-pack/logo-lenovo.svg" alt="Lenovo" /></li>
-		<li><img src="{{ STATIC_URL }}img/logos/logo-pack/logo-dell.svg" alt="Dell" /></li>
-		<li><img src="{{ STATIC_URL }}img/logos/logo-pack/logo-ibm.svg" alt="IBM" /></li>
-		<li><img src="{{ STATIC_URL }}img/logos/logo-pack/logo-hp.svg" alt="HP" /></li>
-		<li class="last-item"><img src="{{ STATIC_URL }}img/logos/logo-pack/logo-intel.svg" alt="Intel" /></li>
-		<li><img src="{{ STATIC_URL }}img/logos/logo-pack/logo-cisco.svg"alt="Cisco" /></li>
-		<li><img src="{{ STATIC_URL }}img/logos/logo-pack/logo-amd.svg"alt="AMD" /></li>
-		<li class="last-item"><img src="{{ STATIC_URL }}img/logos/logo-pack/logo-arm.svg"alt="Intel" /></li>
+	<ul class="inline-logos">
+  		<li class="inline-logos__item">
+  		    <img class="inline-logos__image" src="https://assets.ubuntu.com/v1/68713fd5-logo-lenovo.svg" alt="Lenovo" />
+  		</li>
+  		<li class="inline-logos__item">
+  		    <img class="inline-logos__image" src="https://assets.ubuntu.com/v1/5ddba83a-logo-dell.svg" alt="Dell" />
+  		</li>
+  		<li class="inline-logos__item">
+  		    <img class="inline-logos__image" src="https://assets.ubuntu.com/v1/683950fd-logo-ibm.svg" alt="IBM" />
+  		</li>
+  		<li class="inline-logos__item">
+  		    <img class="inline-logos__image" src="https://assets.ubuntu.com/v1/a298e7ec-logo-hp.svg" alt="HP" />
+  		</li>
+  		<li class="inline-logos__item">
+  		    <img class="inline-logos__image" src="https://assets.ubuntu.com/v1/c24cb4b9-logo-intel.svg" alt="Intel" />
+  		</li>
+  		<li class="inline-logos__item">
+  		    <img class="inline-logos__image" src="https://assets.ubuntu.com/v1/4d6054f9-logo-cisco.svg" alt="Cisco" />
+  		</li>
+  		<li class="inline-logos__item">
+  		    <img class="inline-logos__image" src="https://assets.ubuntu.com/v1/731aab6c-logo-amd.svg" alt="AMD" />
+  		</li>
+  		<li class="inline-logos__item">
+  		    <img class="inline-logos__image" src="https://assets.ubuntu.com/v1/b5352dc1-logo-arm.svg" alt="Intel" />
+  		</li>
 	</ul>
-	<p class="text-center"><a href="/certification">View all certified hardware&nbsp;&rsaquo;</a></p>
+	<p class="text-center twelve-col"><a href="/certification">View all certified hardware&nbsp;&rsaquo;</a></p>
 
-	<ul class="inline-logos no-bullets">
-		<li><img src="{{ STATIC_URL }}img/logos/logo-pack/logo-centrify.png" alt="Centrify" /></li>
-		<li><img src="{{ STATIC_URL }}img/logos/logo-pack/logo-openstack.svg" alt="OpenStack" /></li>
-		<li><img src="{{ STATIC_URL }}img/logos/logo-pack/logo-likewise.png" alt="Likewise" /></li>
-		<li class="last-item"><img src="{{ STATIC_URL }}img/logos/logo-pack/logo-openbravo.png" alt="Openbravo" /></li>
+	<ul class="inline-logos">
+  		<li class="inline-logos__item">
+  		    <img class="inline-logos__image" src="https://assets.ubuntu.com/v1/76999dfc-logo-centrify.png" alt="Centrify" />
+  		</li>
+  		<li class="inline-logos__item">
+  		    <img class="inline-logos__image" src="https://assets.ubuntu.com/v1/eed716e9-logo-openstack.svg" alt="OpenStack" />
+  		</li>
+  		<li class="inline-logos__item">
+  		    <img class="inline-logos__image" src="https://assets.ubuntu.com/v1/c228b4e9-logo-likewise.png" alt="Likewise" />
+  		</li>
+  		<li class="inline-logos__item">
+  		    <img class="inline-logos__image" src="https://assets.ubuntu.com/v1/64493bba-logo-openbravo.png" alt="Openbravo" />
+  		</li>
 	</ul>
 	<p class="text-center"><a href="/partners/certified-software">View all certified software&nbsp;&rsaquo;</a></p>
 </div>


### PR DESCRIPTION
# Done

Add BEM classes to inline-logos to bring inline with Vanilla framework.
## QA

Make sure you have cutting edge vanilla framework and ubuntu vanilla theme. Check instances of inline-logos.
## Details

Card: https://canonical.leankit.com/Boards/View/111185042/119437664
