### PR TITLE
Fix secondary nav font size

### DIFF
--- a/static/css/section/_local.scss
+++ b/static/css/section/_local.scss
@@ -96,7 +96,7 @@ body {
 
       a,
       a:link {
-        font-size: 1em;
+        font-size: .875em;
       }
     }
 


### PR DESCRIPTION
## Done

Fix secondary nav font size so it’s the same size as live
## QA

Have a look at the secondary nav at small and make sure it’s the same as live (14px)
