### PR TITLE
Build new risc-v download page

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -1393,6 +1393,8 @@ download:
 
     - title: AMD-Xilinx
       path: /download/amd-xilinx
+    - title: RISC-V
+      path: /download/risc-v
     - title: Alternative downloads
       path: /download/alternative-downloads
 

--- a/navigation.yaml
+++ b/navigation.yaml
@@ -1393,8 +1393,6 @@ download:
 
     - title: AMD-Xilinx
       path: /download/amd-xilinx
-    - title: RISC-V
-      path: /download/risc-v
     - title: Alternative downloads
       path: /download/alternative-downloads
 

--- a/templates/download/risc-v/index.html
+++ b/templates/download/risc-v/index.html
@@ -1,0 +1,67 @@
+{% extends "download/_base_download.html" %}
+
+{% block title %}Download Ubuntu for RISC-V Platforms{% endblock %}
+
+{% block meta_description %}Use Ubuntu on RISC-V platforms for the familiar developer experience and an accelerated path to production.{% endblock meta_description %}
+
+{% block meta_copydoc%}https://docs.google.com/document/d/1kkJeq9HdH3iWV35HwihcJd3CxZw9Jy21W66lJl8VbWs/edit#{% endblock meta_copydoc %}
+
+{% block content %}
+
+<section class="p-strip--suru-topped">
+  <div class="row u-vertically-center">
+    <div class="col-6">
+      <h1>Download Ubuntu for RISC-V Platforms</h1>
+      <h2 class="p-heading--3">Ubuntu - now available for multiple RISC-V platforms</h2>
+      <p>Run Ubuntu with your favourite RISC-V boards. Ubuntu recently enabled SiFive Unmatched, StarFive VisionFive and Allwinner Nezha in Ubuntu 22.04.1. Download the images for those boards below.</p>
+      <p>Pick the OS image to match your hardware, flash it onto SD/microSD card, load it onto your board and away you go.</p>
+      <p>
+        <a href="/download/contact-us" class="js-invoke-modal p-button">Get in touch</a>
+      </p>
+    </div>
+    <div class="col-6 u-hide--medium u-hide--small u-align--center">
+        {{
+            image (
+            url="https://assets.ubuntu.com/v1/4d5b8d51-riscv-color.svg",
+            alt="",
+            width="300",
+            height="48",
+            hi_def=True,
+            loading="auto"
+            ) | safe
+          }}
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-shallow">
+  <div class="u-fixed-width">
+    <div class="p-tabs">
+      <div class="p-tabs__list js-tabbed-content" role="tablist" aria-label="Install RISC-V">
+        <div class="p-tabs__item">
+          <button class="p-tabs__link" role="tab" aria-selected="true" aria-controls="quemu-sifive-image-tab" id="quemu-sifive-image" tabindex="-1">SiFive Unmatched, QEMU</button>
+        </div>
+        <div class="p-tabs__item">
+          <button class="p-tabs__link" role="tab" aria-selected="false" aria-controls="starfive-visionfive-board-tab" id="starfive-visionfive-board">StarFive VisionFive</button>
+        </div>
+        <div class="p-tabs__item">
+            <button class="p-tabs__link" role="tab" aria-selected="false" aria-controls="allwinner-nezha-tab" id="allwinner-nezha">AllWinner Nezha</button>
+        </div>
+        <div class="p-tabs__item">
+            <button class="p-tabs__link" role="tab" aria-selected="false" aria-controls="live-installer-tab" id="live-installer">Live installer</button>
+        </div>
+      </div>
+      {% include "download/risc-v/tab-1.html" %}
+      {% include "download/risc-v/tab-2.html" %}
+      {% include "download/risc-v/tab-3.html" %}
+      {% include "download/risc-v/tab-4.html" %}
+    </div>
+  </div>
+</section>
+
+<!-- Set default Marketo information for contact form below-->
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/internet-of-things" data-form-id="4532" data-lp-id="" data-return-url="https://ubuntu.com/pricing/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html"></div>
+
+<script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
+
+{% endblock content %}

