### PR TITLE
Remove defualt webkit appearance on page elems in iOS

### DIFF
--- a/static/css/_scratch.scss
+++ b/static/css/_scratch.scss
@@ -7,7 +7,10 @@
     -----------------------------------------------------------------
 */
 
-
+// Disable default iOS styling on page elements
+* {
+  -webkit-appearance: none;
+}
 
 // Temporarally adding this until the small-viewport change
 // is merged into the theme. - KW 20160409


### PR DESCRIPTION
## Done

Remove default webkit styling on all page elements.
## QA
1. Navigate to /phone/features
2. Scroll to contextual footer at bottom of page on iOS device
3. Ensure that 'Subscribe' button does not have rounded corner for color gradient
## Issue / Card
#89
