### PR TITLE
Update release animal for 21.10

### DIFF
--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -36,9 +36,9 @@
     </div>
     <div class="col-6 u-align--center u-hide--small">
       {{ image (
-        url="https://assets.ubuntu.com/v1/cae223aa-HH-FF-download-mascots.svg",
+        url="https://assets.ubuntu.com/v1/5d05e2fc-II-FF-download-mascots.svg",
         alt="",
-        width="504",
+        width="442",
         height="143",
         hi_def=True,
         loading="auto"

--- a/templates/download/server/step2.html
+++ b/templates/download/server/step2.html
@@ -28,8 +28,8 @@
           image(
           url="https://assets.ubuntu.com/v1/28e0ebb7-Focal-Fossa-gradient-outline.svg",
           alt="",
-          height="1500",
-          width="1922",
+          height="200",
+          width="256",
           hi_def=True,
           loading="lazy"
           ) | safe
@@ -113,16 +113,15 @@
       </p>
     </div>
     <div class="col-4 col-start-large-8 u-hide--small u-align--center u-vertically-center">
-
-      {{ image (
-        url="https://assets.ubuntu.com/v1/2e66eda7-Hirsuit_Hippo_Colour.svg",
-        alt="",
-        width="300",
-        height="128",
-        hi_def=True,
-        loading="lazy"
-        ) | safe
-      }}
+        {{ image (
+          url="https://assets.ubuntu.com/v1/c9a911d5-II-grad-mascot.svg",
+          alt="",
+          width="263",
+          height="150",
+          hi_def=True,
+          loading="lazy"
+          ) | safe
+        }}
     </div>
   </div>
   {% endif %}


### PR DESCRIPTION
## Done

- Update release animal for 21.10 on /download and /download/server (manual install step)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/download and http://0.0.0.0:8001/download/server (manual install step)
- See that the animals look correct

## Issue / Card

Fixes #4530

## Screenshots

![image](https://user-images.githubusercontent.com/441217/136932911-666db53a-79bb-42ed-8227-13c28fcb2e65.png)

![image](https://user-images.githubusercontent.com/441217/136933112-e77377fb-2f03-420c-9512-0949fb74e57d.png)