--- a/templates/download/risc-v/tab-1.html
+++ b/templates/download/risc-v/tab-1.html
@@ -1,0 +1,37 @@
+<div tabindex="0" role="tabpanel" id="quemu-sifive-image-tab" aria-labelledby="quemu-sifive-image">
+	<div class="row u-vertically-center u-no-padding">
+		<div class="col-6">
+			<h2>Download Ubuntu Server Preinstalled Image</h2>
+			<h3 class="p-heading--4">Ubuntu Server 22.04.1</h3>
+			<div class="p-notification--information is-inline">
+				<div class="p-notification__content">
+					<h4 class="p-notification__title">Note:</h4>
+					<p class="p-notification__message">It is an early RISC-V developer access through Ubuntu 22.04.1 and this is a preinstalled image, if you have a NVMe drive, we advise you to use the Ubuntu Server live installer which can be found <a href="https://cdimage.ubuntu.com/releases/22.04.1/release/ubuntu-22.04.1-live-server-riscv64.img.gz">here</a>.</p>
+				</div>
+			</div>
+			<p>
+				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/22.04.1/release/ubuntu-22.04.1-preinstalled-server-riscv64+unmatched.img.xz">Download 64-bit</a>
+			</p>
+			<p>Works on:</p>
+			<ul class="p-list">
+				<li class="p-list__item is-ticked">The Unmatched board</li>
+				<li class="p-list__item is-ticked">QEMU</li>
+			</ul>
+		</div>
+		<div class="col-6 u-hide--medium u-hide--small u-align--center">
+			{{ image (
+				url="https://assets.ubuntu.com/v1/37c094a9-SiFive+Unmatched+Board.jpg",
+				alt="",
+				width="720",
+				height="480",
+				hi_def=True,
+				loading="auto"
+				) | safe
+			  }}
+		</div>
+	</div>
+	<div class="u-fixed-width">
+		<h4>First time installing Ubuntu on QEMU/Unmatched?</h4>
+		<p>Please see the <a href="https://wiki.ubuntu.com/RISC-V">wiki.ubuntu.com/RISC-V</a> for more information.</p>
+	</div>
+</div>

--- a/templates/download/risc-v/tab-2.html
+++ b/templates/download/risc-v/tab-2.html
@@ -1,0 +1,36 @@
+<div tabindex="0" role="tabpanel" id="starfive-visionfive-board-tab" aria-labelledby="starfive-visionfive-board" hidden="true">
+	<div class="row u-vertically-center u-no-padding">
+		<div class="col-6">
+			<h2>Download Ubuntu Server</h2>
+			<h3 class="p-heading--4">Ubuntu Server 22.04.1</h3>
+			<div class="p-notification--information">
+				<div class="p-notification__content">
+					<h5 class="p-notification__title">Note:</h5>
+					<p>It is an early RISC-V developer access through Ubuntu 22.04.1.</p>
+				</div>
+			</div>
+			<p>
+				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/22.04.1/release/ubuntu-22.04.1-preinstalled-server-riscv64+visionfive.img.xz">Download 64-bit</a>
+			</p>
+			<p>Works on:</p>
+			<ul class="p-list">
+				<li class="p-list__item is-ticked">The VisionFive board</li>
+			</ul>
+		</div>
+		<div class="col-6 u-hide--medium u-hide--small u-align--center">
+			{{ image (
+				url="https://assets.ubuntu.com/v1/470a2398-StarFive+VisionFive+Board-NoBg.png",
+				alt="",
+				width="1056",
+				height="854",
+				hi_def=True,
+				loading="auto"
+				) | safe
+			  }}
+		</div>
+	</div>
+	<div class="u-fixed-width">
+		<h4>First time installing Ubuntu on the VisionFive?</h4>
+		<p>Please see the <a href="https://discourse.ubuntu.com/t/ubuntu-on-the-visionfive-and-the-nezha-boards/29858	">How to install Ubuntu on the VisionFive</a> for more information.</p>
+	</div>
+</div>

--- a/templates/download/risc-v/tab-3.html
+++ b/templates/download/risc-v/tab-3.html
@@ -1,0 +1,36 @@
+<div tabindex="0" role="tabpanel" id="allwinner-nezha-tab" aria-labelledby="allwinner-nezha" aria-hidden="true">
+	<div class="row u-vertically-center u-no-padding">
+		<div class="col-6">
+			<h2>Download Ubuntu Server</h2>
+			<h3 class="p-heading--4">Ubuntu Server 22.04.1</h3>
+			<div class="p-notification--information is-inline">
+				<div class="p-notification__content">
+					<h4 class="p-notification__title">Note:</h4>
+					<p class="p-notification__message">It is an early RISC-V developer access through Ubuntu 22.04.1.</p>
+				</div>
+			</div>
+			<p>
+				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/22.04.1/release/ubuntu-22.04.1-preinstalled-server-riscv64+nezha.img.xz">Download 64-bit</a>
+			</p>
+			<p>Works on:</p>
+			<ul class="p-list">
+				<li class="p-list__item is-ticked">The Nezha board</li>
+			</ul>
+		</div>
+		<div class="col-6 u-hide--medium u-hide--small u-align--center">
+			{{ image (
+				url="https://assets.ubuntu.com/v1/0cc9bac3-Allwinner+Nezha+Board.png",
+				alt="",
+				width="600",
+				height="400",
+				hi_def=True,
+				loading="auto"
+				) | safe
+			  }}
+		</div>
+	</div>
+	<div class="u-fixed-width">
+		<h4>First time installing Ubuntu on the Nezha?</h4>
+		<p>Please see the <a href="https://xilinx-wiki.atlassian.net/wiki/spaces/A/pages/2037317633/Getting+Started+with+Certified+Ubuntu+20.04+LTS+for+Xilinx+Devices?utm_source=canonical&utm_medium=referral&utm_campaign=ubuntu&utm_content=download&utm_term=desktop_image">How to install Ubuntu on the Nezha</a> (TODO link does not exist yet) for more information.</p>
+	</div>
+</div>

