### PR TITLE
Remove whitespace below "Ubuntu Desktop" box

### DIFF
--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -20,7 +20,7 @@
         </div><!-- / .seven-col -->
 
         <div class="twelve-col no-margin-bottom ">
-            <div class="box box-highlight clearfix">
+            <div class="box box-highlight clearfix no-padding-bottom">
                 <div class="two-col text-center">
                     <img src="{{ ASSET_SERVER_URL }}4cd0df1c-picto-download-orange.svg" alt="" width="113" height="113" />
                 </div>
@@ -28,7 +28,7 @@
                     <h2><a href="/download/desktop">Ubuntu Desktop&nbsp;&rsaquo;</a></h2>
                     <p>Download Ubuntu desktop and replace your current operating system whether it&rsquo;s Windows or Mac OS, or, run Ubuntu alongside it.</p>
                 </div>
-                <div class="twelve-col">
+                <div class="twelve-col no-margin-bottom">
                     <p class="ubuntu-upgrade">Do you want to upgrade? <a href="/download/desktop/upgrade">Follow our simple guide&nbsp;&rsaquo;</a></p>
                 </div>
             </div>


### PR DESCRIPTION
For #437, remove extra padding and margin from below
the top box on the `/download` page.
## QA

Visit `/download` and behold how there is now extra row of white below the
top "Ubuntu Desktop" box.
