### PR TITLE
Fix partner active link

### DIFF
--- a/templates/phone/_nav_secondary.html
+++ b/templates/phone/_nav_secondary.html
@@ -3,5 +3,5 @@
     <li><a{% if level_2 == 'features' %} class="active"{% endif %} href="/phone/features" >Features</a></li>
     <li><a{% if level_2 == 'devices' or level_2 == 'devices-in' %} class="active"{% endif %} href="/phone/devices" >Devices</a></li>
     <li><a{% if level_2 == 'developers' %} class="active"{% endif %} href="/phone/developers" >For developers</a></li>
-    <li{% if level_2 == 'partners' %}  class="active"{% endif %}><a href="/phone/partners">For partners</a></li>
+    <li><a{% if level_2 == 'partners' %}  class="active"{% endif %} href="/phone/partners">For partners</a></li>
 </ul>


### PR DESCRIPTION
## Done

Phone > Partners: the current page is not highlighted in breadcrumbs
Move active class django snippet
## QA

Go to /phone/partners and make sure that ‘partners’ is highlighted in breadcrumb
## Issue / Card

Fixes #135
