### PR TITLE
Pro nav

### DIFF
--- a/templates/templates/navigation-enterprise-h.html
+++ b/templates/templates/navigation-enterprise-h.html
@@ -110,8 +110,8 @@
           </h4>
           <ul class="p-text-list--small is-bordered">
             <li class="p-list__item u-show--small u-hide--medium u-hide--large"><a href="/support">Get support</a></li>
+            <li class="p-list__item"><a href="/pro">Ubuntu Pro</a></li>
             <li class="p-list__item"><a href="/livepatch">Livepatch security updates</a></li>
-            <li class="p-list__item"><a href="/esm">Extended Security Maintenance</a></li>
             <li class="p-list__item"><a href="/landscape">Landscape remote management</a></li>
             <li class="p-list__item"><a href="/landscape/features">Compliance reporting</a></li>
             <li class="p-list__item"><a href="/model-driven-operations">Model-driven operations</a></li>


### PR DESCRIPTION
## Done

- Added "Ubuntu Pro" item to the Enterprise dropdown nav

## QA

- VIsit https://ubuntu-com-12109.demos.haus/
- Click "Enterprise" in the main navigation, see that "Ubuntu Pro" appears under Support and Services
