### PR TITLE
Update copy referencing beta launch and update contextual footer links

### DIFF
--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -570,15 +570,15 @@
         <h2>Secure enterprise management with Ubuntu Pro Desktop</h2>
         <p>Ubuntu Pro Desktop is a comprehensive subscription delivering enterprise-grade security, management tooling, and extended support for developers and organisations.</p>
         <ul class="p-list">
-          <li class="p-list__item is-ticked">Security updates for the <a href="/esm">full open source stack</a></li>
+          <li class="p-list__item is-ticked">Security updates for the <a href="/esm">full open source stack</a> (beta)</li>
           <li class="p-list__item is-ticked">Advanced <a href="/engage/microsoft-active-directory">Active Directory</a> and LDAP integration</li>
           <li class="p-list__item is-ticked">Estate <a href="https://landscape.canonical.com/landscape-features">monitoring and management</a></li>
           <li class="p-list__item is-ticked"><a href="/security/certifications#fips">FIPS 140-2 certified modules</a> and <a href="/security/certifications#cis">CIS hardening</a></li>
           <li class="p-list__item is-ticked">Minimise rolling reboots with <a href="/livepatch">Kernel Livepatch</a></li>
           <li class="p-list__item is-ticked">Optional weekday or 24x7 support tiers</li>
         </ul>
-        <p class="p-heading--4">Free for personal use</p>
-        <p>Secure your open source stack with a personal Ubuntu Pro license and get security patching for over 23,000 packages in the Ubuntu Universe repository.</p>
+        <p class="p-heading--4">Free for personal use on up to five machines</p>
+        <p>Secure your open source stack with a personal Ubuntu Pro license and get beta access security patching for over 23,000 packages in the Ubuntu Universe repository.</p>
         <p><a href="/pro">Get started with a free subscription&nbsp;&rsaquo;</a></p>
         <p><a href="/desktop/organisations">Ubuntu Desktop for organisations&nbsp;&rsaquo;</a></p>
       </div>

--- a/templates/desktop/index.html
+++ b/templates/desktop/index.html
@@ -132,7 +132,7 @@
   <div class="row p-divider">
     <div class="col-6 p-divider__block">
       <h3>Support and management tools</h3>
-      <p>Ubuntu Pro Desktop is a comprehensive subscription delivering enterprise-grade security, management tooling, and extended support for developers and organisations. Ubuntu Pro Desktop is free for personal use on up to three machines.</p>
+      <p>Ubuntu Pro Desktop is a comprehensive subscription delivering enterprise-grade security, management tooling, and extended support for developers and organisations. Ubuntu Pro Desktop is free for personal use on up to five machines.</p>
       <p><a href="/desktop/organisations">Learn more about Ubuntu for enterprises&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-6 p-divider__block">

--- a/templates/desktop/organisations.html
+++ b/templates/desktop/organisations.html
@@ -51,7 +51,7 @@
       </div>
       <h3>Secure open-source stack</h3>
       <div>
-        <p>Receive 10 years of security patches for Ubuntu LTS releases with Extended Security Maintenance (<a href="/security/esm">ESM</a>) and coverage for over 23,000 packages in the Ubuntu Universe repository. Minimise downtime with Kernel <a href="/security/livepatch">Livepatch</a>.</p>
+        <p>Receive 10 years of security patches for Ubuntu LTS releases with Extended Security Maintenance (<a href="/security/esm">ESM</a>) and beta coverage for over 23,000 packages in the Ubuntu Universe repository. Minimise downtime with Kernel <a href="/security/livepatch">Livepatch</a>.</p>
         <p><a href="/pro">Learn more about Ubuntu Pro&nbsp;&rsaquo;</a></p>
       </div>
     </div>
@@ -575,17 +575,15 @@
   <div class="row u-vertically-center">
     <div class="col-7">
       <h2>Secure enterprise management with Ubuntu Pro Desktop</h2>
-      <p>Ubuntu Pro Desktop is a comprehensive subscription delivering enterprise-grade security, management tooling, and extended support for developers and organisations. Ubuntu Pro Desktop is free for personal use on up to three machines.</p>
+      <p>Ubuntu Pro Desktop is a comprehensive subscription delivering enterprise-grade security, management tooling, and extended support for developers and organisations. Ubuntu Pro Desktop is free for personal use on up to five machines.</p>
       <ul class="p-list">
