### PR TITLE
Redirect broken tutorial

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -910,6 +910,7 @@ t/(?P<path>.*)/?: /tutorials/{path}
 tutorial/(?P<path>.*)/?: /tutorials/{path}
 tutorials/microstack-get-started? : /openstack/tutorials
 tutorials/install-openstack-with-conjure-up? : /openstack/tutorials
+tutorials/electron-kiosk/?: https://mir-server.io/docs/make-a-secure-ubuntu-web-kiosk
 
 # Image builder
 build: /core/build


### PR DESCRIPTION
## Done

Redirect old borken tutorial to new

## QA

- Go https://ubuntu-com-12238.demos.haus/tutorials/electron-kiosk/ , it should redirect to https://mir-server.io/docs/make-a-secure-ubuntu-web-kiosk

## Issue / Card

Fixes https://github.com/canonical/ubuntu.com/issues/11847


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
