### PR TITLE
Recover success message

### DIFF
--- a/static/js/src/dynamic-forms.js
+++ b/static/js/src/dynamic-forms.js
@@ -3,11 +3,15 @@
     var triggeringHash = "#get-in-touch";
     var formContainer = document.getElementById("contact-form-container");
     var contactButtons = document.querySelectorAll(".js-invoke-modal");
+    const contactForm = document.getElementById("contact-form-container");
+    const returnData = window.location.pathname + "#success";
 
     contactButtons.forEach(function (contactButton) {
       contactButton.addEventListener("click", function (e) {
         e.preventDefault();
-
+        if (window.location.pathname) {
+          contactForm.setAttribute("data-return-url", returnData);
+        }
         if (contactButton.dataset.formLocation) {
           fetchForm(contactButton.dataset, contactButton);
         } else {

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -988,6 +988,15 @@ body {
   }
 }
 
+// Styling to display a success message when forms are successfully submitted.
+#success {
+  display: none;
+}
+
+#success:target {
+  display: block;
+}
+
 html {
   scroll-behavior: smooth;
 }

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -80,6 +80,13 @@
   {% endif %}
 
   <div class="wrapper u-no-margin--top">
+    <div id="success">
+        <div class="p-notification--positive u-no-margin--bottom">
+            <p class="p-notification__response">
+              Your submission was sent successfully! <a href="#" onclick="location.href = document.referrer; return false;"><i class="p-icon--close">Close</i></a>
+            </p>
+        </div>
+    </div>
     <div id="main-content" class="inner-wrapper">
       {% block content_head %}{% endblock %}
       {% block content_container %}


### PR DESCRIPTION
## Done
- Display a success message when interactive forms are successfully submitted.
- The success message was removed yesterday because of the cache issue and this PR is to make it back. 

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Please check if a success message appears when interactive forms are submitted. 

## Screenshots

![image](https://user-images.githubusercontent.com/57550290/139263081-98749db8-237e-4978-a003-7f04ce711d7e.png)
