### PR TITLE
Add charmed kubeflow beta banner

### DIFF
--- a/templates/ai/index.html
+++ b/templates/ai/index.html
@@ -9,6 +9,9 @@
 {% block content %}
 
 <section class="p-strip--suru-topped is-dark is-bordered">
+  {% if not ("2022-09-06" | date_has_passed) %}
+    {% include "shared/_charmed-kubeflow-beta-banner.html" %}
+  {% endif %}
   <div class="row u-equal-height">
     <div class="col-6">
       <h1>AI on Ubuntu: the path<br>to production</h1>

--- a/templates/ai/what-is-kubeflow.html
+++ b/templates/ai/what-is-kubeflow.html
@@ -8,6 +8,9 @@
 
 <section class="p-strip u-no-padding--top u-no-padding--bottom">
   <div class="p-strip--suru-topped">
+    {% if not ("2022-09-06" | date_has_passed) %}
+      {% include "shared/_charmed-kubeflow-beta-banner.html" %}
+    {% endif %}
     <div class="row u-equal-height">
       <div class="col-6">
         <h1 class="u-sv2">What is Kubeflow?</h1>

--- a/templates/shared/_charmed-kubeflow-beta-banner.html
+++ b/templates/shared/_charmed-kubeflow-beta-banner.html
@@ -1,0 +1,9 @@
+<div class="u-fixed-width">
+  <div class="p-notification--information is-inline">
+    <div class="p-notification__content">
+      <h5 class="p-notification__title">The Charmed Kubeflow 1.6 beta is here:</h5>
+      <p class="p-notification__message">
+        <code>juju deploy kubeflow --channel 1.6/beta</code><br /> Read more in our <a href="/blog/kubeflow-beta-release-mlops">blog</a> and share your <a href="https://discourse.charmhub.io/t/kubeflow-1-6/6842">feedback</a> with us.</p>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Done

- Added banner for charmed kubeflow beta
- Reused `date_has_passed` function to takedown banner

## QA

- Check banner shows on https://ubuntu-com-11944.demos.haus/ai, https://ubuntu-com-11944.demos.haus/ai/what-is-kubeflow

**The blog link won't work until release date (17-08-2022)**

## Issue / Card

Fixes https://github.com/canonical/web-squad/issues/5802

## Screenshots

![charmed-kubeflow-beta-banner](https://user-images.githubusercontent.com/14939793/184632411-b6217f5a-598a-4df1-a622-9ef90cc88f18.png)



## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
