### PR TITLE
Add tutorial link on free token

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.test.tsx
@@ -179,7 +179,7 @@ describe("DetailsTabs", () => {
     expect(wrapper.find("[data-test='contract-token']").exists()).toBe(true);
   });
 
-  it("does not display docs links for the free subscription", () => {
+  it("Display tutorial link for the free subscription", () => {
     const wrapper = mount(
       <DetailsTabs
         subscription={freeSubscriptionFactory.build()}
@@ -189,6 +189,9 @@ describe("DetailsTabs", () => {
     );
     // Switch to the docs tab:
     wrapper.find("[data-test='docs-tab']").simulate("click");
-    expect(wrapper.find("[data-test='doc-link']").exists()).toBe(false);
+    const docsLinks = wrapper.find("[data-test='doc-link']");
+    expect(docsLinks.at(0).text()).toBe(
+      "Ubuntu Pro (esm-apps --beta) tutorial"
+    );
   });
 });

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.tsx
@@ -158,8 +158,15 @@ const DetailsTabs = ({
   const isBlender = isBlenderSubscription(subscription);
 
   const isFree = isFreeSubscription(subscription);
-  // Don't display any docs links for the free subscription.
-  const docs = isFree ? [] : generateDocLinks(subscription.entitlements);
+  // Display tutorial link for the free subscription.
+  const docs = isFree
+    ? [
+        {
+          label: "Ubuntu Pro (esm-apps --beta) tutorial",
+          url: "https://discourse.ubuntu.com/t/ubuntu-pro-beta-tutorial/31018",
+        },
+      ]
+    : generateDocLinks(subscription.entitlements);
   const setTab = (tab: ActiveTab) => {
     setActiveTab(tab);
     sendAnalyticsEvent({


### PR DESCRIPTION
## Done

- Add "Ubuntu Pro (esm-apps --beta) tutorial" link on free token

## QA

- Go to `/pro/dashboard`
- Click "Free Personal Token" and check the "Ubuntu Pro (esm-apps --beta) tutorial" appears.

<img width="1052" alt="Screenshot 2022-10-18 at 4 47 25 pm" src="https://user-images.githubusercontent.com/57550290/196464810-fc1421aa-b7d7-4d37-bbcb-4237c446d44d.png">


## Issue / Card

Fixes [#732](https://github.com/canonical/commercial-squad/issues/732)
