### PR TITLE
update blog tag on /wsl

### DIFF
--- a/templates/wsl/index.html
+++ b/templates/wsl/index.html
@@ -309,7 +309,7 @@
   </div>
 </section>
 
-{% with section_classes='p-strip is-deep is-bordered', heading_topic='Ubuntu WSL', tag_name='wsl', tag_id='3328', limit='4' %}
+{% with section_classes='p-strip is-deep is-bordered', heading_topic='Ubuntu WSL', tag_name='ubuntu-wsl', tag_id='3332', limit='4' %}
   {% include "shared/_latest_news_strip.html" %}
 {% endwith %}
 


### PR DESCRIPTION
## Done

- Updated the include on /wsl to use the updated blog tag

## QA

- Visit https://ubuntu-com-12037.demos.haus/wsl
- Or check out this branch, run `dotrun` and visit http://0.0.0.0:8001/wsl
- See that there are blogs listed under the "Latest Ubuntu WSL news from our blog ›" section
- See also the "our blog" link works
- Compare to live, where are there no posts and the "our blog" link 404s: https://ubuntu.com/blog/tag/wsl

## Issue / Card

Fixes https://github.com/canonical/web-squad/issues/5962
