### PR TITLE
Engage pages access to content feature

### DIFF
--- a/templates/engage/shared/_de_thank-you.html
+++ b/templates/engage/shared/_de_thank-you.html
@@ -37,13 +37,32 @@
 <section class="p-strip">
   <div class="row">
     <div class="col-8">
-      {% if 'pages.ubuntu.com' in resource_url %}
-      <p>
-        {{ resource_name }} ist jetzt zum Download bereit.
-      </p>
-      <p>
-        <a class="p-button--positive" href="{{ resource_url }}">Herunterladen</a>
-      </p>
+      {% if 'pages.ubuntu.com' or 'assets.ubuntu.com' in resource_url %}
+        {% if form_details and "access_to_content" in metadata and metadata.access_to_content == "true" %}
+
+        <h3>Wir haben eine Kopie des Whitepapers per e-mail {{ resource_name }} an {{ form_details.email }}</h3>
+        <p>
+          <a class="p-button--positive" href="{{ request_url }}">Zurück zur letzten Seite</a>
+          <a class="p-button" href="/contact-us">Kontaktiere uns</a>
+        </p>          
+        <p>
+          Nicht erhalten? Überprüfen Sie Ihren Spam-Ordner und ob Sie die richtige E-Mail-Adresse verwendet haben.
+        </p>
+        <p>
+          <a href="{{ request_url }}">Oder versuchen Sie es erneut</a>
+        </p>
+
+      {% else %}
+        {% if "thank_you_text" in metadata %}
+          <p>{{ metadata["thank_you_text"] }}</p>
+        {% else %}
+          <p>{{ resource_name }} ist jetzt zum Download bereit.</p>
+        {% endif %}
+        {% if "contact_form_only" not in metadata and metadata.contact_form_only != "true" or ("access_to_content" in metadata and metadata.access_to_content == "true") %}
+        <p>
+          <a class="p-button--positive" href="{{ resource_url }}">Herunterladen</a>
+        </p>
+        {% endif %}
       {% else %}
         <p>
           Diese Downloadanfrage wird leider nicht erkannt. Bitte teilen Sie uns dies unter <a href="https://github.com/canonical-websites/www.ubuntu.com/issues/new?body=Bad+resource+download+link+from {{ request.url | urlencode }}">Einreichung und Ausgabe auf GitHub </a>. Und lassen Sie uns wissen, was Sie zum Herunterladen ausgenommen haben.

--- a/templates/engage/shared/_en_engage_form.html
+++ b/templates/engage/shared/_en_engage_form.html
@@ -4,7 +4,7 @@
     <ul class="p-list">
       <li class="p-list__item">
         <label for="firstName">First name:</label>
-        <input required id="firstName" name="firstName" maxlength="255" type="text">
+        <input required id="firstName" name="firstName" maxlength="255" type="text" value="">
       </li>
       <li>
         <label for="lastName">Last name:</label>
@@ -12,7 +12,7 @@
       </li>
       <li>
         <label for="email">Work email:</label>
-        <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$">
+        <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" value="">
       </li>
       <li>
         <label for="company">Company name:</label>

--- a/templates/engage/shared/_es_thank-you.html
+++ b/templates/engage/shared/_es_thank-you.html
@@ -35,21 +35,39 @@
 </section>
 
 <section class="p-strip">
-  <div class="row">
-    <div class="col-8">
-      {% if 'pages.ubuntu.com' in resource_url %}
-      <p>
-        El {{ resource_name }} est&aacute; listo para descargar.
-      </p>
-      <p>
-        <a class="p-button--positive" href="{{ resource_url }}">Descarga</a>
-      </p>
-      {% else %}
+  <div class="u-fixed-width">
+    {% if 'pages.ubuntu.com' or 'assets.ubuntu.com' in resource_url %}
+      {% if form_details and "access_to_content" in metadata and metadata.access_to_content == "true" %}
+
+        <h3>Le hemos enviado una copia de {{ resource_name }} a {{ form_details.email }}</h3>
         <p>
