### PR TITLE
updating the number of languages translated

### DIFF
--- a/templates/desktop/index.html
+++ b/templates/desktop/index.html
@@ -1,7 +1,7 @@
 {% extends "desktop/base_desktop.html" %}
 
 {% block title %}Ubuntu PC operating system{% endblock %}
-{% block meta_description %}Fast, secure and stylishly simple, the Ubuntu operating system is used by 40 million people worldwide every day.{% endblock %}
+{% block meta_description %}Fast, secure and stylishly simple, the Ubuntu operating system is used by 50 million people worldwide every day.{% endblock %}
 {% block meta_keywords %}Ubuntu, Ubuntu operating system, OS, Linux, Windows alternative, Mac alternative, thin client{% endblock %}
 
 {% block extra_body_class %}desktop-home{% endblock %}
@@ -50,7 +50,7 @@
 
         <div class="equal-height--vertical-divider__item four-col last-col">
             <h2>Accessible</h2>
-            <p>Computing is for everyone regardless of nationality, gender or disability. Ubuntu is fully translated into over 100 languages and includes essential assistive technologies.</p>
+            <p>Computing is for everyone regardless of nationality, gender or disability. Ubuntu is fully translated into over 50 languages and includes essential assistive technologies.</p>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Done
- updated /desktop to say 50 languages translated consistently
- updated the (copy doc)[https://docs.google.com/document/d/1ZhMkLlkXcimHTIe1taXy24vbbR9pBkZd49H2sJqeQH0/edit]
## QA
1. go to /desktop and see that the meta description and text says 50 lang
## Issue / Card

Fixes [bug 1573719](https://bugs.launchpad.net/ubuntu-website-content/+bug/1573719)
