### PR TITLE
adding applied micro 15.10 back per Kiko

### DIFF
--- a/templates/download/server/arm.html
+++ b/templates/download/server/arm.html
@@ -30,6 +30,7 @@
                     <h4>Applied Micro X-Gene ARMv8</h4>
                     <ul class="no-bullets">
                         <li><a href="http://ports.ubuntu.com/ubuntu-ports/dists/trusty/main/installer-arm64/current/images/generic/netboot/xgene/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Applied Micro X-Gene ARMv8 14.04 download', 'eventLabel' : 'From Download ARM', 'eventValue' : undefined });" class="external">14.04 LTS</a></li>
+                        <li><a href="http://ports.ubuntu.com/ubuntu-ports/dists/wily/main/installer-arm64/current/images/netboot/ubuntu-installer/arm64/xgene-uboot/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Applied Micro X-Gene ARMv8 15.10 download', 'eventLabel' : 'From Download ARM', 'eventValue' : undefined });" class="external">15.10</a></li>
                     </ul>
                     <p><a class="external" href="https://wiki.ubuntu.com/ARM/Server/Install/Mustang">Installation instructions for the Mustang platform</a></p>
                 </div>


### PR DESCRIPTION
## Done

added a link to 15.10 for Applied Micro per a comment left by Kiko
## QA
1. go to /download/server/arm
2. see that Applied Micro X-Gene ARMv8 has 15.10 (again)
## Issue / Card

[trello](https://trello.com/c/qzvcT4vF)
