### PR TITLE
Remove unwanted padding

### DIFF
--- a/static/css/section/_local.scss
+++ b/static/css/section/_local.scss
@@ -2,6 +2,13 @@ body {
   background-size: cover;
 }
 
+@media only screen and (max-width : 768px) {
+  .nav-secondary .breadcrumb {
+    padding-bottom: 0;
+    padding-top: 0;
+  }
+}
+
 // pulling in the old guidelines version of combined-list
 .row .combined-list {
   ul,


### PR DESCRIPTION
## Done

Remove unwanted padding from breadcrumb.
## QA

Run make run. Go to /internet-of-things on small and make sure there’s no white gap above the image.
This might need to go back to vanilla-framework eventually.
## Issue / Card

Issue: No issue but this one brought it up https://github.com/ubuntudesign/www.ubuntu.com/issues/103 
