### PR TITLE
k8s 1.24ck1 updates

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -442,7 +442,7 @@ kubernetes:
         - title: Charmed Kubernetes Addons
           path: /kubernetes/docs/cdk-addons
           hidden: True
-        - title: Howto Addons
+        - title: How to Addons
           path: /kubernetes/docs/how-to-addons
           hidden: True
         - title: Logging

--- a/navigation.yaml
+++ b/navigation.yaml
@@ -439,8 +439,11 @@ kubernetes:
         - title: Basic Operations
           path: /kubernetes/docs/operations
           hidden: True
-        - title: CDK Addons
+        - title: Charmed Kubernetes Addons
           path: /kubernetes/docs/cdk-addons
+          hidden: True
+        - title: Howto Addons
+          path: /kubernetes/docs/how-to-addons
           hidden: True
         - title: Logging
           path: /kubernetes/docs/logging

--- a/templates/kubernetes/docs/1.24/components.md
+++ b/templates/kubernetes/docs/1.24/components.md
@@ -131,7 +131,7 @@ These are the container images used by this release:
 -  kubernetesui/dashboard:v2.5.1
 -  kubernetesui/metrics-scraper:v1.0.7
 -  metrics-server/metrics-server:v0.5.2
--  nvidia/k8s-device-plugin:v0.11.0
+-  nvidia/k8s-device-plugin:v0.12.2
 -  pause:3.6
 -  sig-storage/csi-attacher:v3.3.0
 -  sig-storage/csi-attacher:v3.4.0

--- a/templates/kubernetes/docs/1.24/release-notes.md
+++ b/templates/kubernetes/docs/1.24/release-notes.md
@@ -13,6 +13,49 @@ layout: [base, ubuntu-com]
 toc: False
 ---
 
