### PR TITLE
converting LinuxONE form to sales request

### DIFF
--- a/templates/download/server/linuxone-signup-thank-you.html
+++ b/templates/download/server/linuxone-signup-thank-you.html
@@ -1,6 +1,6 @@
 {% extends "management/base_management.html" %}
 
-{% block title %}Thank you | Ubuntu LinuxONE newsletter{% endblock %}
+{% block title %}Thank you | Ubuntu LinuxONE{% endblock %}
 
 {% block second_level_nav_items %}
 <div class="strip-inner-wrapper">
@@ -12,8 +12,8 @@
 <div class="row row-hero no-border equal-height">
     <div class="strip-inner-wrapper">
         <div class="thank-you eight-col equal-height__item">
-            <h1>Thank you for signing up for our Newsletter</h1>
-            <p class="intro">We hope you enjoy using Ubuntu.</p>
+            <h1>Thank you for signing up to purchase Ubuntu Advantage</h1>
+            <p class="intro">We hope you enjoy using Ubuntu and will be in touch within one working day.</p>
         </div>
         <div class="four-col last-col equal-height__item equal-height__align-vertically">
             <img src="{{ ASSET_SERVER_URL }}52d53696-picto-thankyou-midaubergine.svg" alt="smile" width="200" height="200" />

--- a/templates/download/server/thank-you-linuxone.html
+++ b/templates/download/server/thank-you-linuxone.html
@@ -12,14 +12,14 @@ Thanks for downloading Ubuntu for LinuxONE and z Systems
 {% endblock second_level_nav_items %}
 
 {% block head_extra %}
-  <meta http-equiv="refresh" content="3;url=http://cdimage.ubuntu.com/releases/16.04/release/ubuntu-16.04-server-s390x.iso">
+<meta http-equiv="refresh" content="3;url=http://cdimage.ubuntu.com/releases/16.04/release/ubuntu-16.04-server-s390x.iso">
 {% endblock %}
 
 {% block content %}
 
 <div class="row row-hero no-border">
     <div class="strip-inner-wrapper">
-        <div class="seven-col">
+        <div class="six-col">
             <h1>Thanks for downloading Ubuntu for LinuxONE and z&nbsp;Systems</h1>
             <p>Thank you for downloading Ubuntu {{lts_release_full}} for IBM LinuxONE and z Systems. Your ISO download should start automatically.</p>
             <p>If it doesn&rsquo;t, or for alternative options <a href="http://cdimage.ubuntu.com/releases/xenial/release ">visit the download page</a>.</p>
@@ -27,100 +27,134 @@ Thanks for downloading Ubuntu for LinuxONE and z Systems
             <p>Your use of Ubuntu on z Systems and LinuxONE in production constitutes <a href="http://www.ubuntu.com/legal/short-terms">acceptance of these terms</a>.</p>
             <p>For questions about Ubuntu Advantage for LinuxONE and z Systems, please call us +44 (0) 207 630 2406 or email us at <a href="mailto:ibm@ubuntu.com">ibm@ubuntu.com</a>.</p>
         </div>
-        <div class="five-col last-col box">
-            <h2>Stay connected</h2>
-            <p>As you move into a production environment keep up-to-date on new features, upgrades and how others are using Ubuntu {{lts_release_full}} on IBM LinuxOne and z Systems.</p>
+        <div class="six-col last-col box">
+            <h2>Purchase Ubuntu Advantage</h2>
+            <p>As you move into a production environment you need to purchase Ubuntu Advantage for your server. Complete this form and someone from Canonical sales will get in touch.</p>
+
             <!-- MARKETO FORM -->
-            <script src="{{ ASSET_SERVER_URL }}d55f58bb-jquery.validate.js"></script>
-            <script src="{{ ASSET_SERVER_URL }}6ce35d3e-jquery-ui.min.js"></script>‌​
-            <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" class="newsletter-signup" id="mktoForm_1400">
+            <script src="//assets.ubuntu.com/v1/37b1db88-jquery.min.js"></script>
+            <script src="//assets.ubuntu.com/v1/d55f58bb-jquery.validate.js"></script>
+            <script src="//assets.ubuntu.com/v1/6ce35d3e-jquery-ui.min.js"></script>‌​
+
+            <form action="https://pages.ubuntu.com/index.php/leadCapture/save" method="post" id="mktoForm_1400">
                 <fieldset>
                     <ul class="no-bullets">
-                        <li class="mktFormReq mktField">    
-                            <label for="FirstName" class="mktoLabel">First name: <span>*</span></label>
-                            <input required id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField mktoRequired" />
+                        <li  class="mktFormReq mktField">
+                            <label for="FirstName" class="mktoLabel " >First name: <span>*</span></label>
+                            <input required  id="FirstName" name="FirstName" maxlength="255" type="text" class="mktoField   mktoRequired" >
                         </li>
