### PR TITLE
Update tco calc buttons

### DIFF
--- a/templates/openstack/pricing-calculator.html
+++ b/templates/openstack/pricing-calculator.html
@@ -33,7 +33,7 @@
     <div class="col-5 p-card">
       <p class="p-heading--5">Have non-standard requirements?</p>
       <p>Tell us more about your specific needs here - we will send you a detailed report and help you find the cloud architecture that best suits your requirements.</p>
-      <a class="js-invoke-modal" href="/openstack/contact-us">Get in touch&nbsp;&rsaquo;</a>
+      <a href="/openstack/contact-us">Get in touch&nbsp;&rsaquo;</a>
     </div>
   </div>
 


### PR DESCRIPTION
## Done

- Responding to [comment](https://docs.google.com/document/d/1n3ExZwFVlw5LyAp7O3CgPthVgx8yRX5-Wg_gBQLf73c/edit?disco=AAAAOSt-wZQ) in the copy doc - update the contact buttons for the pricing calculator on `/openstack/pricing-calculator`

## QA

- View page at: https://ubuntu-com-10630.demos.haus/openstack/pricing-calculator
- Check in the "Have non-standard requirements?" card there is no longer a CTA. Get it touch should be a link
- Check under the calculations there's an "Email me those estimates" button.
- They both should point to the same pop up modal


## Issue / Card

Fixes #10629 

## Screenshots

![Screenshot 2021-10-14 at 17 06 00](https://user-images.githubusercontent.com/58959073/137355335-9c880f00-bfd4-4210-a6c4-74ab5cc29486.png)

![Screenshot 2021-10-14 at 17 06 05](https://user-images.githubusercontent.com/58959073/137355346-260da9a4-6a6e-4c6a-b659-ed31388ece7b.png)


