### PR TITLE
Add RISC-V link to global nav

### DIFF
--- a/templates/templates/navigation-download-h.html
+++ b/templates/templates/navigation-download-h.html
@@ -52,6 +52,9 @@
             <li class='p-list__item'><a class='p-link' href='/download/amd-xilinx'>
               AMD-Xilinx Evaluation kits & SOMs
             </a></li>
+            <li class='p-list__item'><a class='p-link' href='/download/risc-v'>
+              RISC-V platforms
+            </a></li>            
           </ul>
         </div>
         <div class="col-3">


### PR DESCRIPTION
## Done

- Adds RISC-V link to global nav as per [copydoc](https://docs.google.com/document/d/11pX5gxOE6UWljIGRBZdwuCL1MHzs4pNgxJpK0mcIqdQ/edit)

## QA

- Go to https://ubuntu-com-12009.demos.haus/, open the 'Download' drop-down of the top navigation.
- Check a link for 'RISC-V platforms' is visible in the correct column and links to  https://ubuntu-com-12009.demos.haus//download/risc-v

## Issue / Card

Fixes https://github.com/canonical/web-squad/issues/5913
