### PR TITLE
Update form return url

### DIFF
--- a/templates/ai/contact-us.html
+++ b/templates/ai/contact-us.html
@@ -9,7 +9,7 @@
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
   formid="3231",
   lpId="6279",
-  returnURL="https://ubuntu.com/ai/thank-you?product=ai-index-workshop" %}
+  returnURL="/ai/thank-you?product=ai-index-workshop" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'ai-index-assessment' %}
@@ -17,7 +17,7 @@
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
   formid="3231",
   lpId="6279",
-  returnURL="https://ubuntu.com/ai/thank-you?product=ai-managed" %}
+  returnURL="/ai/thank-you?product=ai-managed" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'ai-index-managed' %}
@@ -25,7 +25,7 @@
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
   formid="3231",
   lpId="6279",
-  returnURL="https://ubuntu.com/ai/thank-you?product=ai-managed" %}
+  returnURL="/ai/thank-you?product=ai-managed" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'ai-install' %}
@@ -33,7 +33,7 @@
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
   formid="3231",
   lpId="6279",
-  returnURL="https://ubuntu.com/ai/thank-you?product=ai-managed" %}
+  returnURL="/ai/thank-you?product=ai-managed" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'ai-consulting' %}
@@ -41,7 +41,7 @@
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
   formid="3231",
   lpId="6279",
-  returnURL="https://ubuntu.com/ai/thank-you?product=ai-managed" %}
+  returnURL="/ai/thank-you?product=ai-managed" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
     {% elif product == 'ai-features' %}
@@ -49,7 +49,7 @@
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
   formid="3231",
   lpId="6279",
-  returnURL="https://ubuntu.com/ai/thank-you?product=ai-features" %}
+  returnURL="/ai/thank-you?product=ai-features" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% else %}
@@ -57,7 +57,7 @@
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
   formid="3231",
   lpId="6279",
-  returnURL="https://ubuntu.com/ai/thank-you?product=ai-managed" %}
+  returnURL="/ai/thank-you?product=ai-managed" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% endif %}

--- a/templates/appliance/contact-us.html
+++ b/templates/appliance/contact-us.html
@@ -8,7 +8,7 @@
   intro_text="If you are thinking about using Ubuntu Appliance in your commerical product or anything else, please fill in your details below and a member of our team will get in touch.",
   formid="1266",
   lpId="2166",
-  returnURL="https://www.ubuntu.com/appliance/thank-you" %}
+  returnURL="/appliance/thank-you" %}
   {% include "shared/_client-contact-us-form.html" %}
 {% endwith %}
 

--- a/templates/aws/contact-us.html
+++ b/templates/aws/contact-us.html
@@ -8,7 +8,7 @@
   intro_text="Already running Ubuntu on AWS, or planning a migration to the public cloud? Canonical has the expertise to assist you in your project, whether it involves application architecture, optimisation or streamlining operations at scale. Share some details about your project with us and let's get started.",
   formid="3473",
   lpId="",
-  returnURL="https://www.ubuntu.com/aws/thank-you" %}
+  returnURL="/aws/thank-you" %}
   {% include "shared/_client-contact-us-form.html" %}
 {% endwith %}
 

--- a/templates/azure/contact-us.html
+++ b/templates/azure/contact-us.html
@@ -8,7 +8,7 @@
   intro_text="Already running Ubuntu on Azure, or planning a migration to the public cloud? Canonical has the expertise to assist you in your project, whether it involves application architecture, optimisation or streamlining operations at scale. Share some details about your project with us and let's get started.",
   formid="3564",
   lpId="",
-  returnURL="https://www.ubuntu.com/azure/thank-you" %}
+  returnURL="/azure/thank-you" %}
   {% include "shared/_client-contact-us-form.html" %}
 {% endwith %}
 

--- a/templates/azure/private-offer.html
+++ b/templates/azure/private-offer.html
@@ -52,7 +52,7 @@
       </p>
     </div>
     <div class="col-5">
-      {% with id="3888", returnURL="https://ubuntu.com/azure/thank-you", cta="Contact Us" %}
+      {% with id="3888", returnURL="/azure/thank-you", cta="Contact Us" %}
       {% include "engage/shared/_en_engage_form.html" %}
       {% endwith %}
     </div>

