### PR TITLE
Create python module to fetch user subscriptions

### DIFF
--- a/templates/subscription-centre/base_subscription-centre.html
+++ b/templates/subscription-centre/base_subscription-centre.html
@@ -1,0 +1,7 @@
+{% extends "templates/base.html" %}
+
+{% block meta_copydoc %}{% endblock meta_copydoc %}
+
+{% block outer_content %}
+  {% block content %}{% endblock %}
+{% endblock %}

--- a/templates/subscription-centre/index.html
+++ b/templates/subscription-centre/index.html
@@ -1,0 +1,6 @@
+{% extends "subscription-centre/base_subscription-centre.html" %}
+
+{% block content %}
+<h2>Response {{ data }}</h2>
+{% endblock content%}
+

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -81,6 +81,7 @@ from webapp.views import (
     mirrors_query,
     build_tutorials_query,
     openstack_engage,
+    subscription_centre,
 )
 
 from webapp.shop.views import (
@@ -1036,6 +1037,9 @@ app.add_url_rule(
     "/openstack/install",
     view_func=openstack_install,
 )
+
+# Subscription centre
+app.add_url_rule("/subscription-centre", view_func=subscription_centre)
 
 
 @app.before_request

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -961,18 +961,21 @@ def thank_you():
 
 
 def subscription_centre():
-    leadId = flask.request.args.get("id")
+    sfdcLeadId = flask.request.args.get("id")
     try:
         response = marketo_api.request(
             "GET",
-            f"/rest/v1/lead/{leadId}.json",
-            {"fields": "prototype_interests,email"},
+            "/rest/v1/leads.json",
+            {
+                "filterType": "sfdcLeadId",
+                "filterValues": sfdcLeadId,
+                "fields": "prototype_interests,email",
+            },
         )
         data = response.json()
-    except Exception:
-        return flask.jsonify(
-            {"error": "There was an issue with your request."}, 400
-        )
+    except HTTPError:
+        flask.current_app.extensions["sentry"].captureException()
+
     return flask.render_template(
         "subscription-centre/index.html", data=data["result"]
     )

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -958,3 +958,21 @@ def thank_you():
     return flask.render_template(
         "thank-you.html", referrer=flask.request.args.get("referrer")
     )
+
+
+def subscription_centre():
+    leadId = flask.request.args.get("id")
+    try:
+        response = marketo_api.request(
+            "GET",
+            f"/rest/v1/lead/{leadId}.json",
+            {"fields": "prototype_interests,email"},
+        )
+        data = response.json()
+    except Exception:
+        return flask.jsonify(
+            {"error": "There was an issue with your request."}, 400
+        )
+    return flask.render_template(
+        "subscription-centre/index.html", data=data["result"]
+    )


### PR DESCRIPTION
## Done

- Create python module to fetch user subscriptions
- Create folder/files where subscription centre will reside

## QA

- Make sure you have Marketo credentials in your `.env.local`
- using a test marketo accout (there is one called 'test' I recommend using, that's already filled in), fill in the user info field (on marketo) called '__prototype_interests' with a comma separated list. 
- Get the <leadId> from the url params
- Run the project and visit /subsciption-centre?id=(leadId)
- You should see the response that includes the comma separated list

## Issue / Card

Fixes https://warthogs.atlassian.net/jira/software/c/projects/WD/boards/932?modal=detail&selectedIssue=WD-229
