### PR TITLE
fixed management heros for all screens

### DIFF
--- a/static/css/section/_management.scss
+++ b/static/css/section/_management.scss
@@ -426,23 +426,3 @@ body.management-ema-whitepaper {
 		}
 	}
 }
-
-/* Medium / Tablet viewport
--------------------------------------------------------------- */
-@media only screen and (min-width : 986px) {
-	body.management-ubuntu-advantage,
-	body.management-working-with-landscape {
-		.row-hero {
-			background-image: url("#{$asset-server}544a9eb7-image-ubuntuadvantage.svg");
-			background-position: 694px 50%;
-			background-repeat: no-repeat;
-		}
-	}
-	body.management {
-		.tabbed-menu {
-		}
-		.tabbed-content {
-
-		}
-	}
-}

--- a/templates/management/ubuntu-advantage.html
+++ b/templates/management/ubuntu-advantage.html
@@ -21,7 +21,7 @@
     </p>
   </div><!-- /.eight-col -->
   <div class="four-col last-col">
-    <img src="{{ ASSET_SERVER_URL }}544a9eb7-image-ubuntuadvantage.svg" alt="" width="378" height="180" class="for-medium" />
+    <img src="{{ ASSET_SERVER_URL }}544a9eb7-image-ubuntuadvantage.svg" alt="" width="378" height="180" class="priority-0" />
   </div>
 </div>
 <div class="row row-grey row-pricing">

--- a/templates/management/working-with-landscape.html
+++ b/templates/management/working-with-landscape.html
@@ -13,7 +13,10 @@
 		<div class="eight-col">
 			<p>Landscape provides a single, easy-to-use, browser-based control panel, through which you can manage your machines from anywhere. With a fully scriptable API, you can integrate it with your current Linux management tools, extending their capabilities and giving you the power to do more with fewer resources. Most important of all however, is Landscape&rsquo;s ease of use. In fact, for experienced Linux administrators, the learning curve is practically non-existent.</p>
 		</div><!-- /.eight-col -->
-			<p class="twelve-col"><a class="button--primary" href="https://landscape.canonical.com/trial-registration">Get a free 30-day trial</a> or <a href="/management/contact-us">contact us about Landscape&nbsp;&rsaquo;</a></p>
+    <div class="four-col last-col">
+      <img src="{{ ASSET_SERVER_URL }}544a9eb7-image-ubuntuadvantage.svg" alt="" width="378" height="180" class="priority-0" />
+    </div>
+		<p class="twelve-col"><a class="button--primary" href="https://landscape.canonical.com/trial-registration">Get a free 30-day trial</a> or <a href="/management/contact-us">contact us about Landscape&nbsp;&rsaquo;</a></p>
 	</div><!-- /.row .row-hero -->
 
 	<div id="landscape-videos" class="row">


### PR DESCRIPTION
## Done
- remove background url of picto
- added real picto to 'working with Landscape'
- removed other empty medium classes from old tabs?
## QA
1. go to /management/working-with-landscape or /management/ubuntu-advantage
2. look at small/medium/large screens
3. small - no picto illustration - medium shrinking picto - large one picto
## Issue / Card

`Fixes #241
