### PR TITLE
Clear the search pagination

### DIFF
--- a/templates/search.html
+++ b/templates/search.html
@@ -61,7 +61,7 @@
 {% endif %} {# results #}
 
 {% if nav_items %}
-    <nav class="bottom-nav" id="page-nav">
+    <nav class="bottom-nav" id="page-nav clear">
         <ul class="nav-forward">
 {% for item in nav_items %}
 {% if item.direction == 'forward' %}


### PR DESCRIPTION
## Done

Clear the search pagination 
## QA

As search doesn’t work locally, the only way to QA this is to search on live, inspect the content and find 'page-nav’ and add the class ‘clear’ the nav should appear before you.
## Issue / Card

Related to work carried out on this card: https://trello.com/c/v0deMnJG
