### PR TITLE
Custom thank-you text for engage pages

### DIFF
--- a/templates/engage/thank-you.html
+++ b/templates/engage/thank-you.html
@@ -37,13 +37,19 @@
 <section class="p-strip">
   <div class="row">
     <div class="col-8">
+      <p>
+        {% if "thank_you_text" in metadata %}
+          {{ metadata["thank_you_text"] }}
+        {% else %}
+          The {{ resource_name }} is now ready to download.
+        {% endif %}
+      </p>
       {% if 'pages.ubuntu.com' or 'assets.ubuntu.com' in resource_url %}
-      <p>
-        The {{ resource_name }} is now ready to download.
-      </p>
-      <p>
-        <a class="p-button--positive" href="{{ resource_url }}">Download</a>
-      </p>
+        {% if "contact_form_only" not in metadata and metadata.contact_form_only != "true" %}
+          <p>
+            <a class="p-button--positive" href="{{ resource_url }}">Download</a>
+          </p>
+        {% endif %}
       {% else %}
         <p>
           Sorry, we do not recognise this download request.  Please let us know by <a href="https://github.com/canonical-websites/www.ubuntu.com/issues/new?body=Bad+resource+download+link+from {{ request.url | urlencode }}">filing and issue on GitHub</a>. And let us know what you excepted to download.
@@ -53,7 +59,7 @@
   </div>
 </section>
 
-{% if related | length > 0 %}
+{% if related[1:3] | length > 0 %}
 <section class="p-strip--light">
   <div class="row">
     <div class="col-8">
@@ -61,7 +67,7 @@
     </div>
   </div>
   <div class="row p-divider">
-    {% for page in related[0:3] %}
+    {% for page in related[1:3] %}
     <div class="col-4 p-divider__block">
       <!-- THREE ADDITIONAL CTAs -->
       <h4>{{page["topic_name"]}}</h4>

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -486,7 +486,12 @@ def engage_thank_you(engage_pages):
             flask.abort(404)
 
         # Stop potential spamming of /engage/<engage-page>/thank-you
-        if "resource_url" not in metadata or metadata["resource_url"] == "":
+        if (
+            "resource_url" not in metadata or metadata["resource_url"] == ""
+        ) and (
+            "contact_form_only" not in metadata
+            or metadata["contact_form_only"] == "true"
+        ):
             return flask.abort(404)
 
         language = metadata["language"]
@@ -518,6 +523,7 @@ def engage_thank_you(engage_pages):
         return flask.render_template(
             template_language,
             request_url=flask.request.referrer,
+            metadata=metadata,
             resource_name=metadata["type"],
             resource_url=metadata["resource_url"],
             related=related,


### PR DESCRIPTION
## Done

- Added custom thank-you text for engage pages thank you page
- Added Form only engage page

## QA

- Go to https://ubuntu-com-11978.demos.haus/engage/hpe-battle-card/thank-you and check that now we can show the custom text that appears in the [discourse `thank_you_text` metadata](https://discourse.ubuntu.com/t/hpe-sell-more-infrastructure-and-open-source-support/30098)
- Check that other engage pages on https://ubuntu-com-11978.demos.haus/engage are showing the default text as usual.

## Issue / Card

Fixes #11971
Fixes #11972  

## Screenshots

![image](https://user-images.githubusercontent.com/14939793/187420050-4c0afaa6-2e54-449e-b237-4eeca0bf4294.png)



## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
