### PR TITLE
Fix menu drop-down item active states

### DIFF
--- a/templates/cloud/_nav_secondary.html
+++ b/templates/cloud/_nav_secondary.html
@@ -7,6 +7,6 @@
 		<li><a{% if level_2 == 'lxd' %} class="active"{% endif %} href="/cloud/lxd">LXD</a></li>
 		<li><a{% if level_2 == 'snappy' %} class="active"{% endif %} href="/cloud/snappy">Snappy</a></li>
     <li><a{% if level_2 == 'storage' %} class="active"{% endif %} href="/cloud/storage">Cloud storage</a></li>
-		<li><a{% if level_2 == 'partners' %} class="active"{% endif %} href="/cloud/partners">Partners</a></li>
+		<li><a{% if level_1 == 'cloud' and level_2 == 'partners' %} class="active"{% endif %} href="/cloud/partners">Partners</a></li>
 		<li><a class="last-item{% if level_2 == 'plans-and-pricing' %} active{% endif %}" href="/cloud/plans-and-pricing">Plans and pricing</a></li>
   </ul>

--- a/templates/desktop/_nav_secondary.html
+++ b/templates/desktop/_nav_secondary.html
@@ -1,10 +1,10 @@
 	<ul{% if list_class %} class="{{ list_class }}"{% endif %} class="second-level-nav">
 		<li><a{% if level_1 == 'desktop' and not level_2 %} class="active"{% endif %} href="/desktop">Overview</a></li>
-		<li><a{% if level_2 == 'features' %} class="active"{% endif %} href="/desktop/features">Features</a></li>
+		<li><a{% if level_1 == 'desktop' and level_2 == 'features' %} class="active"{% endif %} href="/desktop/features">Features</a></li>
 		<li><a{% if level_2 == 'enterprise' %} class="active"{% endif %} href="/desktop/enterprise">For enterprise</a></li>
 		<li><a{% if level_2 == 'education' %} class="active"{% endif %} href="/desktop/education">For education</a></li>
 		<li><a{% if level_2 == 'government' %} class="active"{% endif %} href="/desktop/government">For government</a></li>
-		<li><a{% if level_2 == 'developers' %} class="active"{% endif %} href="/desktop/developers">For developers</a></li>
+		<li><a{% if level_1 == 'desktop' and level_2 == 'developers' %} class="active"{% endif %} href="/desktop/developers">For developers</a></li>
 		<li><a{% if level_2 == 'ubuntu-kylin' %} class="active"{% endif %} href="/desktop/ubuntukylin">For China</a></li>
-		<li><a{% if level_2 == 'partners' %} class="active"{% endif %} href="/desktop/partners">For partners</a></li>
+		<li><a{% if level_1 == 'desktop' and level_2 == 'partners' %} class="active"{% endif %} href="/desktop/partners">For partners</a></li>
 	</ul>

--- a/templates/internet-of-things/_nav_secondary.html
+++ b/templates/internet-of-things/_nav_secondary.html
@@ -1,7 +1,7 @@
 	<ul{% if list_class %} class="{{ list_class }}"{% endif %} class="second-level-nav">
 		<li><a{% if level_1 == 'internet-of-things' and not level_2 %} class="active"{% endif %} href="/internet-of-things">Overview</a></li>
-		<li><a{% if level_2 == 'features' %} class="active"{% endif %} href="/internet-of-things/features">Features</a></li>
+		<li><a{% if level_1 == 'internet-of-things' and level_2 == 'features' %} class="active"{% endif %} href="/internet-of-things/features">Features</a></li>
 		<li><a{% if level_2 == 'digital-signage' %} class="active"{% endif %} href="/internet-of-things/digital-signage">Digital signage</a></li>
