### PR TITLE
fix flaky login cypress tests

### DIFF
--- a/tests/cypress/plugins/index.js
+++ b/tests/cypress/plugins/index.js
@@ -1,7 +1,14 @@
 /// <reference types="cypress" />
 const puppeteer = require("puppeteer");
 
+async function clearBrowserCookies(page) {
+  const client = await page.target().createCDPSession();
+  await await client.send("Network.clearBrowserCookies");
+}
+
 module.exports = async (on, config) => {
+  let cookies;
+
   on("task", {
     log(message) {
       console.log(message);
@@ -14,31 +21,54 @@ module.exports = async (on, config) => {
       return null;
     },
     login({ username, password }) {
-      return (async () => {
-        const browser = await puppeteer.launch({
-          ignoreHTTPSErrors: true,
-          headless: false,
-        });
-        const page = await browser.newPage();
-
-        await page.goto(config.baseUrl + "/login?test_backend=true", {
-          // The app redirects to the login-page
-          waitUntil: "networkidle2", // Wait until login-page has been reached
-        });
-        await page.click("#cookie-policy-button-accept");
-        await page.type("#id_email", username); // Insert username in form
-        await page.type("#id_password", password); // Insert password
-        await page.click('button[type="submit"]'); // Click login button
-        await page.waitForNavigation({ waitUntil: "networkidle2" });
-        await page.click('button[type="submit"]'); // Click "Yes, log me in"
-
-        await page.waitForNavigation({ waitUntil: "networkidle2" });
-        await page.click("#proceed-button"); // dismiss Chrome built-in warning: "The information that you’re about to submit is not secure"
-        await page.waitForTimeout(5000); // puppeteer doesn't respond to waitForNavigation at this point
-        const cookies = await page.cookies();
-        await browser.close();
+      let browser;
+      if (cookies) {
         return { cookies };
-      })();
+      } else {
+        return (async () => {
+          try {
+            browser = await puppeteer.launch({
+              ignoreHTTPSErrors: true,
+              headless: false,
+              args: [
+                `--unsafely-treat-insecure-origin-as-secure=${config.baseUrl}`,
+              ],
+            });
+            const page = await browser.newPage();
+            clearBrowserCookies(page);
+
+            page.on("error", (err) => {
+              throw new Error("Puppeteer error:", err);
+            });
+
+            await page.goto(config.baseUrl + "/login?test_backend=true", {
+              // The app redirects to the login-page
+              waitUntil: "networkidle2", // Wait until login-page has been reached
+            });
+            await page.click("#cookie-policy-button-accept");
+            await page.type("#id_email", username); // Insert username in form
+            await page.type("#id_password", password); // Insert password
+            await Promise.all([
+              page.click('button[type="submit"]'), // Click login button
+              page.waitForNavigation(),
+            ]);
+            await Promise.all([
+              page.click('button[type="submit"]'), // Click "Yes, log me in"
+              page.waitForNavigation(),
+            ]);
+
+            await page.waitForNavigation({ waitUntil: "networkidle2" });
+
+            cookies = await page.cookies();
+            await browser.close();
+
+            return { cookies };
+          } catch (error) {
+            browser.close();
+            throw new Error(error);
+          }
+        })();
+      }
     },
   });
 };

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -4,15 +4,23 @@ Cypress.Commands.add("acceptCookiePolicy", () => {
   cy.findByRole("button", { name: "Accept all and visit site" }).click();
 });
 
-Cypress.Commands.add("login", ({ username, password }) => {
-  cy.task("login", { username, password }, { timeout: 20000 }).then(
-    async (user) => {
-      user.cookies.forEach(({ name, value }) => {
-        cy.setCookie(name, value);
-      });
+Cypress.Commands.add(
+  "login",
+  (
+    { username, password } = {
+      username: Cypress.env("UBUNTU_USERNAME"),
+      password: Cypress.env("UBUNTU_PASSWORD"),
     }
-  );
-});
+  ) =>
+    cy
+      .task("login", { username, password }, { timeout: 30000 })
+      .then((user) => {
+        user.cookies.forEach(({ name, value }) => {
+          cy.setCookie(name, value);
+        });
+        cy.reload();
+      })
+);
 
 Cypress.Commands.add("iframeLoaded", { prevSubject: "element" }, ($iframe) => {
   const contentWindow = $iframe.prop("contentWindow");


### PR DESCRIPTION
## Done
fix flaky login cypress tests
- add unsafely-treat-insecure-origin-as-secure flag
- cache cookies between runs once logged in

