### PR TITLE
Increase z-index of banner in cloud to sit on top of hero rows

### DIFF
--- a/static/css/section/_cloud.scss
+++ b/static/css/section/_cloud.scss
@@ -44,6 +44,15 @@
 -------------------------------------------------------------- */
 
 .cloud {
+
+  // XXX Ant (09.04.2016)
+  // https://github.com/ubuntudesign/www.ubuntu.com/issues/211
+  // Override the banner z-index so the dropdown menu appears above the clouds
+  // in the hero row of /cloud/partners
+  .banner {
+    z-index: 5;
+  }
+
   .juju-charms-list {
     .box {
       padding: 0;


### PR DESCRIPTION
## Done
- Increase the z-index of `.banner` in the cloud section to sit on top of the row-hero cloud image
## QA
- Go to `/cloud/partners`
- Hover over Download in the menu and see the drop down sits on top of the clouds in the row hero
## Issue / Card
- FIxes https://github.com/ubuntudesign/www.ubuntu.com/issues/211
