### PR TITLE
Adjust legacy user subscriptions rules

### DIFF
--- a/tests/advantage/helpers.py
+++ b/tests/advantage/helpers.py
@@ -129,6 +129,7 @@ def make_listing(
 
 
 def make_contract_item(
+    id: int = None,
     contract_id: str = None,
     created_at: str = None,
     start_date: str = None,
@@ -143,6 +144,7 @@ def make_contract_item(
 ) -> ContractItem:
 
     return ContractItem(
+        id=id or 123,
         contract_id=contract_id or "cAaBbCcDdEeFfGg",
         created_at=created_at or "2020-01-01T00:00:00Z",
         start_date=start_date or "2020-01-01T00:00:00Z",
@@ -182,6 +184,7 @@ def make_renewal(
 
 
 def make_legacy_contract_item(
+    id: int = None,
     contract_id: str = None,
     created_at: str = None,
     start_date: str = None,
@@ -203,6 +206,7 @@ def make_legacy_contract_item(
     )
 
     return ContractItem(
+        id=id or 123,
         contract_id=contract_id or "cAaBbCcDdEeFfGg",
         created_at=created_at or "2020-01-01T00:00:00Z",
         start_date=start_date or "2020-01-01T00:00:00Z",
@@ -236,6 +240,7 @@ def make_purchase_contract_item(
 
 
 def make_free_trial_contract_item(
+    id: int = None,
     contract_id: str = None,
     created_at: str = None,
     start_date: str = None,
@@ -245,6 +250,7 @@ def make_free_trial_contract_item(
     trial_id: str = None,
 ) -> ContractItem:
     return ContractItem(
+        id=id or 123,
         contract_id=contract_id or "cAaBbCcDdEeFfGg",
         created_at=created_at or "2020-01-01T00:00:00Z",
         start_date=start_date or "2020-01-01T00:00:00Z",

--- a/tests/advantage/test_parsers.py
+++ b/tests/advantage/test_parsers.py
@@ -331,6 +331,7 @@ class TestParsers(unittest.TestCase):
 
         expectation = [
             ContractItem(
+                id=5,
                 contract_id="cAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP2",
                 created_at="2014-06-01T10:00:00Z",
                 start_date="2014-06-01T10:00:00Z",
@@ -355,6 +356,7 @@ class TestParsers(unittest.TestCase):
 
         expectation = [
             ContractItem(
+                id=3,
                 contract_id="cAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP2",
                 created_at="2014-02-01T10:00:00Z",
                 start_date="2014-03-01T10:00:00Z",
@@ -380,6 +382,7 @@ class TestParsers(unittest.TestCase):
 
         expectation = [
             ContractItem(
+                id=6,
                 contract_id="cAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP2",
                 created_at="2014-01-01T10:00:00Z",
                 start_date="2014-01-01T10:00:00Z",
@@ -438,6 +441,7 @@ class TestParsers(unittest.TestCase):
             ],
             items=[
                 ContractItem(
+                    id=10,
                     contract_id="cAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
                     created_at="2017-01-02T10:00:00Z",
                     start_date="2017-01-02T10:00:00Z",
@@ -449,6 +453,7 @@ class TestParsers(unittest.TestCase):
                     trial_id="tAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
                 ),
                 ContractItem(
+                    id=11,
                     contract_id="cAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
                     created_at="2017-02-02T10:00:00Z",
                     start_date="2017-02-02T10:00:00Z",
@@ -484,6 +489,7 @@ class TestParsers(unittest.TestCase):
                 ],
                 items=[
                     ContractItem(
+                        id=10,
                         contract_id="cAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
                         created_at="2017-01-02T10:00:00Z",
                         start_date="2017-01-02T10:00:00Z",

--- a/webapp/advantage/ua_contracts/builders.py
+++ b/webapp/advantage/ua_contracts/builders.py
@@ -146,12 +146,17 @@ def build_legacy_item_groups(user_summary: List) -> List:
                 continue
 
             for item in contract.items:
-                if item.renewal is not None:
+                if (
+                    item.product_listing_id is None
+                    or item.subscription_id is None
+                ):
                     legacy_item_groups.append(
                         {
                             "account": user_details.get("account"),
                             "contract": contract,
                             "items": [item],
+                            "renewal": item.renewal,
+                            "item_id": item.id,
                             "listing": None,
                             "marketplace": "canonical-ua",
                             "subscriptions": user_details.get("subscriptions"),
@@ -173,11 +178,12 @@ def build_final_user_subscriptions(
         subscriptions: List[Subscription] = group.get("subscriptions")
         items: List[ContractItem] = group.get("items")
         type = group.get("type")
+        renewal = group.get("renewal")
+        item_id = group.get("item_id")
         subscription_id = group.get("subscription_id")
         aggregated_values = get_items_aggregated_values(items)
         number_of_machines = aggregated_values.get("number_of_machines")
         price_info = get_price_info(number_of_machines, items, listing)
-        renewal = items[0].renewal if type == "legacy" else None
         product_name = (
             contract.name if type != "free" else "Free Personal Token"
         )
@@ -191,7 +197,7 @@ def build_final_user_subscriptions(
         )
 
         id = make_user_subscription_id(
-            account, type, contract, renewal, subscription_id
+            account, type, contract, renewal, subscription_id, item_id
         )
 
         user_subscription = UserSubscription(

--- a/webapp/advantage/ua_contracts/helpers.py
+++ b/webapp/advantage/ua_contracts/helpers.py
@@ -175,6 +175,9 @@ def get_user_subscription_statuses(
             statuses["is_downsizeable"] = True
             statuses["is_cancellable"] = True
 
+    if type == "legacy" and renewal is None:
+        return statuses
+
     if type == "legacy":
         statuses["is_renewal_actionable"] = renewal.actionable
 
@@ -283,6 +286,7 @@ def make_user_subscription_id(
     contract: Contract,
     renewal: Renewal = None,
     subscription_id: str = None,
+    item_id: id = None,
 ) -> str:
     id_elements = [type, account.id, contract.id]
     if renewal:
@@ -290,6 +294,9 @@ def make_user_subscription_id(
 
     if subscription_id:
         id_elements.append(subscription_id)
+
+    if item_id:
+        id_elements.append(str(item_id))
 
     return "||".join(id_elements)
 

--- a/webapp/advantage/ua_contracts/parsers.py
+++ b/webapp/advantage/ua_contracts/parsers.py
@@ -122,6 +122,7 @@ def parse_contract_items(raw_items: List[Dict] = None) -> List[ContractItem]:
         raw_renewal = raw_item.get("renewal")
 
         item = ContractItem(
+            id=raw_item.get("id"),
             contract_id=raw_item.get("contractID"),
             created_at=raw_item.get("created"),
             start_date=raw_item.get("effectiveFrom"),

--- a/webapp/advantage/ua_contracts/primitives.py
+++ b/webapp/advantage/ua_contracts/primitives.py
@@ -30,6 +30,7 @@ class Renewal:
 class ContractItem:
     def __init__(
         self,
+        id: int,
         contract_id: str,
         created_at: str,
         start_date: str,
@@ -42,6 +43,7 @@ class ContractItem:
         trial_id: str = None,
         renewal: Renewal = None,
     ):
+        self.id = id
         self.contract_id = contract_id
         self.created_at = created_at
         self.start_date = start_date


### PR DESCRIPTION
## Done

- change the legacy user subscription rule to not reject contract items without a renewal; instead create a legacy user subscription for each contract item without a product listing id or subscription id
- extract contract item id, as we will need a unique value to create a unique ID for user subscriptions of legacy contract items without renewal ID.

## QA

- Go to https://ubuntu.com/advantage (prod)
- Login
- You will only see your free subscription
- Go to https://ubuntu-com-10680.demos.haus/advantage (prod)
- Login
- You should see 8 product items and you should be able to switch between them


## Issue / Card

Fixes #https://github.com/canonical-web-and-design/ubuntu.com/issues/10676