-        <li class="p-list__item is-ticked">Security updates for the <a href="/esm">full open source stack</a></li>
+        <li class="p-list__item is-ticked">Security updates for the <a href="/esm">full open source stack</a> (beta)</li>
         <li class="p-list__item is-ticked">Advanced <a href="/engage/microsoft-active-directory">Active Directory</a> and LDAP integration</li>
         <li class="p-list__item is-ticked">Estate <a href="https://landscape.canonical.com/landscape-features">monitoring and management</a></li>
         <li class="p-list__item is-ticked"><a href="/security/certifications#fips">FIPS 140-2 certified modules</a> and <a href="/security/certifications#cis">CIS hardening</a></li>
         <li class="p-list__item is-ticked">Minimise rolling reboots with <a href="/livepatch">Kernel Livepatch</a></li>
         <li class="p-list__item is-ticked">Optional weekday or 24x7 support tiers</li>
       </ul>
-      <p>For more information, download our whitepaper:</p>
-      <p><a class="p-button" href="/engage/adopting-secure-enterprise-linux-desktop">Adopting a secure enterprise Linux desktop</a></p>
       <p><a href="/pro">More details and pricing&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-5 u-align--center u-hide--medium u-hide--small">

--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -149,12 +149,12 @@
 <section class="p-strip">
   <div class="u-fixed-width">
     <h2>Secure enterprise management with Ubuntu Pro Desktop</h2>
-    <p>Ubuntu Pro Desktop is a comprehensive subscription delivering enterprise-grade security, management tooling, and extended support for developers and organisations. Ubuntu Pro Desktop is free for personal use on up to three machines.</p>
+    <p>Ubuntu Pro Desktop is a comprehensive subscription delivering enterprise-grade security, management tooling, and extended support for developers and organisations. Ubuntu Pro Desktop is free for personal use on up to five machines.</p>
   </div>
   <div class="row">
     <div class="col-6">
       <ul class="p-list">
-        <li class="p-list__item is-ticked">Security updates for the <a href="/esm">full open source stack</a></li>
+        <li class="p-list__item is-ticked">Security updates for the <a href="/esm">full open source stack</a> (beta)</li>
         <li class="p-list__item is-ticked">Advanced <a href="/engage/microsoft-active-directory">Active Directory</a> and LDAP integration</li>
         <li class="p-list__item is-ticked">Estate <a href="https://landscape.canonical.com/landscape-features">monitoring and management</a></li>
         <li class="p-list__item is-ticked"><a href="/security/certifications#fips">FIPS 140-2 certified modules</a> and <a href="/security/certifications#cis">CIS hardening</a></li>
@@ -175,8 +175,6 @@
     </div>
   </div>
   <div class="u-fixed-width">
-    <p>For more information, download our whitepaper:</p>
-    <p><a href="/engage/adopting-secure-enterprise-linux-desktop">Adopting a secure enterprise Linux desktop&nbsp;&rsaquo;</a></p>
     <p><a class="p-button--positive" href="/pro">Register today</a></p>
   </div>
 </section>

--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -105,12 +105,12 @@
 <section class="p-strip--light">
   <div class="u-fixed-width">
     <h2>Secure enterprise management with Ubuntu Pro Desktop</h2>
-    <p>Ubuntu Pro Desktop is a comprehensive subscription delivering enterprise-grade security, management tooling, and extended support for developers and organisations. Ubuntu Pro Desktop is free for personal use on up to three machines.</p>
+    <p>Ubuntu Pro Desktop is a comprehensive subscription delivering enterprise-grade security, management tooling, and extended support for developers and organisations. Ubuntu Pro Desktop is free for personal use on up to five machines.</p>
   </div>
   <div class="row">
     <div class="col-6">
       <ul class="p-list">
-        <li class="p-list__item is-ticked">Security updates for the <a href="/esm">full open source stack</a></li>
+        <li class="p-list__item is-ticked">Security updates for the <a href="/esm">full open source stack</a> (beta)</li>
         <li class="p-list__item is-ticked">Advanced <a href="/engage/microsoft-active-directory">Active Directory</a> and LDAP integration</li>
         <li class="p-list__item is-ticked">Estate <a href="https://landscape.canonical.com/landscape-features">monitoring and management</a></li>
         <li class="p-list__item is-ticked"><a href="/security/certifications#fips">FIPS 140-2 certified modules</a> and <a href="/security/certifications#cis">CIS hardening</a></li>
@@ -131,8 +131,6 @@
     </div>
   </div>
   <div class="u-fixed-width">
-    <p>For more information, download our whitepaper:</p>
-    <p><a href="/engage/adopting-secure-enterprise-linux-desktop">Adopting a secure enterprise Linux desktop&nbsp;&rsaquo;</a></p>
     <p><a class="p-button--positive" href="/pro">Register today</a></p>
   </div>
 </section>

