### PR TITLE
fixing order, https and hero for /download/ubuntu-flavours

### DIFF
--- a/templates/download/ubuntu-flavours.html
+++ b/templates/download/ubuntu-flavours.html
@@ -20,7 +20,7 @@ full Ubuntu archive for packages and updates.{% endblock %}
 		and updates.
 		</p>
 	</div><!-- /.eight-col -->
-    <div class="five-col last-col equal-height__item equal-height__align-vertically">
+    <div class="four-col push-one last-col equal-height__item equal-height__align-vertically">
         <img src="{{ ASSET_SERVER_URL }}ebfb7122-picto-generic-warmgrey.svg" width="200" height="200" alt="" class="priority-0" />
     </div>
 </div>
@@ -29,16 +29,6 @@ full Ubuntu archive for packages and updates.{% endblock %}
     <div class="twelve-col">
 
         <ul class="list--grid twelve-col no-bullets no-margin-bottom">
-          <li class="list--grid__item four-col">
-            <div class="one-col list--grid__image-container">
-                <img src="{{ ASSET_SERVER_URL }}267e8693-Kubuntu_logo.svg" alt="Kubuntu icon">
-            </div>
-            <div class="three-col last-col list--grid__description">
-                <h3><a class="external" href="http://www.kubuntu.org/">Kubuntu</a></h3>
-                <p>Kubuntu offers the KDE Plasma Workspace experience, a
-                good-looking system for home and office use.</p>
-            </div>
-          </li>
           <li class="list--grid__item four-col">
             <div class="one-col list--grid__image-container">
                 <img src="{{ ASSET_SERVER_URL }}c0c81698-Edubuntu_logo.svg" alt="Edubuntu icon">
@@ -50,7 +40,39 @@ full Ubuntu archive for packages and updates.{% endblock %}
                 quickly and easily.</p>
             </div>
           </li>
+          <li class="list--grid__item four-col">
+            <div class="one-col list--grid__image-container">
+                <img src="{{ ASSET_SERVER_URL }}267e8693-Kubuntu_logo.svg" alt="Kubuntu icon">
+            </div>
+            <div class="three-col last-col list--grid__description">
+                <h3><a class="external" href="https://www.kubuntu.org/">Kubuntu</a></h3>
+                <p>Kubuntu offers the KDE Plasma Workspace experience, a
+                good-looking system for home and office use.</p>
+            </div>
+          </li>
           <li class="list--grid__item four-col last-col">
+            <div class="one-col list--grid__image-container">
+                <img src="{{ ASSET_SERVER_URL }}600c73c4-Lubuntu.svg" alt="Lubuntu icon">
+            </div>
+            <div class="three-col last-col list--grid__description">
+                <h3><a class="external" href="http://lubuntu.net/">Lubuntu</a></h3>
+                <p>Lubuntu is a fast, energy saving and lightweight variant of
+                Ubuntu using LXDE. It is popular with PC and laptop users
+                running on low-spec hardware.</p>
+            </div>
+          </li>
+
+          <li class="list--grid__item four-col">
+            <div class="one-col list--grid__image-container">
+                <img src="{{ ASSET_SERVER_URL }}2a8f9030-mythbuntu.svg" alt="Mythbuntu icon">
+            </div>
+            <div class="three-col last-col list--grid__description">
+                <h3><a class="external" href="http://www.mythbuntu.org/">Mythbuntu</a></h3>
+                <p>Mythbuntu is a standalone MythTV based PVR system. It can be
+                a standalone system or integrated with an existing MythTV network.</p>
+            </div>
+          </li>
+          <li class="list--grid__item four-col">
             <div class="one-col list--grid__image-container">
                 <img src="{{ ASSET_SERVER_URL }}61f6a064-gnome.svg" alt="Ubuntu GNOME icon">
             </div>
@@ -60,6 +82,18 @@ full Ubuntu archive for packages and updates.{% endblock %}
                 applications from the GNOME Desktop Environment.</p>
             </div>
           </li>
+          <li class="list--grid__item four-col last-col">
+            <div class="one-col list--grid__image-container">
+                <img src="{{ ASSET_SERVER_URL }}a9914e3f-ubuntu-kylin.svg" alt="Ubuntu Kylin icon">
+            </div>
+            <div class="three-col last-col list--grid__description">
+                <h3><a class="external" href="http://www.ubuntukylin.com/index.php?lang=en">Ubuntu Kylin</a></h3>
+                <p>The Ubuntu Kylin project is tuned to the needs of Chinese
+                users, providing a thoughtful and elegant Chinese experience
+                out-of-the-box.</p>
+            </div>
+          </li>
+
           <li class="list--grid__item four-col">
             <div class="one-col list--grid__image-container">
                 <img src="{{ ASSET_SERVER_URL }}b89d0c93-mate.svg" alt="Ubuntu MATE icon">
