### PR TITLE
Ensure /cloud/juju boxes are an equal height

### DIFF
--- a/templates/cloud/juju.html
+++ b/templates/cloud/juju.html
@@ -157,7 +157,7 @@
         <p>Bundles are pre-configured collections of charms that can be deployed in seconds.</p>
     </div>
 
-    <div class="twelve-col">
+    <div class="twelve-col equal-height">
         <div class="juju-bundle-card six-col">
             <div class="juju-bundle-card__image-container">
                 <object wmode="transparent" width="100%" class="juju-bundle-card__image" type="image/svg+xml" data="https://api.jujucharms.com/charmstore/v4/bundle/apache-core-batch-processing-20/diagram.svg"></object>


### PR DESCRIPTION
## Done

Added `.equal-height` to boxes container
## QA
- Navigate to /cloud/juju
- Scroll to "Bundles" section
- Ensure all boxes are an equal height
## Issue / Card

Fixes: #593
