### PR TITLE
fixing the hr in /cloud and /iot sections per Robin's reco

### DIFF
--- a/templates/cloud/shared/_contextual_footer.html
+++ b/templates/cloud/shared/_contextual_footer.html
@@ -1,4 +1,4 @@
-<div id="context-footer" class="context-footer {{ level_1 }}-context-footer clearfix no-border">
+<div id="context-footer" class="context-footer {{ level_1 }}-context-footer row clearfix no-border">
 <hr />
   <div class="strip-inner-wrapper">
     <div class="twelve-col equal-height--vertical-divider no-margin-bottom">

--- a/templates/internet-of-things/shared/_contextual_footer.html
+++ b/templates/internet-of-things/shared/_contextual_footer.html
@@ -1,4 +1,4 @@
-<div id="context-footer" class="context-footer {{ level_1 }}-context-footer clearfix no-border">
+<div id="context-footer" class="context-footer {{ level_1 }}-context-footer row clearfix no-border">
 <hr />
 	<div class="twelve-col equal-height--vertical-divider no-margin-bottom">
 


### PR DESCRIPTION
## Done

added a .row to the contextual footer for the cloud and iot sections as they were exceeding the box
## QA

go to the overview of very section and see that the hr fits
## Issue / Card
- https://github.com/ubuntudesign/www.ubuntu.com/pull/552
