### PR TITLE
Add remaining meganav sections

### DIFF
--- a/meganav.yaml
+++ b/meganav.yaml
@@ -438,7 +438,7 @@ use_case:
           description: Performant open source
           url: /managed/apps
         - title: Managed infrastructure
-          description: Infrastructre support
+          description: Infrastructure support
           url: /pricing/infra
         - title: Observability
           description: Monitoring tools

--- a/meganav.yaml
+++ b/meganav.yaml
@@ -36,6 +36,7 @@
 #             - title:
 #               url:
 #       section_footer: (optional)
+#         copy:
 #         cta_title:
 #         cta_url:
 
@@ -83,6 +84,10 @@ products:
             - title: Ubuntu Certified Hardware
               description: Machines you can trust
               url: /certified
+      section_footer:
+        copy: Not sure where to start, need some guidance or just ready to learn more? We're here to help you.
+        cta_title: Contact us
+        cta_url: /contact-us
 
     - title: Ubuntu OS
       primary_links:

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@canonical/cookie-policy": "3.4.0",
     "@canonical/latest-news": "1.4.1",
     "@canonical/react-components": "0.37.4",
-    "@canonical/global-nav": "3.1.4",
+    "@canonical/global-nav": "3.2.0",
     "@reduxjs/toolkit": "1.7.1",
     "@sentry/react": "6.11.0",
     "@sentry/tracing": "6.11.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,4 @@ jinja2==3.0.3
 google-api-python-client==2.35.0
 google-auth-httplib2==0.1.0
 google-auth-oauthlib==0.4.6
+numpy==1.23.0

--- a/static/sass/_global-settings.scss
+++ b/static/sass/_global-settings.scss
@@ -13,5 +13,5 @@ $color-mid-x-light: #e5e5e5;
 $font-use-subset-latin: true;
 $font-allow-cyrillic-greek-latin: true;
 $font-display-option: fallback;
-$breakpoint-navigation-threshold: 1024px;
+$breakpoint-navigation-threshold: 1150px;
 $threshold-6-12-col: $breakpoint-navigation-threshold;

