### PR TITLE
adding some styling for code and pre elements as well as fixing up so…

### DIFF
--- a/static/css/section/_download.scss
+++ b/static/css/section/_download.scss
@@ -1148,3 +1148,22 @@ $grid-border-style: 1px dotted #888;
     display: inline-block;
     padding-top: .5em;
 }
+
+// XXX code stuff
+pre {
+  border-radius: 4px;
+  background-color: #2c001e;
+  border: 1px solid #2c001e;
+  overflow: scroll;
+  padding-top: 1em;
+  padding-bottom: 1em;
+}
+pre > code {
+  border: 0;
+  background: transparent;
+  font-size: 1em;
+  font-weight: 300;
+  padding: 0.7em 1em;
+  color: #fff;
+  width: 100%;
+}

--- a/static/css/section/_local.scss
+++ b/static/css/section/_local.scss
@@ -1724,6 +1724,9 @@ $item-spacing: 20px;
       margin-bottom: 0;
     }
   }
+  .box {
+    clear: both;
+  }
 }
 
 .list-stepped__title {

--- a/templates/download/how-to-verify.html
+++ b/templates/download/how-to-verify.html
@@ -18,8 +18,7 @@
             <h1>How to verify your Ubuntu download</h1>
 
             <div class="box warning">
-              <p><b>NOTE:</b> You will need to use a terminal app to verify an Ubuntu ISO image.
-              These instructions assume basic knowledge of the command line, checking of SHA256 checksums and use of GnuPG.</p>
+              <p><strong>NOTE:</strong> You will need to use a terminal app to verify an Ubuntu ISO image. These instructions assume basic knowledge of the command line, checking of SHA256 checksums and use of GnuPG.</p>
             </div>
 
             <p>Verifying your ISO helps insure the data integrity and authenticity of
@@ -56,38 +55,36 @@
             </h3>
 
             <div class="box box-tip">
-              <p><b>Tip:</b> On non-Linux systems, you might need to download the GPG tools for this next step.
-              To check if you have the GPG tools installed, run the command <code>gpg --version</code> or <code>gpg2 --version</code>.</p>
+              <p><b>Tip:</b> On non-Linux systems, you might need to download the GPG tools for this next step. To check if you have the GPG tools installed, run the command <code>gpg --version</code> or <code>gpg2 --version</code>.</p>
             </div>
 
             <h4>Find out what key was used to issue the signature</h4>
 
             <p>Running GnuPG to verify the signature we can find out what key is needed (note: some versions of the gpg command are gpg2).</p>
 
-            <code>
-              <pre>
-    gpg --verify SHA256SUMS.gpg SHA256SUMS
-    gpg: Signature made Fri 25 Mar 04:36:20 2016 GMT using DSA key ID FBB75451
-    gpg: Can't check signature: No public key
-    gpg: Signature made Fri 25 Mar 04:36:20 2016 GMT using RSA key ID EFE21092
-    gpg: Can't check signature: No public key
-              </pre>
-            </code>
+            <pre>
+                <code>
+gpg --verify SHA256SUMS.gpg SHA256SUMS
+gpg: Signature made Fri 25 Mar 04:36:20 2016 GMT using DSA key ID FBB75451
+gpg: Can't check signature: No public key
+gpg: Signature made Fri 25 Mar 04:36:20 2016 GMT using RSA key ID EFE21092
+gpg: Can't check signature: No public key</code>
+            </pre>
 
             <p>Looking at the output, you can see the key IDs are 0xFBB75451 (generated in 2004, deprecated) and 0xEFE21092 (generated in 2012, current).</p>
 
             <h4>Now get the public key from the Ubuntu key server and add them to your keyring.</h4>
 
-            <code>
-              <pre>gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys 0xFBB75451 0xEFE21092
+              <pre>
+                  <code>
+gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys 0xFBB75451 0xEFE21092
 gpg: /Users/lola/.gnupg/trustdb.gpg: trustdb created
-gpg: key EFE21092: public key "Ubuntu CD Image Automatic Signing Key (2012) <cdimage@ubuntu.com>" imported
-gpg: key FBB75451: public key "Ubuntu CD Image Automatic Signing Key <cdimage@ubuntu.com>" imported
+gpg: key EFE21092: public key "Ubuntu CD Image Automatic Signing Key (2012) &lt;cdimage@ubuntu.com>" imported
+gpg: key FBB75451: public key "Ubuntu CD Image Automatic Signing Key &lt;cdimage@ubuntu.com>" imported
 gpg: no ultimately trusted keys found
 gpg: Total number processed: 2
-gpg:               imported: 2
-              </pre>
-            </code>
+gpg:               imported: 2</code>
+            </pre>
         </li>
 
         <li class="list-stepped__item">
@@ -95,26 +92,25 @@ gpg:               imported: 2
             Verify signature
             </h3>
             <p>Now you can re-run the original command to verify the signature.</p>
-            <code>
-              <pre>gpg --verify SHA256SUMS.gpg SHA256SUMS
+
+            <div class="twelve-col ">
+                <pre>
+                    <code>
+gpg --verify SHA256SUMS.gpg SHA256SUMS
 gpg: Signature made Fri 25 Mar 04:36:20 2016 GMT using DSA key ID FBB75451
-gpg: Good signature from "Ubuntu CD Image Automatic Signing Key <cdimage@ubuntu.com>" [unknown]
+gpg: Good signature from "Ubuntu CD Image Automatic Signing Key &lt;cdimage@ubuntu.com>" [unknown]
 gpg: WARNING: This key is not certified with a trusted signature!
 gpg:          There is no indication that the signature belongs to the owner.
 Primary key fingerprint: C598 6B4F 1257 FFA8 6632  CBA7 4618 1433 FBB7 5451
 gpg: Signature made Fri 25 Mar 04:36:20 2016 GMT using RSA key ID EFE21092
-gpg: Good signature from "Ubuntu CD Image Automatic Signing Key (2012) <cdimage@ubuntu.com>" [unknown]
+gpg: Good signature from "Ubuntu CD Image Automatic Signing Key (2012) &lt;cdimage@ubuntu.com>" [unknown]
 gpg: WARNING: This key is not certified with a trusted signature!
 gpg:          There is no indication that the signature belongs to the owner.
-Primary key fingerprint: 8439 38DF 228D 22F7 B374  2BC0 D94A A3F0 EFE2 1092
-              </pre>
-            </code>
+Primary key fingerprint: 8439 38DF 228D 22F7 B374  2BC0 D94A A3F0 EFE2 1092</code>
+                </pre>
+            </div>
             <div class="box">
-              This is an example of a ‘good’ signature. GPG is only validating the integrity of the
-              given file. The warning messages indicate that your current GnuPG trust database does
-              not have trust information for the signing key and that, unless you have actually verified
-              and signed one of the public keys belonging to signers of the Ubuntu ISO image signing key,
-              you will get these warnings.
+              This is an example of a ‘good’ signature. GPG is only validating the integrity of the given file. The warning messages indicate that your current GnuPG trust database does not have trust information for the signing key and that, unless you have actually verified and signed one of the public keys belonging to signers of the Ubuntu ISO image signing key, you will get these warnings.
             </div>
         </li>
 
@@ -125,13 +121,13 @@ Primary key fingerprint: 8439 38DF 228D 22F7 B374  2BC0 D94A A3F0 EFE2 1092
             <p>Now you need to generate a sha256 checksum for the downloaded ISO and compare it to the one you downloaded in your SHA256SUM file.</p>
 
             <p>On Ubuntu, the command to check will look like:</p>
-            <code><pre>sha256sum -c SHA256SUMS 2>&1 | grep OK</pre></code>
+            <pre class="twelve-col"><code>sha256sum -c SHA256SUMS 2>&amp;1 | grep OK</code></pre>
 
             <p>On Mac OS X, the command and good output will look like the following.</p>
-            <code><pre>shasum -a 256 -c SHA256SUMS 2>&1 | grep OK</pre></code>
+            <pre class="twelve-col"><code>shasum -a 256 -c SHA256SUMS 2>&amp;1 | grep OK</code></pre>
 
             <p>If you’re using Windows, you may need to download a <a class="external" href="http://www.labtestproject.com/files/win/sha256sum/sha256sum.exe">SHA-256 tool</a> first. Once you have, your command will look like:
-            <code><pre>ubuntu-16.04-desktop-amd64.iso: OK</pre></code>
+            <pre class="twelve-col"><code>ubuntu-16.04-desktop-amd64.iso: OK</code></pre>
 
             <p>If you get no results (or any result other than that shown above) you will need to check your download again.</p>
         </li>


### PR DESCRIPTION
## Done
- fixed the pre code (not code pre) on /download/how-to-verify
- added colour to the blocks
- remove the pre from the inline code
- escaped a few chars
## QA
1. go to /download/how-to-verify
2. see that the code blocks have some padding
3. see that the pre blocks have some color like the autopilot instructions
4. see that the list-step .box now clears itself
## Issue / Card

hopefully this augments Robin's https://github.com/ubuntudesign/www.ubuntu.com/issues/550 and further fixes #542
