### PR TITLE
Move notes above status table

### DIFF
--- a/templates/security/cve/cve.html
+++ b/templates/security/cve/cve.html
@@ -56,6 +56,19 @@
         <p>{{ cve.ubuntu_description }}</p>
         {% endif %}
 
+        {% if cve.status == 'active' and cve.notes %}
+          <h2>Notes</h2>
+          <table>
+            <tr><th style="width: 10em;">Author</th><th>Note</th></tr>
+            {% for note in cve.notes %}
+            <tr>
+              <td><a href="https://launchpad.net/~{{ note.author }}">{{ note.author }}</a></td>
+              <td><pre>{{ note.note }}</pre></td>
+            </tr>
+            {% endfor %}
+          </table>
+        {% endif %}
+
         {%if cve.mitigation %}
         <h2>Mitigation</h2>
         <pre>{{ cve.mitigation }}</pre>
@@ -273,19 +286,6 @@
 
     <div class="row">
       <div class="col-9">
-        {% if cve.status == 'active' and cve.notes %}
-          <h2>Notes</h2>
-          <table>
-            <tr><th style="width: 10em;">Author</th><th>Note</th></tr>
-            {% for note in cve.notes %}
-            <tr>
-              <td><a href="https://launchpad.net/~{{ note.author }}">{{ note.author }}</a></td>
-              <td><pre>{{ note.note }}</pre></td>
-            </tr>
-            {% endfor %}
-          </table>
-        {% endif %}
-
         <h2>References</h2>
         <ul>
           {% if cve.references %}


### PR DESCRIPTION
## Done

- Moved notes above status table as per discussion in linked issue

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/CVE-2022-0847
    - Be sure to test on mobile, tablet and desktop screen sizes
- See that the "Notes" section is above the status table 

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/11342
