### PR TITLE
Phone `hero-row`s need top padding

### DIFF
--- a/static/css/section/_phone.scss
+++ b/static/css/section/_phone.scss
@@ -863,8 +863,6 @@ body.phone-partners {
 // --------------------------------------------------------------
 body.phone {
   .row-hero {
-    padding-top: 0;
-
     a img {
       vertical-align: middle;
       margin-right: 10px;


### PR DESCRIPTION
Fixes #537
## QA
- `make run`
- Go to http://localhost:8001/phone/devices, http://localhost:8001/phone/developers and http://localhost:8001/phone/partners and check the hero row has enough top padding
- Check some other pages in the `/phone` section, see that hero-rows everywhere look fine
