### PR TITLE
Display the invoice status in the table

### DIFF
--- a/templates/account/invoices/index.html
+++ b/templates/account/invoices/index.html
@@ -30,7 +30,8 @@
           <thead>
             <th>Service</th>
             <th>Date</th>
-            <th class="u-align--right" style="padding-right: 15%">Total</th>
+            <th width="10%">Status</th>
+            <th class="u-align--right" style="padding-right: 5%">Total</th>
             <th>Download PDF</th>
           </thead>
           <tbody>
@@ -38,7 +39,16 @@
               <tr>
                 <td aria-label="Service">{{ invoice.service }}{% if invoice.period %} ({{ invoice.period }}){% endif %}</td>
                 <td aria-label="Date">{{ invoice.date }}</td>
-                <td class="u-align--right" aria-label="Total" style="padding-right: 15%">
+                <td aria-label="Status">
+                  {% if invoice.status == "paid" %}
+                  <div class="p-label--new">Paid</div>
+                  {% elif invoice.status == "open" %}
+                  <div class="p-label--deprecated">Failed</div>
+                  {% else %}
+                  <div class="p-label">{{ invoice.status }}</div>
+                  {% endif %}
+                </td>
+                <td class="u-align--right" aria-label="Total" style="padding-right: 5%">
                   {% if invoice.total %}
                     <span class="js-format-price">
                       {{ invoice.total }}

--- a/webapp/advantage/views.py
+++ b/webapp/advantage/views.py
@@ -1075,6 +1075,7 @@ def invoices_view(**kwargs):
 
             total = None
             invoice = raw_payment.get("invoice")
+            status = invoice.get("status")
             if invoice and invoice.get("total"):
                 cost = invoice.get("total") / 100
                 currency = invoice.get("currency")
@@ -1103,6 +1104,7 @@ def invoices_view(**kwargs):
                     "total": total,
                     "download_file_name": "Download",
                     "download_link": download_link,
+                    "status": status,
                 }
             )
 


### PR DESCRIPTION
## Done
- Simply display the invoice status in the invoice table to help the user select the correct invoice. Of course this could and should be further improved.

## QA
- Open the demo at /advantage/subscribe?test_backend=true
- Purchase a subscription using the following card number: 4000000000009995
- See that the purchase fails due to `insufficient_funds`
- Switch to the invoice view and see that status in the table

## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/10652

## Screenshots
![image](https://user-images.githubusercontent.com/1413534/137776308-7fc80e09-d4ba-4318-9ba4-d5a65dd19adc.png)

