### PR TITLE
added newsletter to linuxone download thankyou

### DIFF
--- a/templates/download/server/linuxone-newsletter-thank-you.html
+++ b/templates/download/server/linuxone-newsletter-thank-you.html
@@ -1,0 +1,48 @@
+{% extends "management/base_management.html" %}
+
+{% block title %}Thank you | Ubuntu LinuxONE newsletter{% endblock %}
+
+{% block second_level_nav_items %}
+<div class="strip-inner-wrapper">
+    {% include "templates/_nav_breadcrumb.html" with section_title="Download" subsection_title="Server" page_title="Thank you"  %}
+</div>
+{% endblock second_level_nav_items %}
+
+{% block content %}
+<div class="row row-hero no-border equal-height">
+    <div class="strip-inner-wrapper">
+        <div class="thank-you eight-col equal-height__item">
+            <h1>Thank you for signing up for our Newsletter</h1>
+            <p class="intro">We hope you enjoy using Ubuntu.</p>
+        </div>
+        <div class="four-col last-col equal-height__item equal-height__align-vertically">
+            <img src="{{ ASSET_SERVER_URL }}52d53696-picto-thankyou-midaubergine.svg" alt="smile" width="200" height="200" />
+        </div>
+    </div>
+</div>
+
+{% include "shared/_thank_you_footer.html" %}
+
+
+{% endblock content %}
+{% block footer_extra %}
+<!-- Google Code for Services Canonical - contact us Conversion Page -->
+<script>
+/* <![CDATA[ */
+var google_conversion_id = 1012391776;
+var google_conversion_language = "en";
+var google_conversion_format = "3";
+var google_conversion_color = "ffffff";
+var google_conversion_label = "utP4CMDOwQMQ4L7f4gM";
+var google_conversion_value = 0;
+/* ]]> */
+</script>
+<script type="text/javascript" src="http://www.googleadservices.com/pagead/conversion.js">
+</script>
+<noscript>
+    <div style="display:inline;">
+        <img height="1" width="1" style="border-style:none;" alt="" src="http://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=utP4CMDOwQMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
+    </div>
+</noscript>
+{{ marketo }}
+{% endblock footer_extra %}

--- a/templates/download/server/thank-you-linuxone.html
+++ b/templates/download/server/thank-you-linuxone.html
@@ -19,9 +19,47 @@ Thanks for downloading Ubuntu for LinuxONE and z Systems
 
 <div class="row row-hero no-border">
     <div class="strip-inner-wrapper">
-        <h1>Thanks for downloading Ubuntu for LinuxONE and z&nbsp;Systems</h1>
-        <p>Your ISO download should start automatically.</p>
-        <p>If it doesn&rsquo;t, or for alternative options <a href="http://cdimage.ubuntu.com/releases/16.04/release/">visit the download page</a>.</p>
+        <div class="seven-col">
+            <h1>Thanks for downloading Ubuntu for LinuxONE and z&nbsp;Systems</h1>
+            <p>Your ISO download should start automatically.</p>
+            <p>If it doesn&rsquo;t, or for alternative options <a href="http://cdimage.ubuntu.com/releases/16.04/release/">visit the download page</a>.</p>
+        </div>
+        <div class="five-col last-col box">
+            <h2>Newsletter sign-up</h2>
+            <p>Stay up-to-date on new features, upgrades and how others are using Ubuntu on IBM LinuxOne and z&nbsp;Systems.</p>
+            <!-- MARKETO FORM -->
+            <script src="{{ ASSET_SERVER_URL }}d55f58bb-jquery.validate.js"></script>
+            <script src="{{ ASSET_SERVER_URL }}6ce35d3e-jquery-ui.min.js"></script>‌​
+            <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_1400">
+                <fieldset>
+                    <ul class="no-bullets">
+                        <li  class="mktFormReq mktField">
+                            <label for="Email" class="mktoLabel " >Email address: <span>*</span></label>
+                            <input required  id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField  mktoRequired" >
+                        </li>
+                        <li class="mktField">
+                            <input class="mktoField" value="yes" id="NewsletterOpt-In" name="NewsletterOpt-In" type="checkbox">
+                            <label  class="mktoLabel mktoHasWidth" for="NewsletterOpt-In">I would like to receive occasional news from Canonical by email.</label>
+                        </li>
+                        <li  class="mktField">
+                            <button type="submit" class="mktoButton link-cta-download button--primary">Sign-up</button></span><input type="hidden" name="formid" class="mktoField " value="1400"><input type="hidden" name="lpId" class="mktoField " value="2469"><input type="hidden" name="subId" class="mktoField" value="30"><input type="hidden" name="munchkinId" class="mktoField" value="066-EOV-335"><input type="hidden" name="lpurl" class="mktoField" value="//pages.ubuntu.com/download-LinuxONE.html?cr={creative}&amp;kw={keyword}"><input type="hidden" name="cr" class="mktoField " value=""><input type="hidden" name="kw" class="mktoField " value=""><input type="hidden" name="q" class="mktoField " value="">
+                        </li>
+                    </ul>
+                </fieldset>
+                <input type="hidden" name="returnURL" value="http://www.ubuntu.com/download/server/linuxone-newsletter-thank-you" />
+                <input type="hidden" name="retURL" value="http://www.ubuntu.com/download/server/linuxone-newsletter-thank-you" />
+            </form>
+            <script>
+            $("#mktoForm_1400").validate({
+                errorElement: "span",
+                errorClass: "mktFormMsg mktError",
+                onkeyup: false,
+                onclick: false,
+                onblur: false
+            });
+            </script>
+            <script src="{{ ASSET_SERVER_URL }}f97fa297-stateCountry.js"></script>
+        </div>
     </div>
 </div>
 <div class="row row-grey no-border">

