### PR TITLE
Fix link typo on /intel-iot

### DIFF
--- a/templates/download/iot/intel-iot.html
+++ b/templates/download/iot/intel-iot.html
@@ -113,25 +113,25 @@
         <tr>
           <th>Intel Atom® X6000E Series and Intel® Pentium® and Celeron® N and J Series Processors <br/>(Elkhart Lake)</th>
           <td class="u-align--center" data-heading="Ubuntu Core 22"><p><button href="" class="p-button is-dense" disabled="">Coming soon</button></p></td>
-          <td class="u-align--center" data-heading="Ubuntu Desktop 22.04"><p><a href="http://cdimage.ubuntu.com/jammy/daily-live/manual/jammy-desktop-amd64+intel-iot.iso" class="p-button is-dense">Download</a></p></td>
+          <td class="u-align--center" data-heading="Ubuntu Desktop 22.04"><p><a href="https://cdimage.ubuntu.com/jammy/daily-live/manual/jammy-desktop-amd64+intel-iot.iso" class="p-button is-dense">Download</a></p></td>
           <td class="u-align--center" data-heading="Ubuntu Server 22.04"><p><a href="https://cdimage.ubuntu.com/ubuntu-server/jammy/daily-live/manual/jammy-live-server-amd64+intel-iot.iso" class="p-button is-dense">Download</a></p></td>
         </tr>
         <tr>
           <th>11th Gen Intel® Core™ processors <br/>(Tiger Lake)</th>
           <td class="u-align--center" data-heading="Ubuntu Core 22"><p><button href="" class="p-button is-dense" disabled="">Coming soon</button></p></td>
-          <td class="u-align--center" data-heading="Ubuntu Desktop 22.04"><p><a href="http://cdimage.ubuntu.com/jammy/daily-live/manual/jammy-desktop-amd64+intel-iot.iso" class="p-button is-dense">Download</a></p></td>
+          <td class="u-align--center" data-heading="Ubuntu Desktop 22.04"><p><a href="https://cdimage.ubuntu.com/jammy/daily-live/manual/jammy-desktop-amd64+intel-iot.iso" class="p-button is-dense">Download</a></p></td>
           <td class="u-align--center" data-heading="Ubuntu Server 22.04"><p><a href="https://cdimage.ubuntu.com/ubuntu-server/jammy/daily-live/manual/jammy-live-server-amd64+intel-iot.iso" class="p-button is-dense">Download</a></p></td>
         </tr>
         <tr>
           <th>Intel 12th Gen Intel® Core™ processors <br/>(Alder Lake S, P)</th>
           <td class="u-align--center" data-heading="Ubuntu Core 22"><p><button href="" class="p-button is-dense" disabled="">Coming soon</button></p></td>
-          <td class="u-align--center" data-heading="Ubuntu Desktop 22.04"><p><a href="http://cdimage.ubuntu.com/jammy/daily-live/manual/jammy-desktop-amd64+intel-iot.iso" class="p-button is-dense">Download</a></p></td>
+          <td class="u-align--center" data-heading="Ubuntu Desktop 22.04"><p><a href="https://cdimage.ubuntu.com/jammy/daily-live/manual/jammy-desktop-amd64+intel-iot.iso" class="p-button is-dense">Download</a></p></td>
           <td class="u-align--center" data-heading="Ubuntu Server 22.04"><p><a href="https://cdimage.ubuntu.com/ubuntu-server/jammy/daily-live/manual/jammy-live-server-amd64+intel-iot.iso" class="p-button is-dense">Download</a></p></td>
         </tr>
         <tr>
           <th>Intel® Xeon® D processors <br/>(Ice Lake)</th>
           <td class="u-align--center" data-heading="Ubuntu Core 22">-</td>
-          <td class="u-align--center" data-heading="Ubuntu Desktop 22.04"><p><a href="http://cdimage.ubuntu.com/jammy/daily-live/manual/jammy-desktop-amd64+intel-iot.iso" class="p-button is-dense">Download</a></p></td>
+          <td class="u-align--center" data-heading="Ubuntu Desktop 22.04"><p><a href="https://cdimage.ubuntu.com/jammy/daily-live/manual/jammy-desktop-amd64+intel-iot.iso" class="p-button is-dense">Download</a></p></td>
           <td class="u-align--center" data-heading="Ubuntu Server 22.04"><p><a href="https://cdimage.ubuntu.com/ubuntu-server/jammy/daily-live/manual/jammy-live-server-amd64+intel-iot.iso" class="p-button is-dense">Download</a></p></td>
         </tr>                
       </tbody>


### PR DESCRIPTION
## Done

- Fixes the links that had types on /intel-iot, see [copydoc](https://docs.google.com/document/d/1hxKzPs6e6JQaa9tBqfZ55GAXrVnEryEWBja8HlXy-lc/edit)

## QA

- Compare against copydoc

## Issue / Card

Fixes https://github.com/canonical/web-squad/issues/6207
