### PR TITLE
Fix label for renewals

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.test.tsx
@@ -306,6 +306,7 @@ describe("SubscriptionDetails", () => {
       type: UserSubscriptionType.Legacy,
       statuses: userSubscriptionStatusesFactory.build({
         is_renewed: false,
+        is_renewal_actionable: true,
       }),
     });
 
@@ -410,5 +411,27 @@ describe("SubscriptionDetails", () => {
     );
 
     expect(wrapper.find(".p-chip__value").text()).toBe("Auto-renewal off");
+  });
+  it("it does not display label for unactionable subs", () => {
+    const contract = userSubscriptionFactory.build({
+      type: UserSubscriptionType.Legacy,
+      statuses: userSubscriptionStatusesFactory.build({
+        is_renewed: false,
+        is_renewal_actionable: false,
+      }),
+    });
+
+    queryClient.setQueryData("userSubscriptions", [contract]);
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <SubscriptionDetails
+          onCloseModal={jest.fn()}
+          selectedId={contract.id}
+          setHasUnsavedChanges={jest.fn()}
+        />
+      </QueryClientProvider>
+    );
+
+    expect(wrapper.find(".p-chip__value").exists()).toBe(false)
   });
 });

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.test.tsx
@@ -432,6 +432,6 @@ describe("SubscriptionDetails", () => {
       </QueryClientProvider>
     );
 
-    expect(wrapper.find(".p-chip__value").exists()).toBe(false)
+    expect(wrapper.find(".p-chip__value").exists()).toBe(false);
   });
 });

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
@@ -81,7 +81,7 @@ export const SubscriptionDetails = forwardRef<HTMLDivElement, Props>(
         if (
           subscription?.current_number_of_machines &&
           (subscription?.current_number_of_machines ?? 0) <
-          (subscription?.number_of_machines ?? 0)
+            (subscription?.number_of_machines ?? 0)
         ) {
           setNotification({
             severity: "caution",
@@ -153,7 +153,7 @@ export const SubscriptionDetails = forwardRef<HTMLDivElement, Props>(
                     </>
                   ) : null}
                   {subscription.type == "monthly" ||
-                    subscription.type == "yearly" ? (
+                  subscription.type == "yearly" ? (
                     <>
                       {subscription.statuses.is_renewed ? (
                         <button className="p-chip--positive">
@@ -182,7 +182,7 @@ export const SubscriptionDetails = forwardRef<HTMLDivElement, Props>(
             {isFree ? null : (
               <>
                 {subscription.statuses.has_access_to_support &&
-                  subscription.type !== UserSubscriptionType.Trial ? (
+                subscription.type !== UserSubscriptionType.Trial ? (
                   <Button
                     appearance="positive"
                     className="p-subscriptions__details-action"

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
@@ -81,7 +81,7 @@ export const SubscriptionDetails = forwardRef<HTMLDivElement, Props>(
         if (
           subscription?.current_number_of_machines &&
           (subscription?.current_number_of_machines ?? 0) <
-            (subscription?.number_of_machines ?? 0)
+          (subscription?.number_of_machines ?? 0)
         ) {
           setNotification({
             severity: "caution",
@@ -142,14 +142,18 @@ export const SubscriptionDetails = forwardRef<HTMLDivElement, Props>(
                           <span className="p-chip__value">Renewed</span>
                         </button>
                       ) : (
-                        <button className="p-chip--caution">
-                          <span className="p-chip__value">Not renewed</span>
-                        </button>
+                        <>
+                          {subscription.statuses.is_renewal_actionable ? (
+                            <button className="p-chip--caution">
+                              <span className="p-chip__value">Not renewed</span>
+                            </button>
+                          ) : null}
+                        </>
                       )}
                     </>
                   ) : null}
                   {subscription.type == "monthly" ||
-                  subscription.type == "yearly" ? (
+                    subscription.type == "yearly" ? (
                     <>
                       {subscription.statuses.is_renewed ? (
                         <button className="p-chip--positive">
@@ -178,7 +182,7 @@ export const SubscriptionDetails = forwardRef<HTMLDivElement, Props>(
             {isFree ? null : (
               <>
                 {subscription.statuses.has_access_to_support &&
-                subscription.type !== UserSubscriptionType.Trial ? (
+                  subscription.type !== UserSubscriptionType.Trial ? (
                   <Button
                     appearance="positive"
                     className="p-subscriptions__details-action"

--- a/webapp/shop/api/ua_contracts/helpers.py
+++ b/webapp/shop/api/ua_contracts/helpers.py
@@ -298,7 +298,7 @@ def get_user_subscription_statuses(
             if start <= time_now <= end:
                 statuses["is_renewable"] = True
 
-        if renewal.actionable and renewal.status in ["done", "closed"]:
+        if renewal.status in ["done", "closed"]:
             statuses["is_renewed"] = True
 
     return statuses


### PR DESCRIPTION
## Done

- Make unactionable renewals not show the "not renewaed" label

## QA

- Go to https://ubuntu-com-12219.demos.haus/pro/dashboard?email=albert.kolozsvari%2Btester4@canonical.com
- The subscription should not show a label

## Issue / Card

Fixes #https://github.com/canonical/commercial-squad/issues/742