### PR TITLE
Fix Cloud partner logos on /cloud/partners

### DIFF
--- a/templates/cloud/partners/index.html
+++ b/templates/cloud/partners/index.html
@@ -155,9 +155,10 @@
 
 {% block footer_extra %}
 <script>
-    partnersApiParams = '?programme__name=Certified%20Public%20Cloud&programme__name=Charm%20Partner%20Programme&programme__name=OpenStack&featured=true';
-    partnersElementId = '#cloud-partners';
+    YUI().use('event-base', function (Y) {
+        Y.on('domready', function () {
+            core.loadPartners('?programme__name=Certified%20Public%20Cloud&programme__name=Charm%20Partner%20Programme&programme__name=OpenStack&featured=true', '#cloud-partners');
+        });
+    });
 </script>
-{% load versioned_static  %}
-<script src="{% versioned_static 'js/partners.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
## Done

Cloud partner logos not appearing on /cloud/partners
## QA

Go to /cloud/partners and ensure that the partner logos are appearing
## Issue / Card

Card: https://trello.com/c/i4juGiwT
Issue: Fixes #616
