### PR TITLE
Remove mkto classes

### DIFF
--- a/templates/advantage/_stripe-modal.html
+++ b/templates/advantage/_stripe-modal.html
@@ -274,7 +274,6 @@
       <span id="js-progress-indicator" class="p-modal__progress u-hide">
         <i class="p-icon--success u-hide"></i>
         <i class="p-icon--spinner u-animation--spin"></i>&nbsp;&nbsp;
-        <span></span>
       </span>
 
       <div class="row u-no-padding">

--- a/templates/blog/newsletter-form.html
+++ b/templates/blog/newsletter-form.html
@@ -9,45 +9,44 @@
 
       <ul class="p-list">
         <li class="p-list__item u-clearfix">
-          <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightscloudserver" name="insightscloudserver" value="true" />
+          <input type="checkbox" id="insightscloudserver" name="insightscloudserver" value="true" />
           <label for="insightscloudserver">Cloud and Server</label>
         </li>
 
         <li class="p-list__item u-clearfix">
-          <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsdesktop" name="insightsdesktop" value="true" />
+          <input type="checkbox" id="insightsdesktop" name="insightsdesktop" value="true" />
           <label for="insightsdesktop">Desktop</label>
         </li>
 
         <li class="p-list__item u-clearfix">
-          <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsiot" name="insightsiot" value="true" />
+          <input type="checkbox" id="insightsiot" name="insightsiot" value="true" />
           <label for="insightsiot">Internet of Things</label>
         </li>
 
         <li class="p-list__item u-clearfix">
-          <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" id="insightsrobotics" name="insightsrobotics" value="true" type="checkbox">
+          <input id="insightsrobotics" name="insightsrobotics" value="true" type="checkbox">
           <label for="insightsrobotics">Robotics</label>
         </li>
 
         <li class="p-list__item u-clearfix">
-          <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" id="insightstutorials" name="insightstutorials" value="true" type="checkbox">
+          <input id="insightstutorials" name="insightstutorials" value="true" type="checkbox">
           <label for="insightstutorials">Tutorials</label>
         </li>
       </ul>
 
-      <div class="mktFormReq mktField">
+      <div>
         <label>
           <span class="u-no-margin--top">Work email: <span>*</span></span>
-          <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" />
+          <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"/>
         </label>
       </div>
 
-      <div class="mktField mktLblRight">
-        <span class="mktInput mktLblRight">
-          <input class="u-no-margin--top mktFormCheckbox" name="canonicalUpdatesOptIn" id="CanonicalUpdatesOptIn" value="yes" type="checkbox" />
+      <div>
+        <span>
+          <input class="u-no-margin--top" name="canonicalUpdatesOptIn" id="CanonicalUpdatesOptIn" value="yes" type="checkbox" />
           <label for="CanonicalUpdatesOptIn" class="p-form__label u-no-margin--top">
             <small>I agree to receive information about Canonical's products and services.</small>
           </label>
-          <span class="mktFormMsg"></span>
         </span>
       </div>
 
@@ -58,19 +57,19 @@
       </p>
 
       <div>
-        <span class="mktoButtonWrap p-card--content">
+        <span class="p-card--content">
           <button type="submit" class="u-no-margin--bottom">Subscribe now</button>
         </span>
 
-        <input value="1212" class="mktoField mktoFieldDescriptor" name="formid" type="hidden">
+        <input value="1212" name="formid" type="hidden">
         <input type="hidden" name="Consent_to_Processing__c" value="yes" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
         <input type="hidden" name="thankyoumessage" value="Thank you for subscribing!<br />You will begin receiving emails as new content is posted. You may unsubscribe any time by clicking the link in the email.">
       </div>
     </form>

--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -166,43 +166,42 @@
         <h4 class="p-muted-heading">Newsletter signup</h4>
         <hr class="u-sv1" />
         <h3 class="p-card--title">Select topics you're interested in</h3>
-        <form action="/marketo/submit" method="post" id="mktoForm_1212" novalidate="novalidate" onsubmit="ga('send', 'Newsletter', 'Signup', 'New homepage newsletter signup');">
+        <form action="/marketo/submit" method="post" id="mktoForm_1212" onsubmit="ga('send', 'Newsletter', 'Signup', 'New homepage newsletter signup');">
           <div class="p-card--content">
             <ul class="p-list">
               <li class="p-list__item u-clearfix">
-                <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightscloudserver" name="insightscloudserver" value="true" />
+                <input type="checkbox" id="insightscloudserver" name="insightscloudserver" value="true" />
                 <label for="insightscloudserver">Cloud and Server</label>
               </li>
               <li class="p-list__item u-clearfix">
-                <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsdesktop" name="insightsdesktop" value="true" />
+                <input type="checkbox" id="insightsdesktop" name="insightsdesktop" value="true" />
                 <label for="insightsdesktop">Desktop</label>
               </li>
               <li class="p-list__item u-clearfix">
-                <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" type="checkbox" id="insightsiot" name="insightsiot" value="true" />
+                <input type="checkbox" id="insightsiot" name="insightsiot" value="true" />
                 <label for="insightsiot">Internet of Things</label>
               </li>
               <li class="p-list__item u-clearfix">
-                <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" id="insightsrobotics" name="insightsrobotics" value="true" type="checkbox">
+                <input id="insightsrobotics" name="insightsrobotics" value="true" type="checkbox">
                 <label for="insightsrobotics">Robotics</label>
               </li>
               <li class="p-list__item u-clearfix">
-                <input class="mktoLogicalField mktoCheckboxList mktoHasWidth" id="insightstutorials" name="insightstutorials" value="true" type="checkbox">
+                <input id="insightstutorials" name="insightstutorials" value="true" type="checkbox">
                 <label for="insightstutorials">Tutorials</label>
               </li>
             </ul>
-            <div class="mktFormReq mktField">
+            <div>
               <label>
                 <span class="u-no-margin--top">Work email: <span>*</span></span>
-                <input required  id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField  mktoRequired" />
+                <input required  id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
               </label>
             </div>
-            <div class="mktField mktLblRight">
-              <span class="mktInput mktLblRight">
-                <input class="mktFormCheckbox" name="canonicalUpdatesOptIn" id="CanonicalUpdatesOptIn" value="yes" type="checkbox" />
+            <div>
+              <span>
+                <input name="canonicalUpdatesOptIn" id="CanonicalUpdatesOptIn" value="yes" type="checkbox" />
                 <label for="CanonicalUpdatesOptIn" class="p-form__label u-no-margin--top">
                   <small>I agree to receive information about Canonical's products and services.</small>
                 </label>
-                <span class="mktFormMsg"></span>
               </span>
             </div>
             <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}" style="margin: 1rem 0;"></div>
@@ -212,36 +211,24 @@
 
 
             <div>
-              <span class="mktoButtonWrap p-card--content">
+              <span class="p-card--content">
                 <button type="submit" class="u-no-margin--bottom">Subscribe now</button>
               </span>
-              <input value="1212" class="mktoField mktoFieldDescriptor" name="formid" type="hidden">
+              <input value="1212" name="formid" type="hidden">
               <input type="hidden" name="Consent_to_Processing__c" value="yes" />
               <input type="hidden" name="returnURL" value="http://{{ http_host }}/download/desktop/thank-you?newsletter=true" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
               <input type="hidden" name="thankyoumessage" value="Thank you for subscribing!<br />You will begin receiving emails as new content is posted. You may unsubscribe any time by clicking the link in the email.">
             </div>
           </div>
         </form>
       </div>
-      <script src="https://assets.ubuntu.com/v1/5d7e5bbf-jquery-2.2.0.min.js"></script>
-      <script src="https://assets.ubuntu.com/v1/d55f58bb-jquery.validate.js"></script>
-      <script>
-        $("#mktoForm_1212").validate({
-          errorPlacement: function(error, element) {
-            error.appendTo( element.parent().addClass( "p-form-validation is-error" ));
-            error.appendTo( element.addClass( "p-form-validation__input" ));
-          },
-          errorElement: "span",
-          errorClass: "p-form-validation__message"
-        });
-      </script>
     </div>
   </div>
 </section>

--- a/templates/download/server/s390x.html
+++ b/templates/download/server/s390x.html
@@ -27,29 +27,29 @@
       <form class="p-form u-no-margin--top" action="/marketo/submit" method="post" id="mktoForm_1400">
         <fieldset style="border: 1px solid #c0c0c0;">
           <ul class="p-list u-no-margin--bottom">
-            <li class="mktFormReq mktField p-list__item">
-              <label for="firstName" aria-label="FirstName" class="mktoLabel">First name: <span>*</span></label>
-              <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField   mktoRequired">
+            <li class="p-list__item">
+              <label for="firstName" aria-label="FirstName">First name: <span>*</span></label>
+              <input required id="firstName" name="firstName" maxlength="255" type="text">
             </li>
-            <li class="mktFormReq mktField p-list__item">
-              <label for="lastName" aria-label="LastName" class="mktoLabel">Last name: <span>*</span></label>
-              <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField   mktoRequired">
+            <li class="p-list__item">
+              <label for="lastName" aria-label="LastName">Last name: <span>*</span></label>
+              <input required id="lastName" name="lastName" maxlength="255" type="text">
             </li>
-            <li class="mktFormReq mktField p-list__item">
-              <label for="company" aria-label="Company" class="mktoLabel">Company name: <span>*</span></label>
-              <input required id="company" name="company" maxlength="255" type="text" class="mktoField   mktoRequired">
+            <li class="p-list__item">
+              <label for="company" aria-label="Company">Company name: <span>*</span></label>
+              <input required id="company" name="company" maxlength="255" type="text">
             </li>
-            <li class="mktFormReq mktField p-list__item">
-              <label for="email" aria-label="Email" class="mktoLabel">Email address: <span>*</span></label>
-              <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField  mktoRequired">
+            <li class="p-list__item">
+              <label for="email" aria-label="Email">Email address: <span>*</span></label>
+              <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$">
             </li>
-            <li class="mktFormReq mktField p-list__item">
-              <label for="phone" aria-label="phone" class="mktoLabel">Mobile/cell phone number: <span>*</span></label>
-              <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired">
+            <li class="p-list__item">
+              <label for="phone" aria-label="phone">Mobile/cell phone number: <span>*</span></label>
+              <input required id="phone" name="phone" maxlength="255" type="tel">
             </li>
-            <li class="mktField p-list__item">
-              <label for="NumUbuntuServers__c" aria-label="NumUbuntuServers__c" class="mktoLabel">Number of drawers you are purchasing support for:</label>
-              <select id="NumUbuntuServers__c" name="NumUbuntuServers__c" class="mktoField">
+            <li class="p-list__item">
+              <label for="NumUbuntuServers__c" aria-label="NumUbuntuServers__c">Number of drawers you are purchasing support for:</label>
+              <select id="NumUbuntuServers__c" name="NumUbuntuServers__c">
                 <option value="">Select...</option>
 
                 <option value="zBC12" disabled>zBC12</option>
@@ -86,16 +86,16 @@
                 <option value="z15/LinuxONE III - 4 drawers (up to 190 cores)"> - 4 drawers (up to 190 cores)</option>
               </select>
             </li>
-            <li class="mktField p-list__item">
-              <label for="Comments_from_Contact__c" aria-label="Comments_from_Contact__c" class="mktoLabel">Serial number(s)</label>
-              <textarea id="Comments_from_Contact__c" name="Comments_from_Contact__c" rows="2" class="mktoField " maxlength="2000"></textarea>
+            <li class="p-list__item">
+              <label for="Comments_from_Contact__c" aria-label="Comments_from_Contact__c">Serial number(s)</label>
+              <textarea id="Comments_from_Contact__c" name="Comments_from_Contact__c" rows="2" maxlength="2000"></textarea>
             </li>
-            <li class="mktField p-list__item">
-              <label for="purchaseordernumber" aria-label="purchaseordernumber" class="mktoLabel">Purchase order number:</label>
-              <input id="purchaseordernumber" name="purchaseordernumber" maxlength="255" type="text" class="mktoField ">
+            <li class="p-list__item">
+              <label for="purchaseordernumber" aria-label="purchaseordernumber">Purchase order number:</label>
+              <input id="purchaseordernumber" name="purchaseordernumber" maxlength="255" type="text">
             </li>
-            <li class="mktField p-list__item">
-              <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox"> <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I would like to receive occasional news from Canonical by email.</label>
+            <li class="p-list__item">
+              <input value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox"> <label for="canonicalUpdatesOptIn">I would like to receive occasional news from Canonical by email.</label>
             </li>
 
             <li class="p-list__item">
@@ -103,16 +103,16 @@
             </li>
 
             <li><p>All information provided will be handled in accordance with the Canonical <a href="/legal" target="_blank" rel="noopener noreferrer">privacy policy</a>. Your use of Ubuntu on IBM Z and LinuxONE in production constitutes <a href="/legal/short-terms">acceptance of these terms</a>.</p></li>
-            <li class="mktField p-list__item">
-              <button onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'LinuxONE server', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });" type="submit" class="mktoButton p-button--positive is-wide u-no-margin--bottom">Accept terms and download</button>
-              <input type="hidden" aria-hidden="true" name="formid" class="mktoField " value="1400">
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+            <li class="p-list__item">
+              <button onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'LinuxONE server', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });" type="submit" class="p-button--positive is-wide u-no-margin--bottom">Accept terms and download</button>
+              <input type="hidden" aria-hidden="true" name="formid" value="1400">
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
             </li>
           </ul>
         </fieldset>

--- a/templates/download/shared/_get-ebook-security.html
+++ b/templates/download/shared/_get-ebook-security.html
@@ -30,56 +30,56 @@
 
     <div class="col-4 col-start-large-9">
       <!-- MARKETO FORM -->
-      <form action="/marketo/submit" method="post" id="mktoForm_1917" class="marketo-form">
+      <form action="/marketo/submit" method="post" id="mktoForm_1917">
         <fieldset style="border: 0;">
           <ul class="p-list">
-            <li class="mktFormReq mktField p-list__item">
-              <label for="firstName" class="mktoLabel">First name:</label>
-              <input required  id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" >
+            <li class="p-list__item">
+              <label for="firstName">First name:</label>
+              <input required  id="firstName" name="firstName" maxlength="255" type="text" >
             </li>
-            <li class="mktFormReq mktField p-list__item">
-              <label for="lastName" class="mktoLabel">Last name:</label>
-              <input required  id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired">
+            <li class="p-list__item">
+              <label for="lastName">Last name:</label>
+              <input required  id="lastName" name="lastName" maxlength="255" type="text">
             </li>
-            <li class="mktFormReq mktField p-list__item">
-              <label for="company" class="mktoLabel">Company Name:</label>
-              <input required  id="company" name="company" maxlength="255" type="text" class="mktoField mktoRequired">
+            <li class="p-list__item">
+              <label for="company">Company Name:</label>
+              <input required  id="company" name="company" maxlength="255" type="text">
             </li>
-            <li class="mktFormReq mktField p-list__item">
-              <label for="email" class="mktoLabel ">Work email address:</label>
-              <input required  id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired">
+            <li class="p-list__item">
+              <label for="email">Work email address:</label>
+              <input required  id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$">
             </li>
-            <li class="mktFormReq mktField p-list__item">
-              <label for="phone" class="mktoLabel">Mobile/cell phone number:</label>
-              <input required  id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField mktoRequired mktoInvalid">
+            <li class="p-list__item">
+              <label for="phone">Mobile/cell phone number:</label>
+              <input required  id="phone" name="phone" maxlength="255" type="tel">
             </li>
             {% include "shared/forms/_country.html" %}
             {% include "shared/forms/_state.html" %}
-            <li class="mktFormReq mktField p-list__item">
-              <label for="mktoPersonNotes" class="mktoLabel">Are you working on a commercial IoT deployment?</label>
-              <select required id="mktoPersonNotes" name="mktoPersonNotes" class="mktoField mktoRequired mktoInvalid"><option value="">Select...</option>
+            <li class="p-list__item">
+              <label for="mktoPersonNotes">Are you working on a commercial IoT deployment?</label>
+              <select required id="mktoPersonNotes" name="mktoPersonNotes"><option value="">Select...</option>
               <option value="Working on a commercial IoT deployment">Yes</option>
               <option value="Not working on a commercial IoT deployment">No</option></select>
             </li>
-            <li class="mktField p-list__item">
-              <input class="mktoField" value="yes" id="CanonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
-              <label class="mktoLabel mktoHasWidth" for="CanonicalUpdatesOptIn"><small>I would like to receive occasional news from Canonical by email.</small></label>
+            <li class="p-list__item">
+              <input value="yes" id="CanonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
+              <label for="CanonicalUpdatesOptIn"><small>I would like to receive occasional news from Canonical by email.</small></label>
             </li>
             <li class="p-list__item">
               <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}" style="margin: 2rem 0;"></div>
             </li>
-            <li class="mktField p-list__item">
-              <button type="submit" class="mktoButton p-button--positive">Download the white paper</button>
-              <input type="hidden" name="formid" class="mktoField" value="1917">
+            <li class="p-list__item">
+              <button type="submit" class="p-button--positive">Download the white paper</button>
+              <input type="hidden" name="formid" value="1917">
               <input type="hidden" name="Consent_to_Processing__c" value="yes" />
               <input type="hidden" name="returnURL" value="https://assets.ubuntu.com/v1/fe2cb442-IoTSecurityWhitepaper-FinalReport.zip" aria-label="">
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
             </li>
             <li>All information provided will be handled in accordance with the Canonical <a href="/legal">privacy policy</a>.</li>
           </ul>

--- a/templates/download/shared/_get_ebook_maas.html
+++ b/templates/download/shared/_get_ebook_maas.html
@@ -34,60 +34,60 @@
 
     <div class="col-4 col-start-large-9">
       <!-- MARKETO FORM -->
-      <form action="/marketo/submit" method="post" id="mktoForm_1862" class="marketo-form">
+      <form action="/marketo/submit" method="post" id="mktoForm_1862">
         <fieldset style="border: 0;">
           <ul class="p-list">
-            <li class="mktFormReq mktField p-list__item">
-              <label for="1-FirstName" class="mktoLabel">First name:</label>
-              <input required id="1-FirstName" name="firstName" maxlength="255" type="text" class="mktoField   mktoRequired">
+            <li class="p-list__item">
+              <label for="1-FirstName">First name:</label>
+              <input required id="1-FirstName" name="firstName" maxlength="255" type="text">
             </li>
-            <li class="mktFormReq mktField p-list__item">
-              <label for="1-LastName" class="mktoLabel">Last name:</label>
-              <input required id="1-LastName" name="lastName" maxlength="255" type="text" class="mktoField   mktoRequired">
-            </li>
-
-            <li class="mktFormReq mktField p-list__item">
-              <label for="1-Company" class="mktoLabel">Company name:</label>
-              <input required id="1-Company" name="company" maxlength="255" type="text" class="mktoField   mktoRequired">
+            <li class="p-list__item">
+              <label for="1-LastName">Last name:</label>
+              <input required id="1-LastName" name="lastName" maxlength="255" type="text">
             </li>
 
-            <li class="mktFormReq mktField p-list__item">
-              <label for="title" class="mktoLabel">Job title:</label>
-              <input required id="title" name="title" maxlength="255" type="text" class="mktoField mktoRequired" />
+            <li class="p-list__item">
+              <label for="1-Company">Company name:</label>
+              <input required id="1-Company" name="company" maxlength="255" type="text">
             </li>
 
-            <li class="mktFormReq mktField p-list__item">
-              <label for="1-Email" class="mktoLabel">Email:</label>
-              <input required id="1-Email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField  mktoRequired">
+            <li class="p-list__item">
+              <label for="title">Job title:</label>
+              <input required id="title" name="title" maxlength="255" type="text" />
+            </li>
+
+            <li class="p-list__item">
+              <label for="1-Email">Email:</label>
+              <input required id="1-Email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$">
             </li>
 
             {% include "shared/forms/_country.html" %}
 
-            <li class="mktFormReq mktField p-list__item">
-              <label for="1-Phone" class="mktoLabel">Mobile/cell phone number:</label>
-              <input required id="1-Phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired">
+            <li class="p-list__item">
+              <label for="1-Phone">Mobile/cell phone number:</label>
+              <input required id="1-Phone" name="phone" maxlength="255" type="tel">
             </li>
 
