### PR TITLE
Fix copy typo

### DIFF
--- a/templates/security/disa-stig.html
+++ b/templates/security/disa-stig.html
@@ -12,7 +12,7 @@
    <div class="col-8">
      <h1>DISA-STIG on Ubuntu</h1>
      <h2 class="p-heading--4">Comply with the DISA Security Technical Implementation Guide</h2>
-     <p>Security Technical Implementation Guides (STIG) are developed by the Defense Information System Agency (DISA) for the U.S. Department of Defense (DoD). <a href="/cloud/public-cloud">Ubuntu Pro on Public Clouds</a> and <a href="/pro">Ubuntu Pro (Infra)</a> have the necessary <a href="/security/fips">certifications</a> and controls to comply with DISA-STIG guidelines on Linux.</p>
+     <p>Security Technical Implementation Guides (STIG) are developed by the Defense Information System Agency (DISA) for the U.S. Department of Defense (DoD). <a href="/cloud/public-cloud">Ubuntu Pro on public cloud</a> and <a href="/pro">Ubuntu Pro (Infra)</a> have the necessary <a href="/security/fips">certifications</a> and controls to comply with DISA-STIG guidelines on Linux.</p>
      <a class="p-button--positive js-invoke-modal" href="/security/contact-us">Contact us</a>
      <a class="p-button" href="/pro">Get Ubuntu Pro (Infra)</a>
    </div>


### PR DESCRIPTION
## Done

- Fixed small typo "Pubic Clouds" to "public cloud"
- Doc: https://docs.google.com/document/d/1zJwZzc-cERj9YKNXFtmrXwynJptyT7-D3qCNzBctRfo/edit#heading=h.pc9i27tqv0qt

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: https://ubuntu-com-12146.demos.haus/security/disa-stig
    - Be sure to test on mobile, tablet and desktop screen sizes
- See that typo has been fixed and that copy matches the doc
