### PR TITLE
Require SSO login for /pro beta signup form

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -957,6 +957,7 @@ security/cve/sitemap(?P<suffix>.*).xml: /security/cves/sitemap{suffix}.xml
 
 /advantage: "/pro"
 /advantage/(?P<path>.*): "/pro/{path}"
+/pro/get-in-touch: "/pro#get-in-touch"
 
 # USN redirects
 /security/notices/months(/.*)?/?: /security/notices

--- a/templates/pro/index.html
+++ b/templates/pro/index.html
@@ -622,7 +622,11 @@
       <p>
         If you were an active customer before October 4th, 2022, this trial lasts for up to 1 year - until the end of your current contract. At the end of the trial, you can choose to upgrade to full Pro (at extra cost), or remain as an Ubuntu Pro (Infra-only) customer at your current price.
       </p>
-      <button class="js-invoke-modal">Request beta access at no extra cost</button>
+      {% if user_info %}
+        <button class="js-invoke-modal">Request beta access at no extra cost</button>
+      {% else %}
+        <a class="p-button" href="/login?next=/pro/get-in-touch">Login to request beta access</a>
+      {% endif %}
     </div>
   </div>
 </section>

--- a/templates/shared/forms/interactive/advantage-beta.html
+++ b/templates/shared/forms/interactive/advantage-beta.html
@@ -15,15 +15,29 @@
             <ul class="p-list">
               <li class="p-list__item">
                 <label for="firstName">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
+                {% if user_info %}
+                  {% set first_name = user_info.fullname.split(' ')[0] %}
+                  {% set last_name = user_info.fullname | replace(first_name + " ", "") %}
+                  <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" value="{{ first_name }}" />
+                {% else %}
+                  <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
+                {% endif %}
               </li>
               <li class="p-list__item">
                 <label for="lastName">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
+                {% if user_info %}
+                  <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" value="{{ last_name }}" />
+                {% else %}
+                  <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
+                {% endif %}
               </li>
               <li class="p-list__item">
                 <label for="email">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
+                {% if user_info %}
+                  <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" value="{{ user_info.email }}" disabled/>
+                {% else %}
+                  <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
+                {% endif %}
               </li>
               <li class="p-list__item">
                 <label class="p-checkbox">


### PR DESCRIPTION
## Done

- Added a check to see if the user is logged in on /pro. If they're logged in, they can trigger the contact modal and the fields will be pre-populated with their SSO info (and the email field will be disabled). If they're not logged in, they're directed to SSO, and then returned to the page with the modal already open.

## QA

- Visit https://ubuntu-com-12248.demos.haus/pro
- Make sure you're logged out of SSO
- Find the "Login to request beta access" CTA and click it
- You should be taken to SSO and asked to login
- Login
- When you've successfully logged in, you should be returned to /pro with the contact modal already populated (including a disabled email address field)
- Visit /pro again (without the #get-in-touch hash)
- See that the "Login to request beta access" CTA has been updated to read "Request beta access at no extra cost", and triggers the modal when clicked
