### PR TITLE
disable buttons when the form is submitted

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionEdit/SubscriptionEdit.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionEdit/SubscriptionEdit.tsx
@@ -208,15 +208,17 @@ const SubscriptionEdit = ({
                 <Button
                   appearance="base"
                   className="p-subscription__resize-action"
+                  disabled={isResizing}
                   onClick={onClose}
                   type="button"
                 >
                   Cancel
                 </Button>
                 <ActionButton
+                  data-testId="resize-submit-button"
                   appearance="positive"
                   className="p-subscription__resize-action"
-                  disabled={!dirty || !isValid}
+                  disabled={!dirty || !isValid || isResizing}
                   loading={isResizing}
                   success={isResized}
                   type="submit"


### PR DESCRIPTION
## Done

- disable submit and cancel buttons when the form is submitted


## QA
- checkout this branch
- go to /advantage?test_backend=true
- edit existing subscription and attempt to change the size
- check that none of the buttons (resize/cancel) can be clicked until the request has finished

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/10573

