### PR TITLE
Fix mis-aligned CTA on phone partners in 'Easier hardware enablement' section

### DIFF
--- a/templates/phone/partners.html
+++ b/templates/phone/partners.html
@@ -113,7 +113,7 @@
       <h2>Easier hardware enablement</h2>
       <p>Ubuntu&rsquo;s core system is based around a typical Android Board Support Package (BSP), so you don&rsquo;t need to invest in new ones. And we have teams based in Taipei, Shanghai, London, Beijing and Boston, who can engage with your engineering and factory operations.</p>
     </div>
-    <div class="twelve-col vertical-divider">
+    <div class="twelve-col vertical-divider equal-height">
       <div class="four-col">
         <blockquote class="pull-quote">
           <p><span>&ldquo;</span>We are very excited by our partnership with Ubuntu and look forward to an onward successful relationship.<span>&rdquo;</span></p>


### PR DESCRIPTION
## Done

added equal-height to fix a float issue on a cta below
## QA
1. go to /phone/partners
2. see that the 'Learn more about the Ubuntu features ›' CTA is aligned left
## Issue / Card
#199
