### PR TITLE
Edit padding on The best choice for developers row

### DIFF
--- a/static/css/section/_local.scss
+++ b/static/css/section/_local.scss
@@ -295,7 +295,9 @@ body {
 .billboard__content {
   background: rgba(255,255,255,.85);
   color: $cool-grey;
-  padding: 20px;
+  @media only screen and (min-width : $breakpoint-medium) {
+    padding: 20px;
+  }
 }
 .billboard__title {
   @media only screen and (min-width : $breakpoint-large) {


### PR DESCRIPTION
## Done

Remove left and right padding from the content in 'The best choice for developers’ section of /internet-of-things
## QA

Make sure the content in the 'The best choice for developers’ section of /internet-of-things doesn’t have too much left and right padding.
## Issue / Card

Issue: Fixes #632
Card: https://trello.com/c/PFXeJXbe 
