### PR TITLE
New laptop image for "Buy a managed cloud"

### DIFF
--- a/static/css/section/_homepage.scss
+++ b/static/css/section/_homepage.scss
@@ -488,7 +488,7 @@ body.homepage .row--cloud-products {
   background-color: #fff;
 
   @media only screen and (min-width : 768px) {
-    background-image: url('#{$asset-server}f27582be-image-cloud-static.jpg');
+    background-image: url('#{$asset-server}890dec32-cloud-laptop.jpg?w=792');
     background-repeat: no-repeat;
     background-position: 77% center;
     background-size: 50%;
@@ -1320,7 +1320,7 @@ body.homepage-maas-takeover {
       background-position: center center;
       padding-top: 30px;
     }
-    
+
     .strip-inner-wrapper {
       min-height: 40vw;
       overflow: visible;
@@ -1334,7 +1334,7 @@ body.homepage-maas-takeover {
           margin-top: 50px;
         }
       }
-      
+
       .row-hero__image--small-screen {
         padding-top: 20px;
       }


### PR DESCRIPTION
Replace the existing image with [this one](https://www.dropbox.com/s/q6mdexzc0ccydah/ubuntu-home-cloud.jpg?dl=0).

The only difference in the image is that it has a slight shadow below the laptop.

Also, pull it in at the correct size - 792px wide. It's never going to be displayed bigger than that.
## QA

Run the site, visit the homepage, check the laptop in the image next to "Buy a managed cloud"
has a small shadow below it, matching [this new image](https://www.dropbox.com/s/q6mdexzc0ccydah/ubuntu-home-cloud.jpg?dl=0).
