### PR TITLE
Remove vanilla external bg image

### DIFF
--- a/static/css/section/_local.scss
+++ b/static/css/section/_local.scss
@@ -1050,14 +1050,11 @@ html.no-svg {
   }
 }
 
-h3.external {
-  background-image: none;
-  
-  span {
-    background: url("#{$asset-server}e1bba201-external-link-cool-grey.svg") left center no-repeat;
-    background-size: 20px;
-    padding-left: 26px;
-  }
+// for headings of external list links, currentley only seen on download/alternative-downloads
+.external--title span {  
+  background: url("#{$asset-server}e1bba201-external-link-cool-grey.svg") left center no-repeat;
+  background-size: 20px;
+  padding-left: 26px;
 }
 
 footer.global ul.inline li:after {

--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -37,7 +37,7 @@
         <p>BitTorrent is a peer-to-peer download network that sometimes enables higher download speeds and more reliable downloads of large files. You will need to install a BitTorrent client on your computer in order to enable this download method.</p>
     </div>
      <div class="four-col">
-        <h3 class="external"><span>Ubuntu {{latest_release}}</span></h3>
+        <h3 class="external--title"><span>Ubuntu {{latest_release}}</span></h3>
         <ul class="no-bullets list">
             <li><a class="download-torrent" href="http://releases.ubuntu.com/{{latest_release}}/ubuntu-{{latest_release}}-desktop-amd64.iso.torrent">Ubuntu {{latest_release}} Desktop (64-bit)&nbsp;&rsaquo;</a></li>
             <li><a class="download-torrent" href="http://releases.ubuntu.com/{{latest_release}}/ubuntu-{{latest_release}}-desktop-i386.iso.torrent">Ubuntu {{latest_release}} Desktop (32-bit)&nbsp;&rsaquo;</a></li>
@@ -46,7 +46,7 @@
         </ul>
     </div><!-- /.four-col -->
     <div class="four-col">
-        <h3 class="external"><span>Ubuntu {{ lts_release }} LTS</span></h3>
+        <h3 class="external--title"><span>Ubuntu {{ lts_release }} LTS</span></h3>
         <ul class="no-bullets list">
             <li><a class="download-lts" href="http://releases.ubuntu.com/{{ lts_release }}/ubuntu-{{ lts_release }}-desktop-amd64.iso.torrent">Ubuntu {{ lts_release }} LTS Desktop (64-bit)&nbsp;&rsaquo;</a></li>
             <li><a class="download-lts" href="http://releases.ubuntu.com/{{ lts_release }}/ubuntu-{{ lts_release }}-desktop-i386.iso.torrent">Ubuntu {{ lts_release }} LTS Desktop (32-bit)&nbsp;&rsaquo;</a></li>
@@ -55,7 +55,7 @@
         </ul>
     </div><!-- /.four-col -->
     <div class="four-col last-col">
-        <h3 class="external"><span>Ubuntu 12.04.5 LTS</span></h3>
+        <h3 class="external--title"><span>Ubuntu 12.04.5 LTS</span></h3>
         <ul class="no-bullets list">
             <li><a class="download-lts" href="http://releases.ubuntu.com/12.04/ubuntu-12.04.5-alternate-amd64.iso.torrent">Ubuntu 12.04.5 alternate (64-bit)&nbsp;&rsaquo;</a></li>
             <li><a class="download-lts" href="http://releases.ubuntu.com/12.04/ubuntu-12.04.5-alternate-i386.iso.torrent">Ubuntu 12.04.5 alternate (32-bit)&nbsp;&rsaquo;</a></li>
@@ -72,7 +72,7 @@
         <h2>Other images</h2>
         <p>For other versions of the Ubuntu installer please select your nearest mirror; however, we recommend you use  the <a href="/download">standard installer</a> as all other packages are available in Ubuntu Software Centre.</p>
     </div>
-    <h3 class="external"><span>Select the nearest mirror</span></h3>
+    <h3 class="external--title"><span>Select the nearest mirror</span></h3>
     <ul class="twelve-col no-bullets list">
       <li class="four-col"><a class="download-mirror" href="http://mirror.eftel.com/ubuntu/releases-DVD/">Australia &rsaquo;</a></li>
       <li class="four-col"><a class="download-mirror" href="http://ftp.funet.fi/pub/Linux/INSTALL/Ubuntu/dvd-releases/releases">Finland &rsaquo;</a></li>


### PR DESCRIPTION
## Done

Remove vanilla external bg image from /download/alternative-downloads external headings
## QA

Pop on over to /download/alternative-downloads and make sure the headings with the external icon on the left don’t have an orange icon on the right
