### PR TITLE
Add row: targeting mid to high end devices

### DIFF
--- a/templates/phone/partners.html
+++ b/templates/phone/partners.html
@@ -94,6 +94,19 @@
   </div>
 </section>
 
+<section class="row no-border strip-light">
+    <div class="strip-inner-wrapper">
+        <div class="seven-col">
+            <img src="https://assets.ubuntu.com/v1/955f6fd7-targeting-row.png" alt="Ubuntu phone handsets" />
+        </div>
+        <div class="prepend-one four-col last-col">
+            <h2>Targeting mid to high end&nbsp;devices</h2>
+            <p>With a user experience and partner differentiation strategy that revolves around content and services &mdash; Ubuntu is tailored for users that require higher data usage and higher quality devices. By targeting mid to high end devices with Ubuntu, carriers and device manufacturers can deliver a superior experience while leveraging Ubuntu&rsquo;s service layer differentiation opportunities.</p>
+        </div>
+    </div>
+</section>
+
+
 <section class="row strip-dark row-case-studies no-border">
   <div class="strip-inner-wrapper">
     <div class="eight-col">


### PR DESCRIPTION
Takes care of #198.
## QA

Run site and visit `/phone/partners`, check "Targeting mid to high end devices" row is there as on [live](http://www.ubuntu.com/phone/partners)
