### PR TITLE
Remove block access to content

### DIFF
--- a/templates/engage/shared/_de_thank-you.html
+++ b/templates/engage/shared/_de_thank-you.html
@@ -59,9 +59,9 @@
             <p>{{ resource_name }} ist jetzt zum Download bereit.</p>
           {% endif %}
           {% if "contact_form_only" not in metadata and metadata.contact_form_only != "true" or ("access_to_content" in metadata and metadata.access_to_content == "true") %}
-            <p>
-              <a class="p-button--positive" href="{{ resource_url }}">Herunterladen</a>
-            </p>
+          <p>
+            <a class="p-button--positive" href="{{ resource_url }}">Herunterladen</a>
+          </p>
           {% endif %}
         {% endif %}
       {% else %}

--- a/templates/engage/shared/_de_thank-you.html
+++ b/templates/engage/shared/_de_thank-you.html
@@ -59,9 +59,9 @@
             <p>{{ resource_name }} ist jetzt zum Download bereit.</p>
           {% endif %}
           {% if "contact_form_only" not in metadata and metadata.contact_form_only != "true" or ("access_to_content" in metadata and metadata.access_to_content == "true") %}
-          <p>
-            <a class="p-button--positive" href="{{ resource_url }}">Herunterladen</a>
-          </p>
+            <p>
+              <a class="p-button--positive" href="{{ resource_url }}">Herunterladen</a>
+            </p>
           {% endif %}
         {% endif %}
       {% else %}

--- a/templates/engage/thank-you.html
+++ b/templates/engage/thank-you.html
@@ -43,7 +43,7 @@
       <p>
         <a class="p-button--positive" href="{{ request_url }}">Back to last page</a>
         <a class="p-button" href="/contact-us">Contact us</a>
-      </p>          
+      </p>
       <p>
         Not received it? Check your spam folder and that you've used the right email address.
       </p>

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -539,8 +539,7 @@ def engage_thank_you(engage_pages):
         try:
             form_details = flask.session["form_details"]
         except KeyError:
-            # Forbid direct access to thank-you page
-            return flask.abort(403)
+            form_details = None
 
         return flask.render_template(
             template_language,


### PR DESCRIPTION
## Done

As part of access to content, remove block so that it's still possible to access the thank-you page directly to download whitepapers.

## QA

- Go to https://ubuntu-com-12107.demos.haus/engage/test-access-to-content and fill up the form
- Check that the thank-you page shows the "email sent" message
- Go to any other whitepaper and check that you can access the /thank-you page without filling up the form

Fixes https://github.com/canonical/web-squad/issues/5818

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
