### PR TITLE
adding red to error classes on forms and fixed a desktop partners Ame…

### DIFF
--- a/static/css/section/_local.scss
+++ b/static/css/section/_local.scss
@@ -18,6 +18,12 @@ body {
         border-bottom: 0;
     }
 }
+/// XXX Peter - marketo required field marker
+.mktoLabel > span,
+.mktError {
+  color: #df382c;
+}
+
 // fixes main nav not closing issue
 @media only screen and (max-width: $navigation-threshold) {
     .banner .nav-primary #nav:hover {

--- a/templates/desktop/partners.html
+++ b/templates/desktop/partners.html
@@ -2,7 +2,7 @@
 
 {% block title %}For partners{% endblock %}
 {% block meta_keywords %}Ubuntu, Ubuntu operating system, OS, Linux, Windows alternative, Mac alternative, thin client, PC operating system, Open-Source, OEM, tenders, desktop, laptop{% endblock %}
-{% block meta_description %}Canonical partners offer Ubuntu certified pre-loaded hardware which integrates component drivers for optimal device performance. Service offerings by Canonical also available for partners include technical support, bespoke engineering, specialized training and consulting services.{% endblock %}
+{% block meta_description %}Canonical partners offer Ubuntu certified pre-loaded hardware which integrates component drivers for optimal device performance. Service offerings by Canonical also available for partners include technical support, bespoke engineering, specialised training and consulting services.{% endblock %}
 
 {% block second_level_nav_items %}
     {% include "templates/_nav_breadcrumb.html" with section_title="Desktop" page_title="For partners"  %}
@@ -12,7 +12,7 @@
 <div class="row row-hero">
     <h1>Ubuntu for partners</h1>
     <div class="seven-col">
-        <p class="intro">We partner with the world&rsquo;s leading hardware manufacturers and silicon vendors to help deliver an extensive range of Ubuntu certified desktops, notebooks and servers. Becoming a partner means you work with our engineering and certification teams to guarantee the compatibility and optimized performance of all your hardware for the life of the OS.</p>
+        <p>We partner with the world&rsquo;s leading hardware manufacturers and silicon vendors to help deliver an extensive range of Ubuntu certified desktops, notebooks and servers. Becoming a partner means you work with our engineering and certification teams to guarantee the compatibility and optimised performance of all your hardware for the life of the OS.</p>
         <p><a href="http://partners.ubuntu.com/programmes/hardware" class="external">Learn more about becoming a partner</a></p>
     </div>
     <div class="five-col last-col text-center">
@@ -109,7 +109,7 @@
     </div>
     <div class="six-col last-col">
         <h2>Considering buying new devices with Ubuntu?</h2>
-        <p>An increasing number of private and public entities are migrating to Ubuntu, as it offers a robust solution with equivalent performance to other, proprietary systems, but at a much lower cost. Canonical is ready to share best practices with organizations wishing to deploy Ubuntu.</p>
+        <p>An increasing number of private and public entities are migrating to Ubuntu, as it offers a robust solution with equivalent performance to other proprietary systems but at a much lower cost. Canonical is ready to share best practices with organisations wishing to deploy Ubuntu.</p>
         <p>We have extensive experience helping companies worldwide. We have registered global deployments of over two million computers. Canonical can help to meet this growing demand by supporting organisations who are inviting requests for tender.</p>
         <p><a href="http://www.ubuntu.com/desktop/tenders/contact-us" class="external">Contact us about your tender</a></p>
         <p><a href="https://insights.ubuntu.com/2015/04/17/tendering-with-ubuntu/" class="external">Learn more about tendering with Ubuntu</a></p>


### PR DESCRIPTION
## Done

[List of work items including drive-bys]
## QA
1. go to any form (e.g. /tablet/contact-us)
2. see that the *'s are red
3. return an empty form
4. see that the error messages are red
5. go to /desktop/partners 
6. see that the fixed paragraph intro to not class="intro" and some Americanisations are removed
## Issue / Card

Fixes #338
[card](https://trello.com/c/rTWFrylZ)
