### PR TITLE
change to Pro for /account and /account/invoices

### DIFF
--- a/templates/account/index.html
+++ b/templates/account/index.html
@@ -11,7 +11,7 @@
   <section class="p-strip--suru-topped p-strip-account-page">
     <div class="row">
       <div class="col-12">
-        <h1>Ubuntu Advantage for&nbsp;Infrastructure</h1>
+        <h1>Ubuntu Pro</h1>
 
         <p>You are signed in as {{email}}&emsp;
           <span class="u-hide--large u-hide--medium"><br/></br/></span>

--- a/templates/account/invoices/index.html
+++ b/templates/account/invoices/index.html
@@ -20,7 +20,7 @@
       <select name="marketplace" id="marketplace-dropdown">
         <option value="">All invoices</option>
         <option value="blender" {% if marketplace == 'blender' %}selected{% endif %}>Blender Support</option>
-        <option value="canonical-ua" {% if marketplace == 'canonical-ua' %}selected{% endif %}>Canonical UA</option>
+        <option value="canonical-ua" {% if marketplace == 'canonical-ua' %}selected{% endif %}>Ubuntu Pro</option>
       </select>
     </div>
   </div>
@@ -40,7 +40,7 @@
               <tr>
                 <td aria-label="Service">
                   {% if invoice.marketplace == "canonical-ua"%}
-                    Canonical UA
+                    Ubuntu Pro
                   {% elif invoice.marketplace == "blender" %}
                     Blender Support
                   {% elif invoice.marketplace == "canonical-cube" %}


### PR DESCRIPTION
## Done

- Changed Invoice listings to now show Ubuntu Pro instead of Canonical UA
- Changes /account page to show Ubuntu Pro instead of Ubuntu Advantage for Infrastructure

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [/account](https://ubuntu-com-12136.demos.haus/account) should show Ubuntu Pro instead of Ubuntu Advantage for Infrastructure
- [/account/invoices](https://ubuntu-com-12136.demos.haus/account/invoices) should show Ubuntu Pro instead of Canonical UA in the dropdown as well as the invoice listing.

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
