### PR TITLE
Make the space for your content row grey

### DIFF
--- a/templates/phone/developers.html
+++ b/templates/phone/developers.html
@@ -54,7 +54,7 @@
   </div>
 </div>
 
-<div class="row row-shine no-border flex">
+<div class="row row--grey row-shine no-border flex">
   <div class="flex-container flex-align-center flex-margin-auto">
     <div class="strip-inner-wrapper">
       <div class="for-mobile"><img src="{{ ASSET_SERVER_URL }}d4117ccb-space-for-content-row.jpg?w=468" alt="" /></div>


### PR DESCRIPTION
## Done
- Added row--grey to the Space for you content row
## QA
- Go to phone/developer page
- Go to mobile size
- Scroll down to the Space for your content section
- Chek it has a grey background
## Issue / Card
- Fixes https://github.com/ubuntudesign/www.ubuntu.com/issues/194