--- a/templates/download/risc-v/tab-3.html
+++ b/templates/download/risc-v/tab-3.html
@@ -31,6 +31,6 @@
 	</div>
 	<div class="u-fixed-width">
 		<h4>First time installing Ubuntu on the Nezha?</h4>
-		<p>Please see the <a href="https://xilinx-wiki.atlassian.net/wiki/spaces/A/pages/2037317633/Getting+Started+with+Certified+Ubuntu+20.04+LTS+for+Xilinx+Devices?utm_source=canonical&utm_medium=referral&utm_campaign=ubuntu&utm_content=download&utm_term=desktop_image">How to install Ubuntu on the Nezha</a> (TODO link does not exist yet) for more information.</p>
+		<p>Please see the <a href="https://discourse.ubuntu.com/t/ubuntu-on-the-visionfive-and-the-nezha-boards/29858">How to install Ubuntu on the Nezha</a> for more information.</p>
 	</div>
 </div>

--- a/templates/download/risc-v/tab-4.html
+++ b/templates/download/risc-v/tab-4.html
@@ -1,0 +1,38 @@
+<div tabindex="0" role="tabpanel" id="live-installer-tab" aria-labelledby="live-installer" aria-hidden="true">
+	<div class="row u-vertically-center u-no-padding">
+		<div class="col-6">
+			<h2>Download Ubuntu Server Live Installer</h2>
+			<h3 class="p-heading--4">Ubuntu Server 22.04.1</h3>
+			<div class="p-notification--information is-inline">
+				<div class="p-notification__content">
+					<h4 class="p-notification__title">Note:</h4>
+					<p class="p-notification__message">It is an early RISC-V developer access through Ubuntu 22.04.1. This image works on the SiFive Unmatched Board and on QEMU.</p>
+				</div>
+			</div>
+			<p>
+				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/22.04.1/release/ubuntu-22.04.1-live-server-riscv64.img.gz">Download 64-bit</a>
+			</p>
+			<p>Works on:</p>
+			<ul class="p-list">
+				<li class="p-list__item is-ticked">QEMU</li>
+				<li class="p-list__item is-ticked">The Unmatched board</li>
+			</ul>
+		</div>
+		<div class="col-6 u-hide--medium u-hide--small u-align--center">
+			{{
+				image (
+				url="https://assets.ubuntu.com/v1/308d48cd-Qemu-logo.png",
+				alt="",
+				width="377",
+				height="120",
+				hi_def=True,
+				loading="auto|lazy"
+				) | safe
+			  }}
+		</div>
+	</div>
+	<div class="u-fixed-width">
+		<h4>First time installing Ubuntu on QEMU/Unmatched?</h4>
+		<p>Please see the <a href="https://discourse.ubuntu.com/t/ubuntu-installation-on-the-sifive-hifive-unmatched-board-using-a-server-install-image/27804">Ubuntu installation on the SiFive HiFive Unmatched board using a server install image - RISC-V-docs</a> and <a href="https://discourse.ubuntu.com/t/ubuntu-installation-on-a-risc-v-virtual-machine-using-a-server-install-image-and-qemu/27636">Ubuntu installation on a RISC-V virtual machine using a server install image and QEMU</a> for more information.</p>
+	</div>
+</div>

--- a/templates/download/risc-v/tab-4.html
+++ b/templates/download/risc-v/tab-4.html
@@ -14,21 +14,20 @@
 			</p>
 			<p>Works on:</p>
 			<ul class="p-list">
-				<li class="p-list__item is-ticked">QEMU</li>
 				<li class="p-list__item is-ticked">The Unmatched board</li>
+				<li class="p-list__item is-ticked">QEMU</li>
 			</ul>
 		</div>
 		<div class="col-6 u-hide--medium u-hide--small u-align--center">
-			{{
-				image (
-				url="https://assets.ubuntu.com/v1/308d48cd-Qemu-logo.png",
+			{{ image (
+				url="https://assets.ubuntu.com/v1/37c094a9-SiFive+Unmatched+Board.jpg",
 				alt="",
-				width="377",
-				height="120",
+				width="720",
+				height="480",
 				hi_def=True,
-				loading="auto|lazy"
+				loading="auto"
 				) | safe
-			  }}
+			}}
 		</div>
 	</div>
 	<div class="u-fixed-width">


### PR DESCRIPTION
## Done

Build new Risc-v download page

## QA

- Go to https://ubuntu-com-11942.demos.haus/download/risc-v
    - Be sure to test on mobile, tablet and desktop screen sizes

- Check [copy docs](https://docs.google.com/document/d/1kkJeq9HdH3iWV35HwihcJd3CxZw9Jy21W66lJl8VbWs/edit#)
- Don't forget to check the marketo ID, tab functionality, meta title. 
- At the time writing there is no meta image

## Issue / Card

Fixes https://github.com/canonical/web-squad/issues/5814

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
