### PR TITLE
Add renewal status tag on user subscriptions

### DIFF
--- a/static/js/src/advantage/api/types.ts
+++ b/static/js/src/advantage/api/types.ts
@@ -41,6 +41,7 @@ export type UserSubscriptionStatuses = {
   should_present_auto_renewal: boolean;
   has_access_to_support: boolean;
   has_access_to_token: boolean;
+  is_renewed: boolean;
 };
 
 export type UserSubscription = {

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.test.tsx
@@ -12,6 +12,7 @@ import { UserSubscription } from "advantage/api/types";
 import SubscriptionEdit from "../SubscriptionEdit";
 import { Notification } from "@canonical/react-components";
 import * as usePendingPurchase from "advantage/subscribe/react/hooks/usePendingPurchase";
+import { UserSubscriptionType } from "advantage/api/enum";
 
 describe("SubscriptionDetails", () => {
   let queryClient: QueryClient;
@@ -276,5 +277,138 @@ describe("SubscriptionDetails", () => {
     expect(
       wrapper.find("Button[data-test='cancel-trial-button']").exists()
     ).toBe(true);
+  });
+
+  it("it does display the expired label", () => {
+    const contract = userSubscriptionFactory.build({
+      type: UserSubscriptionType.Legacy,
+      statuses: userSubscriptionStatusesFactory.build({
+        is_expired: true,
+      }),
+    });
+
+    queryClient.setQueryData("userSubscriptions", [contract]);
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <SubscriptionDetails
+          onCloseModal={jest.fn()}
+          selectedId={contract.id}
+          setHasUnsavedChanges={jest.fn()}
+        />
+      </QueryClientProvider>
+    );
+
+    expect(wrapper.find(".p-chip__value").text()).toBe("Expired");
+  });
+
+  it("it does display the not renewed label for legacy not renewed", () => {
+    const contract = userSubscriptionFactory.build({
+      type: UserSubscriptionType.Legacy,
+      statuses: userSubscriptionStatusesFactory.build({
+        is_renewed: false,
+      }),
+    });
+
+    queryClient.setQueryData("userSubscriptions", [contract]);
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <SubscriptionDetails
+          onCloseModal={jest.fn()}
+          selectedId={contract.id}
+          setHasUnsavedChanges={jest.fn()}
+        />
+      </QueryClientProvider>
+    );
+
+    expect(wrapper.find(".p-chip__value").text()).toBe("Not renewed");
+  });
+
+  it("it does display the renewed label for legacy renewed", () => {
+    const contract = userSubscriptionFactory.build({
+      type: UserSubscriptionType.Legacy,
+      statuses: userSubscriptionStatusesFactory.build({
+        is_renewed: true,
+      }),
+    });
+
+    queryClient.setQueryData("userSubscriptions", [contract]);
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <SubscriptionDetails
+          onCloseModal={jest.fn()}
+          selectedId={contract.id}
+          setHasUnsavedChanges={jest.fn()}
+        />
+      </QueryClientProvider>
+    );
+
+    expect(wrapper.find(".p-chip__value").text()).toBe("Renewed");
+  });
+
+  it("it doesn't display a label for legacy without renewal", () => {
+    const contract = userSubscriptionFactory.build({
+      type: UserSubscriptionType.Legacy,
+      renewal_id: null,
+      statuses: userSubscriptionStatusesFactory.build({
+        is_renewed: true,
+      }),
+    });
+
+    queryClient.setQueryData("userSubscriptions", [contract]);
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <SubscriptionDetails
+          onCloseModal={jest.fn()}
+          selectedId={contract.id}
+          setHasUnsavedChanges={jest.fn()}
+        />
+      </QueryClientProvider>
+    );
+
+    expect(wrapper.find(".p-chip__value").exists()).toBe(false);
+  });
+
+  it("it does display the auto-renewed label for shop purchases", () => {
+    const contract = userSubscriptionFactory.build({
+      type: UserSubscriptionType.Monthly,
+      statuses: userSubscriptionStatusesFactory.build({
+        is_renewed: true,
+      }),
+    });
+
+    queryClient.setQueryData("userSubscriptions", [contract]);
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <SubscriptionDetails
+          onCloseModal={jest.fn()}
+          selectedId={contract.id}
+          setHasUnsavedChanges={jest.fn()}
+        />
+      </QueryClientProvider>
+    );
+
+    expect(wrapper.find(".p-chip__value").text()).toBe("Auto-renewal on");
+  });
+
+  it("it does display the auto-renewed off label for shop purchases", () => {
+    const contract = userSubscriptionFactory.build({
+      type: UserSubscriptionType.Monthly,
+      statuses: userSubscriptionStatusesFactory.build({
+        is_renewed: false,
+      }),
+    });
+
+    queryClient.setQueryData("userSubscriptions", [contract]);
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <SubscriptionDetails
+          onCloseModal={jest.fn()}
+          selectedId={contract.id}
+          setHasUnsavedChanges={jest.fn()}
+        />
+      </QueryClientProvider>
+    );
+
+    expect(wrapper.find(".p-chip__value").text()).toBe("Auto-renewal off");
   });
 });

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
@@ -80,7 +80,7 @@ export const SubscriptionDetails = forwardRef<HTMLDivElement, Props>(
         if (
           subscription?.current_number_of_machines &&
           (subscription?.current_number_of_machines ?? 0) <
-            (subscription?.number_of_machines ?? 0)
+          (subscription?.number_of_machines ?? 0)
         ) {
           setNotification({
             severity: "caution",
@@ -128,6 +128,40 @@ export const SubscriptionDetails = forwardRef<HTMLDivElement, Props>(
               >
                 Close
               </button>
+              {subscription.statuses.is_expired ? (
+                <button className="p-chip--negative">
+                  <span className="p-chip__value">Expired</span>
+                </button>
+              ) : (
+                <>
+                  {subscription.type == "legacy" && subscription.renewal_id ? (
+                    <>
+                      {subscription.statuses.is_renewed ? (
+                        <button className="p-chip--positive">
+                          <span className="p-chip__value">Renewed</span>
+                        </button>
+                      ) : (
+                        <button className="p-chip--caution">
+                          <span className="p-chip__value">Not renewed</span>
+                        </button>
+                      )}
+                    </>
+                  ) : null}
+                  {subscription.type == "monthly" || subscription.type == "yearly" ? (
+                    <>
+                      {subscription.statuses.is_renewed ? (
+                        <button className="p-chip--positive">
+                          <span className="p-chip__value">Auto-renewal on</span>
+                        </button>
+                      ) : (
+                        <button className="p-chip--caution">
+                          <span className="p-chip__value">Auto-renewal off</span>
+                        </button>
+                      )}
+                    </>
+                  ) : null}
+                </>
+              )}
             </header>
             <ExpiryNotification
               borderless

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
@@ -80,7 +80,7 @@ export const SubscriptionDetails = forwardRef<HTMLDivElement, Props>(
         if (
           subscription?.current_number_of_machines &&
           (subscription?.current_number_of_machines ?? 0) <
-          (subscription?.number_of_machines ?? 0)
+            (subscription?.number_of_machines ?? 0)
         ) {
           setNotification({
             severity: "caution",
@@ -147,7 +147,8 @@ export const SubscriptionDetails = forwardRef<HTMLDivElement, Props>(
                       )}
                     </>
                   ) : null}
-                  {subscription.type == "monthly" || subscription.type == "yearly" ? (
+                  {subscription.type == "monthly" ||
+                  subscription.type == "yearly" ? (
                     <>
                       {subscription.statuses.is_renewed ? (
                         <button className="p-chip--positive">
@@ -155,7 +156,9 @@ export const SubscriptionDetails = forwardRef<HTMLDivElement, Props>(
                         </button>
                       ) : (
                         <button className="p-chip--caution">
-                          <span className="p-chip__value">Auto-renewal off</span>
+                          <span className="p-chip__value">
+                            Auto-renewal off
+                          </span>
                         </button>
                       )}
                     </>

--- a/static/js/src/advantage/react/hooks/useUserSubscriptions.test.tsx
+++ b/static/js/src/advantage/react/hooks/useUserSubscriptions.test.tsx
@@ -100,6 +100,7 @@ describe("useUserSubscriptions", () => {
       should_present_auto_renewal: false,
       has_access_to_support: true,
       has_access_to_token: true,
+      is_renewed: true,
     });
   });
 

--- a/static/js/src/advantage/react/hooks/useUserSubscriptions.ts
+++ b/static/js/src/advantage/react/hooks/useUserSubscriptions.ts
@@ -61,6 +61,7 @@ export const selectStatusesSummary = (
   ),
   has_access_to_support: hasStatus(subscriptions, "has_access_to_support"),
   has_access_to_token: hasStatus(subscriptions, "has_access_to_token"),
+  is_renewed: hasStatus(subscriptions, "is_renewed"),
 });
 
 export const selectUASubscriptions = (subscriptions: UserSubscription[]) =>
@@ -76,10 +77,10 @@ export const selectBlenderSubscriptions = (subscriptions: UserSubscription[]) =>
 export const selectAutoRenewableSubscriptionsByMarketplace = (
   targetMarketplace: UserSubscription["marketplace"]
 ) => (subscriptions: UserSubscription[]) =>
-  subscriptions.filter(
-    ({ statuses, marketplace }) =>
-      statuses.should_present_auto_renewal && marketplace === targetMarketplace
-  );
+    subscriptions.filter(
+      ({ statuses, marketplace }) =>
+        statuses.should_present_auto_renewal && marketplace === targetMarketplace
+    );
 
 /**
  * Find the subscriptions with for period.
@@ -87,7 +88,7 @@ export const selectAutoRenewableSubscriptionsByMarketplace = (
 export const selectSubscriptionsForPeriod = (
   period: UserSubscriptionPeriod
 ) => (subscriptions: UserSubscription[]) =>
-  subscriptions.filter((subscription) => subscription.period === period);
+    subscriptions.filter((subscription) => subscription.period === period);
 
 export const useUserSubscriptions = <D = UserSubscription[]>(
   options?: UseQueryOptions<UserSubscription[], unknown, D, "userSubscriptions">

--- a/static/js/src/advantage/react/hooks/useUserSubscriptions.ts
+++ b/static/js/src/advantage/react/hooks/useUserSubscriptions.ts
@@ -77,10 +77,10 @@ export const selectBlenderSubscriptions = (subscriptions: UserSubscription[]) =>
 export const selectAutoRenewableSubscriptionsByMarketplace = (
   targetMarketplace: UserSubscription["marketplace"]
 ) => (subscriptions: UserSubscription[]) =>
-    subscriptions.filter(
-      ({ statuses, marketplace }) =>
-        statuses.should_present_auto_renewal && marketplace === targetMarketplace
-    );
+  subscriptions.filter(
+    ({ statuses, marketplace }) =>
+      statuses.should_present_auto_renewal && marketplace === targetMarketplace
+  );
 
 /**
  * Find the subscriptions with for period.
@@ -88,7 +88,7 @@ export const selectAutoRenewableSubscriptionsByMarketplace = (
 export const selectSubscriptionsForPeriod = (
   period: UserSubscriptionPeriod
 ) => (subscriptions: UserSubscription[]) =>
-    subscriptions.filter((subscription) => subscription.period === period);
+  subscriptions.filter((subscription) => subscription.period === period);
 
 export const useUserSubscriptions = <D = UserSubscription[]>(
   options?: UseQueryOptions<UserSubscription[], unknown, D, "userSubscriptions">

--- a/static/js/src/advantage/tests/factories/api.ts
+++ b/static/js/src/advantage/tests/factories/api.ts
@@ -50,6 +50,7 @@ export const userSubscriptionStatusesFactory = Factory.define<UserSubscriptionSt
     should_present_auto_renewal: false,
     has_access_to_support: true,
     has_access_to_token: true,
+    is_renewed: true,
   })
 );
 

--- a/tests/shop/advantage/test_helpers.py
+++ b/tests/shop/advantage/test_helpers.py
@@ -593,6 +593,7 @@ class TestHelpers(unittest.TestCase):
                     "should_present_auto_renewal": False,
                     "has_access_to_support": True,
                     "has_access_to_token": True,
+                    "is_renewed": False,
                 },
             },
             "test_yearly_user_subscription_just_started": {
@@ -625,6 +626,7 @@ class TestHelpers(unittest.TestCase):
                     "should_present_auto_renewal": True,
                     "has_access_to_support": True,
                     "has_access_to_token": True,
+                    "is_renewed": False,
                 },
             },
             "test_yearly_user_subscription_expiring": {
@@ -657,6 +659,7 @@ class TestHelpers(unittest.TestCase):
                     "should_present_auto_renewal": True,
                     "has_access_to_support": True,
                     "has_access_to_token": True,
+                    "is_renewed": False,
                 },
             },
             "test_yearly_user_subscription_expiring_but_auto_renewing": {
@@ -692,6 +695,7 @@ class TestHelpers(unittest.TestCase):
                     "should_present_auto_renewal": True,
                     "has_access_to_support": True,
                     "has_access_to_token": True,
+                    "is_renewed": True,
                 },
             },
             "test_yearly_user_subscription_grace_period": {
@@ -726,6 +730,7 @@ class TestHelpers(unittest.TestCase):
                     "should_present_auto_renewal": True,
                     "has_access_to_support": True,
                     "has_access_to_token": True,
+                    "is_renewed": False,
                 },
             },
             "test_monthly_user_subscription": {
@@ -761,6 +766,7 @@ class TestHelpers(unittest.TestCase):
                     "should_present_auto_renewal": True,
                     "has_access_to_support": True,
                     "has_access_to_token": True,
+                    "is_renewed": True,
                 },
             },
             "test_cancelled_user_subscription": {
@@ -795,6 +801,7 @@ class TestHelpers(unittest.TestCase):
                     "should_present_auto_renewal": False,
                     "has_access_to_support": True,
                     "has_access_to_token": True,
+                    "is_renewed": False,
                 },
             },
             "test_expired_user_subscription": {
@@ -822,6 +829,7 @@ class TestHelpers(unittest.TestCase):
                     "should_present_auto_renewal": False,
                     "has_access_to_support": True,
                     "has_access_to_token": True,
+                    "is_renewed": False,
                 },
             },
             "test_trial_user_subscription": {
@@ -855,6 +863,7 @@ class TestHelpers(unittest.TestCase):
                     "should_present_auto_renewal": False,
                     "has_access_to_support": True,
                     "has_access_to_token": True,
+                    "is_renewed": False,
                 },
             },
             "test_pending_purchases_user_subscription": {
@@ -886,6 +895,7 @@ class TestHelpers(unittest.TestCase):
                     "should_present_auto_renewal": False,
                     "has_access_to_support": True,
                     "has_access_to_token": True,
+                    "is_renewed": False,
                 },
             },
             "test_legacy_user_subscription": {
@@ -917,6 +927,7 @@ class TestHelpers(unittest.TestCase):
                     "should_present_auto_renewal": False,
                     "has_access_to_support": True,
                     "has_access_to_token": True,
+                    "is_renewed": False,
                 },
             },
             "test_non_actionable_legacy_user_subscription": {
@@ -943,6 +954,7 @@ class TestHelpers(unittest.TestCase):
                     "should_present_auto_renewal": False,
                     "has_access_to_support": True,
                     "has_access_to_token": True,
+                    "is_renewed": False,
                 },
             },
             "test_closed_legacy_user_subscription": {
@@ -974,6 +986,7 @@ class TestHelpers(unittest.TestCase):
                     "should_present_auto_renewal": False,
                     "has_access_to_support": True,
                     "has_access_to_token": True,
+                    "is_renewed": True,
                 },
             },
             "test_billing_user_subscription": {
@@ -1007,6 +1020,7 @@ class TestHelpers(unittest.TestCase):
                     "should_present_auto_renewal": True,
                     "has_access_to_support": False,
                     "has_access_to_token": False,
+                    "is_renewed": False,
                 },
             },
         }

--- a/webapp/shop/api/ua_contracts/helpers.py
+++ b/webapp/shop/api/ua_contracts/helpers.py
@@ -216,6 +216,9 @@ def get_user_subscription_statuses(
         # has_access_to_token describes whether this user subscription displays
         # the token or not. At the moment `billing` users do not have access
         "has_access_to_token": False,
+        # is_renewed describes whether this user subscription has been renewed
+        # already or not
+        "is_renewed": False,
     }
 
     if account.role != "billing":
@@ -260,6 +263,10 @@ def get_user_subscription_statuses(
             subscriptions, subscription_id
         )
 
+        statuses["is_renewed"] = is_subscription_auto_renewing(
+            subscriptions, subscription_id
+        )
+
         is_cancelled = True if not current_number_of_machines else False
         statuses["is_cancelled"] = is_cancelled
         statuses["should_present_auto_renewal"] = (
@@ -288,6 +295,9 @@ def get_user_subscription_statuses(
             time_now = datetime.utcnow().replace(tzinfo=pytz.utc)
             if start <= time_now <= end:
                 statuses["is_renewable"] = True
+
+        if renewal.actionable and renewal.status in ["done", "closed"]:
+            statuses["is_renewed"] = True
 
     return statuses
 
@@ -364,6 +374,21 @@ def is_billing_subscription_active(
             return True
 
     return False
+
+
+def is_subscription_auto_renewing(
+    subscriptions: List[Subscription], subscription_id: str
+) -> bool:
+    subscription = [
+        subscription
+        for subscription in subscriptions
+        if subscription.id == subscription_id
+    ]
+
+    if not subscription:
+        return False
+
+    return subscription[0].is_auto_renewing
 
 
 def is_billing_subscription_auto_renewing(


### PR DESCRIPTION
## Done

- Add renewal status tag on user subscriptions

![image](https://user-images.githubusercontent.com/6387619/189105136-20b538b0-05ea-44cd-b695-9f1bd3981250.png)

## QA

- Go to https://ubuntu-com-12012.demos.haus/
- Login
- Buy monthly/early subscription
- Go to /advantage
- Check that renewal tag changes based on the auto-renewal setting
- Ask for help with testing the tag for renewals

## Issue / Card

Fixes #https://github.com/canonical/commercial-squad/issues/711
