### PR TITLE
align center juju logo

### DIFF
--- a/templates/cloud/partners/index.html
+++ b/templates/cloud/partners/index.html
@@ -97,7 +97,7 @@
         <p>Canonical&rsquo;s Charm Partner Programme helps you leverage the power of Juju, the service orchestration tool, by helping you create Juju charms for your products. Charms encapsulate all the important configuration information, defining how your services will be deployed and how they will work with other services.</p>
         <p><a href="http://partners.ubuntu.com/partner-programmes/software#charm-partner-programme">Learn more about the Charm Partner Programme&nbsp;&rsaquo;</a></p>
     </div>
-    <div class="four-col for-small">
+    <div class="four-col for-small align-center">
         <img src="{{ ASSET_SERVER_URL }}f7bff337-logo-juju-171x174.png" width="171" height="171" alt="Juju" />
     </div>
 </div><!-- /.row -->


### PR DESCRIPTION
## Done

Add align-center class to juju logo for small
## QA

Go to /cloud/partners and have a butchers at the juju logo in the 'Charm Partner Programme’ section in small, it should be centred see
## Issue / Card

Card: https://trello.com/c/MTk1d06v
Issue: https://github.com/ubuntudesign/www.ubuntu.com/issues/376 
