### PR TITLE
fix wrapping 'see features' bug

### DIFF
--- a/templates/phone/features.html
+++ b/templates/phone/features.html
@@ -58,7 +58,7 @@
       </div><!-- /col -->
     </div
     <div class="strip-inner-wrapper">
-       <h3>See the features in action</h3>
+       <h3 class="clear">See the features in action</h3>
        <ul class="no-bullets">
            <li class="three-col">
                <a class="external" href="https://www.youtube.com/watch?v=Qocy2Ypz-_Y">


### PR DESCRIPTION
## Done

added .clear to the h3 that was wrapping
## QA
1. go to /phone/features on a small screen
2. see that 'See the features in action' h3 doesn't wrap and is below the image
## Issue / Card

Fixes #189
## Screenshots

![image](https://cloud.githubusercontent.com/assets/441217/14413619/619915e6-ff77-11e5-8fdd-321b3e7c9d22.png)
