### PR TITLE
Build why-openstack page

### DIFF
--- a/templates/openstack/why-openstack.html
+++ b/templates/openstack/why-openstack.html
@@ -35,11 +35,23 @@ https://docs.google.com/document/d/1StqylVToo1URkhLvNfl17vZ52H35fXCVOR1aMKG1aGU/
     </div>
   </div>
 </section>
-<section class="p-strip--suru-blog-header" id="case-study">
-  <div class="row">
+<section class="p-strip--suru-blog-header is-shallow" id="case-study">
+  <div class="row u-vertically-center">
     <div class="col-6">
-     <h2 class="p-heading--4">Firmus redefined cloud sustainability and designed one of the most efficient data centres in the world</h2>
-     <p><a class="p-button" href="https://pages.ubuntu.com/rs/066-EOV-335/images/Firmus+Case+study.pdf+?_ga=2.233998550.99652456.1662360547-1232158778.1655899900">Read case study</a></p>
+     <h2 class="p-heading--3 u-sv1">Firmus redefines cloud sustainability with ultra-efficient data centre powered by grid connected renewable energy</h2>
+     <p><a class="p-button--positive" href="https://pages.ubuntu.com/rs/066-EOV-335/images/Firmus+Case+study.pdf+?_ga=2.233998550.99652456.1662360547-1232158778.1655899900">Read case study</a></p>
+    </div>
+    <div class="col-6 u-align--center u-hide--small u-hide--medium">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/2a4cf06c-Firmus+building.jpg",
+        alt="",
+        width="1024",
+        height="662",
+        hi_def=True,
+        loading="lazy",
+        attrs={"style":"padding: 2rem"}
+        ) | safe
+      }}
     </div>
   </div>
 </section>
@@ -93,30 +105,6 @@ https://docs.google.com/document/d/1StqylVToo1URkhLvNfl17vZ52H35fXCVOR1aMKG1aGU/
   </div>
 </section>
 <section class="p-strip">
-  <div class="row">
-    <div class="col-4 u-align--center u-vertically-center u-hide--medium u-hide--small">
-      {{ image (
-        url="https://assets.ubuntu.com/v1/cf1b8768-FinancialServicesPage-ImpactFinServ_2020.svg",
-        alt="",
-        width="258",
-        height="150",
-        hi_def=True,
-        loading="lazy"
-        ) | safe
-      }}
-    </div>
-    <div class="col-8">
-      <h2>Cloud pricing webinar</h2>
-      <p class="p-heading--4">Compare cloud pricing across leading public and private cloud platforms</p>
-      <p>From AWS, Azure and Google to VMWare and OpenStack &mdash; a comprehensive look at pricing and TCO estimates.</p>
-      <p>
-        <a href="" class="p-button">Register to the webinar now</a>
-      </p>
-    </div>
-  </div>
-</section>
-  
-<section class="p-strip--light">
   <div class="row">
     <div class="col-6">
       <h2>Get in touch</h2>

--- a/templates/openstack/why-openstack.html
+++ b/templates/openstack/why-openstack.html
@@ -11,7 +11,7 @@ https://docs.google.com/document/d/1StqylVToo1URkhLvNfl17vZ52H35fXCVOR1aMKG1aGU/
 {% endblock meta_copydoc %}
 
 {% block content %}
-<section class="p-strip--suru-topped is-bordered">
+<section class="p-strip--suru-topped">
   <div class="row">
     <div class="col-7">
       <h1>OpenStack: what is it and why do you need it?</h1>
@@ -35,7 +35,14 @@ https://docs.google.com/document/d/1StqylVToo1URkhLvNfl17vZ52H35fXCVOR1aMKG1aGU/
     </div>
   </div>
 </section>
-
+<section class="p-strip--suru-blog-header" id="case-study">
+  <div class="row">
+    <div class="col-6">
+     <h2 class="p-heading--4">Firmus redefined cloud sustainability and designed one of the most efficient data centres in the world</h2>
+     <p><a class="p-button" href="https://pages.ubuntu.com/rs/066-EOV-335/images/Firmus+Case+study.pdf+?_ga=2.233998550.99652456.1662360547-1232158778.1655899900">Read case study</a></p>
+    </div>
+  </div>
+</section>
 <section class="p-strip">
   <div class="row">
     <div class="col-4 u-align--center u-vertically-center u-hide--medium u-hide--small">
