### PR TITLE
Re-buy expired product

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/ExpiryNotification/ExpiryNotification.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/ExpiryNotification/ExpiryNotification.tsx
@@ -82,16 +82,16 @@ const MESSAGES: Messages = {
           <>
             If you don&apos;t renew it, it will disappear from your dashboard in
             90 days. To renew your expired subscription, purchase it again by
-            clicking <strong>Buy new subscription</strong>. Your token will
-            remain the same.
+            clicking the <strong>Renew Subscription</strong> button. Your token
+            will remain the same.
           </>
         ),
         [UserSubscriptionType.Yearly]: (
           <>
             If you don&apos;t renew it, it will disappear from your dashboard in
             90 days. To renew your expired subscription, purchase it again by
-            clicking <strong>Buy new subscription</strong>. Your token will
-            remain the same.
+            clicking the <strong>Renew Subscription</strong> button. Your token
+            will remain the same.
           </>
         ),
       },
@@ -112,16 +112,16 @@ const MESSAGES: Messages = {
           <>
             If you don&apos;t renew it, it will disappear from your dashboard in
             90 days. To renew your expired subscription, purchase it again by
-            clicking <strong>Buy new subscription</strong>. Your token will
-            remain the same.
+            clicking the <strong>Renew Subscription</strong> button. Your token
+            will remain the same.
           </>
         ),
         [UserSubscriptionType.Yearly]: (
           <>
             If you don&apos;t renew it, it will disappear from your dashboard in
             90 days. To renew your expired subscription, purchase it again by
-            clicking <strong>Buy new subscription</strong>. Your token will
-            remain the same.
+            clicking the <strong>Renew Subscription</strong> button. Your token
+            will remain the same.
           </>
         ),
       },

