### PR TITLE
Add dividers into /desktop/developers

### DIFF
--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -86,6 +86,8 @@
             <p><a class="external" href="https://developer.ubuntu.com">To find out more about snaps</a></p>
         </div>
     </div>
+</div>
+<div class="row">
     <div class="twelve-col">
         <div class="seven-col">
             <h3>By developers, for developers</h3>
@@ -96,6 +98,9 @@
             <img src="{{ ASSET_SERVER_URL }}7d0573d2-desktop-developer-developers.jpg" alt="Developer laptop" />
         </div>
     </div>
+</div>
+
+<div class="row">
     <div class="ten-col prepend-one">
         <blockquote class="pull-quote">
             <p><span>&ldquo;</span>Ubuntu has been the perfect OS given its popularity with developers and its cloud capabilities. That&rsquo;s why it&rsquo;s preloaded on the 4th generation of our XPS 13 laptop and our new Precision M3800 Mobile Workstation.<span>&rdquo;</span></p>


### PR DESCRIPTION
## Done

Add proper distinction between rows at /desktop/developers
## QA
- Navigate to /desktop/developers
- Check that "Snaps are the new apps" and "By developers, for developers" are divided by a dotted border with consistent spacing.
## Issue / Card
#567
