### PR TITLE
Make BQ Aquaris E4.5 sold out

### DIFF
--- a/templates/phone/_devices.html
+++ b/templates/phone/_devices.html
@@ -85,10 +85,7 @@
                 <li>Weight: 123g</li>
             </ul>
             <p itemprop="price">Only 169,90&euro;</p>
-            <p><a itemprop="url" class="button--primary" href="{{ BQ_E45_BUY_LINK }}">
-                <span class="external">Buy now</span>
-                </a>
-            </p>
+            <p><a itemprop="url" class="button--primary button--primary__deactivated">Sold out</a></p>
         </div>
     </div>
 </section>


### PR DESCRIPTION
## Done

Fix bug 1580683 - Dead link on devices page: The E4.5 is no longer sold so the buy link yields a 404
## QA

Go to the /phone/devices page and note that the E4.5 now has a ‘Sold out’ button, although, I doubt you’ll be able to see the words as the contrast is pretty bad. I’m going to see if there’s an issue in for this.
## Issue / Card

Bug: https://bugs.launchpad.net/ubuntu-website-content/+bug/1580683
Card: https://trello.com/c/rMuXYg2B
