### PR TITLE
Fix contextual footer by marking up last column correctly

### DIFF
--- a/templates/download/shared/_contextual_footer.html
+++ b/templates/download/shared/_contextual_footer.html
@@ -148,7 +148,7 @@
 
 {% if level_3 == 'install-openstack-with-autopilot' or level_3 == 'install-autopilot-testdrive' %}
 
-<div class="equal-height--vertical-divider__item four-col">
+<div class="equal-height--vertical-divider__item four-col last-col">
     <h3>Ask Ubuntu</h3>
     <p>Do you have any questions or feedback about setting up OpenStack Autopilot?</p>
     <p><a href="http://askubuntu.com/questions/ask?tags=landscape+openstack-autopilot" class="external">Talk to us on Ask Ubuntu</a></p>


### PR DESCRIPTION
For #129.

Fix contextual footer so final column doesn't wrap.
## QA

Run site and visit `/download/cloud/install-openstack-with-autopilot` and `/download/cloud/install-autopilot-testdrive`.

Check the contextual footer is all inline.
