### PR TITLE
Remove erroneous `list-stepped__title` title classes

### DIFF
--- a/templates/download/desktop/burn-a-dvd-on-mac-osx.html
+++ b/templates/download/desktop/burn-a-dvd-on-mac-osx.html
@@ -24,28 +24,28 @@
     <div class="strip-inner-wrapper">
         <ol class="list-stepped eight-col append-one">
             <li class="list-stepped__item">
-                <p class="list-stepped__title">Launch <strong>'Disk Utility'</strong> (Applications &rarr; Utilities &rarr; Disk Utility).</p>
+                <p>Launch <strong>'Disk Utility'</strong> (Applications &rarr; Utilities &rarr; Disk Utility).</p>
             </li>
             <li class="list-stepped__item">
-                <p class="list-stepped__title">Insert your blank DVD.</p>
+                <p>Insert your blank DVD.</p>
             </li>
             <li class="list-stepped__item">
-                <p class="list-stepped__title">Drag and drop your .iso file to the left pane in Disk Utility. Now both the blank disc and the .iso should be listed.</p>
+                <p>Drag and drop your .iso file to the left pane in Disk Utility. Now both the blank disc and the .iso should be listed.</p>
             </li>
             <li class="list-stepped__item">
-                <p class="list-stepped__title">Select the .iso file, and click on the <strong>'Burn'</strong> button in the toolbar.</p>
+                <p>Select the .iso file, and click on the <strong>'Burn'</strong> button in the toolbar.</p>
                 <div class="help-image">
                     <a href="{{ ASSET_SERVER_URL }}53029019-desktop-burn-a-dvd-on-mac-4.png" title="Click to enlarge image"><img src="{{ ASSET_SERVER_URL }}53029019-desktop-burn-a-dvd-on-mac-4.png?w=444" alt="" height="388" width="444"></a>
                 </div>
             </li>
             <li class="list-stepped__item">
-                <p class="list-stepped__title">Ensure that the <strong>'Verify burned data'</strong> checkbox is ticked (you may need to click on the disclosure triangle to see the checkbox).</p>
+                <p>Ensure that the <strong>'Verify burned data'</strong> checkbox is ticked (you may need to click on the disclosure triangle to see the checkbox).</p>
                 <div class="help-image">
                     <a href="{{ ASSET_SERVER_URL }}65cc3384-desktop-burn-a-dvd-on-mac-5.png" title="Click to enlarge image"><img src="{{ ASSET_SERVER_URL }}65cc3384-desktop-burn-a-dvd-on-mac-5.png?w=444" alt="" height="388" width="444"></a>
                 </div>
             </li>
             <li class="list-stepped__item">
-                <p class="list-stepped__title">Click <strong>'Burn'</strong>. The data will be burned and verified.</p>
+                <p>Click <strong>'Burn'</strong>. The data will be burned and verified.</p>
             </li>
         </ol>
     </div><!-- /.box -->

--- a/templates/download/desktop/burn-a-dvd-on-ubuntu.html
+++ b/templates/download/desktop/burn-a-dvd-on-ubuntu.html
@@ -24,31 +24,31 @@
     <div class="strip-inner-wrapper">
         <ol class="list-stepped eight-col append-one">
             <li class="list-stepped__item">
-                <p class="list-stepped__title">Insert a blank CD into your burner. A 'CD/DVD Creator', 'Choose Disc Type' or 'Blank Disc' window might pop up. Close this, because we will not be using it.</p>
+                <p>Insert a blank CD into your burner. A 'CD/DVD Creator', 'Choose Disc Type' or 'Blank Disc' window might pop up. Close this, because we will not be using it.</p>
                 <div class="help-image">
                     <a href="{{ ASSET_SERVER_URL }}d7c64451-download-desktop-burn-a-dvd-on-ubuntu-1.jpg" title="Click to enlarge image"><img src="{{ ASSET_SERVER_URL }}d7c64451-download-desktop-burn-a-dvd-on-ubuntu-1.jpg" alt=""></a>
                 </div>
             </li>
             <li class="list-stepped__item">
