### PR TITLE
Fix lxd command typo and update example to latest LTS

### DIFF
--- a/templates/lxd/index.html
+++ b/templates/lxd/index.html
@@ -171,11 +171,11 @@
         <h3 class="p-stepped-list__title">Install the OS you’d like to use in your container or VM</h3>
         <div class="p-stepped-list__content">
           <h4>Container</h4>
-            <p>Command: <pre><code>lxc launch &lt;image_server&gt;:&lt;image_name&gt;&lt;instance_name&gt;</code></pre></p>
-            <p>Example: <pre><code>lxc launch ubuntu:20.04 ubuntu-container</code></pre></p>
+            <p>Command: <pre><code>lxc launch &lt;image_server&gt;:&lt;image_name&gt; &lt;instance_name&gt;</code></pre></p>
+            <p>Example: <pre><code>lxc launch ubuntu:22.04 ubuntu-container</code></pre></p>
           <h4>VM</h4>
-            <p>Command: <pre><code>lxc launch &lt;image_server&gt;:&lt;image_name&gt;&lt;instance_name&gt; --vm</code></pre></p>
-            <p>Example: <pre><code>lxc launch ubuntu:20.04 ubuntu-container-vm --vm</code></pre></p>
+            <p>Command: <pre><code>lxc launch &lt;image_server&gt;:&lt;image_name&gt; &lt;instance_name&gt; --vm</code></pre></p>
+            <p>Example: <pre><code>lxc launch ubuntu:22.04 ubuntu-container-vm --vm</code></pre></p>
             <p>Check the <a href="https://images.linuxcontainers.org/">community image server</a> for other Linux distributions.</p>
         </div>
       </li>


### PR DESCRIPTION
## Done

- Fixed missing space in command description.
- Updated the example command to show usage with the latest LTS version.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://127.0.0.1:8001/lxd
- See the updated commands and example usages.

## Issue / Card

N/A

## Screenshots

![image](https://user-images.githubusercontent.com/8691351/198854040-0aadb502-81db-4530-b811-089ce7ad9ec8.png)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
