### PR TITLE
add "People and culture" blog topic

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -242,6 +242,8 @@ blog:
       path: /blog/topics/design
     - title: Robotics
       path: /blog/topics/robotics
+    - title: People and culture
+      path: /blog/people-and-culture
     - title: Archives
       path: /blog/archives
     - title: Upcoming

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -878,7 +878,6 @@ blog/category/(?P<category>[^/]+)/year/(?P<year>[0-9]{4})/?: /blog/archives?cate
 # Group archive pages
 blog/canonical-announcements/?: https://canonical.com/press-centre
 blog/press-centre/?: https://canonical.com/press-centre
-blog/people-and-culture/?: /blog/archives?group=people-and-culture
 blog/phone-and-tablet/?: /blog/archives?group=phone-and-tablet
 blog/page/(?P<page>[0-9]+)/(?P<group>[^/]+)/?: /blog/archives?group={group}&page={page}
 blog/group/(?P<group>[^/]+)/?: /blog/archives?group={group}

--- a/templates/blog/people-and-culture.html
+++ b/templates/blog/people-and-culture.html
@@ -1,0 +1,27 @@
+{% extends "templates/one-column.html" %}
+
+{% block title %}People and culture{% endblock %}
+
+{% block content %}
+
+  <section class="p-strip--suru-blog-header">
+    <div class="u-fixed-width">
+      <h1>People and culture</h1>
+      <p class="p-heading--4">
+        Read about our people led initiatives that define our culture.
+      </p>
+    </div>
+  </section>
+
+  <section class="p-strip is-shallow">
+    {% include 'blog/posts.html' %}
+  </section>
+
+  <section class="p-strip is-shallow">
+    {% with %}
+      {% set total_pages = total_pages %}
+      {% set current_page = current_page %}
+      {% include "shared/_pagination.html" %}
+    {% endwith %}
+  </section>
+{% endblock %}

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -534,7 +534,7 @@ app.add_url_rule(
     view_func=BlogCustomTopic.as_view("blog_topic", blog_views=blog_views),
 )
 app.add_url_rule(
-    "/blog/<regex('cloud-and-server|desktop|internet-of-things'):slug>",
+    "/blog/<regex('cloud-and-server|desktop|internet-of-things|people-and-culture'):slug>",  # noqa: E501
     view_func=BlogCustomGroup.as_view("blog_group", blog_views=blog_views),
 )
 app.add_url_rule(


### PR DESCRIPTION
## Done

- Added "People and culture" topic to the ubuntu.com blog

## QA

- Visit https://ubuntu-com-12307.demos.haus/blog
- See that "People and culture" appears on the subnav
- Click the link
- See that you're taken to /blog/people-and-culture (the copy in the hero strip comes from Hanna Neuborn)

## Issue / Card

Fixes https://github.com/canonical/web-squad/issues/6177