@@ -73,49 +107,6 @@ full Ubuntu archive for packages and updates.{% endblock %}
           </li>
           <li class="list--grid__item four-col">
             <div class="one-col list--grid__image-container">
-                <img src="{{ ASSET_SERVER_URL }}2a8f9030-mythbuntu.svg" alt="Mythbuntu icon">
-            </div>
-            <div class="three-col last-col list--grid__description">
-                <h3><a class="external" href="http://www.mythbuntu.org/">Mythbuntu</a></h3>
-                <p>Mythbuntu is a standalone MythTV based PVR system. It can be
-                a standalone system or integrated with an existing MythTV network.</p>
-            </div>
-          </li>
-          <li class="list--grid__item four-col last-col">
-            <div class="one-col list--grid__image-container">
-                <img src="{{ ASSET_SERVER_URL }}36e8f12b-Xubuntu_logo.svg" alt="Xbuntu icon">
-            </div>
-            <div class="three-col last-col list--grid__description">
-                <h3><a class="external" href="http://xubuntu.org/">Xubuntu</a></h3>
-                <p>Xubuntu provides a light, stable and configurable desktop
-                environment with conservative workflows, thanks to its choice of
-                Xfce as the desktop environment.</p>
-            </div>
-          </li>
-          <li class="list--grid__item four-col">
-            <div class="one-col list--grid__image-container">
-                <img src="{{ ASSET_SERVER_URL }}600c73c4-Lubuntu.svg" alt="Lubuntu icon">
-            </div>
-            <div class="three-col last-col list--grid__description">
-                <h3><a class="external" href="http://lubuntu.net/">Lubuntu</a></h3>
-                <p>Lubuntu is a fast, energy saving and lightweight variant of
-                Ubuntu using LXDE. It is popular with PC and laptop users
-                running on low-spec hardware.</p>
-            </div>
-          </li>
-          <li class="list--grid__item four-col">
-            <div class="one-col list--grid__image-container">
-                <img src="{{ ASSET_SERVER_URL }}a9914e3f-ubuntu-kylin.svg" alt="Ubuntu Kylin icon">
-            </div>
-            <div class="three-col last-col list--grid__description">
-                <h3><a class="external" href="http://www.ubuntukylin.com/index.php?lang=en">Ubuntu Kylin</a></h3>
-                <p>The Ubuntu Kylin project is tuned to the needs of Chinese
-                users, providing a thoughtful and elegant Chinese experience
-                out-of-the-box.</p>
-            </div>
-          </li>
-          <li class="list--grid__item four-col last-col">
-            <div class="one-col list--grid__image-container">
                 <img src="{{ ASSET_SERVER_URL }}4a512076-ubuntustudio.svg" alt="Ubuntu Studio icon">
             </div>
             <div class="three-col last-col list--grid__description">
@@ -123,6 +114,17 @@ full Ubuntu archive for packages and updates.{% endblock %}
                 <p>Ubuntu Studio is a multimedia content creation flavor of
                 Ubuntu, aimed at the audio, video and graphic enthusiast or
                 professional.</p>
+            </div>
+          </li>
+          <li class="list--grid__item four-col last-col">
+            <div class="one-col list--grid__image-container">
+                <img src="{{ ASSET_SERVER_URL }}36e8f12b-Xubuntu_logo.svg" alt="Xbuntu icon">
+            </div>
+            <div class="three-col last-col list--grid__description">
+                <h3><a class="external" href="https://xubuntu.org/">Xubuntu</a></h3>
+                <p>Xubuntu provides a light, stable and configurable desktop
+                environment with conservative workflows, thanks to its choice of
+                Xfce as the desktop environment.</p>
             </div>
           </li>
         </ul>


### PR DESCRIPTION
## Done
- fixed the hear to make the picto spacing look like live
- realised the order of the releases was out of date
- realised a few more urls should be https
## QA
1. go to /download/ubuntu-flavours
2. see the banner/hear looks more like live
3. see the order of the flavours is now alphabetical
4. see that a few more are https
## Issue / Card

[List of links to Github issues/bugs and cards if needed]

Fixes #351
