### PR TITLE
Fix search path

### DIFF
--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -130,7 +130,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                 <a href="#search-search" class="search-toggle__link open"></a>
                 <a href="#" class="search-toggle__link close"></a>
             </div>
-            <form action="#" id="google-appliance-search-form" class="header-search">
+            <form action="/search" id="google-appliance-search-form" class="header-search">
             		<label for="edit-keys" class="accessibility-aid">Search</label>
                 <input type="search" maxlength="255" name="q" id="edit-keys" class="form-text" placeholder="Search" value="{{ query }}" />
                 <button type="submit">


### PR DESCRIPTION
For #352. Search should go to `/search?q` rather than just `/?q`.

The search results page will still be broken (ConnectionError). This is expected.
## QA

Run the site, use the search box.
