### PR TITLE
Add redirect for cloud pricing report

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -478,6 +478,8 @@ engage/custom-ubuntu-pro-image-on-azure: "/engage/unlisted/custom-ubuntu-pro-ima
 engage/ShellOnboarding: "/engage/unlisted/shell-onboarding"
 engage/AT&TProOnboarding: "/engage/unlisted/at&t-onboarding"
 engage/smart-start-whitepaper/?: "/engage/4-ways-to-accelerate-time-to-market-for-iot-devices"
+engage/cloud-pricing-report-2021/?: "/engage/cloud-pricing-report"
+engage/cloud-pricing-report-2022/?: "/engage/cloud-pricing-report"
 enterprise-canonical-kubernetes/?: "https://assets.ubuntu.com/v1/Enterprise-Canonical-Kubernetes.pdf"
 es/?: "/"
 esm/?: "/security/esm"


### PR DESCRIPTION
## Done

**from**:
https://ubuntu.com/engage/cloud-pricing-report-2021
https://ubuntu.com/engage/cloud-pricing-report-2022
**to**:
https://ubuntu.com/engage/cloud-pricing-report

## QA

- Visit the webpages in the 'from' list and make sure they redirect to the 'to' destination.

## Issue / Card

Fixes https://github.com/canonical/web-squad/issues/6144