-          Disculpa, no hemos entendido la petici&oacute; de descarga.  Por favor, inf&oacute;rmanos rellenando <a href="https://github.com/canonical-websites/www.ubuntu.com/issues/new?body=Bad+resource+download+link+from {{ request.url | urlencode }}">este formulario en GitHub</a>. Y dinos qu&eacute; esperabas descargarte.
+          <a class="p-button--positive" href="{{ request_url }}">A la p&aacute;gina anterior</a>
+          <a class="p-button" href="/contact-us">Cont&aacute;ctanos</a>
+        </p>          
+        <p>
+          ¿No lo ha recibido? Revise la carpeta de spam y aseg&uacute;rese de haber introducido el e-mail correcto.
         </p>
+        <p>
+          <a href="{{ request_url }}">O pruebe enviarlo de nuevo.</a>
+        </p>
+
+      {% else %}
+        {% if "thank_you_text" in metadata %}
+          <p>{{ metadata["thank_you_text"] }}</p>
+        {% else %}
+          <p>
+            El {{ resource_name }} est&aacute; listo para descargar.
+          </p>
+        {% if "contact_form_only" not in metadata and metadata.contact_form_only != "true" or ("access_to_content" in metadata and metadata.access_to_content == "true") %}
+          <p>
+            <a class="p-button--positive" href="{{ resource_url }}">Descargar</a>
+          </p>
       {% endif %}
-    </div>
+    {% else %}
+      <p>
+        Disculpa, no hemos entendido la petici&oacute; de descarga.  Por favor, inf&oacute;rmanos rellenando <a href="https://github.com/canonical-websites/www.ubuntu.com/issues/new?body=Bad+resource+download+link+from {{ request.url | urlencode }}">este formulario en GitHub</a>. Y dinos qu&eacute; esperabas descargarte.
+      </p>
+    {% endif %}
   </div>
 </section>
 

--- a/templates/engage/shared/_fr_thank-you.html
+++ b/templates/engage/shared/_fr_thank-you.html
@@ -37,13 +37,36 @@
 <section class="p-strip">
   <div class="row">
     <div class="col-8">
-      {% if 'pages.ubuntu.com' in resource_url %}
-      <p>
-        La {{ resource_name }} est prête à être téléchargée.
-      </p>
-      <p>
-        <a class="p-button--positive" href="{{ resource_url }}">Download</a>
-      </p>
+      {% if 'pages.ubuntu.com' or 'assets.ubuntu.com' in resource_url %}
+        {% if form_details and "access_to_content" in metadata and metadata.access_to_content == "true" %}
+  
+
+        <h3>Nous avons envoyé une copie de {{ resource_name }} à {{ form_details.email }}</h3>
+        <p>
+          <a class="p-button--positive" href="{{ request_url }}">Retour à la dernière page</a>
+          <a class="p-button" href="/contact-us">Contactez-nous</a>
+        </p>          
+        <p>
+          Pas reçu? Vérifiez votre dossier spam et vérifiez que vous avez utilisé la bonne adresse e-mail.
+        </p>
+        <p>
+          <a href="{{ request_url }}">Ou essayez de le renvoyer</a>
+        </p>
+
+        {% else %}
+          {% if "thank_you_text" in metadata %}
+            <p>{{ metadata["thank_you_text"] }}</p>
+          {% else %}
+          <p>
+            La {{ resource_name }} est prête à être téléchargée.
+          </p>
+          {% endif %}
+          {% if "contact_form_only" not in metadata and metadata.contact_form_only != "true" or ("access_to_content" in metadata and metadata.access_to_content == "true") %}
+            <p>
+              <a class="p-button--positive" href="{{ resource_url }}">Téléchargée</a>
+            </p>
+          {% endif %}
+        {% endif %}
       {% else %}
         <p>
             Désolé, nous ne reconnaissons pas cette demande de téléchargement. Veuillez nous le <a href="https://github.com/canonical-websites/www.ubuntu.com/issues/new?body=Bad+resource+download+link+from {{ request.url | urlencode }}">faire savoir en déposant et en émettant un problème sur GitHub</a>. Et dites-nous ce que vous attendiez de télécharger.

