### PR TITLE
Add Brightbox logo to public cloud list

### DIFF
--- a/templates/cloud/shared/_guest-list.html
+++ b/templates/cloud/shared/_guest-list.html
@@ -63,4 +63,12 @@
             <p>Get started on Interoute&nbsp;›</p>
         </a>
     </li>
+    <li class="box four-col  last-col">
+        <a href="https://www.brightbox.com/">
+            <div>
+                <img class="logo-brightbox" src="{{ ASSET_SERVER_URL }}43c55d04-logo-brightbox.svg" alt="Brightbox" height="35">
+            </div>
+            <p>Get started on Brightbox&nbsp;›</p>
+        </a>
+    </li>
 </ul>


### PR DESCRIPTION
## Done

Added Brightbox logo to public cloud list
## QA
- Navigate to /cloud/public-cloud
- Scroll to logo grid at bottom of page
- Check that Brightbox logo / link displays correctly
## Issue / Card

Trello: https://trello.com/c/CV8J2htV
