### PR TITLE
openstack training hero image again

### DIFF
--- a/static/css/section/_cloud.scss
+++ b/static/css/section/_cloud.scss
@@ -872,7 +872,7 @@ body.cloud-ubuntu-openstack-reference-architecture {
 
   .row--training__image {
     position: absolute;
-    top: -125px;
+    top: -122px;
     right: -20px;
   }
 
@@ -1415,7 +1415,6 @@ body.cloud-ubuntu-openstack-reference-architecture {
 
   .row--training__image {
     position: absolute;
-    top: -142px;
     right: -20px;
   }
 

--- a/templates/cloud/openstack/training/index.html
+++ b/templates/cloud/openstack/training/index.html
@@ -17,7 +17,7 @@
     <div class="six-col">
         <p>Train your sysadmins and devops engineers to become Ubuntu OpenStack experts. Canonical runs training programmes to suit all environments and all levels of experience. Explore, prototype and design with cloud technologies so you can get the most out of OpenStack.</p>
     </div>
-    <div class="five-col last-col text-center">
+    <div class="five-col last-col text-center not-for-small">
         <img class="row--training__image" alt="" src="{{ ASSET_SERVER_URL }}58f24048-image-ubuntu-openstack-medals.png" />
     </div>
 </div>


### PR DESCRIPTION
## Done

Reposition /cloud/openstack/training hero image and hide for small
## QA

Go to /cloud/openstack/training and make sure the medals are positioned on the border above, also check that the medals have been removed on small
## Issue / Card

Fixes https://github.com/ubuntudesign/ubuntu-vanilla-theme/issues/156
