### PR TITLE
Update mascot asset on /download

### DIFF
--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -33,13 +33,13 @@
       <p>
         <strong>Do you want to upgrade?</strong> <a href="/tutorials/tutorial-upgrading-ubuntu-desktop">Follow our simple guide</a>
       </p>
-    </div>
+    </div>   
     <div class="col-6 u-hide--medium u-hide--small u-align--center">
       {{ image (
-        url="https://assets.ubuntu.com/v1/fe859a7f-Jammy+Jellyfish+RGB.svg",
+        url="https://assets.ubuntu.com/v1/beadabd5-mascots_kudu-jelly.svg",
         alt="",
-        width="260",
-        height="150",
+        width="540",
+        height="195",
         hi_def=True,
         loading="auto"
         ) | safe


### PR DESCRIPTION
## Done

- Added a Kinetic + Jammy combo asset on /download (thanks @lyubomir-popov for v quick turnaround on the asset itself)

## QA

- Visit https://ubuntu-com-12209.demos.haus/download
- See that the mascot asset features both the LTS (Jammy) and the latest release (Kinetic)

## Issue / Card

Fixes https://github.com/canonical/web-squad/issues/6129
