### PR TITLE
updating events and linuxone dropdown

### DIFF
--- a/templates/cloud/shared/_events_overview.html
+++ b/templates/cloud/shared/_events_overview.html
@@ -4,34 +4,6 @@
             <div class="event-details-wrapper clearfix" itemscope itemtype="http://data-vocabulary.org/Event">
                 <div class="six-col equal-height--vertical-divider__item no-margin-bottom last-col">
                     <div class="event-map">
-                        <a href="https://insights.ubuntu.com/event/opnfv-summit-2/"><span class="image-wrap avatar"><img class="avatar" src="//maps.googleapis.com/maps/api/staticmap?center=Berlin, Germany&amp;zoom=12&amp;size=106x106&amp;sensor=false" alt=""></span></a>
-                    </div><!-- /.event-map -->
-                    <h3><a class="external" href="https://insights.ubuntu.com/event/opnfv-summit-2/">Collaborate and innovate at the OPNFV Summit</a></h3>
-                    <dl class="event-details">
-                        <dt class="accessibility-aid">Date:</dt>
-                        <dd class="event-date">20 - 23 June 2016<span class="accesibilty-aid"><time itemprop="startDate" datetime="2016-06-20T00:00"></time><time itemprop="endDate" datetime="2016-06-23T00:00"></time></span></dd>
-                        <dt class="accessibility-aid">Location:</dt>
-                        <dd class="location" itemprop="location" itemscope="" itemtype="http://schema.org/PostalAddress">Berlin, Germany</dd>
-                    </dl>
-                </div><!-- /.six-col last-col -->
-            </div><!-- /.event-details-wrapper clearfix -->
-            <div class="event-details-wrapper clearfix" itemscope itemtype="http://data-vocabulary.org/Event">
-                <div class="six-col equal-height--vertical-divider__item no-margin-bottom last-col">
-                    <div class="event-map">
-                        <a href="https://insights.ubuntu.com/event/openstack-day-germany/"><span class="image-wrap avatar"><img class="avatar" src="//maps.googleapis.com/maps/api/staticmap?center=Cologne, Germany&amp;zoom=12&amp;size=106x106&amp;sensor=false" alt=""></span></a>
-                    </div><!-- /.event-map -->
-                    <h3><a class="external" href="https://insights.ubuntu.com/event/openstack-day-germany/">OpenStack Day Germany</a></h3>
-                    <dl class="event-details">
-                        <dt class="accessibility-aid">Date:</dt>
-                        <dd class="event-date">21 - 22 June 2016<span class="accesibilty-aid"><time itemprop="startDate" datetime="2016-06-21T00:00"></time><time itemprop="endDate" datetime="2016-06-22T00:00"></time></span></dd>
-                        <dt class="accessibility-aid">Location:</dt>
-                        <dd class="location" itemprop="location" itemscope="" itemtype="http://schema.org/PostalAddress">Cologne, Germany</dd>
-                    </dl>
-                </div><!-- /.six-col last-col -->
-            </div><!-- /.event-details-wrapper clearfix -->
-            <div class="event-details-wrapper clearfix" itemscope itemtype="http://data-vocabulary.org/Event">
-                <div class="six-col equal-height--vertical-divider__item no-margin-bottom last-col">
-                    <div class="event-map">
                         <a href="https://insights.ubuntu.com/event/ubuconla/"><span class="image-wrap avatar"><img class="avatar" src="//maps.googleapis.com/maps/api/staticmap?center=Lima, Peru&amp;zoom=12&amp;size=106x106&amp;sensor=false" alt=""></span></a>
                     </div><!-- /.event-map -->
                     <h3><a class="external" href="https://insights.ubuntu.com/event/ubuconla/">UbuConLA</a></h3>
@@ -40,6 +12,34 @@
                         <dd class="event-date">6 - 7 August 2016<span class="accesibilty-aid"><time itemprop="startDate" datetime="2016-08-06T00:00"></time><time itemprop="endDate" datetime="2016-08-07T00:00"></time></span></dd>
                         <dt class="accessibility-aid">Location:</dt>
                         <dd class="location" itemprop="location" itemscope="" itemtype="http://schema.org/PostalAddress">Lima, Peru</dd>
