### PR TITLE
22.10 launch

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -31,27 +31,33 @@ openstack_lts:
 
 checksums:
   desktop:
+    "22.10": "b98f13cd86839e70cb7757d46840230496b3febea309dd73bd5f81383474e47b *ubuntu-22.10-desktop-amd64.iso"
     "22.04.1": "c396e956a9f52c418397867d1ea5c0cf1a99a49dcf648b086d2fb762330cc88d *ubuntu-22.04.1-desktop-amd64.iso"
     "21.10": "f8d3ab0faeaecb5d26628ae1aa21c9a13e0a242c381aa08157db8624d574b830 *ubuntu-21.10-desktop-amd64.iso"
     "20.04.5": "2980570ea889f3467a04df15c8421ef1dc80ecef7bb37243da97f5714cf3f8ef *ubuntu-20.04.5-desktop-amd64.iso"
   live-server:
+    "22.10": "874452797430a94ca240c95d8503035aa145bd03ef7d84f9b23b78f3c5099aed *ubuntu-22.10-live-server-amd64.iso"
     "22.04.1": "10f19c5b2b8d6db711582e0e27f5116296c34fe4b313ba45f9b201a5007056cb *ubuntu-22.04.1-live-server-amd64.iso"
     "21.10": "e84f546dfc6743f24e8b1e15db9cc2d2c698ec57d9adfb852971772d1ce692d4 *ubuntu-21.10-live-server-amd64.iso"
     "20.04.5": "5035be37a7e9abbdc09f0d257f3e33416c1a0fb322ba860d42d74aa75c3468d4 *ubuntu-20.04.5-live-server-amd64.iso"
     "18.04.6": "6c647b1ab4318e8c560d5748f908e108be654bad1e165f7cf4f3c1fc43995934 *ubuntu-18.04.6-live-server-amd64.iso"
   desktop-arm64+raspi:
+    "22.10": "c9cf57399a5e3e3a9803740f8107ef52891b7d3ac293106d3257396b75ddf7de *ubuntu-22.10-preinstalled-desktop-arm64+raspi.img.xz"
     "22.04.1": "680c2c1770b53d90e825fd9a40178f605af47acfff681ad5f68d38094d1c32eb *ubuntu-22.04.1-preinstalled-desktop-arm64+raspi.img.xz"
     "21.10": "5187d507099f26bc4d8218085109af498fae5ff93b40c668f83bab5c7574d954 *ubuntu-21.10-preinstalled-desktop-arm64+raspi.img.xz"
     "21.04": "d89ee327a00b98d7166b1a8cc95d17762aaacd3b4d0fc756c5b6b65df1708f48 *ubuntu-21.04-preinstalled-desktop-arm64+raspi.img.xz"
   server-arm64+raspi:
+    "22.10": "170d860a49039499d349eeb69276c997e26ada811f5b4bce761b55a6461914a2 *ubuntu-22.10-preinstalled-server-arm64+raspi.img.xz"
     "22.04.1": "5d0661eef1a0b89358159f3849c8f291be2305e5fe85b7a16811719e6e8ad5d1 *ubuntu-22.04.1-preinstalled-server-arm64+raspi.img.xz"
     "21.10": "126f940d3b270a6c1fc5a183ac8a3d193805fead4f517296a7df9d3e7d691a03 *ubuntu-21.10-preinstalled-server-arm64+raspi.img.xz"
     "20.04.5": "44b98acd3fd4379c6b194696520b6aecb2f596b601e43e9b6934c83f0aa61026 *ubuntu-20.04.5-preinstalled-server-arm64+raspi.img.xz"
   server-armhf+raspi:
+    "22.10": "a869ade13fb1a983da95eb92093e640692a930d01354d63f05571234ca0cd6b5 *ubuntu-22.10-preinstalled-server-armhf+raspi.img.xz"
     "22.04.1": "342fb581ce11208c26f35675acafdc3d56ac2838b1297a508e602f88606903f1 *ubuntu-22.04.1-preinstalled-server-armhf+raspi.img.xz"
     "21.10": "341593c9607ed20744cd86941d94d73e3ba4f74e8ef2633eec63ce9b0cfac5a1 *ubuntu-21.10-preinstalled-server-armhf+raspi.img.xz"
     "20.04.5": "065c41846ddf7a1c636a1aac5a7d49ebcee819b141f9d57fd586c5f84b9b7942 *ubuntu-20.04.5-preinstalled-server-armhf+raspi.img.xz"
   server-riscv64:
