### PR TITLE
added dotted boarder to Ubuntu Advantage section of server/management

### DIFF
--- a/static/css/section/_management.scss
+++ b/static/css/section/_management.scss
@@ -178,14 +178,14 @@ body.management-working-with-landscape {
 	.row-hero .link-cta-canonical {
 		margin-bottom: 10px;
 	}
-	.ubuntu-advantage { 
-  	margin-bottom: 0; 
+	.ubuntu-advantage {
+  	margin-bottom: 0;
   }
-	
-	.ubuntu-advantage img { 
-    margin-left: -$gutter-width; 
+
+	.ubuntu-advantage img {
+    margin-left: -$gutter-width;
   }
-	
+
 	.row-purchase-advantage .box {
 		background: $light-grey url('#{$asset-server}3cc9f80f-pictogram-reduce-costs-115x115.png') 20px 20px no-repeat;
 		padding-bottom: 1em;
@@ -363,18 +363,18 @@ body.management-ema-whitepaper {
 			margin-left: -20px;
 		}
 	}
-	
+
 	html.no-svg,
 	html.opera-mini {
 		.row-return-investment {
 			background-image: url("#{$asset-server}d1dbbf8e-image-cutyouritcosts.png");
 		}
 	}
-		
+
 	body.management-home {
 		.margin-top { margin-top: 20px; }
 	}
-	
+
 	.three-divided li {
 		width: 30%;
 		padding-bottom: 38px;
@@ -383,7 +383,7 @@ body.management-ema-whitepaper {
 	.row-cloud-management .three-divided li {
 		padding-bottom: 0;
 	}
-	
+
 	body.management-ubuntu-advantage {
 		.price {
 			margin-bottom: 0;
@@ -407,6 +407,8 @@ body.management-ema-whitepaper {
 @media only screen and (min-width : 984px) {
 	.row-ubuntu-advantage-promo {
 		overflow: hidden;
+    border-bottom: 1px dotted #888888;
+    margin-bottom: 1px;
 
 		img.touch-border {
 			float: none;


### PR DESCRIPTION
## Done

added the dotted boarder back to the Ubuntu Advantage section
## QA
1. go to /server/management
2. see that there is a dotted boarder on bottom of the 'Ubuntu Advantage: what’s included?' section
## Issue / Card

Fixes #178
## Screenshot

![image](https://cloud.githubusercontent.com/assets/441217/14408702/7853d972-fef7-11e5-87fb-af4f385c9901.png)
