### PR TITLE
Return 404 for not found unlisted engage pages

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -485,7 +485,10 @@ def unlisted_engage_page(slug):
     Renders an engage page that is separate from the
     discourse implementation
     """
-    return flask.render_template(f"engage/unlisted/{slug}.html")
+    try:
+        return flask.render_template(f"engage/unlisted/{slug}.html")
+    except jinja2.exceptions.TemplateNotFound:
+        return flask.abort(404)
 
 
 def openstack_install():


### PR DESCRIPTION
## Done

/engage/unlisted/whatever  type of pages will break the site, it should return 404 if the engage page doesn't exist.

## QA

- Check out this feature branch
- View the site locally in your web browser at: https://ubuntu-com-11918.demos.haus/engage/unlisted/whatever or any other unlisted engage pages that doesn't exist should return 404

## Issue / Card

Fixes https://github.com/canonical/ubuntu.com/issues/11729

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
