### PR TITLE
Esm page update - div chart instead of a table

### DIFF
--- a/build.js
+++ b/build.js
@@ -28,7 +28,7 @@ let entries = {
   tabbedContent: "./static/js/src/tabbed-content.js",
   utmInheritance: "./static/js/src/utm-inheritance.js",
   "kernel-form": "./static/js/src/kernel-form.js",
-  "random-partner-logos": "./static/js/src/random-partner-logos.js",
+  "random-partner-logos": "./static/js/src/random-partner-logos.js"
 };
 
 const isDev = process && process.env && process.env.NODE_ENV === "development";

--- a/static/js/src/accordion.js
+++ b/static/js/src/accordion.js
@@ -21,7 +21,7 @@ it into view
 @param {HTMLElement} element The tab that acts as the handles.
 */
 function moveInView(element) {
-  // Returns a Boolean based on whether the element in in view
+  // Returns a Boolean based on whether the element is in view
   function isInViewport(element) {
     const rect = element.getBoundingClientRect();
     return (

--- a/static/js/src/accordion.js
+++ b/static/js/src/accordion.js
@@ -21,7 +21,7 @@ it into view
 @param {HTMLElement} element The tab that acts as the handles.
 */
 function moveInView(element) {
-  // Returns a Boolean based on whether the element is in view
+  // Returns a Boolean based on whether the element in in view
   function isInViewport(element) {
     const rect = element.getBoundingClientRect();
     return (

--- a/static/sass/_pattern_active-reveal.scss
+++ b/static/sass/_pattern_active-reveal.scss
@@ -2,6 +2,7 @@
   .p-active-reveal {
     .p-active-reveal__item {
       display: none;
+      margin-top: 0;
     }
 
     .p-active-reveal__switch:checked ~ .p-active-reveal__item {

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -890,9 +890,11 @@ a:hover {
 .u-table-border-bottom {
   border-bottom: 1px solid $color-mid-light;
 }
-.u-overflow-table {
-  min-width: 720px;
-  @media only screen and (min-width: 720px) {
+.u-esm-overflow-table {
+  @media only screen and (max-width: $breakpoint-medium) {
     overflow-x: scroll;
+    .p-table {
+      min-width: $breakpoint-medium;
+    }
   }
 }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -906,7 +906,7 @@ a:hover {
 
   background: url("https://assets.ubuntu.com/v1/18717572-05_suru2_light_glow_8K_edited.png")
     70% bottom;
-    background-size: cover;
+  background-size: cover;
 }
 .p-table--esm-chart {
   border-spacing: 0;
@@ -937,6 +937,87 @@ a:hover {
     }
     th:nth-child(3) {
       width: 68.5%;
+    }
+  }
+}
+
+.p-esm-chart {
+  .p-esm-chart__right-col-axis {
+    border-top: 1px solid $colors--light-theme--border-low-contrast;
+    display: flex;
+    justify-content: space-between;
+  }
+
+  .p-esm-chart__axis-tick {
+    border-right: 1px solid $colors--light-theme--border-low-contrast;
+    flex: 1 1 auto;
+    text-align: right;
+    width: 10%;
+  }
+
+  .p-esm-chart__label {
+    display: flex;
+    flex: 1 1 auto;
+    gap: 0.5rem;
+    margin-bottom: 0;
+    margin-top: 0rem !important;
+  }
+
+  .p-esm-chart__label-numbers {
+    display: inline-block;
+    flex: 0 0 auto;
+    text-align: right;
+    width: 3rem;
+  }
+
+  .p-esm-chart__label-text {
+    @extend %muted-text;
+
+    display: inline-block;
+  }
+
+  .p-esm-chart__left-col {
+    grid-column: auto / span 3;
+    padding: 0 0 0 0.5rem;
+  }
+
+  .p-esm-chart__right-col {
+    grid-column: auto / span 9;
+  }
+
+  .p-esm-chart__right-col--Ubuntu-Pro {
+    background-color: $color-x-dark;
+    color: $color-x-light;
+    font-weight: $font-weight-bold;
+  }
+
+  .p-esm-chart__right-col-lts {
+    background: #e95420;
+    color: $color-x-light;
+    font-weight: $font-weight-bold;
+    width: 50%;
+  }
+
+  .p-esm-chart__row {
+    @extend %vf-row;
+    @include vf-b-row-reset;
+
+    @supports (display: grid) {
+      grid-gap: 0;
+      grid-template-columns: repeat(12, minmax(0, 1fr));
+
+      @media (min-width: $threshold-4-6-col) {
+        grid-template-columns: repeat(12, minmax(0, 1fr));
+      }
+
+      @media (min-width: $threshold-6-12-col) {
+        grid-template-columns: repeat(12, minmax(0, 1fr));
+      }
+    }
+
+    p {
+      padding-left: $sph--small;
+      padding-right: $sph--small;
     }
   }
 }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -890,3 +890,9 @@ a:hover {
 .u-table-border-bottom {
   border-bottom: 1px solid $color-mid-light;
 }
+.u-overflow-table {
+  min-width: 720px;
+  @media only screen and (min-width: 720px) {
+    overflow-x: scroll;
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -973,7 +973,7 @@ a:hover {
     @extend %muted-text;
 
     display: inline-block;
-    
+
     @media (max-width: $threshold-6-12-col) {
       overflow: hidden;
       text-overflow: ellipsis;

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -974,6 +974,12 @@ a:hover {
     @extend %muted-text;
 
     display: inline-block;
+    
+    @media (max-width: $threshold-6-12-col) {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
   }
 
   .p-esm-chart__left-col {

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -906,6 +906,7 @@ a:hover {
 
   background: url("https://assets.ubuntu.com/v1/18717572-05_suru2_light_glow_8K_edited.png")
     70% bottom;
+    background-size: cover;
 }
 .p-table--esm-chart {
   border-spacing: 0;

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -884,17 +884,58 @@ a:hover {
     flex: 0 0 10%;
   }
 }
-.u-table-border-top {
+.u-table-border--top {
   border-top: 1px solid $color-mid-light;
 }
-.u-table-border-bottom {
+.u-table-border--bottom {
   border-bottom: 1px solid $color-mid-light;
+}
+.u-table-border--right {
+  border-right: 1px solid $color-mid-light;
 }
 .u-esm-overflow-table {
   @media only screen and (max-width: $breakpoint-medium) {
     overflow-x: scroll;
     .p-table {
       min-width: $breakpoint-medium;
+    }
+  }
+}
+.p-strip--pro-banner {
+  @extend %vf-strip;
+
+  background: url("https://assets.ubuntu.com/v1/18717572-05_suru2_light_glow_8K_edited.png")
+    70% bottom;
+}
+.p-table--esm-chart {
+  border-spacing: 0;
+  @media only screen and (min-width: $breakpoint-medium) {
+    td:nth-child(1) {
+      padding-left: 0;
+    }
+    th:nth-child(1) {
+      width: 5.8%;
+    }
+    th:nth-child(2) {
+      width: 19%;
+    }
+    th:nth-child(3) {
+      width: 70.5%;
+    }
+  }
+  @media only screen and (max-width: $breakpoint-small) {
+    td:nth-child(1) {
+      padding-left: 0;
+      padding-right: 0;
+    }
+    th:nth-child(1) {
+      width: 7%;
+    }
+    th:nth-child(2) {
+      width: 19%;
+    }
+    th:nth-child(3) {
+      width: 68.5%;
     }
   }
 }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -960,7 +960,6 @@ a:hover {
     flex: 1 1 auto;
     gap: 0.5rem;
     margin-bottom: 0;
-    margin-top: 0 !important;
   }
 
   .p-esm-chart__label-numbers {

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -960,7 +960,7 @@ a:hover {
     flex: 1 1 auto;
     gap: 0.5rem;
     margin-bottom: 0;
-    margin-top: 0rem !important;
+    margin-top: 0 !important;
   }
 
   .p-esm-chart__label-numbers {

--- a/templates/pricing/pro.html
+++ b/templates/pricing/pro.html
@@ -9,7 +9,7 @@
 
 {% block content %}
 
-<section id="ua-infra" class="p-strip--image is-deep" style="background-image:url('https://assets.ubuntu.com/v1/18717572-05_suru2_light_glow_8K_edited.png'); background-position: bottom right;">
+<section id="ua-infra" class="p-strip--pro-banner is-deep">
   <div class="u-fixed-width">
     <h1 class="p-heading--2 u-no-margin--bottom"><strong>Ubuntu Pro: more security, compliance, and support</strong></h1>
     <h2 class="u-no-padding--top u-text--muted">Covering all aspects of open infrastructure and applications</h2>

--- a/templates/security/esm.html
+++ b/templates/security/esm.html
@@ -354,57 +354,79 @@
         </table>
       </div>
     </div>
-
+    
     <div class="u-fixed-width">
-      <table aria-hidden="true" class="p-table--esm-chart">
-        <thead class="u-hidden">
-          <th colspan="2" width="35%">&nbsp;</th>
-          <th colspan="10" width="65%">&nbsp;</th>
-        </thead>
-        <tbody>
-          <tr height="254px">
-            <td colspan="2" class="u-table-border--top u-no-padding--top">
-              <p>
-                <strong class="u-align--right">2,300</strong>
-                <span class="u-text--muted"> Ubuntu Main packages,</span>
-                <br>
-                <strong class="u-align--right">23,000</strong>
-                <span class="u-text--muted">plus Ubuntu Universe packages</span>
-              </p>
-            </td>
-            <td colspan="10" style="background-color:#000; color:#ffffff;padding-top: 0"><strong>Ubuntu Pro</strong></td>
-          </tr>
-          <tr style="border-top: none; line-height: .5rem;">
-            <td colspan="2" class="u-table-border--top" style="overflow: hidden; white-space: nowrap;text-overflow: ellipsis;">
-              <p>
-                <strong class="u-align--right">2,300</strong>
-                <span class="u-text--muted">Ubuntu Main packages</span>
-              </p>
-            </td>
-            <td colspan="5" style="background-color:#E95420; color:#ffffff; border-top: 1px solid #E95420;"><strong>Ubuntu LTS</strong></td>
-            <td colspan="5" style="background-color:#000; color:#ffffff; border-top:1px solid #000;">&nbsp;</td>
-          </tr>
-          <tr class="u-hide--small u-hide--medium" style="border-top: 0;">
-            <td colspan="2" width="50%">&nbsp;</td>
-            <td class="u-align--right u-table-border--right">GA</td>
-            <td class="u-align--right u-table-border--right">1 year</td>
-            <td class="u-align--right u-table-border--right">2 years</td>
-            <td class="u-align--right u-table-border--right">3 years</td>
-            <td class="u-align--right u-table-border--right">4 years</td>
-            <td class="u-align--right u-table-border--right">5 years</td>
-            <td class="u-align--right u-table-border--right">6 years</td>
-            <td class="u-align--right u-table-border--right">7 years</td>
-            <td class="u-align--right u-table-border--right">8 years</td>
-            <td class="u-align--right u-table-border--right">9 years</td>
-            <td class="u-align--right u-table-border--right" style="padding-left: 0.3rem">10 years</td>
-          </tr>
-          <tr class="u-hide--large" style="border-top: 0;">
-            <td colspan="2" class="u-align--right u-table-border--right">GA</td>
-            <td colspan="5" class="u-align--right u-table-border--right">5 years</td>
-            <td colspan="5" class="u-align--right u-table-border--right">10 years</td>
-          </tr>
-        </tbody>
-      </table>
+      <div class="p-esm-chart">
+        <div class="p-esm-chart__row">
+          <div class="p-esm-chart__left-col">
+            <hr class="u-no-margin--bottom">
+            <p class="p-esm-chart__label">
+              <strong class="p-esm-chart__label-numbers">2,300</strong>
+              <span class="p-esm-chart__label-text"> Ubuntu Main packages, plus</span>
+            </p>
+            <p class="p-esm-chart__label">
+              <strong class="p-esm-chart__label-numbers">23,000</strong>
+              <span class="p-esm-chart__label-text">Ubuntu Universe packages</span>
+            </p>
+          </div>
+          <div class="p-esm-chart__right-col p-esm-chart__right-col--Ubuntu-Pro" style="height: 16.5rem;">
+            <p>Ubuntu Pro</p>
+          </div>
+        </div>
+        <div class="p-esm-chart__row">
+          <div class="p-esm-chart__left-col">
+            <p class="p-esm-chart__label" style="padding-top: 0">
+              <strong class="p-esm-chart__label-numbers">2,300</strong>
+              <span class="u-truncate p-esm-chart__label-text"> Ubuntu Main packages</span>
+            </p>
+          </div>
+          <div class="p-esm-chart__right-col" style="background-color: #000">
+            <div class="p-esm-chart__right-col-lts">
+              <div style="background: #E95420;">
+                <p style="margin-bottom: 0; padding-top: 0;">Ubuntu Pro LTS</p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="p-esm-chart__row">
+          <div class="p-esm-chart__left-col">
+            <hr class="u-no-margin--bottom">
+            <p class="u-align-text--right">GA</p>
+          </div>
+          <div class="p-esm-chart__right-col p-esm-chart__right-col-axis">
+            <div class="p-esm-chart__axis-tick u-hide--small u-hide--medium">
+              <p>1 year</p>
+            </div>
+            <div class="p-esm-chart__axis-tick u-hide--small u-hide--medium">
+              <p>2 years</p>
+            </div>
+            <div class="p-esm-chart__axis-tick u-hide--small u-hide--medium">
+              <p>3 years</p>
+            </div>
+            <div class="p-esm-chart__axis-tick u-hide--small u-hide--medium">
+              <p>4 years</p>
+            </div>
+            <div class="p-esm-chart__axis-tick">
+              <p>5 years</p>
+            </div>
+            <div class="p-esm-chart__axis-tick u-hide--small u-hide--medium">
+              <p>6 years</p>
+            </div>
+            <div class="p-esm-chart__axis-tick u-hide--small u-hide--medium">
+              <p>7 years</p>
+            </div>
+            <div class="p-esm-chart__axis-tick u-hide--small u-hide--medium">
+              <p>8 years</p>
+            </div>
+            <div class="p-esm-chart__axis-tick u-hide--small u-hide--medium">
+              <p>9 years</p>
+            </div>
+            <div class="p-esm-chart__axis-tick">
+              <p>10 years</p>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   </section>
 

--- a/templates/security/esm.html
+++ b/templates/security/esm.html
@@ -375,6 +375,7 @@
         </div>
         <div class="p-esm-chart__row">
           <div class="p-esm-chart__left-col">
+            <hr class="u-no-margin--bottom">
             <p class="p-esm-chart__label" style="padding-top: 0">
               <strong class="p-esm-chart__label-numbers">2,300</strong>
               <span class="u-truncate p-esm-chart__label-text"> Ubuntu Main packages</span>

--- a/templates/security/esm.html
+++ b/templates/security/esm.html
@@ -8,26 +8,23 @@
 
 {% block content %}
 
-<section class="p-strip--image is-deep u-no-margin-bottom" style="background-image:url('https://assets.ubuntu.com/v1/18717572-05_suru2_light_glow_8K_edited.png')">
-  <div class="row u-equal-height">
-    <div class="col-12">
+<section class="p-strip--image is-deep" style="background-image:url('https://assets.ubuntu.com/v1/18717572-05_suru2_light_glow_8K_edited.png'); background-position: bottom right;">
+  <div class="u-fixed-width p-strip is-shallow u-no-padding--top">
       <h1 class="p-heading--2 u-no-margin--bottom"><strong>Extended Security Maintenance (ESM)</strong></h1>
       <h2 class="u-no-padding--top u-text--muted">Extra security patching for Ubuntu LTS, now included in Ubuntu Pro</h2>
-    </div>
   </div>
 </section>
-
-<section class="p-strip is-deep">
-  <div class="row">
-    <div class="col-6">
-      <h2>10 year security coverage</h2>
-    </div>
-    <div class="col-6">
-      <p>Security maintenance for the entire collection of software packages shipped with Ubuntu.</p>
-      <p>ESM enables continuous vulnerability management for critical, high and medium CVEs.</p>
-      <p>
+<section class="p-strip is-deep u-no-padding--bottom">
+  <div class="p-strip u-no-padding--top">
+    <div class="row">
+      <div class="col-6">
+        <h2>10 year security coverage</h2>
+      </div>
+      <div class="col-6">
+        <p>Security maintenance for the entire collection of software packages shipped with Ubuntu.</p>
+        <p>ESM enables continuous vulnerability management for critical, high and medium CVEs.</p>
         <a href="/security/esm#get-in-touch" class="p-button--positive js-invoke-modal">Contact us</a>
-      </p>
+      </div>
     </div>
   </div>
 </section>
@@ -330,7 +327,7 @@
     <div class="u-fixed-width">
       <hr />
       <h2>What's the difference?</h2>
-      <div class="esm-table">
+      <div class="esm-table p-strip is-shallow">
         <table class="p-table">
           <thead>
             <tr>
@@ -357,14 +354,12 @@
         </table>
       </div>
     </div>
-  </section>
-    
-  <section class="p-strip is-deep u-no-padding--top">
+
     <div class="u-fixed-width">
       <table class="p-table" style="border-spacing:0;">
         <tbody>
           <tr>
-            <td colspan="2" style="border-top: 1px solid #E5E5E5;" width="28%"><strong>2,300</strong> Ubuntu Main packages, plus<br /><strong>23,000</strong> Ubuntu Universe packages</td>
+            <td colspan="2" style="border-top: 1px solid #E5E5E5;" width="25.75%"><strong>2,300</strong> Ubuntu Main packages, plus<br /><strong>23,000</strong> Ubuntu Universe packages</td>
             <td colspan="10" style="background-color:black; color:#ffffff; height: 277px">Ubuntu Pro</td>
           </tr>
           <tr>
@@ -521,7 +516,7 @@
     <div class="row">
       <hr />
       <div class="col-6">
-        <h2>ESM on public clouds with Ubuntu Pro</h2>
+        <h2>ESM on public clouds <br class="u-hide--small u-hide--medium">with Ubuntu Pro</h2>
       </div>
       <div class="col-6">
         <p>If you are running Ubuntu 16.04 LTS images on the public cloud and are looking for continued security coverage with ESM, it is recommended to launch new, Ubuntu Pro images for <a href="/azure/pro">Azure</a>, <a href="/aws/pro">AWS</a> and <a href="/gcp/pro">Google Cloud</a>. Ubuntu Pro images are paid, premium images that are optimised and priced for the cloud, with security and compliance features built-in.</p>
@@ -542,14 +537,12 @@
           <script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script>
         </div>
         <p>Ubuntu 16.04 LTS Xenial Xerus moves out from the standard LTS security updates transitions to the extended security maintenance (ESM) period in April 2021. Learn about the ESM period and six key considerations when assessing and planning your migration path.</p>
-        <p>
-          <a href="/engage/migrating-to-20.04" class="p-button">Watch the webinar</a>
-        </p>
+        <a href="/engage/migrating-to-20.04" class="p-button">Watch the webinar</a>
       </div>
     </div>
   </section>
 
-  <section class="p-strip is-deep">
+  <section class="p-strip is-deep u-no-padding--top">
     <hr class="is-fixed-width"/>
     <div class="p-strip is-deep">
       <div class="u-fixed-width">

--- a/templates/security/esm.html
+++ b/templates/security/esm.html
@@ -8,318 +8,555 @@
 
 {% block content %}
 
-<section class="p-strip--suru-topped is-bordered">
+<section class="p-strip--image is-deep u-no-margin-bottom" style="background-image:url('https://assets.ubuntu.com/v1/18717572-05_suru2_light_glow_8K_edited.png')">
   <div class="row u-equal-height">
-    <div class="col-8">
-      <span class="u-sv3"><h1>Extended Security Maintenance</h1></span>
-      <span class="u-sv3"><p class="p-heading--4">Security updates for Ubuntu LTS for additional 5 years</p></span>
-      <p>Continue to receive security updates for the Ubuntu base OS, critical software packages and infrastructure components with Extended Security Maintenance (ESM). ESM provides five additional years of security maintenance, enabling an organization's continuous vulnerability management.</p>
-      <p>ESM is available through an Ubuntu Advantage for Infrastructure subscription for physical servers, virtual machines, containers and desktops, and is free for personal use. ESM is also included in the Ubuntu Pro premium images that are optimised for <a href="/cloud/public-cloud">the public cloud</a>, and these also provide security maintenance for high and critical CVEs for the entire collection of software packages shipped with Ubuntu.</p>
-      <p>
-        <a href="/pro" class="p-button--positive">Get started with Ubuntu Advantage</a>
-        <a href="/security/esm#get-in-touch" class="p-button">Contact us</a  >
-        </p>
-      </div>
-      <div class="col-4 u-vertically-center u-hide--medium u-hide--small u-align--center">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/92a095cb-Shield-greentick.svg",
-          alt="",
-          height="226",
-          width="190",
-          hi_def=True,
-          loading="auto",
-          ) | safe
-        }}
-      </div>
-    </div>
-  </section>
-
-  <div class="p-strip is-shallow">
-    <div class="u-fixed-width">
-      <div class="p-heading-icon--small">
-        <div class="p-heading-icon__header">
-          <h4 class="p-heading-icon__title u-no-max-width u-no-margin--bottom">Extended Security Maintenance for Ubuntu 16.04 LTS is available from April 2021 until 2026. <a href="/blog/ubuntu-16-04-lts-transitions-to-extended-security-maintenance-esm">Learn more&nbsp;&rsaquo;</a></h4>
-        </div>
-      </div>
+    <div class="col-12">
+      <h1 class="p-heading--2 u-no-margin--bottom"><strong>Extended Security Maintenance (ESM)</strong></h1>
+      <h2 class="u-no-padding--top u-text--muted">Extra security patching for Ubuntu LTS, now included in Ubuntu Pro</h2>
     </div>
   </div>
+</section>
 
-  <section class="p-strip--suru-accent">
-    <div class="row p-divider is-dark">
-      <div class="col-6 p-divider__block">
-        <div class="p-heading-icon--small">
-          <div class="p-heading-icon__header">
-            {{
-              image(
-              url="https://assets.ubuntu.com/v1/fc781c43-Case+study+-+white.svg",
-              alt="",
-              height="32",
-              width="32",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-heading-icon__img"},
-              ) | safe
-            }}
-            <p class="p-heading--4">Case study</p>
-          </div>
-          <h4>
-            Interana uses ESM while planning public cloud upgrades to 18.04
-          </h4>
-          <p>
-            Due to the large amounts of customer data that Interana handles, ensuring that security was tight was a priority. Rather than rush the upgrade from Ubuntu 14.04LTS, which would have been a major inconvenience for its customers, Interana turned to Canonical and ESM.
-          </p>
-          <p><a href="/blog/interana-uses-esm-to-maintain-system-security-while-upgrading-its-customers-to-ubuntu-18-04-lts-across-public-clouds" class="p-button">Read more in the case study</a></p>
-        </div>
-      </div>
-      <div class="col-6 p-divider__block">
-        <div class="p-heading-icon--small">
-          <div class="p-heading-icon__header">
-            {{
-              image(
-              url="https://assets.ubuntu.com/v1/fc781c43-Case+study+-+white.svg",
-              alt="",
-              height="32",
-              width="32",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-heading-icon__img"},
-              ) | safe
-            }}
-            <p class="p-heading--4">Case study</p>
-          </div>
-          <h4>
-            TIM maintains system security and client confidence with ESM
-          </h4>
-          <p>
-            To ensure the ongoing security of Ubuntu 14.04 LTS machines, ESM provided TIM, the world's largest trade recommendations network, the freedom to upgrade within their own timeframe. This approach saved time and money for this finserv organisation.
-          </p>
-          <p><a href="/engage/case-study-acuris" class="p-button">Read more in the case study</a></p>
-        </div>
-      </div>
+<section class="p-strip is-deep">
+  <div class="row">
+    <div class="col-6">
+      <h2>10 year security coverage</h2>
     </div>
-  </section>
-  <section class="p-strip is-bordered">
-    <div class="row">
-      <div class="col-8">
-        <h2>Is Ubuntu 16.04 LTS still supported beyond April 2021?</h2>
-        <p>
-          Ubuntu 16.04 LTS will still be supported beyond its free initial five-year maintenance period in April 2021, as it transitions to the extended security maintenance phase - with five additional years of security ensured.
-        </p>
-        <p>
-          <a href="/16-04">Learn more about Ubuntu 16.04 LTS moving to ESM &nbsp;&rsaquo;</a>
-        </p>
-      </div>
+    <div class="col-6">
+      <p>Security maintenance for the entire collection of software packages shipped with Ubuntu.</p>
+      <p>ESM enables continuous vulnerability management for critical, high and medium CVEs.</p>
+      <p>
+        <a href="/security/esm#get-in-touch" class="p-button--positive js-invoke-modal">Contact us</a>
+      </p>
     </div>
-  </section>
-  <section class="p-strip is-deep is-bordered" id="get-esm">
-    <div class="row">
-      <div class="col-8">
-        <h2>Free for personal use</h2>
-        <p>Canonical provides Ubuntu Advantage Essential subscriptions, which include ESM, free of charge for individuals on up to 3 machines. For our community of <a href="https://wiki.ubuntu.com/Membership">Ubuntu members</a>, we will gladly increase that to 50 machines.</p>
-        <a href="/pro" class="p-button--positive u-no-margin--bottom">Get ESM now</a>
-      </div>
-    </div>
+  </div>
+</section>
 
+<section class="p-strip is-deep u-no-padding--top">
+  <div class="row">
+    <div class="col-small-1 col-medium-1 col-1">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/ab22825a-ansible+logo.png",
+        alt="Ansible",
+        attrs={"class":"p-logo-section__logo"},
+        width="280",
+        height="280",
+        hi_def=False,
+        loading="lazy",
+        ) | safe
+      }}
+    </div>
+    <div class="col-small-1 col-medium-1 col-1">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/df2c8fa0-apache+tomcat+logo.png",
+        alt="Apache Tomcat",
+        attrs={"class":"p-logo-section__logo"},
+        width="280",
+        height="280",
+        hi_def=False,
+        loading="lazy",
+        ) | safe
+      }}
+    </div>
+    <div class="col-small-1 col-medium-1 col-1">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/fad485a5-docker+logo.png",
+        alt="Docker",
+        attrs={"class":"p-logo-section__logo"},
+        width="280",
+        height="280",
+        hi_def=False,
+        loading="lazy",
+        ) | safe
+      }}
+    </div>
+    <div class="col-small-1 col-medium-1 col-1">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/a5ceec76-drupal+logo.png",
+        alt="Drupal",
+        attrs={"class":"p-logo-section__logo"},
+        width="280",
+        height="280",
+        hi_def=False,
+        loading="lazy",
+        ) | safe
+      }}
+    </div>
+    <div class="col-small-1 col-medium-1 col-1">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/810bed2f-etcd+logo.png",
+        alt="E T C D",
+        attrs={"class":"p-logo-section__logo"},
+        width="280",
+        height="280",
+        hi_def=False,
+        loading="lazy",
+        ) | safe
+      }}
+    </div>
+    <div class="col-small-1 col-medium-1 col-1">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/ebff661c-glusterfs+logo.png",
+        alt="Gluster",
+        attrs={"class":"p-logo-section__logo"},
+        width="280",
+        height="280",
+        hi_def=False,
+        loading="lazy",
+        ) | safe
+      }}
+    </div>
+    <div class="col-small-1 col-medium-1 col-1">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/2f883d00-go+logo.png",
+        alt="GoLang",
+        attrs={"class":"p-logo-section__logo"},
+        width="280",
+        height="280",
+        hi_def=False,
+        loading="lazy",
+        ) | safe
+      }}
+    </div>
+    <div class="col-small-1 col-medium-1 col-1">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/fabdefb7-kafka+logo.png",
+        alt="Kafka",
+        attrs={"class":"p-logo-section__logo"},
+        width="280",
+        height="280",
+        hi_def=False,
+        loading="lazy",
+        ) | safe
+      }}
+    </div>
+    <div class="col-small-1 col-medium-1 col-1">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/d00a6ac1-nagios+logo.png",
+        alt="Nagios",
+        attrs={"class":"p-logo-section__logo"},
+        width="280",
+        height="280",
+        hi_def=False,
+        loading="lazy",
+        ) | safe
+      }}
+    </div>
+    <div class="col-small-1 col-medium-1 col-1">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/2dfa0b07-nginex+logo.png",
+        alt="nginex",
+        attrs={"class":"p-logo-section__logo"},
+        width="280",
+        height="280",
+        hi_def=False,
+        loading="lazy",
+        ) | safe
+      }}
+    </div>
+    <div class="col-small-1 col-medium-1 col-1">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/2303838b-node-logo.png",
+        alt="Node J S",
+        attrs={"class":"p-logo-section__logo"},
+        width="280",
+        height="280",
+        hi_def=False,
+        loading="lazy",
+        ) | safe
+      }}
+    </div>
+    <div class="col-small-1 col-medium-1 col-1">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/c9baeb67-openjdk+logo.png",
+        alt="Open J D K",
+        attrs={"class":"p-logo-section__logo"},
+        width="280",
+        height="280",
+        hi_def=False,
+        loading="lazy",
+        ) | safe
+      }}
+    </div>
+  <div class="row">
+    <div class="col-small-1 col-medium-1 col-1">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/71547ec1-perl+logo.png",
+        alt="Perl",
+        attrs={"class":"p-logo-section__logo"},
+        width="280",
+        height="280",
+        hi_def=False,
+        loading="lazy",
+        ) | safe
+      }}
+    </div>
+    <div class="col-small-1 col-medium-1 col-1">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/75484ed4-pg-bouncer+logo.png",
+        alt="P G Bouncecr",
+        attrs={"class":"p-logo-section__logo"},
+        width="280",
+        height="280",
+        hi_def=False,
+        loading="lazy",
+        ) | safe
+      }}
+    </div>
+    <div class="col-small-1 col-medium-1 col-1">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/8b428ac2-php+logo.png",
+        alt="P H P",
+        attrs={"class":"p-logo-section__logo"},
+        width="280",
+        height="280",
+        hi_def=False,
+        loading="lazy",
+        ) | safe
+      }}
+    </div>
+    <div class="col-small-1 col-medium-1 col-1">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/1dfdcd1c-powerdns+logo.png",
+        alt="Power D N S",
+        attrs={"class":"p-logo-section__logo"},
+        width="280",
+        height="280",
+        hi_def=False,
+        loading="lazy",
+        ) | safe
+      }}
+    </div>
+    <div class="col-small-1 col-medium-1 col-1">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/fbaf6348-puppet+logo.png",
+        alt="Puppet",
+        attrs={"class":"p-logo-section__logo"},
+        width="280",
+        height="280",
+        hi_def=False,
+        loading="lazy",
+        ) | safe
+      }}
+    </div>
+    <div class="col-small-1 col-medium-1 col-1">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/f2803dcb-python+logo.png",
+        alt="Python",
+        attrs={"class":"p-logo-section__logo"},
+        width="280",
+        height="280",
+        hi_def=False,
+        loading="lazy",
+        ) | safe
+      }}
+    </div>
+    <div class="col-small-1 col-medium-1 col-1">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/7b5c7032-redis+logo.png",
+        alt="Redis",
+        attrs={"class":"p-logo-section__logo"},
+        width="280",
+        height="280",
+        hi_def=False,
+        loading="lazy",
+        ) | safe
+      }}
+    </div>
+    <div class="col-small-1 col-medium-1 col-1">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/bc7ceb58-ruby-rails+logo.png",
+        alt="Ruby on Rails",
+        attrs={"class":"p-logo-section__logo"},
+        width="280",
+        height="280",
+        hi_def=False,
+        loading="lazy",
+        ) | safe
+      }}
+    </div>
+    <div class="col-small-1 col-medium-1 col-1">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/fd0e15fd-rust+logo.png",
+        alt="Rust",
+        attrs={"class":"p-logo-section__logo"},
+        width="280",
+        height="280",
+        hi_def=False,
+        loading="lazy",
+        ) | safe
+      }}
+    </div>
+    <div class="col-small-1 col-medium-1 col-1">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/62c2f466-vagrant+logo.png",
+        alt="Vagrant",
+        attrs={"class":"p-logo-section__logo"},
+        width="280",
+        height="280",
+        hi_def=False,
+        loading="lazy",
+        ) | safe
+      }}
+    </div>
+    <div class="col-small-1 col-medium-1 col-1">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/12295113-wordpress+logo.png",
+        alt="Wordpress",
+        attrs={"class":"p-logo-section__logo"},
+        width="280",
+        height="280",
+        hi_def=False,
+        loading="lazy",
+        ) | safe
+      }}
+    </div>
+    <div class="col-small-1 col-medium-1 col-1">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/6b559369-zookeeper+logo.png",
+        alt="Apache Zookeper",
+        attrs={"class":"p-logo-section__logo"},
+        width="280",
+        height="280",
+        hi_def=False,
+        loading="lazy",
+        ) | safe
+      }}
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-deep u-no-padding--top">
     <div class="u-fixed-width">
