### PR TITLE
Added syllabus file and links in index

### DIFF
--- a/templates/credentialing/index.html
+++ b/templates/credentialing/index.html
@@ -65,6 +65,7 @@
               class="p-button--positive"
               >Start</a
             >
+            <a href="/credentialing/syllabus?exam=Linux%20Essentials" class="p-button">Syllabus</a>
           </div>
         </div>
       </li>
@@ -89,6 +90,7 @@
               class="p-button--positive"
               >Start</a
             >
+            <a href="/credentialing/syllabus?exam=Desktop%20Essentials" class="p-button">Syllabus</a>
           </div>
         </div>
       </li>
@@ -113,6 +115,7 @@
               class="p-button--positive"
               >Start</a
             >
+            <a href="/credentialing/syllabus?exam=Server%20Essentials" class="p-button">Syllabus</a>
           </div>
         </div>
       </li>

--- a/templates/credentialing/syllabus.html
+++ b/templates/credentialing/syllabus.html
@@ -20,10 +20,10 @@
       {% for exam in syllabus_data %}
       <div tabindex="0" role="tabpanel" id="{{exam['exam_name']}}-tab" aria-labelledby="{{exam['exam_name']}}" {% if (exam_name and exam_name!=exam["exam_name"]) or (not exam_name and loop.index!=1) %}hidden="hidden"{% endif %}>
         <p>{{exam['exam_description']}}</p>
-        <ol class="p-list--nested-counter">
+        <ol class="p-stepped-list">
           {% for chapter in exam["syllabus"] %}
-          <li><strong>{{chapter['chapter_title']}}</strong>
-            <ol>
+          <li class="p-stepped-list__item"><h3 class="p-stepped-list__title">{{chapter['chapter_title']}}</h3>
+            <ol class="p-stepped-list__content">
               {% for section in chapter['chapter_sections'] %}
               <li>{{section}}</li>
               {% endfor %}

