### PR TITLE
Implement renewal expiration notification

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/ExpiryNotification/ExpiryNotification.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/ExpiryNotification/ExpiryNotification.test.tsx
@@ -4,6 +4,7 @@ import { mount } from "enzyme";
 import ExpiryNotification, {
   ExpiryNotificationSize,
 } from "./ExpiryNotification";
+import { UserSubscriptionType } from "advantage/api/enum";
 import { userSubscriptionStatusesFactory } from "advantage/tests/factories/api";
 import { Notification } from "@canonical/react-components";
 
@@ -132,5 +133,115 @@ describe("ExpiryNotification", () => {
       />
     );
     expect(wrapper.find(Notification).prop("onDismiss")).toBe(onDismiss);
+  });
+
+  it("is expiring shows default message", () => {
+    const statuses = userSubscriptionStatusesFactory.build({
+      is_expiring: true,
+    });
+    const onDismiss = jest.fn();
+    const wrapper = mount(
+      <ExpiryNotification
+        size={ExpiryNotificationSize.Large}
+        subscriptionType={UserSubscriptionType.Monthly}
+        statuses={statuses}
+        onDismiss={onDismiss}
+      />
+    );
+    expect(wrapper.find("[data-test='is_expiring-large']").exists()).toBe(true);
+    expect(wrapper.find(Notification).prop("title")).toBe(
+      "Your subscription is about to expire."
+    );
+    expect(wrapper.find(Notification).prop("children")).toBe(
+      "Enable auto-renewals via the renewal settings menu to ensure service continuity."
+    );
+  });
+
+  it("is expiring shows default message for non-defined cases", () => {
+    const statuses = userSubscriptionStatusesFactory.build({
+      is_expiring: true,
+    });
+    const onDismiss = jest.fn();
+    const wrapper = mount(
+      <ExpiryNotification
+        size={ExpiryNotificationSize.Large}
+        subscriptionType={UserSubscriptionType.Free}
+        statuses={statuses}
+        onDismiss={onDismiss}
+      />
+    );
+    expect(wrapper.find("[data-test='is_expiring-large']").exists()).toBe(true);
+    expect(wrapper.find(Notification).prop("title")).toBe(
+      "Your subscription is about to expire."
+    );
+    expect(wrapper.find(Notification).prop("children")).toBe(
+      "Click on renew subscription or enable auto-renewals via the renewal settings menu to ensure service continuity."
+    );
+  });
+
+  it("is expiring shows legacy message", () => {
+    const statuses = userSubscriptionStatusesFactory.build({
+      is_expiring: true,
+    });
+    const onDismiss = jest.fn();
+    const wrapper = mount(
+      <ExpiryNotification
+        size={ExpiryNotificationSize.Large}
+        subscriptionType={UserSubscriptionType.Legacy}
+        statuses={statuses}
+        onDismiss={onDismiss}
+      />
+    );
+    expect(wrapper.find("[data-test='is_expiring-large']").exists()).toBe(true);
+    expect(wrapper.find(Notification).prop("title")).toBe(
+      "Your subscription is about to expire."
+    );
+    expect(wrapper.find(Notification).prop("children")).toBe(
+      "Click on Renew subscription to to ensure service continuity."
+    );
+  });
+
+  it("is in grace period shows default message", () => {
+    const statuses = userSubscriptionStatusesFactory.build({
+      is_in_grace_period: true,
+    });
+    const onDismiss = jest.fn();
+    const wrapper = mount(
+      <ExpiryNotification
+        size={ExpiryNotificationSize.Large}
+        subscriptionType={UserSubscriptionType.Legacy}
+        statuses={statuses}
+        onDismiss={onDismiss}
+      />
+    );
+    expect(wrapper.find("[data-test='is_expiring-large']").exists()).toBe(true);
+    expect(wrapper.find(Notification).prop("title")).toBe(
+      "Your subscription has expired."
+    );
+    expect(wrapper.find(Notification).prop("children")).toBe(
+      "If you don't renew it, it will disappear from your dashboard in 90 days. Click on Renew subscription to to ensure service continuity."
+    );
+  });
+
+  it("is expired shows default message", () => {
+    const statuses = userSubscriptionStatusesFactory.build({
+      is_expired: true,
+    });
+    const onDismiss = jest.fn();
+    const wrapper = mount(
+      <ExpiryNotification
+        size={ExpiryNotificationSize.Large}
+        subscriptionType={UserSubscriptionType.Legacy}
+        statuses={statuses}
+        onDismiss={onDismiss}
+      />
+    );
+    expect(wrapper.find("[data-test='is_expiring-large']").exists()).toBe(true);
+    expect(wrapper.find(Notification).prop("title")).toBe(
+      "Your subscription has expired."
+    );
+    expect(wrapper.find(Notification).prop("children")).toBe(
+      "If you don't renew it, it will disappear from your dashboard in 90 days. Click on Renew subscription to to ensure service continuity."
+    );
   });
 });

