### PR TITLE
Fix typo on form thank-you

### DIFF
--- a/templates/thank-you.html
+++ b/templates/thank-you.html
@@ -8,7 +8,7 @@
   <div class="row">
     <div class="col-7">
       <h1>Thanks for getting in touch</h1>
-      <h2 class="p-heading--three">Your submittion was successful.</h2>
+      <h2 class="p-heading--three">Your submission was successful.</h2>
       {% if referrer and referrer != "" %}
       <p><a href="{{ referrer }}" class="p-button--neutral">Return to learn more</a></p>
       {% endif %}


### PR DESCRIPTION
## Done

- s/submittion/sumbission/

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/thank-you?referrer=https://ubuntu.com/blog/ubuntu-14-04-and-16-04-lifecycle-extended-to-ten-years
- See that it is now spelled correctly.
