### PR TITLE
Fix download section padding

### DIFF
--- a/static/css/section/_download.scss
+++ b/static/css/section/_download.scss
@@ -86,8 +86,16 @@
 .download {
 
     .wrapper .row {
-        padding: 40px;
-        padding-top: 2em;
+        @media only screen and (min-width : $breakpoint-large) {
+          padding: 40px;
+          padding-top: 2em;
+        }
+    }
+    
+    @media only screen and (min-width : $breakpoint-medium) {
+      .strip-inner-wrapper {
+        padding: 0;
+      }
     }
 
     #main-content .row-hero {

--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -40,7 +40,7 @@
                     <h2><a href="/download/server">Ubuntu Server&nbsp;&rsaquo;</a></h2>
                     <p>Whether you want to configure a simple file server or build a fifty thousand-node cloud, you can rely on Ubuntu Server and its five years of guaranteed free upgrades.</p>
                 </div>
-                <div class="two-col last-col equal-height__item equal-height__align-vertically">
+                <div class="two-col last-col align-center equal-height__item equal-height__align-vertically">
                     <a href="/download/server"><img src="{{ ASSET_SERVER_URL }}0fdf9cfe-picto-server-darkaubergine.svg" alt="" width="113" height="113" /></a>
                 </div>
             </div>
@@ -49,7 +49,7 @@
                     <h2><a href="/download/cloud">Ubuntu Cloud&nbsp;&rsaquo;</a></h2>
                     <p>Ubuntu is the reference OS for OpenStack. Canonical&rsquo;s OpenStack Autopilot is a fully automated deployment of an OpenStack cloud on Ubuntu &mdash; just add servers.</p>
                 </div>
-                <div class="two-col last-col  equal-height__item equal-height__align-vertically">
+                <div class="two-col last-col align-center equal-height__item equal-height__align-vertically">
                     <a href="/download/cloud"><img src="{{ ASSET_SERVER_URL }}dfd42685-picto-cloud-darkaubergine.svg" alt="" width="113" height="113" /></a>
                 </div>
             </div>
@@ -61,7 +61,7 @@
                     <h2><a href="/download/ubuntu-kylin">Ubuntu Kylin&nbsp;&rsaquo;</a></h2>
                     <p>Created specifically for the needs of Chinese users, Ubuntu Kylin {{lts_release_full}} includes many unique features and five years support from Canonical.</p>
                 </div>
-                <div class="two-col last-col equal-height__item equal-height__align-vertically">
+                <div class="two-col last-col align-center equal-height__item equal-height__align-vertically">
                     <a href="/download/ubuntu-kylin"><img src="{{ ASSET_SERVER_URL }}590018e7-picto-ubuntukylin.svg" alt="Ubuntu Kylin logo" height="112" width="112" /></a>
                 </div>
             </div>
@@ -70,7 +70,7 @@
                     <h2><a href="https://developer.ubuntu.com/en/snappy/start/" class="external">Ubuntu Core</a></h2>
                     <p>Are you a developer who wants to try snappy Ubuntu Core?  The new, transactionally updated Ubuntu for clouds and devices. </p>
                 </div>
-                <div class="two-col last-col equal-height__item equal-height__align-vertically">
+                <div class="two-col last-col align-center equal-height__item equal-height__align-vertically">
                     <a href="https://developer.ubuntu.com/en/snappy/start/"><img src="{{ ASSET_SERVER_URL }}cde21f03-snappy.png" alt="Ubuntu Kylin logo" height="112" width="112" /></a>
                 </div>
             </div>
@@ -79,7 +79,7 @@
                     <h2><a href="/download/alternative-downloads">Alternative downloads&nbsp;&rsaquo;</a></h2>
                     <p>There are several other ways to get Ubuntu including torrents, which can potentially mean a quicker download, our network installer for older systems and special configurations and links to our regional DVD image mirrors for our older releases.</p>
                 </div>
-                <div class="five-col last-col no-margin-bottom equal-height__item equal-height__align-vertically">
+                <div class="five-col last-col align-center no-margin-bottom equal-height__item equal-height__align-vertically">
                     <a href="/download/alternative-downloads"><img src="{{ ASSET_SERVER_URL }}be3876ec-picto-download-warmgrey.svg" alt="Chinese Ubuntu logo" height="112" width="112" /></a>
                 </div>
             </div>
@@ -93,7 +93,7 @@
                 by the full Ubuntu archive for packages and updates.
                 </p>
             </div>
-            <div class="five-col last-col text-center no-margin-bottom align-vertically priority-0">
+            <div class="five-col last-col align-center no-margin-bottom align-vertically priority-0">
                 <a href="/download/ubuntu-flavours"><img src="{{ ASSET_SERVER_URL }}ebfb7122-picto-generic-warmgrey.svg" alt="" height="112" width="112" /></a>
             </div>
         </div>


### PR DESCRIPTION
## Done

Fix issue #624 - download section has too much left/right margin on small screen
## QA

Head on over to the download section and peruse the section in small mode, the extra padding either side should be less more than on live
## Issue / Card

Card: https://trello.com/c/LAYInWyH
Issue: https://github.com/ubuntudesign/www.ubuntu.com/issues/624
