### PR TITLE
Display VAT error message

### DIFF
--- a/static/js/src/PurchaseModal/components/BuyButton/BuyButton.tsx
+++ b/static/js/src/PurchaseModal/components/BuyButton/BuyButton.tsx
@@ -107,7 +107,7 @@ const BuyButton = ({ setError, quantity, product, action }: Props) => {
         },
         onError: (error) => {
           setIsLoading(false);
-
+          console.log(error);
           if (error instanceof Error)
             if (
               error.message.includes("can only make one purchase at a time")
@@ -124,6 +124,9 @@ const BuyButton = ({ setError, quantity, product, action }: Props) => {
                 VATNumber:
                   "That VAT number is invalid. Check the number and try again.",
               });
+              setError(
+                <>That VAT number is invalid. Check the number and try again.</>
+              );
             } else {
               Sentry.captureException(error);
               setError(

--- a/static/js/src/PurchaseModal/components/BuyButton/BuyButton.tsx
+++ b/static/js/src/PurchaseModal/components/BuyButton/BuyButton.tsx
@@ -88,7 +88,6 @@ const BuyButton = ({
 
   const handlePurchaseError = (error: any) => {
     setIsLoading(false);
-    console.log(error);
     if (
       error instanceof Error &&
       error.message.includes("can only make one purchase at a time")
@@ -106,6 +105,19 @@ const BuyButton = ({
       });
       setError(
         <>That VAT number is invalid. Check the number and try again.</>
+      );
+    } else if (error.message.includes("tax_id_cannot_be_validated")) {
+      setFormikErrors({
+        VATNumber:
+          "VAT number could not be validated at this time, please try again later or contact customer success if the problem persists.",
+      });
+      setError(
+        <>
+          VAT number could not be validated at this time, please try again later
+          or contact
+          <a href="mailto:customersuccess@canonical.com">customer success</a> if
+          the problem persists.
+        </>
       );
     } else {
       Sentry.captureException(error);

--- a/static/js/src/PurchaseModal/components/BuyButton/BuyButton.tsx
+++ b/static/js/src/PurchaseModal/components/BuyButton/BuyButton.tsx
@@ -99,15 +99,15 @@ const BuyButton = ({
           <a href="/account/payment-methods">payment methods</a> to retry.
         </>
       );
-    }  else if (error.message.includes("tax_id_invalid")) {
-        setFormikErrors({
-          VATNumber:
-            "That VAT number is invalid. Check the number and try again.",
-        });
-        setError(
-          <>That VAT number is invalid. Check the number and try again.</>
-        );
-      } else {
+    } else if (error.message.includes("tax_id_invalid")) {
+      setFormikErrors({
+        VATNumber:
+          "That VAT number is invalid. Check the number and try again.",
+      });
+      setError(
+        <>That VAT number is invalid. Check the number and try again.</>
+      );
+    } else {
       Sentry.captureException(error);
       setError(
         <>

--- a/static/js/src/PurchaseModal/components/BuyButton/BuyButton.tsx
+++ b/static/js/src/PurchaseModal/components/BuyButton/BuyButton.tsx
@@ -113,6 +113,20 @@ const BuyButton = ({ setError, quantity, product, action }: Props) => {
                 <a href="/account/payment-methods">payment methods</a> to retry.
               </>
             );
+          } else if (
+            error instanceof Error &&
+            error.message.includes("invalid VAT")
+          ) {
+            setError(
+              <>That VAT number is invalid. Check the number and try again.</>
+            );
+          } else if (
+            error instanceof Error &&
+            error.message.includes("eu_vat")
+          ) {
+            setError(
+              <>That VAT number is invalid. Check the number and try again.</>
+            );
           } else {
             Sentry.captureException(error);
             setError(


### PR DESCRIPTION
## Done

- Display VAT error message when VAT number is wrong 
## QA

1. Go to /pro/subscribe
2. type any wrong number in VAT field
<img width="432" alt="image" src="https://user-images.githubusercontent.com/57550290/203968287-30d50471-43bb-4ea3-a81e-5929a13e45d2.png">
3. Click `Buy` button and see this error message displays at the top and also below the input field
<img width="857" alt="Screenshot 2022-11-25 at 9 37 52 am" src="https://user-images.githubusercontent.com/57550290/203968184-d4bbbacd-fcf2-4322-a6a8-7ff7bf47b721.png">

![Image Pasted at 2022-11-28 17-27](https://user-images.githubusercontent.com/57550290/204577369-63237835-4378-43f5-b2ce-34801ae26566.png)


## Issue / Card

Fixes https://warthogs.atlassian.net/jira/software/c/projects/WD/boards/801?modal=detail&selectedIssue=WD-669
