### PR TITLE
desktop/enterprise: incorrect text in release schedule section

### DIFF
--- a/templates/shared/_release_schedule.html
+++ b/templates/shared/_release_schedule.html
@@ -8,6 +8,11 @@
     <div class="five-col last-col equal-height__item equal-height__align-vertically">
         <h2 id="a-release-schedule-you-can-depend-on">A release schedule you can depend on</h2>
         <h3>Stay up-to-date with regular updates and upgrades</h3>
-        <p>Long-term support (LTS) releases of Ubuntu Server are supported by Canonical for five years. Every six months, interim releases bring new features, while hardware enablement updates add support for the latest machines to all supported LTS releases.</p>
+    {% if level_1 == 'desktop' %}
+        <p>Every two years there is a new long-term support (LTS) release of Ubuntu Desktop that is supported for five years. During that time, there will be regular security fixes and other critical updates which are, and always will be, free of charge.</p>
+    {% endif %}
+    {% if level_1 == 'server' %}
+        <p>Long-term support (LTS) releases of Ubuntu Server are supported by Canonical for five years. Every six months, interim releases bring new features, while hardware enablement updates add support for the latest machines to all supported LTS releases. </p>
+    {% endif %}    
     </div><!-- /.four-col -->
 </div><!-- /.row -->


### PR DESCRIPTION
## Done

Add conditional to display desktop and server versions of the copy
## QA

Make sure the copy in the 'A release schedule you can depend on' section on /desktop/enterprise and /server has the appropriate section specific content as per the copy docs.
## Issue / Card

Issue: Fixes #646
Card: https://trello.com/c/cvVfaxJA
Desktop doc: https://docs.google.com/document/d/1OcjFhwRofOdcWdJsNHZMvRowqhHNN0R2-aqJfK22ho8/edit#
Server doc: https://docs.google.com/document/d/1GqYEDkZPsCaLY9zXr9iX7nyIX9DBpE8i5A5Lx0rsUJg/edit#
