### PR TITLE
Add CTA to "What is observability"

### DIFF
--- a/templates/observability/index.html
+++ b/templates/observability/index.html
@@ -16,7 +16,8 @@
         <h2>Monitoring tools and dashboards, secured and supported</h2>
         <p>Metrics, distributed tracing, logs, dashboards, alerts. Always know how well your applications are running in the Cloud, in containers, on virtual machines or bare metal.</p>
         <p>Canonical offers security and support for the best in class open source monitoring tools and dashboards, and can also run these tools for you on private and public clouds.</p>
-        <p><a href="/observability/contact-us" class="p-button--positive js-invoke-modal">Contact Us</a></p>
+        <a href="/observability/contact-us" class="p-button--positive js-invoke-modal">Contact Us</a>
+        <a href="/observability/what-is-observability">What is Observability?</a>
       </div>
       <div class="col-5 u-align--center u-vertically-center u-hide--small">
         {{ image (


### PR DESCRIPTION
## Done

- Added the CTA to link to "What is observability" from the `/observability` page.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes `#-1`

## Screenshots

[If relevant, please include a screenshot.]
