### PR TITLE
/download/server/arm - remove illustration and picto for smalls screens

### DIFF
--- a/templates/download/server/arm.html
+++ b/templates/download/server/arm.html
@@ -52,7 +52,7 @@
    		</div><!-- /.twelve-col -->
     </div><!-- /.box -->
 </div><!-- /.row -->
-<div class="row">
+<div class="row no-border">
 		<div class="six-col no-margin-bottom">
 			<h3>For developers</h3>
 			<p>Ubuntu Server is available for developer platforms powered by certified ARM SoCs as an over-the-network installer. Network boot infrastructure is required.</p>


### PR DESCRIPTION
## Done

added priority-0 for the two images on /download/server/arm
## QA
1. go to /download/server/arm on a small screen
2. see there are no illustrations or pictos
## Issue / Card

Fixes #176 
## Screenshots

![image](https://cloud.githubusercontent.com/assets/441217/14410199/264a5eec-ff21-11e5-8807-3edf18ae4294.png)
