### PR TITLE
Smaller image version

### DIFF
--- a/templates/download/ubuntu-flavours.html
+++ b/templates/download/ubuntu-flavours.html
@@ -73,7 +73,7 @@ full Ubuntu archive for packages and updates.{% endblock %}
           </li>
           <li class="list--grid__item four-col">
             <div class="one-col list--grid__image-container">
-                <img src="{{ ASSET_SERVER_URL }}40cba064-mythbuntu.svg" alt="Mythbuntu icon">
+                <img src="{{ ASSET_SERVER_URL }}2a8f9030-mythbuntu.svg" alt="Mythbuntu icon">
             </div>
             <div class="three-col last-col list--grid__description">
                 <h3><a class="external" href="http://www.mythbuntu.org/">Mythbuntu</a></h3>


### PR DESCRIPTION
Takes care of #185.
## QA

Run site and visit `/download/ubuntu-flavours` on small viewport and check mythbuntu logo is the same size as the others.
