### PR TITLE
test: define separate test block for each form

### DIFF
--- a/tests/cypress/forms/forms_spec.js
+++ b/tests/cypress/forms/forms_spec.js
@@ -60,18 +60,16 @@ context("Static marketo forms", () => {
     cy.findByText(/Let’s discuss/).click();
     cy.findByRole("heading", { name: /Thank you/ });
   });
-
 });
 
 context("Interactive marketo forms", () => {
-  it(
-    "should check each interactive contact modal",
-    { scrollBehavior: "center" },
-    () => {
-      cy.visit("/");
-      cy.acceptCookiePolicy();
-
-      interactiveForms.forEach((form) => {
+  interactiveForms.forEach((form) => {
+    it(
+      `can submit a contact dialog form on ${form.url}`,
+      { scrollBehavior: "center" },
+      () => {
+        cy.visit("/");
+        cy.acceptCookiePolicy();
         cy.visit(form.url);
         cy.findByTestId("interactive-form-link").click();
         cy.findByRole("dialog").within(() => {
@@ -84,19 +82,19 @@ context("Interactive marketo forms", () => {
           cy.findByText(form.submitBtn).click();
         });
         cy.url().should("include", "#success");
-      });
-    }
-  );
+      }
+    );
+  });
 
   // wrote separate test for some pages as there are same email inputs in the modal and in the page.
-  it(
-    "should check interactive contact modal With Email TestId",
-    { scrollBehavior: "center" },
-    () => {
-      cy.visit("/");
-      cy.acceptCookiePolicy();
+  formsWithEmailTestId.forEach((form) => {
+    it(
+      `can submit a contact form with e-mail on ${form.url}`,
+      { scrollBehavior: "center" },
+      () => {
+        cy.visit("/");
+        cy.acceptCookiePolicy();
 
-      formsWithEmailTestId.forEach((form) => {
         cy.visit(form.url);
         cy.findByTestId("interactive-form-link").click();
 
@@ -112,9 +110,9 @@ context("Interactive marketo forms", () => {
         });
 
         cy.url().should("include", "#success");
-      });
-    }
-  );
+      }
+    );
+  });
 
   // wrote separate test for /robotics page as cypress couldn't find the job title input field by label text
   it(


### PR DESCRIPTION
## Done

- define separate test block for each form

## Why is this needed
This will result  in better error reporting and cypress beforeEach/afterEach requests interception

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
