### PR TITLE
Remove .inner-wrapper styles for small and medium

### DIFF
--- a/static/css/section/_local.scss
+++ b/static/css/section/_local.scss
@@ -10,17 +10,17 @@ body {
   }
 }
 
-<<<<<<< 65930b0b90d351260a66b51dd6300dd802334c9f
 @media only screen and (min-width : $breakpoint-large) {
   .inner-wrapper {
     margin-bottom: 30px;
-=======
+  }
+}
+
 @media only screen and (max-width : $breakpoint-medium) {
   .inner-wrapper {
     border-radius: 0;
     box-shadow: none;
     padding-bottom: 0;
->>>>>>> Remove .inner-wrapper styles for small and medium
   }
 }
 


### PR DESCRIPTION
## Done

Remove .inner-wrapper styles for small and medium
## QA

Head to a section that isn’t full width such as cloud and resize to small or medium, there should be no rounded corners or shadow as is on live. 
## Issue / Card

Card: https://trello.com/c/Y2M5RFFh
Issue: https://github.com/ubuntudesign/www.ubuntu.com/issues/647
