### PR TITLE
Update charts for Ubuntu 22.10

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -53,6 +53,12 @@ export var smallReleases = [
     taskName: "Ubuntu 22.04 LTS",
     status: "ESM",
   },
+  {
+    startDate: new Date("2022-10-20T00:00:00"),
+    endDate: new Date("2023-07-20T00:00:00"),
+    taskName: "Ubuntu 22.10",
+    status: "INTERIM_RELEASE",
+  },
 ];
 
 export var serverAndDesktopReleases = [
@@ -129,10 +135,10 @@ export var serverAndDesktopReleases = [
     status: "HARDWARE_AND_MAINTENANCE_UPDATES",
   },
   {
-    startDate: new Date("2027-04-01T00:00:00"),
-    endDate: new Date("2032-04-09T00:00:00"),
-    taskName: "22.04 LTS (Jammy Jellyfish)",
-    status: "ESM",
+    startDate: new Date("2022-10-20T00:00:00"),
+    endDate: new Date("2023-07-20T00:00:00"),
+    taskName: "22.10 (Kinetic Kudu)",
+    status: "INTERIM_RELEASE",
   },
 ];
 
@@ -1417,6 +1423,7 @@ export var kubernetesStatus = {
 };
 
 export var smallReleaseNames = [
+  "Ubuntu 22.10",
   "Ubuntu 22.04 LTS",
   "Ubuntu 21.10",
   "Ubuntu 21.04",
@@ -1425,6 +1432,7 @@ export var smallReleaseNames = [
 ];
 
 export var desktopServerReleaseNames = [
+  "22.10 (Kinetic Kudu)",
   "22.04 LTS (Jammy Jellyfish)",
   "21.10 (Impish Indri)",
   "21.04 (Hirsute Hippo)",


### PR DESCRIPTION
## Done

Update charts with latest 22.10 version

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- Go to https://ubuntu-com-12207.demos.haus/desktop/developers and check that it contains the new 22.10 Kinetic Kudu release

## Issue / Card

Fixes https://github.com/canonical/web-squad/issues/6121


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
