### PR TITLE
Fix incorrect id value for aria-controls attributes

### DIFF
--- a/templates/advantage/table/_contract-name.html
+++ b/templates/advantage/table/_contract-name.html
@@ -1,5 +1,5 @@
 <td class="u-no-padding p-table-title {% if open_subscription == contract['contractInfo']['id'] %} p-table--open{% endif %}">
-  <button class="u-toggle u-toggle--full-width u-align--left" aria-controls="#expanded-details-{{ outer_loop.index }}-{{ loop.index }}" aria-expanded="false" data-shown-text="Hide" data-hidden-text="Show">
+  <button class="u-toggle u-toggle--full-width u-align--left" aria-controls="expanded-details-{{ outer_loop.index }}-{{ loop.index }}" aria-expanded="false" data-shown-text="Hide" data-hidden-text="Show">
     {% if contract['is_trialled'] %}
       <span class="p-label--new">Free trial</span>
     {% else %}

--- a/templates/appliance/shared/_verify-checksums-pc.html
+++ b/templates/appliance/shared/_verify-checksums-pc.html
@@ -1,6 +1,6 @@
 <p>
   <span class="p-contextual-menu--left">
-    <a href="#" class="p-contextual-menu__toggle" data-trigger="click" aria-controls="#menu-4" aria-expanded="false" aria-haspopup="true"><i class="p-icon--information"></i>&nbsp;&nbsp;&nbsp;How to verify your download</a>
+    <a href="#" class="p-contextual-menu__toggle" data-trigger="click" aria-controls="menu-4" aria-expanded="false" aria-haspopup="true"><i class="p-icon--information"></i>&nbsp;&nbsp;&nbsp;How to verify your download</a>
     <span class="p-contextual-menu__dropdown" id="menu-4" aria-hidden="true" aria-label="Verification instructions:" style="width: 600px; max-width: 70vw; padding: 1rem; z-index: 10;">
       <span class="p-contextual-menu__group">
         <small>Run this command in your terminal in the directory the iso was downloaded to verify the SHA256 checksum:</small><br />

--- a/templates/appliance/shared/_verify-checksums.html
+++ b/templates/appliance/shared/_verify-checksums.html
@@ -1,6 +1,6 @@
 <p>
 <span class="p-contextual-menu--left">
-    <a href="#" class="p-contextual-menu__toggle" data-trigger="click" aria-controls="#menu-4" aria-expanded="false" aria-haspopup="true"><i class="p-icon--information"></i>&nbsp;&nbsp;&nbsp;Verify your download</a>
+    <a href="#" class="p-contextual-menu__toggle" data-trigger="click" aria-controls="menu-4" aria-expanded="false" aria-haspopup="true"><i class="p-icon--information"></i>&nbsp;&nbsp;&nbsp;Verify your download</a>
     <span class="p-contextual-menu__dropdown" id="menu-4" aria-hidden="true" aria-label="Verification instructions:" style="width: 600px; max-width: 70vw; padding: 1rem; z-index: 10;">
       <span class="p-contextual-menu__group">
         <small>Run this command in your terminal in the directory the iso was downloaded to verify the SHA256 checksum:</small><br />

--- a/templates/credentialling/microcerts.html
+++ b/templates/credentialling/microcerts.html
@@ -257,7 +257,7 @@
           <td data-heading="Action" class="p-table__cell--share-actions u-hide--small">
           <div class="p-share-button u-align--right">
             <span class="p-contextual-menu p-contextual-menu--right u-hide--small">
-              <button class="p-button p-contextual-menu__toggle has-icon u-no-margin--bottom" aria-controls="#share-menu" aria-expanded="false" aria-haspopup="true" data-trigger="click"><i class="p-icon--chevron-down p-contextual-menu__indicator"></i><span>Share</span></button>
+              <button class="p-button p-contextual-menu__toggle has-icon u-no-margin--bottom" aria-controls="share-menu" aria-expanded="false" aria-haspopup="true" data-trigger="click"><i class="p-icon--chevron-down p-contextual-menu__indicator"></i><span>Share</span></button>
               <span class="p-contextual-menu__dropdown" id="share-menu" aria-hidden="true">
                 <span class="p-contextual-menu__group">
                   <a href="https://www.linkedin.com/shareArticle?mini=true&amp;url={{ module['badge-url'] }}" class="p-contextual-menu__link">Share via LinkedIn</a>

--- a/templates/download/shared/_verify-checksums.html
+++ b/templates/download/shared/_verify-checksums.html
@@ -1,7 +1,7 @@
 <p>
   You can
   <span class="p-contextual-menu--left">
-    <a href="#" class="p-contextual-menu__toggle" data-trigger="click" aria-controls="#menu-4" aria-expanded="false" aria-haspopup="true">verify your download</a>
+    <a href="#" class="p-contextual-menu__toggle" data-trigger="click" aria-controls="menu-4" aria-expanded="false" aria-haspopup="true">verify your download</a>
     <span class="p-contextual-menu__dropdown" id="menu-4" aria-hidden="true" aria-label="Verification instructions:" style="width: 600px; max-width: 70vw; padding: 1rem;">
       {% if releases.checksums[system] and releases.checksums[system][version] %}
       <span class="p-contextual-menu__group">

--- a/templates/templates/_navigation.html
+++ b/templates/templates/_navigation.html
@@ -90,7 +90,7 @@
           {% if child.title != "Overview" %}
             {% if child.path == '/blog/topics' %}
             <li class="breadcrumbs__item p-contextual-menu u-hide--small">
-              <a aria-controls="#topics" data-trigger="hover" class="breadcrumbs__link u-no-margin--bottom {% if child.active %}p-link--active{% else %}p-link--soft{% endif %} p-contextual-menu__toggle" href="#">{{ child.title }}</a>
+              <a aria-controls="topics" data-trigger="hover" class="breadcrumbs__link u-no-margin--bottom {% if child.active %}p-link--active{% else %}p-link--soft{% endif %} p-contextual-menu__toggle" href="#">{{ child.title }}</a>
 
               <span class="p-contextual-menu__dropdown" id="topics" aria-hidden="true" aria-label="submenu" style="left: 1rem; font-size: .875rem;">
                 <span class="p-contextual-menu__group">


### PR DESCRIPTION
## Done

- Fixed the incorrect ID values for `aria-controls` attributes

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

- Check that the "Ubuntu", "Windows", and "macOS" tabs still work in the "Installation instructions" section on the following pages:
  - https://ubuntu-com-12102.demos.haus/appliance/adguard/intel-nuc
  - https://ubuntu-com-12102.demos.haus/appliance/lxd/intel-nuc
  - https://ubuntu-com-12102.demos.haus/appliance/mosquitto/intel-nuc
  - https://ubuntu-com-12102.demos.haus/appliance/nextcloud/intel-nuc
  - https://ubuntu-com-12102.demos.haus/appliance/openhab/intel-nuc
  - https://ubuntu-com-12102.demos.haus/appliance/plex/intel-nuc
  - https://ubuntu-com-12102.demos.haus/appliance/adguard/raspberry-pi
  - https://ubuntu-com-12102.demos.haus/appliance/lxd/raspberry-pi
  - https://ubuntu-com-12102.demos.haus/appliance/mosquitto/raspberry-pi
  - https://ubuntu-com-12102.demos.haus/appliance/nextcloud/raspberry-pi
  - https://ubuntu-com-12102.demos.haus/appliance/openhab/raspberry-pi
  - https://ubuntu-com-12102.demos.haus/appliance/plex/raspberry-pi

## Issue / Card

Fixes #11879