### PR TITLE
Remove pro page on cypress test

### DIFF
--- a/tests/cypress/forms/forms_spec.js
+++ b/tests/cypress/forms/forms_spec.js
@@ -135,23 +135,6 @@ context("Interactive marketo forms", () => {
     }
   );
 
-  it("should check interactive contact modal on /pro", () => {
-    cy.visit("/pro");
-    cy.acceptCookiePolicy();
-    cy.findByRole("link", {
-      name: /Join our free beta programme for Ubuntu Pro on prem/,
-    }).click();
-    cy.findByRole("link", { name: /Next/ }).click();
-    cy.findByLabelText(/First name:/).type("Test");
-    cy.findByLabelText(/Last name:/).type("Test");
-    cy.findByLabelText(/Work email:/).type("test@test.com");
-    cy.findByLabelText(/I agree to receive information/).click({
-      force: true,
-    });
-    cy.findByText(/Let's discuss/).click();
-    cy.findByRole("heading", { name: /Thank you/ });
-  });
-
   // wrote separate test for /robotics page as cypress couldn't find the job title input field by label text
   it(
     "should check interactive contact modal on /robotics",


### PR DESCRIPTION
## Done

- Pro page needs to be removed in cypress test as this link  "Join our free beta programme for Ubuntu Pro on prem" doesn't exist any more. 

## QA
https://discourse.canonical.com/t/how-to-run-cypress-test-locally-for-forms-on-ubuntu-com/558