-      <hr class="p-separator">
+      <hr />
+      <h2>What's the difference?</h2>
+      <div class="esm-table">
+        <table class="p-table">
+          <thead>
+            <tr>
+              <th width="50%">Security patching<br /> <span style="text-transform: initial; color: #666666;">(Coverage for critical, high and selected medium CVEs)</span></th>
+              <th width="33.33%" class="u-align--left">Ubuntu LTS</th>
+              <th width="33.33%" class="u-align--left">Ubuntu Pro (Infra-only)<br /> <span style="text-transform: initial; color: #666666;">(Previously known as ”Ubuntu Advantage for Infrastructure”)</span></th>
+              <th width="33.33%" class="u-align--left">Ubuntu Pro</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Over 2,300 packages in Ubuntu Main repository</td>
+              <td class="u-align--left">5 years </td>
+              <td class="u-align--left">10 years</td>
+              <td class="u-align--left">10 years</td>
+            </tr>
+            <tr>
+              <td>Over 23,000 packages in Ubuntu Universe repository</td>
+              <td class="u-align--left">Best effort</td>
+              <td class="u-align--left">Best effort</td>
+              <td class="u-align--left">10 years</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </div>
+  </section>
+    
+  <section class="p-strip is-deep u-no-padding--top">
+    <div class="u-fixed-width">
+      <table class="p-table" style="border-spacing:0;">
+        <tbody>
+          <tr>
+            <td colspan="2" style="border-top: 1px solid #E5E5E5;" width="28%"><strong>2,300</strong> Ubuntu Main packages, plus<br /><strong>23,000</strong> Ubuntu Universe packages</td>
+            <td colspan="10" style="background-color:black; color:#ffffff; height: 277px">Ubuntu Pro</td>
+          </tr>
+          <tr>
+            <td colspan="2"><strong>2,300</strong> Ubuntu Main  packages</td>
+            <td colspan="5" style="background-color:#E95420; color:#ffffff; border-top: 1px solid #E95420;">Ubuntu LTS</td>
+            <td colspan="5" style="background-color:black; color:#ffffff; border-top:1px solid #000;">&nbsp;</td>
+          </tr>
+          <tr class="u-hide--small u-hide--medium" style="border-top: 0;">
+            <td width="50%">&nbsp;</td>
+            <td class="u-align--right" style="border-right: 1px solid #E5E5E5;">GA</td>
+            <td class="u-align--right" style="border-right: 1px solid #E5E5E5;">1 year</td>
+            <td class="u-align--right" style="border-right: 1px solid #E5E5E5;">2 years</td>
+            <td class="u-align--right" style="border-right: 1px solid #E5E5E5;">3 years</td>
+            <td class="u-align--right" style="border-right: 1px solid #E5E5E5;">4 years</td>
+            <td class="u-align--right" style="border-right: 1px solid #E5E5E5;">5 years</td>
+            <td class="u-align--right" style="border-right: 1px solid #E5E5E5;">6 years</td>
+            <td class="u-align--right" style="border-right: 1px solid #E5E5E5;">7 years</td>
+            <td class="u-align--right" style="border-right: 1px solid #E5E5E5;">8 years</td>
+            <td class="u-align--right" style="border-right: 1px solid #E5E5E5;">9 years</td>
+            <td class="u-align--right" style="border-right: 1px solid #E5E5E5;">10 years</td>
+          </tr>
+          <tr class="u-hide--large" style="border-top: 0;">
+            <td width="50%">&nbsp;</td>
+            <td class="u-align--right" style="border-right: 1px solid #E5E5E5;">GA</td>
+            <td colspan="5" class="u-align--right" style="border-right: 1px solid #E5E5E5;">5 years</td>
+            <td colspan="5" class="u-align--right" style="border-right: 1px solid #E5E5E5;">10 years</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
 