-                        <li class="mktFormReq mktField">    
-                            <label for="LastName" class="mktoLabel">Last name: <span>*</span></label>
-                            <input required id="LastName" name="LastName" maxlength="255" type="text" class="mktoField mktoRequired" />
+                        <li  class="mktFormReq mktField">
+                            <label for="LastName" class="mktoLabel " >Last Name: <span>*</span></label>
+                            <input required  id="LastName" name="LastName" maxlength="255" type="text" class="mktoField   mktoRequired" >
                         </li>
-                        <li class="mktFormReq mktField">    
-                            <label for="Company" class="mktoLabel">Company name: <span>*</span></label>
-                            <input required id="Company" name="Company" maxlength="255" type="text" class="mktoField mktoRequired" />
+                        <li  class="mktFormReq mktField">
+                            <label for="Company" class="mktoLabel " >Company name: <span>*</span></label>
+                            <input required  id="Company" name="Company" maxlength="255" type="text" class="mktoField   mktoRequired" >
                         </li>
-                        <li class="mktFormReq mktField">
-                            <label for="Email" class="mktoLabel">Email address: <span>*</span></label>
-                            <input required  id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField  mktoRequired" />
+                        <li  class="mktFormReq mktField">
+                            <label for="Email" class="mktoLabel " >Email address: <span>*</span></label>
+                            <input required  id="Email" name="Email" maxlength="255" type="email" class="mktoField mktoEmailField  mktoRequired" >
                         </li>
-                        <li class="mktFormReq mktField">    
-                            <label for="Phone" class="mktoLabel">Phone number: <span>*</span></label>
-                            <input required id="Phone" name="Phone" maxlength="255" type="text" class="mktoField mktoRequired" />
+                        <li  class="mktFormReq mktField">
+                            <label for="Phone" class="mktoLabel " >Phone number: <span>*</span></label>
+                            <input required  id="Phone" name="Phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" >
                         </li>
