### PR TITLE
Fix multi period subscriptions

### DIFF
--- a/tests/advantage/fixtures/contract-item-shop.json
+++ b/tests/advantage/fixtures/contract-item-shop.json
@@ -16,6 +16,7 @@
     "lastModified": "2014-03-01T10:00:00Z",
     "metric": "units",
     "productListingID": "lAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP2",
+    "subscriptionID": "sAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP2",
     "purchaseID": "pAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP2",
     "reason": "purchase_made",
     "value": 1

--- a/tests/advantage/helpers.py
+++ b/tests/advantage/helpers.py
@@ -137,6 +137,7 @@ def make_contract_item(
     value: int = None,
     product_listing_id: str = None,
     purchase_id: str = None,
+    subscription_id: str = None,
     trial_id: str = None,
     renewal: Renewal = None,
 ) -> ContractItem:
@@ -150,6 +151,7 @@ def make_contract_item(
         value=value or 5,
         product_listing_id=product_listing_id or "lAaBbCcDdEeFfGg",
         purchase_id=purchase_id or "pAaBbCcDdEeFfGg",
+        subscription_id=subscription_id or "sAaBbCcDdEeFfGg",
         trial_id=trial_id or None,
         renewal=renewal or None,
     )

--- a/tests/advantage/test_helpers.py
+++ b/tests/advantage/test_helpers.py
@@ -14,7 +14,6 @@ from tests.advantage.helpers import (
 )
 from webapp.advantage.models import Entitlement
 from webapp.advantage.ua_contracts.helpers import (
-    group_items_by_listing,
     get_items_aggregated_values,
     get_machine_type,
     is_trialling_user_subscription,
@@ -25,43 +24,60 @@ from webapp.advantage.ua_contracts.helpers import (
     get_user_subscription_statuses,
     extract_last_purchase_ids,
     get_price_info,
-    get_subscription_by_period,
     set_listings_trial_status,
     apply_entitlement_rules,
     to_dict,
+    group_shop_items,
 )
 
 
 class TestHelpers(unittest.TestCase):
-    def test_group_items_by_listing(self):
+    def test_group_shop_items(self):
         items = [
-            make_contract_item(product_listing_id="listing-id-1"),
-            make_contract_item(product_listing_id="listing-id-2"),
-            make_contract_item(product_listing_id="listing-id-1"),
-            make_contract_item(product_listing_id="listing-id-2"),
-            make_contract_item(product_listing_id="listing-id-2"),
-            make_contract_item(product_listing_id="listing-id-3"),
+            make_contract_item(
+                product_listing_id="listing-id-1", subscription_id="sub-id-1"
+            ),
+            make_contract_item(
+                product_listing_id="listing-id-2", subscription_id="sub-id-1"
+            ),
+            make_contract_item(
+                product_listing_id="listing-id-1", subscription_id="sub-id-1"
+            ),
+            make_contract_item(
+                product_listing_id="listing-id-2", subscription_id="sub-id-1"
+            ),
+            make_contract_item(
+                product_listing_id="listing-id-2", subscription_id="sub-id-2"
+            ),
+            make_contract_item(
+                product_listing_id="listing-id-3", subscription_id="sub-id-1"
+            ),
         ]
 
-        grouped_items = group_items_by_listing(items=items)
+        grouped_items = group_shop_items(items=items)
 
-        expected_number_of_groups = 3
+        expected_number_of_groups = 4
         expected_number_of_items_in_first_group = 2
-        expected_number_of_items_in_second_group = 3
+        expected_number_of_items_in_second_group = 2
         expected_number_of_items_in_third_group = 1
+        expected_number_of_items_in_forth_group = 1
 
         self.assertEqual(expected_number_of_groups, len(grouped_items))
         self.assertEqual(
             expected_number_of_items_in_first_group,
-            len(grouped_items["listing-id-1"]),
+            len(grouped_items["listing-id-1||sub-id-1"]),
         )
         self.assertEqual(
             expected_number_of_items_in_second_group,
-            len(grouped_items["listing-id-2"]),
+            len(grouped_items["listing-id-2||sub-id-1"]),
         )
         self.assertEqual(
             expected_number_of_items_in_third_group,
-            len(grouped_items["listing-id-3"]),
+            len(grouped_items["listing-id-2||sub-id-2"]),
+        )
+        self.assertEqual(
+            expected_number_of_items_in_forth_group,
+            len(grouped_items["listing-id-3||sub-id-1"]),
         )
 
     def test_get_items_aggregated_values(self):
@@ -234,27 +250,35 @@ class TestHelpers(unittest.TestCase):
 
     def test_is_user_subscription_not_cancelled(self):
         listing = make_listing(id="lAaBbCcDd")
+        subscription_id = "sub-id-1"
         subscriptions = [
             make_subscription(
+                id=subscription_id,
                 period="monthly",
                 items=[make_subscription_item(product_listing_id="lAaBbCcDd")],
             )
         ]
 
-        is_cancelled = is_user_subscription_cancelled(listing, subscriptions)
+        is_cancelled = is_user_subscription_cancelled(
+            listing, subscriptions, subscription_id
+        )
 
         self.assertEqual(is_cancelled, False)
 
     def test_is_user_subscription_cancelled(self):
         listing = make_listing(id="lAaBbCcDd")
+        subscription_id = "sub-id-1"
         subscriptions = [
             make_subscription(
+                id=subscription_id,
                 period="monthly",
                 items=[make_subscription_item(product_listing_id="randomID")],
             )
         ]
 
-        is_cancelled = is_user_subscription_cancelled(listing, subscriptions)
+        is_cancelled = is_user_subscription_cancelled(
+            listing, subscriptions, subscription_id
+        )
 
         self.assertEqual(is_cancelled, True)
 
@@ -386,13 +410,15 @@ class TestHelpers(unittest.TestCase):
                 "parameters": {
                     "type": "monthly",
                     "end_date": "2020-09-01T00:00:00Z",
+                    "subscription_id": "sub-id-1",
                     "subscriptions": [
                         make_subscription(
+                            id="sub-id-1",
                             items=[
                                 make_subscription_item(
                                     product_listing_id="listing-id"
                                 )
-                            ]
+                            ],
                         )
                     ],
                     "listing": make_listing(id="listing-id"),
@@ -415,13 +441,16 @@ class TestHelpers(unittest.TestCase):
                 "parameters": {
                     "type": "monthly",
                     "end_date": "2020-09-05T00:00:00Z",
+                    "subscription_id": "sub-id-1",
                     "subscriptions": [
                         make_subscription(
+                            id="sub-id-1",
                             items=[
                                 make_subscription_item(
                                     product_listing_id="random-id"
                                 )
-                            ]
+                            ],
+                            status="deactivated",
                         )
                     ],
                     "listing": make_listing(id="listing-id"),
@@ -568,6 +597,7 @@ class TestHelpers(unittest.TestCase):
                         type=parameters.get("type"),
                         end_date=parameters.get("end_date"),
                         renewal=parameters.get("renewal"),
+                        subscription_id=parameters.get("subscription_id"),
                         subscriptions=parameters.get("subscriptions"),
                         listing=parameters.get("listing"),
                     )
