### PR TITLE
update let's talk link

### DIFF
--- a/templates/advantage/index-no-login.html
+++ b/templates/advantage/index-no-login.html
@@ -434,7 +434,7 @@
       <div class="p-strip is-shallow u-no-padding--top">
         <h2>Available everywhere</h2>
         <p>Enterprise-grade security and compliance delivered on every cloud, <br>data centre, and desktop.</p>
-        <p><a href="#" class="js-invoke-modal">Let's talk</a></p>
+        <p><a href="https://ubuntu.com/contact-us/form?product=pro">Let's talk</a></p>
       </div>
     </div>
     <div class="col-6 col-medium-6">


### PR DESCRIPTION
## Done

- update the "Let's talk" link on u.c/pro to direct to https://ubuntu.com/contact-us/form?product=pro, rather than trigger a contact modal

## QA

- Visit /pro
- Find the "Let's talk" link and follow it
- It should lead you to https://ubuntu.com/contact-us/form?product=pro

