### PR TITLE
Change what fields the unsubscribe button updates on marketo

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -754,12 +754,12 @@ body {
   z-index: 10;
 }
 
-#unsubscribe {
+#unsubscribed {
   display: none;
   position: absolute;
 }
 
-#unsubscribe:target {
+#unsubscribed:target {
   display: block;
   z-index: 10;
 }

--- a/templates/subscription-centre/index.html
+++ b/templates/subscription-centre/index.html
@@ -91,7 +91,7 @@
     <p id="modal-description">Are you sure you want to unsubscribe from all topics?</p>
     <footer class="p-modal__footer">
       <button class="u-no-margin--bottom" aria-controls="modal">Cancel</button>
-      <button id="unsubscribe-btn" class="p-button--negative u-no-margin--bottom">Unsubscribe</button>
+      <button id="unsubscribe" class="p-button--negative u-no-margin--bottom">Unsubscribe</button>
     </footer>
     </div>
   </section>
@@ -106,27 +106,18 @@
 <script>
   // Handles form submissions
   (function() {
-    const generalUdatesOptin = document.querySelector("#general-updates");
     const form = document.querySelector("#subscription-centre");
     const returnUrl = document.querySelector("#return-url");
     let hasRun = false;
 
-    const clearFields = () => {
-      generalUdatesOptin.checked = false;
-    };
-
     const handleUpdatePreferencesBtn = (e) => {
       e.preventDefault();
-
-      returnUrl.value = "#updated";
       form.submit();
     };
 
     const handleUnsubscribeBtn = async (e) => {
       e.preventDefault();
-
-      await clearFields();
-      returnUrl.value = "#unsubscribe";
+      returnUrl.value = "#unsubscribed";
       form.submit();
     };
 
@@ -137,7 +128,7 @@
 
     document.querySelector("#update-preferences").addEventListener("click", handleUpdatePreferencesBtn, { once: true });
 
-    document.querySelector("#unsubscribe-btn").addEventListener("click", handleUnsubscribeBtn, { once: true });
+    document.querySelector("#unsubscribe").addEventListener("click", handleUnsubscribeBtn, { once: true });
 
     form.addEventListener('input', () => {
       if (hasRun) return;

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -86,7 +86,7 @@
         </div>
       </div>
     </div>
-    <div id="unsubscribe" class="p-strip u-no-padding--top">
+    <div id="unsubscribed" class="p-strip u-no-padding--top">
       <div class="u-fixed-width">
         <div class="p-notification--positive u-no-margin--bottom">
           <div class="p-notification__content">

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -972,14 +972,14 @@ def subscription_centre():
         return flask.redirect("/blog")
 
     if flask.request.method == "POST":
-        if return_url == "#unsubscribe":
-            subscription_centre_submit(sfdcLeadId, True)
-            return flask.redirect(f"/{return_url}")
-        else:
+        if not return_url:
             subscription_centre_submit(sfdcLeadId, False)
             return flask.redirect(
-                f"{flask.request.path}?id={sfdcLeadId}{return_url}"
+                f"{flask.request.path}?id={sfdcLeadId}#updated"
             )
+        else:
+            subscription_centre_submit(sfdcLeadId, True)
+            return flask.redirect(f"/{return_url}")
 
     with open("subscriptions.yaml") as subscriptions:
         subscriptions = yaml.load(subscriptions, Loader=yaml.FullLoader)
@@ -1008,11 +1008,8 @@ def subscription_centre():
 
 def subscription_centre_submit(sfdcLeadId, unsubscribe):
     updatesOptIn = flask.request.form.get("generalUpdates") or False
-    if unsubscribe:
-        tagListString = ""
-    else:
-        tagListArray = flask.request.form.getlist("tags")
-        tagListString = ",".join(tagListArray)
+    tagListArray = flask.request.form.getlist("tags")
+    tagListString = ",".join(tagListArray)
 
     payload = {
         "lookupField": "sfdcLeadId",
@@ -1021,6 +1018,7 @@ def subscription_centre_submit(sfdcLeadId, unsubscribe):
                 "sfdcLeadId": sfdcLeadId,
                 "prototype_interests": tagListString,
                 "canonicalUpdatesOptIn": updatesOptIn,
+                "unsubscribed": unsubscribe,
             }
         ],
     }


### PR DESCRIPTION
## Done

- Updates what fields the unsubscribe button updates
- This led to some minor refactors of the code

## QA

- Go to [the user's marketo](https://pastebin.canonical.com/p/cGw8JBDgnx/) and check the 'Unsubscribed' field is `false`, if it is `true`, change it to `false`
- Go to https://ubuntu-com-12335.demos.haus/subscription-centre?id= and use [this user's](https://pastebin.canonical.com/p/GDbFhyTdyV/) id and click 'unsubscribe'. You should be redirected to the u.com homepage and a notification message will appear.
- Go back to the [user's marketo](https://pastebin.canonical.com/p/cGw8JBDgnx/) and see the the 'unsubscribed' field is now `true`


## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-678
