### PR TITLE
cloud plans and pricing - move class for active nav from li to a

### DIFF
--- a/templates/cloud/_nav_secondary.html
+++ b/templates/cloud/_nav_secondary.html
@@ -8,5 +8,5 @@
 		<li><a{% if level_2 == 'snappy' %} class="active"{% endif %} href="/cloud/snappy">Snappy</a></li>
     <li><a{% if level_2 == 'storage' %} class="active"{% endif %} href="/cloud/storage">Cloud storage</a></li>
 		<li><a{% if level_2 == 'partners' %} class="active"{% endif %} href="/cloud/partners">Partners</a></li>
-		<li class="last-item{% if level_2 == 'plans-and-pricing' %} active{% endif %}"><a href="/cloud/plans-and-pricing">Plans and pricing</a></li>
+		<li><a class="last-item{% if level_2 == 'plans-and-pricing' %} active{% endif %}" href="/cloud/plans-and-pricing">Plans and pricing</a></li>
   </ul>


### PR DESCRIPTION
## Done

Moved the active class to the correct place in the markup in the secondary nav
## QA

/cloud/plans-and-pricing

See that the nav item is now highlighted
## Issue / Card

fix for #172 