-    <div class="row" id="benefits">
-      <div class="col-10">
-        <h2>What is covered?</h2>
+  <section class="p-strip is-deep u-no-padding--top">
+    <div class="row">
+      <h3 class="p-text--x-small-capitalised">Case studies</h3>
+      <hr />
+      <div class="col-3">
+        <div style="max-width: 118px;">
+          {{
+            image (
+            url="https://assets.ubuntu.com/v1/e32cef6a-aa62411e-8a50-467b-9b76-edb083819144.svg",
+            alt="",
+            width="1224",
+            height="792",
+            hi_def=True,
+            loading="lazy"
+            ) | safe
+          }}
+        </div>
+      </div>
+      <div class="col-9">
+        <h4>
+          Interana uses ESM while planning public cloud upgrades to 18.04
+        </h4>
+        <p>
+          Due to the large amounts of customer data that Interana handles, ensuring that security was tight was a priority. Rather than rush the upgrade from Ubuntu 14.04LTS, which would have been a major inconvenience for its customers, Interana turned to Canonical and ESM.
+        </p>
+        <p><a href="/blog/interana-uses-esm-to-maintain-system-security-while-upgrading-its-customers-to-ubuntu-18-04-lts-across-public-clouds">Read more in the case study</a></p>
+      </div>
+    </div>
+    <div class="row">
+      <hr />
+      <div class="col-3">
+        <div style="max-width: 118px;">
+          {{
+            image (
+            url="https://assets.ubuntu.com/v1/593b675f-TIM_Logo.png",
+            alt="",
+            width="300",
+            height="127",
+            hi_def=True,
+            loading="lazy"
+            ) | safe
+          }}
+        </div>
+      </div>
+      <div class="col-9">
+        <h4>
+          TIM maintains system security and client confidence with ESM
+        </h4>
+        <p>
+          To ensure the ongoing security of Ubuntu 14.04 LTS machines, ESM provided TIM, the world's largest trade recommendations network, the freedom to upgrade within their own timeframe.
+        </p>
+        <p>This approach saved time and money for this finserv organisation.</p>
+        <p><a href="/engage/case-study-acuris">Read more in the case study</a></p>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-strip is-deep u-no-padding--top">
+    <div class="row">
+      <hr />
+      <div class="col-6">
+        <h2>What's covered?</h2>
+      </div>
+      <div class="col-6">
         <p>ESM continues security updates and <a href="/security/livepatch">kernel livepatching</a> for high and critical CVEs (Common Vulnerabilities and Exposures).</p>
       </div>
