### PR TITLE
remove /pro/beta redirect

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -951,7 +951,6 @@ security/cve/sitemap(?P<suffix>.*).xml: /security/cves/sitemap{suffix}.xml
 
 /advantage: "/pro"
 /advantage/(?P<path>.*): "/pro/{path}"
-/pro/beta/?: https://discourse.ubuntu.com/t/ubuntu-pro-beta-tutorial/31018
 
 # USN redirects
 /security/notices/months(/.*)?/?: /security/notices


### PR DESCRIPTION
## Done

- Removed the redirect from /pro/beta to the discourse post

## QA

- Visit /pro/beta
- See that you are not redirected, and that the page matches the copy doc
