### PR TITLE
Remove overflow hidden from global nav

### DIFF
--- a/static/css/section/_local.scss
+++ b/static/css/section/_local.scss
@@ -579,9 +579,6 @@ strong {
   margin-left: 0;
 }
 
-.global {
-  overflow: hidden;
-}
 .cookie-policy {
   box-shadow: (0 -1px 2px rgba(0, 0, 0, 0.2));
   background-color: #fae4dc;


### PR DESCRIPTION
## Done

Remove overflow hidden from global nav
## QA

Make sure the hover over secondary nav is working

This has reintroduced horizontal scrolling at small, will address that separately