--- a/static/js/src/advantage/react/components/Subscriptions/ReBuyExpired/ReBuyExpiredButton/ReBuyExpiredButton.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/ReBuyExpired/ReBuyExpiredButton/ReBuyExpiredButton.tsx
@@ -1,0 +1,267 @@
+import React, { useEffect, useState } from "react";
+import { ActionButton } from "@canonical/react-components";
+import * as Sentry from "@sentry/react";
+
+import useStripeCustomerInfo from "PurchaseModal/hooks/useStripeCustomerInfo";
+import usePurchase from "advantage/subscribe/react/hooks/usePurchase";
+import useFreeTrial from "advantage/subscribe/react/hooks/useFreeTrial";
+import usePendingPurchase from "advantage/subscribe/react/hooks/usePendingPurchase";
+import { getSessionData } from "utils/getSessionData";
+import { getErrorMessage } from "advantage/error-handler";
+import { BuyButtonProps } from "PurchaseModal/utils/utils";
+import { checkoutEvent, purchaseEvent } from "advantage/ecom-events";
+import { Product } from "advantage/subscribe/react/utils/utils";
+
+type Props = {
+  quantity: number;
+  product: Product;
+} & BuyButtonProps;
+
+const BuyButton = ({
+  quantity,
+  product,
+  areTermsChecked,
+  isDescriptionChecked,
+  isUsingFreeTrial,
+  isMarketingOptInChecked,
+  setTermsChecked,
+  setIsDescriptionChecked,
+  setIsMarketingOptInChecked,
+  setError,
+  setStep,
+}: Props) => {
+  const [isLoading, setIsLoading] = useState(false);
+
+  const [sessionData, setSessionData] = useState({
+    gclid: "",
+    utm_campaign: "",
+    utm_source: "",
+    utm_medium: "",
+  });
+
+  useEffect(() => {
+    setSessionData({
+      gclid: getSessionData("gclid"),
+      utm_campaign: getSessionData("utm_campaign"),
+      utm_source: getSessionData("utm_source"),
+      utm_medium: getSessionData("utm_medium"),
+    });
+  }, []);
+
+  const { data: userInfo } = useStripeCustomerInfo();
+
+  const SanitisedQuantity = Number(quantity) ?? 0;
+
+  const purchaseMutation = usePurchase({
+    quantity: SanitisedQuantity,
+    product,
+  });
+
+  const freeTrialMutation = useFreeTrial();
+
+  const {
+    data: pendingPurchase,
+    setPendingPurchaseID,
+    error: purchaseError,
+  } = usePendingPurchase();
+
+  const GAFriendlyProduct = {
+    id: product?.id,
+    name: product?.name,
+    price: (product?.price?.value ?? 0) / 100,
+    quantity: SanitisedQuantity,
+  };
+
+  const handleOnPurchaseBegin = () => {
+    // empty the product selector state persisted in the local storage
+    // after the user chooses to make a purchase
+    // to prevent page refreshes from causing accidental double purchasing
+    localStorage.removeItem("ua-subscribe-state");
+    setIsLoading(true);
+  };
+
+  const handleOnAfterPurchaseSuccess = () => {
+    if (window.isGuest && !window.isLoggedIn) {
+      location.href = `/pro/subscribe/thank-you?email=${encodeURIComponent(
+        userInfo?.customerInfo?.email
+      )}`;
+    } else {
+      location.pathname = "/pro";
+    }
+  };
+
+  const onStartTrialClick = () => {
+    handleOnPurchaseBegin();
+
+    freeTrialMutation.mutate(undefined, {
+      onSuccess: () => {
+        handleOnAfterPurchaseSuccess();
+      },
+      onError: (error) => {
+        setIsLoading(false);
+        if (
+          error instanceof Error &&
+          error.message.includes("account already had or has access to product")
+        ) {
+          setError(<>You already have trialled this product</>);
+        } else {
+          Sentry.captureException(error);
+          setError(
+            <>
+              Sorry, there was an unknown error with the free trial. Check the
+              details and try again. Contact{" "}
+              <a href="https://ubuntu.com/contact-us">Canonical sales</a> if the
+              problem persists.
+            </>
+          );
+        }
+      },
+    });
+  };
+
+  const proSelectorStates = [
+    "pro-selector-productType",
+    "pro-selector-version",
+    "pro-selector-quantity",
+    "pro-selector-feature",
+    "pro-selector-support",
+    "pro-selector-sla",
+    "pro-selector-period",
+    "pro-selector-publicCloud",
+  ];
+
+  const onPayClick = () => {
+    handleOnPurchaseBegin();
+    checkoutEvent(GAFriendlyProduct, "3");
+    purchaseMutation.mutate(undefined, {
+      onSuccess: (data) => {
+        //start polling
+        setPendingPurchaseID(data);
+        proSelectorStates.forEach((state) => localStorage.removeItem(state));
+      },
+      onError: (error) => {
+        setIsLoading(false);
+        if (
+          error instanceof Error &&
+          error.message.includes("can only make one purchase at a time")
+        ) {
+          setError(
+            <>
+              You already have a pending purchase. Please go to{" "}
+              <a href="/account/payment-methods">payment methods</a> to retry.
+            </>
+          );
+        } else {
+          Sentry.captureException(error);
+          setError(
+            <>
+              Sorry, there was an unknown error with the payment. Check the
+              details and try again. Contact{" "}
+              <a href="https://ubuntu.com/contact-us">Canonical sales</a> if the
+              problem persists.
+            </>
+          );
+        }
+      },
+    });
+  };
+
+  useEffect(() => {
+    // the initial call was successful but it returned an error while polling the purchase status
+    if (purchaseError) {
+      setIsLoading(false);
+      if (
+        purchaseError.message.includes(
+          "We are unable to authenticate your payment method"
+        )
+      ) {
+        setError(
+          <>
+            We were unable to verify your credit card. Check the details and try
+            again. Contact{" "}
+            <a href="https://ubuntu.com/contact-us">Canonical sales</a> if the
+            problem persists.
+          </>
+        );
+      } else {
+        const knownError = getErrorMessage(purchaseError);
+
+        if (!knownError) {
+          Sentry.captureException(purchaseError);
+          setError(
+            <>
+              We were unable to process the payment. Check the details and try
+              again. Contact{" "}
+              <a href="https://ubuntu.com/contact-us">Canonical sales</a> if the
+              problem persists.
+            </>
+          );
+        } else {
+          setError(knownError);
+        }
+      }
+      setTermsChecked(false);
+      setIsDescriptionChecked(false);
+      setIsMarketingOptInChecked(false);
+      setStep(1);
+    }
+  }, [purchaseError]);
+
+  useEffect(() => {
+    if (pendingPurchase?.status === "done") {
+      const purchaseInfo = {
+        id: pendingPurchase?.id,
+        origin: "UA Shop",
+        total: pendingPurchase?.invoice?.total / 100,
+        tax: pendingPurchase?.invoice?.taxAmount / 100,
+      };
+
+      purchaseEvent(purchaseInfo, GAFriendlyProduct);
+
+      // The state of the product selector is stored in the local storage
+      // if a purchase is successful we empty it so the customer will see
+      // the default values pre-selected instead of what they just bought.
+      localStorage.removeItem("ua-subscribe-state");
+
+      const request = new XMLHttpRequest();
+      const formData = new FormData();
+      formData.append("formid", "3756");
+      formData.append("email", userInfo?.customerInfo?.email ?? "");
+      formData.append("Consent_to_Processing__c", "yes");
+      formData.append("GCLID__c", sessionData?.gclid || "");
+      formData.append("utm_campaign", sessionData?.utm_campaign || "");
+      formData.append("utm_source", sessionData?.utm_source || "");
+      formData.append("utm_medium", sessionData?.utm_medium || "");
+      formData.append("store_name__c", "ua");
+      formData.append(
+        "canonicalUpdatesOptIn",
+        isMarketingOptInChecked ? "yes" : "no"
+      );
+
+      request.open("POST", "/marketo/submit");
+      request.send(formData);
+
+      request.onreadystatechange = () => {
+        if (request.readyState === 4) {
+          handleOnAfterPurchaseSuccess();
+        }
+      };
+    }
+  }, [pendingPurchase]);
+
+  return (
+    <ActionButton
+      className="col-small-2 col-medium-2 col-3 u-no-margin"
+      appearance="positive"
+      aria-label="Buy"
+      style={{ textAlign: "center" }}
+      disabled={!areTermsChecked || !isDescriptionChecked || isLoading}
+      onClick={isUsingFreeTrial ? onStartTrialClick : onPayClick}
+      loading={isLoading}
+    >
+      Buy
+    </ActionButton>
+  );
+};
+
+export default BuyButton;

