### PR TITLE
Put install instructions in their own row

### DIFF
--- a/templates/download/cloud/install-openstack-with-autopilot.html
+++ b/templates/download/cloud/install-openstack-with-autopilot.html
@@ -29,248 +29,250 @@
     </div>
 </div>
 
-<div class="strip-inner-wrapper">
-    <div class="clearfix instruction" id="download-help">
-        <div class="five-col instruction__bullet">
-            <div class="one-col">
-                <span class="instruction__step">1</span>
+<div class="row row-install-autopilot">
+    <div class="strip-inner-wrapper">
+        <div class="clearfix instruction" id="download-help">
+            <div class="five-col instruction__bullet">
+                <div class="one-col">
+                    <span class="instruction__step">1</span>
+                </div>
+                <div class="four-col last-col">
+                    <h3 class="instruction__title">Set up your hardware</h3>
+                </div>
             </div>
-            <div class="four-col last-col">
-                <h3 class="instruction__title">Set up your hardware</h3>
+            <div class="seven-col last-col instruction__details right">
+                <p>You&rsquo;ll need  at least five machines with two disks in each, two of which have two network interfaces (NICs).</p>
+                <p>No hardware available? <a href="/download/cloud">Test drive OpenStack Autopilot for virtual machines</a></p>
+                <p><a href="/download/server">Install Ubuntu Server</a> on one of the machines with two network interfaces.</p>
+                <p>You need to setup a private network with all machines plugged in and enough IP addresses available for all physical and virtual machines you plan to run.</p>
             </div>
         </div>
