### PR TITLE
Add external links to external button CTAs

### DIFF
--- a/templates/phone/_devices.html
+++ b/templates/phone/_devices.html
@@ -33,7 +33,10 @@
             </ul>
     
             <p itemprop="price">Only &dollar;369.99</p>
-            <p><a itemprop="url" class="button--primary" href="http://en.jd.com/1104324.html?utm_source=UbuntuCN&amp;utm_medium=website&amp;utm_campaign=PRO5ONSALE">Buy now</a></p>
+            <p><a itemprop="url" class="button--primary" href="http://en.jd.com/1104324.html?utm_source=UbuntuCN&amp;utm_medium=website&amp;utm_campaign=PRO5ONSALE">
+                    <span class="external">Buy now</span>
+                </a>
+            </p>
         </div>
     </div>
 </section>
@@ -56,7 +59,10 @@
                 <li>Slots for two micro-SIM cards for phone use across multiple networks</li>
             </ul>
             <p itemprop="price">Only 199,90&euro;</p>
-            <p><a itemprop="url" class="button--primary" href="{{ BQ_E5_BUY_LINK }}">Buy now</a></p>
+            <p><a itemprop="url" class="button--primary" href="{{ BQ_E5_BUY_LINK }}">
+                    <span class="external">Buy now</span>
+                </a>
+            </p>
         </div>
     </div>
 </section>
@@ -79,7 +85,10 @@
                 <li>Weight: 123g</li>
             </ul>
             <p itemprop="price">Only 169,90&euro;</p>
-            <p><a itemprop="url" class="button--primary" href="{{ BQ_E45_BUY_LINK }}">Buy now</a></p>
+            <p><a itemprop="url" class="button--primary" href="{{ BQ_E45_BUY_LINK }}">
+                <span class="external">Buy now</span>
+                </a>
+            </p>
         </div>
     </div>
 </section>

--- a/templates/tablet/devices.html
+++ b/templates/tablet/devices.html
@@ -43,7 +43,10 @@
             <li>Lightweight at only 470g</li>
           </ul>
         </div>
-        <p><a itemprop="url" class="button--primary" href="https://store.bq.com/gl/ubuntu-edition/?utm_source=Ubuntu.com_devices&amp;utm_medium=Button&amp;utm_campaign=m10-ubuntu-edition-canonical&amp;">Buy now</a></p>
+        <p><a itemprop="url" class="button--primary" href="https://store.bq.com/gl/ubuntu-edition/?utm_source=Ubuntu.com_devices&amp;utm_medium=Button&amp;utm_campaign=m10-ubuntu-edition-canonical&amp;">
+                <span class="external">Buy now</span>
+            </a>
+        </p>
       </div>
       <div class="device-image five-col prepend-one align-center last-col not-for-small">
         <p><img itemprop="image" src="{{ ASSET_SERVER_URL }}954529ef-Front-Portrait.png?w=400" alt="BQ Aquaris M10" /></p>


### PR DESCRIPTION
## Done

Added external icons to Buttons that link out to external sites;
- /tablet/devices
- /phone/devices
## QA

Run code, navigate to pages above and check that all "Buy now" buttons have an external link icon as per the screenshot below.
## Issue / Card

Fixes: #639 
## Screenshots

<img width="442" alt="screenshot 2016-05-16 14 51 15" src="https://cloud.githubusercontent.com/assets/505570/15291423/ac4cc302-1b75-11e6-98a0-c648a0a32d98.png">
