### PR TITLE
fix(copy): update try landscape contextual footer copy LANDPM-477

### DIFF
--- a/templates/shared/contextual_footers/_support_landscape.html
+++ b/templates/shared/contextual_footers/_support_landscape.html
@@ -1,5 +1,5 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--4">Try Landscape for free</h3>
-  <p>At just 1&cent; per machine hour, you can use Landscape without subscribing to Ubuntu Advantage. Sign-up today and get a $100 free credit that is good for up to 60 days and see the features for yourself.</p>
-  <p><a href="https://landscape.canonical.com/signup" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'landscape.canonical.com trial', 'eventLabel' : 'Try Landscape for 30 days', 'eventValue' : undefined });">Get your $100 Landscape credit&nbsp;&rsaquo;</a></p>
+  <p>Landscape is the most cost-effective way to manage desktops, servers, and clouds. Landscape is available with an Ubuntu Pro subscription. Self-hosted Landscape has a free tier for up to 10 machines for personal use, or evaluation purposes.</p>
+  <p><a href="/landscape/install" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'install Landscape CTA', 'eventLabel' : 'Install Landscape today', 'eventValue' : undefined });">Install Landscape today&nbsp;&rsaquo;</a></p>
 </div>


### PR DESCRIPTION
## Done

- updated the copy for the landscape contextual footer to match the request in https://warthogs.atlassian.net/browse/LANDPM-477

## QA

- Visit:
  - https://ubuntu-com-12347.demos.haus/support
  - https://ubuntu-com-12347.demos.haus/pricing/consulting
  - https://ubuntu-com-12347.demos.haus/support/community-support
  - https://ubuntu-com-12347.demos.haus/security/docker-images
- See that the "Try Landscape for free" section matches the copy in the JIRA ticket, and that the link takes you to /landscape/install

## Issue / Card

Fixes https://github.com/canonical/web-squad/issues/6273 / https://warthogs.atlassian.net/browse/LANDPM-477

