### PR TITLE
various padding, margin and typos caught by Yaili

### DIFF
--- a/static/css/section/_download.scss
+++ b/static/css/section/_download.scss
@@ -209,31 +209,35 @@ html.opera-mini {
   min-height: 9.5em;
 }
 
-.download .inner-wrapper form fieldset {
-    background: none;
-    margin: 0;
-    padding-left: $gutter-width;
-    padding-top: 2px;
-    padding-bottom: 0;
-    padding-right: 0;
-}
-
-.download .inner-wrapper form select {
-    font-weight: 300;
-    margin-bottom: 30px;
-    width: 100%;
-}
-
-.download .strip-inner-wrapper form button,
-.download .strip-inner-wrapper form .link-cta-download,
-.download .strip-inner-wrapper .link-cta-download {
-    font-size: 1.21875em;
-    padding: 10px 14px;
-    border: 0;
-    float: left;
-    text-align: center;
-    width: 100%;
-    margin-bottom: 1em;
+.download {
+  .inner-wrapper {
+    form fieldset {
+      background: none;
+      margin: 0;
+      padding-left: $gutter-width;
+      padding-top: 2px;
+      padding-bottom: 0;
+      padding-right: 0;
+    }
+    form select {
+      font-weight: 300;
+      margin-bottom: 30px;
+      width: 100%;
+    }
+  }
+  .strip-inner-wrapper {
+    form button,
+    form .link-cta-download,
+    .link-cta-download {
+      font-size: 1.21875em;
+      padding: 10px 14px;
+      border: 0;
+      float: left;
+      text-align: center;
+      width: 100%;
+      margin-bottom: 1em;
+    }
+  }
 }
 
 .download #main-content .row-background a:link.link-cta-download {
@@ -1148,9 +1152,6 @@ span.step {
   font-size: 1.375em;
   height: 2em;
   line-height: 1.75;
-}
-.download .row {
-  padding: 2.5em 0 0 0;
 }
 
 // XXX - add provision for stepped list without headings in VF

--- a/static/css/section/_local.scss
+++ b/static/css/section/_local.scss
@@ -366,6 +366,8 @@ body {
     .inner-wrapper {
         max-width: 100%;
         margin-top: 0;
+        margin-bottom: 0;
+        padding-bottom: 0;
     }
     .row {
         padding-left: 0;
@@ -430,10 +432,11 @@ body {
         hr {
             box-shadow: none;
             height: 3px;
+            margin: 0;
         }
 
         .strip-inner-wrapper {
-            padding: 1em 1em 0;
+            padding: 2em 1em 1em 1em;
         }
     }
     .row--dark {
@@ -479,7 +482,7 @@ body {
     }
   }
 }
-.download,
+
 .tablet,
 .phone {
   .row {
@@ -1551,6 +1554,9 @@ button.button--primary__deactivated:hover {
     }
     .nav-secondary .breadcrumb li a {
         padding: 8px 10px 0;
+    }
+    .nav-secondary .breadcrumb li a.breadcrumb-link {
+      padding: 8px 10px 0 0;
     }
 }
 /// XXX Karl (10.04.2016)

--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -29,7 +29,7 @@
 
                     <p>Recommended system requirements:</p>
 
-                    <ul>
+                    <ul class="list-ticks--compact">
                         <li>2 GHz dual core processor or better</li>
                         <li>2 GB system memory</li>
                         <li>25 GB of free hard drive space</li>
@@ -40,7 +40,7 @@
                 </div>
                 <div class="equal-height--vertical-divider__item four-col last-col no-margin-bottom download-button">
                     <p>
-                        <a class="button--primary" href="/download/desktop/contribute/?version=16.04&architecture=amd64">Download</a>
+                        <a class="link-cta-download button--primary" href="/download/desktop/contribute/?version=16.04&amp;architecture=amd64">Download</a>
                     </p>
                     <ul class="no-bullets">
                         <li><a href="/download/alternative-downloads">Alternative downloads and torrents&nbsp;&rsaquo;</a></li>

--- a/templates/download/desktop/upgrade.html
+++ b/templates/download/desktop/upgrade.html
@@ -21,7 +21,7 @@
             </div>
             <div class="nine-col last-col no-margin-bottom">
                 <p>If you are upgrading from a version released prior to Ubuntu 15.10, <a class="external" href="https://help.ubuntu.com/community/UpgradeNotes">please read the upgrade notes for more information</a>.</p>
-                <p>For more recent versions, please read the release notes for Ubuntu <a class="external" href="https://wiki.ubuntu.com/{{ lts_release_name }}/ReleaseNotes">{{ lts_release }} LTS</a> and for <a class="external" href="https://wiki.ubuntu.com/{{ latest_release_name }}/ReleaseNotes">Ubuntu {{ latest_release }}</a>.</p>
+                <p>For more recent versions, please read the release notes for <a class="external" href="https://wiki.ubuntu.com/{{ latest_release_name }}/ReleaseNotes">Ubuntu {{ latest_release }}</a>.</p>
             </div><!-- /.nine-col -->
         </div><!-- /.box -->
         <div class="twelve-col box no-border no-margin-bottom download-help">

--- a/templates/download/server/index.html
+++ b/templates/download/server/index.html
@@ -20,7 +20,7 @@
             <div class="box box-highlight clearfix vertical-divider">
                 <div class="eight-col equal-height--vertical-divider__item no-margin-bottom">
                     <h2>Ubuntu Server {{lts_release}} LTS</h2>
-                    <p>The Long Term Support version of Ubuntu Server, including the Icehouse release of OpenStack and support guaranteed until April 2019 &mdash; 64-bit only.</p>
+                    <p>The long-term support version of Ubuntu Server, including the Icehouse release of OpenStack and support guaranteed until April 2019 &mdash; 64-bit only.</p>
                     <p><strong>Recommended for most users.</strong></p>
                     <p><a href="https://wiki.ubuntu.com/{{lts_release_name}}/ReleaseNotes" class="external">Ubuntu Server {{lts_release}} LTS release notes</a></p>
                 </div>


### PR DESCRIPTION
## Done
- got rid of padding around the contextual footers
- got rid of space on top of the download section
- fixed some typos on /download/desktop, /download/server, /download/desktop/upgrade
## QA
1. look at the secondary nav in /download and see that it aligns left
2. look a the contextual footer and see that is, tighter, more vertically ballanced and there is no grey before the footer
3. on /download/desktop see that the download button is will width
