### PR TITLE
Add link on /pro

### DIFF
--- a/templates/pro/index.html
+++ b/templates/pro/index.html
@@ -24,9 +24,6 @@
       <div class="col-6 col-medium-3">
         <p>Ubuntu Pro (currently in public beta) expands our famous ten-year security coverage to an additional 23,000 packages beyond the main operating system.
         </p>
-        <p>
-          Including Ansible, Apache Tomcat, Apache Zookeeper, Docker, Drupal, Nagios, Node.js, phpMyAdmin, Puppet, PowerDNS, Python 2, Redis, Rust, WordPress, and many more...
-        </p>
       </div>
     </div>
   </div>
@@ -724,7 +721,7 @@
         <td class="u-no-padding--right" data-heading="Ubuntu Pro">Yes</td>
       </tr>
       <tr>
-        <td class="u-no-padding--left" data-heading="Other features">Optional Support</td>
+        <td class="u-no-padding--left" data-heading="Other features"><a href="/support">Optional Support</a></td>
         <td data-heading="Ubuntu LTS">No</td>
         <td data-heading="Ubuntu Pro (Infra-only)">Yes</td>
         <td class="u-no-padding--right" data-heading="Ubuntu Pro">Yes</td>


### PR DESCRIPTION
## Done

- Add link on /pro based on [copydoc](https://docs.google.com/document/d/1In4NSnckAtL51_7D_AZCHa6TPnPGXqctXo-5rE77_aY/edit#)

## QA

- Compare against changes in copydoc

## Issue / Card

Fixes https://github.com/canonical/web-squad/issues/6180


