### PR TITLE
Fix padding for global nav visibility

### DIFF
--- a/static/css/section/_local.scss
+++ b/static/css/section/_local.scss
@@ -1,5 +1,9 @@
 body {
   background-size: cover;
+  
+  @media only screen and (min-width : 768px) {
+    padding-top: 30px;
+  }
 }
 
 @media only screen and (max-width : 768px) {


### PR DESCRIPTION
## Done

Reinstate padding to show global nav but pop it in a media query so not for small
## QA

Check that you can see the global nav on large and medium but not on small
## Issue / Card

Fixes https://github.com/ubuntudesign/www.ubuntu.com/issues/182
