### PR TITLE
Reduce spacing underneath "Seamless connectivity" row

### DIFF
--- a/templates/internet-of-things/features.html
+++ b/templates/internet-of-things/features.html
@@ -68,7 +68,7 @@
   </div>
 </div>
 
-<div class="row no-border">
+<div class="row no-border no-padding-bottom">
   <div class="seven-col">
     <h2>Seamless connectivity to the cloud</h2>
     <p>From testing and development to updates in the wild, the cloud is integral  to Ubuntu Core. Leading tech players are already throwing their weight behind the platform, with the likes of both Microsoft and Amazon using Ubuntu Core images on their public clouds. Images can be deployed on any OpenStack private cloud, too. </p>


### PR DESCRIPTION
For #164, reduce the spacing underneath the seamless connectivity row.
## QA

Run the site, go to `/internet-of-things/features`, look at the
"Seamless connectivity" row. It should have a large but nonetheless
reasonable amount of padding at the bottom, as opposed to the
unreasonably amount of space it had previously.
