### PR TITLE
Remove intro class

### DIFF
--- a/templates/internet-of-things/features.html
+++ b/templates/internet-of-things/features.html
@@ -13,7 +13,7 @@
 <div class="row row-hero">
   <div class="six-col">
       <h1>Features</h1>
-      <p>Ubuntu Core can power  devices of practically any type and size, with the security and extensibility of a full-scale OS.</p>
+      <p>Ubuntu Core can power devices of practically any type and size, with the security and extensibility of a full-scale OS.</p>
       <ul class="six-col list-ticks--compact">
         <li>Safe, reliable, transactional updates with tests and rollback</li>
         <li>Applications confined by Canonical&rsquo;s AppArmor kernel security system</li>

--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -29,7 +29,7 @@
   </div>
   <div class="eight-col last-col equal-height__item">
       <h2>Why Ubuntu Core?</h2>
-      <p class="intro">Create differentiated devices that will continue to generate revenue over your product's lifetime, with a software platform that&rsquo;s easy to update and upgrade.</p>
+      <p>Create differentiated devices that will continue to generate revenue over your product's lifetime, with a software platform that&rsquo;s easy to update and upgrade.</p>
       <ul class="clear list-ticks--compact">
           <li>Faster, more reliable and stronger security guarantees for apps and users.</li>
           <li>Atomic transaction upgrades for apps and the Ubuntu Core software itself, all of which can be rolled back if needed, for simple maintenance and upgrades.</li>


### PR DESCRIPTION
## Done

IoT > Overview: the first paragraph in "Why Ubuntu Core" row should not be p.intro
Drive by space removal on /internet-of-things/features
## QA

Go to /internet-of-things and check that 'Why Ubuntu Core’ no longer has a class
## Issue / Card

Issue: Fixes #633
Card: https://trello.com/c/JAH7Egtg
