### PR TITLE
Turn off DEBUG when not using the dev settings

### DIFF
--- a/webapp/dev_settings.py
+++ b/webapp/dev_settings.py
@@ -1,4 +1,5 @@
 from settings import *
 
 INSTALLED_APPS += ['django_extensions']
+DEBUG = True
 TEMPLATE_DEBUG = False

--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -22,7 +22,7 @@ INSTALLED_APPS = [
 ]
 
 ALLOWED_HOSTS = ['*']
-DEBUG = True
+DEBUG = False
 ROOT_URLCONF = 'webapp.urls'
 WSGI_APPLICATION = 'webapp.wsgi.application'
 LANGUAGE_CODE = 'en-us'


### PR DESCRIPTION
Move the DEBUG option from the main config file, into the dev settings
config.
# QA steps

``` bash
make run
```

Visit a 404 page and check you get the Django debug screen, e.g. http://127.0.0.1:8001/does-not-exist.

Now run with gunicorn:

``` bash
docker-compose run --service-ports web bash -c "pip install gunicorn && gunicorn -b 0.0.0.0:5000 webapp.wsgi"
```

Visit a 404 page like http://127.0.0.1:8001/does-not-exist and check you get a real "Not found" page rather than the Django debug version.
