### PR TITLE
Update pricing tables for Ubuntu Pro

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "start": "yarn run build && concurrently --kill-others --raw 'yarn run watch-css' 'yarn run watch-js' 'yarn run serve'",
     "cypress:run": "cypress run --config-file tests/cypress/cypress.json --config baseUrl=http://0.0.0.0:${PORT:-8001}/",
     "cypress:open": "cypress open --config-file tests/cypress/cypress.json --config baseUrl=http://0.0.0.0:${PORT:-8001}/",
-    "check-prettier": "prettier -c 'static/js/src/**/*.{js,jsx,ts,tsx}' 'static/sass/**/*.scss'"
+    "check-prettier": "prettier -c 'static/js/src/**/*.{js,jsx,ts,tsx}' 'static/sass/**/*.scss'",
+    "format-prettier": "prettier -w 'static/js/src/**/*.{js,jsx,ts,tsx}' 'static/sass/**/*.scss'"
   },
   "keywords": [
     "website",

--- a/static/sass/_pattern_table.scss
+++ b/static/sass/_pattern_table.scss
@@ -48,4 +48,60 @@
       }
     }
   }
+
+  .p-table--pricing-pro-maas {
+    :nth-child(1){
+      @media (min-width: $breakpoint-medium) {
+        
+      }
+      @media (min-width: $breakpoint-large) {
+        width: calc(50% + 2.5rem);
+      }
+    }
+    :nth-child(1){
+      @media (min-width: $breakpoint-medium) {
+      
+      }
+      @media (min-width: $breakpoint-large) {
+      
+      }
+    }
+    :nth-child(1){
+      @media (min-width: $breakpoint-medium) {
+      
+      }
+      @media (min-width: $breakpoint-large) {
+      
+      }
+    }
+    :nth-child(1){
+      @media (min-width: $breakpoint-medium) {
+      
+      }
+      @media (min-width: $breakpoint-large) {
+      
+      }
+    }
+  }
+
+  .p-table {
+    &.is-not-indented {
+      td:first-child {
+        padding-left: 0;
+      }
+
+      td:last-child {
+        padding-right: 0;
+      }
+    }
+
+    &.is-list {
+      table-layout: auto; 
+      
+      td:first-child {
+        text-align: right;
+        width: 3ch;
+      }
+    }
+  }
 }

