### PR TITLE
temp scratch duplication of main site background image pending upstre…

### DIFF
--- a/static/css/_scratch.scss
+++ b/static/css/_scratch.scss
@@ -7,6 +7,20 @@
 	-----------------------------------------------------------------
 
 */
+
+// Temporarally adding this until the small-viewport change
+// is merged into the theme. - KW 20160409
+body {
+  background-color: $light-grey;
+  background-image: url('#{$asset-path}img/backgrounds/image-background-paper.png?w=$breakpoint-medium');
+  background-position: center top;
+  background-repeat: repeat-y;
+
+  @media only screen and (min-width : $breakpoint-medium) {
+    background-image: url('#{$asset-path}img/backgrounds/image-background-paper.png');
+  }
+}
+
 // additional helper class for shouty text
 .caps {
 	text-transform: uppercase;


### PR DESCRIPTION
…am chnages in the ubuntu-vanilla-theme project
## Done

Added a background image for small viewports
## QA

Go to any page where the background image shows through the content well - /tablet is a good example - and see that there is origami background at all viewports.
## Issue / Card

This will fix:
- #138 
- #139 
- #134 
- #127 
- #194 
