### PR TITLE
fix broken de engage thank you page

### DIFF
--- a/templates/engage/shared/_de_thank-you.html
+++ b/templates/engage/shared/_de_thank-you.html
@@ -40,28 +40,29 @@
       {% if 'pages.ubuntu.com' or 'assets.ubuntu.com' in resource_url %}
         {% if form_details and "access_to_content" in metadata and metadata.access_to_content == "true" %}
 
-        <h3>Wir haben eine Kopie des Whitepapers per e-mail {{ resource_name }} an {{ form_details.email }}</h3>
-        <p>
-          <a class="p-button--positive" href="{{ request_url }}">Zurück zur letzten Seite</a>
-          <a class="p-button" href="/contact-us">Kontaktiere uns</a>
-        </p>          
-        <p>
-          Nicht erhalten? Überprüfen Sie Ihren Spam-Ordner und ob Sie die richtige E-Mail-Adresse verwendet haben.
-        </p>
-        <p>
-          <a href="{{ request_url }}">Oder versuchen Sie es erneut</a>
-        </p>
+          <h3>Wir haben eine Kopie des Whitepapers per e-mail {{ resource_name }} an {{ form_details.email }}</h3>
+          <p>
+            <a class="p-button--positive" href="{{ request_url }}">Zurück zur letzten Seite</a>
+            <a class="p-button" href="/contact-us">Kontaktiere uns</a>
+          </p>          
+          <p>
+            Nicht erhalten? Überprüfen Sie Ihren Spam-Ordner und ob Sie die richtige E-Mail-Adresse verwendet haben.
+          </p>
+          <p>
+            <a href="{{ request_url }}">Oder versuchen Sie es erneut</a>
+          </p>
 
-      {% else %}
-        {% if "thank_you_text" in metadata %}
-          <p>{{ metadata["thank_you_text"] }}</p>
         {% else %}
-          <p>{{ resource_name }} ist jetzt zum Download bereit.</p>
-        {% endif %}
-        {% if "contact_form_only" not in metadata and metadata.contact_form_only != "true" or ("access_to_content" in metadata and metadata.access_to_content == "true") %}
-        <p>
-          <a class="p-button--positive" href="{{ resource_url }}">Herunterladen</a>
-        </p>
+          {% if "thank_you_text" in metadata %}
+            <p>{{ metadata["thank_you_text"] }}</p>
+          {% else %}
+            <p>{{ resource_name }} ist jetzt zum Download bereit.</p>
+          {% endif %}
+          {% if "contact_form_only" not in metadata and metadata.contact_form_only != "true" or ("access_to_content" in metadata and metadata.access_to_content == "true") %}
+            <p>
+              <a class="p-button--positive" href="{{ resource_url }}">Herunterladen</a>
+            </p>
+          {% endif %}
         {% endif %}
       {% else %}
         <p>


### PR DESCRIPTION
## Done

- Fixed broken template syntax on DE engage thank you page

## QA

- Visit https://ubuntu-com-12092.demos.haus/engage/de/openstack-made-easy/thank-you
- You should see the page, rather than a 500 error (compare to live: https://ubuntu.com/engage/de/openstack-made-easy/thank-you)

## Issue / Card

Fixes https://github.com/canonical/ubuntu.com/issues/12091