--- a/static/sass/_pattern_table.scss
+++ b/static/sass/_pattern_table.scss
@@ -86,11 +86,13 @@
 
   .p-table {
     &.is-not-indented {
-      td:first-child {
+      td:first-child,
+      th:first-child {
         padding-left: 0;
       }
 
-      td:last-child {
+      td:last-child,
+      th:first-child {
         padding-right: 0;
       }
     }

--- a/static/sass/_pattern_table.scss
+++ b/static/sass/_pattern_table.scss
@@ -50,36 +50,9 @@
   }
 
   .p-table--pricing-pro-maas {
-    :nth-child(1){
-      @media (min-width: $breakpoint-medium) {
-        
-      }
+    :nth-child(1) {
       @media (min-width: $breakpoint-large) {
         width: calc(50% + 2.5rem);
-      }
-    }
-    :nth-child(1){
-      @media (min-width: $breakpoint-medium) {
-      
-      }
-      @media (min-width: $breakpoint-large) {
-      
-      }
-    }
-    :nth-child(1){
-      @media (min-width: $breakpoint-medium) {
-      
-      }
-      @media (min-width: $breakpoint-large) {
-      
-      }
-    }
-    :nth-child(1){
-      @media (min-width: $breakpoint-medium) {
-      
-      }
-      @media (min-width: $breakpoint-large) {
-      
       }
     }
   }
@@ -98,8 +71,8 @@
     }
 
     &.is-list {
-      table-layout: auto; 
-      
+      table-layout: auto;
+
       td:first-child {
         text-align: right;
         width: 3ch;

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -870,3 +870,12 @@ a:hover {
   text-decoration: underline 1px;
   text-underline-offset: 0.075em;
 }
+
+.u-overflow-pricing-pro-table {
+  @media only screen and (max-width: 720px) {
+    overflow-x: scroll;
+    .p-table {
+      table-layout: initial;
+    }
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -871,11 +871,16 @@ a:hover {
   text-underline-offset: 0.075em;
 }
 
+// pricing/pro custom styles
 .u-overflow-pricing-pro-table {
-  @media only screen and (max-width: 720px) {
-    overflow-x: scroll;
-    .p-table {
-      table-layout: initial;
-    }
+  td {
+    text-overflow: initial;
+  }
+}
+.u-pro-support {
+  display: flex;
+  justify-content: space-between;
+  .u-pro-support__logos {
+    flex: 0 0 10%;
   }
 }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -884,3 +884,9 @@ a:hover {
     flex: 0 0 10%;
   }
 }
+.u-table-border-top {
+  border-top: 1px solid $color-mid-light;
+}
+.u-table-border-bottom {
+  border-bottom: 1px solid $color-mid-light;
+}

--- a/templates/pricing/pro.html
+++ b/templates/pricing/pro.html
@@ -9,7 +9,7 @@
 
 {% block content %}
 
-<section id="ua-infra" class="p-strip--image is-deep" style="background-image:url('https://assets.ubuntu.com/v1/d11e6f0f-05_suru2_light_glow_3K.jpg')">
+<section id="ua-infra" class="p-strip--image is-deep" style="background-image:url('https://assets.ubuntu.com/v1/18717572-05_suru2_light_glow_8K_edited.png')">
   <div class="u-fixed-width">
     <h1>Ubuntu Pro: more security, compliance, and support</h1>
     <p>Ubuntu Pro covers all aspects of open infrastructure and applications.</p>
@@ -30,10 +30,10 @@
   </div>
   <hr class="is-fixed-width">
   <div class="row">
-    <div class="col-5">
+    <div class="col-6">
       <h3 class="p-heading--2">Ubuntu Pro (Infra-only)</h3>
     </div>
-    <div class="col-7">
+    <div class="col-6">
       <div class="u-overflow-pricing-pro-table">
         <table class="p-table">
           <thead>
@@ -68,10 +68,10 @@
 
   <div class="row">
     <hr class="is-fixed-width">
-    <div class="col-5">
+    <div class="col-6">
       <h3 class="p-heading--2 u-no-margin--bottom">Ubuntu Pro</h3>
     </div>
-    <div class="col-7">
+    <div class="col-6">
       <div class="u-overflow-pricing-pro-table">
         <table class="p-table">
           <thead>
@@ -105,8 +105,8 @@
   </div>
 
   <div class="row">
-    <div class="col-5">&nbsp;</div>
-    <div class="col-7">
+    <div class="col-6">&nbsp;</div>
+    <div class="col-6">
       <p>N.B.: Weekday support is half the price of 24/7 support</p>
       <p>Please refer to the list of <a href="/support">supported infrastructure and applications</a>.</p>
       <p>See our consulting, architecture, deployment and training packages for OpenStack, Kubernetes and Kubeflow.</p>
@@ -122,13 +122,13 @@
 
   <div class="row">
     <hr class="is-fixed-width">
-    <div class="col-5">
-      <h3 class="p-heading--2">Ubuntu Pro (Infra-only) vs Ubuntu Pro</h3>
+    <div class="col-6">
+      <h3 class="p-heading--2">Ubuntu Pro (Infra-only) vs <br class="u-hide--small u-hide--medium">Ubuntu Pro</h3>
     </div>
 
-    <div class="col-7">
+    <div class="col-6">
       <h5 class="u-no-margin--bottom">Ubuntu Pro (Infra-only):</h5>
-      <table class="p-table--mobile-card">
+      <table>
         <tbody>
           <tr><td class="u-align--left"><span style="margin-right: 1rem;">1</span> Expanded Security Maintenance for Application (esm-apps) – in beta</td></tr>
           <tr><td class="u-align--left"><span style="margin-right: 1rem;">2</span> Kernel Livepatch service to avoid reboots</td></tr>
@@ -147,11 +147,11 @@
   </div>
 
   <div class="row">
-    <div class="col-5">&nbsp;</div>
-    <div class="col-7">
+    <div class="col-6">&nbsp;</div>
+    <div class="col-6">
       <h5 class="u-no-margin--bottom">Ubuntu Pro:</h5>
       <p><i>All of the above, plus:</i></p>
-      <table class="p-table--mobile-card">
+      <table>
         <tbody>
           <tr><td class="u-align--left"><span style="margin-right: 1rem;">12</span> Expanded Security Maintenance for Infrastructure (esm-infra)</td></tr>
           <tr><td class="u-align--left"><span style="margin-right: 1rem;">13</span> Advanced Active Directory policies for Ubuntu Desktop</td></tr>
@@ -165,11 +165,11 @@
 <section class="p-strip is-deep u-no-padding--top">
   <div class="row">
     <hr class="is-fixed-width">
-    <div class="col-5">
+    <div class="col-6">
       <h3 class="p-heading--2">Support: Infra vs Full-stack</h3>
     </div>
 
-    <div class="col-7">
+    <div class="col-6">
       <h5 class="u-no-margin--bottom"><a href="/support">Infra support</a></h5>
       <p>Over 2,300 open source deb packages in Ubuntu Main repository for 10 years, including:</p>
         <div class="row">
@@ -268,8 +268,8 @@
   </div>
 
   <div class="row">
-    <div class="col-5">&nbsp;</div>
-    <div class="col-7">
+    <div class="col-6">&nbsp;</div>
+    <div class="col-6">
       <hr class="is-fixed-width">
       <h5 class="u-no-margin--bottom"><a href="/support">Full stack support</a></h5>
       <p>Over 23,000 open source deb packages in Ubuntu Universe repository for 10 years, including:</p>
@@ -363,8 +363,8 @@
   </div>
 
   <div class="row">
-    <div class="col-5">&nbsp;</div>
-    <div class="col-7">
+    <div class="col-6">&nbsp;</div>
+    <div class="col-6">
       <p>N.B.: Weekly support is half the price of 24/7 support</p>
       <p>Please refer to the list of supported infrastructure and applications.</p>
       <p>See our consulting, architecture, deployment and training packages for OpenStack, Kubernetes and Kubeflow.</p>
@@ -381,13 +381,13 @@
 
   <div class="row">
     <hr class="is-fixed-width">
-    <div class="col-5">
+    <div class="col-6">
       <h3 class="p-heading--2">UA Advanced Storage</h3>
       <p>Only applies if attaching more than 192TB of raw Ceph/Swift capacity  per node in the cluster. Priced by the amount exceeding the total of 192TB per node included in Ubuntu Pro.</p>
     </div>
 
-    <div class="col-7">
-      <table class="p-table--mobile-card">
+    <div class="col-6">
+      <table>
         <thead>
           <tr>
             <th width="50%">UA Advanced Storage</th>
@@ -431,8 +431,8 @@
     </div>
   </div>
   <div class="row">
-    <div class="col-5">&nbsp;</div>
-    <div class="col-7">
+    <div class="col-6">&nbsp;</div>
+    <div class="col-6">
       <p>Prices are for Ubuntu Pro + 24/7 support contracts.<br class="u-hide--small">Weekday support is currently discounted by 50%.</p>
       <p><a href="/support/contact-us" class="p-button--positive js-invoke-modal">Get in touch</a></p>
     </div>
@@ -442,13 +442,13 @@
   <section class="p-strip is-deep u-no-padding--top">
     <hr class="is-fixed-width">
     <div class="row">
-      <div class="col-5">
+      <div class="col-6">
         <h3 class="p-heading--2">Fully managed OpenStack, Kubernetes and LMA</h3>
         <p>We manage infrastructure at both the host and the guest level. Infrastructure includes Ceph and Swift storage, Kubernetes, OpenStack and the recommended logging, monitoring and alerting stack.</p>
       </div>
   
-      <div class="col-7">
-        <table class="p-table--mobile-card">
+      <div class="col-6">
+        <table>
           <thead>
             <tr>
               <th width="50%">Feature</th>
@@ -488,28 +488,26 @@
     </div>
 
   <div class="row">
-    <div class="col-5">&nbsp;</div>
-    <div class="col-7">
+    <div class="col-6">&nbsp;</div>
+    <div class="col-6">
       <p>* On a VMware or OpenStack cluster, managed guests can be priced per host in the cluster.</p>
       <p><a href="/support/contact-us" class="p-button--positive js-invoke-modal">Get in touch</a></p>
     </div>
   </div>
-
 </section>
-
 
 <section class="p-strip is-deep u-no-padding--top">
   <hr class="is-fixed-width">
   <div class="row">
-    <div class="col-5">
+    <div class="col-6">
       <h3 class="p-heading--2">MAAS</h3>
       <p>Support and commercial capabilities for MAAS are included with Ubuntu Pro and Ubuntu Pro (Infra-only). These additional charges apply for machines managed by MAAS and <em>not</em> covered by an Ubuntu Pro contract.</p>
     </div>
-    <div class="col-7">
-        <table class="p-table--mobile-card">
+    <div class="col-6">
+        <table>
           <thead>
             <tr>
-              <th style="width: 50%;">Feature</th>
+              <th>Feature</th>
               <th class="u-align--right">No Support</th>
               <th class="u-align--right">Weekday support</th>
               <th class="u-align--right">24/7 support</th>
@@ -563,11 +561,11 @@
 
 <section class="p-strip is-deep u-no-padding--top">
   <hr class="is-fixed-width">
-  <div class="row">
-    <div class="col-5">
+  <div class="row p-strip is-deep u-no-padding--top">
+    <div class="col-6">
       <h3 class="p-heading--2">Any questions? Call us:</h3>
     </div>
-    <div class="col-7">
+    <div class="col-6">
       <h3><tel href="+17372040291">+1&nbsp;737&nbsp;204&nbsp;0291</tel>&nbsp;(Americas)<br /><tel href="+442036565291">+44&nbsp;203&nbsp;656&nbsp;5291</tel>&nbsp;(Rest of the World)</h3>
       <p>or <a href="/support/contact-us" class="js-invoke-modal">contact us online</a></p>
     </div>

--- a/templates/pricing/pro.html
+++ b/templates/pricing/pro.html
@@ -39,8 +39,8 @@
           <thead>
             <tr>
               <th colspan="2">No Support</th>
-              <th colspan="2">24/7<br />Infra support</th>
-              <th colspan="2">24/7<br />Full Stack support</th>
+              <th colspan="2">24/7 Infra support</th>
+              <th colspan="2">24/7 Full support</th>
             </tr>
           </thead>
           <tbody>
@@ -77,8 +77,8 @@
           <thead>
             <tr>
               <th colspan="2">No Support</th>
-              <th colspan="2">24/7<br />Infra support</th>
-              <th colspan="2">24/7<br />Full Stack support</th>
+              <th colspan="2">24/7 Infra support</th>
+              <th colspan="2">24/7 Full support</th>
             </tr>
           </thead>
           <tbody>
@@ -145,7 +145,7 @@
         <tbody>
           <tr>
             <td>1</td>
-            <td>Expanded Security Maintenance for Application (esm-apps) – in beta</td>
+            <td>Expanded Security Maintenance for Infrastructure (esm-infra)</td>
           </tr>
           <tr>
             <td>2</td>
@@ -183,14 +183,13 @@
   <div class="row">
     <div class="col-6">&nbsp;</div>
     <div class="col-6">
-      <hr class="u-no-margin--bottom">
       <h4 class="p-heading--5 u-no-margin--bottom u-sv-1">Ubuntu Pro:</h5>
       <p><i>All of the above, plus:</i></p>
       <table class="p-table is-list is-not-indented">
         <tbody>
           <tr>
             <td>9</td>
-            <td class="u-align--left">Expanded Security Maintenance for Infrastructure (esm-infra)</td>
+            <td class="u-align--left">Expanded Security Maintenance for Application (esm-apps) – in beta</td>
           </tr>
           <tr>
             <td>10</td>
@@ -312,7 +311,7 @@
     <div class="col-6">&nbsp;</div>
     <div class="col-6">
       <hr class="is-fixed-width u-no-margin--bottom">
-      <h4 class="p-heading--5 u-no-margin--bottom"><a href="/support">Full stack support</a></h5>
+      <h4 class="p-heading--5 u-no-margin--bottom"><a href="/support">Full support</a></h5>
       <p>Over 23,000 open source deb packages in Ubuntu Universe repository for 10 years, including:</p>
       <div class="u-pro-support">
         <div class="u-pro-support__logos">
@@ -552,33 +551,33 @@
             </tr>
             <tr>
               <td>Phone and ticket support</td>
-              <td class="u-align--right">&dash;</td>
-              <td class="u-align--right">&dollar;5,475</td>
-              <td class="u-align--right">&dollar;5,475</td>
+              <td class="u-align--right">None</td>
+              <td class="u-align--right">Office hours</td>
+              <td class="u-align--right">24/7</td>
             </tr>
             <tr>
               <td>Response time - SLA Sev 1</td>
               <td class="u-align--right">&dash;</td>
-              <td class="u-align--right">&dollar;3,985</td>
-              <td class="u-align--right">&dollar;3,985</td>
+              <td class="u-align--right">4 hours</td>
+              <td class="u-align--right">1 hour</td>
             </tr>
             <tr>
               <td>Knowledge base access</td>
-              <td class="u-align--right">yes</td>
-              <td class="u-align--right">yes</td>
-              <td class="u-align--right">yes</td>
+              <td class="u-align--right">Included</td>
+              <td class="u-align--right">Included</td>
+              <td class="u-align--right">Included</td>
             </tr>
             <tr>
               <td>Role based access controls (RBAC)</td>
-              <td class="u-align--right">yes</td>
-              <td class="u-align--right">yes</td>
-              <td class="u-align--right">yes</td>
+              <td class="u-align--right">Included</td>
+              <td class="u-align--right">Included</td>
+              <td class="u-align--right">Included</td>
             </tr>
             <tr>
               <td>High availability</td>
-              <td class="u-align--right">yes</td>
-              <td class="u-align--right">yes</td>
-              <td class="u-align--right">yes</td>
+              <td class="u-align--right">Included</td>
+              <td class="u-align--right">Included</td>
+              <td class="u-align--right">Included</td>
             </tr>
           </tbody>
         </table>

--- a/templates/pricing/pro.html
+++ b/templates/pricing/pro.html
@@ -172,6 +172,7 @@
   <div class="row">
     <div class="col-6">&nbsp;</div>
     <div class="col-6">
+      <hr class="u-no-margin--bottom">
       <h4 class="p-heading--5 u-no-margin--bottom u-sv-1">Ubuntu Pro:</h5>
       <p><i>All of the above, plus:</i></p>
       <table class="p-table is-list is-not-indented">
@@ -513,7 +514,7 @@
       <p><a href="/support/contact-us" class="p-button--positive js-invoke-modal">Get in touch</a></p>
     </div>
   </div>
-
+</section>
 <section class="p-strip is-deep u-no-padding--top">
   <hr class="is-fixed-width u-no-margin--bottom">
   <div class="row">

--- a/templates/pricing/pro.html
+++ b/templates/pricing/pro.html
@@ -9,11 +9,10 @@
 
 {% block content %}
 
-<section id="ua-infra" class="p-strip--suru-topped is-bordered">
+<section id="ua-infra" class="p-strip--image is-deep" style="background-image:url('https://assets.ubuntu.com/v1/d11e6f0f-05_suru2_light_glow_3K.jpg')">
   <div class="u-fixed-width">
-    <h1>Ubuntu Pro: security, compliance, and support</h1>
+    <h1>Ubuntu Pro: more security, compliance, and support</h1>
     <p>Ubuntu Pro covers all aspects of open infrastructure and applications.</p>
-    <p>Please refer to the <a href="/legal/ubuntu-advantage-service-description">service description</a> for full details.</p>
     <ul class="p-inline-list">
       <li class="p-inline-list__item">
         <a href="/support/contact-us" class="p-button--positive js-invoke-modal" data-testid="interactive-form-link">Get in touch</a>
@@ -25,126 +24,555 @@
   </div>
 </section>
 
-<section class="p-strip is-shallow" id="ua-infra">
-  <div class="u-fixed-width">
-    <h2 class="p-heading--3">Security maintenance and compliance</h2>
+<section class="p-strip is-deep">
+  <div class="row">
+    <h2 class="p-text--x-small-capitalised">Pricing (per machine, per year)</h4>
+  </div>
+  <hr class="is-fixed-width">
+  <div class="row">
+    <div class="col-5">
+      <h3 class="p-heading--2">Ubuntu Pro (Infra-only)</h3>
+    </div>
+    <div class="col-7">
+      <div class="u-overflow-pricing-pro-table">
+        <table class="p-table">
+          <thead>
+            <tr>
+              <th colspan="2">No Support</th>
+              <th colspan="2">24/7<br />Infra support</th>
+              <th colspan="2">24/7<br />Full Stack support</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Desktop</td>
+              <td>Server</td>
+              <td>Desktop</td>
+              <td>Server</td>
+              <td>Desktop</td>
+              <td>Server</td>
+            </tr>
+            <tr>
+              <td>&dash;</td>
+              <td>&dollar;225</td>
+              <td>&dash;</td>
+              <td>&dollar;1500</td>
+              <td>&dash;</td>
+              <td>&dash;</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
   </div>
 
-  {% include "shared/pricing/_ua-for-infrastructure.html" %}
-
-  <div class="u-fixed-width">
-    <h2 class="p-heading--3">Ubuntu Pro + <a href="/support">phone and ticket support</a></h2>
-    <p>Please refer to the list of <a href="/support">supported infrastructure and applications</a>.</p>
+  <div class="row">
+    <hr class="is-fixed-width">
+    <div class="col-5">
+      <h3 class="p-heading--2 u-no-margin--bottom">Ubuntu Pro</h3>
+    </div>
+    <div class="col-7">
+      <div class="u-overflow-pricing-pro-table">
+        <table class="p-table">
+          <thead>
+            <tr>
+              <th colspan="2">No Support</th>
+              <th colspan="2">24/7<br />Infra support</th>
+              <th colspan="2">24/7<br />Full Stack support</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Desktop</td>
+              <td>Server</td>
+              <td>Desktop</td>
+              <td>Server</td>
+              <td>Desktop</td>
+              <td>Server</td>
+            </tr>
+            <tr>
+              <td>&dollar;25</td>
+              <td>&dollar;500</td>
+              <td>&dash;</td>
+              <td>&dollar;1775</td>
+              <td>&dollar;300</td>
+              <td>&dollar;3400</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
   </div>
 
-  <div class="u-fixed-width">
-    <div style="overflow-x: auto;">
-      <table class="p-table">
-        <thead>
-          <tr>
-            <th style="width: 50%;">Ubuntu Pro + <a href="/support">weekday support</a></th>
-            <th class="u-align--right"><a href="/support">Infra Support</a></th>
-            <th class="u-align--right"><a href="/support">Full Stack Support</a></th>
-            <th></th>
-          </tr>
-        </thead>
+  <div class="row">
+    <div class="col-5">&nbsp;</div>
+    <div class="col-7">
+      <p>N.B.: Weekday support is half the price of 24/7 support</p>
+      <p>Please refer to the list of <a href="/support">supported infrastructure and applications</a>.</p>
+      <p>See our consulting, architecture, deployment and training packages for OpenStack, Kubernetes and Kubeflow.</p>
+      <p><a href="/pricing/pro#get-in-touch">Solve compliance and security for your Ubuntu estate</a>.</p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-deep u-no-padding--top">
+  <div class="row">
+    <h2 class="p-text--x-small-capitalised">What's the difference</h4>
+  </div>
+
+  <div class="row">
+    <hr class="is-fixed-width">
+    <div class="col-5">
+      <h3 class="p-heading--2">Ubuntu Pro (Infra-only) vs Ubuntu Pro</h3>
+    </div>
+
+    <div class="col-7">
+      <h5 class="u-no-margin--bottom">Ubuntu Pro (Infra-only):</h5>
+      <table class="p-table--mobile-card">
         <tbody>
-          <tr>
-            <td>Ubuntu Pro (Infra-only) - per machine per year</td>
-            <td class="u-align--right">$750</td>
-            <td class="u-align--right">n/a</td>
-          </tr>
-          <tr>
-            <td>Ubuntu Pro - per machine per year</td>
-            <td class="u-align--right">$885</td>
-            <td class="u-align--right">$1,700</td>
-          </tr>
-          <tr>
-            <td>Desktop - per machine per year</td>
-            <td class="u-align--right">n/a</td>
-            <td class="u-align--right">$150</td>
-          </tr>
+          <tr><td class="u-align--left"><span style="margin-right: 1rem;">1</span> Expanded Security Maintenance for Application (esm-apps) – in beta</td></tr>
+          <tr><td class="u-align--left"><span style="margin-right: 1rem;">2</span> Kernel Livepatch service to avoid reboots</td></tr>
+          <tr><td class="u-align--left"><span style="margin-right: 1rem;">3</span> Ubuntu systems management with Landscape</td></tr>
+          <tr><td class="u-align--left"><span style="margin-right: 1rem;">4</span> Knowledge base access</td></tr>
+          <tr><td class="u-align--left"><span style="margin-right: 1rem;">5</span> Certified Windows drivers for KVM guests</td></tr>
+          <tr><td class="u-align--left"><span style="margin-right: 1rem;">6</span> FIPS 140 certified crypto modules</td></tr>
+          <tr><td class="u-align--left"><span style="margin-right: 1rem;">7</span> Common Criteria EAL2 certified</td></tr>
+          <tr><td class="u-align--left"><span style="margin-right: 1rem;">8</span> Ubuntu Security Guide (USG) with CIS Benchmark and DISA-STIG profiles</td></tr>
+          <tr><td class="u-align--left"><span style="margin-right: 1rem;">9</span> Desktop - per machine per year</td></tr>
+          <tr><td class="u-align--left"><span style="margin-right: 1rem;">10</span> Expanded Security Maintenance for Infrastructure (esm-infra)	</td></tr>
+          <tr><td class="u-align--left"><span style="margin-right: 1rem;">11</span> Advanced Active Directory policies for Ubuntu Desktop</td></tr>
         </tbody>
       </table>
     </div>
   </div>
 
-  <div class="u-fixed-width">
-    <div style="overflow-x: auto;">
-      <table class="p-table">
-        <thead>
-          <tr>
-            <th style="width: 50%;">Ubuntu Pro + <a href="/support">24/7 support</a></th>
-            <th class="u-align--right"><a href="/support">Infra Support</a></th>
-            <th class="u-align--right"><a href="/support">Full Stack Support</a></th>
-            <th></th>
-          </tr>
-        </thead>
+  <div class="row">
+    <div class="col-5">&nbsp;</div>
+    <div class="col-7">
+      <h5 class="u-no-margin--bottom">Ubuntu Pro:</h5>
+      <p><i>All of the above, plus:</i></p>
+      <table class="p-table--mobile-card">
         <tbody>
-          <tr>
-            <td>Ubuntu Pro (Infra-only) - per machine per year</td>
-            <td class="u-align--right">$1,500</td>
-            <td class="u-align--right">n/a</td>
-          </tr>
-          <tr>
-            <td>Ubuntu Pro - per machine per year</td>
-            <td class="u-align--right">$1,775</td>
-            <td class="u-align--right">$3,400</td>
-          </tr>
-          <tr>
-            <td>Desktop - per machine per year</td>
-            <td class="u-align--right">n/a</td>
-            <td class="u-align--right">$300</td>
-          </tr>
+          <tr><td class="u-align--left"><span style="margin-right: 1rem;">12</span> Expanded Security Maintenance for Infrastructure (esm-infra)</td></tr>
+          <tr><td class="u-align--left"><span style="margin-right: 1rem;">13</span> Advanced Active Directory policies for Ubuntu Desktop</td></tr>
         </tbody>
       </table>
     </div>
   </div>
 
-  <div class="u-fixed-width">
-    <p>See our consulting, architecture, deployment and training packages for <a href="/pricing/consulting#openstack">OpenStack</a>, <a href="/pricing/consulting#kubernetes">Kubernetes</a> and <a href="/pricing/consulting#kubeflow">Kubeflow</a>.</p>
-    <p><a href="/support/contact-us" class="p-button js-invoke-modal">Solve compliance and security for your Ubuntu estate</a></p>
+</section>
+
+<section class="p-strip is-deep u-no-padding--top">
+  <div class="row">
+    <hr class="is-fixed-width">
+    <div class="col-5">
+      <h3 class="p-heading--2">Support: Infra vs Full-stack</h3>
+    </div>
+
+    <div class="col-7">
+      <h5 class="u-no-margin--bottom"><a href="/support">Infra support</a></h5>
+      <p>Over 2,300 open source deb packages in Ubuntu Main repository for 10 years, including:</p>
+        <div class="row">
+          <div class="col-small-1 col-medium-1 col-1">
+          {{
+            image (
+            url="https://assets.ubuntu.com/v1/3ad7e0a9-systemd-logo.png",
+            alt="",
+            width="67",
+            height="64",
+            hi_def=False,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
+            ) | safe
+          }}
+          </div>
+          <div class="col-small-1 col-medium-1 col-1">
+            {{
+              image (
+              url="https://assets.ubuntu.com/v1/a3e33ca1-RabbitMQ.png",
+              alt="",
+              width="144",
+              height="144",
+              hi_def=False,
+              loading="lazy",
+              attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
+          </div>
+          <div class="col-small-1 col-medium-1 col-1">
+            {{
+              image (
+              url="https://assets.ubuntu.com/v1/ff1530cc-OpenSSL.png",
+              alt="",
+              width="144",
+              height="144",
+              hi_def=False,
+              loading="lazy",
+              attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
+          </div>
+          <div class="col-small-1 col-medium-1 col-1">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/bc7ceb58-ruby-rails+logo.png",
+              alt="Ruby on Rails",
+              attrs={"class":"p-logo-section__logo"},
+              width="280",
+              height="280",
+              hi_def=False,
+              loading="lazy",
+              ) | safe
+            }}
+          </div>
+          <div class="col-small-1 col-medium-1 col-1">
+            {{
+              image (
+              url="https://assets.ubuntu.com/v1/247a8141-php+logo.png",
+              alt="",
+              width="63",
+              height="64",
+              hi_def=False,
+              loading="lazy",
+              attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
+          </div>
+          <div class="col-small-1 col-medium-1 col-1">
+            {{
+              image (
+              url="https://assets.ubuntu.com/v1/55e1eab0-Nginx.png",
+              alt="",
+              width="144",
+              height="144",
+              hi_def=False,
+              loading="lazy",
+              attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
+          </div>
+          <div class="col-small-1 col-medium-1 col-1">
+            {{
+              image (
+              url="https://assets.ubuntu.com/v1/343dc96b-MySQL.png",
+              alt="",
+              width="144",
+              height="144",
+              hi_def=False,
+              loading="lazy",
+              attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
+          </div>
+        </div>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-5">&nbsp;</div>
+    <div class="col-7">
+      <hr class="is-fixed-width">
+      <h5 class="u-no-margin--bottom"><a href="/support">Full stack support</a></h5>
+      <p>Over 23,000 open source deb packages in Ubuntu Universe repository for 10 years, including:</p>
+      <div class="row">
+        <div class="col-small-1 col-medium-1 col-1">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/df2c8fa0-apache+tomcat+logo.png",
+            alt="Apache Tomcat",
+            attrs={"class":"p-logo-section__logo"},
+            width="280",
+            height="280",
+            hi_def=False,
+            loading="lazy",
+            ) | safe
+          }}
+        </div>
+        <div class="col-small-1 col-medium-1 col-1">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/d00a6ac1-nagios+logo.png",
+            alt="Nagios",
+            attrs={"class":"p-logo-section__logo"},
+            width="280",
+            height="280",
+            hi_def=False,
+            loading="lazy",
+            ) | safe
+          }}
+        </div>
+        <div class="col-small-1 col-medium-1 col-1">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/2303838b-node-logo.png",
+            alt="Node J S",
+            attrs={"class":"p-logo-section__logo"},
+            width="280",
+            height="280",
+            hi_def=False,
+            loading="lazy",
+            ) | safe
+          }}
+        </div>
+        <div class="col-small-1 col-medium-1 col-1">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/fbaf6348-puppet+logo.png",
+            alt="Puppet",
+            attrs={"class":"p-logo-section__logo"},
+            width="280",
+            height="280",
+            hi_def=False,
+            loading="lazy",
+            ) | safe
+          }}
+        </div>
+        <div class="col-small-1 col-medium-1 col-1">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/7b5c7032-redis+logo.png",
+            alt="Redis",
+            attrs={"class":"p-logo-section__logo"},
+            width="280",
+            height="280",
+            hi_def=False,
+            loading="lazy",
+            ) | safe
+          }}
+        </div>
+        <div class="col-small-1 col-medium-1 col-1">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/fd0e15fd-rust+logo.png",
+            alt="Rust",
+            attrs={"class":"p-logo-section__logo"},
+            width="280",
+            height="280",
+            hi_def=False,
+            loading="lazy",
+            ) | safe
+          }}
+        </div>
+        <div class="col-small-1 col-medium-1 col-1">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/12295113-wordpress+logo.png",
+            alt="Wordpress",
+            attrs={"class":"p-logo-section__logo"},
+            width="280",
+            height="280",
+            hi_def=False,
+            loading="lazy",
+            ) | safe
+          }}
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-5">&nbsp;</div>
+    <div class="col-7">
+      <p>N.B.: Weekly support is half the price of 24/7 support</p>
+      <p>Please refer to the list of supported infrastructure and applications.</p>
+      <p>See our consulting, architecture, deployment and training packages for OpenStack, Kubernetes and Kubeflow.</p>
+      <p>Solve compliance and security for your Ubuntu estate.</p>
+    </div>
   </div>
 </section>
 
