### PR TITLE
fixed grey round instruction steps

### DIFF
--- a/static/css/section/_download.scss
+++ b/static/css/section/_download.scss
@@ -655,7 +655,7 @@ html.opera-mini {
   float: left;
   text-align: center;
   vertical-align: top;
-  width: 18px;
+  width: 40px;
   font-size: 1.375em;
   padding: 0 9px;
   height: auto;
@@ -989,7 +989,7 @@ html.opera-mini {
   #download-help li span,
   #ubuntu-help li span {
     font-size: 1.4375em;
-    height: 20px;
+    height: 40px;
     padding: 0 11px 20px 11px;
     margin-right: 20px;
   }


### PR DESCRIPTION
## Done

fixed the round grey instruction steps
## QA
1. go to /download/desktop/burn-a-dvd-on-ubuntu or any download instruction page
2. see the grey round numbers are round and in the correct position
## Issue / Card

Fixes #349
Fixes #336

![image](https://cloud.githubusercontent.com/assets/441217/14443673/9bb4ed9c-0038-11e6-8d07-18d87ea89f76.png)
