### PR TITLE
add discourse tutorial links

### DIFF
--- a/templates/advantage/index-no-login.html
+++ b/templates/advantage/index-no-login.html
@@ -326,7 +326,7 @@
 <section class="p-strip is-x-deep u-no-padding--top">
   <div class="u-fixed-width">
     <h2>Ready to try Ubuntu Pro beta today?</h2>
-    <a class="p-heading--2" href="https://ubuntu.com/pro/beta">Discover the step-by-step tutorial</a>
+    <a class="p-heading--2" href="https://discourse.ubuntu.com/t/ubuntu-pro-beta-tutorial/31018">Discover the step-by-step tutorial</a>
   </div>
 </section>
 <section class="p-strip is-x-deep u-no-padding--top">
@@ -737,7 +737,7 @@
     <h2>Experience Ubuntu Pro in action:</h2>
     <a class="p-heading--2" href="https://ubuntu.com/engage/introduction-to-ubuntu-pro">Webinar&nbsp;&rsaquo;</a>
     &nbsp;&nbsp;
-    <a class="p-heading--2" href="#">Tutorials&nbsp;&rsaquo;</a>
+    <a class="p-heading--2" href="https://discourse.ubuntu.com/t/ubuntu-pro-beta-tutorial/31018">Tutorials&nbsp;&rsaquo;</a>
   </div>
 </section>
 

--- a/webapp/shop/decorators.py
+++ b/webapp/shop/decorators.py
@@ -73,7 +73,7 @@ def shop_decorator(area=None, permission=None, response="json", redirect=None):
                     flask.session[metadata_key] = value
 
             # shop under maintenance
-            if flask.request.path == "/advantage/subscribe":
+            if flask.request.path == "/pro/subscribe":
                 return flask.render_template("advantage/maintenance.html")
 
             # if logged in, get rid of guest token


### PR DESCRIPTION
## Done

- Added two links to the beta discourse tutorial: https://discourse.ubuntu.com/t/ubuntu-pro-beta-tutorial/31018

## QA

- View the page at /pro, see that "Discover the step-by-step tutorial" and "Tutorials" both link to https://discourse.ubuntu.com/t/ubuntu-pro-beta-tutorial/31018
