### PR TITLE
corrected OpenStack cApiTaliSaTion

### DIFF
--- a/templates/legal/ubuntu-advantage/service-description.html
+++ b/templates/legal/ubuntu-advantage/service-description.html
@@ -104,7 +104,7 @@
                     <li class="nested-counter__item"><a href="#support-scope-packages">Packages&nbsp;&rsaquo;</a></li>
                     <li class="nested-counter__item"><a href="#support-scope-kernels">Kernels&nbsp;&rsaquo;</a></li>
                     <li class="nested-counter__item"><a href="#support-scope-landscape">Landscape&nbsp;&rsaquo;</a></li>
-                    <li class="nested-counter__item"><a href="#support-scope-openstack">Openstack&nbsp;&rsaquo;</a></li>
+                    <li class="nested-counter__item"><a href="#support-scope-openstack">OpenStack&nbsp;&rsaquo;</a></li>
                 </ol>
             </li>
             <li class="nested-counter__item"><a href="#response-times">Response times&nbsp;&rsaquo;</a></li>


### PR DESCRIPTION
## Done

Corrected "Openstack" to "OpenStack" on new contents pane.
## QA
- `make run`
- go to /legal/ubuntu-advantage/service-description
- Ensure that the 2.6 entry on the right hand menu is "OpenStack"