-                <p class="list-stepped__title">16.04 no longer comes with a CD/DVD burner, so using the Ubuntu Software Store, search for &#8216;Brasero&#8217; and click &#8216;Install&#8217;.</p>
+                <p>16.04 no longer comes with a CD/DVD burner, so using the Ubuntu Software Store, search for &#8216;Brasero&#8217; and click &#8216;Install&#8217;.</p>
                 <div class="help-image">
                     <a href="{{ ASSET_SERVER_URL }}41d04a0c-download-desktop-burn-a-dvd-on-ubuntu-2.jpg" title="Click to enlarge image"><img src="{{ ASSET_SERVER_URL }}41d04a0c-download-desktop-burn-a-dvd-on-ubuntu-2.jpg" alt=""></a>
                 </div>
             </li>
             <li class="list-stepped__item">
-                <p class="list-stepped__title">Open Brasero and click on the &#8216;Burn image&#8217; button.</p>
+                <p>Open Brasero and click on the &#8216;Burn image&#8217; button.</p>
                 <div class="help-image">
                     <a href="{{ ASSET_SERVER_URL }}0184442a-download-desktop-burn-a-dvd-on-ubuntu-3.jpg" title="Click to enlarge image"><img src="{{ ASSET_SERVER_URL }}0184442a-download-desktop-burn-a-dvd-on-ubuntu-3.jpg" alt=""></a>
                 </div>
             </li>
             <li class="list-stepped__item">
-                <p class="list-stepped__title">Then select the ISO you downloaded in the &#8216;Select a disc image to write&#8217; box and your DVD drive in the &#8216;Select a disc to write to&#8217; box and click the &#8216;Burn&#8217; button.</p>
+                <p>Then select the ISO you downloaded in the &#8216;Select a disc image to write&#8217; box and your DVD drive in the &#8216;Select a disc to write to&#8217; box and click the &#8216;Burn&#8217; button.</p>
                 <div class="help-image">
                     <a href="{{ ASSET_SERVER_URL }}cd309124-download-desktop-burn-a-dvd-on-ubuntu-4.jpg" title="Click to enlarge image"><img src="{{ ASSET_SERVER_URL }}cd309124-download-desktop-burn-a-dvd-on-ubuntu-4.jpg" alt=""></a>
                 </div>
             </li>
             <li class="list-stepped__item">
-                <p class="list-stepped__title">Once the DVD is burned, you can restart your computer and try or install Ubuntu.</p>
+                <p>Once the DVD is burned, you can restart your computer and try or install Ubuntu.</p>
                 <div class="help-image">
                     <a href="{{ ASSET_SERVER_URL }}29cc6f88-download-desktop-burn-a-dvd-on-ubuntu-5.jpg" title="Click to enlarge image"><img src="{{ ASSET_SERVER_URL }}29cc6f88-download-desktop-burn-a-dvd-on-ubuntu-5.jpg" alt=""></a>
                 </div>

--- a/templates/download/desktop/burn-a-dvd-on-windows.html
+++ b/templates/download/desktop/burn-a-dvd-on-windows.html
@@ -25,13 +25,13 @@
         <h2>Windows 7 / 8 / 10</h2>
         <ol class="list-stepped eight-col append-one">
             <li class="list-stepped__item">
-                <p class="list-stepped__title">Right-click on an ISO image and choose <strong>'Burn disc image'</strong>.</p>
+                <p>Right-click on an ISO image and choose <strong>'Burn disc image'</strong>.</p>
                 <div class="help-image">
                     <a href="{{ ASSET_SERVER_URL }}64efd281-windows-10-burn-1.jpg" title="Click to enlarge image"><img src="{{ ASSET_SERVER_URL }}64efd281-windows-10-burn-1.jpg" alt="" height="443" width="444"></a>
                 </div>
             </li>
             <li class="list-stepped__item">
-                <p class="list-stepped__title">Select a disc burner (drive) and choose <strong>'Burn'</strong>. If you check <strong>'Verify disc after burning'</strong>, it will confirm that the ISO image has been burned correctly.</p>
+                <p>Select a disc burner (drive) and choose <strong>'Burn'</strong>. If you check <strong>'Verify disc after burning'</strong>, it will confirm that the ISO image has been burned correctly.</p>
                 <div class="help-image">
                     <a href="{{ ASSET_SERVER_URL }}c2ce3ee7-windows-10-burn-2.jpg" title="Click to enlarge image"><img src="{{ ASSET_SERVER_URL }}c2ce3ee7-windows-10-burn-2.jpg" alt="" height="444" width="443"></a>
                 </div>
