### PR TITLE
Ignores free contracts outside of personal accounts

### DIFF
--- a/tests/shop/advantage/fixtures/account.json
+++ b/tests/shop/advantage/fixtures/account.json
@@ -16,5 +16,6 @@
   ],
   "id": "aAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
   "name": "Account Name",
+  "type": "paid",
   "userRoleOnAccount": "admin"
 }

--- a/tests/shop/advantage/fixtures/accounts.json
+++ b/tests/shop/advantage/fixtures/accounts.json
@@ -3,6 +3,7 @@
     "createdAt": "2010-01-01T10:00:00Z",
     "id": "a123AbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
     "name": "Free",
+    "type": "personal",
     "userRoleOnAccount": "admin"
   },
   {
@@ -23,6 +24,7 @@
     ],
     "id": "aAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
     "name": "Account Name",
+    "type": "paid",
     "userRoleOnAccount": "admin"
   }
 ]

--- a/tests/shop/advantage/test_advantage_mapper.py
+++ b/tests/shop/advantage/test_advantage_mapper.py
@@ -44,11 +44,13 @@ class TestGetAccounts(unittest.TestCase):
             Account(
                 id="a123AbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
                 name="Free",
+                type="personal",
                 role="admin",
             ),
             Account(
                 id="aAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
                 name="Account Name",
+                type="paid",
                 role="admin",
             ),
         ]
@@ -335,6 +337,7 @@ class TestGetPurchaseAccount(unittest.TestCase):
         expectation = Account(
             id="aAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpP",
             name="Account Name",
+            type="paid",
             role="admin",
         )
 

--- a/webapp/shop/api/ua_contracts/builders.py
+++ b/webapp/shop/api/ua_contracts/builders.py
@@ -53,10 +53,11 @@ def build_free_item_groups(user_summary: List) -> List:
             if contract.items is None:
                 continue
 
-            if contract.product_id == "free":
+            account: Account = user_details.get("account")
+            if account.type == "personal" and contract.product_id == "free":
                 free_item_groups.append(
                     {
-                        "account": user_details.get("account"),
+                        "account": account,
                         "contract": contract,
                         "items": contract.items,
                         "listing": None,

--- a/webapp/shop/api/ua_contracts/primitives.py
+++ b/webapp/shop/api/ua_contracts/primitives.py
@@ -122,11 +122,13 @@ class Account:
         self,
         id: str,
         name: str = None,
+        type: str = None,
         role: str = None,
         token: str = None,
     ):
         self.id = id
         self.name = name
+        self.type = type
         self.role = role
         self.token = token
 

--- a/webapp/shop/api/ua_contracts/schema.py
+++ b/webapp/shop/api/ua_contracts/schema.py
@@ -71,6 +71,7 @@ class PurchaseSchema(BaseSchema):
 class AccountSchema(BaseSchema):
     id = String(required=True, attribute="id")
     name = String(required=True)
+    type = String(required=True)
     userRoleOnAccount = String(required=True, attribute="role")
 
     @post_load


### PR DESCRIPTION
## Done

We had a bug in the backend between Nov 2020 and May 2021 that resulted in the creation of free contracts in some paid accounts. That is wrong, and we are cleaning this up in the backend already.

However, in order to be able to direct customers to get their correct free personal token, we need to make sure `/pro/dashboard` does not display these incorrect contracts.

As a general measure, this is a good idea regardless of this bug. As a kind of necessary pre-condition, this PR makes the account type available to the frontend code in general. The backend has had this attribute exposed for a long time now.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes CSS-2568.