### PR TITLE
Update homepage takeover

### DIFF
--- a/static/css/section/_homepage.scss
+++ b/static/css/section/_homepage.scss
@@ -1343,25 +1343,26 @@ body.homepage-maas-takeover {
 
 // 16.04 takeover
 .release-1604 .row-hero {
+  background: #6d2263;
+  background: -moz-linear-gradient(45deg,  #6d2263 0%, #c3472e 100%);
+  background: -webkit-linear-gradient(45deg,  #6d2263 0%,#c3472e 100%);
+  background: linear-gradient(45deg,  #6d2263 0%,#c3472e 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#6d2263', endColorstr='#c3472e',GradientType=1 );
   background-image: url('https://assets.ubuntu.com/v1/34ab80ea-image-background-16-04.jpg?w=1150');
   background-position: right center;
-  margin-bottom: 20px;
-  margin-left: 20px;
-  margin-right: 20px;
-  padding-top: 20px;
+  margin: 10px;
+  padding-top: 10px;
   width: auto;
 
   @media only screen and (min-width : 768px) {
     background-image: url('https://assets.ubuntu.com/v1/34ab80ea-image-background-16-04.jpg');
     background-size: cover;
-    margin-bottom: 40px;
-    margin-left: 40px;
-    margin-right: 40px;
+    margin: 20px;
     min-height: 540px;
   }
 
   @media only screen and (min-width : 986px) {
-    min-height: 800px;
+    min-height: 85vh;
   }
 
   a {
@@ -1388,7 +1389,7 @@ body.homepage-maas-takeover {
   @media only screen and (min-width : 768px) {
     &__title {
       font-size: 3em;
-      margin-top: 100px;
+      margin-top: 6vh;
     }
 
     &__text {
@@ -1400,7 +1401,6 @@ body.homepage-maas-takeover {
     &__title {
       font-size: 4.5em;
       line-height: 1.8;
-      margin-top: 130px;
     }
 
     &__text {

--- a/templates/takeovers/_1604_takeover.html
+++ b/templates/takeovers/_1604_takeover.html
@@ -7,7 +7,7 @@
             </div>
             <div class="equal-height">
                 <div class="row-hero__text five-col">
-                    <p class="intro">Discover Ubuntu&rsquo;s sixth long-term support&nbsp;release</p>
+                    <p class="intro">Discover Ubuntu&rsquo;s sixth long-term support&nbsp;release.</p>
                     <p><a href="/download" class="button--primary intro" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : '16.04 release takeover', 'eventLabel' : 'Get Ubuntu 16.04 LTS link', 'eventValue' : undefined });">Get Ubuntu 16.04&nbsp;LTS</a></p>
                     <p class="intro"><a href="/desktop/features" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage Link', 'eventAction' : '16.04 release takeover', 'eventLabel' : 'Learn more about Ubuntu link', 'eventValue' : undefined });">Learn more about Ubuntu&nbsp;&rsaquo;</a></p>
                 </div>


### PR DESCRIPTION
## Done
- Added full stop to text
- Changed the margin around the takeover
- Set the min-height to be based on the viewport height
## QA
- Go to the homepage
- Check the bottom of the takeover is just above the fold
- Check there is just 20px margin on desktop and 10px on medium screens
