### PR TITLE
removing all but the width 100% on download buttons and making /downl…

### DIFF
--- a/static/css/section/_download.scss
+++ b/static/css/section/_download.scss
@@ -229,11 +229,6 @@ html.opera-mini {
     form button,
     form .link-cta-download,
     .link-cta-download {
-      font-size: 1.21875em;
-      padding: 10px 14px;
-      border: 0;
-      float: left;
-      text-align: center;
       width: 100%;
       margin-bottom: 1em;
     }
@@ -1056,12 +1051,6 @@ html.opera-mini {
     .download {
         .gap-from-top {
             margin-top: 53px;
-        }
-    }
-    .download-cloud,
-    .download-server {
-        .gap-from-top {
-            margin-top: 88px;
         }
     }
 }

--- a/templates/download/cloud/index.html
+++ b/templates/download/cloud/index.html
@@ -439,7 +439,7 @@
                 <input type="hidden" name="formVid" class="mktoField" value="1325" />
                 <input type="hidden" name="returnURL" value="http://www.ubuntu.com/download/cloud/thank-you" />
                 <input type="hidden" name="retURL" value="http://www.ubuntu.com/download/cloud/thank-you" />
-                <button type="submit" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Autopilot test drive', 'eventLabel' : 'from download cloud', 'eventValue' : undefined });">Download</button>
+                <button class="button--primary" type="submit" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Autopilot test drive', 'eventLabel' : 'from download cloud', 'eventValue' : undefined });">Download</button>
               </li>
               <li class="smaller">All information provided will be handled in accordance with the Canonical <a href="http://www.ubuntu.com/legal" target="_blank">privacy policy</a>.</li>
             </ul>

--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -5,9 +5,9 @@
 {% block extra_body_class %}download-desktop-home{% endblock %}
 
 {% block second_level_nav_items %}
-    <div class="strip-inner-wrapper">
-        {% include "templates/_nav_breadcrumb.html" with section_title="Download" page_title="Desktop"  %}
-    </div>
+<div class="strip-inner-wrapper">
+    {% include "templates/_nav_breadcrumb.html" with section_title="Download" page_title="Desktop"  %}
+</div>
 {% endblock second_level_nav_items %}
 
 {% block content %}
@@ -15,7 +15,6 @@
     <div class="strip-inner-wrapper">
         <div class="eight-col append-four">
             <h1>Download Ubuntu Desktop</h1>
-            <h2>{{lts_new_release}}</h2>
         </div><!-- /.eight-col -->
     </div>
 
@@ -38,9 +37,9 @@
                     </ul>
 
                 </div>
-                <div class="equal-height--vertical-divider__item four-col last-col no-margin-bottom download-button">
+                <div class="equal-height--vertical-divider__item four-col last-col no-margin-bottom gap-from-top">
                     <p>
-                        <a class="link-cta-download button--primary" href="/download/desktop/contribute/?version=16.04&amp;architecture=amd64">Download</a>
+                        <a class="button--primary link-cta-download" href="/download/desktop/contribute/?version=16.04&amp;architecture=amd64">Download</a>
                     </p>
                     <ul class="no-bullets">
                         <li><a href="/download/alternative-downloads">Alternative downloads and torrents&nbsp;&rsaquo;</a></li>
@@ -48,9 +47,9 @@
                     </ul>
                 </div><!-- /.four-col -->
             </div><!-- /.box -->
-        </div>
-    </div>
-</div>
+        </div><!-- /.twelve-col -->
+    </div><!-- /.strip-inner-wrapper -->
+</div><!-- /.row -->
 
 <div class="row row-easy-ways">
     <div class="strip-inner-wrapper">

--- a/templates/download/server/index.html
+++ b/templates/download/server/index.html
@@ -15,30 +15,23 @@
     <div class="strip-inner-wrapper">
         <div class="eight-col append-four">
             <h1>Download Ubuntu Server</h1>
+            <h2>{{lts_new_release}}</h2>
         </div>
-        <div class="twelve-col no-margin-bottom">
-            <div class="box box-highlight clearfix vertical-divider">
-                <div class="eight-col equal-height--vertical-divider__item no-margin-bottom">
+        <div class="strip-inner-wrapper">
+            <div class="twelve-col no-margin-bottom">
+                <div class="box box-highlight clearfix equal-height--vertical-divider">
+                    <div class="equal-height--vertical-divider__item eight-col no-margin-bottom">
                     <h2>Ubuntu Server {{lts_release}} LTS</h2>
                     <p>The long-term support version of Ubuntu Server, including the Icehouse release of OpenStack and support guaranteed until April 2019 &mdash; 64-bit only.</p>
                     <p><strong>Recommended for most users.</strong></p>
                     <p><a href="https://wiki.ubuntu.com/{{lts_release_name}}/ReleaseNotes" class="external">Ubuntu Server {{lts_release}} LTS release notes</a></p>
                 </div>
-                <div class="four-col last-col">
-                    <form class="form-download gap-from-top" action="/download/server/thank-you/" method="get">
-                        <fieldset>
-                            <input name="version" value="{{lts_release}}" type="hidden">
-                            <input name="architecture" value="amd64" type="hidden">
-                        </fieldset>
-                        <div>
-                            <button type="submit">Download</button>
-                        </div>
-                    </form>
+                <div class="equal-height--vertical-divider__item four-col last-col no-margin-bottom gap-from-top">
+                    <p><a href="/download/server/thank-you?version={{lts_release}}&amp;architecture=amd64" class="link-cta-download button--primary">Download</a></p>
                     <p><a href="/download/alternative-downloads">Alternative downloads and torrents&nbsp;&rsaquo;</a></p>
                 </div><!-- /.four-col -->
             </div><!-- /.box -->
         </div>
-
     </div>
 </div><!-- /.row -->
 

--- a/templates/download/server/linuxone.html
+++ b/templates/download/server/linuxone.html
@@ -318,13 +318,13 @@
                       </optgroup>
                     </select>
                   </li>
-                  <li  class="mktField">
+                  <li class="mktField">
                     <input class="mktoField" value="yes" id="NewsletterOpt-In" name="NewsletterOpt-In" type="checkbox">
                     <label  class="mktoLabel mktoHasWidth" for="NewsletterOpt-In">I would like to receive occasional news from Canonical by email.</label>
                   </li>
                   <li>All information provided will be handled in accordance with the Canonical <a href="http://www.ubuntu.com/legal" target="_blank">privacy policy</a>.</li>
                   <li  class="mktField">
-                    <button type="submit" class="mktoButton" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'IBM LinuxONE', 'eventLabel' : '16.04 LTS', 'eventValue' : undefined });" >Download ISO</button></span><input type="hidden" name="formid" class="mktoField " value="1400"><input type="hidden" name="lpId" class="mktoField " value="2469"><input type="hidden" name="subId" class="mktoField " value="30"><input type="hidden" name="munchkinId" class="mktoField " value="066-EOV-335"><input type="hidden" name="lpurl" class="mktoField " value="//pages.ubuntu.com/download-LinuxONE.html?cr={creative}&amp;kw={keyword}"><input type="hidden" name="cr" class="mktoField " value=""><input type="hidden" name="kw" class="mktoField " value=""><input type="hidden" name="q" class="mktoField " value="">
+                    <button type="submit" class="mktoButton link-cta-download button--primary" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'IBM LinuxONE', 'eventLabel' : '16.04 LTS', 'eventValue' : undefined });" >Download ISO</button></span><input type="hidden" name="formid" class="mktoField " value="1400"><input type="hidden" name="lpId" class="mktoField " value="2469"><input type="hidden" name="subId" class="mktoField " value="30"><input type="hidden" name="munchkinId" class="mktoField " value="066-EOV-335"><input type="hidden" name="lpurl" class="mktoField " value="//pages.ubuntu.com/download-LinuxONE.html?cr={creative}&amp;kw={keyword}"><input type="hidden" name="cr" class="mktoField " value=""><input type="hidden" name="kw" class="mktoField " value=""><input type="hidden" name="q" class="mktoField " value="">
                   </li>
                 </ul>
               </fieldset>