--- a/static/js/src/advantage/react/components/Subscriptions/ReBuyExpired/ReBuyExpiredButton/index.ts
+++ b/static/js/src/advantage/react/components/Subscriptions/ReBuyExpired/ReBuyExpiredButton/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ReBuyExpiredButton";

--- a/static/js/src/advantage/react/components/Subscriptions/ReBuyExpired/ReBuyExpiredModal.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/ReBuyExpired/ReBuyExpiredModal.tsx
@@ -1,0 +1,153 @@
+import React from "react";
+import { UserSubscription } from "advantage/api/types";
+import {
+  Product,
+  Periods,
+  BuyButtonProps,
+} from "advantage/subscribe/react/utils/utils";
+
+type Props = {
+  subscription: UserSubscription;
+  closeModal: () => void;
+};
+
+import PurchaseModal from "PurchaseModal";
+import Summary from "./Summary/Summary";
+import ReBuyExpiredButton from "./ReBuyExpiredButton";
+import usePreview from "advantage/subscribe/react/hooks/usePreview";
+import { useLastPurchaseIds } from "advantage/react/hooks";
+import { selectPurchaseIdsByMarketplaceAndPeriod } from "advantage/react/hooks/useLastPurchaseIds";
+
+const ReBuyExpiredModal = ({ subscription, closeModal }: Props) => {
+  const termsLabel = (
+    <>
+      I agree to the{" "}
+      <a
+        href="/legal/ubuntu-advantage-service-terms"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Ubuntu Pro service terms
+      </a>
+    </>
+  );
+
+  const descriptionLabel = (
+    <>
+      I agree to the{" "}
+      <a
+        href="/legal/ubuntu-pro-description"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Ubuntu Pro description
+      </a>
+    </>
+  );
+
+  const marketingLabel =
+    "I agree to receive information about Canonical's products and services";
+
+  const price: number = subscription.price || 0;
+  const product: Product = {
+    canBeTrialled: false,
+    longId: subscription.listing_id || "",
+    name: subscription.product_name || "",
+    period: Periods.yearly,
+    price: {
+      value: price / subscription.number_of_machines,
+      currency: "USD",
+    },
+    private: false,
+    id: "physical-uai-essential-weekday-yearly", // does not matter
+    productID: "",
+    marketplace: "canonical-ua",
+  };
+
+  const { data: lastPurchaseId } = useLastPurchaseIds(
+    subscription?.account_id,
+    {
+      select: selectPurchaseIdsByMarketplaceAndPeriod(
+        subscription?.marketplace,
+        subscription?.period
+      ),
+    }
+  );
+
+  window.previousPurchaseIds = {
+    monthly: "",
+    yearly: lastPurchaseId || "",
+  };
+
+  const { data: preview } = usePreview({
+    quantity: subscription.current_number_of_machines,
+    product,
+  });
+  const ReBuyExpiredSummary = () => {
+    return (
+      <Summary
+        quantity={subscription.current_number_of_machines}
+        product={product}
+      />
+    );
+  };
+
+  const BuyButton = ({
+    areTermsChecked,
+    isDescriptionChecked,
+    isMarketingOptInChecked,
+    setTermsChecked,
+    setIsMarketingOptInChecked,
+    setIsDescriptionChecked,
+    setError,
+    setStep,
+    isUsingFreeTrial,
+  }: BuyButtonProps) => {
+    return (
+      <ReBuyExpiredButton
+        quantity={subscription.current_number_of_machines}
+        product={product}
+        areTermsChecked={areTermsChecked}
+        isMarketingOptInChecked={isMarketingOptInChecked}
+        isDescriptionChecked={isDescriptionChecked}
+        setTermsChecked={setTermsChecked}
+        setIsMarketingOptInChecked={setIsMarketingOptInChecked}
+        setIsDescriptionChecked={setIsDescriptionChecked}
+        setError={setError}
+        setStep={setStep}
+        isUsingFreeTrial={isUsingFreeTrial}
+      />
+    );
+  };
+
+  return (
+    <div
+      className="p-modal p-modal--ua-payment is-details-mode"
+      id="purchase-modal"
+    >
+      <div
+        id="react-root"
+        className="p-modal__dialog ua-dialog"
+        role="dialog"
+        aria-labelledby="modal-title"
+      >
+        <PurchaseModal
+          accountId={subscription.account_id}
+          termsLabel={termsLabel}
+          descriptionLabel={descriptionLabel}
+          marketingLabel={marketingLabel}
+          product={product}
+          preview={preview}
+          quantity={subscription.current_number_of_machines}
+          closeModal={closeModal}
+          Summary={ReBuyExpiredSummary}
+          BuyButton={BuyButton}
+          modalTitle={`Renew ${subscription.product_name}`}
+          marketplace="canonical-ua"
+        />
+      </div>
+    </div>
+  );
+};
+
+export default ReBuyExpiredModal;

