### PR TITLE
Cue beta signup spreadsheet

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -53,6 +53,16 @@ env:
       key: api_secret
       name: marketo
 
+  - name: GOOGLE_SERVICE_ACCOUNT_EMAIL
+    secretKeyRef:
+      key: email
+      name: google-service-account
+
+  - name: GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY
+    secretKeyRef:
+      key: private-key
+      name: google-service-account
+
   - name: SENTRY_DSN
     value: https://0293bb7fc3104e56bafd2422e155790c@sentry.is.canonical.com//13
 
@@ -445,6 +455,16 @@ staging:
       secretKeyRef:
         key: api_secret
         name: marketo
+
+    - name: GOOGLE_SERVICE_ACCOUNT_EMAIL
+      secretKeyRef:
+        key: email
+        name: google-service-account
+
+    - name: GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY
+      secretKeyRef:
+        key: private-key
+        name: google-service-account
 
     - name: SENTRY_DSN
       value: https://0293bb7fc3104e56bafd2422e155790c@sentry.is.canonical.com//13

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,6 @@ sortedcontainers==2.4.0
 vcrpy-unittest==0.1.7
 webargs==7.0.1
 jinja2==3.0.3
+google-api-python-client==2.35.0
+google-auth-httplib2==0.1.0
+google-auth-oauthlib==0.4.6

--- a/templates/credentials/index.html
+++ b/templates/credentials/index.html
@@ -13,12 +13,12 @@
       <h1>Canonical Credentials</h1>
       <p class="p-heading--4">Learn, Certify, Excel!</p>
       <p>Find the shortest path to your passion.<br/>Develop and certify your skills on the world's most popular Linux OS.</p>
-      <button
-        class="p-button"
-        disabled="">
+      <a 
+        href="/credentials/sign-up"
+        class="p-button--positive"
+        >
         Apply for free beta access!
-      </button>
-      <p>Link will be live on <strong>9 November 2022 at 00:00 UTC</strong></p>
+      </a>
     </div>
     <div class="col-4 col-start-large-9 u-hide--small u-hide--medium u-vertically-center">
       {{
@@ -65,11 +65,11 @@
         </div>
       </li>
     </ul>
-    <!-- <a
-      href="#"
+    <a
+      href="/credentials/sign-up"
       class="p-button--positive"
       >Enroll now ></a
-    > -->
+    >
   </div>
 </section>
 

--- a/templates/shared/_credentials-contact-us-form.html
+++ b/templates/shared/_credentials-contact-us-form.html
@@ -346,7 +346,7 @@
               In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.
             </li>
             <li class=" p-list__item">
-              <button type="submit" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Form', 'eventAction' : 'cloud contact-us', 'eventLabel' : '{{product}}', 'eventValue' : undefined });">Submit</button>
+              <button type="submit" class="p-button--positive" id="formSubmitButton" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Form', 'eventAction' : 'cloud contact-us', 'eventLabel' : '{{product}}', 'eventValue' : undefined });">Submit</button>
             </li>
           </ul>
           <!-- hidden fields -->
@@ -428,6 +428,9 @@ for (var i = 0, l = sliders.length; i < l; i++) {
 }
 
 function getCustomFields() {
+  // disable submit button when form is submitted to stop duplicates
+  document.getElementById("formSubmitButton").setAttribute("disabled","true");
+
   const nativeLanguage = document.getElementById("NativeLanguage");
   const cueMotivation = document.getElementById("CUEMotivation");
   const jobTitle = document.getElementById("JobTitle");

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -919,7 +919,19 @@ def marketo_submit():
             spreadsheetId="1L-e0pKXmBo8y_Gv9_jy9P59xO-w4FnZdcTqbGJPMNg0",
             range="Sheet1",
             valueInputOption="RAW",
-            body={"values": [[field for field in form_fields.values()]]},
+            body={
+                "values": [
+                    [
+                        form_fields.get("firstName"),
+                        form_fields.get("lastName"),
+                        form_fields.get("email"),
+                        form_fields.get("Job_Role__c"),
+                        form_fields.get("title"),
+                        form_fields.get("Comments_from_lead__c"),
+                        form_fields.get("canonicalUpdatesOptIn")
+                    ]
+                ]
+            },
         ).execute()
 
     # Send enrichment data

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -27,6 +27,9 @@ from canonicalwebteam.discourse import (
     DocParser,
 )
 
+from google.oauth2 import service_account
+from googleapiclient.discovery import build
+
 # Local
 from webapp.login import user_info
 from webapp.marketo import MarketoAPI
@@ -892,6 +895,32 @@ def marketo_submit():
             ),
             400,
         )
+
+    if payload["formId"] == "3801":
+        service_account_info = {
+            "token_uri": "https://oauth2.googleapis.com/token",
+            "client_email": os.getenv("GOOGLE_SERVICE_ACCOUNT_EMAIL"),
+            "private_key": os.getenv(
+                "GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY"
+            ).replace("\\n", "\n"),
+            "scopes": [
+                "https://www.googleapis.com/auth/spreadsheets.readonly"
+            ],
+        }
+
+        credentials = service_account.Credentials.from_service_account_info(
+            service_account_info,
+        )
+
+        service = build("sheets", "v4", credentials=credentials)
+
+        sheet = service.spreadsheets()
+        sheet.values().append(
+            spreadsheetId="1L-e0pKXmBo8y_Gv9_jy9P59xO-w4FnZdcTqbGJPMNg0",
+            range="Sheet1",
+            valueInputOption="RAW",
+            body={"values": [[field for field in form_fields.values()]]},
+        ).execute()
 
     # Send enrichment data
     try:

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -928,7 +928,7 @@ def marketo_submit():
                         form_fields.get("Job_Role__c"),
                         form_fields.get("title"),
                         form_fields.get("Comments_from_lead__c"),
-                        form_fields.get("canonicalUpdatesOptIn")
+                        form_fields.get("canonicalUpdatesOptIn"),
                     ]
                 ]
             },


### PR DESCRIPTION
## Done

- Marketo is unreliable so we are also storing a backup in google spreadsheet

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Checkout /credentials
  - Link to sign up form should be available
- Checkout /credentials/sign-up
  - Filled out data should appear in [Marketo](https://engage-sj.marketo.com/?munchkinId=066-EOV-335#/classic/SL100906930B2LA1)
  - Filled out data should appear in [Google Sheets](https://docs.google.com/spreadsheets/d/1L-e0pKXmBo8y_Gv9_jy9P59xO-w4FnZdcTqbGJPMNg0/edit?usp=sharing) 

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