@@ -577,6 +607,11 @@ class TestHelpers(unittest.TestCase):
     def test_extract_last_purchase_ids(self):
         subscriptions = [
             make_subscription(period="monthly", last_purchase_id="pABC1"),
+            make_subscription(
+                period="monthly",
+                last_purchase_id="pABC1",
+                status="deactivated",
+            ),
             make_subscription(period="yearly", last_purchase_id="pABC2"),
         ]
 
@@ -610,49 +645,6 @@ class TestHelpers(unittest.TestCase):
         }
 
         self.assertEqual(last_purchase_ids, expectation)
-
-    def test_get_subscription_by_period(self):
-        subscriptions = [
-            make_subscription(id="yearly_sub", period="yearly"),
-            make_subscription(id="monthly_sub", period="monthly"),
-        ]
-        listing = make_listing(period="monthly")
-
-        subscription = get_subscription_by_period(subscriptions, listing)
-
-        self.assertEqual(subscription.id, "monthly_sub")
-
-    def test_get_subscription_by_period_has_no_subscription(self):
-        subscriptions = [
-            make_subscription(id="yearly_sub", period="yearly"),
-        ]
-
-        listing = make_listing(period="monthly")
-
-        subscription = get_subscription_by_period(subscriptions, listing)
-
-        self.assertEqual(subscription, None)
-
-    def test_get_subscription_by_period_with_listing_without_period(self):
-        subscriptions = [
-            make_subscription(id="yearly_sub", period="yearly"),
-            make_subscription(id="monthly_sub", period="monthly"),
-        ]
-
-        listing = make_listing()
-        listing.period = None
-
-        subscription = get_subscription_by_period(subscriptions, listing)
-
-        self.assertEqual(subscription, None)
-
-    def test_get_subscription_by_period_with_no_listing(self):
-        subscriptions = None
-        listing = None
-
-        subscription = get_subscription_by_period(subscriptions, listing)
-
-        self.assertEqual(subscription, None)
 
     def test_set_listings_trial_status_to_true(self):
         subscriptions = [

--- a/tests/advantage/test_parsers.py
+++ b/tests/advantage/test_parsers.py
@@ -362,6 +362,7 @@ class TestParsers(unittest.TestCase):
                 reason="purchase_made",
                 value=1,
                 product_listing_id="lAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP2",
+                subscription_id="sAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP2",
                 purchase_id="pAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP2",
                 trial_id=None,
             ),

