### PR TITLE
removed picto from community row on small screens

### DIFF
--- a/templates/shared/_community.html
+++ b/templates/shared/_community.html
@@ -22,6 +22,6 @@
 	</div>
 {% endif %}
 	<div class="three-col last-col equal-height__item equal-height__align-vertically align-center">
-		<img src="{{ ASSET_SERVER_URL }}039628d5-picto-community-orange.svg" alt="" width="136" height="136" />
+		<img src="{{ ASSET_SERVER_URL }}039628d5-picto-community-orange.svg" class="not-for-small" alt="" width="136" height="136" />
 	</div>
 </div>


### PR DESCRIPTION
## Done

added class 'not-for-small' to community row
## QA
1. go to /desktop and /server on a small screen
2. see that the fish bowl picto isn't there on the community rows
## Issue / Card

https://trello.com/c/5AiKGTb8 
