### PR TITLE
make cypress wait for API responses

### DIFF
--- a/tests/cypress/integration/advantage/subscribe_spec.js
+++ b/tests/cypress/integration/advantage/subscribe_spec.js
@@ -197,6 +197,9 @@ context("/advantage/subscribe", () => {
   });
 
   it("redirects logged-in user to /advantage on after successful purchase", () => {
+    cy.intercept("POST", "/advantage/subscribe*").as("purchase");
+    cy.intercept("GET", "/advantage/purchases/*").as("pendingPurchase");
+
     cy.login();
     cy.visit(getTestURL("/advantage/subscribe"));
     cy.acceptCookiePolicy();
@@ -212,6 +215,9 @@ context("/advantage/subscribe", () => {
       force: true,
     });
     cy.findByRole("button", { name: "Buy" }).click();
+
+    cy.wait("@purchase");
+    cy.wait("@pendingPurchase");
 
     cy.url().should("include", getTestURL("/advantage"));
   });


### PR DESCRIPTION
## Done

- Ensures that cypress waits for API responses and `subscribe_spec.js` test doesn't fail due to timeout