### PR TITLE
Remove some bespoke inline-logos styles on IoT

### DIFF
--- a/static/css/section/_things.scss
+++ b/static/css/section/_things.scss
@@ -3,58 +3,56 @@
   @media only screen and (min-width: 768px) {
     // Leave row-cta here for now but if it spreads to other sections maybe think about it being a new pattern.
     .row-cta {
-      padding: 80px 40px 60px;  
+      padding: 80px 40px 60px;
     }
   }
 
   @media only screen and (min-width: 984px) {
     .row-cta {
-      padding: 90px 40px 70px;  
+      padding: 90px 40px 70px;
     }
   }
   // override the darkness
   .row-case-studies {
     background: $light-grey;
     color: $cool-grey;
-    
+
     p,
     .pull-quote cite {
-      color: $cool-grey; 
+      color: $cool-grey;
     }
   }
-  
-  // had to biggerise the logos  
+
+  // had to biggerise the logos
   .inline-logos--large li {
-    margin: 30px 0;
-    
+
     img {
       height: auto;
       max-height: 65px;
-      max-width: 230px;
     }
-  } 
-  
+  }
+
   // events - in contextual footer
   #context-footer {
     .event {
-      display: inline-block; 
-      
+      display: inline-block;
+
       @media only screen and (max-width: 480px) {
         width: 100%;
-      } 
-      
+      }
+
       @media only screen and (min-width: 768px) {
-        display: table-cell; 
+        display: table-cell;
       }
     }
-        
+
     .event-map {
       float: right;
-  		
+
       @media only screen and (min-width: 769px) {
         display: inline-block;
       }
-  
+
       img {
         margin-left: 20px;
         width: 56px;
@@ -64,17 +62,17 @@
         }
       }
     }
-  	
+
     .event h3 {
       margin-bottom: 0;
       width: 65%;
       float: left;
-  		
+
       @media only screen and (min-width: 769px) {
         width: 65%;
       }
     }
-  	
+
     .event-details {
       color: $warm-grey;
       font-size: .8125em;
@@ -85,17 +83,17 @@
       float: left;
       margin-top: 4px;
       width: 65%;
-      
+
       @media only screen and (min-width: 769px) {
         width: 65%;
       }
     }
-  
+
     .event-details dd {
       margin-left: 0;
       padding-right: 0;
     }
-  
+
     .location {
       box-sizing: border-box;
       background: url('#{$asset-server}dc06486f-location.svg') 0 5px no-repeat;
@@ -105,7 +103,7 @@
       padding: 6px 20px 6px 24px;
       width: 100%;
     }
-    
+
     .venue {
       box-sizing: border-box;
       background: url('#{$asset-server}48947556-gps.svg') 0 5px no-repeat;
@@ -115,7 +113,7 @@
       padding: 6px 20px 6px 24px;
       width: 100%;
     }
-    
+
     .event-date {
       background: url('#{$asset-server}c7d1850b-calendar.svg') 0 4px no-repeat;
       background-size: 20px 20px;
@@ -123,7 +121,7 @@
       display: block;
       padding: 6px 20px 6px 24px;
     }
-    
+
     .image-wrap {
       background-size: 78px 78px;
       position: relative;
@@ -132,12 +130,12 @@
       vertical-align: middle;
       margin-bottom: 0;
     }
-    
+
     .image-wrap img {
       border-radius: 4px;
       margin-top: 7px;
     }
