### PR TITLE
/internet-of-things/robotics page copy updates

### DIFF
--- a/templates/internet-of-things/robotics.html
+++ b/templates/internet-of-things/robotics.html
@@ -112,7 +112,7 @@
     <div class="col-6">
       <h2>Ubuntu runs on the robotic platforms that matter</h2>
       <p>Want to run Ubuntu Core on your hardware or write apps for an IoT device?</p>
-      <p><a class="p-link--external" href="https://developer.ubuntu.com/en/snappy/">Learn more about Ubuntu core on robotic platforms</a></p>
+      <p><a class="p-link--external" href="https://developer.ubuntu.com/core">Learn more about Ubuntu core on robotic platforms</a></p>
     </div>
     <div class="col-6">
       <ul class="p-inline-images u-no-margin--top">


### PR DESCRIPTION
## Done

- Updated robotics page to reflect copydoc changes

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/internet-of-things/robotics](http://0.0.0.0:8001//internet-of-things/robotics)
- Check if the[ copydoc](https://docs.google.com/document/d/1g8XpVzDkAdFETrfZvOf5Q6WlYwHCBYQ8Y6TgTlyTEYc/edit#heading=h.ev5crmk9lb8v) matches the page


## Issue / Card

Fixes: #3004 


