### PR TITLE
Build /download/mediatek page

### DIFF
--- a/templates/download/mediatek.html
+++ b/templates/download/mediatek.html
@@ -39,20 +39,28 @@
       <p><a href="#" class="p-button--positive">Download 64-bit</a></p>
       <p>Works on:</p>
       <ul class="p-list">
-        <li class="p-list__item is-ticked">Mediatek Genio 1200</li>
+        <li class="p-list__item is-ticked">MediaTek Genio 1200</li>
       </ul>
     </div>
     <div class="col-5 u-vertically-center u-align--center u-hide--small u-hide--medium">
-      IMAGE NEEDED
+      {{ image (
+        url="https://assets.ubuntu.com/v1/aa889cf5-MediaTek_Genio+1200_Back_NOBG_Shadow_0422.png",
+        alt="",
+        width="3840",
+        height="2160",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
     </div>
   </div>
   <div class="u-fixed-width">
-    <h3 class="p-heading--4">First time installing Ubuntu on Mediatek?</h3>
-    <p>Please see the <a href="#">link to be provided</a> for more information.</p>
+    <h3 class="p-heading--4">First time installing Ubuntu on MediaTek?</h3>
+    <p>Please check the <a href="https://www.mediatek.com/aiot/products/mediatek-genio/1200">MediaTek Genio page</a> for more information.</p>
     <div class="p-notification--information is-inline">
       <div class="p-notification__content">
         <p class="p-notification__title">Note:</p>
-        <p class="p-notification__message"> Please ensure that your Mediatek Genio platform has the latest boot FW. FW updates and instructions are available on the <a href="https://people.canonical.com/~platform/images/xilinx/kria-ubuntu-22.04/iot-limerick-kria-classic-desktop-2204-x06-20220614-78.img.xz">link to be provided</a>.</p>
+        <p class="p-notification__message"> Please ensure that your MediaTek Genio platform has the latest boot FW. FW updates and instructions are available on the <a href="https://people.canonical.com/~platform/images/xilinx/kria-ubuntu-22.04/iot-limerick-kria-classic-desktop-2204-x06-20220614-78.img.xz">link to be provided</a>.</p>
       </div>
     </div>
   </div>  
@@ -67,20 +75,28 @@
       <p><a href="https://people.canonical.com/~platform/images/xilinx/kria/iot-kria-classic-desktop-2004-x03-20211110-98.img.xz" class="p-button--positive">Download 64-bit</a></p>
       <p>Works on:</p>
       <ul class="p-list">
-        <li class="p-list__item is-ticked">Mediatek Genio 1200</li>
+        <li class="p-list__item is-ticked">MediaTek Genio 1200</li>
       </ul>
     </div>
     <div class="col-5 u-vertically-center u-align--center u-hide--small u-hide--medium">
-      IMAGE NEEDED
+      {{ image (
+        url="https://assets.ubuntu.com/v1/aa889cf5-MediaTek_Genio+1200_Back_NOBG_Shadow_0422.png",
+        alt="",
+        width="3840",
+        height="2160",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
     </div>
   </div>
   <div class="u-fixed-width">
-    <h3 class="p-heading--4">First time installing Ubuntu on Mediatek?</h3>
-    <p>Please see the <a href="#">link to be provided</a> for more information.</p>
+    <h3 class="p-heading--4">First time installing Ubuntu on MediaTek?</h3>
+    <p>Please check the <a href="https://www.mediatek.com/aiot/products/mediatek-genio/1200">MediaTek Genio page</a> for more information.</p>
     <div class="p-notification--information is-inline">
       <div class="p-notification__content">
         <p class="p-notification__title">Note:</p>
-        <p class="p-notification__message"> Please ensure that your Mediatek Genio platform has the latest boot FW. FW updates and instructions are available on the <a href="#">link to be provided</a>.</p>
+        <p class="p-notification__message"> Please ensure that your MediaTek Genio platform has the latest boot FW. FW updates and instructions are available on the <a href="#">link to be provided</a>.</p>
       </div>
     </div>
     <p><a href="/download/contact-us" class="js-invoke-modal p-button--positive">Get in touch</a></p>

--- a/templates/download/mediatek.html
+++ b/templates/download/mediatek.html
@@ -1,0 +1,93 @@
+{% extends "download/_base_download.html" %}
+
+{% block title %}Install Ubuntu on MediaTek{% endblock %}
+
+{% block meta_description %}Use Ubuntu on MediaTek for the familiar developer experience and an accelerated path to production {% endblock meta_description %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1RMvAI7Soa_zIlP0e63BMcFT3DJfvLrMS2EyiOvcy-xc/edit#{% endblock meta_copydoc %}
+
+{% block content %}
+
+<section class="p-strip--suru-topped is-bordered">
+  <div class="row">
+    <div class="col-7">
+      <h1>Install Ubuntu on MediaTek</h1>
+      <p>Run Ubuntu on your MediaTek Genio 1200. </p>
+      <p>Pick the OS image, flash it onto internal EMMC, and away you go.</p>
+      <p><a href="/download/contact-us" class="js-invoke-modal p-button--positive">Get in touch</a></p>
+    </div>
+    <div class="col-5 u-vertically-center u-align--center u-hide--small u-hide--medium">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/0ebb345c-MediaTek_logo.svg",
+        alt="",
+        width="1024",
+        height="268",
+        hi_def=True,
+        loading="auto"
+        ) | safe
+      }}
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="row">
+    <div class="col-7">
+      <h2>Download Ubuntu Server</h2>
+      <h3 class="p-heading--4">Ubuntu Server 22.04 LTS</h4>
+      <p>The version of Ubuntu with up to 10 years of long term support, until April 2032.</p>
+      <p><a href="#" class="p-button--positive">Download 64-bit</a></p>
+      <p>Works on:</p>
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">Mediatek Genio 1200</li>
+      </ul>
+    </div>
+    <div class="col-5 u-vertically-center u-align--center u-hide--small u-hide--medium">
+      IMAGE NEEDED
+    </div>
+  </div>
+  <div class="u-fixed-width">
+    <h3 class="p-heading--4">First time installing Ubuntu on Mediatek?</h3>
+    <p>Please see the <a href="#">link to be provided</a> for more information.</p>
+    <div class="p-notification--information is-inline">
+      <div class="p-notification__content">
+        <p class="p-notification__title">Note:</p>
+        <p class="p-notification__message"> Please ensure that your Mediatek Genio platform has the latest boot FW. FW updates and instructions are available on the <a href="https://people.canonical.com/~platform/images/xilinx/kria-ubuntu-22.04/iot-limerick-kria-classic-desktop-2204-x06-20220614-78.img.xz">link to be provided</a>.</p>
+      </div>
+    </div>
+  </div>  
+</section>
+
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-7">
+      <h2>Download Ubuntu Core</h2>
+      <h3 class="p-heading--4">Ubuntu Core 22</h4>
+      <p>The version of Ubuntu with up to 10 years of long term support, until April 2030.</p>
+      <p><a href="https://people.canonical.com/~platform/images/xilinx/kria/iot-kria-classic-desktop-2004-x03-20211110-98.img.xz" class="p-button--positive">Download 64-bit</a></p>
+      <p>Works on:</p>
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">Mediatek Genio 1200</li>
+      </ul>
+    </div>
+    <div class="col-5 u-vertically-center u-align--center u-hide--small u-hide--medium">
+      IMAGE NEEDED
+    </div>
+  </div>
+  <div class="u-fixed-width">
+    <h3 class="p-heading--4">First time installing Ubuntu on Mediatek?</h3>
+    <p>Please see the <a href="#">link to be provided</a> for more information.</p>
+    <div class="p-notification--information is-inline">
+      <div class="p-notification__content">
+        <p class="p-notification__title">Note:</p>
+        <p class="p-notification__message"> Please ensure that your Mediatek Genio platform has the latest boot FW. FW updates and instructions are available on the <a href="#">link to be provided</a>.</p>
+      </div>
+    </div>
+    <p><a href="/download/contact-us" class="js-invoke-modal p-button--positive">Get in touch</a></p>
+  </div>  
+</section>
+
+<!-- Set default Marketo information for contact form below-->
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/internet-of-things" data-form-id="4644" data-lp-id="" data-return-url="https://ubuntu.com/download/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html"></div>
+
+{% endblock content %}


### PR DESCRIPTION
## Done

**Don't merge:** Release date postponed, waiting for a official release date, possibly around March
** Blocked** Waiting on 3 links
- Builds /download/mediatek page based off of [copydoc](https://docs.google.com/document/d/1Tm3cVVkWkzriQQ7kgbgKfKoeGZaew1M5OMbpLPSDGIc/edit#heading=h.142hynaix65t)

## QA
- Demo at https://ubuntu-com-12110.demos.haus/
- Go to /download/mediatek  and compare against [copydoc](https://docs.google.com/document/d/1Tm3cVVkWkzriQQ7kgbgKfKoeGZaew1M5OMbpLPSDGIc/edit#heading=h.142hynaix65t)
- Check the download links download the correct image

## Issue / Card

Fixes https://github.com/canonical/web-squad/issues/5990