### PR TITLE
Update styling for `list-stepped`

### DIFF
--- a/static/css/section/_local.scss
+++ b/static/css/section/_local.scss
@@ -1586,10 +1586,8 @@ button.button--primary__deactivated:hover {
 .list-stepped__item {
   counter-increment: instructions;
   min-height: 50px;
-  padding-top: 60px;
-  padding-bottom: 60px;
-  padding-left: 40px;
-  padding-right: 40px;
+  padding-top: 20px;
+  padding-bottom: 20px;
 
   &:before {
     display: block;


### PR DESCRIPTION
After discussion with Lil, we agreed to radically reduce the padding
between list items, and remove the left and right padding on list items.
## QA

`make run`

Visit some of the `list-stepped` pages and check the styling looks okay:
- http://localhost:8001/download/desktop/create-a-usb-stick-on-ubuntu
- http://localhost:8001/download/desktop/create-a-usb-stick-on-mac-osx
- http://localhost:8001/download/desktop/create-a-usb-stick-on-windows
