### PR TITLE
Fix devices CTA Button for Meizu Pro5

### DIFF
--- a/templates/phone/_devices.html
+++ b/templates/phone/_devices.html
@@ -33,8 +33,7 @@
             </ul>
     
             <p itemprop="price"></p>
-            <p><a itemprop="url" class="button--primary cta-deactivated" href="">Coming soon</a></p>
-    
+            <p><a itemprop="url" class="button--primary" href="http://www.meizu.com/en/products/pro5ubuntu/summary.html">Pre-order now</a></p>
         </div>
     </div>
 </section>


### PR DESCRIPTION
## Done

Fix devices CTA Button for Meizu Pro5
## QA

Make sure the link and button text for the first item the Meizu Pro5 is the same as live
## Issue / Card

https://github.com/ubuntudesign/www.ubuntu.com/issues/342
