### PR TITLE
Fix certified download links

### DIFF
--- a/templates/certified/model-details.html
+++ b/templates/certified/model-details.html
@@ -86,18 +86,7 @@
             {% elif release.level == "Certified" %}
               <p>The {{ vendor }} {{ name }} with the components described below has been awarded the status of certified for Ubuntu.</p>
               <p class="u-no-margin--bottom">
-                {% if category == "Desktop" or category == "Laptop" %}
-                <a href="/download/desktop" class="p-button">Download</a>
-                {% endif %}
-                {% if category == "Ubuntu Core" %}
-                <a href="/download/iot" class="p-button">Download</a>
-                {% endif %}
-                {% if category == "Server" %}
-                <a href="/download/server" class="p-button">Download</a>
-                {% endif %}
-                {% if category == "Server SoC" %}
-                <a href="/download/server/arm" class="p-button">Download</a>
-                {% endif %}
+                <a href="{{ release.download_url }}" class="p-button">Download</a>
               </p>
             {% endif %}
             {% if release.kernel %}

--- a/tests/cassettes/TestCertification.test_model_details.yaml
+++ b/tests/cassettes/TestCertification.test_model_details.yaml
@@ -9,7 +9,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.27.0
     method: GET
     uri: https://certification.canonical.com/api/v1/certifiedmodeldetails/?format=json&canonical_id=201807-26311
   response:
@@ -21,16 +21,10 @@ interactions:
         "http://e.huawei.com/en/products/cloud-computing-dc/servers", "id": 11209,
         "kernel_version": "4.15.0-46-generic", "level": "Certified", "make": "Huawei
         Technologies Co., Ltd.", "model": "2288 V5", "name": "1903-11209", "network":