--- a/templates/credentialing/syllabus.html
+++ b/templates/credentialing/syllabus.html
@@ -1,0 +1,142 @@
+{% extends "credentialing/base_cube.html" %}
+
+{% block title %} Canonical Credentialing -- Syllabus {% endblock %}
+
+{% block meta_description %}The Canonical Ubuntu Essentials exams certify knowledge and verify skills in general Linux, Ubuntu Desktop, and Ubuntu Server topics.{% endblock meta_description %}
+{% block meta_copydoc %} https://docs.google.com/document/d/1T1K7jyUa32-OURET6AjN2CD_c80TaUmj9EncYT70PNw/edit?usp=sharing {% endblock meta_copydoc %}
+
+{% block content %}
+
+<section class="p-strip--suru-topped">
+  <div class="u-fixed-width">
+    <div class="p-tabs">
+      <div class="p-tabs__list" role="tablist" aria-label="CUE Syllabus">
+        {% for exam in syllabus_data %}
+        <div class="p-tabs__item">
+          <button class="p-tabs__link" role="tab" aria-controls="{{exam['exam_name']}}-tab" id="{{exam['exam_name']}}" {% if (exam_name and exam_name!=exam["exam_name"]) or (not exam_name and loop.index!=1) %}aria-selected="false"{% else %}aria-selected="true"{% endif %}>{{exam["exam_name"]}}</button>
+        </div>
+        {% endfor %}
+      </div>
+      {% for exam in syllabus_data %}
+      <div tabindex="0" role="tabpanel" id="{{exam['exam_name']}}-tab" aria-labelledby="{{exam['exam_name']}}" {% if (exam_name and exam_name!=exam["exam_name"]) or (not exam_name and loop.index!=1) %}hidden="hidden"{% endif %}>
+        <p>{{exam['exam_description']}}</p>
+        <ol class="p-list--nested-counter">
+          {% for chapter in exam["syllabus"] %}
+          <li><strong>{{chapter['chapter_title']}}</strong>
+            <ol>
+              {% for section in chapter['chapter_sections'] %}
+              <li>{{section}}</li>
+              {% endfor %}
+            </ol>
+          </li>
+          {% endfor %}
+        </ol>
+      </div>
+      {% endfor %}
+    </div>
+  </div>
+</section>
+<script>
+  (function () {
+  var keys = {
+    left: 'ArrowLeft',
+    right: 'ArrowRight',
+  };
+
+  var direction = {
+    ArrowLeft: -1,
+    ArrowRight: 1,
+  };
+
+  /**
+    Attaches a number of events that each trigger
+    the reveal of the chosen tab content
+    @param {Array} tabs an array of tabs within a container
+  */
+  function attachEvents(tabs) {
+    tabs.forEach(function (tab, index) {
+      tab.addEventListener('keyup', function (e) {
+        if (e.code === keys.left || e.code === keys.right) {
+          switchTabOnArrowPress(e, tabs);
+        }
+      });
+
+      tab.addEventListener('click', function (e) {
+        e.preventDefault();
+        setActiveTab(tab, tabs);
+      });
+
+      tab.addEventListener('focus', function () {
+        setActiveTab(tab, tabs);
+      });
+
+      tab.index = index;
+    });
+  }
+
+  /**
+    Determine which tab to show when an arrow key is pressed
+    @param {KeyboardEvent} event
+    @param {Array} tabs an array of tabs within a container
+  */
+  function switchTabOnArrowPress(event, tabs) {
+    var pressed = event.code;
+
+    if (direction[pressed]) {
+      var target = event.target;
+      if (target.index !== undefined) {
+        if (tabs[target.index + direction[pressed]]) {
+          tabs[target.index + direction[pressed]].focus();
+        } else if (pressed === keys.left) {
+          tabs[tabs.length - 1].focus();
+        } else if (pressed === keys.right) {
+          tabs[0].focus();
+        }
+      }
+    }
+  }
+
+  /**
+    Cycles through an array of tab elements and ensures 
+    only the target tab and its content are selected
+    @param {HTMLElement} tab the tab whose content will be shown
+    @param {Array} tabs an array of tabs within a container
+  */
+  function setActiveTab(tab, tabs) {
+    tabs.forEach(function (tabElement) {
+      var tabContent = document.getElementById(tabElement.getAttribute('aria-controls'));
+
+      if (tabElement === tab) {
+        tabElement.setAttribute('aria-selected', true);
+        tabContent.removeAttribute('hidden');
+      } else {
+        tabElement.setAttribute('aria-selected', false);
+        tabContent.setAttribute('hidden', true);
+      }
+    });
+  }
+
+  /**
+    Attaches events to tab links within a given parent element,
+    and sets the active tab if the current hash matches the id
+    of an element controlled by a tab link
+    @param {String} selector class name of the element 
+    containing the tabs we want to attach events to
+  */
+  function initTabs(selector) {
+    var tabContainers = [].slice.call(document.querySelectorAll(selector));
+
+    tabContainers.forEach(function (tabContainer) {
+      var tabs = [].slice.call(tabContainer.querySelectorAll('[aria-controls]'));
+      attachEvents(tabs);
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    initTabs('[role="tablist"]');
+  });
+})();
+
+</script>
+
+{% endblock %}

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -44,6 +44,7 @@ from webapp.context import (
 
 from webapp.shop.flaskparser import UAContractsValidationError
 from webapp.shop.cube.views import (
+    cred_syllabus_data,
     cube_home,
     cred_schedule,
     cred_scheduled,
@@ -910,6 +911,7 @@ app.add_url_rule(
 app.add_url_rule("/credentialing/scheduled", view_func=cred_scheduled)
 app.add_url_rule("/credentialing/assessments", view_func=cred_assessments)
 app.add_url_rule("/credentialing/exam", view_func=cred_exam)
+app.add_url_rule("/credentialing/syllabus",view_func=cred_syllabus_data)
 app.add_url_rule("/cube/microcerts", view_func=cube_microcerts)
 app.add_url_rule("/cube/microcerts.json", view_func=get_microcerts)
 app.add_url_rule(

--- a/webapp/shop/cube/syllabus.json
+++ b/webapp/shop/cube/syllabus.json
@@ -1,0 +1,160 @@
+[
+  {
+    "exam_name": "Linux Essentials",
+    "exam_description": "Prove your knowledge of the Linux community, history, and philosophy. Topics include common Linux commands, open source and software licensing, and basic knowledge of Linux architecture and file hierarchy.",
+    "syllabus": [
+      {
+        "chapter_title": "Identify and execute common Linux commands.",
+        "chapter_sections": [
+          "Navigation commands",
+          "System information commands",
+          "Regular expressions and their functions"
+        ]
+      },
+      {
+        "chapter_title": "Manipulate files using the command line.",
+        "chapter_sections": [
+          "Understand basic shell syntax",
+          "Create, read, move, delete, copy, and convert files",
+          "Locate files on a system",
+          "Compare files",
+          "Modify file contents",
+          "Search through files"
+        ]
+      },
+      {
+        "chapter_title": "Understand the fundamentals of Linux architecture.",
+        "chapter_sections": [
+          "Packaging styles",
+          "File types",
+          "Purposes of major directories"
+        ]
+      }
+    ]
+  },
+  {
+    "exam_name": "Desktop Essentials",
+    "exam_description": "Demonstrate your knowledge of Ubuntu Desktop administrative essentials. Focus on package management, system installation, data gathering, and managing printing and displays.",
+    "syllabus": [
+      {
+        "chapter_title": "Be acquainted with the Ubuntu community and its conventions.",
+        "chapter_sections": [
+          "Identify the year of Ubuntu’s first release",
+          "Understand what an LTS is and entails",
+          "Understand the formula behind Ubuntu’s LTS numbering"
+        ]
+      },
+      {
+        "chapter_title": "Install and operate Ubuntu on your system.",
+        "chapter_sections": [
+          "Install Ubuntu via ISO",
+          "Identify installation styles",
+          "Back up data to remote locations",
+          "Configure automatic upgrades",
+          "Synchronise time",
+          "Manage locales",
+          "Work with GRUB 2",
+          "Manage users, groups, and passwords"
+        ]
+      },
+      {
+        "chapter_title": "Manage packages on an Ubuntu system.",
+        "chapter_sections": [
+          "Install packages, including from PPA repositories",
+          "Identify the packages installed on your system",
+          "Check your system for specific packages",
+          "Read package descriptions",
+          "Identify dependencies",
+          "Download package information from all configured sources",
+          "Install snaps"
+        ]
+      },
+      {
+        "chapter_title": "Gather important system information.",
+        "chapter_sections": [
+          "Display and record your current Ubuntu distribution",
+          "Display and record CPU capabilities",
+          "Set up remote system journaling",
+          "Obtain and interpret kernel information"
+        ]
+      },
+      {
+        "chapter_title": "Manage files and permissions.",
+        "chapter_sections": [
+          "Check file permissions",
+          "Grant and revoke permissions",
+          "Interpret permission attribute strings",
+          "Create and manage partitions",
+          "Work with common file editors"
+        ]
+      },
+      {
+        "chapter_title": "Configure and manage displays and other desktop hardware.",
+        "chapter_sections": [
+          "Enable and disable devices from the command line",
+          "Distinguish between desktop and server environments",
+          "Set a monitor’s resolution from the command line",
+          "Configure multiple monitors",
+          "Understand the differences between X and Wayland"
+        ]
+      },
+      {
+        "chapter_title": "Configure networking capabilities.",
+        "chapter_sections": [
+          "Configure and use SSH",
+          "Copy files and directories with rsync",
+          "Identify MAC addresses",
+          "Set static IPs",
+          "Configure DHCP"
+        ]
+      }
+    ]
+  },
+  {
+    "exam_name": "Server Essentials",
+    "exam_description": "Illustrate your knowledge of common Ubuntu Server administrative tasks and troubleshooting. Topics include job control, performance tuning, services management, and Bash scripting.",
+    "syllabus": [
+      {
+        "chapter_title": "Perform common administrative tasks.",
+        "chapter_sections": [
+          "Manage users, groups, and permissions",
+          "Configure local storage",
+          "Manage partitions and filesystems",
+          "Keep systems secure",
+          "Configure network interfaces",
+          "Back up data to remote locations",
+          "Encrypt disks"
+        ]
+      },
+      {
+        "chapter_title": "Troubleshoot issues.",
+        "chapter_sections": [
+          "Obtain diagnostic information about disks, services, ports, and connections",
+          "Find and interpret log files",
+          "Identify and interpret system performance metrics",
+          "Understand the purpose and functions of virtual filesystems",
+          "Take appropriate precautions before attempting irreversible operations"
+        ]
+      },
+      {
+        "chapter_title": "Configure and control automated tasks.",
+        "chapter_sections": [
+          "Write and interpret Bash scripts",
+          "Manage cron jobs",
+          "Configure system logging rules, including rotation"
+        ]
+      },
+      {
+        "chapter_title": "Tune your system for greater performance.",
+        "chapter_sections": [
+          "Configure GRUB 2",
+          "Modify kernel parameters",
+          "Queue commands",
+          "Monitor resources",
+          "Manage system services",
+          "Configure service recovery"
+        ]
+      }
+    ]
+  }
+]

--- a/webapp/shop/cube/views.py
+++ b/webapp/shop/cube/views.py
@@ -596,3 +596,10 @@ def cube_study_labs_button(edx_api, **kwargs):
         )
 
     return flask.jsonify({"text": text, "redirect_url": redirect_url})
+
+@shop_decorator(area="cube", permission="user", response="html")
+def cred_syllabus_data(**kawrgs):
+    exam_name = flask.request.args.get("exam")
+    syllabus_file = open("webapp/shop/cube/syllabus.json","r")
+    syllabus_data = json.load(syllabus_file)
+    return flask.render_template("credentialing/syllabus.html", syllabus_data=syllabus_data, exam_name=exam_name)


### PR DESCRIPTION
## Done

- Add syllabus for each microcertification

## QA

- Visit https://ubuntu-com-11996.demos.haus/credentialing
  - Verify that the Syllabus button appears in each exam description
  - Verify that clicking each Syllabus button takes you to the corresponding tab on https://ubuntu-com-11996.demos.haus/credentialing/syllabus


## Issue / Card

https://warthogs.atlassian.net/jira/software/c/projects/CRED/boards/776

## Screenshots

Exam descriptions with Syllabus button:
![cue-descriptions](https://user-images.githubusercontent.com/995051/188689455-366824fd-48a9-4cf9-b0c5-6387fd69f900.png)

Tabbed syllabus:
![cue-syllabus](https://user-images.githubusercontent.com/995051/188689479-9240d147-8f0e-4741-b5d9-77f9119afa15.png)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
