### PR TITLE
update canonical logos on /hpc

### DIFF
--- a/templates/hpc/index.html
+++ b/templates/hpc/index.html
@@ -233,8 +233,8 @@
           image (
           url="https://assets.ubuntu.com/v1/3c891a50-Canonical+MAAS.svg",
           alt="",
-          width="453",
-          height="88",
+          width="308",
+          height="60",
           hi_def=True,
           loading="auto"
         ) | safe
@@ -252,8 +252,8 @@
           image (
           url="https://assets.ubuntu.com/v1/54f0ce21-ubuntu-logo-2022-LRG.png",
           alt="",
-          height="88",
-          width="250",
+          height="60",
+          width="170",
           hi_def=True,
           loading="auto"
           ) | safe
@@ -300,8 +300,8 @@
           image (
           url="https://assets.ubuntu.com/v1/53cfe748-Canonical+Charmhub.svg",
           alt="",
-          height="88",
-          width="557",
+          height="60",
+          width="379",
           hi_def=True,
           loading="lazy"
         ) | safe
@@ -319,8 +319,8 @@
           image (
           url="https://assets.ubuntu.com/v1/e6cd15f7-Charmed+Kubernetes_RGB_2022.svg",
           alt="",
-          width="576",
-          height="88",
+          width="392",
+          height="60",
           hi_def=True,
           loading="lazy"
         ) | safe
@@ -369,8 +369,8 @@
           image (
           url="https://assets.ubuntu.com/v1/0b784c9c-Canonical+OpenStack.svg",
           alt="",
-          width="600",
-          height="94",
+          width="385",
+          height="60",
           hi_def=True,
           loading="lazy"
         ) | safe
@@ -660,7 +660,8 @@
           image (
           url="https://assets.ubuntu.com/v1/54f0ce21-ubuntu-logo-2022-LRG.png",
           alt="",
-          width="288",
+          height="60",
+          width="170",
           hi_def=True,
           loading="auto"
           ) | safe

--- a/templates/hpc/index.html
+++ b/templates/hpc/index.html
@@ -231,10 +231,10 @@
       <div class="col-6 u-vertically-center u-hide--medium u-hide--small u-align--center">
         {{
           image (
-          url="https://assets.ubuntu.com/v1/f05bbf77-maas-logo.png",
+          url="https://assets.ubuntu.com/v1/3c891a50-Canonical+MAAS.svg",
           alt="",
-          width="288",
-          height="288",
+          width="453",
+          height="88",
           hi_def=True,
           loading="auto"
         ) | safe
@@ -252,7 +252,8 @@
           image (
           url="https://assets.ubuntu.com/v1/54f0ce21-ubuntu-logo-2022-LRG.png",
           alt="",
-          width="288",
+          height="88",
+          width="250",
           hi_def=True,
           loading="auto"
           ) | safe
@@ -297,10 +298,10 @@
       <div class="col-6 u-vertically-center u-hide--medium u-hide--small u-align--center">
         {{
           image (
-          url="https://assets.ubuntu.com/v1/87213a3b-Charm+hub_black-orange_hex.svg",
+          url="https://assets.ubuntu.com/v1/53cfe748-Canonical+Charmhub.svg",
           alt="",
-          width="300",
-          height="50",
+          height="88",
+          width="557",
           hi_def=True,
           loading="lazy"
         ) | safe
@@ -318,8 +319,8 @@
           image (
           url="https://assets.ubuntu.com/v1/e6cd15f7-Charmed+Kubernetes_RGB_2022.svg",
           alt="",
-          width="300",
-          height="45",
+          width="576",
+          height="88",
           hi_def=True,
           loading="lazy"
         ) | safe
@@ -366,10 +367,10 @@
       <div class="col-6 u-vertically-center u-hide--medium u-hide--small u-align--center">
         {{
           image (
-          url="https://assets.ubuntu.com/v1/bbbd7671-Canonical+OpenStack.svg",
+          url="https://assets.ubuntu.com/v1/0b784c9c-Canonical+OpenStack.svg",
           alt="",
-          width="300",
-          height="47",
+          width="600",
+          height="94",
           hi_def=True,
           loading="lazy"
         ) | safe
@@ -514,7 +515,7 @@
           Intel oneAPI HPC toolkit
         </p>
         <p>
-          Hit the ground running with Ubuntu and use Intel’s development tool chain to ease compilation and get optimal performance for HPC workloads.
+          Hit the ground running with Ubuntu and use Intel's development tool chain to ease compilation and get optimal performance for HPC workloads.
         </p>
         <p>
           Juju charms help you simplify operations by assisting in the installation, maintenance and integration of applications.


### PR DESCRIPTION
## Done

- updated the Canonical product logos on /hpc

## QA

- Visit https://ubuntu-com-12077.demos.haus/hpc
- See that the logos in the MAAS, Ubuntu, OpenStack, CharmHub and Kubernetes sections are consistent with each other and look good.

## Issue / Card

Fixes https://github.com/canonical/web-squad/issues/6019
