### PR TITLE
Remove full-stops from lists on /cloud

### DIFF
--- a/templates/cloud/index.html
+++ b/templates/cloud/index.html
@@ -109,10 +109,10 @@ valueOf()+(h?'&utmxhash='+escape(h.substr(1)):'')+
     <div class="eight-col">
         <p>Hundreds of services and pre-configured applications available for single&dash;command deployment to any cloud.</p>
         <ul class="list-ticks--compact">
-            <li>Find solutions for anything from databases and big data to containers and benchmarking.</li>
-            <li>Write your own solution in any language and add it to the store.</li>
-            <li>Model, configure, deploy and manage entire cloud environments with only a few commands.</li>
-            <li>Increase productivity, improve workflow, reuse solutions and deploy across all major public and private clouds.</li>
+            <li>Find solutions for anything from databases and big data to containers and benchmarking</li>
+            <li>Write your own solution in any language and add it to the store</li>
+            <li>Model, configure, deploy and manage entire cloud environments with only a few commands</li>
+            <li>Increase productivity, improve workflow, reuse solutions and deploy across all major public and private clouds</li>
         </ul>
         <p><a href="/cloud/juju">Learn more about Juju&nbsp;&rsaquo;</a></p>
     </div>
@@ -237,9 +237,9 @@ valueOf()+(h?'&utmxhash='+escape(h.substr(1)):'')+
         <h2>Use Ubuntu on certified public clouds</h2>
         <p class="intro">The most popular operating system across public clouds.</p>
         <ul class=" list-ticks--compact">
-            <li>Canonical guarantees the consistency, security and performance of Ubuntu on all our certified public clouds.</li>
-            <li>Enterprise-grade commercial support is available.</li>
-            <li>Twice as popular on the Amazon cloud as all other operating systems combined.<a href="#fn2" id="r2">**</a></li>
+            <li>Canonical guarantees the consistency, security and performance of Ubuntu on all our certified public clouds</li>
+            <li>Enterprise-grade commercial support is available</li>
+            <li>Twice as popular on the Amazon cloud as all other operating systems combined<a href="#fn2" id="r2">**</a></li>
         </ul>
         <p><a href="/cloud/public-cloud">Get Ubuntu on the public cloud&nbsp;&rsaquo;</a></p>
     </div>


### PR DESCRIPTION
List items shoudn't have full stops at the end.
## QA

Run the site, go to `/cloud`, check the lists under "Juju is the universal app store for the cloud"
and "Use Ubuntu on certified public clouds" no longer have full stops.
