### PR TITLE
Full-width layout contextual-footer padding

### DIFF
--- a/static/css/section/_local.scss
+++ b/static/css/section/_local.scss
@@ -448,7 +448,9 @@ body {
         color: #ebebea;
     }
     #context-footer div div:first-child {
+      @media only screen and (min-width : $breakpoint-large + 80) {
         padding-left: 0;
+      }
     }
     hr {
       box-shadow: none;


### PR DESCRIPTION
Normalise padding for contextual-footer on full-width pages,
'cos it seems to have reverted.
## QA
- `make run`
- Open full-width sections, http://localhost:8001/phone, http://localhost:8001/tablet, http://localhost:8001/download
- Check contextual-footers have a decent amount of space around them, and have equal-looking space on top and bottom, on a few pages in the sections
- Open a non-full-width section (e.g. http://localhost:8001/desktop) and check contextual-footer still looks fine