@@ -46,19 +46,19 @@
             <li class="list-stepped__item">Download and install <a href="http://infrarecorder.org/?page_id=5" class="exernal">Infra Recorder</a>, a free and open-source image-burning program.</p>
             </li>
             <li class="list-stepped__item">
-                <p class="list-stepped__title">Insert a blank DVD in the drive and select <strong>&lsquo;Do nothing&rsquo;</strong> or <strong>&lsquo;Cancel&rsquo;</strong> if an autorun dialog box pops up.</p>
+                <p>Insert a blank DVD in the drive and select <strong>&lsquo;Do nothing&rsquo;</strong> or <strong>&lsquo;Cancel&rsquo;</strong> if an autorun dialog box pops up.</p>
             </li>
             <li class="list-stepped__item">
-                <p class="list-stepped__title">Open Infra Recorder and click the <strong>'Write Image'</strong> button in the main screen. Alternatively you can select the <strong>'Actions'</strong> menu, then <strong>'Burn image'</strong>.</p>
+                <p>Open Infra Recorder and click the <strong>'Write Image'</strong> button in the main screen. Alternatively you can select the <strong>'Actions'</strong> menu, then <strong>'Burn image'</strong>.</p>
                 <div class="help-image">
                     <a href="{{ ASSET_SERVER_URL }}cfb3e0b1-cd_windows_01_medium.jpg" title="Click to enlarge image"><img src="{{ ASSET_SERVER_URL }}cfb3e0b1-cd_windows_01_medium.jpg" alt="" height="408" width="448"></a>
                 </div>
             </li>
             <li class="list-stepped__item">
-                <p class="list-stepped__title">Select the Ubuntu DVD image file you want to use, then click <strong>'Open'</strong>.</p>
+                <p>Select the Ubuntu DVD image file you want to use, then click <strong>'Open'</strong>.</p>
             </li>
             <li class="list-stepped__item">
-                <p class="list-stepped__title">In the dialog box, click <strong>'OK'</strong>.</p>
+                <p>In the dialog box, click <strong>'OK'</strong>.</p>
             </li>
         </ol>
     </div><!-- /.box -->

--- a/templates/download/desktop/create-a-usb-stick-on-mac-osx.html
+++ b/templates/download/desktop/create-a-usb-stick-on-mac-osx.html
@@ -26,28 +26,28 @@
     <div class="strip-inner-wrapper">
         <ol class="list-stepped eight-col append-one">
             <li class="list-stepped__item">
-                <p class="list-stepped__title">Download the <a href="/download/desktop">64-bit Ubuntu Desktop ISO</a></p>
+                <p>Download the <a href="/download/desktop">64-bit Ubuntu Desktop ISO</a></p>
             </li>
             <li class="list-stepped__item">
-                <p class="list-stepped__title">Launch UNetbootin and allow the osascript to make changes</p>
+                <p>Launch UNetbootin and allow the osascript to make changes</p>
                 <div class="help-image">
                     <a href="{{ ASSET_SERVER_URL }}6ee463ef-mac-usb-1-osautils.jpg?w=494" title="Click to enlarge image"><img src="{{ ASSET_SERVER_URL }}6ee463ef-mac-usb-1-osautils.jpg?w=494" alt="Type your password"></a>
                 </div>
             </li>
             <li class="list-stepped__item">
-                <p class="list-stepped__title">Select the ‘Diskimage’ radio button and then click the '...’ button</p>
+                <p>Select the ‘Diskimage’ radio button and then click the '...’ button</p>
                 <div class="help-image">
                     <a href="{{ ASSET_SERVER_URL }}85365387-mac-usb-2-select-diskimage.jpg?w=494" title="Click to enlarge image"><img src="{{ ASSET_SERVER_URL }}85365387-mac-usb-2-select-diskimage.jpg?w=494" alt="unetbootin"></a>
                 </div>
             </li>
             <li class="list-stepped__item">