--- a/templates/engage/shared/_it_thank-you.html
+++ b/templates/engage/shared/_it_thank-you.html
@@ -37,16 +37,38 @@
 <section class="p-strip">
   <div class="row">
     <div class="col-8">
-      {% if 'pages.ubuntu.com' in resource_url %}
-      <p>
-        La {{ resource_name }} risorsa è ora pronta per il download.
-      </p>
-      <p>
-        <a class="p-button--positive" href="{{ resource_url }}">Download</a>
-      </p>
+      {% if 'pages.ubuntu.com' or 'assets.ubuntu.com' in resource_url %}
+        {% if form_details and "access_to_content" in metadata and metadata.access_to_content == "true" %}
+
+        <h3>Abbiamo inviato una copia di {{ resource_name }} a {{ form_details.email }}</h3>
+        <p>
+          <a class="p-button--positive" href="{{ request_url }}">Torna all'ultima pagina</a>
+          <a class="p-button" href="/contact-us">Contattaci</a>
+        </p>          
+        <p>
+          Non l'hai ricevuto? Controlla la tua cartella spam e di aver utilizzato l'indirizzo email corretto.
+        </p>
+        <p>
+          <a href="{{ request_url }}">Oppure prova a inviarlo di nuovo</a>
+        </p>
+
+        {% else %}
+          {% if "thank_you_text" in metadata %}
+            <p>{{ metadata["thank_you_text"] }}</p>
+          {% else %}
+            <p>
+              La {{ resource_name }} risorsa è ora pronta per il scarica.
+            </p>
+          {% endif %}
+          {% if "contact_form_only" not in metadata and metadata.contact_form_only != "true" or ("access_to_content" in metadata and metadata.access_to_content == "true") %}
+          <p>
+            <a class="p-button--positive" href="{{ resource_url }}">Scarica</a>
+          </p>
+          {% endif %}
+        {% endif %}
       {% else %}
         <p>
-            Spiacenti, non riconosciamo questa richiesta di download. Fatecelo sapere tramite <a href="https://github.com/canonical-websites/www.ubuntu.com/issues/new?body=Bad+resource+download+link+from {{ request.url | urlencode }}"> archiviazione ed emissione su GitHub </a>. E facci sapere cosa hai escluso per il download.
+            Spiacenti, non riconosciamo questa richiesta di scarica. Fatecelo sapere tramite <a href="https://github.com/canonical-websites/www.ubuntu.com/issues/new?body=Bad+resource+download+link+from {{ request.url | urlencode }}"> archiviazione ed emissione su GitHub </a>. E facci sapere cosa hai escluso per il download.
         </p>
       {% endif %}
     </div>

--- a/templates/engage/shared/_pt_thank-you.html
+++ b/templates/engage/shared/_pt_thank-you.html
@@ -37,13 +37,32 @@
 <section class="p-strip">
   <div class="row">
     <div class="col-8">
-      {% if 'pages.ubuntu.com' in resource_url %}
-      <p>
-        {{ resource_name | capitalize }} est&aacute; pronto para download.
-      </p>
-      <p>
-        <a class="p-button--positive" href="{{ resource_url }}">Download</a>
-      </p>
+      {% if 'pages.ubuntu.com' or 'assets.ubuntu.com' in resource_url %}
+        {% if form_details and "access_to_content" in metadata and metadata.access_to_content == "true" %}
+          <h3>Enviamos uma cópia do e-mail {{ resource_name }} para {{ form_details.email }}</h3>
+          <p>
+            <a class="p-button--positive" href="{{ request_url }}">Voltar para a última página</a>
+            <a class="p-button" href="/contact-us">Contate-Nos</a>
+          </p>          
+          <p>
+            Não recebeu? Verifique sua pasta de spam e se você usou o endereço de e-mail correto.
+          </p>
+          <p>
+            <a href="{{ request_url }}">Ou tente reenviar</a>
+          </p>
+
+      {% else %}
+        {% if "thank_you_text" in metadata %}
+          <p>{{ metadata["thank_you_text"] }}</p>
+        {% else %}
+        <p>
+          {{ resource_name | capitalize }} est&aacute; pronto para download.
+        </p>
+        {% if "contact_form_only" not in metadata and metadata.contact_form_only != "true" or ("access_to_content" in metadata and metadata.access_to_content == "true") %}
+        <p>
+          <a class="p-button--positive" href="{{ resource_url }}">Download</a>
+        </p>
+        {% endif %}
       {% else %}
         <p>
           Desculpe, não reconhecemos esta solicitação de download. Informe-nos por <a href="https://github.com/canonical-websites/www.ubuntu.com/issues/new?body=Bad+resource+download+link+from {{ request.url | urlencode }}">arquivamento e problema no GitHub </a>. E diga-nos o que você deseja baixar.

