### PR TITLE
Undo align-items:center for row leaders

### DIFF
--- a/static/css/section/_cloud.scss
+++ b/static/css/section/_cloud.scss
@@ -1935,3 +1935,8 @@ html.js .cloud-openstack-managed-cloud .js__required {
 .ubuntu-pie .other-label {
   fill: #888;
 }
+
+.row--leaders__container {
+  align-items: stretch;
+}
+

--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -42,7 +42,7 @@
 </div>
 
 <div class="row row--leaders equal-height">
-  <div class="five-col equal-height__item equal-height__align-vertically">
+  <div class="five-col equal-height__item equal-height__align-vertically row--leaders__container">
     <h2>Industry leaders use Ubuntu Core</h2>
     <p>From Dell and Microsoft to a host of trailblazing tech startups, the Internet of Things is already embracing Ubuntu Core.</p>
     <p><a href="/internet-of-things/partners">Learn more about partnering with Ubuntu&nbsp;&rsaquo;</a></p>


### PR DESCRIPTION
(For #153)

The link in `/internet-of-things` "Industry leaders" section was indented weirdly.

This was because of an `align-items: center` from `equal-height__align-vertically` in vanilla framework. I've overridden this for now.
## QA

Run site and visit `/internet-of-things` and find the "Industry leaders..." row.

Check the link is aligned with the rest of the text.
