### PR TITLE
updated kernel and server charts, tables and some text

### DIFF
--- a/templates/info/release-end-of-life.html
+++ b/templates/info/release-end-of-life.html
@@ -45,25 +45,26 @@
 <div class="row no-border">
 	<div class="eight-col">
 		<h2>Kernel release end of life</h2>
-		<p>The Ubuntu LTS enablement stacks provide newer kernel and X support for existing Ubuntu LTS releases. These can be installed manually, or are automatically shipped if installing from 12.04.2/14.04.2 and newer release media. These newer enablement stacks are meant for desktop and server use only, and not recommended for cloud or virtual images. The Ubuntu kernel support lifecycle is as follows:</p>
+		<p>The Ubuntu LTS enablement stacks provide newer kernel and X support for existing Ubuntu LTS releases. These can be installed manually, or are automatically shipped if installing from 12.04.2/14.04.2 and newer release media. These newer enablement stacks are meant for desktop and server, and even recommended for cloud or virtual images. The Ubuntu kernel support lifecycle is as follows:</p>
 	</div>
 	<div class="twelve-col">
-		<p><img src="{{ ASSET_SERVER_URL }}073a5f7e-release_eof-kernel.jpg" alt="" class="not-for-small" /></p>
+		<p><img src="{{ ASSET_SERVER_URL }}58b4ccee-kernel-release-eol-20160613.png" alt="" class="not-for-small" /></p>
 		<table class="for-small">
 			<thead>
 				<tr><th>Release</th><th>Released</th><th>End of life</th></tr>
 			</thead>
 			<tbody>
+                <tr><td>Ubuntu 16.04.5</td><td>Aug-2018</td><td>Apr-2021</td></tr>
 				<tr><td>Ubuntu 18.04.0</td><td>Apr-2018</td><td>Apr-2023</td></tr>
 				<tr><td>Ubuntu 16.04.4</td><td>Feb-2018</td><td>Aug-2018</td></tr>
 				<tr><td>Ubuntu 17.10</td><td>Oct-2017</td><td>Jul-2018</td></tr>
-				<tr><td>Ubuntu 16.04.3</td><td>Aug-2017</td><td>Aug-2018</td></tr>
+				<tr><td>Ubuntu 16.04.3</td><td>Aug-2017</td><td>Feb-2018</td></tr>
 				<tr><td>Ubuntu 17.04</td><td>Apr-2017</td><td>Jan-2018</td></tr>
-				<tr><td>Ubuntu 16.04.2</td><td>Feb-2017</td><td>Aug-2018</td></tr>
+				<tr><td>Ubuntu 16.04.2 (v4.8)</td><td>Feb-2017</td><td>Aug-2017</td></tr>
 				<tr><td>Ubuntu 16.10</td><td>Oct-2016</td><td>Jul-2017</td></tr>
-				<tr><td>Ubuntu 16.04.1</td><td>Aug-2016</td><td>Apr-2021</td></tr>
+				<tr><td>Ubuntu 16.04.1 (v4.4)</td><td>Aug-2016</td><td>Apr-2021</td></tr>
 				<tr><td>Ubuntu 14.04.5</td><td>Aug-2016</td><td>May-2019</td></tr>
-				<tr><td>Ubuntu 16.04.0</td><td>Apr-2016</td><td>Apr-2021</td></tr>
+				<tr><td>Ubuntu 16.04.0 (v4.4)</td><td>Apr-2016</td><td>Apr-2021</td></tr>
 				<tr><td>Ubuntu 14.04.4 (v4.2)</td><td>Feb-2016</td><td>Aug-2016</td></tr>
 				<tr><td>Ubuntu 15.10 (v4.2)</td><td>Oct-2015</td><td>Oct-2015</td></tr>
 				<tr><td>Ubuntu 14.04.3 (v3.19)</td><td>Aug-2015</td><td>Aug-2016</td></tr>
@@ -95,7 +96,7 @@
 		<p>Canonical&rsquo;s Ubuntu Cloud archive allows users the ability to install newer releases of <a href="/cloud/openstack" class="external">Ubuntu OpenStack</a> on an Ubuntu Server as they become available up through the next Ubuntu LTS release. The Ubuntu OpenStack support lifecycle is as follows:</p>
 	</div>
 	<div class="twelve-col">
-		<p><img src="{{ ASSET_SERVER_URL }}56887a2c-release_eof-openstack.jpg" alt="" class="not-for-small" /></p>
+		<p><img src="{{ ASSET_SERVER_URL }}3371cc40-openstack-release-eol-20160613.png" alt="" class="not-for-small" /></p>
 		<table class="for-small">
 			<thead>
 				<tr><th>Release</th><th>Released</th><th>End of life</th><th>Extended customer support</th></tr>
@@ -105,8 +106,8 @@
 				<tr><td>Ubuntu 18.04 LTS</td><td>Oct-2018</td><td>Oct-2023</td></tr>
 				<tr><td>OpenStack Q</td><td>Apr-2018</td><td>Apr-2021</td></tr>
 				<tr><td>OpenStack P</td><td>Oct-2017</td><td>Apr-2019</td></tr>
-				<tr><td>OpenStack O</td><td>Apr-2017</td><td>Jan-2019</td><td>Aug-2019</td></tr>
-				<tr><td>OpenStack N</td><td>Oct-2016</td><td>Apr-2018</td></tr>
+				<tr><td>OpenStack Ocata</td><td>Apr-2017</td><td>Jan-2019</td><td>Aug-2019</td></tr>
+				<tr><td>OpenStack Newton</td><td>Oct-2016</td><td>Apr-2018</td></tr>
 				<tr><td>OpenStack Mitaka</td><td>Apr-2016</td><td>Apr-2021</td></tr>
 				<tr><td>Ubuntu 16.04 LTS</td><td>Apr-2016</td><td>Apr-2021</td></tr>
 				<tr><td>OpenStack Mitaka</td><td>Apr-2016</td><td>Apr-2019</td></tr>


### PR DESCRIPTION
## Done

updated OpenStack and kernel charts
## QA
1. go to /info/release-end-of-life
2. see that the kernel and OpenStack charts/tablets on ss are updated per [sheet](https://docs.google.com/spreadsheets/d/1KIuOAa620yseE0uhIl67u2SlS0bWlPI_d98bvYM2Yl8/edit#gid=1712489059)
3. see that the copy has been updated per [copy doc](https://docs.google.com/document/d/1-l3B7AoyDoETaL80UhlfEWCVKmMWPdy3zoF5LpsGcYQ/edit)
## Issue / Card

[trello card](https://trello.com/c/JPsgjTlZ)
