### PR TITLE
update the meta refresh and direct link on the linux one thank you page

### DIFF
--- a/templates/download/server/thank-you-linuxone.html
+++ b/templates/download/server/thank-you-linuxone.html
@@ -12,7 +12,7 @@ Thanks for downloading Ubuntu for LinuxONE and z Systems
 {% endblock second_level_nav_items %}
 
 {% block head_extra %}
-  <!--meta http-equiv="refresh" content="3;url=http://cdimage.ubuntu.com/releases/16.04/release/ubuntu-16.04-server-s390x.iso" -->
+  <meta http-equiv="refresh" content="3;url=http://cdimage.ubuntu.com/releases/16.04/release/ubuntu-16.04-server-s390x.iso">
 {% endblock %}
 
 {% block content %}
@@ -21,7 +21,7 @@ Thanks for downloading Ubuntu for LinuxONE and z Systems
     <div class="strip-inner-wrapper">
         <h1>Thanks for downloading Ubuntu for LinuxONE and z&nbsp;Systems</h1>
         <p>Your ISO download should start automatically.</p>
-        <p>If it doesn&rsquo;t, or for alternative options <a href="http://cdimage.ubuntu.com/releases/xenial/beta-2/">visit the download page</a>.</p>
+        <p>If it doesn&rsquo;t, or for alternative options <a href="http://cdimage.ubuntu.com/releases/16.04/release/">visit the download page</a>.</p>
     </div>
 </div>
 <div class="row row-grey no-border">


### PR DESCRIPTION
## Done

update the meta refresh and direct link on the linux one thank you page
## QA
- go to /download/server/thank-you-linuxone
- it won't work yet, but will try to update
## Issue / Card

https://trello.com/c/yTW59V06
