### PR TITLE
templates/kernel/index.html: Fix link to Ubuntu CVE priorities

### DIFF
--- a/templates/kernel/index.html
+++ b/templates/kernel/index.html
@@ -86,7 +86,7 @@
 <section class="p-strip--light is-bordered">
   <div class="u-fixed-width">
     <h2 id="kernel-security">Kernel security</h2>
-    <p>The Canonical Kernel Team's primary focus is the careful maintenance of kernels and their variants for regular delivery via the <a href="https://wiki.ubuntu.com/StableReleaseUpdates">Ubuntu SRU process</a> and the Canonical <a href="/security/livepatch">livepatch service</a>. This includes rigorous management of all Linux kernel Common Vulnerabilities and Exposures (CVE) lists (with a focus on patching  all <a href="https://git.launchpad.net/ubuntu-cve-tracker/tree/README#n199">high and critical</a> CVEs) review and application of all relevant patches for all critical and serious kernel defects in the mailing lists and then rigorously testing newly updated kernels end-to-end each SRU cycle.</p>
+    <p>The Canonical Kernel Team's primary focus is the careful maintenance of kernels and their variants for regular delivery via the <a href="https://wiki.ubuntu.com/StableReleaseUpdates">Ubuntu SRU process</a> and the Canonical <a href="/security/livepatch">livepatch service</a>. This includes rigorous management of all Linux kernel Common Vulnerabilities and Exposures (CVE) lists (with a focus on patching  all <a href="https://people.canonical.com/~ubuntu-security/priority.html">high and critical</a> CVEs) review and application of all relevant patches for all critical and serious kernel defects in the mailing lists and then rigorously testing newly updated kernels end-to-end each SRU cycle.</p>
   </div>
 </section>
 


### PR DESCRIPTION
Instead of linking to a specific line number within the README in the ubuntu-cve-tracker repo (which may change over time), instead link to the nicer looking HTML page on people.canonical.com/~ubuntu-security/priority.html

Signed-off-by: Alex Murray <alex.murray@canonical.com>

## Done

- [List of work items including drive-bys - remember to add the why and what of this work.]

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
