### PR TITLE
Update links on /core

### DIFF
--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -451,7 +451,7 @@
           <p class="p-heading-icon__title">Whitepaper</h4>
         </div>
       </div>
-      <h3 class="p-heading--4"><a href="/engage/embedded-linux-make-or-buy/" onclick="dataLayer.push({' event' : 'GAEvent' , 'eventCategory' : 'product page' , 'eventAction' : 'core - left' , 'eventLabel' : 'Whitepaper - Embedded Linux ' , 'eventValue' : '1' });">Embedded Linux: make or buy?&nbsp;&rsaquo;</a></h3>
+      <h3 class="p-heading--4"><a href="https://canonical.foleon.com/whitepapers/yocto-vs-ubuntu-core/" onclick="dataLayer.push({' event' : 'GAEvent' , 'eventCategory' : 'product page' , 'eventAction' : 'core - left' , 'eventLabel' : 'Whitepaper - Embedded Linux ' , 'eventValue' : '1' });">Embedded Linux: Yocto or Ubuntu Core?&nbsp;&rsaquo;</a></h3>
     </div>
     <div class="col-4 p-divider__block">
       <div class="p-heading-icon--small">
@@ -489,7 +489,7 @@
           <p class="p-heading-icon__title">Whitepaper</p>
         </div>
       </div>
-      <h3 class="p-heading--4"><a href="/engage/iot-disk-encryption" onclick="dataLayer.push({' event' : 'GAEvent', 'eventCategory' : 'product page' , 'eventAction' : 'core - center' , 'eventLabel' : 'Whitepaper - Securing IoT device data against physical access' , 'eventValue' : '1' });">Securing IoT device data against physical access&nbsp;&rsaquo;</a></h3>
+      <h3 class="p-heading--4"><a href="/engage/embedded-linux-make-or-buy/" onclick="dataLayer.push({' event' : 'GAEvent', 'eventCategory' : 'product page' , 'eventAction' : 'core - center' , 'eventLabel' : 'Whitepaper - Embedded Linux ' , 'eventValue' : '1' });">Embedded Linux: make or buy?&nbsp;&rsaquo;</a></h3>
       <!-- rtp section center end -->
     </div>
   </div>
@@ -516,7 +516,7 @@
           <p class="p-heading-icon__title">Webinar</p>
         </div>
       </div>
-      <h3 class="p-heading--4"><a href="/engage/intro-to-ubuntu-core22-webinar" onclick="dataLayer.push({' event' : 'GAEvent', 'eventCategory' : 'product page' , 'eventAction' : 'core - left' , 'eventLabel' : 'Webinar - Introuction to Ubuntu Core 20 ' , 'eventValue' : '1' });">Introduction to Ubuntu Core 22&nbsp;&rsaquo;</a></h3>
+      <h3 class="p-heading--4"><a href="https://ubuntu.com/engage/intro-to-ubuntu-core22-webinar#:~:text=With%204%20releases%20behind%2C%20Ubuntu,edge%20devices%20makers%20must%20face." onclick="dataLayer.push({' event' : 'GAEvent', 'eventCategory' : 'product page' , 'eventAction' : 'core - left' , 'eventLabel' : 'Webinar - Introuction to Ubuntu Core 22 ' , 'eventValue' : '1' });">Introduction to Ubuntu Core 22&nbsp;&rsaquo;</a></h3>
       <!-- rtp section left end -->
     </div>
     <div class="col-4 p-divider__block">


### PR DESCRIPTION
## Done

- Updated as per [copy doc](https://docs.google.com/document/d/1UFpefDRSAcndNBnWp0hDyzqk74aciqhBWJEi05htWmU/edit#heading=h.dcmyfgbm6gnd)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/core
    - Be sure to test on mobile, tablet and desktop screen sizes
- See that the requested changes have been made

## Issue / Card

Fixes https://github.com/canonical/web-squad/issues/6251