-<section class="p-strip--light is-shallow" id="storage">
-  <div class="u-fixed-width">
-    <h2 class="p-heading--3">Software-defined storage &ndash; Ceph and Swift</h2>
-    <p>Only applies if attaching more than 192TB of raw Ceph/Swift capacity per node in the cluster. Priced by the amount exceeding the total of 192TB per node included in Ubuntu Pro.</p>
+
+<section class="p-strip is-deep u-no-padding--top">
+  <div class="row">
+    <h2 class="p-text--x-small-capitalised">Fully managed OpenStack, Kubernetes and LMA</h4>
   </div>
-  {% include "shared/pricing/_ua-advanced-storage.html" %}
-  <div class="u-fixed-width">
-    <a href="/support/contact-us" class="p-button--positive js-invoke-modal">Get in touch</a>
+
+  <div class="row">
+    <hr class="is-fixed-width">
+    <div class="col-5">
+      <h3 class="p-heading--2">UA Advanced Storage</h3>
+      <p>Only applies if attaching more than 192TB of raw Ceph/Swift capacity  per node in the cluster. Priced by the amount exceeding the total of 192TB per node included in Ubuntu Pro.</p>
+    </div>
+
+    <div class="col-7">
+      <table class="p-table--mobile-card">
+        <thead>
+          <tr>
+            <th width="50%">UA Advanced Storage</th>
+            <th>Tier Price</th>
+            <th>Additional Per TB</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Up to 150 TB</td>
+            <td class="u-align--right">0</td>
+            <td class="u-align--right">&dollar;33.33</td>
+          </tr>
+          <tr>
+            <td>150 - 1,500 TB</td>
+            <td class="u-align--right">&dollar;5,000</td>
+            <td class="u-align--right">&dollar;25.00</td>
+          </tr>
+          <tr>
+            <td>1500 - 3,000 TB</td>
+            <td class="u-align--right">&dollar;38,750</td>
+            <td class="u-align--right">&dollar;13.33</td>
+          </tr>
+          <tr>
+            <td>3,000 to 15,000 TB</td>
+            <td class="u-align--right">&dollar;58,750</td>
+            <td class="u-align--right">&dollar;6.67</td>
+          </tr>
+          <tr>
+            <td>15,000 to 30,000 TB </td>
+            <td class="u-align--right">&dollar;138,750</td>
+            <td class="u-align--right">&dollar;3.33</td>
+          </tr>
+          <tr>
+            <td>Beyond 30,000 TB</td>
+            <td class="u-align--right">&dollar;188,750</td>
+            <td class="u-align--right">&dollar;0</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-5">&nbsp;</div>
+    <div class="col-7">
+      <p>Prices are for Ubuntu Pro + 24/7 support contracts.<br class="u-hide--small">Weekday support is currently discounted by 50%.</p>
+      <p><a href="/support/contact-us" class="p-button--positive js-invoke-modal">Get in touch</a></p>
+    </div>
+  </div>
+</section>
+
+  <section class="p-strip is-deep u-no-padding--top">
+    <hr class="is-fixed-width">
+    <div class="row">
+      <div class="col-5">
+        <h3 class="p-heading--2">Fully managed OpenStack, Kubernetes and LMA</h3>
+        <p>We manage infrastructure at both the host and the guest level. Infrastructure includes Ceph and Swift storage, Kubernetes, OpenStack and the recommended logging, monitoring and alerting stack.</p>
+      </div>
+  
+      <div class="col-7">
+        <table class="p-table--mobile-card">
+          <thead>
+            <tr>
+              <th width="50%">Feature</th>
+              <th class="u-align--right">Per VM</th>
+              <th class="u-align--right">Per host</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><a href="https://ubuntu.com/kubernetes/managed">Managed Kubernetes</a> on public cloud, VMware or OpenStack</td>
+              <td class="u-align--right">&dollar;1,305</td>
+              <td class="u-align--right">&dollar;2,925*</td>
+            </tr>
+            <tr>
+              <td><a href="https://ubuntu.com/openstack/managed">Managed OpenStack</a> on bare metal</td>
+              <td class="u-align--right">&nbsp;</td>
+              <td class="u-align--right">&dollar;5,475</td>
+            </tr>
+            <tr>
+              <td><a href="https://ubuntu.com/kubernetes/managed">Managed Kubernetes</a> on bare metal</td>
+              <td class="u-align--right">&nbsp;</td>
+              <td class="u-align--right">&dollar;3,985</td>
+            </tr>
+            <tr>
+              <td><a href="https://ubuntu.com/ceph">Managed Ceph</a> on bare metal</td>
+              <td class="u-align--right">&nbsp;</td>
+              <td class="u-align--right">&dollar;3,985</td>
+            </tr>
+            <tr>
+              <td>Combined offering - managed on-demand K8s on fully managed OpenStack</td>
+              <td class="u-align--right">&nbsp;</td>
+              <td class="u-align--right">&dollar;6,351</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+  <div class="row">
+    <div class="col-5">&nbsp;</div>
+    <div class="col-7">
+      <p>* On a VMware or OpenStack cluster, managed guests can be priced per host in the cluster.</p>
+      <p><a href="/support/contact-us" class="p-button--positive js-invoke-modal">Get in touch</a></p>
+    </div>
   </div>
 
 </section>
 
