### PR TITLE
updated the info/release-end-of-life page and added new desktop image

### DIFF
--- a/templates/info/release-end-of-life.html
+++ b/templates/info/release-end-of-life.html
@@ -17,11 +17,11 @@
 </div><!-- / .row -->
 <div class="row no-border">
 	<div class="seven-col">
-		<h2>Eleven years and 23 releases &mdash; and all on time</h2>
-		<p>Standard Ubuntu releases are supported for 9 months and Ubuntu LTS (Long Term Support) releases are supported for five years on both the desktop and the server. During that time, there will be security fixes and other critical updates. The Ubuntu support lifecycle is as follows:</p>
+		<h2>Ubuntu Server and desktop release end of life</h2>
+		<p>Standard Ubuntu releases are supported for 9 months and Ubuntu LTS (long-term support) releases are supported for five years on both the desktop and the server. During that time, there will be security fixes and other critical updates. The Ubuntu support lifecycle is as follows:</p>
 	</div>
 	<div class="twelve-col">
-		<img src="{{ ASSET_SERVER_URL }}4a135f44-release_eof-ubuntu.jpg" alt="" class="not-for-small" />
+		<img class="releasecycle-image-load" src="{{ ASSET_SERVER_URL }}ac31b45e-release-chart-desktop-big.png?w=800" width="800" alt="Ubuntu Desktop release cycle, 5 year long term support" class="not-for-small" />
 		<table class="for-small">
 			<thead>
 				<tr><th>Release</th><th>Released</th><th>End of life</th></tr>


### PR DESCRIPTION
## Done

Updated the heading and a few words on the page and updated the image to use the one from the /desktop/enterprise and /server pages.
## QA
1. go to //info/release-end-of-life
2. see that it has the same updates as the [copy doc](https://docs.google.com/document/d/1-l3B7AoyDoETaL80UhlfEWCVKmMWPdy3zoF5LpsGcYQ/edit#)
## Issue / Card

[trello card](https://trello.com/c/OqTnIu8a)
