### PR TITLE
Add Cloudinary to the blog images

### DIFF
--- a/templates/blog/blog-card.html
+++ b/templates/blog/blog-card.html
@@ -1,4 +1,4 @@
-<div class="col-4 blog-p-card--post">
+<div class="col-4 col-medium-2 blog-p-card--post">
   {% include "blog/blog-card-header.html" %}
 
   <div class="blog-p-card__content">
@@ -6,21 +6,21 @@
     {% if article.image and article.image.source_url %}
     <div class="u-crop--16-9">
       <a href="/blog/{{ article.slug }}" aria-hidden="true" tabindex="-1">
-        <img src="{{ article.image.source_url }}" alt="" class="p-card__image">
+        {{ article.image.rendered|safe }}
       </a>
     </div>
     {% endif %}
-      
+
     <h3 class="p-heading--4">
       <a href="/blog/{{ article.slug }}">{{ article.title.rendered|safe }}</a>
     </h3>
-    
+
     <p>
       <em>by
         <a href="/blog/author/{{article.author.slug}}">{{ article.author.name }}</a>
         on {{ article.date }}</em>
     </p>
-      
+
       {% if summary_visible or not article.image.source_url %}
       <p class="{% if summary_visible %}u-hide--small{% endif %}" style="padding-top:1rem;">{{ article.excerpt.raw.replace("[…]", "")|truncate(162) }}</p>
       {% endif %}

--- a/templates/blog/index.html
+++ b/templates/blog/index.html
@@ -18,7 +18,7 @@
       {% if loop.index in [1,2] %}
         {% with summary_visible=True %}{% include "blog/blog-card.html" %}{% endwith %}
       {% elif loop.index == 3 %}
-        <div class="col-4">
+        <div class="col-4 col-4 col-medium-2">
           {% include 'blog/newsletter-form.html' %}
         </div>
       </div>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -522,7 +522,7 @@ app.add_url_rule(
 # blog section
 
 blog_views = BlogViews(
-    api=BlogAPI(session=session),
+    api=BlogAPI(session=session, thumbnail_width=555, thumbnail_height=311),
     excluded_tags=[3184, 3265, 3408, 3960],
     per_page=11,
     blog_title="Ubuntu blog",


### PR DESCRIPTION
## Done
- Used the blog modules Cloudinary image to render the blog image
- Added some medium screen grid classes to improve that view
- Increased the thumbnail size to accommodate the size of the image on small screens

## QA
- Open the demo
- Go to /blog
- Check all viewports render well
- Check the Network tab for images is 2MB instead of >10MB in production

## Issue / Card

Fixes https://github.com/canonical/ubuntu.com/issues/11979

## Screenshots

### Large
![image](https://user-images.githubusercontent.com/1413534/187442020-f3cbbd3c-aa31-4f41-9c61-3e58ea5d1bab.png)

### Medium
![image](https://user-images.githubusercontent.com/1413534/187441947-20bd3c48-8f72-45ab-a529-9e4e56b0f139.png)

### Small
![image](https://user-images.githubusercontent.com/1413534/187442100-09075ad4-47c7-4f5d-b3eb-6bf64f0c46f6.png)