+    "22.10": "858feb7f96e94ad904624262ee4a669caebafd012a2812e19e0dd21be9b6faa6 *ubuntu-22.10-preinstalled-server-riscv64+unmatched.img.xz"
     "22.04.1": "a4cf79456e09c7c03c96ef4b0924dd54ab1706d86af09d29a7c117855e80eac6 *ubuntu-22.04.1-preinstalled-server-riscv64+unmatched.img.xz"
     "21.10": "8067892fa627eb219b31dc629f31f3bda6b015dfeabf2fdc9b0ed150bf7984b8 *ubuntu-21.10-preinstalled-server-riscv64+unmatched.img.xz"
   core-22-arm64+raspi:

--- a/releases.yaml
+++ b/releases.yaml
@@ -1,13 +1,13 @@
 latest:
-  slug: ImpishIndri
-  name: "Impish Indri"
-  short_version: "21.10"
-  full_version: "21.10"
+  slug: KineticKudu
+  name: "Kinetic Kudu"
+  short_version: "22.10"
+  full_version: "22.10"
   core_version: "22"
-  release_date: "October 2021"
-  eol: "July 2022"
+  release_date: "October 2022"
+  eol: "July 2023"
   past_eol_date: false
-  release_notes_url: "https://discourse.ubuntu.com/t/impish-indri-release-notes/21951"
+  release_notes_url: "https://discourse.ubuntu.com/t/kinetic-kudu-release-notes/27976"
 lts:
   slug: JammyJellyfish
   name: "Jammy Jellyfish"
@@ -16,6 +16,16 @@ lts:
   release_date: "April 2022"
   eol: "April 2027"
   release_notes_url: "https://discourse.ubuntu.com/t/jammy-jellyfish-release-notes/24668"
+previous_latest:
+  slug: ImpishIndri
+  name: "Impish Indri"
+  short_version: "21.10"
+  full_version: "21.10"
+  core_version: "22"
+  release_date: "October 2021"
+  eol: "July 2022"
+  past_eol_date: true
+  release_notes_url: "https://discourse.ubuntu.com/t/impish-indri-release-notes/21951"
 previous_lts:
   name: "Focal Fossa"
   short_version: "20.04"

--- a/releases.yaml
+++ b/releases.yaml
@@ -16,16 +16,6 @@ lts:
   release_date: "April 2022"
   eol: "April 2027"
   release_notes_url: "https://discourse.ubuntu.com/t/jammy-jellyfish-release-notes/24668"
-previous_latest:
-  slug: ImpishIndri
-  name: "Impish Indri"
-  short_version: "21.10"
-  full_version: "21.10"
-  core_version: "22"
-  release_date: "October 2021"
-  eol: "July 2022"
-  past_eol_date: true
-  release_notes_url: "https://discourse.ubuntu.com/t/impish-indri-release-notes/21951"
 previous_lts:
   name: "Focal Fossa"
   short_version: "20.04"

--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -53,6 +53,12 @@ export var smallReleases = [
     taskName: "Ubuntu 22.04 LTS",
     status: "ESM",
   },
+  {
+    startDate: new Date("2022-10-20T00:00:00"),
+    endDate: new Date("2023-07-20T00:00:00"),
+    taskName: "Ubuntu 22.10",
+    status: "INTERIM_RELEASE",
+  },
 ];
 
 export var serverAndDesktopReleases = [
@@ -129,10 +135,10 @@ export var serverAndDesktopReleases = [
     status: "HARDWARE_AND_MAINTENANCE_UPDATES",
   },
   {
-    startDate: new Date("2027-04-01T00:00:00"),
-    endDate: new Date("2032-04-09T00:00:00"),
-    taskName: "22.04 LTS (Jammy Jellyfish)",
-    status: "ESM",
+    startDate: new Date("2022-10-20T00:00:00"),
+    endDate: new Date("2023-07-20T00:00:00"),
+    taskName: "22.10 (Kinetic Kudu)",
+    status: "INTERIM_RELEASE",
   },
 ];
 
