### PR TITLE
Add .inline-icons and .box-padded-feature to local

### DIFF
--- a/static/css/section/_local.scss
+++ b/static/css/section/_local.scss
@@ -750,3 +750,80 @@ footer.global ul.inline li:after {
 #context-footer div div.feature-one { display: table-cell; }
 
 #context-footer div div.feature-two { padding-left: 0; }
+
+// inline-icons imported from old guidelines
+.inline-icons {
+	margin: 0 0 $gutter-width;
+
+	li {
+		margin-right: 20px;
+		margin-bottom: 20px;
+		text-align: left;
+		display: inline-block;
+
+		&.last-item { margin-right: 0; }
+	}
+
+	&.no-margin-bottom li { margin-bottom: 0; }
+
+	img {
+		vertical-align: middle;
+		height: 30px;
+	}
+}
+
+@media only screen and (min-width: 984px) {
+	.inline-icons {
+    text-align: left;
+    margin-bottom: 20px;
+  }
+} // end @media only screen and (min-width: 984px)
+ 
+// box-padded-feature imported from old guidelines
+.box-padded-feature {
+  border-radius: 4px;
+  background: url('#{$asset-path}patterns/soft-centre-bkg.gif') repeat scroll 0 0 $cool-grey;
+  border: 0;
+  margin-bottom: 20px;
+  padding: 11px 5px 6px;
+
+  h3 {
+    @include font-size(19.5);
+    color: $white;
+    margin-left: ($gutter-width / 4);
+  }
+
+  h4 {
+    @include font-size(16);
+    font-weight: normal;
+  }
+
+  > div {
+    border-radius: 4px;
+    background: $white;
+    overflow: hidden;
+    padding: 20px 8px;
+  }
+
+  div div {
+    margin-bottom: 0;
+  }
+
+  .inline-icons {
+    display: table;
+    width: 100%;
+    margin: 0;
+    text-align: center;
+
+    li {
+      display: table-cell;
+      text-align: left;
+      float: none;
+    }
+  }
+
+  .one-col {
+    width: 48px;
+    float: left;
+  }
+}

--- a/templates/legal/terms-and-policies/privacy-policy/third-parties.html
+++ b/templates/legal/terms-and-policies/privacy-policy/third-parties.html
@@ -12,7 +12,7 @@
 		<p class="eight-col">For information on how our selected third parties may use your information, please see their <a href="/privacy-policy">privacy policies</a>.</p>
 </div><!-- /.row -->
 <div class="row no-border">
-	<ul class="inline-icons">
+	<ul class="inline-list">
 		<li><a href="http://www.3sat.de/page/?source=/service/140014/index.html">3sat Mediathek</a></li>
 		<li><a href="http://about.7digital.com/terms-and-conditions-use">7Digital</a></li>
 		<li><a href="http://www.abc.net.au/privacy.htm">ABC iView</a></li>

--- a/templates/privacy-policy/third-parties.html
+++ b/templates/privacy-policy/third-parties.html
@@ -9,7 +9,7 @@
 		<p class="eight-col">For information on how our selected third parties may use your information, please see their <a href="/privacy-policy">privacy policies</a>.</p>
 </div><!-- /.row -->
 <div class="row no-border">
-	<ul class="inline-icons">
+	<ul class="inline-list">
 		<li><a href="http://www.3sat.de/page/?source=/service/140014/index.html">3sat Mediathek</a></li>
 		<li><a href="http://about.7digital.com/terms-and-conditions-use">7Digital</a></li>
 		<li><a href="http://www.abc.net.au/privacy.htm">ABC iView</a></li>


### PR DESCRIPTION
# Done

Add .inline-icons and .box-padded-feature to local (not BEMed as it’s a pattern that will hopefully be retired soon)
## QA

Requires bleeding edge vf and uvt. Run make run in ubuntu-website. Run gulp build in node_modules in vf and uvt. Pop over to /server/hyperscale and check the inline icons in 'Works with all your hardware and software’ look the same as live.
## Details

Card: https://trello.com/c/RR6SNQGr
