### PR TITLE
[21.10 release] Remove 21.04 webinar from /download/server

### DIFF
--- a/templates/download/server/step2.html
+++ b/templates/download/server/step2.html
@@ -101,12 +101,6 @@
         <button type="submit" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Server download', 'eventAction' : 'Select option', 'eventLabel' : 'Manual install - latest', 'eventValue' : undefined });">Download Ubuntu Server {{ releases.latest.full_version }}</button>
       </form>
       <p>
-        <a href="/engage/ubuntu-21.04-release-webinar?utm_source=brighttalk-portal&utm_medium=web&utm_content=ubuntu%2021.04&utm_campaign=webcasts-server-download">
-          Watch the webinar - "What's new in Ubuntu Server 21.04?"&nbsp;&rsaquo;
-        </a>
-      </p>
-
-      <p>
         <a href="{{ releases.latest.release_notes_url }}">
           Read the Ubuntu Server {{ releases.latest.short_version }} release notes&nbsp;&rsaquo;
         </a>


### PR DESCRIPTION
## Done

- Remove 21.04 webinar from /download/server

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/server
- See that the webinar has been removed
