### PR TITLE
add verticle line to download box on /download/server

### DIFF
--- a/templates/download/server/index.html
+++ b/templates/download/server/index.html
@@ -14,14 +14,14 @@
         <h1>Download Ubuntu Server</h1>
     </div>
     <div class="twelve-col no-margin-bottom">
-        <div class="box box-highlight clearfix vertical-divider">
-            <div class="eight-col no-margin-bottom">
+  		<div class="box box-highlight clearfix equal-height--vertical-divider">
+  			<div class="equal-height--vertical-divider__item eight-col no-margin-bottom">
                 <h2>Ubuntu Server {{lts_release}} LTS</h2>
                 <p>The Long Term Support version of Ubuntu Server, including the Icehouse release of OpenStack and support guaranteed until April 2019 &mdash; 64-bit only.</p>
                 <p><strong>Recommended for most users.</strong></p>
                 <p><a href="https://wiki.ubuntu.com/{{lts_release_name}}/ReleaseNotes" class="external">Ubuntu Server {{lts_release}} LTS release notes</a></p>
             </div>
-            <div class="four-col last-col">
+            <div class="equal-height--vertical-divider__item four-col last-col no-margin-bottom download-button">
                 <form class="form-download gap-from-top" action="/download/server/thank-you/" method="get">
                     <fieldset>
                         <input name="version" value="{{lts_release}}" type="hidden">
@@ -37,13 +37,13 @@
     </div>
 
     <div class="twelve-col no-margin-bottom">
-        <div class="box box-highlight clearfix vertical-divider">
-            <div class="eight-col no-margin-bottom">
+      <div class="box box-highlight clearfix equal-height--vertical-divider">
+        <div class="equal-height--vertical-divider__item eight-col no-margin-bottom">
                 <h2>Ubuntu Server {{latest_release}}</h2>
                 <p>The latest version of Ubuntu Server, including the {{openstack_version}} release of OpenStack and support for nine months &ndash; 64-bit only.</p>
                 <p><a href="https://wiki.ubuntu.com/{{latest_release_name}}/ReleaseNotes" class="external">Ubuntu Server {{latest_release}} release notes</a></p>
             </div>
-            <div class="four-col last-col">
+            <div class="equal-height--vertical-divider__item four-col last-col no-margin-bottom download-button">
                 <form class="form-download gap-from-top" action="/download/server/thank-you/" method="get">
                     <fieldset>
                         <input name="version" value="{{latest_release}}" type="hidden">


### PR DESCRIPTION
## Done

made sever download boxes look like live and desktop boxes
## QA
1. go to /download/server
2. see that here is a verticle line between the download type and the button area
## Issue / Card

Fixes #350
