### PR TITLE
Update centos logo on homepage

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -34,7 +34,7 @@
   <div class="row">
     <div class="p-heading-icon">
       <div class="p-heading-icon__header">
-        <img src="https://assets.ubuntu.com/v1/89451f56-centos.png" alt="" class="p-heading-icon__img" >
+        <img src="https://assets.ubuntu.com/v1/5a869d54-centos.png" alt="" class="p-heading-icon__img" >
         <h2 class="p-heading--4 p-heading-icon__title" style="padding-top:0.4rem"><a href="/blog/migrating-to-ubuntu-lts-six-facts-for-centos-users">CentOS users, 6 things to know when considering a migration to Ubuntu LTS&nbsp;&rsaquo;</a></h2>
       </div>
     </div>


### PR DESCRIPTION
## Done

- Update centos logo on homepage as suggested in [this issue](https://github.com/canonical/ubuntu.com/issues/11953)

## QA

- Go to u.com homepage and check the logo is updated to the one in the issue

## Issue / Card

Fixes https://github.com/canonical/ubuntu.com/issues/11953