--- a/templates/blender/contact-us.html
+++ b/templates/blender/contact-us.html
@@ -8,7 +8,7 @@
   intro_text="Blender has partnered with Canonical to offer enterprise-grade support for the Blender LTS application suite. We can help you unleash more capabilities and supply the right level of support you need to have the best, hassle-free experience.",
   formid="4052",
   lpId="",
-  returnURL="https://www.ubuntu.com/blender/thank-you.html" %}
+  returnURL="/blender/thank-you.html" %}
   {% include "shared/_blender-contact-us-form.html" %}
 {% endwith %}
 

--- a/templates/ceph/contact-us.html
+++ b/templates/ceph/contact-us.html
@@ -8,7 +8,7 @@
   intro_text="If you are thinking about using Ceph, please fill in your details below and a member of our team will get in touch.",
   formid="1233",
   lpId="2001",
-  returnURL="https://www.ubuntu.com/ceph/thank-you" %}
+  returnURL="/ceph/thank-you" %}
   {% include "shared/_client-contact-us-form.html" %}
 {% endwith %}
 

--- a/templates/contact-us/form/index.html
+++ b/templates/contact-us/form/index.html
@@ -12,7 +12,7 @@
     intro_text="Just fill in the form below to arrange a meeting with the Canonical / Ubuntu team at Kubecon.",
     formid="3394",
     lpId="2154",
-    returnURL="https://ubuntu.com/blog/ubuntu-kubecon-americas-2019" %}
+    returnURL="/blog/ubuntu-kubecon-americas-2019" %}
     {% include "shared/_cloud-contact-us-form.html" %}
   {% endwith %}
 
@@ -22,7 +22,7 @@
       intro_text="Blender has partnered with Canonical to offer enterprise-grade support for the Blender LTS application suite. We can help you unleash more capabilities and supply the right level of support you need to have the best, hassle-free experience.",
       formid="4052",
       lpId="",
-      returnURL="https://ubuntu.com/contact-us/form/thank-you?product=blender-support" %}
+      returnURL="/contact-us/form/thank-you?product=blender-support" %}
       {% include "shared/_cloud-contact-us-form.html" %}
     {% endwith %}
 
@@ -33,7 +33,7 @@
     intro_text="Fill in your details below and a member of our team will be in touch.",
     formid="1257",
     lpId="2154",
-    returnURL="https://ubuntu.com/contact-us/form/thank-you" %}
+    returnURL="/contact-us/form/thank-you" %}
     {% include "shared/_cloud-contact-us-form.html" %}
   {% endwith %}
 
@@ -43,7 +43,7 @@
   intro_text="Just fill in the form below and a member of our team will be in touch within one working day.",
   formid="1257",
   lpId="2154",
-  returnURL="https://ubuntu.com/contact-us/form/thank-you" %}
+  returnURL="/contact-us/form/thank-you" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
 

--- a/templates/containers/contact-us.html
+++ b/templates/containers/contact-us.html
@@ -9,7 +9,7 @@
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
   formid="1964",
   lpId="3828",
-  returnURL="https://www.ubuntu.com/containers/thank-you" %}
+  returnURL="/containers/thank-you" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'containers-kubernetes' %}
@@ -17,7 +17,7 @@
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
   formid="2243",
   lpId="4986",
-  returnURL="https://www.ubuntu.com/containers/thank-you?product=containers-kubernetes" %}
+  returnURL="/containers/thank-you?product=containers-kubernetes" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'containers-kubernetes-foundation' %}
@@ -25,7 +25,7 @@
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
   formid="2243",
   lpId="4986",
-  returnURL="https://www.ubuntu.com/containers/thank-you?product=containers-kubernetes-foundation" %}
+  returnURL="/containers/thank-you?product=containers-kubernetes-foundation" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'containers-lxd' %}
@@ -33,7 +33,7 @@
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
   formid="1964",
   lpId="3828",
-  returnURL="https://www.ubuntu.com/containers/thank-you" %}
+  returnURL="/containers/thank-you" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'containers-overview' %}
@@ -41,7 +41,7 @@
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
   formid="1964",
   lpId="3828",
