### PR TITLE
Update desktop download page for 22.10 release

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -16,16 +16,6 @@ lts:
   release_date: "April 2022"
   eol: "April 2027"
   release_notes_url: "https://discourse.ubuntu.com/t/jammy-jellyfish-release-notes/24668"
-previous_latest:
-  slug: ImpishIndri
-  name: "Impish Indri"
-  short_version: "21.10"
-  full_version: "21.10"
-  core_version: "22"
-  release_date: "October 2021"
-  eol: "July 2022"
-  past_eol_date: true
-  release_notes_url: "https://discourse.ubuntu.com/t/impish-indri-release-notes/21951"
 previous_lts:
   name: "Focal Fossa"
   short_version: "20.04"

--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -23,7 +23,7 @@
 
     <div class="col-8 p-divider__block">
       <h2>Ubuntu {{ releases.lts.full_version }} LTS</h2>
-      <p class="u-no-padding--top">Download the latest <abbr title="Long-term support">LTS</abbr> version of Ubuntu, for desktop PCs and laptops. LTS stands for long-term support &mdash; which means five years of free security and maintenance updates, guaranteed until {{ releases.lts.eol }}.</p>
+      <p class="u-no-padding--top">The latest <abbr title="Long-term support">LTS</abbr> version of Ubuntu, for desktop PCs and laptops. LTS stands for long-term support &mdash; which means five years of free security and maintenance updates, guaranteed until {{ releases.lts.eol }}.</p>
       <p><a href="{{ releases.lts.release_notes_url }}">Ubuntu {{ releases.lts.short_version }} LTS release notes</a></p>
       <p>Recommended system requirements:</p>
       <ul class="p-list is-split">
@@ -48,6 +48,37 @@
       </div>
       <p>
         <a class="p-button--positive is-wide" href="/download/desktop/thank-you?version={{ releases.lts.full_version }}&amp;architecture=amd64" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });">Download</a>
+        <script>performance.mark("Download (Desktop) button rendered")</script>
+      </p>
+      <p><small>For other versions of Ubuntu Desktop including torrents, the network installer, a list of local mirrors and past releases <a href="/download/alternative-downloads">see our alternative downloads</a>.</small></p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="row">
+
+    <div class="col-8 p-divider__block">
+      <h2>Ubuntu {{ releases.latest.full_version }}</h2>
+      <p class="u-no-padding--top">The latest version of the Ubuntu operating system for desktop PCs and laptops, Ubuntu {{ releases.latest.short_version }} comes with nine months of security and maintenance updates, until {{ releases.latest.eol }}.</p>
+      <p>Recommended system requirements are the same as for Ubuntu {{ releases.lts.short_version }} LTS.</p>
+      <p><a href="{{ releases.latest.release_notes_url }}">Ubuntu {{ releases.latest.short_version }} release notes</a></p>
+    </div>
+    <div class="col-4">
+      <div class="u-align--center u-sv4">
+        {{
+          image (
+          url="https://assets.ubuntu.com/v1/38ba52dc-Kinetic+Kudo+22.10.svg",
+          alt="",
+          width="173",
+          height="150",
+          hi_def=True,
+          loading="auto|lazy"
+          ) | safe
+        }}
+      </div>
+      <p>
+        <a class="p-button--positive is-wide" href="/download/desktop/thank-you?version={{ releases.latest.full_version }}&amp;architecture=amd64" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">Download</a>
         <script>performance.mark("Download (Desktop) button rendered")</script>
       </p>
       <p><small>For other versions of Ubuntu Desktop including torrents, the network installer, a list of local mirrors and past releases <a href="/download/alternative-downloads">see our alternative downloads</a>.</small></p>


### PR DESCRIPTION
## Done

Updates for 22.10.

## QA

**Only 22.10 release updates**. I could not close the other comments, they were already addressed. Download links won't be ready until the release date

- Go to https://ubuntu-com-12174.demos.haus/download/desktop
- If demo doesn't build, please checkout this branch and `dotrun` it.
- Compare against [copy doc](https://docs.google.com/document/d/1ScuTtdrm3-iAvizTDxksVTAerV6QkCUN8Sg60uUlJsk/edit#)

## Issue / Card

Fixes https://github.com/canonical/ubuntu.com/issues/12161

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
