### PR TITLE
Update pricing table

### DIFF
--- a/templates/pricing/pro.html
+++ b/templates/pricing/pro.html
@@ -19,7 +19,7 @@
         <a href="/support/contact-us" class="p-button--positive js-invoke-modal" data-testid="interactive-form-link">Get in touch</a>
       </li>
       <li class="p-inline-list__item">
-        <a href="/pro" class="p-button">Purchase a subscription</a>
+        <a href="/pro/subscribe" class="p-button">Purchase a subscription</a>
       </li>
     </ul>
   </div>

--- a/templates/shared/pricing/_ua-for-infrastructure.html
+++ b/templates/shared/pricing/_ua-for-infrastructure.html
@@ -4,23 +4,23 @@
       <thead>
         <tr>
           <th style="width: 50%;"></th>
-          <th class="u-align--right">Ubuntu Pro</th>
           <th class="u-align--right">Ubuntu Pro (Infra-only)</th>
+          <th class="u-align--right">Ubuntu Pro</th>
           <th></th>
         </tr>
       </thead>
       <tbody>
         <tr>
           <td>Physical server</td>
-          <td class="u-align--right">$500</td>
           <td class="u-align--right">$225</td>
+          <td class="u-align--right">$500</td>
           <td></td>
         </tr>
         {% if no_desktop != "true" %}
         <tr>
           <td>Desktop</td>
-          <td class="u-align--right">$25</td>
           <td class="u-align--right">n/a</td>
+          <td class="u-align--right">$25</td>
           <td></td>
         </tr>
         {% endif %}
@@ -32,8 +32,8 @@
         </tr>
         <tr>
           <td><a href="/esm">Expanded Security Maintenance</a> for Application (esm-apps) &mdash; in beta</td>
-          <td class="u-align--right">Included</td>
           <td class="u-align--right">Not included</td>
+          <td class="u-align--right">Included</td>
           <td></td>
         </tr>
         <tr>
@@ -50,8 +50,8 @@
         </tr>
         <tr>
           <td><a href="/engage/microsoft-active-directory">Advanced Active Directory</a> policies for Ubuntu Desktop</td>
-          <td class="u-align--right">Included</td>
           <td class="u-align--right">Not included</td>
+          <td class="u-align--right">Included</td>
           <td></td>
         </tr>        
         <tr>


### PR DESCRIPTION
## Done

- switched the columns in the first table of /pricing/pro to better align with the tables below
- updated the "Purchase a subscription" link to point to /pro/subscribe

## QA

- visit https://ubuntu-com-12130.demos.haus/pricing/pro
- see that the "UBUNTU PRO (INFRA-ONLY)" column appears before "UBUNTU PRO" in the first table, and that the values in each column are correct
- click "Purchase a subscription" and see that you're taken to /pro/subscribe
