### PR TITLE
Add contact data privacy notice link

### DIFF
--- a/templates/legal/dataprivacy/index.html
+++ b/templates/legal/dataprivacy/index.html
@@ -38,9 +38,9 @@
       <ul class="p-list">
         <li class="p-list__item"><a href="/legal/dataprivacy/newsletter">Newsletter privacy notice&nbsp;&rsaquo;</a></li>
         <li class="p-list__item"><a href="/legal/dataprivacy/webinar">Webinar privacy notice&nbsp;&rsaquo;</a></li>
-        <li class="p-list__item"><a href="/legal/dataprivacy/online-purchase">Online purchase privacy notice&nbsp;&rsquo;</a></li>
-        <li class="p-list__item"><a href="/legal/dataprivacy/snap-store">Snap Store privacy notice&nbsp;&rsquo;</a></li>
-        <li class="p-list__item"><a href="/legal/dataprivacy/contact">Contact us and enquiries privacy notice&nbsp;&rsquo;</a></li>
+        <li class="p-list__item"><a href="/legal/dataprivacy/online-purchase">Online purchase privacy notice&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a href="/legal/dataprivacy/snap-store">Snap Store privacy notice&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a href="/legal/dataprivacy/contact">Contact us and enquiries privacy notice&nbsp;&rsaquo;</a></li>
       </ul>
       <h2 id="information-we-collect-from-you">Information we collect from you</h2>
       <ul class="p-list">


### PR DESCRIPTION
## Done

Add link to contact data privacy notice

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: <http://0.0.0.0:8001/legal/dataprivacy>
- Check that there is a link to `/legal/dataprivacy/contact` under the 'Privacy notices' heading


## Issue / Card
Fixes #3173 