### PR TITLE
Create new contact form for /security/fips

### DIFF
--- a/templates/security/fips.html
+++ b/templates/security/fips.html
@@ -259,7 +259,7 @@
 {% with first_item="_security_discussion", second_item="_security_esm", third_item="_security_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/security-fips.html" data-form-id="4208" data-lp-id="2154" data-return-url="/security-fips/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/security-fips.html" data-form-id="4208" data-lp-id="2154" data-return-url="/security/thank-you?product=fips" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 
 {% endblock content %}

--- a/templates/security/thank-you.html
+++ b/templates/security/thank-you.html
@@ -11,6 +11,10 @@
 
   {% with thanks_context="about LTS Docker Images" %}{% include "shared/_thank_you.html" %}{% endwith %}
 
+{% elif product == 'fips' %}
+
+  {% with thanks_context="your interest in FIPS 140-3 and Ubuntu", thanks_message="Thank you for registering your interest in the OpenJDK for FIPS beta programme. If selected as a participant, you will receive an email from Canonical with more details on getting started." %}{% include "shared/_thank_you.html" %}{% endwith %}
+
 {% elif product == 'esm' %}
 
   {% with thanks_context="about Extended Security Maintenance" %}{% include "shared/_thank_you.html" %}{% endwith %}

--- a/templates/shared/forms/interactive/security-fips.html
+++ b/templates/shared/forms/interactive/security-fips.html
@@ -105,7 +105,8 @@
 									<label for="Comments_from_lead__c">What would you like to talk to us about?</label>
 									<textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
 								</li>
-							</ul>
+                            </ul>
+                            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
 							<input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %%" />
 							<input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
 							<input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />


### PR DESCRIPTION
## Done

- Create a new modal contact form 
- Add a notification card at the top of the page
- Update `/security/fips` to use the form 

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/fips
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to `/security/fips` and check  the "Join our free beta programme for a FIPS-validated OpenJDK" link and `contact us` button is working properly
- Please check the page and the form against [form doc](https://docs.google.com/document/d/1dA6y-0VCsug50cUnWsNsFQYp1-leg8JZ_EU1rCKJeiA/edit#) and [brief](https://docs.google.com/document/d/1dzUObyMPCrlLRNVj7lfjxIG02os1tTUDAxN3IB0UNLo/edit)
- [Demo](https://ubuntu-com-10718.demos.haus/security/fips)


## Issue / Card

Fixes [#4552](https://github.com/canonical-web-and-design/web-squad/issues/4552)

## Screenshots
![Screenshot 2021-10-26 at 8 25 20 am](https://user-images.githubusercontent.com/57550290/138828595-49ee003a-8380-4bfe-9c6a-c5aef6cb52b4.png)
![image](https://user-images.githubusercontent.com/57550290/138829349-24a61cf0-7af2-48a6-808c-bea8bdd28bb0.png)


