### PR TITLE
using django for release name on /server and /desktop/ubuntu-kylin

### DIFF
--- a/templates/desktop/ubuntu-kylin.html
+++ b/templates/desktop/ubuntu-kylin.html
@@ -49,7 +49,7 @@
 		</ul>
 	</div>
 	<div class="eight-col">
- 		<p><a href="https://wiki.ubuntu.com/XenialXerus/ReleaseNotes/UbuntuKylin" class="external">Read the full release notes</a></p>
+ 		<p><a href="https://wiki.ubuntu.com/{{latest_release_name}}/ReleaseNotes/UbuntuKylin" class="external">Read the full release notes</a></p>
     </div>
 </div>
 

--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -50,7 +50,7 @@
             </ul>
         </div>
         <div class="eleven-col">
-            <p><a class="external" href="https://wiki.ubuntu.com/XenialXerus/ReleaseNotes">Read more in the release notes</a></p>
+            <p><a class="external" href="https://wiki.ubuntu.com/{{lts_release_name}}/ReleaseNotes">Read more in the release notes</a></p>
         </div>
     </div>
 


### PR DESCRIPTION
## Done

change from XenialXerus to {{latest_release_name}} on /server/ and  /desktop/ubuntu-kylin
## QA

1.go to  /server and  /desktop/ubuntu-kylin
2. see that the release notes still work
