### PR TITLE
Build /subscription-centre template

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -870,3 +870,9 @@ a:hover {
   text-decoration: underline 1px;
   text-underline-offset: 0.075em;
 }
+
+// Style for a shallow p-separator
+hr.p-separator.is-shallow {
+  margin-bottom: 2rem;
+  margin-top: 2rem;
+}

--- a/subscriptions.yaml
+++ b/subscriptions.yaml
@@ -155,3 +155,11 @@ Internet of Things:
   - IoT app stores
   - IoT boards
   - Real Time
+
+Security & Compliance:
+  - CVEs (security notices)
+  - Extended Security Maintenance
+  - Security certifications and compliance
+  - Identity & Access management
+  - Live patching
+  - Security hardening

--- a/templates/subscription-centre/index.html
+++ b/templates/subscription-centre/index.html
@@ -8,7 +8,7 @@
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
     </div>
     <div class="col-8">
-      <form action="">
+      <form action="" id="subscription-centre">
         <div class="row">
           <div class="col-3">
             <label for="newsletter-frequency"><strong>I'd like to receive a newletter</strong></label>
@@ -21,60 +21,193 @@
             </select>
           </div>
         </div>
-        <label class="p-checkbox u-sv3">
-          <input type="checkbox" aria-labelledby="generalUpdates" class="p-checkbox__input" name="generalUpdates" value="yes">
-          <span class="p-checkbox__label" id="generalUpdates">Include regular updates about Canonical's products and services, including webinar and event invites</span>
+        <label class="p-checkbox">
+          <input id="general-updates" type="checkbox" aria-labelledby="generalUpdates" class="p-checkbox__input" name="generalUpdates" value="yes-general-updates">
+          <span class="p-checkbox__label">Include regular updates about Canonical's products and services, including webinar and event invites</span>
         </label>
-        <hr class="u-sv3">
-        <aside class="p-accordion">
-          <ul class="p-accordion__list">
-            <li class="p-accordion__group">
-              <div role="heading" aria-level="2" class="p-accordion__heading">
-                <button type="button" class="p-accordion__tab" id="tab1" aria-controls="tab1-section" aria-expanded="false">Networking</button>
-              </div>
-              <section class="p-accordion__panel has-tick-elements" id="tab1-section" aria-controls="tab1-section" aria-hidden="true">
-                <label class="p-checkbox">
-                  <input type="checkbox" class="p-checkbox__input" name="software" value="kubernetes">
-                  <span class="p-checkbox__label">Kubernetes</span>
-                </label>
-                <label class="p-checkbox">
-                  <input type="checkbox" class="p-checkbox__input" name="software" value="docker">
-                  <span class="p-checkbox__label">Docker</span>
-                </label>
-                <label class="p-checkbox">
-                  <input type="checkbox" class="p-checkbox__input" name="software" value="juju">
-                  <span class="p-checkbox__label">Juju</span>
-                </label>
-                <label class="p-checkbox">
-                  <input type="checkbox" class="p-checkbox__input" name="software" value="ceph">
-                  <span class="p-checkbox__label">Ceph</span>
-                </label>
-              </section>
-            </li>
-            <li class="p-accordion__group">
-              <div role="heading" aria-level="2" class="p-accordion__heading">
-                <button type="button" class="p-accordion__tab" id="tab2" aria-controls="tab2-section" aria-expanded="false">Miscellaneous</button>
-              </div>
-              <section class="p-accordion__panel has-tick-elements" id="tab2-section" aria-hidden="true" aria-labelledby="tab2">
-                <label class="p-radio">
-                  <input type="radio" class="p-radio__input" name="vendor" value="juju-gui">
-                  <span class="p-radio__label">Juju GUI</span>
-                </label>
-                <label class="p-radio">
-                  <input type="radio" class="p-radio__input" name="vendor" value="centos-support">
-                  <span class="p-radio__label">CentOS support</span>
-                </label>
-                <label class="p-radio">
-                  <input type="radio" class="p-radio__input" name="vendor" value="juju-metrics">
-                  <span class="p-radio__label">Collecting Juju metrics</span>
-                </label>
-              </section>
-            </li>
-          </ul>
-        </aside>
+        <hr class="p-separator is-shallow">
+        <div class="row">
+          <div class="col-6">
+            <div class="p-accordion">
+              <ul class="p-accordion__list" id="subscriptions-list">
+                {% for category in categories %}
+                  <li class="p-accordion__group">
+                    <div role="heading" aria-level="2" class="p-accordion__heading">
+                      <button type="button" class="p-accordion__tab" id="tab{{ loop.index }}" aria-controls="tab{{ loop.index }}-section" aria-expanded="false"><strong>{{ category }}</strong></button>
+                    </div>
+                    <section class="p-accordion__panel has-tick-elements" id="tab{{ loop.index }}-section" aria-controls="tab{{ loop.index }}-section" aria-hidden="true">
+                      <div class="row">
+                        {% for tag in categories[category] %}
+                        <div class="col-3">
+                          <label class="p-checkbox">
+                            <input type="checkbox" class="p-checkbox__input" name="{{ catagory }}" aria-labelledby="{{ tag }}" value="{{ tag }}" {% if tag in interests%}checked{% endif %}>
+                            <span class="p-checkbox__label" id="{{ tag }}">{{ tag }}</span>
+                          </label>
+                        </div>
+                        {% endfor %}
+                      </div>
+                    </section>
+                  </li>
+                {% endfor %}
+              </ul>
+            </div>
+          </div>
+        </div>
       </form>
     </div>
   </div>
