### PR TITLE
Fix indentation by removing nested <code>

### DIFF
--- a/templates/cloud/lxd.html
+++ b/templates/cloud/lxd.html
@@ -96,9 +96,9 @@
         <h2>Getting started with LXD</h2>
         <p>The simplest way to try LXD is by using it with its command line tool. This can easily be done on your laptop or desktop machine.</p>
         <p>On a system running {{ lts_release_full }} you can install LXD with:</p>
-        <pre><code>sudo apt update
+        <pre>sudo apt update
 sudo apt install lxd
-sudo lxd init</code></pre>
+sudo lxd init</pre>
         <p>For other Ubuntu releases, like Ubuntu {{ lts_release_full }} and Ubuntu Core, detailed instructions are available on <a href="https://linuxcontainers.org/lxd/getting-started-cli/" class="external">linuxcontainers.org</a></p>
         <p><a href="/download/server">Download Ubuntu Server&nbsp;&rsaquo;</a></p>
     </div>


### PR DESCRIPTION
Fixes #575
## QA

Go to http://localhost:8001/cloud/lxd and behold that `sudo apt update` is no longer extra-indented.
