### PR TITLE
Use Flask-base v0.9.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-canonicalwebteam.flask-base==0.9.1
+canonicalwebteam.flask-base==0.9.2
 alembic==1.5.4
 canonicalwebteam.http==1.0.3
 canonicalwebteam.blog==6.4.0


### PR DESCRIPTION
Upgrade to the freshly minted [Flask-Base 0.9.2](https://github.com/canonical-web-and-design/canonicalwebteam.flask-base/pull/51).

This should prevent old CSS files from being loaded at new hash URLs, which should mean we no longer ever get stale CSS on releases.

QA
--

Load [the demo](https://ubuntu-com-10738.demos.haus), check everything looks fine. Also check invalid hashes lead to 404s: https://ubuntu-com-10738.demos.haus/static/css/styles.css?v=53216fd