### PR TITLE
Disable buy button when a value is missing

### DIFF
--- a/static/js/src/PurchaseModal/PurchaseModal.tsx
+++ b/static/js/src/PurchaseModal/PurchaseModal.tsx
@@ -66,6 +66,7 @@ const PurchaseModal = ({
   const { data: userInfo } = useStripeCustomerInfo();
 
   const [isCardValid, setCardValid] = useState(false);
+  const [isTaxSaved, setTaxSaved] = useState(false);
 
   window.accountId = accountId ?? window.accountId;
 
@@ -180,7 +181,13 @@ const PurchaseModal = ({
               items={[
                 {
                   title: "Region and taxes",
-                  content: <Taxes product={product} quantity={quantity} />,
+                  content: (
+                    <Taxes
+                      product={product}
+                      quantity={quantity}
+                      setTaxSaved={setTaxSaved}
+                    />
+                  ),
                 },
                 {
                   title: "Your purchase",
@@ -230,6 +237,7 @@ const PurchaseModal = ({
                 quantity={quantity}
                 action={action}
                 isCardValid={isCardValid}
+                isTaxSaved={isTaxSaved}
               ></BuyButton>
             </ModalFooter>
           </>

--- a/static/js/src/PurchaseModal/components/BuyButton/BuyButton.tsx
+++ b/static/js/src/PurchaseModal/components/BuyButton/BuyButton.tsx
@@ -17,6 +17,7 @@ type Props = {
   product: Product;
   action: Action;
   isCardValid: boolean;
+  isTaxSaved: boolean;
 };
 
 const BuyButton = ({
@@ -25,6 +26,7 @@ const BuyButton = ({
   product,
   action,
   isCardValid,
+  isTaxSaved,
 }: Props) => {
   const [isLoading, setIsLoading] = useState(false);
   const [isButtonDisabled, setIsButtonDisabled] = useState(true);
@@ -38,9 +40,9 @@ const BuyButton = ({
   } = useFormikContext<FormValues>();
 
   const genericPurchaseMutation = useMakePurchase();
-
   useEffect(() => {
     if (
+      !isTaxSaved ||
       !isCardValid ||
       !values.email ||
       !values.name ||
@@ -60,7 +62,7 @@ const BuyButton = ({
     } else {
       setIsButtonDisabled(false);
     }
-  }, [values, isCardValid]);
+  }, [values, isCardValid, isTaxSaved]);
 
   const buyAction = values.FreeTrial === "useFreeTrial" ? "trial" : action;
 

--- a/static/js/src/PurchaseModal/components/BuyButton/BuyButton.tsx
+++ b/static/js/src/PurchaseModal/components/BuyButton/BuyButton.tsx
@@ -27,6 +27,7 @@ const BuyButton = ({
   isCardValid,
 }: Props) => {
   const [isLoading, setIsLoading] = useState(false);
+  const [isButtonDisabled, setIsButtonDisabled] = useState(true);
 
   const { data: userInfo } = useStripeCustomerInfo();
 
@@ -38,12 +39,28 @@ const BuyButton = ({
 
   const genericPurchaseMutation = useMakePurchase();
 
-  const isButtonDisabled =
-    !values.captchaValue ||
-    !values.TermsAndConditions ||
-    !values.Description ||
-    isLoading ||
-    !isCardValid;
+  useEffect(() => {
+    if (
+      !isCardValid ||
+      !values.email ||
+      !values.name ||
+      !values.address ||
+      !values.postalCode ||
+      !values.city ||
+      !values.country ||
+      !values.captchaValue ||
+      !values.TermsAndConditions ||
+      !values.Description ||
+      isLoading ||
+      (values.country === "US" && !values.usState) ||
+      (values.country === "CA" && !values.caProvince) ||
+      (values.buyingFor === "organisation" && !values.organisationName)
+    ) {
+      setIsButtonDisabled(true);
+    } else {
+      setIsButtonDisabled(false);
+    }
+  }, [values, isCardValid]);
 
   const buyAction = values.FreeTrial === "useFreeTrial" ? "trial" : action;
 

--- a/static/js/src/PurchaseModal/components/BuyButton/BuyButton.tsx
+++ b/static/js/src/PurchaseModal/components/BuyButton/BuyButton.tsx
@@ -62,7 +62,7 @@ const BuyButton = ({
     } else {
       setIsButtonDisabled(false);
     }
-  }, [values, isCardValid, isTaxSaved]);
+  }, [values, isLoading, isCardValid, isTaxSaved]);
 
   const buyAction = values.FreeTrial === "useFreeTrial" ? "trial" : action;
 

--- a/static/js/src/PurchaseModal/components/Taxes/Taxes.test.tsx
+++ b/static/js/src/PurchaseModal/components/Taxes/Taxes.test.tsx
@@ -16,7 +16,7 @@ describe("PaymentMethodSummary", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <Formik initialValues={{}} onSubmit={jest.fn()}>
-          <Taxes product={product} quantity={1} />
+          <Taxes product={product} quantity={1} setTaxSaved={jest.fn()} />
         </Formik>
       </QueryClientProvider>
     );
@@ -29,7 +29,7 @@ describe("PaymentMethodSummary", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <Formik initialValues={{}} onSubmit={jest.fn()}>
-          <Taxes product="test" quantity={1} />
+          <Taxes product="test" quantity={1} setTaxSaved={jest.fn()} />
         </Formik>
       </QueryClientProvider>
     );
@@ -44,7 +44,7 @@ describe("PaymentMethodSummary", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <Formik initialValues={{}} onSubmit={jest.fn()}>
-          <Taxes product={product} quantity={1} />
+          <Taxes product={product} quantity={1} setTaxSaved={jest.fn()} />
         </Formik>
       </QueryClientProvider>
     );
@@ -61,7 +61,7 @@ describe("PaymentMethodSummary", () => {
     const { getByTestId } = render(
       <QueryClientProvider client={queryClient}>
         <Formik initialValues={{}} onSubmit={jest.fn()}>
-          <Taxes product="test" quantity={1} />
+          <Taxes product="test" quantity={1} setTaxSaved={jest.fn()} />
         </Formik>
       </QueryClientProvider>
     );

--- a/static/js/src/PurchaseModal/components/Taxes/Taxes.tsx
+++ b/static/js/src/PurchaseModal/components/Taxes/Taxes.tsx
@@ -20,9 +20,10 @@ import useStripeCustomerInfo from "PurchaseModal/hooks/useStripeCustomerInfo";
 type TaxesProps = {
   product: any;
   quantity: number;
+  setTaxSaved: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
-const Taxes = ({ product, quantity }: TaxesProps) => {
+const Taxes = ({ product, quantity, setTaxSaved }: TaxesProps) => {
   const {
     errors,
     touched,
@@ -51,11 +52,13 @@ const Taxes = ({ product, quantity }: TaxesProps) => {
 
   const onSaveClick = () => {
     setIsEditing(false);
+    setTaxSaved(true);
     taxMutation.mutate();
   };
 
   const onEditClick = () => {
     setIsEditing(true);
+    setTaxSaved(false);
   };
 
   const validateRequired = (value: string) => {

--- a/static/js/src/PurchaseModal/components/Taxes/Taxes.tsx
+++ b/static/js/src/PurchaseModal/components/Taxes/Taxes.tsx
@@ -40,6 +40,7 @@ const Taxes = ({ product, quantity, setTaxSaved }: TaxesProps) => {
   useEffect(() => {
     if (savedCountry) {
       setIsEditing(!savedCountry);
+      setTaxSaved(savedCountry);
     }
   }, [savedCountry]);
 


### PR DESCRIPTION
## Done

Disable buy button when a value is missing

## QA

- Go to /pro/subscribe
- Check `Buy now` button is disabled when a value is missing.
- Check `Buy now` button is active when all values are filled. 

## Issue / Card

Fixes https://warthogs.atlassian.net/jira/software/c/projects/WD/boards/801?modal=detail&selectedIssue=WD-668


[WD-668]: https://warthogs.atlassian.net/browse/WD-668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