-                        <li class="mktField">
-                            <input class="mktoField" value="yes" id="NewsletterOpt-In" name="NewsletterOpt-In" type="checkbox" />
-                            <label class="mktoLabel mktoHasWidth" for="NewsletterOpt-In">I would like to receive occasional news from Canonical by email.</label>
-                        </li>
-                        <li class="mktField">
-                            <button type="submit" class="mktoButton link-cta-download button--primary">Stay up to date</button>
-                            
-                            <input type="hidden" name="formid" class="mktoField " value="1400" />
-                            <input type="hidden" name="lpId" class="mktoField " value="2469" />
-                            <input type="hidden" name="subId" class="mktoField" value="30" />
-                            <input type="hidden" name="munchkinId" class="mktoField" value="066-EOV-335" />
-                            <input type="hidden" name="lpurl" class="mktoField" value="//pages.ubuntu.com/download-LinuxONE.html?cr={creative}&amp;kw={keyword}" />
-                            <input type="hidden" name="cr" class="mktoField " value="" />
-                            <input type="hidden" name="kw" class="mktoField " value="" />
-                            <input type="hidden" name="q" class="mktoField " value="" />
-                        </li>
-                    </ul>
-                </fieldset>
-                <input type="hidden" name="returnURL" value="http://www.ubuntu.com/download/server/linuxone-newsletter-thank-you" />
-                <input type="hidden" name="retURL" value="http://www.ubuntu.com/download/server/linuxone-newsletter-thank-you" />
-            </form>
-            <script>
-            $("#mktoForm_1400").validate({
-                errorElement: "span",
-                errorClass: "mktFormMsg mktError",
-                onkeyup: false,
-                onclick: false,
-                onblur: false
-            });
-            </script>
-            <script src="{{ ASSET_SERVER_URL }}f97fa297-stateCountry.js"></script>
+                        <li  class="mktField">
+                            <label for="NumUbuntuServers__c" class="mktoLabel " >Number of drawers you are purchasing support for:</label>
+                            <select id="NumUbuntuServers__c" name="NumUbuntuServers__c" class="mktoField " ><option value="">Select...</option>
+                                <option value="zBC12" disabled>zBC12</option>
+                                <option value="1 drawer (up to 13 cores)"> - 1 drawer (up to 13 cores)</option>
+                                <option value="zEC12" disabled>zEC12</option>
+                                <option value="1 drawer (up to 20 cores)"> - 1 drawer (up to 20 cores)</option>
+                                <option value="2 drawers (up to 43 cores)"> - 2 drawers (up to 43 cores)</option>
+                                <option value="3 drawers (up to 66 cores)"> - 3 drawers (up to 66 cores)</option>
+                                <option value="4 drawers (up to 10 cores)"> - 4 drawers (up to 10 cores)</option>
+                                <option value="Z13s/Rockhopper" disabled> Z13s/Rockhopper</option>
+                                <option value="1 drawer (up to 20 cores)"> - 1 drawer (up to 20 cores)</option>
+                                <option value="Z13/Emperor" disabled>Z13/Emperor</option>
+                                <option value="1 drawer (up to 30 cores)"> - 1 drawer (up to 30 cores)</option>
+                                <option value="2 drawers (up to 63 cores)"> - 2 drawers (up to 63 cores)</option>
+                                <option value="3 drawers (up to 96 cores)"> - 3 drawers (up to 96 cores)</option>
+                                <option value="4 drawer (up to 141 cores)"> - 4 drawer (up to 141 cores)</option></select>
+                            </li>
+                            <li  class="mktField">
+                                <label for="Comments_from_Contact__c" class="mktoLabel " >Serial number(s)</label>
+                                <textarea id="Comments_from_Contact__c" name="Comments_from_Contact__c" rows="2" class="mktoField " maxlength="2000" ></textarea>
+                            </li>
+                            <li  class="mktField">
+                                <label for="purchaseordernumber" class="mktoLabel " >Purchase order number:</label>
+                                <input id="purchaseordernumber" name="purchaseordernumber" maxlength="255" type="text" class="mktoField  " >
+                            </li>
+                            <li  class="mktField">
+                                <input class="mktoField" value="yes" id="NewsletterOpt-In" name="NewsletterOpt-In" type="checkbox">
+                                <label  class="mktoLabel mktoHasWidth" for="NewsletterOpt-In">I would like to receive occasional news from Canonical by email.</label>
+                            </li>
+
+                            <li  class="mktField">
+                                <input name="Optin_cloud_nuture" id="Optin_cloud_nuture" type="checkbox" value="yes" class="mktoField">                                <label for="Optin_cloud_nuture" class="mktoLabel " >I would like to receive eBooks and White Papers by Canonical.</label>
+                            </li>
+                            <li>All information provided will be handled in accordance with the Canonical <a href="http://www.ubuntu.com/legal" target="_blank">privacy policy</a>.</li>
+                            <li  class="mktField">
+                                <button type="submit" class="mktoButton">Download</button></span><input type="hidden" name="formid" class="mktoField " value="1400"><input type="hidden" name="lpId" class="mktoField " value="2469"><input type="hidden" name="subId" class="mktoField " value="30"><input type="hidden" name="munchkinId" class="mktoField " value="066-EOV-335"><input type="hidden" name="lpurl" class="mktoField " value="//pages.ubuntu.com/download-LinuxONE.html?cr={creative}&amp;kw={keyword}"><input type="hidden" name="cr" class="mktoField " value=""><input type="hidden" name="kw" class="mktoField " value=""><input type="hidden" name="q" class="mktoField " value="">
+                            </li>
+                        </ul>
+                    </fieldset>
+                    <input type="hidden" name="returnURL" value="http://www.ubuntu.com/download/server/linuxone-signup-thank-you" />
+                    <input type="hidden" name="retURL" value="http://www.ubuntu.com/download/server/linuxone-signup-thank-you" />
+                </form>
+                <script>
+                $("#mktoForm_1400").validate({
+                    errorElement: "span",
+                    errorClass: "mktFormMsg mktError",
+                    onkeyup: false,
+                    onclick: false,
+                    onblur: false
+                });
+                $(function(){$("#comments").hide()});
+                $('#Ubuntu_User__c').on('change',function(){
+                    var selection = $(this).val();
+                    if(selection == 'Commercially only') {
+                        $('#comments').show();
+                    } else {
+                        $('#comments').hide();
+                    }
+                });
+                </script>
+                <!-- /MARKETO FORM -->
+            </div>
         </div>
     </div>
-</div>
-<div class="row row-grey no-border">
-    <div class="strip-inner-wrapper">
-        <div class="twelve-col no-margin-bottom equal-height">
-            <div class="four-col support box box-highlight equal-height__item">
-                <div class="align-center four-col">
-                    <img alt="ubuntu advantage" src="{{ ASSET_SERVER_URL }}0838729a-picto-bookmark-warmgrey.svg" width="113" height="113" />
+    <div class="row row-grey no-border">
+        <div class="strip-inner-wrapper">
+            <div class="twelve-col no-margin-bottom equal-height">
+                <div class="four-col support box box-highlight equal-height__item">
+                    <div class="align-center four-col">
+                        <img alt="ubuntu advantage" src="{{ ASSET_SERVER_URL }}0838729a-picto-bookmark-warmgrey.svg" width="113" height="113" />
+                    </div>
+                    <h3>Forrester Research eBook</h3>
+                    <p>Get more from the cloud with the right platform approach.</p>
+                    <p><a href="https://pages.ubuntu.com/Forrester_TAP_Report_2016.html"  class="external">Download eBook</a></p>
                 </div>
