### PR TITLE
add redirect for /pro/beta to discourse post

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -951,6 +951,7 @@ security/cve/sitemap(?P<suffix>.*).xml: /security/cves/sitemap{suffix}.xml
 
 /advantage: "/pro"
 /advantage/(?P<path>.*): "/pro/{path}"
+/pro/beta/?: https://discourse.ubuntu.com/t/ubuntu-pro-beta-tutorial/31018
 
 # USN redirects
 /security/notices/months(/.*)?/?: /security/notices


### PR DESCRIPTION
## Done

- redirect /pro/beta to https://discourse.ubuntu.com/t/ubuntu-pro-beta-tutorial/31018

## QA

- Visit /pro/beta
- See that you are redirected to https://discourse.ubuntu.com/t/ubuntu-pro-beta-tutorial/31018
