### PR TITLE
Add previous and next buttons for doc navigation

### DIFF
--- a/templates/templates/docs/shared/_docs.html
+++ b/templates/templates/docs/shared/_docs.html
@@ -100,6 +100,52 @@
     <main class="col-9">
       {{ document.body_html | safe }}
 
+      <div class="p-strip">
+        <hr class="u-no-margin--bottom">
+        <div class="p-article-pagination">
+          {% set nav_items = navigation.nav_items %}
+          {% set ns = namespace(use_next=false, outer_title=none) %}
+
+          {%- for page in nav_items|reverse recursive %}
+            {% if ns.use_next and not page.hidden and page.navlink_text and not page.navlink_href %}
+              {% set ns.outer_title = page.navlink_text %}
+            {% endif %}
+            {{- loop(page.children|reverse) }}
+            {% if page.is_active %}
+                {% set ns.use_next = true %}
+            {% elif ns.use_next and not page.hidden and page.navlink_text %}
+              {% if page.navlink_href %}
+                <a class="p-article-pagination__link--previous" href="{{ page.navlink_href }}">
+                  <span class="p-article-pagination__label">Previous</span>
+                  <span class="p-article-pagination__title">{% if ns.outer_title %}{{ ns.outer_title }}: {% endif %}{{ page.navlink_text }}</span>
+                </a>
+                {% set ns.use_next = false %}
+              {% endif %}
+            {% endif %}
+          {%- endfor %}
+
+          {% set ns.outer_title = none %}
+          {% set ns.use_next = false %}
+
+          {%- for page in nav_items recursive %}
+            {% if page.is_active %}
+                {% set ns.use_next = true %}
+            {% elif ns.use_next and not page.hidden and page.navlink_text %}
+              {% if page.navlink_href %}
+                <a class="p-article-pagination__link--next" href="{{ page.navlink_href }}">
+                  <span class="p-article-pagination__label">Next</span>
+                  <span class="p-article-pagination__title">{% if ns.outer_title %}{{ ns.outer_title }}: {% endif %}{{ page.navlink_text }}</span>
+                </a>
+                {% set ns.use_next = false %}
+              {% else %}
+                {% set ns.outer_title = page.navlink_text %}
+              {% endif %}
+            {% endif %}
+            {{- loop(page.children) }}
+          {%- endfor %}
+        </div>
+      </div>
+
 			<div class="p-strip is-shallow">
 				<div class="p-notification--information">
 					<div class="p-notification__content">


### PR DESCRIPTION
## Done
This change allows users to navigate through documentation pages by clicking a previous or next page button, making navigation faster when reading sequentially. The buttons show the name of the previous and upcoming pages, and the links correspond to the adjacent pages, regardless of section, with section pages included.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots
Here are some examples:
The end of the Server Documentation [munin page](https://ubuntu-com-12132.demos.haus/server/docs/tools-munin) will show:

![munin](https://user-images.githubusercontent.com/35419443/194167733-37f93ee5-89c1-4398-8e68-bdd278bb5c2d.png)

The [introduction](https://ubuntu-com-12132.demos.haus/server/docs) to the Server Documentation will show:

![intro](https://user-images.githubusercontent.com/35419443/194168010-9e18c604-6517-49d2-996c-2477bfa813c6.png)

Likewise, Ubuntu Core's [How-To home page](https://ubuntu-com-12132.demos.haus/core/docs/how-to) will show:

![corehowto](https://user-images.githubusercontent.com/35419443/194168275-44a199ac-2f77-4eee-b670-e579c1485a4e.png)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
