### PR TITLE
Phone hero

### DIFF
--- a/templates/desktop/index.html
+++ b/templates/desktop/index.html
@@ -32,7 +32,7 @@
         <p><a href="/desktop/features">Explore features&nbsp;&rsaquo;</a></p>
     </div>
     <div class="pull-right right priority-0 equal-height__item">
-        <img src="{{ ASSET_SERVER_URL }}0e7183ed-desktop-overview-complete.jpg?op=region&rect=0,0,600,300" alt="The Guardian website on Firefox in {{ lts_release_full }}" />
+        <img src="{{ ASSET_SERVER_URL }}0e7183ed-desktop-overview-complete.jpg?op=region&rect=0,0,600,300" alt="The Guardian website on Firefox in 16.04 LTS" />
     </div>
 </div>
 

--- a/templates/phone/partners.html
+++ b/templates/phone/partners.html
@@ -37,7 +37,7 @@
 
         </div>
         <div class="seven-col prepend-one last-col">
-            <img src="{{ ASSET_SERVER_URL }}7fb3d062-intro-row.png" alt="Four phones showing {{ lts_release_full }}" />
+            <img src="{{ ASSET_SERVER_URL }}7fb3d062-intro-row.png" alt="Four phones showing 16.04 LTS" />
         </div><!-- /.seven-col -->
     </div>
 </section><!-- .row -->

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -2,8 +2,8 @@
 <!doctype html>
 
 {# Release versions - update as appropriate #}
-{% with latest_release_name="XenialXerus" latest_release="16.04" latest_release_full='16.04 LTS' %}
-{% with lts_release_name="XenialXerus" lts_release="16.04" lts_release_full='16.04 LTS' %}
+{% with latest_release_name="XenialXerus" latest_release="16.04" latest_release_full='16.04 <abbr title="long-term support">LTS</abbr>' %}
+{% with lts_release_name="XenialXerus" lts_release="16.04" lts_release_full='16.04 <abbr title="long-term support">LTS</abbr>' %}
 {% with openstack_version="Mitaka" %}
 
 <!--[if lt IE 7]> <html class="no-js lt-ie10 lt-ie9 lt-ie8 lt-ie7" lang="en" dir="ltr"> <![endif]-->


### PR DESCRIPTION
## Done

Remove abbreviation from LTS variable
Increase negative margins on flush images on the /management/compliance page
## QA

Go to http://www.ubuntu.com/phone/partners & http://www.ubuntu.com/desktop and note the erroneous LTS" />s then head to the same pages and make sure they’re no longer there.

Increase negative margins on flush images on the /management/compliance page so the images are flush.
