### PR TITLE
putting OS Autopilot in left contextual footer of /download/server/in…

### DIFF
--- a/templates/download/server/install-ubuntu-server.html
+++ b/templates/download/server/install-ubuntu-server.html
@@ -72,6 +72,6 @@
     </div><!-- /.strip-inner-wrapper -->
 </div><!-- /.row -->
 
-{% include "download/shared/_contextual_footer.html"  with first_item="_download_documentation" second_item="_download_server_guide" third_item="_download_helping_hands" %}
+{% include "download/shared/_contextual_footer.html"  with first_item="_download_openstack_autopilot" second_item="_download_server_guide" third_item="_download_helping_hands" %}
 
 {% endblock content %}


### PR DESCRIPTION
## Done

Updated the footer on the /download/server/install-ubuntu-server page
## QA
1. go to /download/server/install-ubuntu-server
2. compare the left footer to copy doc
## Issue / Card

[trello card](https://trello.com/c/j2qgevvl)