-            <li class="mktField p-list__item">
-              <input class="mktoField" value="yes" id="1-canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
-              <label class="mktoLabel mktoHasWidth" for="1-canonicalUpdatesOptIn"><small>I would like to receive occasional news from Canonical by email.</small></label>
+            <li class="p-list__item">
+              <input value="yes" id="1-canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
+              <label for="1-canonicalUpdatesOptIn"><small>I would like to receive occasional news from Canonical by email.</small></label>
             </li>
 
             <li class="p-list__item" >
               <div class="g-recaptcha" style="margin-bottom: 2rem;" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}"></div>
             </li>
 
-            <li class="mktField p-list__item">
-              <button type="submit" class="p-button--positive mktoButton" aria-label="Submit">Download the eBook</button>
-              <input type="hidden" name="formid" class="mktoField " value="1862" aria-label="">
+            <li class="p-list__item">
+              <button type="submit" class="p-button--positive" aria-label="Submit">Download the eBook</button>
+              <input type="hidden" name="formid" value="1862" aria-label="">
               <input type="hidden" name="returnURL" value="https://assets.ubuntu.com/v1/05f610df-eBook_MAAS.pdf.zip" aria-label="">
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
               <input type="hidden" name="Consent_to_Processing__c" value="yes" aria-label="" />
             </li>
             <li>All information provided will be handled in accordance with the Canonical <a href="/legal">privacy policy</a>.</li>

--- a/templates/download/shared/_server_weekly_news.html
+++ b/templates/download/shared/_server_weekly_news.html
@@ -4,39 +4,39 @@
       <h2 class="p-modal__title" id="modal-title">Get Ubuntu Server pro tips</h2>
       <button class="p-modal__close" aria-label="Close active modal" aria-controls="modal">Close</button>
     </header>
-    <form action="/marketo/submit" method="post" id="mktoForm_3485" class="marketo-form">
+    <form action="/marketo/submit" method="post" id="mktoForm_3485">
       <div class="row u-no-padding">
         <div class="col-6">
-          <label for="firstName" class="mktoLabel">First name:</label>
-          <input required  id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" >
-          <label for="lastName" class="mktoLabel">Last name:</label>
-          <input required  id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired">
-          <label for="company" class="mktoLabel">Company name:</label>
-          <input required  id="company" name="company" maxlength="255" type="text" class="mktoField mktoRequired">
+          <label for="firstName">First name:</label>
+          <input required  id="firstName" name="firstName" maxlength="255" type="text">
+          <label for="lastName">Last name:</label>
+          <input required  id="lastName" name="lastName" maxlength="255" type="text">
+          <label for="company">Company name:</label>
+          <input required  id="company" name="company" maxlength="255" type="text">
         </div>
         <div class="col-6">
-          <label for="title" class="mktoLabel">Job title:</label>
-          <input required  id="title" name="title" maxlength="255" type="text" class="mktoField mktoRequired">
-          <label for="email" class="mktoLabel ">Work email:</label>
-          <input required  id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired">
-          <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
-          <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+          <label for="title">Job title:</label>
+          <input required  id="title" name="title" maxlength="255" type="text">
+          <label for="email">Work email:</label>
+          <input required  id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$">
+          <label for="phone">Mobile/cell phone number:</label>
+          <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
         </div>
       </div>
-      <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
-      <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn"><small>I would like to receive occasional news from Canonical by email.</small></label>
+      <input value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
+      <label for="canonicalUpdatesOptIn"><small>I would like to receive occasional news from Canonical by email.</small></label>
       <p><small>All information provided will be handled in accordance with the Canonical <a href="/legal">privacy policy</a>.</small></p>
       <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}" style="margin: 2rem 0;"></div>
-      <button type="submit" class="mktoButton p-button--positive">Download the pro tips</button>
-      <input type="hidden" name="formid" class="mktoField" value="3485">
+      <button type="submit" class="p-button--positive">Download the pro tips</button>
+      <input type="hidden" name="formid" value="3485">
       <input type="hidden" name="Consent_to_Processing__c" value="yes" />
-      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
       <input type="hidden" name="returnURL" value="https://assets.ubuntu.com/v1/f401c3f4-Ubuntu_Server_CLI_pro_tips_2020-04.pdf" />
     </form>
   </div>

--- a/templates/embedded/index.html
+++ b/templates/embedded/index.html
@@ -863,15 +863,4 @@
 {% endblock content %}
 
 {% block footer_extra %}
-<script src="https://assets.ubuntu.com/v1/5d7e5bbf-jquery-2.2.0.min.js"></script>
-<script src="https://assets.ubuntu.com/v1/d55f58bb-jquery.validate.js"></script>
-<script>
-  $("#mktoForm").validate({
-    errorElement: "span",
-    errorClass: "mktFormMsg mktError",
-    onkeyup: false,
-    onclick: false,
-    onblur: false
-  });
-</script>
 {% endblock footer_extra %}

--- a/templates/engage/shared/_de_engage_form.html
+++ b/templates/engage/shared/_de_engage_form.html
@@ -2,64 +2,64 @@
 <form action="/marketo/submit" method="post" id="mktoForm_{{ id }}" onSubmit="fbq('trackCustom', 'Download');">
   <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
     <ul class="p-list u-no-margin--bottom">
-      <li class="mktFormReq mktField p-list__item">
-        <label for="firstName" class="mktoLabel ">Vorname:</label>
-        <input required id="firstName" name="firstName" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="First Name">
+      <li class="p-list__item">
+        <label for="firstName">Vorname:</label>
+        <input required id="firstName" name="firstName" maxlength="255" type="text" aria-label="First Name">
       </li>
-      <li class="mktFormReq mktField">
-        <label for="lastName" class="mktoLabel ">Nachname:</label>
-        <input required id="lastName" name="lastName" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="Last Name">
+      <li>
+        <label for="lastName">Nachname:</label>
+        <input required id="lastName" name="lastName" maxlength="255" type="text" aria-label="Last Name">
       </li>
-      <li class="mktFormReq mktField">
-        <label for="email" class="mktoLabel ">Email beruflich:</label>
-        <input required id="email" name="email" maxlength="255" class="mktoField mktoEmailField  mktoRequired" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" aria-label="Email">
+      <li>
+        <label for="email">Email beruflich:</label>
+        <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" aria-label="Email">
       </li>
-      <li class="mktFormReq mktField">
-        <label for="company" class="mktoLabel ">Name des Unternehmens:</label>
-        <input required id="company" name="company" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="Company Name">
+      <li>
+        <label for="company">Name des Unternehmens:</label>
+        <input required id="company" name="company" maxlength="255" type="text" aria-label="Company Name">
       </li>
-      <li class="mktFormReq mktField">
-        <label for="title" class="mktoLabel ">Tätigkeitsbezeichnung:</label>
-        <input required id="title" name="title" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="Job Title">
+      <li>
+        <label for="title">Tätigkeitsbezeichnung:</label>
+        <input required id="title" name="title" maxlength="255" type="text" aria-label="Job Title">
       </li>
-      <li class="mktFormReq mktField">
-        <label for="phone" class="mktoLabel ">Handynummer:</label>
-        <input required id="phone" name="phone" maxlength="255" class="mktoField mktoTelField  mktoRequired" type="tel" aria-label="Phone Number">
+      <li>
+        <label for="phone">Handynummer:</label>
+        <input required id="phone" name="phone" maxlength="255" type="tel" aria-label="Phone Number">
       </li>
-      <li class="mktField">
-        <input name="utm_campaign" class="mktoField mktoFormCol" value="{{utm_campaign}}" type="hidden" aria-label="utm_campaign">
+      <li>
+        <input name="utm_campaign" value="{{utm_campaign}}" type="hidden" aria-label="utm_campaign">
       </li>
-      <li class="mktField">
-        <input name="utm_medium" class="mktoField mktoFormCol" value="{{utm_medium}}" type="hidden" aria-label="utm_medium">
+      <li>
+        <input name="utm_medium" value="{{utm_medium}}" type="hidden" aria-label="utm_medium">
       </li>
-      <li class="mktField">
-        <input name="utm_source" class="mktoField mktoFormCol" value="{{utm_source}}" type="hidden" aria-label="utm_source">
+      <li>
+        <input name="utm_source" value="{{utm_source}}" type="hidden" aria-label="utm_source">
       </li>
-      <li class="mktField">
-        <input name="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="yes" class="mktoField" type="checkbox">
-        <label for="canonicalUpdatesOptIn" class="mktoLabel">Ich erkläre mich damit einverstanden, Informationen zu Produkten und Services von Canoncical zu erhalten.</label>
+      <li>
+        <input name="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="yes" type="checkbox">
+        <label for="canonicalUpdatesOptIn">Ich erkläre mich damit einverstanden, Informationen zu Produkten und Services von Canoncical zu erhalten.</label>
       </li>
-      <li class="mktField">
+      <li>
         <p>Mit der Absendung dieses Formulars bestätige ich, dass ich die <a href="/legal/data-privacy" target="_blank" rel="noopener noreferrer" class="mchNoDecorate">Datenschutzrichtlinie von Canonical</a> gelesen habe und ihr zustimme.</p>
         <input name="RichText" type="hidden" aria-label="RichText">
       </li>
       <li class="p-list__item">
         <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}" style="margin: 2rem 0;"></div>
       </li>
-      <li class="mktField">
-        <input name="Consent_to_Processing__c" class="mktoField  mktoFormCol" value="Yes" type="hidden" aria-label="Consent_to_Processing__c">
+      <li>
+        <input name="Consent_to_Processing__c" value="Yes" type="hidden" aria-label="Consent_to_Processing__c">
       </li>
-      <li class="mktField">
-        <button type="submit" class="mktoButton">eBook herunterladen</button>
-        <input name="formid" class="mktoField" value="{{ id }}" type="hidden" aria-label="formid">
+      <li>
+        <button type="submit">eBook herunterladen</button>
+        <input name="formid" value="{{ id }}" type="hidden" aria-label="formid">
         <input type="hidden" name="returnURL" value="{{ returnURL }}" aria-label="returnURL">
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
       </li>
     </ul>
   </fieldset>

--- a/templates/engage/shared/_en_engage_form.html
+++ b/templates/engage/shared/_en_engage_form.html
@@ -1,73 +1,73 @@
 <!-- MARKETO FORM -->
-<form action="/marketo/submit" method="post" class="marketo-form" id="mktoForm_{{ id }}" onSubmit="fbq('trackCustom', 'Download');">
+<form action="/marketo/submit" method="post" id="mktoForm_{{ id }}" onSubmit="fbq('trackCustom', 'Download');">
   <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
     <ul class="p-list">
-      <li class="mktFormReq mktField p-list__item">
-        <label for="firstName" class="mktoLabel">First Name:</label>
-        <input required id="firstName" name="firstName" maxlength="255" class="mktoField   mktoRequired" type="text"
+      <li class="p-list__item">
+        <label for="firstName">First Name:</label>
+        <input required id="firstName" name="firstName" maxlength="255" type="text"
           aria-label="First Name">
       </li>
-      <li class="mktFormReq mktField">
-        <label for="lastName" class="mktoLabel ">Last Name:</label>
-        <input required id="lastName" name="lastName" maxlength="255" class="mktoField   mktoRequired" type="text"
+      <li>
+        <label for="lastName">Last Name:</label>
+        <input required id="lastName" name="lastName" maxlength="255" type="text"
           aria-label="Last Name">
       </li>
-      <li class="mktFormReq mktField">
-        <label for="email" class="mktoLabel ">Work email:</label>
-        <input required id="email" name="email" maxlength="255" class="mktoField mktoEmailField  mktoRequired" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"
+      <li>
+        <label for="email">Work email:</label>
+        <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"
           aria-label="Email">
       </li>
-      <li class="mktFormReq mktField">
-        <label for="company" class="mktoLabel ">Company Name:</label>
-        <input required id="company" name="company" maxlength="255" class="mktoField   mktoRequired" type="text"
+      <li>
+        <label for="company">Company Name:</label>
+        <input required id="company" name="company" maxlength="255" type="text"
           aria-label="Company Name">
       </li>
-      <li class="mktFormReq mktField">
-        <label for="title" class="mktoLabel ">Job Title:</label>
-        <input required id="title" name="title" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="Job Title">
+      <li>
+        <label for="title">Job Title:</label>
+        <input required id="title" name="title" maxlength="255" type="text" aria-label="Job Title">
       </li>
-      <li class="mktFormReq mktField">
-        <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
-        <input required id="phone" name="phone" maxlength="255" class="mktoField mktoTelField  mktoRequired" type="tel"
+      <li>
+        <label for="phone">Mobile/cell phone number:</label>
+        <input required id="phone" name="phone" maxlength="255" type="tel"
           aria-label="Phone Number">
       </li>
-      <li class="mktField">
-        <input name="utm_campaign" aria-label="utm_campaign" class="mktoField  mktoFormCol" value="{{utm_campaign}}"
+      <li>
+        <input name="utm_campaign" aria-label="utm_campaign" value="{{utm_campaign}}"
           type="hidden">
       </li>
-      <li class="mktField">
-        <input name="utm_medium" aria-label="utm_medium" class="mktoField  mktoFormCol" value="{{utm_medium}}" type="hidden">
+      <li>
+        <input name="utm_medium" aria-label="utm_medium" value="{{utm_medium}}" type="hidden">
       </li>
-      <li class="mktField">
-        <input name="utm_source" aria-label="utm_source" class="mktoField  mktoFormCol" value="{{utm_source}}" type="hidden">
+      <li>
+        <input name="utm_source" aria-label="utm_source" value="{{utm_source}}" type="hidden">
       </li>
-      <li class="mktField">
+      <li>
         <input name="canonicalUpdatesOptIn" aria-label="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="yes"
-          class="mktoField" type="checkbox"><label for="canonicalUpdatesOptIn" class="mktoLabel ">I agree to receive
+          type="checkbox"><label for="canonicalUpdatesOptIn">I agree to receive
           information about Canonical's products and services.</label>
       </li>
-      <li class="mktField">
+      <li>
         <p>In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.
           <input name="RichText" aria-label="RichText" type="hidden">
         </p>
       </li>
-      <li class="mktField">
+      <li>
         <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}" style="margin: 2rem 0;"></div>
       </li>
-      <li class="mktField">
-        <input name="Consent_to_Processing__c" aria-label="Consent" class="mktoField  mktoFormCol" value="Yes" type="hidden">
+      <li>
+        <input name="Consent_to_Processing__c" aria-label="Consent" value="Yes" type="hidden">
       </li>
-      <li class="mktField">
-        <button type="submit" class="mktoButton u-no-margin--bottom" >{% if cta %}{{ cta }}{% else %}Download the whitepaper{% endif %}</button>
-        <input name="formid" aria-label="formid" class="mktoField" value="{{ id }}" type="hidden">
+      <li>
+        <button type="submit" class="u-no-margin--bottom" >{% if cta %}{{ cta }}{% else %}Download the whitepaper{% endif %}</button>
+        <input name="formid" aria-label="formid" value="{{ id }}" type="hidden">
         <input type="hidden" name="returnURL" aria-label="returnURL" value="{{ returnURL }}" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
       </li>
     </ul>
   </fieldset>

--- a/templates/engage/shared/_es_engage_form.html
+++ b/templates/engage/shared/_es_engage_form.html
@@ -1,72 +1,72 @@
 <!-- MARKETO FORM -->
-<form action="/marketo/submit" method="post" class="marketo-form" id="mktoForm_{{ id }}" onSubmit="fbq('trackCustom', 'Download');">
+<form action="/marketo/submit" method="post" id="mktoForm_{{ id }}" onSubmit="fbq('trackCustom', 'Download');">
   <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
     <ul class="p-list">
-      <li class="mktFormReq mktField p-list__item">
-        <label for="firstName" class="mktoLabel">Nombre:</label>
-        <input required id="firstName" name="firstName" maxlength="255" class="mktoField   mktoRequired" type="text"
+      <li class="p-list__item">
+        <label for="firstName">Nombre:</label>
+        <input required id="firstName" name="firstName" maxlength="255" type="text"
           aria-label="Nombre">
       </li>
-      <li class="mktFormReq mktField">
-        <label for="lastName" class="mktoLabel ">Apellido:</label>
-        <input required id="lastName" name="lastName" maxlength="255" class="mktoField   mktoRequired" type="text"
+      <li>
+        <label for="lastName">Apellido:</label>
+        <input required id="lastName" name="lastName" maxlength="255" type="text"
           aria-label="Apellido">
       </li>
-      <li class="mktFormReq mktField">
-        <label for="email" class="mktoLabel ">E-mail de trabajo:</label>
-        <input required id="email" name="email" maxlength="255" class="mktoField mktoEmailField  mktoRequired" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"
+      <li>
+        <label for="email">E-mail de trabajo:</label>
+        <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"
           aria-label="E-mail de trabajo">
       </li>
-      <li class="mktFormReq mktField">
-        <label for="company" class="mktoLabel ">Nombre de la compañía:</label>
-        <input required id="company" name="company" maxlength="255" class="mktoField   mktoRequired" type="text"
+      <li>
+        <label for="company">Nombre de la compañía:</label>
+        <input required id="company" name="company" maxlength="255" type="text"
           aria-label="Nombre de la compañía">
       </li>
-      <li class="mktFormReq mktField">
-        <label for="title" class="mktoLabel ">Título del puesto de trabajo:</label>
-        <input required id="title" name="title" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="Título del puesto de trabajo">
+      <li>
+        <label for="title">Título del puesto de trabajo:</label>
+        <input required id="title" name="title" maxlength="255" type="text" aria-label="Título del puesto de trabajo">
       </li>
-      <li class="mktFormReq mktField">
-        <label for="phone" class="mktoLabel ">Número del teléfono móvil/celular:</label>
-        <input required id="phone" name="phone" maxlength="255" class="mktoField mktoTelField  mktoRequired" type="tel"
+      <li>
+        <label for="phone">Número del teléfono móvil/celular:</label>
+        <input required id="phone" name="phone" maxlength="255" type="tel"
           aria-label="Número de teléfono">
       </li>
-      <li class="mktField">
-        <input name="utm_campaign" aria-label="utm_campaign" class="mktoField  mktoFormCol" value="{{utm_campaign}}"
+      <li>
+        <input name="utm_campaign" aria-label="utm_campaign" value="{{utm_campaign}}"
           type="hidden">
       </li>
-      <li class="mktField">
-        <input name="utm_medium" aria-label="utm_medium" class="mktoField  mktoFormCol" value="{{utm_medium}}" type="hidden">
+      <li>
+        <input name="utm_medium" aria-label="utm_medium"value="{{utm_medium}}" type="hidden">
       </li>
-      <li class="mktField">
-        <input name="utm_source" aria-label="utm_source" class="mktoField  mktoFormCol" value="{{utm_source}}" type="hidden">
+      <li>
+        <input name="utm_source" aria-label="utm_source" value="{{utm_source}}" type="hidden">
       </li>
-      <li class="mktField">
+      <li>
         <input name="canonicalUpdatesOptIn" aria-label="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="yes"
-          class="mktoField" type="checkbox"><label for="canonicalUpdatesOptIn" class="mktoLabel ">Acepto recibir información sobre los productos y servicios de Canonical</label>
+          type="checkbox"><label for="canonicalUpdatesOptIn">Acepto recibir información sobre los productos y servicios de Canonical</label>
       </li>
-      <li class="mktField">
+      <li>
         <p>Al enviar este formulario, confirmo que he leído y acepto el <a href="/legal/data-privacy/contact">Aviso de Privacidad</a> y la <a href="/legal/data-privacy">Política de Privacidad</a> de Canonical.
           <input name="RichText" aria-label="RichText" type="hidden">
         </p>
       </li>
-      <li class="mktField">
+      <li>
         <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}" style="margin: 2rem 0;"></div>
       </li>
-      <li class="mktField">
-        <input name="Consent_to_Processing__c" aria-label="Consent" class="mktoField  mktoFormCol" value="Yes" type="hidden">
+      <li>
+        <input name="Consent_to_Processing__c" aria-label="Consent" value="Yes" type="hidden">
       </li>
