### PR TITLE
Make cancel confirm case insensitive

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionCancel/SubscriptionCancel.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionCancel/SubscriptionCancel.tsx
@@ -29,7 +29,11 @@ enum CancelError {
 
 const CancelSchema = Yup.object().shape({
   cancel: Yup.string()
-    .matches(/^cancel$/, "You must enter the correct confirmation text")
+    .test(
+      "confirmationText",
+      "You must enter the correct confirmation text",
+      (item) => item?.toLowerCase() === "cancel"
+    )
     .required("The confirmation text is required"),
 });
 


### PR DESCRIPTION
## Done

- Male the cancellation confirm case insensitive

## QA

- go to https://ubuntu-com-10646.demos.haus/advantage?test_backend=true with a monthly sub
- click edit and then cancel
- see that the confirmation field accepts all case variations on the word "cancel"


## Screenshots
![image](https://user-images.githubusercontent.com/11927929/137704374-5e04fdca-cec6-446c-87b5-46dbe285970c.png)

