### PR TITLE
Unset video object on /phone when video is closed

### DIFF
--- a/static/js/scratch.js
+++ b/static/js/scratch.js
@@ -271,7 +271,7 @@ YUI().use('node','gallery-carousel','gallery-carousel-anim','substitute', 'galle
             if(Y.one('.show-video')) {
                 Y.one('.show-video').on('click',function(e) {
                     e.preventDefault();
-                    //Y.one('#panel').addClass('flipped');
+                    Y.one('.video-container.for-mobile').set('innerHTML','');
                     setTimeout(function(){ Y.one('.the-video').set('innerHTML','<div class="videoWrapper"><iframe style="width:100%" src="http://www.youtube.com/embed/-dpfHYpfEXY?showinfo=0&hd=1&rel=0&modestbranding=0&autoplay=1" frameborder="0" allowfullscreen></iframe></div>');Y.one('#topbar').setStyle('z-index', '50');}, 1000);
                 });
             }


### PR DESCRIPTION
## Done
- Abstracted video object into variable so the same embed code is not repeated x3
- Remove video object from video container when close action is clicked and re-add it to hidden container so it's there if use clicks the 'Watch' action again
## QA
- Run code
- Turn up volume
- Navigate to /phone
- Click "Watch the video"
- Click "Close the video"
- Ensure video stops playing and video audio no longer plays
## Issue / Card

Trello: https://trello.com/c/dAUZVdEz
Fixes: #250