--- a/static/sass/_pattern_navigation-dropdown.scss
+++ b/static/sass/_pattern_navigation-dropdown.scss
@@ -132,13 +132,18 @@
   }
 
   .dropdown-window__footer {
-    align-items: center;
-    border-top: $dropdown-border;
-    display: flex;
-    justify-content: space-between;
-    padding: 1rem 0;
+    padding: 0 1rem;
 
-    a {
+    @media (min-width: $breakpoint-navigation-threshold) {
+      align-items: start;
+      border-top: $dropdown-border;
+      display: flex;
+      justify-content: space-between;
+      padding: 1rem 0;
+    }
+
+    [class*="p-button"] {
+      background: transparent;
       margin: 0;
     }
   }

--- a/templates/templates/_navigation.html
+++ b/templates/templates/_navigation.html
@@ -31,16 +31,20 @@
     </div>
     <nav class="p-navigation__nav js-show-nav u-hide" aria-label="Categories">
       <ul class="p-navigation__items">
-        <li class="p-navigation__item--dropdown-toggle" role="menuitem" id="enterprise" onmouseover="fetchDropdown('/templates/navigation-enterprise-h', 'enterprise-content'); this.onmouseover = null;">
-          <a class="p-navigation__link" href="#enterprise-content" onfocus="fetchDropdown('/templates/navigation-enterprise-h', 'enterprise-content');">Enterprise</a>
-          <div class="u-hide dropdown-content-mobile" id="enterprise-content-mobile" onclick="event.stopPropagation()"></div>
+        <li class="p-navigation__item--dropdown-toggle" role="menuitem" id="products" onmouseover="fetchDropdown('/templates/meganav/products', 'products-content'); this.onmouseover = null;">
+          <a class="p-navigation__link" href="#products-content" onfocus="fetchDropdown('/templates/meganav/products', 'products-content');">Products</a>
+          <div class="u-hide dropdown-content-mobile" id="products-content-mobile" onclick="event.stopPropagation()"></div>
         </li>
-        <li class="p-navigation__item--dropdown-toggle" role="menuitem" id="developer" onmouseover="fetchDropdown('/templates/navigation-developer-h', 'developer-content'); this.onmouseover = null;">
-          <a class="p-navigation__link" href="#developer-content" onfocus="fetchDropdown('/templates/navigation-developer-h', 'developer-content');">Developer</a>
-          <div class="u-hide dropdown-content-mobile" id="developer-content-mobile" onclick="event.stopPropagation()"></div>
+        <li class="p-navigation__item--dropdown-toggle" role="menuitem" id="use-case" onmouseover="fetchDropdown('/templates/meganav/use-case', 'use-case-content'); this.onmouseover = null;">
+          <a class="p-navigation__link" href="#use-case-content" onfocus="fetchDropdown('/templates/meganav/use-case', 'use-case-content');">Use Case</a>
+          <div class="u-hide dropdown-content-mobile" id="use-case-content-mobile" onclick="event.stopPropagation()"></div>
         </li>
-        <li class="p-navigation__item--dropdown-toggle" role="menuitem" id="community" onmouseover="fetchDropdown('/templates/navigation-community-h', 'community-content'); this.onmouseover = null;">
-          <a class="p-navigation__link" href="#community-content" onfocus="fetchDropdown('/templates/navigation-community-h', 'community-content');">Community</a>
+        <li class="p-navigation__item--dropdown-toggle" role="menuitem" id="support" onmouseover="fetchDropdown('/templates/meganav/support', 'support-content'); this.onmouseover = null;">
+          <a class="p-navigation__link" href="#support-content" onfocus="fetchDropdown('/templates/meganav/support', 'support-content');">Support</a>
+          <div class="u-hide dropdown-content-mobile" id="support-content-mobile" onclick="event.stopPropagation()"></div>
+        </li>
+        <li class="p-navigation__item--dropdown-toggle" role="menuitem" id="community" onmouseover="fetchDropdown('/templates/meganav/community', 'community-content'); this.onmouseover = null;">
+          <a class="p-navigation__link" href="#community-content" onfocus="fetchDropdown('/templates/meganav/community', 'community-content');">Community</a>
           <div class="u-hide dropdown-content-mobile" id="community-content-mobile" onclick="event.stopPropagation()"></div>
         </li>
         <li class="p-navigation__item--dropdown-toggle" role="menuitem" id="get-ubuntu" onmouseover="fetchDropdown('/templates/meganav/get-ubuntu', 'get-ubuntu-content'); this.onmouseover = null;">
@@ -70,8 +74,9 @@
 </header>
 <div class="dropdown-window-overlay fade-animation"></div>
 <div class="dropdown-window slide-animation {% if breadcrumbs and breadcrumbs.children or breadcrumbs.grandchildren %}is-reduced {% elif breadcrumbs == 'tutorials' %}is-reduced{% endif %}">
-  <div class="u-hide dropdown-content-desktop" id="enterprise-content"></div>
-  <div class="u-hide dropdown-content-desktop" id="developer-content"></div>
+  <div class="u-hide dropdown-content-desktop" id="products-content"></div>
+  <div class="u-hide dropdown-content-desktop" id="use-case-content"></div>
+  <div class="u-hide dropdown-content-desktop" id="support-content"></div>
   <div class="u-hide dropdown-content-desktop" id="community-content"></div>
   <div class="u-hide dropdown-content-desktop" id="get-ubuntu-content"></div>
 </div>

--- a/templates/templates/meganav/base.html
+++ b/templates/templates/meganav/base.html
@@ -19,7 +19,7 @@
         {% for side_nav_section in sections.side_nav_sections %}
           <div class="col-9 dropdown-window__sidenav-content"  {% if loop.index != 1 %}hidden="true"{% endif %} id="tab-content-{{ key }}-{{ loop.index }}" tabindex="0" role="tabpanel" aria-labelledby="tab-{{ key }}-{{ loop.index }}" >
             <div class="row u-no-padding"> 
-              <div class="col-6 dropdown-window__main-panel  {% if side_nav_section.secondary_links %}is-bordered{% endif %}">
+              <div class="col-{% if side_nav_section.secondary_links %}6{% else %}9{% endif %} dropdown-window__main-panel  {% if side_nav_section.secondary_links %}is-bordered{% endif %}">
                 <a class="dropdown-window__sidenav-back" href="#" onclick="hideSection(event);" aria-controls="tab-content-{{ key }}-{{ loop.index }}">Back</a>
                 {% for links_section in side_nav_section.primary_links %}
                   {% if links_section.title %}
@@ -27,7 +27,11 @@
                   {% endif %}
                   
                   <div class="row">
-                    {% set split_links_list = split_list(links_section.links) %}
+                    {% if side_nav_section.secondary_links %}
+                      {% set split_links_list = split_list(links_section.links, 2) %}
+                    {% else %}
+                      {% set split_links_list = split_list(links_section.links, 3) %}
+                    {% endif %}
 
                     <div class="col-3">
                       <ul class="p-list">
@@ -58,6 +62,22 @@
                         {% endfor %}
                       </ul>
                     </div>
+
+                    {% if secondary_links not in side_nav_section %}
+                      <div class="col-3">
+                        <ul class="p-list">
+                          {% for link in split_links_list[2] %}
+                            {% with 
+                              url = link.url, 
+                              title = link.title, 
+                              description = link.description 
+                            %}
+                              {% include "templates/meganav/_list-item.html" %}
+                            {% endwith %}
+                          {% endfor %}
+                        </ul>
+                      </div>
+                    {% endif %}
                   </div>
                 {% endfor %}
               </div>      
@@ -76,19 +96,28 @@
                 {% endfor %}
               </div>
             </div>
+
+            {% if side_nav_section.section_footer %}
+              <div class="col-9 dropdown-window__footer">
+                {% if "copy" in side_nav_section.section_footer %}
+                  <p>{{ side_nav_section.section_footer['copy'] }}</p>
+                {% endif %}
+
+                <a href="{{side_nav_section.section_footer['cta_url'] }}" class="p-button is-dark">{{ side_nav_section.section_footer['cta_title'] }}</a>
+              </div>
+            {% endif %}
           </div>
         {% endfor %}
       {% elif "primary_links" in sections %}
         <div class="row u-no-padding"> 
           <div class="col-9 dropdown-window__main-panel  {% if sections.secondary_links %}is-bordered{% endif %}">
-            <a class="dropdown-window__sidenav-back" href="#" onclick="hideSection(event);" aria-controls="tab-content-">Back</a>
             {% for links_section in sections.primary_links %}
               {% if links_section.title %}
                 <p class="p-muted-heading is-muted">{{ links_section.title }}</p>
               {% endif %}
               
               <div class="row">
-                {% set split_links_list = split_list(links_section.links) %}
+                {% set split_links_list = split_list(links_section.links, 3) %}
 
                 <div class="col-3">
                   <ul class="p-list">
@@ -109,6 +138,20 @@
                 <div class="col-3">
                   <ul class="p-list">
                     {% for link in split_links_list[1] %}
+                      {% with 
+                        url = link.url, 
+                        title = link.title, 
+                        description = link.description 
+                      %}
+                        {% include "templates/meganav/_list-item.html" %}
+                      {% endwith %}
+                    {% endfor %}
+                  </ul>
+                </div>
+
+                <div class="col-3">
+                  <ul class="p-list">
+                    {% for link in split_links_list[2] %}
                       {% with 
                         url = link.url, 
                         title = link.title, 

--- a/templates/templates/meganav/base.html
+++ b/templates/templates/meganav/base.html
@@ -8,7 +8,7 @@
               <ul class="p-side-navigation__list js-tabs u-no-margin--bottom js-tabbed-content" role="tablist" aria-label="Categories">
                 {% for side_nav_section in sections.side_nav_sections %}
                   <li class="p-side-navigation__item">
-                    <a href="#" class="p-side-navigation__link js-tab {{ 'is-active' if loop.index == 1 }}" id="tab-{{ loop.index }}" aria-controls="tab-content-{{ loop.index }}" role="tab" aria-selected="{{ 'true' if loop.index == 1 else 'false' }}" tabindex="{{ '0' if loop.index == 1 else '-1' }}" onclick="showSection(event);">{{ side_nav_section.title }}</a>
+                    <a href="#" class="p-side-navigation__link js-tab {{ 'is-active' if loop.index == 1 }}" id="tab-{{ key }}-{{ loop.index }}" aria-controls="tab-content-{{ key }}-{{ loop.index }}" role="tab" aria-selected="{{ 'true' if loop.index == 1 else 'false' }}" tabindex="{{ '0' if loop.index == 1 else '-1' }}" onclick="showSection(event);">{{ side_nav_section.title }}</a>
                   </li>
                 {% endfor %}
                 </ul>
@@ -17,10 +17,10 @@
         </div>
 
         {% for side_nav_section in sections.side_nav_sections %}
-          <div class="col-9 dropdown-window__sidenav-content"  {% if loop.index != 1 %}hidden="true"{% endif %} id="tab-content-{{ loop.index }}" tabindex="0" role="tabpanel" aria-labelledby="tab-{{ loop.index }}" >
+          <div class="col-9 dropdown-window__sidenav-content"  {% if loop.index != 1 %}hidden="true"{% endif %} id="tab-content-{{ key }}-{{ loop.index }}" tabindex="0" role="tabpanel" aria-labelledby="tab-{{ key }}-{{ loop.index }}" >
             <div class="row u-no-padding"> 
               <div class="col-6 dropdown-window__main-panel  {% if side_nav_section.secondary_links %}is-bordered{% endif %}">
-                <a class="dropdown-window__sidenav-back" href="#" onclick="hideSection(event);" aria-controls="tab-content-{{ loop.index }}">Back</a>
+                <a class="dropdown-window__sidenav-back" href="#" onclick="hideSection(event);" aria-controls="tab-content-{{ key }}-{{ loop.index }}">Back</a>
                 {% for links_section in side_nav_section.primary_links %}
                   {% if links_section.title %}
                     <p class="p-muted-heading is-muted">{{ links_section.title }}</p>

--- a/templates/templates/meganav/base.html
+++ b/templates/templates/meganav/base.html
@@ -78,6 +78,65 @@
             </div>
           </div>
         {% endfor %}
+      {% elif "primary_links" in sections %}
+        <div class="row u-no-padding"> 
+          <div class="col-9 dropdown-window__main-panel  {% if sections.secondary_links %}is-bordered{% endif %}">
+            <a class="dropdown-window__sidenav-back" href="#" onclick="hideSection(event);" aria-controls="tab-content-">Back</a>
+            {% for links_section in sections.primary_links %}
+              {% if links_section.title %}
+                <p class="p-muted-heading is-muted">{{ links_section.title }}</p>
+              {% endif %}
+              
+              <div class="row">
+                {% set split_links_list = split_list(links_section.links) %}
+
+                <div class="col-3">
+                  <ul class="p-list">
+                    {% for link in split_links_list[0] %}
+                      {% with 
+                        url = link.url, 
+                        title = link.title, 
+                        description = link.description,
+                        secondary_cta_url = link.secondary_cta_url,
+                        secondary_cta_title = link.secondary_cta_title 
+                      %}
+                        {% include "templates/meganav/_list-item.html" %}
+                      {% endwith %}
+                    {% endfor %}
+                  </ul>
+                </div>
+
+                <div class="col-3">
+                  <ul class="p-list">
+                    {% for link in split_links_list[1] %}
+                      {% with 
+                        url = link.url, 
+                        title = link.title, 
+                        description = link.description 
+                      %}
+                        {% include "templates/meganav/_list-item.html" %}
+                      {% endwith %}
+                    {% endfor %}
+                  </ul>
+                </div>
+              </div>
+            {% endfor %}
+          </div>      
+
+          <div class="col-3 dropdown-window__side-panel">
+            {% for links_section in sections.secondary_links %}
+              <p class="p-muted-heading is-muted">{{ links_section.title }}</h2>
+              
+              <ul class="p-list">
+                {% for link in links_section.links %}
+                  <li class="p-list__item">
+                    <a href="{{ link.url }}">{{ link.title }}</a>
+                  </li>
+                {% endfor %}
+              </ul>
+            {% endfor %}
+          </div>
+        </div>
       {% endif %}
     </div>
   </div>

--- a/templates/templates/meganav/community.html
+++ b/templates/templates/meganav/community.html
@@ -1,0 +1,5 @@
+{% set nav = get_meganav("community") %}
+
+{% with sections = nav.sections %}
+  {% include "templates/meganav/base.html" %}
+{% endwith %}

--- a/templates/templates/meganav/community.html
+++ b/templates/templates/meganav/community.html
@@ -1,5 +1,5 @@
 {% set nav = get_meganav("community") %}
 
-{% with sections = nav.sections %}
+{% with sections = nav.sections, key = "community" %}
   {% include "templates/meganav/base.html" %}
 {% endwith %}

--- a/templates/templates/meganav/get-ubuntu.html
+++ b/templates/templates/meganav/get-ubuntu.html
@@ -1,5 +1,5 @@
 {% set nav = get_meganav("get_ubuntu") %}
 
-{% with sections = nav.sections %}
+{% with sections = nav.sections, key = "get_ubuntu" %}
   {% include "templates/meganav/base.html" %}
 {% endwith %}

--- a/templates/templates/meganav/products.html
+++ b/templates/templates/meganav/products.html
@@ -1,5 +1,5 @@
 {% set nav = get_meganav("products") %}
 
-{% with sections = nav.sections %}
+{% with sections = nav.sections, key = "products" %}
   {% include "templates/meganav/base.html" %}
 {% endwith %}

--- a/templates/templates/meganav/products.html
+++ b/templates/templates/meganav/products.html
@@ -1,0 +1,5 @@
+{% set nav = get_meganav("products") %}
+
+{% with sections = nav.sections %}
+  {% include "templates/meganav/base.html" %}
+{% endwith %}

--- a/templates/templates/meganav/support.html
+++ b/templates/templates/meganav/support.html
@@ -1,0 +1,5 @@
+{% set nav = get_meganav("support") %}
+
+{% with sections = nav.sections %}
+  {% include "templates/meganav/base.html" %}
+{% endwith %}

--- a/templates/templates/meganav/support.html
+++ b/templates/templates/meganav/support.html
@@ -1,5 +1,5 @@
 {% set nav = get_meganav("support") %}
 
-{% with sections = nav.sections %}
+{% with sections = nav.sections, key = "support" %}
   {% include "templates/meganav/base.html" %}
 {% endwith %}

--- a/templates/templates/meganav/use-case.html
+++ b/templates/templates/meganav/use-case.html
@@ -1,5 +1,5 @@
 {% set nav = get_meganav("use_case") %}
 
-{% with sections = nav.sections %}
+{% with sections = nav.sections, key = "use_case" %}
   {% include "templates/meganav/base.html" %}
 {% endwith %}

--- a/templates/templates/meganav/use-case.html
+++ b/templates/templates/meganav/use-case.html
@@ -1,0 +1,5 @@
+{% set nav = get_meganav("use_case") %}
+
+{% with sections = nav.sections %}
+  {% include "templates/meganav/base.html" %}
+{% endwith %}

--- a/webapp/context.py
+++ b/webapp/context.py
@@ -4,6 +4,7 @@ import datetime
 import calendar
 import logging
 import json
+import numpy
 from urllib.parse import parse_qs, urlencode
 
 # Packages
@@ -136,20 +137,8 @@ def descending_years(end_year):
     return range(now.year, end_year, -1)
 
 
-def split_list(array):
-    half = len(array) // 2
-    first_half = array[:half]
-    second_half = array[half:]
-
-    # If there are an odd number of items in the list,
-    # the second half will one more item than the first,
-    # but we want the opposite to be true, so move the first
-    # item from the second half to the first half
-    if len(second_half) > len(first_half):
-        first_half.append(second_half[0])
-        second_half.pop(0)
-
-    return [first_half, second_half]
+def split_list(array, parts):
+    return numpy.array_split(array, parts)
 
 
 def get_json_feed(url, offset=0, limit=None):

--- a/yarn.lock
+++ b/yarn.lock
@@ -1292,12 +1292,12 @@
   resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.4.0.tgz#0d6708da340df5867fd2cc9dbd95538c46f20cf8"
   integrity sha512-cdVqxQmGu+j+Q86UobihWWVFzGzHlekFeMFxlbRpm+yqxEOUCrLkA9/t/RsMfLNDToP2ECPgsMbS20aPlA2tIg==
 
-"@canonical/global-nav@3.1.4":
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/@canonical/global-nav/-/global-nav-3.1.4.tgz#f75ccf951086f219f33791aedc9fac326b6886ff"
-  integrity sha512-gNWGvElqG6RFW0QpMqwq4bQXjUnZR2bTFgu+Ms1UL9/oD8u0anQ+k7lE5fZivcJPej3OJTkPL9GZQ6LGtWoeNg==
+"@canonical/global-nav@3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@canonical/global-nav/-/global-nav-3.2.0.tgz#6b6c6cefafb22220fa3c43c4176cf2c27ed5a403"
+  integrity sha512-mNxKPFLdib0Wa0pXRvEt/hlSC0MSe3MKTxyu/Hy3sJTt/gDQBvwfDXaVnkIhI7rZoZmRWl8TxsFuaS2apTQrig==
   dependencies:
-    vanilla-framework "3.7.1"
+    vanilla-framework "3.8.1"
 
 "@canonical/latest-news@1.4.1":
   version "1.4.1"
@@ -8849,6 +8849,20 @@ vanilla-framework@3.7.1:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-3.7.1.tgz#ee107f0695cffb386760164a2bb1901a610d3929"
   integrity sha512-QR188kOz6mENe4/owkifksgrK6EsTcymG39Wr3nereUadxh1GlipNsxo0MhozhBP0ZvQkBwD8V734j8wjdcydg==
+  dependencies:
+    "@canonical/cookie-policy" "3.4.0"
+    "@canonical/latest-news" "1.4.1"
+    autoprefixer "10.4.8"
+    postcss "8.4.14"
+    postcss-cli "9.1.0"
+    postcss-scss "4.0.4"
+    sass "1.54.0"
+    yaml "1.10.2"
+
+vanilla-framework@3.8.1:
+  version "3.8.1"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-3.8.1.tgz#9534f89a3120b95b0d3ece022ceabf10812fecdc"
+  integrity sha512-rtG4ipxyHWOlA2cwUzskGZY1NieVt57uDq2TidY8Fk1+jQDo9wbe5N3M7S9e4oI+UhTXUKTKRvLYDP6s4TMsqQ==
   dependencies:
     "@canonical/cookie-policy" "3.4.0"
     "@canonical/latest-news" "1.4.1"


### PR DESCRIPTION
## Done

- Added Products, Use Case, Community and Support sections to the meganav

## QA

- Visit https://ubuntu-com-12251.demos.haus/
- Open all of the dropdowns in the mega nav
- See that they work as expected:
  - Dropdowns should animate open and closed (they will switch instantly when navigating from one dropdown to another)
  - Some sections contain a side navigation, which should work
- Check the mobile view, see that it works

## Issue / Card

Fixes https://github.com/canonical/web-squad/issues/5983, https://github.com/canonical/web-squad/issues/5985, https://github.com/canonical/web-squad/issues/5986, https://github.com/canonical/web-squad/issues/5987
