### PR TITLE
feat(subnav): add link to landscape subnav LANDPM-474

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -635,6 +635,8 @@ landscape:
       path: /landscape/install
     - title: Docs
       path: https://docs.ubuntu.com/landscape/en/
+    - title: Forums
+      path: https://discourse.ubuntu.com/c/landscape/89
     - title: Log in to Landscape
       path: https://landscape.canonical.com/login/authenticate
 


### PR DESCRIPTION
## Done

- added "Forums" link to /landscape bubble subnav

## QA

- Visit /landscape
- See that the subnav includes "Forums"
- Click the link and see that you're taken to discourse

## Issue / Card

Fixes https://github.com/canonical/web-squad/issues/6274 / https://warthogs.atlassian.net/browse/LANDPM-474
