### PR TITLE
Fix charm link

### DIFF
--- a/templates/about/packages.html
+++ b/templates/about/packages.html
@@ -44,9 +44,9 @@
       <h2>Charms are packages for cloud software operations</h2>
       <p>In the cloud world, it is useful to share software operations code as much as it is useful to share the code of the applications themselves. Rather than having many different organisations code operations separately, Ubuntu enables community-based operations collaboration with a standard 'charm' package for operations.</p>
       <p>Charms handle the application lifecycle - deployment, integration and configuration, upgrades, and teardown.</p>
-      <p>There are charms for both VM-based cloud operations, and Kubernetes-based cloud operations. Charms can use a range of operating systems, but most charms as Ubuntu-based, so they benefit from the standard security and familiarity of the rest of Ubuntu.</p>
+      <p>There are charms for both VM-based cloud operations, and Kubernetes-based cloud operations. Charms can use a range of operating systems, but most charms as Ubuntu-based, so they benefit from the standard security and familiarity of the rest of Ubuntu.</p>
       <p>
-        <a href="https://discourse.juju.is/t/charm-writing/1260">
+        <a href="https://juju.is/docs/sdk/hello-world">
           Get started making a charm
         </a>
       </p>


### PR DESCRIPTION
## Done

- The "get started making a charm" is a private unlisted discourse topic, which is not accessible by search engines and people outside of the org, so replacing it with a public link.

- Also remove a stranger character that can't be rendered correctly.

## QA

- Go to https://ubuntu-com-12138.demos.haus/about/packages.
- Check that the problems mentioned in [the issue](https://github.com/canonical/ubuntu.com/issues/11786) are fixed:
  - Strange character
  - Inaccessible link at [Get started making a charm](https://discourse.juju.is/t/charm-writing/1260?_ga=2.57613417.231841935.1665062587-211299447.1665062587)

## Issue / Card

Fixes https://github.com/canonical/ubuntu.com/issues/11786


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