@@ -59,11 +66,8 @@ https://docs.google.com/document/d/1StqylVToo1URkhLvNfl17vZ52H35fXCVOR1aMKG1aGU/
       </p>
     </div>
   </div>
-
-  <div class="u-fixed-width">
-    <hr class="p-separator"/>
-  </div>
-
+</section>
+<section class="p-strip--light">
   <div class="row">
     <div class="col-8">
       <h2>An Introduction to OpenStack</h2>
@@ -87,11 +91,8 @@ https://docs.google.com/document/d/1StqylVToo1URkhLvNfl17vZ52H35fXCVOR1aMKG1aGU/
       }}
     </div>
   </div>
-
-  <div class="u-fixed-width">
-    <hr class="p-separator"/>
-  </div>
-
+</section>
+<section class="p-strip">
   <div class="row">
     <div class="col-4 u-align--center u-vertically-center u-hide--medium u-hide--small">
       {{ image (

--- a/templates/openstack/why-openstack.html
+++ b/templates/openstack/why-openstack.html
@@ -1,0 +1,144 @@
+{% extends "openstack/_base_openstack.html" %}
+
+{% block title %}Why OpenStack{% endblock %}
+
+{% block meta_description %}
+OpenStack is the world's leading open-source cloud platform for building cost-effective infrastructure. Discover where to start using OpenStack for your organisation.
+{% endblock meta_description %}
+
+{% block meta_copydoc %}
+https://docs.google.com/document/d/1StqylVToo1URkhLvNfl17vZ52H35fXCVOR1aMKG1aGU/edit#
+{% endblock meta_copydoc %}
+
+{% block content %}
+<section class="p-strip--suru-topped is-bordered">
+  <div class="row">
+    <div class="col-7">
+      <h1>OpenStack: what is it and why do you need it?</h1>
+      <p>It is challenging to optimise your organisation's cloud maintenance costs and build an infrastructure competitive to hyperscalers. </p>
+      <p>OpenStack &mdash; world's leading open source cloud platform &mdash; enables to save up to 65% compared to hyperscalers. It is supported by leading industry players, and successfully used by thousands of organisations all over the world. </p>
+      <p>Not sure where to start?</p>
+      <p>
+        <a class="p-button--positive js-invoke-modal" href="/openstack/contact-us"> Get in touch </a>
+      </p>
+    </div>
+    <div class="col-5 u-align--center u-vertically-center u-hide--medium u-hide--small"> 
+      {{ image (
+        url="https://assets.ubuntu.com/v1/3409bb95-OpenStack-Logo-Vertical-white.svg",
+        alt="",
+        width="300",
+        height="145",
+        hi_def=True,
+        loading="auto"
+        ) | safe
+      }}
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="row">
+    <div class="col-4 u-align--center u-vertically-center u-hide--medium u-hide--small">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/168111aa-Cloud+migration.svg",
+        alt="",
+        width="200",
+        height="200",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+    <div class="col-8">
+      <h2>A business guide to cloud migration</h2>
+      <h3>Knowing where to start</h3>
+      <p>With cloud technology having become the standard for modern IT infrastructure, all businesses will need to migrate to it sooner or later. But some things are easier said than done, especially if you're looking to maintain availability, integrate with existing systems and keep control of your budget during this migration.</p>
+      <p>What cloud architecture is best for your organisation? What are the typical cloud computing models? How to migrate to the cloud with little interference?</p>
+      <p>
+        <a href="https://pages.ubuntu.com/rs/066-EOV-335/images/Business.Guide.to.Cloud.Migration.WP.05.01.22.pdf">Read the whitepaper to find out&nbsp;&rsaquo;</a>
+      </p>
+    </div>
+  </div>
+
+  <div class="u-fixed-width">
+    <hr class="p-separator"/>
+  </div>
+
+  <div class="row">
+    <div class="col-8">
+      <h2>An Introduction to OpenStack</h2>
+      <h3>Why mastering OpenStack is so important today?</h3>
+      <p>30% of organisations worldwide report the usage of OpenStack in production.</p>
+      <p>It is widely used to build local private and public cloud infrastructure. Edge and hybrid multi-cloud environments are also showing further OpenStack adoption.</p>
+      <p> OpenStack has become the de-facto standard for open infrastructure implementation, along with the Linux kernel and kernel-based virtual machine (KVM) hypervisor.</p>
+      <p>
+        <a href="/engage/openstack-introduction">Download the whitepaper to learn more&nbsp;&rsaquo;</a>
+      </p>
+    </div>
+    <div class="col-4 u-align--center u-vertically-center u-hide--medium u-hide--small">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/669390e0-openstack-cloud.svg",
+        alt="",
+        width="263",
+        height="150",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+  </div>
+
+  <div class="u-fixed-width">
+    <hr class="p-separator"/>
+  </div>
+
+  <div class="row">
+    <div class="col-4 u-align--center u-vertically-center u-hide--medium u-hide--small">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/cf1b8768-FinancialServicesPage-ImpactFinServ_2020.svg",
+        alt="",
+        width="258",
+        height="150",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+    <div class="col-8">
+      <h2>Cloud pricing webinar</h2>
+      <h3>Compare cloud pricing across leading public and private cloud platforms</h3>
+      <p>From AWS, Azure and Google to VMWare and OpenStack &mdash; a comprehensive look at pricing and TCO estimates.</p>
+      <p>
+        <a href="" class="p-button">Register to the webinar now</a>
+      </p>
+    </div>
+  </div>
+</section>
+  
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-6">
+      <h2>Get in touch</h2>
+      <p>Let's work together on expanding the benefits of using Charmed OpenStack in your organisation.</p>
+      <p>
+        <a href="/openstack/contact-us" class="p-button--positive js-invoke-modal">Get in touch</a>
+      </p>
+    </div>
+    <div class="col-6 u-vertically-center u-hide--medium u-hide--small u-align--center">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/24a03775-Contact+us.svg",
+        alt="",
+        width="240",
+        height="171",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+  </div>
+</section>
+
+<!-- Set default Marketo information for contact form below-->
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/openstack" data-form-id="1251" data-lp-id="2086" data-return-url="https://ubuntu.com/openstack/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+</div>
+{% endblock content %}

--- a/templates/openstack/why-openstack.html
+++ b/templates/openstack/why-openstack.html
@@ -51,11 +51,11 @@ https://docs.google.com/document/d/1StqylVToo1URkhLvNfl17vZ52H35fXCVOR1aMKG1aGU/
     </div>
     <div class="col-8">
       <h2>A business guide to cloud migration</h2>
-      <h3>Knowing where to start</h3>
+      <p class="p-heading--4">Knowing where to start</p>
       <p>With cloud technology having become the standard for modern IT infrastructure, all businesses will need to migrate to it sooner or later. But some things are easier said than done, especially if you're looking to maintain availability, integrate with existing systems and keep control of your budget during this migration.</p>
       <p>What cloud architecture is best for your organisation? What are the typical cloud computing models? How to migrate to the cloud with little interference?</p>
       <p>
-        <a href="https://pages.ubuntu.com/rs/066-EOV-335/images/Business.Guide.to.Cloud.Migration.WP.05.01.22.pdf">Read the whitepaper to find out&nbsp;&rsaquo;</a>
+        <a href="https://pages.ubuntu.com/rs/066-EOV-335/images/Business.Guide.to.Cloud.Migration.WP.05.01.22.pdf">Download the whitepaper to find out&nbsp;&rsaquo;</a>
       </p>
     </div>
   </div>
@@ -67,12 +67,12 @@ https://docs.google.com/document/d/1StqylVToo1URkhLvNfl17vZ52H35fXCVOR1aMKG1aGU/
   <div class="row">
     <div class="col-8">
       <h2>An Introduction to OpenStack</h2>
-      <h3>Why mastering OpenStack is so important today?</h3>
+      <p class="p-heading--4">Why mastering OpenStack is so important today?</p>
       <p>30% of organisations worldwide report the usage of OpenStack in production.</p>
       <p>It is widely used to build local private and public cloud infrastructure. Edge and hybrid multi-cloud environments are also showing further OpenStack adoption.</p>
       <p> OpenStack has become the de-facto standard for open infrastructure implementation, along with the Linux kernel and kernel-based virtual machine (KVM) hypervisor.</p>
       <p>
-        <a href="/engage/openstack-introduction">Download the whitepaper to learn more&nbsp;&rsaquo;</a>
+        <a href="/engage/openstack-introduction">Read the whitepaper to learn more&nbsp;&rsaquo;</a>
       </p>
     </div>
     <div class="col-4 u-align--center u-vertically-center u-hide--medium u-hide--small">
@@ -106,7 +106,7 @@ https://docs.google.com/document/d/1StqylVToo1URkhLvNfl17vZ52H35fXCVOR1aMKG1aGU/
     </div>
     <div class="col-8">
       <h2>Cloud pricing webinar</h2>
-      <h3>Compare cloud pricing across leading public and private cloud platforms</h3>
+      <p class="p-heading--4">Compare cloud pricing across leading public and private cloud platforms</p>
       <p>From AWS, Azure and Google to VMWare and OpenStack &mdash; a comprehensive look at pricing and TCO estimates.</p>
       <p>
         <a href="" class="p-button">Register to the webinar now</a>
@@ -139,6 +139,6 @@ https://docs.google.com/document/d/1StqylVToo1URkhLvNfl17vZ52H35fXCVOR1aMKG1aGU/
 </section>
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/openstack" data-form-id="1251" data-lp-id="2086" data-return-url="https://ubuntu.com/openstack/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/openstack" data-form-id="4578" data-lp-id="2086" data-return-url="https://ubuntu.com/openstack/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
 {% endblock content %}

--- a/templates/openstack/why-openstack.html
+++ b/templates/openstack/why-openstack.html
@@ -19,7 +19,7 @@ https://docs.google.com/document/d/1StqylVToo1URkhLvNfl17vZ52H35fXCVOR1aMKG1aGU/
       <p>OpenStack &mdash; world's leading open source cloud platform &mdash; enables to save up to 65% compared to hyperscalers. It is supported by leading industry players, and successfully used by thousands of organisations all over the world. </p>
       <p>Not sure where to start?</p>
       <p>
-        <a class="p-button--positive js-invoke-modal" href="/openstack/contact-us"> Get in touch </a>
+        <button class="p-button--positive js-invoke-modal" href="/openstack/contact-us"> Get in touch </button>
       </p>
     </div>
     <div class="col-5 u-align--center u-vertically-center u-hide--medium u-hide--small"> 
@@ -39,7 +39,7 @@ https://docs.google.com/document/d/1StqylVToo1URkhLvNfl17vZ52H35fXCVOR1aMKG1aGU/
   <div class="row u-vertically-center">
     <div class="col-6">
      <h2 class="p-heading--3 u-sv1">Firmus redefines cloud sustainability with ultra-efficient data centre powered by grid connected renewable energy</h2>
-     <p><a class="p-button--positive" href="https://pages.ubuntu.com/rs/066-EOV-335/images/Firmus+Case+study.pdf+?_ga=2.233998550.99652456.1662360547-1232158778.1655899900">Read case study</a></p>
+     <p><button class="p-button--positive" href="https://pages.ubuntu.com/rs/066-EOV-335/images/Firmus+Case+study.pdf+?_ga=2.233998550.99652456.1662360547-1232158778.1655899900">Read case study</></p>
     </div>
     <div class="col-6 u-align--center u-hide--small u-hide--medium">
       {{ image (
@@ -110,7 +110,7 @@ https://docs.google.com/document/d/1StqylVToo1URkhLvNfl17vZ52H35fXCVOR1aMKG1aGU/
       <h2>Get in touch</h2>
       <p>Let's work together on expanding the benefits of using Charmed OpenStack in your organisation.</p>
       <p>
-        <a href="/openstack/contact-us" class="p-button--positive js-invoke-modal">Get in touch</a>
+        <button href="/openstack/contact-us" class="p-button--positive js-invoke-modal">Get in touch</button>
       </p>
     </div>
     <div class="col-6 u-vertically-center u-hide--medium u-hide--small u-align--center">


### PR DESCRIPTION

## Done

- Build page on `/openstack/why-openstack`

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Compare page against [copy doc](https://docs.google.com/document/d/1StqylVToo1URkhLvNfl17vZ52H35fXCVOR1aMKG1aGU/edit#)
- Demo : https://ubuntu-com-11992.demos.haus/openstack/why-openstack

## Issue / Card

Fixes [#5823](https://github.com/canonical/web-squad/issues/5823)

## Screenshots
<img width="1440" alt="Why OpenStack | Ubuntu (2022-09-01 10-51-50)" src="https://user-images.githubusercontent.com/57550290/187886183-be180996-8bf5-4065-9c0e-55355fb6cb4c.png">

