### PR TITLE
select dropdowns return to browser defaults

### DIFF
--- a/static/css/_scratch.scss
+++ b/static/css/_scratch.scss
@@ -8,7 +8,8 @@
 */
 
 // Disable default iOS styling on page elements
-* {
+input[type=button],
+button {
   -webkit-appearance: none;
 }
 

--- a/static/css/section/_download.scss
+++ b/static/css/section/_download.scss
@@ -211,9 +211,7 @@ body.download .inner-wrapper form fieldset {
 }
 
 body.download .inner-wrapper form select {
-  font-weight: 300;
-  margin-bottom: 30px;
-  width: 100%;
+  margin-bottom: 20px;
 }
 
 body.download .inner-wrapper form button,


### PR DESCRIPTION
## Done

removed overzealous -webkit-appearance: none to return the download dropdown select to browser normal
## QA
1. go to /download/desktop
2. see that the dropdown looks like the browser default
## Issue / Card

Fixes: https://github.com/ubuntudesign/ubuntu-vanilla-theme/issues/122
