### PR TITLE
Remove duplicate discourse.ubuntu.com listing on /legal/websites

### DIFF
--- a/templates/legal/websites.html
+++ b/templates/legal/websites.html
@@ -38,9 +38,6 @@
           <a class="p-link--external" href="https://design.ubuntu.com">design.ubuntu.com</a>
         </li>
         <li class="p-list__item">
-          <a class="p-link--external" href="https://discourse.ubuntu.com">discourse.ubuntu.com</a>
-        </li>
-        <li class="p-list__item">
           <a class="p-link--external" href="https://discourse.juju.is">discourse.juju.is</a>
         </li>
         <li class="p-list__item">


### PR DESCRIPTION
## Done

- Remove duplicate discourse.ubuntu.com listing
- And updated the [copy doc](https://docs.google.com/spreadsheets/d/19V5BOEkR_OkKu0P8UFNk-e9DaYSrC18TaznlXheSFjY/edit#gid=0).

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/legal/websites
- See that discourse.ubuntu.com is listed once


## Issue / Card

Fixes #10633