### PR TITLE
We missed a "UA", copy change to "Ubuntu Pro"

### DIFF
--- a/static/js/src/navigation.js
+++ b/static/js/src/navigation.js
@@ -205,7 +205,7 @@ if (accountContainer && accountContainerSmall) {
         accountContainer.innerHTML = `<div class="p-navigation__dropdown-link">
             <a href="#" class="p-navigation__link-anchor p-navigation__toggle" aria-controls="user-menu" aria-expanded="false" aria-haspopup="true">${data.account.fullname}</a>
             <ul class="p-navigation__dropdown--right" id="user-menu" aria-hidden="true">
-              <li><a href="/pro/dashboard" class="p-navigation__dropdown-item">UA subscriptions</a></li>
+              <li><a href="/pro/dashboard" class="p-navigation__dropdown-item">Ubuntu Pro dashboard</a></li>
               <li>
                 <hr class="u-no-margin--bottom">
                 <a href="/account/invoices" class="p-navigation__dropdown-item">Invoices & Payments</a>


### PR DESCRIPTION
## Done

We missed a "UA", copy change to "Ubuntu Pro"
change user menu navigation item copy

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]


## Screenshots

![image](https://user-images.githubusercontent.com/930099/197976551-9b021542-51cf-43fc-ab2e-9716cb7efc78.png)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
