### PR TITLE
Fix: thank you page missing closing endif

### DIFF
--- a/templates/engage/shared/_es_thank-you.html
+++ b/templates/engage/shared/_es_thank-you.html
@@ -58,10 +58,12 @@
           <p>
             El {{ resource_name }} est&aacute; listo para descargar.
           </p>
+        {% endif %}
         {% if "contact_form_only" not in metadata and metadata.contact_form_only != "true" or ("access_to_content" in metadata and metadata.access_to_content == "true") %}
           <p>
             <a class="p-button--positive" href="{{ resource_url }}">Descargar</a>
           </p>
+        {% endif %}
       {% endif %}
     {% else %}
       <p>

--- a/templates/engage/shared/_pt_thank-you.html
+++ b/templates/engage/shared/_pt_thank-you.html
@@ -51,17 +51,19 @@
             <a href="{{ request_url }}">Ou tente reenviar</a>
           </p>
 
-      {% else %}
-        {% if "thank_you_text" in metadata %}
-          <p>{{ metadata["thank_you_text"] }}</p>
         {% else %}
-        <p>
-          {{ resource_name | capitalize }} est&aacute; pronto para download.
-        </p>
-        {% if "contact_form_only" not in metadata and metadata.contact_form_only != "true" or ("access_to_content" in metadata and metadata.access_to_content == "true") %}
-        <p>
-          <a class="p-button--positive" href="{{ resource_url }}">Download</a>
-        </p>
+          {% if "thank_you_text" in metadata %}
+            <p>{{ metadata["thank_you_text"] }}</p>
+          {% else %}
+          <p>
+            {{ resource_name | capitalize }} est&aacute; pronto para download.
+          </p>
+          {% endif %}
+          {% if "contact_form_only" not in metadata and metadata.contact_form_only != "true" or ("access_to_content" in metadata and metadata.access_to_content == "true") %}
+          <p>
+            <a class="p-button--positive" href="{{ resource_url }}">Download</a>
+          </p>
+          {% endif %}
         {% endif %}
       {% else %}
         <p>

--- a/templates/engage/shared/_ru_thank-you.html
+++ b/templates/engage/shared/_ru_thank-you.html
@@ -51,17 +51,19 @@
             <a href="{{ request_url }}">Или попробуйте отправить повторно</a>
           </p>
 
-      {% else %}
-        {% if "thank_you_text" in metadata %}
-          <p>{{ metadata["thank_you_text"] }}</p>
         {% else %}
-        <p>
-          {{ resource_name }} готов к загрузке.
-        </p>
-        {% if "contact_form_only" not in metadata and metadata.contact_form_only != "true" or ("access_to_content" in metadata and metadata.access_to_content == "true") %}
-        <p>
-          <a class="p-button--positive" href="{{ resource_url }}">Загрузить</a>
-        </p>
+          {% if "thank_you_text" in metadata %}
+            <p>{{ metadata["thank_you_text"] }}</p>
+          {% else %}
+          <p>
+            {{ resource_name }} готов к загрузке.
+          </p>
+          {% endif %}
+          {% if "contact_form_only" not in metadata and metadata.contact_form_only != "true" or ("access_to_content" in metadata and metadata.access_to_content == "true") %}
+          <p>
+            <a class="p-button--positive" href="{{ resource_url }}">Загрузить</a>
+          </p>
+          {% endif %}
         {% endif %}
       {% else %}
         <p>


### PR DESCRIPTION
## Done

- A few pages missing an `endif`.

## QA

- Check https://ubuntu-com-12068.demos.haus/engage/ES-Business-guide-to-hybrid-multicloud, fill out the form and make sure the page renders.
- Same with https://ubuntu-com-12068.demos.haus/engage/ru/enterprise-kubernetes-comparison
- Same with https://ubuntu-com-12068.demos.haus/engage/pt/vmware-para-o-openstack
- If you get a marketo error after submitting the form, it means marketo form doesn't work on demo, so test this PR locally, you may need to comment out line 832-831 (to skip submission to marketo).



## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
