### PR TITLE
Remove insights content

### DIFF
--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -221,7 +221,6 @@
                 <img src="{{ ASSET_SERVER_URL }}ec77da7a-picto-startfirst-darkaubergine.svg" width="153" height="153" alt="" />
             </div>
         </div>
-        {% include "shared/_enterprise_blog.html" %}
 
         <div class="row row-grey equal-height no-border">
         {% if level_1 == 'desktop' and not level_2 %}


### PR DESCRIPTION
## Done

Remove insights content form main page as it’s duplicated in contextual footer
## QA

Go to /server and make sure the 'Further reading from Ubuntu Insights’ section isn’t on the page as is on live betwixt 'The fast track to virtualisation’ and 'A thriving community'
## Issue / Card

Card: https://trello.com/c/wifqRMFm
