### PR TITLE
Correct regex URL rules for download and search

### DIFF
--- a/webapp/urls.py
+++ b/webapp/urls.py
@@ -7,10 +7,10 @@ urlpatterns = load_redirects()
 urlpatterns += patterns(
     '',
     url(
-        r'^(?P<template>download/(desktop|server|cloud)/thank-you)[^\/]$',
+        r'^(?P<template>download/(desktop|server|cloud)/thank-you)$',
         DownloadView.as_view()
     ),
-    url(r'^(?P<template>search)[^\/]$', SearchView.as_view()),
+    url(r'^(?P<template>search)$', SearchView.as_view()),
     url(r'^(?P<template>.*)[^\/]$', UbuntuTemplateFinder.as_view()),
     url(r'$^', UbuntuTemplateFinder.as_view()),
 )


### PR DESCRIPTION
## Done

Update URL regex rules for download and search
## QA
- `make clean-all && make run`
- Make sure `/search` loads and download works as expected.