-<section class="p-strip is-shallow" id="managed">
-  <div class="u-fixed-width">
-    <h2 class="p-heading--3">Fully managed OpenStack, Kubernetes and LMA</h2>
-    <p>We manage infrastructure at both the host and the guest level. Infrastructure includes Ceph and Swift storage, Kubernetes, OpenStack and the recommended logging, monitoring and alerting stack.</p>
-  </div>
-  {% include "shared/pricing/_openstack-kubernetes-lma.html" %}
-  <div class="u-fixed-width">
-    <a href="/support/contact-us" class="p-button--positive js-invoke-modal">Get in touch</a>
+
+<section class="p-strip is-deep u-no-padding--top">
+  <hr class="is-fixed-width">
+  <div class="row">
+    <div class="col-5">
+      <h3 class="p-heading--2">MAAS</h3>
+      <p>Support and commercial capabilities for MAAS are included with Ubuntu Pro and Ubuntu Pro (Infra-only). These additional charges apply for machines managed by MAAS and <em>not</em> covered by an Ubuntu Pro contract.</p>
+    </div>
+    <div class="col-7">
+        <table class="p-table--mobile-card">
+          <thead>
+            <tr>
+              <th style="width: 50%;">Feature</th>
+              <th class="u-align--right">No Support</th>
+              <th class="u-align--right">Weekday support</th>
+              <th class="u-align--right">24/7 support</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Per managed machine - annual</td>
+              <td class="u-align--right">&dollar;30</td>
+              <td class="u-align--right">&dollar;50</td>
+              <td class="u-align--right">&dollar;100</td>
+            </tr>
+            <tr>
+              <td>Phone and ticket support</td>
+              <td class="u-align--right">&dash;</td>
+              <td class="u-align--right">&dollar;5,475</td>
+              <td class="u-align--right">&dollar;5,475</td>
+            </tr>
+            <tr>
+              <td>Response time - SLA Sev 1</td>
+              <td class="u-align--right">&dash;</td>
+              <td class="u-align--right">&dollar;3,985</td>
+              <td class="u-align--right">&dollar;3,985</td>
+            </tr>
+            <tr>
+              <td>Knowledge base access</td>
+              <td class="u-align--right">yes</td>
+              <td class="u-align--right">yes</td>
+              <td class="u-align--right">yes</td>
+            </tr>
+            <tr>
+              <td>Role based access controls (RBAC)</td>
+              <td class="u-align--right">yes</td>
+              <td class="u-align--right">yes</td>
+              <td class="u-align--right">yes</td>
+            </tr>
+            <tr>
+              <td>High availability</td>
+              <td class="u-align--right">yes</td>
+              <td class="u-align--right">yes</td>
+              <td class="u-align--right">yes</td>
+            </tr>
+          </tbody>
+        </table>
+        <p>
+          <a href="/support/contact-us" class="p-button--positive js-invoke-modal">Get in touch</a>
+        </p>
+    </div>
   </div>
 </section>
 
