### PR TITLE
update whitepaper asset link on /pricing/desktops and /desktop/orgs

### DIFF
--- a/templates/desktop/organisations.html
+++ b/templates/desktop/organisations.html
@@ -14,7 +14,7 @@
       </p>
       <p><a class="p-button--positive js-invoke-modal" href="/desktop/contact-us" data-testid="interactive-form-link">Contact us</a></p>
       <p><a href="/pro">Secure open-source with Ubuntu Pro&nbsp;&rsaquo;</a></p>
-      <p><a href="https://assets.ubuntu.com/v1/47a19d56-Ubuntu+Desktop+DS+06.09.22.pdf">Get pricing details&nbsp;&rsaquo;</a></p>
+      <p><a href="https://assets.ubuntu.com/v1/65ca4536-Ubuntu+Desktop+DS+06.09.22.pdf">Get pricing details&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-6 u-hide--medium u-hide--small">
       {{ image (

--- a/templates/pricing/desktops.html
+++ b/templates/pricing/desktops.html
@@ -12,7 +12,7 @@
     <div class="col-8">
       <h1>Ubuntu Desktop <br/> Enterprise Services</h1>
       <p>Day zero support for Ubuntu Desktop deployment, compliance and custom configuration.</p>
-      <a class="p-button" href="https://assets.ubuntu.com/v1/47a19d56-Ubuntu+Desktop+DS+06.09.22.pdf">Download the datasheet</a>
+      <a class="p-button" href="https://assets.ubuntu.com/v1/65ca4536-Ubuntu+Desktop+DS+06.09.22.pdf">Download the datasheet</a>
       <a href="/desktop/contact-us" class="p-button--positive js-invoke-modal">Get in touch</a>
     </div>
   </div>
@@ -226,7 +226,7 @@
       </tfoot>
     </table>
     <p>
-      <a class="p-button" href="https://assets.ubuntu.com/v1/47a19d56-Ubuntu+Desktop+DS+06.09.22.pdf">Download the datasheet</a>
+      <a class="p-button" href="https://assets.ubuntu.com/v1/65ca4536-Ubuntu+Desktop+DS+06.09.22.pdf">Download the datasheet</a>
       <a href="/desktop/contact-us" class="p-button--positive js-invoke-modal">Get in touch</a>
     </p>
   </div>


### PR DESCRIPTION
## Done

- Updated an asset link on /desktop/organisations and /pricing/desktops, according to the copy docs:
  - https://docs.google.com/document/d/1RuxCA6GYh9UriNv26HCZP9UHo4b4_9fYaaMtGQuH_xc/edit
  - https://docs.google.com/document/d/1xVtaZ7wr5sdBqye3Gc-XWXEpNqXaol8uDdMwJ_KyOO8/edit#

## QA

- Visit /desktop/organisations and /pricing/desktops
- See that the links to the datasheet have been updated to point to this asset: https://assets.ubuntu.com/v1/65ca4536-Ubuntu+Desktop+DS+06.09.22.pdf

## Issue / Card

Fixes https://github.com/canonical/web-squad/issues/6039