### PR TITLE
Fix anchor link column

### DIFF
--- a/templates/tutorials/tutorial.html
+++ b/templates/tutorials/tutorial.html
@@ -138,7 +138,7 @@
 
       <hr class="u-sv3">
       <footer class="l-tutorial-section__footer row">
-        <div class="col-6 col-small-2 col-medium-3 u-vertically-center">
+        <div class="col-4 col-small-2 col-medium-3 u-vertically-center">
           <a class="l-tutorial__bug-link" href="https://discourse.ubuntu.com{{ document.topic_path }}">
             <small>Suggest changes&nbsp;&rsaquo;</small>
           </a>

--- a/templates/tutorials/tutorial.html
+++ b/templates/tutorials/tutorial.html
@@ -138,12 +138,12 @@
 
       <hr class="u-sv3">
       <footer class="l-tutorial-section__footer row">
-        <div class="col-4 col-small-2 col-medium-3 u-vertically-center">
+        <div class="col-6 col-small-2 col-medium-3">
           <a class="l-tutorial__bug-link" href="https://discourse.ubuntu.com{{ document.topic_path }}">
             <small>Suggest changes&nbsp;&rsaquo;</small>
           </a>
         </div>
-        <div class="col-6 col-small-2 col-medium-3 u-align--right">
+        <div class="col-8 col-small-2 col-medium-3 u-align--right">
           <div class="l-tutorial__duration">
             <small>
               <span class="u-hide--small">about</span>


### PR DESCRIPTION
## Done

- Made anchor link column smaller so that it doesn't affect pagination, see issue for context

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: https://ubuntu-com-12247.demos.haus/tutorials/gpio-on-raspberry-pi#1-overview (or any other )
    - See that the link does not extend to the space right above the pagination buttons

## Issue / Card

Fixes https://github.com/canonical/ubuntu.com/issues/12246
