### PR TITLE
Reduce padding right

### DIFF
--- a/static/sass/_pattern_subscribe.scss
+++ b/static/sass/_pattern_subscribe.scss
@@ -114,6 +114,7 @@
 
     > .heading {
       height: 125px;
+      padding-right: 1rem;
       padding-top: 1.5rem;
     }
 


### PR DESCRIPTION
## Done

-Reduce padding right so "Security coverage for critical, high and selected medium CVEs for:" don't overflow to the next line

## QA

- Go to /pro/subscribe
- Scroll down to step 4 - What security coverage do you need? 
- Check "Security coverage for critical, high and selected medium CVEs for:" 
<img width="1052" alt="image" src="https://user-images.githubusercontent.com/57550290/204760049-56e0ad94-6934-4220-a425-c720dad58572.png">

## Issue / Card

Fixes #https://warthogs.atlassian.net/browse/WD-790
