### PR TITLE
Update /server What's new for 21.10 release

### DIFF
--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -18,11 +18,6 @@
           Download Ubuntu Server
         </a>
       </p>
-      <p>
-        <a class="p-link--inverted" href="/engage/ubuntu-21.04-release-webinar">
-          Watch the webinar - "What's new in Ubuntu Server 21.04?"&nbsp;&rsaquo;
-        </a>
-      </p>
     </div>
     <div class="col-5 u-vertically-center u-align--center u-hide--small">
       {{
@@ -46,17 +41,23 @@
     </h2>
     <ul class="p-list is-split">
       <li class="p-list__item is-ticked">Supported by Canonical until {{ releases.latest.eol }}</li>
-      <li class="p-list__item is-ticked">Ability to convert Debian Installer (DI) preseed scripts into Ubuntu Server Live Installer artifacts</li>
-      <li class="p-list__item is-ticked">APT phased updates for regressions monitoring and immediate elimination</li>
-      <li class="p-list__item is-ticked">Stability updates to the high availability (HA) stack, including pacemaker and corosync</li>
-      <li class="p-list__item is-ticked">The latest stable Linux 5.11 kernel for the latest hardware and security updates</li>
+      <li class="p-list__item is-ticked">Certified native drivers for NVIDIA virtual GPU (vGPU) software on Ubuntu 20.04 LTS and Ubuntu 18.04 LTS <sup>*</sup></li>
+      <li class="p-list__item is-ticked">Minimal system installation option through the Ubuntu Server Live Installer</li>
+      <li class="p-list__item is-ticked"><a class="p-link--external" href="http://manpages.ubuntu.com/manpages/xenial/man1/needrestart.1.html">Needrestart</a> by default for automated daemon restarts after applying library upgrades</li>
+      <li class="p-list__item is-ticked">The latest stable Linux 5.13 kernel for the latest hardware and security updates</li>
       <li class="p-list__item is-ticked">Runs on all major architectures - x86-64, ARM v7, ARM64, POWER8, POWER9, IBM s390x (LinuxONE) and RISC-V</li>
-      <li class="p-list__item is-ticked">Updates to QEMU (5.2), libvirt (7.0), PHP (7.4.9), Apache2 (2.4.46), nginx (1.18), GCC (1.189), Python (3.9.2), Bind9 (9.16.8)</li>
+      <li class="p-list__item is-ticked">Updates to QEMU (6.0), libvirt (7.6), PHP (8.0.8), Apache2 (2.4.48), GCC (11.2.0), Python (3.9.4), Bind9 (9.16.15), Open vSwitch (2.16.0) and OpenLDAP (2.5.6)</li>
     </ul>
     <p>
+      <small>
+        <sup>*</sup> available to <a href="/advantage">Ubuntu Advantage</a> customers only
+      </small>
+    </p>
+    <p>
       <a
+      class="p-link--external"
       href="{{ releases.latest.release_notes_url }}">
-        Read more in the release notes&nbsp;&rsaquo;
+        Read more in the release notes
       </a>
     </p>
   </div>
@@ -82,9 +83,10 @@
       <li class="p-list__item is-ticked">Updates to QEMU (v4.2), libvirt (v6.0), PHP (v7.4), Ruby (v2.7), GCC (V9.3), Python (v3.8), MySQL (v8.0), NGINX (v1.17)</li>
     </ul>
     <p>
-      <a class="p-link--external"
+      <a
+      class="p-link--external"
       href="{{ releases.lts.release_notes_url }}">
-        Read more in the release notes&nbsp;&rsaquo;
+        Read more in the release notes
       </a>
     </p>
   </div>


### PR DESCRIPTION
## Done

- Update /server What's new for 21.10 release
- Removed the webinar link

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/server
- Compare to the [copy doc](https://docs.google.com/document/d/1vxLhtbjgPs9PCNEhr7fbhEoErCPMXYFfU4UTKH7Kbq4/edit#heading=h.8u2ayk5kd6l8) - please note, releases.yaml might make the h2, eol date and release notes links look wrong


## Issue / Card

Fixes #4532

## Screenshots

![image](https://user-images.githubusercontent.com/441217/136936678-aeadf376-40c8-4c55-871f-24b02b366f00.png)

