### PR TITLE
Re-fix align-vertically centering issue

### DIFF
--- a/static/css/section/_local.scss
+++ b/static/css/section/_local.scss
@@ -1648,7 +1648,7 @@ button.button--primary__deactivated:hover {
 
 // Override the "align-items: center" from equal-height__align-vertically,
 // which makes all items appear horizontally centered
-.equal-height > .equal-height__horizontal-left {
+.equal-height > .equal-height__align-vertically {
   align-items: stretch;
 }
 

--- a/templates/phone/developers.html
+++ b/templates/phone/developers.html
@@ -45,7 +45,7 @@
 		</div>
 	</div>
 
-    <div id="scopes-content" class="section-build six-col last-col equal-height__item equal-height__align-vertically equal-height__horizontal-left">
+    <div id="scopes-content" class="section-build six-col last-col equal-height__item equal-height__align-vertically">
       <h2>Build more than just an app</h2>
       <p>By leveraging scopes, your content and services become an integral part of the default phone experience &mdash; and at a fraction of the cost of developing and maintaining a traditional app. It&rsquo;s never been this easy to develop a mobile&nbsp;experience.</p>
       <p>The Ubuntu SDK also support mainstream HTML5 apps beautifully, while a rich Qt/QML based native app environment can be used to develop deeper experiences, like&nbsp;games.</p>


### PR DESCRIPTION
@pmahnke's [original fix](https://github.com/ubuntudesign/www.ubuntu.com/commit/3f466e2cb6ad2e93624c7e7dd4f7f7c6e98dfb3b) was accidentally [reverted](https://github.com/ubuntudesign/www.ubuntu.com/commit/64c835a6595506615b809000636a14203de9471d) by @anthonydillon. Here I'm re-implementing it.
## QA

Check `/phone/developers` and `/desktop` don't have any weirdly centred text.