--- a/static/js/src/advantage/react/components/Subscriptions/ExpiryNotification/ExpiryNotification.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/ExpiryNotification/ExpiryNotification.test.tsx
@@ -214,7 +214,9 @@ describe("ExpiryNotification", () => {
         onDismiss={onDismiss}
       />
     );
-    expect(wrapper.find("[data-test='is_in_grace_period-large']").exists()).toBe(true);
+    expect(
+      wrapper.find("[data-test='is_in_grace_period-large']").exists()
+    ).toBe(true);
     expect(wrapper.find(Notification).prop("title")).toBe(
       "Your subscription has expired."
     );

--- a/static/js/src/advantage/react/components/Subscriptions/ExpiryNotification/ExpiryNotification.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/ExpiryNotification/ExpiryNotification.test.tsx
@@ -39,7 +39,7 @@ describe("ExpiryNotification", () => {
     expect(wrapper.find("[data-test='is_expired-large']").exists()).toBe(true);
     expect(wrapper.find(Notification).prop("borderless")).toBe(false);
     expect(wrapper.find(Notification).prop("title")).toBe(
-      "This subscription has expired."
+      "Your subscription has expired."
     );
   });
 
@@ -214,7 +214,7 @@ describe("ExpiryNotification", () => {
         onDismiss={onDismiss}
       />
     );
-    expect(wrapper.find("[data-test='is_expiring-large']").exists()).toBe(true);
+    expect(wrapper.find("[data-test='is_in_grace_period-large']").exists()).toBe(true);
     expect(wrapper.find(Notification).prop("title")).toBe(
       "Your subscription has expired."
     );
@@ -236,7 +236,7 @@ describe("ExpiryNotification", () => {
         onDismiss={onDismiss}
       />
     );
-    expect(wrapper.find("[data-test='is_expiring-large']").exists()).toBe(true);
+    expect(wrapper.find("[data-test='is_expired-large']").exists()).toBe(true);
     expect(wrapper.find(Notification).prop("title")).toBe(
       "Your subscription has expired."
     );

--- a/static/js/src/advantage/react/components/Subscriptions/ExpiryNotification/ExpiryNotification.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/ExpiryNotification/ExpiryNotification.tsx
@@ -7,6 +7,7 @@ import type { NotificationProps } from "@canonical/react-components";
 import React, { ReactNode } from "react";
 
 import { UserSubscriptionStatuses } from "advantage/api/types";
+import { UserSubscriptionType } from "advantage/api/enum";
 
 export enum ExpiryNotificationSize {
   Small = "small",
@@ -22,6 +23,7 @@ export enum StatusKey {
 type Props = PropsWithSpread<
   {
     showMultiple?: boolean;
+    subscriptionType?: UserSubscriptionType | "default";
     size: ExpiryNotificationSize;
     statuses: UserSubscriptionStatuses;
   },
@@ -30,7 +32,12 @@ type Props = PropsWithSpread<
 
 type Messages = Record<
   StatusKey,
-  { [K in ExpiryNotificationSize]?: { message: ReactNode; title?: ReactNode } }
+  {
+    [K in ExpiryNotificationSize]?: {
+      message: { [K in UserSubscriptionType | "default"]?: ReactNode };
+      title?: ReactNode;
+    };
+  }
 >;
 
 // The expiry status keys in priority order.
@@ -48,39 +55,97 @@ export const ORDERED_STATUS_KEYS = [
 const MESSAGES: Messages = {
   [StatusKey.IsExpiring]: {
     [ExpiryNotificationSize.Large]: {
-      message: "Verify your renewal settings below.",
+      message: {
+        default:
+          "Click on renew subscription or enable auto-renewals via the renewal settings menu to ensure service continuity.",
+        [UserSubscriptionType.Legacy]:
+          "Click on Renew subscription to to ensure service continuity.",
+        [UserSubscriptionType.Monthly]:
+          "Enable auto-renewals via the renewal settings menu to ensure service continuity.",
+        [UserSubscriptionType.Yearly]:
+          "Enable auto-renewals via the renewal settings menu to ensure service continuity.",
+      },
       title: "Your subscription is about to expire.",
     },
     [ExpiryNotificationSize.Small]: {
-      message: "Subscription about to expire",
+      message: {
+        default: "Your subscription is about to expire.",
+      },
     },
   },
   [StatusKey.IsExpired]: {
     [ExpiryNotificationSize.Large]: {
-      message: (
-        <>
-          Please <a href="/contact-us">contact us</a>.
-        </>
-      ),
+      message: {
+        default:
+          "If you don't renew it, it will disappear from your dashboard in 90 days. Click on Renew subscription to to ensure service continuity.",
+        [UserSubscriptionType.Monthly]: (
+          <>
+            If you don't renew it, it will disappear from your dashboard in 90
+            days. Contact{" "}
+            <a href="mailto:customersuccess@canonical.com">
+              customersuccess@canonical.com
+            </a>{" "}
+            to renew.
+          </>
+        ),
+        [UserSubscriptionType.Yearly]: (
+          <>
+            If you don't renew it, it will disappear from your dashboard in 90
+            days. Contact{" "}
+            <a href="mailto:customersuccess@canonical.com">
+              customersuccess@canonical.com
+            </a>{" "}
+            to renew.
+          </>
+        ),
+      },
       title: "This subscription has expired.",
     },
     [ExpiryNotificationSize.Small]: {
-      message: "Subscription expired",
+      message: {
+        default: "Subscription expired",
+      },
     },
   },
   [StatusKey.IsInGracePeriod]: {
     [ExpiryNotificationSize.Large]: {
-      message: "It will be removed within 14 days if it's not renewed.",
+      message: {
+        default:
+          "If you don't renew it, it will disappear from your dashboard in 90 days. Click on Renew subscription to to ensure service continuity.",
+        [UserSubscriptionType.Monthly]: (
+          <>
+            If you don't renew it, it will disappear from your dashboard in 90
+            days. Contact{" "}
+            <a href="mailto:customersuccess@canonical.com">
+              customersuccess@canonical.com
+            </a>{" "}
+            to renew.
+          </>
+        ),
+        [UserSubscriptionType.Yearly]: (
+          <>
+            If you don't renew it, it will disappear from your dashboard in 90
+            days. Contact{" "}
+            <a href="mailto:customersuccess@canonical.com">
+              customersuccess@canonical.com
+            </a>{" "}
+            to renew.
+          </>
+        ),
+      },
       title: "Your subscription has expired.",
     },
     [ExpiryNotificationSize.Small]: {
-      message: "Subscription expired",
+      message: {
+        default: "Subscription expired",
+      },
     },
   },
 };
 
 const ExpiryNotification = ({
   showMultiple = false,
+  subscriptionType,
   size,
   statuses,
   ...notificationProps
@@ -99,7 +164,10 @@ const ExpiryNotification = ({
   const notifications = statusesToShow.map((statusKey) => {
     const notification = MESSAGES[statusKey][size];
     return {
-      children: notification?.message,
+      children:
+        subscriptionType && notification?.message[subscriptionType]
+          ? notification?.message[subscriptionType]
+          : notification?.message["default"],
       key: `${statusKey}-${size}`,
       // Display a title for large notifications.
       title: size === ExpiryNotificationSize.Large ? notification?.title : null,

--- a/static/js/src/advantage/react/components/Subscriptions/ExpiryNotification/ExpiryNotification.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/ExpiryNotification/ExpiryNotification.tsx
@@ -80,8 +80,8 @@ const MESSAGES: Messages = {
           "If you don't renew it, it will disappear from your dashboard in 90 days. Click on Renew subscription to to ensure service continuity.",
         [UserSubscriptionType.Monthly]: (
           <>
-            If you don&apos;t renew it, it will disappear from your dashboard in 90
-            days. Contact{" "}
+            If you don&apos;t renew it, it will disappear from your dashboard in
+            90 days. Contact{" "}
             <a href="mailto:customersuccess@canonical.com">
               customersuccess@canonical.com
             </a>{" "}
@@ -90,8 +90,8 @@ const MESSAGES: Messages = {
         ),
         [UserSubscriptionType.Yearly]: (
           <>
-            If you don&apos;t renew it, it will disappear from your dashboard in 90
-            days. Contact{" "}
+            If you don&apos;t renew it, it will disappear from your dashboard in
+            90 days. Contact{" "}
             <a href="mailto:customersuccess@canonical.com">
               customersuccess@canonical.com
             </a>{" "}
@@ -114,8 +114,8 @@ const MESSAGES: Messages = {
           "If you don't renew it, it will disappear from your dashboard in 90 days. Click on Renew subscription to to ensure service continuity.",
         [UserSubscriptionType.Monthly]: (
           <>
-            If you don&apos;t renew it, it will disappear from your dashboard in 90
-            days. Contact{" "}
+            If you don&apos;t renew it, it will disappear from your dashboard in
+            90 days. Contact{" "}
             <a href="mailto:customersuccess@canonical.com">
               customersuccess@canonical.com
             </a>{" "}
@@ -124,9 +124,9 @@ const MESSAGES: Messages = {
         ),
         [UserSubscriptionType.Yearly]: (
           <>
-            If you don&apos;t renew it, it will disappear from your dashboard in 90
-            days. Contact{" "}
-            <a href='mailto:customersuccess@canonical.com'>
+            If you don&apos;t renew it, it will disappear from your dashboard in
+            90 days. Contact{" "}
+            <a href="mailto:customersuccess@canonical.com">
               customersuccess@canonical.com
             </a>{" "}
             to renew.

--- a/static/js/src/advantage/react/components/Subscriptions/ExpiryNotification/ExpiryNotification.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/ExpiryNotification/ExpiryNotification.tsx
@@ -80,7 +80,7 @@ const MESSAGES: Messages = {
           "If you don't renew it, it will disappear from your dashboard in 90 days. Click on Renew subscription to to ensure service continuity.",
         [UserSubscriptionType.Monthly]: (
           <>
-            If you don't renew it, it will disappear from your dashboard in 90
+            If you don&apos;t renew it, it will disappear from your dashboard in 90
             days. Contact{" "}
             <a href="mailto:customersuccess@canonical.com">
               customersuccess@canonical.com
@@ -90,7 +90,7 @@ const MESSAGES: Messages = {
         ),
         [UserSubscriptionType.Yearly]: (
           <>
-            If you don't renew it, it will disappear from your dashboard in 90
+            If you don&apos;t renew it, it will disappear from your dashboard in 90
             days. Contact{" "}
             <a href="mailto:customersuccess@canonical.com">
               customersuccess@canonical.com
@@ -99,7 +99,7 @@ const MESSAGES: Messages = {
           </>
         ),
       },
-      title: "This subscription has expired.",
+      title: "Your subscription has expired.",
     },
     [ExpiryNotificationSize.Small]: {
       message: {
@@ -114,7 +114,7 @@ const MESSAGES: Messages = {
           "If you don't renew it, it will disappear from your dashboard in 90 days. Click on Renew subscription to to ensure service continuity.",
         [UserSubscriptionType.Monthly]: (
           <>
-            If you don't renew it, it will disappear from your dashboard in 90
+            If you don&apos;t renew it, it will disappear from your dashboard in 90
             days. Contact{" "}
             <a href="mailto:customersuccess@canonical.com">
               customersuccess@canonical.com
@@ -124,9 +124,9 @@ const MESSAGES: Messages = {
         ),
         [UserSubscriptionType.Yearly]: (
           <>
-            If you don't renew it, it will disappear from your dashboard in 90
+            If you don&apos;t renew it, it will disappear from your dashboard in 90
             days. Contact{" "}
-            <a href="mailto:customersuccess@canonical.com">
+            <a href='mailto:customersuccess@canonical.com'>
               customersuccess@canonical.com
             </a>{" "}
             to renew.

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
@@ -171,6 +171,7 @@ export const SubscriptionDetails = forwardRef<HTMLDivElement, Props>(
               borderless
               className="p-subscriptions__details-notification"
               size={ExpiryNotificationSize.Large}
+              subscriptionType={subscription.type}
               statuses={subscription.statuses}
             />
             {notification ? <Notification {...notification} /> : null}

--- a/webapp/shop/api/ua_contracts/builders.py
+++ b/webapp/shop/api/ua_contracts/builders.py
@@ -248,9 +248,9 @@ def build_final_user_subscriptions(
             statuses=statuses,
         )
 
-        # Do not return expired user subscriptions after 30 days
+        # Do not return expired user subscriptions after 90 days
         show_user_subscription = True
-        days_to_show = -120 if type == "legacy" else -30
+        days_to_show = -90
         if type != "free":
             parsed_end_date = parse(user_subscription.end_date)
             time_now = datetime.utcnow().replace(tzinfo=pytz.utc)


### PR DESCRIPTION
## Done

- Update is_expiring, is_grace_period and is_expired notifications
- Implement custom messages for subscription details
- Make all subscriptions disappear after a max of 90 days 

## QA

- Hard to QA since we no longer have monthly subscriptions.
- Some screenshots for proof:

Is expiring soon:
![image](https://user-images.githubusercontent.com/6387619/194294817-597eda87-333a-4ac6-aa96-8176ba60f5d9.png)

Grace period:
![image](https://user-images.githubusercontent.com/6387619/194294706-e1316921-ff71-4424-8557-7ac60ae8b18f.png)

Expired:
![image](https://user-images.githubusercontent.com/6387619/194294904-3e158a98-942a-468b-9146-5dc723005598.png)

## Issue / Card

Fixes #https://github.com/canonical/commercial-squad/issues/710