-      <div class="row">
-        <div class="col-10" style="overflow: auto;">
-          <table style="width: auto;">
-            <thead>
-              <tr>
-                <th scope="col">Released</th>
-                <th scope="col">Coverage</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>Ubuntu 14.04 LTS (Trusty Tahr)</td>
-                <td>
-                  <ul>
-                    <li>The Ubuntu base OS and scale-out infrastructure</li>
-                    <li>Kernel livepatching</li>
-                    <li>x86-64 architecture</li>
-                  </ul>
-                  <a href="https://wiki.ubuntu.com/SecurityTeam/ESM/14.04" class="p-button">Learn more</a>
-                </td>
-              </tr>
-              <tr>
-                <td><a href="/16-04">Ubuntu 16.04 LTS (Xenial Xerus)&nbsp;&rsaquo;</a></td>
-                <td>
-                  <ul>
-                    <li>The Ubuntu base OS and scale-out infrastructure</li>
-                    <li>Kernel livepatching</li>
-                    <li>x86-64 architecture</li>
-                  </ul>
-                  <a href="https://wiki.ubuntu.com/SecurityTeam/ESM/16.04" class="p-button">Learn more</a>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      </div>
-
-      <div class="u-fixed-width">
-        <hr class="p-separator">
-      </div>
-
-      <div class="row">
-        <div class="col-8">
-          <h2>ESM on Azure, AWS and Google Cloud with Ubuntu Pro</h2>
-          <p>
-            If you are running Ubuntu 16.04 LTS images on the public cloud and are looking for continued security coverage with ESM, it is recommended to launch new, Ubuntu Pro images for <a href="/azure/pro">Azure</a>, <a href="/aws/pro">AWS</a> and <a href="/gcp/pro">Google Cloud</a>. Ubuntu Pro images are paid, premium images that are optimised and priced for the cloud, with security and compliance features built-in.
-          </p>
-          <p>Learn more about Ubuntu Pro 16.04 LTS on <a href="/16-04/azure">Azure</a> | <a href="/aws/pro">AWS</a> | <a href="/gcp/pro">Google Cloud</a></p>
-        </div>
-      </div>
-      <div class="u-fixed-width">
-        <hr class="p-separator">
-      </div>
-
-      <div class="row" id="faq">
-        <div class="col-8">
-          <h2>Common questions</h2>
-
-          <h4 class="u-no-max-width">How to enable ESM?</h4>
-          <div class="row">
-            <h5 class="col-4">Attach your subscription</h5>
-            <div class="col-4">
-              <pre><code>sudo ua attach [TOKEN]</code></pre>
-              <p>Note: obtain the subscription token via the <a href="/pro">Ubuntu Advantage portal</a>. Attaching the subscription is not necessary on Ubuntu Pro.</p>
-            </div>
-          </div>
-          <div class="row">
-            <h5 class="col-4">If ESM is not listed as enabled after attaching your Token, the ESM entitlement can be enabled using the UA client.</h5>
-            <div class="col-4">
-              <pre><code>sudo ua enable esm-infra</code></pre>
-            </div>
-          </div>
-          <div class="row">
-            <h5 class="col-4">If ESM is enabled manually, the status of this entitlement can be confirmed with the UA client as well.</h5>
-            <div class="col-4">
-              <pre><code>sudo ua status</code></pre>
-            </div>
-          </div>
-          <div class="row">
-            <h5 class="col-4 u-sv3">ESM is now enabled!</h5>
-          </div>
-
-          <h4 class="u-no-max-width">Do all levels of Ubuntu Advantage for Infrastructure have access to Ubuntu ESM?</h4>
-          <p>Yes. Ubuntu ESM is available for UA-I Essential, Standard and Advanced customers. For more information on levels please visit our <a href="/pricing">pricing page</a>. Existing UA customers can retrieve their credentials through the <a href="/pro">Ubuntu Advantage portal</a>.</p>
-
-          <h4 class="u-no-max-width">How can we ensure the security of our Ubuntu systems after the end of Standard Security Maintenance?</h4>
-          <p>
-            To ensure security continuity when a particular release reaches the end of its Standard Security Maintenance window, sign up for <a href="/pro">Ubuntu Advantage</a> for free on up to 3 machines or through a paid subscription for enterprise use.
-          </p>
-          <p>
-            <a href="/about/release-cycle">Learn more about release dates and maintenance cadences &nbsp;&rsaquo;</a>
-          </p>
-          <p>
-            <a href="/pro" class="p-button">Sign up for Ubuntu Advantage subscription</a>
-          </p>
-          <h4 id="how-long" class="u-no-max-width">How long will Ubuntu ESM be maintained?</h4>
-          <p>All Ubuntu LTS releases until further announcement have ESM updates provided for five years establishing a lifecycle of ten years.</p>
-          <table>
-            <thead>
-              <tr>
-                <th>Release</th>
-                <th>Release date</th>
-                <th>End of Life</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>Ubuntu 14.04 (Trusty Tahr)</td>
-                <td>April 2014</td>
-                <td>April 2024</td>
-              </tr>
-              <tr>
-                <td>Ubuntu 16.04 (Xenial Xerus)</td>
-                <td>April 2016</td>
-                <td>April 2026</td>
-              </tr>
-              <tr>
-                <td>Ubuntu 18.04 (Bionic Beaver)</td>
-                <td>April 2018</td>
-                <td>April 2028</td>
-              </tr>
-              <tr>
-                <td>Ubuntu 20.04 (Focal Fossa)</td>
-                <td>April 2020</td>
-                <td>April 2030</td>
-              </tr>
-            </tbody>
-          </table>
-
-          <h4 class="u-no-max-width">Is it possible to purchase Ubuntu ESM months down the road when needed, with or without backdating the cost, or does it need to be in place in advance?</h4>
-          <p>You can purchase Ubuntu Advantage support at any time. It does not need to be in place in advance, although we strongly recommend you eliminate the gap between when Ubuntu ESM is enabled on your system(s), to avoid exposing your systems to security vulnerabilities. Ubuntu Advantage is priced year-over-year so there is no backdating.</p>
-
-          <h4 class="u-no-max-width">We're mirroring the repository on our internal Landscape server. Can we still get Ubuntu ESM if using Landscape?</h4>
-          <p>ESM is just a regular Ubuntu archive, but authenticated and served over HTTPS. Archive mirroring is already available in Landscape and is a supported mechanism for mirroring the ESM archive.</p>
-        </div>
-      </div>
-    </section>
-
-    <section class="p-strip">
-      <div class="row u-equal-height">
-        <div class="col-6">
-          <h2>Ubuntu 16.04 LTS moving to Extended Security Maintenance period</h2>
-          <p>
-            Ubuntu 16.04 LTS Xenial Xerus transitions to the extended security maintenance (ESM) period in April 2021. Register for our webinar to learn about the ESM period and six key considerations when assessing and planning your migration path.
-          </p>
-          <p><a href="/engage/16-04-ESM-webinar" class="p-button--positive">Watch the webinar</a></p>
-        </div>
-        <div class="col-6 u-align--center">
-          {{
-            image(
-            url="https://assets.ubuntu.com/v1/332c020e-webinar-social-1604-to-esm.jpg",
-            alt="",
-            width="450",
-            height="250",
-            hi_def=True,
-            loading="lazy",
-            ) | safe
-          }}
-        </div>
-      </div>
-    </section>
-
-    <section class="p-strip--light">
-      <div class="row u-equal-height">
-        <div class="col-5 u-hide--medium u-hide--small u-align--center">
-          {{
-            image(
-            url="https://assets.ubuntu.com/v1/c4b290c8-Contact+us.svg",
-            alt="",
-            height="200",
-            width="281",
-            hi_def=True,
-            loading="lazy",
-            ) | safe
-          }}
-        </div>
-        <div class="col-7 u-vertically-center">
-          <div>
-            <h2>Secure your Ubuntu estate</h2>
-            <p class="u-no-margin--bottom">If you would like to discuss ESM or Ubuntu Advantage please <a href="/security/contact-us" data-testid="interactive-form-link" class="js-invoke-modal">get in touch</a>.</p>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    {% with first_item="_support_landscape", second_item="_support_contact_us", third_item="_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
-
-    <!-- Set default Marketo information for contact form below-->
-    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/esm" data-form-id="3764" data-lp-id="" data-return-url="https://ubuntu.com/security/thank-you?product=esm" data-lp-url="">
     </div>
+    <br />
+    <div class="u-fixed-width">
+      <table class="p-table">
+        <thead>
+          <tr>
+            <th width="25%">Release</th>
+            <th width="25.5%">Ubuntu Base OS security coverage</th>
+            <th width="25%">Security updates - Universe repo (applications & toolchains)</th>
+            <th width="10%">Kernel Livepatch</th>
+            <th>Architectures supported with ESM</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Ubuntu 14.04 LTS (Trusty Tahr)</td>
+            <td>Until 2024</td>
+            <td>n/a</td>
+            <td>yes</td>
+            <td>x86</td>
+          </tr>
+          <tr>
+            <td>Ubuntu 16.04 LTS (Xenial Xerus)</td>
+            <td>Until 2026</td>
+            <td>Until 2026</td>
+            <td>yes</td>
+            <td>x86</td>
+          </tr>
+          <tr>
+            <td>Ubuntu 18.04 LTS (Bionic Beaver)</td>
+            <td>Until 2028</td>
+            <td>Until 2028</td>
+            <td>yes</td>
+            <td>x86, ARM, S390X, POWER, RISC-V</td>
+          </tr>
+          <tr>
+            <td>Ubuntu 20.04 LTS (Focal Fossa)</td>
+            <td>Until 2030</td>
+            <td>Until 2030</td>
+            <td>yes</td>
+            <td>x86, ARM, S390X, POWER, RISC-V</td>
+          </tr>
+          <tr>
+            <td>Ubuntu 22.04 LTS (Jammy Jellyfish)</td>
+            <td>Until 2032</td>
+            <td>Until 2032</td>
+            <td>yes</td>
+            <td>x86, ARM, S390X, POWER, RISC-V</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
 
-    {% endblock content %}
-    {% block footer_extra %}{{ marketo }}{% endblock footer_extra %}
+  <section class="p-strip is-deep u-no-padding--top">
+    <div class="row">
+      <hr />
+      <div class="col-6">
+        <h2>ESM on public clouds with Ubuntu Pro</h2>
+      </div>
+      <div class="col-6">
+        <p>If you are running Ubuntu 16.04 LTS images on the public cloud and are looking for continued security coverage with ESM, it is recommended to launch new, Ubuntu Pro images for <a href="/azure/pro">Azure</a>, <a href="/aws/pro">AWS</a> and <a href="/gcp/pro">Google Cloud</a>. Ubuntu Pro images are paid, premium images that are optimised and priced for the cloud, with security and compliance features built-in.</p>
+        <p>Learn more about Ubuntu Pro 16.04 LTS on <a href="/16-04/azure">Azure</a> | <a href="/aws/pro">AWS</a> | <a href="/gcp/pro">Google Cloud</a></p>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-strip is-deep u-no-padding--top">
+    <div class="row">
+      <hr />
+      <div class="col-6">
+        <h2>Ubuntu 16.04 LTS out of standard security maintenance</h2>
+      </div>
+      <div class="col-6">
+        <div class="jsBrightTALKEmbedWrapper">
+          <script class="jsBrightTALKEmbedConfig" type="application/json">{ "channelId" : "6793", "language": "en-US", "commId" : "453617", "displayMode" : "standalone" }</script>
+          <script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script>
+        </div>
+        <p>Ubuntu 16.04 LTS Xenial Xerus moves out from the standard LTS security updates transitions to the extended security maintenance (ESM) period in April 2021. Learn about the ESM period and six key considerations when assessing and planning your migration path.</p>
+        <p>
+          <a href="/engage/migrating-to-20.04" class="p-button">Watch the webinar</a>
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-strip is-deep">
+    <hr class="is-fixed-width"/>
+    <div class="p-strip is-deep">
+      <div class="u-fixed-width">
+        <h2>Secure your Ubuntu estate.<br /><a href="/support/contact-us?product=contextual-footer-landscape" class="js-invoke-modal" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'support contact-us', 'eventLabel' : 'Contact us', 'eventValue' : undefined });">Get in touch to discuss ESM</a></h2>
+      </div>
+    </div>
+  </section>
+
+  {% endblock content %}
+  {% block footer_extra %}{{ marketo }}{% endblock footer_extra %}

