### PR TITLE
Correct Core 20 download for /download/iot/intel-iotg

### DIFF
--- a/templates/download/iot/intel-iotg.html
+++ b/templates/download/iot/intel-iotg.html
@@ -51,7 +51,7 @@
     <div class="col-6 p-divider__block">
       <h3>Ubuntu Core 20</h3>
       <p>
-        <a class="p-button--positive" href="http://cdimage.ubuntu.com/releases/focal/release/inteliotg/ubuntu-core-20-amd64+intel-iot.img.xz">Download</a>
+        <a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/focal/release/inteliotg/ubuntu-core-20-amd64+intel-iot.img.xz">Download</a>
       </p>
       <p>Please see the <a href="https://assets.ubuntu.com/v1/377806cd-October_25-Release+Notes.pdf">release notes</a> and <a href="https://assets.ubuntu.com/v1/87e46aa7-Installation+Instructions+Core+Image+Intel+IoTG+Platforms.pdf">instructions</a> for more information.</p>
     </div>


### PR DESCRIPTION
## Done

- Correct Core 20 download for /download/iot/intel-iotg

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/iot/intel-iotg
- See that the correct core download works

