### PR TITLE
fix logo title blocks to align side by side in small screens

### DIFF
--- a/static/css/section/_things.scss
+++ b/static/css/section/_things.scss
@@ -7,6 +7,15 @@
     }
   }
 
+  /// logo title blocks to allign side by side in small screens
+  @media only screen and (max-width: $breakpoint-medium) {
+    .twelve-col .one-col,
+    .twelve-col .three-col {
+      width: initial;
+    }
+  }
+
+
   @media only screen and (min-width: 984px) {
     .row-cta {
       padding: 90px 40px 70px;
@@ -208,4 +217,3 @@ body.internet-of-things-developers {
   padding-top: 0;
   margin-bottom: 0;
 }
-


### PR DESCRIPTION
## Done

[List of work items including drive-bys]
## QA
1. go to /internet-of-things/features and /internet-of-things/partners on a small screen
2. see that the sections with one-col icon with three-col titles are side by side

![image](https://cloud.githubusercontent.com/assets/441217/14444628/9d6b9d10-003e-11e6-9281-842097530830.png)
## Issue / Card

Fixes #358
