### PR TITLE
fixing /download/server support date and OS release name

### DIFF
--- a/templates/download/server/index.html
+++ b/templates/download/server/index.html
@@ -21,7 +21,7 @@
                 <div class="box box-highlight clearfix equal-height--vertical-divider">
                     <div class="equal-height--vertical-divider__item eight-col no-margin-bottom">
                     <h2>Ubuntu Server {{lts_release_full}}</h2>
-                    <p>The long-term support version of Ubuntu Server, including the Icehouse release of OpenStack and support guaranteed until April 2019 &mdash; 64-bit only.</p>
+                    <p>The long-term support version of Ubuntu Server, including the {{openstack_version}} release of OpenStack and support guaranteed until April 2021 &mdash; 64-bit only.</p>
                     <p><a href="https://wiki.ubuntu.com/{{lts_release_name}}/ReleaseNotes" class="external">Ubuntu Server {{lts_release_full}} release notes</a></p>
                 </div>
                 <div class="equal-height--vertical-divider__item four-col last-col no-margin-bottom gap-from-top">

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -1,7 +1,7 @@
 {% load versioned_static  %}
 <!doctype html>
 
-{% with lts_release="16.04" latest_release="16.04" lts_release_full="16.04 LTS" latest_release_full="16.04 LTS"  latest_release_name="XenialXerus" lts_release_name="XenialXerus" openstack_version="Liberty" %}
+{% with lts_release="16.04" latest_release="16.04" lts_release_full="16.04 LTS" latest_release_full="16.04 LTS"  latest_release_name="XenialXerus" lts_release_name="XenialXerus" openstack_version="Mitaka" %}
 
 <!--[if lt IE 7]> <html class="no-js lt-ie10 lt-ie9 lt-ie8 lt-ie7" lang="en" dir="ltr"> <![endif]-->
 <!--[if IE 7]>    <html class="no-js lt-ie10 lt-ie9 lt-ie8" lang="en" dir="ltr"> <![endif]-->


### PR DESCRIPTION
## Done

updated /download/server to have:
- support date of 2021
- reference Mitaka for the OpenStack release name
- updated the copy doc
## QA
1. go to /download/server
2. see the above changes
## Issue / Card
- [bug 1573233](https://bugs.launchpad.net/ubuntu-website-content/+bug/1573233)
