### PR TITLE
Update /iot/smart-home copy

### DIFF
--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -254,10 +254,10 @@
       <p class="p-heading--4 u-sv2"><a href="/internet-of-things/smart-displays">Signage&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-3">
-      <p class="p-heading--4 u-sv2"><a href="/internet-of-things/smart-city">Smart Cities&nbsp;&rsaquo;</a></p>
+      <p class="p-heading--4 u-sv2"><a href="/internet-of-things/smart-city">Smart cities&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-3">
-      <p class="p-heading--4 u-sv2"><a href="/internet-of-things/smart-home">Smart Home&nbsp;&rsaquo;</a></p>
+      <p class="p-heading--4 u-sv2"><a href="/internet-of-things/smart-home">Smart home&nbsp;&rsaquo;</a></p>
     </div>
   </div>
   <div class="u-fixed-width">

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -141,7 +141,7 @@
     <h3 class="u-sv3">Get Core. Get snaps. Get going.</h3>
   </div>
   <div class="row u-equal-height u-align--center u-vertically-center u-hide--medium u-hide--small">
-    <div class="col-2">
+    <div class="col-3">
       <div class="u-sv2">
       {{ image (
         url="https://assets.ubuntu.com/v1/af98e3d6-automotive_car-network.svg",
@@ -154,7 +154,7 @@
         }}
       </div>
     </div>
-    <div class="col-2">
+    <div class="col-3">
       <div class="u-sv2">
         {{ image (
           url="https://assets.ubuntu.com/v1/5e32acc5-Factory.svg",
@@ -167,7 +167,7 @@
         }}
       </div>
     </div>
-    <div class="col-2">
+    <div class="col-3">
       <div class="u-sv2">
         {{ image (
           url="https://assets.ubuntu.com/v1/e39199bc-Internet+of+Things_digital-gateways.svg",
@@ -180,7 +180,7 @@
           }}
       </div>
     </div>
-    <div class="col-2">
+    <div class="col-3">
       <div class="u-sv2">
         {{ image (
           url="https://assets.ubuntu.com/v1/38efd13b-solution-robot.svg",
@@ -193,7 +193,23 @@
         }}
       </div>
     </div>
-    <div class="col-2">
+  </div>
+  <div class="row u-align--center">
+    <div class="col-3">
+      <p class="p-heading--4 u-sv2"><a href="/automotive">Automotive&nbsp;&rsaquo;</a></p>
+    </div>
+    <div class="col-3">
+      <p class="p-heading--4 u-sv2"><a href="/industrial">Industrial&nbsp;&rsaquo;</a></p>
+    </div>
+    <div class="col-3">
+      <p class="p-heading--4 u-sv2"><a href="/internet-of-things">IoT Gateways&nbsp;&rsaquo;</a></p>
+    </div>
+    <div class="col-3">
+      <p class="p-heading--4 u-sv2"><a href="robotics">Robotics&nbsp;&rsaquo;</a></p>
+    </div>
+  </div>
+  <div class="row u-equal-height u-align--center u-vertically-center u-hide--medium u-hide--small">
+    <div class="col-3">
       <div class="u-sv2">
         {{ image (
           url="https://assets.ubuntu.com/v1/ec2d60d0-IoT_Digital_Signage.svg",
@@ -206,7 +222,7 @@
           }}
       </div>
     </div>
-    <div class="col-2">
+    <div class="col-3">
       <div class="u-sv2">
         {{ image (
           url="https://assets.ubuntu.com/v1/e395cad3-Kubernetes_Financial_Overview.svg",
@@ -219,25 +235,29 @@
         }}
       </div>
     </div>
+    <div class="col-3">
+      <div class="u-sv2">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/32675035-smart-home.png",
+          alt="",
+          width="110",
+          height="80",
+          hi_def=True,
+          loading="lazy",
+          ) | safe
+        }}
+      </div>
+    </div>
   </div>
   <div class="row u-align--center">
-    <div class="col-2">
-      <p class="p-heading--4 u-sv2"><a href="/automotive">Automotive&nbsp;&rsaquo;</a></p>
-    </div>
-    <div class="col-2">
-      <p class="p-heading--4 u-sv2"><a href="/industrial">Industrial&nbsp;&rsaquo;</a></p>
-    </div>
-    <div class="col-2">
-      <p class="p-heading--4 u-sv2"><a href="/internet-of-things">IoT Gateways&nbsp;&rsaquo;</a></p>
-    </div>
-    <div class="col-2">
-      <p class="p-heading--4 u-sv2"><a href="robotics">Robotics&nbsp;&rsaquo;</a></p>
-    </div>
-    <div class="col-2">
+    <div class="col-3">
       <p class="p-heading--4 u-sv2"><a href="/internet-of-things/smart-displays">Signage&nbsp;&rsaquo;</a></p>
     </div>
-    <div class="col-2">
+    <div class="col-3">
       <p class="p-heading--4 u-sv2"><a href="/internet-of-things/smart-city">Smart Cities&nbsp;&rsaquo;</a></p>
+    </div>
+    <div class="col-3">
+      <p class="p-heading--4 u-sv2"><a href="/internet-of-things/smart-home">Smart Home&nbsp;&rsaquo;</a></p>
     </div>
   </div>
   <div class="u-fixed-width">

--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -165,6 +165,29 @@
         </div>
       </div>
     </div>
+    <div class="col-6 p-tile">
+      <div class="row p-tile__row">
+        <div class="col-3 col-medium-3 u-hide--small">
+          <div class="u-align--center">
+            {{ 
+              image (
+                url="https://assets.ubuntu.com/v1/32675035-smart-home.png",
+                alt="",
+                width="220",
+                height="160",
+                hi_def=True,
+                loading="lazy"
+              ) | safe
+            }}  
+          </div>
+        </div>
+        <div class="col-3 col-medium-3">
+          <h2 class="p-heading--3">Smart home</h2>
+          <p>Reduce development cost for consumer devices with Ubuntu.</p>
+          <p><a href="/internet-of-things/smart-home">Learn more&nbsp;&rsaquo;</a></p>
+        </div>
+      </div>
+    </div>
   </div>
 </section>
 

--- a/templates/internet-of-things/smart-home.html
+++ b/templates/internet-of-things/smart-home.html
@@ -57,7 +57,7 @@
   <div class="row">
     <div class="col-6">
       <h3>Devices that speak a common language</h3>
-      <p>Canonical <a href="#">recently announced</a> its membership in the Connectivity Standards Alliance and its upcoming support for the Matter standard. <a href="#get-in-touch" class="js-invoke-modal">Sign up</a> to receive smart home and IoT news.</p>
+      <p>Canonical <a href="https://ubuntu.com/blog/canonical-joins-the-connectivity-standards-alliance">recently announced</a> its membership in the Connectivity Standards Alliance and its upcoming support for the Matter standard. <a href="#get-in-touch" class="js-invoke-modal">Sign up</a> to receive smart home and IoT news.</p>
     </div>
     <div class="col-6 u-hide--medium u-hide--small">
       {{

--- a/templates/internet-of-things/smart-home.html
+++ b/templates/internet-of-things/smart-home.html
@@ -52,6 +52,30 @@
 
 <section class="p-strip">
   <div class="u-fixed-width">
+    <h2>Universal compatibility</h2>
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <h3>Devices that speak a common language</h3>
+      <p>Canonical <a href="#">recently announced</a> its membership in the Connectivity Standards Alliance and its upcoming support for the Matter standard. <a href="#get-in-touch" class="js-invoke-modal">Sign up</a> to receive smart home and IoT news.</p>
+    </div>
+    <div class="col-6 u-hide--medium u-hide--small">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/d988b991-matter_lkup_rgb_night.png",
+          alt="",
+          height="178",
+          width="513",
+          hi_def=True,
+          loading="lazy"
+        ) | safe
+      }}
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="u-fixed-width">
     <h2>Secure, resilient, low-touch</h2>
   </div>
   <div class="row">
@@ -117,7 +141,7 @@
   </div>
 </section>
 
-<section class="p-strip--light">
+<section class="p-strip">
   <div class="u-fixed-width">
     <h2>How to develop your open source smart home application</h2>
 


### PR DESCRIPTION
## Done

:warning: **don't merge yet**: we're waiting on a link to a press release before this can go live, we should have it on the 21st September :warning: 
- Updated the copy on /iot/smart-home based on the [copy doc](https://docs.google.com/document/d/1zwB-6Flt0Jm7XIxhWUWRJjKC1WCGVmVVNmPHtyOTHuE/edit#heading=h.bng9y130lz6e)
- Added a link to /smart-home from /core and /internet-of-things

## QA

- Visit https://ubuntu-com-12041.demos.haus/internet-of-things/smart-home
- See that the copy matches the new section in the copy doc
- Visit https://ubuntu-com-12041.demos.haus/internet-of-things
- See that the Smart home link works
- Visit https://ubuntu-com-12041.demos.haus/core
- See that the Smart home link works

## Issue / Card

Fixes https://github.com/canonical/web-squad/issues/5939
