### PR TITLE
Python2 fallback for URLLib import

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -2,7 +2,10 @@ import json
 import sys
 import os
 import re
-from urllib.error import URLError
+try:
+    from urllib.error import URLError
+except ImportError:
+    from urllib2 import URLError
 
 from feedparser import parse
 from django_template_finder_view import TemplateFinder


### PR DESCRIPTION
## Done

Added fallback import for python 2
## QA

make clean-all and make run.
Check site correctly loads on python 2 and 3.
