### PR TITLE
Update /credentialing links to point to Production.

### DIFF
--- a/templates/credentialing/index.html
+++ b/templates/credentialing/index.html
@@ -61,7 +61,7 @@
           <div class="p-matrix__desc">
             <p>Prove your knowledge of the Linux community, history, and philosophy. Topics include common Linux commands, open source and software licensing, and basic knowledge of Linux architecture and file hierarchy.</p>
             <a
-              href="https://qa.cube.ubuntu.com/auth/login/tpa-saml/?auth_entry=login&idp=ubuntuone&next=/courses/course-v1:Canonical%2bcue-linuxessentials%2b2022/courseware/2022/start/"
+              href="https://cube.ubuntu.com/auth/login/tpa-saml/?auth_entry=login&idp=ubuntuone&next=/courses/course-v1:Canonical%2bcue-linux%2b2022/courseware/2022/start/"
               class="p-button--positive"
               >Start</a
             >
@@ -85,7 +85,7 @@
           <div class="p-matrix__desc">
             <p>Demonstrate your knowledge of Ubuntu Desktop administrative essentials. Topics include package management, system installation, data gathering, and managing printing and displays.</p>
             <a
-              href="https://qa.cube.ubuntu.com/auth/login/tpa-saml/?auth_entry=login&idp=ubuntuone&next=/courses/course-v1:Canonical%2bcue-desktop%2b2022/courseware/2022/start/"
+              href="https://cube.ubuntu.com/auth/login/tpa-saml/?auth_entry=login&idp=ubuntuone&next=/courses/course-v1:Canonical%2bcue-desktop%2b2022/courseware/2022/start/"
               class="p-button--positive"
               >Start</a
             >
@@ -109,7 +109,7 @@
           <div class="p-matrix__desc">
             <p>Illustrate your knowledge of common Ubuntu Server administrative tasks and troubleshooting. Topics include job control, performance tuning, services management, and Bash scripting.</p>
             <a
-              href="https://qa.cube.ubuntu.com/auth/login/tpa-saml/?auth_entry=login&idp=ubuntuone&next=/courses/course-v1:Canonical%2bcue-server%2b2022/courseware/2022/start/"
+              href="https://cube.ubuntu.com/auth/login/tpa-saml/?auth_entry=login&idp=ubuntuone&next=/courses/course-v1:Canonical%2bcue-server%2b2022/courseware/2022/start/"
               class="p-button--positive"
               >Start</a
             >
@@ -142,7 +142,7 @@
             <div class="p-matrix__desc">
               <p> </p>
               <a
-                href="https://qa.cube.ubuntu.com/auth/login/tpa-saml/?auth_entry=login&idp=ubuntuone&next=/courses/course-v1:Canonical%2bcue%2b2022/courseware/2022/start/"
+                href="https://cube.ubuntu.com/auth/login/tpa-saml/?auth_entry=login&idp=ubuntuone&next=/courses/course-v1:Canonical%2bcue%2b2022/courseware/2022/start/"
                 class="p-button--positive"
                 >Start
               </a>


### PR DESCRIPTION
## Done

- Updated links on /credentialing to point to exams on the Production Open edX instance

## QA

- Go to https://ubuntu-com-11941.demos.haus/credentialing
  - Click each Start button and verify that you land on cube.ubuntu.com (_not_ qa.cube.ubuntu.com)

## Issue / Card

Part of https://github.com/canonical/commercial-squad/issues/693

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