-        [{"bus": "pci", "category": "NETWORK", "identifier": "8086:37d0", "make":
-        "Intel Corp.", "name": "Ethernet Connection X722 for 10GbE SFP+", "subproduct_name":
-        "", "subsystem": "", "subvendor_id": "", "vendor_id": 4103}, {"bus": "pci",
-        "category": "NETWORK", "identifier": "8086:37d1", "make": "Intel Corp.", "name":
-        "Ethernet Connection X722 for 1GbE", "subproduct_name": "", "subsystem": "",
-        "subvendor_id": "", "vendor_id": 4103}], "notes": [], "processor": [{"bus":
-        "dmi", "category": "PROCESSOR", "identifier": "dmi:Intel(R)Xeon(R)Gold6152CPU@2.10GHz",
-        "make": "Intel Corp.", "name": "Intel(R) Xeon(R) Gold 6152 CPU @ 2.10GHz",
-        "subproduct_name": "", "subsystem": "", "subvendor_id": "", "vendor_id": 4103},
-        {"bus": "dmi", "category": "PROCESSOR", "identifier": "dmi:Intel(R)Xeon(R)Platinum8153CPU@2.00GHz",
+        [{"bus": "pci", "category": "NETWORK", "identifier": "8086:37d1", "make":
+        "Intel Corp.", "name": "Ethernet Connection X722 for 1GbE", "subproduct_name":
+        "", "subsystem": "", "subvendor_id": "", "vendor_id": 4103}], "notes": [],
+        "processor": [{"bus": "dmi", "category": "PROCESSOR", "identifier": "dmi:Intel(R)Xeon(R)Platinum8153CPU@2.00GHz",
         "make": "Intel Corp.", "name": "Intel(R) Xeon(R) Platinum 8153 CPU @ 2.00GHz",
         "subproduct_name": "", "subsystem": "", "subvendor_id": "", "vendor_id": 4103}],
         "resource_uri": "/api/v1/certifiedmodeldetails/11209/", "video": [{"bus":
@@ -52,9 +46,6 @@ interactions:
         "subvendor_id": "", "vendor_id": 4103}], "notes": [], "processor": [{"bus":
         "dmi", "category": "PROCESSOR", "identifier": "dmi:Intel(R)Xeon(R)Gold6152CPU@2.10GHz",
         "make": "Intel Corp.", "name": "Intel(R) Xeon(R) Gold 6152 CPU @ 2.10GHz",
-        "subproduct_name": "", "subsystem": "", "subvendor_id": "", "vendor_id": 4103},
-        {"bus": "dmi", "category": "PROCESSOR", "identifier": "dmi:Intel(R)Xeon(R)Platinum8153CPU@2.00GHz",
-        "make": "Intel Corp.", "name": "Intel(R) Xeon(R) Platinum 8153 CPU @ 2.00GHz",
         "subproduct_name": "", "subsystem": "", "subvendor_id": "", "vendor_id": 4103}],
         "resource_uri": "/api/v1/certifiedmodeldetails/10879/", "video": [{"bus":
         "pci", "category": "VIDEO", "identifier": "19e5:1711", "make": "Huawei Technologies
@@ -68,11 +59,11 @@ interactions:
       Connection:
       - Keep-Alive
       Content-Length:
-      - '3767'
+      - '3038'
       Content-Type:
       - application/json
       Date:
-      - Mon, 24 May 2021 15:00:30 GMT
+      - Tue, 02 Aug 2022 09:51:09 GMT
       Keep-Alive:
       - timeout=5, max=100
       Server:
@@ -94,7 +85,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.27.0
     method: GET
     uri: https://certification.canonical.com/api/v1/componentsummaries/?format=json&canonical_id=201807-26311
   response:
@@ -111,9 +102,51 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 24 May 2021 15:00:31 GMT
+      - Tue, 02 Aug 2022 09:51:09 GMT
       Keep-Alive:
       - timeout=5, max=99
+      Server:
+      - gunicorn/19.9.0
+      Strict-Transport-Security:
+      - max-age=2592000
+      Vary:
+      - Accept,Cookie
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.27.0
+    method: GET
+    uri: https://certification.canonical.com/api/v1/certifiedmodels/?format=json&canonical_id=201807-26311
+  response:
+    body:
+      string: '{"meta": {"limit": 20, "next": null, "offset": 0, "previous": null,
+        "total_count": 1}, "objects": [{"canonical_id": "201807-26311", "category":
+        "Server", "completed": "2019-09-30T23:08:43.828005", "level": "Certified",
+        "major_release": "18.04 LTS", "make": "Huawei Technologies Co., Ltd.", "model":
+        "2288 V5", "release": "18.04 LTS", "resource_uri": "/api/v1/certifiedmodels/201807-26311/"}]}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '392'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 02 Aug 2022 09:51:09 GMT
+      Keep-Alive:
+      - timeout=5, max=98
       Server:
       - gunicorn/19.9.0
       Strict-Transport-Security:

--- a/webapp/certified/helpers.py
+++ b/webapp/certified/helpers.py
@@ -1,0 +1,35 @@
+def get_download_url(model_details):
+    """
+    Return the appropriate ubuntu models.com/download url for the model
+    :param model: a certifiedmodel resource
+    :param model_details: a certifiedmodeldetails resource
+    :return: appropriate ubuntu.com/download url
+    """
+    platform_category = model_details.get("category", "").lower()
+    architecture = model_details.get("architecture", "").lower()
+
+    if model_details.get("level") == "Enabled":
+        # Enabled systems use oem images without download links.
+        return
+
+    if platform_category in ["desktop", "laptop"]:
+        return "https://ubuntu.com/download/desktop"
+
+    if "core" in platform_category:
+        return "https://ubuntu.com/download/iot/"
+
+    if "server" in platform_category:
+        # Server platforms have special landing pages based on architecture.
+        arch = ""
+        if "arm" in architecture:
+            arch = "arm"
+        elif "ppc" in architecture:
+            arch = "power"
+        elif "s390x" in architecture:
+            arch = "s390x"
+        else:
+            return "https://ubuntu.com/download/server/"
+
+        return f"https://ubuntu.com/download/server/{arch}"
+
+    return "https://ubuntu.com/download"

--- a/webapp/certified/views.py
+++ b/webapp/certified/views.py
@@ -9,6 +9,8 @@ from requests import Session
 from webapp.certified.api import CertificationAPI, PartnersAPI
 from urllib.parse import urlencode
 
+from webapp.certified.helpers import get_download_url
+
 session = Session()
 talisker.requests.configure(session)
 api = CertificationAPI(
@@ -142,6 +144,7 @@ def certified_model_details(canonical_id):
             "level": model_release["level"],
             "notes": model_release["notes"],
             "version": ubuntu_version,
+            "download_url": get_download_url(model_release),
             "components": {},
         }
 


### PR DESCRIPTION
## Done

Restore the utility function to create the download links

## QA

Check that the download button of these two pages:
s390x: https://ubuntu-com-11920.demos.haus/certified/201909-27363
ppc64le: https://ubuntu-com-11920.demos.haus/certified/201805-26248

Go to these
s390x: https://ubuntu.com/download/server/s390x
ppc64le: https://ubuntu.com/download/server/power

## Issue / Card

Fixes https://github.com/canonical/ubuntu.com/issues/11584

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
