### PR TITLE
Update /aws/pro for 22.04

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -853,3 +853,13 @@ html {
 img.has-shadow {
   box-shadow: 0 0 1rem #e5e5e5;
 }
+
+// Style for status labels (similar to chips but non-clickable)
+.p-status-label--rounded {
+  background-color: #ddf2e0;
+  border-radius: map-get($line-heights, h4);
+  margin-bottom: map-get($sp-after, h4) - map-get($nudges, h4);
+  padding-bottom: map-get($nudges, h4);
+  padding-left: $sph--x-large;
+  padding-right: $sph--x-large;
+}

--- a/templates/aws/pro.html
+++ b/templates/aws/pro.html
@@ -11,6 +11,14 @@
       <h1>Ubuntu Pro for AWS</h1>
       <p class="p-heading--3">For production. For professionals.</p>
       <p>Ubuntu Pro for AWS is a premium image delivering the most comprehensive open source security and AWS compliance. Ubuntu Pro is suitable for small to large-scale Linux enterprise operations offering pay-as-you-go billing on your existing AWS invoice.</p>
+      <div class="u-sv2">
+        <h3 class="p-heading--4" style="display:inline;padding-right:0.8rem;">Ubuntu Pro 22.04 LTS</h3>
+        <button class="p-chip--positive is-inline" style="pointer-events:none;">
+          <span class="p-chip__value">Latest</span>
+        </button>
+      </div>
+      <p>Delivers additional layer of security and compliance services and security patches covering a wider range of packages, until 2032.</p>
+      <p><a href="https://aws.amazon.com/marketplace/pp/prodview-uy7jg4dds3qjw" class="p-button--positive">Launch now</a></p>
     </div>
     <div class="col-5 u-align--center u-vertically-center u-hide--medium u-hide--small">
       {{
@@ -28,26 +36,21 @@
 </section>
 
 <section class="p-strip is-shallow u-sv3">
-  <div class="row p-divider">
-    <div class="col-3 p-divider__block">
-      <h3 class="p-heading--4">Ubuntu Pro 22.04 LTS</h3>
-      <p>The latest LTS release includes the 5.15 kernel out of the box. Ubuntu Pro 22.04 LTS provides extended maintenance through 2032.</p>
-      <p><a href="https://aws.amazon.com/marketplace/pp/prodview-uy7jg4dds3qjw" class="p-button--positive">Launch now</a></p>
-    </div>    
-    <div class="col-3 p-divider__block">
+  <div class="row p-divider"> 
+    <div class="col-4 p-divider__block">
       <h3 class="p-heading--4">Ubuntu Pro 20.04 LTS</h3>
-      <p>The latest LTS release includes the 5.4 kernel out of the box. Ubuntu Pro 20.04 LTS provides extended maintenance through 2030.</p>
+      <p>Maintained until 2030.</p>
       <p><a href="https://aws.amazon.com/marketplace/pp/B087L1R4G4" class="p-button--positive">Launch now</a></p>
     </div>
-    <div class="col-3 p-divider__block">
+    <div class="col-4 p-divider__block">
       <h3 class="p-heading--4">Ubuntu Pro 18.04 LTS</h3>
-      <p>Ubuntu 18.04 LTS release includes 5.4 kernel and provides extended maintenance through 2028.
+      <p>Maintained until 2028.
     </p>
       <p><a href="https://aws.amazon.com/marketplace/pp/B0821T9RL2" class="p-button--positive">Launch now</a></p>
     </div>
-    <div class="col-3 p-divider__block">
+    <div class="col-4 p-divider__block">
       <h3 class="p-heading--4">Ubuntu Pro 16.04 LTS</h3>
-      <p>Ubuntu 16.04 LTS shipped in 2016 with the 4.4 kernel, and is covered with Ubuntu Pro through 2026.</p>
+      <p>Maintained until 2026.</p>
       <p><a href="https://aws.amazon.com/marketplace/pp/B0821WW873" class="p-button--positive">Launch now</a></p>
     </div>
   </div>
@@ -62,7 +65,7 @@
       <ul class="p-matrix u-clearfix">
         <li class="p-matrix__item">
           <div class="p-matrix__content">
-            <h3 class="p-matrix__title">FIPS & CC-EAL2 certified</h3>
+            <h3 class="p-matrix__title">FIPS &amp; CC-EAL2 certified</h3>
             <div class="p-matrix__desc">
               <p>Certified components to enable operating environments under compliance regimes like FedRAMP, HIPAA, PCI and ISO.</p>
             </div>
@@ -137,7 +140,7 @@
     <div class="col-6">
       <h2>AWS compliance made easy</h2>
       <p><strong>Ubuntu Pro for AWS: FIPS compliance made easy</strong></p>
-      <p>The FIPS certified Ubuntu Pro image is now available on AWS. Ubuntu Pro FIPS is the critical foundation for state agencies administering federal programs and private sector companies with government contracts. Ubuntu Pro FIPS is built upon the power of Ubuntu Pro’s enhanced stability, AWS compliance and security features and is maintained to provide your organisation with the strongest FIPS foundation now and in the future.</p>
+      <p>The FIPS certified Ubuntu Pro image is now available on AWS. Ubuntu Pro FIPS is the critical foundation for state agencies administering federal programs and private sector companies with government contracts. Ubuntu Pro FIPS is built upon the power of Ubuntu Pro's enhanced stability, AWS compliance and security features and is maintained to provide your organisation with the strongest FIPS foundation now and in the future.</p>
      <p><a href="https://www.brighttalk.com/webcast/6793/449853" class="p-button--positive">Watch the webinar</a></p>
     </div>
     <div class="col-6">
@@ -287,16 +290,19 @@
     </div>
   </div>
   <div class="row p-divider">
-    <div class="col-3 p-divider__block">
+    <div class="col-2 p-divider__block">
+      <h3 class="p-heading--4"><a href="https://aws.amazon.com/marketplace/pp/prodview-uy7jg4dds3qjw">22.04 LTS</a></h3>
+    </div>    
+    <div class="col-2 p-divider__block">
       <h3 class="p-heading--4"><a href="https://aws.amazon.com/marketplace/pp/B087L1R4G4">20.04 LTS</a></h3>
     </div>
-    <div class="col-3 p-divider__block">
+    <div class="col-2 p-divider__block">
       <h3 class="p-heading--4"><a href="https://aws.amazon.com/marketplace/pp/B0821T9RL2">18.04 LTS</a></h3>
     </div>
-    <div class="col-3 p-divider__block">
+    <div class="col-2 p-divider__block">
       <h3 class="p-heading--4"><a href="https://aws.amazon.com/marketplace/pp/B0821WW873">16.04 LTS</a></h3>
     </div>
-    <div class="col-3 p-divider__block">
+    <div class="col-2 p-divider__block">
       <h3 class="p-heading--4"><a href="https://aws.amazon.com/marketplace/pp/B0821V7QJP">14.04 LTS</a></h3>
     </div>
   </div>

--- a/templates/aws/pro.html
+++ b/templates/aws/pro.html
@@ -11,12 +11,10 @@
       <h1>Ubuntu Pro for AWS</h1>
       <p class="p-heading--3">For production. For professionals.</p>
       <p>Ubuntu Pro for AWS is a premium image delivering the most comprehensive open source security and AWS compliance. Ubuntu Pro is suitable for small to large-scale Linux enterprise operations offering pay-as-you-go billing on your existing AWS invoice.</p>
-      <div class="u-sv2">
-        <h3 class="p-heading--4" style="display:inline;padding-right:0.8rem;">Ubuntu Pro 22.04 LTS</h3>
-        <button class="p-chip--positive is-inline" style="pointer-events:none;">
-          <span class="p-chip__value">Latest</span>
-        </button>
-      </div>
+      <h3 class="p-heading--4">
+        Ubuntu Pro 22.04 LTS
+        <span class="p-status-label--rounded">Latest</span>
+      </h3>
       <p>Delivers additional layer of security and compliance services and security patches covering a wider range of packages, until 2032.</p>
       <p><a href="https://aws.amazon.com/marketplace/pp/prodview-uy7jg4dds3qjw" class="p-button--positive">Launch now</a></p>
     </div>
@@ -36,6 +34,9 @@
 </section>
 
 <section class="p-strip is-shallow u-sv3">
+  <div class="u-fixed-width">
+    <h2>Previous Releases</h2>
+  </div>
   <div class="row p-divider"> 
     <div class="col-4 p-divider__block">
       <h3 class="p-heading--4">Ubuntu Pro 20.04 LTS</h3>

--- a/templates/azure/pro.html
+++ b/templates/azure/pro.html
@@ -11,12 +11,9 @@
       <h1>Ubuntu Pro for Azure</h1>
       <p class="p-heading--3">For production. For professionals.</p>
       <p>Ubuntu Pro for Azure is a premium image delivering the most comprehensive open source security and Azure compliance. Ubuntu Pro is suitable for small to large-scale Linux enterprise operations offering pay-as-you-go billing on your existing Azure invoice.</p>
-      <div class="u-sv2">
-        <h3 class="p-heading--4" style="display:inline;padding-right:0.8rem;">Ubuntu Pro 22.04 LTS</h3>
-        <button class="p-chip--positive is-inline" style="pointer-events:none;">
-          <span class="p-chip__value">Latest</span>
-        </button>
-      </div>
+      <h3 class="p-heading--4">Ubuntu Pro 22.04 LTS
+        <span class="p-status-label--rounded">Latest</span>
+      </h3>
       <p>Delivers additional layer of security and compliance services and security patches covering a wider range of packages, until 2032.</p>
       <p><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-jammy" class="p-button--positive">Launch now</a></p>
     </div>


### PR DESCRIPTION
## Done

- Update /aws/pro for 22.04 based on [copydoc](https://docs.google.com/document/d/1pLRWJZSpE04nYt-yHBtCjxGI7VZsigcP2UJIBmR8i-0/edit#heading=h.rwz46gtc2v3z)
- Updates /azure/pro to follow the same `p-status-label--rounded` pattern for the 'latest' label as /aws/pro

## QA

- Go to https://ubuntu-com-12134.demos.haus/aws/pro and see that it matches the [copydoc](https://docs.google.com/document/d/1pLRWJZSpE04nYt-yHBtCjxGI7VZsigcP2UJIBmR8i-0/edit#heading=h.rwz46gtc2v3z)
- Compare 'status' chip the design, found at the bottom of [this page](https://docs.google.com/document/d/1uiJ00ycDhyBP_QOIwSV5Jc21I-h0eZft1dONsIAqOxA/edit#). Note, the one used in this PR is a new pattern that is being suggested to vanilla [here](https://github.com/canonical/vanilla-framework/issues/4574)

## Screenshots

Status chip:
![image](https://user-images.githubusercontent.com/58276363/194506579-8ddc1091-262a-41a7-9140-9bcfd89a727c.png)


## Issue / Card

Fixes https://github.com/canonical/ubuntu.com/issues/11685
