### PR TITLE
updated contextual footer label and li font sizes for small screens

### DIFF
--- a/static/css/section/_contextual_footer.scss
+++ b/static/css/section/_contextual_footer.scss
@@ -112,7 +112,7 @@
     margin-bottom: 5px;
     margin-left: 0;
 
-    &.li {
+    li {
       @extend %contextual-footer-responsive-fonts;
     }
   }


### PR DESCRIPTION
## Done
- updated the _contextual_footer.scss to not make further reading too small and to make the label 14px
## QA

IN A SMALL SCREEN
1. go to /cloud/maas and see that the label is 13px in the footer for the cloud newsletter signup
   2, go to /desktop and see that the label is 13px in the footer for the device newletter signup
2. go to any page with further news and see that li's are 14px
## Issue / Card

Fixes: #627 and #628 
