### PR TITLE
Fix German thank-you page missing endif

### DIFF
--- a/templates/engage/shared/_de_thank-you.html
+++ b/templates/engage/shared/_de_thank-you.html
@@ -52,16 +52,17 @@
           <a href="{{ request_url }}">Oder versuchen Sie es erneut</a>
         </p>
 
-      {% else %}
-        {% if "thank_you_text" in metadata %}
-          <p>{{ metadata["thank_you_text"] }}</p>
         {% else %}
-          <p>{{ resource_name }} ist jetzt zum Download bereit.</p>
-        {% endif %}
-        {% if "contact_form_only" not in metadata and metadata.contact_form_only != "true" or ("access_to_content" in metadata and metadata.access_to_content == "true") %}
-        <p>
-          <a class="p-button--positive" href="{{ resource_url }}">Herunterladen</a>
-        </p>
+          {% if "thank_you_text" in metadata %}
+            <p>{{ metadata["thank_you_text"] }}</p>
+          {% else %}
+            <p>{{ resource_name }} ist jetzt zum Download bereit.</p>
+          {% endif %}
+          {% if "contact_form_only" not in metadata and metadata.contact_form_only != "true" or ("access_to_content" in metadata and metadata.access_to_content == "true") %}
+          <p>
+            <a class="p-button--positive" href="{{ resource_url }}">Herunterladen</a>
+          </p>
+          {% endif %}
         {% endif %}
       {% else %}
         <p>


### PR DESCRIPTION
## Done

- Missing endif in the German thank you pages. This fixes it.

## QA

- Go to  https://ubuntu-com-12090.demos.haus/engage/de/openstack-made-easy fill up the form, and this should work now

## Issue / Card

Fixes https://sentry.is.canonical.com/canonical/ubuntu-com/issues/28863/?referrer=alert_email



## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
