### PR TITLE
Update table to include 22.04

### DIFF
--- a/static/sass/_pattern_component-table.scss
+++ b/static/sass/_pattern_component-table.scss
@@ -38,6 +38,14 @@
     }
 
     &:nth-child(6) {
+      width: 10%;
+      @media only screen and (min-width: $breakpoint-medium) {
+        justify-content: center;
+        text-align: center;
+      }
+    }
+
+    &:nth-child(7) {
       width: 25%;
     }
   }

--- a/templates/certified/model-details.html
+++ b/templates/certified/model-details.html
@@ -141,6 +141,7 @@
           <th class="u-align--center">16.04 LTS</th>
           <th class="u-align--center">18.04 LTS</th>
           <th class="u-align--center">20.04 LTS</th>
+          <th class="u-align--center">22.04 LTS</th>
           <th>Comments</th>
         </tr>
       </thead>
@@ -235,7 +236,29 @@
             {% else %}
              <td data-heading="20.04 LTS"></td>
             {% endif %}
-          <td data-heading="Comments" >{{ component.note }}</td>
+            {% if '22.04 LTS' in component.lts_releases %}
+              {% if component.lts_releases['22.04 LTS'][0].third_party_driver %}
+              <td data-heading="22.04 LTS">
+                {{ image (
+                  url="https://assets.ubuntu.com/v1/8dd0626d-3rd-party-icon.svg",
+                  alt="May require third-party driver",
+                  width="21",
+                  height="14",
+                  hi_def=True,
+                  attrs={"style":"margin-left: 0.45rem;"},
+                  loading="lazy"
+                  ) | safe
+                }}
+              </td>
+              {% elif component.lts_releases['22.04 LTS'][0].status == 'inprogress' %}
+              <td data-heading="22.04 ESM"><i class="p-icon--help">In progress</i></td>
+              {% elif component.lts_releases['22.04 LTS'][0].status == 'certified' %}
+              <td data-heading="22.04 LTS"><i class="p-icon--success">Supported</i></td>
+              {% endif %}
+            {% else %}
+             <td data-heading="22.04 LTS"><i class="p-icon--error"></i></td>
+            {% endif %}
+            <td data-heading="Comments" >{{ component.note }}</td>
         </tr>
         {% endfor %}
     </table>


### PR DESCRIPTION
## Done

- Added 22.04 column and updated sass file

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/certified/202204-30238
    - Be sure to test on mobile, tablet and desktop screen sizes
- See that the relevant column has been added to the table

## Issue / Card

Fixes https://github.com/canonical/ubuntu.com/issues/12250