-      <li class="mktField">
-        <button type="submit" class="mktoButton u-no-margin--bottom">{% if cta %}{{ cta }}{% else %}Descargar el documento técnico{% endif %}</button>
-        <input name="formid" aria-label="formid" class="mktoField" value="{{ id }}" type="hidden">
+      <li>
+        <button type="submit" class="u-no-margin--bottom">{% if cta %}{{ cta }}{% else %}Descargar el documento técnico{% endif %}</button>
+        <input name="formid" aria-label="formid" value="{{ id }}" type="hidden">
         <input type="hidden" name="returnURL" aria-label="returnURL" value="{{ returnURL }}" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
       </li>
     </ul>
   </fieldset>

--- a/templates/engage/shared/_fr_engage_form.html
+++ b/templates/engage/shared/_fr_engage_form.html
@@ -1,60 +1,60 @@
-<form action="/marketo/submit" method="post" id="mktoForm_{{ id }}" class="marketo-form" onSubmit="fbq('trackCustom', 'Download');">
+<form action="/marketo/submit" method="post" id="mktoForm_{{ id }}" onSubmit="fbq('trackCustom', 'Download');">
   <fieldset>
     <h3>Prenons contact</h3>
     <ul class="p-list u-no-margin--bottom">
-      <li class="mktFormReq mktField p-list__item">
-        <label for="firstName" class="mktoLabel">Prénom :</label>
-        <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" />
+      <li class="p-list__item">
+        <label for="firstName">Prénom :</label>
+        <input required id="firstName" name="firstName" maxlength="255" type="text"/>
       </li>
-      <li class="mktFormReq mktField p-list__item">
-        <label for="lastName" class="mktoLabel">Nom :</label>
-        <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" />
+      <li class="p-list__item">
+        <label for="lastName">Nom :</label>
+        <input required id="lastName" name="lastName" maxlength="255" type="text"/>
       </li>
-      <li class="mktFormReq mktField p-list__item">
-        <label for="email" class="mktoLabel">Adresse électronique professionnelle :</label>
-        <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" />
+      <li class="p-list__item">
+        <label for="email">Adresse électronique professionnelle :</label>
+        <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
       </li>
-      <li class="mktFormReq mktField p-list__item">
-        <label for="phone" class="mktoLabel">N° de téléphone portable:</label>
-        <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField mktoRequired" />
+      <li class="p-list__item">
+        <label for="phone">N° de téléphone portable:</label>
+        <input required id="phone" name="phone" maxlength="255" type="tel" />
       </li>
-      <li class="mktFormReq mktField p-list__item">
-        <label for="company" class="mktoLabel">Société :</label>
-        <input required id="company" name="company" maxlength="255" type="text" class="mktoField mktoRequired" />
+      <li class="p-list__item">
+        <label for="company">Société :</label>
+        <input required id="company" name="company" maxlength="255" type="text"/>
       </li>
-      <li class="mktFormReq mktField p-list__item">
-        <label for="title" class="mktoLabel">Votre fonction ou poste:</label>
-        <input required id="title" name="title" maxlength="255" type="text" class="mktoField mktoRequired" />
+      <li class="p-list__item">
+        <label for="title">Votre fonction ou poste:</label>
+        <input required id="title" name="title" maxlength="255" type="text"/>
       </li>
-      <li class="mktFormReq mktField p-list__item">
-        <label for="Comments_from_lead__c" class="mktoLabel">Décrivez vos besoins de support :</label>
-        <textarea required id="Comments_from_lead__c" name="Comments_from_lead__c" rows="4" class="mktoField mktoRequired" maxlength="2000"></textarea>
+      <li class="p-list__item">
+        <label for="Comments_from_lead__c">Décrivez vos besoins de support :</label>
+        <textarea required id="Comments_from_lead__c" name="Comments_from_lead__c" rows="4" maxlength="2000"></textarea>
       </li>
 
-      <li class="mktField p-list__item">
-        <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-        <label for="canonicalUpdatesOptIn" class="mktoLabel">J'accepte de recevoir des informations sur les produits et services de Canonical.</label>
+      <li class="p-list__item">
+        <input value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+        <label for="canonicalUpdatesOptIn">J'accepte de recevoir des informations sur les produits et services de Canonical.</label>
       </li>
       <li class="p-list__item">
         <p>En soumettant ce formulaire, je confirme que j'ai lu et que j'accepte les conditions suivantes : <a href="/legal/data-privacy" target="_blank" rel="noopener noreferrer" class="mchNoDecorate">Politique de confidentialité</a></p>
       </li>
-      <li class="mktField">
+      <li>
         <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}" style="margin: 2rem 0;"></div>
       </li>
-      <li class="mktField p-list__item">
-        <button type="submit" class="mktoButton p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Form', 'eventAction' : 'cloud contact-us', 'eventLabel' : 'server-esm', 'eventValue' : undefined });">{% if cta %}{{ cta }}{% else %}Télécharger le livre blanc{% endif %}</button>
+      <li class="p-list__item">
+        <button type="submit" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Form', 'eventAction' : 'cloud contact-us', 'eventLabel' : 'server-esm', 'eventValue' : undefined });">{% if cta %}{{ cta }}{% else %}Télécharger le livre blanc{% endif %}</button>
       </li>
     </ul>
     <!-- hidden fields -->
-    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="{{ id }}" />
+    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="{{ id }}" />
     <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
     <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="{{ returnURL }}" />
-    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
   </fieldset>
 </form>

--- a/templates/engage/shared/_it_engage_form.html
+++ b/templates/engage/shared/_it_engage_form.html
@@ -1,72 +1,72 @@
 <!-- MARKETO FORM -->
-<form action="/marketo/submit" method="post" class="marketo-form" id="mktoForm_{{ id }}" onSubmit="fbq('trackCustom', 'Download');">
+<form action="/marketo/submit" method="post" id="mktoForm_{{ id }}" onSubmit="fbq('trackCustom', 'Download');">
   <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
     <ul class="p-list">
-      <li class="mktFormReq mktField p-list__item">
-        <label for="firstName" class="mktoLabel">Nome:</label>
-        <input required id="firstName" name="firstName" maxlength="255" class="mktoField   mktoRequired" type="text"
+      <li class="p-list__item">
+        <label for="firstName">Nome:</label>
+        <input required id="firstName" name="firstName" maxlength="255" type="text"
           aria-label="Nome">
       </li>
-      <li class="mktFormReq mktField">
-        <label for="lastName" class="mktoLabel ">Cognome:</label>
-        <input required id="lastName" name="lastName" maxlength="255" class="mktoField   mktoRequired" type="text"
+      <li>
+        <label for="lastName">Cognome:</label>
+        <input required id="lastName" name="lastName" maxlength="255" type="text"
           aria-label="Cognome">
       </li>
-      <li class="mktFormReq mktField">
-        <label for="email" class="mktoLabel ">E-mail lavorativa:</label>
-        <input required id="email" name="email" maxlength="255" class="mktoField mktoEmailField  mktoRequired" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"
+      <li>
+        <label for="email">E-mail lavorativa:</label>
+        <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"
           aria-label="E-mail lavorativa">
       </li>
-      <li class="mktFormReq mktField">
-        <label for="company" class="mktoLabel ">Nome società:</label>
-        <input required id="company" name="company" maxlength="255" class="mktoField   mktoRequired" type="text"
+      <li>
+        <label for="company">Nome società:</label>
+        <input required id="company" name="company" maxlength="255" type="text"
           aria-label="Nome società">
       </li>
-      <li class="mktFormReq mktField">
-        <label for="title" class="mktoLabel ">Titolo lavorativo:</label>
-        <input required id="title" name="title" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="Titolo lavorativo">
+      <li>
+        <label for="title">Titolo lavorativo:</label>
+        <input required id="title" name="title" maxlength="255" type="text" aria-label="Titolo lavorativo">
       </li>
-      <li class="mktFormReq mktField">
-        <label for="phone" class="mktoLabel ">Numero di telefono:</label>
-        <input required id="phone" name="phone" maxlength="255" class="mktoField mktoTelField  mktoRequired" type="tel"
+      <li>
+        <label for="phone">Numero di telefono:</label>
+        <input required id="phone" name="phone" maxlength="255" type="tel"
           aria-label="Numero di telefono">
       </li>
-      <li class="mktField">
-        <input name="utm_campaign" aria-label="utm_campaign" class="mktoField  mktoFormCol" value="{{utm_campaign}}"
+      <li>
+        <input name="utm_campaign" aria-label="utm_campaign" value="{{utm_campaign}}"
           type="hidden">
       </li>
-      <li class="mktField">
-        <input name="utm_medium" aria-label="utm_medium" class="mktoField  mktoFormCol" value="{{utm_medium}}" type="hidden">
+      <li>
+        <input name="utm_medium" aria-label="utm_medium" value="{{utm_medium}}" type="hidden">
       </li>
-      <li class="mktField">
-        <input name="utm_source" aria-label="utm_source" class="mktoField  mktoFormCol" value="{{utm_source}}" type="hidden">
+      <li>
+        <input name="utm_source" aria-label="utm_source" value="{{utm_source}}" type="hidden">
       </li>
-      <li class="mktField">
+      <li>
         <input name="canonicalUpdatesOptIn" aria-label="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="yes"
-          class="mktoField" type="checkbox"><label for="canonicalUpdatesOptIn" class="mktoLabel ">Accetto di ricevere informazioni sui prodotti e servizi Canonical.</label>
+          type="checkbox"><label for="canonicalUpdatesOptIn" >Accetto di ricevere informazioni sui prodotti e servizi Canonical.</label>
       </li>
-      <li class="mktField">
+      <li>
         <p>Inviando questo modulo, confermo di aver letto e di accettare la Nota sulla <a href="/legal/data-privacy/contact">Privacy e l'Informativa</a> sulla <a href="/legal/data-privacy">Privacy di Canonical.</a>
           <input name="RichText" aria-label="RichText" type="hidden">
         </p>
       </li>
-      <li class="mktField">
+      <li>
         <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}" style="margin: 2rem 0;"></div>
       </li>
-      <li class="mktField">
-        <input name="Consent_to_Processing__c" aria-label="Consent" class="mktoField  mktoFormCol" value="Yes" type="hidden">
+      <li>
+        <input name="Consent_to_Processing__c" aria-label="Consent" value="Yes" type="hidden">
       </li>
-      <li class="mktField">
-        <button type="submit" class="mktoButton u-no-margin--bottom" >{% if cta %}{{ cta }}{% else %}Scarica il whitepaper{% endif %}</button>
-        <input name="formid" aria-label="formid" class="mktoField" value="{{ id }}" type="hidden">
+      <li>
+        <button type="submit" class="u-no-margin--bottom" >{% if cta %}{{ cta }}{% else %}Scarica il whitepaper{% endif %}</button>
+        <input name="formid" aria-label="formid" value="{{ id }}" type="hidden">
         <input type="hidden" name="returnURL" aria-label="returnURL" value="{{ returnURL }}" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
       </li>
     </ul>
   </fieldset>

--- a/templates/engage/shared/_pt_engage_form.html
+++ b/templates/engage/shared/_pt_engage_form.html
@@ -1,72 +1,72 @@
 <!-- MARKETO FORM -->
-<form action="/marketo/submit" method="post" class="marketo-form" id="mktoForm_{{ id }}" onSubmit="fbq('trackCustom', 'Download');">
+<form action="/marketo/submit" method="post" id="mktoForm_{{ id }}" onSubmit="fbq('trackCustom', 'Download');">
   <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
     <ul class="p-list">
-      <li class="mktFormReq mktField p-list__item">
-        <label for="firstName" class="mktoLabel">Primeiro Nome:</label>
-        <input required id="firstName" name="firstName" maxlength="255" class="mktoField   mktoRequired" type="text"
+      <li class="p-list__item">
+        <label for="firstName">Primeiro Nome:</label>
+        <input required id="firstName" name="firstName" maxlength="255" type="text"
           aria-label="First Name">
       </li>
-      <li class="mktFormReq mktField">
-        <label for="lastName" class="mktoLabel ">Último Nome:</label>
-        <input required id="lastName" name="lastName" maxlength="255" class="mktoField   mktoRequired" type="text"
+      <li>
+        <label for="lastName">Último Nome:</label>
+        <input required id="lastName" name="lastName" maxlength="255" type="text"
           aria-label="Last Name">
       </li>
-      <li class="mktFormReq mktField">
-        <label for="email" class="mktoLabel ">Email do trabalho:</label>
-        <input required id="email" name="email" maxlength="255" class="mktoField mktoEmailField  mktoRequired" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"
+      <li>
+        <label for="email">Email do trabalho:</label>
+        <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"
           aria-label="Email">
       </li>
-      <li class="mktFormReq mktField">
-        <label for="company" class="mktoLabel ">Nome da Empresa:</label>
-        <input required id="company" name="company" maxlength="255" class="mktoField   mktoRequired" type="text"
+      <li>
+        <label for="company">Nome da Empresa:</label>
+        <input required id="company" name="company" maxlength="255" type="text"
           aria-label="Company Name">
       </li>
-      <li class="mktFormReq mktField">
-        <label for="title" class="mktoLabel ">Titulo do trabalho:</label>
-        <input required id="title" name="title" maxlength="255" class="mktoField   mktoRequired" type="text" aria-label="Job Title">
+      <li>
+        <label for="title">Titulo do trabalho:</label>
+        <input required id="title" name="title" maxlength="255" type="text" aria-label="Job Title">
       </li>
-      <li class="mktFormReq mktField">
-        <label for="phone" class="mktoLabel ">Telemóvel:</label>
-        <input required id="phone" name="phone" maxlength="255" class="mktoField mktoTelField  mktoRequired" type="tel"
+      <li>
+        <label for="phone">Telemóvel:</label>
+        <input required id="phone" name="phone" maxlength="255" type="tel"
           aria-label="Phone Number">
       </li>
-      <li class="mktField">
-        <input name="utm_campaign" aria-label="utm_campaign" class="mktoField  mktoFormCol" value="{{utm_campaign}}"
+      <li>
+        <input name="utm_campaign" aria-label="utm_campaign"value="{{utm_campaign}}"
           type="hidden">
       </li>
-      <li class="mktField">
-        <input name="utm_medium" aria-label="utm_medium" class="mktoField  mktoFormCol" value="{{utm_medium}}" type="hidden">
+      <li>
+        <input name="utm_medium" aria-label="utm_medium" value="{{utm_medium}}" type="hidden">
       </li>
-      <li class="mktField">
-        <input name="utm_source" aria-label="utm_source" class="mktoField  mktoFormCol" value="{{utm_source}}" type="hidden">
+      <li>
+        <input name="utm_source" aria-label="utm_source" value="{{utm_source}}" type="hidden">
       </li>
-      <li class="mktField">
+      <li>
         <input name="canonicalUpdatesOptIn" aria-label="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="yes"
-          class="mktoField" type="checkbox"><label for="canonicalUpdatesOptIn" class="mktoLabel ">Concordo em receber informações sobre os produtos e serviços da Canonical.</label>
+           type="checkbox"><label for="canonicalUpdatesOptIn">Concordo em receber informações sobre os produtos e serviços da Canonical.</label>
       </li>
-      <li class="mktField">
+      <li>
         <p>Ao submeter este formulário, confirmo que li e concordo com o <a href="/legal/data-privacy/contact">Aviso de privacidade</a> e a <a href="/legal/data-privacy">Política de privacidade da Canonical</a>.
           <input name="RichText" aria-label="RichText" type="hidden">
         </p>
       </li>
-      <li class="mktField">
+      <li>
         <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}" style="margin: 2rem 0;"></div>
       </li>
-      <li class="mktField">
-        <input name="Consent_to_Processing__c" aria-label="Consent" class="mktoField  mktoFormCol" value="Yes" type="hidden">
+      <li>
+        <input name="Consent_to_Processing__c" aria-label="Consent" value="Yes" type="hidden">
       </li>
-      <li class="mktField">
-        <button type="submit" class="mktoButton u-no-margin--bottom">{% if cta %}{{ cta }}{% else %}Descarregue o documento{% endif %}</button>
-        <input name="formid" aria-label="formid" class="mktoField" value="{{ id }}" type="hidden">
+      <li>
+        <button type="submit" class="u-no-margin--bottom">{% if cta %}{{ cta }}{% else %}Descarregue o documento{% endif %}</button>
+        <input name="formid" aria-label="formid"value="{{ id }}" type="hidden">
         <input type="hidden" name="returnURL" aria-label="returnURL" value="{{ returnURL }}" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
       </li>
     </ul>
   </fieldset>

--- a/templates/gov/form.html
+++ b/templates/gov/form.html
@@ -168,27 +168,27 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
             <ul class="p-list">
-              <li class="mktFormReq mktField p-list__item">
-                <label for="firstName" class="mktoLabel">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="lastName" class="mktoLabel">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="email">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="phone" class="mktoLabel ">Work phone:</label>
-                <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="phone">Work phone:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
               </li>
-              <li class="mktField p-list__item">
-                <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-                <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
+              <li class="p-list__item">
+                <input value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                <label for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
               </li>
               <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical&rsquo;s Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
               <li class="p-list__item">
@@ -198,27 +198,27 @@
             <div class="u-hide">
               <h3>Your comments</h3>
               <ul class="p-list">
-                <li class="mktFormReq mktField p-list__item">
-                  <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
-                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
+                <li class="p-list__item">
+                  <label for="Comments_from_lead__c">What would you like to talk to us about?</label>
+                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
             </div>
 
             <div class="pagination">
               <a class="pagination__link--previous p-button--neutral" href="">Previous</a>
-              <button type="submit" class="pagination__link--next p-button--positive mktoButton" aria-label="Submit">Let's talk</button>
+              <button type="submit" class="pagination__link--next p-button--positive" aria-label="Submit">Let's talk</button>
             </div>
           </form>
         </div>

--- a/templates/internet-of-things/edgex.html
+++ b/templates/internet-of-things/edgex.html
@@ -138,13 +138,13 @@
           <input type="hidden" name="formid" value="3690">
           <input type="hidden" name="edgeXblogsubscription" value="yes">
           <input type="hidden" name="returnURL" value="/internet-of-things/edgex#subscribed">
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
         </form>
       </div>
 

--- a/templates/kubernetes/_get_ebook.html
+++ b/templates/kubernetes/_get_ebook.html
@@ -27,44 +27,44 @@
     </div>
     <div class="col-4 col-start-large-8">
       <!-- MARKETO FORM -->
-      <form action="/marketo/submit" method="post" id="mktoForm_2542" class="marketo-form">
+      <form action="/marketo/submit" method="post" id="mktoForm_2542">
         <ul class="p-list">
-          <li class="mktFormReq mktField p-list__item">
-            <label for="3-FirstName" class="mktoLabel">First name:</label>
-            <input required id="3-FirstName" name="firstName" maxlength="255" type="text" class="mktoField   mktoRequired">
+          <li class="p-list__item">
+            <label for="3-FirstName">First name:</label>
+            <input required id="3-FirstName" name="firstName" maxlength="255" type="text">
           </li>
-          <li class="mktFormReq mktField p-list__item">
-            <label for="3-LastName" class="mktoLabel">Last name:</label>
-            <input required id="3-LastName" name="lastName" maxlength="255" type="text" class="mktoField   mktoRequired">
-          </li>
-
-          <li class="mktFormReq mktField p-list__item">
-            <label for="3-Company" class="mktoLabel">Company name:</label>
-            <input required id="3-Company" name="company" maxlength="255" type="text" class="mktoField   mktoRequired">
+          <li class="p-list__item">
+            <label for="3-LastName">Last name:</label>
+            <input required id="3-LastName" name="lastName" maxlength="255" type="text">
           </li>
 
-          <li class="mktFormReq mktField p-list__item">
-            <label for="3-Email" class="mktoLabel">Email:</label>
-            <input required id="3-Email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField  mktoRequired">
+          <li class="p-list__item">
+            <label for="3-Company">Company name:</label>
+            <input required id="3-Company" name="company" maxlength="255" type="text">
+          </li>
+
+          <li class="p-list__item">
+            <label for="3-Email">Email:</label>
+            <input required id="3-Email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$">
           </li>
 
           {% include "shared/forms/_country.html" %}
 
