### PR TITLE
Only fix the nav padding for larger screens

### DIFF
--- a/static/css/section/_phone.scss
+++ b/static/css/section/_phone.scss
@@ -59,7 +59,9 @@
 
 // Full-width nav alignment fix
 .phone .nav-secondary .breadcrumb li .breadcrumb-link {
-  padding-left: 0;
+  @media only screen and (min-width : $navigation-threshold) {
+    padding-left: 0;
+  }
 }
 
 

--- a/static/css/section/_tablet.scss
+++ b/static/css/section/_tablet.scss
@@ -69,7 +69,9 @@
 
 // Full-width nav alignment fix
 .tablet .nav-secondary .breadcrumb li .breadcrumb-link {
-  padding-left: 0;
+  @media only screen and (min-width : $navigation-threshold) {
+    padding-left: 0;
+  }
 }
 
 .tablet-overview,


### PR DESCRIPTION
## QA

Run site, go to `/phone` and `/tablet`, check secondary nav looks properly left-aligned on both large screens and small screens.
