### PR TITLE
add link to /core/services/guide on services page

### DIFF
--- a/templates/core/services/index.html
+++ b/templates/core/services/index.html
@@ -226,6 +226,27 @@
   </div>
 </section>
 
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-8">
+      <h2>Read our IoT Professional Services guide</h2>
+      <p>Iot Professional Services is a package that allows enterprises to bootstrap commercial IoT products. Find out how with our guide.</p>
+      <a href="/core/services/guide" class="p-button--positive">View the guide</a>
+    </div>
+    <div class="col-4 u-hide--small u-hide--medium u-align--center">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/29d3fc14-image-document-ip.svg",
+        alt="",
+        width="166",
+        height="200",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+  </div>
+</section>
+
 <!-- Set default Marketo information for contact form below -->
 <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/internet-of-things" data-form-id="1663" data-lp-id="3143" data-return-url="https://ubuntu.com/core/services/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>


### PR DESCRIPTION
## Done

- Added new section to /core/services that links to /core/services/guide, according to the [copy doc](https://docs.google.com/document/d/11z973-P-vuaVp7gCQpoQly0gzqNMYX7ETPVghEkDDsE/edit)

## QA

- Visit https://ubuntu-com-11760.demos.haus/core/services
- See that the new section has been added

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/5234

