### PR TITLE
fix second resize not waiting for purchases status - 324

### DIFF
--- a/static/js/src/advantage/subscribe/react/hooks/usePendingPurchase.jsx
+++ b/static/js/src/advantage/subscribe/react/hooks/usePendingPurchase.jsx
@@ -16,7 +16,7 @@ const usePendingPurchase = () => {
   const stripe = useStripe();
 
   const { isLoading, isError, isSuccess, data, error } = useQuery(
-    "pendingPurchase",
+    ["pendingPurchase", pendingPurchaseID],
     async () => {
       const res = await getPurchase(pendingPurchaseID);
 


### PR DESCRIPTION
## Done

- fix second resize not waiting for purchases status

## QA

- Check out this feature branch
- login and go to /advantage
- Resize a user subscription
- It will succeed and show you the green notification
- Resize again
- it should resize the subscription without throwing any errors

## Issue / Card

Fixes https://github.com/canonical-web-and-design/commercial-squad/issues/324

