### PR TITLE
Fix broken package links

### DIFF
--- a/templates/security/cve/cve.html
+++ b/templates/security/cve/cve.html
@@ -131,9 +131,13 @@
                       <td rowspan="{{ package.statuses | length }}">
                         <a href="/security/cves?q=&package={{ package["name"] }}">{{ package["name"] }}</a><br>
                         <small>
-                        <a href="https://launchpad.net/distros/ubuntu/+source/{{ package["name"] }}">Launchpad</a>,
-                        <a href="https://packages.ubuntu.com/search?suite=all&section=all&arch=any&searchon=sourcenames&keywords={{ package["name"] }}">Ubuntu</a>,
-                        <a href="https://tracker.debian.org/{{ package["name"] }}">Debian</a>
+                        {% if package["name"] in kenetic_packages or package["name"] in melodic_packages  %}
+                          <a href="/robotics/ros-esm">ROS ESM</a>
+                        {% else %}
+                          <a href="https://launchpad.net/distros/ubuntu/+source/{{ package["name"] }}">Launchpad</a>,
+                          <a href="https://packages.ubuntu.com/search?suite=all&section=all&arch=any&searchon=sourcenames&keywords={{ package["name"] }}">Ubuntu</a>,
+                          <a href="https://tracker.debian.org/{{ package["name"] }}">Debian</a>
+                        {% endif %}
                         </small>
                       </td>
                     {% endif %}

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -7,6 +7,7 @@ from math import ceil, floor
 import flask
 import dateutil
 import talisker.requests
+import bs4 as bs
 from feedgen.entry import FeedEntry
 from feedgen.feed import FeedGenerator
 from mistune import Markdown
@@ -465,12 +466,35 @@ def cve(cve_id):
             for tag in tags:
                 formatted_tags.append({"name": package_name, "text": tag})
 
+    base_lp = "https://git.launchpad.net/ubuntu-cve-tracker/tree"
+
+    kenetic_packages = list_package_names(
+        f"{base_lp}/ros-esm-xenial-kinetic-supported.txt"
+    )
+    melodic_packages = list_package_names(
+        f"{base_lp}/ros-esm-bionic-melodic-supported.txt"
+    )
+
     return flask.render_template(
         "security/cve/cve.html",
         cve=cve,
         patches=formatted_patches,
         tags=formatted_tags,
+        kenetic_packages=kenetic_packages,
+        melodic_packages=melodic_packages,
     )
+
+
+# This is a temporary fix. To be removed pending redesign
+# Parses given URL to create a list of package names
+def list_package_names(url):
+
+    source = session.get(url).text
+    soup = bs.BeautifulSoup(source, "lxml")
+    raw_string = soup.code(string=True)[0].split()
+    package_list = list(raw_string)
+
+    return package_list
 
 
 # CVE API


### PR DESCRIPTION
## Done

- Fixed broken links for Xenial (Kinetic) and Xenial(Melodic) packages (see issue for context)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: https://ubuntu-com-12222.demos.haus/security/CVE-2021-37146
    - See that the links to Launchpad, Ubuntu, and Debian have been replaced with a link to ROS ESM for relevant packages (in this case, just the first 2)
- Check that link works

## Issue / Card

Fixes https://github.com/canonical/ubuntu.com/issues/12154
