### PR TITLE
Add Meizu Pro 5 price

### DIFF
--- a/templates/phone/_devices.html
+++ b/templates/phone/_devices.html
@@ -32,7 +32,7 @@
                 <li>Weight: 168g</li>
             </ul>
     
-            <p itemprop="price"></p>
+            <p itemprop="price">Only &dollar;369.99</p>
             <p><a itemprop="url" class="button--primary" href="http://en.jd.com/1104324.html?utm_source=UbuntuCN&amp;utm_medium=website&amp;utm_campaign=PRO5ONSALE">Buy now</a></p>
         </div>
     </div>


### PR DESCRIPTION
## Done

Add Meizu Pro 5 price
## QA

Go to /phone/devices and make sure the Meizu Pro 5 has the same price as the doc (spoiler: it’s $369.99)
## Issue / Card

Card: https://trello.com/c/9VPqBxay
Doc: https://docs.google.com/document/d/1fuktWHXOV6iX5ZmdWzzHnkJoCfveca3mioQxeBYlJI8/edit#
