### PR TITLE
Fix hover state here until it lands in vanilla

### DIFF
--- a/static/css/section/_local.scss
+++ b/static/css/section/_local.scss
@@ -328,6 +328,10 @@ body {
   }
 }
 
+.nav-secondary .second-level-nav li a:hover, .nav-secondary .third-level-nav li a:hover {
+    color: $link-color;
+}
+
 // extra rules for full width sections other than homepage
 .phone,
 .tablet {


### PR DESCRIPTION
For #253, I'm fixing it locally for now. Ultimately the fix should land in vanilla and we shouldn't need the local version.
## QA

Run the site and check hovering over links in the secondary nav turns them orange.
