### PR TITLE
Remove the shadow on cloud event thumbnails

### DIFF
--- a/static/css/section/_cloud.scss
+++ b/static/css/section/_cloud.scss
@@ -227,21 +227,8 @@
   }
 
   .image-wrap img {
-      -moz-border-radius: 4px;
-      -webkit-border-radius: 4px;
     border-radius: 4px;
     margin-top: 7px;
-  }
-
-  .image-wrap:after {
-    background: url("https://insights.ubuntu.com/wp-content/themes/resource-centre/static/img/white-squircle.png") no-repeat;
-    background-size: 78px 78px;
-    content: ' ';
-    width: 78px;
-    height: 78px;
-    position: absolute;
-    top: 0;
-    left: 0;
   }
 }
 


### PR DESCRIPTION
## Done
- Removed the :after styles on the thumbnails in the cloud overview page
## QA
- Go to `/cloud` scroll down to the events
- Check the google map thumbnails dont have the old shadow styling
## Issue / Card
- Fixes: https://github.com/ubuntudesign/ubuntu-vanilla-theme/issues/43, https://github.com/ubuntudesign/www.ubuntu.com/issues/222
