### PR TITLE
Fix homepage takeunder overflow issue

### DIFF
--- a/static/css/section/_homepage.scss
+++ b/static/css/section/_homepage.scss
@@ -519,6 +519,7 @@ body.homepage .row-featured {
   padding-left: 0;
   padding-right: 0;
   margin-top: -20px;
+  overflow: hidden;
 
   @media only screen and (min-width : $breakpoint-medium) {
     padding-left: 20px;


### PR DESCRIPTION
## Done

Fix overflow issue on homepage takeunder
## QA

Go to the live homepage and see that there’s is very much lots of horizontal scroll, then pop along to your local version and you should fins that the scrolling issue has gone 
