### PR TITLE
Fix sticky scrolling on mobile

### DIFF
--- a/static/css/section/_local.scss
+++ b/static/css/section/_local.scss
@@ -1,8 +1,3 @@
-body,
-html {
-  overflow-x: hidden;
-}
-
 body {
   background-size: cover;
   @media only screen and (min-width : $breakpoint-medium) {
@@ -106,19 +101,19 @@ body {
     ul.third-level-nav {
       margin-top: -15px;
       padding-top: 0;
-      
+
       li {
         box-sizing: border-box;
         padding-left: 10px;
         width: 50%;
-        
+
         a,
         a:link {
           font-size: 1.142857143em;
         }
       }
     }
-    
+
     ul.second-level-nav li {
       box-sizing: border-box;
       width: 50%;
@@ -168,7 +163,7 @@ body {
     &.open {
       border-bottom: 1px solid $alto-grey;
       display: inherit;
-    
+
       ul.breadcrumb li .after {
         background-image: url('#{$asset-server}cadd096c-nav-up-arrow.svg');
       }
@@ -507,7 +502,7 @@ body {
 .tablet {
   .row-hero {
     margin-top: 0;
-    
+
     h1 {
       padding-top: 20px;
     }
@@ -541,16 +536,16 @@ body {
 .phone {
   .row {
     padding: 20px 10px 0;
-    
+
     @media only screen and (min-width : $breakpoint-medium) {
       padding: 40px 10px 20px;
     }
-    
+
     @media only screen and (min-width : $breakpoint-large) {
       padding: 100px 40px;
     }
   }
-  
+
   .row-hero {
     padding: 0 10px 0;
 


### PR DESCRIPTION
## Done
- Removed the overflow-x styling which was setting overflow-y to scroll on body and html. Causing two scrollbars
## QA
- Shrink your browser window down or better still load your localhost on you phone
- Scroll up and down and see that it moves smoothly
## Issue / Card

Fixes: https://github.com/ubuntudesign/www.ubuntu.com/issues/625
Card: https://trello.com/c/EsC1OEtw