-		<li><a{% if level_2 == 'partners' %} class="active"{% endif %} href="/internet-of-things/partners">For partners</a></li>
-		<li><a{% if level_2 == 'developers' %} class="active"{% endif %} href="/internet-of-things/developers">For developers</a></li>
+		<li><a{% if level_1 == 'internet-of-things' and level_2 == 'partners' %} class="active"{% endif %} href="/internet-of-things/partners">For partners</a></li>
+		<li><a{% if level_1 == 'internet-of-things' and level_2 == 'developers' %} class="active"{% endif %} href="/internet-of-things/developers">For developers</a></li>
 	</ul>

--- a/templates/phone/_nav_secondary.html
+++ b/templates/phone/_nav_secondary.html
@@ -1,7 +1,7 @@
 <ul{% if list_class %} class="{{ list_class }}"{% endif %} class="second-level-nav">
     <li><a{% if level_1 == 'phone' and not level_2 %} class="active"{% endif %} href="/phone">Overview</a></li>
-    <li><a{% if level_2 == 'features' %} class="active"{% endif %} href="/phone/features" >Features</a></li>
-    <li><a{% if level_2 == 'devices' or level_2 == 'devices-in' %} class="active"{% endif %} href="/phone/devices" >Devices</a></li>
-    <li><a{% if level_2 == 'developers' %} class="active"{% endif %} href="/phone/developers" >For developers</a></li>
-    <li><a{% if level_2 == 'partners' %}  class="active"{% endif %} href="/phone/partners">For partners</a></li>
+    <li><a{% if level_1 == 'phone' and level_2 == 'features' %} class="active"{% endif %} href="/phone/features" >Features</a></li>
+    <li><a{% if level_1 == 'phone' and level_2 == 'devices' or level_2 == 'devices-in' %} class="active"{% endif %} href="/phone/devices" >Devices</a></li>
+    <li><a{% if level_1 == 'phone' and level_2 == 'developers' %} class="active"{% endif %} href="/phone/developers" >For developers</a></li>
+    <li><a{% if level_1 == 'phone' and level_2 == 'partners' %}  class="active"{% endif %} href="/phone/partners">For partners</a></li>
 </ul>

--- a/templates/tablet/_nav_secondary.html
+++ b/templates/tablet/_nav_secondary.html
@@ -1,7 +1,7 @@
 	<ul{% if list_class %} class="{{ list_class }}"{% endif %} class="second-level-nav">
 		<li><a{% if level_1 == 'tablet' and not level_2 %} class="active"{% endif %} href="/tablet">Overview</a></li>
-		<li><a{% if level_2 == 'features' %} class="active"{% endif %} href="/tablet/features">Features</a></li>
-		<li><a{% if level_2 == 'devices' %} class="active"{% endif %} href="/tablet/devices">Devices</a></li>
-		<li><a{% if level_2 == 'developers' %} class="active"{% endif %} href="/tablet/developers">For developers</a></li>
-		<li><a{% if level_2 == 'partners' %} class="active"{% endif %} href="/tablet/partners">For partners</a></li>
+		<li><a{% if level_1 == 'tablet' and level_2 == 'features' %} class="active"{% endif %} href="/tablet/features">Features</a></li>
+		<li><a{% if level_1 == 'tablet' and level_2 == 'devices' %} class="active"{% endif %} href="/tablet/devices">Devices</a></li>
+		<li><a{% if level_1 == 'tablet' and level_2 == 'developers' %} class="active"{% endif %} href="/tablet/developers">For developers</a></li>
+		<li><a{% if level_1 == 'tablet' and level_2 == 'partners' %} class="active"{% endif %} href="/tablet/partners">For partners</a></li>
 	</ul>


### PR DESCRIPTION
## Done

Fix menu drop-down item active states
## QA

If you go to /desktop/features, then hover over "Desktop" -> "Features" in the main drop-down navigation, you'll notice that the word "Features" doesn't highlight orange.

However, if you similarly go and hover over "Phone" -> "Features" (while still on /desktop/features) it also should highlight orange, it didn’t before.

The same applies for multiple sections with the same names such as /partners /developers /devices
## Issue / Card

Card: https://trello.com/c/3EdK9tID
Issue: Fixes https://github.com/ubuntudesign/www.ubuntu.com/issues/445
