### PR TITLE
increase cypress login timeout

### DIFF
--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -5,11 +5,13 @@ Cypress.Commands.add("acceptCookiePolicy", () => {
 });
 
 Cypress.Commands.add("login", ({ username, password }) => {
-  cy.task("login", { username, password }).then(async (user) => {
-    user.cookies.forEach(({ name, value }) => {
-      cy.setCookie(name, value);
-    });
-  });
+  cy.task("login", { username, password }, { timeout: 20000 }).then(
+    async (user) => {
+      user.cookies.forEach(({ name, value }) => {
+        cy.setCookie(name, value);
+      });
+    }
+  );
 });
 
 Cypress.Commands.add("iframeLoaded", { prevSubject: "element" }, ($iframe) => {


### PR DESCRIPTION
## Done

- increase cypress login task timeout to reduce e2e timeout errors for logged-in tests