@@ -1417,6 +1423,7 @@ export var kubernetesStatus = {
 };
 
 export var smallReleaseNames = [
+  "Ubuntu 22.10",
   "Ubuntu 22.04 LTS",
   "Ubuntu 21.10",
   "Ubuntu 21.04",
@@ -1425,6 +1432,7 @@ export var smallReleaseNames = [
 ];
 
 export var desktopServerReleaseNames = [
+  "22.10 (Kinetic Kudu)",
   "22.04 LTS (Jammy Jellyfish)",
   "21.10 (Impish Indri)",
   "21.04 (Hirsute Hippo)",

--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -21,7 +21,7 @@
   <section class="u-image-position p-strip--suru-topped is-bordered">
     <div class="row u-vertically-center">
       <div class="col-6">
-        <h1>Ubuntu Desktop for&nbsp;Linux developers</h1>
+        <h1>Ubuntu Desktop for developers</h1>
         <p>Whether you're an app or web developer, engineering manager, data scientist, or AI/ML researcher &mdash; Ubuntu is your ideal workstation.</p>
         <p><a href="/download/desktop" class="p-button--positive">Get Ubuntu now</a></p>
       </div>
@@ -142,6 +142,11 @@
               <td>Apr 2027</td>
               <td>Apr 2032</td>
             </tr>
+            <tr>
+              <td><strong>22.10 (Kinetic Kudu)</strong></td>
+              <td>Apr 2022</td>
+              <td>Jul 2023</td>
+            </tr>
           </tbody>
         </table>
       </div>
@@ -258,7 +263,7 @@
       <div class="col-8">
         <h3>A rich ecosystem</h3>
         <ul class="p-list">
-          <li class="p-list__item is-ticked">With a <a href="https://snapcraft.io/store">Snap Store</a> of over 7,000 applications in addition to the Ubuntu archive, it's easy to tailor Ubuntu desktop to your needs.</li>
+          <li class="p-list__item is-ticked">With a <a href="https://snapcraft.io/store">Snap Store</a> of over 7,000 applications in addition to the Ubuntu repository, it's easy to tailor Ubuntu desktop to your needs.</li>
           <li class="p-list__item is-ticked">Development tools include Visual Studio Code, IntelliJ, GitKraken, Unity and Blender.</li>
           <li class="p-list__item is-ticked">Office productivity tools include Slack, Microsoft Teams, Dropbox, and Zoom as well as the Microsoft-compatible LibreOffice.</li>
           <li class="p-list__item is-ticked">Media, gaming, and content creation apps include Spotify, Steam, Discord and OBS Studio.</li>
@@ -504,6 +509,32 @@
   <section class="p-strip--light">
     <div class="row">
       <div class="col-8">
+        <h2>What's new in Ubuntu {{ releases.latest.short_version }}</h2>
+      </div>
+    </div>
+    <div class="u-fixed-width">
+      <ul class="p-list is-split">
+        <li class="p-list__item is-ticked">Linux 5.19 kernel</li>
+        <li class="p-list__item is-ticked">GNOME 43 desktop environment
+          <ul>
+            <li>New quick settings interface</li>
+            <li>New spread effect for multitasking</li>
+            <li>Dynamic UI for the file manager</li>
+          </ul>
+        </li>
+        <li class="p-list__item is-ticked">Pipewire as the default audio system delivering improve bluetooth performance</li>
+        <li class="p-list__item is-ticked">Up-to-date toolchains, including Python 3.10, PHP 8.1, Ruby 3.1, Perl 5.34, Go 1.19, GCC 12.2, Rust 1.61</li>
+        <li class="p-list__item is-ticked">Core productivity apps LibreOffice 7.4, Thunderbird 102, and Firefox 105</li>
+        <li class="p-list__item is-ticked">Multi-threaded CPU squashfs decompression for faster Snap startup</li>
+      </ul>
+    </div>
+    <div class="u-fixed-width">
+      <p><a href="{{ releases.latest.release_notes_url }}">Read the full release notes&nbsp;&rsaquo;</a></p>
+    </div>
+  </section>
+  <section class="p-strip--suru">
+    <div class="row">
+      <div class="col-8">
         <h2>What's new in Ubuntu {{ releases.lts.short_version }}</h2>
       </div>
     </div>
@@ -539,7 +570,7 @@
       </ul>
     </div>
     <div class="u-fixed-width">
-      <p><a href="{{ releases.lts.release_notes_url }}">Read the full release notes&nbsp;&rsaquo;</a></p>
+      <p><a class="p-link--inverted" href="{{ releases.lts.release_notes_url }}">Read the full release notes&nbsp;&rsaquo;</a></p>
     </div>
   </section>
   <section class="p-strip">

--- a/templates/desktop/flavours.html
+++ b/templates/desktop/flavours.html
@@ -14,12 +14,12 @@
       <p class="p-heading--3">What are Ubuntu flavours?</p>
       <p>Ubuntu flavours offer a unique way to experience Ubuntu, each with their own choice of default applications and settings. Ubuntu flavours are owned and developed by members of our global community and backed by the full Ubuntu archive for packages and updates.</p>
     </div>
-    <div class="col-6 u-align--center">
+    <div class="col-6 u-align--center u-vertically-center u-hide--small u-hide--medium">
       {{ image (
-        url="https://assets.ubuntu.com/v1/e10bc9c7-ubuntu-flavors-cloud.png",
+        url="https://assets.ubuntu.com/v1/dc0b7c84-ubuntu+flavours.png",
         alt="",
-        width="300",
-        height="276",
+        width="1072",
+        height="460",
         hi_def=True,
         loading="auto"
         ) | safe
@@ -265,9 +265,57 @@
     </div>
   </div>
 </section>
-
 <section class="p-strip--light">
   <div class="row">
+    <div class="col-6">
+      <div class="p-heading-icon">
+        <div class="p-heading-icon__header">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/219d06b0-ubuntu-unity-logo.png",
+            alt="",
+            width="32",
+            height="32",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-heading-icon__img"}
+            ) | safe
+          }}
+          <h3 class="p-heading-icon__title">Ubuntu Unity</h3>
+        </div>
+        <div>
+          <p>Bringing the best of Ubuntu and Unity together, Ubuntu Unity is a beautiful, slick and lightweight Ubuntu flavour. With its beautiful design, efficient and elegant workflow, and features like the heads-up display (HUD), the Global Menu, powerful search and a high level of customizability (using the Unity Tweak Tool), you'll be able to work with an unparalleled level of efficiency. You can also choose from a wide range of window animations and effects available in Compiz.</p>
+          <p><a href="https://ubuntuunity.org" class="p-button--positive">Get Ubuntu Unity</a></p>
+          <p><a href="https://discourse.ruds.io/c/ubuntu-unity/5">Join the Ubuntu Unity community&nbsp;&rsaquo;</a></p>
+          <p><a href="https://twitter.com/ubuntu_unity">Follow Ubuntu Unity&nbsp;&rsaquo;</a></p>
+        </div>
+      </div>
+    </div>
+    <div class="col-6 u-vertically-center u-align--center u-hide--small u-hide--medium">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/e96f6b6d-ubuntu-unity-desktop-screenshot.png",
+        alt="",
+        width="1920",
+        height="1080",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+  </div>
+</section>
+<section class="p-strip">
+  <div class="row">
+    <div class="col-6 u-vertically-center u-align--center u-hide--small u-hide--medium">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/5f23328b-xubuntu-2204-screenshot.png",
+        alt="",
+        width="1920",
+        height="1080",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
     <div class="col-6">
       <div class="p-heading-icon">
         <div class="p-heading-icon__header">
@@ -291,17 +339,6 @@
           <p><a href="https://twitter.com/xubuntu">Follow Xubuntu&nbsp;&rsaquo;</a></p>
         </div>
       </div>
-    </div>
-    <div class="col-6 u-vertically-center u-align--center u-hide--small u-hide--medium">
-      {{ image (
-        url="https://assets.ubuntu.com/v1/5f23328b-xubuntu-2204-screenshot.png",
-        alt="",
-        width="1920",
-        height="1080",
-        hi_def=True,
-        loading="lazy"
-        ) | safe
-      }}
     </div>
   </div>
 </section>

--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -23,7 +23,7 @@
 
     <div class="col-8 p-divider__block">
       <h2>Ubuntu {{ releases.lts.full_version }} LTS</h2>
-      <p class="u-no-padding--top">Download the latest <abbr title="Long-term support">LTS</abbr> version of Ubuntu, for desktop PCs and laptops. LTS stands for long-term support &mdash; which means five years of free security and maintenance updates, guaranteed until {{ releases.lts.eol }}.</p>
+      <p class="u-no-padding--top">The latest <abbr title="Long-term support">LTS</abbr> version of Ubuntu, for desktop PCs and laptops. LTS stands for long-term support &mdash; which means five years of free security and maintenance updates, guaranteed until {{ releases.lts.eol }}.</p>
       <p><a href="{{ releases.lts.release_notes_url }}">Ubuntu {{ releases.lts.short_version }} LTS release notes</a></p>
       <p>Recommended system requirements:</p>
       <ul class="p-list is-split">
@@ -48,6 +48,37 @@
       </div>
       <p>
         <a class="p-button--positive is-wide" href="/download/desktop/thank-you?version={{ releases.lts.full_version }}&amp;architecture=amd64" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });">Download</a>
