### PR TITLE
Improve accuracy of code coverage reports

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,5 +1,5 @@
 name: PR checks
-on: pull_request
+on: [push, pull_request]
 env:
   SECRET_KEY: insecure_test_key
   DATABASE_URL: postgres://postgres:pw@localhost:5432/postgres
@@ -169,7 +169,7 @@ jobs:
         run: /snap/bin/dotrun --env SEARCH_API_KEY=fake-key exec coverage run --source=. -m unittest discover tests
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           flags: python
 
@@ -187,7 +187,7 @@ jobs:
           yarn test-js --coverage
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           flags: javascript
 


### PR DESCRIPTION
## Done

- run PR checks on `push` event in addition to `pull request` 
  - ensures code coverage is also uploaded on pull request merge
- use latest version of codecov uploader: `codecov/codecov-action@v2`

You can see how it runs on last PR commit, but not on merge commit below. This can lead to codecov displaying incorrect results - report after merge is never uploaded.

![image](https://user-images.githubusercontent.com/7452681/138674647-999f069f-2a24-47c5-a474-556f6bc8cdce.png)
https://github.com/canonical-web-and-design/ubuntu.com/commits/main