### PR TITLE
Add flavours row; fix image in alternative download

### DIFF
--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -82,8 +82,21 @@
             <h2><a href="/download/alternative-downloads">Alternative downloads&nbsp;&rsaquo;</a></h2>
             <p>There are several other ways to get Ubuntu including torrents, which can potentially mean a quicker download, our network installer for older systems and special configurations and links to our regional DVD image mirrors for our older releases.</p>
         </div>
-        <div class="five-col last-col no-margin-bottom equal-height__item equal-height__align-vertically">
+        <div class="five-col last-col text-center no-margin-bottom equal-height__item equal-height__align-vertically">
             <img src="{{ ASSET_SERVER_URL }}be3876ec-picto-download-warmgrey.svg" alt="Chinese Ubuntu logo" height="112" width="112" />
+        </div>
+    </div>
+
+    <div class="twelve-col no-margin-bottom box equal-height">
+        <div class="seven-col no-margin-bottom">
+            <h2><a href="/download/ubuntu-flavours">Ubuntu flavours&nbsp;&rsaquo;</a></h2>
+            <p>Ubuntu flavours offer a unique way to experience Ubuntu with
+            different choices of default applications and settings, backed
+            by the full Ubuntu archive for packages and updates.
+            </p>
+        </div>
+        <div class="five-col last-col text-center no-margin-bottom align-vertically">
+            <img src="{{ ASSET_SERVER_URL }}ebfb7122-picto-generic-warmgrey.svg" alt="" height="112" width="112" />
         </div>
     </div>
 </div>


### PR DESCRIPTION
Fixes: #69 #120.
## QA

Run site, visit `/download`, and check the bottom two rows (alternative download & ubuntu flavours) look like [live](http://www.ubuntu.com/download).
