### PR TITLE
updating deactivated button style

### DIFF
--- a/static/css/section/_local.scss
+++ b/static/css/section/_local.scss
@@ -1050,9 +1050,10 @@ a.button--primary__deactivated,
 a.button--primary__deactivated:hover,
 button.button--primary__deactivated,
 button.button--primary__deactivated:hover {
-  background: #efefef;
-  color: #fff;
+  background: $ubuntu-orange;
+  color: $white;
   cursor: not-allowed;
+  opacity: .3;
 }
 // XXX Ant (10.04.2016)
 // https://github.com/ubuntudesign/www.ubuntu.com/issues/260


### PR DESCRIPTION
## Done

updated deactivated button to be orange with 30% opacity per @yaili 
## QA
1. go to /phone/devices
2. look at the 'sold out' buttons
3. see that they are orange and 30% opaque
## Issue / Card

[Fixes bug 1594005](https://bugs.launchpad.net/ubuntu-website-content/+bug/1594005)
## Screenshots

![image](https://cloud.githubusercontent.com/assets/441217/16411225/ef9546e2-3d1d-11e6-9c2d-d4f9807a88bc.png)