-  returnURL="https://www.ubuntu.com/containers/thank-you" %}
+  returnURL="/containers/thank-you" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% else %}
@@ -49,7 +49,7 @@
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
   formid="1964",
   lpId="3828",
-  returnURL="https://www.ubuntu.com/containers/thank-you" %}
+  returnURL="/containers/thank-you" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% endif %}

--- a/templates/core/contact-us.html
+++ b/templates/core/contact-us.html
@@ -8,7 +8,7 @@
   intro_text="If you are thinking about using Ubuntu Core to power your Internet of Things devices or anything else, please fill in your details below and a member of our team will get in touch.",
   formid="1266",
   lpId="2166",
-  returnURL="https://www.ubuntu.com/core/thank-you" %}
+  returnURL="/core/thank-you" %}
   {% include "shared/_client-contact-us-form.html" %}
 {% endwith %}
 

--- a/templates/cube/contact-us.html
+++ b/templates/cube/contact-us.html
@@ -8,7 +8,7 @@
   intro_text="Provide your contact information to join the beta candidate pool.",
   formid="3801",
   lpId="7140",
-  returnURL="https://ubuntu.com/cube/thank-you" %}
+  returnURL="/cube/thank-you" %}
   {% include "shared/_cube-contact-us-form.html" %}
 {% endwith %}
 {% endblock content %}

--- a/templates/dell/contact-us.html
+++ b/templates/dell/contact-us.html
@@ -8,7 +8,7 @@
   intro_text="From the desktop to the edge, from the data centre to the multi-cloud environment, Dell and Canonical work together to bring you joint solutions that work out-of-the-box for a consistent open source experience spanning the Dell EMC hardware portfolio.",
   formid="3454",
   lpId="2166",
-  returnURL="https://www.ubuntu.com/dell/thank-you" %}
+  returnURL="/dell/thank-you" %}
   {% include "shared/_client-contact-us-form.html" %}
 {% endwith %}
 

--- a/templates/desktop/contact-us.html
+++ b/templates/desktop/contact-us.html
@@ -10,7 +10,7 @@
   intro_text="Considering Ubuntu for your school or university? Are you interested in cost-effective systems management and professional support?",
   formid="1253",
   lpId="1409",
-  returnURL="https://www.ubuntu.com/desktop/thank-you",
+  returnURL="/desktop/thank-you",
   side1="shared/forms/_desktop_help.html",
   side2="shared/forms/_desktop_ua-shop.html" %}
   {% include "shared/_client-contact-us-form.html" %}
@@ -22,7 +22,7 @@
   intro_text="Considering Ubuntu for your organisation? Are you interested in cost-effective systems management and professional support?",
   formid="1253",
   lpId="1409",
-  returnURL="https://www.ubuntu.com/desktop/thank-you",
+  returnURL="/desktop/thank-you",
   side1="shared/forms/_desktop_help.html",
   side2="shared/forms/_desktop_ua-shop.html" %}
   {% include "shared/_client-contact-us-form.html" %}

--- a/templates/download/contact-us.html
+++ b/templates/download/contact-us.html
@@ -10,7 +10,7 @@
   intro_text="Can't find your board of choice? Fill out the form and a member of our team will be in touch",
   formid="4126",
   lpId="",
-  returnURL="https://www.ubuntu.com/download/thank-you?product=supported-platforms" %}
+  returnURL="/download/thank-you?product=supported-platforms" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
 
@@ -20,7 +20,7 @@
   intro_text="",
   formid="1257",
   lpId="",
-  returnURL="https://www.ubuntu.com/download/thank-you" %}
+  returnURL="/download/thank-you" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
 

--- a/templates/financial-services/contact-us.html
+++ b/templates/financial-services/contact-us.html
@@ -9,7 +9,7 @@
   intro_text="Considering Ubuntu? Just fill in the form below and a member of our team will be in touch.",
   formid="3709",
   lpId="2065",
-  returnURL="https://ubuntu.com/financial-services/thank-you" %}
+  returnURL="/financial-services/thank-you" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
 