--- a/static/js/src/advantage/react/components/Subscriptions/ReBuyExpired/Summary/Summary.test.jsx
+++ b/static/js/src/advantage/react/components/Subscriptions/ReBuyExpired/Summary/Summary.test.jsx
@@ -1,0 +1,73 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { add, format } from "date-fns";
+
+import { product, preview } from "advantage/subscribe/react/utils/test/Mocks";
+import * as usePreview from "advantage/subscribe/react/hooks/usePreview";
+import Summary from "./Summary";
+
+const DATE_FORMAT = "dd MMMM yyyy";
+
+describe("Summary", () => {
+  it("renders correctly with no preview", () => {
+    jest.spyOn(usePreview, "default").mockImplementation(() => {
+      return { data: null };
+    });
+
+    render(<Summary quantity={3} product={product} />);
+
+    expect(screen.getByText("Ubuntu Pro")).toBeInTheDocument();
+    expect(screen.getByText("3 x $500.00")).toBeInTheDocument();
+    expect(screen.getByTestId("start-date")).toHaveTextContent(
+      format(new Date(), DATE_FORMAT)
+    );
+    expect(screen.getByTestId("end-date")).toHaveTextContent(
+      format(
+        add(new Date(), {
+          years: 1,
+        }),
+        DATE_FORMAT
+      )
+    );
+
+    expect(screen.getByTestId("subtotal")).toHaveTextContent("$1,500.00");
+  });
+
+  it("renders correctly with a preview with tax amount", () => {
+    jest.spyOn(usePreview, "default").mockImplementation(() => {
+      return {
+        data: {
+          ...preview,
+          taxAmount: 99999,
+          total: 12345,
+          subscriptionEndOfCycle: null,
+        },
+      };
+    });
+
+    render(<Summary quantity={3} product={product} />);
+
+    expect(screen.getByTestId("tax")).toHaveTextContent("$999.99");
+    expect(screen.getByTestId("total")).toHaveTextContent("$123.45");
+  });
+
+  it("renders correctly with a preview with a different end of cycle", () => {
+    jest.spyOn(usePreview, "default").mockImplementation(() => {
+      return {
+        data: {
+          ...preview,
+          taxAmount: 10000,
+          total: 30000,
+          subscriptionEndOfCycle: "2042-02-03T16:32:54Z",
+        },
+      };
+    });
+
+    render(<Summary quantity={3} product={product} />);
+
+    expect(screen.getByTestId("for-this-period")).toHaveTextContent("$200.00");
+    expect(screen.getByTestId("end-date")).toHaveTextContent(
+      "03 February 2042"
+    );
+  });
+});