--- a/templates/security/esm.html
+++ b/templates/security/esm.html
@@ -460,7 +460,7 @@
       </div>
     </div>
     <br />
-    <div class="u-fixed-width">
+    <div class="u-fixed-width u-esm-overflow-table">
       <table class="p-table">
         <thead>
           <tr>

--- a/templates/security/esm.html
+++ b/templates/security/esm.html
@@ -358,19 +358,29 @@
     <div class="u-fixed-width">
       <table aria-hidden="true" class="p-table--esm-chart">
         <thead class="u-hidden">
-          <th width="6%"></th>
-          <th colspan="2" width="25%">&nbsp;</th>
+          <th colspan="2" width="35%">&nbsp;</th>
           <th colspan="10" width="65%">&nbsp;</th>
         </thead>
         <tbody>
           <tr height="254px">
-            <td class="u-align--right u-table-border--top u-no-padding-right u-no-padding--top"><strong>2,300</strong><br /><strong>23,000</strong></td>
-            <td colspan="2" class="u-table-border--top u-no-padding--top" width="25.75%"> <span class="u-text--muted"> Ubuntu Main packages, plus<br /> Ubuntu Universe packages</span></td>
+            <td colspan="2" class="u-table-border--top u-no-padding--top">
+              <p>
+                <strong class="u-align--right">2,300</strong>
+                <span class="u-text--muted"> Ubuntu Main packages,</span>
+                <br>
+                <strong class="u-align--right">23,000</strong>
+                <span class="u-text--muted">plus Ubuntu Universe packages</span>
+              </p>
+            </td>
             <td colspan="10" style="background-color:#000; color:#ffffff;padding-top: 0"><strong>Ubuntu Pro</strong></td>
           </tr>
