### PR TITLE
Add ASSET_SERVER_URL for use in templates

### DIFF
--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -43,6 +43,8 @@ TEMPLATE_CONTEXT_PROCESSORS = [
     "django_asset_server_url.asset_server_url"   # {{ ASSET_SERVER_URL }}
 ]
 
+ASSET_SERVER_URL = '//assets.ubuntu.com/v1/'
+
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,


### PR DESCRIPTION
(Card: https://canonical.leankit.com/Boards/View/111185042/116654399)

Setup `ASSET_SERVER_URL` ready for use in URLs in templates.

We'll use this when migrating the assets over to the new assets server
([card](https://canonical.leankit.com/Boards/View/111185042/116654400)).
# QA

`make run` and try adding `{{ ASSET_SERVER_URL }}` to a template file.

Make sure it comes out on the front-end as `//assets.ubuntu.com/v1/`.
