### PR TITLE
Add trans white overlay background to billboard content

### DIFF
--- a/static/css/section/_local.scss
+++ b/static/css/section/_local.scss
@@ -265,18 +265,10 @@ body {
 }
 
 // billboard__content
-@media only screen and (min-width: $breakpoint-medium) {
-  .billboard__content {
-    background: rgba(255,255,255,.85);
-    color: $cool-grey;
-    padding: 20px;
-  }
-
-  .billboard__content--large {
-    background: rgba(255,255,255,.85);
-    color: $cool-grey;
-    padding: 20px;
-  }
+.billboard__content {
+  background: rgba(255,255,255,.85);
+  color: $cool-grey;
+  padding: 20px;
 }
 
 .billboard__title {


### PR DESCRIPTION
## Done
- Removed media query around billboard content
## QA
1. Go to /tablet/partners on screens less than 468px
2. Go to "Partner with us" section
3. Text should have transparent white background
## Issue / Card
#148
## Screenshots

Expected:

<img width="776" alt="screenshot 2016-04-11 10 58 21" src="https://cloud.githubusercontent.com/assets/505570/14423561/5d911180-ffd4-11e5-852e-b28905b721da.png">
