### PR TITLE
Refactor and style mobile header navigation

### DIFF
--- a/static/css/section/_local.scss
+++ b/static/css/section/_local.scss
@@ -24,8 +24,49 @@ body {
     display: inherit;
   }
 
+  #menu.active:after {
+    background-image: url(https://assets.ubuntu.com/v1/f9f534bd-nav-arrow.svg);
+    background-repeat: no-repeat;
+    background-position: 50% 26px;
+    content: "";
+    display: block;
+    height: 23px;
+    margin-left: 0;
+    padding-bottom: 17px;
+    position: relative;
+    top: -5px;
+    width: 48px;
+    z-index: 999;
+  }
+
   .banner .nav-primary ul {
     display: none;
+
+    li {
+      border-left: 1px solid #cccccc;
+      border-right: 0;
+
+      a,
+      a:link,
+      a.active,
+      a.active:link {
+        font-weight: 300;
+      }
+
+      // XXX Ant (10.04.2016)
+      // Added !important to override some deep selectors in Vanilla
+      a:hover,
+      a:link:hover {
+        background: $light-grey !important;
+        color: $text-color !important;
+      }
+
+      a.active:hover,
+      a.active:link:hover {
+        background: #dddddd !important;
+        color: $text-color !important;
+      }
+    }
 
     &.active {
       display: block;
@@ -35,12 +76,67 @@ body {
       }
     }
   }
-}
 
-@media only screen and (max-width : 768px) {
-  .nav-secondary .breadcrumb {
-    padding-bottom: 0;
-    padding-top: 0;
+  .nav-secondary {
+
+    ul.third-level-nav li {
+      padding-left: 30px;
+    }
+
+    ul.second-level-nav li {
+      box-sizing: border-box;
+      width: 50%;
+      margin: 0;
+      float: left;
+
+      a,
+      a:link {
+        font-size: 1em;
+      }
+    }
+
+    .breadcrumb {
+      padding-bottom: 0;
+      padding-top: 0;
+
+
+      li .after {
+        background-image: url('https://assets.ubuntu.com/v1/74545443-nav-down-arrow.svg');
+        background-position: center center;
+        background-repeat: no-repeat;
+        background-size: 18px;
+        float: right;
+        height: 18px;
+        padding: 10px;
+        position: relative;
+        right: 3px;
+        top: 0;
+        width: 18px;
+      }
+
+      li .breadcrumb-link {
+        color: $text-color;
+
+        &:after,
+        &--second-level:after {
+          content: '';
+        }
+      }
+
+      li a.active,
+      li a.active:link {
+        font-weight: 700;
+        color: $black;
+      }
+    }
+
+    &:hover {
+      border-bottom: 1px solid $box-border;
+
+      ul.breadcrumb li .after {
+        background-image: url('https://assets.ubuntu.com/v1/cadd096c-nav-up-arrow.svg');
+      }
+    }
   }
 }
 
@@ -1488,4 +1584,3 @@ button.button--primary__deactivated:hover {
 .pull-left--less {
   margin-left: -20px;
 }
-

--- a/templates/templates/_nav_breadcrumb.html
+++ b/templates/templates/_nav_breadcrumb.html
@@ -1,20 +1,22 @@
 <ul class="breadcrumb">
 	{% if level_2 and not level_3 and not tertiary %}
-	<li><a{% if section_title == 'Things' %} id="IoT-breadcrumb"{% endif %} class="breadcrumb-link" href="/{{ level_1 }}/">{{ section_title }}</a>
+		<li><a{% if section_title == 'Things' %} id="IoT-breadcrumb"{% endif %} class="breadcrumb-link" href="/{{ level_1 }}/">{{ section_title }}</a>
 	{% else %}
-	{% if level_3 %}
-	<li><a class="breadcrumb-link" href="/{{ level_1 }}/">{{ section_title }}</a>
-	<ul class="second-level-nav">
-	<li><a class="breadcrumb-link--second-level" href="/{{ level_1 }}/{{ level_2 }}/">{{ subsection_title }}</a>
-	{% else %}
-	{% if level_2 %}
-	<li><a class="breadcrumb-link" href="/{{ level_1 }}/">{{ section_title }}</a>
-	<ul class="second-level-nav">
-	<li><a class="active" href="/{{ level_1 }}/{{ level_2 }}/">{{ page_title }}</a>
-	{% else %}
-	<li><a{% if section_title == 'Things' %} id="IoT-breadcrumb"{% endif %} class="breadcrumb-link" href="/{{ level_1 }}/">{{ section_title }}</a>
-	{% endif %}
-	{% endif %}
+		{% if level_3 %}
+			<li><a class="breadcrumb-link" href="/{{ level_1 }}/">{{ section_title }}</a>
+			<ul class="second-level-nav">
+				<li><a class="breadcrumb-link--second-level" href="/{{ level_1 }}/{{ level_2 }}/">{{ subsection_title }}</a></li>
+			</ul>
+		{% else %}
+			{% if level_2 %}
+				<li><a class="breadcrumb-link" href="/{{ level_1 }}/">{{ section_title }}</a>
+				<ul class="second-level-nav">
+					<li><a class="active" href="/{{ level_1 }}/{{ level_2 }}/">{{ page_title }}</a></li>
+				</ul>
+			{% else %}
+				<li><a{% if section_title == 'Things' %} id="IoT-breadcrumb"{% endif %} class="breadcrumb-link" href="/{{ level_1 }}/">{{ section_title }}</a>
+			{% endif %}
+		{% endif %}
 	{% endif %}
 {% if level_3 %}
 	{% with ""|add:level_1|add:"/_nav_tertiary.html" as tertiary %}


### PR DESCRIPTION
## Done
- Reworked the header menu
- Tried the match the current design of live
## QA
- Load the site on mobile screen
- Check the primary drop down works correctly
- Touch or hover over search and see the search row appears
- Click on a section like Cloud
- Check the secondary level nav appears correctly on hover
- Click into a tried level page like OpenStack and check the active and sub pages navigation appears correctly and styled like live
- See that the arrows are back
## Issue / Card

Fixes https://github.com/ubuntudesign/www.ubuntu.com/issues/184
