### PR TITLE
Fix broken retail partners link

### DIFF
--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -641,7 +641,7 @@
       <div class="col-4">
        <h3>Buy it pre-installed</h3>
        <p>Ubuntu is available on a huge range of devices from the world's largest hardware manufacturers including Dell, HP, and Lenovo.</p>
-       <p><a href="https://partners.ubuntu.com/programmes/retail">Find out more about our retail partners</a></p>
+       <p><a href="https://canonical.com/partners/desktop">Find out more about our retail partners</a></p>
       </div>
       <div class="col-4">
        <h3>Join our community</h3>


### PR DESCRIPTION
## Done

- Fixed broken link on /desktop/developers

## QA

- Visit https://ubuntu-com-12303.demos.haus/desktop/developers
- Find the "Find out more about our retail partners"
- See that it takes you to https://canonical.com/partners/desktop

## Issue / Card

Fixes https://github.com/canonical/ubuntu.com/issues/12289
