### PR TITLE
Add missing data-testid on /esm

### DIFF
--- a/templates/security/esm.html
+++ b/templates/security/esm.html
@@ -23,7 +23,7 @@
       <div class="col-6">
         <p>Security maintenance for the entire collection of software packages shipped with Ubuntu.</p>
         <p>ESM enables continuous vulnerability management for critical, high and medium CVEs.</p>
-        <a href="/security/esm#get-in-touch" class="p-button--positive js-invoke-modal">Contact us</a>
+        <a href="/security/esm#get-in-touch" class="p-button--positive js-invoke-modal" data-testid="interactive-form-link">Contact us</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Done

- Fix [test failing](https://github.com/canonical/ubuntu.com/actions/runs/3630198453) by adding `data-testid` on `/esm`
<img width="945" alt="image" src="https://user-images.githubusercontent.com/57550290/206136955-cdc9e6c8-be12-413a-8d49-5cd81e7da6b3.png">

## QA
https://discourse.canonical.com/t/how-to-run-cypress-test-locally-for-forms-on-ubuntu-com/558