+        <script>performance.mark("Download (Desktop) button rendered")</script>
+      </p>
+      <p><small>For other versions of Ubuntu Desktop including torrents, the network installer, a list of local mirrors and past releases <a href="/download/alternative-downloads">see our alternative downloads</a>.</small></p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="row">
+
+    <div class="col-8 p-divider__block">
+      <h2>Ubuntu {{ releases.latest.full_version }}</h2>
+      <p class="u-no-padding--top">The latest version of the Ubuntu operating system for desktop PCs and laptops, Ubuntu {{ releases.latest.short_version }} comes with nine months of security and maintenance updates, until {{ releases.latest.eol }}.</p>
+      <p>Recommended system requirements are the same as for Ubuntu {{ releases.lts.short_version }} LTS.</p>
+      <p><a href="{{ releases.latest.release_notes_url }}">Ubuntu {{ releases.latest.short_version }} release notes</a></p>
+    </div>
+    <div class="col-4">
+      <div class="u-align--center u-sv4">
+        {{
+          image (
+          url="https://assets.ubuntu.com/v1/38ba52dc-Kinetic+Kudo+22.10.svg",
+          alt="",
+          width="173",
+          height="150",
+          hi_def=True,
+          loading="auto|lazy"
+          ) | safe
+        }}
+      </div>
+      <p>
+        <a class="p-button--positive is-wide" href="/download/desktop/thank-you?version={{ releases.latest.full_version }}&amp;architecture=amd64" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">Download</a>
         <script>performance.mark("Download (Desktop) button rendered")</script>
       </p>
       <p><small>For other versions of Ubuntu Desktop including torrents, the network installer, a list of local mirrors and past releases <a href="/download/alternative-downloads">see our alternative downloads</a>.</small></p>

