### PR TITLE
Reorder what's new list on desktop/developers

### DIFF
--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -53,11 +53,11 @@
     <div class="combined-list">
         <ul class="list-ticks six-col">
             <li>Linux 4.4 kernel</li>
-            <li>Firefox 45, Thunderbird 38.6 and Chromium 48 updates</li>
+            <li>Easy install of 35 different development environments with <a class="external" href="https://wiki.ubuntu.com/ubuntu-make">Ubuntu Make</a>.</li>
             <li class="last-item">LibreOffice 5.1 with improvements to menu and sidebars and support for remote servers</li>
         </ul>
         <ul class="list-ticks six-col last-col">
-            <li>Easy install of 35 different development environments with <a class="external" href="https://wiki.ubuntu.com/ubuntu-make">Ubuntu Make</a>.</li>
+            <li>Firefox 45, Thunderbird 38.6 and Chromium 48 updates</li>
             <li class="last-item">Python 3.5, Golang 1.6, Unity 7.3.2, Gtk 3.16.7, Compiz 0.9.12.1 and qt 5.4.2 updates</li>
         </ul>
     </div>


### PR DESCRIPTION
## Done

Reorder the bullets in "What's new” section as per issue
## QA

Go to /desktop/developers and make sure the list in "What’s new in 16.04?” section has been reordered so the bullet points have the two one-liners at the top.
## Issue / Card

Card: https://trello.com/c/LN28tuFI
Issue: Fixes #565
