### PR TITLE
update /pro and /support subnavs

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -310,10 +310,12 @@ support:
       path: /pro/dashboard
     - title: Account users
       path: /pro/users
-
-    - title: Community support
-      path: /support/community-support
-
+    - title: Support
+      path: /support
+    - title: Pricing
+      path: /pricing/pro
+    - title: Discourse
+      path: https://discourse.ubuntu.com/c/ubuntu-pro
 pro:
   title: Pro
   path: /pro
@@ -325,8 +327,12 @@ pro:
       path: /pro/dashboard
     - title: Account users
       path: /pro/users
-    - title: Community support
-      path: /support/community-support
+    - title: Support
+      path: /support
+    - title: Pricing
+      path: /pricing/pro
+    - title: Discourse
+      path: https://discourse.ubuntu.com/c/ubuntu-pro
 
 account:
   title: Account

--- a/static/js/src/navigation.js
+++ b/static/js/src/navigation.js
@@ -299,21 +299,3 @@ if (accountContainer && accountContainerSmall) {
       );
     });
 }
-
-if (
-  localStorage.getItem("dismissedOnboardingNotification") === "false" ||
-  localStorage.getItem("dismissedOnboardingNotification") === null
-) {
-  document
-    .querySelectorAll(".breadcrumbs__item a.breadcrumbs__link")
-    .forEach((element) => {
-      if (element.textContent === "Account users") {
-        element.parentElement.innerHTML = `
-          <div class="breadcrumbs__link">
-          <a class="p-link--soft" href="/pro/users">Account users</a>
-          <span class="p-label--positive">New</span>
-          </div>
-        `;
-      }
-    });
-}


### PR DESCRIPTION
## Done

I received a request from @lechsandecki via Mattermost to update the subnav on /pro and /support to:

Your subscriptions | Account users | Support | Pricing | Discourse

and to drop the "New" tag on Account users - this PR does both things.

## QA

- Visit https://ubuntu-com-12276.demos.haus/pro
- See that the subnav matches the list above
- Visit https://ubuntu-com-12276.demos.haus/support
- See that the subnav matches the list above
