### PR TITLE
Add pro service description checkbox

### DIFF
--- a/static/js/src/PurchaseModal/PurchaseModal.tsx
+++ b/static/js/src/PurchaseModal/PurchaseModal.tsx
@@ -19,6 +19,7 @@ import { BuyButtonProps } from "./utils/utils";
 type Props = {
   accountId?: string;
   termsLabel: React.ReactNode;
+  descriptionLabel: React.ReactNode;
   marketingLabel: React.ReactNode;
   product?: any;
   preview?: any;
@@ -34,6 +35,7 @@ type Props = {
 const PurchaseModal = ({
   accountId,
   termsLabel,
+  descriptionLabel,
   marketingLabel,
   product,
   preview,
@@ -143,6 +145,7 @@ const PurchaseModal = ({
         ) : (
           <StepTwo
             termsLabel={termsLabel}
+            descriptionLabel={descriptionLabel}
             marketingLabel={marketingLabel}
             setStep={setStep}
             error={error}

--- a/static/js/src/PurchaseModal/components/ModalSteps/StepTwo.tsx
+++ b/static/js/src/PurchaseModal/components/ModalSteps/StepTwo.tsx
@@ -14,6 +14,7 @@ import { BuyButtonProps } from "../../utils/utils";
 
 type StepTwoProps = {
   termsLabel: React.ReactNode;
+  descriptionLabel: React.ReactNode;
   marketingLabel: React.ReactNode;
   setStep: React.Dispatch<React.SetStateAction<number>>;
   error: React.ReactNode | null;
@@ -29,6 +30,7 @@ type StepTwoProps = {
 
 function StepTwo({
   termsLabel,
+  descriptionLabel,
   marketingLabel,
   setStep,
   error,
@@ -43,6 +45,7 @@ function StepTwo({
 }: StepTwoProps) {
   const [areTermsChecked, setTermsChecked] = useState(false);
   const [isMarketingOptInChecked, setIsMarketingOptInChecked] = useState(false);
+  const [isDescriptionChecked, setIsDescriptionChecked] = useState(false);
   const { isLoading: isUserInfoLoading } = useStripeCustomerInfo();
   const [isUsingFreeTrial, setIsUsingFreeTrial] = useState(
     product?.canBeTrialled
@@ -85,6 +88,10 @@ function StepTwo({
           <PaymentMethodSummary setStep={setStep} />
           <TermsCheckbox label={termsLabel} setTermsChecked={setTermsChecked} />
           <TermsCheckbox
+            label={descriptionLabel}
+            setTermsChecked={setIsDescriptionChecked}
+          />
+          <TermsCheckbox
             label={marketingLabel}
             setTermsChecked={setIsMarketingOptInChecked}
           />
@@ -98,6 +105,8 @@ function StepTwo({
           isMarketingOptInChecked={isMarketingOptInChecked}
           setIsMarketingOptInChecked={setIsMarketingOptInChecked}
           setTermsChecked={setTermsChecked}
+          isDescriptionChecked={isDescriptionChecked}
+          setIsDescriptionChecked={setIsDescriptionChecked}
           setError={setError}
           setStep={setStep}
         />

--- a/static/js/src/PurchaseModal/utils/utils.ts
+++ b/static/js/src/PurchaseModal/utils/utils.ts
@@ -96,8 +96,10 @@ export type BuyButtonProps = {
   areTermsChecked: boolean;
   isUsingFreeTrial: boolean;
   isMarketingOptInChecked: boolean;
+  isDescriptionChecked: boolean;
   setTermsChecked: React.Dispatch<React.SetStateAction<boolean>>;
   setIsMarketingOptInChecked: React.Dispatch<React.SetStateAction<boolean>>;
+  setIsDescriptionChecked: React.Dispatch<React.SetStateAction<boolean>>;
   setError: React.Dispatch<React.SetStateAction<React.ReactNode>>;
   setStep: React.Dispatch<React.SetStateAction<number>>;
 };

--- a/static/js/src/advantage/offers/components/BuyButton.tsx
+++ b/static/js/src/advantage/offers/components/BuyButton.tsx
@@ -18,9 +18,11 @@ type Props = {
 const BuyButton = ({
   offer,
   areTermsChecked,
+  isDescriptionChecked,
   isMarketingOptInChecked,
   setTermsChecked,
   setIsMarketingOptInChecked,
+  setIsDescriptionChecked,
   setError,
   setStep,
 }: Props) => {
@@ -75,6 +77,7 @@ const BuyButton = ({
         },
         onError: (error) => {
           setTermsChecked(false);
+          setIsDescriptionChecked(false);
           setIsMarketingOptInChecked(false);
           setIsLoading(false);
           if (
@@ -143,6 +146,7 @@ const BuyButton = ({
         }
       }
       setTermsChecked(false);
+      setIsDescriptionChecked(false);
       setIsMarketingOptInChecked(false);
       setStep(1);
     }
@@ -191,7 +195,7 @@ const BuyButton = ({
       appearance="positive"
       aria-label="Buy"
       style={{ textAlign: "center" }}
-      disabled={!areTermsChecked || isLoading}
+      disabled={!areTermsChecked || !isDescriptionChecked || isLoading}
       onClick={onPayClick}
       loading={isLoading}
     >

--- a/static/js/src/advantage/offers/components/Offer/Offer.tsx
+++ b/static/js/src/advantage/offers/components/Offer/Offer.tsx
@@ -32,6 +32,19 @@ const termsLabel = (
   </>
 );
 
+const descriptionLabel = (
+  <>
+    I agree to the{" "}
+    <a
+      href="/legal/ubuntu-pro-description"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Ubuntu Pro description
+    </a>
+  </>
+);
+
 const marketingLabel =
   "I agree to receive information about Canonical's products and services";
 
@@ -53,8 +66,10 @@ const Offer = ({ offer }: Props) => {
   const BuyOfferButton = ({
     areTermsChecked,
     isMarketingOptInChecked,
+    isDescriptionChecked,
     setTermsChecked,
     setIsMarketingOptInChecked,
+    setIsDescriptionChecked,
     setError,
     setStep,
     isUsingFreeTrial,
@@ -63,9 +78,11 @@ const Offer = ({ offer }: Props) => {
       <BuyButton
         offer={offer}
         areTermsChecked={areTermsChecked}
+        isDescriptionChecked={isDescriptionChecked}
         isMarketingOptInChecked={isMarketingOptInChecked}
         setTermsChecked={setTermsChecked}
         setIsMarketingOptInChecked={setIsMarketingOptInChecked}
+        setIsDescriptionChecked={setIsDescriptionChecked}
         setError={setError}
         setStep={setStep}
         isUsingFreeTrial={isUsingFreeTrial}
@@ -137,6 +154,7 @@ const Offer = ({ offer }: Props) => {
           <PurchaseModal
             accountId={account_id}
             termsLabel={termsLabel}
+            descriptionLabel={descriptionLabel}
             marketingLabel={marketingLabel}
             Summary={OfferSummary}
             closeModal={closeModal}

--- a/static/js/src/advantage/react/components/Subscriptions/RenewalModal/RenewButton/RenewButton.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/RenewalModal/RenewButton/RenewButton.tsx
@@ -19,8 +19,10 @@ const BuyButton = ({
   closeModal,
   areTermsChecked,
   isMarketingOptInChecked,
+  isDescriptionChecked,
   setTermsChecked,
   setIsMarketingOptInChecked,
+  setIsDescriptionChecked,
   setError,
   setStep,
 }: Props) => {
@@ -126,6 +128,7 @@ const BuyButton = ({
         }
       }
       setTermsChecked(false);
+      setIsDescriptionChecked(false);
       setIsMarketingOptInChecked(false);
       setStep(1);
     }
@@ -167,7 +170,7 @@ const BuyButton = ({
       appearance="positive"
       aria-label="Buy"
       style={{ textAlign: "center" }}
-      disabled={!areTermsChecked || isLoading}
+      disabled={!areTermsChecked || !isDescriptionChecked || isLoading}
       onClick={onPayClick}
       loading={isLoading}
     >

--- a/static/js/src/advantage/react/components/Subscriptions/RenewalModal/RenewalModal.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/RenewalModal/RenewalModal.tsx
@@ -26,6 +26,19 @@ const RenewalModal = ({ subscription, closeModal }: Props) => {
     </>
   );
 
+  const descriptionLabel = (
+    <>
+      I agree to the{" "}
+      <a
+        href="/legal/ubuntu-pro-description"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Ubuntu Pro description
+      </a>
+    </>
+  );
+
   const marketingLabel =
     "I agree to receive information about Canonical's products and services";
 
@@ -43,9 +56,11 @@ const RenewalModal = ({ subscription, closeModal }: Props) => {
 
   const BuyButton = ({
     areTermsChecked,
+    isDescriptionChecked,
     isMarketingOptInChecked,
     setTermsChecked,
     setIsMarketingOptInChecked,
+    setIsDescriptionChecked,
     setError,
     setStep,
     isUsingFreeTrial,
@@ -56,8 +71,10 @@ const RenewalModal = ({ subscription, closeModal }: Props) => {
         closeModal={closeModal}
         areTermsChecked={areTermsChecked}
         isMarketingOptInChecked={isMarketingOptInChecked}
+        isDescriptionChecked={isDescriptionChecked}
         setTermsChecked={setTermsChecked}
         setIsMarketingOptInChecked={setIsMarketingOptInChecked}
+        setIsDescriptionChecked={setIsDescriptionChecked}
         setError={setError}
         setStep={setStep}
         isUsingFreeTrial={isUsingFreeTrial}
@@ -79,6 +96,7 @@ const RenewalModal = ({ subscription, closeModal }: Props) => {
         <PurchaseModal
           accountId={subscription.account_id}
           termsLabel={termsLabel}
+          descriptionLabel={descriptionLabel}
           marketingLabel={marketingLabel}
           quantity={subscription.number_of_machines}
           closeModal={closeModal}

--- a/static/js/src/advantage/subscribe/blender/components/BuyButton/BuyButton.tsx
+++ b/static/js/src/advantage/subscribe/blender/components/BuyButton/BuyButton.tsx
@@ -14,9 +14,11 @@ import { FormContext } from "../../utils/FormContext";
 
 const BuyButton = ({
   areTermsChecked,
+  isDescriptionChecked,
   isMarketingOptInChecked,
   setTermsChecked,
   setIsMarketingOptInChecked,
+  setIsDescriptionChecked,
   setError,
   setStep,
 }: BuyButtonProps) => {
@@ -143,6 +145,7 @@ const BuyButton = ({
         }
       }
       setTermsChecked(false);
+      setIsDescriptionChecked(false);
       setIsMarketingOptInChecked(false);
       setStep(1);
     }
@@ -191,7 +194,7 @@ const BuyButton = ({
       appearance="positive"
       aria-label="Buy"
       style={{ textAlign: "center" }}
-      disabled={!areTermsChecked || isLoading}
+      disabled={!areTermsChecked || !isDescriptionChecked || isLoading}
       onClick={onPayClick}
       loading={isLoading}
     >

--- a/static/js/src/advantage/subscribe/blender/components/PaymentModal/PaymentModal.tsx
+++ b/static/js/src/advantage/subscribe/blender/components/PaymentModal/PaymentModal.tsx
@@ -31,6 +31,19 @@ export default function PaymentModal({ isHidden }: Props) {
     </>
   );
 
+  const descriptionLabel = (
+    <>
+      I agree to the{" "}
+      <a
+        href="/legal/ubuntu-pro-description"
+        target="_blank"
+        rel="noopener norefferer"
+      >
+        Ubuntu Pro description
+      </a>
+    </>
+  );
+
   const marketingLabel =
     "I agree to receive information about Canonical's products and services";
 
@@ -45,6 +58,7 @@ export default function PaymentModal({ isHidden }: Props) {
             <PurchaseModal
               termsLabel={termsLabel}
               marketingLabel={marketingLabel}
+              descriptionLabel={descriptionLabel}
               product={product}
               preview={preview}
               quantity={quantity}

--- a/static/js/src/advantage/subscribe/react/components/BuyButton/BuyButton.tsx
+++ b/static/js/src/advantage/subscribe/react/components/BuyButton/BuyButton.tsx
@@ -14,9 +14,11 @@ import { FormContext } from "../../utils/FormContext";
 
 const BuyButton = ({
   areTermsChecked,
+  isDescriptionChecked,
   isUsingFreeTrial,
   isMarketingOptInChecked,
   setTermsChecked,
+  setIsDescriptionChecked,
   setIsMarketingOptInChecked,
   setError,
   setStep,
@@ -181,6 +183,7 @@ const BuyButton = ({
         }
       }
       setTermsChecked(false);
+      setIsDescriptionChecked(false);
       setIsMarketingOptInChecked(false);
       setStep(1);
     }
@@ -234,7 +237,7 @@ const BuyButton = ({
       appearance="positive"
       aria-label="Buy"
       style={{ textAlign: "center" }}
-      disabled={!areTermsChecked || isLoading}
+      disabled={!areTermsChecked || !isDescriptionChecked || isLoading}
       onClick={isUsingFreeTrial ? onStartTrialClick : onPayClick}
       loading={isLoading}
     >

--- a/static/js/src/advantage/subscribe/react/components/PaymentModal/PaymentModal.tsx
+++ b/static/js/src/advantage/subscribe/react/components/PaymentModal/PaymentModal.tsx
@@ -33,6 +33,19 @@ export default function PaymentModal({ isHidden }: Props) {
     </>
   );
 
+  const descriptionLabel = (
+    <>
+      I agree to the{" "}
+      <a
+        href="/legal/ubuntu-pro-description"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Ubuntu Pro description
+      </a>
+    </>
+  );
+
   const marketingLabel =
     "I agree to receive information about Canonical's products and services";
 
@@ -46,6 +59,7 @@ export default function PaymentModal({ isHidden }: Props) {
           <Modal close={closePortal}>
             <PurchaseModal
               termsLabel={termsLabel}
+              descriptionLabel={descriptionLabel}
               marketingLabel={marketingLabel}
               product={product}
               preview={preview}

--- a/static/js/src/advantage/subscribe/react/utils/utils.ts
+++ b/static/js/src/advantage/subscribe/react/utils/utils.ts
@@ -94,8 +94,10 @@ export const getIsFreeTrialEnabled = () =>
 export type BuyButtonProps = {
   areTermsChecked: boolean;
   isUsingFreeTrial: boolean;
+  isDescriptionChecked: boolean;
   isMarketingOptInChecked: boolean;
   setTermsChecked: React.Dispatch<React.SetStateAction<boolean>>;
+  setIsDescriptionChecked: React.Dispatch<React.SetStateAction<boolean>>;
   setIsMarketingOptInChecked: React.Dispatch<React.SetStateAction<boolean>>;
   setError: React.Dispatch<React.SetStateAction<React.ReactNode>>;
   setStep: React.Dispatch<React.SetStateAction<number>>;

--- a/tests/cypress/integration/advantage/subscribe_spec.js
+++ b/tests/cypress/integration/advantage/subscribe_spec.js
@@ -95,6 +95,9 @@ context("/pro/subscribe", () => {
       // and cypress complains (it would usually indicate an issue, in our case it's intentional).
       force: true,
     });
+    cy.findByLabelText(/I agree to the Ubuntu Pro description/).click({
+      force: true,
+    });
 
     cy.intercept("POST", "/pro/subscribe*", slowDownResponse).as("trial");
 
@@ -143,6 +146,9 @@ context("/pro/subscribe", () => {
       // Need to use { force: true } because the actual input element (radio button)
       // that the label is for is invisible (we use our own styles)
       // and cypress complains (it would usually indicate an issue, in our case it's intentional).
+      force: true,
+    });
+    cy.findByLabelText(/I agree to the Ubuntu Pro description/).click({
       force: true,
     });
 


### PR DESCRIPTION
## Done

- Add pro service description checkbox on step 2 of the payment modal

## QA

- Go to `/pro/subscribe`
- Click "Buy now" Button 
- Fill in the forms 
- Check three checkboxes are displaying
<img width="566" alt="image" src="https://user-images.githubusercontent.com/57550290/195807189-8bfb64a2-a496-4a99-a1c3-b2ab628d5912.png">


## Issue / Card

Fixes [#731](https://github.com/canonical/commercial-squad/issues/731)

