### PR TITLE
Normalise 'Further reading' font-size

### DIFF
--- a/static/css/_scratch.scss
+++ b/static/css/_scratch.scss
@@ -27,10 +27,17 @@ body {
   }
 }
 // increasing .context-footer li (further reading bug)
-.context-footer li {
-  font-size: 1.230769231em;
-  label {
-    font-size: .812500317em;
+.context-footer {
+  p,
+  li {
+    font-size: .875em;
+  }
+  @media only screen and (min-width : $breakpoint-medium) {
+    p,
+    label,
+    li {
+      font-size: 1em;
+    }
   }
 }
 // additional helper class for shouty text

--- a/static/css/section/_local.scss
+++ b/static/css/section/_local.scss
@@ -447,7 +447,6 @@ body {
       box-shadow: none;
       height: 3px;
     }
-  }
 
   .feature-one {
     padding-left: 0;

--- a/templates/templates/_further_reading_links.html
+++ b/templates/templates/_further_reading_links.html
@@ -19,7 +19,7 @@
           $('#insights-footer-feed').append(html);
         }
       }, failure: function () {
-        var html = "<ul class='no-bullets smaller'><li>Read news, case studies, whitepapers and more on <a class='external' href='https://insights.ubuntu.com'>insights.ubuntu.com</a></li></ul>"; // default if feed fails
+        var html = "<ul class='no-bullets'><li>Read news, case studies, whitepapers and more on <a class='external' href='https://insights.ubuntu.com'>insights.ubuntu.com</a></li></ul>"; // default if feed fails
         if ($('#insights-footer-feed')) {
           $('#insights-footer-feed').append(html);
         }


### PR DESCRIPTION
## Done

makes the size of contextual footer <li>'s the same as other text

NOTE: _this should be fixed in either uvt or vanilla itself; however, I couldn't find it anywhere and fixed it more locally_
## QA
1. go to a page with a further reading block like /cloud/openstack
2. see that the further reading block's font is the same as the other ones
3. see that the label on the form field is also the same
## Issue / Card

Fixes #419 - Contextual footer third block (further reading) text size should not be smaller 
## Screenshots

![image](https://cloud.githubusercontent.com/assets/441217/14582112/05f64f7a-03f4-11e6-91de-dd2fc14ed219.png)
