### PR TITLE
copy change ua to pro in cli help text

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.tsx
@@ -188,7 +188,7 @@ const DetailsTabs = ({
                     <>
                       To attach a machine:{" "}
                       <code data-test="contract-token">
-                        sudo ua attach {token?.contract_token}
+                        sudo pro attach {token?.contract_token}
                       </code>
                     </>
                   ),


### PR DESCRIPTION
## Done

change ua to pro in cli help text

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
