### PR TITLE
Updated release note links

### DIFF
--- a/templates/download/iot/intel-iotg.html
+++ b/templates/download/iot/intel-iotg.html
@@ -53,14 +53,14 @@
       <p>
         <a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/focal/release/inteliotg/ubuntu-core-20-amd64+intel-iot.img.xz">Download</a>
       </p>
-      <p>Please see the <a href="https://assets.ubuntu.com/v1/64bc3890-December_6-Release+Notes.pdf">release notes</a> and <a href="https://assets.ubuntu.com/v1/87e46aa7-Installation+Instructions+Core+Image+Intel+IoTG+Platforms.pdf">instructions</a> for more information.</p>
+      <p>Please see the <a href="https://assets.ubuntu.com/v1/642fcdac-December_14-Release+Notes.pdf">release notes</a> and <a href="https://assets.ubuntu.com/v1/87e46aa7-Installation+Instructions+Core+Image+Intel+IoTG+Platforms.pdf">instructions</a> for more information.</p>
     </div>
     <div class="col-6 p-divider__block">
       <h3>Ubuntu Desktop 20.04</h3>
       <p>
         <a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/focal/release/inteliotg/ubuntu-20.04-desktop-amd64+intel-iot.iso">Download</a>
       </p>
-      <p>Please see the <a href="https://assets.ubuntu.com/v1/64bc3890-December_6-Release+Notes.pdf">release notes</a> and <a href="https://assets.ubuntu.com/v1/840e465f-Installation+Instructions+Desktop+Image+Intel+IoTG+Platforms.pdf">instructions</a> for more information.</p>
+      <p>Please see the <a href="https://assets.ubuntu.com/v1/642fcdac-December_14-Release+Notes.pdf">release notes</a> and <a href="https://assets.ubuntu.com/v1/840e465f-Installation+Instructions+Desktop+Image+Intel+IoTG+Platforms.pdf">instructions</a> for more information.</p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- Updated release notes as per [copy doc](https://docs.google.com/document/d/1hxKzPs6e6JQaa9tBqfZ55GAXrVnEryEWBja8HlXy-lc/edit)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: https://ubuntu-com-11049.demos.haus/download/iot/intel-iotg
    - Be sure to test on mobile, tablet and desktop screen sizes
- Test that links work and match the copy doc

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/4702