### PR TITLE
/download/server fixes

### DIFF
--- a/templates/download/server/index.html
+++ b/templates/download/server/index.html
@@ -23,7 +23,6 @@
                     <div class="equal-height--vertical-divider__item eight-col no-margin-bottom">
                     <h2>Ubuntu Server {{lts_release_full}}</h2>
                     <p>The long-term support version of Ubuntu Server, including the Icehouse release of OpenStack and support guaranteed until April 2019 &mdash; 64-bit only.</p>
-                    <p><strong>Recommended for most users.</strong></p>
                     <p><a href="https://wiki.ubuntu.com/{{lts_release_name}}/ReleaseNotes" class="external">Ubuntu Server {{lts_release_full}} release notes</a></p>
                 </div>
                 <div class="equal-height--vertical-divider__item four-col last-col no-margin-bottom gap-from-top">

--- a/templates/download/server/thank-you.html
+++ b/templates/download/server/thank-you.html
@@ -55,7 +55,7 @@ Thanks for downloading Ubuntu Server
         </div><!-- /.strip-inner-wrapper -->
     </div><!-- /.row .row-grey -->
 
-{% include "download/shared/_contextual_footer.html"  with first_item="_download_server_installation" second_item="_download_server_guide" third_item="_download_helping_hands" %}
+{% include "download/shared/_contextual_footer.html"  with first_item="_download_server_installation" second_item="_download_server_guide" third_item="_download_verify_your_download" %}
 
 {% endblock content %}
 {% block footer_extra %}


### PR DESCRIPTION
## Done

removed the 'recommended for all users' and added verify to thank-you
## QA

go to /download/server
see that the 'Recommended for most users' (used when there are two versions) is not there

go to /download/sever/thank-you
see that the rightmost contextual footer is the verify one.
