### PR TITLE
Redirect old blog post to new blog post url

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -848,6 +848,7 @@ telcos/?: "/telco"
 
 # Blog redirects
 blog/search/?: /search
+blog/canonical-announces-ubuntu-22-04-lts-support-for-flexran-reference-software-2/?: /blog/canonical-announces-ubuntu-22-04-lts-support-for-flexran-reference-software
 
 # Copied from https://github.com/canonical-web-and-design/blog.ubuntu.com/blob/master/redirects.yaml
 


### PR DESCRIPTION
## Done

Got a request from Felicia to redirect to new blog post, so that Google results go to the right URL

## QA

- https://ubuntu-com-12074.demos.haus/blog/canonical-announces-ubuntu-22-04-lts-support-for-flexran-reference-software-2 should redirect to https://ubuntu-com-12074.demos.haus/blog/canonical-announces-ubuntu-22-04-lts-support-for-flexran-reference-software


## Issue / Card

Fixes #

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
