### PR TITLE
Override for-medium

### DIFF
--- a/static/css/section/_local.scss
+++ b/static/css/section/_local.scss
@@ -1537,9 +1537,9 @@ html.no-svg {
 // XXX Ant (10.04.2016)
 // Move to Vanilla
 // Untility class for-medium fix
-@media only screen and (min-width: $site-max-width) {
+@media only screen and (max-width: $breakpoint-medium) {
   .for-tablet, .for-medium {
-    display: none;
+    display: block;
   }
 }
 


### PR DESCRIPTION
## Done

Reverse for-medium so it displays as it should, same as live
## QA

Go to the homepage and make sure the for medium image appears in small and medium
## Issue / Card

https://github.com/ubuntudesign/www.ubuntu.com/issues/309
