### PR TITLE
fix link on download/iot

### DIFF
--- a/templates/download/iot/index.html
+++ b/templates/download/iot/index.html
@@ -124,7 +124,7 @@
           ) | safe
         }}
         <p>
-          <a href="/download/iot/risc-v">Install Ubuntu Server&nbsp;&rsaquo;</a>
+          <a href="/download/risc-v">Install Ubuntu Server&nbsp;&rsaquo;</a>
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Done

- Fixed broken link on /download/iot

## QA

- visit https://ubuntu-com-11951.demos.haus/download/iot
- find the RISC-V link under "Supported Platform"
- the link should take you to /download/risc-v
