### PR TITLE
fix ceph logo URL and limit asset server image sizes

### DIFF
--- a/templates/cloud/storage/index.html
+++ b/templates/cloud/storage/index.html
@@ -57,7 +57,7 @@
             <div class="equal-height--vertical-divider__item six-col last-col">
                 <h2>Ceph</h2>
                 <p class="six-col">A converged storage framework that has been designed to present object, block, and file storage from a single distributed computer cluster.</p>
-                <div class="align-center"><img src="{{ ASSET_SERVER_URL }}da39a3ee-ceph-logo.png" alt="Swift logo" width="160" height="160" /></div>
+                <div class="align-center"><img src="{{ ASSET_SERVER_URL }}6c2ee5b9-ceph-logo.png?w=160" alt="Ceph logo" width="160" height="160" /></div>
             </div>
         </div>
     </div>
@@ -67,12 +67,12 @@
             <div class="equal-height--vertical-divider__item six-col">
                 <h2>NexentaEdge</h2>
                 <p class="six-col">Block and object storage offering inline de&dash;duplication &amp; compression, low latency block services, instant snapshots, and enterprise grade, end&dash;to&dash;end data integrity.</p>
-                <div class="align-center"><img src="{{ ASSET_SERVER_URL }}888cd4eb-nexenta-logo.png" alt="Swift logo" width="160" height="160" /></div>
+                <div class="align-center"><img src="{{ ASSET_SERVER_URL }}888cd4eb-nexenta-logo.png?w=160" alt="Swift logo" width="160" height="160" /></div>
             </div>
             <div class="equal-height--vertical-divider__item six-col last-col">
                 <h2>SwiftStack</h2>
                 <p class="six-col">An object storage system built on OpenStack Swift, with an innovative storage controller for global management and <abbr title="Network File System">NFS</abbr> and <abbr title="Server Message Block">SMB</abbr>/<abbr title="Common Internet File System">CIFS</abbr> file gateways.</p>
-                <div class="align-center"><img src="{{ ASSET_SERVER_URL }}d5950d6c-swiftstack.png" alt="Swift logo" width="160" height="160" /></div>
+                <div class="align-center"><img src="{{ ASSET_SERVER_URL }}d5950d6c-swiftstack.png?w=160" alt="Swift logo" width="160" height="160" /></div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Done

Fixed the Ceph logo 404ing and the incorrect alt text. I also added width params on the other logos' URLs to optimise loaded images.
## QA

/cloud/storage

See that the logo is now loading.
## Issue / Card

A fix for #169 
