### PR TITLE
Add `u-hide--medium` class

### DIFF
--- a/templates/security/index.html
+++ b/templates/security/index.html
@@ -16,7 +16,7 @@
       </p>
     </div>
 
-    <div class="col-4 u-hide--small u-vertically-center">
+    <div class="col-4 u-hide--small u-hide--medium u-vertically-center">
       {{
         image(
           url="https://assets.ubuntu.com/v1/c3814c0a-shields-security-white.svg",
@@ -352,7 +352,7 @@
           width="200",
           hi_def=True,
           loading="lazy",
-          attrs={"class": "u-hide--small"}
+          attrs={"class": "u-hide--small u-hide--medium"}
         ) | safe
       }}
     </div>


### PR DESCRIPTION
## Done

- Add `u-hide--medium` on two images 

## QA

1. Go to https://ubuntu-com-12075.demos.haus/security 
2. Check images are hidden on medium/small screens