--- a/templates/pricing/desktops.html
+++ b/templates/pricing/desktops.html
@@ -238,7 +238,7 @@
       <p>Ubuntu Pro Desktop is a comprehensive subscription for secure enterprise Linux adoption. It provides security, management tooling and support for your Ubuntu Desktop fleet.</p>
       <ul class="p-list">
         <li class="p-list__item is-ticked">
-          Security updates for the <a href="/esm">full open source stack</a>
+          Security updates for the <a href="/esm">full open source stack</a> (beta)
         </li>
         <li class="p-list__item is-ticked">
           Advanced <a href="/engage/microsoft-active-directory">Active Directory</a> and LDAP integration
@@ -256,10 +256,6 @@
           Optional weekday or 24x7 support tiers
         </li>
       </ul>
-      <p>For more information, download our whitepaper:</p>
-      <p>
-        <a class="p-button" href="/engage/adopting-secure-enterprise-linux-desktop">Adopting a secure enterprise Linux desktop</a>
-      </p>
       <p>
         <a href="/desktop/organisations">Find out more&nbsp;&rsaquo;</a>
       </p>

--- a/templates/shared/contextual_footers/_download_enterprise_support.html
+++ b/templates/shared/contextual_footers/_download_enterprise_support.html
@@ -1,6 +1,5 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--4">Professional support for Ubuntu</h3>
   <p>Get professional support for Ubuntu from Canonical. We help organisations around the world to manage their Ubuntu cloud, server and desktop deployments.</p>
-  <p><a href="/pro" class="button--primary">Buy Ubuntu Advantage</a></p>
-  <p><a href="/support" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Ubuntu Advantage page', 'eventLabel' : 'Enterprise support', 'eventValue' : undefined });">Find out more&nbsp;&rsaquo;</a></p>
+  <p><a href="/pro" class="button--primary">Ubuntu Pro&nbsp;&rsaquo;</a></p>
 </div>

--- a/templates/shared/contextual_footers/_download_helping_hands.html
+++ b/templates/shared/contextual_footers/_download_helping_hands.html
@@ -2,8 +2,9 @@
   <h3 class="p-heading--4">Helping hands</h3>
   <p>If you get stuck, help is always at hand.</p>
   <ul class="p-list">
-      <li><a href="https://askubuntu.com/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'askubuntu.com', 'eventLabel' : 'Helping hands', 'eventValue' : undefined });">Ask Ubuntu</a></li>
-      <li><a href="https://ubuntuforums.org/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'ubuntuforums', 'eventLabel' : 'Helping hands', 'eventValue' : undefined });">Ubuntu Forums</a></li>
-      <li><a href="https://answers.launchpad.net/ubuntu" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Launchpad Answers', 'eventLabel' : 'Helping hands', 'eventValue' : undefined });">Launchpad Answers</a></li>
+    <li><a href="https://discourse.ubuntu.com/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'discourse.ubuntu.com', 'eventLabel' : 'Helping hands', 'eventValue' : undefined });">Ubuntu Discourse</a></li>
+    <li><a href="https://askubuntu.com/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'askubuntu.com', 'eventLabel' : 'Helping hands', 'eventValue' : undefined });">Ask Ubuntu</a></li>
+    <li><a href="https://answers.launchpad.net/ubuntu" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Launchpad Answers', 'eventLabel' : 'Helping hands', 'eventValue' : undefined });">Launchpad Answers</a></li>
+    <li><a href="https://wiki.ubuntu.com/IRC/ChannelList" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'IRC-based support', 'eventLabel' : 'Helping hands', 'eventValue' : undefined });">IRC-based support</a></li>
   </ul>
 </div>


### PR DESCRIPTION
## Done

- Updated copy referencing beta launch and update contextual footer links

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: 
    - https://ubuntu-com-12085.demos.haus/pricing/desktops
    - https://ubuntu-com-12085.demos.haus/desktop/organisations
    - https://ubuntu-com-12085.demos.haus/desktop/developers
    - https://ubuntu-com-12085.demos.haus/download/desktop
    - https://ubuntu-com-12085.demos.haus/download/desktop/thank-you
    - https://ubuntu-com-12085.demos.haus/download (addressed comments not beta related)
    - Compare against beta related comments in docs listed on [spreadsheet](https://docs.google.com/spreadsheets/d/12AHtT35OfSDYH1kjZ0XzfrI88HTsUyD28sg_yCTe-ts/edit#gid=0) lines 19-25

## Issue / Card

Fixes https://github.com/canonical/web-squad/issues/6033, https://github.com/canonical/web-squad/issues/6035