--- a/templates/download/ubuntu-kylin.html
+++ b/templates/download/ubuntu-kylin.html
@@ -25,14 +25,14 @@
                 <form class="form-download gap-from-top lts" action="http://cdimage.ubuntu.com/ubuntukylin/releases/{{lts_release}}/release/ubuntukylin-{{lts_release}}-desktop-amd64.iso" method="get">
                     <fieldset>
                         <div>
-                            <button type="submit" class="button--primary cta-large" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : '{{lts_release}} 64 bit', 'eventLabel' : 'From English-language Chinese download', 'eventValue' : undefined });">Download 64-bit</button>
+                            <button type="submit" class="link-cta-download button--primary" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : '{{lts_release}} 64 bit', 'eventLabel' : 'From English-language Chinese download', 'eventValue' : undefined });">Download 64-bit</button>
                         </div>
                     </fieldset>
                 </form>
                 <form class="form-download lts" action="http://cdimage.ubuntu.com/ubuntukylin/releases/{{lts_release}}/release/ubuntukylin-{{lts_release}}-desktop-i386.iso" method="get">
                     <fieldset>
                         <div>
-                            <button type="submit" class="button--primary cta-large" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : '{{lts_release}} 32 bit', 'eventLabel' : 'From English-language Chinese download', 'eventValue' : undefined });">Download 32-bit</button>
+                            <button type="submit" class="link-cta-download button--primary" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : '{{lts_release}} 32 bit', 'eventLabel' : 'From English-language Chinese download', 'eventValue' : undefined });">Download 32-bit</button>
                         </div>
                     </fieldset>
                 </form>


### PR DESCRIPTION
## Done

resetting download buttons to be more like default
## QA
1. go to /download/desktop, /download/server, /download/ubuntu-kylin, /download/cloud
2. see that the buttons are more vanilla like, but still have width: 100%
## Issue / Card

Fixes: https://github.com/ubuntudesign/ubuntu-vanilla-theme/issues/125