-<section class="p-strip--light is-bordered is-shallow">
-  <div class="u-fixed-width">
-    <h2 class="p-heading--3" id="maas">MAAS</h2>
-    <p>Support and commercial capabilities for MAAS are included with Ubuntu Pro and Ubuntu Pro (Infra-only). These additional charges apply for machines managed by MAAS and <em>not</em> covered by an Ubuntu Pro contract.</p>
-  </div>
-  {% include "shared/pricing/_maas-pricing.html" %}
-  <div class="u-fixed-width">
-    <p>
-      <a href="/support/contact-us" class="p-button--positive js-invoke-modal">Get in touch</a>
-    </p>
+<section class="p-strip is-deep u-no-padding--top">
+  <hr class="is-fixed-width">
+  <div class="row">
+    <div class="col-5">
+      <h3 class="p-heading--2">Any questions? Call us:</h3>
+    </div>
+    <div class="col-7">
+      <h3><tel href="+17372040291">+1&nbsp;737&nbsp;204&nbsp;0291</tel>&nbsp;(Americas)<br /><tel href="+442036565291">+44&nbsp;203&nbsp;656&nbsp;5291</tel>&nbsp;(Rest of the World)</h3>
+      <p>or <a href="/support/contact-us" class="js-invoke-modal">contact us online</a></p>
+    </div>
   </div>
 </section>
-
-{% with colour="white", border="false" %}{% include "shared/_call-sales.html" %}{% endwith %}
-
 
 <!-- Set default Marketo information for contact form below-->
 <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/pricing-infra" data-form-id="1240" data-lp-id="2065" data-return-url="https://ubuntu.com/pricing/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">

--- a/templates/pricing/pro.html
+++ b/templates/pricing/pro.html
@@ -35,7 +35,7 @@
     </div>
     <div class="col-6">
       <div class="u-overflow-pricing-pro-table">
-        <table class="p-table p-table--not-indented">
+        <table class="p-table is-not-indented">
           <thead>
             <tr>
               <th colspan="2">No Support</th>
@@ -73,7 +73,7 @@
     </div>
     <div class="col-6">
       <div class="u-overflow-pricing-pro-table">
-        <table class="p-table p-table--not-indented">
+        <table class="p-table is-not-indented">
           <thead>
             <tr>
               <th colspan="2">No Support</th>
@@ -406,7 +406,7 @@
     </div>
 
     <div class="col-6">
-      <table class="p-table p-table--not-indented--advanced-storage">
+      <table class="p-table p-table--advanced-storage is-not-indented">
         <thead>
           <tr>
             <th width="40%">The storage node size</th>
@@ -467,7 +467,7 @@
       </div>
   
       <div class="col-6">
-        <table class="p-table p-table--not-indented--openstack-k9s-lma">
+        <table class="p-table is-not-indented p-table--openstack-k9s-lma">
           <thead>
             <tr>
               <th width="35%">Feature</th>
@@ -522,7 +522,7 @@
       <p>Support and commercial capabilities for MAAS are included with Ubuntu Pro and Ubuntu Pro (Infra-only). These additional charges apply for machines managed by MAAS and <em>not</em> covered by an Ubuntu Pro contract.</p>
     </div>
     <div class="col-6">
-        <table class="p-table p-table--not-indented--pro-maas">
+        <table class="p-table is-not-indented p-table--pro-maas">
           <thead>
             <tr>
               <th>Feature</th>

--- a/templates/pricing/pro.html
+++ b/templates/pricing/pro.html
@@ -26,7 +26,7 @@
 
 <section class="p-strip is-deep">
   <div class="row">
-    <h2 class="p-text--x-small-capitalised">Pricing (per machine, per year)</h2>
+    <h2 class="p-text--x-small-capitalised">Pricing</h2>
   </div>
   <hr class="is-fixed-width u-no-margin--bottom">
   <div class="row">

--- a/templates/pricing/pro.html
+++ b/templates/pricing/pro.html
@@ -26,7 +26,7 @@
 
 <section class="p-strip is-deep">
   <div class="row">
