### PR TITLE
Update Masters conference page

### DIFF
--- a/templates/masters-conference/index.html
+++ b/templates/masters-conference/index.html
@@ -24,7 +24,7 @@
 <section class="p-strip is-bordered">
   <div class="row">
     <div class="col-8">
-      <h3>Ubuntu Masters 3: Join the community</h3>
+      <h3><strong>Ubuntu Masters 3</strong>: The community expands</h3>
     </div>
   </div>
 
@@ -89,8 +89,8 @@
           loading="lazy",
         ) | safe
       }}
-      <h4>Mastering multicloud</h4>
-      <p>June 30, 3:30-4:30pm BST</p>
+      <h4>Mastering multicloud with  SLURM and Juju</h4>
+      <p>June 30, 5-6pm BST</p>
       <p>
         <strong>
           Erik Lonroth, Tech Lead HPC & Open Source Forum Chairman<br>
@@ -106,7 +106,7 @@
 <section class="p-strip">
   <div class="row">
     <div class="col-8">
-      <h3>Ubuntu Masters 2: The virtual conference</h3>
+      <h3><strong>Ubuntu Masters 2</strong>: The virtual conference</h3>
     </div>
   </div>
 
@@ -174,7 +174,7 @@
 <section class="p-strip--light">
   <div class="row">
     <div class="col-8">
-      <h3>Ubuntu Masters 1: The California sessions</h3>
+      <h3><strong>Ubuntu Masters 1</strong>: The California launch</h3>
     </div>
   </div>
 


### PR DESCRIPTION
## Done

Updated /masters-conference

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/masters-conference
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the page matches [the copy doc](https://docs.google.com/document/d/1Z63eMCe9o4Onk2ezPFLPDTbI-uJezAOzI-aSpXmZ5lc/edit)


## Issue / Card

Fixes #7683 


## Screenshots

![ubuntu-masters-homepage](https://user-images.githubusercontent.com/501889/84270516-b446d480-ab22-11ea-9ec2-ebe11fad5ee3.png)

