### PR TITLE
Centralise hero image on /download/ubuntu-flavours

### DIFF
--- a/static/css/section/_download.scss
+++ b/static/css/section/_download.scss
@@ -1124,3 +1124,9 @@ $grid-border-style: 1px dotted #888;
         }
     }
 }
+
+.download.download-ubuntu-flavours .row.row-flavours-hero {
+  @media only screen and (min-width: $breakpoint-medium) {
+    padding-bottom: 0;
+  }
+}

--- a/templates/download/ubuntu-flavours.html
+++ b/templates/download/ubuntu-flavours.html
@@ -13,7 +13,7 @@ full Ubuntu archive for packages and updates.{% endblock %}
 {% endblock second_level_nav_items %}
 
 {% block content %}
-<div class="row row-flavours-hero row-image-centered equal-height">
+<div class="row row-flavours-hero row-image-centered equal-height no-border">
     <div class="strip-inner-wrapper">
         <div class="seven-col equal-height__item">
             <h1>Ubuntu flavours</h1>


### PR DESCRIPTION
When the full-width layout was implemented, the
`equal-height` markup on this row was removed, but that
led to the image looking squashed up against the text.

I'm putting the `equal-height` stuff back to give the
image some breathing-room.

Fixes #441.
## QA

Check `/download/ubuntu-flavours` in all viewport sizes and check the image
looks fine.
