### PR TITLE
Add 'LTS' to intro on desktop/developers

### DIFF
--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -48,7 +48,7 @@
 </div>
 
 <div class="row row-grey">
-    <h2>What&rsquo;s new in {{latest_release}} LTS?</h2>
+    <h2>What&rsquo;s new in {{latest_release_full}}?</h2>
     <p class="eight-col">Alongside support for the very latest hardware, Ubuntu {{latest_release}} includes new versions of many core apps and developer technologies.</p>
     <div class="combined-list">
         <ul class="list-ticks six-col">


### PR DESCRIPTION
## Done

Added 'LTS' to intro
## QA
- Go to /desktop/developers
- Scroll to 'What's new...' section
- Check that LTS is added after 1604
## Issue / Card

Fixes #566 

[List of links to Github issues/bugs and cards if needed]

Top tip: If this is related to a Github issue, use the keyword "Fixes" to auto-resolve that issue when this PR is merged.

e.g. `Fixes #1`
## Screenshots

[if relevant, include a screenshot]

Fixes: #566
