### PR TITLE
Copy update: openstack/consulting (WD-757)

### DIFF
--- a/static/js/data/openstack-deployment-stats.json
+++ b/static/js/data/openstack-deployment-stats.json
@@ -1,32 +1,20 @@
 {
   "stats": [
-    { "index": 1, "percentage": 35, "id": "centos", "name": "CentOS" },
+    { "index": 1, "percentage": 27, "id": "centos", "name": "CentOS" },
     { "index": 2, "percentage": 7, "id": "debian", "name": "Debian" },
     {
       "index": 3,
-      "percentage": 1,
-      "id": "microsoft-windows-server",
-      "name": "Microsoft Windows Server"
-    },
-    {
-      "index": 4,
-      "percentage": 13,
+      "percentage": 12,
       "id": "red-hat-enterprise-linux",
       "name": "Red Hat Enterprise Linux"
     },
     {
-      "index": 5,
-      "percentage": 40,
+      "index": 4,
+      "percentage": 48,
       "id": "ubuntu-server",
       "name": "Ubuntu Server"
     },
-    {
-      "index": 6,
-      "percentage": 1,
-      "id": "opensuse-server",
-      "name": "openSUSE Server"
-    },
 
-    { "index": 7, "percentage": 3, "id": "other", "name": "Other" }
+    { "index": 5, "percentage": 6, "id": "other", "name": "Other" }
   ]
 }

--- a/templates/openstack/consulting.html
+++ b/templates/openstack/consulting.html
@@ -147,7 +147,7 @@
   <div class="row">
     <div class="u-hide--small u-hide--medium col-6">
       <h2>Number 1 platform for OpenStack implementation</h2>
-      <p>According to the <a href="https://www.openstack.org/analytics/">OpenStack User Survey 2021</a> results, Ubuntu Server is the most popular operating system for OpenStack implementation. Ubuntu Server powers 40% of OpenStack clouds all over the world. It has been chosen as a platform for OpenStack implementation by leading companies in the telco, finance, hardware manufacturing, retail, automotive and healthcare sectors.</p>
+      <p>According to the <a href="https://www.openstack.org/analytics/">OpenStack User Survey 2022</a> results, Ubuntu Server is the most popular operating system for OpenStack implementation. Ubuntu Server powers 48% of OpenStack clouds all over the world. It has been chosen as a platform for OpenStack implementation by leading companies in the telco, finance, hardware manufacturing, retail, automotive and healthcare sectors.</p>
     </div>
     <div class="u-hide--small col-6">
       <div id="openstack-pie-chart"></div>
@@ -157,7 +157,7 @@
     </div>
   </div>
   <div class="u-hide--large u-fixed-width">
-    <p>According to the <a href="https://www.openstack.org/analytics/">OpenStack User Survey 2020</a> results, Ubuntu Server is the most popular operating system for OpenStack implementation. Ubuntu Server powers 40% of OpenStack clouds all over the world. It has been chosen as a platform for OpenStack implementation by leading companies in the telco, finance, hardware manufacturing, retail, automotive and healthcare sectors.</p>
+    <p>According to the <a href="https://www.openstack.org/analytics/">OpenStack User Survey 2022</a> results, Ubuntu Server is the most popular operating system for OpenStack implementation. Ubuntu Server powers 48% of OpenStack clouds all over the world. It has been chosen as a platform for OpenStack implementation by leading companies in the telco, finance, hardware manufacturing, retail, automotive and healthcare sectors.</p>
   </div>
 
   <script src="https://d3js.org/d3.v6.min.js"></script>

--- a/templates/openstack/index.html
+++ b/templates/openstack/index.html
@@ -755,7 +755,7 @@
   <div class="row">
     <div class="u-hide--small u-hide--medium col-6">
       <h2>Number 1 platform for OpenStack implementation</h2>
-      <p>According to the <a href="https://www.openstack.org/analytics/">OpenStack User Survey 2021</a> results, Ubuntu Server is the most popular operating system for OpenStack implementation. Ubuntu Server powers 40% of OpenStack clouds all over the world. It has been chosen as a platform for private cloud implementation by leading companies in the telco, finance, hardware manufacturing, retail, automotive and healthcare sectors.</p>
+      <p>According to the <a href="https://www.openstack.org/analytics/">OpenStack User Survey 2022</a> results, Ubuntu Server is the most popular operating system for OpenStack implementation. Ubuntu Server powers 48% of OpenStack clouds all over the world. It has been chosen as a platform for private cloud implementation by leading companies in the telco, finance, hardware manufacturing, retail, automotive and healthcare sectors.</p>
       <a href="/openstack/compare">Compare OpenStack distros&nbsp;&rsaquo;</a>
     </div>
     <div class="u-hide--small col-6">
@@ -766,7 +766,7 @@
     </div>
   </div>
   <div class="u-hide--large u-fixed-width">
-    <p>According to the <a href="https://www.openstack.org/analytics/">OpenStack User Survey 2020</a> results, Ubuntu Server is the most popular operating system for OpenStack implementation. Ubuntu Server powers 40% of OpenStack clouds all over the world. It has been chosen as a platform for OpenStack implementation by leading companies in the telco, finance, hardware manufacturing, retail, automotive and healthcare sectors.</p>
+    <p>According to the <a href="https://www.openstack.org/analytics/">OpenStack User Survey 2022</a> results, Ubuntu Server is the most popular operating system for OpenStack implementation. Ubuntu Server powers 48% of OpenStack clouds all over the world. It has been chosen as a platform for OpenStack implementation by leading companies in the telco, finance, hardware manufacturing, retail, automotive and healthcare sectors.</p>
     <a href="/openstack/compare">Compare OpenStack distros&nbsp;&rsaquo;</a>
   </div>
 


### PR DESCRIPTION
## Done

- /openstack and /openstack/consulting
  - copy updates
  - graph updates

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Visit https://ubuntu-com-12317.demos.haus/openstack and https://ubuntu-com-12317.demos.haus/openstack/consulting
  - Ensure the section "Number 1 platform for OpenStack implementation" has link text "OpenStack User Survey 2022" on all screen sizes.
  - Ensure the graph has: 
    - Ubuntu Server: 48%
    - CentOS: 27%
    - Red Hat Enterprise Linux: 12%
    - Debian: 7%
    - Other: 6%
- Check the above at all breakpoints

## Issue / Card

Fixes https://github.com/canonical/marketplace-tribe/issues/2944 

## Screenshots

![image](https://user-images.githubusercontent.com/479384/203990729-0f564a3d-929c-4005-b516-b1f8f36e872d.png)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
