### PR TITLE
Add new version of vertical-divider classes#

### DIFF
--- a/templates/tablet/developers.html
+++ b/templates/tablet/developers.html
@@ -60,8 +60,8 @@
     <div class="twelve-col">
       <h2 class="twelve-col">Build it your way</h2>
     </div>
-    <div class="twelve-col vertical-divider">
-      <div class="four-col">
+    <div class="twelve-col equal-height--vertical-divider">
+      <div class="four-col equal-height--vertical-divider__item">
         <div class="four-col clearfix no-margin-bottom">
           <div class="inline-small one-col align-center">
             <img width="50" alt="A selection of apps" src="{{ ASSET_SERVER_URL }}c5022a72-browser-tabs.svg">
@@ -72,7 +72,7 @@
         </div>
         <p>For graphics-heavy apps and games, Ubuntu offers full native OpenGL, alongside a QML development environment that lets you combine game engines written in C or C++ with JavaScript-based UI glue. That&rsquo;s why firms like EA, Valve Software and Unity Technologies are already committing to Ubuntu.</p>
       </div>
-      <div class="four-col">
+      <div class="four-col equal-height--vertical-divider__item">
         <div class="four-col clearfix no-margin-bottom">
           <div class="inline-small one-col align-center">
             <img width="50" alt="" src="{{ ASSET_SERVER_URL }}5b24f6af-terminal-app-symbolic.svg">
@@ -83,7 +83,7 @@
         </div>
         <p>Our unique web app system lets you adapt any web property for installation as an app on Ubuntu. Running independently of the browser, it can be granted its own icon and access to system services. HTML5 apps written for other platforms can also be easily adapted to Ubuntu. Our browser supports WebRTC services to allow web based communication to just work.</p>
       </div>
-      <div class="four-col last-col">
+      <div class="four-col equal-height--vertical-divider__item last-col">
         <div class="four-col clearfix no-margin-bottom">
           <div class="inline-small one-col align-center">
             <img width="50" alt="" src="{{ ASSET_SERVER_URL }}4ed8f862-search.svg">
@@ -124,13 +124,13 @@
         <img class="not-for-small row--scopes__image" src="{{ ASSET_SERVER_URL }}d2fe0846-tablet-developers-scopes.png?w=984" srcset="{{ ASSET_SERVER_URL }}d2fe0846-tablet-developers-scopes.png?w=700 880w, {{ ASSET_SERVER_URL }}d2fe0846-tablet-developers-scopes.png?w=800 980w, {{ ASSET_SERVER_URL }}d2fe0846-tablet-developers-scopes.png?w=984 1064w" alt="Two tablets running Ubuntu displaying a selection of films" />
         <img class="for-small row--scopes__image" src="{{ ASSET_SERVER_URL }}d2fe0846-tablet-developers-scopes.png?w=480" alt="Two tablets running Ubuntu displaying a selection of films" />
      </div>
-      <div class="twelve-col no-margin-bottom vertical-divider">
-        <div class="six-col">
+      <div class="twelve-col no-margin-bottom equal-height--vertical-divider">
+        <div class="six-col equal-height--vertical-divider__item">
           <h3>What is a scope?</h3>
           <p>Ubuntu&rsquo;s scopes are like filters through which you can surface your content on an Ubuntu tablet or phone, without building an app. They use a straightforward framework for containing data sources, delivering content by topic, straight to the user&rsquo;s fingertips.</p>
           <p><a href="https://developer.ubuntu.com/en/scopes/" class="external">Visit our developer site</a></p>
         </div>
-        <div class="six-col last-col no-margin-bottom">
+        <div class="six-col equal-height--vertical-divider__item last-col no-margin-bottom">
           <h3>Easy to create</h3>
           <p>By using our predefined layouts and card designs you can piece together a unique mobile experience at a fraction of the cost of an app. Scopes are developed using the Ubuntu Scopes UI toolkit, available through the Ubuntu SDK using JavaScript, C++ or Go.</p>
           <p><a href="http://design.ubuntu.com/" class="external">Visit our design guide</a></p>


### PR DESCRIPTION
For #143, add new version of `equal-height--vertical-divider` so we get
vertical lines between elements.
## QA

Run site, go to `/tablet/developers`. Check there are vertical dividers in
"Build it your way" and "What is a scope?" / "Easy to create".
