### PR TITLE
Sanitize blog slugs

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -15,6 +15,7 @@ from ubuntu_release_info.data import Data
 from geolite2 import geolite2
 from requests import Session
 from requests.exceptions import HTTPError
+from urllib.parse import quote
 
 from canonicalwebteam.search.models import get_search_results
 from canonicalwebteam.search.views import NoAPIKeyError
@@ -666,6 +667,8 @@ class BlogView(flask.views.View):
 
 class BlogRedirects(BlogView):
     def dispatch_request(self, slug):
+
+        slug = quote(slug, safe="/:?&")
         article = self.blog_views.api.get_article(
             slug, self.blog_views.tag_ids, self.blog_views.excluded_tags
         )


### PR DESCRIPTION
## Done

For security, to avoid users injecting all sorts of weird characters in the URLs and ending up with 500s, santisize URL

## QA

- Test that https://ubuntu-com-11960.demos.haus/blog/ubuntu-22-04-lts-released%0A doesn't cause a 500 now
- Check that other blogs on https://ubuntu-com-11960.demos.haus/blog work.

## Issue / Card

Fixes https://github.com/canonical/web-squad/issues/5842



## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
