### PR TITLE
Make the invoice status display more resilient

### DIFF
--- a/templates/account/invoices/index.html
+++ b/templates/account/invoices/index.html
@@ -40,12 +40,14 @@
                 <td aria-label="Service">{{ invoice.service }}{% if invoice.period %} ({{ invoice.period }}){% endif %}</td>
                 <td aria-label="Date">{{ invoice.date }}</td>
                 <td aria-label="Status">
-                  {% if invoice.status == "paid" %}
-                  <div class="p-label--new">Paid</div>
-                  {% elif invoice.status == "open" %}
-                  <div class="p-label--deprecated">Failed</div>
-                  {% else %}
-                  <div class="p-label">{{ invoice.status }}</div>
+                  {% if invoice.status %}
+                    {% if invoice.status == "paid" %}
+                    <div class="p-label--new">Paid</div>
+                    {% elif invoice.status == "open" %}
+                    <div class="p-label--deprecated">Failed</div>
+                    {% else %}
+                    <div class="p-label">{{ invoice.status }}</div>
+                    {% endif %}
                   {% endif %}
                 </td>
                 <td class="u-align--right" aria-label="Total" style="padding-right: 5%">

--- a/webapp/advantage/views.py
+++ b/webapp/advantage/views.py
@@ -822,9 +822,10 @@ def invoices_view(**kwargs):
             created_at = raw_payment["createdAt"]
 
             total = None
+            status = None
             invoice = raw_payment.get("invoice")
-            status = invoice.get("status")
             if invoice and invoice.get("total"):
+                status = invoice.get("status")
                 cost = invoice.get("total") / 100
                 currency = invoice.get("currency")
                 total = f"{cost} {currency}"


### PR DESCRIPTION
## Done
Make the invoice status display more resilient

## QAd
- Go to /account/invoices
- Check the invoice table renders with status


## Issue / Card
Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/10750
https://sentry.is.canonical.com/canonical/ubuntu-com/issues/22872/

