### PR TITLE
Prevent horizontal scroll of pages

### DIFF
--- a/static/css/section/_local.scss
+++ b/static/css/section/_local.scss
@@ -1,3 +1,8 @@
+html,
+body {
+  overflow-x: hidden;
+}
+
 body {
   background-size: cover;
 
@@ -1716,4 +1721,3 @@ button.button--primary__deactivated:hover {
 .header-search input[type=search] {
     padding-right: 40px;
 }
-


### PR DESCRIPTION
## Done

Added rule to prevent overflow-x on body and html page elements.
## QA

Pull down code, load small screen and ensure that page cannot shift to the right.
