### PR TITLE
Resizing calculations fix

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionEdit/SubscriptionEdit.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionEdit/SubscriptionEdit.tsx
@@ -134,7 +134,12 @@ const ResizeSummary = ({
             <br />
           </>
         ) : null}
-        {!isPreviewLoading && !preview ? <>You will be charged nothing.<br /></> : null}
+        {!isPreviewLoading && !preview ? (
+          <>
+            You will be charged nothing.
+            <br />
+          </>
+        ) : null}
         {!isPreviewLoading ? (
           <>
             Your {isMonthly ? "monthly" : "yearly"} payment will be{" "}
@@ -337,7 +342,9 @@ const SubscriptionEdit = ({
                 />
                 <ResizeSummary
                   oldNumberOfMachines={subscription.number_of_machines}
-                  currentNumberOfMachines={subscription.current_number_of_machines}
+                  currentNumberOfMachines={
+                    subscription.current_number_of_machines
+                  }
                   newNumberOfMachines={values.size}
                   isBlender={isBlender}
                   unitName={unitName}

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionEdit/SubscriptionEdit.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionEdit/SubscriptionEdit.tsx
@@ -100,6 +100,7 @@ type ResizeSummaryProps = {
 };
 
 const ResizeSummary = ({
+  oldNumberOfMachines,
   newNumberOfMachines,
   currentNumberOfMachines,
   unitName,
@@ -116,7 +117,7 @@ const ResizeSummary = ({
 
   const isDecreasing = newNumberOfMachines - currentNumberOfMachines < 0;
   const isMonthly = period === UserSubscriptionPeriod.Monthly;
-  const unitPrice = (price ?? 0) / 100 / currentNumberOfMachines;
+  const unitPrice = (price ?? 0) / 100 / oldNumberOfMachines;
 
   return (
     <div>
@@ -335,8 +336,8 @@ const SubscriptionEdit = ({
                   wrapperClassName="u-sv3"
                 />
                 <ResizeSummary
-                  oldNumberOfMachines={subscription.current_number_of_machines}
-                  currentNumberOfMachines={subscription.number_of_machines}
+                  oldNumberOfMachines={subscription.number_of_machines}
+                  currentNumberOfMachines={subscription.current_number_of_machines}
                   newNumberOfMachines={values.size}
                   isBlender={isBlender}
                   unitName={unitName}

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionEdit/SubscriptionEdit.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionEdit/SubscriptionEdit.tsx
@@ -133,6 +133,7 @@ const ResizeSummary = ({
             <br />
           </>
         ) : null}
+        {!isPreviewLoading && !preview ? <>You will be charged nothing.<br /></> : null}
         {!isPreviewLoading ? (
           <>
             Your {isMonthly ? "monthly" : "yearly"} payment will be{" "}

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionEdit/SubscriptionEdit.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionEdit/SubscriptionEdit.tsx
@@ -100,7 +100,6 @@ type ResizeSummaryProps = {
 };
 
 const ResizeSummary = ({
-  oldNumberOfMachines,
   newNumberOfMachines,
   currentNumberOfMachines,
   unitName,
@@ -110,12 +109,12 @@ const ResizeSummary = ({
   preview,
   isPreviewLoading,
 }: ResizeSummaryProps) => {
-  const absoluteDelta = Math.abs(newNumberOfMachines - oldNumberOfMachines);
+  const absoluteDelta = Math.abs(newNumberOfMachines - currentNumberOfMachines);
   if (absoluteDelta === 0) {
     return null;
   }
 
-  const isDecreasing = newNumberOfMachines - oldNumberOfMachines < 0;
+  const isDecreasing = newNumberOfMachines - currentNumberOfMachines < 0;
   const isMonthly = period === UserSubscriptionPeriod.Monthly;
   const unitPrice = (price ?? 0) / 100 / currentNumberOfMachines;
 

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionEdit/SubscriptionEdit.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionEdit/SubscriptionEdit.tsx
@@ -89,6 +89,7 @@ const generateError = (error: Error | null) => {
 type ResizeSummaryProps = {
   oldNumberOfMachines: number;
   newNumberOfMachines: number;
+  currentNumberOfMachines: number;
   isBlender: boolean;
   unitName: string;
   price: UserSubscription["price"];
@@ -101,6 +102,7 @@ type ResizeSummaryProps = {
 const ResizeSummary = ({
   oldNumberOfMachines,
   newNumberOfMachines,
+  currentNumberOfMachines,
   unitName,
   price,
   period,
@@ -115,7 +117,7 @@ const ResizeSummary = ({
 
   const isDecreasing = newNumberOfMachines - oldNumberOfMachines < 0;
   const isMonthly = period === UserSubscriptionPeriod.Monthly;
-  const unitPrice = (price ?? 0) / 100 / oldNumberOfMachines;
+  const unitPrice = (price ?? 0) / 100 / currentNumberOfMachines;
 
   return (
     <div>
@@ -334,6 +336,7 @@ const SubscriptionEdit = ({
                 />
                 <ResizeSummary
                   oldNumberOfMachines={subscription.current_number_of_machines}
+                  currentNumberOfMachines={subscription.number_of_machines}
                   newNumberOfMachines={values.size}
                   isBlender={isBlender}
                   unitName={unitName}


### PR DESCRIPTION
## Done

- On editing the subscriptions on Ubuntu Pro, the calculations on downsizing were incorrect. This PR fixes that

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to /pro/subscribe
- Buy any subscription and go through the full payment flow
- Go back to /pro/dashboard and try to increase the number of machines to 5. Save it
- Now try to decrease it to 3. 
- It should calculate the difference in money correctly.  

## Issue / Card

Fixes https://github.com/canonical/commercial-squad/issues/739

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
