### PR TITLE
Update thunderbird version to 91.1.2

### DIFF
--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -81,7 +81,7 @@
         <li class="p-list__item is-ticked">NVIDIA driver support for Wayland sessions</li>
         <li class="p-list__item is-ticked">PulseAudio 15 delivering improved audio quality over Bluetooth</li>
         <li class="p-list__item is-ticked">Up to date toolchains including Python 3.9, PHP 8, Ruby 2.7,  Perl 5.32, Golang 1.17 and GCC-11</li>
-        <li class="p-list__item is-ticked">Core productivity apps LibreOffice 7.2.1, Thunderbird 91.1.1 and Firefox 93</li>
+        <li class="p-list__item is-ticked">Core productivity apps LibreOffice 7.2.1, Thunderbird 91.1.2 and Firefox 93</li>
       </ul>
       <p>
         21.10 builds on key additions from 21.04, including:


### PR DESCRIPTION
## Done

- Update thunderbird version

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/destkop/developers
- See that it is now 91.1.2

