### PR TITLE
Show takeovers for Chinese language users from Taiwan (zh-TW)

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -1383,7 +1383,9 @@
     var language = navigator.language || navigator.userLanguage || navigator.browserLanguage || navigator.systemLanguage;
 
     if (language.indexOf('-') !== -1 ) {
-      language = language.split('-')[0];
+      if (language !== "zh-TW") {
+        language = language.split('-')[0];
+      }
     }
 
     return language


### PR DESCRIPTION
## Done

Added exception for "compound" language

## QA

Change your browser language. Instructions for chrome:

- Open the Google Chrome browser.
- In the upper-right corner of the window, click the Menu icon in Google Chrome. ![image](https://user-images.githubusercontent.com/14939793/137509322-430c7300-8bd6-47a2-8aa9-f139c2d6c3ec.png).
- From the drop-down menu that appears, select Settings.
- In the next window, scroll to the bottom and click the Button that opens the advanced menu in Chrome settings. drop-down.
- Scroll down to the Languages section and click the down arrow on the right side of the Language option. 
- Add language - Chinese traditional
- Move the language to the top, so it becomes the your preferred language.

Now visit https://ubuntu-com-10643.demos.haus/ and refresh a few times to see the new traditional Chinese takeover show

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/10625

## Screenshots
![takeover-taiwan](https://user-images.githubusercontent.com/14939793/137510131-c3780721-e0fc-44b9-9933-3b70f4b995b9.png)

