### PR TITLE
fixed .equal-height > .equal-height__align-vertically to work on h2 a…

### DIFF
--- a/static/css/section/_local.scss
+++ b/static/css/section/_local.scss
@@ -1645,7 +1645,11 @@ button.button--primary__deactivated:hover {
 // Override the "align-items: center" from equal-height__align-vertically,
 // which makes all items appear horizontally centered
 .equal-height > .equal-height__align-vertically {
-  align-items: stretch;
+  h2,
+  p {
+    align-items: stretch;
+    width: 100%;
+  }
 }
 
 .pull-left--less {

--- a/templates/server/hyperscale.html
+++ b/templates/server/hyperscale.html
@@ -73,7 +73,7 @@
 		<p>Ubuntu now runs on every significant ARM platform deployed in the datacentre, including the recently-announced Baidu storage cluster.</p>
 	</div>
 	<div class="five-col last-col equal-height__item equal-height__align-vertically">
-		<img src="{{ ASSET_SERVER_URL }}c74f59b7-picto-reducecosts-warmgrey.svg" width="199" height="199" alt="" />
+		<img src="{{ ASSET_SERVER_URL }}c74f59b7-picto-reducecosts-warmgrey.svg" width="199" height="199" class="priority-0" alt="" />
 	</div>
 </div>
 


### PR DESCRIPTION
## Done
- fixed .equal-height > .equal-height__align-vertically to work on h2 and p, not images
- hid server/hyperscale picto on small screens
## QA
1. go to /server/hyperscale and see picto center aligned
   ![image](https://cloud.githubusercontent.com/assets/441217/14452641/e54f37e2-0087-11e6-80b2-fe1398455f97.png)
2. go to /desktop and see the 'complete' section is still left aligned
   ![image](https://cloud.githubusercontent.com/assets/441217/14452635/d3f70d30-0087-11e6-9ead-177dc4429080.png)
## Issue / Card

Fixes #339 and #356