--- a/templates/gcp/contact-us.html
+++ b/templates/gcp/contact-us.html
@@ -8,7 +8,7 @@
   intro_text="Already running Ubuntu on GCP, or planning a migration to the public cloud? Canonical has the expertise to assist you in your project, whether it involves application architecture, optimisation or streamlining operations at scale. Share some details about your project with us and let's get started.",
   formid="3860",
   lpId="",
-  returnURL="https://www.ubuntu.com/gcp/thank-you" %}
+  returnURL="/gcp/thank-you" %}
   {% include "shared/_client-contact-us-form.html" %}
 {% endwith %}
 

--- a/templates/gov/contact-us.html
+++ b/templates/gov/contact-us.html
@@ -8,7 +8,7 @@
   intro_text="Canonical certifies, secures and supports open infrastructure for the public sector. Tell us about your project.",
   formid="3609",
   lpId="",
-  returnURL="https://ubuntu.com/gov/thank-you" %}
+  returnURL="/gov/thank-you" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
 

--- a/templates/ibm/contact-us.html
+++ b/templates/ibm/contact-us.html
@@ -8,7 +8,7 @@
   intro_text="From the servers to the cloud, IBM and Canonical work together to bring you joint solutions that work out-of-the-box for a consistent open source experience spanning the IBM  portfolio.",
   formid="1444",
   lpId="2649",
-  returnURL="https://ubuntu.com/ibm/thank-you" %}
+  returnURL="/ibm/thank-you" %}
   {% include "shared/_client-contact-us-form.html" %}
 {% endwith %}
 

--- a/templates/internet-of-things/contact-us.html
+++ b/templates/internet-of-things/contact-us.html
@@ -11,7 +11,7 @@
   intro_text="If you are thinking about building a digital signage product on Ubuntu, please fill in your details below and a member of our team will get in touch.",
   formid="1422",
   lpId="2166",
-  returnURL="https://ubuntu.com/internet-of-things/thank-you?product=digital-signage" %}
+  returnURL="/internet-of-things/thank-you?product=digital-signage" %}
   {% include "shared/_client-contact-us-form.html" %}
 {% endwith %}
 
@@ -21,7 +21,7 @@
   intro_text="If you would like to know more about Ubuntu for edge gateways please fill in your details below and a member of our team will get in touch.",
   formid="1663",
   lpId="3143",
-  returnURL="https://ubuntu.com/internet-of-things/thank-you?product=gateways" %}
+  returnURL="/internet-of-things/thank-you?product=gateways" %}
   {% include "shared/_client-contact-us-form.html" %}
 {% endwith %}
 
@@ -31,7 +31,7 @@
   intro_text="If you would like to know more about Ubuntu for Robotics please fill in your details below and a member of our team will get in touch.",
   formid="1650",
   lpId="2838",
-  returnURL="https://ubuntu.com/internet-of-things/thank-you?product=robotics" %}
+  returnURL="/internet-of-things/thank-you?product=robotics" %}
   {% include "shared/_client-contact-us-form.html" %}
 {% endwith %}
 
@@ -41,7 +41,7 @@
   intro_text="Enhance your software distribution with a custom, dedicated app store. Fill in your details below and a member of our team will be in touch.",
   formid="2639",
   lpId="5811",
-  returnURL="https://ubuntu.com/internet-of-things/thank-you?product=appstore" %}
+  returnURL="/internet-of-things/thank-you?product=appstore" %}
   {% include "shared/_client-contact-us-form.html" %}
 {% endwith %}
 
@@ -51,7 +51,7 @@
   intro_text="We would love to hear what you want to create, and be your partner in innovation.",
   formid="2639",
   lpId="5811",
-  returnURL="https://ubuntu.com/internet-of-things/thank-you?product=automotive" %}
+  returnURL="/internet-of-things/thank-you?product=automotive" %}
   {% include "shared/_client-contact-us-form.html" %}
 {% endwith %}
 
@@ -61,7 +61,7 @@
   intro_text="If you would like to know more about Ubuntu for networking, please fill in your details below and a member of our team will get in touch.",
   formid="3484",
   lpId="",
-  returnURL="https://ubuntu.com/internet-of-things/thank-you?product=networking" %}
+  returnURL="/internet-of-things/thank-you?product=networking" %}
   {% include "shared/_client-contact-us-form.html" %}
 {% endwith %}
 