--- a/templates/engage/shared/_ru_thank-you.html
+++ b/templates/engage/shared/_ru_thank-you.html
@@ -38,15 +38,34 @@
   <div class="row">
     <div class="col-8">
       {% if 'pages.ubuntu.com' or 'assets.ubuntu.com' in resource_url %}
-      <p>
-        {{ resource_name }} готов к загрузке.
-      </p>
-      <p>
-        <a class="p-button--positive" href="{{ resource_url }}">Загрузить</a>
-      </p>
+        {% if form_details and "access_to_content" in metadata and metadata.access_to_content == "true" %}
+          <h3>Мы отправили вам копию {{ resource_name }} по {{ form_details.email }}</h3>
+          <p>
+            <a class="p-button--positive" href="{{ request_url }}">Вернуться к последней странице</a>
+            <a class="p-button" href="/contact-us">Свяжитесь с нами</a>
+          </p>          
+          <p>
+            Не получил? Проверьте папку со спамом и убедитесь, что вы использовали правильный адрес электронной почты.
+          </p>
+          <p>
+            <a href="{{ request_url }}">Или попробуйте отправить повторно</a>
+          </p>
+
+      {% else %}
+        {% if "thank_you_text" in metadata %}
+          <p>{{ metadata["thank_you_text"] }}</p>
+        {% else %}
+        <p>
+          {{ resource_name }} готов к загрузке.
+        </p>
+        {% if "contact_form_only" not in metadata and metadata.contact_form_only != "true" or ("access_to_content" in metadata and metadata.access_to_content == "true") %}
+        <p>
+          <a class="p-button--positive" href="{{ resource_url }}">Загрузить</a>
+        </p>
+        {% endif %}
       {% else %}
         <p>
-          Sorry, we do not recognise this download request.  Please let us know by <a href="https://github.com/canonical-websites/www.ubuntu.com/issues/new?body=Bad+resource+download+link+from {{ request.url | urlencode }}">filing and issue on GitHub</a>. And let us know what you excepted to download.
+          К сожалению, мы не распознаем этот запрос на загрузку. Пожалуйста, дайте нам знать <a href="https://github.com/canonical-websites/www.ubuntu.com/issues/new?body=Bad+resource+download+link+from {{ request.url | urlencode }}">заполнив вопрос на GitHub</a>, дайте нам знать, что вы ожидали загрузить.
         </p>
       {% endif %}
     </div>

--- a/templates/engage/thank-you.html
+++ b/templates/engage/thank-you.html
@@ -35,31 +35,44 @@
 </section>
 
 <section class="p-strip">
-  <div class="row">
-    <div class="col-8">
+  <div class="u-fixed-width">
+  {% if 'pages.ubuntu.com' or 'assets.ubuntu.com' in resource_url %}
+    {% if form_details and "access_to_content" in metadata and metadata.access_to_content == "true" %}
+    
+      <h3>We've emailed a copy of {{ resource_name }} to {{ form_details.email }}</h3>
       <p>
