### PR TITLE
hide pictos on small screen for /download page

### DIFF
--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -36,21 +36,21 @@
 
 <div class="row row-list-download no-border">
     <div class="twelve-col equal-height no-margin-bottom">
-        <div class="six-col box equal-height__item">
-            <div class="four-col">
+        <div class="six-col box equal-height">
+            <div class="four-col equal-height__item">
                 <h2><a href="/download/server">Ubuntu Server&nbsp;&rsaquo;</a></h2>
                 <p>Whether you want to configure a simple file server or build a fifty thousand-node cloud, you can rely on Ubuntu Server and its five years of guaranteed free upgrades.</p>
             </div>
-            <div class="two-col last-col equal-height__item equal-height__align-vertically">
+            <div class="two-col last-col equal-height__item equal-height__align-vertically priority-0">
                 <img src="{{ ASSET_SERVER_URL }}0fdf9cfe-picto-server-darkaubergine.svg" alt="" width="113" height="113" />
             </div>
         </div>
         <div class="six-col last-col box equal-height">
-            <div class="equal-height__item four-col">
+            <div class="four-col equal-height__item">
                 <h2><a href="/download/cloud">Ubuntu Cloud&nbsp;&rsaquo;</a></h2>
                 <p>Ubuntu is the reference OS for OpenStack. Canonical&rsquo;s OpenStack Autopilot is a fully automated deployment of an OpenStack cloud on Ubuntu &mdash; just add servers.</p>
             </div>
-            <div class="two-col last-col equal-height__item equal-height__align-vertically">
+            <div class="two-col last-col equal-height__item equal-height__align-vertically priority-0">
                 <img src="{{ ASSET_SERVER_URL }}dfd42685-picto-cloud-darkaubergine.svg" alt="" width="113" height="113" />
             </div>
         </div>
@@ -62,7 +62,7 @@
                 <h2><a href="/download/ubuntu-kylin">Ubuntu Kylin&nbsp;&rsaquo;</a></h2>
                 <p>Created specifically for the needs of Chinese users, Ubuntu Kylin {{ lts_release }} LTS includes many unique features and five years support from Canonical.</p>
             </div>
-            <div class="two-col last-col equal-height__item equal-height__align-vertically">
+            <div class="two-col last-col equal-height__item equal-height__align-vertically priority-0">
                 <img src="{{ ASSET_SERVER_URL }}c5cb0f8e-picto-ubuntu.svg" alt="Ubuntu Kylin logo" height="112" width="112" />
             </div>
         </div>
@@ -71,8 +71,8 @@
                 <h2><a href="https://developer.ubuntu.com/en/snappy/start/ " class="external">Ubuntu Core</a></h2>
                 <p>Are you a developer who wants to try snappy Ubuntu Core?  The new, transactionally updated Ubuntu for clouds and devices. </p>
             </div>
-            <div class="two-col last-col equal-height__item equal-height__align-vertically">
-                <img src="{{ ASSET_SERVER_URL }}cde21f03-snappy.png" alt="Ubuntu Kylin logo" height="112" width="112" />
+            <div class="two-col last-col equal-height__item equal-height__align-vertically priority-0">
+                <img src="{{ ASSET_SERVER_URL }}cde21f03-snappy.png" alt="Ubuntu core logo" height="112" width="112" />
             </div>
         </div>
     </div>
@@ -82,8 +82,8 @@
             <h2><a href="/download/alternative-downloads">Alternative downloads&nbsp;&rsaquo;</a></h2>
             <p>There are several other ways to get Ubuntu including torrents, which can potentially mean a quicker download, our network installer for older systems and special configurations and links to our regional DVD image mirrors for our older releases.</p>
         </div>
-        <div class="five-col last-col text-center no-margin-bottom equal-height__item equal-height__align-vertically">
-            <img src="{{ ASSET_SERVER_URL }}be3876ec-picto-download-warmgrey.svg" alt="Chinese Ubuntu logo" height="112" width="112" />
+        <div class="five-col last-col text-center no-margin-bottom equal-height__item equal-height__align-vertically priority-0">
+            <img src="{{ ASSET_SERVER_URL }}be3876ec-picto-download-warmgrey.svg" alt="" height="112" width="112" />
         </div>
     </div>
 
@@ -95,7 +95,7 @@
             by the full Ubuntu archive for packages and updates.
             </p>
         </div>
-        <div class="five-col last-col text-center no-margin-bottom align-vertically">
+        <div class="five-col last-col text-center no-margin-bottom align-vertically priority-0">
             <img src="{{ ASSET_SERVER_URL }}ebfb7122-picto-generic-warmgrey.svg" alt="" height="112" width="112" />
         </div>
     </div>


### PR DESCRIPTION
## Done
- added priority-0 to the divs containing icons for all but the top one on /download
- fixed up the classes on the server and cloud boxes so the icons were in the correct locations on larger screens
## QA
1. go to download
2. look at smalls screens and see that the server/cloud/kylin/snappy/alt icons do not display
## Issue / Card
#170
