### PR TITLE
Fix full-width secondary-nav left padding globally

### DIFF
--- a/static/css/section/_local.scss
+++ b/static/css/section/_local.scss
@@ -1698,3 +1698,10 @@ $item-spacing: 20px;
       }
   }
 }
+
+// Full-width nav alignment fix
+.nav-secondary .strip-inner-wrapper .breadcrumb li .breadcrumb-link {
+  @media only screen and (min-width : $navigation-threshold) {
+    padding-left: 0;
+  }
+}

--- a/static/css/section/_phone.scss
+++ b/static/css/section/_phone.scss
@@ -57,14 +57,6 @@
   }
 }
 
-// Full-width nav alignment fix
-.phone .nav-secondary .breadcrumb li .breadcrumb-link {
-  @media only screen and (min-width : $navigation-threshold) {
-    padding-left: 0;
-  }
-}
-
-
 @media only screen and (max-width : 768px) {
 
   .video-container.for-mobile {

--- a/static/css/section/_tablet.scss
+++ b/static/css/section/_tablet.scss
@@ -67,13 +67,6 @@
   }
 }
 
-// Full-width nav alignment fix
-.tablet .nav-secondary .breadcrumb li .breadcrumb-link {
-  @media only screen and (min-width : $navigation-threshold) {
-    padding-left: 0;
-  }
-}
-
 .tablet-overview,
 .tablet-features {
   .billboard {


### PR DESCRIPTION
This is my proposed solution instead of #534.
- Remove custom fixes from _tablet.scss and _phone.scss.
- Create new across-the-board fix for full-width pages only, to re-fix phone, tablet and desktop
## QA
- `make run`
- Go to http://localhost:8001/tablet, http://localhost:8001/phone and http://localhost:8001/desktop
- Check each section has a properly left-aligned secondary nav
- Go to some other non-full-width areas, e.g. http://localhost:8001/desktop, and check the secondary-nav still looks good.
