### PR TITLE
Update CVE values on /16-04

### DIFF
--- a/templates/16-04/index.html
+++ b/templates/16-04/index.html
@@ -50,21 +50,20 @@
     </div>
   </div>
   <div class="row" style="margin-top: 1rem">
-    <div class="col-4">
-      <span style="font-size: 3rem; line-height: 4rem">{{ total_patches_applied }}</span>
+    <div class="col-4 u-sv3">
+      <span style="font-size: 3rem; line-height: 4rem">{{ notices_since_esm }}</span>
       <hr>
-      <span class="p-muted-heading">16.04 LTS ESM <br>PATCHES APPLIED</span>
+      <span class="p-muted-heading">USNS ISSUED<sup><a href="#os-footnote">*</a></sup></span>
     </div>
     <div class="col-4">
-      <span style="font-size: 3rem; line-height: 4rem">{{ total_notices_issued }}</span>
+      <!-- Hardcoded for now until this issue is fixed https://github.com/canonical-web-and-design/ubuntu-com-security-api/issues/56 -->
+      <span style="font-size: 3rem; line-height: 4rem">343</span>
       <hr>
-      <span class="p-muted-heading">USNS ISSUED</span>
+      <span class="p-muted-heading">CVES ADDRESSED<sup><a href="#os-footnote">*</a></sup></span>
     </div>
-    <div class="col-4">
-      <span style="font-size: 3rem; line-height: 4rem">{{ total_cves_issued }}</span>
-      <hr>
-      <span class="p-muted-heading">CVES ADDRESSED</span>
-    </div>
+  </div>
+  <div class="u-fixed-width">
+    <p id="os-footnote"><small>* Since the start of ESM phase</small></p>
   </div>
   <div class="row" id="notice-feed" style="margin-top: 3rem">
     {% for notice in latest_notices %}
@@ -89,9 +88,9 @@
       <h2>Ubuntu 16.04 LTS Extended Security Maintenance (ESM)</h2>
       <h3>What is Ubuntu ESM?</h3>
       <p><a href="/security/esm">Extended Security Maintenance</a> (ESM) provides extended Linux kernel and open source security updates for the Ubuntu base OS, key infrastructure components, like Ceph, OpenStack and Kubernetes, as well as open source applications, like PostgreSQL and NGINX.</p>
-      <p>ESM is available for free on up to three machines and for broader enterprise use through an Ubuntu Advantage subscription. The subscription includes additional services such FIPS-compliant modules and the Canonical Livepatch Service to apply critical kernel patches without unplanned downtime.</p>
+      <p>ESM is available for free on up to three machines and for broader enterprise use through an Ubuntu Advantage subscription. The subscription includes additional services such FIPS-compliant modules and the Ubuntu Livepatch Service to apply critical kernel patches without unplanned downtime.</p>
       <p>
-        <a href="/security/livepatch">Learn more about Canonical Livepatch&nbsp;&rsaquo;</a>
+        <a href="/security/livepatch">Learn more about Ubuntu Livepatch&nbsp;&rsaquo;</a>
       </p>
     </div>
     <div class="col-6 u-hide--small u-align--center u-vertically-center">

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -135,11 +135,13 @@ def sixteen_zero_four():
     except HTTPError:
         flask.current_app.extensions["sentry"].captureException()
 
+    notices_since_esm = total_notices_issued - 1477
     context = {
         "total_patches_applied": 69,  # hard-coded for now
         "total_notices_issued": f"{total_notices_issued:,}",
         "total_cves_issued": f"{total_cves_issued:,}",
         "latest_notices": latest_notices,
+        "notices_since_esm": notices_since_esm,
     }
 
     return flask.render_template("16-04/index.html", **context)


### PR DESCRIPTION
## Done

- Add another variable for `notices_since_esm` to the view. This is USNS issued minus `1477`
- Hardcoded CVE's addressed since ESM as there is a [bug](https://github.com/canonical-web-and-design/ubuntu-com-security-api/issues/56) with the filter from in the API 
- Removed patches applied
- Changed 'Canonical' to 'Ubuntu' in What is Ubuntu ESM section

## QA

- View page at: https://ubuntu-com-10733.demos.haus/16-04
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check page matches [copy doc](https://docs.google.com/document/d/1wclofqY9b3v_M9igpkYn6or5uXx0B_Xb_nVVzGBbOLY/edit#)


## Issue / Card

Fixes #10725 

## Screenshots

![Screenshot 2021-10-27 at 15 33 04](https://user-images.githubusercontent.com/58959073/139086965-592515a2-1e1f-4a42-b9d0-dffecd3b2aa9.png)