-                <p class="list-stepped__title">Select the Ubuntu ISO file you downloaded and click 'Open'</p>
+                <p>Select the Ubuntu ISO file you downloaded and click 'Open'</p>
                 <div class="help-image">
                     <a href="{{ ASSET_SERVER_URL }}1325c614-mac-usb-3-select-iso.jpg?w=494" title="Click to enlarge image"><img src="{{ ASSET_SERVER_URL }}1325c614-mac-usb-3-select-iso.jpg?w=494" alt="Select disk image"></a>
                 </div>
             </li>
             <li class="list-stepped__item">
-                <p class="list-stepped__title">Then select your flash drive in the bottom row and click 'OK'</p>
+                <p>Then select your flash drive in the bottom row and click 'OK'</p>
                 <div class="box box-tip no-margin-bottom">
                     <p><strong>Tip:</strong> If you are unsure which one is your flash drive, in a terminal you can type</p>
                     <pre>diskutil list</pre>
@@ -58,13 +58,13 @@
                 </div>
             </li>
             <li class="list-stepped__item">
-                <p class="list-stepped__title">After UNetbootin finishes, click ‘Exit’ and restart your Mac</p>
+                <p>After UNetbootin finishes, click ‘Exit’ and restart your Mac</p>
                 <div class="help-image">
                     <a href="{{ ASSET_SERVER_URL }}74bbe11c-mac-usb-5-done.jpg?w=494" title="Click to enlarge image"><img src="{{ ASSET_SERVER_URL }}74bbe11c-mac-usb-5-done.jpg?w=494" alt="unetbootin complete"></a>
                 </div>
             </li>
             <li class="list-stepped__item">
-                <p class="list-stepped__title">Press alt/option key while the Mac is restarting to choose the USB stick to try or install Ubuntu</p>
+                <p>Press alt/option key while the Mac is restarting to choose the USB stick to try or install Ubuntu</p>
             </li>
         </ol>
     </div>

--- a/templates/download/desktop/create-a-usb-stick-on-ubuntu.html
+++ b/templates/download/desktop/create-a-usb-stick-on-ubuntu.html
@@ -24,31 +24,31 @@
     <div class="strip-inner-wrapper">
         <ol class="list-stepped nine-col append-one">
             <li class="list-stepped__item">
-                <p class="list-stepped__title">Insert a USB stick with at least 2GB of free space</p>
+                <p>Insert a USB stick with at least 2GB of free space</p>
             </li>
             <li class="list-stepped__item">
-                <p class="list-stepped__title">Open the dash and search for <strong>Startup Disk Creator</strong></p>
+                <p>Open the dash and search for <strong>Startup Disk Creator</strong></p>
             </li>
             <li class="list-stepped__item">
-                <p class="list-stepped__title">Select the <strong>Startup Disk Creator</strong> to launch the app</p>
+                <p>Select the <strong>Startup Disk Creator</strong> to launch the app</p>
                 <div class="help-image">
                     <a href="{{ ASSET_SERVER_URL }}be194ecf-usb-1604-startup-disk-creator.png?w=550" title="Click to enlarge image"><img src="{{ ASSET_SERVER_URL }}be194ecf-usb-1604-startup-disk-creator.png?w=550" alt="Find the Startup Disk Creator"></a>
                 </div>
             </li>
             <li class="list-stepped__item">
-                <p class="list-stepped__title">Click <strong>'Other'</strong> to choose the downloaded ISO file if it isn’t found automatically, select the file and click <strong>'Open'</strong></p>
+                <p>Click <strong>'Other'</strong> to choose the downloaded ISO file if it isn’t found automatically, select the file and click <strong>'Open'</strong></p>
                 <div class="help-image">
                     <a href="{{ ASSET_SERVER_URL }}a2cf98cc-usb-1604-select-iso.png?w=550" title="Click to enlarge image"><img src="{{ ASSET_SERVER_URL }}a2cf98cc-usb-1604-select-iso.png?w=550" alt="Select the ISO"></a>
                 </div>
             </li>
             <li class="list-stepped__item">
