### PR TITLE
update pro subnav to read "Pro"

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -310,6 +310,18 @@ support:
     - title: Community support
       path: /support/community-support
 
+pro:
+  title: Pro
+  path: /pro
+
+  children:
+    - title: Your subscriptions
+      path: /pro
+    - title: Account users
+      path: /pro/users
+    - title: Community support
+      path: /support/community-support
+
 account:
   title: Account
   path: /account


### PR DESCRIPTION
## Done

- previously the subnav heading on /pro read "Support", now it reads "Pro"

## QA

- Go to /pro
- See "Pro" in the subnav
- Yay!

