### PR TITLE
Add video to /kubernetes banner

### DIFF
--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -12,7 +12,6 @@
     <div class="col-7">
       <h1>Enterprise Kubernetes for multi-cloud operations</h1>
       <p class="p-heading--4">Container orchestration streamlined from cloud to edge</p>
-
       <p>
         Ubuntu is the reference platform for Kubernetes on all major public clouds.<br>
         Canonical Kubernetes is built on Ubuntu and combines security with optimal price-performance.<br>
@@ -23,15 +22,8 @@
         <a href="/kubernetes/install">Try it now&nbsp;&rsaquo;</a>
       </p>
     </div>
-    <div class="col-5 u-align--center u-hide--small">
-      {{
-        image(
-        url="https://assets.ubuntu.com/v1/f145e15a-K8s_Multi-cloud_solid.svg",
-        alt="",
-        width="400",
-        hi_def=True,
-        ) | safe
-      }}
+    <div class="col-5 u-align--center u-hide--small u-embedded-media">
+      <iframe title="Kubernetes by Canonical" class="u-embedded-media__element" src="https://www.youtube.com/embed/tG5kqnnytIg" allowfullscreen=""></iframe>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- Add video to /kubernetes banner as per [copydoc](https://docs.google.com/document/d/1b018GoKMF3abEFJlUkfAEK2JEhXWICKF4V0dGdTvgJs/edit#)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/kubernetes or https://ubuntu-com-10685.demos.haus/kubernetes
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare against [copydoc](https://docs.google.com/document/d/1b018GoKMF3abEFJlUkfAEK2JEhXWICKF4V0dGdTvgJs/edit#)
- Go to /kubernetes and check the video works


## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/10669