+  <hr class="p-separator is-fixed-width">
+  <div class="row">
+    <div class="col-6">
+      <p><button id="unsubscribe" class="p-button u-float-left" aria-controls="modal">Unsubscribe</button></p>
+    </div>
+    <div class="col-6">
+      <p><button class="p-button--positive u-float-right">Update Preferences</button></p>
+    </div>
+  </div>
 </section>
+
+<div class="p-modal" id="modal">
+  <section class="p-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="modal-title" aria-describedby="modal-description">
+    <header class="p-modal__header">
+      <h2 class="p-modal__title" id="modal-title">Unsubscribe</h2>
+      <button class="p-modal__close" aria-label="Close active modal" aria-controls="modal">Close</button>
+    </header>
+    <p id="modal-description">Are you sure you want to unsubscribe from all topics?</p>
+    <footer class="p-modal__footer">
+      <button class="u-no-margin--bottom" aria-controls="modal">Cancel</button>
+      <button class="p-button--negative u-no-margin--bottom">Unsubscribe</button>
+    </footer>
+    </div>
+  </section>
+</div>
+
+<script>
+  (function () {
+  var currentDialog = null;
+  var lastFocus = null;
+  var ignoreFocusChanges = false;
+  var focusAfterClose = null;
+  const unsubscribeButton =  document.querySelector("#unsubscribe");
+
+  // Traps the focus within the currently open modal dialog
+  function trapFocus(e) {
+    if (ignoreFocusChanges) return;
+
+    if (currentDialog.contains(e.target)) {
+      lastFocus = e.target;
+    } else {
+      focusFirstDescendant(currentDialog);
+      if (lastFocus == document.activeElement) {
+        focusLastDescendant(currentDialog);
+      }
+      lastFocus = document.activeElement;
+    }
+  }
+
+  // Attempts to focus given element
+  function attemptFocus(child) {
+    if (child.focus) {
+      ignoreFocusChanges = true;
+      child.focus();
+      ignoreFocusChanges = false;
+      return document.activeElement === child;
+    }
+
+    return false;
+  }
+
+  // Focuses first child element
+  function focusFirstDescendant(element) {
+    for (var i = 0; i < element.childNodes.length; i++) {
+      var child = element.childNodes[i];
+      if (attemptFocus(child) || focusFirstDescendant(child)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // Focuses last child element
+  function focusLastDescendant(element) {
+    for (var i = element.childNodes.length - 1; i >= 0; i--) {
+      var child = element.childNodes[i];
+      if (attemptFocus(child) || focusLastDescendant(child)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+    Toggles visibility of modal dialog.
+    @param {HTMLElement} modal Modal dialog to show or hide.
+    @param {HTMLElement} sourceEl Element that triggered toggling modal
+    @param {Boolean} open If defined as `true` modal will be opened, if `false` modal will be closed, undefined toggles current visibility.
+  */
+  function toggleModal(modal, sourceEl, open) {
+    if (modal && modal.classList.contains('p-modal')) {
+      if (typeof open === 'undefined') {
+        open = modal.style.display === 'none';
+      }
+
+      if (open) {
+        currentDialog = modal;
+        modal.style.display = 'flex';
+        focusFirstDescendant(modal);
+        focusAfterClose = sourceEl;
+        document.addEventListener('focus', trapFocus, true);
+      } else {
+        modal.style.display = 'none';
+        if (focusAfterClose && focusAfterClose.focus) {
+          focusAfterClose.focus();
+        }
+        document.removeEventListener('focus', trapFocus, true);
+        currentDialog = null;
+      }
+    }
+  }
+
+  // Find and hide all modals on the page
+  function closeModals() {
+    var modals = [].slice.apply(document.querySelectorAll('.p-modal'));
+    modals.forEach(function (modal) {
+      toggleModal(modal, false, false);
+    });
+  }
+
+  // Add click handler for clicks on elements with aria-controls
+  document.addEventListener('click', function (event) {
+    var targetControls = event.target.getAttribute('aria-controls');
+    if (targetControls) {
+      toggleModal(document.getElementById(targetControls), event.target);
+    }
+  });
+
+  // Add handler to close modal when clicking 'close' or outside the modal
+  document.addEventListener("click", function(e) {
+    if (!e.target.closest("#unsubscribe")) {
+      if (e.target.matches(".p-modal__close") || !e.target.closest(".p-modal__dialog")) {
+        closeModals();
+      }
+    }
+  });
+
+  // Add handler for closing modals using ESC key.
+  document.addEventListener('keydown', function (e) {
+    e = e || window.event;
+
+    if (e.code === 'Escape') {
+      closeModals();
+    } else if (e.keyCode === 27) {
+      closeModals();
+    }
+  });
+
+
+  // init the dialog that is initially closed
+  toggleModal(document.querySelector('#modal'), document.querySelector('[aria-controls=modal]'), false);
+  })();
+</script>
 {% endblock content%}
 

--- a/templates/subscription-centre/index.html
+++ b/templates/subscription-centre/index.html
@@ -1,5 +1,7 @@
 {% extends "subscription-centre/base_subscription-centre.html" %}
 
+{% block title %}Subscription Centre{% endblock %}
+
 {% block content %}
 <section class="p-strip--suru-topped" style="padding-top:192px">
   <div class="row">

--- a/templates/subscription-centre/index.html
+++ b/templates/subscription-centre/index.html
@@ -1,6 +1,80 @@
 {% extends "subscription-centre/base_subscription-centre.html" %}
 
 {% block content %}
-<h2>Response {{ data }}</h2>
+<section class="p-strip--suru-topped" style="padding-top:192px">
+  <div class="row">
+    <div class="col-4">
+      <h1 class="p-heading--2">Subscription centre</h1>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+    </div>
+    <div class="col-8">
+      <form action="">
+        <div class="row">
+          <div class="col-3">
+            <label for="newsletter-frequency"><strong>I'd like to receive a newletter</strong></label>
+          </div>
+          <div class="col-2">
+            <select name="newsletter-frequency" id="newsletter-frequency">
+              <option value="daily">Every day</option>
+              <option value="weekly">Every week</option>
+              <option value="monthly">Every month</option>
+            </select>
+          </div>
+        </div>
+        <label class="p-checkbox u-sv3">
+          <input type="checkbox" aria-labelledby="generalUpdates" class="p-checkbox__input" name="generalUpdates" value="yes">
+          <span class="p-checkbox__label" id="generalUpdates">Include regular updates about Canonical's products and services, including webinar and event invites</span>
+        </label>
+        <hr class="u-sv3">
+        <aside class="p-accordion">
+          <ul class="p-accordion__list">
+            <li class="p-accordion__group">
+              <div role="heading" aria-level="2" class="p-accordion__heading">
+                <button type="button" class="p-accordion__tab" id="tab1" aria-controls="tab1-section" aria-expanded="false">Networking</button>
+              </div>
+              <section class="p-accordion__panel has-tick-elements" id="tab1-section" aria-controls="tab1-section" aria-hidden="true">
+                <label class="p-checkbox">
+                  <input type="checkbox" class="p-checkbox__input" name="software" value="kubernetes">
+                  <span class="p-checkbox__label">Kubernetes</span>
+                </label>
+                <label class="p-checkbox">
+                  <input type="checkbox" class="p-checkbox__input" name="software" value="docker">
+                  <span class="p-checkbox__label">Docker</span>
+                </label>
+                <label class="p-checkbox">
+                  <input type="checkbox" class="p-checkbox__input" name="software" value="juju">
+                  <span class="p-checkbox__label">Juju</span>
+                </label>
+                <label class="p-checkbox">
+                  <input type="checkbox" class="p-checkbox__input" name="software" value="ceph">
+                  <span class="p-checkbox__label">Ceph</span>
+                </label>
+              </section>
+            </li>
+            <li class="p-accordion__group">
+              <div role="heading" aria-level="2" class="p-accordion__heading">
+                <button type="button" class="p-accordion__tab" id="tab2" aria-controls="tab2-section" aria-expanded="false">Miscellaneous</button>
+              </div>
+              <section class="p-accordion__panel has-tick-elements" id="tab2-section" aria-hidden="true" aria-labelledby="tab2">
+                <label class="p-radio">
+                  <input type="radio" class="p-radio__input" name="vendor" value="juju-gui">
+                  <span class="p-radio__label">Juju GUI</span>
+                </label>
+                <label class="p-radio">
+                  <input type="radio" class="p-radio__input" name="vendor" value="centos-support">
+                  <span class="p-radio__label">CentOS support</span>
+                </label>
+                <label class="p-radio">
+                  <input type="radio" class="p-radio__input" name="vendor" value="juju-metrics">
+                  <span class="p-radio__label">Collecting Juju metrics</span>
+                </label>
+              </section>
+            </li>
+          </ul>
+        </aside>
+      </form>
+    </div>
+  </div>
+</section>
 {% endblock content%}
 

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -962,6 +962,9 @@ def thank_you():
 
 def subscription_centre():
     sfdcLeadId = flask.request.args.get("id")
+    with open("subscriptions.yaml") as subscriptions:
+        subscriptions = yaml.load(subscriptions, Loader=yaml.FullLoader)
+
     try:
         response = marketo_api.request(
             "GET",
@@ -977,5 +980,7 @@ def subscription_centre():
         flask.current_app.extensions["sentry"].captureException()
 
     return flask.render_template(
-        "subscription-centre/index.html", data=data["result"]
+        "subscription-centre/index.html",
+        categories=subscriptions,
+        interests=data["result"][0]["prototype_interests"],
     )


### PR DESCRIPTION
## Done

- Add logic to python module pull in subscriptions.yaml tags
- Build /subscription-centre template and populate with user subscriptions
- Build 'unsubscribe' modal and associated JS
- Add SCSS class for `p-separator.is-shallow`
- Update subscriptions.yaml with missing data

## QA

- Check that all the tags are being pulled from subscriptions.yaml and rendered on /subscription-centre
- Check that the a user previously selected tags are selected on page load
- Check the page/modal are accessible

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-231