-    <h2 class="p-text--x-small-capitalised">Pricing (per machine, per year)</h4>
+    <h2 class="p-text--x-small-capitalised">Pricing (per machine, per year)</h2>
   </div>
   <hr class="is-fixed-width">
   <div class="row">
@@ -45,18 +45,18 @@
           </thead>
           <tbody>
             <tr>
-              <td>Desktop</td>
-              <td>Server</td>
-              <td>Desktop</td>
-              <td>Server</td>
-              <td>Desktop</td>
-              <td>Server</td>
+              <td class="u-truncate">Desktop</td>
+              <td class="u-truncate">Server</td>
+              <td class="u-truncate">Desktop</td>
+              <td class="u-truncate">Server</td>
+              <td class="u-truncate">Desktop</td>
+              <td class="u-truncate">Server</td>
             </tr>
             <tr>
               <td>&dash;</td>
               <td>&dollar;225</td>
               <td>&dash;</td>
-              <td>&dollar;1500</td>
+              <td>&dollar;1,500</td>
               <td>&dash;</td>
               <td>&dash;</td>
             </tr>
@@ -83,52 +83,54 @@
           </thead>
           <tbody>
             <tr>
-              <td>Desktop</td>
-              <td>Server</td>
-              <td>Desktop</td>
-              <td>Server</td>
-              <td>Desktop</td>
-              <td>Server</td>
+              <td class="u-truncate">Desktop</td>
+              <td class="u-truncate">Server</td>
+              <td class="u-truncate">Desktop</td>
+              <td class="u-truncate">Server</td>
+              <td class="u-truncate">Desktop</td>
+              <td class="u-truncate">Server</td>
             </tr>
             <tr>
               <td>&dollar;25</td>
               <td>&dollar;500</td>
               <td>&dash;</td>
-              <td>&dollar;1775</td>
+              <td>&dollar;1,775</td>
               <td>&dollar;300</td>
-              <td>&dollar;3400</td>
+              <td>&dollar;3,400</td>
             </tr>
           </tbody>
         </table>
       </div>
-    </div>
-  </div>
-
-  <div class="row">
-    <div class="col-6">&nbsp;</div>
-    <div class="col-6">
-      <p>N.B.: Weekday support is half the price of 24/7 support</p>
-      <p>Please refer to the list of <a href="/support">supported infrastructure and applications</a>.</p>
-      <p>See our consulting, architecture, deployment and training packages for OpenStack, Kubernetes and Kubeflow.</p>
-      <p><a href="/pricing/pro#get-in-touch">Solve compliance and security for your Ubuntu estate</a>.</p>
+      <div class="u-fixed-width">
+        <hr />
+        <div>
+          <p><span style="width: 40px; margin-right: 15px">N.B.:</span>Price is per machine per year</p>
+          <hr />
+          <p style="text-indent: 50px;">Weekday support is half the price of 24/7 support</p>
+        </div>
+        <hr />
+        <div>
+          <p>Please refer to the list of <a href="/support">supported infrastructure and applications</a>.</p>
+        </div>
+      </div>
     </div>
   </div>
 </section>
 
 <section class="p-strip is-deep u-no-padding--top">
   <div class="row">
-    <h2 class="p-text--x-small-capitalised">What's the difference</h4>
+    <h2 class="p-text--x-small-capitalised">What's the difference</h2>
   </div>
 
   <div class="row">
     <hr class="is-fixed-width">
     <div class="col-6">
-      <h3 class="p-heading--2">Ubuntu Pro (Infra-only) vs <br class="u-hide--small u-hide--medium">Ubuntu Pro</h3>
+      <h3 class="p-heading--2">Ubuntu Pro (Infra-only) vs Ubuntu Pro</h3>
     </div>
 
     <div class="col-6">
-      <h5 class="u-no-margin--bottom">Ubuntu Pro (Infra-only):</h5>
-      <table>
+      <h4 class="p-heading--5 u-no-margin--bottom">Ubuntu Pro (Infra-only):</h4>
+      <table class="p-table">
         <tbody>
           <tr><td class="u-align--left"><span style="margin-right: 1rem;">1</span> Expanded Security Maintenance for Application (esm-apps) – in beta</td></tr>
           <tr><td class="u-align--left"><span style="margin-right: 1rem;">2</span> Kernel Livepatch service to avoid reboots</td></tr>
@@ -138,9 +140,6 @@
           <tr><td class="u-align--left"><span style="margin-right: 1rem;">6</span> FIPS 140 certified crypto modules</td></tr>
           <tr><td class="u-align--left"><span style="margin-right: 1rem;">7</span> Common Criteria EAL2 certified</td></tr>
           <tr><td class="u-align--left"><span style="margin-right: 1rem;">8</span> Ubuntu Security Guide (USG) with CIS Benchmark and DISA-STIG profiles</td></tr>
-          <tr><td class="u-align--left"><span style="margin-right: 1rem;">9</span> Desktop - per machine per year</td></tr>
-          <tr><td class="u-align--left"><span style="margin-right: 1rem;">10</span> Expanded Security Maintenance for Infrastructure (esm-infra)	</td></tr>
-          <tr><td class="u-align--left"><span style="margin-right: 1rem;">11</span> Advanced Active Directory policies for Ubuntu Desktop</td></tr>
         </tbody>
       </table>
     </div>
@@ -149,12 +148,12 @@
   <div class="row">
     <div class="col-6">&nbsp;</div>
     <div class="col-6">
-      <h5 class="u-no-margin--bottom">Ubuntu Pro:</h5>
+      <h4 class="p-heading--5 u-no-margin--bottom">Ubuntu Pro:</h4>
       <p><i>All of the above, plus:</i></p>
-      <table>
+      <table class="p-table">
         <tbody>
-          <tr><td class="u-align--left"><span style="margin-right: 1rem;">12</span> Expanded Security Maintenance for Infrastructure (esm-infra)</td></tr>
-          <tr><td class="u-align--left"><span style="margin-right: 1rem;">13</span> Advanced Active Directory policies for Ubuntu Desktop</td></tr>
+          <tr><td class="u-align--left"><span style="margin-right: 1rem;">9</span> Expanded Security Maintenance for Infrastructure (esm-infra)</td></tr>
+          <tr><td class="u-align--left"><span style="margin-right: 1rem;">10</span> Advanced Active Directory policies for Ubuntu Desktop</td></tr>
         </tbody>
       </table>
     </div>
@@ -170,10 +169,10 @@
     </div>
 
     <div class="col-6">
-      <h5 class="u-no-margin--bottom"><a href="/support">Infra support</a></h5>
+      <h4 class="p-heading--5 u-no-margin--bottom"><a href="/support">Infra support</a></h4>
       <p>Over 2,300 open source deb packages in Ubuntu Main repository for 10 years, including:</p>
-        <div class="row">
-          <div class="col-small-1 col-medium-1 col-1">
+        <div class="u-pro-support">
+          <div class="u-pro-support__logos">
           {{
             image (
             url="https://assets.ubuntu.com/v1/3ad7e0a9-systemd-logo.png",
@@ -186,7 +185,7 @@
             ) | safe
           }}
           </div>
-          <div class="col-small-1 col-medium-1 col-1">
+          <div class="u-pro-support__logos">
             {{
               image (
               url="https://assets.ubuntu.com/v1/a3e33ca1-RabbitMQ.png",
@@ -199,7 +198,7 @@
               ) | safe
             }}
           </div>
-          <div class="col-small-1 col-medium-1 col-1">
+          <div class="u-pro-support__logos">
             {{
               image (
               url="https://assets.ubuntu.com/v1/ff1530cc-OpenSSL.png",
@@ -212,7 +211,7 @@
               ) | safe
             }}
           </div>
-          <div class="col-small-1 col-medium-1 col-1">
+          <div class="u-pro-support__logos">
             {{ image (
               url="https://assets.ubuntu.com/v1/bc7ceb58-ruby-rails+logo.png",
               alt="Ruby on Rails",
@@ -224,7 +223,7 @@
               ) | safe
             }}
           </div>
-          <div class="col-small-1 col-medium-1 col-1">
+          <div class="u-pro-support__logos">
             {{
               image (
               url="https://assets.ubuntu.com/v1/247a8141-php+logo.png",
@@ -237,7 +236,7 @@
               ) | safe
             }}
           </div>
-          <div class="col-small-1 col-medium-1 col-1">
+          <div class="u-pro-support__logos">
             {{
               image (
               url="https://assets.ubuntu.com/v1/55e1eab0-Nginx.png",
@@ -250,7 +249,7 @@
               ) | safe
             }}
           </div>
