### PR TITLE
Fix cypress test

### DIFF
--- a/templates/security/index.html
+++ b/templates/security/index.html
@@ -61,7 +61,7 @@
         Learn about cybersecurity and zero trust as well as the common challenges faced in the implementation of cybersecurity programs, including challenges in vulnerability management, secure configuration of software and defenses against malware. See how Canonical and Ubuntu can help manage these challenges and lay the software foundation of a successful cybersecurity program.
       </p>
       <p>
-        <a class="p-button js-invoke-modal" data-testid="interactive-form-link" href="/security/contact-us">Contact us</a>
+        <a class="p-button js-invoke-modal" href="/security/contact-us">Contact us</a>
       </p>
     </div>
     <div class="col-6 u-hide--small u-hide--medium u-align--center">

--- a/tests/cypress/forms/forms_spec.js
+++ b/tests/cypress/forms/forms_spec.js
@@ -199,6 +199,7 @@ context("Interactive marketo forms", () => {
       cy.visit("/download/iot/intel-iotg");
       cy.acceptCookiePolicy();
       cy.findByTestId("interactive-form-link").click();
+      cy.findByLabelText(/Tell us more about your project/).type("Test");
       cy.findByRole("link", { name: /Next/ }).click();
       cy.findByLabelText(/First name/).type("Test");
       cy.findByLabelText(/Last name:/).type("Test");


### PR DESCRIPTION
## Done

- Remove duplicated `data-testid`
- Update cypress test for the required field on `/download/iot/intel-iotg`

## QA

How to run cypress test locally for forms on ubuntu.com 

1. Make sure you have marketo keys in your .env.local
2. Move this file `/tests/cypress/forms/forms_spec.js` into the `/tests/cypress/integration` folder.
(The cypress test for forms is only run once a day, so it is in the separate folder called `forms`. The other cypress tests are run every time a PR is made so they are in the `integration` folder.)
3. Run `ubuntu.com` locally 
4. Go to` package.json` and update `baseURL` of the “cypress:open” script to the url where ubuntu.com is currently running in your machine.
(i.g.)  "cypress:open": "cypress open --config-file tests/cypress/cypress.json --config baseUrl=http://192.168.64.4:${PORT:-8001}/" 
5. `yarn add cypress@8.7.0` if you don’t have cypress installed locally 
6. `yarn run cypress:open` in your terminal 
7. Click `forms_spec.js`

<img width="623" alt="image" src="https://user-images.githubusercontent.com/57550290/186448757-027965d0-3908-4fdb-9d9c-9f3e1c770621.png">

## Issue / Card

Fixes #
