### PR TITLE
removed orange in download section on sidebar elements

### DIFF
--- a/static/css/section/_download.scss
+++ b/static/css/section/_download.scss
@@ -468,9 +468,6 @@ body.download .box h4 {
   font-weight: normal;
 }
 
-body.download .sidebar li a,
-body.download-alternative-downloads #main-content .row ul li { color: $ubuntu-orange; }
-
 body.download .box ul li p {
   color: #333;
   margin-bottom: 0;

--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -23,7 +23,7 @@
     <h2>Network installer</h2>
     <div class="eight-col">
         <p>The network installer lets you install Ubuntu over the network. This is useful, for example, if you have an old machine with a non-bootable CD-ROM or a computer that can&rsquo;t run the graphical interface-based installer, either because they don&rsquo;t meet the minimum requirements for the live CD/DVD or because they require extra configuration before  the graphical desktop can be used, or if you want to install Ubuntu on a large number of computers at once.</p>
-        <ul>
+        <ul class="list-ticks--compact">
             <li><a class="download-network external" href="http://cdimage.ubuntu.com/netboot/{{latest_release}}/">Download the network installer for {{latest_release}}</a></li>
             <li><a class="download-network external" href="http://cdimage.ubuntu.com/netboot/14.04/">Download the network installer for 14.04 LTS</a></li>
             <li><a class="download-network external" href="http://cdimage.ubuntu.com/netboot/12.04/">Download network installer for 12.04 LTS</a></li>


### PR DESCRIPTION
## Done

removed the orage for lists in download section sidebars and also change the network installer list to the compact tick list style
## QA
1. go to /download/alternative-downloads
2. see that the list in the network installer section is now list ticks compact
3. also see that I removed the odd orage sidebar css in the download section
## Issue / Card

Fixes #162
