### PR TITLE
Update wording /cloud/lxd's "Try LXD" contextual footer section

### DIFF
--- a/templates/cloud/shared/_contextual_footer.html
+++ b/templates/cloud/shared/_contextual_footer.html
@@ -63,7 +63,7 @@
     {% if feature_2 == "try-lxd" %}
     <div class="equal-height--vertical-divider__item four-col picto">
       <h3>Try LXD for real, now</h3>
-      <p>30 mins access to a system with live LXD containers</p>
+      <p>Get 30 minutes free access to a system with live LXD containers.</p>
       <p><a href="https://linuxcontainers.org/lxd/try-it/" class="external">Try LXD</a></p>
     </div>
     {% endif %}


### PR DESCRIPTION
Update wording on contextual footer to match copydoc:

https://docs.google.com/document/d/1VT5-v6dpMeFBadq_uoQj-m27BEWKMbwAvPz6uucpSE0
## QA

Ensure the Try LXD section text matches doc
