### PR TITLE
Various drive-bye

### DIFF
--- a/static/css/section/_local.scss
+++ b/static/css/section/_local.scss
@@ -489,6 +489,7 @@ body {
 .tablet {
   .row-hero {
     margin-top: 0;
+    
     h1 {
       padding-top: 20px;
     }
@@ -534,6 +535,13 @@ body {
   
   .row-hero {
     padding: 0 10px 0;
+
+    @media only screen and (min-width : $breakpoint-medium) {
+      padding: 40px 10px 20px;
+    }
+    @media only screen and (min-width : $breakpoint-large) {
+      padding: 100px 40px;
+    }
   }
 }
 

--- a/templates/download/server/index.html
+++ b/templates/download/server/index.html
@@ -11,84 +11,78 @@
 {% endblock second_level_nav_items %}
 
 {% block content %}
-<div class="row row-grey">
+<div class="row row-grey row-hero">
     <div class="strip-inner-wrapper">
         <div class="eight-col append-four">
             <h1>Download Ubuntu Server</h1>
         </div>
-        <div class="strip-inner-wrapper">
-            <div class="twelve-col no-margin-bottom">
-                <div class="box box-highlight clearfix equal-height--vertical-divider">
-                    <div class="equal-height--vertical-divider__item eight-col no-margin-bottom">
-                        <h2>Ubuntu Server {{lts_release_full}}</h2>
-                        <p>The long-term support version of Ubuntu Server, including the {{openstack_version}} release of OpenStack and support guaranteed until April 2021 &mdash; 64-bit only.</p>
-                        <p><a href="https://wiki.ubuntu.com/{{lts_release_name}}/ReleaseNotes" class="external">Ubuntu Server {{lts_release_full}} release notes</a></p>
-                    </div>
-                    <div class="equal-height--vertical-divider__item four-col last-col no-margin-bottom gap-from-top">
-                        <p><a href="/download/server/thank-you?version={{lts_release}}&amp;architecture=amd64" class="link-cta-download button--primary">Download</a></p>
-                        <p><a href="/download/alternative-downloads">Alternative downloads and torrents&nbsp;&rsaquo;</a></p>
-                    </div><!-- /.four-col -->
-                </div><!-- /.box -->
-            </div>
+        <div class="twelve-col no-margin-bottom">
+            <div class="box box-highlight clearfix equal-height--vertical-divider">
+                <div class="equal-height--vertical-divider__item eight-col no-margin-bottom">
+                    <h2>Ubuntu Server {{lts_release_full}}</h2>
+                    <p>The long-term support version of Ubuntu Server, including the {{openstack_version}} release of OpenStack and support guaranteed until April 2021 &mdash; 64-bit only.</p>
+                    <p><a href="https://wiki.ubuntu.com/{{lts_release_name}}/ReleaseNotes" class="external">Ubuntu Server {{lts_release_full}} release notes</a></p>
+                </div>
+                <div class="equal-height--vertical-divider__item four-col last-col no-margin-bottom gap-from-top">
+                    <p><a href="/download/server/thank-you?version={{lts_release}}&amp;architecture=amd64" class="link-cta-download button--primary">Download</a></p>
+                    <p><a href="/download/alternative-downloads">Alternative downloads and torrents&nbsp;&rsaquo;</a></p>
+                </div><!-- /.four-col -->
+            </div><!-- /.box -->
         </div>
-    </div><!-- /.row -->
+    </div>
+</div>
 
-    <div class="row">
-        <div class="strip-inner-wrapper">
-            <div class="twelve-col">
-                <h2>How you can use Ubuntu Server</h2>
+<div class="row row-grey">
+    <div class="strip-inner-wrapper">
+        <h2 class="twelve-col">How you can use Ubuntu Server</h2>
+        <div class="equal-height">
+            <div class="six-col box">
+                <h3>OpenStack</h3>
+                <p>Build your cloud with Autopilot, the easiest way to create and manage an OpenStack cloud. Test drive on VMs or build a free test cloud on your own hardware for up to ten machines today.</p>
+                <p><a href="/download/cloud">Get started with  Autopilot&nbsp;&rsaquo;</a></p>
             </div>
-            <div class="equal-height">
-                <div class="six-col box">
-                    <h3>OpenStack</h3>
-                    <p>Build your cloud with Autopilot, the easiest way to create and manage an OpenStack cloud. Test drive on VMs or build a free test cloud on your own hardware for up to ten machines today.</p>
-                    <p><a href="/download/cloud">Get started with  Autopilot&nbsp;&rsaquo;</a></p>
-                </div>
-                <div class="six-col box last-col">
-                    <h3>Ubuntu Server for ARM</h3>
-                    <p>Optimised for hyperscale deployments and certified on a number of ARM chipsets, Ubuntu Server for ARM includes the 64-bit ARMv8 platforms.</p>
-                    <p><a href="/download/server/arm">Get Ubuntu Server for ARM&nbsp;&rsaquo;</a></p>
-                </div>
-                <div class="six-col box">
-                    <h3>Ubuntu for POWER8</h3>
-                    <p>Ubuntu is now available on the IBM POWER8 platform, bringing the entire Ubuntu and OpenStack ecosystem to IBM POWER8</p>
-                    <p><a href="/download/server/power8">Get Ubuntu {{latest_release}} for  POWER8&nbsp;&rsaquo;</a></p>
-                </div>
-                <div class="six-col box last-col">
-                    <h3>Ubuntu for IBM LinuxONE</h3>
-                    <p>IBM LinuxONE and z Systems leverage open technology solutions to meet the demands of the new application economy. Ubuntu is now available, with Juju and Ubuntu OpenStack.</p>
-                    <p><a href="/download/server/linuxone">Get Ubuntu for LinuxONE&nbsp;&rsaquo;</a></p>
-                </div>
+            <div class="six-col box last-col">
+                <h3>Ubuntu Server for ARM</h3>
+                <p>Optimised for hyperscale deployments and certified on a number of ARM chipsets, Ubuntu Server for ARM includes the 64-bit ARMv8 platforms.</p>
+                <p><a href="/download/server/arm">Get Ubuntu Server for ARM&nbsp;&rsaquo;</a></p>
+            </div>
+            <div class="six-col box">
+                <h3>Ubuntu for POWER8</h3>
+                <p>Ubuntu is now available on the IBM POWER8 platform, bringing the entire Ubuntu and OpenStack ecosystem to IBM POWER8</p>
+                <p><a href="/download/server/power8">Get Ubuntu {{latest_release}} for POWER8&nbsp;&rsaquo;</a></p>
+            </div>
+            <div class="six-col box last-col">
+                <h3>Ubuntu for IBM LinuxONE</h3>
+                <p>IBM LinuxONE and z Systems leverage open technology solutions to meet the demands of the new application economy. Ubuntu is now available, with Juju and Ubuntu OpenStack.</p>
+                <p><a href="/download/server/linuxone">Get Ubuntu for LinuxONE&nbsp;&rsaquo;</a></p>
             </div>
         </div>
     </div>
+</div>
 
-    <div class="row no-border">
-        <div class="strip-inner-wrapper">
-            <div class="twelve-col">
-                <h2>Get the version you need</h2>
-            </div>
-            <div class="twelve-col">
-                <div class="equal-height equal-height--vertical-divider">
-                    <div class="four-col equal-height--vertical-divider__item">
-                        {% include "download/shared/_buy_a_usb.html" %}
-                    </div><!-- /.desktop -->
-                    <div class="four-col equal-height--vertical-divider__item">
-                        <h3 class="header--download">Find alternative downloads</h3>
-                        <p>Ubuntu is available via BitTorrent links and  regional mirrors. You can also use the network installer.</p>
-                        <p><a href="/download/alternative-downloads">Alternative downloads&nbsp;&rsaquo;</a></p>
-                    </div><!-- /.four-col -->
-                    <div class="four-col equal-height--vertical-divider__item last-col">
-                        <h3 class="header--server">Download a previous release</h3>
-                        <p>Looking for a previous LTS point release with its original stack? Older versions of Ubuntu remain available.</p>
-                        <p><a href="http://releases.ubuntu.com" class="external">Previous releases</a></p>
-                    </div>
+<div class="row no-border">
+    <div class="strip-inner-wrapper">
+        <h2 class="twelve-col">Get the version you need</h2>
+        <div class="twelve-col">
+            <div class="equal-height equal-height--vertical-divider">
+                <div class="four-col equal-height--vertical-divider__item">
+                    {% include "download/shared/_buy_a_usb.html" %}
+                </div>
+                <div class="four-col equal-height--vertical-divider__item">
+                    <h3 class="header--download">Find alternative downloads</h3>
+                    <p>Ubuntu is available via BitTorrent links and  regional mirrors. You can also use the network installer.</p>
+                    <p><a href="/download/alternative-downloads">Alternative downloads&nbsp;&rsaquo;</a></p>
+                </div>
+                <div class="four-col equal-height--vertical-divider__item last-col">
+                    <h3 class="header--server">Download a previous release</h3>
+                    <p>Looking for a previous LTS point release with its original stack? Older versions of Ubuntu remain available.</p>
+                    <p><a href="http://releases.ubuntu.com" class="external">Previous releases</a></p>
                 </div>
             </div>
         </div>
     </div>
 </div>
 
-    {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_download_server_installation" second_item="_download_server_guide" third_item="_download_helping_hands" %}
+{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_download_server_installation" second_item="_download_server_guide" third_item="_download_helping_hands" %}
 
-    {% endblock content %}
+{% endblock content %}

--- a/templates/download/server/linuxone.html
+++ b/templates/download/server/linuxone.html
@@ -14,7 +14,7 @@
 {% endblock second_level_nav_items %}
 
 {% block content %}
-<div class="row row-grey">
+<div class="row row-grey no-border">
     <div class="strip-inner-wrapper">
         <div class="eight-col append-four">
             <h1>Ubuntu for IBM LinuxONE and z&nbsp;Systems</h1>

--- a/templates/download/ubuntu-flavours.html
+++ b/templates/download/ubuntu-flavours.html
@@ -29,7 +29,7 @@ full Ubuntu archive for packages and updates.{% endblock %}
     </div>
 </div>
 
-<div class="row">
+<div class="row no-border">
     <div class="strip-inner-wrapper">
         <div class="twelve-col">
         <ul class="list--grid twelve-col no-bullets no-margin-bottom">

--- a/templates/phone/_devices.html
+++ b/templates/phone/_devices.html
@@ -107,7 +107,7 @@
     </div>
 </section>
 
-<section class="row row--note strip-light">
+<section class="row row--note strip-light no-border">
     <div class="strip-inner-wrapper">
         <p class="note">Please note: prices and availability may vary.</p>
     </div>

--- a/templates/phone/devices-in.html
+++ b/templates/phone/devices-in.html
@@ -7,7 +7,9 @@
 {% block meta_description %}Ubuntu is now available all over Europe on the BQ Aquaris E4.5, direct from the BQ website. Many more devices are in the works, so watch this space.{% endblock %}
 
 {% block second_level_nav_items %}
-	{% include "templates/_nav_breadcrumb.html" with section_title="Phone" page_title="Devices"  %}
+    <div class="strip-inner-wrapper">
+	{% include "templates/_nav_breadcrumb.html" with section_title="Phone" page_title="Devices" %}
+    </div>
 {% endblock second_level_nav_items %}
 
 {% block content %}


### PR DESCRIPTION
## Done

Remove borders from various last rows
Spotted some bad things on /phone section live, the padding on the heroes has gone pear shaped
## QA

Check the following pages last row have no border:

/download/server/linuxone
/download/ubuntu-flavours
/phone/_devices

and have a scoot around the /phone section paying attention to the heroes and how they differ from live
## Issue / Card

Card for /download/ubuntu-flavours - https://trello.com/c/I0sxpr3R
Issue for /download/ubuntu-flavours - https://github.com/ubuntudesign/www.ubuntu.com/issues/629
