### PR TITLE
Fix phone/partners: link too large

### DIFF
--- a/templates/phone/partners.html
+++ b/templates/phone/partners.html
@@ -61,7 +61,7 @@
       <h2>A super-sized developer opportunity</h2>
       <img class="twelve-col for-small" src="{{ ASSET_SERVER_URL }}619a89e6-Convergence_Devices_david_music.png?w=480" alt="" />
       <p>This is much more than a PC experience driven by a smartphone. It means mobile apps will now run on a full PC interface &mdash; a huge opportunity for mobile app developers, who will be able to give their users a wider range of features when their app is running on a desktop-sized display.</p>
-      <a href="https://developer.ubuntu.com/en/start/ubuntu-for-devices" class="external">Learn more about developing with Ubuntu</a>
+      <p><a href="https://developer.ubuntu.com/en/start/ubuntu-for-devices" class="external">Learn more about developing with Ubuntu</a></p>
     </div>
     <div class="twelve-col not-for-small">
       <img class="row-dev-opportunity--image" src="{{ ASSET_SERVER_URL }}619a89e6-Convergence_Devices_david_music.png?w=984" alt="Ubuntu on a phone, tablet and PC monitor" />


### PR DESCRIPTION
## Done

Fix phone/partners: link in "super sized dev opportunity" too large. It needed to be in `<p>` it is now, it’s happy.
## QA

Mooch on over to phone/partners and make sure the 'Learn more about developing with Ubuntu’ link is in a `<p>` and looks spiffing on small screens
## Issue / Card

Issue: Fixes #386 
Card: https://trello.com/c/zRQD4f1f
