### PR TITLE
Update to a smaller google cloud svg

### DIFF
--- a/templates/download/cloud/index.html
+++ b/templates/download/cloud/index.html
@@ -33,7 +33,7 @@
       </header>
       <div class="p-card__content">
         <a class="u-align--center u-vertically-center" style="min-height:10rem;display: flex;" href="https://console.cloud.google.com/launcher/browse?q=ubuntu&filter=category:os&filter=price:free">
-          <img src="{{ ASSET_SERVER_URL }}82d7c6ea-cloud-logo.svg" width="211" alt="" style="align-self: center;max-height: 10rem;">
+          <img src="{{ ASSET_SERVER_URL }}79a533b8-google-cloud.png?w=211" width="211" alt="" style="align-self: center;max-height: 10rem;">
         </a>
         <p>Google Cloud Platform lets you build and host applications and websites, store data, and analyze data on Google’s scalable infrastructure.</p>
       </div>


### PR DESCRIPTION
## Done

- updated the google cloud svg to a more modern and far smaller version

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: [/download/cloud](http://0.0.0.0:8001/download/cloud)
- Run through the following [QA steps](https://github.com/canonical-webteam/practices/blob/master/workflow/qa-steps.md)
- See that the google logo is < 5k

## Issue / Card

Fixes #4614

