### PR TITLE
add side navigation js to shared docs template

### DIFF
--- a/templates/core/docs/document.html
+++ b/templates/core/docs/document.html
@@ -8,8 +8,3 @@
 %}
   {% include "templates/docs/shared/_docs.html" %}
 {% endwith %}
-
-{% block outer_content %}
-  <script src="{{ versioned_static('js/dist/side-navigation.js') }}" defer></script>
-  {% block content %}{% endblock %}
-{% endblock %}

--- a/templates/server/docs/document.html
+++ b/templates/server/docs/document.html
@@ -8,8 +8,3 @@
 %}
   {% include "templates/docs/shared/_docs.html" %}
 {% endwith %}
-
-{% block outer_content %}
-  <script src="{{ versioned_static('js/dist/side-navigation.js') }}" defer></script>
-  {% block content %}{% endblock %}
-{% endblock %}

--- a/templates/templates/docs/shared/_docs.html
+++ b/templates/templates/docs/shared/_docs.html
@@ -50,6 +50,7 @@
   placeholder=placeholder
 %}
   {% include "templates/docs/shared/_search-box.html" %}
+  <script src="{{ versioned_static('js/dist/side-navigation.js') }}" defer></script>
 {% endwith %}
 
 <div class="p-strip is-shallow">


### PR DESCRIPTION
## Done

- Fixed server docs side nav expanding functionality in multiple places

## QA

- Visit:
  - https://ubuntu-com-12050.demos.haus/ceph/docs
  - https://ubuntu-com-12050.demos.haus/server/docs
  - https://ubuntu-com-12050.demos.haus/core/docs
  - https://ubuntu-com-12050.demos.haus/security/certifications/docs
  - https://ubuntu-com-12050.demos.haus/security/livepatch/docs
- See that all the expandable nav sections work correctly i.e.
![Peek 2022-09-22 16-45](https://user-images.githubusercontent.com/2376968/191792922-6da66239-1300-48d8-9905-cd2e9b73559a.gif)