@@ -71,7 +71,7 @@
   intro_text="If you are thinking about using Ubuntu Core to power your Internet of Things devices, please fill in your details below and a member of our team will get in touch.",
   formid="1266",
   lpId="2551",
-  returnURL="https://ubuntu.com/internet-of-things/thank-you?product=iot",
+  returnURL="/internet-of-things/thank-you?product=iot",
   side1="shared/forms/_desktop_help.html",
   side2="shared/forms/_desktop_ua-shop.html" %}
   {% include "shared/_client-contact-us-form.html" %}

--- a/templates/kubernetes/contact-us.html
+++ b/templates/kubernetes/contact-us.html
@@ -10,7 +10,7 @@
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
   formid="3230",
   lpId="6274",
-  returnURL="https://ubuntu.com/kubernetes/thank-you" %}
+  returnURL="/kubernetes/thank-you" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'kubernetes-managed' %}
@@ -18,7 +18,7 @@
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
   formid="3230",
   lpId="6274",
-  returnURL="https://ubuntu.com/kubernetes/thank-you?product=kubernetes-managed" %}
+  returnURL="/kubernetes/thank-you?product=kubernetes-managed" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'kubernetes-kubeadm' %}
@@ -26,7 +26,7 @@
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
   formid="3230",
   lpId="6274",
-  returnURL="https://ubuntu.com/kubernetes/thank-you?product=kubernetes-kubeadm" %}
+  returnURL="/kubernetes/thank-you?product=kubernetes-kubeadm" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'multicloud' %}
@@ -34,7 +34,7 @@
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
   formid="3230",
   lpId="6274",
-  returnURL="https://ubuntu.com/kubernetes/thank-you?product=multicloud" %}
+  returnURL="/kubernetes/thank-you?product=multicloud" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'kubernetes-install' %}
@@ -42,7 +42,7 @@
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
   formid="3230",
   lpId="6274",
-  returnURL="https://ubuntu.com/kubernetes/thank-you?product=kubernetes-install" %}
+  returnURL="/kubernetes/thank-you?product=kubernetes-install" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'kubernetes-features' %}
@@ -50,7 +50,7 @@
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
   formid="3230",
   lpId="6274",
-  returnURL="https://ubuntu.com/kubernetes/thank-you?product=kubernetes-features" %}
+  returnURL="/kubernetes/thank-you?product=kubernetes-features" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'kubernetes-consulting' %}
@@ -58,7 +58,7 @@
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
   formid="3230",
   lpId="6274",
-  returnURL="https://ubuntu.com/kubernetes/thank-you?product=kubernetes-consulting" %}
+  returnURL="/kubernetes/thank-you?product=kubernetes-consulting" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'kubernetes-add-on' %}
@@ -66,7 +66,7 @@
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
   formid="3230",
   lpId="6274",
-  returnURL="https://ubuntu.com/kubernetes/thank-you?product=kubernetes-add-on" %}
+  returnURL="/kubernetes/thank-you?product=kubernetes-add-on" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% elif product == 'kubernetes-support' %}
@@ -74,7 +74,7 @@
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
   formid="3230",
   lpId="6274",
-  returnURL="https://ubuntu.com/kubernetes/thank-you?product=kubernetes-support" %}
+  returnURL="/kubernetes/thank-you?product=kubernetes-support" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% else %}
@@ -82,7 +82,7 @@
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
   formid="3230",
   lpId="6274",
-  returnURL="https://ubuntu.com/kubernetes/thank-you" %}
+  returnURL="/kubernetes/thank-you" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
   {% endif %}

--- a/templates/managed/contact-us.html
+++ b/templates/managed/contact-us.html
@@ -12,7 +12,7 @@
   intro_text="Rely on our experienced engineers to deploy and operate your apps, with full lifecycle coverage included.",
   formid="3545",
   lpId="2166",
-  returnURL="https://www.ubuntu.com/managed/thank-you" %}
+  returnURL="/managed/thank-you" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
 

