### PR TITLE
Initial update of releases.yaml for 21.10

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -1,12 +1,12 @@
 latest:
-  slug: HirsuteHippo
-  name: "Hirsute Hippo"
-  short_version: "21.04"
-  full_version: "21.04"
-  release_date: "April 2021"
-  eol: "January 2022"
+  slug: ImpishIndri
+  name: "Impish Indri"
+  short_version: "21.10"
+  full_version: "21.10"
+  release_date: "October 2021"
+  eol: "July 2022"
   past_eol_date: false
-  release_notes_url: "https://discourse.ubuntu.com/t/hirsute-hippo-release-notes/19221"
+  release_notes_url: "https://discourse.ubuntu.com/t/impish-indri-release-notes/21951"
 lts:
   slug: FocalFossa
   name: "Focal Fossa"
@@ -30,17 +30,16 @@ previous_previous_lts:
 
 checksums:
   desktop:
-    "21.04": "fa95fb748b34d470a7cfa5e3c1c8fa1163e2dc340cd5a60f7ece9dc963ecdf88 *ubuntu-21.04-desktop-amd64.iso"
+    "21.10": "fa95fb748b34d470a7cfa5e3c1c8fa1163e2dc340cd5a60f7ece9dc963ecdf88 *ubuntu-21.10-desktop-amd64.iso"
     "20.04.3": "5fdebc435ded46ae99136ca875afc6f05bde217be7dd018e1841924f71db46b5 *ubuntu-20.04.3-desktop-amd64.iso"
   live-server:
-    "21.04": "e4089c47104375b59951bad6c7b3ee5d9f6d80bfac4597e43a716bb8f5c1f3b0 *ubuntu-21.04-live-server-amd64.iso"
+    "21.10": "e4089c47104375b59951bad6c7b3ee5d9f6d80bfac4597e43a716bb8f5c1f3b0 *ubuntu-21.10-live-server-amd64.iso"
     "20.04.3": "f8e3086f3cea0fb3fefb29937ab5ed9d19e767079633960ccb50e76153effc98 *ubuntu-20.04.3-live-server-amd64.iso"
   desktop-arm64+raspi:
-    "21.04": "d89ee327a00b98d7166b1a8cc95d17762aaacd3b4d0fc756c5b6b65df1708f48 *ubuntu-21.04-preinstalled-desktop-arm64+raspi.img.xz"
+    "21.10": "d89ee327a00b98d7166b1a8cc95d17762aaacd3b4d0fc756c5b6b65df1708f48 *ubuntu-21.10-preinstalled-desktop-arm64+raspi.img.xz"
   server-arm64+raspi:
-    "21.04": "3df85b93b66ccd2d370c844568b37888de66c362eebae5204bf017f6f5875207 *ubuntu-21.04-preinstalled-server-arm64+raspi.img.xz"
+    "21.10": "3df85b93b66ccd2d370c844568b37888de66c362eebae5204bf017f6f5875207 *ubuntu-21.10-preinstalled-server-arm64+raspi.img.xz"
     "20.04.3": "7e405f473d8a9e3254cd702edaeecd5509a85cde1e9e99e120f6c82156c6958f *ubuntu-20.04.3-preinstalled-server-arm64+raspi.img.xz"
   server-armhf+raspi:
-    "21.04": "c9a9a5177a03fcbb6203b38e5c3c4e5447fd9e8891515da4146f319f04eb3495 *ubuntu-21.04-preinstalled-server-armhf+raspi.img.xz"
-    "20.04.3": "1984c349d5d6b74279402325b6985587d1d32c01695f2946819ce25b638baa0e *ubuntu-20.04.3-preinstalled-server-armhf+raspi.img.xz
-"
+    "21.10": "c9a9a5177a03fcbb6203b38e5c3c4e5447fd9e8891515da4146f319f04eb3495 *ubuntu-21.10-preinstalled-server-armhf+raspi.img.xz"
+    "20.04.3": "1984c349d5d6b74279402325b6985587d1d32c01695f2946819ce25b638baa0e *ubuntu-20.04.3-preinstalled-server-armhf+raspi.img.xz"


### PR DESCRIPTION
## Done

- Initial update of releases.yaml for 21.10
- NOTE - checksums, isos and torrents not live yet

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/download 
- See that the text refers to the 21.10 release

## Issue / Card

Fixes #10579
