### PR TITLE
if a contract has a renewal, show the alert icon regardless of expiry date

### DIFF
--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -90,16 +90,18 @@
                       <td class="u-no-padding{% if open_subscription == contract['contractInfo']['id'] %} p-table--open"{% endif %}">
                         <button class="u-toggle u-toggle--full-width u-align--left" aria-controls="#expanded-details-{{ outer_loop.index }}-{{ loop.index }}" aria-expanded="false" data-shown-text="Hide" data-hidden-text="Show">
                           {{ contract['contractInfo']['name'] }} &nbsp;<i class="p-icon--contextual-menu">Open</i>
-                          {% if contract['expiring'] %}
-                            <div class="u-toggle__supplemental" style="color: #666; font-size: 14px;"><i class="p-icon--warning"></i>&nbsp;&nbsp;
-                              {% if contract["contractInfo"]["daysTillExpiry"] == 0 %}
-                                Ends today
-                              {% elif contract["contractInfo"]["daysTillExpiry"] == 1 %}
-                                Ends in 1 day
-                              {% else %}
-                                Ends in {{ contract["contractInfo"]["daysTillExpiry"] }} days
-                              {% endif %}
-                            </div>
+                          {% if contract["renewal"] %}
+                            {% if contract["renewal"]["renewable"] or contract["renewal"]["actionable"] == false %}
+                              <div class="u-toggle__supplemental" style="color: #666; font-size: 14px;"><i class="p-icon--warning"></i>&nbsp;&nbsp;
+                                {% if contract["contractInfo"]["daysTillExpiry"] == 0 %}
+                                  Ends today
+                                {% elif contract["contractInfo"]["daysTillExpiry"] == 1 %}
+                                  Ends in 1 day
+                                {% else %}
+                                  Ends in {{ contract["contractInfo"]["daysTillExpiry"] }} days
+                                {% endif %}
+                              </div>
+                            {% endif %}
                           {% endif %}
                         </button>
                       </td>
@@ -156,31 +158,33 @@
                                 <td class="u-align--left"><strong>{{ contract['contractInfo']['createdAtFormatted'] }}</strong></td>
                               </tr>
                               {% if contract['contractInfo']['effectiveTo'] %}
-                                {% if contract["expiring"] %}
-                                  <tr style="border-top: 0;">
-                                    <td class="u-align--right">
-                                      <i class="p-icon--warning" style="margin-top: 0.3rem;"></i>&nbsp;&nbsp;Ends:
-                                    </td>
-                                    <td class="u-align--left"><strong>{{ contract['contractInfo']['effectiveToFormatted'] }}</strong>&nbsp;&mdash;&nbsp;
-                                      {% if contract["contractInfo"]["daysTillExpiry"] == 0 %}
-                                        today
-                                      {% elif contract["contractInfo"]["daysTillExpiry"] == 1 %}
-                                        in 1 day
-                                      {% else %}
-                                        in {{ contract["contractInfo"]["daysTillExpiry"] }} days
-                                      {% endif %}
-                                    </td>
-                                  </tr>
-                                {% else %}
-                                  <tr style="border-top: 0;">
-                                    <td class="u-align--right">Ends:</td>
-                                    <td class="u-align--left">
-                                      <strong>{{ contract['contractInfo']['effectiveToFormatted'] }}</strong>
-                                      {% if open_subscription == contract['contractInfo']['id'] and request.args.get('renewed') %}
-                                      <div class="p-label--updated">Renewed</div>
-                                      {% endif %}
-                                    </td>
-                                  </tr>
+                                {% if contract["renewal"] %}
+                                  {% if contract["renewal"]["renewable"] or contract["renewal"]["actionable"] == false %}
+                                    <tr style="border-top: 0;">
+                                      <td class="u-align--right">
+                                        <i class="p-icon--warning" style="margin-top: 0.3rem;"></i>&nbsp;&nbsp;Ends:
+                                      </td>
+                                      <td class="u-align--left"><strong>{{ contract['contractInfo']['effectiveToFormatted'] }}</strong>&nbsp;&mdash;&nbsp;
+                                        {% if contract["contractInfo"]["daysTillExpiry"] == 0 %}
+                                          today
+                                        {% elif contract["contractInfo"]["daysTillExpiry"] == 1 %}
+                                          in 1 day
+                                        {% else %}
+                                          in {{ contract["contractInfo"]["daysTillExpiry"] }} days
+                                        {% endif %}
+                                      </td>
+                                    </tr>
+                                  {% else %}
+                                    <tr style="border-top: 0;">
+                                      <td class="u-align--right">Ends:</td>
+                                      <td class="u-align--left">
+                                        <strong>{{ contract['contractInfo']['effectiveToFormatted'] }}</strong>
+                                        {% if open_subscription == contract['contractInfo']['id'] and request.args.get('renewed') %}
+                                        <div class="p-label--updated">Renewed</div>
+                                        {% endif %}
+                                      </td>
+                                    </tr>
+                                  {% endif %}
                                 {% endif %}
                               {% endif %}
                               {% if contract["renewal"] %}


### PR DESCRIPTION
## Done

Displayed the warning icon on a subscription row if it has an open renewal at all times (previously it would only be if the subscription was expiring in < 30 days)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/advantage
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