-        {% if "thank_you_text" in metadata %}
-          {{ metadata["thank_you_text"] }}
-        {% else %}
-          The {{ resource_name }} is now ready to download.
-        {% endif %}
+        <a class="p-button--positive" href="{{ request_url }}">Back to last page</a>
+        <a class="p-button" href="/contact-us">Contact us</a>
+      </p>          
+      <p>
+        Not received it? Check your spam folder and that you've used the right email address.
       </p>
-      {% if 'pages.ubuntu.com' or 'assets.ubuntu.com' in resource_url %}
-        {% if "contact_form_only" not in metadata and metadata.contact_form_only != "true" %}
-          <p>
-            <a class="p-button--positive" href="{{ resource_url }}">Download</a>
-          </p>
-        {% endif %}
+      <p>
+        <a href="{{ request_url }}">Or try resending it</a>
+      </p>
+
+    {% else %}
+      {% if "thank_you_text" in metadata %}
+        <p>{{ metadata["thank_you_text"] }}</p>
       {% else %}
+        <p>The {{ resource_name }} is now ready to download.</p>
+      {% endif %}
+      {% if "contact_form_only" not in metadata and metadata.contact_form_only != "true" or ("access_to_content" in metadata and metadata.access_to_content == "true") %}
         <p>
-          Sorry, we do not recognise this download request.  Please let us know by <a href="https://github.com/canonical-websites/www.ubuntu.com/issues/new?body=Bad+resource+download+link+from {{ request.url | urlencode }}">filing and issue on GitHub</a>. And let us know what you excepted to download.
+          <a class="p-button--positive" href="{{ resource_url }}">Download</a>
         </p>
       {% endif %}
-    </div>
+    {% endif %}
+      
+  {% else %}
+    <p>
+      Sorry, we do not recognise this download request.  Please let us know by <a href="https://github.com/canonical-websites/www.ubuntu.com/issues/new?body=Bad+resource+download+link+from {{ request.url | urlencode }}">filing and issue on GitHub</a>. And let us know what you excepted to download.
+    </p>
+  {% endif %}
   </div>
 </section>
 
-{% if related[1:3] | length > 0 %}
+{% if related | length > 0 %}
 <section class="p-strip--light">
   <div class="row">
     <div class="col-8">
@@ -67,7 +80,7 @@
     </div>
   </div>
   <div class="row p-divider">
-    {% for page in related[1:3] %}
+    {% for page in related %}
     <div class="col-4 p-divider__block">
       <!-- THREE ADDITIONAL CTAs -->
       <h4>{{page["topic_name"]}}</h4>

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -520,6 +520,12 @@ def engage_thank_you(engage_pages):
         else:
             template_language = "engage/thank-you.html"
 
+        try:
+            form_details = flask.session["form_details"]
+        except KeyError:
+            # Forbid direct access to thank-you page
+            return flask.abort(403)
+
         return flask.render_template(
             template_language,
             request_url=flask.request.referrer,
@@ -527,6 +533,7 @@ def engage_thank_you(engage_pages):
             resource_name=metadata["type"],
             resource_url=metadata["resource_url"],
             related=related,
+            form_details=form_details,
         )
 
     return render_template
@@ -864,6 +871,11 @@ def marketo_submit():
         pass
 
     if return_url:
+        # Personalize thank-you page
+        flask.session["form_details"] = {
+            "name": flask.request.form.get("firstName"),
+            "email": flask.request.form.get("email"),
+        }
         return flask.redirect(return_url)
 
     if referrer:


### PR DESCRIPTION
## Done

This feature will block users from accessing the resource (e.g. a whitepaper) directly, instead it will send an email with the resource attached (pending work on marketo back-end).
This is triggered by the metadata `access_to_content` which is set in the discourse topic

## QA

- Check https://ubuntu-com-12042.demos.haus/engage
- Click on the "Test access to content" engage page.
- Fill out the form and click download
- Compare with design https://miro.com/app/board/uXjVOjU5hYI=/

## Issue / Card

Fixes https://github.com/canonical/web-squad/issues/5817

## Screenshot

![image](https://user-images.githubusercontent.com/14939793/191790865-8fa43325-ff90-4f8a-9e15-a480ac5a69c2.png)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
