### PR TITLE
Update flavor screenshots to 22.04

### DIFF
--- a/templates/desktop/flavours.html
+++ b/templates/desktop/flavours.html
@@ -55,10 +55,10 @@
   </div>
   <div class="col-6 u-vertically-center u-align--center u-hide--small u-hide--medium">
     {{ image (
-      url="https://assets.ubuntu.com/v1/f193dc55-Kubuntu.png",
+      url="https://assets.ubuntu.com/v1/7c6fa2da-kubuntu-2204-screenshot.png",
       alt="",
-      width="1030",
-      height="777",
+      width="2560",
+      height="1440",
       hi_def=True,
       loading="lazy"
       ) | safe
@@ -70,7 +70,7 @@
   <div class="row">
     <div class="col-6 u-vertically-center u-align--center u-hide--small u-hide--medium">
       {{ image (
-        url="https://assets.ubuntu.com/v1/8e2f71f3-Lubuntu.png",
+        url="https://assets.ubuntu.com/v1/8d50725a-lubuntu-2204-screenshot.png",
         alt="",
         width="1920",
         height="1080",
@@ -151,9 +151,9 @@
   <div class="row">
     <div class="col-6 u-vertically-center u-align--center u-hide--small u-hide--medium">
       {{ image (
-        url="https://assets.ubuntu.com/v1/bab544b2-UbuntuKylin.png",
+        url="https://assets.ubuntu.com/v1/0bd4870d-Kylin2204.png",
         alt="",
-        width="1366",
+        width="1360",
         height="768",
         hi_def=True,
         loading="lazy"
@@ -294,10 +294,10 @@
     </div>
     <div class="col-6 u-vertically-center u-align--center u-hide--small u-hide--medium">
       {{ image (
-        url="https://assets.ubuntu.com/v1/909faa35-Xubuntu.png",
+        url="https://assets.ubuntu.com/v1/5f23328b-xubuntu-2204-screenshot.png",
         alt="",
-        width="1440",
-        height="900",
+        width="1920",
+        height="1080",
         hi_def=True,
         loading="lazy"
         ) | safe


### PR DESCRIPTION
## Done

- Updated Flavor screenshots to 22.04

## QA

- Check the /desktop/flavours page

## Fixes

https://github.com/canonical/web-squad/issues/5925
