### PR TITLE
523 - Ensure cloud chevron does not inherit link color

### DIFF
--- a/static/css/section/_local.scss
+++ b/static/css/section/_local.scss
@@ -134,6 +134,11 @@ body {
         }
     }
 }
+
+.breadcrumb-link--second-level:after {
+  color: $warm-grey;
+}
+
 // pulling in the old guidelines version of combined-list
 .row .combined-list {
     div,


### PR DESCRIPTION
## Done

Add explicit color to second level chevrons so they don't inherit parent color
## QA
- Navigate to /cloud/openstack
- check that chevrons in secodnary nav are not unbuntu orange
## Issue / Card

Fixes #523 
## Screenshots

Should look like: 

<img width="384" alt="screenshot 2016-04-20 12 49 07" src="https://cloud.githubusercontent.com/assets/505570/14673541/793799a8-06f6-11e6-899a-d3ad2015d780.png">