--- a/webapp/advantage/ua_contracts/parsers.py
+++ b/webapp/advantage/ua_contracts/parsers.py
@@ -130,6 +130,7 @@ def parse_contract_items(raw_items: List[Dict] = None) -> List[ContractItem]:
             value=raw_item.get("value"),
             product_listing_id=raw_item.get("productListingID"),
             purchase_id=raw_item.get("purchaseID"),
+            subscription_id=raw_item.get("subscriptionID"),
             trial_id=raw_item.get("trialID"),
             renewal=parse_renewal(raw_renewal) if raw_renewal else None,
         )

--- a/webapp/advantage/ua_contracts/primitives.py
+++ b/webapp/advantage/ua_contracts/primitives.py
@@ -37,6 +37,7 @@ class ContractItem:
         reason: str,
         value: int,
         product_listing_id: str = None,
+        subscription_id: str = None,
         purchase_id: str = None,
         trial_id: str = None,
         renewal: Renewal = None,
@@ -49,6 +50,7 @@ class ContractItem:
         self.value = value
         self.product_listing_id = product_listing_id
         self.purchase_id = purchase_id
+        self.subscription_id = subscription_id
         self.trial_id = trial_id
         self.renewal = renewal
 


### PR DESCRIPTION
## Done

Fix the situation where we have two subscriptions for the same period still showing up: 
- Let's say we bought product X
- We cancel the subscription
- We buy product X again
- We only see one single user subscription

There are two problems:
1. Last purchase id was fetched incorrectly
2. Even when if fetched correctly, the resizing is bugged, because the pre-filled number of machines in the input field is the total of both cancelled and active subscription, instead of the the active on

Solution:
- Instead of splitting contract items by product listing id only, we will split them by product listing id _AND_ stripe subscription ID
- Each shop contract item comes with subscription ID, but we were not extracting it before with the parser

## QA

- Create new UO account or have one with 0 monthly subscriptions
- Go to: https://ubuntu-com-10618.demos.haus/advantage?test_backend=true
- Buy product X
- Check your user subscriptions at: https://ubuntu-com-10618.demos.haus/advantage/user-subscriptions?test_backend=true (no new advantage yet)
- We cancel the one and only monthly subscription (the one we just bought)
- We buy product X again
- We now see two user subscriptions for your product: https://ubuntu-com-10618.demos.haus/advantage/user-subscriptions?test_backend=true

## Issue / Card

Fixes #https://github.com/canonical-web-and-design/commercial-squad/issues/325