### PR TITLE
add link to pro press release

### DIFF
--- a/templates/advantage/base_advantage.html
+++ b/templates/advantage/base_advantage.html
@@ -7,7 +7,7 @@
   {% block content %}{% endblock %}
 
   <!-- Set default Marketo information for contact form below-->
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/advantage-beta" data-form-id="1257" data-lp-id="1257" data-return-url="https://ubuntu.com/pro/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/advantage-beta" data-form-id="4669" data-lp-id="4669" data-return-url="https://ubuntu.com/pro/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
   </div>
 
 {% endblock %}

--- a/templates/advantage/index-no-login.html
+++ b/templates/advantage/index-no-login.html
@@ -576,7 +576,7 @@
           Ubuntu Security Guide (USG) enables CIS Server and Workstation Level 1 and 2 scripts, certified audit tooling, and DISA-STIG profiles</p>
       </div>
       <hr class="u-no-margin--bottom">
-      <p><a href="#">Read the press release</a></p>
+      <p><a href="/blog/ubuntu-pro-beta-release">Read the press release</a></p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- Added a link to an as yet unpublished press release

## QA

- Visit https://ubuntu-com-12116.demos.haus/pro
- Find the "Read the press release" link, see that it points to https://ubuntu.com/blog/ubuntu-pro-beta-release
- It will 404 at the moment, it is due to be published at 13:55 UK time
