### PR TITLE
update link to datasheet

### DIFF
--- a/templates/kubernetes/managed.html
+++ b/templates/kubernetes/managed.html
@@ -17,7 +17,7 @@
       <p>Focus on your applications while Canonical builds and manages your Kubernetes clusters. Run your Kubernetes anywhere with a flexible pricing model. Take back control whenever you are ready.</p>
       <div>
         <a href="/kubernetes/contact-us?product=kubernetes-managed" class="js-invoke-modal p-button--positive" data-testid="interactive-form-link">Talk to an expert</a>
-        <a href="https://assets.ubuntu.com/v1/c5f59e1c-Enterprise_Kubernetes+Datasheet_16.09.21.pdf">Read the datasheet&nbsp;&rsaquo;</a>
+        <a href="https://assets.ubuntu.com/v1/0041f679-Enterprise_Kubernetes+Datasheet_27.09.22.pdf">Read the datasheet&nbsp;&rsaquo;</a>
       </div>
     </div>
     <div class="col-5 u-hide--medium u-hide--small u-align--center">


### PR DESCRIPTION
## Done

- Updated a the datasheet linked to on /kubernetes/managed

## QA

- Visit https://ubuntu-com-12062.demos.haus/kubernetes/managed
- Click the "Read the datasheet" link in the hero strip
- See that it links to https://assets.ubuntu.com/v1/0041f679-Enterprise_Kubernetes+Datasheet_27.09.22.pdf, and not the one that's currently live (https://assets.ubuntu.com/v1/c5f59e1c-Enterprise_Kubernetes+Datasheet_16.09.21.pdf)

## Issue / Card

Fixes https://github.com/canonical/web-squad/issues/6006