--- a/templates/shared/_thank_you.html
+++ b/templates/shared/_thank_you.html
@@ -1,4 +1,5 @@
 <div class="row row-hero no-border equal-height">
+  {% if level_1 == "tablet" or level_1 == "phone" or level_1 == "download" %}<div class="strip-inner-wrapper">{% endif %}
 	<div class="thank-you eight-col equal-height__item">
 		<h1>Thank you for {{ thanks_context }}</h1>
 		<p class="intro">A member of our team will be in touch {{ details }}within <strong>one working day</strong></p>
@@ -7,4 +8,6 @@
 		<img src="{{ ASSET_SERVER_URL }}52d53696-picto-thankyou-midaubergine.svg" alt="smile" width="200" height="200" />
 	</div>
 </div>
-{% include "shared/_thank_you_footer.html" %}	
+  {% if level_1 == "tablet" or level_1 == "phone" or level_1 == "download" %}</div>{% endif %}
+
+{% include "shared/_thank_you_footer.html" %}

--- a/templates/shared/_thank_you_footer.html
+++ b/templates/shared/_thank_you_footer.html
@@ -1,5 +1,5 @@
 <div class="row equal-height no-border">
-  {% if level_1 == "tablet" %}<div class="strip-inner-wrapper">{% endif %}
+  {% if level_1 == "tablet" or level_1 == "download" %}<div class="strip-inner-wrapper">{% endif %}
 	<h2 class="twelve-col">More about our enterprise services</h2>
 	<ul id="thank-you-extra" class="no-bullets">
 		<li class="advantage four-col first">
@@ -18,5 +18,5 @@
 			<p><a href="/management">Learn about Landscape&nbsp;&rsaquo;</a></p>
 		</li>
 	</ul>
-	{% if level_1 == "tablet" %}</div>{% endif %}
+	{% if level_1 == "tablet"  or level_1 == "download" %}</div>{% endif %}
 </div><!-- end row-->


### PR DESCRIPTION
## Done
- added a newsletter form to the LinuxONE download thank you page
- created a newsletter sign-up thank you page
- updated the existing thankyou footer to support the full-width download section
## QA
1. go to /download/server/thank-you-linuxone
2. stop the download
3. see the new form and that it reads like the [copy doc](https://docs.google.com/document/d/1GptXtMfbgOjOmqb8DZCCTRwogkiP_cM95U9Z0gFSt7g/edit#)
4. fill out the form 
5. it will 404 as it goes to www.ubunut.com
6. go to /download/server/linuxone-newsletter-thank-you on your local host
7. read that this page is ok and like the [copy doc](https://docs.google.com/document/d/1r0OxvuPg5dGjg_5Ly03x0EJmAKM1jsF7uybsMNwSekM/edit#) plus the generic footer
## Issue / Card
- https://trello.com/c/ZxkIJthC
