### PR TITLE
Remove border on grey-box as it is not on live

### DIFF
--- a/static/css/section/_local.scss
+++ b/static/css/section/_local.scss
@@ -12,6 +12,10 @@ body {
 .row.row-grey {
   border-bottom: 1px dotted $warm-grey;
   margin-top: 0;
+
+  &.no-border {
+    border-bottom: 0;
+  }
 }
 
 @media only screen and (max-width : 768px) {
@@ -1068,7 +1072,7 @@ html.no-svg {
 }
 
 // for headings of external list links, currentley only seen on download/alternative-downloads
-.external--title span {  
+.external--title span {
   background: url("#{$asset-server}e1bba201-external-link-cool-grey.svg") left center no-repeat;
   background-size: 20px;
   padding-left: 26px;
@@ -1426,4 +1430,12 @@ button.button--primary__deactivated:hover {
     background: #efefef;
     color: #fff;
     cursor: not-allowed;
+}
+
+// XXX Ant (10.04.2016)
+// https://github.com/ubuntudesign/www.ubuntu.com/issues/260
+// Remove border of grey-box as it didnt have borders before but is extending
+// box in the theme.
+.box-grey {
+  border: 0;
 }


### PR DESCRIPTION
## Done
- Removed border on `box-grey` (this will need to be moved to the theme)
- Add no-border to `row-grey` as a drive by
## QA
- Go to `/download/server/thank-you-linuxone`
- Cancel the download
- Check there are no borders around the 3 boxes
## Issue / Card

Fixes https://github.com/ubuntudesign/www.ubuntu.com/issues/260 
