### PR TITLE
Instant provisioning for TA exams

### DIFF
--- a/templates/credentials/assessments.html
+++ b/templates/credentials/assessments.html
@@ -17,22 +17,20 @@
       <thead>
         <tr>
           <th>Exam</th>
-          <th>Date</th>
+          <th>Status</th>
           <th>Time</th>
           <th>Timezone</th>
-          <th>Status</th>
-          <th>UUID</th>
+          <th>Email</th>
         </tr>
       </thead>
       <tbody>
         {% for exam in exams %}
         <tr>
-          <td><a href="/credentials/exam?id={{ exam['id'] }}">{{ exam["name"] }}</a></td>
-          <td>{{ exam["date"] }}</td>
-          <td>{{ exam["time"] }}</td>
-          <td>{{ exam["timezone"] }}</td>
+          <td><a href="/credentials/exam?id={{ exam['id'] }}">{{ exam["name"] }}</a><br />{{ exam["id"] }}</td>
           <td>{{ exam["state"] }}</td>
-          <td>{{ exam["uuid"] }}</td>
+          <td>{{ exam["date"] }}<br />{{ exam["time"] }}</td>
+          <td>{{ exam["timezone"] }}</td>
+          <td>{{ exam["user_email"] }}</td>
         </tr>
         {% endfor %}
       </tbody>

--- a/templates/credentials/provision.html
+++ b/templates/credentials/provision.html
@@ -22,21 +22,34 @@
     <h1>Welcome to the CUE: Linux Beta!</h1>
     <h2>Take your exam now</h2>
     {% if assessment %}
