### PR TITLE
Disable thank you page for pro beta contact form

### DIFF
--- a/templates/shared/forms/interactive/advantage-beta.html
+++ b/templates/shared/forms/interactive/advantage-beta.html
@@ -138,7 +138,7 @@
                   <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="/advantage" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %%" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />


### PR DESCRIPTION
Fixes canonical-web-and-design/commercial-squad#351

## Done

- change the redirect from the pro beta contact form to /advantage

## QA

- go to https://ubuntu-com-10745.demos.haus/advantage
- click "Join our free beta programme for Ubuntu Pro on prem ›"
- fill in the form and submit
- you should still be on https://ubuntu-com-10745.demos.haus/advantage


## Issue / Card

Fixes https://github.com/canonical-web-and-design/commercial-squad/issues/351
