### PR TITLE
fix desktop/org image dimensions

### DIFF
--- a/templates/desktop/organisations.html
+++ b/templates/desktop/organisations.html
@@ -20,8 +20,8 @@
       {{ image (
         url="https://assets.ubuntu.com/v1/f29015c6-image-laptop.png",
         alt="",
-        width="622",
-        height="489",
+        width="750",
+        height="484",
         hi_def=True,
         loading="auto"
         ) | safe


### PR DESCRIPTION
## Done

- Fixed the warped image in the hero section of https://ubuntu-com-11926.demos.haus/desktop/organisations

## QA

- visit /desktop/organisations
- see that the image is not distorted
