### PR TITLE
tweaking the hr for cloud and iot sections

### DIFF
--- a/static/css/section/_local.scss
+++ b/static/css/section/_local.scss
@@ -1440,9 +1440,7 @@ html.opera-mini {
   }
 
   .about,
-  .cloud,
   .desktop,
-  .internet-of-things,
   .legal,
   .management,
   .server,
@@ -1456,6 +1454,14 @@ html.opera-mini {
       margin-right: -40px;
     }
   }
+
+  .cloud,
+  .internet-of-things,
+  #context-footer hr {
+    margin-left: -20px;
+    margin-right: -20px;
+  }
+
 } /* end fix for vanilla margins on non-full screen pages */
 
 #context-footer div div.feature-two {


### PR DESCRIPTION
## Done

reduced the margin left and right on the contextual footer hr for the cloud and iot sections as they were exceeding the box... not sure why
## QA

go to the overview of very section and see that the hr fits
## Screenshots

BAD
![image](https://cloud.githubusercontent.com/assets/441217/14688814/53694a3c-073c-11e6-8913-d5496c8f32c0.png)

GOOD
![image](https://cloud.githubusercontent.com/assets/441217/14688825/5fffc6f4-073c-11e6-953a-16d160046ccd.png)