-                <h3>Forrester Research eBook</h3>
-                <p>Get more from the cloud with the right platform approach.</p>
-                <p><a href="https://pages.ubuntu.com/Forrester_TAP_Report_2016.html"  class="external">Download eBook</a></p>
-            </div>
-            <div class="four-col one box box-highlight equal-height__item">
-                <div class="align-center four-col">
-                    <img alt="ubuntu one" src="{{ ASSET_SERVER_URL }}8a199d55-picto-articles-warmgrey.svg" width="113" height="113" />
+                <div class="four-col one box box-highlight equal-height__item">
+                    <div class="align-center four-col">
+                        <img alt="ubuntu one" src="{{ ASSET_SERVER_URL }}8a199d55-picto-articles-warmgrey.svg" width="113" height="113" />
+                    </div>
+                    <h3>IDC Analyst White Paper</h3>
+                    <p>Learn more about next generation applications on Ubuntu for LinuxONE/z.</p>
+                    <p><a href="http://www-01.ibm.com/marketing/iwm/dre/signup?source=stg-web&S_PKG=ov47989&S_TACT=C47305CW" class="external">Download whitepaper</a></p>
                 </div>
-                <h3>IDC Analyst White Paper</h3>
-                <p>Learn more about next generation applications on Ubuntu for LinuxONE/z.</p>
-                <p><a href="http://www-01.ibm.com/marketing/iwm/dre/signup?source=stg-web&S_PKG=ov47989&S_TACT=C47305CW" class="external">Download whitepaper</a></p>
-            </div>
-            <div class="four-col ask last-col box box-highlight equal-height__item">
-                <div class="align-center four-col">
-                    <img alt="ubuntu advantage" src="{{ ASSET_SERVER_URL }}87cb77c7-picto-desktop-warmgrey.svg" width="113" height="113" />
+                <div class="four-col ask last-col box box-highlight equal-height__item">
+                    <div class="align-center four-col">
+                        <img alt="ubuntu advantage" src="{{ ASSET_SERVER_URL }}87cb77c7-picto-desktop-warmgrey.svg" width="113" height="113" />
+                    </div>
+                    <h3>IBM Systems Magazine Webinar</h3>
+                    <p>Discover the Cloud and scale out world of Ubuntu on IBM.</p>
+                    <p><a href="https://ibmsystemsmag.webex.com/ibmsystemsmag/lsr.php?RCID=8a447682b6dd0bffe57723fc5238d202" class="external">Watch webinar on-demand</a></p>
                 </div>
-                <h3>IBM Systems Magazine Webinar</h3>
-                <p>Discover the Cloud and scale out world of Ubuntu on IBM.</p>
-                <p><a href="https://ibmsystemsmag.webex.com/ibmsystemsmag/lsr.php?RCID=8a447682b6dd0bffe57723fc5238d202" class="external">Watch webinar on-demand</a></p>
-            </div>
-        </div><!-- /.row .row-box -->
-    </div><!-- /.strip-inner-wrapper -->
-</div><!-- /.row .row-grey -->
+            </div><!-- /.row .row-box -->
+        </div><!-- /.strip-inner-wrapper -->
+    </div><!-- /.row .row-grey -->
 
-{% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_download_server_installation" second_item="_download_server_guide" third_item="_download_helping_hands" %}
+    {% include "shared/contextual_footers/_contextual_footer.html"  with first_item="_download_server_installation" second_item="_download_server_guide" third_item="_download_helping_hands" %}
 
-{% endblock content %}
+    {% endblock content %}


### PR DESCRIPTION
## Done
- converted the current newsletter form to one that get's a sales person to call
- updated the thank-you page to confirm that form change
## QA
1. go to  /download/server/thank-you-linuxone (stop the automatic download) and see the form has changed and looks a bit like  the [copy doc](https://docs.google.com/document/d/1GptXtMfbgOjOmqb8DZCCTRwogkiP_cM95U9Z0gFSt7g/edit#) or the [marketo form](https://pages.ubuntu.com/download-LinuxONE.html)
2. either fill out the form or go to /download/server/linuxone-signup-thank-you and see that it talks about Ubuntu Advantage and sales [copy doc](https://docs.google.com/document/d/1hjnuMElaMzdrinZv7R-k2QfNd2Eu8xCHxRN_DPUSSgg/edit#heading=h.4x7lh54eg6q5)
## Issue / Card

[trello card](https://trello.com/c/11lFhnGv)
[marketo form](https://app-sjg.marketo.com/#AR1257A1LA1)
