### PR TITLE
updating MAAS.io link on /cloud/maas

### DIFF
--- a/templates/shared/contextual_footers/_cloud_maas.html
+++ b/templates/shared/contextual_footers/_cloud_maas.html
@@ -1,3 +1,3 @@
 <h3 class="contextual-footer__title">Install MAAS</h3>
 <p class="contextual-footer__text">Metal as a Service (MAAS) brings the language of the cloud to physical servers.</p>
-<p class="contextual-footer__text"><a href="https://www.maas.io" class="external">Find out more at maas.io</a></p>
+<p class="contextual-footer__text"><a href="http://maas.io" class="external" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'MAAS.io', 'eventLabel' : 'From /cloud/maas', 'eventValue' : undefined });">Find out more at maas.io</a></p>


### PR DESCRIPTION
## Done
- updated the MAAS.io link in the contextual footer partial
- added GTM tracking code
## QA
1. go to the footer of /cloud/maas
2. click on the link 'Find out more at maas.io'
3. see that it goes to MAASi.io
## Issue / Card

Fixes: #694 
[Card](https://trello.com/c/2jSa1aO6)