--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -33,13 +33,13 @@
       <p>
         <strong>Do you want to upgrade?</strong> <a href="/tutorials/tutorial-upgrading-ubuntu-desktop">Follow our simple guide</a>
       </p>
-    </div>
+    </div>   
     <div class="col-6 u-hide--medium u-hide--small u-align--center">
       {{ image (
-        url="https://assets.ubuntu.com/v1/fe859a7f-Jammy+Jellyfish+RGB.svg",
+        url="https://assets.ubuntu.com/v1/beadabd5-mascots_kudu-jelly.svg",
         alt="",
-        width="260",
-        height="150",
+        width="540",
+        height="195",
         hi_def=True,
         loading="auto"
         ) | safe

--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -46,12 +46,10 @@
     <h2 class="u-sv2">
       Download Ubuntu Desktop
     </h2>
-    <p class="p-muted-heading">
-      Recommended desktop
-    </p>
   </div>
   <div class="row">
-    <div class="col-8">
+    <div class="col-6">
+      <p class="p-muted-heading">&nbsp;</p>
       <h3>
         Ubuntu Desktop {{ releases.lts.full_version }} LTS
       </h3>
@@ -67,16 +65,24 @@
         </a>
       </p>
     </div>
-    <div class="col-4 u-vertically-center u-align--center u-hide--small u-hide--medium">
-      {{ image (
-        url="https://assets.ubuntu.com/v1/fe859a7f-Jammy+Jellyfish+RGB.svg",
-        alt="",
-        width="260",
-        height="150",
-        hi_def=True,
-        loading="lazy"
-        ) | safe
-      }}
+    <div class="col-6">
+      <p class="p-muted-heading">
+        Recommended desktop
+      </p>
+      <h3>
+        Ubuntu Desktop {{ releases.latest.full_version }}
+      </h3>
+      <p>
+        The latest development release of Ubuntu with nine months of support, until {{ releases.latest.eol }}.
+      </p>
+      <p>
+        <a
+        class="p-button--positive"
+        href="/download/raspberry-pi/thank-you?version={{ releases.latest.full_version }}&amp;architecture=desktop-arm64+raspi"
+        onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 64-bit - desktop', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">
+          Download 64-bit
+        </a>
+      </p>
     </div>
   </div>
 
@@ -190,6 +196,22 @@
           Download 64-bit
         </a>
         <a class="p-button" href="/download/raspberry-pi/thank-you?version={{ releases.lts.full_version }}&amp;architecture=server-armhf+raspi" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 32-bit - server', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });">
+          Download 32-bit
+        </a>
+      </p>
+    </div>
+    <div class="col-6">
+      <h3>
+        Ubuntu Server {{ releases.latest.full_version }}
+      </h3>
+      <p>
+        The latest development release of Ubuntu with nine months of support, until {{ releases.latest.eol }}.
+      </p>
+      <p>
+        <a class="p-button--positive" href="/download/raspberry-pi/thank-you?version={{ releases.latest.full_version }}&amp;architecture=server-arm64+raspi" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 64-bit - server', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">
+          Download 64-bit
+        </a>
+        <a class="p-button" href="/download/raspberry-pi/thank-you?version={{ releases.latest.full_version }}&amp;architecture=server-armhf+raspi" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 32-bit - server', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">
           Download 32-bit
         </a>
       </p>

--- a/templates/download/server/manual.html
+++ b/templates/download/server/manual.html
@@ -22,18 +22,16 @@
         <li class="p-list__item is-ticked">Commercial support for enterprise customers</li>
       </ul>
     </div>
-    <div class="col-5 col-start-large-8 u-hide--medium u-hide--small u-align--center u-vertically-center" style="min-height: 228px">
-      <div class="u-hide--medium u-hide--small u-align--center">
-        {{ image (
-          url="https://assets.ubuntu.com/v1/fe859a7f-Jammy+Jellyfish+RGB.svg",
-          alt="",
-          width="260",
-          height="150",
-          hi_def=True,
-          loading="auto"
-          ) | safe
-        }}
-      </div>
+    <div class="col-5 u-align--center u-hide--medium u-hide--small u-align--center u-vertically-center">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/38ba52dc-Kinetic+Kudo+22.10.svg",
+        alt="",
+        width="288",
+        height="250",
+        hi_def=True,
+        loading="auto"
+        ) | safe
+      }}
     </div>
   </div>
   <div class="row">
