### PR TITLE
updating /download/cloud conjure-up instructions

### DIFF
--- a/templates/download/server/_other-ways.html
+++ b/templates/download/server/_other-ways.html
@@ -9,10 +9,10 @@
                     {% if level_2 == 'cloud' %}
                         <h3 class="header--upgrade">sudo apt install openstack</h3>
                         <p>To setup Ubuntu OpenStack by hand run:</p>
-                        <pre><code>sudo apt install conjure-up</code></pre>
+                        <pre><code>sudo apt install openstack</code></pre>
                         <p>Followed by</p>
                         <pre><code>conjure-up openstack</code></pre>
-                        <p><a href="https://help.ubuntu.com/lts/clouddocs/installer/">More documentation&nbsp;&rsaquo;</a></p>
+                        <p><a class="external" href="http://conjure-up.io/">More information on conjure-up.io</a></p>
                     {% else %}
                         {% include "download/shared/_buy_a_usb.html" %}
                     {% endif %}
@@ -20,8 +20,7 @@
                 <div class="equal-height--vertical-divider__item four-col">
                     <h3 class="header--openstack">Ubuntu OpenStack tools</h3>
                     <p>Use our award winning tools, proven in production to deploy, manage and scale your OpenStack environment:</p>
-                    <pre><code>sudo add-apt-repository cloud-archive:juno</code></pre>
-                    <p><a href="https://help.ubuntu.com/lts/clouddocs/en/Intro.html">Follow the step-by-step guide&nbsp;&rsaquo;</a></p>
+                    <p><a class="external" href="https://help.ubuntu.com/lts/clouddocs/en/Intro.html">Learn more</a></p>
                 </div><!-- /.four-col -->
                 <div class="equal-height--vertical-divider__item four-col last-col">
                     <h3 class="header--download">Run Ubuntu in the public cloud</h3>


### PR DESCRIPTION
## Done
- Updated the 'sudo apt install openstack' section per business request
- DRIVE BY - Updated 'Ubuntu OpenStack tools' per copy doc
## QA
1. go to /download/cloud
2. see that the copy of the two above sections match the [copy doc](https://docs.google.com/document/d/1y3uaLNn7dxZKcLq2OmVJ96o3NOqn4OTJflty2GmxV9I/edit#heading=h.1vmylhpub0fp)
## Issue / Card

Fixes [bug 1576439](https://bugs.launchpad.net/ubuntu-website-content/+bug/1576439)
## Screenshots

![image](https://cloud.githubusercontent.com/assets/441217/15051760/df70f5dc-12bf-11e6-9570-351589ca9fb6.png)