--- a/static/js/src/advantage/react/components/Subscriptions/ReBuyExpired/Summary/Summary.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/ReBuyExpired/Summary/Summary.tsx
@@ -1,0 +1,155 @@
+import React from "react";
+import { Row, Col } from "@canonical/react-components";
+import { add, format } from "date-fns";
+
+import { formatter, Product } from "advantage/subscribe/react/utils/utils";
+import usePreview from "advantage/subscribe/react/hooks/usePreview";
+import { UserSubscription } from "advantage/api/types";
+
+const DATE_FORMAT = "dd MMMM yyyy";
+
+type Props = {
+  quantity: UserSubscription["number_of_machines"];
+  product: Product;
+};
+
+function Summary({ quantity, product }: Props) {
+  const sanitisedQuanity = Number(quantity) ?? 0;
+  const { data: preview } = usePreview({ quantity: sanitisedQuanity, product });
+
+  let totalSection = (
+    <Row className="u-no-padding u-sv1">
+      <Col size={4}>
+        <div className="u-text-light">Subtotal:</div>
+      </Col>
+      <Col size={8}>
+        <div data-testid="subtotal">
+          {formatter.format(
+            ((product?.price?.value ?? 0) * sanitisedQuanity) / 100
+          )}
+        </div>
+      </Col>
+    </Row>
+  );
+
+  if (preview?.taxAmount) {
+    totalSection = (
+      <>
+        {preview?.subscriptionEndOfCycle && (
+          <Row className="u-no-padding u-sv1">
+            <Col size={4}>
+              <div className="u-text-light">For this period:</div>
+            </Col>
+            <Col size={8}>
+              <div data-testid="for-this-period">
+                {formatter.format((preview?.total - preview?.taxAmount) / 100)}
+              </div>
+            </Col>
+          </Row>
+        )}
+        <Row className="u-no-padding u-sv1">
+          <Col size={4}>
+            <div className="u-text-light">Tax:</div>
+          </Col>
+          <Col size={8}>
+            <div data-testid="tax">
+              {formatter.format(preview?.taxAmount / 100)}
+            </div>
+          </Col>
+        </Row>
+        <Row className="u-no-padding u-sv1">
+          <Col size={4}>
+            <div className="u-text-light">Total</div>
+          </Col>
+          <Col size={8}>
+            <div data-testid="total">
+              <b>{formatter.format(preview?.total / 100)}</b>
+            </div>
+          </Col>
+        </Row>
+      </>
+    );
+  } else if (preview) {
+    totalSection = (
+      <Row className="u-no-padding u-sv1">
+        <Col size={4}>
+          <div className="u-text-light">
+            Total
+            {preview?.subscriptionEndOfCycle && " for this period"}
+          </div>
+        </Col>
+        <Col size={8}>
+          <div>
+            <b>{formatter.format(preview?.total / 100)}</b>
+          </div>
+        </Col>
+      </Row>
+    );
+  }
+
+  return (
+    <section
+      id="summary-section"
+      className="p-strip is-shallow u-no-padding--top"
+    >
+      <Row className="u-no-padding u-sv1">
+        <Col size={4}>
+          <div className="u-text-light">Plan type:</div>
+        </Col>
+        <Col size={8}>
+          <div
+            data-testid="name"
+            dangerouslySetInnerHTML={{ __html: product?.name ?? "" }}
+          />
+        </Col>
+      </Row>
+      <Row className="u-no-padding u-sv1">
+        <Col size={4}>
+          <div className="u-text-light">Machines:</div>
+        </Col>
+        <Col size={8}>
+          <div data-testid="machines">
+            {quantity} x {formatter.format((product?.price?.value ?? 0) / 100)}
+          </div>
+        </Col>
+      </Row>
+      <Row className="u-no-padding u-sv1">
+        <Col size={4}>
+          <div className="u-text-light">Starts:</div>
+        </Col>
+        <Col size={8}>
+          <div data-testid="start-date">{format(new Date(), DATE_FORMAT)}</div>
+        </Col>
+      </Row>
+      <Row className="u-no-padding u-sv1">
+        <Col size={4}>
+          <div className="u-text-light">Ends:</div>
+        </Col>
+
+        {preview?.subscriptionEndOfCycle ? (
+          <Col size={8}>
+            <div data-testid="end-date">
+              {format(new Date(preview?.subscriptionEndOfCycle), DATE_FORMAT)}
+            </div>
+            <br />
+            <small>The same date as your existing subscription.</small>
+          </Col>
+        ) : (
+          <Col size={8}>
+            <div data-testid="end-date">
+              {format(
+                add(new Date(), {
+                  months: product?.period === "monthly" ? 1 : 12,
+                }),
+                DATE_FORMAT
+              )}
+            </div>
+          </Col>
+        )}
+      </Row>
+      {totalSection}
+    </section>
+  );
+}
+
+export default Summary;

