### PR TITLE
Add checksum for 18.04.6 live server

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -35,6 +35,7 @@ checksums:
   live-server:
     "21.10": "e84f546dfc6743f24e8b1e15db9cc2d2c698ec57d9adfb852971772d1ce692d4 *ubuntu-21.10-live-server-amd64.iso"
     "20.04.3": "f8e3086f3cea0fb3fefb29937ab5ed9d19e767079633960ccb50e76153effc98 *ubuntu-20.04.3-live-server-amd64.iso"
+    "18.04.6": "6c647b1ab4318e8c560d5748f908e108be654bad1e165f7cf4f3c1fc43995934 *ubuntu-18.04.6-live-server-amd64.iso"
   desktop-arm64+raspi:
     "21.10": "5187d507099f26bc4d8218085109af498fae5ff93b40c668f83bab5c7574d954 *ubuntu-21.10-preinstalled-desktop-arm64+raspi.img.xz"
   server-arm64+raspi:


### PR DESCRIPTION
## Done

- Added a checksum for the 18.04.6 live server as it was missing

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/server
- Download the manual install and 18.04.6 and see on the thankyou page that it displays the correct checksum

## Issue / Card

Fixes #10704 

## Screenshots

![image](https://user-images.githubusercontent.com/441217/138662608-5dcfe28b-9e61-4fb8-8847-86645b72b59b.png)