+                    </dl>
+                </div><!-- /.six-col last-col -->
+            </div><!-- /.event-details-wrapper clearfix -->
+            <div class="event-details-wrapper clearfix" itemscope itemtype="http://data-vocabulary.org/Event">
+                <div class="six-col equal-height--vertical-divider__item no-margin-bottom last-col">
+                    <div class="event-map">
+                        <a href="https://insights.ubuntu.com/event/openstack-days-silicon-valley/"><span class="image-wrap avatar"><img class="avatar" src="//maps.googleapis.com/maps/api/staticmap?center=Silicon Valley&amp;zoom=12&amp;size=106x106&amp;sensor=false" alt=""></span></a>
+                    </div><!-- /.event-map -->
+                    <h3><a class="external" href="https://insights.ubuntu.com/event/openstack-days-silicon-valley/">OpenStack Days Silicon Valley</a></h3>
+                    <dl class="event-details">
+                        <dt class="accessibility-aid">Date:</dt>
+                        <dd class="event-date">9 - 10 August 2016<span class="accesibilty-aid"><time itemprop="startDate" datetime="2016-08-09T00:00"></time><time itemprop="endDate" datetime="2016-08-10T00:00"></time></span></dd>
+                        <dt class="accessibility-aid">Location:</dt>
+                        <dd class="location" itemprop="location" itemscope="" itemtype="http://schema.org/PostalAddress">Silicon Valley</dd>
+                    </dl>
+                </div><!-- /.six-col last-col -->
+            </div><!-- /.event-details-wrapper clearfix -->
+            <div class="event-details-wrapper clearfix" itemscope itemtype="http://data-vocabulary.org/Event">
+                <div class="six-col equal-height--vertical-divider__item no-margin-bottom last-col">
+                    <div class="event-map">
+                        <a href="https://insights.ubuntu.com/event/juju-charmer-summit-pasadena-2016/"><span class="image-wrap avatar"><img class="avatar" src="//maps.googleapis.com/maps/api/staticmap?center=Pasadena, Califormnia, USA&amp;zoom=12&amp;size=106x106&amp;sensor=false" alt=""></span></a>
+                    </div><!-- /.event-map -->
+                    <h3><a class="external" href="https://insights.ubuntu.com/event/juju-charmer-summit-pasadena-2016/">Juju Charmer Summit Pasadena 2016</a></h3>
+                    <dl class="event-details">
+                        <dt class="accessibility-aid">Date:</dt>
+                        <dd class="event-date">12 - 14 September 2016<span class="accesibilty-aid"><time itemprop="startDate" datetime="2016-09-12T00:00"></time><time itemprop="endDate" datetime="2016-09-14T00:00"></time></span></dd>
+                        <dt class="accessibility-aid">Location:</dt>
+                        <dd class="location" itemprop="location" itemscope="" itemtype="http://schema.org/PostalAddress">Pasadena, Califormnia, USA</dd>
                     </dl>
                 </div><!-- /.six-col last-col -->
             </div><!-- /.event-details-wrapper clearfix -->

--- a/templates/download/server/thank-you-linuxone.html
+++ b/templates/download/server/thank-you-linuxone.html
@@ -63,19 +63,19 @@ Thanks for downloading Ubuntu for LinuxONE and z Systems
                             <label for="NumUbuntuServers__c" class="mktoLabel " >Number of drawers you are purchasing support for:</label>
                             <select id="NumUbuntuServers__c" name="NumUbuntuServers__c" class="mktoField " ><option value="">Select...</option>
                                 <option value="zBC12" disabled>zBC12</option>
-                                <option value="1 drawer (up to 13 cores)"> - 1 drawer (up to 13 cores)</option>
+                                <option value="zBC12 - 1 drawer (up to 13 cores)"> - 1 drawer (up to 13 cores)</option>
                                 <option value="zEC12" disabled>zEC12</option>
-                                <option value="1 drawer (up to 20 cores)"> - 1 drawer (up to 20 cores)</option>
-                                <option value="2 drawers (up to 43 cores)"> - 2 drawers (up to 43 cores)</option>
-                                <option value="3 drawers (up to 66 cores)"> - 3 drawers (up to 66 cores)</option>
-                                <option value="4 drawers (up to 10 cores)"> - 4 drawers (up to 10 cores)</option>
+                                <option value="zEC12 - 1 drawer (up to 20 cores)"> - 1 drawer (up to 20 cores)</option>
+                                <option value="zEC12 - 2 drawers (up to 43 cores)"> - 2 drawers (up to 43 cores)</option>
+                                <option value="zEC12 - 3 drawers (up to 66 cores)"> - 3 drawers (up to 66 cores)</option>
+                                <option value="zEC12 - 4 drawers (up to 10 cores)"> - 4 drawers (up to 10 cores)</option>
                                 <option value="Z13s/Rockhopper" disabled> Z13s/Rockhopper</option>
-                                <option value="1 drawer (up to 20 cores)"> - 1 drawer (up to 20 cores)</option>
+                                <option value="Z13s/Rockhopper - 1 drawer (up to 20 cores)"> - 1 drawer (up to 20 cores)</option>
                                 <option value="Z13/Emperor" disabled>Z13/Emperor</option>
-                                <option value="1 drawer (up to 30 cores)"> - 1 drawer (up to 30 cores)</option>
-                                <option value="2 drawers (up to 63 cores)"> - 2 drawers (up to 63 cores)</option>
-                                <option value="3 drawers (up to 96 cores)"> - 3 drawers (up to 96 cores)</option>
-                                <option value="4 drawer (up to 141 cores)"> - 4 drawer (up to 141 cores)</option></select>
+                                <option value="Z13/Emperor - 1 drawer (up to 30 cores)"> - 1 drawer (up to 30 cores)</option>
+                                <option value="Z13/Emperor - 2 drawers (up to 63 cores)"> - 2 drawers (up to 63 cores)</option>
+                                <option value="Z13/Emperor - 3 drawers (up to 96 cores)"> - 3 drawers (up to 96 cores)</option>
+                                <option value="Z13/Emperor - 4 drawer (up to 141 cores)"> - 4 drawer (up to 141 cores)</option></select>
                             </li>
                             <li  class="mktField">
                                 <label for="Comments_from_Contact__c" class="mktoLabel " >Serial number(s)</label>


### PR DESCRIPTION
## Done
- updated the /cloud overview events
- added details to the linuxone form
## QA
1. go to /cloud
2. see that all the events are current
3. go to /download/server/thank-you-linuxone and see all the dropdown values are better
## Issue / Card

[trello card](https://trello.com/c/tGhbD845)
