### PR TITLE
/cloud/openstack - change alignment of autopilot row image to bottom

### DIFF
--- a/static/css/section/_cloud.scss
+++ b/static/css/section/_cloud.scss
@@ -249,7 +249,7 @@
 .row-autopilot {
   @media only screen and (min-width : 768px) {
     background-image: url('#{$asset-server}6e179925-image-cloud-openstack-autopilot-screenshot.jpg?op=region&rect=0,0,300,600');
-    background-position: right top;
+    background-position: right bottom;
     background-repeat: no-repeat;
   }
 


### PR DESCRIPTION
## Done

Changed the background image positioning of the autopilot row
## QA

/cloud/openstack

view the autopilot row in medium viewport and see that the image is now aligned on the bottom of the row, hiding the cut-off of the screenshot.
## Issue / Card

fix for #159 
