### PR TITLE
Handle not found WordPress posts

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -675,6 +675,9 @@ class BlogRedirects(BlogView):
         if isinstance(group, dict) and group["id"] == 2100:
             return flask.redirect(f"https://canonical.com/blog/{slug}")
 
+        if not article:
+            return flask.abort(404)
+
         return flask.render_template("blog/article.html", article=article)
 
 


### PR DESCRIPTION
## Done

- Handle not found Blog posts

## QA

- Go to a blog post that doesn't exist like https://ubuntu-com-11947.demos.haus/blog/pepe it should return 404. In contrast, https://ubuntu.com/blog/pepe would break with a 500
- Check that the rest of the blogs work https://ubuntu-com-11947.demos.haus/blog/

## Issue / Card

Fixes https://github.com/canonical/ubuntu.com/issues/11948

