### PR TITLE
Fix secondary nav alignment in full-width pages

### DIFF
--- a/static/css/section/_phone.scss
+++ b/static/css/section/_phone.scss
@@ -57,6 +57,12 @@
   }
 }
 
+// Full-width nav alignment fix
+.phone .nav-secondary .breadcrumb li .breadcrumb-link {
+  padding-left: 0;
+}
+
+
 @media only screen and (max-width : 768px) {
 
   .video-container.for-mobile {

--- a/static/css/section/_tablet.scss
+++ b/static/css/section/_tablet.scss
@@ -67,6 +67,11 @@
   }
 }
 
+// Full-width nav alignment fix
+.tablet .nav-secondary .breadcrumb li .breadcrumb-link {
+  padding-left: 0;
+}
+
 .tablet-overview,
 .tablet-features {
   .billboard {


### PR DESCRIPTION
For #307, remove padding from leftmost item in nav in full-width layouts, so secondary nav lines up with the logo.
## QA

Run site, visit `/phone` & `/tablet` and check the secondary nav looks left aligned.
