### PR TITLE
Ubuntu pro price changes

### DIFF
--- a/templates/pricing/pro.html
+++ b/templates/pricing/pro.html
@@ -42,27 +42,23 @@
         <thead>
           <tr>
             <th style="width: 50%;">Ubuntu Pro + weekday support</th>
-            <th class="u-align--right">Infra-only support</th>
-            <th class="u-align--right">Apps-only support</th>
-            <th class="u-align--right">Infra+Apps support</th>
+            <th class="u-align--right">Infra Support</th>
+            <th class="u-align--right">Full Stack Support</th>
           </tr>
         </thead>
         <tbody>
           <tr>
-            <td>Ubuntu Pro (Infra-only)</td>
+            <td>Ubuntu Pro (Infra)</td>
             <td class="u-align--right">$750</td>
-            <td class="u-align--right">n/a</td>
             <td class="u-align--right">n/a</td>
           </tr>
           <tr>
             <td>Ubuntu Pro</td>
             <td class="u-align--right">$885</td>
-            <td class="u-align--right">$1,500</td>
             <td class="u-align--right">$1,700</td>
           </tr>
           <tr>
             <td>Desktop</td>
-            <td class="u-align--right">n/a</td>
             <td class="u-align--right">n/a</td>
             <td class="u-align--right">$150</td>
           </tr>
@@ -77,27 +73,23 @@
         <thead>
           <tr>
             <th style="width: 50%;">Ubuntu Pro + 24/7 support</th>
-            <th class="u-align--right">Infra-only support</th>
-            <th class="u-align--right">Apps-only support</th>
-            <th class="u-align--right">Infra+Apps support</th>
+            <th class="u-align--right">Infra Support</th>
+            <th class="u-align--right">Full Stack Support</th>
           </tr>
         </thead>
         <tbody>
           <tr>
-            <td>Ubuntu Pro (Infra-only)</td>
+            <td>Ubuntu Pro (Infra)</td>
             <td class="u-align--right">$1,500</td>
-            <td class="u-align--right">n/a</td>
             <td class="u-align--right">n/a</td>
           </tr>
           <tr>
             <td>Ubuntu Pro</td>
             <td class="u-align--right">$1,775</td>
-            <td class="u-align--right">$3,000</td>
             <td class="u-align--right">$3,400</td>
           </tr>
           <tr>
             <td>Desktop</td>
-            <td class="u-align--right">n/a</td>
             <td class="u-align--right">n/a</td>
             <td class="u-align--right">$300</td>
           </tr>

--- a/templates/pricing/pro.html
+++ b/templates/pricing/pro.html
@@ -44,6 +44,7 @@
             <th style="width: 50%;">Ubuntu Pro + weekday support</th>
             <th class="u-align--right">Infra Support</th>
             <th class="u-align--right">Full Stack Support</th>
+            <th></th>
           </tr>
         </thead>
         <tbody>

--- a/templates/pricing/pro.html
+++ b/templates/pricing/pro.html
@@ -75,6 +75,7 @@
             <th style="width: 50%;">Ubuntu Pro + 24/7 support</th>
             <th class="u-align--right">Infra Support</th>
             <th class="u-align--right">Full Stack Support</th>
+            <th></th>
           </tr>
         </thead>
         <tbody>

--- a/templates/shared/pricing/_ua-for-infrastructure.html
+++ b/templates/shared/pricing/_ua-for-infrastructure.html
@@ -12,7 +12,7 @@
       <tbody>
         <tr>
           <td>Physical server</td>
-          <td class="u-align--right">$450</td>
+          <td class="u-align--right">$500</td>
           <td class="u-align--right">$225</td>
           <td></td>
         </tr>


### PR DESCRIPTION
## Done

- Ubuntu pro price page changes.

## QA

- Go to: https://ubuntu-com-12100.demos.haus/pricing/pro
- Is the price showing $500? It should.
- Do you see any Apps Only column? You should not.

## Issue / Card

Fixes #https://github.com/canonical/web-squad/issues/6047