### PR TITLE
Add Credentialling syllabus

### DIFF
--- a/templates/credentialing/index.html
+++ b/templates/credentialing/index.html
@@ -65,6 +65,7 @@
               class="p-button--positive"
               >Start</a
             >
+            <a href="/credentialing/syllabus?exam=Linux%20Essentials" class="p-button">Syllabus</a>
           </div>
         </div>
       </li>
@@ -89,6 +90,7 @@
               class="p-button--positive"
               >Start</a
             >
+            <a href="/credentialing/syllabus?exam=Desktop%20Essentials" class="p-button">Syllabus</a>
           </div>
         </div>
       </li>
@@ -113,6 +115,7 @@
               class="p-button--positive"
               >Start</a
             >
+            <a href="/credentialing/syllabus?exam=Server%20Essentials" class="p-button">Syllabus</a>
           </div>
         </div>
       </li>

--- a/templates/credentialing/index.html
+++ b/templates/credentialing/index.html
@@ -63,6 +63,7 @@
             <a
               href="https://cube.ubuntu.com/auth/login/tpa-saml/?auth_entry=login&idp=ubuntuone&next=/courses/course-v1:Canonical%2bcue-linux%2b2022/courseware/2022/start/"
               class="p-button--positive"
+              style="display: none;"
               >Start</a
             >
             <a href="/credentialing/syllabus?exam=Linux%20Essentials" class="p-button">Syllabus</a>
@@ -88,6 +89,7 @@
             <a
               href="https://cube.ubuntu.com/auth/login/tpa-saml/?auth_entry=login&idp=ubuntuone&next=/courses/course-v1:Canonical%2bcue-desktop%2b2022/courseware/2022/start/"
               class="p-button--positive"
+              style="display: none;"
               >Start</a
             >
             <a href="/credentialing/syllabus?exam=Desktop%20Essentials" class="p-button">Syllabus</a>
@@ -113,6 +115,7 @@
             <a
               href="https://cube.ubuntu.com/auth/login/tpa-saml/?auth_entry=login&idp=ubuntuone&next=/courses/course-v1:Canonical%2bcue-server%2b2022/courseware/2022/start/"
               class="p-button--positive"
+              style="display: none;"
               >Start</a
             >
             <a href="/credentialing/syllabus?exam=Server%20Essentials" class="p-button">Syllabus</a>
@@ -147,6 +150,7 @@
               <a
                 href="https://cube.ubuntu.com/auth/login/tpa-saml/?auth_entry=login&idp=ubuntuone&next=/courses/course-v1:Canonical%2bcue%2b2022/courseware/2022/start/"
                 class="p-button--positive"
+                style="display: none;"
                 >Start
               </a>
             </div>

--- a/templates/credentialing/syllabus.html
+++ b/templates/credentialing/syllabus.html
@@ -20,10 +20,10 @@
       {% for exam in syllabus_data %}
       <div tabindex="0" role="tabpanel" id="{{exam['exam_name']}}-tab" aria-labelledby="{{exam['exam_name']}}" {% if (exam_name and exam_name!=exam["exam_name"]) or (not exam_name and loop.index!=1) %}hidden="hidden"{% endif %}>
         <p>{{exam['exam_description']}}</p>
-        <ol class="p-list--nested-counter">
+        <ol class="p-stepped-list">
           {% for chapter in exam["syllabus"] %}
-          <li><strong>{{chapter['chapter_title']}}</strong>
-            <ol>
+          <li class="p-stepped-list__item"><h3 class="p-stepped-list__title">{{chapter['chapter_title']}}</h3>
+            <ol class="p-stepped-list__content">
               {% for section in chapter['chapter_sections'] %}
               <li>{{section}}</li>
               {% endfor %}

