### PR TITLE
Adapt user subscriptions to multiple marketplaces

### DIFF
--- a/webapp/advantage/ua_contracts/api.py
+++ b/webapp/advantage/ua_contracts/api.py
@@ -82,7 +82,7 @@ class UAContractsAPI:
             method="get",
             path=(
                 f"v1/accounts/{account_id}/contracts"
-                f"?productTags=ua&productTags=classic&productTags=pro"
+                f"?productTags=ua,classic,pro,blender"
             ),
             error_rules=["default"],
         )

--- a/webapp/advantage/ua_contracts/builders.py
+++ b/webapp/advantage/ua_contracts/builders.py
@@ -48,6 +48,10 @@ def build_free_item_groups(user_summary: List) -> List:
         contracts: List[Contract] = user_details.get("contracts")
 
         for contract in contracts:
+            # skip contracts without items
+            if contract.items is None:
+                continue
+
             if contract.product_id == "free":
                 free_item_groups.append(
                     {
@@ -72,6 +76,14 @@ def build_trial_item_groups(
         contracts: List[Contract] = user_details.get("contracts")
 
         for contract in contracts:
+            # skip free contracts
+            if contract.product_id == "free":
+                continue
+
+            # skip contracts without items
+            if contract.items is None:
+                continue
+
             for item in contract.items:
                 if item.reason == "trial_started":
                     listing = listings[item.product_listing_id]
@@ -172,10 +184,12 @@ def build_final_user_subscriptions(
         contract: Contract = group.get("contract")
         subscriptions: List[Subscription] = group.get("subscriptions")
         items: List[ContractItem] = group.get("items")
+        marketplace = group.get("marketplace")
         type = group.get("type")
         subscription_id = group.get("subscription_id")
         aggregated_values = get_items_aggregated_values(items)
         number_of_machines = aggregated_values.get("number_of_machines")
+        end_date = aggregated_values.get("end_date")
         price_info = get_price_info(number_of_machines, items, listing)
         renewal = items[0].renewal if type == "legacy" else None
         product_name = (
@@ -183,7 +197,7 @@ def build_final_user_subscriptions(
         )
         statuses = get_user_subscription_statuses(
             type=type,
-            end_date=aggregated_values.get("end_date"),
+            end_date=end_date,
             renewal=renewal,
             subscription_id=subscription_id,
             subscriptions=subscriptions or [],
@@ -200,10 +214,10 @@ def build_final_user_subscriptions(
             account_id=account.id,
             entitlements=apply_entitlement_rules(contract.entitlements),
             start_date=aggregated_values.get("start_date"),
-            end_date=aggregated_values.get("end_date"),
+            end_date=end_date,
             number_of_machines=number_of_machines,
             product_name=product_name,
-            marketplace=group.get("marketplace"),
+            marketplace=marketplace,
             price=price_info.get("price"),
             currency=price_info.get("currency"),
             machine_type=get_machine_type(contract.product_id),

--- a/webapp/advantage/views.py
+++ b/webapp/advantage/views.py
@@ -72,17 +72,25 @@ def get_user_subscriptions(**kwargs):
     g.api.set_convert_response(True)
 
     email = kwargs.get("email")
+    advantage_marketplaces = ["canonical-ua", "blender"]
 
-    listings = g.api.get_product_listings("canonical-ua")
+    listings = {}
+    for marketplace in advantage_marketplaces:
+        marketplace_listings = g.api.get_product_listings(marketplace)
+        listings.update(marketplace_listings)
+
     accounts = g.api.get_accounts(email=email)
 
     user_summary = []
     for account in accounts:
         contracts = g.api.get_account_contracts(account_id=account.id)
-        subscriptions = g.api.get_account_subscriptions(
-            account_id=account.id,
-            marketplace="canonical-ua",
-        )
+        subscriptions = []
+        for marketplace in advantage_marketplaces:
+            market_subscriptions = g.api.get_account_subscriptions(
+                account_id=account.id,
+                marketplace=marketplace,
+            )
+            subscriptions.extend(market_subscriptions)
 
         user_summary.append(
             {


### PR DESCRIPTION
## Done

- Adapt /advantage/user-subscriptions to return `blender` subscriptions

## QA

- Will be easier to QA when we can make blender purchases.

## Issue / Card

Fixes #https://github.com/canonical-web-and-design/commercial-squad/issues/318