### PR TITLE
Set the copydoc link for the Ubuntu Pro legal page

### DIFF
--- a/templates/legal/ubuntu-pro-description/_base_legal_markdown.html
+++ b/templates/legal/ubuntu-pro-description/_base_legal_markdown.html
@@ -2,7 +2,7 @@
 {% block title %}{{ title }}{% endblock title %}
 {% block meta_description %}{{ description }}{% endblock meta_description %}
 
-{% block meta_copydoc %}https://docs.google.com/document/d/1vQNdVmpsB3iQP7SnJHxT3A8rbD5jSAzTEoYUOepR-SM/edit#{% endblock meta_copydoc %}
+{% block meta_copydoc %}https://docs.google.com/document/d/15URkXf2vh7bv89n-cWQPeaP2EehSNUnUCoZvGbNTYFA/edit#{% endblock meta_copydoc %}
 
 {% block outer_content %}
   {% block content %}


### PR DESCRIPTION
## Done
Set the copydoc link for the Ubuntu Pro legal page

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/legal/ubuntu-pro-description
- Check the source and make sure the copydoc meta points at the link specified in the ticket.
## Issue / Card

Fixes https://github.com/canonical/commercial-squad/issues/750
