### PR TITLE
update for Ubuntu Advantage service description

### DIFF
--- a/templates/legal/ubuntu-advantage/service-description.html
+++ b/templates/legal/ubuntu-advantage/service-description.html
@@ -534,46 +534,49 @@
         <h3>1. Service initiation</h3>
 
         <ol class="numbered">
-            <li><span class="number"><span class="number">1.1</span></span> Upon commencement of the services, Canonical will provide access for a single technical representative to Landscape, the support portal and the online knowledge base.</li>
+            <li><span class="number">1.1</span> Upon commencement of the services, Canonical will provide access for a single technical representative to Landscape, the support portal and the online knowledge base.</li>
             <li><span class="number">1.2</span> The customer -- through their initial technical representative -- may select their chosen technical representatives to interface with Canonical based on the number of systems under support as represented in the table below. These technical representatives will hold credentials to the support portal and will act as primary points of contact for support requests.</li>
         </ol>
 
-        <table class="twelve-col">
-            <caption>Table of machines under support</caption>
-            <thead>
-                <tr>
-                    <th>Number of machines under Ubuntu Advantage support</th>
-                    <th>Technical representatives</th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr>
-                    <td>1-20</td>
-                    <td>2</td>
-                </tr>
-                <tr>
-                    <td>21-50</td>
-                    <td>3</td>
-                </tr>
-                <tr>
-                    <td>51-250</td>
-                    <td>6</td>
-                </tr>
-                <tr>
-                    <td>251-1000</td>
-                    <td>9</td>
-                </tr>
-                <tr>
-                    <td>1001-5000</td>
-                    <td>12</td>
-                </tr>
-                <tr>
-                    <td>5001+</td>
-                    <td>15</td>
-                </tr>
-            </tbody>
-        </table>
+    </div>
 
+    <table class="eight-col">
+        <caption>Table of machines under support</caption>
+        <thead>
+            <tr>
+                <th>Number of machines under Ubuntu Advantage support</th>
+                <th>Technical representatives</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>1-20</td>
+                <td>2</td>
+            </tr>
+            <tr>
+                <td>21-50</td>
+                <td>3</td>
+            </tr>
+            <tr>
+                <td>51-250</td>
+                <td>6</td>
+            </tr>
+            <tr>
+                <td>251-1000</td>
+                <td>9</td>
+            </tr>
+            <tr>
+                <td>1001-5000</td>
+                <td>12</td>
+            </tr>
+            <tr>
+                <td>5001+</td>
+                <td>15</td>
+            </tr>
+        </tbody>
+    </table>
+
+    <div class="eight-col">
         <ol class="numbered">
             <li><span class="number">1.3</span> The customer may change their specified technical representatives at any time by submitting a support request via the support portal.</li>
         </ol>
@@ -597,22 +600,35 @@
             <li><span class="number">3.2</span> Response times will be as set forth in the Service Description for the applicable service offering.</li>
             <li><span class="number">3.3</span> When setting the severity level, Canonical&#39;s Support Team will use the definitions as stated below:</li>
         </ol>
+    </div>
 
-        <h4>Level 1 - Core functionality not available</h4>
+    <table class="twelve-col">
+        <tr>
+            <th><strong>Level 1</strong><br />
+                Core functionality not available</th>
+            <td>Canonical will use continuous effort according to the service level purchased, through appropriate support engineer(s) and/or development engineer(s), to provide a work-around or permanent solution. As soon as core functionality is available, the severity level will be lowered to the new appropriate severity level.</td>
+        </tr>
 
-        <p>Canonical will use continuous effort according to the service level purchased, through appropriate support engineer(s) and/or development engineer(s), to provide a work-around or permanent solution. As soon as core functionality is available, the severity level will be lowered to the new appropriate severity level.</p>
+        <tr>
+            <th><strong>Level 2</strong><br />
+                Core&nbsp;functionality&nbsp;severely&nbsp;degraded</th>
+            <td>Canonical will provide concerted  efforts during the applicable business hours to provide the customer with a work-around or permanent solution. As soon as core functionality is no longer severely degraded, the severity level will be lowered to level 3.</td>
+        </tr>
 
-        <h4>Level 2 - Core functionality severely degraded</h4>
+        <tr>
+            <th><strong>Level 3</strong><br />
+                Standard support request</th>
+            <td>Canonical will use reasonable efforts during the applicable business hours to provide the customer with a work-around or permanent solution as soon as possible, balanced against higher severity level cases. If a work-around is provided, Canonical&#39;s support engineers will continue to work on developing a permanent resolution to the case.</td>
+        </tr>
 
-        <p>Canonical will provide concerted  efforts during the applicable business hours to provide the customer with a work-around or permanent solution. As soon as core functionality is no longer severely degraded, the severity level will be lowered to level 3.</p>
+        <tr>
+            <th><strong>Level 4</strong><br />
+                Non-urgent request</th>
+            <td>Level 4 requests include cosmetic issues, informational requests, feature requests, and similar matters.  Canonical does not provide a timeline or guarantee for inclusion of any feature requests. Canonical will review each level 4 case and determine whether it is a product enhancement to be considered for a future release, an issue to be fixed in the current release or an issue to be fixed in a future release. Canonical will review and respond to information requests with a reasonable level of effort during coverage hours. Canonical may close cases representing level 4 issues after responding if Canonical believes it is appropriate to do so.</td>
+        </tr>
+    </table>
 
-        <h4>Level 3 - Standard support request</h4>
-
-        <p>Canonical will use reasonable efforts during the applicable business hours to provide the customer with a work-around or permanent solution as soon as possible, balanced against higher severity level cases. If a work-around is provided, Canonical&#39;s support engineers will continue to work on developing a permanent resolution to the case.</p>
-
-        <h4>Level 4 - Non-urgent request</h4>
-
-        <p>Level 4 requests include cosmetic issues, informational requests, feature requests, and similar matters.  Canonical does not provide a timeline or guarantee for inclusion of any feature requests. Canonical will review each level 4 case and determine whether it is a product enhancement to be considered for a future release, an issue to be fixed in the current release or an issue to be fixed in a future release. Canonical will review and respond to information requests with a reasonable level of effort during coverage hours. Canonical may close cases representing level 4 issues after responding if Canonical believes it is appropriate to do so.</p>
+    <div class="eight-col">
 
         <h3>4. Languages</h3>
 


### PR DESCRIPTION
## Done

Major update to the Ubuntu Advantage service description that is urgenly due Monday
## QA
1. go to /legal/ubuntu-advantage/service-description
2. compare the text to the copy docs
   - [1 - Ubuntu Advantage Service Description](https://docs.google.com/document/d/1JuxYXtJOdXwe7MbV1JlQmStUfRKakVR3Tjo6y0p5XqY/edit)
   - [2 - Ubuntu Advantage Support Scope Documentation](https://docs.google.com/document/d/1Z-L0noGit7HrKOMIy_Yi4_V7o42bgMnhsuK_10cIefw/edit#heading=h.61p4ccan0olz)
   - [3 - Ubuntu Advantage Support Process Documentation](https://docs.google.com/document/d/1QWadKPq0SuHOG-NfjZ1PZg4NlBLlGiyyHJfVf8z5o_4/edit#heading=h.c7fgw9dhbeey)
   - [4 - Ubuntu Advantage Management Escalation Docu...](https://docs.google.com/document/d/1DK2w_92ONDODQp4T3w5eJYf-nrZD8f-G0PazadcPtw8/edit#)
3. see that it looks ok in S/M/L screens
## Issue / Card

[trello](https://trello.com/c/XcMl0y3W)
