### PR TITLE
update intel-iot download page

### DIFF
--- a/templates/download/iot/intel-iot.html
+++ b/templates/download/iot/intel-iot.html
@@ -98,13 +98,15 @@
     <h2>Ubuntu optimised for next-gen Intel SoCs</h2>
     <p>Intel's portfolio of edge-ready compute and connectivity technologies make it easy to deploy edge applications quickly. Enhanced for IoT, they enable processing at the edge to get critical insights and business value from your data with compute resources where you need them most.</p>
     <p><strong>Download Ubuntu for your Intel hardware.</strong> Below you will find links for the production-grade family of Ubuntu images, along with release notes and installation instructions.</p>
-    <p><a href="https://assets.ubuntu.com/v1/62b21eaf-LookoutCanyon_ReleaseNotes_22.04_221115.pdf">Release notes for Ubuntu Desktop and Server 22.04 can be found here&nbsp;&rsaquo;</a></p>
-    <p><a href="https://assets.ubuntu.com/v1/ac6f1e1b-LookoutCanyon_ReleaseNotes_20.04_221115.pdf">Release notes for Ubuntu Desktop and Server 20.04 can be found here&nbsp;&rsaquo;</a></p>    
+    <p><a href="https://assets.ubuntu.com/v1/a492a35c-LookoutCanyon_ReleaseNotes_22.04_221115_V1.1.pdf">Release notes for Ubuntu Desktop and Server 22.04&nbsp;&rsaquo;</a></p>
+    <p><a href="https://assets.ubuntu.com/v1/fd2fa325-LookoutCanyon_ReleaseNotes_20.04_221115_V1.1.pdf">Release notes for Ubuntu Desktop and Server 20.04&nbsp;&rsaquo;</a></p>    
+    <p><a href="https://assets.ubuntu.com/v1/e1201039-LookoutCanyon_ReleaseNotes_UC22_221130.pdf">Release notes for Ubuntu Core 22&nbsp;&rsaquo;</a></p>
+    <p><a href="https://assets.ubuntu.com/v1/c657029e-LookoutCanyon_ReleaseNotes_UC20_221130.pdf">Release notes for Ubuntu Core 20&nbsp;&rsaquo;</a></p>    
     <table class="p-table--mobile-card" aria-label="Ubuntu 22.04 for intel downloads">
       <thead>
         <tr>
           <th><span class="u-off-screen">Hardware type</span></th>
-          <th class="u-align--center">Ubuntu Core 22</th>
+          <th class="u-align--center">Ubuntu Core 22 <p class="u-no-margin--bottom"><a href="https://assets.ubuntu.com/v1/82c977a8-Installation+Instructions+Core+Image+Intel+IoT+Platforms.pdf">Instructions</a><p></p></th>
           <th class="u-align--center">Ubuntu Desktop 22.04 <p class="u-no-margin--bottom"><a href="https://assets.ubuntu.com/v1/2715b851-Installation+Instructions+Desktop+Image+Intel+IoT+Platforms.pdf">Instructions</a><p></th>
           <th class="u-align--center">Ubuntu Server 22.04 <p class="u-no-margin--bottom"><a href="https://assets.ubuntu.com/v1/a0b71e1e-Installation+Instructions+Server+Image+Intel+IoT+Platforms.pdf">Instructions</a><p></th>
         </tr>
@@ -112,19 +114,19 @@
       <tbody>
         <tr>
           <th>Intel Atom® X6000E Series and Intel® Pentium® and Celeron® N and J Series Processors <br/>(former codename Elkhart Lake)</th>
-          <td class="u-align--center" data-heading="Ubuntu Core 22"><p><button href="" class="p-button is-dense" disabled="">Coming soon</button></p></td>
+          <td class="u-align--center" data-heading="Ubuntu Core 22"><p><a href="https://cdimage.ubuntu.com/ubuntu-core/22/stable/20221021.3/ubuntu-core-22-amd64+intel-iot.img.xz" class="p-button is-dense">Download</a></p></td>
           <td class="u-align--center" data-heading="Ubuntu Desktop 22.04"><p><a href="https://cdimage.ubuntu.com/jammy/daily-live/manual/jammy-desktop-amd64+intel-iot.iso" class="p-button is-dense">Download</a></p></td>
           <td class="u-align--center" data-heading="Ubuntu Server 22.04"><p><a href="https://cdimage.ubuntu.com/ubuntu-server/jammy/daily-live/manual/jammy-live-server-amd64+intel-iot.iso" class="p-button is-dense">Download</a></p></td>
         </tr>
         <tr>
           <th>11th Gen Intel® Core™ processors <br/>(former codename Tiger Lake)</th>
