### PR TITLE
Correct the Kernel lifecycle versions

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -538,13 +538,13 @@ export var kernelReleases1404 = [
   {
     startDate: new Date("2016-08-21T00:00:00"),
     endDate: new Date("2019-04-20T00:00:00"),
-    taskName: "Ubuntu 14.04.5 LTS (v3.13)",
+    taskName: "Ubuntu 14.04.5 LTS (v4.4)",
     status: "LTS",
   },
   {
     startDate: new Date("2019-04-20T00:00:00"),
     endDate: new Date("2024-04-19T00:00:00"),
-    taskName: "Ubuntu 14.04.5 LTS (v3.13)",
+    taskName: "Ubuntu 14.04.5 LTS (v4.4)",
     status: "ESM",
   },
   {
@@ -649,13 +649,13 @@ export var kernelReleasesALL = [
   {
     startDate: new Date("2016-05-01T00:00:00"),
     endDate: new Date("2016-08-21T00:00:00"),
-    taskName: "Ubuntu 14.04.5 LTS (v3.13)",
+    taskName: "Ubuntu 14.04.5 LTS (v4.4)",
     status: "EARLY",
   },
   {
     startDate: new Date("2016-08-21T00:00:00"),
     endDate: new Date("2019-04-20T00:00:00"),
-    taskName: "Ubuntu 14.04.5 LTS (v3.13)",
+    taskName: "Ubuntu 14.04.5 LTS (v4.4)",
     status: "LTS",
   },
   {
@@ -874,13 +874,13 @@ export var kernelReleasesLTS = [
   {
     startDate: new Date("2016-08-21T00:00:00"),
     endDate: new Date("2018-04-01T00:00:00"),
-    taskName: "Ubuntu 14.04.5 LTS (v3.13)",
+    taskName: "Ubuntu 14.04.5 LTS (v4.4)",
     status: "LTS",
   },
   {
     startDate: new Date("2018-04-01T00:00:00"),
     endDate: new Date("2019-04-20T00:00:00"),
-    taskName: "Ubuntu 14.04.5 LTS (v3.13)",
+    taskName: "Ubuntu 14.04.5 LTS (v4.4)",
     status: "CVE",
   },
   {
@@ -1409,7 +1409,7 @@ export var kernelReleaseNames2004 = [
   "Ubuntu 20.04.2 LTS (v5.8)",
   "Ubuntu 20.04.3 LTS (v5.11)",
   "Ubuntu 20.04.4 LTS (v5.13)",
-  "Ubuntu 20.04.5 LTS",
+  "Ubuntu 20.04.5 LTS (v5.15)",
 ];
 
 export var kernelReleaseNames1804 = [
@@ -1436,7 +1436,7 @@ export var kernelReleaseNames1404 = [
   "Ubuntu 14.04.2 LTS (v3.16)",
   "Ubuntu 14.04.3 LTS (v3.19)",
   "Ubuntu 14.04.4 LTS (v4.2)",
-  "Ubuntu 14.04.5 LTS (v3.13)",
+  "Ubuntu 14.04.5 LTS (v4.4)",
 ];
 
 export var kernelReleaseNamesALL = [
@@ -1446,7 +1446,7 @@ export var kernelReleaseNamesALL = [
   "Ubuntu 14.04.3 LTS (v3.19)",
   "Ubuntu 14.04.4 LTS (v4.2)",
   "Ubuntu 16.04.0 LTS (v4.4)",
-  "Ubuntu 14.04.5 LTS (v3.13)",
+  "Ubuntu 14.04.5 LTS (v4.4)",
   "Ubuntu 16.04.1 LTS (v4.4)",
   "Ubuntu 16.04.2 LTS (v4.8)",
   "Ubuntu 16.04.3 LTS (v4.10)",
@@ -1463,7 +1463,7 @@ export var kernelReleaseNamesALL = [
   "Ubuntu 20.04.2 LTS (v5.8)",
   "Ubuntu 20.04.3 LTS (v5.11)",
   "Ubuntu 20.04.4 LTS (v5.13)",
-  "Ubuntu 20.04.5 LTS",
+  "Ubuntu 20.04.5 LTS (v5.15)",
 ];
 
 export var kernelReleaseNamesLTS = [
@@ -1473,7 +1473,7 @@ export var kernelReleaseNamesLTS = [
   "Ubuntu 14.04.3 LTS (v3.19)",
   "Ubuntu 14.04.4 LTS (v4.2)",
   "Ubuntu 16.04.0 LTS (v4.4)",
-  "Ubuntu 14.04.5 LTS (v3.13)",
+  "Ubuntu 14.04.5 LTS (v4.4)",
   "Ubuntu 16.04.1 LTS (v4.4)",
   "Ubuntu 16.04.2 LTS (v4.8)",
   "Ubuntu 16.04.3 LTS (v4.10)",
@@ -1490,7 +1490,7 @@ export var kernelReleaseNamesLTS = [
   "Ubuntu 20.04.2 LTS (v5.8)",
   "Ubuntu 20.04.3 LTS (v5.11)",
   "Ubuntu 20.04.4 LTS (v5.13)",
-  "Ubuntu 20.04.5 LTS",
+  "Ubuntu 20.04.5 LTS (v5.15)",
 ];
 
 export var openStackReleaseNames = [

--- a/templates/shared/_kernel-support-schedule.html
+++ b/templates/shared/_kernel-support-schedule.html
@@ -197,7 +197,7 @@
             </thead>
             <tbody>
               <tr>
-                <td><strong>Ubuntu 14.04.5 LTS (v3.13)</strong></td>
+                <td><strong>Ubuntu 14.04.5 LTS (v4.4)</strong></td>
                 <td>Aug 2016</td>
                 <td>Apr 2019</td>
                 <td>Apr 2022</td>
@@ -285,7 +285,7 @@
                 <td>Mar 2023</td>
               </tr>
               <tr>
-                <td><strong>Ubuntu 14.04.5 LTS (v3.13)</strong></td>
+                <td><strong>Ubuntu 14.04.5 LTS (v4.4)</strong></td>
                 <td>Aug 2016</td>
                 <td>Apr 2018</td>
                 <td>Apr 2019</td>
@@ -387,7 +387,7 @@
                 <td>Jul 2022</td>
               </tr>
               <tr>
-                <td><strong>Ubuntu 20.04.5 LTS</strong></td>
+                <td><strong>Ubuntu 20.04.5 LTS (v5.15)</strong></td>
                 <td>Aug 2022</td>
                 <td>Aug 2024</td>
                 <td>Apr 2025</td>
@@ -445,7 +445,7 @@
                 <td>Apr 2021</td>
               </tr>
               <tr>
-                <td><strong>Ubuntu 14.04.5 LTS (v3.13)</strong></td>
+                <td><strong>Ubuntu 14.04.5 LTS (v4.4)</strong></td>
                 <td>May 2016</td>
                 <td>Aug 2016</td>
                 <td>Apr 2019</td>
@@ -559,7 +559,7 @@
                 <td>Aug 2022</td>
               </tr>
               <tr>
-                <td><strong>Ubuntu 20.04.5 LTS</strong></td>
+                <td><strong>Ubuntu 20.04.5 LTS (v5.15)</strong></td>
                 <td>May 2022</td>
                 <td>Aug 2022</td>
                 <td>Apr 2025</td>


### PR DESCRIPTION
## Done
- Update the version for 14.04.5 LTS
- Add a version to 20.04.5. LTS

## QA
- Check the copy is correct
- Open the demo and go to /kernel/lifecycle#support-lts
- See that Ubuntu 20.04.5 LTS has a version now.

## Issue / Card
Fixes https://github.com/canonical/ubuntu.com/issues/11964