-          <li class="mktFormReq mktField p-list__item">
-            <label for="3-Phone" class="mktoLabel">Mobile/cell phone number:</label>
-            <input required id="3-Phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired">
+          <li class="p-list__item">
+            <label for="3-Phone">Mobile/cell phone number:</label>
+            <input required id="3-Phone" name="phone" maxlength="255" type="tel">
           </li>
 
-          <li class="mktField p-list__item">
-            <input class="mktoField" value="yes" id="3-canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
-            <label class="mktoLabel mktoHasWidth" for="3-canonicalUpdatesOptIn"><small>I would like to receive occasional news from Canonical by email.</small></label>
+          <li class="p-list__item">
+            <input value="yes" id="3-canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
+            <label for="3-canonicalUpdatesOptIn"><small>I would like to receive occasional news from Canonical by email.</small></label>
           </li>
           <li class="p-list__item">
             <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}" style="margin: 2rem 0;"></div>
           </li>
-          <li class="mktField p-list__item">
-            <button type="submit" class="p-button--positive mktoButton" aria-label="Submit">Get the whitepaper</button>
-            <input type="hidden" name="formid" class="mktoField " value="2542" aria-label="">
+          <li class="p-list__item">
+            <button type="submit" class="p-button--positive" aria-label="Submit">Get the whitepaper</button>
+            <input type="hidden" name="formid" value="2542" aria-label="">
             <input type="hidden" name="thankyoumessage" value="Thank you<br />Enjoy the ebook!" aria-lable="">
           </li>
           <li><small>All information provided will be handled in accordance with the Canonical <a href="/legal">privacy policy</a>.</small></li>
@@ -72,13 +72,13 @@
 
         <input type="hidden" name="returnURL" value="https://pages.ubuntu.com/ty-container-whitepaper.html" aria-label="" />
         <input type="hidden" name="Consent_to_Processing__c" value="yes" aria-label="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
       </form>
       <!-- /MARKETO FORM -->
     </div>

--- a/templates/rfp/index.html
+++ b/templates/rfp/index.html
@@ -30,41 +30,41 @@
     </div>
     <div class="col-6">
       <!-- MARKETO FORM -->
-      <form action="/marketo/submit" method="post" id="mktoForm_3285" class="marketo-form">
+      <form action="/marketo/submit" method="post" id="mktoForm_3285">
         <fieldset>
           <ul class="p-list">
 
-            <li class="mktFormReq mktField p-list__item">
-              <label for="firstName" class="mktoLabel ">First name:</label>
-              <input required="" id="firstName" name="firstName" maxlength="255" type="text" class="mktoField   mktoRequired">
+            <li class="p-list__item">
+              <label for="firstName">First name:</label>
+              <input required="" id="firstName" name="firstName" maxlength="255" type="text">
             </li>
 
-            <li class="mktFormReq mktField p-list__item">
-              <label for="lastName" class="mktoLabel ">Last name:</label>
-              <input required="" id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired">
+            <li class="p-list__item">
+              <label for="lastName">Last name:</label>
+              <input required="" id="lastName" name="lastName" maxlength="255" type="text">
             </li>
 
-            <li class="mktFormReq mktField p-list__item">
-              <label for="company" class="mktoLabel ">Company:</label>
-              <input required="" id="company" name="company" maxlength="255" type="text" class="mktoField   mktoRequired">
+            <li class="p-list__item">
+              <label for="company">Company:</label>
+              <input required="" id="company" name="company" maxlength="255" type="text">
             </li>
 
-            <li class="mktFormReq mktField p-list__item">
-              <label for="email" class="mktoLabel ">Email:</label>
-              <input required="" id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField  mktoRequired">
+            <li class="p-list__item">
+              <label for="email">Email:</label>
+              <input required="" id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$">
             </li>
 
-            <li class="mktFormReq mktField p-list__item">
-              <label for="title" class="mktoLabel ">Title:</label>
-              <input required="" id="title" name="title" maxlength="255" type="text" class="mktoField mktoTelField  mktoRequired">
+            <li class="p-list__item">
+              <label for="title">Title:</label>
+              <input required="" id="title" name="title" maxlength="255" type="text">
             </li>
 
-            <li class="mktFormReq mktField p-list__item">
-              <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
-              <input required="" id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired">
+            <li class="p-list__item">
+              <label for="phone">Mobile/cell phone number:</label>
+              <input required="" id="phone" name="phone" maxlength="255" type="tel">
             </li>
 
-            <li  class="p-list__item mktFormReq mktField">
+            <li  class="p-list__item">
               <!-- country -->
               {% include "shared/forms/_country.html" %}
               <!-- state/province -->
@@ -72,26 +72,26 @@
             </li>
 
 
-            <li class="mktFormReq mktField p-list__item">
-              <label for="Comments_from_lead__c" class="mktoLabel">Your message:</label>
-              <textarea required id="Comments_from_lead__c" name="Comments_from_lead__c" rows="4" class="mktoField mktoRequired" maxlength="2000"></textarea>
+            <li class="p-list__item">
+              <label for="Comments_from_lead__c">Your message:</label>
+              <textarea required id="Comments_from_lead__c" name="Comments_from_lead__c" rows="4" maxlength="2000"></textarea>
             </li>
 
-            <li class="mktField p-list__item">
-              <p><input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" /> <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label></p>
+            <li class="p-list__item">
+              <p><input value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" /> <label for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label></p>
             </li>
 
             <li class="p-list__item">
               <p>
                 In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.
-                <input type="hidden" name="Consent_to_Processing__c" class="mktoField  mktoFormCol" value="Yes" >
+                <input type="hidden" name="Consent_to_Processing__c" value="Yes" >
               </p>
             </li>
             <li class="p-list__item">
               <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}" style="margin: 2rem 0;"></div>
             </li>
-            <li  class="mktField">
-              <button type="submit" class="mktoButton">Submit request</button>
+            <li>
+              <button type="submit">Submit request</button>
             </li>
 
           </ul>
@@ -99,13 +99,13 @@
 
         <input type="hidden" name="formid" value="3285" />
         <input type="hidden" name="returnURL" value="/openstack/thank-you?product=rfp" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
       </form>
 
     <!-- /MARKETO FORM -->

--- a/templates/shared/_blender-contact-us-form.html
+++ b/templates/shared/_blender-contact-us-form.html
@@ -10,32 +10,32 @@
       <form action="/marketo/submit" method="post" id="mktoForm_{{formid}}">
 
         <fieldset class="u-no-margin--bottom">
-          <label class="mktoLabel" for="Comments_from_lead_c">Tell us about your project and what problem(s) you’re looking to solve:</label>
-          <textarea required id="Comments_from_lead__c" name="Comments_from_lead__c" maxlength="2000" class="mktoField mktoRequired"></textarea>
+          <label for="Comments_from_lead_c">Tell us about your project and what problem(s) you’re looking to solve:</label>
+          <textarea required id="Comments_from_lead__c" name="Comments_from_lead__c" maxlength="2000"></textarea>
         </fieldset>
 
         <fieldset class="u-no-margin--bottom">
           <p>How should we get in touch?</p>
           <ul class="p-list">
-            <li class="mktFormReq mktField p-list__item">
-              <label for="FirstName" class="mktoLabel">First name:</label>
-              <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" />
+            <li class="p-list__item">
+              <label for="FirstName">First name:</label>
+              <input required id="firstName" name="firstName" maxlength="255" type="text"/>
             </li>
-            <li class="mktFormReq mktField p-list__item">
-              <label for="LastName" class="mktoLabel">Last name:</label>
-              <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" />
+            <li class="p-list__item">
+              <label for="LastName">Last name:</label>
+              <input required id="lastName" name="lastName" maxlength="255" type="text"/>
             </li>
-            <li class="mktFormReq mktField p-list__item">
-              <label for="CompanyName" class="mktoLabel">Company name:</label>
-              <input required id="company" name="company" maxlength="255" type="text" class="mktoField mktoRequired" />
+            <li class="p-list__item">
+              <label for="CompanyName">Company name:</label>
+              <input required id="company" name="company" maxlength="255" type="text"/>
             </li>
-            <li class="mktFormReq mktField p-list__item">
-              <label for="Email" class="mktoLabel">Email address:</label>
-              <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" />
+            <li class="p-list__item">
+              <label for="Email">Email address:</label>
+              <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
             </li>
-            <li class="mktFormReq mktField p-list__item">
-              <label for="Phone" class="mktoLabel">Mobile/cell phone number:</label>
-              <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField mktoRequired" />
+            <li class="p-list__item">
+              <label for="Phone">Mobile/cell phone number:</label>
+              <input required id="phone" name="phone" maxlength="255" type="tel" />
             </li>
           </ul>
         </fieldset>
@@ -43,29 +43,29 @@
 
         <fieldset class="u-no-margin--bottom">
           <ul class="p-list">
-            <li class="mktField p-list__item">
-              <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-              <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
+            <li class="p-list__item">
+              <input value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+              <label for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
             </li>
             <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
             <li class="p-list__item">
                 <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}" style="margin: 2rem 0;"></div>
             </li>
-            <li class="mktField p-list__item">
-              <button type="submit" class="mktoButton p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Form', 'eventAction' : 'blender contact-us', 'eventLabel' : '{{product}}', 'eventValue' : undefined });">Let's discuss</button>
+            <li class="p-list__item">
+              <button type="submit" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Form', 'eventAction' : 'blender contact-us', 'eventLabel' : '{{product}}', 'eventValue' : undefined });">Let's discuss</button>
             </li>
           </ul>
           <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="{{formid}}" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="{{formid}}" />
           <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="{{returnURL}}" />
           <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
         </fieldset>
       </form>
     </div>

--- a/templates/shared/_client-contact-us-form.html
+++ b/templates/shared/_client-contact-us-form.html
@@ -11,21 +11,21 @@
         <fieldset class="u-no-margin--bottom">
           <h3>About you</h3>
           <ul class="p-list">
-            <li class="mktFormReq mktField p-list__item">
-              <label for="firstName" class="mktoLabel">First name:</label>
-              <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" />
+            <li class="p-list__item">
+              <label for="firstName">First name:</label>
+              <input required id="firstName" name="firstName" maxlength="255" type="text" />
             </li>
-            <li class="mktFormReq mktField p-list__item">
-              <label for="lastName" class="mktoLabel">Last name:</label>
-              <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" />
+            <li class="p-list__item">
+              <label for="lastName">Last name:</label>
+              <input required id="lastName" name="lastName" maxlength="255" type="text" />
             </li>
-            <li class="mktFormReq mktField p-list__item">
-              <label for="email" class="mktoLabel">Email address:</label>
-              <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" />
+            <li class="p-list__item">
+              <label for="email">Email address:</label>
+              <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
             </li>
-            <li class="mktFormReq mktField p-list__item">
-              <label for="phone" class="mktoLabel">Mobile/cell phone number:</label>
-              <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField mktoRequired" />
+            <li class="p-list__item">
+              <label for="phone">Mobile/cell phone number:</label>
+              <input required id="phone" name="phone" maxlength="255" type="tel" />
             </li>
             {% include "shared/forms/_country.html" %} {% include "shared/forms/_state.html" %}
           </ul>
@@ -34,13 +34,13 @@
         <fieldset class="u-no-margin--bottom">
           <h3>About your company</h3>
           <ul class="p-list">
-            <li class="mktFormReq mktField p-list__item">
-              <label for="company" class="mktoLabel">Company:</label>
-              <input required id="company" name="company" maxlength="255" type="text" class="mktoField mktoRequired" />
+            <li class="p-list__item">
+              <label for="company">Company:</label>
+              <input required id="company" name="company" maxlength="255" type="text" />
             </li>
-            <li class="mktFormReq mktField p-list__item">
-              <label for="job-title" class="mktoLabel">Job title:</label>
-              <input required id="job-title" name="title" maxlength="255" type="text" class="mktoField mktoRequired" />
+            <li class="p-list__item">
+              <label for="job-title">Job title:</label>
+              <input required id="job-title" name="title" maxlength="255" type="text" />
             </li>
 
           </ul>
@@ -49,32 +49,32 @@
         <fieldset class="u-no-margin--bottom">
           <h3>Your comments</h3>
           <ul class="p-list">
-            <li class="mktFormReq mktField p-list__item">
-              <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
-              <textarea required id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField mktoRequired" maxlength="2000"></textarea>
+            <li class="p-list__item">
+              <label for="Comments_from_lead__c">What would you like to talk to us about?</label>
+              <textarea required id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
             </li>
-            <li class="mktField p-list__item">
-              <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-              <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
+            <li class="p-list__item">
+              <input value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+              <label for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
             </li>
             <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
             <li class="p-list__item">
                 <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}" style="margin: 2rem 0;"></div>
             </li>
-            <li class="mktField p-list__item">
-              <button type="submit" class="mktoButton p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Form', 'eventAction' : 'iot contact-us', 'eventLabel' : '{{product}}', 'eventValue' : undefined });">Submit</button>
+            <li class="p-list__item">
+              <button type="submit" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Form', 'eventAction' : 'iot contact-us', 'eventLabel' : '{{product}}', 'eventValue' : undefined });">Submit</button>
             </li>
           </ul>
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="{{formid}}" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="{{formid}}" />
           <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="{{returnURL}}" />
           <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
         </fieldset>
       </form>
     </div>

--- a/templates/shared/_cloud-contact-us-form-german.html
+++ b/templates/shared/_cloud-contact-us-form-german.html
@@ -13,21 +13,21 @@
         <fieldset class="u-no-margin--bottom">
           <h3>Über Sie</h3>
           <ul class="p-list">
-            <li class="mktFormReq mktField p-list__item">
-              <label for="firstName" class="mktoLabel">Vorname:</label>
-              <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" />
+            <li class="p-list__item">
+              <label for="firstName">Vorname:</label>
+              <input required id="firstName" name="firstName" maxlength="255" type="text" />
             </li>
-            <li class="mktFormReq mktField p-list__item">
-              <label for="lastName" class="mktoLabel">Nachname:</label>
-              <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" />
+            <li class="p-list__item">
+              <label for="lastName">Nachname:</label>
+              <input required id="lastName" name="lastName" maxlength="255" type="text" />
             </li>
-            <li class="mktFormReq mktField p-list__item">
-              <label for="email" class="mktoLabel">Email-Adresse:</label>
-              <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" />
+            <li class="p-list__item">
+              <label for="email">Email-Adresse:</label>
+              <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
             </li>
-            <li class="mktFormReq mktField p-list__item">
-              <label for="phone" class="mktoLabel">Handynummer:</label>
-              <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField mktoRequired" />
+            <li class="p-list__item">
+              <label for="phone">Handynummer:</label>
+              <input required id="phone" name="phone" maxlength="255" type="tel" />
             </li>
             <!-- country -->
             {% with country='Land' %}{% include "shared/forms/_country.html" %}{% endwith %}
@@ -38,50 +38,50 @@
         <fieldset class="u-no-margin--bottom">
           <h3>Über Ihr Unternehmen</h3>
           <ul class="p-list">
-            <li class="mktFormReq mktField p-list__item">
-              <label for="company" class="mktoLabel">Name des Unternehmens:</label>
-              <input required id="company" name="company" maxlength="255" type="text" class="mktoField mktoRequired" />
+            <li class="p-list__item">
+              <label for="company">Name des Unternehmens:</label>
+              <input required id="company" name="company" maxlength="255" type="text" />
             </li>
-            <li class="mktFormReq mktField p-list__item">
-              <label for="title" class="mktoLabel">Ihre Position/Verantwortungsbereich:</label>
-              <input required id="title" name="title" maxlength="255" type="text" class="mktoField mktoRequired" />
+            <li class="p-list__item">
+              <label for="title">Ihre Position/Verantwortungsbereich:</label>
+              <input required id="title" name="title" maxlength="255" type="text" />
             </li>
           </ul>
         </fieldset>
         <fieldset class="u-no-margin--bottom">
           <h3>Anmerkungen</h3>
           <ul class="p-list">
-            <li class="mktFormReq mktField p-list__item">
-              <label for="Comments_from_lead__c" class="mktoLabel">Worüber möchten Sie mit uns sprechen?</label>
-              <textarea required id="Comments_from_lead__c" name="Comments_from_lead__c" rows="4" class="mktoField mktoRequired" maxlength="2000"></textarea>
+            <li class="p-list__item">
+              <label for="Comments_from_lead__c">Worüber möchten Sie mit uns sprechen?</label>
+              <textarea required id="Comments_from_lead__c" name="Comments_from_lead__c" rows="4" maxlength="2000"></textarea>
             </li>
           </ul>
         </fieldset>
         <fieldset class="u-no-margin--bottom">
           <ul class="p-list">
-            <li class="mktField p-list__item">
-              <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-              <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">Ich stimme zu, Informationen über Produkte und Services von Canonical zu erhalten.</label>
+            <li class="p-list__item">
+              <input value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+              <label for="canonicalUpdatesOptIn">Ich stimme zu, Informationen über Produkte und Services von Canonical zu erhalten.</label>
             </li>
             <li class="p-list__item">
               Mit der Absendung dieses Formulars bestätige ich, dass ich <a href="/legal/data-privacy/contact">Canonicals Datenschutzerklärung</a> und <a href="/legal/data-privacy">richtlinie zur Kenntnis</a> genommen habe.
             </li>
             <li class="p-list__item"><div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}"></div></li>
-            <li class="mktField p-list__item">
-              <button style="margin: 1rem 0 0 0" type="submit" class="mktoButton p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Form', 'eventAction' : 'cloud contact-us', 'eventLabel' : '{{product}}', 'eventValue' : undefined });">Absenden</button>
+            <li class="p-list__item">
+              <button style="margin: 1rem 0 0 0" type="submit" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Form', 'eventAction' : 'cloud contact-us', 'eventLabel' : '{{product}}', 'eventValue' : undefined });">Absenden</button>
             </li>
           </ul>
           <!-- hidden fields -->
-          <input type="hidden" aria-hidden="true" name="formid" class="mktoField" value="{{formid}}" aria-label="formid" />
+          <input type="hidden" aria-hidden="true" name="formid" value="{{formid}}" aria-label="formid" />
           <input type="hidden" aria-hidden="true" name="returnURL" value="{{returnURL}}" aria-label="returnURL" />
           <input type="hidden" aria-hidden="true" name="Consent_to_Processing__c" value="yes" aria-label="Consent_to_Processing__c" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
         </fieldset>
       </form>
     </div>

--- a/templates/shared/_cloud-contact-us-form.html
+++ b/templates/shared/_cloud-contact-us-form.html
@@ -11,21 +11,21 @@
         <fieldset class="u-no-margin--bottom">
           <h3>About you</h3>
           <ul class="p-list">
-            <li class="mktFormReq mktField p-list__item">
-              <label for="firstName" class="mktoLabel">First name:</label>
-              <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" />
+            <li class="p-list__item">
+              <label for="firstName">First name:</label>
+              <input required id="firstName" name="firstName" maxlength="255" type="text"/>
             </li>
-            <li class="mktFormReq mktField p-list__item">
-              <label for="lastName" class="mktoLabel">Last name:</label>
-              <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" />
+            <li class="p-list__item">
+              <label for="lastName">Last name:</label>
+              <input required id="lastName" name="lastName" maxlength="255" type="text"/>
             </li>
-            <li class="mktFormReq mktField p-list__item">
-              <label for="email" class="mktoLabel">Email address:</label>
-              <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" />
+            <li class="p-list__item">
+              <label for="email">Email address:</label>
+              <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
             </li>
-            <li class="mktFormReq mktField p-list__item">
-              <label for="phone" class="mktoLabel">Mobile/cell phone number:</label>
-              <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField mktoRequired" />
+            <li class="p-list__item">
+              <label for="phone">Mobile/cell phone number:</label>
+              <input required id="phone" name="phone" maxlength="255" type="tel"/>
             </li>
             <!-- country -->
             {% include "shared/forms/_country.html" %}
@@ -36,30 +36,30 @@
         <fieldset class="u-no-margin--bottom">
           <h3>About your company</h3>
           <ul class="p-list">
-            <li class="mktFormReq mktField p-list__item">
-              <label for="company" class="mktoLabel">Company name:</label>
-              <input required id="company" name="company" maxlength="255" type="text" class="mktoField mktoRequired" />
+            <li class="p-list__item">
+              <label for="company">Company name:</label>
+              <input required id="company" name="company" maxlength="255" type="text" />
             </li>
