### PR TITLE
Update template variables in download pages

### DIFF
--- a/templates/download/desktop/contribute.html
+++ b/templates/download/desktop/contribute.html
@@ -128,14 +128,14 @@
                             <input type="hidden" name="no_shipping" value="1">
                             <input type="hidden" name="rm" value="1">
 
-                            <input type="hidden" name="return" value="http://{{ http_host }}/download/desktop/thank-you/?version={{ version }}&architecture={{ architecture }}">
-                            <input type="hidden" name="cancel_return" value="http://{{ http_host }}/download/desktop/thank-you/?version={{ version }}&architecture={{ architecture }}">
+                            <input type="hidden" name="return" value="http://{{ http_host }}/download/desktop/thank-you/?version={{ version }}&amp;architecture={{ architecture }}">
+                            <input type="hidden" name="cancel_return" value="http://{{ http_host }}/download/desktop/thank-you/?version={{ version }}&amp;architecture={{ architecture }}">
 
                             <input type="hidden" name="bn" value="PP-BuyNowBF:btn_buynowCC_LG.gif:NonHosted">
                             <button type="submit" class="button--primary pay-with-paypal" tabindex="9">Pay with PayPal</button>
 
-                            {% if version and architecture %}
-                            <a href="/download/desktop/thank-you/?version={{ version }}&architecture={{ architecture.split|join:"+" }}" class="skip" tabindex="11">Not now, take me to the download&nbsp;&rsaquo;</a>
+                            {% if start_download %}
+                            <a href="/download/desktop/thank-you/?version={{ version }}&amp;architecture={{ architecture }}" class="skip" tabindex="11">Not now, take me to the download&nbsp;&rsaquo;</a>
                             {% endif %}
                         </div>
                     </div>

--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -2,7 +2,7 @@
 {% load versioned_static  %}
 
 {% block title %}
-{% if version and architecture %}
+{% if start_download %}
 Thanks for downloading Ubuntu Desktop
 {% else %}
 Thank you for your contribution

--- a/templates/download/server/thank-you.html
+++ b/templates/download/server/thank-you.html
@@ -14,13 +14,13 @@ Thanks for downloading Ubuntu Server
 
 {% block content %}
     <noscript>
-        <meta http-equiv="refresh" content="3;url=http://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-server-{{ architecture.split|join:"+" }}.iso">
+        <meta http-equiv="refresh" content="3;url=http://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-server-{{ architecture }}.iso">
     </noscript>
 
     <div class="row row-hero no-border">
         <div class="strip-inner-wrapper">
             <h1>Thanks for downloading Ubuntu Server</h1>
-            <p>Your download should start automatically. If it doesn&rsquo;t, <a href="http://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-server-{{ architecture.split|join:"+" }}.iso">download now</a>.</p>
+            <p>Your download should start automatically. If it doesn&rsquo;t, <a href="http://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-server-{{ architecture }}.iso">download now</a>.</p>
         </div>
     </div>
     <div class="row row-grey no-border">
@@ -65,7 +65,7 @@ Thanks for downloading Ubuntu Server
 // Download file information
 var defaultLocation = 'http://releases.ubuntu.com/'; // Default to releases.ubuntu.com
 var version = '{{ version }}';
-var architecture = '{{ architecture.split|join:"+" }}';
+var architecture = '{{ architecture }}';
 
 // Mirrors for this country
 var mirrors = {{ mirror_list|safe }};


### PR DESCRIPTION
Following on from #703, make sure the download pages
use the new template variables defined in DownloadView
properly.
## QA

Run the site, go to http://127.0.0.1:8001/download/desktop and http://127.0.0.1:8001/download/server
and start a download to check it all works.
