### PR TITLE
Update accordion.js to move to target when panel is opened

### DIFF
--- a/static/js/src/accordion.js
+++ b/static/js/src/accordion.js
@@ -21,7 +21,7 @@ it into view
 @param {HTMLElement} element The tab that acts as the handles.
 */
 function moveInView(element) {
-  // Returns a Boolean based on whether the element in in view
+  // Returns a Boolean based on whether the element is in view
   function isInViewport(element) {
     const rect = element.getBoundingClientRect();
     return (

--- a/static/js/src/accordion.js
+++ b/static/js/src/accordion.js
@@ -11,6 +11,31 @@ function toggleExpanded(element, show) {
     element.setAttribute("aria-expanded", show);
     target.setAttribute("aria-hidden", !show);
   }
+
+  moveInView(element);
+}
+
+/**
+Checks if the top of the opened panel is visible and if it is not, moves
+it into view
+@param {HTMLElement} element The tab that acts as the handles.
+*/
+function moveInView(element) {
+  // Returns a Boolean based on whether the element in in view
+  function isInViewport(element) {
+    const rect = element.getBoundingClientRect();
+    return (
+      rect.top >= 0 &&
+      rect.left >= 0 &&
+      rect.bottom <=
+        (window.innerHeight || document.documentElement.clientHeight) &&
+      rect.right <= (window.innerWidth || document.documentElement.clientWidth)
+    );
+  }
+
+  if (!isInViewport(element)) {
+    element.scrollIntoView();
+  }
 }
 
 /**


### PR DESCRIPTION
## Done

- There was a use case on subscription center where opening large accordion panels would cause the view port to move, and make the contents of the accordion panel not visible. This adds logic to check and move the accordion panel into view when opened.


## QA

- Find an accordion, when opening panels with a lot of content the screenview should always keep the target panel in view.
- You can add more content to a individual panel to see the effect more clearly
