### PR TITLE
[copy update] u.c/model-driven-operations - replace links

### DIFF
--- a/templates/model-driven-operations/index.html
+++ b/templates/model-driven-operations/index.html
@@ -426,7 +426,7 @@
           ) | safe
         }}
       </div>
-      <p><a href="https://juju.is/tutorials">Juju Tutorials:</a> tutorials cover ground from the Charmed Operator Lifecycle Manager to creating a Charmed Operator with the SDK, packaging it as a Charm, publishing it to Charmhub, and to using charmed products such as Kubernetes, Cassandra, Kafka, and much much more.</p>
+      <p><a href="https://juju.is/docs">Juju Tutorials:</a> tutorials cover ground from the Charmed Operator Lifecycle Manager to creating a Charmed Operator with the SDK, packaging it as a Charm, publishing it to Charmhub, and to using charmed products such as Kubernetes, Cassandra, Kafka, and much much more.</p>
     </div>
     <div class="col-3 p-divider__block">
       <div class="u-hide--medium u-hide--small u-align--center">
@@ -441,7 +441,7 @@
           ) | safe
         }}
       </div>
-      <p>Juju Community: Join the conversation on <a href="https://discourse.charmhub.io/">Discourse</a> and <a href="https://chat.charmhub.io">Mattermost</a>. Meet the team at the “<a href="https://discourse.charmhub.io/t/community-events/5295/8">Charmed Office Hours</a>”. Anyone and everyone is welcome to join!</p>
+      <p>Juju Community: Join the conversation on <a href="https://discourse.charmhub.io/tag/community-workshop">Discourse</a> and <a href="https://chat.charmhub.io/charmhub/channels/community-workshops">Mattermost</a>. Meet the team at the “<a href="https://discourse.charmhub.io/t/community-events/5295/8">Charmed Office Hours</a>”. Anyone and everyone is welcome to join!</p>
     </div>
     <div class="col-3 p-divider__block">
       <div class="u-hide--medium u-hide--small u-align--center">


### PR DESCRIPTION
## Done

- Replaced links as per [copy doc](https://docs.google.com/document/d/1G4sSrM-FQIL2c1Uj8PvW6oGUKcJ9HAK5TwnKhFa4sOY/edit#heading=h.g5a048d6b0vb)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Confirm that the links have been replaced.

## Issue / Card

Fixes [canonical/workplace-engineering-squad/#871](https://github.com/canonical/workplace-engineering-squad/issues/871)