-          <div class="col-small-1 col-medium-1 col-1">
+          <div class="u-pro-support__logos">
             {{
               image (
               url="https://assets.ubuntu.com/v1/343dc96b-MySQL.png",
@@ -271,10 +270,10 @@
     <div class="col-6">&nbsp;</div>
     <div class="col-6">
       <hr class="is-fixed-width">
-      <h5 class="u-no-margin--bottom"><a href="/support">Full stack support</a></h5>
+      <h4 class="p-heading--5 u-no-margin--bottom"><a href="/support">Full stack support</a></h4>
       <p>Over 23,000 open source deb packages in Ubuntu Universe repository for 10 years, including:</p>
-      <div class="row">
-        <div class="col-small-1 col-medium-1 col-1">
+      <div class="u-pro-support">
+        <div class="u-pro-support__logos">
           {{ image (
             url="https://assets.ubuntu.com/v1/df2c8fa0-apache+tomcat+logo.png",
             alt="Apache Tomcat",
@@ -286,7 +285,7 @@
             ) | safe
           }}
         </div>
-        <div class="col-small-1 col-medium-1 col-1">
+        <div class="u-pro-support__logos">
           {{ image (
             url="https://assets.ubuntu.com/v1/d00a6ac1-nagios+logo.png",
             alt="Nagios",
@@ -298,7 +297,7 @@
             ) | safe
           }}
         </div>
-        <div class="col-small-1 col-medium-1 col-1">
+        <div class="u-pro-support__logos">
           {{ image (
             url="https://assets.ubuntu.com/v1/2303838b-node-logo.png",
             alt="Node J S",
@@ -310,7 +309,7 @@
             ) | safe
           }}
         </div>
-        <div class="col-small-1 col-medium-1 col-1">
+        <div class="u-pro-support__logos">
           {{ image (
             url="https://assets.ubuntu.com/v1/fbaf6348-puppet+logo.png",
             alt="Puppet",
@@ -322,7 +321,7 @@
             ) | safe
           }}
         </div>
-        <div class="col-small-1 col-medium-1 col-1">
+        <div class="u-pro-support__logos">
           {{ image (
             url="https://assets.ubuntu.com/v1/7b5c7032-redis+logo.png",
             alt="Redis",
@@ -334,7 +333,7 @@
             ) | safe
           }}
         </div>
-        <div class="col-small-1 col-medium-1 col-1">
+        <div class="u-pro-support__logos">
           {{ image (
             url="https://assets.ubuntu.com/v1/fd0e15fd-rust+logo.png",
             alt="Rust",
@@ -346,7 +345,7 @@
             ) | safe
           }}
         </div>
-        <div class="col-small-1 col-medium-1 col-1">
+        <div class="u-pro-support__logos">
           {{ image (
             url="https://assets.ubuntu.com/v1/12295113-wordpress+logo.png",
             alt="Wordpress",
@@ -361,38 +360,28 @@
       </div>
     </div>
   </div>
-
-  <div class="row">
-    <div class="col-6">&nbsp;</div>
-    <div class="col-6">
-      <p>N.B.: Weekly support is half the price of 24/7 support</p>
-      <p>Please refer to the list of supported infrastructure and applications.</p>
-      <p>See our consulting, architecture, deployment and training packages for OpenStack, Kubernetes and Kubeflow.</p>
-      <p>Solve compliance and security for your Ubuntu estate.</p>
-    </div>
-  </div>
 </section>
 
 
 <section class="p-strip is-deep u-no-padding--top">
   <div class="row">
-    <h2 class="p-text--x-small-capitalised">Fully managed OpenStack, Kubernetes and LMA</h4>
+    <h2 class="p-text--x-small-capitalised">Software-defined storage</h2>
   </div>
 
   <div class="row">
     <hr class="is-fixed-width">
     <div class="col-6">
-      <h3 class="p-heading--2">UA Advanced Storage</h3>
+      <h3 class="p-heading--2">Ubuntu Pro storage nodes</h3>
       <p>Only applies if attaching more than 192TB of raw Ceph/Swift capacity  per node in the cluster. Priced by the amount exceeding the total of 192TB per node included in Ubuntu Pro.</p>
     </div>
 
     <div class="col-6">
-      <table>
+      <table class="p-table--advanced-storage">
         <thead>
           <tr>
-            <th width="50%">UA Advanced Storage</th>
-            <th>Tier Price</th>
-            <th>Additional Per TB</th>
+            <th width="40%">The storage node size</th>
+            <th width="20%">Tier Price</th>
+            <th width="30%" class="u-align--right">Additional Per TB</th>
           </tr>
         </thead>
         <tbody>
@@ -433,7 +422,7 @@
   <div class="row">
     <div class="col-6">&nbsp;</div>
     <div class="col-6">
-      <p>Prices are for Ubuntu Pro + 24/7 support contracts.<br class="u-hide--small">Weekday support is currently discounted by 50%.</p>
+      <p>Prices are for Ubuntu Pro + 24/7 support contracts.<br class="u-hide--small">Weekday support is discounted by 50%.</p>
       <p><a href="/support/contact-us" class="p-button--positive js-invoke-modal">Get in touch</a></p>
     </div>
   </div>
@@ -448,10 +437,10 @@
       </div>
   
       <div class="col-6">
-        <table>
+        <table class="p-table--openstack-k9s-lma">
           <thead>
             <tr>
-              <th width="50%">Feature</th>
+              <th width="35%">Feature</th>
               <th class="u-align--right">Per VM</th>
               <th class="u-align--right">Per host</th>
             </tr>
@@ -494,7 +483,6 @@
       <p><a href="/support/contact-us" class="p-button--positive js-invoke-modal">Get in touch</a></p>
     </div>
   </div>
-</section>
 
 <section class="p-strip is-deep u-no-padding--top">
   <hr class="is-fixed-width">
@@ -504,7 +492,7 @@
       <p>Support and commercial capabilities for MAAS are included with Ubuntu Pro and Ubuntu Pro (Infra-only). These additional charges apply for machines managed by MAAS and <em>not</em> covered by an Ubuntu Pro contract.</p>
     </div>
     <div class="col-6">
-        <table>
+        <table class="p-table--pro-maas">
           <thead>
             <tr>
               <th>Feature</th>

--- a/templates/pricing/pro.html
+++ b/templates/pricing/pro.html
@@ -102,15 +102,26 @@
         </table>
       </div>
       <div class="u-fixed-width">
-        <hr />
         <div>
-          <p><span style="width: 40px; margin-right: 15px">N.B.:</span>Price is per machine per year</p>
-          <hr />
-          <p style="text-indent: 50px;">Weekday support is half the price of 24/7 support</p>
-        </div>
-        <hr />
-        <div>
-          <p>Please refer to the list of <a href="/support">supported infrastructure and applications</a>.</p>
+          <table class="p-table">
+            <thead>
+              <th style="width: 3.1rem">&nbsp;</th>
+              <th>&nbsp;</th>
+            </thead>
+            <tbody>
+              <tr>
+                <td class="u-align-left">N.B.:</td>
+                <td class="u-align-left">Price is per machine per year</td>
+              </tr>
+              <tr>
+                <td style="border-top: 0;">&nbsp;</td>
+                <td class="u-table-border-top u-align--left">Weekday support is half the price of 24/7 support</td>
+              </tr>
+              <tr>
+                <td colspan="2" class="u-align-left">Please refer to the list of <a href="/support">supported infrastructure and applications</a>.</td>
+              </tr>
+            </tbody>
+          </table>
         </div>
       </div>
     </div>
@@ -580,7 +591,7 @@
 
 <section class="p-strip is-deep u-no-padding--top">
   <hr class="is-fixed-width u-no-margin--bottom">
-  <div class="row p-strip is-deep u-no-padding--top">
+  <div class="row">
     <div class="col-6">
       <h3 class="p-heading--2">Any questions? Call us:</h3>
     </div>

--- a/templates/pricing/pro.html
+++ b/templates/pricing/pro.html
@@ -9,10 +9,10 @@
 
 {% block content %}
 
-<section id="ua-infra" class="p-strip--image is-deep" style="background-image:url('https://assets.ubuntu.com/v1/18717572-05_suru2_light_glow_8K_edited.png')">
+<section id="ua-infra" class="p-strip--image is-deep" style="background-image:url('https://assets.ubuntu.com/v1/18717572-05_suru2_light_glow_8K_edited.png'); background-position: bottom right;">
   <div class="u-fixed-width">
-    <h1>Ubuntu Pro: more security, compliance, and support</h1>
-    <p>Ubuntu Pro covers all aspects of open infrastructure and applications.</p>
+    <h1 class="p-heading--2 u-no-margin--bottom"><strong>Ubuntu Pro: more security, compliance, and support</strong></h1>
+    <h2 class="u-no-padding--top u-text--muted">Covering all aspects of open infrastructure and applications</h2>
     <ul class="p-inline-list">
       <li class="p-inline-list__item">
         <a href="/support/contact-us" class="p-button--positive js-invoke-modal" data-testid="interactive-form-link">Get in touch</a>
@@ -28,14 +28,14 @@
   <div class="row">
     <h2 class="p-text--x-small-capitalised">Pricing (per machine, per year)</h2>
   </div>
-  <hr class="is-fixed-width">
+  <hr class="is-fixed-width u-no-margin--bottom">
   <div class="row">
     <div class="col-6">
       <h3 class="p-heading--2">Ubuntu Pro (Infra-only)</h3>
     </div>
     <div class="col-6">
       <div class="u-overflow-pricing-pro-table">
-        <table class="p-table">
+        <table class="p-table p-table--not-indented">
           <thead>
             <tr>
               <th colspan="2">No Support</th>
@@ -67,13 +67,13 @@
   </div>
 
   <div class="row">
-    <hr class="is-fixed-width">
+    <hr class="is-fixed-width u-no-margin--bottom">
     <div class="col-6">
       <h3 class="p-heading--2 u-no-margin--bottom">Ubuntu Pro</h3>
     </div>
     <div class="col-6">
       <div class="u-overflow-pricing-pro-table">
-        <table class="p-table">
+        <table class="p-table p-table--not-indented">
           <thead>
             <tr>
               <th colspan="2">No Support</th>
@@ -123,23 +123,47 @@
   </div>
 
   <div class="row">
-    <hr class="is-fixed-width">
+    <hr class="is-fixed-width u-no-margin--bottom">
     <div class="col-6">
-      <h3 class="p-heading--2">Ubuntu Pro (Infra-only) vs Ubuntu Pro</h3>
+      <h3 class="p-heading--2">Ubuntu Pro (Infra-only) vs<br class="u-hide--small u-hide--medium"> Ubuntu Pro</h3>
     </div>
 
     <div class="col-6">
-      <h4 class="p-heading--5 u-no-margin--bottom">Ubuntu Pro (Infra-only):</h4>
-      <table class="p-table">
+      <h4 class="p-heading--5 u-no-margin--bottom">Ubuntu Pro (Infra-only):</h5>
+      <table class="p-table is-list is-not-indented">
         <tbody>
-          <tr><td class="u-align--left"><span style="margin-right: 1rem;">1</span> Expanded Security Maintenance for Application (esm-apps) – in beta</td></tr>
-          <tr><td class="u-align--left"><span style="margin-right: 1rem;">2</span> Kernel Livepatch service to avoid reboots</td></tr>
-          <tr><td class="u-align--left"><span style="margin-right: 1rem;">3</span> Ubuntu systems management with Landscape</td></tr>
-          <tr><td class="u-align--left"><span style="margin-right: 1rem;">4</span> Knowledge base access</td></tr>
-          <tr><td class="u-align--left"><span style="margin-right: 1rem;">5</span> Certified Windows drivers for KVM guests</td></tr>
-          <tr><td class="u-align--left"><span style="margin-right: 1rem;">6</span> FIPS 140 certified crypto modules</td></tr>
-          <tr><td class="u-align--left"><span style="margin-right: 1rem;">7</span> Common Criteria EAL2 certified</td></tr>
-          <tr><td class="u-align--left"><span style="margin-right: 1rem;">8</span> Ubuntu Security Guide (USG) with CIS Benchmark and DISA-STIG profiles</td></tr>
+          <tr>
+            <td>1</td>
+            <td>Expanded Security Maintenance for Application (esm-apps) – in beta</td>
+          </tr>
+          <tr>
+            <td>2</td>
+            <td>Kernel Livepatch service to avoid reboots</td>
+          </tr>
+          <tr>
+            <td>3</td>
+            <td>Ubuntu systems management with Landscape</td>
+          </tr>
+          <tr>
+            <td>4</td>
+            <td>Knowledge base access</td>
+          </tr>
+          <tr>
+            <td>5</td>
+            <td>Certified Windows drivers for KVM guests</td>
+          </tr>
+          <tr>
+            <td>6</td>
+            <td>FIPS 140 certified crypto modules</td>
+          </tr>
+          <tr>
+            <td>7</td>
+            <td>Common Criteria EAL2 certified</td>
+          </tr>
+          <tr>
+            <td>8</td>
+            <td>Ubuntu Security Guide (USG) with CIS Benchmark and DISA-STIG profiles</td>
+          </tr>
         </tbody>
       </table>
     </div>
@@ -148,12 +172,18 @@
   <div class="row">
     <div class="col-6">&nbsp;</div>
     <div class="col-6">
-      <h4 class="p-heading--5 u-no-margin--bottom">Ubuntu Pro:</h4>
+      <h4 class="p-heading--5 u-no-margin--bottom u-sv-1">Ubuntu Pro:</h5>
       <p><i>All of the above, plus:</i></p>
-      <table class="p-table">
+      <table class="p-table is-list is-not-indented">
         <tbody>
-          <tr><td class="u-align--left"><span style="margin-right: 1rem;">9</span> Expanded Security Maintenance for Infrastructure (esm-infra)</td></tr>
-          <tr><td class="u-align--left"><span style="margin-right: 1rem;">10</span> Advanced Active Directory policies for Ubuntu Desktop</td></tr>
+          <tr>
+            <td>9</td>
+            <td class="u-align--left">Expanded Security Maintenance for Infrastructure (esm-infra)</td>
+          </tr>
+          <tr>
+            <td>10</td>
+            <td class="u-align--left">Advanced Active Directory policies for Ubuntu Desktop</td>
+          </tr>
         </tbody>
       </table>
     </div>
@@ -163,7 +193,7 @@
 
 <section class="p-strip is-deep u-no-padding--top">
   <div class="row">
-    <hr class="is-fixed-width">
+    <hr class="is-fixed-width u-no-margin--bottom">
     <div class="col-6">
       <h3 class="p-heading--2">Support: Infra vs Full-stack</h3>
     </div>
@@ -269,8 +299,8 @@
   <div class="row">
     <div class="col-6">&nbsp;</div>
     <div class="col-6">
-      <hr class="is-fixed-width">
-      <h4 class="p-heading--5 u-no-margin--bottom"><a href="/support">Full stack support</a></h4>
+      <hr class="is-fixed-width u-no-margin--bottom">
+      <h4 class="p-heading--5 u-no-margin--bottom"><a href="/support">Full stack support</a></h5>
       <p>Over 23,000 open source deb packages in Ubuntu Universe repository for 10 years, including:</p>
       <div class="u-pro-support">
         <div class="u-pro-support__logos">
@@ -369,14 +399,14 @@
   </div>
 
   <div class="row">
-    <hr class="is-fixed-width">
+    <hr class="is-fixed-width u-no-margin--bottom">
     <div class="col-6">
       <h3 class="p-heading--2">Ubuntu Pro storage nodes</h3>
       <p>Only applies if attaching more than 192TB of raw Ceph/Swift capacity  per node in the cluster. Priced by the amount exceeding the total of 192TB per node included in Ubuntu Pro.</p>
     </div>
 
     <div class="col-6">
-      <table class="p-table--advanced-storage">
+      <table class="p-table p-table--not-indented--advanced-storage">
         <thead>
           <tr>
             <th width="40%">The storage node size</th>
@@ -429,7 +459,7 @@
 </section>
 
   <section class="p-strip is-deep u-no-padding--top">
-    <hr class="is-fixed-width">
+    <hr class="is-fixed-width u-no-margin--bottom">
     <div class="row">
       <div class="col-6">
         <h3 class="p-heading--2">Fully managed OpenStack, Kubernetes and LMA</h3>
@@ -437,7 +467,7 @@
       </div>
   
       <div class="col-6">
-        <table class="p-table--openstack-k9s-lma">
+        <table class="p-table p-table--not-indented--openstack-k9s-lma">
           <thead>
             <tr>
               <th width="35%">Feature</th>
@@ -485,14 +515,14 @@
   </div>
 
 <section class="p-strip is-deep u-no-padding--top">
-  <hr class="is-fixed-width">
+  <hr class="is-fixed-width u-no-margin--bottom">
   <div class="row">
     <div class="col-6">
       <h3 class="p-heading--2">MAAS</h3>
       <p>Support and commercial capabilities for MAAS are included with Ubuntu Pro and Ubuntu Pro (Infra-only). These additional charges apply for machines managed by MAAS and <em>not</em> covered by an Ubuntu Pro contract.</p>
     </div>
     <div class="col-6">
-        <table class="p-table--pro-maas">
+        <table class="p-table p-table--not-indented--pro-maas">
           <thead>
             <tr>
               <th>Feature</th>
@@ -548,7 +578,7 @@
 </section>
 
 <section class="p-strip is-deep u-no-padding--top">
-  <hr class="is-fixed-width">
+  <hr class="is-fixed-width u-no-margin--bottom">
   <div class="row p-strip is-deep u-no-padding--top">
     <div class="col-6">
       <h3 class="p-heading--2">Any questions? Call us:</h3>

--- a/templates/pro/index.html
+++ b/templates/pro/index.html
@@ -41,7 +41,8 @@
       }}
     </div>
     <div class="col-small-1 col-medium-1 col-1">
-      {{ image (
+      {{
+        image (
         url="https://assets.ubuntu.com/v1/df2c8fa0-apache+tomcat+logo.png",
         alt="Apache Tomcat",
         attrs={"class":"p-logo-section__logo"},


### PR DESCRIPTION
## Done

Updated pricing page for Ubuntu pro according to design
Because the design is a radical change in layout and a lot of the content, the [copy doc](https://docs.google.com/document/d/1Ynk0iLa9hjrdich6ATTsybtPbDwW_k4vRI0nk_HNhcI/edit#heading=h.l83dv5879ajz) will need to be revamped. So for this PR please use design only.

## QA

- Go to https://ubuntu-com-12268.demos.haus/pricing/pro and compare with [design](https://www.figma.com/file/ZAihKxF2wmj9wvoPSnPKmY/Commercial%3A-Ubuntu-Pro?node-id=2200%3A15152)

## Issue / Card

Fixes https://github.com/canonical/web-squad/issues/6115
Fixes https://github.com/canonical/web-squad/issues/2341
Fixes https://github.com/canonical/ubuntu.com/issues/5343
Fixes https://github.com/canonical/ubuntu.com/issues/12137

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