-                <p class="list-stepped__title">Select the USB stick in the bottom box and click <strong>'Make Startup Disk'</strong> and then <strong>'Yes'</strong></p>
+                <p>Select the USB stick in the bottom box and click <strong>'Make Startup Disk'</strong> and then <strong>'Yes'</strong></p>
                 <div class="help-image">
                     <a href="{{ ASSET_SERVER_URL }}f5a23872-usb-1604-areyousure.png?w=550" title="Click to enlarge image"><img src="{{ ASSET_SERVER_URL }}f5a23872-usb-1604-areyousure.png?w=550" alt="Confirm USB stick"></a>
                 </div>
             </li>
             <li class="list-stepped__item">
-                <p class="list-stepped__title">That's it! When the process completes, you'll be ready to restart your computer and begin installing Ubuntu</p>
+                <p>That's it! When the process completes, you'll be ready to restart your computer and begin installing Ubuntu</p>
                 <div class="help-image">
                     <a href="{{ ASSET_SERVER_URL }}dac30d7d-usb-1604-writing.png?w=550" title="Click to enlarge image"><img src="{{ ASSET_SERVER_URL }}dac30d7d-usb-1604-writing.png?w=550" alt="Writing the ISO to disk"></a>
                 </div>

--- a/templates/download/desktop/create-a-usb-stick-on-windows.html
+++ b/templates/download/desktop/create-a-usb-stick-on-windows.html
@@ -25,37 +25,37 @@
     <div class="strip-inner-wrapper">
         <ol class="list-stepped eight-col append-one">
             <li class="list-stepped__item">
-                <p class="list-stepped__title">Open Rufus and select your USB stick in the <strong>'Device'</strong> dropdown</p>
+                <p>Open Rufus and select your USB stick in the <strong>'Device'</strong> dropdown</p>
                 <div class="help-image">
                     <a href="{{ ASSET_SERVER_URL }}bf622829-download-desktop-usb-windows-1.jpg" title="Click to enlarge image"><img src="{{ ASSET_SERVER_URL }}bf622829-download-desktop-usb-windows-1.jpg" alt=""></a>
                 </div>
             </li>
             <li class="list-stepped__item">
-                <p class="list-stepped__title">Click the CD Rom icon next to the <strong>'FreeDOS'</strong> dropdown, then find your downloaded Ubuntu ISO and click <strong>'Open'</strong></p>
+                <p>Click the CD Rom icon next to the <strong>'FreeDOS'</strong> dropdown, then find your downloaded Ubuntu ISO and click <strong>'Open'</strong></p>
                 <div class="help-image">
                     <a href="{{ ASSET_SERVER_URL }}fc469e59-download-desktop-usb-windows-2.jpg" title="Click to enlarge image"><img src="{{ ASSET_SERVER_URL }}fc469e59-download-desktop-usb-windows-2.jpg" alt=""></a>
                 </div>
             </li>
             <li class="list-stepped__item">
-                <p class="list-stepped__title">Click <strong>'Yes'</strong> when it asks to download Syslinux software</p>
+                <p>Click <strong>'Yes'</strong> when it asks to download Syslinux software</p>
                 <div class="help-image">
                     <a href="{{ ASSET_SERVER_URL }}69f34161-download-desktop-usb-windows-3.jpg" title="Click to enlarge image"><img src="{{ ASSET_SERVER_URL }}69f34161-download-desktop-usb-windows-3.jpg" alt=""></a>
                 </div>
             </li>
             <li class="list-stepped__item">
-                <p class="list-stepped__title">Click <strong>'OK'</strong> to write in ISO Image mode</p>
+                <p>Click <strong>'OK'</strong> to write in ISO Image mode</p>
                 <div class="help-image">
                     <a href="{{ ASSET_SERVER_URL }}8caaedc2-download-desktop-usb-windows-4.jpg" title="Click to enlarge image"><img src="{{ ASSET_SERVER_URL }}8caaedc2-download-desktop-usb-windows-4.jpg" alt=""></a>
                 </div>
             </li>
             <li class="list-stepped__item">
-                <p class="list-stepped__title">Confirm that your USB stick is selected and then <strong>'OK'</strong> to continue</p>
+                <p>Confirm that your USB stick is selected and then <strong>'OK'</strong> to continue</p>
                 <div class="help-image">
                     <a href="{{ ASSET_SERVER_URL }}ee3b255d-download-desktop-usb-windows-5.jpg" title="Click to enlarge image"><img src="{{ ASSET_SERVER_URL }}ee3b255d-download-desktop-usb-windows-5.jpg" alt=""></a>
                 </div>
             </li>
             <li class="list-stepped__item">
