### PR TITLE
Add automotive link

### DIFF
--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -87,6 +87,7 @@
               <span class="js-footer-accordion-cta" aria-controls="sectors-footer-nav">Sectors</span>
             </h2>
             <ul class="second-level-nav" id="sectors-footer-nav">
+              <li><a href="/automotive">Automotive</a></li>
               <li><a href="/industrial">Industrial</a></li>
               <li><a href="/gov">Government</a></li>
               <li><a href="/telco">Telco</a></li>


### PR DESCRIPTION
## Done

- Add automotive link on the footer

## QA

- Go to https://ubuntu-com-12133.demos.haus/
- Scroll down to the footer
- Can you see the automotive link? [(docs)](https://docs.google.com/document/d/117orMiMtXPBwowp6sjJ1ygjROYjSLnUkvosac7nqmpw/edit)

## Issue / Card

Fixes #https://github.com/canonical/commercial-squad/issues/723