### PR TITLE
Redirect old developers.u.com to u.com/desktop/developers

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -117,6 +117,7 @@ extraHosts:
   - domain: certification.ubuntu.com
   - domain: security-certs.docs.ubuntu.com
   - domain: usn.ubuntu.com
+  - domain: developer.ubuntu.com
 
 # Overrides for production
 production:
@@ -320,6 +321,9 @@ production:
           value: pk_live_68aXqowUeX574aGsVck8eiIE
 
   nginxConfigurationSnippet: |
+    if ($host = 'developer.ubuntu.com' ) {
+      rewrite ^ https://ubuntu.com/desktop/developer permanent;
+    }
     if ($host = 'apps.ubuntu.com' ) {
       rewrite ^ https://snapcraft.io/ permanent;
     }


### PR DESCRIPTION

## Done

- [List of work items including drive-bys - remember to add the why and what of this work.]

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes https://github.com/canonical/ubuntu.com/issues/6214


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
