### PR TITLE
Update Kubernetes Operations survey

### DIFF
--- a/templates/kubernetes/kubernetes-operations-survey.html
+++ b/templates/kubernetes/kubernetes-operations-survey.html
@@ -11,8 +11,8 @@
     <div class="col-6">
         <h1>Kubernetes &amp; cloud native operations survey</h1>
         <p>The Cloud Native space is rapidly expanding and everyone wants to know what everyone else is doing. Where are we succeeding? Where are we hitting walls? The answers to all are right here &mdash; click start &mdash; contribute and get early access to the community report.</p>
-        <p><a class="p-button--positive typeform-share button" href="https://form.typeform.com/to/SbeMKJK4?typeform-medium=embed-snippet" data-mode="popup" data-size="100" target="_blank">Take the survey</a></p>
-        <p>In submitting the survey, I confirm I have read and agreed to Canonical's <a href="/legal/data-privacy">Privacy Policy</a> and <a href="https://pages.ubuntu.com/rs/066-EOV-335/images/Kubernetes%20&%20CloudNative%20Survey%20-%20_Privacy%20Notice%20%E2%80%93%20Survey_.pdf">Privacy Notice</a>. Should you enter the raffle to win a T-shirt through this survey, you agree to the <a href="https://pages.ubuntu.com/rs/066-EOV-335/images/US%20Operator%20Day%20Raffle%202021%20-%20Terms%20and%20Conditions%20%20%281%29.pdf">Competition Terms &amp; Conditions</a>.</p>
+        <p><a class="p-button--positive typeform-share button" href="https://krzty8pox19.typeform.com/to/gAftOg2f?typeform-medium=embed-snippet" data-mode="popup" data-size="100" target="_blank">Take the survey</a></p>
+        <p>In submitting the survey, I confirm I have read and agreed to Canonical's <a href="/legal/data-privacy">Privacy Policy</a> and <a href="https://pages.ubuntu.com/rs/066-EOV-335/images/Kubernetes%20&%20CloudNative%20Survey%20-%20_Privacy%20Notice%20%E2%80%93%20Survey_.pdf">Privacy Notice</a>. Should you enter the raffle to win a T-shirt through this survey, you agree to the <a href="https://pages.ubuntu.com/rs/066-EOV-335/images/Cloud%20Survey%202022%20Q4%20-%20Terms%20and%20Conditions%20-%20Canonical%2026.09.22%20.pdf">Competition Terms &amp; Conditions</a>.</p>
     </div>
     <div class="col-6 u-align--center">
         {{ image (


### PR DESCRIPTION
## Done

Updated the Kubernetes Operations survey as per [the brief](https://docs.google.com/document/d/17t6IVb9DzIj66136Iw08pOpWCof5qHz38B_Qg6K_RcY/edit)

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to https://ubuntu-com-12082.demos.haus/kubernetes/kubernetes-operations-survey
- Check that the "Take the survey" button brings up [this form](https://krzty8pox19.typeform.com/to/gAftOg2f) in a modal
- Check that the "Competition Terms & Conditions" link goes to https://pages.ubuntu.com/rs/066-EOV-335/images/Cloud%20Survey%202022%20Q4%20-%20Terms%20and%20Conditions%20-%20Canonical%2026.09.22%20.pdf

## Issue / Card
Fixes https://github.com/canonical/marketplace-tribe/issues/2878
