### PR TITLE
add temp pro page

### DIFF
--- a/templates/pro/index.html
+++ b/templates/pro/index.html
@@ -1,0 +1,13 @@
+{% extends "templates/base.html" %}
+
+{% block title %}Coming soon{% endblock %}
+
+{% block outer_content %}
+  {% block content %}
+  <section class="p-strip--suru-topped">
+    <div class="u-fixed-width">
+      <h1>Coming soon</h1>
+    </div>
+  </section>
+  {% endblock %}
+{% endblock %}


### PR DESCRIPTION
## Done

- people are finding their way to /pro ahead of schedule, which currently leads to a 404:
![image](https://user-images.githubusercontent.com/2376968/192631869-24ecc74a-a714-4152-9d45-9a2896801c5c.png)
- this PR adds a "Coming soon" page at /pro for a slightly better experience in the short term

## QA

- visit https://ubuntu-com-12067.demos.haus/pro
- see that the page shows "Coming soon", rather than a 404

![image](https://user-images.githubusercontent.com/2376968/192632166-23ae9265-0cd8-4c93-83a9-c6dd8a088a01.png)

