### PR TITLE
Remove link on /model-driven-operations

### DIFF
--- a/templates/model-driven-operations/index.html
+++ b/templates/model-driven-operations/index.html
@@ -441,7 +441,7 @@
           ) | safe
         }}
       </div>
-      <p>Juju Community: Join the conversation on <a href="https://discourse.charmhub.io/tag/community-workshop">Discourse</a> and <a href="https://chat.charmhub.io/charmhub/channels/community-workshops">Mattermost</a>. Meet the team at the “<a href="https://discourse.charmhub.io/t/community-events/5295/8">Charmed Office Hours</a>”. Anyone and everyone is welcome to join!</p>
+      <p>Juju Community: Join the conversation on <a href="https://discourse.charmhub.io/tag/community-workshop">Discourse</a> and <a href="https://chat.charmhub.io/charmhub/channels/community-workshops">Mattermost</a>. Anyone and everyone is welcome to join!</p>
     </div>
     <div class="col-3 p-divider__block">
       <div class="u-hide--medium u-hide--small u-align--center">


### PR DESCRIPTION
## Done

- Remove link on /model-driven-operations

## QA

- Check the link to "[Charmed Office Hours](https://discourse.charmhub.io/t/community-events/5295/8)" is removed from https://ubuntu-com-12308.demos.haus/model-driven-operations.

## Issue / Card

Fixes #12290 
