### PR TITLE
fixing input type submit + lines in contextual footers for small

### DIFF
--- a/static/css/_scratch.scss
+++ b/static/css/_scratch.scss
@@ -9,6 +9,7 @@
 
 // Disable default iOS styling on page elements
 input[type=button],
+input[type=submit],
 button {
   -webkit-appearance: none;
 }

--- a/static/css/section/_local.scss
+++ b/static/css/section/_local.scss
@@ -458,7 +458,12 @@ body {
 
 .internet-of-things,
 .desktop,
-.cloud {
+.cloud,
+.server,
+.management,
+.about,
+.support,
+.legal {
   #context-footer {
     background: #fff;
     padding-bottom: 35px; // replaces the padding taken off .inner-wrapper


### PR DESCRIPTION
## Done

fixing -webkit-appearance for input type=submit and fixing the lines in the footer in more sections
## QA
1. go to /management in a small screen see lines are gone between the last contextual footer box and the footer
2. go to /desktop in a small screen and see the button is our normal one
## Issue / Card

Fixes: https://github.com/ubuntudesign/ubuntu-vanilla-theme/issues/165
