### PR TITLE
Update blog to 6.2.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 alembic==1.4.2
 canonicalwebteam.flask_base==0.6.3
 canonicalwebteam.http==1.0.3
-canonicalwebteam.blog==6.2.2
+canonicalwebteam.blog==6.2.3
 canonicalwebteam.search==0.2.1
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.2.0


### PR DESCRIPTION
Update blog version so we no longer throw a 500 if there are images without src. If there is an image without src it will simply skip it.

## QA
Browse to: https://ubuntu.com/blog/group/phone-and-tablet/feed
It won't work

Browse to: https://ubuntu-com-8139.demos.haus/blog/group/phone-and-tablet/feed
I will work.