### PR TITLE
Add entitlements rules

### DIFF
--- a/tests/advantage/test_helpers.py
+++ b/tests/advantage/test_helpers.py
@@ -709,7 +709,7 @@ class TestHelpers(unittest.TestCase):
         for listing in listings.values():
             self.assertEqual(listing.can_be_trialled, False)
 
-    def test_apply_entitlement_rules(self):
+    def test_apply_entitlement_rules_is_available(self):
         entitlements = [
             Entitlement(
                 type="landscape",
@@ -731,8 +731,10 @@ class TestHelpers(unittest.TestCase):
         expected_entitlements = [
             Entitlement(
                 type="support",
-                enabled_by_default=False,
                 support_level="standard",
+                enabled_by_default=True,
+                is_available=True,
+                is_editable=False,
             ),
             Entitlement(
                 type="esm-infra",
@@ -742,12 +744,61 @@ class TestHelpers(unittest.TestCase):
                 type="esm-apps",
                 enabled_by_default=False,
                 is_available=False,
+                is_editable=False,
             ),
             Entitlement(
                 type="support",
-                enabled_by_default=False,
                 support_level="advanced",
+                enabled_by_default=False,
                 is_available=False,
+                is_editable=False,
+            ),
+        ]
+
+        self.assertEqual(
+            to_dict(final_entitlements), to_dict(expected_entitlements)
+        )
+
+    def test_apply_entitlement_rules_is_enabled(self):
+        entitlements = [
+            Entitlement(
+                type="livepatch",
+                enabled_by_default=True,
+            ),
+            Entitlement(
+                type="fips-updates",
+                enabled_by_default=True,
+            ),
+            Entitlement(
+                type="fips",
+                enabled_by_default=True,
+            ),
+            Entitlement(
+                type="esm-apps",
+                enabled_by_default=True,
+            ),
+        ]
+
+        final_entitlements = apply_entitlement_rules(entitlements)
+
+        expected_entitlements = [
+            Entitlement(
+                type="livepatch",
+                enabled_by_default=False,
+                is_editable=False,
+            ),
+            Entitlement(
+                type="fips-updates",
+                enabled_by_default=False,
+                is_editable=False,
+            ),
+            Entitlement(
+                type="fips",
+                enabled_by_default=True,
+            ),
+            Entitlement(
+                type="esm-apps",
+                enabled_by_default=True,
             ),
         ]
 

--- a/webapp/advantage/models.py
+++ b/webapp/advantage/models.py
@@ -8,11 +8,13 @@ class Entitlement:
         enabled_by_default: bool,
         support_level: str = None,
         is_available: bool = True,
+        is_editable: bool = True,
     ):
         self.type = type
         self.support_level = support_level
         self.enabled_by_default = enabled_by_default
         self.is_available = is_available
+        self.is_editable = is_editable
 
 
 class Product:

--- a/webapp/advantage/ua_contracts/api.py
+++ b/webapp/advantage/ua_contracts/api.py
@@ -9,6 +9,7 @@ from webapp.advantage.ua_contracts.parsers import (
     parse_accounts,
     parse_account,
     parse_users,
+    parse_contract,
 )
 
 
@@ -92,6 +93,21 @@ class UAContractsAPI:
             return parse_contracts(contracts)
 
         return contracts
+
+    def get_contract(self, contract_id: str):
+        response = self._request(
+            method="get",
+            path=f"v1/contracts/{contract_id}",
+            json={},
+            error_rules=["default"],
+        )
+
+        contract = response.json()
+
+        if self.convert_response:
+            return parse_contract(contract)
+
+        return contract
 
     def get_account_users(self, account_id: str):
         response = self._request(

--- a/webapp/advantage/views.py
+++ b/webapp/advantage/views.py
@@ -745,8 +745,102 @@ def cancel_advantage_subscriptions(**kwargs):
 def put_contract_entitlements(contract_id, **kwargs):
     g.api.set_convert_response(True)
 
+    settings = kwargs.get("entitlements")
+
+    contract = g.api.get_contract(contract_id)
+
+    allowed_entitlements = [
+        "cis",
+        "esm-infra",
+        "esm-apps",
+        "fips",
+        "fips-updates",
+        "livepatch",
+        "support",
+    ]
+
+    # validate request body
+    for setting in settings:
+        # prevent updating entitlements not on the allow list
+        if setting["type"] not in allowed_entitlements:
+            return (
+                flask.jsonify(
+                    {
+                        "error": (
+                            f"Updating entitlement '{setting['type']}' "
+                            f"is not allowed."
+                        )
+                    }
+                ),
+                400,
+            )
+
+        # prevent updating entitlements with the status "Not available"
+        has_not_available_entitlements = not any(
+            entitlement
+            for entitlement in contract.entitlements
+            if entitlement.type == setting["type"]
+        )
+
+        if has_not_available_entitlements:
+            return (
+                flask.jsonify(
+                    {
+                        "error": (
+                            f"Entitlement '{setting['type']}' "
+                            f"is not available."
+                        )
+                    }
+                ),
+                400,
+            )
+
+    # merge current entitlements settings with new entitlement settings
+    all_entitlements = settings
+    for entitlement in contract.entitlements:
+        current_setting = any(
+            setting
+            for setting in settings
+            if setting["type"] == entitlement.type
+        )
+
+        if not current_setting:
+            all_entitlements.append(
+                {
+                    "type": entitlement.type,
+                    "is_enabled": entitlement.enabled_by_default,
+                }
+            )
+
+    # check current status of entitlements
+    has_livepatch_on = False
+    has_fips_on = False
+    has_fips_updates_on = False
+    for entitlement in all_entitlements:
+        if entitlement["type"] == "livepatch":
+            has_livepatch_on = entitlement["is_enabled"]
+        if entitlement["type"] == "fips-updates":
+            has_fips_updates_on = entitlement["is_enabled"]
+        if entitlement["type"] == "fips":
+            has_fips_on = entitlement["is_enabled"]
+
+    # check rules on the current statuses
+    if has_fips_on and (has_livepatch_on or has_fips_updates_on):
+        return (
+            flask.jsonify(
+                {
+                    "error": (
+                        "Cannot have FIPS active at the same time as "
+                        "Livepatch or FIPS Updates"
+                    )
+                }
+            ),
+            400,
+        )
+
+    # build entitlement request for the API
     entitlements_request = []
-    for setting in kwargs.get("entitlements"):
+    for setting in settings:
         entitlements_request.append(
             {
                 "type": setting["type"],


### PR DESCRIPTION
## Done

- Add `is_editable` property to entitlements, based on the entitlement rules this will be `True` or `False`
- Entitlement rules are the following:
  - If `FIPS` is on `Livepatch` and `FIPS Updates` cannot be on and vice-versa
  - `FIPS` and `FIPS Updates` cannot be on at the same time
- Add validation to the update entitlements endpoint
- Filter out all entitlements except:
```
"cis",
"esm-infra",
"esm-apps",
"fips",
"fips-updates",
"livepatch",
"support",
```

## QA

- We test with front-end.

## Issue / Card

Fixes #https://github.com/canonical-web-and-design/commercial-squad/issues/268