### PR TITLE
Replace "Microsoft store" with "Microsoft Store."

### DIFF
--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -173,7 +173,7 @@
     <div class="col-8">
       <h3>Access the Linux Terminal on Windows with Ubuntu WSL</h3>
       <p>For a more integrated environment, activate Windows Subsystem for Linux (WSL) to run Linux applications and workflows while developing cross-platform on your Windows machine.</p>
-      <p>You can download Ubuntu directly from the Microsoft store</p>
+      <p>You can download Ubuntu directly from the Microsoft Store.</p>
       <p><a href="https://www.microsoft.com/en-us/p/ubuntu/9pdxgncfsczv?rtc=1&activetab=pivot:overviewtab" class="p-button--positive">Download Ubuntu WSL</a></p>
       <p><a href="/wsl">Learn more about WSL&nbsp;&rsaquo;</a></p>
     </div>


### PR DESCRIPTION
## Done

- Replaced "Microsoft store" with "Microsoft Store." on download/desktop

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/desktop
    - Be sure to test on mobile, tablet and desktop screen sizes

## Screenshots

Before:

![Screenshot_20220822_135301](https://user-images.githubusercontent.com/67292925/185915229-4ba99b1c-ca3c-4cdd-8279-d3493ca03967.png)

After:

![Screenshot_20220822_135315](https://user-images.githubusercontent.com/67292925/185915385-d57334cd-8bd8-4518-976b-eb6a6bdf6945.png)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
