### PR TITLE
Fix "300 services" grid

### DIFF
--- a/static/css/section/_cloud.scss
+++ b/static/css/section/_cloud.scss
@@ -75,7 +75,7 @@
       max-width: 60px;
     }
 
-    /// Make two-col four-col on smaller screens
+    /// Make two-col six-col on smaller screens
     .two-col {
       @media only screen and (max-width: $breakpoint-medium) {
         width: 48.89381%;


### PR DESCRIPTION
Fixes #417.

Remove custom styling to use the default columns for the main grid.

Only, when we get down to $breakpoint-medium, going to full-width
boxes looks a bit ridculous, so instead hack the styling to
make it 2 boxes wide on small screens.
## QA
- `make run`
- Go to http://localhost:8001/cloud/, resize the browser, check the "Over 300 services .." grid looks reasonable at all screen sizes
