### PR TITLE
Build use-cases page

### DIFF
--- a/templates/hpc/base_hpc.html
+++ b/templates/hpc/base_hpc.html
@@ -1,0 +1,5 @@
+{% extends "templates/base.html" %}
+
+{% block outer_content %}
+  {% block content %}{% endblock %}
+{% endblock %}

--- a/templates/hpc/base_hpc.html
+++ b/templates/hpc/base_hpc.html
@@ -1,7 +1,0 @@
-{% extends "templates/base.html" %}
-
-{% block meta_copydoc %}https://drive.google.com/drive/folders/1X8UbhFTDX2I0TqK9jEnMe8Nto3zInC-z{% endblock meta_copydoc %}
-
-{% block outer_content %}
-  {% block content %}{% endblock %}
-{% endblock %}

--- a/templates/hpc/base_hpc.html
+++ b/templates/hpc/base_hpc.html
@@ -1,5 +1,7 @@
 {% extends "templates/base.html" %}
 
+{% block meta_copydoc %}https://drive.google.com/drive/folders/1X8UbhFTDX2I0TqK9jEnMe8Nto3zInC-z{% endblock meta_copydoc %}
+
 {% block outer_content %}
   {% block content %}{% endblock %}
 {% endblock %}

--- a/templates/hpc/use-cases.html
+++ b/templates/hpc/use-cases.html
@@ -41,10 +41,10 @@
         </div>
         <div class="p-logo-section__item">
           {{ image (
-            url="https://assets.ubuntu.com/v1/dc69e636-firmus-black.png",
+            url="https://assets.ubuntu.com/v1/654fe8a7-firmus-logo.png",
             alt="",
-            width="400",
-            height="90",
+            width="288",
+            height="288",
             hi_def=True,
             loading="lazy",
             attrs={"class": "p-logo-section__logo"},
@@ -77,10 +77,10 @@
         </div>
         <div class="p-logo-section__item">
           {{ image (
-            url="https://assets.ubuntu.com/v1/fa4dc838-Daimler.svg",
+            url="https://assets.ubuntu.com/v1/aff445c4-daimler-logo.png",
             alt="",
-            width="145",
-            height="145",
+            width="288",
+            height="288",
             hi_def=True,
             loading="lazy",
             attrs={"class": "p-logo-section__logo"},
@@ -89,10 +89,10 @@
         </div>
         <div class="p-logo-section__item">
           {{ image (
-            url="https://assets.ubuntu.com/v1/ba34b7cc-PGS_LOGO+%281%29.svg",
+            url="https://assets.ubuntu.com/v1/0d09fbe7-pgs-logo.png",
             alt="",
-            width="78",
-            height="100",
+            width="288",
+            height="288",
             hi_def=True,
             loading="lazy",
             attrs={"class": "p-logo-section__logo"},
@@ -101,10 +101,10 @@
         </div>
         <div class="p-logo-section__item">
           {{ image (
-            url="https://assets.ubuntu.com/v1/538f7bf8-astra-zeneca_logo.svg",
+            url="https://assets.ubuntu.com/v1/ef528144-astrazeneca-logo.png",
             alt="",
-            width="130",
-            height="35",
+            width="288",
+            height="288",
             hi_def=True,
             loading="lazy",
             attrs={"class": "p-logo-section__logo"},

--- a/templates/hpc/use-cases.html
+++ b/templates/hpc/use-cases.html
@@ -1,4 +1,4 @@
-{% extends "hpc/base_hpc.html" %}
+{% extends "hpc/_base_hpc.html" %}
 
 {% block title %}HPC use cases delivered through solutions from Canonical{% endblock %}
 {% block meta_description %}HPC is used throughout Automotive, Aerospace, Energy, Healthcare, Life sciences, Governmental, Research, Universities, Media, Entertainment and Financial sectors.{% endblock %}

--- a/templates/hpc/use-cases.html
+++ b/templates/hpc/use-cases.html
@@ -39,7 +39,7 @@
         </div>
         <div class="p-logo-section__item">
           {{ image (
-            url="https://assets.ubuntu.com/v1/25335aae-firmus-white.png",
+            url="https://assets.ubuntu.com/v1/dc69e636-firmus-black.png",
             alt="",
             width="400",
             height="90",
@@ -51,10 +51,10 @@
         </div>
         <div class="p-logo-section__item">
           {{ image (
-            url="https://assets.ubuntu.com/v1/7bbfb1d0-Scania_logo.svg",
+            url="https://assets.ubuntu.com/v1/52e19575-scania-logo.png",
             alt="",
-            width="130",
-            height="34",
+            width="288",
+            height="288",
             hi_def=True,
             loading="lazy",
             attrs={"class": "p-logo-section__logo"},
@@ -129,11 +129,21 @@
         }}
         <h2>Scania simplifies HPC cluster deployments</h2>
         <p>Scania uses Juju and Charms to deploy SLURM, a popular scheduler for HPC workloads. Find out how they simplify installation, operations, and application integration.</p>
-        <p><a class="p-button--positive" href="/">Watch the webinar</a></p>
+        <p><a class="p-button--positive" href="https://www.youtube.com/watch?v=SGrRqCuiT90">Watch the webinar</a></p>
       </div>
     </div>
     <div class="col-6 u-hide--small u-hide--medioum u-align--center u-vertically-center">
-      
+        <a href="https://www.youtube.com/watch?v=SGrRqCuiT90">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/d1b5ac75-Automotive-Masters-vid-screen.png",
+          alt="",
+          width="700",
+          height="400",
+          hi_def=True,
+          loading="lazy"
+          ) | safe
+        }}
+      </a>
     </div>
   </div>
 </section>

--- a/templates/hpc/use-cases.html
+++ b/templates/hpc/use-cases.html
@@ -156,8 +156,8 @@
   </div>
   <div class="row">
     <div class="col-6">
-      <h3>Aerospace and aviation </h3>
-      <p class="p-heading--4">Complex multiphysics computations through CFD</p>
+      <h3 class="p-heading--5">Aerospace and aviation </h3>
+      <p class="p-heading--2">Complex multiphysics computations through CFD</p>
       <p>HPC is used for a variety of purposes in the aerospace industry. From optimising aircraft design to turbine flow using complex multiphysics computations such as fluid dynamics, to structural and thermal simulations, and electromagnetic analysis - all requiring large scale clusters.</p>
       <p>These complex multiphysics computations also drive an increased need for VDI resources.</p>
     </div>
@@ -189,8 +189,8 @@
       }}
     </div>
     <div class="col-6">
-      <h3>Agriculture</h3>
-      <p class="p-heading--4">Simulating future food systems</p>
+      <h3 class="p-heading--5">Agriculture</h3>
+      <p class="p-heading--2">Simulating future food systems</p>
       <p>HPC solutions drive discoveries in plague control, pesticide design, and the analysis of pesticide effects for increased efficiency in the agricultural sector. Plant growth simulations help reduce the number of field trials needed, speeding up optimisation.</p>
       <p>Climate data is used to better understand the impacts of water and climate conditions on agriculture.</p>
       <p>Data from sensors, drones, and satellite imagery is analysed with AI/ML or HPDA to improve anything from crop yield prediction to life stock health.</p>
@@ -201,8 +201,8 @@
   </div>
   <div class="row">
     <div class="col-6">
-      <h3>Automotive</h3>
-      <p class="p-heading--4">Improved efficiency through simulations</p>
+      <h3 class="p-heading--5">Automotive</h3>
+      <p class="p-heading--2">Improved efficiency through simulations</p>
       <p>Automotive companies are optimising vehicle design through multiphysics simulations, such as using computational fluid dynamics to analyse airflow or wind resistance. Other use cases include simulating the performance of individual parts of a vehicle and how they respond to stress, or simulating manufacturing optimisations. All of these drive a huge need for large-scale high-performance computing clusters.</p>
       <p>Large-scale simulation and machine learning clusters also power up training and safety validation for autonomous vehicles.</p>
       <p>Data is being used for anything from fault detection to fleet management, all requiring solutions such as HPDA and AI/ML.</p>
@@ -236,9 +236,9 @@
       }}
     </div>
     <div class="col-6">
-      <h3>Banking and finance</h3>
-      <p class="p-heading--4">Minimising risk with monte carlo simulations</p>
-      <p>The financial services industry uses simulations such as monte carlo to analyse multiple possible outcomes for improved decision-making.  High performance computing clusters also power up risk analyses and fraud detection and protection.</p>
+      <h3 class="p-heading--5">Banking and finance</h3>
+      <p class="p-heading--2">Minimising risk with Monte Carlo simulations</p>
+      <p>The financial services industry uses simulations such as Monte Carlo to analyse multiple possible outcomes for improved decision-making.  High performance computing clusters also power up risk analyses and fraud detection and protection.</p>
       <p>HPC is helping banks deliver improved compliance and portfolio management.</p>
     </div>
   </div>
@@ -247,8 +247,8 @@
   </div>
   <div class="row">
     <div class="col-6">
-      <h3>Construction</h3>
-      <p class="p-heading--4">Improved building safety and materials through simulations</p>
+      <h3 class="p-heading--5">Construction</h3>
+      <p class="p-heading--2">Improved building safety and materials through simulations</p>
       <p>Construction companies can build safer, more efficient and cost-effective structures thanks to fire and smoke simulations, powered by HPC. Complex multiphysics simulations are enabling the industry to create improved materials.</p>
       <p>Data can be collected at a faster rate using in-structure sensors and imagery to assess and predict structural conditions. All of this can be analysed using HPDA and AI/ML solutions on a large-scale.</p>
     </div>
@@ -280,8 +280,8 @@
       }}
     </div>
     <div class="col-6">
-      <h3>Defence and security</h3>
-      <p class="p-heading--4">Simulations that improve safety</p>
+      <h3 class="p-heading--5">Defence and security</h3>
+      <p class="p-heading--2">Simulations that improve safety</p>
       <p>Complex multiphysics simulations can optimise the efficiency of defence solutions and simulate the decommissioning of nuclear components for improved safety.</p>
     </div>
   </div>
@@ -290,8 +290,8 @@
   </div>
   <div class="row">
     <div class="col-6">
-      <h3>Electronics</h3>
-      <p class="p-heading--4">Efficient production and design</p>
+      <h3 class="p-heading--5">Electronics</h3>
+      <p class="p-heading--2">Efficient production and design</p>
       <p>The design and manufacturing of electrical components require complex computations. HPC enables electronics manufacturers to simulate electrical flows and temperature, allowing for both efficient design in terms of materials and effective management of heat dissipation.</p>
     </div>
     <div class="col-6 u-align--center u-vertically-center u-hide--small u-hide--medium">
@@ -322,8 +322,8 @@
       }}
     </div>
     <div class="col-6">
-      <h3>Energy and utilities</h3>
-      <p class="p-heading--4">Discovery and processing</p>
+      <h3 class="p-heading--5">Energy and utilities</h3>
+      <p class="p-heading--2">Discovery and processing</p>
       <p>The time to leverage HPC in energy is now.</p>
       <p>HPC can be used to analyse seismic data or data produced by geophones. This allows exploration teams to get an understanding of the underlying geological area, allowing for the discovery of previously hidden natural resources.</p>
       <p>Complex chemical processes are then required to refine these resources into useful products. This complexity requires the use of chemistry simulations.</p>
@@ -334,8 +334,8 @@
   </div>
   <div class="row">
     <div class="col-6">
-      <h3>Government</h3>
-      <p class="p-heading--4">Increased safety and understanding</p>
+      <h3 class="p-heading--5">Government</h3>
+      <p class="p-heading--2">Increased safety and understanding</p>
       <p>HPC can level-up how governments decommission materials, engage in large-scale infrastructure projects and analyse census information, among many other use cases.</p>
       <p>National laboratories are using HPC to drive discovery in nuclear power, nuclear fusion, renewable energy, nanotechnology and space exploration.</p>
     </div>
@@ -367,8 +367,8 @@
       }}
     </div>
     <div class="col-6">
-      <h3>Healthcare and pharmaceuticals</h3>
-      <p class="p-heading--4">Cancer detection and protein folding</p>
+      <h3 class="p-heading--5">Healthcare and pharmaceuticals</h3>
+      <p class="p-heading--2">Cancer detection and protein folding</p>
       <p>Digital twins are being used to great effect by healthcare and pharmaceutical organisations, for anything from simulating the effects of drug uptake on vital organs to simulating brain functions or blood flow.</p>
       <p>Simulations are also valuable to develop and test medical prosthetics.</p>
       <p>Complex algorithms can enable a better understanding of the underlying chemical processes behind life, leading to breakthrough medical discoveries.</p>
@@ -380,8 +380,8 @@
   </div>
   <div class="row">
     <div class="col-6">
-      <h3>Life sciences</h3>
-      <p class="p-heading--4">Genome sequencing and protein folding</p>
+      <h3 class="p-heading--5">Life sciences</h3>
+      <p class="p-heading--2">Genome sequencing and protein folding</p>
       <p>HPC is opening new doors for genome sequencing. It can help life sciences organisations better understand genetics and diseases. These use cases depend on large high-performance computing clusters.</p>
       <p>A more robust understanding of protein folding is now possible thanks to complex simulation workloads and advanced AI solutions such as AlphaFold.</p>
     </div>
@@ -413,8 +413,8 @@
       }}
     </div>
     <div class="col-6">
-      <h3>Manufacturing and industry</h3>
-      <p class="p-heading--4">Simulations improve assembly and components </p>
+      <h3 class="p-heading--5">Manufacturing and industry</h3>
+      <p class="p-heading--2">Simulations improve assembly and components </p>
       <p>HPC is being used to optimise materials used in manufacturing. It allows companies to create more durable components while using the lowest amount of materials, driving efficiency.</p>
       <p>Simulations can also be used to optimise assembly lines and get a better understanding of processes.</p>
     </div>
@@ -424,8 +424,8 @@
   </div>
   <div class="row">
     <div class="col-6">
-      <h3>Media and entertainment</h3>
-      <p class="p-heading--4">Rendering, audio and video processing</p>
+      <h3 class="p-heading--5">Media and entertainment</h3>
+      <p class="p-heading--2">Rendering, audio and video processing</p>
       <p>HPC can also be highly entertaining. Movie and TV studios use HPC workloads for anything from the rendering of visual effects (VFX) to full-blown animated movies. This, along with video processing, requires large-scale rendering clusters.</p>
       <p>Gaming companies deploy large clusters for the processing and delivery of audio, driven by player-to-player communication.</p>
     </div>
@@ -457,8 +457,8 @@
       }}
     </div>
     <div class="col-6">
