### PR TITLE
Add engage pages endpoint with language

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 canonicalwebteam.flask-base==1.0.5
-canonicalwebteam.discourse==5.0.0
 canonicalwebteam.http==1.0.3
 canonicalwebteam.blog==6.4.0
 canonicalwebteam.search==1.2.7
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.3.1
+canonicalwebteam.discourse==5.0.1
 python-dateutil==2.8.2
 pytz==2020.5
 maxminddb-geolite2==2018.703

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -613,7 +613,16 @@ app.add_url_rule(
     "/openstack/resources", view_func=openstack_engage(engage_pages)
 )
 app.add_url_rule(engage_path, view_func=build_engage_index(engage_pages))
-app.add_url_rule("/engage/<page>", view_func=build_engage_page(engage_pages))
+app.add_url_rule(
+    "/engage/<page>",
+    defaults={"language": None},
+    view_func=build_engage_page(engage_pages),
+)
+app.add_url_rule(
+    "/engage/<language>/<page>",
+    endpoint="language-engage-page",
+    view_func=build_engage_page(engage_pages),
+)
 app.add_url_rule(
     "/engage/<page>/thank-you",
     defaults={"language": None},

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -427,8 +427,11 @@ def build_engage_index(engage_docs):
 
 
 def build_engage_page(engage_pages):
-    def engage_page(page):
-        path = f"/engage/{page}"
+    def engage_page(language, page):
+        if language:
+            path = f"/engage/{language}/{page}"
+        else:
+            path = f"/engage/{page}"
         metadata = engage_pages.get_engage_page(path)
         if not metadata:
             flask.abort(404)


### PR DESCRIPTION
## Done

Add missing language engage page endpoint (works the same as thank-you page)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Check that the engage pages with in languages other than English work now:

https://ubuntu-com-11940.demos.haus/engage/es/guia-para-la-implementacion-de-openstack
https://ubuntu-com-11940.demos.haus/engage/es/comparacion-de-la-plataforma-kubernetes-red-hat-openshift-suse-rancher-y-canonical-kubernetes
https://ubuntu-com-11940.demos.haus/engage/it/italian-2021-cloud-pricing-report


Finally, test a few other engage pages see that the others work:

e.g. https://ubuntu-com-11940.demos.haus/engage/developer-guide-to-operators


## Issue / Card

Reported by [Shereen on Mattermost](https://chat.canonical.com/canonical/pl/aod5ornadpyrinzumwpqxnfqye)



## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
