### PR TITLE
Adapt payment methods page for blender

### DIFF
--- a/webapp/advantage/views.py
+++ b/webapp/advantage/views.py
@@ -579,12 +579,15 @@ def payment_methods_view():
 
     if account:
         account_id = account["id"]
+        subscriptions = []
 
-        subscriptions = g.api.get_account_subscriptions(
-            account_id=account_id,
-            marketplace="canonical-ua",
-            filters={"status": "locked"},
-        )
+        for marketplace in SERVICES:
+            market_subscriptions = g.api.get_account_subscriptions(
+                account_id=account_id,
+                marketplace=marketplace,
+                filters={"status": "locked"},
+            )
+            subscriptions.extend(market_subscriptions)
 
         for subscription in subscriptions:
             if subscription.get("pendingPurchases"):


### PR DESCRIPTION
## Done

- Update payment methods page to solve pending payments problem for all services, not just UA.

## QA

- Go to: https://ubuntu-com-10616.demos.haus/advantage?test_backend=true
- Login 
- Go to: https://ubuntu-com-10616.demos.haus/account/payment-methods?test_backend=true
- Set your card to: 4000 0027 6000 3184
- Go to: https://ubuntu-com-10616.demos.haus/advantage?test_backend=true
- Make a resize or purchase and when you are asked for 3ds check, press cancel so it fails
- Follow the notification instructions and fix your pending payment. It should work.

## Issue / Card

Fixes #https://github.com/canonical-web-and-design/commercial-squad/issues/327