### PR TITLE
Replace 'Edit and illustrate' logos with SVG alts

### DIFF
--- a/templates/desktop/features.html
+++ b/templates/desktop/features.html
@@ -213,16 +213,16 @@
         <p>Edit your photos or create professional illustrations and designs with tools like Gimp and Inkscape, available in the Ubuntu Software Centre.</p>
         <ul class="inline-list">
             <li>
-                <img src="{{ ASSET_SERVER_URL }}83a6c94f-inkscape-icon.png" alt="Inkscape icon" />
+                <img src="{{ ASSET_SERVER_URL }}833323dc-Inkscape.svg" alt="Inkscape icon" />
             </li>
             <li>
-                <img src="{{ ASSET_SERVER_URL }}5c9184f1-gimp-icon.png" alt="Gimp icon" />
+                <img src="{{ ASSET_SERVER_URL }}4d47a674-gimp-60x43.svg" alt="Gimp icon" width="60" />
             </li>
             <li>
-                <img src="{{ ASSET_SERVER_URL }}d658e3ca-lightworks-icon.png" alt="Lightworks icon" />
+                <img src="{{ ASSET_SERVER_URL }}51ebf780-lightworks.svg" alt="Lightworks icon" />
             </li>
             <li>
-                <img src="{{ ASSET_SERVER_URL }}aa19d407-blender-icon.png" alt="Blender icon" />
+                <img src="{{ ASSET_SERVER_URL }}786ed546-blender.svg" alt="Blender icon" />
             </li>
         </ul>
     </div>


### PR DESCRIPTION
## Done

Updated software logos with high res SVG alternatives 
## QA
- Navigate to /desktop/features
- Scroll to 'Edit and illustrate' 
- Check logos display as SVGs
- Check blender logo mark displays as documented here: https://www.blender.org/about/logo/
## Issue / Card

Fixes: #588
