### PR TITLE
Remove trailing slashes in URLs

### DIFF
--- a/requirements/standard.txt
+++ b/requirements/standard.txt
@@ -7,3 +7,4 @@ django-asset-server-url==0.1
 django-versioned-static-url==0.1.1
 django-template-finder-view==0.2
 django-static-root-finder==0.3.1
+django-unslashed==0.3.0

--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -35,8 +35,12 @@ USE_TZ = False
 STATIC_URL = '/static/'
 STATIC_ROOT = "static"
 TEMPLATE_DIRS = [os.path.join(BASE_DIR, "templates")]
+APPEND_SLASH = False
+REMOVE_SLASH = True
 
-MIDDLEWARE_CLASSES = []
+MIDDLEWARE_CLASSES = [
+    'unslashed.middleware.RemoveSlashMiddleware',
+]
 
 STATICFILES_FINDERS = [
     'django_static_root_finder.finders.StaticRootFinder'

--- a/webapp/urls.py
+++ b/webapp/urls.py
@@ -7,10 +7,10 @@ urlpatterns = load_redirects()
 urlpatterns += patterns(
     '',
     url(
-        r'^(?P<template>download/(desktop|server|cloud)/thank-you)/?$',
+        r'^(?P<template>download/(desktop|server|cloud)/thank-you)[^\/]$',
         DownloadView.as_view()
     ),
-    url('^(?P<template>search)/?$', SearchView.as_view()),
-    url(r'^(?P<template>.*)/?$', UbuntuTemplateFinder.as_view()),
+    url(r'^(?P<template>search)[^\/]$', SearchView.as_view()),
+    url(r'^(?P<template>.*)[^\/]$', UbuntuTemplateFinder.as_view()),
+    url(r'$^', UbuntuTemplateFinder.as_view()),
 )
-


### PR DESCRIPTION
## Done

Removes trailing slashes from URLs.
Trailing slashes can't be removed from the root path (`/`), as this is against HTTP spec.

The middleware requires that the URL does not match a URL pattern. The rules have been changed to fail when given a trailing slash.
## QA
- Run site
- Ensure homepage runs correctly
- Browse website to make sure URLs load correctly
- Check URLs with trailing slashes redirect
## Issue / Card

Fixes #142 
