### PR TITLE
Kubernetes case study page updates 2

### DIFF
--- a/templates/engage/kubernetes-case-study.html
+++ b/templates/engage/kubernetes-case-study.html
@@ -4,7 +4,7 @@
 {% block title %}Allan Gray unlocks unprecedented availability and productivity with Charmed Kubernetes{% endblock %}
 
 {% block content %}
-<section class="p-strip--light p-takeover--stats is-deep">
+<section class="p-strip--light p-takeover--stats">
   <div class="row">
     <div class="col-7">
       <h1 style="font-weight: 100">Allan Gray unlocks unprecedented availability and productivity with Charmed Kubernetes</h1>


### PR DESCRIPTION
Updated (again) from Ubuntu K8s to Charmed Kubernetes per branding update.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [http://0.0.0.0:8001/](http://0.0.0.0:8001/)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)