-      <h3>Research and universities</h3>
-      <p class="p-heading--4">Simulations and discovery</p>
+      <h3 class="p-heading--5">Research and universities</h3>
+      <p class="p-heading--2">Simulations and discovery</p>
       <p>Science and research depend on large-scale high performance clusters for new discoveries. Anything from the discovery of new materials or properties of new compounds is made possible through physics simulations.</p>
       <p>Within our planet and across the universe, HPC makes the analysis of instrument data possible &mdash; from particle accelerators to space telescopes.</p>
     </div>
@@ -468,8 +468,8 @@
   </div>
   <div class="row">
     <div class="col-6">
-      <h3>Weather</h3>
-      <p class="p-heading--4">Simulations and prediction</p>
+      <h3 class="p-heading--5">Weather</h3>
+      <p class="p-heading--2">Simulations and prediction</p>
       <p>Our understanding of climate change and weather disruptions is more sophisticated thanks to HPC. Simulations deliver weather predictions through computations on large-scale high-performance clusters.</p>
     </div>
     <div class="col-6 u-align--center u-vertically-center u-hide--small u-hide--medium">

--- a/templates/hpc/use-cases.html
+++ b/templates/hpc/use-cases.html
@@ -7,7 +7,7 @@
 
 {% block content %}
 