--- a/templates/masters-conference/contact-us.html
+++ b/templates/masters-conference/contact-us.html
@@ -8,7 +8,7 @@
   intro_text="Ubuntu Masters are IT practitioners who are driving revolutionary change in the corporate space. Watch videos from our first Ubuntu Masters Conference, featuring these inspiring doers to hear how they are solving complex industry-wide challenges.",
   formid="3475",
   lpId="",
-  returnURL="https://www.ubuntu.com/masters-conference/thank-you" %}
+  returnURL="/masters-conference/thank-you" %}
   {% include "shared/_client-contact-us-form.html" %}
 {% endwith %}
 

--- a/templates/observability/contact-us.html
+++ b/templates/observability/contact-us.html
@@ -9,7 +9,7 @@
   intro_text="Fill in your details below and a member of our training team will be in touch.",
   formid="4072",
   lpId="",
-  returnURL="https://www.ubuntu.com/observability/thank-you" %}
+  returnURL="/observability/thank-you" %}
   {% include "shared/_client-contact-us-form.html" %}
 {% endwith %}
 

--- a/templates/openstack/contact-us.html
+++ b/templates/openstack/contact-us.html
@@ -10,7 +10,7 @@
   intro_text="Fill in your details below and a member of our training team will be in touch.",
   formid="1263",
   lpId="2163",
-  returnURL="https://www.ubuntu.com/openstack/thank-you?product=openstack-training" %}
+  returnURL="/openstack/thank-you?product=openstack-training" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
 
@@ -20,7 +20,7 @@
   intro_text="If you are interested in the Ubuntu OpenStack training, please fill out the form below and we'll get back to you with available dates and locations.",
   formid="1261",
   lpId="2161",
-  returnURL="https://www.ubuntu.com/openstack/thank-you?product=openstack-training-classroom" %}
+  returnURL="/openstack/thank-you?product=openstack-training-classroom" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
 
@@ -30,7 +30,7 @@
   intro_text="Fill in your details below and a member of our training team will be in touch.",
   formid="1223",
   lpId="1973",
-  returnURL="https://www.ubuntu.com/openstack/thank-you?product=openstack-training-onsite" %}
+  returnURL="/openstack/thank-you?product=openstack-training-onsite" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
 
@@ -40,7 +40,7 @@
   intro_text="Fill in your details below and a member of our training team will be in touch.",
   formid="1448",
   lpId="2661",
-  returnURL="https://www.ubuntu.com/openstack/thank-you?product=openstack-training-server-admin" %}
+  returnURL="/openstack/thank-you?product=openstack-training-server-admin" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
 
@@ -50,7 +50,7 @@
   intro_text="Let Canonical help you build your own software-defined storage network.",
   formid="1233",
   lpId="2001",
-  returnURL="https://www.ubuntu.com/openstack/thank-you?product=ubuntu-advantage-storage" %}
+  returnURL="/openstack/thank-you?product=ubuntu-advantage-storage" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
 
@@ -60,7 +60,7 @@
   intro_text="Fill in your details below and a member of our BootStack team will be in touch.",
   formid="1128",
   lpId="1646",
-  returnURL="https://www.ubuntu.com/openstack/thank-you?product=openstack-managed-cloud" %}
+  returnURL="/openstack/thank-you?product=openstack-managed-cloud" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
 
@@ -70,7 +70,7 @@
   intro_text="Fill in your details below and a member of our BootStack team will be in touch.",
   formid="1128",
   lpId="1646",
-  returnURL="https://www.ubuntu.com/openstack/thank-you?product=openstack-managed-cloud" %}
+  returnURL="/openstack/thank-you?product=openstack-managed-cloud" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
 
@@ -80,7 +80,7 @@
   intro_text="Fill in your details below and a member of our Private Cloud Build team will be in touch.",
   formid="1251",
   lpId="2086",
-  returnURL="https://www.ubuntu.com/openstack/thank-you?product=foundation-cloud" %}
+  returnURL="/openstack/thank-you?product=foundation-cloud" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
 
@@ -94,7 +94,7 @@
   intro_text="Fill in your details below and a member of our cloud sales team will be in touch.",
   formid="1251",
   lpId="2086",
-  returnURL="https://www.ubuntu.com/openstack/thank-you" %}
+  returnURL="/openstack/thank-you" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
 

