### PR TITLE
Remove unused styles from styles.scss

### DIFF
--- a/static/sass/_pattern_lists.scss
+++ b/static/sass/_pattern_lists.scss
@@ -207,6 +207,11 @@
     & > li + h3,
     & > li > h4,
     & > li + h5,
+    & > li > .table__wrapper {
+      margin-left: $sp-medium;
+      padding-left: $sp-medium;
+    }
+
     & > .p-list__item > h3,
     & > .p-list__item > h4,
     & > .p-list__item > h5,


### PR DESCRIPTION
## Done

- I went through each style in styles.scss and search the code base for any instance where it was used. If I couldn't find any, I deleted it and any associated reference.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Search the codebase for each style that was removed.

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/4876 
