### PR TITLE
added to ant's hack to stop horizontally centering text

### DIFF
--- a/static/css/section/_local.scss
+++ b/static/css/section/_local.scss
@@ -1481,11 +1481,11 @@ button.button--primary__deactivated:hover {
 
 // Override the "align-items: center" from equal-height__align-vertically,
 // which makes all items appear horizontally centered
-.equal-height > .equal-height__horizontal-left {
+.equal-height > .equal-height__horizontal-left,
+.equal-height > .equal-height__align-vertically {
   align-items: stretch;
 }
 
 .pull-left--less {
   margin-left: -20px;
 }
-


### PR DESCRIPTION
## Done

added .equal-height__align-vertically to ant's hack to stop text from aligning centre

I also tried to check other instances of this class to see if anything was broken... looks ok.
## QA
1. go to /desktop and see that the "Complete" section text is left aligned
## Issue / Card

Fixes #268
## Screenshots

[if relevant, include a screenshot]