@@ -59,19 +57,19 @@
 
   </div>
   <div class="row">
-    <div class="col-12">
-      <button disabled class="p-button u-no-margin--left">
+    <div class="col-12" style="display:flex; flex-wrap: wrap;">
+      <button disabled class="p-button">
         Option 1 - Manual server installation
       </button>
-      <form action="/download/server" method="post" style="display: inline">
+      <form action="/download/server" method="post">
         <input type="hidden" name="next-step" value="multipass">
-        <button type="submit" class="p-button is-inline" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Server download', 'eventAction' : 'Next option', 'eventLabel' : 'Option 2', 'eventValue' : undefined });">
+        <button type="submit" class="p-button" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Server download', 'eventAction' : 'Next option', 'eventLabel' : 'Option 2', 'eventValue' : undefined });" style="margin-right: 1rem">
           Option 2 - Instant Ubuntu VMs
         </button>
       </form>
-      <form action="/download/server" method="post" style="display: inline">
+      <form action="/download/server" method="post">
         <input type="hidden" name="next-step" value="choose">
-        <button type="submit" class="p-button is-inline" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Server download', 'eventAction' : 'Next option', 'eventLabel' : 'Option 3', 'eventValue' : undefined });">
+        <button type="submit" class="p-button" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Server download', 'eventAction' : 'Next option', 'eventLabel' : 'Option 3', 'eventValue' : undefined });">
           Option 3 - Automated server provisioning
         </button>
       </form>