-<section class="p-strip--suru-topped">
+<section class="p-strip--suru-bottomed">
   <div class="row">
     <div class="col-6">
       <h1>High-performance computing use cases</h1>
@@ -15,12 +15,14 @@
       <p>Canonical delivers multiple solutions that help your organisation ease operations and innovate at a greater pace.</p>
       <a class="p-button--positive" href="/hpc/contact-us" data-testid="interactive-form-link">Get in touch</a>
     </div>
-    <div class="col-6 u-embedded-media u-vertically-center u-hide--medium u-hide--small">
-      <iframe width="560" height="315" src="https://www.youtube.com/embed/tGIobcyKViI" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+    <div class="col-6 u-align--center">
+      <div class="u-embedded-media">
+        <iframe class="u-embedded-media__element" src="https://www.youtube.com/embed/tGIobcyKViI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" 	allowfullscreen></iframe>
+      </div>
     </div>
   </div>
 </section>
-<section class="p-strip--light">
+<section class="p-strip">
   <div class="u-fixed-width">
     <div class="p-logo-section">
       <h2 class="p-logo-section__title u-align--center">ADVANCING HIGH-PERFORMANCE WORKLOADS</h2>
@@ -113,7 +115,7 @@
     </div>
   </div>
 </section>
-<section class="p-strip is-bordered">
+<section class="p-strip--light">
   <div class="row">
     <div class="col-6">
       <div>