-          <tr style="border-top: none; line-height: 8px;">
-            <td class="u-align--right u-table-border--top u-no-padding-right"><strong>2,300</strong></td>
-            <td colspan="2" class="u-table-border--top" style="overflow: hidden;white-space: nowrap;text-overflow: ellipsis;"> Ubuntu Main packages</td>
+          <tr style="border-top: none; line-height: .5rem;">
+            <td colspan="2" class="u-table-border--top" style="overflow: hidden; white-space: nowrap;text-overflow: ellipsis;">
+              <p>
+                <strong class="u-align--right">2,300</strong>
+                <span class="u-text--muted">Ubuntu Main packages</span>
+              </p>
+            </td>
             <td colspan="5" style="background-color:#E95420; color:#ffffff; border-top: 1px solid #E95420;"><strong>Ubuntu LTS</strong></td>
             <td colspan="5" style="background-color:#000; color:#ffffff; border-top:1px solid #000;">&nbsp;</td>
           </tr>
@@ -389,8 +399,7 @@
             <td class="u-align--right u-table-border--right" style="padding-left: 0.3rem">10 years</td>
           </tr>
           <tr class="u-hide--large" style="border-top: 0;">
-            <td colspan="2" width="50%">&nbsp;</td>
-            <td class="u-align--right u-table-border--right">GA</td>
+            <td colspan="2" class="u-align--right u-table-border--right">GA</td>
             <td colspan="5" class="u-align--right u-table-border--right">5 years</td>
             <td colspan="5" class="u-align--right u-table-border--right">10 years</td>
           </tr>

