### PR TITLE
Fix is cancelled status

### DIFF
--- a/tests/advantage/test_helpers.py
+++ b/tests/advantage/test_helpers.py
@@ -254,9 +254,17 @@ class TestHelpers(unittest.TestCase):
         subscriptions = [
             make_subscription(
                 id=subscription_id,
+                period="yearly",
+                items=[make_subscription_item(product_listing_id="lAaBbCcDe")],
+            ),
+            make_subscription(
+                id=subscription_id,
                 period="monthly",
-                items=[make_subscription_item(product_listing_id="lAaBbCcDd")],
-            )
+                items=[
+                    make_subscription_item(product_listing_id="lAaBbCcDe"),
+                    make_subscription_item(product_listing_id="lAaBbCcDd"),
+                ],
+            ),
         ]
 
         is_cancelled = is_user_subscription_cancelled(

--- a/webapp/advantage/ua_contracts/helpers.py
+++ b/webapp/advantage/ua_contracts/helpers.py
@@ -239,7 +239,7 @@ def is_user_subscription_cancelled(
             if item.product_listing_id == listing.id:
                 listing_found = True
 
-            break
+                break
 
     is_cancelled = True if not listing_found else False
 


### PR DESCRIPTION
## Done

- Fix is_cancelled status for user subscriptions

## QA

- Go to: https://ubuntu.com/advantage?test_backend=true
- Have two monthly active user subscription
- The older one will wrongly show that it's cancelled, not displaying the Edit Subscription button
- Go to: https://ubuntu-com-10746.demos.haus?test_backend=true
- You will see them both show the Edit Subscription button

## Issue / Card

Fixes #https://github.com/canonical-web-and-design/commercial-squad/issues/354