-      {% set percent_complete = [100 * assessment["provisioning_time"] // assessment["average_provisioning_time"], 100] | min %}
+    {% set percent_complete = [100 * assessment["provisioning_time"] // assessment["average_provisioning_time"], 100] | min %}
       {% if assessment["state"] in ["notified", "released", "in_progress"] %}
       <p>Your exam is ready to go! Click Take Exam to begin.</p>
       <p><a class="p-button--positive" href="/credentials/exam?id={{ assessment['id'] }}">Take Exam</a></p>
       {% elif assessment["state"] in ["created", "drafted", "provisioning", "provisioned", "notifying"] %}
       <p>Your exam environment is being provisioned ({{ percent_complete }}%). <i class="p-icon--spinner u-animation--spin"></i></p>
-      <p>Note that it may take up to 20 minutes for your exam environment to be ready.</p>
+      <div class="p-notification--information">
+        <div class="p-notification__content">
+          <p class="p-notification__message">During this limited testing cycle, exams could potentially take up to 20 minutes to be provisioned under heavy system load.</p>
+        </div>
+      </div>
       {% else %}
       <p>Your exam is complete. Please make sure that you have completed the <a href="/credentials/exit-survey">exit survey</a>.</p>
       {% endif %}
     {% elif reservation %}
     <p>Your exam environment has been scheduled and is awaiting provisioning. <i class="p-icon--spinner u-animation--spin"></i></p>
-    <p>Note that it may take up to 20 minutes for your exam environment to be ready.</p>
+    <div class="p-notification--information">
+      <div class="p-notification__content">
+        <p class="p-notification__message">During this limited testing cycle, exams could potentially take up to 20 minutes to be provisioned under heavy system load.</p>
+      </div>
+    </div>
     {% else %}
-    <p>Click Start to begin your exam. Note that it may take up to 20 minutes for your exam environment to be ready.</p>
+    <p>Click Start to begin your exam.</p>
+    <div class="p-notification--information">
+      <div class="p-notification__content">
+        <p class="p-notification__message">During this limited testing cycle, exams could potentially take up to 20 minutes to be provisioned under heavy system load.</p>
+      </div>
+    </div>
     <form method="post">
       <button class="p-button--positive" type="submit" name="submit">Start</button>
     </form>

--- a/templates/credentials/provision.html
+++ b/templates/credentials/provision.html
@@ -1,0 +1,51 @@
+{% extends "credentials/base_cube.html" %}
+
+{% block title %}Canonical Credentials -- Provision{% endblock %}
+
+{% block meta_description %}The Canonical Ubuntu Essentials exams certify knowledge and verify skills in general Linux, Ubuntu Desktop, and Ubuntu Server topics.{% endblock meta_description %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1QuhO-9FEOGLrYp8bErS_9snqdljl7d6tFAUoNQxoVDQ/edit{% endblock meta_copydoc %}
+
+{% block content %}
+
+<section class="p-strip--suru-topped">
+  <div class="row">
+    {% if error %}
+    <div class="row">
+      <div class="p-notification--negative">
+        <div class="p-notification__content">
+          <h5 class="p-notification__title">Error</h5>
+          <p class="p-notification__message">{{ error }}</p>
+        </div>
+      </div>
+    </div>
+    {% endif %}
+    <h1>Welcome to the CUE: Linux Beta!</h1>
+    <h2>Take your exam now</h2>
+    {% if assessment %}
+      {% set percent_complete = [100 * assessment["provisioning_time"] // assessment["average_provisioning_time"], 100] | min %}
+      {% if assessment["state"] in ["notified", "released", "in_progress"] %}
+        <p>Your exam is ready to go! Click Take Exam to begin.</p>
+        <p><a class="p-button--positive" href="/credentials/exam?id={{ assessment['id'] }}">Take Exam</a></p>
+      {% elif assessment["state"] in ["created", "drafted", "provisioning", "provisioned", "notifying"] %}
+        <p>Your exam environment is being provisioned ({{ percent_complete }}%). <i class="p-icon--spinner u-animation--spin"></i></p>
+        <p>Note that it may take up to 20 minutes for your exam environment to be ready.</p>
+      {% endif %}
+    {% elif reservation %}
+        <p>Your exam environment has been scheduled and is awaiting provisioning. <i class="p-icon--spinner u-animation--spin"></i></p>
+        <p>Note that it may take up to 20 minutes for your exam environment to be ready.</p>
+    {% else %}
+    <p>Click Start to begin your exam. Note that it may take up to 20 minutes for your exam environment to be ready.</p>
+    <form method="post">
+      <button class="p-button--positive" type="submit" name="submit">Start</button>
+    </form>
+    <h2>Or schedule for later</h2>
+    <p>Visit the <a href="/credentials/schedule">Scheduling</a> page if you would prefer to schedule your exam for a time in the next one to seven days.</p>
+    {% endif %}
+  </div>
+</section>
+
+<script>
+  window.setTimeout(() => window.location.reload(), 30000)
+</script>
+
+{% endblock content%}

--- a/templates/credentials/provision.html
+++ b/templates/credentials/provision.html
@@ -24,15 +24,17 @@
     {% if assessment %}
       {% set percent_complete = [100 * assessment["provisioning_time"] // assessment["average_provisioning_time"], 100] | min %}
       {% if assessment["state"] in ["notified", "released", "in_progress"] %}
-        <p>Your exam is ready to go! Click Take Exam to begin.</p>
-        <p><a class="p-button--positive" href="/credentials/exam?id={{ assessment['id'] }}">Take Exam</a></p>
+      <p>Your exam is ready to go! Click Take Exam to begin.</p>
+      <p><a class="p-button--positive" href="/credentials/exam?id={{ assessment['id'] }}">Take Exam</a></p>
       {% elif assessment["state"] in ["created", "drafted", "provisioning", "provisioned", "notifying"] %}
-        <p>Your exam environment is being provisioned ({{ percent_complete }}%). <i class="p-icon--spinner u-animation--spin"></i></p>
-        <p>Note that it may take up to 20 minutes for your exam environment to be ready.</p>
+      <p>Your exam environment is being provisioned ({{ percent_complete }}%). <i class="p-icon--spinner u-animation--spin"></i></p>
+      <p>Note that it may take up to 20 minutes for your exam environment to be ready.</p>
+      {% else %}
+      <p>Your exam is complete. Please make sure that you have completed the <a href="/credentials/exit-survey">exit survey</a>.</p>
       {% endif %}
     {% elif reservation %}
-        <p>Your exam environment has been scheduled and is awaiting provisioning. <i class="p-icon--spinner u-animation--spin"></i></p>
-        <p>Note that it may take up to 20 minutes for your exam environment to be ready.</p>
+    <p>Your exam environment has been scheduled and is awaiting provisioning. <i class="p-icon--spinner u-animation--spin"></i></p>
+    <p>Note that it may take up to 20 minutes for your exam environment to be ready.</p>
     {% else %}
     <p>Click Start to begin your exam. Note that it may take up to 20 minutes for your exam environment to be ready.</p>
     <form method="post">

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -55,6 +55,7 @@ from webapp.shop.cube.views import (
     cred_cancel_exam,
     cred_assessments,
     cred_exam,
+    cred_provision,
 )
 
 from webapp.views import (
@@ -918,6 +919,10 @@ app.add_url_rule("/credentials/exam", view_func=cred_exam)
 app.add_url_rule(
     "/credentials/exit-survey",
     view_func=cred_submit_form,
+)
+app.add_url_rule(
+    "/credentials/provision",
+    view_func=cred_provision,
     methods=["GET", "POST"],
 )
 

--- a/webapp/shop/api/trueability/api.py
+++ b/webapp/shop/api/trueability/api.py
@@ -93,22 +93,15 @@ class TrueAbilityAPI:
         first_name: str,
         last_name: str,
         timezone: str,
+        country_code: str,
     ):
         uri = "/api/v1/assessment_reservations"
-        # headers = {"Content-Type": "application/json"}
         body = {
             "assessment_reservation": {
                 "ability_screen_id": ability_screen_id,
                 "starts_at": starts_at,
-                "additional_time_minutes": 20,
                 "address_attributes": {
-                    "city": "San Antonio",
-                    "country_code": "US",
-                    "street_address": "1234 Pecan",
-                    "street_address2": "Suite 300",
-                    "state": "Texas",
-                    "time_zone": timezone,
-                    "zipcode": "78201",
+                    "country_code": country_code,
                 },
             },
             "user": {
@@ -121,15 +114,14 @@ class TrueAbilityAPI:
         return self.make_request("POST", uri, json=body).json()
 
     def patch_assessment_reservation(
-        self, starts_at: str, timezone: str, uuid: str
+        self, starts_at: str, timezone: str, country_code: str, uuid: str
     ):
         uri = f"/api/v1/assessment_reservations/{uuid}"
         body = {
             "assessment_reservation": {
                 "starts_at": starts_at,
                 "address_attributes": {
-                    "country_code": "US",
-                    "time_zone": timezone,
+                    "country_code": country_code,
                 },
             },
             "user": {"time_zone": timezone},

--- a/webapp/shop/cube/views.py
+++ b/webapp/shop/cube/views.py
@@ -14,6 +14,13 @@ from googleapiclient.discovery import build
 from werkzeug.exceptions import BadRequest
 
 
+TIMEZONE_COUNTRIES = {
+    timezone: country
+    for country, timezones in pytz.country_timezones.items()
+    for timezone in timezones
+}
+
+
 @shop_decorator(area="cube", permission="user_or_guest", response="html")
 def cred_home(
     ua_contracts_api,
@@ -74,11 +81,12 @@ def cred_schedule(
         ability_screen_id = 4190
         email = sso_user["email"]
         first_name, last_name = sso_user["fullname"].rsplit(" ", maxsplit=1)
+        country_code = TIMEZONE_COUNTRIES[timezone]
         response = None
 
         if "uuid" in data:
             response = trueability_api.patch_assessment_reservation(
-                starts_at.isoformat(), timezone, data["uuid"]
+                starts_at.isoformat(), timezone, country_code, data["uuid"]
             )
         else:
             response = trueability_api.post_assessment_reservation(
@@ -88,6 +96,7 @@ def cred_schedule(
                 first_name,
                 last_name,
                 timezone,
+                country_code,
             )
 
         if response and "error" in response:
@@ -296,11 +305,14 @@ def cred_assessments(
                 "date": started_at.strftime("%d %b %Y")
                 if started_at
                 else "N/A",
-                "time": started_at.strftime("%H:%M") if started_at else "N/A",
+                "time": started_at.strftime("%I:%M %p %Z")
+                if started_at
+                else "N/A",
                 "timezone": timezone,
                 "state": r["state"],
                 "id": r["id"],
                 "uuid": r["uuid"],
+                "user_email": user_email,
             }
         )
 
@@ -332,6 +344,59 @@ def cred_exam(
 
     url = trueability_api.get_assessment_redirect(assessment_id)
     return flask.render_template("credentials/exam.html", url=url)
+
+
+@shop_decorator(area="cube", permission="user", response="html")
+@canonical_staff()
+def cred_provision(trueability_api, **_):
+    sso_user = user_info(flask.session)
+    sso_user_email = sso_user["email"]
+    ability_screen_id = 4194
+
+    reservation_uuid = flask.session.get("_assessment_reservation_uuid")
+    assessment = None
+    reservation = None
+    error = None
+
+    if reservation_uuid:
+        response = trueability_api.get_assessment_reservation(reservation_uuid)
+
+        if "error" in response:
+            error = response.get(
+                "message", "An error occurred while fetching your exam."
+            )
+        else:
+            reservation = response["assessment_reservation"]
+            assessment = reservation["assessment"]
+
+    elif flask.request.method == "POST":
+        starts_at = datetime.utcnow() + timedelta(seconds=70)
+        first_name, last_name = sso_user["fullname"].rsplit(" ", maxsplit=1)
+        response = trueability_api.post_assessment_reservation(
+            ability_screen_id,
+            starts_at.isoformat(),
+            sso_user_email,
+            first_name,
+            last_name,
+            "UTC",
+            "DE",
+        )
+
+        if "error" in response:
+            error = response.get(
+                "message", "An error occurred while creating your exam."
+            )
+        else:
+            reservation = response["assessment_reservation"]
+            assessment = reservation["assessment"]
+            flask.session["_assessment_reservation_uuid"] = reservation["uuid"]
+
+    return flask.render_template(
+        "/credentials/provision.html",
+        assessment=assessment,
+        reservation=reservation,
+        error=error,
+    )
 
 
 @shop_decorator(area="cube", permission="user", response="json")

--- a/webapp/shop/cube/views.py
+++ b/webapp/shop/cube/views.py
@@ -365,16 +365,19 @@ def cred_provision(trueability_api, **_):
             ability_screen_id=ability_screen_id,
         )
 
-        for reservation in response["assessment_reservations"]:
-            if reservation.get("user", {}).get("email") != sso_user_email:
+        for response_reservation in response["assessment_reservations"]:
+            if (
+                response_reservation.get("user", {}).get("email")
+                != sso_user_email
+            ):
                 continue
 
-            if reservation.get("state") in [
+            if response_reservation.get("state") in [
                 "created",
                 "scheduled",
                 "processed",
             ]:
-                reservation_uuid = reservation["uuid"]
+                reservation_uuid = response_reservation["uuid"]
                 flask.session[
                     "_assessment_reservation_uuid"
                 ] = reservation_uuid

--- a/webapp/shop/cube/views.py
+++ b/webapp/shop/cube/views.py
@@ -358,6 +358,28 @@ def cred_provision(trueability_api, **_):
     reservation = None
     error = None
 
+    if not reservation_uuid:
+        response = trueability_api.paginate(
+            trueability_api.get_assessment_reservations,
+            "assessment_reservations",
+            ability_screen_id=ability_screen_id,
+        )
+
+        for reservation in response["assessment_reservations"]:
+            if reservation.get("user", {}).get("email") != sso_user_email:
+                continue
+
+            if reservation.get("state") in [
+                "created",
+                "scheduled",
+                "processed",
+            ]:
+                reservation_uuid = reservation["uuid"]
+                flask.session[
+                    "_assessment_reservation_uuid"
+                ] = reservation_uuid
+                break
+
     if reservation_uuid:
         response = trueability_api.get_assessment_reservation(reservation_uuid)
 


### PR DESCRIPTION
## Done

- Implement instant provisioning for TA exams
  - On `GET /credentials/provision`, the session is checked for a reservation UUID.
    - If reservation UUID does not exist, check the API for a reservation and store its UUID if found.
    - If reservation UUID exists, the reservation and assessment are fetched and the status is displayed to the user.
  - On `POST /credentials/provision`, if there is no known reservation:
    - An assessment is scheduled for 70 seconds in the future and the reservation UUID is stored as part of the session.
  - The page automatically refreshes every 30 seconds to display the provisioning status.
- Determine country code based on user's time zone

## QA

- Go to https://ubuntu-com-12350.demos.haus/credentials/provision
  - Click the Start button
  - Wait for provisioning to finish
  - Click the Take Exam button and start the exam

## Screenshots

![cred-provision-start](https://user-images.githubusercontent.com/995051/207901298-7a1ca61d-fc50-4a15-b510-91fbe9a5c803.png)

![cred-provision-wait](https://user-images.githubusercontent.com/995051/207901329-ccb21cd3-edd5-40c2-9d77-017943ce18d7.png)

![cred-provision](https://user-images.githubusercontent.com/995051/207901389-b1f729f5-c212-4633-8f58-a627929d0615.png)

![cred-provision-take](https://user-images.githubusercontent.com/995051/207619274-f4dcd8b5-0256-4b83-9bef-169640e579d8.png)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