-            <li class="mktFormReq mktField p-list__item">
-              <label for="title" class="mktoLabel">Job title:</label>
-              <input required id="title" name="title" maxlength="255" type="text" class="mktoField mktoRequired" />
+            <li class="p-list__item">
+              <label for="title">Job title:</label>
+              <input required id="title" name="title" maxlength="255" type="text" />
             </li>
           </ul>
         </fieldset>
         <fieldset class="u-no-margin--bottom">
           <h3>Your comments</h3>
           <ul class="p-list">
-            <li class="mktFormReq mktField p-list__item">
-              <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
-              <textarea required id="Comments_from_lead__c" name="Comments_from_lead__c" rows="4" class="mktoField mktoRequired" maxlength="2000"></textarea>
+            <li class="p-list__item">
+              <label for="Comments_from_lead__c">What would you like to talk to us about?</label>
+              <textarea required id="Comments_from_lead__c" name="Comments_from_lead__c" rows="4" maxlength="2000"></textarea>
             </li>
           </ul>
         </fieldset>
         <fieldset class="u-no-margin--bottom">
           <ul class="p-list">
-            <li class="mktField p-list__item">
-              <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-              <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
+            <li class="p-list__item">
+              <input value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+              <label for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
             </li>
             <li class="p-list__item">
               In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.
@@ -71,21 +71,21 @@
             </li>
           </ul>
           <ul class="p-list">
-            <li class="mktField p-list__item">
-              <button type="submit" class="mktoButton p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Form', 'eventAction' : 'cloud contact-us', 'eventLabel' : '{{product}}', 'eventValue' : undefined });">Submit</button>
+            <li class="p-list__item">
+              <button type="submit" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Form', 'eventAction' : 'cloud contact-us', 'eventLabel' : '{{product}}', 'eventValue' : undefined });">Submit</button>
             </li>
           </ul>
           <!-- hidden fields -->
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="{{formid}}" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="{{formid}}" />
           <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="{{returnURL}}" />
           <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
         </fieldset>
       </form>
     </div>

--- a/templates/shared/_cube-contact-us-form.html
+++ b/templates/shared/_cube-contact-us-form.html
@@ -100,7 +100,7 @@
             </li>
             <li  class="p-list__item  " id="comments">
               <label for="Comments_from_lead__c" id="LblComments_from_lead__c"  >Why do you want CUBE certification?</label>
-              <textarea class="is-required" required="" id="Comments_from_lead__c" name="Comments_from_lead__c" rows="4" aria-labelledby="LblComments_from_lead__c InstructComments_from_lead__c" class="  mktoRequired" maxlength="2000" aria-required="true" ></textarea>
+              <textarea class="is-required" required="" id="Comments_from_lead__c" name="Comments_from_lead__c" rows="4" aria-labelledby="LblComments_from_lead__c InstructComments_from_lead__c" maxlength="2000" aria-required="true" ></textarea>
             </li>
           </ul>
         </fieldset>
@@ -109,7 +109,7 @@
           <ul class="p-list">
             <li class=" p-list__item">
               <input  value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-              <label class="mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
+              <label for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
             </li>
             <li class="p-list__item">
               In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.
@@ -122,7 +122,7 @@
           </ul>
           <ul class="p-list">
             <li class=" p-list__item">
-              <button type="submit" class="mktoButton p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Form', 'eventAction' : 'cloud contact-us', 'eventLabel' : '{{product}}', 'eventValue' : undefined });">Submit</button>
+              <button type="submit" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Form', 'eventAction' : 'cloud contact-us', 'eventLabel' : '{{product}}', 'eventValue' : undefined });">Submit</button>
             </li>
           </ul>
           <!-- hidden fields -->

--- a/templates/shared/_telco-contact-us.html
+++ b/templates/shared/_telco-contact-us.html
@@ -105,25 +105,25 @@
               <div class="row u-no-padding">
                 <div class="col-6">
                   <ul class="p-list">
-                    <li class="mktFormReq mktField p-list__item">
-                      <label for="FirstName" class="mktoLabel">First name:</label>
-                      <input required id="FirstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                    <li class="p-list__item">
+                      <label for="FirstName">First name:</label>
+                      <input required id="FirstName" name="firstName" maxlength="255" type="text" required="required" />
                     </li>
-                    <li class="mktFormReq mktField p-list__item">
-                      <label for="LastName" class="mktoLabel">Last name:</label>
-                      <input required id="LastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                    <li class="p-list__item">
+                      <label for="LastName">Last name:</label>
+                      <input required id="LastName" name="lastName" maxlength="255" type="text" required="required" />
                     </li>
-                    <li class="mktFormReq mktField p-list__item">
-                      <label for="Email" class="mktoLabel">Email:</label>
-                      <input required id="Email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+                    <li class="p-list__item">
+                      <label for="Email">Email:</label>
+                      <input required id="Email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
                     </li>
-                    <li class="mktFormReq mktField p-list__item">
-                      <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>
-                      <input required id="Phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+                    <li class="p-list__item">
+                      <label for="Phone">Mobile/cell phone number:</label>
+                      <input required id="Phone" name="phone" maxlength="255" type="tel" required="required" />
                     </li>
-                    <li class="mktField p-list__item">
-                      <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-                      <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
+                    <li class="p-list__item">
+                      <input value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                      <label for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
                     </li>
                     <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
                     <li class="p-list__item">
@@ -137,33 +137,33 @@
             <fieldset class="u-no-margin--bottom">
               <h3>Your comments</h3>
               <ul class="p-list">
-                <li class="mktFormReq mktField p-list__item">
-                  <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
-                  <textarea required id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField mktoRequired" maxlength="2000"></textarea>
+                <li class="p-list__item">
+                  <label for="Comments_from_lead__c">What would you like to talk to us about?</label>
+                  <textarea required id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
                 </li>
-                <li class="mktField p-list__item">
-                  <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-                  <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
+                <li class="p-list__item">
+                  <input value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                  <label for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
                 </li>
                 <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
                 <li class="p-list__item">
                     <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}" style="margin: 2rem 0;"></div>
                 </li>
-                <li class="mktField p-list__item">
-                  <button type="submit" class="mktoButton p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Form', 'eventAction' : 'iot contact-us', 'eventLabel' : '{{product}}', 'eventValue' : undefined });">Submit</button>
+                <li class="p-list__item">
+                  <button type="submit" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Form', 'eventAction' : 'iot contact-us', 'eventLabel' : '{{product}}', 'eventValue' : undefined });">Submit</button>
                 </li>
               </ul>
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="{{formid}}" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="{{formid}}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="{{returnURL}}" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
             </fieldset>
           </div>
         </div>

--- a/templates/shared/contextual_footers/_cloud_newsletter.html
+++ b/templates/shared/contextual_footers/_cloud_newsletter.html
@@ -1,31 +1,31 @@
 <div class="col-4 p-divider__block">
-  <form class="mktoForm mktoNoJS" action="/marketo/submit" method="post">
+  <form action="/marketo/submit" method="post">
     <h3 class="p-heading--four">Sign up for our monthly Cloud&nbsp;Newsletter</h3>
-    <ul class="p-list mktoFormRow u-clearfix">
-      <li class="mktoFormCol p-list__item">
-        <label class="u-off-screen mktoLabel" for="email">Your email</label>
-        <input type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" placeholder="Your email" class="mktoField mktoTextField" name="email" id="email" required />
+    <ul class="p-list u-clearfix">
+      <li class="p-list__item">
+        <label class="u-off-screen" for="email">Your email</label>
+        <input type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" placeholder="Your email" name="email" id="email" required />
       </li>
-      <li class="mktField mktLblRight p-list__item">
-        <span class="mktInput mktLblRight">
-          <input class="mktFormCheckbox" name="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="yes" type="checkbox" />
-          <label class="contextual-footer__text--label" for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>&nbsp;<span class="mktFormMsg"></span>
+      <li class="p-list__item">
+        <span>
+          <input name="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="yes" type="checkbox" />
+          <label class="contextual-footer__text--label" for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>&nbsp;
         </span>
       </li>
       <li class="p-list__item u-no-margin--top">
         <p>In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/newsletter">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</p>
       </li>
       <li class="p-list__item">
-        <span class="mktoButtonWrap"><button type="submit" class="mktoButton p-button--neutral"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Cloud newsletter', 'eventLabel' : 'Sign-up for news updates', 'eventValue' : undefined });">Subscribe now</button></span>
-        <input value="1212" class="mktoField mktoFieldDescriptor" name="formid" type="hidden" />
+        <span><button type="submit" class="p-button--neutral"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Cloud newsletter', 'eventLabel' : 'Sign-up for news updates', 'eventValue' : undefined });">Subscribe now</button></span>
+        <input value="1212" name="formid" type="hidden" />
         <input type="hidden" name="Consent_to_Processing__c" value="yes" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
         <input type="hidden" name="returnURL" value="/openstack/newsletter-thank-you" />
       </li>
     </ul>

