### PR TITLE
updated contact cta on desktop/education - regression

### DIFF
--- a/templates/desktop/education.html
+++ b/templates/desktop/education.html
@@ -14,7 +14,7 @@
     <div class="six-col">
         <h1>Ubuntu for education</h1>
         <p class="intro">With a wide range of educational software and certified hardware, Ubuntu provides secure, cost-effective, accessible computing for students, teachers and school administrators.</p>
-        <p><a href="mailto:education@canonical.com" class="button--primary">Contact us</a></p>
+        <p><a href="/desktop/contact-us" class="button--primary">Contact us</a></p>
         {% include "desktop/shared/_share-this.html" with tweet="Learn how #Ubuntu desktop OS helps students and teachers around the world" %}
     </div>
 </div>


### PR DESCRIPTION
## Done

changing /desktop/education contact cta from email to form
## QA
1. go to /desktop/education
2. see that the cta links to the /desktop/contact-us form, not the education@canonical.com email
## Issue / Card

Fixes #426 
