### PR TITLE
get contextual menu by id rather than query selector

### DIFF
--- a/static/js/src/contextual-menu.js
+++ b/static/js/src/contextual-menu.js
@@ -1,6 +1,6 @@
 function toggleMenu(element, show) {
   const dropdownControl = element.getAttribute("aria-controls");
-  const dropdown = document.querySelector(dropdownControl);
+  const dropdown = document.getElementById(dropdownControl);
 
   element.setAttribute("aria-expanded", show);
   dropdown.setAttribute("aria-hidden", !show);
@@ -16,7 +16,9 @@ function attachClickEvent(toggle) {
 }
 
 function attachHoverEvent(toggle) {
-  const dropdown = document.querySelector(toggle.getAttribute("aria-controls"));
+  const dropdown = document.getElementById(
+    toggle.getAttribute("aria-controls")
+  );
   let timer = null;
 
   toggle.addEventListener("click", (e) => {


### PR DESCRIPTION
## Done

- Fixed an issue with the contextual menu JS that was preventing the contextual menu from showing since this update: https://github.com/canonical/ubuntu.com/pull/12102

## QA

- Visit https://ubuntu-com-12224.demos.haus/download/desktop
- Click any download CTA
- You should be taken to a thank you page, cancel the download
- Click "Verify your download"
- A contextual menu should appear with information on how to verify your download on the command line

## Issue / Card

Fixes https://github.com/canonical/ubuntu.com/issues/12218