-          <td class="u-align--center" data-heading="Ubuntu Core 22"><p><button href="" class="p-button is-dense" disabled="">Coming soon</button></p></td>
+          <td class="u-align--center" data-heading="Ubuntu Core 22"><p><a href="https://cdimage.ubuntu.com/ubuntu-core/22/stable/20221021.3/ubuntu-core-22-amd64+intel-iot.img.xz" class="p-button is-dense">Download</a></p></td>
           <td class="u-align--center" data-heading="Ubuntu Desktop 22.04"><p><a href="https://cdimage.ubuntu.com/jammy/daily-live/manual/jammy-desktop-amd64+intel-iot.iso" class="p-button is-dense">Download</a></p></td>
           <td class="u-align--center" data-heading="Ubuntu Server 22.04"><p><a href="https://cdimage.ubuntu.com/ubuntu-server/jammy/daily-live/manual/jammy-live-server-amd64+intel-iot.iso" class="p-button is-dense">Download</a></p></td>
         </tr>
         <tr>
           <th>12th Gen Intel® Core™ processors <br/>(former codename Alder Lake S, P)</th>
-          <td class="u-align--center" data-heading="Ubuntu Core 22"><p><button href="" class="p-button is-dense" disabled="">Coming soon</button></p></td>
+          <td class="u-align--center" data-heading="Ubuntu Core 22"><p><button class="p-button is-dense" disabled="">Coming soon</button></p></td>
           <td class="u-align--center" data-heading="Ubuntu Desktop 22.04"><p><a href="https://cdimage.ubuntu.com/jammy/daily-live/manual/jammy-desktop-amd64+intel-iot.iso" class="p-button is-dense">Download</a></p></td>
           <td class="u-align--center" data-heading="Ubuntu Server 22.04"><p><a href="https://cdimage.ubuntu.com/ubuntu-server/jammy/daily-live/manual/jammy-live-server-amd64+intel-iot.iso" class="p-button is-dense">Download</a></p></td>
         </tr>
@@ -149,13 +151,13 @@
       <tbody>
         <tr>
           <th>Intel Atom® X6000E Series and Intel® Pentium® and Celeron® N and J Series Processors <br/>(former codename Elkhart Lake)</th>
-          <td class="u-align--center" data-heading="Ubuntu Core 20"><p><button href="" class="p-button is-dense" disabled="">Coming soon</button></p></td>
+          <td class="u-align--center" data-heading="Ubuntu Core 20"><p><a href="https://cdimage.ubuntu.com/ubuntu-core/20/stable/20221025.4/ubuntu-core-20-amd64+intel-iot.img.xz" class="p-button is-dense">Download</a></p></td>
           <td class="u-align--center" data-heading="Ubuntu Desktop 20.04"><p><a href="https://cdimage.ubuntu.com/focal/daily-live/manual/focal-desktop-amd64+intel-iot.iso" class="p-button is-dense">Download</a></p></td>
           <td class="u-align--center" data-heading="Ubuntu Server 20.04"><p><a href="https://cdimage.ubuntu.com/ubuntu-server/focal/daily-live/manual/focal-live-server-amd64+intel-iot.iso" class="p-button is-dense">Download</a></p></td>
         </tr>
         <tr>
           <th>11th Gen Intel® Core™ processors <br/>(former codename Tiger Lake)</th>
-          <td class="u-align--center" data-heading="Ubuntu Core 20"><p><button href="" class="p-button is-dense" disabled="">Coming soon</button></p></td>
+          <td class="u-align--center" data-heading="Ubuntu Core 20"><p><a href="https://cdimage.ubuntu.com/ubuntu-core/20/stable/20221025.4/ubuntu-core-20-amd64+intel-iot.img.xz" class="p-button is-dense">Download</a></p></td>
           <td class="u-align--center" data-heading="Ubuntu Desktop 20.04"><p><a href="https://cdimage.ubuntu.com/focal/daily-live/manual/focal-desktop-amd64+intel-iot.iso" class="p-button is-dense">Download</a></p></td>
           <td class="u-align--center" data-heading="Ubuntu Server 20.04"><p><a href="https://cdimage.ubuntu.com/ubuntu-server/focal/daily-live/manual/focal-live-server-amd64+intel-iot.iso" class="p-button is-dense">Download</a></p></td>
         </tr>             


### PR DESCRIPTION
## Done

- updated the content on /download/iot/intel-iot according to the [copy doc](https://docs.google.com/document/d/1hxKzPs6e6JQaa9tBqfZ55GAXrVnEryEWBja8HlXy-lc/edit)

## QA

- Visit https://ubuntu-com-12338.demos.haus/download/iot/intel-iot
- See that the content matches the copy doc

## Issue / Card

Fixes https://github.com/canonical/commercial-squad/issues/751
