### PR TITLE
Remove bottom margin from list--grids

### DIFF
--- a/templates/desktop/education.html
+++ b/templates/desktop/education.html
@@ -65,7 +65,7 @@
         <h2>Countless open source tools and apps available</h2>
     </div>
 
-    <ul class="list--grid twelve-col no-bullets no-margin-bottom">
+    <ul class="list--grid twelve-col no-bullets">
         <li class="list--grid__item four-col">
             <div class="one-col list--grid__image-container">
                 <img src="{{ ASSET_SERVER_URL }}86f02c6d-gcompris-icon.png" alt="Gcompris icon" />

--- a/templates/desktop/features.html
+++ b/templates/desktop/features.html
@@ -56,7 +56,7 @@
             <p>Ubuntu offers thousands of apps available for download. Most are available for free and can be installed with just a few clicks.</p>
         </div>
     </div>
-    <ul class="list--grid twelve-col no-bullets no-margin-bottom">
+    <ul class="list--grid twelve-col no-bullets">
         <li class="list--grid__item four-col">
             <div class="one-col list--grid__image-container">
                 <img src="{{ ASSET_SERVER_URL }}3f3a15ef-logo-telegram.svg?fmt=png&w=60" alt="Skype icon" />


### PR DESCRIPTION
Follow-on from #447.

When I ported in the `list--grid` markup I copied over the
`no-margin-bottom` class, but on reflection both pages
definitely look better without it.
## QA

View `/desktop/features` and `/desktop/education` and behold
the bottom margin under the grids.