+# 1.24+ck1 Bugfix release 
+
+### August 5, 2022 - `charmed-kubernetes --channel 1.24/stable` 
+
+The release bundle can also be [downloaded here](https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/releases/1.24/bundle.yaml).
+
+## What's new
+
+- Jammy Jellyfish (22.04) Support
+
+All Charmed Kubernetes charms now come with the ability to run on `jammy`
+series machines. Xenial (16.04) support has been removed. Focal (20.04)
+remains the default series in all bundles and charms, however the charms
+now advertise `jammy` support and are considered stable for that series.
+
+- Improved Documentation
+
+Vault documentation updated to cover 20.04 `focal` environment.
+Operator charms and replacements for addons now have dedicated guides.
+CIDR size limitations are better described in the charm's `cidr` config option.
+
+- Containerd
+
+Improved GPU support by referencing apt sources with https and refreshing
+NVIDIA repository keys. Also improved NVIDIA driver upgrades and debug messages for
+units that encounter connectivity failures in air-gapped or proxied environments.
+
+Improved upgrade actions for containerd packages as well as NVIDIA packages.
+
+- Docker Registry
+
+Exposes docker registry `cache-*` settings to configure it as a pull-through cache.
+
+- Etcd
+
+Limits the set of TLS ciphers to remove weaker ones.
+ 
+## Fixes
+
+A list of bug fixes and other minor feature updates in this release can be found at
+[the launchpad milestone page for 1.24+ck1](https://launchpad.net/charmed-kubernetes/+milestone/1.24+ck1).
+
+
 # 1.24
 
 ### May 6th, 2022 - `charmed-kubernetes --channel 1.24/stable`

--- a/templates/kubernetes/docs/cdk-addons.md
+++ b/templates/kubernetes/docs/cdk-addons.md
@@ -24,7 +24,7 @@ itself and require some additional steps.
 <div class="p-notification--positive is-inline">
   <div markdown="1" class="p-notification__content">
     <span class="p-notification__title">Note:</span>
-    <p class="p-notification__message">Please see the <./operator-charms"> Operator Charms</a> page for 
+    <p class="p-notification__message">Please see the <a href="/kubernetes/docs/operator-charms"> Operator Charms</a> page for 
     information on how to set-up Juju prior to deploying the addon charms into Charmed Kubernetes.</p>
   </div>
 </div>

--- a/templates/kubernetes/docs/encryption-at-rest.md
+++ b/templates/kubernetes/docs/encryption-at-rest.md
@@ -18,10 +18,10 @@ needed by a cluster, such as usernames and passwords, encryption keys, etc.
 Secrets can be managed independently of the pod(s) which need them and can be
 made available to the pods that require them as needed.
 
-By default, the secret data is stored in plaintext in **etcd**. **Kubernetes**
+By default, the secret data is base64-encoded in **etcd**. **Kubernetes**
 does support [encryption at rest][] for the data in **etcd**, but the key for
-that encryption is stored in plaintext in the config file on the master nodes.
-To protect this key at rest, **Charmed Kubernetes** can use
+that encryption is stored in plaintext in the config file on the control plane
+nodes. To protect this key at rest, **Charmed Kubernetes** can use
 [HashiCorp's Vault][] and [VaultLocker][] to securely generate, share, and
 configure the encryption key used by **Kubernetes**.
 
@@ -29,34 +29,73 @@ configure the encryption key used by **Kubernetes**.
 
 To enable encryption-at-rest for **Charmed Kubernetes**, simply deploy the [Vault charm][] (as
 well as a database backend for it), and relate it to `kubernetes-control-plane` via
-the `vault-kv` relation endpoint.  The easiest way to do this is to deploy **Charmed Kubernetes**
-with the following overlay:
+the `vault-kv` relation endpoint.
+
+The following overlay file ([download][vault-storage-yaml]) alters
+**Charmed Kubernetes** to use **Vault** for encrypted data:
 
 ```yaml
 applications:
+  mysql-innodb-cluster:
+    channel: 8.0/stable
+    charm: mysql-innodb-cluster
+    constraints: cores=2 mem=8G root-disk=64G
+    num_units: 3
+    options:
+      enable-binlogs: true
+      innodb-buffer-pool-size: 256M
+      max-connections: 2000
+      wait-timeout: 3600
   vault:
-    charm: cs:vault
+    channel: 1.7/stable
+    charm: vault
     num_units: 1
-  percona-cluster:
-    charm: cs:percona-cluster
-    num_units: 1
+  vault-mysql-router:
+    channel: 8.0/stable
+    charm: mysql-router
 relations:
-  - ['vault', 'percona-cluster']
-  - ['vault:secrets', 'kubernetes-control-plane:vault-kv']
+- - kubernetes-control-plane:vault-kv
+  - vault:secrets
+- - mysql-innodb-cluster:db-router
+  - vault-mysql-router:db-router
+- - vault-mysql-router:shared-db
+  - vault:shared-db
 ```
 
-To deploy **Charmed Kubernetes** with this overlay - [download it][cdk-vault-overlay]), save it as, e.g.,
-`cdk-vault-overlay.yaml`, and deploy with:
+Save this to a file named `vault-storage-overlay.yaml` and deploy with:
 
+```bash
+juju deploy charmed-kubernetes --overlay ./vault-storage-overlay.yaml
 ```
-juju deploy charmed-kubernetes --overlay cdk-vault-overlay.yaml
+
+Once the deployment settles, you will notice that several applications are in a
+`blocked` state in **Juju**, with **Vault** indicating that it needs to be initialised
+and unsealed. To unseal **Vault**, you can read the
+[vault charm documentation](https://opendev.org/openstack/charm-vault/src/branch/master/src/README.md#post-deployment-tasks)  <!-- wokeignore:rule=master -->
+for in-depth instructions (you may also need to [expose][] **Vault**), or you can use
+the **Vault** client already on the deployed unit with the following steps:
+
+```bash
+juju ssh vault/0
+export HISTCONTROL=ignorespace  # enable leading space to suppress command history
+export VAULT_ADDR='http://localhost:8200'
+vault operator init -key-shares=5 -key-threshold=3  # outputs 5 keys and a root token
+ vault operator unseal {key1}
+ vault operator unseal {key2}
+ vault operator unseal {key3}
+ VAULT_TOKEN={root token} vault token create -ttl 10m  # outputs a {charm token} to auth the charm
+exit
+juju run-action vault/0 authorize-charm token={charm token} --wait
 ```
 
-Once **Vault** comes up (and any time it is rebooted), you will need to [unseal][]
-it.
+<div class="p-notification--information">
+  <div markdown="1" class="p-notification__content">
+    <p class="p-notification__message">It is <strong><em>critical </em></strong> that you save all five unseal keys as well as the root token.  If the <strong>Vault</strong> unit is ever rebooted, you will have to repeat the unseal steps (but not the init step) before the CA can become functional again.</p>
+  </div>
+</div>
 
-Charmed Kubernetes will then automatically enable encryption for the secrets data stored in
-**etcd**.
+Once the deployment settles, **Charmed Kubernetes** will automatically enable
+encryption for the secrets data stored in **etcd**.
 
 ## Known Issues
 
@@ -67,13 +106,14 @@ encryption-as-a-service, will remove this restriction.  In the meantime,
 **LXD** deployments can make use of encryption at the level of the **LXD**
 storage pool, or even full-disk-encryption on the host machine.
 
-[cdk-vault-overlay]: https://raw.githubusercontent.com/juju-solutions/kubernetes-docs/master/assets/cdk-vault-overlay.yaml
+<!-- LINKS -->
+[vault-storage-yaml]: https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/overlays/vault-storage-overlay.yaml
 [secrets]: https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/
 [encryption at rest]: https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/
 [HashiCorp's Vault]: https://www.vaultproject.io/
 [VaultLocker]: https://github.com/openstack-charmers/vaultlocker
 [Vault charm]: https://charmhub.io/vault
-[unseal]: https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/victoria/app-vault.html#initialize-and-unseal-vault
+[expose]: https://juju.is/docs/olm/expose-a-deployed-application
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">

--- a/templates/kubernetes/docs/gpu-workers.md
+++ b/templates/kubernetes/docs/gpu-workers.md
@@ -30,7 +30,12 @@ a particular instance type.
 This can be done with a YAML overlay file. For example, when deploying Charmed
 Kubernetes on AWS, you may decide you wish to use AWS's 'p3.2xlarge' instances
 (you can check the AWS instance definitions on the
-[AWS website][aws-instance]). A YAML overlay file can be constructed like this:
+[AWS website][aws-instance]). NVIDIA also updates its list of supported GPUs
+frequently, so be sure to look at [NVIDIA GPU support docs][nvidia-gpu-support] 
+before installing on a specific AWS instance.
+
+
+A YAML overlay file can be constructed like this:
 
 ```yaml
 #gpu-overlay.yaml
@@ -182,6 +187,7 @@ Thu Mar  3 14:52:26 2022
 [quickstart]: /kubernetes/docs/quickstart
 [aws-instance]: https://aws.amazon.com/ec2/instance-types/
 [azure-instance]: https://docs.microsoft.com/en-us/azure/virtual-machines/windows/sizes-gpu
+[nvidia-gpu-support]: https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/platform-support.html#supported-nvidia-gpus-systems
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">

--- a/templates/kubernetes/docs/how-to-addons.md
+++ b/templates/kubernetes/docs/how-to-addons.md
@@ -1,0 +1,335 @@
+---
+wrapper_template: "templates/docs/markdown.html"
+markdown_includes:
+  nav: "kubernetes/docs/shared/_side-navigation.md"
+context:
+  title: "How to use Charmed Kubernetes addon Operator Charms"
+  description: Explaining how to install and configure addon operator charms with Charmed Kubernetes.
+keywords: operating, add-ons, addons, config
+tags: [operating]
+sidebar: k8smain-sidebar
+permalink: how-to-addons.html
+layout: [base, ubuntu-com]
+toc: False
+---
+
+This page gives step by step guides for deploying the Operator Charm
+versions of the **Charmed Kubernetes** addons. For an explanation
+of these addons, please see the [addons page][].
+
+##  Steps for all addons
+
+In order for Juju to deploy Kubernetes applications, it will need to fetch
+information and be configured to work with your Kubernetes cluster. 
+These steps assume:
+ * You have administrative access to the Charmed Kubernetes cluster.
+ * Your Charmed Kubernetes is running in a model called 'ck-model'. Replace this term in the commands listed for a different model name.
+ * Your Juju controller is running on version 2.9.30+. See instructions for upgrading a controller below.
+
+#### 1. Confirm your Juju controller is up to date
+
+Before creating and using a Kubernetes model, it is recommended to upgrade the 
+controller model to the lastest version:
+
+```bash
+juju upgrade-model -m controller
+```
+
+#### 2. Install kubectl 
+
+You will need **kubectl** to be able to use your Kubernetes cluster. If it is not already
+installed, it is easy to add via a snap package:
+
+```bash
+sudo snap install kubectl --classic
+```
+
+For other platforms and install methods, please see the
+[Kubernetes documentation][kubectl].
+
+#### 3. Retrieve the required configuration
+
+Juju makes use of the **kubectl** config file to access the Kubernetes cluster.
+For Linux-based systems, this file is usually located at `~/.kube/config`
+
+If you are already using `kubectl` to access other clusters you may wish to merge
+the configurations rather than replacing it. The following command fetches the 
+config file for `kubectl` from the Kubernetes cluster and saves it to the default location:
+
+```bash
+juju scp kubernetes-control-plane/0:config ~/.kube/config
+```
+
+#### 4. Add the Kubernetes cluster to Juju
+
+Next, add your Kubernetes cluster as a cloud to your current Juju controller:
+
+```bash
+juju add-k8s ck8s --controller $(juju switch | cut -d: -f1)
+```
+
+You may replace `ck8s` with whatever name you want to use to refer to this cloud, but
+remember to substitute in the correct name in the remaining examples in this page.
+
+<div class="p-notification--positive is-inline">
+  <div markdown="1" class="p-notification__content">
+    <span class="p-notification__title">Note:</span>
+    <p class="p-notification__message"> Some operator charms may require access to storage. Please make sure your Kubernetes cluster has access to a storage class accessible to 
+    the deployed applications.</p>
+  </div>
+</div>
+
+#### 5. Add a model
+
+To be able to deploy operators you will also need to create a Juju model in the cloud:
+
+```
+juju add-model k8s-model ck8s
+```
+
+Again, you should replace `k8s-model` with a name you want to use to refer to
+this Juju model. As well as creating a Juju model, this action will also
+create a Kubernetes namespace of the same name which you can use to easily
+monitor or manage operators you install on the cluster.
+
+#### 6. Switching between models
+
+Juju will automatically "switch" to the new Kubernetes model you just created. 
+
+Most of the instructions for the add-on components here require commands to be run 
+in the model where Charmed Kubernetes is running and also in the model created on the Kubernetes cloud (which we have called `ck8s` in this page). Use the Juju `switch` command to see the currently available models:
+
+```bash
+juju switch
+```
+If you followed the example naming scheme, you should see something like this:
+
+
+```bash
+juju models
+Controller: vs-bos
+
+Model       Cloud/Region           Type        Status     Machines  Cores  Units  Access  Last connection
+
+ck-model         vsphere-boston/Boston  vsphere     available        11     18  21     admin   29 minutes ago
+controller  vsphere-boston/Boston  vsphere     available         1      -  -      admin   just now
+k8s-model*   ck8s/default          kubernetes  available         0      -  -      admin   never connected
+```
+
+In the above case, there are three models available to the current controller. One is the model created
+by the controller itself ("controller"), one is the model where Charmed Kubernetes is installed 
+(in this case, it was called "ck-model") and the final one, which has an asterisk to indicate it is the current
+model, is the one we just created. If you chose poor names or get confused between many different models, it is helpful to note that the "Type" field shows the underlying cloud type, so your kubernetes clouds are easier to spot.
+
+To switch to the model which contains the CK cluster, we can run:
+
+```bash
+juju switch ck-model
+```
+
+...and to switch back to the model in the Kubernetes cloud:
+
+```bash
+juju switch k8s-model
+```
+
+
+## CoreDNS
+CoreDNS is sourced from: <https://github.com/coredns/deployment.git>
+
+CoreDNS has been the default DNS provider for **Charmed Kubernetes** clusters
+since 1.14.
+
+For additional control over CoreDNS, you can also deploy it into the cluster
+using the [CoreDNS Kubernetes operator charm][coredns-charm], as described below.
+
+#### 1. Disable in-tree CoreDNS
+
+You will need access to the Juju model running Charmed Kubernetes (NOT the kubernetes cloud) and turn off the built-in DNS provider
+
+```bash
+juju switch ck-model
+```
+
+(replace "ck-model" with the model contianing Charmed Kubernetes)
+
+With the Charmed Kubernetes model selected from Juju, run:
+
+```bash
+juju config kubernetes-control-plane dns-provider=none
+```
+
+#### 2. Deploy the CoreDNS operator 
+
+Switch back to the Kubernetes cloud:
+
+```bash
+juju switch k8s-model
+```
+
+...and deploy the operator charm:
+
+```bash
+juju deploy coredns --channel=latest/stable --trust
+```
+
+You can check on the status of this deployment using the command:
+
+```
+kubectl get -n 'k8s-model' po
+```
+
+#### 3. Configure Charmed Kubernetes to use this DNS
+
+Although the 'k8s-model' is running on top of the components installed in 'ck-model',
+they are considered to be separate entities. To use an application running in one
+model from a different model, Juju supports 'cross-model relations'. There are a few 
+extra commands to enable this.
+
+```bash
+juju switch k8s-model
+juju offer coredns:dns-provider
+```
+
+The offer command exposes the Juju relation for use in a different model. In the above, we
+expose the `dns-provider` relation endpoint.  
+
+To connect to that, switch models and use the `consume` command:
+
+```bash
+juju switch ck-model
+juju consume k8s-model.coredns
+```
+
+The `consume` command is the counterpart to `offer`. It establishes a connection to the specified model and application, and adds that resource to the current model. A running
+application in the model can then be related to it as thought it were a local model 
+resource. In this case you want to connect it to the kubernetes-control-plane:
+
+```bash
+juju relate -m ck-model coredns kubernetes-control-plane
+```
+
+Once everything settles, new or restarted pods will use the CoreDNS
+charm as their DNS provider. The CoreDNS charm config allows you to change
+the cluster domain, the IP address or config file to forward unhandled
+queries to, add additional DNS servers, or even override the Corefile entirely.
+
+For more details, see the [CoreDNS charm documentation][coredns-docs]
+
+## Kubernetes Dashboard
+
+Sourced from: <https://github.com/kubernetes/dashboard.git>
+
+The Kubernetes Dashboard is a standard and easy way to inspect and
+interact with your Kubernetes cluster. The dashboard operator charm 
+
+#### 1. Disable the in-tree dashboard
+
+Targeting the underlying cluster model ('ck-model' as used in these examples):
+
+```bash
+juju config kubernetes-control-plane enable-dashboard-addons=false
+```
+
+#### 2. Deploy the Dashboard charm
+
+For additional control over the Kubernetes Dashboard, you can also deploy it into
+the cluster using the [Kubernetes Dashboard operator charm][kubernetes-dashboard-charm].
+To do so, set the `enable-dashboard-addons` [kubernetes-control-plane configuration][]
+option to `false` and deploy the charm into a Kubernetes model on your cluster:
+
+```bash
+juju switch k8s-model
+juju deploy kubernetes-dashboard --channel=latest/stable --trust
+```
+
+#### 3. Accessing the Dashboard
+
+Allow the new dashboard time to settle - it needs to fetch and install various images and could take a few minutes depending on the underlying cloud.
+
+Access to the Kubernetes Dashboard works as before. Please use the instructions in the [Operations page][].
+
+
+## Metrics
+
+The metrics addon consists of two services, Kube State Metrics and Kubernetes Metrics Server.
+Both of these can be replaced by charm operators as detailed below. 
+
+Before deploying the new charms, you should turn off the built-in metrics features:
+
+```bash
+juju switch ck-model
+juju config kubernetes-control-plane enable-metrics=false
+```
+
+####  1. Kube-State Metrics
+
+Sourced from: <https://github.com/kubernetes/kube-state-metrics.git>
+
+Kube-State-Metrics is a service which listens to the Kubernetes API server and generates metrics about the state of the objects. It is focused on the health of the various objects running inside kubernetes, such as deployments, nodes and pods.
+
+Deploy the [kube-state-metrics-operator][] charm into this kubernetes model with:
+
+```bash
+juju deploy kube-state-metrics --trust
+```
+
+If you have a prometheus application running in the same model, it can also be related to this:
+
+```bash
+juju relate kube-state-metrics prometheus 
+```
+
+
+#### 2. Kubernetes Metrics Server
+
+The Kubernetes Metrics Server collects resource metrics from Kubelets and exposes them in the Kubernetes apiserver through Metrics API for use by the Horizontal Pod Autoscaler and Vertical Pod Autoscaler. The  Metrics API can also be accessed by `kubectl top`, making it easier to debug autoscaling pipelines.
+
+Since version 1.24, the `metrics-server` can be deployed into the cluster just like any other kubernetes application.
+
+Firstly, ensure that the API aggregation is turned on
+
+```
+juju switch ck-model
+juju config kubernetes-control-plane api-aggregation-extension=true
+```
+
+Then deploy the Kubernetes Metrics Server charm:
+
+```bash
+juju switch k8s-model
+juju deploy kubernetes-metrics-server
+```
+
+Some of the new configuration options available through this charm are:
+
+- upgrade the release of the `metrics-server` via config
+  ```bash
+  juju config kubernetes-metrics-server release="v0.6.0"
+  ```
+- adjust the base image registry if the cluster demands a private registry
+  ```bash
+  juju config kubernetes-metrics-server image-registry="my.registry.server:5000"
+  ```
+- adjust the arguments of the running service
+  ```bash
+  juju config kubernetes-metrics-server extra-args="--kubelet-insecure-tls"
+  ```
+
+
+<!-- LINKS -->
+[addons page]: /kubernetes/docs/cdk-addons
+[Operations page]: /kubernetes/docs/operations
+[kubernetes-control-plane configuration]: https://charmhub.io/kubernetes-control-plane/configure
+[Storage documentation]: /kubernetes/docs/storage
+[GPU workers page]: /kubernetes/docs/gpu-workers
+[LDAP and Keystone page]: /kubernetes/docs/ldap
+[monitoring docs]: /kubernetes/docs/monitoring
+[coredns-charm]: https://charmhub.io/coredns
+[kubernetes-dashboard-charm]: https://charmhub.io/kubernetes-dashboard
+[kube-state-metrics example]: https://github.com/kubernetes/kube-state-metrics/tree/master/examples/standard
+[metrics-server releases]: https://github.com/kubernetes-sigs/metrics-server/releases
+[add a k8s cloud]: https://juju.is/docs/olm/get-started-on-kubernetes#heading--register-the-cluster-with-juju
+[kubernetes-metrics-server]: https://charmhub.io/kubernetes-metrics-server
+[aggregation-extentions]: https://kubernetes.io/docs/tasks/extend-kubernetes/configure-aggregation-layer/
+[coredns-docs]: https://charmhub.io/coredns/docs

--- a/templates/kubernetes/docs/inclusive-naming.md
+++ b/templates/kubernetes/docs/inclusive-naming.md
@@ -41,7 +41,7 @@ inclusive-naming changes, and take care to make non-breaking adjustments.
 Ending with the charms release 1.23, Charmed Kubernetes is replacing the charm
 `kubernetes-master` with `kubernetes-control-plane`. This charm has always
 hosted applications such as the api-server, controller-manager, proxy, and
-scheduler. Aside from [`etcd`](etcd), which is provided by a separate charm,
+scheduler. Aside from [`etcd`][etcd], which is provided by a separate charm,
 these services are considered the central kubernetes control plane services and
 are better represented under this charm name.
 

--- a/templates/kubernetes/docs/inclusive-naming.md
+++ b/templates/kubernetes/docs/inclusive-naming.md
@@ -41,7 +41,7 @@ inclusive-naming changes, and take care to make non-breaking adjustments.
 Ending with the charms release 1.23, Charmed Kubernetes is replacing the charm
 `kubernetes-master` with `kubernetes-control-plane`. This charm has always
 hosted applications such as the api-server, controller-manager, proxy, and
-scheduler. Aside from [`etcd`][etcd], which is provided by a separate charm,
+scheduler. Aside from [`etcd`](etcd), which is provided by a separate charm,
 these services are considered the central kubernetes control plane services and
 are better represented under this charm name.
 
@@ -62,8 +62,9 @@ transition the names of the default branches to `main`.
 
 <!-- LINKS -->
 
+[LXD-image]: https://linuxcontainers.org/lxd/docs/master/image-handling
 [kubernetes-control-plane]: https://charmhub.io/kubernetes-control-plane/docs
-[etcd]: https://charmhub.io/etcd
+[etcd]: /kubernetes/docs/charm-etcd
 [upgrading]: /kubernetes/docs/upgrading
 
 <!-- FEEDBACK -->

--- a/templates/kubernetes/docs/install-manual.md
+++ b/templates/kubernetes/docs/install-manual.md
@@ -181,10 +181,10 @@ each category!
 
 You can use multiple overlays (of different types) if required.  Note that all
 the 'integrator' charms require the use of the `--trust` option. For example,
-to deploy with Calico networking and AWS integration:
+to deploy with Canal networking and AWS integration:
 
 ```bash
-juju deploy charmed-kubernetes --overlay aws-overlay.yaml --trust --overlay calico-overlay.yaml
+juju deploy charmed-kubernetes --overlay aws-overlay.yaml --trust --overlay canal-overlay.yaml
 ```
 
 For more detail on overlays and how they work, see the section [below](#overlay).
@@ -201,11 +201,11 @@ juju deploy charmed-kubernetes
 ```
 
 It is also possible to deploy a specific version of the bundle by including the
-revision number. For example, to deploy the **Charmed Kubernetes** bundle for the Kubernetes 1.23
+revision number. For example, to deploy the **Charmed Kubernetes** bundle for the Kubernetes 1.24
 release, you could run:
 
 ```bash
-juju deploy cs:charmed-kubernetes-862
+juju deploy cs:charmed-kubernetes-1154
 ```
 
 The revision numbers for bundles are generated automatically when the bundle is
@@ -217,6 +217,7 @@ versions of the **Charmed Kubernetes** bundle are shown in the table below:
 
 | Kubernetes version | Charmed Kubernetes bundle                                                                                              |
 | --- |------------------------------------------------------------------------------------------------------------------------------|
+| 1.24.x    | [charmed-kubernetes-1154]((https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/releases/1.24/bundle.yaml)) |
 | 1.23.x    | [charmed-kubernetes-862](https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/releases/1.23/bundle.yaml) |
 | 1.22.x    | [charmed-kubernetes-814](https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/releases/1.22/bundle.yaml) |
 | 1.21.x    | [charmed-kubernetes-733](https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/releases/1.21/bundle.yaml) |
@@ -350,7 +351,7 @@ values:
 
 ```bash
 juju config containerd https_proxy=https://proxy.example.com
-juju config kubernetes-worker snap_proxy:=https://snap-proxy.example.com
+juju config kubernetes-worker snap_proxy=https://snap-proxy.example.com
 ```
 ... we can instead use the following YAML fragment as an overlay:
 

--- a/templates/kubernetes/docs/install-manual.md
+++ b/templates/kubernetes/docs/install-manual.md
@@ -217,7 +217,7 @@ versions of the **Charmed Kubernetes** bundle are shown in the table below:
 
 | Kubernetes version | Charmed Kubernetes bundle                                                                                              |
 | --- |------------------------------------------------------------------------------------------------------------------------------|
-| 1.24.x    | [charmed-kubernetes-1154]((https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/releases/1.24/bundle.yaml)) |
+| 1.24.x    | [charmed-kubernetes-1154](https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/releases/1.24/bundle.yaml) |
 | 1.23.x    | [charmed-kubernetes-862](https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/releases/1.23/bundle.yaml) |
 | 1.22.x    | [charmed-kubernetes-814](https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/releases/1.22/bundle.yaml) |
 | 1.21.x    | [charmed-kubernetes-733](https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/releases/1.21/bundle.yaml) |

--- a/templates/kubernetes/docs/ipv6.md
+++ b/templates/kubernetes/docs/ipv6.md
@@ -175,7 +175,6 @@ No additional issues with IPv6 on MAAS are known at this time.
 
 [dual-stack]: https://kubernetes.io/docs/concepts/services-networking/dual-stack/
 [ip-families]: https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services
-[asset-calico-overlay]: https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/overlays/calico-overlay.yaml
 [asset-ipv4-ipv6-overlay]: https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/overlays/ipv4-ipv6-overlay.yaml
 [asset-nginx-dual-stack]: https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/specs/nginx-dual-stack.yaml
 

--- a/templates/kubernetes/docs/metallb.md
+++ b/templates/kubernetes/docs/metallb.md
@@ -40,7 +40,6 @@ anti-affinity to prevent Kubernetes pods from stacking on a single node.
     <a href="https://metallb.universe.tf/"> MetalLB website</a></p>
   </div>
 </div>
-
 # Deployment
 
 ## Layer 2 mode

--- a/templates/kubernetes/docs/release-notes.md
+++ b/templates/kubernetes/docs/release-notes.md
@@ -13,6 +13,49 @@ layout: [base, ubuntu-com]
 toc: False
 ---
 
+# 1.24+ck1 Bugfix release 
+
+### August 5, 2022 - `charmed-kubernetes --channel 1.24/stable` 
+
+The release bundle can also be [downloaded here](https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/releases/1.24/bundle.yaml).
+
+## What's new
+
+- Jammy Jellyfish (22.04) Support
+
+All Charmed Kubernetes charms now come with the ability to run on `jammy`
+series machines. Xenial (16.04) support has been removed. Focal (20.04)
+remains the default series in all bundles and charms, however the charms
+now advertise `jammy` support and are considered stable for that series.
+
+- Improved Documentation
+
+Vault documentation updated to cover 20.04 `focal` environment.
+Operator charms and replacements for addons now have dedicated guides.
+CIDR size limitations are better described in the charm's `cidr` config option.
+
+- Containerd
+
+Improved GPU support by referencing apt sources with https and refreshing
+NVIDIA repository keys. Also improved NVIDIA driver upgrades and debug messages for
+units that encounter connectivity failures in air-gapped or proxied environments.
+
+Improved upgrade actions for containerd packages as well as NVIDIA packages.
+
+- Docker Registry
+
+Exposes docker registry `cache-*` settings to configure it as a pull-through cache.
+
+- Etcd
+
+Limits the set of TLS ciphers to remove weaker ones.
+ 
+
+## Fixes
+
+A list of bug fixes and other minor feature updates in this release can be found at
+[the launchpad milestone page for 1.24+ck1](https://launchpad.net/charmed-kubernetes/+milestone/1.24+ck1).
+
 # 1.24
 
 ### May 6th, 2022 - `charmed-kubernetes --channel 1.24/stable`

--- a/templates/kubernetes/docs/supported-versions.md
+++ b/templates/kubernetes/docs/supported-versions.md
@@ -46,6 +46,7 @@ versions of the **Charmed Kubernetes** bundle are shown in the table below:
 
 | Kubernetes version | Charmed Kubernetes bundle |
 | --- | --- |
+| 1.24.x    | [charmed-kubernetes-1154]((https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/releases/1.24/bundle.yaml)) |
 | 1.23.x    | [charmed-kubernetes-862](https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/releases/1.23/bundle.yaml) |
 | 1.22.x    | [charmed-kubernetes-814](https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/releases/1.22/bundle.yaml) |
 | 1.21.x    | [charmed-kubernetes-733](https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/releases/1.21/bundle.yaml) |
@@ -177,7 +178,7 @@ channels:
   1.5/candidate:    1.5.5          2017-05-17    (3) 17MB -
   1.5/beta:         1.5.5          2017-05-17    (3) 17MB -
   1.5/edge:         1.5.5          2017-05-17    (3) 17MB -
-```
+
 
 In the above output, the stable release is identified as 1.24, and so 1.23 and
 1.22 are also currently supported.

--- a/templates/kubernetes/docs/supported-versions.md
+++ b/templates/kubernetes/docs/supported-versions.md
@@ -46,7 +46,7 @@ versions of the **Charmed Kubernetes** bundle are shown in the table below:
 
 | Kubernetes version | Charmed Kubernetes bundle |
 | --- | --- |
-| 1.24.x    | [charmed-kubernetes-1154]((https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/releases/1.24/bundle.yaml)) |
+| 1.24.x    | [charmed-kubernetes-1154](https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/releases/1.24/bundle.yaml) |
 | 1.23.x    | [charmed-kubernetes-862](https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/releases/1.23/bundle.yaml) |
 | 1.22.x    | [charmed-kubernetes-814](https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/releases/1.22/bundle.yaml) |
 | 1.21.x    | [charmed-kubernetes-733](https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/releases/1.21/bundle.yaml) |


### PR DESCRIPTION
## Done

- Updated components to include latest images
- All bundle refs updated
- Release notes added
- updates to Vault
- Updates for charmed operators/addons


## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes

