### PR TITLE
fix: closing contact modal when we release mouse on backdrop

### DIFF
--- a/static/js/src/dynamic-forms.js
+++ b/static/js/src/dynamic-forms.js
@@ -5,6 +5,7 @@
     var contactButtons = document.querySelectorAll(".js-invoke-modal");
     const contactForm = document.getElementById("contact-form-container");
     const returnData = window.location.pathname + "#success";
+    const contactModalSelector = "contact-modal";
 
     contactButtons.forEach(function (contactButton) {
       contactButton.addEventListener("click", function (e) {
@@ -175,7 +176,7 @@
 
     function initialiseForm() {
       var contactIndex = 1;
-      var contactModal = document.getElementById("contact-modal");
+      const contactModal = document.getElementById(contactModalSelector);
       var closeModal = document.querySelector(".p-modal__close");
       var closeModalButton = document.querySelector(".js-close");
       var modalPaginationButtons = contactModal.querySelectorAll(
@@ -220,8 +221,12 @@
       }
 
       if (contactModal) {
-        contactModal.addEventListener("click", function (e) {
-          if (e.target.id == "contact-modal") {
+        let isClickStartedInside = false;
+        contactModal.addEventListener("mousedown", function (e) {
+          isClickStartedInside = e.target.id !== contactModalSelector;
+        });
+        contactModal.addEventListener("mouseup", function (e) {
+          if (!isClickStartedInside && e.target.id === contactModalSelector) {
             e.preventDefault();
             close();
           }


### PR DESCRIPTION
## Done

- fixes the closing contact modal when we mousedown inside modal then we release it on backdrop.
(this is a known issue in chrome)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/kubernetes
    - Click on the CTA to open the modal.
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #11648 

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