-        <div class="seven-col last-col instruction__details right">
-            <p>You&rsquo;ll need  at least five machines with two disks in each, two of which have two network interfaces (NICs).</p>
-            <p>No hardware available? <a href="/download/cloud">Test drive OpenStack Autopilot for virtual machines</a></p>
-            <p><a href="/download/server">Install Ubuntu Server</a> on one of the machines with two network interfaces.</p>
-            <p>You need to setup a private network with all machines plugged in and enough IP addresses available for all physical and virtual machines you plan to run.</p>
+        <div class="clearfix instruction">
+            <div class="five-col instruction__bullet">
+                <div class="one-col">
+                    <span class="instruction__step">2</span>
+                </div>
+                <div class="four-col last-col">
+                    <h3 class="instruction__title">Add required repositories</h3>
+                </div>
+            </div>
+            <div class="seven-col last-col instruction__details right">
+                <p>From the command line type the commands below and follow the step-by-step instructions:</p>
+                <p class="command-line">
+                    <input class="command-line__input" value="sudo apt-get install python-software-properties" readonly="readonly">
+                    <button class="js-copy-to-clipboard command-line__copy-button">Copy to clipboard</button>
+                </p>
+                <p class="command-line">
+                    <input class="command-line__input" value="sudo add-apt-repository ppa:juju/stable" readonly="readonly">
+                    <button class="js-copy-to-clipboard command-line__copy-button">Copy to clipboard</button>
+                </p>
+                <p class="command-line">
+                    <input class="command-line__input" value="sudo add-apt-repository ppa:maas/stable" readonly="readonly">
+                    <button class="js-copy-to-clipboard command-line__copy-button">Copy to clipboard</button>
+                </p>
+                <p class="command-line">
+                    <input class="command-line__input" value="sudo add-apt-repository ppa:cloud-installer/stable" readonly="readonly">
+                    <button class="js-copy-to-clipboard command-line__copy-button">Copy to clipboard</button>
+                </p>
+                <p class="command-line">
+                    <input class="command-line__input" value="sudo apt-get update" readonly="readonly">
+                    <button class="js-copy-to-clipboard command-line__copy-button">Copy to clipboard</button>
+                </p>
+            </div>
+        </div>
+        <div class="clearfix instruction">
+            <div class="five-col instruction__bullet">
+                <div class="one-col">
+                    <span class="instruction__step">3</span>
+                </div>
+                <div class="four-col last-col">
+                    <h3 class="instruction__title">Install MAAS</h3>
+                </div>
+            </div>
+            <div class="seven-col last-col instruction__details right">
+                <p>To install MAAS, type the command below and follow the step-by-step instructions:</p>
+                <p class="command-line">
+                  <input class="command-line__input" value="sudo apt-get install maas" readonly="readonly">
+                  <button class="js-copy-to-clipboard command-line__copy-button">Copy to clipboard</button>
+                </p>
+                <p>Create your admin credentials by typing:</p>
+                <p class="command-line">
+                  <input class="command-line__input" value="sudo maas-region-admin createadmin" readonly="readonly">
+                  <button class="js-copy-to-clipboard command-line__copy-button">Copy to clipboard</button>
+                </p>
+                <ul class="no-bullets">
+                    <li>Login to the MAAS UI at http://&lt;maas.ip&gt;/MAAS/</li>
+                    <li>Go to the &ldquo;Images&rdquo; tab and import disk images for &ldquo;14.04 LTS amd64&rdquo;</li>
+                    <li>In your MAAS user&rsquo;s settings (top-right corner) add your personal public SSH key so you can later log into the nodes</li>
+                    <li>Go to the &ldquo;Networks&rdquo; tab and for each of the networks auto-created, click &ldquo;Edit network&rdquo; to add the default gateway and DNS server details</li>
+                </ul>
+            </div>
+        </div>
+        <div class="clearfix instruction">
+            <div class="five-col instruction__bullet">
+                <div class="one-col">
+                    <span class="instruction__step">4</span>
+                </div>
+                <div class="four-col last-col">
+                    <h3 class="instruction__title">Configure the MAAS cluster</h3>
+                </div>
+            </div>
+            <div class="seven-col last-col instruction__details right">
+                <ul>
+                    <li>Go to the &ldquo;Clusters&rdquo; tab, open the &ldquo;Cluster master&rdquo; link, hover over the row for the interface that is connected to the private network and select the edit icon (looks like a pencil &mdash; <img src="{{ ASSET_SERVER_URL }}e4e804d6-edit.svg" alt="" />)
+                        <ul>
+                            <li>Set this interface to manage DHCP and DNS</li>
+                            <li>Set the &ldquo;Router IP&rdquo; to the default gateway</li>
+                        </ul>
+                    </li>
+                    <li>Fill in details for the dynamic and static ranges, remembering to leave gaps for the floating IPs
+                        <ul>
+                            <li>Dynamic range &mdash; that has as many IPs as there are total NICs connected to the network (minimum 15)</li>
+                            <li>Static range &mdash; that has as many IPs as there are machines connected to the network</li>
+                            <li>Floating IP range &mdash; that has as many IPs as instances that you&rsquo;ll have in your cloud</li>
+                        </ul>
+                    </li>
+                </ul>
+            </div>
+        </div>
+        <div class="clearfix instruction">
+            <div class="five-col instruction__bullet">
+                <div class="one-col">
+                    <span class="instruction__step">5</span>
+                </div>
+                <div class="four-col last-col">
+                    <h3 class="instruction__title">Register your hardware with MAAS</h3>
+                </div>
+            </div>
+            <div class="seven-col last-col instruction__details right">
+                <p>Now you need to enlist and commission machines:</p>
+                <ul>
+                    <li>Ensure all machines are set to PXE boot, if possible disable all other boot options, including local disk, in the BIOS
+                    <li>Power the machines on so they will all appear in the &ldquo;Nodes&rdquo; tab of MAAS</li>
+                    <li>Edit each machine filling in the power type and parameters</li>
+                    <li>Select all the machines and, using the &ldquo;Take action&rdquo; dropdown, &ldquo;Commission&rdquo; them.</li>
+                    <li>Wait until all machines have a &ldquo;Ready&rdquo; status</li>
+                </ul>
+            </div>
+        </div>
+        <div class="clearfix instruction">
+            <div class="five-col instruction__bullet">
+                <div class="one-col">
+                    <span class="instruction__step">6</span>
+                </div>
+                <div class="four-col last-col">
+                    <h3 class="instruction__title">Launch OpenStack Autopilot</h3>
+                </div>
+            </div>
+            <div class="seven-col last-col instruction__details right">
+                <p>Setup Landscape and launch the OpenStack Autopilot with the following commands:</p>
+                <p class="command-line">
+                  <input class="command-line__input" value="sudo apt-get install openstack" readonly="readonly">
+                  <button class="js-copy-to-clipboard command-line__copy-button">Copy to clipboard</button>
+                </p>
+                <p class="command-line">
+                  <input class="command-line__input" value="sudo openstack-install" readonly="readonly">
+                  <button class="js-copy-to-clipboard command-line__copy-button">Copy to clipboard</button>
+                </p>
+                <ul>
+                    <li>Choose the &ldquo;Landscape OpenStack Autopilot&rdquo; option</li>
+                    <li>Create a new OpenStack Password</li>
+                    <li>Fill in your:
+                        <ul>
+                            <li>Admin email address</li>
+                            <li>Admin name</li>
+                            <li>MAAS server IP</li>
+                            <li>MAAS user API key &mdash; found in your user&rsquo;s settings (top-right corner)</li>
+                        </ul>
+                    </li>
+                    <li>When everything is installed, you will be given a link</li>
+                    <li>Open that link to access the Landscape UI</li>
+                    <li>Login with your admin email and OpenStack password</li>
+                </ul>
+                <img src="{{ ASSET_SERVER_URL }}9d5bea4c-install-ubuntu-cloud-step4.png" alt="">
+            </div>
+        </div>
+        <div class="clearfix instruction">
+            <div class="five-col instruction__bullet">
+                <div class="one-col">
+                    <span class="instruction__step">7</span>
+                </div>
+                <div class="four-col last-col">
+                    <h3 class="instruction__title">Review your checklist</h3>
+                </div>
+            </div>
+            <div class="seven-col last-col instruction__details right">
+                <p>At the bottom of the setup page there is a checklist with the status of all of your resources. These should all be green, if it isn&rsquo;t follow the instructions to resolve </p>
+                <img src="{{ ASSET_SERVER_URL }}ef70520d-requirements.png" alt="" />
+            </div>
+        </div>
+        <div class="clearfix instruction">
+            <div class="five-col instruction__bullet">
+                <div class="one-col">
+                    <span class="instruction__step">8</span>
+                </div>
+                <div class="four-col last-col">
+                    <h3 class="instruction__title">Choose your OpenStack components</h3>
+                </div>
+            </div>
+            <div class="seven-col last-col instruction__details right">
+                <img src="{{ ASSET_SERVER_URL }}28f70917-Choose+configure.png" alt="" />
+            </div>
+        </div>
+        <div class="clearfix instruction">
+            <div class="five-col instruction__bullet">
+                <div class="one-col">
+                    <span class="instruction__step">9</span>
+                </div>
+                <div class="four-col last-col">
+                    <h3 class="instruction__title">Select the hardware on which to deploy the cloud</h3>
+                </div>
+            </div>
+            <div class="seven-col last-col instruction__details right">
+                <img src="{{ ASSET_SERVER_URL }}9c5da2f5-machine-picker.png" alt="" />
+            </div>
+        </div>
+        <div class="clearfix instruction">
+            <div class="five-col instruction__bullet">
+                <div class="one-col">
+                    <span class="instruction__step">10</span>
+                </div>
+                <div class="four-col last-col">
+                    <h3 class="instruction__title">Select &ldquo;Install&rdquo; to start building your cloud</h3>
+                </div>
+            </div>
+            <div class="seven-col last-col instruction__details right">
+                <img src="{{ ASSET_SERVER_URL }}77bc020b-Installing+region+1++++table+++Progress.png" alt="" />
+            </div>
+        </div>
+        <div class="clearfix instruction">
+            <div class="five-col instruction__bullet">
+                <div class="one-col">
+                    <span class="instruction__step">11</span>
+                </div>
+                <div class="four-col last-col">
+                    <h3 class="instruction__title">Create an OpenStack account to access your Horizon dashboard</h3>
+                </div>
+            </div>
+            <div class="seven-col last-col instruction__details right">
+                <img src="{{ ASSET_SERVER_URL }}19a76480-while-you-wait.png" alt="" /><br/><br/><br/>
+            </div>
+        </div>
+        <div class="clearfix instruction">
+            <div class="five-col instruction__bullet">
+                <div class="one-col">
+                    <span class="instruction__step">12</span>
+                </div>
+                <div class="four-col last-col">
+                    <h3 class="instruction__title">Monitor your region and scale out</h3>
+                </div>
+            </div>
+            <div class="seven-col last-col instruction__details right">
+                <img src="{{ ASSET_SERVER_URL }}5a6d9f8a-install-ubuntu-cloud-step10.png" alt="" />
+            </div>
         </div>
     </div>
