### PR TITLE
fix big data logo cloud

### DIFF
--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -235,7 +235,7 @@
                 'elementId':'#public-cloud-partners'
             },
             {
-                'params': '?service-offered=big-data&featured=true',
+                'params': '?service_offered__name=Big+data',
                 'elementId' : '#big-data-partners'
             }
         ];


### PR DESCRIPTION
## Done

making the /server page big data logo cloud work
## QA
1. go to /server
2. see that the big data cloud works with actual big data partners