-                <p class="list-stepped__title">When it is finished, just restart your computer and start using Ubuntu, or you can install Ubuntu</p>
+                <p>When it is finished, just restart your computer and start using Ubuntu, or you can install Ubuntu</p>
                 <div class="help-image">
                     <a href="{{ ASSET_SERVER_URL }}febc3c7b-download-desktop-usb-windows-7.jpg" title="Click to enlarge image"><img src="{{ ASSET_SERVER_URL }}febc3c7b-download-desktop-usb-windows-7.jpg" alt=""></a>
                 </div>

--- a/templates/download/desktop/try-ubuntu-before-you-install.html
+++ b/templates/download/desktop/try-ubuntu-before-you-install.html
@@ -23,7 +23,7 @@
     <div class="strip-inner-wrapper">
         <ol class="list-stepped eight-col append-one">
             <li class="list-stepped__item">
-                <p class="list-stepped__title">Using a DVD?</p>
+                <p>Using a DVD?</p>
                 <p>Put the Ubuntu DVD into the DVD-drive and restart the computer. You should see a welcome screen prompting you to choose your language and giving you the option to install Ubuntu or try it from the DVD. If you don&rsquo;t get this menu, please <a href="https://help.ubuntu.com/community/BootFromCD">read the booting from the DVD guide</a> for more information.</p>
 
                 <h3>Using a USB drive?</h3>
@@ -37,19 +37,19 @@
                 <p>Depending on your computer and how your USB key was formatted, you should see an entry for &lsquo;removable drive&rsquo; or &lsquo;USB media&rsquo;. Move this to the top of the list to force the computer to start from USB rather than the hard disk. Save your changes and continue.</p>
             </li>
             <li class="list-stepped__item">
-                <p class="list-stepped__title">Choose your preferred language and click on <strong>&lsquo;Try Ubuntu&rsquo;</strong>.</p>
+                <p>Choose your preferred language and click on <strong>&lsquo;Try Ubuntu&rsquo;</strong>.</p>
                 <div class="help-image">
                     <a href="{{ ASSET_SERVER_URL }}49a92ce6-install_1.jpg" title="Click to enlarge image"><img src="{{ ASSET_SERVER_URL }}49a92ce6-install_1.jpg" alt="desktop-install-1" height="340" width="444"></a>
                 </div>
             </li>
             <li class="list-stepped__item">
-                <p class="list-stepped__title">Your live desktop should appear. Have a look around!</p>
+                <p>Your live desktop should appear. Have a look around!</p>
                 <div class="help-image">
                     <a href="{{ ASSET_SERVER_URL }}4688006c-try-ubuntu-16-04.jpg" title="Click to enlarge image"><img src="{{ ASSET_SERVER_URL }}4688006c-try-ubuntu-16-04.jpg" alt="desktop-trial-2" height="263" width="444"></a>
                 </div>
             </li>
             <li class="list-stepped__item">
-                <p class="list-stepped__title">When you&rsquo;re ready to install Ubuntu, double-click on the icon on your desktop: <strong>&rsquo;Install Ubuntu {{lts_release_full}}&rsquo;</strong>.</p>
+                <p>When you&rsquo;re ready to install Ubuntu, double-click on the icon on your desktop: <strong>&rsquo;Install Ubuntu {{lts_release_full}}&rsquo;</strong>.</p>
             </li>
         </ol>
     </div>


### PR DESCRIPTION
## Done

On the following pages:

/download/desktop/burn-a-dvd-on-ubuntu
/download/desktop/create-a-usb-stick-on-ubuntu
/download/desktop/burn-a-dvd-on-windows
/download/desktop/create-a-usb-stick-on-windows
/download/desktop/burn-a-dvd-on-mac-osx
/download/desktop/create-a-usb-stick-on-mac-osx
/download/desktop/try-ubuntu-before-you-install

… I removed the class `list-stepped__title` from the paragraphs in list-stepped__item's, as they are not a titles.
## QA

Check above pages to ensure that the paragraph points are not headings.
## Issue / Card

Fixes: #531 
