### PR TITLE
Fix list of tutorial topics/categories

### DIFF
--- a/templates/tutorials/index.html
+++ b/templates/tutorials/index.html
@@ -33,14 +33,8 @@
         <label for="tutorials-topic">Topic:</label>
         <select name="tutorials-topic" id="tutorials-topic" class="u-no-margin--bottom">
           <option value="">Any</option>
-          {% for item in topics_list %}
-            {% if item == "ua" %}
-              <option value="{{ item }}">Ubuntu Advantage</option>
-            {% elif item == "iot" %}
-              <option value="{{ item }}">IoT</option>
-            {% else %}
-              <option value="{{ item }}">{{item | capitalize}}</option>
-            {% endif %}
+          {% for key in topics_list %}
+            <option value="{{ topics_list[key] }}">{{ key }}</option>
           {% endfor %}
         </select>
       </div>

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -318,12 +318,21 @@ def build_tutorials_index(session, tutorials_docs):
             ]
 
         # Create list of topics
-        topics_list = set()
+        topics_list = {}
         for item in tutorials_docs.parser.tutorials:
-            if "categories" in item and item["categories"] not in topics_list:
-                topics_list = topics_list | set(
-                    item["categories"].replace(" ", "").lower().split(",")
-                )
+            if "categories" in item:
+                for cat in item["categories"].split(", "):
+                    cat_value = cat
+                    cat = cat.strip().capitalize()
+                    if cat == "Ua":
+                        cat = "Ubuntu advantage"
+                        cat_value = "ua"
+                    if cat == "Iot":
+                        cat = "IoT"
+                    if cat == "Aws":
+                        cat = "AWS"
+                    if cat not in topics_list.keys():
+                        topics_list[cat] = cat_value
 
         if query:
             temp_metadata = []
@@ -357,7 +366,9 @@ def build_tutorials_index(session, tutorials_docs):
             tutorials=tutorials,
             page=page,
             topic=topic,
-            topics_list=sorted(list(topics_list)),
+            topics_list=dict(
+                sorted(topics_list.items(), key=lambda key: key[0])
+            ),
             sort=sort,
             query=query,
             posts_per_page=posts_per_page,


### PR DESCRIPTION
## Done

The code duplication (in the template and views function) caused the `Ubuntu advantage` topic to duplicate
Refactored into one single place. Loops should be performant as `continue` should skip the queue if matched.

## QA

- Go to https://ubuntu-com-12235.demos.haus/tutorials
- Check that `Ubuntu advantage` topic is not duplicated and that it does display tutorials

## Issue / Card

Fixes https://github.com/canonical/web-squad/issues/5053

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
