### PR TITLE
update active directory link on homepage

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -855,9 +855,7 @@
     <div class="row">
       <ul class="p-list is-split">
         <li class="p-list__item is-ticked">
-          <a href="/engage/linux-enterprise-whitepaper">
-            Active Directory and LDAP integration
-          </a>
+          <a href="/engage/microsoft-active-directory">Active Directory</a> and LDAP integration
         </li>
         <li class="p-list__item is-ticked">
           Full disk encryption


### PR DESCRIPTION
## Done

- updated link on homepage according to [copy doc](https://docs.google.com/document/d/1ySJxQbqVdeH4Tra0zwBm2Tn0s56kFGnEF7d8xDRTxwU/edit#)

## QA

- Visit https://ubuntu-com-11783.demos.haus/
- See that the "Active Directory" link under "Workstations and Desktops" matches what's in the copy doc

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/5599
