### PR TITLE
Fix cypress test for /credentials/sign-up

### DIFF
--- a/tests/cypress/forms/forms_spec.js
+++ b/tests/cypress/forms/forms_spec.js
@@ -61,19 +61,18 @@ context("Static marketo forms", () => {
     cy.findByRole("heading", { name: /Thank you/ });
   });
 
-  it("should check contact form on /credentials/contact-us", () => {
-    cy.visit("/credentials/contact-us");
+  it("should check contact form on /credentials/sign-up", () => {
+    cy.visit("/credentials/sign-up");
     cy.acceptCookiePolicy();
     cy.findByLabelText(/First name:/).type("Test");
     cy.findByLabelText(/Last name:/).type("Test");
-    cy.findByLabelText(/Work email:/).type("test@test.com");
-    cy.findByLabelText(/Current employer:/).type("Test");
-    cy.findByLabelText(/Employment level:/).select("Senior");
-    cy.findByLabelText(/Title:/).type("Test");
-    cy.findByLabelText(/What is your experience with Ubuntu?/).select(
-      "None or very minimal experience"
-    );
-    cy.findByTestId("form-comment").type("test test test test");
+    cy.findByLabelText(/What is your native language?/).select("English");
+    cy.findByLabelText(/What is your Employment level?/).select("Senior");
+    cy.findByLabelText(/Choose the closest category corresponding to your current occupation:/).select("Software");
+    cy.findByLabelText(/What is your motivation to certify your Linux and Ubuntu skills?/).select("Personal growth");
+    cy.findByLabelText(/When was the last time you had academic or training experience with Linux\/Ubuntu?/).select("Never");
+    cy.findByLabelText(/How long have you used\/worked with Ubuntu?/).select("Never");
+    cy.findByLabelText(/When was the last time you had professional experience with Ubuntu?/).select("Never");
     cy.findByLabelText(/I agree to receive information/).click({
       force: true,
     });


### PR DESCRIPTION
## Done

- Fix cypress test for `/credentials/sign-up`

## QA

https://discourse.canonical.com/t/how-to-run-cypress-test-locally-for-forms-on-ubuntu-com/558

