### PR TITLE
update copy to make lets talk and requestbeta access CTAs more prominent

### DIFF
--- a/templates/pro/index.html
+++ b/templates/pro/index.html
@@ -435,7 +435,7 @@
       <div class="p-strip is-shallow u-no-padding--top">
         <h2>Available everywhere</h2>
         <p>Enterprise-grade security and compliance delivered on every cloud, <br>data centre, and desktop.</p>
-        <p><a href="https://ubuntu.com/contact-us/form?product=pro">Let's talk</a></p>
+        <p><a href="https://ubuntu.com/contact-us/form?product=pro">Contact us</a></p>
       </div>
     </div>
     <div class="col-6 col-medium-6">
@@ -601,7 +601,9 @@
       <h3 class="p-heading--2">Become a customer</h3>
     </div>
     <div class="col-6 col-medium-3">
-      <p>For enterprises to cover their Ubuntu estate - <br class="u-hide--medium u-hide--small">servers and workstations.</p>
+      <p>For enterprises to cover their Ubuntu estate - servers and workstations.<br class="u-hide--medium u-hide--small">
+        <a href="https://ubuntu.com/pricing/pro">See Ubuntu Pro pricing.</a>
+      </p>
       <a href="/pro/subscribe" class="p-button">Buy</a>
     </div>
   </div>
@@ -620,13 +622,7 @@
       <p>
         If you were an active customer before October 4th, 2022, this trial lasts for up to 1 year - until the end of your current contract. At the end of the trial, you can choose to upgrade to full Pro (at extra cost), or remain as an Ubuntu Pro (Infra-only) customer at your current price.
       </p>
-      <p class="u-sv-1">
-        <a href="#" class="js-invoke-modal">Request beta access at no extra cost</a>
-      </p>
-      <hr class="u-no-margin--bottom">
-      <p>
-        <a href="https://ubuntu.com/pricing/pro">Ubuntu Pro pricing</a>
-      </p>
+      <button class="js-invoke-modal">Request beta access at no extra cost</button>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- Change links to buttons (as per https://github.com/canonical/ubuntu.com/issues/12192)

## QA

- Check out this feature branch
- visit the /pro page, verify the ctas have been converted to buttons and Let's talk has changed to "Contact us"

## Issue / Card

Fixes https://github.com/canonical/ubuntu.com/issues/12192

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
