### PR TITLE
handle user not allowed to purchase on account error

### DIFF
--- a/static/js/src/advantage/users/utils.ts
+++ b/static/js/src/advantage/users/utils.ts
@@ -12,6 +12,8 @@ export const errorMessages = {
   ["authentication required"]: "Authentication required",
   ["unauthorized"]: "Unauthorized",
   ["cannot find purchase account"]: "Cannot find purchase account",
+  ["user not allowed to purchase on account"]:
+    "User not allowed to purchase on account",
   ["unknown"]: "An unknown error has occurred.",
 } as const;
 


### PR DESCRIPTION
## Done

- handle user not allowed to purchase error (previously showed up as an unknown error)

## QA

- Log in as a user that has no purchase permissions on account (e.g. technical account)
- go to /advantage/users
- see the error message 


## Issue / Card

https://github.com/canonical-web-and-design/commercial-squad/issues/334

## Screenshots
![image](https://user-images.githubusercontent.com/7452681/137875779-1b1989b0-a2eb-4823-a621-bee2dbde5246.png)