@@ -132,7 +130,7 @@
       <ul class="p-list u-no-margin--bottom">
         <li class="p-list__item">
           <a class="download-torrent p-button u-no-margin--bottom" href="https://releases.ubuntu.com/{{ releases.lts.short_version }}/ubuntu-{{ releases.lts.full_version }}-live-server-amd64.iso.torrent">
-            Ubuntu Server {{ releases.lts.full_version }} LTS
+            Ubuntu Server {{ releases.lts.short_version }} LTS
           </a>
         </li>
         <li class="p-list__item">

--- a/templates/download/server/manual.html
+++ b/templates/download/server/manual.html
@@ -24,10 +24,10 @@
     </div>
     <div class="col-5 u-align--center u-hide--medium u-hide--small u-align--center u-vertically-center">
       {{ image (
-        url="https://assets.ubuntu.com/v1/38ba52dc-Kinetic+Kudo+22.10.svg",
+        url="https://assets.ubuntu.com/v1/fe859a7f-Jammy+Jellyfish+RGB.svg",
         alt="",
-        width="288",
-        height="250",
+        width="260",
+        height="150",
         hi_def=True,
         loading="auto"
         ) | safe
@@ -50,7 +50,7 @@
       </ul>
       <p class="u-sv3">
         <a href="{{ releases.lts.release_notes_url }}">
-          Read the Ubuntu Server {{ releases.lts.short_version }} LTS release notes
+          Read the Ubuntu Server {{ releases.lts.short_version }} LTS release notes&nbsp;&rsaquo;
         </a>
       </p>
     </div>
@@ -103,15 +103,15 @@
       </p>
     </div>
     <div class="col-4 col-start-large-8 u-hide--medium u-hide--small u-align--center u-vertically-center">
-        {{ image (
-          url="https://assets.ubuntu.com/v1/c9a911d5-II-grad-mascot.svg",
-          alt="",
-          width="263",
-          height="150",
-          hi_def=True,
-          loading="lazy"
-          ) | safe
-        }}
+      {{ image (
+        url="https://assets.ubuntu.com/v1/38ba52dc-Kinetic+Kudo+22.10.svg",
+        alt="",
+        width="288",
+        height="250",
+        hi_def=True,
+        loading="auto"
+        ) | safe
+      }}
     </div>
   </div>
   {% endif %}
@@ -130,7 +130,7 @@
       <ul class="p-list u-no-margin--bottom">
         <li class="p-list__item">
           <a class="download-torrent p-button u-no-margin--bottom" href="https://releases.ubuntu.com/{{ releases.lts.short_version }}/ubuntu-{{ releases.lts.full_version }}-live-server-amd64.iso.torrent">
-            Ubuntu Server {{ releases.lts.short_version }} LTS
+            Ubuntu Server {{ releases.lts.full_version }} LTS
           </a>
         </li>
         <li class="p-list__item">


### PR DESCRIPTION
## Done

- [List of work items including drive-bys - remember to add the why and what of this work.]

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/

- Test 22.10 download links on once we get checksums and signal to release:
  - /download/raspberry-pi (desktop and server)
  - /download/desktop (check also the checksums are correct)
  - /download/server


## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
