### PR TITLE
Correct link to 'Verify your download'

### DIFF
--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -43,7 +43,7 @@
                     </p>
                     <ul class="no-bullets">
                         <li><a href="/download/alternative-downloads">Alternative downloads and torrents&nbsp;&rsaquo;</a></li>
-                        <li><a href="/download/how-to-validate-your-download">Verify your download&nbsp;&rsaquo;</a></li>
+                        <li><a href="/download/how-to-verify">Verify your download&nbsp;&rsaquo;</a></li>
                     </ul>
                 </div><!-- /.four-col -->
             </div><!-- /.box -->


### PR DESCRIPTION
## Done
- Correct link to 'Verify your download'
## QA
- Go to `/download/desktop`
- Click 'Verify your download ›'
- Link should go to `/download/how-to-verify`
## Issue / Card
#435
