### PR TITLE
Aligning text table with SVG rendering of same, dropped 10.04/12.04

### DIFF
--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -81,18 +81,6 @@
           </thead>
           <tbody>
             <tr>
-              <td><strong>10.04 LTS (Lucid Lynx)</strong></td>
-              <td>Apr 2010</td>
-              <td>Apr 2015</td>
-              <td>&nbsp;</td>
-            </tr>
-            <tr>
-              <td><strong>12.04 LTS (Precise Pangolin)</strong></td>
-              <td>Apr 2012</td>
-              <td>Apr 2017</td>
-              <td>Apr 2019</td>
-            </tr>
-            <tr>
               <td><strong>14.04 LTS (Trusty Tahr)</strong></td>
               <td>Apr 2014</td>
               <td>Apr 2019</td>
@@ -139,6 +127,12 @@
               <td>Apr 2022</td>
               <td>Apr 2027</td>
               <td>Apr 2032</td>
+            </tr>
+            <tr>
+              <td><strong>22.10 (Kinetic Kudu)</strong></td>
+              <td>Oct 2022</td>
+              <td>Jul 2023</td>
+              <td>&nbsp;</td>
             </tr>
           </tbody>
         </table>


### PR DESCRIPTION
The current template misses the 22.10 release and still includes 10.04 and 12.04. This PR aligns this to match what is visibly rendered in the SVG on the release page (https://ubuntu.com/about/release-cycle). Ideally this should be auto-generated, but currently is not. 