--- a/templates/hpc/use-cases.html
+++ b/templates/hpc/use-cases.html
@@ -1,0 +1,498 @@
+{% extends "hpc/base_hpc.html" %}
+
+{% block title %}HPC use cases delivered through solutions from Canonical{% endblock %}
+{% block meta_description %}HPC is used throughout Automotive, Aerospace, Energy, Healthcare, Life sciences, Governmental, Research, Universities, Media, Entertainment and Financial sectors.{% endblock %}
+{% block meta_image %}https://assets.ubuntu.com/v1/f2123c59-HPC-use-cases-meta-image.png{% endblock meta_image %}
+{% block meta_copydoc %}https://docs.google.com/document/d/133bou6x0uCiZxezjjr6uroq73mSPM3MdSiWpS5WA1XM/edit#{% endblock meta_copydoc %}
+
+{% block content %}
+
+<section class="p-strip--suru-topped">
+  <div class="row">
+    <div class="col-6">
+      <h1>High-performance computing use cases</h1>
+      <p class="p-heading--4">How sectors and industries accelerate innovation with HPC </p>
+      <p>Canonical delivers multiple solutions that help your organisation ease operations and innovate at a greater pace.</p>
+      <a class="p-button--positive" href="/hpc/contact-us" data-testid="interactive-form-link">Get in touch</a>
+    </div>
+    <div class="col-6 u-embedded-media u-vertically-center u-hide--medium u-hide--small">
+      <iframe width="560" height="315" src="https://www.youtube.com/embed/tGIobcyKViI" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+    </div>
+  </div>
+</section>
+<section class="p-strip--light">
+  <div class="u-fixed-width">
+    <div class="p-logo-section">
+      <h2 class="p-logo-section__title u-align--center">ADVANCING HIGH-PERFORMANCE WORKLOADS</h2>
+      <div class="p-logo-section__items">
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/d3ee88a5-2018-logo-tesla.svg",
+            alt="",
+            width="145",
+            height="145",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"},
+            ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/25335aae-firmus-white.png",
+            alt="",
+            width="400",
+            height="90",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"},
+            ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/7bbfb1d0-Scania_logo.svg",
+            alt="",
+            width="130",
+            height="34",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"},
+            ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/a3bb7ca4-mercedes-benz-group-logo.png",
+            alt="",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"},
+            ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/fa4dc838-Daimler.svg",
+            alt="",
+            width="145",
+            height="145",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"},
+            ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/ba34b7cc-PGS_LOGO+%281%29.svg",
+            alt="",
+            width="78",
+            height="100",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"},
+            ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/538f7bf8-astra-zeneca_logo.svg",
+            alt="",
+            width="130",
+            height="35",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"},
+            ) | safe
+          }}
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+<section class="p-strip is-bordered">
+  <div class="row">
+    <div class="col-6">
+      <div>
+        {{
+          image(
+              url="https://assets.ubuntu.com/v1/6e184942-Webinar.svg",
+              alt="",
+              width="32",
+              height="28",
+              hi_def=True,
+              loading="lazy",
+            ) | safe
+        }}
+        <h2>Scania simplifies HPC cluster deployments</h2>
+        <p>Scania uses Juju and Charms to deploy SLURM, a popular scheduler for HPC workloads. Find out how they simplify installation, operations, and application integration.</p>
+        <p><a class="p-button--positive" href="/">Watch the webinar</a></p>
+      </div>
+    </div>
+    <div class="col-6 u-hide--small u-hide--medioum u-align--center u-vertically-center">
+      
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="u-fixed-width">
+    <h2>A new world of possibilities</h2>
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <h3>Aerospace and aviation </h3>
+      <p class="p-heading--4">Complex multiphysics computations through CFD</p>
+      <p>HPC is used for a variety of purposes in the aerospace industry. From optimising aircraft design to turbine flow using complex multiphysics computations such as fluid dynamics, to structural and thermal simulations, and electromagnetic analysis - all requiring large scale clusters.</p>
+      <p>These complex multiphysics computations also drive an increased need for VDI resources.</p>
+    </div>
+    <div class="col-6 u-align--center u-vertically-center u-hide--small u-hide--medium">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/821193fe-Financial+growth.svg",
+        alt="",
+        width="200",
+        height="200",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+  </div>
+  <div class="u-fixed-width">
+    <hr class="p-separator" />
+  </div>
+  <div class="row">
+    <div class="col-6 u-align--center u-vertically-center u-hide--small u-hide--medium">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/9a250d1b-Internet+of+Things_digital-drone.svg",
+        alt="",
+        width="180",
+        height="150",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+    <div class="col-6">
+      <h3>Agriculture</h3>
+      <p class="p-heading--4">Simulating future food systems</p>
+      <p>HPC solutions drive discoveries in plague control, pesticide design, and the analysis of pesticide effects for increased efficiency in the agricultural sector. Plant growth simulations help reduce the number of field trials needed, speeding up optimisation.</p>
+      <p>Climate data is used to better understand the impacts of water and climate conditions on agriculture.</p>
+      <p>Data from sensors, drones, and satellite imagery is analysed with AI/ML or HPDA to improve anything from crop yield prediction to life stock health.</p>
+    </div>
+  </div>
+  <div class="u-fixed-width">
+    <hr class="p-separator" />
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <h3>Automotive</h3>
+      <p class="p-heading--4">Improved efficiency through simulations</p>
+      <p>Automotive companies are optimising vehicle design through multiphysics simulations, such as using computational fluid dynamics to analyse airflow or wind resistance. Other use cases include simulating the performance of individual parts of a vehicle and how they respond to stress, or simulating manufacturing optimisations. All of these drive a huge need for large-scale high-performance computing clusters.</p>
+      <p>Large-scale simulation and machine learning clusters also power up training and safety validation for autonomous vehicles.</p>
+      <p>Data is being used for anything from fault detection to fleet management, all requiring solutions such as HPDA and AI/ML.</p>
+      <p>VDI enables the creation of models through computer-aided design and the visualisation  of complex multiphysics simulations.</p>
+    </div>
+    <div class="col-6 u-align--center u-vertically-center u-hide--small u-hide--medium">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/580f3ae7-automotive.svg",
+        alt="",
+        width="257",
+        height="150",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+  </div>
+  <div class="u-fixed-width">
+    <hr class="p-separator" />
+  </div>
+  <div class="row">
+    <div class="col-6 u-align--center u-vertically-center u-hide--small u-hide--medium">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/ac33d003-Innovation+in+banking.svg",
+        alt="",
+        width="200",
+        height="200",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+    <div class="col-6">
+      <h3>Banking and finance</h3>
+      <p class="p-heading--4">Minimising risk with monte carlo simulations</p>
+      <p>The financial services industry uses simulations such as monte carlo to analyse multiple possible outcomes for improved decision-making.  High performance computing clusters also power up risk analyses and fraud detection and protection.</p>
+      <p>HPC is helping banks deliver improved compliance and portfolio management.</p>
+    </div>
+  </div>
+  <div class="u-fixed-width">
+    <hr class="p-separator" />
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <h3>Construction</h3>
+      <p class="p-heading--4">Improved building safety and materials through simulations</p>
+      <p>Construction companies can build safer, more efficient and cost-effective structures thanks to fire and smoke simulations, powered by HPC. Complex multiphysics simulations are enabling the industry to create improved materials.</p>
+      <p>Data can be collected at a faster rate using in-structure sensors and imagery to assess and predict structural conditions. All of this can be analysed using HPDA and AI/ML solutions on a large-scale.</p>
+    </div>
+    <div class="col-6 u-align--center u-vertically-center u-hide--small u-hide--medium">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/f880a3bd-Enterprise+support.svg",
+        alt="",
+        width="150",
+        height="150",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+  </div>
+  <div class="u-fixed-width">
+    <hr class="p-separator" />
+  </div>
+  <div class="row">
+    <div class="col-6 u-align--center u-vertically-center u-hide--small u-hide--medium">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/9977f64c-shields-security.svg",
+        alt="",
+        width="263",
+        height="150",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+    <div class="col-6">
+      <h3>Defence and security</h3>
+      <p class="p-heading--4">Simulations that improve safety</p>
+      <p>Complex multiphysics simulations can optimise the efficiency of defence solutions and simulate the decommissioning of nuclear components for improved safety.</p>
+    </div>
+  </div>
+  <div class="u-fixed-width">
+    <hr class="p-separator" />
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <h3>Electronics</h3>
+      <p class="p-heading--4">Efficient production and design</p>
+      <p>The design and manufacturing of electrical components require complex computations. HPC enables electronics manufacturers to simulate electrical flows and temperature, allowing for both efficient design in terms of materials and effective management of heat dissipation.</p>
+    </div>
+    <div class="col-6 u-align--center u-vertically-center u-hide--small u-hide--medium">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/122d89aa-Unleash_hardware.svg",
+        alt="",
+        width="251",
+        height="150",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+  </div>
+  <div class="u-fixed-width">
+    <hr class="p-separator" />
+  </div>
+  <div class="row">
+    <div class="col-6 u-align--center u-vertically-center u-hide--small u-hide--medium">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/273fd9ee-4+Implementation.svg",
+        alt="",
+        width="251",
+        height="150",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+    <div class="col-6">
+      <h3>Energy and utilities</h3>
+      <p class="p-heading--4">Discovery and processing</p>
+      <p>The time to leverage HPC in energy is now.</p>
+      <p>HPC can be used to analyse seismic data or data produced by geophones. This allows exploration teams to get an understanding of the underlying geological area, allowing for the discovery of previously hidden natural resources.</p>
+      <p>Complex chemical processes are then required to refine these resources into useful products. This complexity requires the use of chemistry simulations.</p>
+    </div>
+  </div>
+  <div class="u-fixed-width">
+    <hr class="p-separator" />
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <h3>Government</h3>
+      <p class="p-heading--4">Increased safety and understanding</p>
+      <p>HPC can level-up how governments decommission materials, engage in large-scale infrastructure projects and analyse census information, among many other use cases.</p>
+      <p>National laboratories are using HPC to drive discovery in nuclear power, nuclear fusion, renewable energy, nanotechnology and space exploration.</p>
+    </div>
+    <div class="col-6 u-align--center u-vertically-center u-hide--small u-hide--medium">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/69aaa876-compliance.svg",
+        alt="",
+        width="150",
+        height="150",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+  </div>
+  <div class="u-fixed-width">
+    <hr class="p-separator" />
+  </div>
+  <div class="row">
+    <div class="col-6 u-align--center u-vertically-center u-hide--small u-hide--medium">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/1d5f293c-compliance.svg",
+        alt="",
+        width="263",
+        height="150",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+    <div class="col-6">
+      <h3>Healthcare and pharmaceuticals</h3>
+      <p class="p-heading--4">Cancer detection and protein folding</p>
+      <p>Digital twins are being used to great effect by healthcare and pharmaceutical organisations, for anything from simulating the effects of drug uptake on vital organs to simulating brain functions or blood flow.</p>
+      <p>Simulations are also valuable to develop and test medical prosthetics.</p>
+      <p>Complex algorithms can enable a better understanding of the underlying chemical processes behind life, leading to breakthrough medical discoveries.</p>
+      <p>Cancer detection and growth analyses are made possible through machine-learning and image analysis.</p>
+    </div>
+  </div>
+  <div class="u-fixed-width">
+    <hr class="p-separator" />
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <h3>Life sciences</h3>
+      <p class="p-heading--4">Genome sequencing and protein folding</p>
+      <p>HPC is opening new doors for genome sequencing. It can help life sciences organisations better understand genetics and diseases. These use cases depend on large high-performance computing clusters.</p>
+      <p>A more robust understanding of protein folding is now possible thanks to complex simulation workloads and advanced AI solutions such as AlphaFold.</p>
+    </div>
+    <div class="col-6 u-align--center u-vertically-center u-hide--small u-hide--medium">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/e2bf84de-edge-cluster.svg",
+        alt="",
+        width="156",
+        height="150",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+  </div>
+  <div class="u-fixed-width">
+    <hr class="p-separator" />
+  </div>
+  <div class="row">
+    <div class="col-6 u-align--center u-vertically-center u-hide--small u-hide--medium">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/0df476e6-DevOps.svg",
+        alt="",
+        width="251",
+        height="150",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+    <div class="col-6">
+      <h3>Manufacturing and industry</h3>
+      <p class="p-heading--4">Simulations improve assembly and components </p>
+      <p>HPC is being used to optimise materials used in manufacturing. It allows companies to create more durable components while using the lowest amount of materials, driving efficiency.</p>
+      <p>Simulations can also be used to optimise assembly lines and get a better understanding of processes.</p>
+    </div>
+  </div>
+  <div class="u-fixed-width">
+    <hr class="p-separator" />
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <h3>Media and entertainment</h3>
+      <p class="p-heading--4">Rendering, audio and video processing</p>
+      <p>HPC can also be highly entertaining. Movie and TV studios use HPC workloads for anything from the rendering of visual effects (VFX) to full-blown animated movies. This, along with video processing, requires large-scale rendering clusters.</p>
+      <p>Gaming companies deploy large clusters for the processing and delivery of audio, driven by player-to-player communication.</p>
+    </div>
+    <div class="col-6 u-align--center u-vertically-center u-hide--small u-hide--medium">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/4b732966-Laptop.svg",
+        alt="",
+        width="259",
+        height="150",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+  </div>
+  <div class="u-fixed-width">
+    <hr class="p-separator" />
+  </div>
+  <div class="row">
+    <div class="col-6 u-align--center u-vertically-center u-hide--small u-hide--medium">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/e68fd355-1+discovery_AW.svg",
+        alt="",
+        width="263",
+        height="150",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+    <div class="col-6">
+      <h3>Research and universities</h3>
+      <p class="p-heading--4">Simulations and discovery</p>
+      <p>Science and research depend on large-scale high performance clusters for new discoveries. Anything from the discovery of new materials or properties of new compounds is made possible through physics simulations.</p>
+      <p>Within our planet and across the universe, HPC makes the analysis of instrument data possible &mdash; from particle accelerators to space telescopes.</p>
+    </div>
+  </div>
+  <div class="u-fixed-width">
+    <hr class="p-separator" />
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <h3>Weather</h3>
+      <p class="p-heading--4">Simulations and prediction</p>
+      <p>Our understanding of climate change and weather disruptions is more sophisticated thanks to HPC. Simulations deliver weather predictions through computations on large-scale high-performance clusters.</p>
+    </div>
+    <div class="col-6 u-align--center u-vertically-center u-hide--small u-hide--medium">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/75a8a35a-cloud_orange.svg",
+        alt="",
+        width="214",
+        height="146",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+  </div>
+</section>
+<section class="p-strip--light">
+  <div class="row u-equal-height">
+    <div class="col-4 u-hide--medium u-hide--small u-align--left">
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/c4b290c8-Contact+us.svg",
+        alt="",
+        height="280",
+        width="280",
+        hi_def=True,
+        ) | safe
+      }}
+    </div>
+    <div class="col-8 u-vertically-center">
+      <div>
+        <h2>Get in touch</h2>
+        <p>Find out how you can work with Canonical to ease operations and speed up innovation with HPC.</p>
+        <p><a class="p-button--positive" href="/hpc/contact-us">Get in touch</a></p>
+      </div>
+    </div>
+  </div>
+</section>
+{% endblock content %}


### PR DESCRIPTION
## Done

- Build page on `/hpc/use-cases`

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Compare page against [copy doc](https://docs.google.com/document/d/133bou6x0uCiZxezjjr6uroq73mSPM3MdSiWpS5WA1XM/edit#)
- Some assets are missing and I left comment about them in the copy doc. Demo has been shared with the PdM for feedback.
- Demo at https://ubuntu-com-12010.demos.haus/hpc/use-cases

## Issue / Card

Fixes [#5867](https://github.com/canonical/web-squad/issues/5867)

