### PR TITLE
Remove redundant subnav on cve pages and tutorials

### DIFF
--- a/static/sass/_layout-tutorial.scss
+++ b/static/sass/_layout-tutorial.scss
@@ -71,7 +71,7 @@
   }
 
   .l-tutorial__content {
-    margin-top: -9rem; // ensure header is visible when navigating between steps (pt. 1 of 2)
+    margin-top: -26rem; // ensure header is visible when navigating between steps (pt. 1 of 2)
     overflow: hidden; // stops pre from stretching out the flex column
     padding-top: $sp-large;
   }
@@ -81,7 +81,7 @@
 
     &:target {
       display: block;
-      padding-top: 9rem; // ensure header is visible when navigating between steps (pt. 2 of 2)
+      padding-top: 26rem; // ensure header is visible when navigating between steps (pt. 2 of 2)
     }
 
     h2 {

--- a/static/sass/_layout-tutorial.scss
+++ b/static/sass/_layout-tutorial.scss
@@ -1,12 +1,6 @@
 @mixin layout-tutorial {
   .l-tutorial {
-    @extend .row;
-
-    display: flex;
-    flex-direction: column;
-
     @media only screen and (min-width: $breakpoint-medium) {
-      flex-direction: row;
       min-height: calc(100vh - 225px); // minus header, nav and footer height
     }
   }
@@ -14,10 +8,9 @@
   .l-tutorial__sidebar {
     border-bottom: 1px solid $color-mid-light;
 
-    @media only screen and (min-width: $breakpoint-medium) {
+    @media only screen and (min-width: $breakpoint-large) {
       border-bottom: 0;
       border-right: 1px solid $color-mid-light;
-      flex: 0 0 18rem;
     }
   }
 
@@ -38,7 +31,6 @@
     padding-top: $sp-medium;
 
     @media only screen and (min-width: $breakpoint-small) {
-      padding-top: $sp-large;
       position: sticky;
       top: 0;
     }
@@ -82,11 +74,6 @@
     margin-top: -9rem; // ensure header is visible when navigating between steps (pt. 1 of 2)
     overflow: hidden; // stops pre from stretching out the flex column
     padding-top: $sp-large;
-    width: 100%;
-
-    @media only screen and (min-width: $breakpoint-medium) {
-      padding-left: 5%;
-    }
   }
 
   .l-tutorial-section {

--- a/templates/security/cve/cve.html
+++ b/templates/security/cve/cve.html
@@ -3,32 +3,6 @@
 
 {% block content %}
 
-<nav class="p-navigation--secondary">
-  <div class="row">
-    <div class="col-12 u-equal-height">
-      <a class="p-navigation--secondary__banner u-hide--nav-threshold-down" href="/security">
-        <h5 class="p-navigation--secondary__logo">
-          Security
-        </h5>
-      </a>
-      <ul class="breadcrumbs--secondary">
-        <li class="breadcrumbs__item">
-          <a class="breadcrumbs__link p-link--soft" href="/security">Overview</a>
-        </li>
-        <li class="breadcrumbs__item">
-          <a class="breadcrumbs__link p-link--soft" href="/security/certifications">Certifications</a>
-        </li>
-        <li class="breadcrumbs__item">
-          <a class="breadcrumbs__link p-link--soft" href="/security/notices">Notices</a>
-        </li>
-        <li class="breadcrumbs__item">
-          <a class="breadcrumbs__link p-link--active" href="/security/cves">CVEs</a>
-        </li>
-      </ul>
-    </div>
-  </div>
-</nav>
-
 {% if cve.status == 'rejected' or cve.status == 'not-in-ubuntu' %}
   <section class="p-strip--light is-bordered--top">
 {% else %}

--- a/templates/tutorials/tutorial.html
+++ b/templates/tutorials/tutorial.html
@@ -10,23 +10,6 @@
 
 {% block content %}
 
-<nav class="p-navigation--secondary">
-  <div class="row">
-    <div class="col-12 u-equal-height">
-      <a class="p-navigation--secondary__banner u-hide--nav-threshold-down" href="/tutorials">
-        <h5 class="p-navigation--secondary__logo">
-          Tutorials
-        </h5>
-      </a>
-      <ul class="breadcrumbs--secondary">
-        <li class="breadcrumbs__item" style="width: 100%;"> <!-- style only applies to this template -->
-          <a class="breadcrumbs__link p-link--soft" href="{{ document['slug'] }}">{{ document.title }}</a>
-        </li>
-      </ul>
-    </div>
-  </div>
-</nav>
-
 <div class="l-tutorial">
   <aside class="l-tutorial__sidebar">
     <button type="button" class="l-tutorial__nav-toggle p-icon--menu u-hide u-show--small" aria-controls="menu-tutorial" aria-expanded="false">

--- a/templates/tutorials/tutorial.html
+++ b/templates/tutorials/tutorial.html
@@ -10,8 +10,16 @@
 
 {% block content %}
 
-<div class="l-tutorial">
-  <aside class="l-tutorial__sidebar">
+<div class="p-strip">
+  <div class="row">
+    <div class="col-7 col-start-large-5">
+      <h1 class="p-heading--2">{{ document.title }}</h1>
+    </div>
+  </div>
+</div>
+
+<div class="l-tutorial row">
+  <aside class="l-tutorial__sidebar col-4">
     <button type="button" class="l-tutorial__nav-toggle p-icon--menu u-hide u-show--small" aria-controls="menu-tutorial" aria-expanded="false">
       Toggle tutorial menu
     </button>
@@ -27,7 +35,7 @@
       {% endfor %}
     </ol>
   </aside>
-  <div class="l-tutorial__content">
+  <div class="l-tutorial__content col-8">
     {% for section in document.sections %}
     <section class="l-tutorial-section" id="{{ loop.index }}-{{ section['slug']}}">
       <h2 class="p-heading--3">{{ loop.index }}. {{ section["title"]}}</h2>


### PR DESCRIPTION
## Done

- Removed redundant subnav on CVE pages and tutorial guide (see issues for context)
- Added tutorial title to the page as a `h1` element

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: https://ubuntu-com-11983.demos.haus/security/cves
- Click on any CVE (eg: https://ubuntu-com-11983.demos.haus/security/CVE-2021-46837)
- See that only 1 subnav exists
- Go to https://ubuntu-com-11983.demos.haus/tutorials/guidelines#1-overview
- See that only 1 subnav exists
    - Be sure to test on mobile, tablet and desktop screen sizes
    
## Issue / Card

Fixes https://github.com/canonical/ubuntu.com/issues/11982, https://github.com/canonical/ubuntu.com/issues/11985