### PR TITLE
UA: Improve cancel subscription dialog message.

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionCancel/SubscriptionCancelFields/SubscriptionCancelFields.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionCancel/SubscriptionCancelFields/SubscriptionCancelFields.tsx
@@ -29,7 +29,7 @@ const SubscriptionCancelFields = ({ setIsValid, isTrial }: Props) => {
       <ul>
         <li>No additional charge will be incurred.</li>
         <li>
-          The <strong>10 machines</strong> will stop receiving updates and
+          All machines under this subscription will stop receiving updates and
           services at the end of the billing period.
         </li>
         <li>


### PR DESCRIPTION
## Done

UA: Improve cancel subscription dialog message.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- Go to `/advantage` and try to open the dialog to cancel one of your subscriptions.
- Make sure the message is generic and we are not displaying `The <strong>10 machines</strong> will stop receiving updates and` every time.
