### PR TITLE
Bump ubuntu-vanilla-theme to 0.0.28

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
   "author": "Canonical webteam",
   "license": "LGPL v3",
   "dependencies": {
-    "ubuntu-vanilla-theme": "0.0.27"
+    "ubuntu-vanilla-theme": "0.0.28"
   }
 }


### PR DESCRIPTION
Bump theme for /desktop/partners right block quote fix

This is for issue #385 
Upstream PR ubuntudesign/vanilla-framework#343
## QA

On the right hand quote block on /desktop/partners, make sure the end quote does not overlap the full stop.
