### PR TITLE
Render latest news strip dynamically on /download/desktop

### DIFF
--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -223,28 +223,8 @@
   </div>
 </section>
 
-<section class="p-strip">
-  <div class="u-fixed-width">
-    <h2 class="p-heading--4"><a href="/blog/desktop">Follow our blog</a> for the latest on Ubuntu Desktop:</h2>
-  </div>
-  <div class="row p-divider">
-    <div class="col-3 p-divider__block">
-      <p><a href="/blog/planning-phased-ubuntu-22-04-enterprise-desktop-upgrades-with-landscape">Planning phased Ubuntu 22.04 Enterprise Desktop upgrades with Landscape</a></p>
-      <p><em>by <a href="/blog/author/rajanpatel927">Rajan Patel</a> on 8 February 2022</em></p>
-    </div>
-    <div class="col-3 p-divider__block">
-      <p><a href="/blog/get-started-with-linux-game-development-on-ubuntu">Linux game development on Ubuntu: Godot and Unity</a></p>
-      <p><em>by <a href="/blog/author/local-optimum">Oliver Smith</a> on 24 January 2022</em></p>
-    </div>
-    <div class="col-3 p-divider__block">
-      <p><a href="/blog/how-low-can-you-go-running-ubuntu-desktop-on-a-2gb-raspberry-pi-4">How low can you go? Running Ubuntu Desktop on a 2GB Raspberry Pi 4</a></p>
-      <p><em>by <a href="/blog/author/local-optimum">Oliver Smith</a> on 11 January 2022</em></p>
-    </div>
-    <div class="col-3 p-divider__block">
-      <p><a href="/blog/linux-gaming-tutorial-raspberry-pi-minecraft-server-on-ubuntu-desktop">Raspberry Pi Tutorial: Host a Minecraft server on Ubuntu Desktop</a></p>
-      <p><em>by <a href="/blog/author/local-optimum">Oliver Smith</a> on 9 December 2021</em></p>
-    </div>            
-  </div>
-</section>
+{% with section_classes='p-strip is-bordered', heading_topic='Ubuntu Desktop', tag_name='ubuntu-desktop', tag_id='1920', limit='4' %}
+  {% include "shared/_latest_news_strip.html" %}
+{% endwith %}
 
 {% endblock content %}


### PR DESCRIPTION
## Done

- Replace statically rendered latest-news strip with the dynamic latest news module

## QA

- Go to https://ubuntu-com-12098.demos.haus/download/desktop and scroll to the bottom where you will find the latest-news section
- Check that the articles being pulled are coming from [wordpress](https://admin.insights.ubuntu.com/wp-admin/edit.php?tag=ubuntu-desktop)

## Issue / Card

Fixes https://github.com/canonical/web-squad/issues/6034
