### PR TITLE
[copy update] u.c/security - add contact us button to hero strip

### DIFF
--- a/templates/security/index.html
+++ b/templates/security/index.html
@@ -10,7 +10,10 @@
     <div class="col-8">
       <h1>Dedicated to the security of Ubuntu</h1>
       <p>Since its inception in 2004, Ubuntu has been built on a foundation of enterprise-grade, industry leading security practices. From our toolchain to the suite of packages we use and from our update process to our industry standard certifications, Canonical never stops working to keep Ubuntu at the forefront of safety  and reliability.</p>
-      <p><a class="p-button--positive" href="/engage/ubuntu-cybersecurity-webinar" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Watch the Ubuntu security webinar', 'eventLabel' : 'Watch the Ubuntu security webinar', 'eventValue' : undefined });" >Watch the Ubuntu cybersecurity webinar</a></p>
+      <p>
+        <a class="p-button--positive" href="/engage/ubuntu-cybersecurity-webinar" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Watch the Ubuntu security webinar', 'eventLabel' : 'Watch the Ubuntu security webinar', 'eventValue' : undefined });" >Watch the Ubuntu cybersecurity webinar</a>
+        <a class="p-button js-invoke-modal" data-testid="interactive-form-link" href="/security/contact-us">Contact us</a>
+      </p>
     </div>
 
     <div class="col-4 u-hide--small u-vertically-center">


### PR DESCRIPTION
## Done

- Added contact us button to the hero strip as per [copy doc](https://docs.google.com/document/d/1yEocR1WXQvN_B1L1yBYrG_0D7ikS6QhcOz27sYs-teI/edit)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security
- Check that button matches the copy doc

## Issue / Card

Fixes [canonical/workplace-engineering-squad/#785](https://github.com/canonical/workplace-engineering-squad/issues/785)

