### PR TITLE
homepage - restructured HTML to stop text overflowing

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -68,9 +68,9 @@
 </section>
 
 <section class="row row--cloud-products strip no-border">
-    <div class="strip-inner-wrapper equal-height">
-        <div class="four-col equal-height__item equal-height__align-vertically">
-            <div>
+    <div class="strip-inner-wrapper">
+        <div class="four-col equal-height">
+            <div class="equal-height__item equal-height__align-vertically">
                 <h2><a href="/cloud/openstack/managed-cloud">Buy a managed cloud&nbsp;&rsaquo;</a></h2>
                 <p>Get BootStack, a fully managed private OpenStack cloud with our experts responsible for design, deployment and availability.</p>
             </div>


### PR DESCRIPTION
## Done

Restructured the HTML so that the four-col on the homepage doesn't get broken by the vertical alignment.
## QA

Got to homepage.
Witness "Get a managed cloud" text no longer overflows
## Issue / Card

Fixes #287 
