### PR TITLE
Add not allowed entitlements

### DIFF
--- a/tests/advantage/test_parsers.py
+++ b/tests/advantage/test_parsers.py
@@ -276,16 +276,19 @@ class TestParsers(unittest.TestCase):
                 type="entitlement-type",
                 support_level=None,
                 enabled_by_default=True,
+                is_available=True,
             ),
             Entitlement(
                 type="entitlement-type-2",
                 support_level=None,
                 enabled_by_default=False,
+                is_available=True,
             ),
             Entitlement(
                 type="support",
                 support_level="advanced",
                 enabled_by_default=False,
+                is_available=True,
             ),
         ]
 

--- a/webapp/advantage/models.py
+++ b/webapp/advantage/models.py
@@ -7,10 +7,12 @@ class Entitlement:
         type: str,
         enabled_by_default: bool,
         support_level: str = None,
+        is_available: bool = True,
     ):
         self.type = type
         self.support_level = support_level
         self.enabled_by_default = enabled_by_default
+        self.is_available = is_available
 
 
 class Product:

--- a/webapp/advantage/ua_contracts/builders.py
+++ b/webapp/advantage/ua_contracts/builders.py
@@ -8,6 +8,7 @@ from webapp.advantage.ua_contracts.helpers import (
     get_price_info,
     get_subscription_by_period,
     make_user_subscription_id,
+    apply_entitlement_rules,
 )
 from webapp.advantage.ua_contracts.primitives import (
     Contract,
@@ -188,7 +189,7 @@ def build_final_user_subscriptions(
             id=id,
             type=type,
             account_id=account.id,
-            entitlements=contract.entitlements,
+            entitlements=apply_entitlement_rules(contract.entitlements),
             start_date=aggregated_values.get("start_date"),
             end_date=aggregated_values.get("end_date"),
             number_of_machines=number_of_machines,

--- a/webapp/advantage/ua_contracts/parsers.py
+++ b/webapp/advantage/ua_contracts/parsers.py
@@ -76,6 +76,7 @@ def parse_entitlements(
     for raw_entitlement in raw_entitlements:
         affordances = raw_entitlement.get("affordances")
         obligations = raw_entitlement.get("obligations")
+        is_available = raw_entitlement.get("entitled")
 
         support_level = None
         if affordances:
@@ -85,6 +86,7 @@ def parse_entitlements(
             type=raw_entitlement.get("type"),
             support_level=support_level,
             enabled_by_default=obligations.get("enableByDefault"),
+            is_available=is_available,
         )
 
         entitlements.append(entitlement)


### PR DESCRIPTION
## Done

- Add `Not included` entitlements. The API does not return entitlements that are `Not included` for the contract. So we must add them manually.
- `Not included` are the entitlements that have `is_available` == `False`
- Possible `Not included` entitlements are `esm-apps`, `24/5` and `24/7`.
- Filter out entitlements that are not fulfilling this conditions:
```
    allowed_entitlements = [
        "cis",
        "esm-infra",
        "esm-apps",
        "fips",
        "fips-updated",
        "livepatch",
        "livepatch-onprem",
        "support",
    ]

    allowed_support_level = ["standard", "advanced"]
``` 

## QA

- We QA it with the front-end.

## Issue / Card

Fixes #https://github.com/canonical-web-and-design/commercial-squad/issues/269
