### PR TITLE
Redirect not found blogs to 404 page

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -677,7 +677,7 @@ class BlogRedirects(BlogView):
         slug = quote(slug, safe="/:?&")
         context = self.blog_views.get_article(slug)
 
-        if not context["article"]:
+        if "article" not in context:
             return flask.abort(404)
 
         # Redirect canonical annoucements


### PR DESCRIPTION
## Done

Redirect not found blogs to 404 page

## QA

- Check that https://ubuntu-com-12011.demos.haus/blog/this-article-is-invalid goes to 404

## Issue / Card

Fixes https://github.com/canonical/ubuntu.com/issues/12008



## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