--- a/templates/security/esm.html
+++ b/templates/security/esm.html
@@ -8,7 +8,7 @@
 
 {% block content %}
 
-<section class="p-strip--image is-deep" style="background-image:url('https://assets.ubuntu.com/v1/18717572-05_suru2_light_glow_8K_edited.png'); background-position: bottom right;">
+<section class="p-strip--pro-banner is-deep">
   <div class="u-fixed-width p-strip is-shallow u-no-padding--top">
       <h1 class="p-heading--2 u-no-margin--bottom"><strong>Extended Security Maintenance (ESM)</strong></h1>
       <h2 class="u-no-padding--top u-text--muted">Extra security patching for Ubuntu LTS, now included in Ubuntu Pro</h2>
@@ -331,10 +331,10 @@
         <table class="p-table">
           <thead>
             <tr>
-              <th width="50%">Security patching<br /> <span style="text-transform: initial; color: #666666;">(Coverage for critical, high and selected medium CVEs)</span></th>
-              <th width="33.33%" class="u-align--left">Ubuntu LTS</th>
-              <th width="33.33%" class="u-align--left">Ubuntu Pro (Infra-only)<br /> <span style="text-transform: initial; color: #666666;">(Previously known as ”Ubuntu Advantage for Infrastructure”)</span></th>
-              <th width="33.33%" class="u-align--left">Ubuntu Pro</th>
+              <th width="51%">Security patching<br /> <span style="text-transform: initial; color: #666666;">(Coverage for critical, high and selected medium CVEs)</span></th>
+              <th width="15%" class="u-align--left">Ubuntu LTS</th>
+              <th width="24%" class="u-align--left">Ubuntu Pro (Infra-only)<br /> <span style="text-transform: initial; color: #666666;">(Previously known as ”Ubuntu Advantage for Infrastructure”)</span></th>
+              <th width="10%" class="u-align--left">Ubuntu Pro</th>
             </tr>
           </thead>
           <tbody>
@@ -356,36 +356,43 @@
     </div>
 
     <div class="u-fixed-width">
-      <table class="p-table" style="border-spacing:0;">
+      <table aria-hidden="true" class="p-table--esm-chart">
+        <thead class="u-hidden">
+          <th width="6%"></th>
+          <th colspan="2" width="25%">&nbsp;</th>
+          <th colspan="10" width="65%">&nbsp;</th>
+        </thead>
         <tbody>
-          <tr>
-            <td colspan="2" style="border-top: 1px solid #E5E5E5;" width="25.75%"><strong>2,300</strong> Ubuntu Main packages, plus<br /><strong>23,000</strong> Ubuntu Universe packages</td>
-            <td colspan="10" style="background-color:black; color:#ffffff; height: 277px">Ubuntu Pro</td>
+          <tr height="254px">
+            <td class="u-align--right u-table-border--top u-no-padding-right" style="padding-top: 0"><strong>2,300</strong><br /><strong>23,000</strong></td>
+            <td colspan="2" class="u-table-border--top" style="padding-top: 0" width="25.75%"> Ubuntu Main packages, plus<br /> Ubuntu Universe packages</td>
+            <td colspan="10" style="background-color:#000; color:#ffffff;padding-top: 0"><strong>Ubuntu Pro</strong></td>
           </tr>
-          <tr>
-            <td colspan="2"><strong>2,300</strong> Ubuntu Main  packages</td>
-            <td colspan="5" style="background-color:#E95420; color:#ffffff; border-top: 1px solid #E95420;">Ubuntu LTS</td>
-            <td colspan="5" style="background-color:black; color:#ffffff; border-top:1px solid #000;">&nbsp;</td>
+          <tr style="border-top: none; line-height: 8px;">
+            <td class="u-align--right u-table-border--top u-no-padding-right"><strong>2,300</strong></td>
+            <td colspan="2" class="u-table-border--top" style="overflow: hidden;white-space: nowrap;text-overflow: ellipsis;"> Ubuntu Main packages</td>
+            <td colspan="5" style="background-color:#E95420; color:#ffffff; border-top: 1px solid #E95420;"><strong>Ubuntu LTS</strong></td>
+            <td colspan="5" style="background-color:#000; color:#ffffff; border-top:1px solid #000;">&nbsp;</td>
           </tr>
           <tr class="u-hide--small u-hide--medium" style="border-top: 0;">