--- a/templates/security/contact-us.html
+++ b/templates/security/contact-us.html
@@ -10,7 +10,7 @@
   intro_text="",
   formid="3785",
   lpId="",
-  returnURL="https://www.ubuntu.com/security/thank-you?product=docker" %}
+  returnURL="/security/thank-you?product=docker" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
 
@@ -20,7 +20,7 @@
   intro_text="Considering Ubuntu for your business? Just fill in the form below and a member of our team will be in touch.",
   formid="1240",
   lpId="2065",
-  returnURL="https://www.ubuntu.com/support/thank-you" %}
+  returnURL="/support/thank-you" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
 

--- a/templates/server/contact-us.html
+++ b/templates/server/contact-us.html
@@ -11,7 +11,7 @@
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
   formid="1254",
   lpId="2152",
-  returnURL="https://www.ubuntu.com/server/thank-you" %}
+  returnURL="/server/thank-you" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
 
@@ -21,7 +21,7 @@
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
   formid="1254",
   lpId="2152",
-  returnURL="https://www.ubuntu.com/server/thank-you" %}
+  returnURL="/server/thank-you" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
 
@@ -31,7 +31,7 @@
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
   formid="1254",
   lpId="2152",
-  returnURL="https://www.ubuntu.com/server/thank-you" %}
+  returnURL="/server/thank-you" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
 
@@ -41,7 +41,7 @@
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
   formid="1254",
   lpId="2152",
-  returnURL="https://www.ubuntu.com/server/thank-you?product=server-maas" %}
+  returnURL="/server/thank-you?product=server-maas" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
 
@@ -51,7 +51,7 @@
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
   formid="1254",
   lpId="2152",
-  returnURL="https://www.ubuntu.com/server/thank-you" %}
+  returnURL="/server/thank-you" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
 
@@ -61,7 +61,7 @@
   intro_text="Fill in your details below and a member of our sales team will be in touch.",
   formid="1254",
   lpId="2152",
-  returnURL="https://www.ubuntu.com/server/thank-you" %}
+  returnURL="/server/thank-you" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
 

--- a/templates/support/contact-us.html
+++ b/templates/support/contact-us.html
@@ -11,7 +11,7 @@
   intro_text="Considering Ubuntu for your school, research or academic organisation? Just fill in the form below and a member of our team will be in touch.",
   formid="3762",
   lpId="2065",
-  returnURL="https://www.ubuntu.com/support/thank-you?product=education-discount" %}
+  returnURL="/support/thank-you?product=education-discount" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
 
@@ -21,7 +21,7 @@
   intro_text="Considering Ubuntu for your business? Just fill in the form below and a member of our team will be in touch.",
   formid="1240",
   lpId="2065",
-  returnURL="https://www.ubuntu.com/support/thank-you" %}
+  returnURL="/support/thank-you" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
 

--- a/templates/telco/contact-us.html
+++ b/templates/telco/contact-us.html
@@ -9,7 +9,7 @@
   intro_text="Fill in your details below and a member of our training team will be in touch.",
   formid="4048",
   lpId="",
-  returnURL="https://www.ubuntu.com/telco/thank-you" %}
+  returnURL="/telco/thank-you" %}
   {% include "shared/_telco-contact-us.html" %}
 {% endwith %}
 

--- a/templates/telco/osm/contact-us.html
+++ b/templates/telco/osm/contact-us.html
@@ -9,7 +9,7 @@
   intro_text="Fill in your details below and a member of our training team will be in touch.",
   formid="3471",
   lpId="",
-  returnURL="https://www.ubuntu.com/telco/osm/thank-you" %}
+  returnURL="/telco/osm/thank-you" %}
   {% include "shared/_client-contact-us-form.html" %}
 {% endwith %}
 

--- a/templates/training/contact-us.html
+++ b/templates/training/contact-us.html
@@ -10,7 +10,7 @@
   intro_text="Fill in your details below and a member of our training team will be in touch.",
   formid="1263",
   lpId="2163",
-  returnURL="https://www.ubuntu.com/training/thank-you?product=openstack-training" %}
+  returnURL="/training/thank-you?product=openstack-training" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
 
@@ -20,7 +20,7 @@
   intro_text="If you are interested in the Ubuntu OpenStack training, please fill out the form below and we'll get back to you with available dates and locations.",
   formid="1261",
   lpId="2161",
