### PR TITLE
[Copy update] Ubuntu Server download page

### DIFF
--- a/templates/download/server/manual.html
+++ b/templates/download/server/manual.html
@@ -171,7 +171,7 @@
     </div>
   </div>
   <div class="row u-equal-height">
-    <div class="col-4 p-card">
+    <div class="col-3 p-card">
       <h3 class="p-card__title">Ubuntu Server for ARM</h3>
       <p>
         Optimised for hyperscale deployments and certified on ARM chipsets &mdash; Ubuntu Server for ARM includes the 64-bit ARMv7 and ARMv8 platforms.
@@ -180,7 +180,7 @@
         <a href="/download/server/arm">Get Ubuntu Server for ARM&nbsp;&rsaquo;</a>
       </p>
     </div>
-    <div class="col-4 p-card">
+    <div class="col-3 p-card">
       <h3 class="p-card__title">Ubuntu for POWER</h3>
       <p>
         Ubuntu is available on the IBM POWER platform, bringing the entire Ubuntu ecosystem to IBM POWER.
@@ -189,13 +189,22 @@
         <a href="/download/server/power">Get Ubuntu Server for POWER&nbsp;&rsaquo;</a>
       </p>
     </div>
-    <div class="col-4 p-card">
+    <div class="col-3 p-card">
       <h3 class="p-card__title">Ubuntu for IBM Z (s390x)</h3>
       <p>
         IBM Z and LinuxONE leverage open technology solutions to meet the demands of the new application economy. Ubuntu is now available on those platforms with Multipass, MicroK8s and more.
       </p>
       <p>
         <a href="/download/server/s390x">Get Ubuntu Server for IBM Z&nbsp;&rsaquo;</a>
+      </p>
+    </div>
+    <div class="col-3 p-card">
+      <h3 class="p-card__title">Ubuntu for RISC-V</h3>
+      <p>
+        Ubuntu - now available for multiple RISC-V platforms to accelerate innovation.
+      </p>
+      <p>
+        <a href="/download/risc-v">Get Ubuntu Server for SiFive Unmatched, StarFive VisionFive and Allwinner Nezha&nbsp;&rsaquo;</a>
       </p>
     </div>
   </div>


### PR DESCRIPTION
## Done

- Updated Ubuntu Server download page according to the [copy doc](https://docs.google.com/document/d/1Qob4Ni_y1ffIdSWqaw2xH0dxiHZQmkRGP5nuoBhIfyM/edit)

## QA

- Visit the demo at https://ubuntu-com-11993.demos.haus/download/server
- Verify that the page content matches the [copy doc](https://docs.google.com/document/d/1Qob4Ni_y1ffIdSWqaw2xH0dxiHZQmkRGP5nuoBhIfyM/edit)

## Issue / Card

Fixes https://github.com/canonical/commercial-squad/issues/707

## Screenshots

![ubuntu-server-copy](https://user-images.githubusercontent.com/995051/187916425-920fa994-2156-4317-842e-6a8a11b4e5cf.png)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
