### PR TITLE
Store checkout states in local storage

### DIFF
--- a/static/js/src/PurchaseModal/components/BuyButton/BuyButton.tsx
+++ b/static/js/src/PurchaseModal/components/BuyButton/BuyButton.tsx
@@ -87,6 +87,7 @@ const BuyButton = ({ setError, quantity, product, action }: Props) => {
         onSuccess: (data) => {
           //start polling
           setPendingPurchaseID(data);
+          localStorage.clear();
         },
         onError: (error) => {
           setIsLoading(false);

--- a/static/js/src/PurchaseModal/components/BuyButton/BuyButton.tsx
+++ b/static/js/src/PurchaseModal/components/BuyButton/BuyButton.tsx
@@ -73,6 +73,17 @@ const BuyButton = ({ setError, quantity, product, action }: Props) => {
     }
   };
 
+  const proSelectorStates = [
+    "pro-selector-productType",
+    "pro-selector-version",
+    "pro-selector-quantity",
+    "pro-selector-feature",
+    "pro-selector-support",
+    "pro-selector-sla",
+    "pro-selector-period",
+    "pro-selector-publicCloud",
+  ];
+
   const onPayClick = () => {
     handleOnPurchaseBegin();
     checkoutEvent(GAFriendlyProduct, "3");
@@ -87,7 +98,7 @@ const BuyButton = ({ setError, quantity, product, action }: Props) => {
         onSuccess: (data) => {
           //start polling
           setPendingPurchaseID(data);
-          localStorage.clear();
+          proSelectorStates.forEach((state) => localStorage.removeItem(state));
         },
         onError: (error) => {
           setIsLoading(false);

--- a/static/js/src/advantage/subscribe/blender/components/Form/Quantity/Quantity.tsx
+++ b/static/js/src/advantage/subscribe/blender/components/Form/Quantity/Quantity.tsx
@@ -7,6 +7,10 @@ const Quantity = () => {
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setQuantity(Number(event.target.value));
+    localStorage.setItem(
+      "quantity",
+      JSON.stringify(Number(event.target.value))
+    );
   };
 
   return (

--- a/static/js/src/advantage/subscribe/blender/components/Form/Quantity/Quantity.tsx
+++ b/static/js/src/advantage/subscribe/blender/components/Form/Quantity/Quantity.tsx
@@ -7,10 +7,6 @@ const Quantity = () => {
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setQuantity(Number(event.target.value));
-    localStorage.setItem(
-      "quantity",
-      JSON.stringify(Number(event.target.value))
-    );
   };
 
   return (

--- a/static/js/src/advantage/subscribe/react/components/Form/Feature/Feature.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Feature/Feature.tsx
@@ -13,6 +13,10 @@ const Feature = () => {
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setFeature(event.target.value as Features);
+    localStorage.setItem(
+      "feature",
+      JSON.stringify(event.target.value as Features)
+    );
   };
 
   const infraOnlyDisabled = ProductTypes.desktop === productType;

--- a/static/js/src/advantage/subscribe/react/components/Form/Feature/Feature.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Feature/Feature.tsx
@@ -14,7 +14,7 @@ const Feature = () => {
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setFeature(event.target.value as Features);
     localStorage.setItem(
-      "feature",
+      "pro-selector-feature",
       JSON.stringify(event.target.value as Features)
     );
   };

--- a/static/js/src/advantage/subscribe/react/components/Form/ProductType/ProductType.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/ProductType/ProductType.tsx
@@ -39,7 +39,7 @@ const PublicCloudInfo = {
 };
 
 const ProductType = () => {
-  const localPublicCloud = localStorage.getItem("publicCloud");
+  const localPublicCloud = localStorage.getItem("pro-selector-publicCloud");
   const { productType, setProductType } = useContext(FormContext);
   const [publicCloud, setPublicCloud] = useState(
     localPublicCloud
@@ -52,7 +52,7 @@ const ProductType = () => {
   ) => {
     setProductType(event.target.value as ProductTypes);
     localStorage.setItem(
-      "productType",
+      "pro-selector-productType",
       JSON.stringify(event.target.value as ProductTypes)
     );
   };
@@ -75,7 +75,7 @@ const ProductType = () => {
               e.preventDefault();
               setPublicCloud(PublicClouds.aws);
               localStorage.setItem(
-                "publicCloud",
+                "pro-selector-publicCloud",
                 JSON.stringify(PublicClouds.aws)
               );
             }}
@@ -92,7 +92,7 @@ const ProductType = () => {
               e.preventDefault();
               setPublicCloud(PublicClouds.azure);
               localStorage.setItem(
-                "publicCloud",
+                "pro-selector-publicCloud",
                 JSON.stringify(PublicClouds.azure)
               );
             }}
@@ -109,7 +109,7 @@ const ProductType = () => {
               e.preventDefault();
               setPublicCloud(PublicClouds.gcp);
               localStorage.setItem(
-                "publicCloud",
+                "pro-selector-publicCloud",
                 JSON.stringify(PublicClouds.gcp)
               );
             }}

--- a/static/js/src/advantage/subscribe/react/components/Form/ProductType/ProductType.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/ProductType/ProductType.tsx
@@ -39,13 +39,22 @@ const PublicCloudInfo = {
 };
 
 const ProductType = () => {
+  const localPublicCloud = localStorage.getItem("publicCloud");
   const { productType, setProductType } = useContext(FormContext);
-  const [publicCloud, setPublicCloud] = useState(PublicClouds.aws);
+  const [publicCloud, setPublicCloud] = useState(
+    localPublicCloud
+      ? (JSON.parse(localPublicCloud) as PublicClouds)
+      : PublicClouds.aws
+  );
 
   const handleProductTypeChange = (
     event: React.ChangeEvent<HTMLInputElement>
   ) => {
     setProductType(event.target.value as ProductTypes);
+    localStorage.setItem(
+      "productType",
+      JSON.stringify(event.target.value as ProductTypes)
+    );
   };
 
   const publicCloudsSelector = (
@@ -65,6 +74,10 @@ const ProductType = () => {
             onClick={(e) => {
               e.preventDefault();
               setPublicCloud(PublicClouds.aws);
+              localStorage.setItem(
+                "publicCloud",
+                JSON.stringify(PublicClouds.aws)
+              );
             }}
           >
             {PublicCloudInfo[PublicClouds.aws].title}
@@ -78,6 +91,10 @@ const ProductType = () => {
             onClick={(e) => {
               e.preventDefault();
               setPublicCloud(PublicClouds.azure);
+              localStorage.setItem(
+                "publicCloud",
+                JSON.stringify(PublicClouds.azure)
+              );
             }}
           >
             {PublicCloudInfo[PublicClouds.azure].title}
@@ -91,6 +108,10 @@ const ProductType = () => {
             onClick={(e) => {
               e.preventDefault();
               setPublicCloud(PublicClouds.gcp);
+              localStorage.setItem(
+                "publicCloud",
+                JSON.stringify(PublicClouds.gcp)
+              );
             }}
           >
             {PublicCloudInfo[PublicClouds.gcp].title}

--- a/static/js/src/advantage/subscribe/react/components/Form/Quantity/Quantity.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Quantity/Quantity.tsx
@@ -10,6 +10,10 @@ const Quantity = () => {
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     if (Number(event.target.value) > 0) {
       setQuantity(Number(event.target.value));
+      localStorage.setItem(
+        "quantity",
+        JSON.stringify(Number(event.target.value))
+      );
     } else {
       setQuantity("");
     }

--- a/static/js/src/advantage/subscribe/react/components/Form/Quantity/Quantity.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Quantity/Quantity.tsx
@@ -11,7 +11,7 @@ const Quantity = () => {
     if (Number(event.target.value) > 0) {
       setQuantity(Number(event.target.value));
       localStorage.setItem(
-        "quantity",
+        "pro-selector-quantity",
         JSON.stringify(Number(event.target.value))
       );
     } else {

--- a/static/js/src/advantage/subscribe/react/components/Form/Support/Support.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Support/Support.tsx
@@ -25,7 +25,7 @@ const Support = () => {
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setSupport(event.target.value as SupportEnum);
     localStorage.setItem(
-      "support",
+      "pro-selector-support",
       JSON.stringify(event.target.value as SupportEnum)
     );
   };
@@ -205,7 +205,10 @@ const Support = () => {
           })}
           onClick={() => {
             setSupport(SupportEnum.none);
-            localStorage.setItem("support", JSON.stringify(SupportEnum.none));
+            localStorage.setItem(
+              "pro-selector-support",
+              JSON.stringify(SupportEnum.none)
+            );
           }}
         >
           <RadioInput
@@ -244,7 +247,10 @@ const Support = () => {
           })}
           onClick={() => {
             setSupport(SupportEnum.infra);
-            localStorage.setItem("support", JSON.stringify(SupportEnum.infra));
+            localStorage.setItem(
+              "pro-selector-support",
+              JSON.stringify(SupportEnum.infra)
+            );
           }}
         >
           <RadioInput
@@ -279,7 +285,10 @@ const Support = () => {
           })}
           onClick={() => {
             setSupport(SupportEnum.full);
-            localStorage.setItem("support", JSON.stringify(SupportEnum.full));
+            localStorage.setItem(
+              "pro-selector-support",
+              JSON.stringify(SupportEnum.full)
+            );
           }}
         >
           <RadioInput
@@ -329,7 +338,10 @@ const Support = () => {
                   onClick={(e) => {
                     e.preventDefault();
                     setSLA(SLA.weekday);
-                    localStorage.setItem("sla", JSON.stringify(SLA.weekday));
+                    localStorage.setItem(
+                      "pro-selector-sla",
+                      JSON.stringify(SLA.weekday)
+                    );
                   }}
                   style={{ textAlign: "justify" }}
                 >
@@ -347,7 +359,10 @@ const Support = () => {
                   onClick={(e) => {
                     e.preventDefault();
                     setSLA(SLA.everyday);
-                    localStorage.setItem("sla", JSON.stringify(SLA.everyday));
+                    localStorage.setItem(
+                      "pro-selector-sla",
+                      JSON.stringify(SLA.everyday)
+                    );
                   }}
                   style={{ textAlign: "justify" }}
                 >

--- a/static/js/src/advantage/subscribe/react/components/Form/Support/Support.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Support/Support.tsx
@@ -24,6 +24,10 @@ const Support = () => {
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setSupport(event.target.value as SupportEnum);
+    localStorage.setItem(
+      "support",
+      JSON.stringify(event.target.value as SupportEnum)
+    );
   };
 
   const isInfraOnlyDisabled = productType === ProductTypes.desktop;
@@ -199,7 +203,10 @@ const Support = () => {
             "is-selected": SupportEnum.none === support,
             "u-disable": false,
           })}
-          onClick={() => setSupport(SupportEnum.none)}
+          onClick={() => {
+            setSupport(SupportEnum.none);
+            localStorage.setItem("support", JSON.stringify(SupportEnum.none));
+          }}
         >
           <RadioInput
             inline
@@ -235,7 +242,10 @@ const Support = () => {
             "is-selected": SupportEnum.infra === support,
             "u-disable": isInfraOnlyDisabled,
           })}
-          onClick={() => setSupport(SupportEnum.infra)}
+          onClick={() => {
+            setSupport(SupportEnum.infra);
+            localStorage.setItem("support", JSON.stringify(SupportEnum.infra));
+          }}
         >
           <RadioInput
             inline
@@ -267,7 +277,10 @@ const Support = () => {
             "is-selected": SupportEnum.full === support,
             "u-disable": isFullSupportDisabled,
           })}
-          onClick={() => setSupport(SupportEnum.full)}
+          onClick={() => {
+            setSupport(SupportEnum.full);
+            localStorage.setItem("support", JSON.stringify(SupportEnum.full));
+          }}
         >
           <RadioInput
             inline
@@ -316,6 +329,7 @@ const Support = () => {
                   onClick={(e) => {
                     e.preventDefault();
                     setSLA(SLA.weekday);
+                    localStorage.setItem("sla", JSON.stringify(SLA.weekday));
                   }}
                   style={{ textAlign: "justify" }}
                 >
@@ -333,6 +347,7 @@ const Support = () => {
                   onClick={(e) => {
                     e.preventDefault();
                     setSLA(SLA.everyday);
+                    localStorage.setItem("sla", JSON.stringify(SLA.everyday));
                   }}
                   style={{ textAlign: "justify" }}
                 >

--- a/static/js/src/advantage/subscribe/react/components/Form/Version/Version.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Version/Version.tsx
@@ -170,7 +170,7 @@ const Version = () => {
                 e.preventDefault();
                 setVersion(key as LTSVersions);
                 localStorage.setItem(
-                  "version",
+                  "pro-selector-version",
                   JSON.stringify(key as LTSVersions)
                 );
               }}

--- a/static/js/src/advantage/subscribe/react/components/Form/Version/Version.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Version/Version.tsx
@@ -169,6 +169,10 @@ const Version = () => {
               onClick={(e) => {
                 e.preventDefault();
                 setVersion(key as LTSVersions);
+                localStorage.setItem(
+                  "version",
+                  JSON.stringify(key as LTSVersions)
+                );
               }}
             >
               {key} LTS

--- a/static/js/src/advantage/subscribe/react/components/ProductSummary/ProductSummary.tsx
+++ b/static/js/src/advantage/subscribe/react/components/ProductSummary/ProductSummary.tsx
@@ -10,7 +10,7 @@ const ProductSummary = () => {
   const handlePeriodChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
     setPeriod(event.target.value as Periods);
     localStorage.setItem(
-      "period",
+      "pro-selector-period",
       JSON.stringify(event.target.value as Periods)
     );
   };

--- a/static/js/src/advantage/subscribe/react/components/ProductSummary/ProductSummary.tsx
+++ b/static/js/src/advantage/subscribe/react/components/ProductSummary/ProductSummary.tsx
@@ -9,6 +9,10 @@ const ProductSummary = () => {
   const { quantity, period, setPeriod, product } = useContext(FormContext);
   const handlePeriodChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
     setPeriod(event.target.value as Periods);
+    localStorage.setItem(
+      "period",
+      JSON.stringify(event.target.value as Periods)
+    );
   };
 
   const isHidden = !product || !quantity || quantity < 1;

--- a/static/js/src/advantage/subscribe/react/utils/FormContext.tsx
+++ b/static/js/src/advantage/subscribe/react/utils/FormContext.tsx
@@ -70,13 +70,35 @@ export const FormProvider = ({
   initialPeriod = defaultValues.period,
   children,
 }: FormProviderProps) => {
-  const [productType, setProductType] = useState<ProductTypes>(initialType);
-  const [version, setVersion] = useState<LTSVersions>(initialVersion);
-  const [feature, setFeature] = useState<Features>(initialFeature);
-  const [sla, setSLA] = useState<SLA>(initialSLA);
-  const [support, setSupport] = useState<Support>(initialSupport);
-  const [quantity, setQuantity] = useState(initialQuantity);
-  const [period, setPeriod] = useState<Periods>(initialPeriod);
+  const localProductType = localStorage.getItem("productType");
+  const localVersion = localStorage.getItem("version");
+  const localQuantity = localStorage.getItem("quantity");
+  const localFeature = localStorage.getItem("feature");
+  const localSupport = localStorage.getItem("support");
+  const localSLA = localStorage.getItem("sla");
+  const localPeriod = localStorage.getItem("period");
+
+  const [productType, setProductType] = useState<ProductTypes>(
+    localProductType ? JSON.parse(localProductType) : initialType
+  );
+  const [version, setVersion] = useState<LTSVersions>(
+    localVersion ? JSON.parse(localVersion) : initialVersion
+  );
+  const [feature, setFeature] = useState<Features>(
+    localFeature ? JSON.parse(localFeature) : initialFeature
+  );
+  const [sla, setSLA] = useState<SLA>(
+    localSLA ? JSON.parse(localSLA) : initialSLA
+  );
+  const [support, setSupport] = useState<Support>(
+    localSupport ? JSON.parse(localSupport) : initialSupport
+  );
+  const [quantity, setQuantity] = useState(
+    localQuantity ? JSON.parse(localQuantity) : initialQuantity
+  );
+  const [period, setPeriod] = useState<Periods>(
+    localPeriod ? JSON.parse(localPeriod) : initialPeriod
+  );
   const [product, setProduct] = useState<Product | null>(null);
 
   useEffect(() => {

--- a/static/js/src/advantage/subscribe/react/utils/FormContext.tsx
+++ b/static/js/src/advantage/subscribe/react/utils/FormContext.tsx
@@ -70,13 +70,13 @@ export const FormProvider = ({
   initialPeriod = defaultValues.period,
   children,
 }: FormProviderProps) => {
-  const localProductType = localStorage.getItem("productType");
-  const localVersion = localStorage.getItem("version");
-  const localQuantity = localStorage.getItem("quantity");
-  const localFeature = localStorage.getItem("feature");
-  const localSupport = localStorage.getItem("support");
-  const localSLA = localStorage.getItem("sla");
-  const localPeriod = localStorage.getItem("period");
+  const localProductType = localStorage.getItem("pro-selector-productType");
+  const localVersion = localStorage.getItem("pro-selector-version");
+  const localQuantity = localStorage.getItem("pro-selector-quantity");
+  const localFeature = localStorage.getItem("pro-selector-feature");
+  const localSupport = localStorage.getItem("pro-selector-support");
+  const localSLA = localStorage.getItem("pro-selector-sla");
+  const localPeriod = localStorage.getItem("pro-selector-period");
 
   const [productType, setProductType] = useState<ProductTypes>(
     localProductType ? JSON.parse(localProductType) : initialType


### PR DESCRIPTION
## Done

- Store checkout states in local storage 
- Remove stored local storage after purchasing 

## QA

- Go to `/pro/subscribe`
- Select items
- Refresh page or log in and see the selected items remains as selected.


## Issue / Card

Fixes https://warthogs.atlassian.net/jira/software/c/projects/WD/boards/801?modal=detail&selectedIssue=WD-304

![ezgif com-gif-maker (18)](https://user-images.githubusercontent.com/57550290/201078683-e891ea89-c38f-4484-8685-1196515b8eee.gif)