-    <div class="clearfix instruction">
-        <div class="five-col instruction__bullet">
-            <div class="one-col">
-                <span class="instruction__step">2</span>
-            </div>
-            <div class="four-col last-col">
-                <h3 class="instruction__title">Add required repositories</h3>
-            </div>
-        </div>
-        <div class="seven-col last-col instruction__details right">
-            <p>From the command line type the commands below and follow the step-by-step instructions:</p>
-            <p class="command-line">
-                <input class="command-line__input" value="sudo apt-get install python-software-properties" readonly="readonly">
-                <button class="js-copy-to-clipboard command-line__copy-button">Copy to clipboard</button>
-            </p>
-            <p class="command-line">
-                <input class="command-line__input" value="sudo add-apt-repository ppa:juju/stable" readonly="readonly">
-                <button class="js-copy-to-clipboard command-line__copy-button">Copy to clipboard</button>
-            </p>
-            <p class="command-line">
-                <input class="command-line__input" value="sudo add-apt-repository ppa:maas/stable" readonly="readonly">
-                <button class="js-copy-to-clipboard command-line__copy-button">Copy to clipboard</button>
-            </p>
-            <p class="command-line">
-                <input class="command-line__input" value="sudo add-apt-repository ppa:cloud-installer/stable" readonly="readonly">
-                <button class="js-copy-to-clipboard command-line__copy-button">Copy to clipboard</button>
-            </p>
-            <p class="command-line">
-                <input class="command-line__input" value="sudo apt-get update" readonly="readonly">
-                <button class="js-copy-to-clipboard command-line__copy-button">Copy to clipboard</button>
-            </p>
-        </div>
-    </div>
-    <div class="clearfix instruction">
-        <div class="five-col instruction__bullet">
-            <div class="one-col">
-                <span class="instruction__step">3</span>
-            </div>
-            <div class="four-col last-col">
-                <h3 class="instruction__title">Install MAAS</h3>
-            </div>
-        </div>
-        <div class="seven-col last-col instruction__details right">
-            <p>To install MAAS, type the command below and follow the step-by-step instructions:</p>
-            <p class="command-line">
-              <input class="command-line__input" value="sudo apt-get install maas" readonly="readonly">
-              <button class="js-copy-to-clipboard command-line__copy-button">Copy to clipboard</button>
-            </p>
-            <p>Create your admin credentials by typing:</p>
-            <p class="command-line">
-              <input class="command-line__input" value="sudo maas-region-admin createadmin" readonly="readonly">
-              <button class="js-copy-to-clipboard command-line__copy-button">Copy to clipboard</button>
-            </p>
-            <ul class="no-bullets">
-                <li>Login to the MAAS UI at http://&lt;maas.ip&gt;/MAAS/</li>
-                <li>Go to the &ldquo;Images&rdquo; tab and import disk images for &ldquo;14.04 LTS amd64&rdquo;</li>
-                <li>In your MAAS user&rsquo;s settings (top-right corner) add your personal public SSH key so you can later log into the nodes</li>
-                <li>Go to the &ldquo;Networks&rdquo; tab and for each of the networks auto-created, click &ldquo;Edit network&rdquo; to add the default gateway and DNS server details</li>
-            </ul>
-        </div>
-    </div>
-    <div class="clearfix instruction">
-        <div class="five-col instruction__bullet">
-            <div class="one-col">
-                <span class="instruction__step">4</span>
-            </div>
-            <div class="four-col last-col">
-                <h3 class="instruction__title">Configure the MAAS cluster</h3>
-            </div>
-        </div>
-        <div class="seven-col last-col instruction__details right">
-            <ul>
-                <li>Go to the &ldquo;Clusters&rdquo; tab, open the &ldquo;Cluster master&rdquo; link, hover over the row for the interface that is connected to the private network and select the edit icon (looks like a pencil &mdash; <img src="{{ ASSET_SERVER_URL }}e4e804d6-edit.svg" alt="" />)
-                    <ul>
-                        <li>Set this interface to manage DHCP and DNS</li>
-                        <li>Set the &ldquo;Router IP&rdquo; to the default gateway</li>
-                    </ul>
-                </li>
-                <li>Fill in details for the dynamic and static ranges, remembering to leave gaps for the floating IPs
-                    <ul>
-                        <li>Dynamic range &mdash; that has as many IPs as there are total NICs connected to the network (minimum 15)</li>
-                        <li>Static range &mdash; that has as many IPs as there are machines connected to the network</li>
-                        <li>Floating IP range &mdash; that has as many IPs as instances that you&rsquo;ll have in your cloud</li>
-                    </ul>
-                </li>
-            </ul>
-        </div>
-    </div>
-    <div class="clearfix instruction">
-        <div class="five-col instruction__bullet">
-            <div class="one-col">
-                <span class="instruction__step">5</span>
-            </div>
-            <div class="four-col last-col">
-                <h3 class="instruction__title">Register your hardware with MAAS</h3>
-            </div>
-        </div>
-        <div class="seven-col last-col instruction__details right">
-            <p>Now you need to enlist and commission machines:</p>
-            <ul>
-                <li>Ensure all machines are set to PXE boot, if possible disable all other boot options, including local disk, in the BIOS
-                <li>Power the machines on so they will all appear in the &ldquo;Nodes&rdquo; tab of MAAS</li>
-                <li>Edit each machine filling in the power type and parameters</li>
-                <li>Select all the machines and, using the &ldquo;Take action&rdquo; dropdown, &ldquo;Commission&rdquo; them.</li>
-                <li>Wait until all machines have a &ldquo;Ready&rdquo; status</li>
-            </ul>
-        </div>
-    </div>
-    <div class="clearfix instruction">
-        <div class="five-col instruction__bullet">
-            <div class="one-col">
-                <span class="instruction__step">6</span>
-            </div>
-            <div class="four-col last-col">
-                <h3 class="instruction__title">Launch OpenStack Autopilot</h3>
-            </div>
-        </div>
-        <div class="seven-col last-col instruction__details right">
-            <p>Setup Landscape and launch the OpenStack Autopilot with the following commands:</p>
-            <p class="command-line">
-              <input class="command-line__input" value="sudo apt-get install openstack" readonly="readonly">
-              <button class="js-copy-to-clipboard command-line__copy-button">Copy to clipboard</button>
-            </p>
-            <p class="command-line">
-              <input class="command-line__input" value="sudo openstack-install" readonly="readonly">
-              <button class="js-copy-to-clipboard command-line__copy-button">Copy to clipboard</button>
-            </p>
-            <ul>
-                <li>Choose the &ldquo;Landscape OpenStack Autopilot&rdquo; option</li>
-                <li>Create a new OpenStack Password</li>
-                <li>Fill in your:
-                    <ul>
-                        <li>Admin email address</li>
-                        <li>Admin name</li>
-                        <li>MAAS server IP</li>
-                        <li>MAAS user API key &mdash; found in your user&rsquo;s settings (top-right corner)</li>
-                    </ul>
-                </li>
-                <li>When everything is installed, you will be given a link</li>
-                <li>Open that link to access the Landscape UI</li>
-                <li>Login with your admin email and OpenStack password</li>
-            </ul>
-            <img src="{{ ASSET_SERVER_URL }}9d5bea4c-install-ubuntu-cloud-step4.png" alt="">
-        </div>
-    </div>
-    <div class="clearfix instruction">
-        <div class="five-col instruction__bullet">
-            <div class="one-col">
-                <span class="instruction__step">7</span>
-            </div>
-            <div class="four-col last-col">
-                <h3 class="instruction__title">Review your checklist</h3>
-            </div>
-        </div>
-        <div class="seven-col last-col instruction__details right">
-            <p>At the bottom of the setup page there is a checklist with the status of all of your resources. These should all be green, if it isn&rsquo;t follow the instructions to resolve </p>
-            <img src="{{ ASSET_SERVER_URL }}ef70520d-requirements.png" alt="" />
-        </div>
-    </div>
-    <div class="clearfix instruction">
-        <div class="five-col instruction__bullet">
-            <div class="one-col">
-                <span class="instruction__step">8</span>
-            </div>
-            <div class="four-col last-col">
-                <h3 class="instruction__title">Choose your OpenStack components</h3>
-            </div>
-        </div>
-        <div class="seven-col last-col instruction__details right">
-            <img src="{{ ASSET_SERVER_URL }}28f70917-Choose+configure.png" alt="" />
-        </div>
-    </div>
-    <div class="clearfix instruction">
-        <div class="five-col instruction__bullet">
-            <div class="one-col">
-                <span class="instruction__step">9</span>
-            </div>
-            <div class="four-col last-col">
-                <h3 class="instruction__title">Select the hardware on which to deploy the cloud</h3>
-            </div>
-        </div>
-        <div class="seven-col last-col instruction__details right">
-            <img src="{{ ASSET_SERVER_URL }}9c5da2f5-machine-picker.png" alt="" />
-        </div>
-    </div>
-    <div class="clearfix instruction">
-        <div class="five-col instruction__bullet">
-            <div class="one-col">
-                <span class="instruction__step">10</span>
-            </div>
-            <div class="four-col last-col">
-                <h3 class="instruction__title">Select &ldquo;Install&rdquo; to start building your cloud</h3>
-            </div>
-        </div>
-        <div class="seven-col last-col instruction__details right">
-            <img src="{{ ASSET_SERVER_URL }}77bc020b-Installing+region+1++++table+++Progress.png" alt="" />
-        </div>
-    </div>
-    <div class="clearfix instruction">
-        <div class="five-col instruction__bullet">
-            <div class="one-col">
-                <span class="instruction__step">11</span>
-            </div>
-            <div class="four-col last-col">
-                <h3 class="instruction__title">Create an OpenStack account to access your Horizon dashboard</h3>
-            </div>
-        </div>
-        <div class="seven-col last-col instruction__details right">
-            <img src="{{ ASSET_SERVER_URL }}19a76480-while-you-wait.png" alt="" /><br/><br/><br/>
-        </div>
-    </div>
-    <div class="clearfix instruction">
-        <div class="five-col instruction__bullet">
-            <div class="one-col">
-                <span class="instruction__step">12</span>
-            </div>
-            <div class="four-col last-col">
-                <h3 class="instruction__title">Monitor your region and scale out</h3>
-            </div>
-        </div>
-        <div class="seven-col last-col instruction__details right">
-            <img src="{{ ASSET_SERVER_URL }}5a6d9f8a-install-ubuntu-cloud-step10.png" alt="" />
-        </div>
-    </div>
-    </div>
+</div>
 
 <div class="row no-border">
     <div class="strip-inner-wrapper">


### PR DESCRIPTION
Fixes #442.

Put the install instructions
in a proper row, so there's more spacing and there's
a line below above the "Need more help?" row. I
think it just looks better all round.
## QA

Run site, visit `/download/cloud/install-openstack-with-autopilot` and see
that it looks good.
