### PR TITLE
updating windows shasum command on /download/how-to-verify

### DIFF
--- a/templates/download/how-to-verify.html
+++ b/templates/download/how-to-verify.html
@@ -136,7 +136,7 @@ Primary key fingerprint: 8439 38DF 228D 22F7 B374  2BC0 D94A A3F0 EFE2 1092</cod
             <pre class="twelve-col"><code>$ shasum -a 256 -c SHA256SUMS 2>&amp;1 | grep OK</code></pre>
 
             <p>If you’re using Windows, you may need to download a <a class="external" href="http://www.labtestproject.com/files/win/sha256sum/sha256sum.exe">SHA-256 tool</a> first. Once you have, your command will look like:
-            <pre class="twelve-col"><code>ubuntu-16.04-desktop-amd64.iso: OK</code></pre>
+            <pre class="twelve-col"><code>$ sha256sum.exe -c SHA256SUMS</code></pre>
 
             <p>The output you want will look similar to the following:</p>
             <pre class="twelve-col"><code>ubuntu-16.04-desktop-amd64.iso: OK</code></pre>


### PR DESCRIPTION
## Done

the windows command was pasted in wrong
## QA
1. go to /download/how-to-verify
2. look at the windows command 'If you’re using Windows, you may need to download a SHA-256 tool first. Once you have, your command will look like:'
3. see that it says '$ sha256sum.exe -c SHA256SUMS' like in the [copy doc](https://docs.google.com/document/d/1tG0k_QrRZ4KYdnMPNzsbkH66TD8L68H4l01ZHYit8BU/edit)
## Issue / Card

https://trello.com/c/doPAzwkW
