### PR TITLE
bump ubuntu-vanilla-theme version

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
   "author": "Canonical webteam",
   "license": "LGPL v3",
   "dependencies": {
-    "ubuntu-vanilla-theme": "0.0.26"
+    "ubuntu-vanilla-theme": "0.0.27"
   }
 }


### PR DESCRIPTION
## Done

Bumped theme version
## QA

/cloud/openstack/managed-cloud

You can see both of the upstream changes:
- the numbered list now works in all viewports
- the heading styles for contextual footers match live