--- a/static/js/src/advantage/react/components/Subscriptions/ReBuyExpired/Summary/index.ts
+++ b/static/js/src/advantage/react/components/Subscriptions/ReBuyExpired/Summary/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Summary";

--- a/static/js/src/advantage/react/components/Subscriptions/ReBuyExpired/index.ts
+++ b/static/js/src/advantage/react/components/Subscriptions/ReBuyExpired/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ReBuyExpiredModal";

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
@@ -25,6 +25,7 @@ import { SelectedId } from "../Content/types";
 import { sendAnalyticsEvent } from "advantage/react/utils/sendAnalyticsEvent";
 import RenewalModal from "../RenewalModal";
 import { UserSubscriptionType } from "advantage/api/enum";
+import ReBuyExpiredModal from "../ReBuyExpired";
 
 type Props = {
   modalActive?: boolean;
@@ -53,6 +54,9 @@ export const SubscriptionDetails = forwardRef<HTMLDivElement, Props>(
     const [editing, setEditing] = useState(false);
     const [showingCancel, setShowingCancel] = useState(false);
     const [showingRenewalModal, setShowingRenewalModal] = useState(false);
+    const [showingReBuyExpiredModal, setShowingReBuyExpiredModal] = useState(
+      false
+    );
     const [notification, setNotification] = useState<NotificationProps | null>(
       null
     );
@@ -247,6 +251,27 @@ export const SubscriptionDetails = forwardRef<HTMLDivElement, Props>(
                     />
                   </Portal>
                 )}
+                {(subscription.statuses.is_expired ||
+                  subscription.statuses.is_in_grace_period) &&
+                  (subscription.type == "monthly" ||
+                    subscription.type == "yearly") && (
+                    <Button
+                      appearance="neutral"
+                      className="p-subscriptions__details-action"
+                      data-test="renew-button"
+                      disabled={editing}
+                      onClick={() => {
+                        setShowingReBuyExpiredModal(true);
+                        sendAnalyticsEvent({
+                          eventCategory: "Advantage",
+                          eventAction: "subscription-rebuy-expired-modal",
+                          eventLabel: "subscription rebuy expired modal opened",
+                        });
+                      }}
+                    >
+                      Renew subscription&hellip;
+                    </Button>
+                  )}
                 {isResizable ? (
                   <Button
                     appearance="neutral"
@@ -301,6 +326,14 @@ export const SubscriptionDetails = forwardRef<HTMLDivElement, Props>(
             subscription={subscription}
             closeModal={() => {
               setShowingRenewalModal(false);
+            }}
+          />
+        ) : null}
+        {showingReBuyExpiredModal ? (
+          <ReBuyExpiredModal
+            subscription={subscription}
+            closeModal={() => {
+              setShowingReBuyExpiredModal(false);
             }}
           />
         ) : null}


### PR DESCRIPTION
## Done

- If a yearly/monthly product is expired or in grace period. You will have a renew subscription button to repurchase the previous product with the same number of machines.

## QA

- Fetch the branch
- But a product on an account
- Manually change the status of the subscriptions to mark them as expired but changing file:
`webapp/shop/api/ua_contracts/helpers.pywebapp/shop/api/ua_contracts/helpers.py` 
Line 330 to `"is_expired": True,`
- Go to /pro/dashboard you will see the button. The renew subscription button will bring up a modal allowing you to repurchase the previous items.

## Issue / Card

Fixes #https://warthogs.atlassian.net/browse/WD-844