### PR TITLE
Fix engage page links

### DIFF
--- a/templates/edge-computing/index.html
+++ b/templates/edge-computing/index.html
@@ -15,7 +15,7 @@
       <p class="p-heading--4">Edge computing solution</p>
       <p>Serving compute near the consumers, reusing cloud APIs.</p>
       <p>
-        <a href="/engage/CTO-guide-to-micro-clouds-2021" class="p-button--positive u-no-margin--bottom">Download the whitepaper</a>
+        <a href="/engage/edge-infrastructure" class="p-button--positive u-no-margin--bottom">Download the whitepaper</a>
       </p>
     </div>
     <div class="col-5 u-align--center u-vertically-center u-hide--medium u-hide--small">
@@ -408,7 +408,7 @@
       </div>
       <h2 class="p-heading--4">CTOs' Guide to Micro Clouds</h2>
       <p>This whitepaper demonstrates to Technical Leads the concept of micro clouds, a new class of compute for the edge and decentralised environments. Access the report today to get a condensed work of understanding edge computing constraints, values, graphics, and use cases.</p>
-      <p><a href="/engage/CTO-guide-to-micro-clouds-2021" class="p-button">Download the whitepaper</a></p>
+      <p><a href="/engage/edge-infrastructure" class="p-button">Download the whitepaper</a></p>
     </div>
   </div>
 </section>

--- a/templates/internet-of-things/smart-city.html
+++ b/templates/internet-of-things/smart-city.html
@@ -496,7 +496,7 @@
         </div>
       </div>
       <p>
-        <a href="/engage/CTO-guide-to-micro-clouds-2021">CTOs’ Guide to Micro Clouds&nbsp;&rsaquo;</a>
+        <a href="/engage/edge-infrastructure">CTOs’ Guide to Micro Clouds&nbsp;&rsaquo;</a>
       </p>
     </div>
     <div class="col-4">


### PR DESCRIPTION
## Done

The engage page path for this [engage page](https://discourse.ubuntu.com/t/edge-infrastructure-implementation-the-open-source-way/24533) was changed, and the pages linked to that old URL are broken. This is the fix

## QA

- Check that https://ubuntu-com-11954.demos.haus/engage/edge-infrastructure works, and you can download the whitepaper
- Check that /edge-computing "Download the whitepaper" is linking to the correct engage page



## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
