### PR TITLE
removed border on mgmt/ua page from cloud pricing

### DIFF
--- a/static/css/section/_local.scss
+++ b/static/css/section/_local.scss
@@ -352,9 +352,6 @@ body {
       box-shadow: none;
       height: 3px;
     }
-    div > div > div {
-      border: 0; // kills borders on very nested divs... like we have for further reading
-    }
   }
 
   .row--dark {
@@ -1071,7 +1068,7 @@ html.no-svg {
 }
 
 // for headings of external list links, currentley only seen on download/alternative-downloads
-.external--title span {
+.external--title span {  
   background: url("#{$asset-server}e1bba201-external-link-cool-grey.svg") left center no-repeat;
   background-size: 20px;
   padding-left: 26px;


### PR DESCRIPTION
## Done

removed border after cloud intro
## QA
1. go to /management/ubuntu-advantage
2. see there is no border-bottom on 'Ubuntu Advantage for clouds' section
## Issue / Card

Fixes #258
## Screenshots

![image](https://cloud.githubusercontent.com/assets/441217/14409857/335bb838-ff17-11e5-84a6-aae6646c4368.png)
