### PR TITLE
Update Pro beta links to point to /pro/beta

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.tsx
@@ -95,8 +95,7 @@ const generateDocLinks = (
         case EntitlementType.EsmInfra:
           link = {
             label: "Ubuntu Pro (esm-apps --beta) tutorial",
-            url:
-              "/pro/beta",
+            url: "/pro/beta",
           };
           break;
         case EntitlementType.Livepatch:

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.tsx
@@ -96,7 +96,7 @@ const generateDocLinks = (
           link = {
             label: "Ubuntu Pro (esm-apps --beta) tutorial",
             url:
-              "https://discourse.ubuntu.com/t/ubuntu-pro-beta-tutorial/31018",
+              "/pro/beta",
           };
           break;
         case EntitlementType.Livepatch:
@@ -163,7 +163,7 @@ const DetailsTabs = ({
     ? [
         {
           label: "Ubuntu Pro (esm-apps --beta) tutorial",
-          url: "https://discourse.ubuntu.com/t/ubuntu-pro-beta-tutorial/31018",
+          url: "/pro/beta",
         },
       ]
     : generateDocLinks(subscription.entitlements);

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -863,3 +863,10 @@ img.has-shadow {
   padding-left: $sph--x-large;
   padding-right: $sph--x-large;
 }
+
+// Temp fix for anchor underlines
+// Being addressed upstream in https://github.com/canonical/vanilla-framework/issues/4600
+a:hover {
+  text-decoration: underline 1px;
+  text-underline-offset: 0.075em;
+}

--- a/templates/pro/index.html
+++ b/templates/pro/index.html
@@ -326,7 +326,7 @@
 <section class="p-strip is-x-deep u-no-padding--top">
   <div class="u-fixed-width">
     <h2>Ready to try Ubuntu Pro beta today?<br>
-      <a href="https://discourse.ubuntu.com/t/ubuntu-pro-beta-tutorial/31018">Discover the step-by-step tutorial</a>
+      <a href="/pro/beta">Discover the step-by-step tutorial</a>
     </h2>
   </div>
 </section>
@@ -435,7 +435,7 @@
       <div class="p-strip is-shallow u-no-padding--top">
         <h2>Available everywhere</h2>
         <p>Enterprise-grade security and compliance delivered on every cloud, <br>data centre, and desktop.</p>
-        <p><a href="https://ubuntu.com/contact-us/form?product=pro">Contact us</a></p>
+        <p><a class="p-button" href="https://ubuntu.com/contact-us/form?product=pro">Contact us</a></p>
       </div>
     </div>
     <div class="col-6 col-medium-6">
@@ -734,7 +734,7 @@
     <h2>Experience Ubuntu Pro in action: <br>
       <a href="https://ubuntu.com/engage/introduction-to-ubuntu-pro">Webinar&nbsp;&rsaquo;</a>
       &nbsp;&nbsp;
-      <a href="https://discourse.ubuntu.com/t/ubuntu-pro-beta-tutorial/31018">Tutorials&nbsp;&rsaquo;</a>
+      <a href="/pro/beta">Tutorials&nbsp;&rsaquo;</a>
     </h2>
   </div>
 </section>

--- a/templates/pro/index.html
+++ b/templates/pro/index.html
@@ -326,7 +326,7 @@
 <section class="p-strip is-x-deep u-no-padding--top">
   <div class="u-fixed-width">
     <h2>Ready to try Ubuntu Pro beta today?<br>
-      <a href="/pro/beta">Discover the step-by-step tutorial</a>
+      <a href="/pro/beta" style="text-decoration-thickness: 1px; text-underline-offset: 0.075em;">Discover the step-by-step tutorial</a>
     </h2>
   </div>
 </section>

--- a/templates/pro/index.html
+++ b/templates/pro/index.html
@@ -326,7 +326,7 @@
 <section class="p-strip is-x-deep u-no-padding--top">
   <div class="u-fixed-width">
     <h2>Ready to try Ubuntu Pro beta today?<br>
-      <a href="/pro/beta" style="text-decoration-thickness: 1px; text-underline-offset: 0.075em;">Discover the step-by-step tutorial</a>
+      <a href="/pro/beta">Discover the step-by-step tutorial</a>
     </h2>
   </div>
 </section>


### PR DESCRIPTION
## Done

- Updated links on /pro to point to /pro/beta rather than the Discourse post
- appled `p-button` to a "Contact us" link

## QA

- Visit https://ubuntu-com-12208.demos.haus/pro
- See that the "Contact us" link looks like a button
- Find the "Discover the step-by-step tutorial" link and click it
- See that you are taken to /pro/beta
- Revisit /pro
- Find the "Tutorials" link and click it
- See that you are taken to /pro/beta
