### PR TITLE
Update copy for /download/alternative-downloads

### DIFF
--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -44,7 +44,7 @@
         <p>BitTorrent is a peer-to-peer download network that sometimes enables higher download speeds and more reliable downloads of large files. You will need to install a BitTorrent client on your computer in order to enable this download method.</p>
     </div>
      <div class="four-col">
-        <h3 class="external--title"><span>Ubuntu {{latest_release}}</span></h3>
+        <h3 class="external--title"><span>Ubuntu {{latest_release}} LTS</span></h3>
         <ul class="no-bullets list">
             <li><a class="download-torrent" href="http://releases.ubuntu.com/{{latest_release}}/ubuntu-{{latest_release}}-desktop-amd64.iso.torrent">Ubuntu {{latest_release}} Desktop (64-bit)&nbsp;&rsaquo;</a></li>
             <li><a class="download-torrent" href="http://releases.ubuntu.com/{{latest_release}}/ubuntu-{{latest_release}}-desktop-i386.iso.torrent">Ubuntu {{latest_release}} Desktop (32-bit)&nbsp;&rsaquo;</a></li>
@@ -55,10 +55,10 @@
     <div class="four-col">
         <h3 class="external--title"><span>Ubuntu 14.04.4 LTS</span></h3>
         <ul class="no-bullets list">
-            <li><a class="download-lts" href="http://releases.ubuntu.com/14.04/ubuntu-14.04.4-desktop-amd64.iso.torrent">Ubuntu 14.04.4 LTS Desktop (64-bit)&nbsp;&rsaquo;</a></li>
-            <li><a class="download-lts" href="http://releases.ubuntu.com/14.04/ubuntu-14.04.4-desktop-i386.iso.torrent">Ubuntu 14.04.4 LTS Desktop (32-bit)&nbsp;&rsaquo;</a></li>
-            <li><a class="download-lts" href="http://releases.ubuntu.com/14.04/ubuntu-14.04.4-server-amd64.iso.torrent">Ubuntu 14.04.4 LTS Server (64-bit)&nbsp;&rsaquo;</a></li>
-            <li><a class="download-lts" href="http://releases.ubuntu.com/14.04/ubuntu-14.04.4-server-i386.iso.torrent">Ubuntu 14.04.4 LTS Server (32-bit)&nbsp;&rsaquo;</a></li>
+            <li><a class="download-lts" href="http://releases.ubuntu.com/14.04/ubuntu-14.04.4-desktop-amd64.iso.torrent">Ubuntu 14.04.4 Desktop (64-bit)&nbsp;&rsaquo;</a></li>
+            <li><a class="download-lts" href="http://releases.ubuntu.com/14.04/ubuntu-14.04.4-desktop-i386.iso.torrent">Ubuntu 14.04.4 Desktop (32-bit)&nbsp;&rsaquo;</a></li>
+            <li><a class="download-lts" href="http://releases.ubuntu.com/14.04/ubuntu-14.04.4-server-amd64.iso.torrent">Ubuntu 14.04.4 Server (64-bit)&nbsp;&rsaquo;</a></li>
+            <li><a class="download-lts" href="http://releases.ubuntu.com/14.04/ubuntu-14.04.4-server-i386.iso.torrent">Ubuntu 14.04.4 Server (32-bit)&nbsp;&rsaquo;</a></li>
         </ul>
     </div><!-- /.four-col -->
     <div class="four-col last-col">


### PR DESCRIPTION
## Done

Updated copy on /download/alternative-downloads to remove variable referencing {{ lts_release }} and use '14.04' instead.
## QA

Browser to /download/alternative-downloads and cross-ref with copy doc
## Issue / Card

Trello: https://trello.com/c/knmRpkjp

Copy: https://docs.google.com/document/d/1VhmFVE3dK81mE3zcC9FVA6f5SGJ-DHan7WWlrlfRcvo/edit#