--- a/templates/credentialing/syllabus.html
+++ b/templates/credentialing/syllabus.html
@@ -1,0 +1,142 @@
+{% extends "credentialing/base_cube.html" %}
+
+{% block title %} Canonical Credentialing -- Syllabus {% endblock %}
+
+{% block meta_description %}The Canonical Ubuntu Essentials exams certify knowledge and verify skills in general Linux, Ubuntu Desktop, and Ubuntu Server topics.{% endblock meta_description %}
+{% block meta_copydoc %} https://docs.google.com/document/d/1T1K7jyUa32-OURET6AjN2CD_c80TaUmj9EncYT70PNw/edit?usp=sharing {% endblock meta_copydoc %}
+
+{% block content %}
+
+<section class="p-strip--suru-topped">
+  <div class="u-fixed-width">
+    <div class="p-tabs">
+      <div class="p-tabs__list" role="tablist" aria-label="CUE Syllabus">
+        {% for exam in syllabus_data %}
+        <div class="p-tabs__item">
+          <button class="p-tabs__link" role="tab" aria-controls="{{exam['exam_name']}}-tab" id="{{exam['exam_name']}}" {% if (exam_name and exam_name!=exam["exam_name"]) or (not exam_name and loop.index!=1) %}aria-selected="false"{% else %}aria-selected="true"{% endif %}>{{exam["exam_name"]}}</button>
+        </div>
+        {% endfor %}
+      </div>
+      {% for exam in syllabus_data %}
+      <div tabindex="0" role="tabpanel" id="{{exam['exam_name']}}-tab" aria-labelledby="{{exam['exam_name']}}" {% if (exam_name and exam_name!=exam["exam_name"]) or (not exam_name and loop.index!=1) %}hidden="hidden"{% endif %}>
+        <p>{{exam['exam_description']}}</p>
+        <ol class="p-list--nested-counter">
+          {% for chapter in exam["syllabus"] %}
+          <li><strong>{{chapter['chapter_title']}}</strong>
+            <ol>
+              {% for section in chapter['chapter_sections'] %}
+              <li>{{section}}</li>
+              {% endfor %}
+            </ol>
+          </li>
+          {% endfor %}
+        </ol>
+      </div>
+      {% endfor %}
+    </div>
+  </div>
+</section>
+<script>
+  (function () {
+  var keys = {
+    left: 'ArrowLeft',
+    right: 'ArrowRight',
+  };
+
+  var direction = {
+    ArrowLeft: -1,
+    ArrowRight: 1,
+  };
+
+  /**
+    Attaches a number of events that each trigger
+    the reveal of the chosen tab content
+    @param {Array} tabs an array of tabs within a container
+  */
+  function attachEvents(tabs) {
+    tabs.forEach(function (tab, index) {
+      tab.addEventListener('keyup', function (e) {
+        if (e.code === keys.left || e.code === keys.right) {
+          switchTabOnArrowPress(e, tabs);
+        }
+      });
+
+      tab.addEventListener('click', function (e) {
+        e.preventDefault();
+        setActiveTab(tab, tabs);
+      });
+
+      tab.addEventListener('focus', function () {
+        setActiveTab(tab, tabs);
+      });
+
+      tab.index = index;
+    });
+  }
+
+  /**
+    Determine which tab to show when an arrow key is pressed
+    @param {KeyboardEvent} event
+    @param {Array} tabs an array of tabs within a container
+  */
+  function switchTabOnArrowPress(event, tabs) {
+    var pressed = event.code;
+
+    if (direction[pressed]) {
+      var target = event.target;
+      if (target.index !== undefined) {
+        if (tabs[target.index + direction[pressed]]) {
+          tabs[target.index + direction[pressed]].focus();
+        } else if (pressed === keys.left) {
+          tabs[tabs.length - 1].focus();
+        } else if (pressed === keys.right) {
+          tabs[0].focus();
+        }
+      }
+    }
+  }
+
+  /**
+    Cycles through an array of tab elements and ensures 
+    only the target tab and its content are selected
+    @param {HTMLElement} tab the tab whose content will be shown
+    @param {Array} tabs an array of tabs within a container
+  */
+  function setActiveTab(tab, tabs) {
+    tabs.forEach(function (tabElement) {
+      var tabContent = document.getElementById(tabElement.getAttribute('aria-controls'));
+
+      if (tabElement === tab) {
+        tabElement.setAttribute('aria-selected', true);
+        tabContent.removeAttribute('hidden');
+      } else {
+        tabElement.setAttribute('aria-selected', false);
+        tabContent.setAttribute('hidden', true);
+      }
+    });
+  }
+
+  /**
+    Attaches events to tab links within a given parent element,
+    and sets the active tab if the current hash matches the id
+    of an element controlled by a tab link
+    @param {String} selector class name of the element 
+    containing the tabs we want to attach events to
+  */
+  function initTabs(selector) {
+    var tabContainers = [].slice.call(document.querySelectorAll(selector));
+
+    tabContainers.forEach(function (tabContainer) {
+      var tabs = [].slice.call(tabContainer.querySelectorAll('[aria-controls]'));
+      attachEvents(tabs);
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    initTabs('[role="tablist"]');
+  });
+})();
+
+</script>
+
+{% endblock %}

--- a/templates/credentialing/syllabus.html
+++ b/templates/credentialing/syllabus.html
@@ -11,7 +11,7 @@
   <div class="row u-equal-height">
     <div class="col-6">
       <h1> Certification Syllabus</h1>
-      <p class="p-heading--4">Each of our microcertification is specifically designed to be highly relevant to what matters in the industry today.</p>
+      <p class="p-heading--4">Each of our microcertifications is specifically designed to be relevant to what matters in the industry today</p>
     </div>
     <div class="col-4 col-start-large-9 u-hide--small u-vertically-center">
       {{
@@ -58,7 +58,7 @@
   <div class="u-fixed-height">
     <div class="row">
       <a href="/credentialing/schedule">
-        <button class="p-button--positive">Schedule you exam now</button>
+        <button class="p-button--positive">Schedule your exam now</button>
       </a>
     </div>
   </div>

--- a/templates/credentialing/syllabus.html
+++ b/templates/credentialing/syllabus.html
@@ -1,13 +1,33 @@
 {% extends "credentialing/base_cube.html" %}
 
-{% block title %} Canonical Credentialing -- Syllabus {% endblock %}
+{% block title %}Canonical Credentialing -- Syllabus{% endblock %}
 
 {% block meta_description %}The Canonical Ubuntu Essentials exams certify knowledge and verify skills in general Linux, Ubuntu Desktop, and Ubuntu Server topics.{% endblock meta_description %}
-{% block meta_copydoc %} https://docs.google.com/document/d/1T1K7jyUa32-OURET6AjN2CD_c80TaUmj9EncYT70PNw/edit?usp=sharing {% endblock meta_copydoc %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1T1K7jyUa32-OURET6AjN2CD_c80TaUmj9EncYT70PNw/edit?usp=sharing{% endblock meta_copydoc %}
 
 {% block content %}
 
 <section class="p-strip--suru-topped">
+  <div class="row u-equal-height">
+    <div class="col-6">
+      <h1> Certification Syllabus</h1>
+      <p class="p-heading--4">Each of our microcertification is specifically designed to be highly relevant to what matters in the industry today.</p>
+    </div>
+    <div class="col-4 col-start-large-9 u-hide--small u-vertically-center">
+      {{
+        image (
+        url="https://assets.ubuntu.com/v1/7bf909cc-Admin.svg",
+        alt="Canonical Ubuntu Essentials badge",
+        width="175",
+        height="205",
+        hi_def=True,
+        loading="auto"
+        ) | safe
+      }}
+    </div>
+  </div>
+</section>
+<section class="p-strip--light">
   <div class="u-fixed-width">
     <div class="p-tabs">
       <div class="p-tabs__list" role="tablist" aria-label="CUE Syllabus">
@@ -33,6 +53,13 @@
         </ol>
       </div>
       {% endfor %}
+    </div>
+  </div>
+  <div class="u-fixed-height">
+    <div class="row">
+      <a href="/credentialing/schedule">
+        <button class="p-button--positive">Schedule you exam now</button>
+      </a>
     </div>
   </div>
 </section>

--- a/templates/credentialing/syllabus.html
+++ b/templates/credentialing/syllabus.html
@@ -57,7 +57,7 @@
   </div>
   <div class="u-fixed-height">
     <div class="row">
-      <a href="/credentialing/schedule">
+      <a href="/credentialing/schedule" style="display: none;">
         <button class="p-button--positive">Schedule your exam now</button>
       </a>
     </div>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -44,6 +44,7 @@ from webapp.context import (
 
 from webapp.shop.flaskparser import UAContractsValidationError
 from webapp.shop.cube.views import (
+    cred_syllabus_data,
     cube_home,
     cube_microcerts,
     cube_study_labs_button,
@@ -898,6 +899,7 @@ core_als_autils_docs.init_app(app)
 
 # Cube docs
 app.add_url_rule("/credentialing", view_func=cube_home)
+app.add_url_rule("/credentialing/syllabus",view_func=cred_syllabus_data)
 app.add_url_rule("/cube/microcerts", view_func=cube_microcerts)
 app.add_url_rule("/cube/microcerts.json", view_func=get_microcerts)
 app.add_url_rule(

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -899,7 +899,7 @@ core_als_autils_docs.init_app(app)
 
 # Cube docs
 app.add_url_rule("/credentialing", view_func=cube_home)
-app.add_url_rule("/credentialing/syllabus",view_func=cred_syllabus_data)
+app.add_url_rule("/credentialing/syllabus", view_func=cred_syllabus_data)
 app.add_url_rule("/cube/microcerts", view_func=cube_microcerts)
 app.add_url_rule("/cube/microcerts.json", view_func=get_microcerts)
 app.add_url_rule(

--- a/webapp/shop/cube/syllabus.json
+++ b/webapp/shop/cube/syllabus.json
@@ -4,7 +4,7 @@
     "exam_description": "Prove your knowledge of the Linux community, history, and philosophy. Topics include common Linux commands, open source and software licensing, and basic knowledge of Linux architecture and file hierarchy.",
     "syllabus": [
       {
-        "chapter_title": "Identify and execute common Linux commands.",
+        "chapter_title": "Identify and execute common Linux commands",
         "chapter_sections": [
           "Navigation commands",
           "System information commands",
@@ -12,7 +12,7 @@
         ]
       },
       {
-        "chapter_title": "Manipulate files using the command line.",
+        "chapter_title": "Manipulate files using the command line",
         "chapter_sections": [
           "Understand basic shell syntax",
           "Create, read, move, delete, copy, and convert files",
@@ -23,7 +23,7 @@
         ]
       },
       {
-        "chapter_title": "Understand the fundamentals of Linux architecture.",
+        "chapter_title": "Understand the fundamentals of Linux architecture",
         "chapter_sections": [
           "Packaging styles",
           "File types",
@@ -37,7 +37,7 @@
     "exam_description": "Demonstrate your knowledge of Ubuntu Desktop administrative essentials. Focus on package management, system installation, data gathering, and managing printing and displays.",
     "syllabus": [
       {
-        "chapter_title": "Be acquainted with the Ubuntu community and its conventions.",
+        "chapter_title": "Be acquainted with the Ubuntu community and its conventions",
         "chapter_sections": [
           "Identify the year of Ubuntu’s first release",
           "Understand what an LTS is and entails",
@@ -45,7 +45,7 @@
         ]
       },
       {
-        "chapter_title": "Install and operate Ubuntu on your system.",
+        "chapter_title": "Install and operate Ubuntu on your system",
         "chapter_sections": [
           "Install Ubuntu via ISO",
           "Identify installation styles",
@@ -58,7 +58,7 @@
         ]
       },
       {
-        "chapter_title": "Manage packages on an Ubuntu system.",
+        "chapter_title": "Manage packages on an Ubuntu system",
         "chapter_sections": [
           "Install packages, including from PPA repositories",
           "Identify the packages installed on your system",
@@ -70,7 +70,7 @@
         ]
       },
       {
-        "chapter_title": "Gather important system information.",
+        "chapter_title": "Gather important system information",
         "chapter_sections": [
           "Display and record your current Ubuntu distribution",
           "Display and record CPU capabilities",
@@ -79,7 +79,7 @@
         ]
       },
       {
-        "chapter_title": "Manage files and permissions.",
+        "chapter_title": "Manage files and permissions",
         "chapter_sections": [
           "Check file permissions",
           "Grant and revoke permissions",
@@ -89,7 +89,7 @@
         ]
       },
       {
-        "chapter_title": "Configure and manage displays and other desktop hardware.",
+        "chapter_title": "Configure and manage displays and other desktop hardware",
         "chapter_sections": [
           "Enable and disable devices from the command line",
           "Distinguish between desktop and server environments",
@@ -99,7 +99,7 @@
         ]
       },
       {
-        "chapter_title": "Configure networking capabilities.",
+        "chapter_title": "Configure networking capabilities",
         "chapter_sections": [
           "Configure and use SSH",
           "Copy files and directories with rsync",
@@ -115,7 +115,7 @@
     "exam_description": "Illustrate your knowledge of common Ubuntu Server administrative tasks and troubleshooting. Topics include job control, performance tuning, services management, and Bash scripting.",
     "syllabus": [
       {
-        "chapter_title": "Perform common administrative tasks.",
+        "chapter_title": "Perform common administrative tasks",
         "chapter_sections": [
           "Manage users, groups, and permissions",
           "Configure local storage",
@@ -127,7 +127,7 @@
         ]
       },
       {
-        "chapter_title": "Troubleshoot issues.",
+        "chapter_title": "Troubleshoot issues",
         "chapter_sections": [
           "Obtain diagnostic information about disks, services, ports, and connections",
           "Find and interpret log files",
@@ -137,7 +137,7 @@
         ]
       },
       {
-        "chapter_title": "Configure and control automated tasks.",
+        "chapter_title": "Configure and control automated tasks",
         "chapter_sections": [
           "Write and interpret Bash scripts",
           "Manage cron jobs",
@@ -145,7 +145,7 @@
         ]
       },
       {
-        "chapter_title": "Tune your system for greater performance.",
+        "chapter_title": "Tune your system for greater performance",
         "chapter_sections": [
           "Configure GRUB 2",
           "Modify kernel parameters",

--- a/webapp/shop/cube/syllabus.json
+++ b/webapp/shop/cube/syllabus.json
@@ -1,0 +1,160 @@
+[
+  {
+    "exam_name": "Linux Essentials",
+    "exam_description": "Prove your knowledge of the Linux community, history, and philosophy. Topics include common Linux commands, open source and software licensing, and basic knowledge of Linux architecture and file hierarchy.",
+    "syllabus": [
+      {
+        "chapter_title": "Identify and execute common Linux commands.",
+        "chapter_sections": [
+          "Navigation commands",
+          "System information commands",
+          "Regular expressions and their functions"
+        ]
+      },
+      {
+        "chapter_title": "Manipulate files using the command line.",
+        "chapter_sections": [
+          "Understand basic shell syntax",
+          "Create, read, move, delete, copy, and convert files",
+          "Locate files on a system",
+          "Compare files",
+          "Modify file contents",
+          "Search through files"
+        ]
+      },
+      {
+        "chapter_title": "Understand the fundamentals of Linux architecture.",
+        "chapter_sections": [
+          "Packaging styles",
+          "File types",
+          "Purposes of major directories"
+        ]
+      }
+    ]
+  },
+  {
+    "exam_name": "Desktop Essentials",
+    "exam_description": "Demonstrate your knowledge of Ubuntu Desktop administrative essentials. Focus on package management, system installation, data gathering, and managing printing and displays.",
+    "syllabus": [
+      {
+        "chapter_title": "Be acquainted with the Ubuntu community and its conventions.",
+        "chapter_sections": [
+          "Identify the year of Ubuntu’s first release",
+          "Understand what an LTS is and entails",
+          "Understand the formula behind Ubuntu’s LTS numbering"
+        ]
+      },
+      {
+        "chapter_title": "Install and operate Ubuntu on your system.",
+        "chapter_sections": [
+          "Install Ubuntu via ISO",
+          "Identify installation styles",
+          "Back up data to remote locations",
+          "Configure automatic upgrades",
+          "Synchronise time",
+          "Manage locales",
+          "Work with GRUB 2",
+          "Manage users, groups, and passwords"
+        ]
+      },
+      {
+        "chapter_title": "Manage packages on an Ubuntu system.",
+        "chapter_sections": [
+          "Install packages, including from PPA repositories",
+          "Identify the packages installed on your system",
+          "Check your system for specific packages",
+          "Read package descriptions",
+          "Identify dependencies",
+          "Download package information from all configured sources",
+          "Install snaps"
+        ]
+      },
+      {
+        "chapter_title": "Gather important system information.",
+        "chapter_sections": [
+          "Display and record your current Ubuntu distribution",
+          "Display and record CPU capabilities",
+          "Set up remote system journaling",
+          "Obtain and interpret kernel information"
+        ]
+      },
+      {
+        "chapter_title": "Manage files and permissions.",
+        "chapter_sections": [
+          "Check file permissions",
+          "Grant and revoke permissions",
+          "Interpret permission attribute strings",
+          "Create and manage partitions",
+          "Work with common file editors"
+        ]
+      },
+      {
+        "chapter_title": "Configure and manage displays and other desktop hardware.",
+        "chapter_sections": [
+          "Enable and disable devices from the command line",
+          "Distinguish between desktop and server environments",
+          "Set a monitor’s resolution from the command line",
+          "Configure multiple monitors",
+          "Understand the differences between X and Wayland"
+        ]
+      },
+      {
+        "chapter_title": "Configure networking capabilities.",
+        "chapter_sections": [
+          "Configure and use SSH",
+          "Copy files and directories with rsync",
+          "Identify MAC addresses",
+          "Set static IPs",
+          "Configure DHCP"
+        ]
+      }
+    ]
+  },
+  {
+    "exam_name": "Server Essentials",
+    "exam_description": "Illustrate your knowledge of common Ubuntu Server administrative tasks and troubleshooting. Topics include job control, performance tuning, services management, and Bash scripting.",
+    "syllabus": [
+      {
+        "chapter_title": "Perform common administrative tasks.",
+        "chapter_sections": [
+          "Manage users, groups, and permissions",
+          "Configure local storage",
+          "Manage partitions and filesystems",
+          "Keep systems secure",
+          "Configure network interfaces",
+          "Back up data to remote locations",
+          "Encrypt disks"
+        ]
+      },
+      {
+        "chapter_title": "Troubleshoot issues.",
+        "chapter_sections": [
+          "Obtain diagnostic information about disks, services, ports, and connections",
+          "Find and interpret log files",
+          "Identify and interpret system performance metrics",
+          "Understand the purpose and functions of virtual filesystems",
+          "Take appropriate precautions before attempting irreversible operations"
+        ]
+      },
+      {
+        "chapter_title": "Configure and control automated tasks.",
+        "chapter_sections": [
+          "Write and interpret Bash scripts",
+          "Manage cron jobs",
+          "Configure system logging rules, including rotation"
+        ]
+      },
+      {
+        "chapter_title": "Tune your system for greater performance.",
+        "chapter_sections": [
+          "Configure GRUB 2",
+          "Modify kernel parameters",
+          "Queue commands",
+          "Monitor resources",
+          "Manage system services",
+          "Configure service recovery"
+        ]
+      }
+    ]
+  }
+]

--- a/webapp/shop/cube/views.py
+++ b/webapp/shop/cube/views.py
@@ -407,9 +407,14 @@ def cube_study_labs_button(edx_api, **kwargs):
 
     return flask.jsonify({"text": text, "redirect_url": redirect_url})
 
+
 @shop_decorator(area="cube", permission="user", response="html")
 def cred_syllabus_data(**kawrgs):
     exam_name = flask.request.args.get("exam")
-    syllabus_file = open("webapp/shop/cube/syllabus.json","r")
+    syllabus_file = open("webapp/shop/cube/syllabus.json", "r")
     syllabus_data = json.load(syllabus_file)
-    return flask.render_template("credentialing/syllabus.html", syllabus_data=syllabus_data, exam_name=exam_name)
+    return flask.render_template(
+        "credentialing/syllabus.html",
+        syllabus_data=syllabus_data,
+        exam_name=exam_name,
+    )

--- a/webapp/shop/cube/views.py
+++ b/webapp/shop/cube/views.py
@@ -406,3 +406,10 @@ def cube_study_labs_button(edx_api, **kwargs):
         )
 
     return flask.jsonify({"text": text, "redirect_url": redirect_url})
+
+@shop_decorator(area="cube", permission="user", response="html")
+def cred_syllabus_data(**kawrgs):
+    exam_name = flask.request.args.get("exam")
+    syllabus_file = open("webapp/shop/cube/syllabus.json","r")
+    syllabus_data = json.load(syllabus_file)
+    return flask.render_template("credentialing/syllabus.html", syllabus_data=syllabus_data, exam_name=exam_name)


### PR DESCRIPTION
## Done

- Add syllabus for each microcertification

Related:
- https://github.com/canonical/ubuntu.com/pull/11996
- https://github.com/canonical/ubuntu.com/pull/12023

## QA

- Visit https://ubuntu-com-12058.demos.haus/credentialing
  - Verify that the Syllabus button appears in each exam description
  - Verify that clicking each Syllabus button takes you to the corresponding tab on https://ubuntu-com-12058.demos.haus/credentialing/syllabus


## Issue / Card

https://warthogs.atlassian.net/browse/CRED-94

## Screenshots

Tabbed syllabus:
![cue-syllabus](https://user-images.githubusercontent.com/995051/188689479-9240d147-8f0e-4741-b5d9-77f9119afa15.png)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
