### PR TITLE
Use the new version of static-root-finder (fixes 404s)

### DIFF
--- a/requirements/standard.txt
+++ b/requirements/standard.txt
@@ -6,4 +6,4 @@ django-yaml-redirects==0.4
 django-asset-server-url==0.1
 django-versioned-static-url==0.1.1
 django-template-finder-view==0.2
-django-static-root-finder==0.3.0
+django-static-root-finder==0.3.1


### PR DESCRIPTION
So it was the case that non-existent `static` URLs gave a server error.

This should fix that.
## QA

Visit a `static/{something}` URL.
