### PR TITLE
Update cloud/upgrade to use `list-stepped`

### DIFF
--- a/templates/download/desktop/upgrade.html
+++ b/templates/download/desktop/upgrade.html
@@ -25,38 +25,29 @@
             </div><!-- /.nine-col -->
         </div><!-- /.box -->
         <div class="twelve-col box no-border no-margin-bottom download-help">
-            <div class="eight-col">
-                <div class="one-col download-help__step">
-                    <span class="step">1</span>
-                </div>
-                <div class="seven-col last-col">
-                    <h2>Launch the Software Updater</h2>
+            <ol class="eight-col list-stepped">
+                <li class="list-stepped__item">
+                    <h2 class="list-stepped__title">Launch the Software Updater</h2>
                     <p>Press the <strong>Superkey (Windows key)</strong> to launch the Dash and search for <strong>Update Manager</strong></p>
                     <div class="help-image">
                         <a href="{{ ASSET_SERVER_URL }}de3da8d8-download-desktop-upgrade-1.jpg" title="Click to enlarge image"><img src="{{ ASSET_SERVER_URL }}de3da8d8-download-desktop-upgrade-1.jpg" alt="" /></a>
                     </div>
-                </div>
-                <div class="one-col download-help__step">
-                    <span class="step">2</span>
-                </div>
-                <div class="seven-col last-col">
-                    <h2>Check for updates</h2>
+                </li>
+                <li class="list-stepped__item">
+                    <h2 class="list-stepped__title">Check for updates</h2>
                     <p>Select the tab called "<strong>Updates</strong>". Then set the "<strong>Notify me of a new Ubuntu version</strong>" dropdown menu to "<strong>For any new version</strong>". Press <strong>Alt+F2</strong> and type in "<strong>update-manager</strong>" (without the quotes) into the command box. The Update Manager should open up and tell you that a new distribution is available. Click <strong>Upgrade</strong> and follow the on-screen instructions.</p>
                     <div class="help-image">
                         <a href="{{ ASSET_SERVER_URL }}4bcdd988-download-desktop-upgrade-2.jpg" title="Click to enlarge image"><img src="{{ ASSET_SERVER_URL }}4bcdd988-download-desktop-upgrade-2.jpg" alt=""></a>
                     </div>
-                </div>
-                <div class="one-col download-help__step">
-                    <span class="step">3</span>
-                </div>
-                <div class="seven-col last-col">
-                    <h2>Install the upgrade</h2>
+                </li>
+                <li class="list-stepped__item">
+                    <h2 class="list-stepped__title">Install the upgrade</h2>
                     <p>A message will appear informing you of the availability of the new release. Click <strong>Upgrade</strong> and follow the on-screen instructions.</p>
                     <div class="help-image">
                         <a href="{{ ASSET_SERVER_URL }}d709d29a-download-desktop-upgrade-3.jpg" title="Click to enlarge image"><img src="{{ ASSET_SERVER_URL }}d709d29a-download-desktop-upgrade-3.jpg" alt="" /></a>
                     </div>
-                </div>
-            </div><!-- /.box -->
+                </li>
+            </ol>
         </div><!-- /.row -->
     </div>
 </div>


### PR DESCRIPTION
## QA
- `make run`
- Go to http://localhost:8001/download/desktop/upgrade
- Check it now looks similar to other list-stepped implementations in `/download`
