### PR TITLE
Fix cloud heros

### DIFF
--- a/static/css/section/_cloud.scss
+++ b/static/css/section/_cloud.scss
@@ -876,7 +876,7 @@ body.cloud-ubuntu-openstack-reference-architecture {
 
   .row--training__image {
     position: absolute;
-    top: -84px;
+    top: -125px;
     right: -20px;
   }
 
@@ -1419,7 +1419,7 @@ body.cloud-ubuntu-openstack-reference-architecture {
 
   .row--training__image {
     position: absolute;
-    top: -122px;
+    top: -142px;
     right: -20px;
   }
 


### PR DESCRIPTION
## Done

Fix cloud hero h1 positioning to match live
Fix positioning of hero image on /cloud/openstack/training
## QA

Run make run and go to the cloud section, make sure the h1s are similar to live and consistent throughout the section. 
Check positioning of hero image on /cloud/openstack/training
## Issue / Card

Card: 
Hero titles - https://trello.com/c/cbE7BmwV
Cloud training hero image - https://trello.com/c/anWROQqD

Issue: 
Hero titles - https://github.com/ubuntudesign/www.ubuntu.com/issues/205
Cloud training hero image - https://github.com/ubuntudesign/www.ubuntu.com/issues/204
