### PR TITLE
putting the public cloud guest list back from before the vanilla release

### DIFF
--- a/templates/cloud/shared/_guest-list.html
+++ b/templates/cloud/shared/_guest-list.html
@@ -1,68 +1,66 @@
-    <ul class="no-bullets twelve-col">
-        <li class="box four-col">
-            <a href="https://cloud.google.com/docs/">
-                <div>
-                    <img class="logo-gcp" src="{{ ASSET_SERVER_URL }}3d750e6c-logo-google-cloud-platform.png" alt="Google Cloud Platform" />
-                </div>
-                <p>Get started on GCP&nbsp;&rsaquo;</p>
-            </a>
-        </li>
-        <li class="box four-col">
-            <a href="https://help.ubuntu.com/community/EC2StartersGuide">
-                <div>
-                    <img class="logo-amazonwebservices" src="{{ ASSET_SERVER_URL }}5e3fa4e7-logo-amazonwebservices.png" alt="Amazon Web Services (EC2)" />
-                </div>
-                <p>The Ubuntu guide to EC2&nbsp;&rsaquo;</p>
-            </a>
-        </li>
-        <li class="box four-col last-col">
-            <a href="http://brightbox.com">
-                <div>
-                    <img src="{{ ASSET_SERVER_URL }}fb02090d-logo-brightbox-160.png" alt="Brightbox" />
-                </div>
-                <p>Get started on Brightbox&nbsp;&rsaquo;</p>
-            </a>
-        </li>
-
-
-        <li class="box four-col">
-            <a href="https://cloud.oracle.com/marketplace/listing/6071138?_afrLoop=105446854237053&_afrWindowMode=0&_afrWindowId=null">
+<ul class="no-bullets twelve-col">
+    <li class="box four-col">
+        <a href="https://cloud.google.com/docs/">
             <div>
-                <img src="{{ ASSET_SERVER_URL }}0ad254cc-oracle_redbadge.png?h=70" alt="Oracle Cloud" />
+                <img class="logo-gcp" src="{{ ASSET_SERVER_URL }}3d750e6c-logo-google-cloud-platform.png" alt="Google Cloud Platform">
             </div>
-            <p>Get started on Oracle Cloud&nbsp;&rsaquo;</p>
-            </a>
-        </li>
-        <li class="box four-col">
-            <a href="http://www.ibm.com/cloud-computing/social/us/en/startatrial/">
+            <p>Get started on GCP&nbsp;›</p>
+        </a>
+    </li>
+    <li class="box four-col">
+        <a href="https://help.ubuntu.com/community/EC2StartersGuide">
             <div>
-                <img class="logo-ibm" src="{{ ASSET_SERVER_URL }}e986bb33-logo-ibm.png" alt="IBM SmartCloud" />
+                <img class="logo-amazonwebservices" src="{{ ASSET_SERVER_URL }}5e3fa4e7-logo-amazonwebservices.png" alt="Amazon Web Services (EC2)">
             </div>
-            <p>Get started on IBM SmartCloud&nbsp;&rsaquo;</p>
-            </a>
-        </li>
-        <li class="box four-col last-col">
-            <a href="http://www.windowsazure.com/en-us/documentation/services/virtual-machines/">
-                <div>
-                    <img class="logo-windowsazure" src="{{ ASSET_SERVER_URL }}eb041659-Microsoft-Azure_rgb_Blk.svg?w=170" alt="Microsoft Azure" />
-                </div>
-            <p>Get started on Microsoft Azure&nbsp;&rsaquo;</p>
-            </a>
-        </li>
-        <li class="box four-col">
-            <a href="http://www.joyent.com/free-trial">
-                <div>
-                    <img class="logo-joyent" src="{{ ASSET_SERVER_URL }}238b87ea-logo-joyent.png" alt="Joyent" />
-                </div>
-                <p>Get started on Joyent&nbsp;&rsaquo;</p>
-            </a>
-        </li>
-        <li class="box four-col">
-            <a href="https://solutionexchange.vmware.com/store/products/ubuntu-12-04-lts--2#.VA_9Dq2zDsa">
-                <div>
-                    <img class="logo-joyent" src="{{ ASSET_SERVER_URL }}20e30152-logo-vmware.png" alt="VMware" height="35" />
-                </div>
-                <p>Get started on VMware&nbsp;&rsaquo;</p>
-            </a>
-        </li>
-    </ul>
+            <p>The Ubuntu guide to EC2&nbsp;›</p>
+        </a>
+    </li>
+    <li class="box four-col last-col">
+        <a href="https://cloud.oracle.com/marketplace/listing/6071138?_afrLoop=105446854237053&amp;_afrWindowMode=0&amp;_afrWindowId=null">
+            <div>
+                <img src="{{ ASSET_SERVER_URL }}0ad254cc-oracle_redbadge.png?h=70" alt="Oracle Cloud">
+            </div>
+            <p>Get started on Oracle Cloud&nbsp;›</p>
+        </a>
+    </li>
+    <li class="box four-col">
+        <a href="http://www.windowsazure.com/en-us/documentation/services/virtual-machines/">
+            <div>
+                <img class="logo-windowsazure" src="{{ ASSET_SERVER_URL }}eb041659-Microsoft-Azure_rgb_Blk.svg?w=170" alt="Microsoft Azure">
+            </div>
+            <p>Get started on Microsoft Azure&nbsp;›</p>
+        </a>
+    </li>
+    <li class="box four-col">
+        <a href="http://www.joyent.com/free-trial">
+            <div>
+                <img class="logo-joyent" src="{{ ASSET_SERVER_URL }}238b87ea-logo-joyent.png" alt="Joyent">
+            </div>
+            <p>Get started on Joyent&nbsp;›</p>
+        </a>
+    </li>
+    <li class="box four-col  last-col">
+        <a href="https://solutionexchange.vmware.com/store/products/ubuntu-12-04-lts--2#.VA_9Dq2zDsa">
+            <div>
+                <img class="logo-joyent" src="{{ ASSET_SERVER_URL }}20e30152-logo-vmware.png" alt="VMware" height="35">
+            </div>
+            <p>Get started on VMware&nbsp;›</p>
+        </a>
+    </li>
+    <li class="box four-col">
+        <a href="https://vexxhost.com/public-cloud/">
+            <div>
+                <img class="logo-vexxhost" src="{{ ASSET_SERVER_URL }}d539a864-vexxhost_logo.png" alt="Vexxhost">
+            </div>
+            <p>Get started on Vexxhost&nbsp;›</p>
+        </a>
+    </li>
+    <li class="box four-col">
+        <a href="https://cloudstore.interoute.com/">
+            <div>
+                <img class="logo-interoute" src="{{ ASSET_SERVER_URL }}dcb07d27-1280px-Interoute_Logo_RGB.jpg?h=85" alt="Interoute">
+            </div>
+            <p>Get started on Interoute&nbsp;›</p>
+        </a>
+    </li>
+</ul>


### PR DESCRIPTION
## Done

adding back the changes to the public cloud guest list, seems that that fix didn't make it to vanilla
## QA
1. go to /cloud/public-cloud
2. see that the list is the same as the [copy doc](https://docs.google.com/document/d/1ZzUIh9Tfz5SvkrHyo4-izzmUjRka1Tn0UQisKcXGEPA/edit)
## Issue / Card

https://trello.com/c/2MEpFLOw
## Screenshots

![image](https://cloud.githubusercontent.com/assets/441217/14530440/f2adeaf8-0250-11e6-9c79-b06d96a29284.png)
