### PR TITLE
Implement CUBE purchase modal (step 2: summary & buy button)

### DIFF
--- a/static/js/src/cube/api/purchase.ts
+++ b/static/js/src/cube/api/purchase.ts
@@ -1,0 +1,26 @@
+export const postPurchaseData = async (
+  accountID: string,
+  productListingId: string,
+  preview: boolean
+) => {
+  // Pass arguments to the flask backend eg. "test_backend=true"
+  const queryString = window.location.search;
+
+  const response = await fetch(`/cube/microcerts/purchase.json${queryString}`, {
+    method: "POST",
+    cache: "no-store",
+    credentials: "include",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      account_id: accountID,
+      product_listing_id: productListingId,
+      ...(preview && { preview: "true" }),
+    }),
+  });
+
+  const data = await response.json();
+  return data;
+};

--- a/static/js/src/cube/components/CubeBuyButton/CubeBuyButton.tsx
+++ b/static/js/src/cube/components/CubeBuyButton/CubeBuyButton.tsx
@@ -1,0 +1,140 @@
+import React, { useEffect, useState } from "react";
+import { ActionButton } from "@canonical/react-components";
+import * as Sentry from "@sentry/react";
+import { BuyButtonProps } from "../../../PurchaseModal/utils/utils";
+import useStripeCustomerInfo from "../../../PurchaseModal/hooks/useStripeCustomerInfo";
+import { getErrorMessage } from "../../../advantage/error-handler";
+import usePurchase from "../../hooks/usePurchase";
+import usePendingPurchase from "../../hooks/usePendingPurchase";
+
+export type Props = BuyButtonProps & { productListingId: string };
+
+const CubeBuyButton = ({
+  areTermsChecked,
+  setTermsChecked,
+  setError,
+  setStep,
+  productListingId,
+}: Props) => {
+  const [isLoading, setIsLoading] = useState(false);
+
+  const purchaseMutation = usePurchase(productListingId);
+
+  const {
+    data: pendingPurchase,
+    setPendingPurchaseId,
+    error: purchaseError,
+  } = usePendingPurchase();
+
+  const { data: userInfo } = useStripeCustomerInfo();
+
+  const handleOnAfterPurchaseSuccess = () => {
+    const testBackend = window?.location?.search?.includes("test_backend=true")
+      ? "&test_backend=true"
+      : "";
+
+    if (window.isGuest) {
+      location.href = `/cube/thank-you?email=${encodeURIComponent(
+        userInfo?.customerInfo?.email
+      )}${testBackend}`;
+    } else {
+      location.pathname = "/cube/microcerts";
+    }
+  };
+
+  const onPayClick = () => {
+    setIsLoading(true);
+
+    purchaseMutation.mutate(undefined, {
+      onSuccess: (data) => {
+        //start polling
+        setPendingPurchaseId(data);
+      },
+      onError: (error) => {
+        setIsLoading(false);
+        if (
+          error instanceof Error &&
+          error.message.includes("can only make one purchase at a time")
+        ) {
+          setError(
+            <>
+              You already have a pending purchase. Please go to{" "}
+              <a href="/account/payment-methods">payment methods</a> to retry.
+            </>
+          );
+        } else {
+          Sentry.captureException(error);
+          setError(
+            <>
+              Sorry, there was an unknown error with with the payment. Check the
+              details and try again. Contact{" "}
+              <a href="https://ubuntu.com/contact-us">Canonical sales</a> if the
+              problem persists.
+            </>
+          );
+        }
+      },
+    });
+  };
+
+  useEffect(() => {
+    // the initial call was successful but it returned an error while polling the purchase status
+    if (purchaseError instanceof Error) {
+      setIsLoading(false);
+      if (
+        purchaseError.message.includes(
+          "We are unable to authenticate your payment method"
+        )
+      ) {
+        setError(
+          <>
+            We were unable to verify your credit card. Check the details and try
+            again. Contact{" "}
+            <a href="https://ubuntu.com/contact-us">Canonical sales</a> if the
+            problem persists.
+          </>
+        );
+      } else {
+        const knownError = getErrorMessage(purchaseError);
+
+        if (!knownError) {
+          Sentry.captureException(purchaseError);
+          setError(
+            <>
+              We were unable to process the payment. Check the details and try
+              again. Contact{" "}
+              <a href="https://ubuntu.com/contact-us">Canonical sales</a> if the
+              problem persists.
+            </>
+          );
+        } else {
+          setError(knownError);
+        }
+      }
+      setTermsChecked(false);
+      setStep(1);
+    }
+  }, [purchaseError]);
+
+  useEffect(() => {
+    if (pendingPurchase?.status === "done") {
+      handleOnAfterPurchaseSuccess();
+    }
+  }, [pendingPurchase]);
+
+  return (
+    <ActionButton
+      className="col-small-2 col-medium-2 col-3 u-no-margin"
+      appearance="positive"
+      aria-label="Buy"
+      style={{ textAlign: "center" }}
+      disabled={!areTermsChecked || isLoading}
+      loading={isLoading}
+      onClick={onPayClick}
+    >
+      Buy
+    </ActionButton>
+  );
+};
+
+export default CubeBuyButton;

