### PR TITLE
added padding for non-full screen sections everywhere

### DIFF
--- a/static/css/section/_local.scss
+++ b/static/css/section/_local.scss
@@ -1374,7 +1374,7 @@ html.opera-mini {
 }
 // end @media only screen and (min-width : $breakpoint-large)
 
-} /* start of fix for vanilla margins on non-full screen pages */
+/* start of fix for vanilla margins on non-full screen pages */
 @media only screen and (min-width: $breakpoint-medium) {
   #context-footer div div.feature-one {
     display: table-cell;
@@ -1390,14 +1390,10 @@ html.opera-mini {
     .row {
       margin-left: 0;
       margin-right: 0;
-      hr {
-        margin-left: -40px;
-        margin-right: -40px;
-      }
     }
   }
 
-  .about, //XXX PRM
+  .about,
   .cloud,
   .desktop,
   .internet-of-things,
@@ -1406,16 +1402,25 @@ html.opera-mini {
   .server,
   .support {
     .row {
-      padding-left: 40px;
-      padding-right: 40px;
+      padding-left: 20px;
+      padding-right: 20px;
+    }
+    hr {
+      margin-left: -20px;
+      margin-right: -20px;
     }
   }
+  /* XXX vanilla fix? */
+  .equal-height--vertical-divider .equal-height--vertical-divider__item {
+    border-bottom: 0;
+  }
 }
+
 @media only screen and (min-width: $breakpoint-large) {
   #context-footer div div.feature-one {
     display: table-cell;
   }
-  .about-context-footer, //XXX PRM
+  .about-context-footer,
   .cloud-context-footer,
   .desktop-context-footer,
   .internet-of-things-context-footer,


### PR DESCRIPTION
## Done

making the non-full width sections have the original 40px padding
## QA
1. go to management, legal, cloud, desktop, about, iot, server or server and see that there is 40px padding between the content and the containing box
2. see that the contextual footer also has the padding, but the hr orange line goes to the box
## Issue / Card

Fixes https://github.com/ubuntudesign/ubuntu-vanilla-theme/issues/41
