### PR TITLE
Fix broken references link

### DIFF
--- a/templates/security/notices/usn.html
+++ b/templates/security/notices/usn.html
@@ -92,7 +92,7 @@
 
         {% if notice.references %}
           {% for reference in notice.references %}
-            <li class="p-list__item"><a href="{{ reference }}">{{ reference }}</li>
+            <li class="p-list__item"><a href="{{ reference }}">{{ reference }}</a></li>
           {% endfor %}
         {% endif %}
       </ul>


### PR DESCRIPTION
## Done

- Fixed broken references link

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/notices/USN-5583-2
    - Be sure to test on mobile, tablet and desktop screen sizes
- See that the "Related Notices" title is no longer a link

## Issue / Card

Fixes https://github.com/canonical/ubuntu.com/issues/12028