### PR TITLE
Hide honeypot on /download/server/thank-you

### DIFF
--- a/templates/download/shared/_server_weekly_news.html
+++ b/templates/download/shared/_server_weekly_news.html
@@ -21,12 +21,14 @@
           <input required  id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$">
           <label for="phone">Mobile/cell phone number:</label>
           <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
-          {# These are honey pot fields to catch bots #}
-          <label class="website" for="website">Website:</label>
-          <input name="website" type="text" class="website" autocomplete="off" value="" id="website" tabindex="-1" />
-          <label class="name" for="name">Name:</label>
-          <input name="name" type="text" class="name" autocomplete="off" value="" id="name" tabindex="-1" />
-          {# End of honey pots #}
+          <div class="u-off-screen">
+            {# These are honey pot fields to catch bots #}
+            <label class="website" for="website">Website:</label>
+            <input name="website" type="text" class="website" autocomplete="off" value="" id="website" tabindex="-1" />
+            <label class="name" for="name">Name:</label>
+            <input name="name" type="text" class="name" autocomplete="off" value="" id="name" tabindex="-1" />
+            {# End of honey pots #}
+          </div>
         </div>
       </div>
       <input value="yes" id="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">


### PR DESCRIPTION
## Done

- Hide honeypot on /download/server/thank-you

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/server and download the manual install
- See if the CLI form has the honeypot fields removed

## Screenshot

![image](https://user-images.githubusercontent.com/441217/138103164-185ac408-6a78-42a0-b6a9-82c3ce3181e6.png)
