### PR TITLE
Make test_backend persist

### DIFF
--- a/templates/cube/index.html
+++ b/templates/cube/index.html
@@ -13,7 +13,7 @@
       <h1>You&rsquo;re a professional.</br>Prove it with CUBE.</h1>
       <p class="p-heading--4">The Certified Ubuntu Engineer (CUBE) is a professional endorsement indicating mastery of Ubuntu. You need to pass 15 microcerts to earn your CUBE qualification.</p>
       <p>
-        <a href="/cube/microcerts" class="p-button--positive">View the microcerts</a>
+        <a href="/cube/microcerts{% if get_test_backend %}?test_backend=true{% endif %}" class="p-button--positive">View the microcerts</a>
       </p>
     </div>
     <div class="col-5 col-start-large-8 u-hide--small p-cube-animation">

--- a/webapp/advantage/decorators.py
+++ b/webapp/advantage/decorators.py
@@ -130,11 +130,13 @@ def cube_decorator(response="json"):
 
             if response == "html":
                 if not user_info(flask.session):
-                    return flask.redirect(
-                        "/login?test_backend=true"
-                        if is_test_backend
-                        else "/login"
-                    )
+                    if is_test_backend:
+                        return flask.redirect(
+                            "/login?test_backend=true&"
+                            "next=/cube/microcerts?test_backend=true"
+                        )
+
+                    return flask.redirect("/login?next=/cube/microcerts")
 
             elif response == "json":
                 if not user_info(flask.session):

--- a/webapp/cube/views.py
+++ b/webapp/cube/views.py
@@ -193,12 +193,16 @@ def cube_microcerts():
 
             courses.append(course)
 
+    edx_register_url = f"{edx_url}{flask.request.base_url}"
+    if flask.request.args.get("test_backend"):
+        edx_register_url = edx_register_url + "?test_backend=true"
+
     return flask.render_template(
         "cube/microcerts.html",
         **{
             "account_id": account["id"] if account else None,
             "edx_user": edx_user,
-            "edx_register_url": f"{edx_url}%2F",
+            "edx_register_url": edx_register_url,
             "sso_user": sso_user,
             "certified_badge": certified_badge or None,
             "modules": courses,


### PR DESCRIPTION
## Done

- CUBE is terrible for testing at the moment because the testing flag gets dropped with every chance.
- This PR should patch at least the common user journeys

## QA

0. Ideally have an account without Edx user. DO NOT CREATE ONE UNTIL YOU REACH THE LAST STEP!!!
1. Test the /cube page
- Go to https://ubuntu-com-10760.demos.haus/cube
- Check the URL of the microcerts green button - DO NO CLICK ON IT YET! Hover over to see the link or inspect element.
- You should see /cube/microcerts
- Go to https://ubuntu-com-10760.demos.haus/cube?test_backend=true
- You should see /cube/microcerts?test_backend=true so the flag is there
2. Test the login redirect - because only logged in users can reach /cube/microcerts
- Go to https://ubuntu-com-10760.demos.haus/cube - BE LOGGED OUT!!!
- Click the microcerts link and login
- You should be redirected to /cube/microcerts
- LOG OUT!!!
- Go to https://ubuntu-com-10760.demos.haus/cube?test_backend=true - BE LOGGED OUT!!!
- Click the microcerts link and login
- You should be redirected to /cube/microcerts?test_backend=true
3. Test the Edx account creation redirect - Ideally you'd QA with a Ubuntu One account without an Edx account
- When you reach /cube/microcerts, if you have no Edx account you will get a pop-up asking you to create one
- If you click the create Edx account button in the pop-up and create the account you should be sent back to /cube/microcerts without losing the session
- If you already have an account copy-paste this URL and go there (this is the Edx account creating url, you can manually use it):
https://qa.cube.ubuntu.com/auth/login/tpa-saml/?auth_entry=login&idp=ubuntuone&next=https://ubuntu-com-10760.demos.haus/cube/microcerts?test_backend=true

## Issue / Card

Fixes #https://github.com/canonical-web-and-design/commercial-squad/issues/356
