### PR TITLE
Update the hero content of the RISC-V download page

### DIFF
--- a/templates/download/risc-v/index.html
+++ b/templates/download/risc-v/index.html
@@ -2,7 +2,7 @@
 
 {% block title %}Download Ubuntu for RISC-V Platforms{% endblock %}
 
-{% block meta_description %}Use Ubuntu on RISC-V platforms for the familiar developer experience and an accelerated path to production.{% endblock meta_description %}
+{% block meta_description %}Use Ubuntu on RISC-V platforms for the familiar developer experience and an accelerated path to production{% endblock meta_description %}
 
 {% block meta_copydoc%}https://docs.google.com/document/d/1kkJeq9HdH3iWV35HwihcJd3CxZw9Jy21W66lJl8VbWs/edit#{% endblock meta_copydoc %}
 
@@ -12,8 +12,8 @@
   <div class="row u-vertically-center">
     <div class="col-6">
       <h1>Download Ubuntu for RISC-V Platforms</h1>
-      <h2 class="p-heading--3">Ubuntu - now available for multiple RISC-V platforms</h2>
-      <p>Run Ubuntu with your favourite RISC-V boards. Ubuntu recently enabled SiFive Unmatched, StarFive VisionFive and Allwinner Nezha in Ubuntu 22.04.1 and the LicheeRV and Microchip Polarfire SoC FPGA Icicle Kit in 22.10. Download the images for those boards below.</p>
+      <h2 class="p-heading--3">Ubuntu &mdash; now available for multiple RISC-V platforms</h2>
+      <p>Run Ubuntu with your favourite RISC-V boards. Ubuntu recently enabled SiFive Unmatched, StarFive VisionFive, Allwinner Nezha, and Sipeed LicheeRV in 22.10. Download the images for those boards below.</p>
       <p>Pick the OS image to match your hardware, flash it onto SD/microSD card, load it onto your board and away you go.</p>
       <p>
         <a href="/download/contact-us" class="js-invoke-modal p-button">Get in touch</a>
@@ -49,7 +49,7 @@
         </div>
         <div class="p-tabs__item">
             <button class="p-tabs__link" role="tab" aria-selected="false" aria-controls="sipeed-licheerv-dock-tab" id="sipeed-licheerv-dock">Sipeed LicheeRV Dock</button>
-        </div>            
+        </div>
         <div class="p-tabs__item">
             <button class="p-tabs__link" role="tab" aria-selected="false" aria-controls="live-installer-tab" id="live-installer">Live installer</button>
         </div>


### PR DESCRIPTION
## Done
- Updated the hero content of the RISC-V page based on the suggestions in [the copy doc](https://docs.google.com/document/d/1kkJeq9HdH3iWV35HwihcJd3CxZw9Jy21W66lJl8VbWs/edit#heading=h.etjq4twyztv2)
- _Drive by_: to encode the dash in the sub-heading 

## QA
- Check the copy changes match [the copy doc](https://docs.google.com/document/d/1kkJeq9HdH3iWV35HwihcJd3CxZw9Jy21W66lJl8VbWs/edit#heading=h.etjq4twyztv2)

## Issue / Card
Fixes https://github.com/canonical/web-squad/issues/6163
