### PR TITLE
Remove errant grid-list__img classes

### DIFF
--- a/templates/tablet/features.html
+++ b/templates/tablet/features.html
@@ -35,7 +35,7 @@
       <p>With Ubuntu&rsquo;s convergence features, you can now get a full PC experience on your Ubuntu Tablet. Simply connect a mouse and keyboard wirelessly to your tablet when it&rsquo;s time to get something done, whether it&rsquo;s serious work or serious gaming. And to enjoy your content on an even grander scale, you can connect to a monitor or TV. It&rsquo;s the best of both worlds: portability and big-screen productivity.</p>
     </div>
     <div class="twelve-col">
-      <img class="grid-list__img" src="{{ ASSET_SERVER_URL }}3485a9ae-tablet-diagram.svg" alt="Convergence illustration" />
+      <img src="{{ ASSET_SERVER_URL }}3485a9ae-tablet-diagram.svg" alt="Convergence illustration" />
     </div>
   </div>
 </section>
@@ -47,7 +47,7 @@
       <p>Ubuntu Tablet lets you create and access documents, spreadsheets and presentations with LibreOffice, the Microsoft-compatible productivity suite. And when you need to see your documents at scale, just connect your Ubuntu Tablet to a monitor.</p>
     </div>
     <div class="twelve-col">
-      <img class="grid-list__img" class="row--mobile-office__image" src="{{ ASSET_SERVER_URL }}a450d2c9-tablet-features-pc.png?w=983" alt="Ubuntu Tablet connected to a monitor" />
+      <img class="row--mobile-office__image" src="{{ ASSET_SERVER_URL }}a450d2c9-tablet-features-pc.png?w=983" alt="Ubuntu Tablet connected to a monitor" />
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

Remove errant grid-list__img classes
## QA

Go to http://www.ubuntu.com/tablet/features and have a look at the teeny tiny images in the 'Convergence that just clicks' and 'The tablet that’s also a PC’ sections, then pop to the same page locally and note that the images are not teeny tiny

Card: https://trello.com/c/GqHr79yh
