### PR TITLE
Update heading

### DIFF
--- a/templates/management/ubuntu-advantage.html
+++ b/templates/management/ubuntu-advantage.html
@@ -45,7 +45,7 @@
     <div class="six-col prepend-three append-three row-pricing__image-container">
       <img class="row-pricing__image" src="{{ ASSET_SERVER_URL }}cb9ee959-picto-desktop-orange.svg" alt="" width="100%" />
     </div>
-    <h3 class="row-pricing__title">Ubuntu Advantage for&nbsp;desktops</h3>
+    <h3 class="row-pricing__title">Ubuntu Advantage Desktop</h3>
     <p>from <span class="ua-price">$150</span> per year</p>
     <p><a href="#ubuntu-advantage-for-desktop">Learn more&nbsp;&rsaquo;</a></p>
   </div>


### PR DESCRIPTION
## Done

Change 'Ubuntu Advantage for desktops’ heading 
## QA

Check that the heading has changed from 'Ubuntu Advantage for desktops' to 'Ubuntu Advantage Desktop'
## Issue / Card

Card: https://trello.com/c/hljhsolF
Doc: https://docs.google.com/document/d/1PmWJqPvOvNjUmLs_6UYtLhWySNzdxQxg6NimoD1eiOw/edit#heading=h.5owtwp7aqe1x
