### PR TITLE
Fix a bunch of mobile bugs in the desktop section

### DIFF
--- a/static/css/section/_desktop.scss
+++ b/static/css/section/_desktop.scss
@@ -94,7 +94,6 @@
 .desktop .share-this {
   clear: both;
   display: block;
-  float: left;
   height: 25px;
   margin-top: 20px;
   position: relative;
@@ -105,15 +104,7 @@
     float: left;
     margin: 0;
     padding: 0;
-    width: 80px;
-
-    :first-child {
-      width: 80px;
-    }
-
-    :last-child {
-      margin-right: 0;
-    }
+    width: 110px;
   }
 
   .twitter-share-button {
@@ -227,7 +218,7 @@
 .desktop-home #main-content {
   .row-industry img {
     display: block;
-    margin: 0 auto;
+    margin: 0 auto 10px;
     max-width: 150px;
   }
 
@@ -245,6 +236,7 @@
       background-position: 73% 13%, bottom right;
       margin-top: 0;
       min-height: 573px;
+      border-bottom: 0;
 
       h1 {
         margin-top: 40px;
@@ -522,6 +514,7 @@
       background-position: right 10px center;
       margin-top: 0;
       min-height: 574px;
+      border-bottom: 0;
 
       h1 {
         margin-top: 40px;
@@ -565,6 +558,7 @@
       background-position: right 0px top;
       margin-top: 0;
       min-height: 574px;
+      border-bottom: 0;
 
       h1 {
         padding-top: 40px;

--- a/static/css/section/_local.scss
+++ b/static/css/section/_local.scss
@@ -18,14 +18,74 @@ body {
   }
 }
 
+// XXX Ant (10.04.2016)
+// https://github.com/ubuntudesign/www.ubuntu.com/issues/295
+// Move to Vanilla
+// Fixed height in grid elements with only images
+.one-col,
+.two-col,
+.three-col,
+.four-col,
+.five-col,
+.six-col,
+.seven-col,
+.eight-col,
+.nine-col,
+.ten-col,
+.eleven-col,
+.twelve-col {
+  display: inline-block;
+}
+
 // fixes main nav not closing issue
 @media only screen and (max-width: $navigation-threshold) {
   .banner .nav-primary #nav:hover {
     display: inherit;
   }
 
+  #menu.active:after {
+    background-image: url(https://assets.ubuntu.com/v1/f9f534bd-nav-arrow.svg);
+    background-repeat: no-repeat;
+    background-position: 50% 26px;
+    content: "";
+    display: block;
+    height: 23px;
+    margin-left: 0;
+    padding-bottom: 17px;
+    position: relative;
+    top: -5px;
+    width: 48px;
+    z-index: 999;
+  }
+
   .banner .nav-primary ul {
     display: none;
+
+    li {
+      border-left: 1px solid #cccccc;
+      border-right: 0;
+
+      a,
+      a:link,
+      a.active,
+      a.active:link {
+        font-weight: 300;
+      }
+
+      // XXX Ant (10.04.2016)
+      // Added !important to override some deep selectors in Vanilla
+      a:hover,
+      a:link:hover {
+        background: $light-grey !important;
+        color: $text-color !important;
+      }
+
+      a.active:hover,
+      a.active:link:hover {
+        background: #dddddd !important;
+        color: $text-color !important;
+      }
+    }
 
     &.active {
       display: block;
@@ -35,12 +95,67 @@ body {
       }
     }
   }
-}
 
-@media only screen and (max-width : 768px) {
-  .nav-secondary .breadcrumb {
-    padding-bottom: 0;
-    padding-top: 0;
+  .nav-secondary {
+
+    ul.third-level-nav li {
+      padding-left: 30px;
+    }
+
+    ul.second-level-nav li {
+      box-sizing: border-box;
+      width: 50%;
+      margin: 0;
+      float: left;
+
+      a,
+      a:link {
+        font-size: 1em;
+      }
+    }
+
+    .breadcrumb {
+      padding-bottom: 0;
+      padding-top: 0;
+
+
+      li .after {
+        background-image: url('https://assets.ubuntu.com/v1/74545443-nav-down-arrow.svg');
+        background-position: center center;
+        background-repeat: no-repeat;
+        background-size: 18px;
+        float: right;
+        height: 18px;
+        padding: 10px;
+        position: relative;
+        right: 3px;
+        top: 0;
+        width: 18px;
+      }
+
+      li .breadcrumb-link {
+        color: $text-color;
+
+        &:after,
+        &--second-level:after {
+          content: '';
+        }
+      }
+
+      li a.active,
+      li a.active:link {
+        font-weight: 700;
+        color: $black;
+      }
+    }
+
+    &:hover {
+      border-bottom: 1px solid $box-border;
+
+      ul.breadcrumb li .after {
+        background-image: url('https://assets.ubuntu.com/v1/cadd096c-nav-up-arrow.svg');
+      }
+    }
   }
 }
 
@@ -1481,8 +1596,7 @@ button.button--primary__deactivated:hover {
 
 // Override the "align-items: center" from equal-height__align-vertically,
 // which makes all items appear horizontally centered
-.equal-height > .equal-height__horizontal-left,
-.equal-height > .equal-height__align-vertically {
+.equal-height > .equal-height__horizontal-left {
   align-items: stretch;
 }
 

--- a/templates/desktop/education.html
+++ b/templates/desktop/education.html
@@ -10,7 +10,7 @@
 
 {% block content %}
 
-<div class="row row-hero no-border">
+<div class="row row-hero">
     <div class="six-col">
         <h1>Ubuntu for education</h1>
         <p class="intro">With a wide range of educational software and certified hardware, Ubuntu provides secure, cost-effective, accessible computing for students, teachers and school administrators.</p>

--- a/templates/desktop/government.html
+++ b/templates/desktop/government.html
@@ -9,7 +9,7 @@
 
 {% block content %}
 
-<div class="row row-hero no-border">
+<div class="row row-hero">
     <h1>Ubuntu for government</h1>
     <div class="six-col">
         <p class="intro">Ubuntu provides central and local government departments with secure, open source, cost-effective, accessible computing on an extensive range of certified hardware.</p>

--- a/templates/desktop/index.html
+++ b/templates/desktop/index.html
@@ -11,7 +11,7 @@
 {% endblock second_level_nav_items %}
 
 {% block content %}
-<div class="row row-hero no-border">
+<div class="row row-hero">
     <div class="six-col">
         <h1>Ubuntu for desktops</h1>
         <p class="intro">Learn how the Ubuntu desktop operating system powers millions of PCs and laptops around the world.</p>

--- a/templates/desktop/ubuntu-kylin.html
+++ b/templates/desktop/ubuntu-kylin.html
@@ -11,7 +11,7 @@
 {% block content %}
 <div class="row row-hero">
 	<h1>Ubuntu Kylin for&nbsp;China</h1>
-	<div class="six-col no-margin-bottom">
+	<div class="six-col">
 		<p>Ubuntu Kylin is an official flavour of Ubuntu.  It is a free PC operating system created for China and complies with the Chinese Government procurement regulations.  It includes all the features you&rsquo;ve come to expect from Ubuntu, alongside essential Chinese software and apps. The interface has been designed specifically to put Chinese users first &mdash; and with new support for touch screens and HiDPI monitors, it runs beautifully on all kinds of hardware.</p>
 		<p><a href="http://cn.ubuntu.com" class="button--primary">Ubuntu 中国网站现已面世</a></p>
 		<p><a href="/download/ubuntu-kylin">Download Ubuntu Kylin&nbsp;&rsaquo;</a></p>


### PR DESCRIPTION
## Done
- Unfloated the social container so it had padding below
- Drive fixes for some padding
- Removed `no-border` classes from heros and added border: 0 to them bespokely which adds bottom border too all heros on mobile
- Added inline-block for grid element so cols with only images have margin-bottom
## QA
- Check through the desktop section on mobile and see all is ok
- Check the issues have been fixed
## Issue / Card

Fixes https://github.com/ubuntudesign/www.ubuntu.com/issues/300 https://github.com/ubuntudesign/www.ubuntu.com/issues/295 https://github.com/ubuntudesign/www.ubuntu.com/issues/299