--- a/static/js/src/cube/components/CubeBuyButton/index.ts
+++ b/static/js/src/cube/components/CubeBuyButton/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./CubeBuyButton";

--- a/static/js/src/cube/components/CubePurchase/CubePurchase.tsx
+++ b/static/js/src/cube/components/CubePurchase/CubePurchase.tsx
@@ -1,13 +1,17 @@
 import React, { useState } from "react";
-import { ActionButton, Button, Modal } from "@canonical/react-components";
+import { Button } from "@canonical/react-components";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { ReactQueryDevtools } from "react-query/devtools";
 import { Elements } from "@stripe/react-stripe-js";
 import { loadStripe } from "@stripe/stripe-js";
+import CubePurchaseModal from "../CubePurchaseModal";
 
-import PurchaseModal from "../../../PurchaseModal";
+type Props = {
+  productName: string;
+  productListingId: string;
+};
 
-const CubePurchase = () => {
+const CubePurchase = ({ productName, productListingId }: Props) => {
   const [modalOpen, setModalOpen] = useState(false);
   const closeHandler = () => setModalOpen(false);
 
@@ -25,30 +29,6 @@ const CubePurchase = () => {
     },
   });
 
-  const termsLabel = (
-    <>
-      I agree to the{" "}
-      <a
-        href="/legal/terms-and-policies/cube-terms"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        CUBE service terms
-      </a>
-    </>
-  );
-
-  // TODO: replace these
-  const summary = () => (
-    <div>
-      <h3>Summary</h3>
-      <p>CUBE</p>
-    </div>
-  );
-  const buyButton = () => <ActionButton>Buy</ActionButton>;
-  const product = "CUBE";
-  const quantity = 1;
-
   return (
     <div>
       <Button appearance={"positive"} onClick={() => setModalOpen(true)}>
@@ -57,23 +37,11 @@ const CubePurchase = () => {
       {modalOpen ? (
         <QueryClientProvider client={queryClient}>
           <Elements stripe={stripePromise}>
-            <Modal
-              className="p-modal--ua-payment"
-              style={{ textAlign: "initial" }}
-              close={closeHandler}
-            >
-              <PurchaseModal
-                modalTitle="Complete purchase"
-                marketplace="canonical-cube"
-                termsLabel={termsLabel}
-                isFreeTrialApplicable={false}
-                product={product}
-                quantity={quantity}
-                closeModal={closeHandler}
-                Summary={summary}
-                BuyButton={buyButton}
-              />
-            </Modal>
+            <CubePurchaseModal
+              productName={productName}
+              productListingId={productListingId}
+              closeHandler={closeHandler}
+            />
           </Elements>
           <ReactQueryDevtools initialIsOpen={false} />
         </QueryClientProvider>

--- a/static/js/src/cube/components/CubePurchaseModal/CubePurchaseModal.tsx
+++ b/static/js/src/cube/components/CubePurchaseModal/CubePurchaseModal.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { Modal } from "@canonical/react-components";
+import PurchaseModal from "../../../PurchaseModal";
+import { BuyButtonProps } from "../../../PurchaseModal/utils/utils";
+import Summary from "../Summary";
+import CubeBuyButton from "../CubeBuyButton";
+import usePreview from "../../hooks/usePreview";
+
+type Props = {
+  productName: string;
+  productListingId: string;
+  closeHandler: () => void;
+};
+
+const CubePurchaseModal = ({
+  productName,
+  productListingId,
+  closeHandler,
+}: Props) => {
+  // Fetch preview data so that the user doesn't have to wait for it on the
+  // second modal view
+  usePreview(productListingId);
+
+  const termsLabel = (
+    <>
+      I agree to the{" "}
+      <a
+        href="/legal/terms-and-policies/cube-terms"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        CUBE service terms
+      </a>
+    </>
+  );
+
+  const summary = () => <Summary productListingId={productListingId} />;
+
+  const buyButton = ({ ...props }: BuyButtonProps) => (
+    <CubeBuyButton productListingId={productListingId} {...props} />
+  );
+
+  const quantity = 1;
+
+  return (
+    <Modal
+      className="p-modal--ua-payment"
+      style={{ textAlign: "initial" }}
+      close={closeHandler}
+    >
+      <PurchaseModal
+        modalTitle="Complete purchase"
+        marketplace="canonical-cube"
+        termsLabel={termsLabel}
+        isFreeTrialApplicable={false}
+        product={productName}
+        quantity={quantity}
+        closeModal={closeHandler}
+        Summary={summary}
+        BuyButton={buyButton}
+      />
+    </Modal>
+  );
+};
+
+export default CubePurchaseModal;

--- a/static/js/src/cube/components/CubePurchaseModal/index.ts
+++ b/static/js/src/cube/components/CubePurchaseModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./CubePurchaseModal";

--- a/static/js/src/cube/components/MicrocertificationsTable/MicrocertificationsTable.tsx
+++ b/static/js/src/cube/components/MicrocertificationsTable/MicrocertificationsTable.tsx
@@ -41,6 +41,7 @@ const TableView = () => {
             studyLabURL: module["study_lab"],
             takeURL: module["take_url"],
             status: module["status"],
+            productListingId: module["product_listing_id"],
           }));
 
           setModules(modules);
@@ -100,7 +101,8 @@ const TableView = () => {
     badgeURL: string,
     studyLabURL: string,
     takeURL: string,
-    status: Status
+    status: Status,
+    productListingId: string
   ) => (
     <div className="u-no-padding--top u-align--right">
       {status === Status.Enrolled ? (
@@ -147,7 +149,10 @@ const TableView = () => {
           ]}
         />
       ) : (
-        <CubePurchase />
+        <CubePurchase
+          productName={moduleName}
+          productListingId={productListingId}
+        />
       )}
     </div>
   );
@@ -165,7 +170,18 @@ const TableView = () => {
         { content: "Action", className: "u-align--right" },
       ]}
       rows={modules.map(
-        ({ name, badgeURL, topics, studyLabURL, takeURL, status }, index) => {
+        (
+          {
+            name,
+            badgeURL,
+            topics,
+            studyLabURL,
+            takeURL,
+            status,
+            productListingId,
+          },
+          index
+        ) => {
           return {
             key: name,
             columns: [
@@ -197,7 +213,8 @@ const TableView = () => {
                   badgeURL,
                   studyLabURL,
                   takeURL,
-                  status
+                  status,
+                  productListingId
                 ),
               },
             ],

--- a/static/js/src/cube/components/Summary/Summary.tsx
+++ b/static/js/src/cube/components/Summary/Summary.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { Row, Col } from "@canonical/react-components";
+import { formatter } from "../../../advantage/subscribe/renderers/form-renderer";
+import usePreview from "../../hooks/usePreview";
+
+type Props = {
+  productListingId: string;
+};
+
+const Summary = ({ productListingId }: Props) => {
+  const { isLoading, isError, data: preview } = usePreview(productListingId);
+
+  return (
+    <section
+      id="summary-section"
+      className="p-strip is-shallow u-no-padding--top"
+      aria-live="polite"
+      aria-busy={isLoading ? "true" : "false"}
+    >
+      {isLoading ? (
+        <Row className="u-no-padding u-sv1">
+          <Col size={12} className="u-align--center">
+            <i className="p-icon--spinner u-animation--spin u-align--center"></i>
+          </Col>
+        </Row>
+      ) : isError ? (
+        <i className="u-align--center">
+          An error occurred while fetching product information.
+        </i>
+      ) : (
+        <>
+          <Row className="u-no-padding u-sv1">
+            <Col size={4}>
+              <div className="u-text-light">Product:</div>
+            </Col>
+            <Col size={8}>
+              <div>{preview?.lineItems[0]?.description}</div>
+            </Col>
+          </Row>
+          <Row className="u-no-padding u-sv1">
+            <Col size={4}>
+              <div className="u-text-light">Subtotal:</div>
+            </Col>
+            <Col size={8}>
+              <div>{formatter.format(preview?.amountDue / 100)}</div>
+            </Col>
+          </Row>
+        </>
+      )}
+    </section>
+  );
+};
+
+export default Summary;

--- a/static/js/src/cube/components/Summary/index.ts
+++ b/static/js/src/cube/components/Summary/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Summary";

--- a/static/js/src/cube/hooks/usePendingPurchase.tsx
+++ b/static/js/src/cube/hooks/usePendingPurchase.tsx
@@ -1,0 +1,92 @@
+import { useState } from "react";
+import { useQuery } from "react-query";
+import { useStripe } from "@stripe/react-stripe-js";
+import { getPurchase, postInvoiceID } from "../../advantage/api/contracts";
+
+type PurchaseError = Error & { dontRetry: boolean };
+
+const requires3DSCheck = (
+  pi_decline_code: string,
+  pi_status: string,
+  pi_secret: string
+) => {
+  return (
+    pi_decline_code === "authentication_required" ||
+    (pi_status === "requires_action" && pi_secret)
+  );
+};
+
+const usePendingPurchase = () => {
+  const [pendingPurchaseId, setPendingPurchaseId] = useState("");
+
+  const stripe = useStripe();
+
+  const { isLoading, isError, isSuccess, data, error } = useQuery(
+    ["pendingPurchase", pendingPurchaseId],
+    async () => {
+      const res = await getPurchase(pendingPurchaseId);
+
+      if (!res.stripeInvoices || res.status === "processing") {
+        throw new Error("Missing invoice");
+      }
+
+      const {
+        pi_decline_code,
+        pi_status,
+        pi_secret,
+        id: stripeInvoiceId,
+      } = res.stripeInvoices[0];
+
+      if (requires3DSCheck(pi_decline_code, pi_status, pi_secret)) {
+        if (!stripe) {
+          throw new Error("Stripe is not loaded");
+        }
+
+        const threeDSResponse = await stripe.confirmCardPayment(pi_secret);
+        if (threeDSResponse.error) {
+          const error = Error(threeDSResponse.error.message) as PurchaseError;
+          error.dontRetry = true;
+          throw error;
+        }
+      }
+
+      //Card declined
+      if (pi_status === "requires_payment_method") {
+        const invoiceRes = await postInvoiceID(
+          "purchase",
+          pendingPurchaseId,
+          stripeInvoiceId
+        );
+
+        const error = Error(
+          JSON.parse(invoiceRes.errors).decline_code
+        ) as PurchaseError;
+        error.dontRetry = true;
+        throw error;
+      }
+
+      if (res.status === "done") {
+        return res;
+      } else {
+        throw new Error("Not done yet");
+      }
+    },
+    {
+      enabled: !!pendingPurchaseId,
+      retry: (_, error: PurchaseError) => {
+        return !error.dontRetry;
+      },
+    }
+  );
+
+  return {
+    setPendingPurchaseId,
+    isLoading,
+    isError,
+    isSuccess,
+    data,
+    error,
+  };
+};
+
+export default usePendingPurchase;

--- a/static/js/src/cube/hooks/usePreview.tsx
+++ b/static/js/src/cube/hooks/usePreview.tsx
@@ -1,0 +1,40 @@
+import { useQuery } from "react-query";
+import { postPurchaseData } from "../api/purchase";
+import useStripeCustomerInfo from "../../PurchaseModal/hooks/useStripeCustomerInfo";
+
+const usePreview = (productListingId: string) => {
+  const { isError: isUserInfoError } = useStripeCustomerInfo();
+
+  const { isLoading, isError, isSuccess, data, error } = useQuery(
+    ["preview", productListingId],
+    async () => {
+      if (!window.accountId) {
+        throw new Error("Account ID missing");
+      }
+
+      const res = await postPurchaseData(
+        window.accountId,
+        productListingId,
+        true
+      );
+
+      if (res.errors) {
+        throw new Error(res.errors);
+      }
+      return res;
+    },
+    {
+      enabled: !!window.accountId && !!productListingId && !isUserInfoError,
+    }
+  );
+
+  return {
+    isLoading,
+    isError,
+    isSuccess,
+    data,
+    error,
+  };
+};
+
+export default usePreview;

--- a/static/js/src/cube/hooks/usePurchase.tsx
+++ b/static/js/src/cube/hooks/usePurchase.tsx
@@ -1,0 +1,26 @@
+import { useMutation } from "react-query";
+import { postPurchaseData } from "../api/purchase";
+
+const usePurchase = (productListingId: string) => {
+  const mutation = useMutation(async () => {
+    if (!window.accountId) {
+      throw new Error("Account ID missing");
+    }
+
+    const res = await postPurchaseData(
+      window.accountId,
+      productListingId,
+      false
+    );
+
+    if (res.errors) {
+      throw new Error(res.errors);
+    }
+
+    return res.id;
+  });
+
+  return mutation;
+};
+
+export default usePurchase;

--- a/templates/cube/microcerts.html
+++ b/templates/cube/microcerts.html
@@ -216,6 +216,7 @@
 </div>
 
 <script >
+window.accountId = "{% if account_id %}{{ account_id }}{% endif %}";
 window.stripePublishableKey = "{{ get_stripe_publishable_key }}";
 
 const myObserver = new ResizeObserver((entries) => {


### PR DESCRIPTION
## Done

- Implement step 2 of CUBE payment modal (summary and "Buy" button)

Depends on https://github.com/canonical-web-and-design/ubuntu.com/pull/10656

## QA

- Run the server with `dotrun`
- Go to http://localhost:8001/cube/microcerts?test_backend=true
- Click on the "Purchase" button for a microcert where you are unenrolled or have failed
- Complete the purchase process and verify that the "Purchase" button in the microcerts table has been replaced by the "Take" button

## Issue / Card

Fixes https://github.com/canonical-web-and-design/commercial-squad/issues/240

## Screenshots

![cube-purchase](https://user-images.githubusercontent.com/995051/139075178-dd9e600e-32af-4cff-b866-7e441d0c9218.png)


