### PR TITLE
Add accessible label to all search submit buttons

### DIFF
--- a/static/js/src/tutorial-list.test.js
+++ b/static/js/src/tutorial-list.test.js
@@ -5,8 +5,8 @@ describe("handleFilter", () => {
   const Filters = `
     <form class="p-search-box u-no-margin--bottom" id="tutorials-search" action="">
       <input type="search" class="p-search-box__input" id="tutorials-search-input" name="search" placeholder="Search" required="" autocomplete="on">
-      <button type="reset" class="p-search-box__reset"><i class="p-icon--close"></i></button>
-      <button type="submit" class="p-search-box__button"><i class="p-icon--search"></i></button>
+      <button type="reset" class="p-search-box__reset"><i class="p-icon--close">Close</i></button>
+      <button type="submit" class="p-search-box__button"><i class="p-icon--search">Submit</i></button>
     </form>
     <select name="tutorials-topic" id="tutorials-topic" class="u-no-margin--bottom">
       <option value="">Any</option>

--- a/templates/certified/search-results.html
+++ b/templates/certified/search-results.html
@@ -14,7 +14,7 @@
     <div class="u-fixed-width">
       <div class="p-search-box">
         <input class="p-search-box__input" type="text" name="q" value="{{ query or '' }}" placeholder="Search">
-        <button type="submit" class="p-search-box__button"><i class="p-icon--search"></i></button>
+        <button type="submit" class="p-search-box__button"><i class="p-icon--search">Submit</i></button>
       </div>
     </div>
     <div class="row">

--- a/templates/certified/shared/category-search-results.html
+++ b/templates/certified/shared/category-search-results.html
@@ -6,7 +6,7 @@
     <div class="u-fixed-width">
       <div class="p-search-box">
         <input class="p-search-box__input" type="text" name="q" value="{{ query or '' }}" placeholder="{{ placeholder or '' }}">
-        <button type="submit" class="p-search-box__button"><i class="p-icon--search"></i></button>
+        <button type="submit" class="p-search-box__button"><i class="p-icon--search">Submit</i></button>
       </div>
     </div>
     <div class="row">

--- a/templates/search.html
+++ b/templates/search.html
@@ -30,7 +30,7 @@
       {% if siteSearch %}
         <input name="siteSearch" type="hidden" value="{{ siteSearch }}" />
       {% endif %}
-      <button type="submit" alt="search" class="p-search-box__button" alt="search"><i class="p-icon--search"></i></button>
+      <button type="submit" alt="search" class="p-search-box__button" alt="search"><i class="p-icon--search">Submit</i></button>
     </form>
   </div>
 

--- a/templates/templates/_navigation.html
+++ b/templates/templates/_navigation.html
@@ -59,7 +59,7 @@
       <div class="p-navigation__search u-show--small u-hide" style="z-index: 39;">
         <form action="/search" class="p-search-box" id="ubuntu-global-search-form">
           <input type="search" class="p-search-box__input" name="q" placeholder="Search our sites" required="" aria-label="Search our sites">
-          <button type="reset" class="p-search-box__reset"><i class="p-icon--close"></i></button>
+          <button type="reset" class="p-search-box__reset"><i class="p-icon--close">Close</i></button>
           <button type="submit" class="p-search-box__button"><i class="p-icon--search">Search</i></button>
         </form>
       </div>

--- a/templates/templates/docs/shared/_search-box.html
+++ b/templates/templates/docs/shared/_search-box.html
@@ -6,7 +6,7 @@
         {% if siteSearch %}
             <input name="siteSearch" type="hidden" value="{{ siteSearch }}" />
         {% endif %}
-        <button type="submit" alt="search" class="p-search-box__button" alt="search"><i class="p-icon--search"></i></button>
+        <button type="submit" alt="search" class="p-search-box__button" alt="search"><i class="p-icon--search">Submit</i></button>
         </form>
     </div>
 </div>

--- a/templates/tutorials/index.html
+++ b/templates/tutorials/index.html
@@ -23,8 +23,8 @@
         <label for="tutorials-search-input">Search tutorials containing:</label>
         <form class="p-search-box u-no-margin--bottom" id="tutorials-search" action="">
           <input type="search" class="p-search-box__input" id="tutorials-search-input" name="search" placeholder="Search" required="" autocomplete="on">
-          <button type="reset" class="p-search-box__reset"><i class="p-icon--close"></i></button>
-          <button type="submit" class="p-search-box__button"><i class="p-icon--search"></i></button>
+          <button type="reset" class="p-search-box__reset"><i class="p-icon--close">Close</i></button>
+          <button type="submit" class="p-search-box__button"><i class="p-icon--search">Submit</i></button>
         </form>
       </div>
     </div>


### PR DESCRIPTION
## Done

- Added "Submit" label to search input submit buttons that previously were missing an accessible label

## QA

- Visit https://ubuntu-com-11995.demos.haus/core/services/guide/custom-image
- Using the [WAVE extension](https://wave.webaim.org/extension/), see that the "Empty button" error is not present
- Compare to the live page to confirm that the error is present in production https://ubuntu.com/core/services/guide/custom-image
- Visit any of the URLs listed in [this spreadsheet](https://docs.google.com/spreadsheets/d/12PCiksNMTyIrb2jEbXkCrj4thtPg5eng5rYPexCAObE/edit#gid=0) (best to pick a few at random given there are 500 rows in that sheet) and confirm the same thing. There should always be one less error on the demo than there is on production.

Live:
![Screenshot from 2022-09-02 16-51-55](https://user-images.githubusercontent.com/2376968/188192819-62ddc4e4-dc4f-4cfb-a751-089de014a74c.png)

Demo:
![image](https://user-images.githubusercontent.com/2376968/188192938-4243fcaa-e044-4a94-b23d-87fe789061de.png)


## Issue / Card

Fixes #11890 
