### PR TITLE
[Copy update] /security/docker-images

### DIFF
--- a/templates/security/docker-images.html
+++ b/templates/security/docker-images.html
@@ -16,7 +16,7 @@
       <p><pre><code>$ docker pull ubuntu/<span class="typer" id="main" data-words="nginx,redis,grafana,prometheus,cassandra,cortex,apache2,mysql" data-delay="50" data-deleteDelay="2000" data-colors="#111111">nginx</span></code></pre></p>
       <p>
         <a href="/security/contact-us?product=docker" data-testid="interactive-form-link" class="p-button--positive js-invoke-modal">Get commercial support</a>
-        <a href="/blog/canonical-publishes-lts-docker-image-portfolio-on-docker-hub">Explore the images&nbsp;&rsaquo;</a>
+        <a href="https://hub.docker.com/u/ubuntu">Explore the images&nbsp;&rsaquo;</a>
       </p>
     </div>
     <div class="col-4 u-vertically-center u-hide--medium u-hide--small u-align--center">


### PR DESCRIPTION
## Done

- Updated "Explore the images" link as per [copy doc](https://docs.google.com/document/d/1zZibtjU141e4mBxo_0PtfYxJ6e5fyaaAdFZ6v945XAM/edit)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: https://ubuntu-com-11952.demos.haus/security/docker-images
    - Be sure to test on mobile, tablet and desktop screen sizes
- Click on the link and see that it has been updated correctly

## Issue / Card

Fixes https://github.com/canonical/web-squad/issues/5854
