### PR TITLE
copy changes to add link and change adv to pro

### DIFF
--- a/templates/security/disa-stig.html
+++ b/templates/security/disa-stig.html
@@ -14,7 +14,7 @@
      <h2 class="p-heading--4">Comply with the DISA Security Technical Implementation Guide</h2>
      <p>Security Technical Implementation Guides (STIG) are developed by the Defense Information System Agency (DISA) for the U.S. Department of Defense (DoD). <a href="/cloud/public-cloud">Ubuntu Pro on Public Clouds</a> and <a href="/pro">Ubuntu Pro (Infra)</a> have the necessary <a href="/security/fips">certifications</a> and controls to comply with DISA-STIG guidelines on Linux.</p>
      <a class="p-button--positive js-invoke-modal" href="/security/contact-us">Contact us</a>
-     <a class="p-button" href="/pro">Get Ubuntu Pro</a>
+     <a class="p-button" href="/pro">Get Ubuntu Pro (Infra)</a>
    </div>
    <div class="col-4 u-hide--medium u-hide--small u-align--center">
     {{ image (

--- a/templates/security/disa-stig.html
+++ b/templates/security/disa-stig.html
@@ -12,9 +12,9 @@
    <div class="col-8">
      <h1>DISA-STIG on Ubuntu</h1>
      <h2 class="p-heading--4">Comply with the DISA Security Technical Implementation Guide</h2>
-     <p>Security Technical Implementation Guides (STIG) are developed by the Defense Information System Agency (DISA) for the U.S. Department of Defense (DoD). <a href="/cloud/public-cloud">Ubuntu Pro</a> and <a href="/pro">Ubuntu Advantage</a> have the necessary <a href="/security/fips">certifications</a> and controls to comply with DISA-STIG guidelines on Linux.</p>
+     <p>Security Technical Implementation Guides (STIG) are developed by the Defense Information System Agency (DISA) for the U.S. Department of Defense (DoD). <a href="/cloud/public-cloud">Ubuntu Pro on Public Clouds</a> and <a href="/pro">Ubuntu Pro (Infra)</a> have the necessary <a href="/security/fips">certifications</a> and controls to comply with DISA-STIG guidelines on Linux.</p>
      <a class="p-button--positive js-invoke-modal" href="/security/contact-us">Contact us</a>
-     <a class="p-button" href="/pro">Get Ubuntu Advantage</a>
+     <a class="p-button" href="/pro">Get Ubuntu Pro</a>
    </div>
    <div class="col-4 u-hide--medium u-hide--small u-align--center">
     {{ image (
@@ -92,7 +92,7 @@
           }}
          </td>
          <td>
-           Defense Information System Agency <a href="https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux">Security Technical Implementation Guides (STIGs)</a> for Ubuntu
+           Defense Information System Agency <a href="https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux">Security Technical Implementation Guides (STIGs)</a> and <a href="https://public.cyber.mil/stigs/supplemental-automation-content/">Supplemental Automation Content</a> for Ubuntu
           </td>
          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/2ccda8d7-tick-orange.svg", alt="Yes: Configuration guide", width="14", height="14", hi_def=True, loading="lazy",) | safe }}</td>
          <td class="u-align--center">{{ image(url="https://assets.ubuntu.com/v1/2ccda8d7-tick-orange.svg", alt="Yes: Configuration guide", width="14", height="14", hi_def=True, loading="lazy",) | safe }}</td>


### PR DESCRIPTION
## Done

- DISA-STIG page has new link to [Supplemental Automation Content](https://public.cyber.mil/stigs/supplemental-automation-content/) and Advantage naming changed to Pro
- Copy doc: https://docs.google.com/document/d/1zJwZzc-cERj9YKNXFtmrXwynJptyT7-D3qCNzBctRfo/edit?usp=sharing

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Visit [https://ubuntu-com-12140.demos.haus/security/disa-stig](https://ubuntu-com-12140.demos.haus/security/disa-stig)
    - No mention of Ubuntu Advantage (changed to Ubuntu Pro and Ubuntu Pro on Public Clouds)
    -  page has new link to [Supplemental Automation Content](https://public.cyber.mil/stigs/supplemental-automation-content/) 
## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
