### PR TITLE
Fix sub-pixeling on takeovers

### DIFF
--- a/static/sass/_pattern_takeovers.scss
+++ b/static/sass/_pattern_takeovers.scss
@@ -5,7 +5,7 @@
     @extend %vf-strip;
     background-blend-mode: multiply, multiply, normal, normal;
     @content;
-    background-position: top right, top left, right 100%, left top;
+    background-position: top right, top left, right bottom -1px, left top;
     background-repeat: no-repeat;
     background-size: 74% 99.83%, 68% 91%, 103.8% 20.26%, 100% 99.8%;
     margin: 0;
@@ -13,7 +13,7 @@
     padding-top: 6rem;
 
     @media (max-width: $breakpoint-medium) {
-      background-position: top right, top left, right 100%, left top;
+      background-position: top right, top left, right bottom -1px, left top;
       background-repeat: no-repeat;
       background-size: 135% 97.83%, 148% 83%, 119% 13%, 100% 99.83%;
       padding-bottom: 8rem;


### PR DESCRIPTION
## Done

change the directions to remove sub-pixing on the takeovers

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/takeovers/templates
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that there is no thin line below the homepage takeovers at any browser width



