### PR TITLE
Ua service desc bug 1572086

### DIFF
--- a/templates/legal/ubuntu-advantage/service-description.html
+++ b/templates/legal/ubuntu-advantage/service-description.html
@@ -42,7 +42,7 @@
 
         <h2 id="ua-support-scope">2. Support scope</h2>
 
-        <p>Each service offering includes access to Canonical&#39;s knowledge base and the support scope. The expectations are detailed in the <a href="#appendix-1">support scope documentation</a>.</p>
+        <p>Each service offering includes access to Canonical's knowledge base and the support described below within the scope and subject to the exceptions detailed in the <a href="#appendix-1">support scope documentation</a>.</p>
 
         <ol class="numbered">
             <li><span class="number">2.1</span> Releases
@@ -57,7 +57,7 @@
             </li>
             <li><span class="number">2.3</span> Packages
                 <ol class="numbered">
-                    <li><span class="number">2.3.1</span> The services apply only to packages found in the Ubuntu Main Rrepository and Canonical-owned packages in the Universe Repository except (i) the "proposed" and "backports" repository pockets, and (ii) the exclusions noted in the applicable support scope documentation.</li>
+                    <li><span class="number">2.3.1</span> The services apply only to packages found in the Ubuntu Main Repository and Canonical-owned packages in the Universe Repository except (i) the "proposed" and "backports" repository pockets, and (ii) the exclusions noted in the applicable support scope documentation.</li>
                     <li><span class="number">2.3.2</span> Canonical will not provide support for any packages that have been modified from the version in the Ubuntu archives.</li>
                 </ol>
             </li>
@@ -79,8 +79,8 @@
                     <li><span class="number">2.6.1</span> This section applies to services purchased for the support of OpenStack.</li>
                     <li><span class="number">2.6.2</span> The minimum number of supported nodes for an OpenStack deployment is 5.</li>
                     <li><span class="number">2.6.3</span> For installations not deployed using Canonical&#39;s reference architecture, support is limited to bugs in the Ubuntu OpenStack packages themselves. Support is also not included for deployment, configuration, or optimization issues in OpenStack installations.</li>
-                    <li><span class="number">2.6.5</span> Support for up to a total of 3 TB of usable storage per deployed node. This allowance can be used for  of Ubuntu Advantage Ceph, or Ubuntu Advantage Swift or a combination of these.</li>
-                    <li><span class="number">2.6.6</span> Supported versions of OpenStack:
+                    <li><span class="number">2.6.4</span> Support for up to a total of 3 TB of usable storage per deployed node. This allowance can be used for  of Ubuntu Advantage Ceph, or Ubuntu Advantage Swift or a combination of these.</li>
+                    <li><span class="number">2.6.5</span> Supported versions of OpenStack:
                         <ul>
                             <li>The version of OpenStack provided initially in the release of a Long Term Support (LTS) version of Ubuntu is supported for the entire lifecycle of that Ubuntu version.</li>
                             <li>Releases of OpenStack released after an LTS version of Ubuntu are available in the Ubuntu Cloud Archive and are supported for a minimum of 18 months from the release date of the Ubuntu version that included the applicable OpenStack release.</li>


### PR DESCRIPTION
## Done

fixed /legal/ubuntu-advantage/service-description based on a bug
## QA
1. go to /legal/ubuntu-advantage/service-description

see that the following was completed

> 2
> Please change the wording for section "2. Support scope" back to the original wording:
> Each service offering includes access to Canonical’s knowledge base and the support described below within the scope and subject to the exceptions detailed in the support scope documentation: [URL].
> 
> 2.3.1
> Repository is misspelled as Rrepository
> 
> 2.6
> The update skips the number 2.6.4. Please change 2.6.5 to 2.6.4 and 2.6.6 to 2.6.5
## Issue / Card

https://bugs.launchpad.net/ubuntu-website-content/+bug/1572086
