### PR TITLE
Disable infra support for 14.04 and 16.04

### DIFF
--- a/static/js/src/advantage/subscribe/react/components/Form/Support/Support.test.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Support/Support.test.tsx
@@ -15,17 +15,6 @@ beforeAll(() => {
   global.window.productList = productListFixture as ProductListings;
 });
 
-test("Full support is disabled if Xenial is selected", () => {
-  render(
-    <FormProvider initialVersion={LTSVersions.xenial}>
-      <Support />
-    </FormProvider>
-  );
-
-  expect(screen.getByTestId("infra-support")).not.toHaveClass("u-disable");
-  expect(screen.getByTestId("full-support")).toHaveClass("u-disable");
-});
-
 test("Full support is disabled if Infra is selected", () => {
   render(
     <FormProvider initialFeature={Features.infra}>
@@ -51,6 +40,17 @@ test("Infra support is disabled if desktop is selected", () => {
 test("Infra and full support are disabled if Trusty is selected", () => {
   render(
     <FormProvider initialVersion={LTSVersions.trusty}>
+      <Support />
+    </FormProvider>
+  );
+
+  expect(screen.getByTestId("infra-support")).toHaveClass("u-disable");
+  expect(screen.getByTestId("full-support")).toHaveClass("u-disable");
+});
+
+test("Infra and full support are disabled if Xenial is selected", () => {
+  render(
+    <FormProvider initialVersion={LTSVersions.xenial}>
       <Support />
     </FormProvider>
   );

--- a/static/js/src/advantage/subscribe/react/components/Form/Support/Support.test.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Support/Support.test.tsx
@@ -4,13 +4,59 @@ import "@testing-library/jest-dom";
 import { FormProvider } from "advantage/subscribe/react/utils/FormContext";
 import Support from "./Support";
 import {
+  LTSVersions,
   ProductListings,
   ProductTypes,
+  Features,
 } from "advantage/subscribe/react/utils/utils";
 import { productListFixture } from "advantage/subscribe/react/utils/test/Mocks";
 
 beforeAll(() => {
   global.window.productList = productListFixture as ProductListings;
+});
+
+test("Full support is disabled if Xenial is selected", () => {
+  render(
+    <FormProvider initialVersion={LTSVersions.xenial}>
+      <Support />
+    </FormProvider>
+  );
+
+  expect(screen.getByTestId("infra-support")).not.toHaveClass("u-disable");
+  expect(screen.getByTestId("full-support")).toHaveClass("u-disable");
+});
+
+test("Full support is disabled if Infra is selected", () => {
+  render(
+    <FormProvider initialFeature={Features.infra}>
+      <Support />
+    </FormProvider>
+  );
+
+  expect(screen.getByTestId("infra-support")).not.toHaveClass("u-disable");
+  expect(screen.getByTestId("full-support")).toHaveClass("u-disable");
+});
+
+test("Infra support is disabled if desktop is selected", () => {
+  render(
+    <FormProvider initialType={ProductTypes.desktop}>
+      <Support />
+    </FormProvider>
+  );
+
+  expect(screen.getByTestId("infra-support")).toHaveClass("u-disable");
+  expect(screen.getByTestId("full-support")).not.toHaveClass("u-disable");
+});
+
+test("Infra and full support are disabled if Trusty is selected", () => {
+  render(
+    <FormProvider initialVersion={LTSVersions.trusty}>
+      <Support />
+    </FormProvider>
+  );
+
+  expect(screen.getByTestId("infra-support")).toHaveClass("u-disable");
+  expect(screen.getByTestId("full-support")).toHaveClass("u-disable");
 });
 
 test("The section is disabled if a public cloud is selected", () => {

--- a/static/js/src/advantage/subscribe/react/components/Form/Support/Support.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Support/Support.tsx
@@ -31,7 +31,9 @@ const Support = () => {
   };
 
   const isInfraOnlyDisabled =
-    productType === ProductTypes.desktop || version === LTSVersions.trusty;
+    productType === ProductTypes.desktop ||
+    version === LTSVersions.trusty ||
+    version === LTSVersions.xenial;
 
   const isFullSupportDisabled =
     feature === Features.infra ||

--- a/static/js/src/advantage/subscribe/react/components/Form/Support/Support.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Support/Support.tsx
@@ -30,7 +30,9 @@ const Support = () => {
     );
   };
 
-  const isInfraOnlyDisabled = productType === ProductTypes.desktop;
+  const isInfraOnlyDisabled =
+    productType === ProductTypes.desktop || version === LTSVersions.trusty;
+
   const isFullSupportDisabled =
     feature === Features.infra ||
     version === LTSVersions.trusty ||
@@ -110,6 +112,7 @@ const Support = () => {
               "is-selected": support === SupportEnum.infra,
               "u-disable": isInfraOnlyDisabled,
             })}
+            data-testid="infra-support"
           >
             <label className="p-radio u-align-text--center">
               <input
@@ -153,6 +156,7 @@ const Support = () => {
               "is-selected": support === SupportEnum.full,
               "u-disable": isFullSupportDisabled,
             })}
+            data-testid="full-support"
           >
             <label className="p-radio u-align-text--center">
               <input

--- a/static/js/src/advantage/subscribe/react/utils/FormContext.tsx
+++ b/static/js/src/advantage/subscribe/react/utils/FormContext.tsx
@@ -111,7 +111,11 @@ export const FormProvider = ({
   }, [support, sla]);
 
   useEffect(() => {
-    if (version === LTSVersions.trusty || version === LTSVersions.xenial) {
+    if (version === LTSVersions.trusty) {
+      setSupport(Support.none);
+    }
+
+    if (version === LTSVersions.xenial) {
       if (support !== Support.none) {
         setSupport(Support.infra);
       }

--- a/static/js/src/advantage/subscribe/react/utils/FormContext.tsx
+++ b/static/js/src/advantage/subscribe/react/utils/FormContext.tsx
@@ -114,11 +114,8 @@ export const FormProvider = ({
     if (version === LTSVersions.trusty) {
       setSupport(Support.none);
     }
-
     if (version === LTSVersions.xenial) {
-      if (support !== Support.none) {
-        setSupport(Support.infra);
-      }
+      setSupport(Support.none);
     }
   }, [version, support]);
 


### PR DESCRIPTION
Fixes canonical/commercial-squad#729 or https://warthogs.atlassian.net/jira/software/c/projects/WD/boards/801?modal=detail&selectedIssue=WD-651

Co-authored-by: minkyngkm <min.kim@canonical.com>

## Done

- Disable infra support for 14.04 and  16.04
- Add tests

## QA

1. Go [here](https://ubuntu-com-12173.demos.haus/pro/subscribe)
2. Select full support
3. Go back up and select 14.04
4. "no support" should be selected and the other options should be disabled

same QA steps for 16.04
