### PR TITLE
Remove the Spanish homepage call out

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -75,7 +75,4 @@
   {% with lang="zh", text="嗨！你知道我们有中文站吗？立即带我去！", url="https://cn.ubuntu.com", icon="https://assets.ubuntu.com/v1/8114528b-picto-ubuntu-orange.png" %}
     {% include "shared/_notice_default.html" %}
   {% endwith %}
-  {% with lang="es", text="Join us at Cloud Expo Europe Madrid", url="/blog/canonical-cloud-expo-europe-madrid-2021", icon="https://assets.ubuntu.com/v1/8114528b-picto-ubuntu-orange.png" %}
-    {% include "shared/_notice_default.html" %}
-  {% endwith %}
 {% endblock notices_content %}


### PR DESCRIPTION
## Done
Remove the Spanish homepage call out

## QA
- Check out the demo and see that the page works well
- Extra bonus points for setting your VPN to Spain and loading the homepage 

## Issue / Card
Fixes https://github.com/canonical/ubuntu.com/issues/11955