### PR TITLE
Update USN template

### DIFF
--- a/templates/security/notices/usn.html
+++ b/templates/security/notices/usn.html
@@ -63,10 +63,10 @@
               <div>
                 <small>
                   {% if package.pocket == "esm-infra" %}
-                    Available with <a href="/pro">UA Infra or UA Desktop</a>
+                    Available with <a href="/pro">Ubuntu Pro (Infra-only)</a>
                   {% endif %}
                   {% if package.pocket == "esm-apps" %}
-                    Available with <a href="/pro">UA Apps or UA Desktop</a>
+                    Available with <a href="/pro">Ubuntu Pro</a>
                   {% endif %}
                 </small>
               </div>


### PR DESCRIPTION
## Done

- Updated USN as per request (see issue for a link to the thread if needed):
![Screenshot 2022-10-05 at 17 48 06](https://user-images.githubusercontent.com/17607612/194104412-71dbd99d-3c4f-4815-829b-c6ae25b92882.png)


## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/notices/USN-5656-1 
    - See that the text has been updated as requested
    - Be sure to test on mobile, tablet and desktop screen sizes

## Issue / Card

Fixes https://github.com/canonical/ubuntu.com/issues/12126

## Screenshots
![Screenshot 2022-10-05 at 17 49 55](https://user-images.githubusercontent.com/17607612/194104845-ebbf4efe-784b-4c35-9f3a-b3328e498c4b.png)

