### PR TITLE
Remove yearly auto-renewals

### DIFF
--- a/webapp/shop/api/ua_contracts/helpers.py
+++ b/webapp/shop/api/ua_contracts/helpers.py
@@ -271,9 +271,13 @@ def get_user_subscription_statuses(
 
         is_cancelled = True if not current_number_of_machines else False
         statuses["is_cancelled"] = is_cancelled
-        statuses["should_present_auto_renewal"] = (
-            statuses["is_subscription_active"] and not is_cancelled
-        )
+
+        if type == "yearly":
+            statuses["should_present_auto_renewal"] = False
+        elif type == "monthly":
+            statuses["should_present_auto_renewal"] = (
+                statuses["is_subscription_active"] and not is_cancelled
+            )
 
         # If the subscription is set to auto-renew, we shouldn't alarm the
         # user.


### PR DESCRIPTION
## Done

- Remove yearly auto-renewals

## QA

- Buy a yearly subscriptions
- Go to /pro
- You will not see the auto-renewal settings button anymore

## Issue / Card

Fixes #https://github.com/canonical/commercial-squad/issues/741