-  returnURL="https://www.ubuntu.com/training/thank-you?product=openstack-training-classroom" %}
+  returnURL="/training/thank-you?product=openstack-training-classroom" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
 
@@ -30,7 +30,7 @@
   intro_text="Fill in your details below and a member of our training team will be in touch.",
   formid="1223",
   lpId="1973",
-  returnURL="https://www.ubuntu.com/training/thank-you?product=openstack-training-onsite" %}
+  returnURL="/training/thank-you?product=openstack-training-onsite" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
 
@@ -40,7 +40,7 @@
   intro_text="Fill in your details below and a member of our training team will be in touch.",
   formid="1448",
   lpId="2661",
-  returnURL="https://www.ubuntu.com/training/thank-you?product=openstack-training-server-admin" %}
+  returnURL="/training/thank-you?product=openstack-training-server-admin" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
 
@@ -50,7 +50,7 @@
 intro_text="Fill in your details below and a member of our training team will be in touch.",
 formid="1448",
 lpId="2661",
-returnURL="https://www.ubuntu.com/training/thank-you?product=kubeflow-training-onsite" %}
+returnURL="/training/thank-you?product=kubeflow-training-onsite" %}
 {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
 
@@ -60,7 +60,7 @@ returnURL="https://www.ubuntu.com/training/thank-you?product=kubeflow-training-o
 intro_text="Fill in your details below and a member of our training team will be in touch.",
 formid="1448",
 lpId="2661",
-returnURL="https://www.ubuntu.com/training/thank-you?product=maas-training-onsite" %}
+returnURL="/training/thank-you?product=maas-training-onsite" %}
 {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
 
@@ -70,7 +70,7 @@ returnURL="https://www.ubuntu.com/training/thank-you?product=maas-training-onsit
 intro_text="Fill in your details below and a member of our training team will be in touch.",
 formid="1448",
 lpId="2661",
-returnURL="https://www.ubuntu.com/training/thank-you?product=landscape-training-onsite" %}
+returnURL="/training/thank-you?product=landscape-training-onsite" %}
 {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
 
@@ -80,7 +80,7 @@ returnURL="https://www.ubuntu.com/training/thank-you?product=landscape-training-
 intro_text="Fill in your details below and a member of our training team will be in touch.",
 formid="1448",
 lpId="2661",
-returnURL="https://www.ubuntu.com/training/thank-you?product=juju-administrator-training-onsite" %}
+returnURL="/training/thank-you?product=juju-administrator-training-onsite" %}
 {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
 
@@ -90,7 +90,7 @@ returnURL="https://www.ubuntu.com/training/thank-you?product=juju-administrator-
 intro_text="Fill in your details below and a member of our training team will be in touch.",
 formid="1448",
 lpId="2661",
-returnURL="https://www.ubuntu.com/training/thank-you?product=juju-administrator-training-onsite" %}
+returnURL="/training/thank-you?product=juju-administrator-training-onsite" %}
 {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
 
@@ -101,7 +101,7 @@ returnURL="https://www.ubuntu.com/training/thank-you?product=juju-administrator-
   intro_text="Fill in your details below and a member of our cloud sales team will be in touch.",
   formid="1251",
   lpId="2086",
-  returnURL="https://www.ubuntu.com/training/thank-you" %}
+  returnURL="/training/thank-you" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
 

--- a/templates/wsl/contact-us.html
+++ b/templates/wsl/contact-us.html
@@ -9,7 +9,7 @@
   intro_text="Ubuntu brings you the best-in-class, seamless experience for the Windows Subsystem for Linux. We can help you unleash more capabilities and supply the right level of support you need to have the best experience out-of-the-box.",
   formid="3755",
   lpId="",
-  returnURL="https://www.ubuntu.com/wsl/thank-you" %}
+  returnURL="/wsl/thank-you" %}
   {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
 


### PR DESCRIPTION
## Done
- Removed `www.ubuntu.com` and `https://ubuntu.com` from returnURL 

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)

## Issue / Card

Fixes [#4536](https://github.com/canonical-web-and-design/web-squad/issues/4536)
