### PR TITLE
fix expandable navigation in server docs

### DIFF
--- a/templates/server/docs/document.html
+++ b/templates/server/docs/document.html
@@ -8,3 +8,8 @@
 %}
   {% include "templates/docs/shared/_docs.html" %}
 {% endwith %}
+
+{% block outer_content %}
+  <script src="{{ versioned_static('js/dist/side-navigation.js') }}" defer></script>
+  {% block content %}{% endblock %}
+{% endblock %}


### PR DESCRIPTION
## Done

- This change fixes server documentation navigation. Note that other docs may still be affected other than core and server

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #12048 



## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
