### PR TITLE
Update /cpu-compatibility chipsets and h1

### DIFF
--- a/templates/cpu-compatibility/index.html
+++ b/templates/cpu-compatibility/index.html
@@ -10,12 +10,12 @@
 
 <section class="p-strip is-deep u-no-padding--bottom">
   <div class="row">
-    <div class="col-7">
+    <div class="col-8">
       <h1>CPU compatibility matrix for Ubuntu Server and OpenStack</h1>
       <p>The CPU compatibility matrix for Ubuntu and related products. The matrix shows which Ubuntu LTS version introduces an initial support for a given processor or chipset. Canonical recommends running the latest LTS release to take advantage of the full capabilities of a CPU.</p>
     </div>
 
-    <div class="col-5 u-vertically-center u-align--center u-hide--small">
+    <div class="col-4 u-vertically-center u-align--center u-hide--small">
       {{ image (
         url="https://assets.ubuntu.com/v1/c4f35e06-products-hero-ubuntu.svg",
         alt="products hero ubuntu",


### PR DESCRIPTION
## Done

- Update /cpu-compatibility chipsets and h1
- From a roadmap breakout, we notices Milan was there a few times an that Sapphire should not, also the title needed to be more specific

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/cpu-compatibility
- See that some chipsets where removed and codenames updated
- See that the H1 adds server and openstack


## Screenshots

![image](https://user-images.githubusercontent.com/441217/139104571-7d5eca26-7ec5-461a-bb22-31f864cd5e28.png)

