### PR TITLE
Add IoT devices option in the product selector

### DIFF
--- a/static/js/src/advantage/subscribe/react/components/Form/Feature/Feature.test.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Feature/Feature.test.tsx
@@ -4,6 +4,7 @@ import "@testing-library/jest-dom";
 import { FormProvider } from "advantage/subscribe/react/utils/FormContext";
 import Feature from "./Feature";
 import {
+  IoTDevices,
   ProductListings,
   ProductTypes,
 } from "advantage/subscribe/react/utils/utils";
@@ -41,5 +42,17 @@ test("The section is disabled if a public cloud is selected", () => {
     </FormProvider>
   );
 
+  expect(screen.getByTestId("wrapper")).toHaveClass("u-disable");
+});
+
+test("The section is disabled if IoT devices - Ubuntu Core is selected", async () => {
+  render(
+    <FormProvider
+      initialType={ProductTypes.iotDevice}
+      initialIoTDevice={IoTDevices.core}
+    >
+      <Feature />
+    </FormProvider>
+  );
   expect(screen.getByTestId("wrapper")).toHaveClass("u-disable");
 });

--- a/static/js/src/advantage/subscribe/react/components/Form/Feature/Feature.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Feature/Feature.tsx
@@ -11,7 +11,7 @@ import {
 import { FormContext } from "advantage/subscribe/react/utils/FormContext";
 
 const Feature = () => {
-  const { productType, feature, setFeature, ioTDevice } = useContext(
+  const { productType, feature, setFeature, iotDevice } = useContext(
     FormContext
   );
 
@@ -32,7 +32,7 @@ const Feature = () => {
         "p-divider": true,
         "u-disable":
           isPublicCloud(productType) ||
-          (isIoTDevice(productType) && ioTDevice === IoTDevices.core),
+          (isIoTDevice(productType) && iotDevice === IoTDevices.core),
       })}
       data-testid="wrapper"
     >

--- a/static/js/src/advantage/subscribe/react/components/Form/Feature/Feature.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Feature/Feature.tsx
@@ -3,13 +3,17 @@ import classNames from "classnames";
 import { Col, RadioInput, Row } from "@canonical/react-components";
 import {
   Features,
+  IoTDevices,
+  isIoTDevice,
   isPublicCloud,
   ProductTypes,
 } from "advantage/subscribe/react/utils/utils";
 import { FormContext } from "advantage/subscribe/react/utils/FormContext";
 
 const Feature = () => {
-  const { productType, feature, setFeature } = useContext(FormContext);
+  const { productType, feature, setFeature, ioTDevice } = useContext(
+    FormContext
+  );
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setFeature(event.target.value as Features);
@@ -26,7 +30,9 @@ const Feature = () => {
       className={classNames({
         row: true,
         "p-divider": true,
-        "u-disable": isPublicCloud(productType),
+        "u-disable":
+          isPublicCloud(productType) ||
+          (isIoTDevice(productType) && ioTDevice === IoTDevices.core),
       })}
       data-testid="wrapper"
     >

--- a/static/js/src/advantage/subscribe/react/components/Form/ProductType/ProductType.test.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/ProductType/ProductType.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import userEvent from "@testing-library/user-event";
 import { FormProvider } from "advantage/subscribe/react/utils/FormContext";
@@ -34,4 +34,27 @@ test("Type selector displays the public cloud section if a public cloud is selec
     "href",
     "https://aws.amazon.com/marketplace/search/results?page=1&filters=VendorId&VendorId=e6a5002c-6dd0-4d1e-8196-0a1d1857229b&searchTerms=ubuntu+pro"
   );
+});
+
+test("2 tabs display when IoT devices is selected", () => {
+  render(
+    <FormProvider>
+      <ProductType />
+    </FormProvider>
+  );
+  userEvent.click(screen.getByText("IoT and devices"));
+  expect(screen.findByText("Ubuntu Classic"));
+  expect(screen.findByText("Ubuntu Core"));
+});
+
+test("A button displays when Ubuntu Core is selected", () => {
+  render(
+    <FormProvider>
+      <ProductType />
+    </FormProvider>
+  );
+  userEvent.click(screen.getByText("IoT and devices"));
+  const tab = screen.getByText("Ubuntu Core");
+  fireEvent.click(tab);
+  expect(screen.findByText("Learn more about Ubuntu Core"));
 });

--- a/static/js/src/advantage/subscribe/react/components/Form/ProductType/ProductType.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/ProductType/ProductType.tsx
@@ -2,6 +2,8 @@ import React, { useContext, useState } from "react";
 import { Button, Col, Row } from "@canonical/react-components";
 import { RadioInput } from "@canonical/react-components";
 import {
+  IoTDevices,
+  isIoTDevice,
   isPublicCloud,
   ProductTypes,
   PublicClouds,
@@ -37,10 +39,11 @@ const PublicCloudInfo = {
     link: "",
   },
 };
-
 const ProductType = () => {
   const localPublicCloud = localStorage.getItem("pro-selector-publicCloud");
-  const { productType, setProductType } = useContext(FormContext);
+  const { productType, setProductType, ioTDevice, setIoTDevice } = useContext(
+    FormContext
+  );
   const [publicCloud, setPublicCloud] = useState(
     localPublicCloud
       ? (JSON.parse(localPublicCloud) as PublicClouds)
@@ -133,6 +136,68 @@ const ProductType = () => {
     </>
   );
 
+  const IoTDeviceselector = (
+    <>
+      <div className="p-segmented-control">
+        <div
+          className="p-segmented-control__list"
+          role="tablist"
+          aria-label="IoT device options"
+        >
+          <button
+            className="p-segmented-control__button"
+            role="tab"
+            aria-selected={ioTDevice === IoTDevices.classic}
+            aria-controls={IoTDevices.classic}
+            id={IoTDevices.classic}
+            onClick={(e) => {
+              e.preventDefault();
+              setIoTDevice(IoTDevices.classic);
+              localStorage.setItem(
+                "pro-selector-iotDevice",
+                JSON.stringify(IoTDevices.classic)
+              );
+            }}
+          >
+            Ubuntu Classic
+          </button>
+          <dfn></dfn>
+          <button
+            className="p-segmented-control__button"
+            role="tab"
+            aria-selected={ioTDevice === IoTDevices.core}
+            aria-controls={IoTDevices.core}
+            id={IoTDevices.core}
+            onClick={(e) => {
+              e.preventDefault();
+              setIoTDevice(IoTDevices.core);
+              localStorage.setItem(
+                "pro-selector-iotDevice",
+                JSON.stringify(IoTDevices.core)
+              );
+            }}
+          >
+            Ubuntu Core
+          </button>
+        </div>
+      </div>
+      {ioTDevice === IoTDevices.core && (
+        <>
+          <p>
+            <strong> Ubuntu Core </strong>
+          </p>
+          <p>
+            If you are interested in Ubuntu Core, please{" "}
+            <a href="/core/contact-us">contact us</a>.
+          </p>
+          <Button element="a" href="/core">
+            Learn more about Ubuntu Core
+          </Button>
+        </>
+      )}
+    </>
+  );
+
   return (
     <>
       <Row>
@@ -165,6 +230,18 @@ const ProductType = () => {
             onChange={handleProductTypeChange}
             checked={productType === ProductTypes.desktop}
           />
+        </Col>
+        <Col size={12}>
+          <RadioInput
+            label="IoT devices"
+            name="type"
+            value={ProductTypes.ioTDevice}
+            onChange={handleProductTypeChange}
+            checked={productType === ProductTypes.ioTDevice}
+          />
+        </Col>
+        <Col size={12} style={{ marginLeft: "35px" }}>
+          {isIoTDevice(productType) ? IoTDeviceselector : null}
         </Col>
       </Row>
     </>

--- a/static/js/src/advantage/subscribe/react/components/Form/ProductType/ProductType.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/ProductType/ProductType.tsx
@@ -41,7 +41,7 @@ const PublicCloudInfo = {
 };
 const ProductType = () => {
   const localPublicCloud = localStorage.getItem("pro-selector-publicCloud");
-  const { productType, setProductType, ioTDevice, setIoTDevice } = useContext(
+  const { productType, setProductType, iotDevice, setIoTDevice } = useContext(
     FormContext
   );
   const [publicCloud, setPublicCloud] = useState(
@@ -147,7 +147,7 @@ const ProductType = () => {
           <button
             className="p-segmented-control__button"
             role="tab"
-            aria-selected={ioTDevice === IoTDevices.classic}
+            aria-selected={iotDevice === IoTDevices.classic}
             aria-controls={IoTDevices.classic}
             id={IoTDevices.classic}
             onClick={(e) => {
@@ -165,7 +165,7 @@ const ProductType = () => {
           <button
             className="p-segmented-control__button"
             role="tab"
-            aria-selected={ioTDevice === IoTDevices.core}
+            aria-selected={iotDevice === IoTDevices.core}
             aria-controls={IoTDevices.core}
             id={IoTDevices.core}
             onClick={(e) => {
@@ -181,7 +181,7 @@ const ProductType = () => {
           </button>
         </div>
       </div>
-      {ioTDevice === IoTDevices.core && (
+      {iotDevice === IoTDevices.core && (
         <>
           <p>
             <strong> Ubuntu Core </strong>
@@ -235,9 +235,9 @@ const ProductType = () => {
           <RadioInput
             label="IoT and devices"
             name="type"
-            value={ProductTypes.ioTDevice}
+            value={ProductTypes.iotDevice}
             onChange={handleProductTypeChange}
-            checked={productType === ProductTypes.ioTDevice}
+            checked={productType === ProductTypes.iotDevice}
           />
         </Col>
         <Col size={12} style={{ marginLeft: "35px" }}>

--- a/static/js/src/advantage/subscribe/react/components/Form/ProductType/ProductType.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/ProductType/ProductType.tsx
@@ -233,7 +233,7 @@ const ProductType = () => {
         </Col>
         <Col size={12}>
           <RadioInput
-            label="IoT devices"
+            label="IoT and devices"
             name="type"
             value={ProductTypes.ioTDevice}
             onChange={handleProductTypeChange}

--- a/static/js/src/advantage/subscribe/react/components/Form/Quantity/Quantity.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Quantity/Quantity.tsx
@@ -2,10 +2,16 @@ import React, { useContext } from "react";
 import classNames from "classnames";
 import { Col, Input, Row } from "@canonical/react-components";
 import { FormContext } from "advantage/subscribe/react/utils/FormContext";
-import { isPublicCloud } from "advantage/subscribe/react/utils/utils";
+import {
+  IoTDevices,
+  isIoTDevice,
+  isPublicCloud,
+} from "advantage/subscribe/react/utils/utils";
 
 const Quantity = () => {
-  const { quantity, setQuantity, productType } = useContext(FormContext);
+  const { quantity, setQuantity, productType, ioTDevice } = useContext(
+    FormContext
+  );
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     if (Number(event.target.value) > 0) {
@@ -22,7 +28,9 @@ const Quantity = () => {
   return (
     <div
       className={classNames({
-        "u-disable": isPublicCloud(productType),
+        "u-disable":
+          isPublicCloud(productType) ||
+          (isIoTDevice(productType) && ioTDevice === IoTDevices.core),
       })}
       data-testid="wrapper"
     >

--- a/static/js/src/advantage/subscribe/react/components/Form/Quantity/Quantity.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Quantity/Quantity.tsx
@@ -9,7 +9,7 @@ import {
 } from "advantage/subscribe/react/utils/utils";
 
 const Quantity = () => {
-  const { quantity, setQuantity, productType, ioTDevice } = useContext(
+  const { quantity, setQuantity, productType, iotDevice } = useContext(
     FormContext
   );
 
@@ -30,7 +30,7 @@ const Quantity = () => {
       className={classNames({
         "u-disable":
           isPublicCloud(productType) ||
-          (isIoTDevice(productType) && ioTDevice === IoTDevices.core),
+          (isIoTDevice(productType) && iotDevice === IoTDevices.core),
       })}
       data-testid="wrapper"
     >

--- a/static/js/src/advantage/subscribe/react/components/Form/Support/Support.test.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Support/Support.test.tsx
@@ -8,6 +8,7 @@ import {
   ProductListings,
   ProductTypes,
   Features,
+  IoTDevices,
 } from "advantage/subscribe/react/utils/utils";
 import { productListFixture } from "advantage/subscribe/react/utils/test/Mocks";
 
@@ -66,5 +67,17 @@ test("The section is disabled if a public cloud is selected", () => {
     </FormProvider>
   );
 
+  expect(screen.getByTestId("wrapper")).toHaveClass("u-disable");
+});
+
+test("The section is disabled if IoT devices - Ubuntu Core is selected", async () => {
+  render(
+    <FormProvider
+      initialType={ProductTypes.iotDevice}
+      initialIoTDevice={IoTDevices.core}
+    >
+      <Support />
+    </FormProvider>
+  );
   expect(screen.getByTestId("wrapper")).toHaveClass("u-disable");
 });

--- a/static/js/src/advantage/subscribe/react/components/Form/Support/Support.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Support/Support.tsx
@@ -8,6 +8,8 @@ import {
   SLA,
   Support as SupportEnum,
   LTSVersions,
+  IoTDevices,
+  isIoTDevice,
 } from "advantage/subscribe/react/utils/utils";
 import { FormContext } from "advantage/subscribe/react/utils/FormContext";
 
@@ -20,6 +22,7 @@ const Support = () => {
     setSupport,
     productType,
     version,
+    ioTDevice,
   } = useContext(FormContext);
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -44,7 +47,9 @@ const Support = () => {
     <div
       className={classNames({
         row: true,
-        "u-disable": isPublicCloud(productType),
+        "u-disable":
+          isPublicCloud(productType) ||
+          (isIoTDevice(productType) && ioTDevice === IoTDevices.core),
       })}
       data-testid="wrapper"
     >

--- a/static/js/src/advantage/subscribe/react/components/Form/Support/Support.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Support/Support.tsx
@@ -22,7 +22,7 @@ const Support = () => {
     setSupport,
     productType,
     version,
-    ioTDevice,
+    iotDevice,
   } = useContext(FormContext);
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -49,7 +49,7 @@ const Support = () => {
         row: true,
         "u-disable":
           isPublicCloud(productType) ||
-          (isIoTDevice(productType) && ioTDevice === IoTDevices.core),
+          (isIoTDevice(productType) && iotDevice === IoTDevices.core),
       })}
       data-testid="wrapper"
     >

--- a/static/js/src/advantage/subscribe/react/components/Form/Version/Version.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Version/Version.tsx
@@ -145,7 +145,7 @@ const DesktopVersionDetails: {
 };
 
 const Version = () => {
-  const { version, setVersion, productType, ioTDevice } = useContext(
+  const { version, setVersion, productType, iotDevice } = useContext(
     FormContext
   );
 
@@ -192,7 +192,7 @@ const Version = () => {
       className={classNames({
         "u-disable":
           isPublicCloud(productType) ||
-          (isIoTDevice(productType) && ioTDevice === IoTDevices.core),
+          (isIoTDevice(productType) && iotDevice === IoTDevices.core),
       })}
       data-testid="wrapper"
     >

--- a/static/js/src/advantage/subscribe/react/components/Form/Version/Version.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Version/Version.tsx
@@ -2,6 +2,8 @@ import React, { useContext } from "react";
 import { Col, List, Row, StatusLabel } from "@canonical/react-components";
 import classNames from "classnames";
 import {
+  IoTDevices,
+  isIoTDevice,
   isPublicCloud,
   LTSVersions,
   ProductTypes,
@@ -143,7 +145,9 @@ const DesktopVersionDetails: {
 };
 
 const Version = () => {
-  const { version, setVersion, productType } = useContext(FormContext);
+  const { version, setVersion, productType, ioTDevice } = useContext(
+    FormContext
+  );
 
   const versionDetails =
     productType === ProductTypes.desktop
@@ -185,7 +189,11 @@ const Version = () => {
 
   return (
     <div
-      className={classNames({ "u-disable": isPublicCloud(productType) })}
+      className={classNames({
+        "u-disable":
+          isPublicCloud(productType) ||
+          (isIoTDevice(productType) && ioTDevice === IoTDevices.core),
+      })}
       data-testid="wrapper"
     >
       <Row>

--- a/static/js/src/advantage/subscribe/react/components/ProductSummary/ProductSummary.tsx
+++ b/static/js/src/advantage/subscribe/react/components/ProductSummary/ProductSummary.tsx
@@ -1,12 +1,24 @@
 import React, { useContext } from "react";
 import { Col, Row, Select, StatusLabel } from "@canonical/react-components";
 import { FormContext } from "advantage/subscribe/react/utils/FormContext";
-import { isMonthlyAvailable, Periods } from "../../utils/utils";
+import {
+  IoTDevices,
+  isMonthlyAvailable,
+  Periods,
+  ProductTypes,
+} from "../../utils/utils";
 import { currencyFormatter } from "advantage/react/utils";
 import PaymentModal from "../PaymentModal";
 
 const ProductSummary = () => {
-  const { quantity, period, setPeriod, product } = useContext(FormContext);
+  const {
+    quantity,
+    period,
+    setPeriod,
+    product,
+    iotDevice,
+    productType,
+  } = useContext(FormContext);
   const handlePeriodChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
     setPeriod(event.target.value as Periods);
     localStorage.setItem(
@@ -14,8 +26,11 @@ const ProductSummary = () => {
       JSON.stringify(event.target.value as Periods)
     );
   };
-
-  const isHidden = !product || !quantity || quantity < 1;
+  const isHidden =
+    !product ||
+    !quantity ||
+    quantity < 1 ||
+    (productType === ProductTypes.iotDevice && iotDevice === IoTDevices.core);
 
   return (
     <>
@@ -74,9 +89,13 @@ const ProductSummary = () => {
           </Col>
           <Col size={2} className="u-align--right">
             <p className="p-heading--2">
-              {currencyFormatter.format(
-                ((product?.price.value ?? 0) / 100) * (Number(quantity) ?? 0)
-              )}
+              {productType === ProductTypes.iotDevice &&
+              iotDevice === IoTDevices.core
+                ? currencyFormatter.format(0)
+                : currencyFormatter.format(
+                    ((product?.price.value ?? 0) / 100) *
+                      (Number(quantity) ?? 0)
+                  )}
             </p>{" "}
             <p className="p-text--small">
               per {period === Periods.yearly ? "year" : "month"}

--- a/static/js/src/advantage/subscribe/react/components/ProductSummary/ProductSummary.tsx
+++ b/static/js/src/advantage/subscribe/react/components/ProductSummary/ProductSummary.tsx
@@ -89,13 +89,9 @@ const ProductSummary = () => {
           </Col>
           <Col size={2} className="u-align--right">
             <p className="p-heading--2">
-              {productType === ProductTypes.iotDevice &&
-              iotDevice === IoTDevices.core
-                ? currencyFormatter.format(0)
-                : currencyFormatter.format(
-                    ((product?.price.value ?? 0) / 100) *
-                      (Number(quantity) ?? 0)
-                  )}
+              {currencyFormatter.format(
+                ((product?.price.value ?? 0) / 100) * (Number(quantity) ?? 0)
+              )}
             </p>{" "}
             <p className="p-text--small">
               per {period === Periods.yearly ? "year" : "month"}

--- a/static/js/src/advantage/subscribe/react/utils/FormContext.tsx
+++ b/static/js/src/advantage/subscribe/react/utils/FormContext.tsx
@@ -154,8 +154,15 @@ export const FormProvider = ({
 
   useEffect(() => {
     const product = getProduct(productType, feature, support, sla, period);
-    setProduct(window.productList[product] ?? null);
-  }, [feature, productType, sla, support, period]);
+    if (
+      productType === ProductTypes.iotDevice &&
+      iotDevice === IoTDevices.core
+    ) {
+      setProduct(null);
+    } else {
+      setProduct(window.productList[product] ?? null);
+    }
+  }, [feature, productType, sla, support, period, iotDevice]);
 
   useEffect(() => {
     if (!isMonthlyAvailable(product)) {

--- a/static/js/src/advantage/subscribe/react/utils/FormContext.tsx
+++ b/static/js/src/advantage/subscribe/react/utils/FormContext.tsx
@@ -9,6 +9,7 @@ import {
   Periods,
   SLA,
   isMonthlyAvailable,
+  IoTDevices,
 } from "./utils";
 
 interface FormContext {
@@ -27,6 +28,8 @@ interface FormContext {
   product: Product | null;
   period: Periods;
   setPeriod: React.Dispatch<React.SetStateAction<Periods>>;
+  ioTDevice: IoTDevices;
+  setIoTDevice: React.Dispatch<React.SetStateAction<IoTDevices>>;
 }
 
 export const defaultValues: FormContext = {
@@ -45,6 +48,8 @@ export const defaultValues: FormContext = {
   period: Periods.yearly,
   setPeriod: () => {},
   product: null,
+  ioTDevice: IoTDevices.classic,
+  setIoTDevice: () => {},
 };
 
 export const FormContext = createContext<FormContext>(defaultValues);
@@ -57,6 +62,7 @@ interface FormProviderProps {
   initialSupport?: Support;
   initialQuantity?: number | string;
   initialPeriod?: Periods;
+  initialIoTDevice?: IoTDevices;
   children: React.ReactNode;
 }
 
@@ -68,6 +74,7 @@ export const FormProvider = ({
   initialSupport = defaultValues.support,
   initialQuantity = defaultValues.quantity,
   initialPeriod = defaultValues.period,
+  initialIoTDevice = defaultValues.ioTDevice,
   children,
 }: FormProviderProps) => {
   const localProductType = localStorage.getItem("pro-selector-productType");
@@ -77,6 +84,7 @@ export const FormProvider = ({
   const localSupport = localStorage.getItem("pro-selector-support");
   const localSLA = localStorage.getItem("pro-selector-sla");
   const localPeriod = localStorage.getItem("pro-selector-period");
+  const localIoTDevice = localStorage.getItem("pro-selector-iotDevice");
 
   const [productType, setProductType] = useState<ProductTypes>(
     localProductType ? JSON.parse(localProductType) : initialType
@@ -100,6 +108,9 @@ export const FormProvider = ({
     localPeriod ? JSON.parse(localPeriod) : initialPeriod
   );
   const [product, setProduct] = useState<Product | null>(null);
+  const [ioTDevice, setIoTDevice] = useState<IoTDevices>(
+    localIoTDevice ? JSON.parse(localIoTDevice) : initialIoTDevice
+  );
 
   useEffect(() => {
     if (support === Support.none) {
@@ -170,6 +181,8 @@ export const FormProvider = ({
         period,
         setPeriod,
         product,
+        ioTDevice,
+        setIoTDevice,
       }}
     >
       {children}

--- a/static/js/src/advantage/subscribe/react/utils/FormContext.tsx
+++ b/static/js/src/advantage/subscribe/react/utils/FormContext.tsx
@@ -28,7 +28,7 @@ interface FormContext {
   product: Product | null;
   period: Periods;
   setPeriod: React.Dispatch<React.SetStateAction<Periods>>;
-  ioTDevice: IoTDevices;
+  iotDevice: IoTDevices;
   setIoTDevice: React.Dispatch<React.SetStateAction<IoTDevices>>;
 }
 
@@ -48,7 +48,7 @@ export const defaultValues: FormContext = {
   period: Periods.yearly,
   setPeriod: () => {},
   product: null,
-  ioTDevice: IoTDevices.classic,
+  iotDevice: IoTDevices.classic,
   setIoTDevice: () => {},
 };
 
@@ -74,7 +74,7 @@ export const FormProvider = ({
   initialSupport = defaultValues.support,
   initialQuantity = defaultValues.quantity,
   initialPeriod = defaultValues.period,
-  initialIoTDevice = defaultValues.ioTDevice,
+  initialIoTDevice = defaultValues.iotDevice,
   children,
 }: FormProviderProps) => {
   const localProductType = localStorage.getItem("pro-selector-productType");
@@ -108,7 +108,7 @@ export const FormProvider = ({
     localPeriod ? JSON.parse(localPeriod) : initialPeriod
   );
   const [product, setProduct] = useState<Product | null>(null);
-  const [ioTDevice, setIoTDevice] = useState<IoTDevices>(
+  const [iotDevice, setIoTDevice] = useState<IoTDevices>(
     localIoTDevice ? JSON.parse(localIoTDevice) : initialIoTDevice
   );
 
@@ -181,7 +181,7 @@ export const FormProvider = ({
         period,
         setPeriod,
         product,
-        ioTDevice,
+        iotDevice,
         setIoTDevice,
       }}
     >

--- a/static/js/src/advantage/subscribe/react/utils/utils.ts
+++ b/static/js/src/advantage/subscribe/react/utils/utils.ts
@@ -108,6 +108,12 @@ export enum ProductTypes {
   virtual = "virtual",
   desktop = "desktop",
   publicCloud = "publicCloud",
+  ioTDevice = "ioTDevice",
+}
+
+export enum IoTDevices {
+  classic = "classic",
+  core = "core",
 }
 
 export enum PublicClouds {
@@ -195,6 +201,12 @@ export const isMonthlyAvailable = (product: Product | null) => {
 
 export const isPublicCloud = (type: ProductTypes) =>
   type === ProductTypes.publicCloud;
+
+export const isIoTDevice = (type: ProductTypes) =>
+  type === ProductTypes.ioTDevice;
+
+export const isDeviceUbuntuCore = (type: IoTDevices) =>
+  type === IoTDevices.core;
 
 export const formatter = new Intl.NumberFormat("en-US", {
   style: "currency",

--- a/static/js/src/advantage/subscribe/react/utils/utils.ts
+++ b/static/js/src/advantage/subscribe/react/utils/utils.ts
@@ -108,7 +108,7 @@ export enum ProductTypes {
   virtual = "virtual",
   desktop = "desktop",
   publicCloud = "publicCloud",
-  ioTDevice = "ioTDevice",
+  iotDevice = "iotDevice",
 }
 
 export enum IoTDevices {
@@ -203,7 +203,7 @@ export const isPublicCloud = (type: ProductTypes) =>
   type === ProductTypes.publicCloud;
 
 export const isIoTDevice = (type: ProductTypes) =>
-  type === ProductTypes.ioTDevice;
+  type === ProductTypes.iotDevice;
 
 export const isDeviceUbuntuCore = (type: IoTDevices) =>
   type === IoTDevices.core;
@@ -250,6 +250,26 @@ export const getProduct = (
       return "uai-standard-desktop-yearly";
     case `${ProductTypes.desktop}-${Features.pro}-${Support.full}-${SLA.everyday}-${Periods.yearly}`:
       return "uai-advanced-desktop-yearly";
+    case `${ProductTypes.iotDevice}-${Features.infra}-${Support.none}-${SLA.none}-${Periods.yearly}`:
+      return "uai-essential-physical-yearly";
+    case `${ProductTypes.iotDevice}-${Features.infra}-${Support.none}-${SLA.none}-${Periods.monthly}`:
+      return "uai-essential-physical-monthly";
+    case `${ProductTypes.iotDevice}-${Features.infra}-${Support.infra}-${SLA.weekday}-${Periods.yearly}`:
+      return "uai-standard-physical-yearly";
+    case `${ProductTypes.iotDevice}-${Features.infra}-${Support.infra}-${SLA.everyday}-${Periods.yearly}`:
+      return "uai-advanced-physical-yearly";
+    case `${ProductTypes.iotDevice}-${Features.pro}-${Support.none}-${SLA.none}-${Periods.yearly}`:
+      return "uaia-essential-physical-yearly";
+    case `${ProductTypes.iotDevice}-${Features.pro}-${Support.none}-${SLA.none}-${Periods.monthly}`:
+      return "uaia-essential-physical-monthly";
+    case `${ProductTypes.iotDevice}-${Features.pro}-${Support.infra}-${SLA.weekday}-${Periods.yearly}`:
+      return "uio-standard-physical-yearly";
+    case `${ProductTypes.iotDevice}-${Features.pro}-${Support.infra}-${SLA.everyday}-${Periods.yearly}`:
+      return "uio-advanced-physical-yearly";
+    case `${ProductTypes.iotDevice}-${Features.pro}-${Support.full}-${SLA.weekday}-${Periods.yearly}`:
+      return "uaia-standard-physical-yearly";
+    case `${ProductTypes.iotDevice}-${Features.pro}-${Support.full}-${SLA.everyday}-${Periods.yearly}`:
+      return "uaia-advanced-physical-yearly";
     default:
       return "no-product";
   }


### PR DESCRIPTION

## Done

- Add IoT devices option in the product selector

## QA

- Go to `/pro/subscribe`
- Click `IoT devices`
<img width="481" alt="image" src="https://user-images.githubusercontent.com/57550290/204875728-fe517e76-7ea5-4398-a015-d8a4c007f127.png">
- R
-Please refer to the issue below and QA accordingly 

## Issue / Card

Fixes #https://warthogs.atlassian.net/jira/software/c/projects/WD/boards/801?modal=detail&selectedIssue=WD-808
