### PR TITLE
Add template tag to import feeds

### DIFF
--- a/requirements/standard.txt
+++ b/requirements/standard.txt
@@ -1,6 +1,5 @@
+
 Django==1.9.6
-feedparser==5.1.3
-requests==2.3.0
 whitenoise==3.1
 django-yaml-redirects==0.4
 django-asset-server-url==0.1
@@ -8,3 +7,7 @@ django-versioned-static-url==0.7
 django-template-finder-view==0.2
 django-static-root-finder==0.3.1
 django-unslashed==0.3.0
+cachecontrol==0.11.6
+feedparser==5.2.1
+lockfile==0.12.2
+requests==2.10.0

--- a/webapp/lib/feeds.py
+++ b/webapp/lib/feeds.py
@@ -1,0 +1,35 @@
+import feedparser
+import logging
+import requests
+from cachecontrol import CacheControlAdapter
+from cachecontrol.caches import FileCache
+from cachecontrol.heuristics import ExpiresAfter
+from django.conf import settings
+
+
+logger = logging.getLogger(__name__)
+
+
+def get_feed(feed_url):
+    """
+    Return feed parsed feed
+    """
+    requests_timeout = getattr(settings, 'FEED_TIMOUT', 1)
+
+    cache_adapter = CacheControlAdapter(
+        cache=FileCache('.web_cache'),
+        heuristic=ExpiresAfter(hours=1),
+    )
+
+    session = requests.Session()
+    session.mount('http://', cache_adapter)
+    session.mount('https://', cache_adapter)
+
+    show_exceptions = getattr(settings, 'DEBUG', True)
+
+    feed_request = session.get(
+        feed_url,
+        timeout=requests_timeout
+    )
+
+    return feedparser.parse(feed_request.text)

--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -51,6 +51,9 @@ TEMPLATES = [
         'DIRS': [os.path.join(BASE_DIR, 'templates')],
         'APP_DIRS': True,
         'OPTIONS': {
+            'builtins': [
+                'webapp.templatetags.feeds',
+            ],
             'context_processors': [
                 'django_asset_server_url.asset_server_url',
             ],

--- a/webapp/templatetags/feeds.py
+++ b/webapp/templatetags/feeds.py
@@ -1,0 +1,9 @@
+from django import template
+from webapp.lib import feeds
+
+register = template.Library()
+
+
+@register.simple_tag
+def get_feed(feed_url):
+    return feeds.get_feed(feed_url).entries


### PR DESCRIPTION
Initial version to import feeds into template context, carried over from canonical.com.
Example usage:

```
{% get_feed 'https://feedurl/' as feed %}
{% for entry in feed %}
{{ entry.title }}
{% endfor %}
```
## QA
- `make clean-all && make run`
- Try loading a feed in a template, such as:
  
  ```
  {% get_feed 'https://insights.ubuntu.com/feed' as feed %}
  {% for item in feed %}
  <h2>{{ item.title }}</h2>
  <p>{{ item.summary|safe }}</p>
  {% endfor %}
  ```
