### PR TITLE
update landscape pricing for pro launch

### DIFF
--- a/templates/landscape/pricing.html
+++ b/templates/landscape/pricing.html
@@ -90,12 +90,12 @@
         </tr>
         <tr>
           <td>Pricing</td>
-          <td><a href="/pro/subscribe">Pricing calculator for Ubuntu Advantage</a></td>
-          <td>Free for up to 10 machines for personal use, or evaluation purposes.<br /><br />Beyond the free tier, <a href="/pro">Ubuntu Advantage</a> is required for more than 10 machines on self-hosted Landscape</td>
+          <td><a href="/pro/subscribe">Pricing calculator for Ubuntu Pro</a></td>
+          <td>Free for up to 10 machines for personal use, or evaluation purposes.<br /><br />Beyond the free tier, <a href="/pro">Ubuntu Pro</a> is required for more than 10 machines on self-hosted Landscape</td>
         </tr>
         <tr>
           <td></td>
-          <td>Landscape SaaS is included with <a href="/pro">Ubuntu Advantage</a></td>
+          <td>Landscape SaaS is included with <a href="/pro">Ubuntu Pro</a></td>
           <td><a href="/landscape/install">Set up your self-hosted Landscape</a></td>
         </tr>
       </tbody>


### PR DESCRIPTION
## Done

- updated instances of "Ubuntu Advantage" to "Ubuntu Pro" on /landscape/pricing, according to copy doc: https://docs.google.com/document/d/1pESmRniuiaDHkbzY_60GlOJdCiH2pZ9erI9KV49eDyM/edit

## QA

- visit https://ubuntu-com-12086.demos.haus/landscape/pricing
- see that the page matches the copy doc

## Issue / Card

Fixes https://github.com/canonical/web-squad/issues/6025