-    
+
     .image-wrap:after {
       background: url("#{$asset-server}5fb0cac2-white-squircle.png") no-repeat;
       background-size: 78px 78px;
@@ -153,7 +151,7 @@
 
 .border-small {
   border-bottom: 1px dotted #888;
-  
+
   @media only screen and (min-width: 768px) {
     border: 0;
   }
@@ -163,7 +161,7 @@
 .internet-of-things-overview {
   #main-content .row-hero {
     margin-top: 0;
-    
+
     @media only screen and (min-width: 768px) {
       background-image: url('#{$asset-server}8d5f669e-DARWIN_2.png?q=60&w=984');
       background-position: 309px -35px;
@@ -172,14 +170,14 @@
       margin-top: 0;
       min-height: 550px;
     }
-    
+
     @media only screen and (min-width: 768px) {
       h1 {
         margin-top: 17%;
       }
     }
   }
-  
+
   .row-developers {
     @media only screen and (min-width: 768px) {
       background: url('#{$asset-server}a301749d-iot-overview-developer.jpg?q=70&w=984') center center no-repeat;
@@ -187,7 +185,7 @@
       min-height: 460px;
     }
   }
-  
+
   .row--leaders {
     min-height: 438px;
   }
@@ -202,20 +200,20 @@
       color: #fff;
       margin-top: 0;
       padding-top: 40px;
-    }    
+    }
   }
-  
+
   .row-supported-hardware {
     background: url('#{$asset-server}be523ae7-dell-edge-gateway-5000-series.jpg?h=300') 50% 100% no-repeat;
     padding-bottom: 300px;
-    
+
     @media only screen and (min-width: 768px) {
       background: url('#{$asset-server}be523ae7-dell-edge-gateway-5000-series.jpg?h=400') 90% 50% no-repeat;
       min-height: 400px;
       padding-bottom: inherit;
     }
   }
-  
+
   // override the bullshit at line 26 of desktop.scss
   @media only screen and (min-width: 768px) {
     .row-case-studies > h2:first-child {
@@ -229,13 +227,13 @@
 }
 
 //internet-of-things/features
-body.internet-of-things-features {  
+body.internet-of-things-features {
   #main-content .row-hero {
     background-position: 430px -25px;
     background-size: 69%;
     margin-top: 0;
     padding-top: 20px;
-    
+
     @media only screen and (max-width: 768px) {
       background-position: 400px 20px;
     }
@@ -247,7 +245,7 @@ body.internet-of-things-features {
       padding-top: 40px;
     }
   }
-  
+
   @media only screen and (min-width: 768px) {
     .row-marketplace {
       background: url('#{$asset-server}d1f7b4c2-iot-features-led.jpg?q=60&w=984') left -74px no-repeat;
@@ -256,7 +254,7 @@ body.internet-of-things-features {
       overflow: hidden;
     }
   }
-  
+
   @media only screen and (max-width: 768px) {
     .row-marketplace {
       min-height: 400px;
@@ -265,7 +263,7 @@ body.internet-of-things-features {
 }
 
 //internet-of-things/developers
-body.internet-of-things-developers {  
+body.internet-of-things-developers {
   @media only screen and (min-width: 768px) {
     #main-content .row-hero {
       background: url('#{$asset-server}8b907c80-iot-developers-hero.jpg?q=60&w=984') center center no-repeat;
@@ -277,30 +275,30 @@ body.internet-of-things-developers {
     @media only screen and (min-width: 984px) {
       min-height: 560px;
     }
-  
+
     .row-autonomous {
       background: url('#{$asset-server}ec11fa9e-developers-robots-erle-spider.jpg?q=60') -80px 50% no-repeat;
       background-size: 55% auto;
-      
+
       .row-autonomous__content {
         padding: 50px 0;
       }
     }
-  
+
     .row-toys {
       background: url('#{$asset-server}039723db-iot-developers-robot.jpg?q=60&amp;w=984') center center no-repeat;
       background-size: cover;
-      
+
       @media only screen and (min-width: 984px) {
         min-height: 420px;
       }
-      
+
       .row-toys__content {
         padding-top: 20px;
       }
     }
   }
-  
+
   // here be dragons
   .snappy-language-image {
     margin-top: -27px;


### PR DESCRIPTION
## Done
- Removed some of the bespoke inline-logos styles which were making logos overlap and to large on small screens
## QA
- Go to `/internet-of-things/partners`
- Wait for the `A GROWING LIST OF PARTNERS` section to add its logos
- Check they look ok on different screen sizes
- Reload a few times to get different logos and check they are ok too incase there are edge cases.
## Issue / Card
- Fixes: https://github.com/ubuntudesign/www.ubuntu.com/issues/177
