### PR TITLE
Remove mistune

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,6 @@ Flask-WTF==0.15.1
 requests==2.27.0
 sqlalchemy==1.3.23
 marshmallow==3.14.1
-mistune==0.8.4
 psycopg2-binary==2.9.3
 pyyaml==5.4.1
 ubuntu-release-info==21.1


### PR DESCRIPTION
## Done

Looking [at this old changes](https://github.com/canonical-web-and-design/ubuntu.com/commit/68efa93bf5c52f32ac793ec80ef3e68a5b6ff738) it seems that we no longer need mistune? At least not pinned? As we already removed alembic

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- View the demo https://ubuntu-com-11915.demos.haus/ and check any /security pages that could be broken with this removal.

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