-            <td width="50%">&nbsp;</td>
-            <td class="u-align--right" style="border-right: 1px solid #E5E5E5;">GA</td>
-            <td class="u-align--right" style="border-right: 1px solid #E5E5E5;">1 year</td>
-            <td class="u-align--right" style="border-right: 1px solid #E5E5E5;">2 years</td>
-            <td class="u-align--right" style="border-right: 1px solid #E5E5E5;">3 years</td>
-            <td class="u-align--right" style="border-right: 1px solid #E5E5E5;">4 years</td>
-            <td class="u-align--right" style="border-right: 1px solid #E5E5E5;">5 years</td>
-            <td class="u-align--right" style="border-right: 1px solid #E5E5E5;">6 years</td>
-            <td class="u-align--right" style="border-right: 1px solid #E5E5E5;">7 years</td>
-            <td class="u-align--right" style="border-right: 1px solid #E5E5E5;">8 years</td>
-            <td class="u-align--right" style="border-right: 1px solid #E5E5E5;">9 years</td>
-            <td class="u-align--right" style="border-right: 1px solid #E5E5E5;">10 years</td>
+            <td colspan="2" width="50%">&nbsp;</td>
+            <td class="u-align--right u-table-border--right">GA</td>
+            <td class="u-align--right u-table-border--right">1 year</td>
+            <td class="u-align--right u-table-border--right">2 years</td>
+            <td class="u-align--right u-table-border--right">3 years</td>
+            <td class="u-align--right u-table-border--right">4 years</td>
+            <td class="u-align--right u-table-border--right">5 years</td>
+            <td class="u-align--right u-table-border--right">6 years</td>
+            <td class="u-align--right u-table-border--right">7 years</td>
+            <td class="u-align--right u-table-border--right">8 years</td>
+            <td class="u-align--right u-table-border--right">9 years</td>
+            <td class="u-align--right u-table-border--right" style="padding-left: 0.3rem">10 years</td>
           </tr>
           <tr class="u-hide--large" style="border-top: 0;">
-            <td width="50%">&nbsp;</td>
-            <td class="u-align--right" style="border-right: 1px solid #E5E5E5;">GA</td>
-            <td colspan="5" class="u-align--right" style="border-right: 1px solid #E5E5E5;">5 years</td>
-            <td colspan="5" class="u-align--right" style="border-right: 1px solid #E5E5E5;">10 years</td>
+            <td colspan="2" width="50%">&nbsp;</td>
+            <td class="u-align--right u-table-border--right">GA</td>
+            <td colspan="5" class="u-align--right u-table-border--right">5 years</td>
+            <td colspan="5" class="u-align--right u-table-border--right">10 years</td>
           </tr>
         </tbody>
       </table>
@@ -550,6 +557,11 @@
       </div>
     </div>
   </section>
+
+
+  <!-- Set default Marketo information for contact form below-->
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/esm" data-form-id="3764" data-lp-id="" data-return-url="https://ubuntu.com/security/thank-you?product=esm" data-lp-url="">
+  </div>
 
   {% endblock content %}
   {% block footer_extra %}{{ marketo }}{% endblock footer_extra %}

--- a/templates/security/esm.html
+++ b/templates/security/esm.html
@@ -362,7 +362,7 @@
             <hr class="u-no-margin--bottom">
             <p class="p-esm-chart__label">
               <strong class="p-esm-chart__label-numbers">2,300</strong>
-              <span class="p-esm-chart__label-text"> Ubuntu Main packages, plus</span>
+              <span class="p-esm-chart__label-text"> Ubuntu Main packages + </span>
             </p>
             <p class="p-esm-chart__label">
               <strong class="p-esm-chart__label-numbers">23,000</strong>

--- a/templates/security/esm.html
+++ b/templates/security/esm.html
@@ -331,9 +331,9 @@
         <table class="p-table">
           <thead>
             <tr>
-              <th width="51%">Security patching<br /> <span style="text-transform: initial; color: #666666;">(Coverage for critical, high and selected medium CVEs)</span></th>
+              <th width="51%">Security patching<br /> <span class="u-text--muted">(Coverage for critical, high and selected medium CVEs)</span></th>
               <th width="15%" class="u-align--left">Ubuntu LTS</th>
-              <th width="24%" class="u-align--left">Ubuntu Pro (Infra-only)<br /> <span style="text-transform: initial; color: #666666;">(Previously known as ”Ubuntu Advantage for Infrastructure”)</span></th>
+              <th width="24%" class="u-align--left">Ubuntu Pro (Infra-only)<br /> <span class="u-text--muted">(Previously known as ”Ubuntu Advantage for Infrastructure”)</span></th>
               <th width="10%" class="u-align--left">Ubuntu Pro</th>
             </tr>
           </thead>
@@ -364,8 +364,8 @@
         </thead>
         <tbody>
           <tr height="254px">
-            <td class="u-align--right u-table-border--top u-no-padding-right" style="padding-top: 0"><strong>2,300</strong><br /><strong>23,000</strong></td>
-            <td colspan="2" class="u-table-border--top" style="padding-top: 0" width="25.75%"> Ubuntu Main packages, plus<br /> Ubuntu Universe packages</td>
+            <td class="u-align--right u-table-border--top u-no-padding-right u-no-padding--top"><strong>2,300</strong><br /><strong>23,000</strong></td>
+            <td colspan="2" class="u-table-border--top u-no-padding--top" width="25.75%"> <span class="u-text--muted"> Ubuntu Main packages, plus<br /> Ubuntu Universe packages</span></td>
             <td colspan="10" style="background-color:#000; color:#ffffff;padding-top: 0"><strong>Ubuntu Pro</strong></td>
           </tr>
           <tr style="border-top: none; line-height: 8px;">

--- a/templates/shared/forms/interactive/esm.html
+++ b/templates/shared/forms/interactive/esm.html
@@ -7,7 +7,7 @@
     <div class="js-pagination js-pagination--1">
       
       <div class="js-formfield">
-        <h3 class="p-heading--5">Where are you running Ubuntu 16.04 or Ubuntu 14.04?</h3>
+        <h3 class="p-heading--5">Where are you running Ubuntu LTS?</h3>
         <div class="row u-no-padding">
           <div class="col-4 u-sv3">
             <label class="p-checkbox">
@@ -51,7 +51,7 @@
               <input type="checkbox" aria-labelledby="private-cloud" class="p-checkbox__input">
               <span class="p-checkbox__label" id="private-cloud">Private cloud</span>
             </label>
-            
+
           </div>
           <div class="col-4 u-sv3">
             <label class="p-checkbox">
@@ -68,6 +68,11 @@
               <input type="checkbox" aria-labelledby="mission-critical" class="p-checkbox__input">
               <span class="p-checkbox__label" id="mission-critical">Mission-critical</span>
             </label>
+
+            <label class="p-checkbox">
+              <input type="checkbox" aria-labelledby="iot-devices" class="p-checkbox__input">
+              <span class="p-checkbox__label" id="iot-devices">IoT devices</span>
+            </label>
             
           </div>
         </div>
@@ -81,9 +86,8 @@
               <label class="p-checkbox">
                 <input class="p-checkbox__input p-active-reveal__switch" type="checkbox" aria-labelledby="less-5-machines">
                 <span class="p-checkbox__label" id="less-5-machines">&lt; 5 machines</span>
+                <p class="p-form-help-text is-tick-element p-active-reveal__item"><a href="/pro">Ubuntu Pro</a> is free for personal use, on up to 5 machines.</p>
               </label>
-
-              <p class="p-form-help-text p-active-reveal__item" style="margin-top: 0">For a small amount of machines, <a href="/pro">Ubuntu ESM is available for free</a>.</p>
 
               <label class="p-checkbox">
                 <input type="checkbox" aria-labelledby="less-50-machines" class="p-checkbox__input">
@@ -240,4 +244,3 @@
       </div>
     </div>
   </div>
-  


### PR DESCRIPTION
## Done

-Building on top of @carkod 's update. Please see the relevant pr for details. This just replaces a table implementation with a (hopefully cleaner) div implementation.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