--- a/templates/shared/contextual_footers/_devices_newsletter_signup.html
+++ b/templates/shared/contextual_footers/_devices_newsletter_signup.html
@@ -10,7 +10,7 @@
         @media only screen and (min-width: 768px) { #mce-success-response { height: 90%; }}
         #mc_embed_signup input.mce_inline_error { border-color: red; }
       </style>
-      <form action="https://canonical.us3.list-manage.com/subscribe/post?u=56dac47c206ba0f58ec25f314&amp;id=97a67dea26" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="mc-embedded-subscribe-form validate" target="_blank" rel="noopener noreferrer" novalidate>
+      <form action="https://canonical.us3.list-manage.com/subscribe/post?u=56dac47c206ba0f58ec25f314&amp;id=97a67dea26" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" target="_blank" rel="noopener noreferrer">
 
           <h3 class="p-heading--four">Sign up for our monthly Devices newsletter</h3>
 

--- a/templates/shared/contextual_footers/_iot_newsletter_signup.html
+++ b/templates/shared/contextual_footers/_iot_newsletter_signup.html
@@ -1,17 +1,17 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">IoT newsletter</h3>
   <!-- MARKETO FORM -->
-  <form action="/marketo/submit" method="post" id="mktoForm_1670" class="marketo-form">
+  <form action="/marketo/submit" method="post" id="mktoForm_1670">
     <p>Receive regular updates from our IoT newsletter.</p>
     <ul class="p-list">
-      <li class="mktFormReq mktField p-list__item">
-        <label for="email" class="mktoLabel contextual-footer__text--label">Your email address:</label>
-        <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired">
+      <li class="p-list__item">
+        <label for="email" class="contextual-footer__text--label">Your email address:</label>
+        <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$">
       </li>
-      <li class="mktField mktLblRight p-list__item">
-        <span class="mktInput mktLblRight">
-          <input class="mktFormCheckbox" name="canonicalUpdatesOptIn" id="canonicalOptIn" value="yes" type="checkbox" />
-          <label class="contextual-footer__text--label" for="canonicalOptIn">I agree to receive information about Canonical's products and services.</label>&nbsp;<span class="mktFormMsg"></span>
+      <li class="p-list__item">
+        <span>
+          <input name="canonicalUpdatesOptIn" id="canonicalOptIn" value="yes" type="checkbox" />
+          <label class="contextual-footer__text--label" for="canonicalOptIn">I agree to receive information about Canonical's products and services.</label>&nbsp;
         </span>
       </li>
       <li class="p-list__item u-no-margin--top">
@@ -19,19 +19,19 @@
           In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/newsletter">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.
         </p>
       </li>
-      <li class="mktField p-list__item">
-        <button type="submit" class="mktoButton p-button--neutral">Submit</button>
-        <input type="hidden" name="formid" class="mktoField" value="1670">
-        <input type="hidden" name="IoT_Newsletters__c" class="mktoField  mktoFormCol" value="true">
+      <li class="p-list__item">
+        <button type="submit" class="p-button--neutral">Submit</button>
+        <input type="hidden" name="formid" value="1670">
+        <input type="hidden" name="IoT_Newsletters__c" value="true">
         <input type="hidden" name="returnURL" value="/internet-of-things/thank-you?product=newsletter" />
         <input type="hidden" name="Consent_to_Processing__c" value="yes" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
       </li>
     </ul>
   </form>

--- a/templates/shared/contextual_footers/_kubeflow_news_signup.html
+++ b/templates/shared/contextual_footers/_kubeflow_news_signup.html
@@ -1,12 +1,12 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Kubeflow news</h3>
   <!-- MARKETO FORM -->
-  <form action="/marketo/submit" method="post" id="mktoForm_3415" class="marketo-form">
+  <form action="/marketo/submit" method="post" id="mktoForm_3415">
     <p>Subscribe to our newsletter and get a weekly update of <a class="p-link--external" href="https://kubeflow-news.com/">Kubeflow news</a> from across the web.</p>
     <ul class="p-list">
-      <li class="mktFormReq mktField p-list__item">
-        <label for="email" class="mktoLabel contextual-footer__text--label">Work email:</label>
-        <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired">
+      <li class="p-list__item">
+        <label for="email" class="contextual-footer__text--label">Work email:</label>
+        <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$">
       </li>
       <li class="p-list__item u-no-margin--top">
         <p>
@@ -16,20 +16,20 @@
       <li>
         <div class="g-recaptcha" data-sitekey="{{ CAPTCHA_TESTING_API_KEY }}"></div>
       </li>
-      <li class="mktField p-list__item">
-        <button type="submit" class="mktoButton p-button--neutral">Subscribe now</button>
+      <li class="p-list__item">
+        <button type="submit" class="p-button--neutral">Subscribe now</button>
       </li>
     </ul>
     <div>
       <input type="hidden" name="Consent_to_Processing__c" value="Yes">
       <input type="hidden" name="formid" value="3415">
-      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
       <input type="hidden" name="thankyoumessage" value="Thank you for subscribing!<br />You will begin receiving emails as new content is posted. You may unsubscribe any time by clicking the link in the email.">
     </div>
   </form>
@@ -37,17 +37,5 @@
   <!-- /MARKETO FORM -->
 </div>
 
-<script src="https://assets.ubuntu.com/v1/5d7e5bbf-jquery-2.2.0.min.js"></script>
-<script src="https://assets.ubuntu.com/v1/d55f58bb-jquery.validate.js"></script>
 <script src="https://www.google.com/recaptcha/api.js?onload=CaptchaCallback&render=explicit" defer></script>
 
-<script>
-  $("#mktoForm_3415").validate({
-    errorPlacement: function(error, element) {
-      error.appendTo( element.parent().addClass( "p-form-validation is-error" ));
-      error.appendTo( element.addClass( "p-form-validation__input" ));
-    },
-    errorElement: "span",
-    errorClass: "p-form-validation__message"
-  });
-</script>

--- a/templates/shared/contextual_footers/_openstack_install_newsletter.html
+++ b/templates/shared/contextual_footers/_openstack_install_newsletter.html
@@ -1,15 +1,15 @@
 <div class="col-4 p-divider__block">
-    <form class="mktoForm mktoNoJS" action="https://pages.canonical.com/index.php/leadCapture/save" method="post">
+    <form action="https://pages.canonical.com/index.php/leadCapture/save" method="post">
     <h3 class="p-heading--four">Sign up for our monthly Cloud&nbsp;Newsletter</h3>
-        <ul class="p-list mktoFormRow u-clearfix">
-            <li class="mktoFormCol p-list__item">
-                <label class="u-off-screen mktoLabel" for="Email">Your email</label>
-                <input type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" placeholder="Your email" class="mktoField mktoTextField" name="email" id="Email" required />
+        <ul class="p-list u-clearfix">
+            <li class="p-list__item">
+                <label class="u-off-screen" for="Email">Your email</label>
+                <input type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" placeholder="Your email" name="email" id="Email" required />
             </li>
-            <li class="mktField mktLblRight p-list__item">
-                <span class="mktInput mktLblRight">
-                <input class="mktFormCheckbox" name="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="yes" type="checkbox" />
-                <label class="contextual-footer__text--label" for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>&nbsp;<span class="mktFormMsg"></span>
+            <li class="p-list__item">
+                <span>
+                <input name="canonicalUpdatesOptIn" id="canonicalUpdatesOptIn" value="yes" type="checkbox" />
+                <label class="contextual-footer__text--label" for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>&nbsp;
                 </span>
             </li>
             <li class="p-list__item u-no-margin--top">
@@ -17,17 +17,17 @@
             </li>
             <li class="p-list__item">
                 <span class="u-off-screen"><input type="text" name="_marketo_comments" value=""></span>
-                <span class="mktoButtonWrap"><button type="submit" class="mktoButton p-button--neutral"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Cloud newsletter', 'eventLabel' : 'Sign-up for news updates', 'eventValue' : undefined });">Subscribe now</button></span>
-                <input value="1212" class="mktoField mktoFieldDescriptor" name="formid" type="hidden" />
+                <span><button type="submit" class="p-button--neutral"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Cloud newsletter', 'eventLabel' : 'Sign-up for news updates', 'eventValue' : undefined });">Subscribe now</button></span>
+                <input value="1212" name="formid" type="hidden" />
                 <input type="hidden" name="Consent_to_Processing__c" value="yes" />
                 <input type="hidden" name="returnURL" value="/openstack/newsletter-thank-you" />
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
             </li>
         </ul>
     </form>

--- a/templates/shared/contextual_footers/_robotics_newsletter_signup.html
+++ b/templates/shared/contextual_footers/_robotics_newsletter_signup.html
@@ -1,17 +1,17 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--four">Robotics newsletter</h3>
   <!-- MARKETO FORM -->
-  <form action="/marketo/submit" method="post" id="mktoForm_1212" class="marketo-form">
+  <form action="/marketo/submit" method="post" id="mktoForm_1212">
     <p>Receive regular updates from our Robotics newsletter.</p>
     <ul class="p-list">
-      <li class="mktFormReq mktField p-list__item">
-        <label for="Email" class="mktoLabel contextual-footer__text--label">Your email address:</label>
-        <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired">
+      <li class="p-list__item">
+        <label for="Email" class="contextual-footer__text--label">Your email address:</label>
+        <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$">
       </li>
-      <li class="mktField mktLblRight p-list__item">
-        <span class="mktInput mktLblRight">
-          <input class="mktFormCheckbox" name="canonicalUpdatesOptIn" id="canonicalOptIn" value="yes" type="checkbox" />
-          <label class="contextual-footer__text--label" for="canonicalOptIn">I agree to receive information about Canonical's products and services.</label>&nbsp;<span class="mktFormMsg"></span>
+      <li class="p-list__item">
+        <span>
+          <input name="canonicalUpdatesOptIn" id="canonicalOptIn" value="yes" type="checkbox" />
+          <label class="contextual-footer__text--label" for="canonicalOptIn">I agree to receive information about Canonical's products and services.</label>&nbsp;
         </span>
       </li>
 
@@ -22,19 +22,19 @@
           In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/newsletter">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.
         </p>
       </li>
-      <li class="mktField p-list__item">
-        <button type="submit" class="mktoButton p-button--neutral">Submit</button>
+      <li class="p-list__item">
+        <button type="submit" class="p-button--neutral">Submit</button>
         <input type="hidden" name="formid" value="1212">
         <input type="hidden" name="insightsrobotics" value="true">
         <input type="hidden" name="returnURL" value="/robotics/thank-you?product=newsletter" />
         <input type="hidden" name="Consent_to_Processing__c" value="yes" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
       </li>
     </ul>
   </form>
@@ -42,16 +42,5 @@
   <!-- /MARKETO FORM -->
 </div>
 
-<script src="https://assets.ubuntu.com/v1/5d7e5bbf-jquery-2.2.0.min.js"></script>
-<script src="https://assets.ubuntu.com/v1/d55f58bb-jquery.validate.js"></script>
 <script src="https://www.google.com/recaptcha/api.js?onload=CaptchaCallback&render=explicit" defer>
-<script>
-  $("#mktoForm_1212").validate({
-    errorPlacement: function(error, element) {
-      error.appendTo( element.parent().addClass( "p-form-validation is-error" ));
-      error.appendTo( element.addClass( "p-form-validation__input" ));
-    },
-    errorElement: "span",
-    errorClass: "p-form-validation__message"
-  });
-</script>
+

--- a/templates/shared/forms/_country.html
+++ b/templates/shared/forms/_country.html
@@ -1,12 +1,11 @@
 {% if raw != "true" %}
-<li class="mktFormReq mktField p-list_">
-  <label for="country" class="mktoLabel">{{ country or 'Country' }}:</label>
+<li class="p-list_">
+  <label for="country">{{ country or 'Country' }}:</label>
   {% endif %}
   <select
     required
     id="country"
     name="country"
-    class="mktoField mktoRequired mktoValid"
   >
     <option value="">Select...</option
     ><option value="FR">France</option

--- a/templates/shared/forms/_industry.html
+++ b/templates/shared/forms/_industry.html
@@ -1,6 +1,6 @@
-<li class="mktFormReq mktField p-list__item">
-  <label for="Industry" class="mktoLabel">Industry:</label>
-  <select required id="Industry" name="Industry" class="mktoField mktoRequired">
+<li class="p-list__item">
+  <label for="Industry">Industry:</label>
+  <select required id="Industry" name="Industry">
     <option value="">Select...</option>
     <option value="Accountancy &amp; Tax">Accountancy &amp; Tax</option>
     <option value="Aerospace &amp; Aviation">Aerospace &amp; Aviation</option>

--- a/templates/shared/forms/_job_role.html
+++ b/templates/shared/forms/_job_role.html
@@ -1,6 +1,6 @@
-<li class="mktFormReq mktField p-list__item">
-  <label for="Job_Role__c" class="mktoLabel">Job role:</label>
-  <select required id="Job_Role__c" name="Job_Role__c" class="mktoField mktoRequired">
+<li class="p-list__item">
+  <label for="Job_Role__c">Job role:</label>
+  <select required id="Job_Role__c" name="Job_Role__c">
   <option value="">Select...</option>
   <option value="Business and Project Management">Business and Project Management</option>
   <option value="Database Development and Administration">Database Development and Administration</option>

--- a/templates/shared/forms/interactive/_appliance.html
+++ b/templates/shared/forms/interactive/_appliance.html
@@ -120,23 +120,23 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
             <ul class="p-list">
-              <li class="mktFormReq mktField p-list__item">
-                <label for="firstName" class="mktoLabel">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="lastName" class="mktoLabel">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="email">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
               </li>
-              <li class="mktField p-list__item">
-                <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-                <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
+              <li class="p-list__item">
+                <input value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                <label for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
               </li>
               <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
               <li class="p-list__item">
@@ -147,26 +147,26 @@
             <div class="u-hide">
               <h3>Your comments</h3>
               <ul class="p-list">
-                <li class="mktFormReq mktField p-list__item">
-                  <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
-                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
+                <li class="p-list__item">
+                  <label for="Comments_from_lead__c">What would you like to talk to us about?</label>
+                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
             </div>
 
             <div class="pagination">
               <a class="pagination__link--previous p-button--neutral" href="">Previous</a>
-              <button type="submit" class="pagination__link--next p-button--positive mktoButton" aria-label="Submit">Let's discuss</button>
+              <button type="submit" class="pagination__link--next p-button--positive" aria-label="Submit">Let's discuss</button>
             </div>
           </form>
         </div>

--- a/templates/shared/forms/interactive/advantage-beta.html
+++ b/templates/shared/forms/interactive/advantage-beta.html
@@ -99,23 +99,23 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
             <ul class="p-list">
-              <li class="mktFormReq mktField p-list__item">
-                <label for="firstName" class="mktoLabel">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="lastName" class="mktoLabel">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="email">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
               </li>
-              <li class="mktField p-list__item">
-                <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-                <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
+              <li class="p-list__item">
+                <input value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                <label for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
               </li>
               <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
               <li class="p-list__item">
@@ -126,26 +126,26 @@
             <div class="u-hide">
               <h3>Your comments</h3>
               <ul class="p-list">
-                <li class="mktFormReq mktField p-list__item">
-                  <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
-                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
+                <li class="p-list__item">
+                  <label for="Comments_from_lead__c">What would you like to talk to us about?</label>
+                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
             </div>
 
             <div class="pagination">
               <a class="pagination__link--previous p-button--neutral" href="">Previous</a>
-              <button type="submit" class="pagination__link--next p-button--positive mktoButton" aria-label="Submit">Let's discuss</button>
+              <button type="submit" class="pagination__link--next p-button--positive" aria-label="Submit">Let's discuss</button>
             </div>
           </form>
         </div>

--- a/templates/shared/forms/interactive/aws.html
+++ b/templates/shared/forms/interactive/aws.html
@@ -110,27 +110,27 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
             <ul class="p-list">
-              <li class="mktFormReq mktField p-list__item">
-                <label for="firstName" class="mktoLabel">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="lastName" class="mktoLabel">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="email">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
-                <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="phone">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
               </li>
-              <li class="mktField p-list__item">
-                <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-                <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
+              <li class="p-list__item">
+                <input value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                <label for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
               </li>
               <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
               <li class="p-list__item">
@@ -141,26 +141,26 @@
             <div class="u-hide">
               <h3>Your comments</h3>
               <ul class="p-list">
-                <li class="mktFormReq mktField p-list__item">
-                  <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
-                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
+                <li class="p-list__item">
+                  <label for="Comments_from_lead__c">What would you like to talk to us about?</label>
+                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
             </div>
 
             <div class="pagination">
               <a class="pagination__link--previous p-button--neutral" href="">Previous</a>
-              <button type="submit" class="pagination__link--next p-button--positive mktoButton" aria-label="Submit">Let's discuss</button>
+              <button type="submit" class="pagination__link--next p-button--positive" aria-label="Submit">Let's discuss</button>
             </div>
           </form>
         </div>

--- a/templates/shared/forms/interactive/azure-1604.html
+++ b/templates/shared/forms/interactive/azure-1604.html
@@ -11,9 +11,9 @@
         <div class="row u-no-padding">
           <div class="col-4 u-sv3">
             <input type="checkbox" id="about-your-1604-instances-less-than--50-vms">
-            <label for="about-your-1604-instances-less-than--50-vms">< 50 VMs</label>
+            <label for="about-your-1604-instances-less-than--50-vms">&#60; 50 VMs</label>
             <input type="checkbox" id="about-your-1604-instances-less-than-500-vms">
-            <label for="about-your-1604-instances-less-than-500-vms"><500 VMs</label>
+            <label for="about-your-1604-instances-less-than-500-vms">&#60;500 VMs</label>
               <input type="checkbox" id="about-your-1604-instances--greater-than-500-vms">
               <label for="about-your-1604-instances--greater-than-500-vms"> >500 VMs</label>
               <input type="checkbox" id="about-your-1604-instances-containers">
@@ -115,23 +115,23 @@
         <h3 class="p-heading--five">How should we get in touch?</h3>
         <div class="row u-no-padding">
           <div class="col-6">
-            <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+            <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
               <ul class="p-list">
-                <li class="mktFormReq mktField p-list__item">
-                  <label for="firstName" class="mktoLabel">First name:</label>
-                  <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" />
+                <li class="p-list__item">
+                  <label for="firstName">First name:</label>
+                  <input required id="firstName" name="firstName" maxlength="255" type="text" />
                 </li>
-                <li class="mktFormReq mktField p-list__item">
-                  <label for="lastName" class="mktoLabel">Last name:</label>
-                  <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" />
+                <li class="p-list__item">
+                  <label for="lastName">Last name:</label>
+                  <input required id="lastName" name="lastName" maxlength="255" type="text" />
                 </li>
-                <li class="mktFormReq mktField p-list__item">
-                  <label for="email" class="mktoLabel">Work email:</label>
-                  <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" />
+                <li class="p-list__item">
+                  <label for="email">Work email:</label>
+                  <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
                 </li>
-                <li class="mktField p-list__item">
-                  <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-                  <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical’s products and services.</label>
+                <li class="p-list__item">
+                  <input value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                  <label for="canonicalUpdatesOptIn">I agree to receive information about Canonical’s products and services.</label>
                 </li>
                 <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical’s Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
                 <li class="p-list__item">
@@ -142,26 +142,26 @@
               <div class="u-hide">
                 <h3>Your comments</h3>
                 <ul class="p-list">
-                  <li class="mktFormReq mktField p-list__item">
-                    <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
-                    <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
+                  <li class="p-list__item">
+                    <label for="Comments_from_lead__c">What would you like to talk to us about?</label>
+                    <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
                   </li>
                 </ul>
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %%" />
                 <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
                 <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
               </div>
 
               <div class="pagination">
                 <a class="pagination__link--previous p-button--neutral" href="">Previous</a>
-                <button type="submit" class="pagination__link--next p-button--positive mktoButton" aria-label="Submit">Let's discuss</button>
+                <button type="submit" class="pagination__link--next p-button--positive" aria-label="Submit">Let's discuss</button>
               </div>
             </form>
           </div>

--- a/templates/shared/forms/interactive/azure.html
+++ b/templates/shared/forms/interactive/azure.html
@@ -112,25 +112,25 @@
         <div class="col-6">
           <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
             <ul class="p-list">
-              <li class="mktFormReq mktField p-list__item">
-                <label for="firstName" class="mktoLabel">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="lastName" class="mktoLabel">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="email">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
-                <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="phone">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
               </li>
-              <li class="mktField p-list__item">
-                <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-                <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
+              <li class="p-list__item">
+                <input value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                <label for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
               </li>
               <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
               <li class="p-list__item">
@@ -141,26 +141,26 @@
             <div class="u-hide">
               <h3>Your comments</h3>
               <ul class="p-list">
-                <li class="mktFormReq mktField p-list__item">
-                  <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
-                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
+                <li class=" p-list__item">
+                  <label for="Comments_from_lead__c">What would you like to talk to us about?</label>
+                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
             </div>
 
             <div class="pagination">
               <a class="pagination__link--previous p-button--neutral" href="">Previous</a>
-              <button type="submit" class="pagination__link--next p-button--positive mktoButton" aria-label="Submit">Let's discuss</button>
+              <button type="submit" class="pagination__link--next p-button--positive" aria-label="Submit">Let's discuss</button>
             </div>
           </form>
         </div>

--- a/templates/shared/forms/interactive/bootstack.html
+++ b/templates/shared/forms/interactive/bootstack.html
@@ -301,29 +301,29 @@
 
     <div class="js-pagination js-pagination--3 u-hide">
       <h3 class="p-heading--five">How should we get in touch?</h3>
-      <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+      <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
         <div class="row u-no-padding">
           <div class="col-6">
             <ul class="p-list">
-              <li class="mktFormReq mktField p-list__item">
-                <label for="firstName" class="mktoLabel">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="lastName" class="mktoLabel">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="email">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
-                <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="phone">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
               </li>
-              <li class="mktField p-list__item">
-                <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-                <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
+              <li class="p-list__item">
+                <input value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                <label for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
               </li>
               <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
               <li class="p-list__item">
@@ -334,20 +334,20 @@
             <div class="u-hide">
               <h3>Your comments</h3>
               <ul class="p-list">
-                <li class="mktFormReq mktField p-list__item">
-                  <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
-                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
+                <li class="p-list__item">
+                  <label for="Comments_from_lead__c">What would you like to talk to us about?</label>
+                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
             </div>
           </div>
         </div>
@@ -355,7 +355,7 @@
           <div class="col-12">
             <div class="pagination">
               <a class="pagination__link--previous p-button--neutral" href="">Previous</a>
-              <button type="submit" class="pagination__link--next p-button--positive mktoButton" aria-label="Submit">Let's discuss your requirements</button>
+              <button type="submit" class="pagination__link--next p-button--positive" aria-label="Submit">Let's discuss your requirements</button>
             </div>
           </div>
         </div> 

--- a/templates/shared/forms/interactive/cube-beta.html
+++ b/templates/shared/forms/interactive/cube-beta.html
@@ -101,15 +101,15 @@
                 </li>
                 <li class="p-list__item" id="comments">
                   <label for="Comments_from_lead__c" id="LblComments_from_lead__c" >Why do you want CUBE certification?</label>
-                  <textarea class="is-required" required="" id="Comments_from_lead__c" name="Comments_from_lead__c" rows="4" aria-labelledby="LblComments_from_lead__c InstructComments_from_lead__c" class=" mktoRequired" maxlength="2000" aria-required="true" ></textarea>
+                  <textarea class="is-required" required="" id="Comments_from_lead__c" name="Comments_from_lead__c" rows="4" aria-labelledby="LblComments_from_lead__c InstructComments_from_lead__c" maxlength="2000" aria-required="true" ></textarea>
                 </li>
               </ul>
             </fieldset>
 
             <fieldset class="u-no-margin--bottom">
               <ul class="p-list">
-                <li class="mktField p-list__item">
-                  <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                <li class="p-list__item">
+                  <input value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
                   <label for="canonicalUpdatesOptIn">I agree to receive information about Canonical’s products and services.</label>
                 </li>
                 <br>
@@ -120,19 +120,19 @@
                 </li>
               </ul>
               <div class="u-hide">
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %%" />
                 <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
                 <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
               </div>
               <div class="pagination">
-                <button type="submit" class="pagination__link--next p-button--positive mktoButton" aria-label="Submit">Join the beta</button>
+                <button type="submit" class="pagination__link--next p-button--positive" aria-label="Submit">Join the beta</button>
               </div>
             </fieldset>
           </form>

--- a/templates/shared/forms/interactive/embedded.html
+++ b/templates/shared/forms/interactive/embedded.html
@@ -145,29 +145,29 @@
         <div class="col-6">
           <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
             <ul class="p-list">
-              <li class="mktFormReq mktField p-list__item">
-                <label for="firstName" class="mktoLabel">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="lastName" class="mktoLabel">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="company" class="mktoLabel">Company:</label>
-                <input required id="company" name="company" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="company">Company:</label>
+                <input required id="company" name="company" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="email" class="mktoLabel">Email address:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="email">Email address:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
-                <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="phone">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
               </li>
-              <li class="mktField p-list__item">
-                <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-                <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
+              <li class="p-list__item">
+                <input value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                <label for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
               </li>
               <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
               <li class="p-list__item">
@@ -178,26 +178,26 @@
             <div class="u-hide">
               <h3>Your comments</h3>
               <ul class="p-list">
-                <li class="mktFormReq mktField p-list__item">
-                  <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
-                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
+                <li class="p-list__item">
+                  <label for="Comments_from_lead__c">What would you like to talk to us about?</label>
+                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
             </div>
 
             <div class="pagination">
               <a class="pagination__link--previous p-button--neutral" href="">Previous</a>
-              <button type="submit" class="pagination__link--next p-button--positive mktoButton" aria-label="Submit">Let's discuss</button>
+              <button type="submit" class="pagination__link--next p-button--positive" aria-label="Submit">Let's discuss</button>
             </div>
           </form>
         </div>

--- a/templates/shared/forms/interactive/esm.html
+++ b/templates/shared/forms/interactive/esm.html
@@ -87,27 +87,27 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
             <ul class="p-list">
-              <li class="mktFormReq mktField p-list__item">
-                <label for="firstName" class="mktoLabel">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" />
+              <li class="p-list__item">
+                <label for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="lastName" class="mktoLabel">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" />
+              <li class="p-list__item">
+                <label for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" />
+              <li class="p-list__item">
+                <label for="email">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="phone" class="mktoLabel ">Mobile number:</label>
-                <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="phone" >Mobile number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
               </li>
-              <li class="mktField p-list__item">
-                <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-                <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
+              <li class="p-list__item">
+                <input value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                <label for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
               </li>
               <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
               <li class="p-list__item">
@@ -118,26 +118,26 @@
             <div class="u-hide">
               <h3>Your comments</h3>
               <ul class="p-list">
-                <li class="mktFormReq mktField p-list__item">
-                  <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
-                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
+                <li class="p-list__item">
+                  <label for="Comments_from_lead__c">What would you like to talk to us about?</label>
+                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
             </div>
 
             <div class="pagination">
               <a class="pagination__link--previous p-button--neutral" href="">Previous</a>
-              <button type="submit" class="pagination__link--next p-button--positive mktoButton" aria-label="Submit">Let's discuss</button>
+              <button type="submit" class="pagination__link--next p-button--positive" aria-label="Submit">Let's discuss</button>
             </div>
           </form>
         </div>

--- a/templates/shared/forms/interactive/financial.html
+++ b/templates/shared/forms/interactive/financial.html
@@ -103,21 +103,21 @@
         <div class="col-6">
           <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
             <ul class="p-list">
-              <li class="mktFormReq mktField p-list__item">
-                <label for="firstName" class="mktoLabel">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" />
+              <li class="p-list__item">
+                <label for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="lastName" class="mktoLabel">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" />
+              <li class="p-list__item">
+                <label for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" />
+              <li class="p-list__item">
+                <label for="email">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
               </li>
-              <li class="mktField p-list__item">
-                <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-                <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical’s products and services.</label>
+              <li class="p-list__item">
+                <input value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                <label for="canonicalUpdatesOptIn">I agree to receive information about Canonical’s products and services.</label>
               </li>
               <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical’s Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
               <li class="p-list__item">
@@ -128,26 +128,26 @@
             <div class="u-hide">
               <h3>Your comments</h3>
               <ul class="p-list">
-                <li class="mktFormReq mktField p-list__item">
-                  <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
-                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
+                <li class="p-list__item">
+                  <label for="Comments_from_lead__c">What would you like to talk to us about?</label>
+                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
             </div>
 
             <div class="pagination">
               <a class="pagination__link--previous p-button--neutral" href="">Previous</a>
-              <button type="submit" class="pagination__link--next p-button--positive mktoButton" aria-label="Submit">Let's discuss</button>
+              <button type="submit" class="pagination__link--next p-button--positive" aria-label="Submit">Let's discuss</button>
             </div>
           </form>
         </div>

--- a/templates/shared/forms/interactive/gcp.html
+++ b/templates/shared/forms/interactive/gcp.html
@@ -112,25 +112,25 @@
             <div class="col-6">
                 <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
                 <ul class="p-list">
-                    <li class="mktFormReq mktField p-list__item">
-                    <label for="firstName" class="mktoLabel">First name:</label>
-                    <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                    <li class="p-list__item">
+                    <label for="firstName">First name:</label>
+                    <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
                     </li>
-                    <li class="mktFormReq mktField p-list__item">
-                    <label for="lastName" class="mktoLabel">Last name:</label>
-                    <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                    <li class="p-list__item">
+                    <label for="lastName">Last name:</label>
+                    <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
                     </li>
-                    <li class="mktFormReq mktField p-list__item">
-                    <label for="email" class="mktoLabel">Work email:</label>
-                    <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+                    <li class="p-list__item">
+                    <label for="email">Work email:</label>
+                    <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
                     </li>
-                    <li class="mktFormReq mktField p-list__item">
-                    <label for="phone" class="mktoLabel ">Phone number:</label>
-                    <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+                    <li class="p-list__item">
+                    <label for="phone">Phone number:</label>
+                    <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
                     </li>
-                    <li class="mktField p-list__item">
-                    <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-                    <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
+                    <li class="p-list__item">
+                    <input value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                    <label for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
                     </li>
                     <br />
                     <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
@@ -142,26 +142,26 @@
                 <div class="u-hide">
                     <h3>Your comments</h3>
                     <ul class="p-list">
-                    <li class="mktFormReq mktField p-list__item">
-                        <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
-                        <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
+                    <li class="p-list__item">
+                        <label for="Comments_from_lead__c">What would you like to talk to us about?</label>
+                        <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
                     </li>
                     </ul>
-                    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+                    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %%" />
                     <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-                    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-                    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-                    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-                    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-                    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-                    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-                    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+                    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+                    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+                    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+                    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+                    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+                    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+                    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
                     <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
                 </div>
 
                 <div class="pagination">
                     <a class="pagination__link--previous p-button--neutral" href="">Previous</a>
-                    <button type="submit" class="pagination__link--next p-button--positive mktoButton" aria-label="Submit">Let's discuss</button>
+                    <button type="submit" class="pagination__link--next p-button--positive" aria-label="Submit">Let's discuss</button>
                 </div>
                 </form>
             </div>

--- a/templates/shared/forms/interactive/general.html
+++ b/templates/shared/forms/interactive/general.html
@@ -181,25 +181,25 @@
         <div class="col-6">
           <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
             <ul class="p-list">
-              <li class="mktFormReq mktField p-list__item">
-                <label for="firstName" class="mktoLabel">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" />
+              <li class="p-list__item">
+                <label for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="lastName" class="mktoLabel">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" />
+              <li class="p-list__item">
+                <label for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" />
+              <li class="p-list__item">
+                <label for="email">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
-                <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="phone">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
               </li>
-              <li class="mktField p-list__item">
-                <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-                <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
+              <li class="p-list__item">
+                <input value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                <label for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
               </li>
               <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
               <li class="p-list__item">
@@ -210,26 +210,26 @@
             <div class="u-hide">
               <h3>Your comments</h3>
               <ul class="p-list">
-                <li class="mktFormReq mktField p-list__item">
-                  <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
-                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
+                <li class="p-list__item">
+                  <label for="Comments_from_lead__c">What would you like to talk to us about?</label>
+                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
             </div>
 
             <div class="pagination">
               <a class="pagination__link--previous p-button--neutral" href="">Previous</a>
-              <button type="submit" class="pagination__link--next p-button--positive mktoButton" aria-label="Submit">Let's discuss</button>
+              <button type="submit" class="pagination__link--next p-button--positive" aria-label="Submit">Let's discuss</button>
             </div>
           </form>
         </div>

--- a/templates/shared/forms/interactive/internet-of-things.html
+++ b/templates/shared/forms/interactive/internet-of-things.html
@@ -55,31 +55,31 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
             <ul class="p-list">
-              <li class="mktFormReq mktField p-list__item">
-                <label for="firstName" class="mktoLabel">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="lastName" class="mktoLabel">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="company" class="mktoLabel">Company:</label>
-                <input required id="company" name="company" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="company">Company:</label>
+                <input required id="company" name="company" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="email" class="mktoLabel">Email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="email">Email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
-                <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="phone">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
               </li>
-              <li class="mktField p-list__item">
-                <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-                <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
+              <li class="p-list__item">
+                <input value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                <label for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
               </li>
               <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
               <li class="p-list__item">
@@ -90,26 +90,26 @@
             <div class="u-hide">
               <h3>Your comments</h3>
               <ul class="p-list">
-                <li class="mktFormReq mktField p-list__item">
-                  <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
-                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
+                <li class="p-list__item">
+                  <label for="Comments_from_lead__c">What would you like to talk to us about?</label>
+                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
             </div>
 
             <div class="pagination">
               <a class="pagination__link--previous p-button--neutral" href="">Previous</a>
-              <button type="submit" class="pagination__link--next p-button--positive mktoButton" aria-label="Submit">Let's discuss</button>
+              <button type="submit" class="pagination__link--next p-button--positive" aria-label="Submit">Let's discuss</button>
             </div>
           </form>
         </div>

--- a/templates/shared/forms/interactive/kubeflow.html
+++ b/templates/shared/forms/interactive/kubeflow.html
@@ -131,25 +131,25 @@
         <div class="col-6">
           <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
             <ul class="p-list">
-              <li class="mktFormReq mktField p-list__item">
-                <label for="firstName" class="mktoLabel">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="lastName" class="mktoLabel">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="email">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
-                <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="phone">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
               </li>
-              <li class="mktField p-list__item">
-                <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-                <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
+              <li class="p-list__item">
+                <input value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                <label for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
               </li>
               <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
               <li class="p-list__item">
@@ -160,26 +160,26 @@
             <div class="u-hide">
               <h3>Your comments</h3>
               <ul class="p-list">
-                <li class="mktFormReq mktField p-list__item">
-                  <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
-                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
+                <li class="p-list__item">
+                  <label for="Comments_from_lead__c">What would you like to talk to us about?</label>
+                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
             </div>
 
             <div class="pagination">
               <a class="pagination__link--previous p-button--neutral" href="">Previous</a>
-              <button type="submit" class="pagination__link--next p-button--positive mktoButton" aria-label="Submit">Let's discuss</button>
+              <button type="submit" class="pagination__link--next p-button--positive" aria-label="Submit">Let's discuss</button>
             </div>
           </form>
         </div>

--- a/templates/shared/forms/interactive/kubernetes.html
+++ b/templates/shared/forms/interactive/kubernetes.html
@@ -12,27 +12,27 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form p-form p-form--stacked marketo-form">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form p-form p-form--stacked">
             <ul class="p-list">
-              <li class="mktFormReq mktField p-list__item">
-                <label for="firstName" class="mktoLabel">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="lastName" class="mktoLabel">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="email">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
-                <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="phone">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
               </li>
-              <li class="mktField p-list__item">
-                <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-                <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
+              <li class="p-list__item">
+                <input value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                <label for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
               </li>
               <li class="p-list__item">In submitting this form, I confirm that I have read and agree to Canonical's <a href="/legal/terms-and-policies/privacy-policy">Privacy Policy</a>.</li>
               <li class="p-list__item">
@@ -43,25 +43,25 @@
             <div class="u-hide">
               <h3>Your comments</h3>
               <ul class="p-list">
-                <li class="mktFormReq mktField p-list__item">
-                  <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
-                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
+                <li class="p-list__item">
+                  <label for="Comments_from_lead__c">What would you like to talk to us about?</label>
+                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
             </div>
 
             <div class="pagination">
-              <button type="submit" class="pagination__link--next p-button--positive mktoButton" aria-label="Submit">Let's discuss</button>
+              <button type="submit" class="pagination__link--next p-button--positive" aria-label="Submit">Let's discuss</button>
             </div>
           </form>
         </div>

--- a/templates/shared/forms/interactive/managed-apps.html
+++ b/templates/shared/forms/interactive/managed-apps.html
@@ -173,27 +173,27 @@
     <h3 class="p-heading--five">How should we get in touch?</h3>
     <div class="row u-no-padding">
       <div class="col-6">
-        <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+        <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
           <ul class="p-list">
-            <li class="mktFormReq mktField p-list__item">
-              <label for="firstName" class="mktoLabel">First name:</label>
-              <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+            <li class="p-list__item">
+              <label for="firstName">First name:</label>
+              <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
             </li>
-            <li class="mktFormReq mktField p-list__item">
-              <label for="lastName" class="mktoLabel">Last name:</label>
-              <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+            <li class="p-list__item">
+              <label for="lastName">Last name:</label>
+              <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
             </li>
-            <li class="mktFormReq mktField p-list__item">
-              <label for="email" class="mktoLabel">Work email:</label>
-              <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+            <li class="p-list__item">
+              <label for="email">Work email:</label>
+              <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
             </li>
-            <li class="mktFormReq mktField p-list__item">
-              <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
-              <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+            <li class="p-list__item">
+              <label for="phone">Mobile/cell phone number:</label>
+              <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
             </li>
-            <li class="mktField p-list__item">
-              <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-              <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
+            <li class="p-list__item">
+              <input value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+              <label for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
             </li>
             <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
             <li class="p-list__item">
@@ -204,26 +204,26 @@
           <div class="u-hide">
             <h3>Your comments</h3>
             <ul class="p-list">
-              <li class="mktFormReq mktField p-list__item">
-                <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
-                <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
+              <li class="p-list__item">
+                <label for="Comments_from_lead__c">What would you like to talk to us about?</label>
+                <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
               </li>
             </ul>
-            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %%" />
             <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
             <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
           </div>
 
           <div class="pagination">
             <a class="pagination__link--previous p-button--neutral" href="">Previous</a>
-            <button type="submit" class="pagination__link--next p-button--positive mktoButton" aria-label="Submit">Let's discuss</button>
+            <button type="submit" class="pagination__link--next p-button--positive" aria-label="Submit">Let's discuss</button>
           </div>
         </form>
       </div>

--- a/templates/shared/forms/interactive/managed-cassandra.html
+++ b/templates/shared/forms/interactive/managed-cassandra.html
@@ -213,23 +213,23 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
             <ul class="p-list">
-              <li class="mktFormReq mktField p-list__item">
-                <label for="firstName" class="mktoLabel">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" />
+              <li class="p-list__item">
+                <label for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="lastName" class="mktoLabel">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" />
+              <li class="p-list__item">
+                <label for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" />
+              <li class="p-list__item">
+                <label for="email">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"/>
               </li>
-              <li class="mktField p-list__item">
-                <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-                <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
+              <li class="p-list__item">
+                <input value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                <label for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
               </li>
               <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
               <li class="p-list__item">
@@ -239,25 +239,25 @@
             <div class="u-hide">
               <h3>Your comments</h3>
               <ul class="p-list">
-                <li class="mktFormReq mktField p-list__item">
-                  <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
-                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
+                <li class="p-list__item">
+                  <label for="Comments_from_lead__c">What would you like to talk to us about?</label>
+                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
             </div>
             <div class="pagination">
               <a class="pagination__link--previous p-button--neutral" href="">Previous</a>
-              <button type="submit" class="pagination__link--next p-button--positive mktoButton" aria-label="Submit">Let's discuss</button>
+              <button type="submit" class="pagination__link--next p-button--positive" aria-label="Submit">Let's discuss</button>
             </div>
           </form>
         </div>

--- a/templates/shared/forms/interactive/managed-kafka.html
+++ b/templates/shared/forms/interactive/managed-kafka.html
@@ -171,23 +171,23 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
             <ul class="p-list">
-              <li class="mktFormReq mktField p-list__item">
-                <label for="firstName" class="mktoLabel">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" />
+              <li class="p-list__item">
+                <label for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="lastName" class="mktoLabel">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" />
+              <li class="p-list__item">
+                <label for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" />
+              <li class="p-list__item">
+                <label for="email">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
               </li>
-              <li class="mktField p-list__item">
-                <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-                <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
+              <li class="p-list__item">
+                <input value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                <label for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
               </li>
               <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
               <li class="p-list__item">
@@ -197,25 +197,25 @@
             <div class="u-hide">
               <h3>Your comments</h3>
               <ul class="p-list">
-                <li class="mktFormReq mktField p-list__item">
-                  <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
-                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
+                <li class="p-list__item">
+                  <label for="Comments_from_lead__c">What would you like to talk to us about?</label>
+                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
             </div>
             <div class="pagination">
               <a class="pagination__link--previous p-button--neutral" href="">Previous</a>
-              <button type="submit" class="pagination__link--next p-button--positive mktoButton" aria-label="Submit">Let's discuss</button>
+              <button type="submit" class="pagination__link--next p-button--positive" aria-label="Submit">Let's discuss</button>
             </div>
           </form>
         </div>

--- a/templates/shared/forms/interactive/managed-kubernetes.html
+++ b/templates/shared/forms/interactive/managed-kubernetes.html
@@ -12,27 +12,27 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
             <ul class="p-list">
-              <li class="mktFormReq mktField p-list__item">
-                <label for="firstName" class="mktoLabel">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="lastName" class="mktoLabel">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="email">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
-                <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="phone">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
               </li>
-              <li class="mktField p-list__item">
-                <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-                <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
+              <li class="p-list__item">
+                <input value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                <label for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
               </li>
               <li class="p-list__item">In submitting this form, I confirm that I have read and agree to Canonical's <a href="/legal/terms-and-policies/privacy-policy"> Privacy Policy</a></li>
               <li class="p-list__item">
@@ -43,26 +43,26 @@
             <div class="u-hide">
               <h3>Your comments</h3>
               <ul class="p-list">
-                <li class="mktFormReq mktField p-list__item">
-                  <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
-                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
+                <li class="p-list__item">
+                  <label for="Comments_from_lead__c">What would you like to talk to us about?</label>
+                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
             </div>
 
             <div class="pagination">
-              <button type="submit" class="pagination__link--next p-button--positive mktoButton" aria-label="Submit">Let's discuss</button>
+              <button type="submit" class="pagination__link--next p-button--positive" aria-label="Submit">Let's discuss</button>
             </div>
           </form>
         </div>

--- a/templates/shared/forms/interactive/managed-services.html
+++ b/templates/shared/forms/interactive/managed-services.html
@@ -52,27 +52,27 @@
         <h3 class="p-heading--five">How should we get in touch?</h3>
         <div class="row u-no-padding">
           <div class="col-6">
-            <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form" >
+            <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form" >
               <ul class="p-list">
-                <li class="mktFormReq mktField p-list__item">
-                  <label for="firstName" class="mktoLabel">First name:</label>
-                  <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                <li class="p-list__item">
+                  <label for="firstName">First name:</label>
+                  <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
                 </li>
-                <li class="mktFormReq mktField p-list__item">
-                  <label for="lastName" class="mktoLabel">Last name:</label>
-                  <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+                <li class="p-list__item">
+                  <label for="lastName">Last name:</label>
+                  <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
                 </li>
-                <li class="mktFormReq mktField p-list__item">
-                  <label for="email" class="mktoLabel">Work email:</label>
-                  <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+                <li class="p-list__item">
+                  <label for="email">Work email:</label>
+                  <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
                 </li>
-                <li class="mktFormReq mktField p-list__item">
-                  <label for="phone" class="mktoLabel" >Mobile/cell phone number:</label >
-                  <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField mktoRequired" required="required" />
+                <li class="p-list__item">
+                  <label for="phone">Mobile/cell phone number:</label >
+                  <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
                 </li>
-                <li class="mktField p-list__item">
-                  <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-                  <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn" >I agree to receive information about Canonical's products and services.</label >
+                <li class="p-list__item">
+                  <input value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                  <label for="canonicalUpdatesOptIn" >I agree to receive information about Canonical's products and services.</label >
                 </li>
                 <li class="p-list__item">
                   In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact" >Canonical's Privacy Notice</a > and <a href="/legal/data-privacy">Privacy Policy</a>.
@@ -85,25 +85,25 @@
               <div class="u-hide">
                 <h3>Your comments</h3>
                 <ul class="p-list">
-                  <li class="mktFormReq mktField p-list__item">
-                    <label for="Comments_from_lead__c" class="mktoLabel" >What would you like to talk to us about?</label >
-                    <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000" ></textarea>
+                  <li class="p-list__item">
+                    <label for="Comments_from_lead__c">What would you like to talk to us about?</label >
+                    <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000" ></textarea>
                   </li>
                 </ul>
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %%" />
                 <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
                 <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
               </div>
               <div class="pagination">
                 <a class="pagination__link--previous p-button--neutral" href="" >Previous</a >
-                <button type="submit" class="pagination__link--next p-button--positive mktoButton" aria-label="Submit" > Let's discuss </button>
+                <button type="submit" class="pagination__link--next p-button--positive" aria-label="Submit" > Let's discuss </button>
               </div>
             </form>
           </div>

--- a/templates/shared/forms/interactive/masters-conference.html
+++ b/templates/shared/forms/interactive/masters-conference.html
@@ -9,15 +9,15 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
             <ul class="p-list">
-              <li class="mktFormReq mktField p-list__item">
-                <label for="email" class="mktoLabel">Email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="email">Email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
-                <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="phone">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
               </li>
               <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
               <li class="p-list__item">
@@ -27,25 +27,25 @@
 
             <div class="u-hide">
               <ul class="p-list">
-                <li class="mktFormReq mktField p-list__item">
-                  <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
-                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
+                <li class="p-list__item">
+                  <label for="Comments_from_lead__c">What would you like to talk to us about?</label>
+                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
             </div>
 
             <div class="pagination">
-              <button type="submit" class="pagination__link--next p-button--positive mktoButton" aria-label="Submit">Subscribe</button>
+              <button type="submit" class="pagination__link--next p-button--positive" aria-label="Submit">Subscribe</button>
             </div>
           </form>
         </div>

--- a/templates/shared/forms/interactive/observability-contact-us.html
+++ b/templates/shared/forms/interactive/observability-contact-us.html
@@ -177,27 +177,27 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
             <ul class="p-list">
-              <li class="mktFormReq mktField p-list__item">
-                <label for="FirstName" class="mktoLabel">First name:</label>
-                <input required id="FirstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="FirstName">First name:</label>
+                <input required id="FirstName" name="firstName" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="LastName" class="mktoLabel">Last name:</label>
-                <input required id="LastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="LastName">Last name:</label>
+                <input required id="LastName" name="lastName" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="Email" class="mktoLabel">Email:</label>
-                <input required id="Email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="Email">Email:</label>
+                <input required id="Email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="Phone" class="mktoLabel ">Mobile/cell phone number:</label>
-                <input required id="Phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="Phone">Mobile/cell phone number:</label>
+                <input required id="Phone" name="phone" maxlength="255" type="tel" required="required" />
               </li>
-              <li class="mktField p-list__item">
-                <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-                <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
+              <li class="p-list__item">
+                <input value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                <label for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
               </li>
               <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
               <li class="p-list__item">
@@ -208,28 +208,28 @@
             <div class="u-hide">
               <h3>Your comments</h3>
               <ul class="p-list">
-                <li class="mktFormReq mktField p-list__item">
-                  <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
-                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
+                <li class="p-list__item">
+                  <label for="Comments_from_lead__c">What would you like to talk to us about?</label>
+                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
                 </li>
               </ul>
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
             </div>
 
             <div class="pagination">
               <a class="pagination__link--previous p-button--neutral" href="">Previous</a>
-              <button type="submit" class="pagination__link--next p-button--positive mktoButton" aria-label="Submit">Let's discuss</button>
+              <button type="submit" class="pagination__link--next p-button--positive" aria-label="Submit">Let's discuss</button>
             </div>
           </form>
         </div>

--- a/templates/shared/forms/interactive/openstack-cost-calculator.html
+++ b/templates/shared/forms/interactive/openstack-cost-calculator.html
@@ -9,35 +9,35 @@
         <h3 class="p-heading--five">Get cost estimates for your private cloud</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
             <ul class="p-list">
-              <li class="mktFormReq mktField p-list__item">
-                <label for="firstName" class="mktoLabel">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="lastName" class="mktoLabel">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="company" class="mktoLabel">Company name:</label>
-                <input required id="company" name="company" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="company">Company name:</label>
+                <input required id="company" name="company" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="jobTitle" class="mktoLabel">Job title:</label>
-                <input required id="jobTitle" name="title" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="jobTitle">Job title:</label>
+                <input required id="jobTitle" name="title" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="email">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
-                <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="phone">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
               </li>
-              <li class="mktField p-list__item u-sv2">
-                <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-                <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I would like to receive occasional news from Canonical by email.</label>
+              <li class="p-list__item u-sv2">
+                <input value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                <label for="canonicalUpdatesOptIn">I would like to receive occasional news from Canonical by email.</label>
               </li>
               <li class="p-list__item">All information provided will be handled in accordance with the Canonical<a href="/legal/data-privacy/contact">Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
               <li class="p-list__item">
@@ -48,9 +48,9 @@
             <div class="u-hide">
               <h3>Your comments</h3>
               <ul class="p-list">
-                <li class="mktFormReq mktField p-list__item">
-                  <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
-                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
+                <li class="p-list__item">
+                  <label for="Comments_from_lead__c">What would you like to talk to us about?</label>
+                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
                 </li>
               </ul>
               <!-- Use hidden inputs to send default values and values to marketo selected by user on main page -->
@@ -127,19 +127,19 @@
                 <input type="number" id="annual-per-gbps-hosting-external-network-cost" value="6000">
               </div>
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
             </div>
             <div class="pagination">
-              <button type="submit" class="pagination__link--next p-button--positive mktoButton" aria-label="Submit">Get cost estimates</button>
+              <button type="submit" class="pagination__link--next p-button--positive" aria-label="Submit">Get cost estimates</button>
             </div>
           </form>
         </div>

--- a/templates/shared/forms/interactive/openstack.html
+++ b/templates/shared/forms/interactive/openstack.html
@@ -284,29 +284,29 @@
 
     <div class="js-pagination js-pagination--3 u-hide">
       <h3 class="p-heading--five">How should we get in touch?</h3>
-      <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+      <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
         <div class="row u-no-padding">
           <div class="col-6">
             <ul class="p-list">
-              <li class="mktFormReq mktField p-list__item">
-                <label for="firstName" class="mktoLabel">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="lastName" class="mktoLabel">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="email">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
-                <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="phone">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
               </li>
-              <li class="mktField p-list__item">
-                <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-                <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
+              <li class="p-list__item">
+                <input value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                <label for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
               </li>
               <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
               <li class="p-list__item">
@@ -317,20 +317,20 @@
             <div class="u-hide">
               <h3>Your comments</h3>
               <ul class="p-list">
-                <li class="mktFormReq mktField p-list__item">
-                  <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
-                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
+                <li class="p-list__item">
+                  <label for="Comments_from_lead__c">What would you like to talk to us about?</label>
+                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
             </div>
           </div>
         </div>
@@ -338,7 +338,7 @@
           <div class="col-12">
             <div class="pagination">
               <a class="pagination__link--previous p-button--neutral" href="">Previous</a>
-              <button type="submit" class="pagination__link--next p-button--positive mktoButton" aria-label="Submit">Let's discuss your requirements</button>
+              <button type="submit" class="pagination__link--next p-button--positive" aria-label="Submit">Let's discuss your requirements</button>
             </div>
           </div>
         </div> 

--- a/templates/shared/forms/interactive/osm-contact-us.html
+++ b/templates/shared/forms/interactive/osm-contact-us.html
@@ -169,27 +169,27 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
             <ul class="p-list">
-              <li class="mktFormReq mktField p-list__item">
-                <label for="firstName" class="mktoLabel">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="lastName" class="mktoLabel">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="email" class="mktoLabel">Email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="email">Email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
-                <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="phone">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
               </li>
-              <li class="mktField p-list__item">
-                <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-                <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
+              <li class="p-list__item">
+                <input value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                <label for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
               </li>
               <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
               <li class="p-list__item">
@@ -200,27 +200,27 @@
             <div class="u-hide">
               <h3>Your comments</h3>
               <ul class="p-list">
-                <li class="mktFormReq mktField p-list__item">
-                  <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
-                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
+                <li class="p-list__item">
+                  <label for="Comments_from_lead__c">What would you like to talk to us about?</label>
+                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
                 </li>
               </ul>
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
             </div>
 
             <div class="pagination">
               <a class="pagination__link--previous p-button--neutral" href="">Previous</a>
-              <button type="submit" class="pagination__link--next p-button--positive mktoButton" aria-label="Submit">Let's discuss</button>
+              <button type="submit" class="pagination__link--next p-button--positive" aria-label="Submit">Let's discuss</button>
             </div>
           </form>
         </div>

--- a/templates/shared/forms/interactive/partner-dell.html
+++ b/templates/shared/forms/interactive/partner-dell.html
@@ -195,27 +195,27 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
             <ul class="p-list">
-              <li class="mktFormReq mktField p-list__item">
-                <label for="firstName" class="mktoLabel">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="lastName" class="mktoLabel">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="email">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
-                <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="phone">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
               </li>
-              <li class="mktField p-list__item">
-                <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-                <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
+              <li class="p-list__item">
+                <input value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                <label for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
               </li>
               <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
               <li class="p-list__item">
@@ -226,25 +226,25 @@
             <div class="u-hide">
               <h3>Your comments</h3>
               <ul class="p-list">
-                <li class="mktFormReq mktField p-list__item">
-                  <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
-                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
+                <li class="p-list__item">
+                  <label for="Comments_from_lead__c">What would you like to talk to us about?</label>
+                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
             </div>
 
             <div class="pagination">
               <a class="pagination__link--previous p-button--neutral" href="">Previous</a>
-              <button type="submit" class="pagination__link--next p-button--positive mktoButton" aria-label="Submit">Let's discuss</button>
+              <button type="submit" class="pagination__link--next p-button--positive" aria-label="Submit">Let's discuss</button>
             </div>
           </form>
         </div>

--- a/templates/shared/forms/interactive/pricing-infra.html
+++ b/templates/shared/forms/interactive/pricing-infra.html
@@ -151,27 +151,27 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
             <ul class="p-list">
-              <li class="mktFormReq mktField p-list__item">
-                <label for="firstName" class="mktoLabel">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="lastName" class="mktoLabel">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="email">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
-                <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="phone">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
               </li>
-              <li class="mktField p-list__item">
-                <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-                <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
+              <li class="p-list__item">
+                <input value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                <label for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
               </li>
               <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
               <li class="p-list__item">
@@ -181,25 +181,25 @@
             <div class="u-hide">
               <h3>Your comments</h3>
               <ul class="p-list">
-                <li class="mktFormReq mktField p-list__item">
-                  <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
-                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
+                <li class="p-list__item">
+                  <label for="Comments_from_lead__c">What would you like to talk to us about?</label>
+                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
             </div>
 
             <div class="pagination">
               <a class="pagination__link--previous p-button--neutral" href="">Previous</a>
-              <button type="submit" class="pagination__link--next p-button--positive mktoButton" aria-label="Submit">Let's discuss</button>
+              <button type="submit" class="pagination__link--next p-button--positive" aria-label="Submit">Let's discuss</button>
             </div>
           </form>
         </div>

--- a/templates/shared/forms/interactive/robotics.html
+++ b/templates/shared/forms/interactive/robotics.html
@@ -163,27 +163,27 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
             <ul class="p-list">
-              <li class="mktFormReq mktField p-list__item">
-                <label for="firstName" class="mktoLabel">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="lastName" class="mktoLabel">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="email">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
-                <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="phone">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
               </li>
-              <li class="mktField p-list__item">
-                <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-                <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
+              <li class="p-list__item">
+                <input value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                <label for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
               </li>
               <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
               <li class="p-list__item">
@@ -194,25 +194,25 @@
             <div class="u-hide">
               <h3>Your comments</h3>
               <ul class="p-list">
-                <li class="mktFormReq mktField p-list__item">
-                  <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
-                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
+                <li class="p-list__item">
+                  <label for="Comments_from_lead__c">What would you like to talk to us about?</label>
+                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
             </div>
 
             <div class="pagination">
               <a class="pagination__link--previous p-button--neutral" href="">Previous</a>
-              <button type="submit" class="pagination__link--next p-button--positive mktoButton" aria-label="Submit">Let's discuss</button>
+              <button type="submit" class="pagination__link--next p-button--positive" aria-label="Submit">Let's discuss</button>
             </div>
           </form>
         </div>

--- a/templates/shared/forms/interactive/robotics_ros.html
+++ b/templates/shared/forms/interactive/robotics_ros.html
@@ -78,35 +78,35 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
             <ul class="p-list">
-              <li class="mktFormReq mktField p-list__item">
-                <label for="firstName" class="mktoLabel">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" />
+              <li class="p-list__item">
+                <label for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="lastName" class="mktoLabel">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" />
+              <li class="p-list__item">
+                <label for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="company" class="mktoLabel">Company:</label>
-                <input required id="company" name="company" maxlength="255" type="text" class="mktoField mktoRequired">
+              <li class="p-list__item">
+                <label for="company">Company:</label>
+                <input required id="company" name="company" maxlength="255" type="text" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="title" class="mktoLabel">Job title:</label>
-                <input required id="title" name="title" maxlength="255" type="text" class="mktoField mktoRequired" />
+              <li class="p-list__item">
+                <label for="title">Job title:</label>
+                <input required id="title" name="title" maxlength="255" type="text" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="email" class="mktoLabel">Email address:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" />
+              <li class="p-list__item">
+                <label for="email">Email address:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="phone" class="mktoLabel">Phone number:</label>
-                <input id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField">
+              <li class="p-list__item">
+                <label for="phone">Phone number:</label>
+                <input id="phone" name="phone" maxlength="255" type="tel">
               </li>
-              <li class="mktField p-list__item">
-                <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-                <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical’s products and services.</label>
+              <li class="p-list__item">
+                <input value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                <label for="canonicalUpdatesOptIn">I agree to receive information about Canonical’s products and services.</label>
               </li>
               <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical’s Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
               <li class="p-list__item">
@@ -117,25 +117,25 @@
             <div class="u-hide">
               <h3>Your comments</h3>
               <ul class="p-list">
-                <li class="mktFormReq mktField p-list__item">
-                  <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
-                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
+                <li class="p-list__item">
+                  <label for="Comments_from_lead__c">What would you like to talk to us about?</label>
+                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
             </div>
 
             <div class="pagination">
               <a class="pagination__link--previous p-button--neutral" href="">Previous</a>
-              <button type="submit" class="pagination__link--next p-button--positive mktoButton" aria-label="Submit">Let's discuss</button>
+              <button type="submit" class="pagination__link--next p-button--positive" aria-label="Submit">Let's discuss</button>
             </div>
           </form>
         </div>

--- a/templates/shared/forms/interactive/smart-start.html
+++ b/templates/shared/forms/interactive/smart-start.html
@@ -175,31 +175,31 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
             <ul class="p-list">
-              <li class="mktFormReq mktField p-list__item">
-                <label for="firstName" class="mktoLabel">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="lastName" class="mktoLabel">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="company" class="mktoLabel">Company:</label>
-                <input required id="company" name="company" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="company">Company:</label>
+                <input required id="company" name="company" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="email">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
-                <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="phone">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
               </li>
-              <li class="mktField p-list__item">
-                <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-                <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
+              <li class="p-list__item">
+                <input value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                <label for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
               </li>
               <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
               <li class="p-list__item">
@@ -210,25 +210,25 @@
             <div class="u-hide">
               <h3>Your comments</h3>
               <ul class="p-list">
-                <li class="mktFormReq mktField p-list__item">
-                  <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
-                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
+                <li class="p-list__item">
+                  <label for="Comments_from_lead__c">What would you like to talk to us about?</label>
+                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
             </div>
 
             <div class="pagination">
               <a class="pagination__link--previous p-button--neutral" href="">Previous</a>
-              <button type="submit" class="pagination__link--next p-button--positive mktoButton" aria-label="Submit">Let's discuss</button>
+              <button type="submit" class="pagination__link--next p-button--positive" aria-label="Submit">Let's discuss</button>
             </div>
           </form>
         </div>

--- a/templates/shared/forms/interactive/storage.html
+++ b/templates/shared/forms/interactive/storage.html
@@ -138,27 +138,27 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
             <ul class="p-list">
-              <li class="mktFormReq mktField p-list__item">
-                <label for="firstName" class="mktoLabel">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="lastName" class="mktoLabel">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="email">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
-                <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="phone">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
               </li>
-              <li class="mktField p-list__item">
-                <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-                <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
+              <li class="p-list__item">
+                <input value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                <label for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
               </li>
               <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
               <li class="p-list__item">
@@ -169,25 +169,25 @@
             <div class="u-hide">
               <h3>Your comments</h3>
               <ul class="p-list">
-                <li class="mktFormReq mktField p-list__item">
-                  <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
-                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
+                <li class="p-list__item">
+                  <label for="Comments_from_lead__c">What would you like to talk to us about?</label>
+                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
             </div>
 
             <div class="pagination">
               <a class="pagination__link--previous p-button--neutral" href="">Previous</a>
-              <button type="submit" class="pagination__link--next p-button--positive mktoButton" aria-label="Submit">Let's discuss</button>
+              <button type="submit" class="pagination__link--next p-button--positive" aria-label="Submit">Let's discuss</button>
             </div>
           </form>
         </div>

--- a/templates/shared/forms/interactive/support-openstack.html
+++ b/templates/shared/forms/interactive/support-openstack.html
@@ -505,59 +505,54 @@
             action="/marketo/submit"
             method="post"
             id="mktoForm_%% formid %%"
-            class="modal-form marketo-form"
+            class="modal-form"
           >
             <ul class="p-list">
-              <li class="mktFormReq mktField p-list__item">
-                <label for="firstName" class="mktoLabel">First name:</label>
+              <li class="p-list__item">
+                <label for="firstName">First name:</label>
                 <input
                   required
                   id="firstName"
                   name="firstName"
                   maxlength="255"
                   type="text"
-                  class="mktoField mktoRequired"
                   required="required"
                 />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="lastName" class="mktoLabel">Last name:</label>
+              <li class="p-list__item">
+                <label for="lastName">Last name:</label>
                 <input
                   required
                   id="lastName"
                   name="lastName"
                   maxlength="255"
                   type="text"
-                  class="mktoField mktoRequired"
                   required="required"
                 />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="email" class="mktoLabel">Work email:</label>
+              <li class="p-list__item">
+                <label for="email">Work email:</label>
                 <input
                   required
                   id="email"
                   name="email"
                   maxlength="255"
                   type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"
-                  class="mktoField mktoEmailField mktoRequired"
                   required="required"
                 />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
-                <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="phone">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
               </li>
-              <li class="mktField p-list__item">
+              <li class="p-list__item">
                 <input
-                  class="mktoField"
                   value="yes"
                   id="canonicalUpdatesOptIn"
                   name="canonicalUpdatesOptIn"
                   type="checkbox"
                 />
                 <label
-                  class="mktoLabel mktoHasWidth"
                   for="canonicalUpdatesOptIn"
                   >I agree to receive information about Canonical's products and
                   services.</label
@@ -582,20 +577,20 @@
             <div class="u-hide">
               <h3>Your comments</h3>
               <ul class="p-list">
-                <li class="mktFormReq mktField p-list__item">
-                  <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
-                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
+                <li class="p-list__item">
+                  <label for="Comments_from_lead__c">What would you like to talk to us about?</label>
+                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
             </div>
 
             <div class="pagination">
@@ -604,7 +599,7 @@
               >
               <button
                 type="submit"
-                class="pagination__link--next p-button--positive mktoButton"
+                class="pagination__link--next p-button--positive"
                 aria-label="Submit"
               >
                 Let's discuss

--- a/templates/shared/forms/interactive/support.html
+++ b/templates/shared/forms/interactive/support.html
@@ -149,27 +149,27 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
             <ul class="p-list">
-              <li class="mktFormReq mktField p-list__item">
-                <label for="firstName" class="mktoLabel">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="lastName" class="mktoLabel">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="email">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
-                <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="phone">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
               </li>
-              <li class="mktField p-list__item">
-                <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-                <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
+              <li class="p-list__item">
+                <input value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                <label for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
               </li>
               <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
               <li class="p-list__item">
@@ -180,25 +180,25 @@
             <div class="u-hide">
               <h3>Your comments</h3>
               <ul class="p-list">
-                <li class="mktFormReq mktField p-list__item">
-                  <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
-                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
+                <li class="p-list__item">
+                  <label for="Comments_from_lead__c">What would you like to talk to us about?</label>
+                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
             </div>
 
             <div class="pagination">
               <a class="pagination__link--previous p-button--neutral" href="">Previous</a>
-              <button type="submit" class="pagination__link--next p-button--positive mktoButton" aria-label="Submit">Let's discuss</button>
+              <button type="submit" class="pagination__link--next p-button--positive" aria-label="Submit">Let's discuss</button>
             </div>
           </form>
         </div>

--- a/templates/shared/forms/interactive/telco-networks.html
+++ b/templates/shared/forms/interactive/telco-networks.html
@@ -102,27 +102,27 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
             <ul class="p-list">
-              <li class="mktFormReq mktField p-list__item">
-                <label for="firstName" class="mktoLabel">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="lastName" class="mktoLabel">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="email" class="mktoLabel">Email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="email">Email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
-                <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="phone">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
               </li>
-              <li class="mktField p-list__item">
-                <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-                <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
+              <li class="p-list__item">
+                <input value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                <label for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
               </li>
               <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
               <li class="p-list__item">
@@ -133,27 +133,27 @@
             <div class="u-hide">
               <h3>Your comments</h3>
               <ul class="p-list">
-                <li class="mktFormReq mktField p-list__item">
-                  <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
-                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
+                <li class="p-list__item">
+                  <label for="Comments_from_lead__c">What would you like to talk to us about?</label>
+                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
                 </li>
               </ul>
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formValidation" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
             </div>
 
             <div class="pagination">
               <a class="pagination__link--previous p-button--neutral" href="">Previous</a>
-              <button type="submit" class="pagination__link--next p-button--positive mktoButton" aria-label="Submit">Let's discuss</button>
+              <button type="submit" class="pagination__link--next p-button--positive" aria-label="Submit">Let's discuss</button>
             </div>
           </form>
         </div>

--- a/templates/shared/forms/interactive/telco.html
+++ b/templates/shared/forms/interactive/telco.html
@@ -243,27 +243,27 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
             <ul class="p-list">
-              <li class="mktFormReq mktField p-list__item">
-                <label for="firstName" class="mktoLabel">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" />
+              <li class="p-list__item">
+                <label for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="lastName" class="mktoLabel">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" />
+              <li class="p-list__item">
+                <label for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" />
+              <li class="p-list__item">
+                <label for="email">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
-                <input required="" id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired">
+              <li class="p-list__item">
+                <label for="phone">Mobile/cell phone number:</label>
+                <input required="" id="phone" name="phone" maxlength="255" type="tel">
               </li>
-              <li class="mktField p-list__item">
-                <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-                <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
+              <li class="p-list__item">
+                <input value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                <label for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
               </li>
               <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
               <li class="p-list__item">
@@ -274,25 +274,25 @@
             <div class="u-hide">
               <h3>Your comments</h3>
               <ul class="p-list">
-                <li class="mktFormReq mktField p-list__item">
-                  <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
-                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
+                <li class="p-list__item">
+                  <label for="Comments_from_lead__c">What would you like to talk to us about?</label>
+                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
             </div>
 
             <div class="pagination">
               <a class="pagination__link--previous p-button--neutral" href="">Previous</a>
-              <button type="submit" class="pagination__link--next p-button--positive mktoButton" aria-label="Submit">Let's discuss</button>
+              <button type="submit" class="pagination__link--next p-button--positive" aria-label="Submit">Let's discuss</button>
             </div>
           </form>
         </div>

--- a/templates/shared/forms/interactive/wsl.html
+++ b/templates/shared/forms/interactive/wsl.html
@@ -79,31 +79,31 @@
       <h3 class="p-heading--five">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
             <ul class="p-list">
-              <li class="mktFormReq mktField p-list__item">
-                <label for="firstName" class="mktoLabel">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="lastName" class="mktoLabel">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="company" class="mktoLabel">Company:</label>
-                <input required id="company" name="company" maxlength="255" type="text" class="mktoField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="company">Company:</label>
+                <input required id="company" name="company" maxlength="255" type="text" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="email" class="mktoLabel">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" class="mktoField mktoEmailField mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="email">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
               </li>
-              <li class="mktFormReq mktField p-list__item">
-                <label for="phone" class="mktoLabel ">Mobile/cell phone number:</label>
-                <input required id="phone" name="phone" maxlength="255" type="tel" class="mktoField mktoTelField  mktoRequired" required="required" />
+              <li class="p-list__item">
+                <label for="phone">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
               </li>
-              <li class="mktField p-list__item">
-                <input class="mktoField" value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-                <label class="mktoLabel mktoHasWidth" for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
+              <li class="p-list__item">
+                <input value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                <label for="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</label>
               </li>
               <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
               <li class="p-list__item">
@@ -114,25 +114,25 @@
             <div class="u-hide">
               <h3>Your comments</h3>
               <ul class="p-list">
-                <li class="mktFormReq mktField p-list__item">
-                  <label for="Comments_from_lead__c" class="mktoLabel">What would you like to talk to us about?</label>
-                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" class="mktoField" maxlength="2000"></textarea>
+                <li class="p-list__item">
+                  <label for="Comments_from_lead__c">What would you like to talk to us about?</label>
+                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" class="mktoField" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" class="mktoField" id="utm_campaign" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" class="mktoField" id="utm_medium" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" class="mktoField" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" class="mktoField" id="utm_content" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" class="mktoField" id="utm_term" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" class="mktoField" id="GCLID__c" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" class="mktoField" id="FBLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="FBCLID__c" id="FBLID__c" value="" />
             </div>
 
             <div class="pagination">
               <a class="pagination__link--previous p-button--neutral" href="">Previous</a>
-              <button type="submit" class="pagination__link--next p-button--positive mktoButton" aria-label="Submit">Let's discuss</button>
+              <button type="submit" class="pagination__link--next p-button--positive" aria-label="Submit">Let's discuss</button>
             </div>
           </form>
         </div>


### PR DESCRIPTION
## Done
- Removed `mkto` classes including `mktoLogicalField`,`mktoCheckboxList`,`mktFormCheckbox`,`mktoHasWidth`, `mktFormReq`,`mktField`,`mktoField`,` mktoEmailField`,`mktoRequired`,` mktLblRight`,`mktoFieldDescriptor`, `marketo-Form`,`mktoLabel`,`mktoInvalid`

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Please check all the forms are submitting properly

## Issue / Card

Fixes [#4535](https://github.com/canonical-web-and-design/web-squad/issues/4439)
Refer to this [epic](https://github.com/canonical-web-and-design/web-squad/issues/4436)