### PR TITLE
Promote webinar embed on engage pages when webinar date has passed

### DIFF
--- a/templates/engage/base.html
+++ b/templates/engage/base.html
@@ -79,7 +79,11 @@
   </div>
 </section>
 
-
+{% if document["metadata"]["webinar_date"] is defined %}
+  {% if document["metadata"]["webinar_date"] | date_has_passed %}
+    {% include "engage/shared/_webinar-embed.html" %}
+  {% endif %}
+{% endif %}
 
 <section class="p-strip is-shallow is-bordered">
   <div class="row">
@@ -120,22 +124,14 @@
 
 </section>
 
-{% if document["metadata"]["webinar_code"] is defined %}
-{% if "channel_id" in document["metadata"] %}
-  {% set channel_id = document["metadata"]["channel_id"] %}
+{% if document["metadata"]["webinar_date"] is defined %}
+  {% if not document["metadata"]["webinar_date"] | date_has_passed %}
+    {% include "engage/shared/_webinar-embed.html" %}
+  {% endif %}
 {% else %}
-  {% set channel_id = 6793 %}
+  {% include "engage/shared/_webinar-embed.html" %}
 {% endif %}
-<!-- webinar -->
-<section class="p-strip is-shallow" id="register-section">
-  <div class="row" id="webinar">
-    <div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;">
-      <script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : {{channel_id}}, "language": "en-US", "commId" : {{ document["metadata"]["webinar_code"] }}, "displayMode" : "standalone", "height" : "auto" }</script>
-      <script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script>
-    </div>
-  </div>
-</section>
-{% endif %}
+
 
 {% if "youtube_id" in document["metadata"] %}
 <!-- Youtube webinars -->

--- a/templates/engage/shared/_webinar-embed.html
+++ b/templates/engage/shared/_webinar-embed.html
@@ -1,0 +1,16 @@
+{% if document["metadata"]["webinar_code"] is defined %}
+  {% if "channel_id" in document["metadata"] %}
+    {% set channel_id = document["metadata"]["channel_id"] %}
+  {% else %}
+    {% set channel_id = 6793 %}
+  {% endif %}
+  <!-- webinar -->
+  <section class="p-strip is-shallow" id="register-section">
+    <div class="row" id="webinar">
+      <div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;">
+        <script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : {{channel_id}}, "language": "en-US", "commId" : {{ document["metadata"]["webinar_code"] }}, "displayMode" : "standalone", "height" : "auto" }</script>
+        <script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script>
+      </div>
+    </div>
+  </section>
+{% endif %}

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -6,6 +6,7 @@ A Flask application for ubuntu.com
 import os
 import talisker.requests
 import flask
+from datetime import datetime, timedelta
 from canonicalwebteam.flask_base.app import FlaskBase
 from canonicalwebteam.templatefinder import TemplateFinder
 
@@ -1062,3 +1063,15 @@ def cache_headers(response):
         response.cache_control.no_store = True
 
     return response
+
+
+def date_has_passed(date_str):
+    try:
+        date = datetime.strptime(date_str, "%Y-%m-%d")
+        present = datetime.now()
+        return present > date
+    except ValueError:
+        return False
+
+
+app.add_template_filter(date_has_passed)

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -6,7 +6,7 @@ A Flask application for ubuntu.com
 import os
 import talisker.requests
 import flask
-from datetime import datetime, timedelta
+from datetime import datetime
 from canonicalwebteam.flask_base.app import FlaskBase
 from canonicalwebteam.templatefinder import TemplateFinder
 


### PR DESCRIPTION
## Done

- Added support for `webinar_date` metadata in engage pages, and a custom filter to check in the template whether the date has passed. If the date has passed, we show the webinar earlier in the page to help draw attention to it.

## QA
### Engage page with the relevant metadata
- Visit https://ubuntu-com-11931.demos.haus/engage/technical-intro-ubuntu-core22
- See that the Brightalk embed appears above the text content of the engage page
- Visit https://ubuntu-com-11931.demos.haus/engage?resource=webinar
- Select any other webinar
- See that the Brightalk embed appears below the text content of the engage page

### Adding the relevant metadata to an engage page
- Find another webinar engage page where the webinar has already happened, e.g. https://ubuntu-com-11931.demos.haus/engage/intro-to-OSM-webinar
- The Brightalk embed should still appear _below_ the text content, because the discourse post is missing metadata
- Find its associated discourse post in the [engage index](https://discourse.ubuntu.com/t/engage-pages-for-ubuntu-com/18033), e.g. https://discourse.ubuntu.com/t/introduction-to-open-source-mano-osm/29484
- Add a new row to the post's meta data table with the date that the webinar happened, e.g:
```
| webinar_date | 2022-08-02 |
```
- Save the edit, then reload the engage page
- The webinar should appear above the text content

## Issue / Card

Fixes https://github.com/canonical/web-squad/issues/5479