### PR TITLE
Add "Try LXD" to /cloud/lxd contextual footer

### DIFF
--- a/templates/cloud/lxd.html
+++ b/templates/cloud/lxd.html
@@ -106,5 +106,5 @@ sudo apt-get install lxd</code></pre>
     </a>
   </div><!-- /.four-col -->
 </div>
-{% include "cloud/shared/_contextual_footer.html" %}
+{% include "cloud/shared/_contextual_footer.html" with feature_2="try-lxd" %}
 {% endblock content %}

--- a/templates/cloud/shared/_contextual_footer.html
+++ b/templates/cloud/shared/_contextual_footer.html
@@ -59,6 +59,14 @@
     </div>
     {% endif %}
 
+    {% if feature_2 == "try-lxd" %}
+    <div class="equal-height--vertical-divider__item four-col picto">
+      <h3>Try LXD for real, now</h3>
+      <p>Get 30 minutes free access to a system with live LXD containers.</p>
+      <p><a href="https://linuxcontainers.org/lxd/try-it/" class="external">Try LXD</a></p>
+    </div>
+    {% endif %}
+
     {% if feature_3 == none %}
     <div class="equal-height--vertical-divider__item four-col last-col">
       <h3>Further reading</h3>


### PR DESCRIPTION
## Done

Add "Try LXD" to /cloud/lxd contextual footer, reading:
"Get 30 minutes free access to a system with live LXD containers."

https://docs.google.com/document/d/1VT5-v6dpMeFBadq_uoQj-m27BEWKMbwAvPz6uucpSE0/edit#
## QA

Ensure the Try LXD section is in the contextual footer and looks OK
