### PR TITLE
Cred exit survey

### DIFF
--- a/templates/credentials/exit-survey.html
+++ b/templates/credentials/exit-survey.html
@@ -1,0 +1,14 @@
+{% extends "credentials/base_cube.html" %}
+
+{% block title %}Contact us | Certification {% endblock %}
+{% block meta_copydoc %}{% endblock meta_copydoc %}
+
+{% block content %}
+{% with h1="Exit survey",
+intro_text="Help us improve the quality of the exams.",
+formid="4777",
+lpId="7140",
+returnURL="/credentialling/thank-you" %}
+{% include "shared/_credentials-exit-survey.html" %}
+{% endwith %}
+{% endblock content %}

--- a/templates/shared/_credentials-exit-survey.html
+++ b/templates/shared/_credentials-exit-survey.html
@@ -1,0 +1,775 @@
+<section class="p-strip">
+  <div class="row">
+    <div class="col-8">
+      <h1>{{h1}}</h1>
+      <p class="p-heading--4">{{intro_text}}</p>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <form action="/marketo/submit" method="post" id="mktoForm_{{formid}}">
+        <fieldset class="u-no-margin--bottom">
+          <h3>Content</h3>
+          <ul class="p-list">
+            <li class="p-list__item">
+              <label for="ExitSurveyRelevanceofShortFormQuestions" id="LblExitSurveyRelevanceofShortFormQuestions">This
+                exam is a
+                prerequisite for more advanced levels of certification and certifies a fundamental level of knowledge in
+                the Linux/OSS community, Ubuntu Desktop, and Ubuntu Server. Choose the statement that feels more
+                accurate in relation to this goal. </label>
+              <fieldset id="ExitSurveyRelevanceofShortFormQuestions" name="ExitSurveyRelevanceofShortFormQuestions"
+                aria-labelledby="LblExitSurveyRelevanceofShortFormQuestions InstructExitSurveyRelevanceofShortFormQuestions">
+                <div class="row">
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyRelevanceofShortFormQuestions"
+                        aria-labelledby="ExitSurveyRelevanceofShortFormQuestions1">
+                      <span class="p-radio__label" id="ExitSurveyRelevanceofShortFormQuestions1">Not relevant at
+                        all</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyRelevanceofShortFormQuestions"
+                        aria-labelledby="ExitSurveyRelevanceofShortFormQuestions4">
+                      <span class="p-radio__label" id="ExitSurveyRelevanceofShortFormQuestions4">Not very
+                        relevant</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyRelevanceofShortFormQuestions"
+                        aria-labelledby="ExitSurveyRelevanceofShortFormQuestions2">
+                      <span class="p-radio__label" id="ExitSurveyRelevanceofShortFormQuestions2">Somewhat
+                        relevant</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyRelevanceofShortFormQuestions"
+                        aria-labelledby="ExitSurveyRelevanceofShortFormQuestions3">
+                      <span class="p-radio__label" id="ExitSurveyRelevanceofShortFormQuestions3">Very relevant</span>
+                    </label>
+                  </div>
+                </div>
+              </fieldset>
+            </li>
+            <li class="p-list__item">
+              <label for="ExitSurveyRelevanceofQuestions" id="LblExitSurveyRelevanceofQuestions">What is your experience
+                with Ubuntu?</label>
+              <fieldset id="ExitSurveyRelevanceofQuestions" name="ExitSurveyRelevanceofQuestions"
+                aria-labelledby="LblExitSurveyRelevanceofQuestions InstructExitSurveyRelevanceofQuestions">
+                <div class="row">
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyRelevanceofQuestions"
+                        aria-labelledby="ExitSurveyRelevanceofQuestions1">
+                      <span class="p-radio__label" id="ExitSurveyRelevanceofQuestions1">Not relevant at all</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyRelevanceofQuestions"
+                        aria-labelledby="ExitSurveyRelevanceofQuestions2">
+                      <span class="p-radio__label" id="ExitSurveyRelevanceofQuestions2">Somewhat relevant</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyRelevanceofQuestions"
+                        aria-labelledby="ExitSurveyRelevanceofQuestions3">
+                      <span class="p-radio__label" id="ExitSurveyRelevanceofQuestions3">Very relevant</span>
+                    </label>
+                  </div>
+                </div>
+              </fieldset>
+            </li>
+            <li class="p-list__item">
+              <label for="cube_ubuntu_experience" id="Lblcube_ubuntu_experience">Were the questions asked what you
+                expected them to be? Choose the statement that feels the most accurate</label>
+              <div class="row">
+                <div class="col-3">
+                  <select id="cube_ubuntu_experience" name="cube_ubuntu_experience"
+                    aria-labelledby="Lblcube_ubuntu_experience" class="is-required" required="">
+                    <option value="" disabled="disabled" selected="">Select...</option>
+                    <option value="Didnot expect these questions">I did not expect these questions at all </option>
+                    <option value="Many were what I wanted">Many questions were what I anticipated them to be</option>
+                    <option value="Exactly what I anticipated">This is exactly what I was expecting</option>
+                  </select>
+                </div>
+              </div>
+            </li>
+            <li class="p-list__item">
+              <label for="ExitSurveyNumberOfQuestions" id="LblExitSurveyNumberOfQuestions">What do you think about the
+                number of questions?</label>
+              <fieldset id="ExitSurveyNumberOfQuestions" name="ExitSurveyNumberOfQuestions"
+                aria-labelledby="LblExitSurveyNumberOfQuestions InstructExitSurveyNumberOfQuestions">
+                <div class="row">
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyNumberOfQuestions"
+                        aria-labelledby="ExitSurveyNumberOfQuestions1">
+                      <span class="p-radio__label" id="ExitSurveyNumberOfQuestions1">Too many</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyNumberOfQuestions"
+                        aria-labelledby="ExitSurveyNumberOfQuestions2">
+                      <span class="p-radio__label" id="ExitSurveyNumberOfQuestions2">About the right amount</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyNumberOfQuestions"
+                        aria-labelledby="ExitSurveyNumberOfQuestions3">
+                      <span class="p-radio__label" id="ExitSurveyNumberOfQuestions3">Too few</span>
+                    </label>
+                  </div>
+                </div>
+              </fieldset>
+            </li>
+            <li class="p-list__item">
+              <label for="ExitSurveyExamDifficulty" id="LblExitSurveyExamDifficulty">How would you evaluate the exam
+                difficulty level?</label>
+              <fieldset id="ExitSurveyExamDifficulty" name="ExitSurveyExamDifficulty"
+                aria-labelledby="LblExitSurveyExamDifficulty InstructExitSurveyExamDifficulty">
+                <div class="row">
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyExamDifficulty"
+                        aria-labelledby="ExitSurveyExamDifficulty1">
+                      <span class="p-radio__label" id="ExitSurveyExamDifficulty1">Too easy</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyExamDifficulty"
+                        aria-labelledby="ExitSurveyExamDifficulty2">
+                      <span class="p-radio__label" id="ExitSurveyExamDifficulty2">The right difficulty level</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyExamDifficulty"
+                        aria-labelledby="ExitSurveyExamDifficulty3">
+                      <span class="p-radio__label" id="ExitSurveyExamDifficulty3">Too hard</span>
+                    </label>
+                  </div>
+                </div>
+              </fieldset>
+            </li>
+            <li class="p-list__item">
+              <label for="ExitSurveyTimeAllocated" id="LblExitSurveyTimeAllocated">What do you think about the amount of
+                time allocated for the exam?</label>
+              <fieldset id="ExitSurveyTimeAllocated" name="ExitSurveyTimeAllocated"
+                aria-labelledby="LblExitSurveyTimeAllocated InstructExitSurveyTimeAllocated">
+                <div class="row">
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyTimeAllocated"
+                        aria-labelledby="ExitSurveyTimeAllocated1">
+                      <span class="p-radio__label" id="ExitSurveyTimeAllocated1">Too short</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyTimeAllocated"
+                        aria-labelledby="ExitSurveyTimeAllocated2">
+                      <span class="p-radio__label" id="ExitSurveyTimeAllocated2">The right amount of time</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyTimeAllocated"
+                        aria-labelledby="ExitSurveyTimeAllocated3">
+                      <span class="p-radio__label" id="ExitSurveyTimeAllocated3">Too long</span>
+                    </label>
+                  </div>
+                </div>
+              </fieldset>
+            </li>
+          </ul>
+        </fieldset>
+
+        <fieldset class="u-no-margin--bottom">
+          <h3>Platform</h3>
+          <ul class="p-list">
+            <li class="p-list__item">
+              <label for="ExitSurveyPlatformExperience" id="LblExitSurveyPlatformExperience">How would you rate your
+                experience on the platform? </label>
+              <fieldset id="ExitSurveyPlatformExperience" name="ExitSurveyPlatformExperiences"
+                aria-labelledby="LblExitSurveyPlatformExperience InstructExitSurveyPlatformExperience">
+                <div class="row">
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyPlatformExperience"
+                        aria-labelledby="ExitSurveyPlatformExperience1">
+                      <span class="p-radio__label" id="ExitSurveyPlatformExperience1">Enjoyable</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyPlatformExperience"
+                        aria-labelledby="ExitSurveyPlatformExperience2">
+                      <span class="p-radio__label" id="ExitSurveyPlatformExperience2">Meh</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyPlatformExperience"
+                        aria-labelledby="ExitSurveyPlatformExperience3">
+                      <span class="p-radio__label" id="ExitSurveyPlatformExperience3">Terrible</span>
+                    </label>
+                  </div>
+                </div>
+              </fieldset>
+            </li>
+            <li class="p-list__item">
+              <label for="ExitSurveyReasonForNotLikingPlatform" id="ExitSurveyRblreasonForNotLikingPlatform">Were the
+                questions asked what you expected them to be? Choose the statement that feels the most accurate</label>
+              <fieldset id="ExitSurveyReasonForNotLikingPlatform" name="ExitSurveyReasonForNotLikingPlatforms"
+                aria-labelledby="LblExitSurveyReasonForNotLikingPlatform InstructExitSurveyReasonForNotLikingPlatform">
+                <div class="row">
+                  <div class="col-3">
+                    <label class="p-checkbox">
+                      <input class="p-checkbox__input" value="Platform Confusing" aria-labelledby="PlatformConfusing"
+                        name="ExitSurveyReasonForNotLikingPlatform" type="checkbox" />
+                      <span class="p-checkbox__label" id="PlatformConfusing">The platform was confusing</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-checkbox">
+                      <input class="p-checkbox__input" value="Platform Slow" aria-labelledby="PlatformSlow"
+                        name="ExitSurveyReasonForNotLikingPlatform" type="checkbox" />
+                      <span class="p-checkbox__label" id="PlatformSlow">The platform was too slow</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-checkbox">
+                      <input class="p-checkbox__input" value="Platform Crashed" aria-labelledby="PlatformCrashed"
+                        name="ExitSurveyReasonForNotLikingPlatform" type="checkbox" />
+                      <span class="p-checkbox__label" id="PlatformCrashed">The VMs crashed</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-checkbox">
+                      <input class="p-checkbox__input" value="Other" aria-labelledby="Other"
+                        name="ExitSurveyReasonForNotLikingPlatform" type="checkbox" />
+                      <span class="p-checkbox__label" id="Other">Other:</span>
+                    </label>
+                  </div>
+                </div>
+              </fieldset>
+            </li>
+            <li class="p-list__item">
+              <label for="ExitSurveyPlatformBestReasons" id="ExitSurveyRblreasonForNotLikingPlatform">Were the questions
+                asked what you expected them to be? Choose the statement that feels the most accurate</label>
+              <fieldset id="ExitSurveyPlatformBestReasons" name="ExitSurveyPlatformBestReasonss"
+                aria-labelledby="LblExitSurveyPlatformBestReasons InstructExitSurveyPlatformBestReasons">
+                <div class="row">
+                  <div class="col-3">
+                    <label class="p-checkbox">
+                      <input class="p-checkbox__input" value="Scheduling" aria-labelledby="Scheduling"
+                        name="ExitSurveyPlatformBestReasons" type="checkbox" />
+                      <span class="p-checkbox__label" id="Scheduling">Scheduling/Rescheduling</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-checkbox">
+                      <input class="p-checkbox__input" value="Lab Environment" aria-labelledby="GoodLabEnvironment"
+                        name="ExitSurveyPlatformBestReasons" type="checkbox" />
+                      <span class="p-checkbox__label" id="GoodLabEnvironment">Lab Environment</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-checkbox">
+                      <input class="p-checkbox__input" value="Browser Environment"
+                        aria-labelledby="GoodBrowserEnvironment" name="ExitSurveyPlatformBestReasons" type="checkbox" />
+                      <span class="p-checkbox__label" id="GoodBrowserEnvironment">Browser Environment</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-checkbox">
+                      <input class="p-checkbox__input" value="Other" aria-labelledby="GoodOther"
+                        name="ExitSurveyPlatformBestReasons" type="checkbox" />
+                      <span class="p-checkbox__label" id="GoodOther">Other:</span>
+                    </label>
+                  </div>
+                </div>
+              </fieldset>
+            </li>
+            <li class="p-list__item">
+              <label for="ExitSurveyPlatformWorstReasons" id="ExitSurveyRblreasonForNotLikingPlatform">Were the
+                questions asked what you expected them to be? Choose the statement that feels the most accurate</label>
+              <fieldset id="ExitSurveyPlatformWorstReasons" name="ExitSurveyPlatformWorstReasonss"
+                aria-labelledby="LblExitSurveyPlatformWorstReasons InstructExitSurveyPlatformWorstReasons">
+                <div class="row">
+                  <div class="col-3">
+                    <label class="p-checkbox">
+                      <input class="p-checkbox__input" value="Scheduling" aria-labelledby="BadScheduling"
+                        name="ExitSurveyPlatformWorstReasons" type="checkbox" />
+                      <span class="p-checkbox__label" id="BadScheduling">Scheduling/Rescheduling</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-checkbox">
+                      <input class="p-checkbox__input" value="Lab Environment" aria-labelledby="BadLabEnvironment"
+                        name="ExitSurveyPlatformWorstReasons" type="checkbox" />
+                      <span class="p-checkbox__label" id="BadLabEnvironment">Lab Environment</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-checkbox">
+                      <input class="p-checkbox__input" value="Browser Environment"
+                        aria-labelledby="BadBrowserEnvironment" name="ExitSurveyPlatformWorstReasons" type="checkbox" />
+                      <span class="p-checkbox__label" id="BadBrowserEnvironment">Browser Environment</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-checkbox">
+                      <input class="p-checkbox__input" value="Other" aria-labelledby="BadOther"
+                        name="ExitSurveyPlatformWorstReasons" type="checkbox" />
+                      <span class="p-checkbox__label" id="BadOther">Other:</span>
+                    </label>
+                  </div>
+                </div>
+              </fieldset>
+            </li>
+          </ul>
+        </fieldset>
+
+        <fieldset class="u-no-margin--bottom">
+          <h3>Value</h3>
+          <ul class="p-list">
+            <li class="p-list__item">
+              <label for="ExitSurveyValueKnowledge" id="LblExitSurveyValueKnowledge">Do you think this exam is a good
+                tool to evaluate your skills and Linux knowledge? Choose the statement that feels the most accurate:
+              </label>
+              <div class="row">
+                <div class="col-3">
+                  <select id="ExitSurveyValueKnowledge" name="ExitSurveyValueKnowledge"
+                    aria-labelledby="LblExitSurveyValueKnowledge" class="is-required" required="">
+                    <option value="" disabled="disabled" selected="">Select...</option>
+                    <option value="I do not think this exam sufficiently evaluates my skills and knowledge of Linux">I
+                      do not think this exam sufficiently evaluates my skills and knowledge of Linux</option>
+                    <option
+                      value="I feel like this test fairly and accurately assessed my skills and knowledge of Linux">I
+                      feel like this test fairly and accurately assessed my skills and knowledge of Linux</option>
+                    <option value="I am not sure whether this exam really reflects my skills and knowledge of Linux">I
+                      am not sure whether this exam really reflects my skills and knowledge of Linux</option>
+                  </select>
+                </div>
+              </div>
+            </li>
+            <li class="p-list__item">
+              <label for="ExitSurveyValueKnowledgeReason" id="ExitSurveyRblreasonForNotLikingPlatform">If not or unsure,
+                why? Select all that apply:</label>
+              <fieldset id="ExitSurveyValueKnowledgeReason" name="ExitSurveyValueKnowledgeReasons"
+                aria-labelledby="LblExitSurveyValueKnowledgeReason InstructExitSurveyValueKnowledgeReason">
+                <div class="row">
+                  <div class="col-3">
+                    <label class="p-checkbox">
+                      <input class="p-checkbox__input" value="Not enough practical skills questions"
+                        aria-labelledby="NotEnoughPracticalSkillsQuestions" name="ExitSurveyValueKnowledgeReason"
+                        type="checkbox" />
+                      <span class="p-checkbox__label" id="NotEnoughPracticalSkillsQuestions">This exam does not have
+                        enough practical skills questions</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-checkbox">
+                      <input class="p-checkbox__input" value="Not enough theoretical questions"
+                        aria-labelledby="NotEnoughTheoreticalQuestions" name="ExitSurveyValueKnowledgeReason"
+                        type="checkbox" />
+                      <span class="p-checkbox__label" id="NotEnoughTheoreticalQuestions">This exam does not have enough
+                        theoretical questions</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-checkbox">
+                      <input class="p-checkbox__input"
+                        value="The practical skills tested are not relevant to my industry"
+                        aria-labelledby="NotRelevantPracticalSkills" name="ExitSurveyValueKnowledgeReason"
+                        type="checkbox" />
+                      <span class="p-checkbox__label" id="NotRelevantPracticalSkills">The practical skills tested are
+                        not relevant to my industry</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-checkbox">
+                      <input class="p-checkbox__input" value="The questions are too generic"
+                        aria-labelledby="TooGenericQuestions" name="ExitSurveyValueKnowledgeReason" type="checkbox" />
+                      <span class="p-checkbox__label" id="TooGenericQuestions">The questions are too generic</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-checkbox">
+                      <input class="p-checkbox__input" value="The knowledge tested is outdated"
+                        aria-labelledby="OutdatedKnowledgeTested" name="ExitSurveyValueKnowledgeReason"
+                        type="checkbox" />
+                      <span class="p-checkbox__label" id="OutdatedKnowledgeTested">The knowledge tested is
+                        outdated</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-checkbox">
+                      <input class="p-checkbox__input"
+                        value="The platform did not permit me to showcase my skills in a meaningful way"
+                        aria-labelledby="DidnotPermitToShowcaseSkills" name="ExitSurveyValueKnowledgeReason"
+                        type="checkbox" />
+                      <span class="p-checkbox__label" id="DidnotPermitToShowcaseSkills">The platform did not permit me
+                        to showcase my skills in a meaningful way</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-checkbox">
+                      <input class="p-checkbox__input" value="Other" aria-labelledby="BadOther"
+                        name="ExitSurveyValueKnowledgeReason" type="checkbox" />
+                      <span class="p-checkbox__label" id="BadOther">Other:</span>
+                    </label>
+                  </div>
+                </div>
+              </fieldset>
+            </li>
+            <li class="p-list__item">
+              <label for="ExitSurveyReasonablePrice" id="LblExitSurveyReasonablePrice">What would be a reasonable price
+                range for this type of exam?</label>
+              <fieldset id="ExitSurveyReasonablePrice" name="ExitSurveyReasonablePrice"
+                aria-labelledby="LblExitSurveyReasonablePrice InstructExitSurveyReasonablePrice">
+                <div class="row">
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyReasonablePrice"
+                        aria-labelledby="ExitSurveyReasonablePrice1">
+                      <span class="p-radio__label" id="ExitSurveyReasonablePrice1">Free - 20$</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyReasonablePrice"
+                        aria-labelledby="ExitSurveyReasonablePrice2">
+                      <span class="p-radio__label" id="ExitSurveyReasonablePrice2">20$ - 50$</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyReasonablePrice"
+                        aria-labelledby="ExitSurveyReasonablePrice3">
+                      <span class="p-radio__label" id="ExitSurveyReasonablePrice3">50$ - 100$</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyReasonablePrice"
+                        aria-labelledby="ExitSurveyReasonablePrice3">
+                      <span class="p-radio__label" id="ExitSurveyReasonablePrice3">> 100$</span>
+                    </label>
+                  </div>
+                </div>
+              </fieldset>
+            </li>
+            <li class="p-list__item">
+              <label for="ExitSurveyMoreExams" id="LblExitSurveyMoreExams">Would you purchase more exams?</label>
+              <fieldset id="ExitSurveyMoreExams" name="ExitSurveyMoreExams"
+                aria-labelledby="LblExitSurveyMoreExams InstructExitSurveyMoreExams">
+                <div class="row">
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyMoreExams"
+                        aria-labelledby="ExitSurveyMoreExams1">
+                      <span class="p-radio__label" id="ExitSurveyMoreExams1">Yes</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyMoreExams"
+                        aria-labelledby="ExitSurveyMoreExams2">
+                      <span class="p-radio__label" id="ExitSurveyMoreExams2">No</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyMoreExams"
+                        aria-labelledby="ExitSurveyMoreExams3">
+                      <span class="p-radio__label" id="ExitSurveyMoreExams3">Other:</span>
+                    </label>
+                  </div>
+                </div>
+              </fieldset>
+            </li>
+            <li class="p-list__item">
+              <label for="ExitSurveyWhyPrice" id="LblExitSurveyWhyPrice">Why?</label>
+              <input id="ExitSurveyWhyPrice" name="ExitSurveyWhyPrice" maxlength="255"
+                aria-labelledby="LblExitSurveyWhyPrice" type="text" class="is-required" required=""
+                aria-required="true">
+            </li>
+          </ul>
+        </fieldset>
+
+        <fieldset class="u-no-margin--bottom">
+          <h3>Benchmark</h3>
+          <ul class="p-list">
+            <li class="p-list__item">
+              <label for="ExitSurveyBenchmarkPlatform" id="LblExitSurveyBenchmarkPlatform">How would you say the content
+                of this exam compares to similar Linux basics exams you have taken in the past? </label>
+              <fieldset id="ExitSurveyBenchmarkPlatform" name="ExitSurveyBenchmarkPlatform"
+                aria-labelledby="LblExitSurveyBenchmarkPlatform InstructExitSurveyBenchmarkPlatform">
+                <div class="row">
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyBenchmarkPlatform"
+                        aria-labelledby="ExitSurveyBenchmarkPlatform1">
+                      <span class="p-radio__label" id="ExitSurveyBenchmarkPlatform1">More enjoyable</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyBenchmarkPlatform"
+                        aria-labelledby="ExitSurveyBenchmarkPlatform2">
+                      <span class="p-radio__label" id="ExitSurveyBenchmarkPlatform2">Similar</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyBenchmarkPlatform"
+                        aria-labelledby="ExitSurveyBenchmarkPlatform3">
+                      <span class="p-radio__label" id="ExitSurveyBenchmarkPlatform3">Less enjoyable</span>
+                    </label>
+                  </div>
+                </div>
+              </fieldset>
+            </li>
+            <li class="p-list__item">
+              <label for="ExitSurveyBenchmarkContent" id="LblExitSurveyBenchmarkContent">How would you say the
+                experience on the platform compares to similar Linux basics exams you have taken in the past?</label>
+              <fieldset id="ExitSurveyBenchmarkContent" name="ExitSurveyBenchmarkContent"
+                aria-labelledby="LblExitSurveyBenchmarkContent InstructExitSurveyBenchmarkContent">
+                <div class="row">
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyBenchmarkContent"
+                        aria-labelledby="ExitSurveyBenchmarkContent1">
+                      <span class="p-radio__label" id="ExitSurveyBenchmarkContent1">More relevant</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyBenchmarkContent"
+                        aria-labelledby="ExitSurveyBenchmarkContent2">
+                      <span class="p-radio__label" id="ExitSurveyBenchmarkContent2">Similar</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyBenchmarkContent"
+                        aria-labelledby="ExitSurveyBenchmarkContent3">
+                      <span class="p-radio__label" id="ExitSurveyBenchmarkContent3">Not as relevant</span>
+                    </label>
+                  </div>
+                </div>
+              </fieldset>
+            </li>
+          </ul>
+        </fieldset>
+
+        <fieldset class="u-no-margin--bottom">
+          <h3>Overall experience</h3>
+          <ul class="p-list">
+            <li class="p-list__item">
+              <label for="ExitSurveyOverallExperienceRating" id="LblExitSurveyOverallExperienceRating">How would you
+                rate your overall experience?</label>
+              <fieldset id="ExitSurveyOverallExperienceRating" name="ExitSurveyOverallExperienceRating"
+                aria-labelledby="LblExitSurveyOverallExperienceRating InstructExitSurveyOverallExperienceRating">
+                <div class="row">
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyOverallExperienceRating"
+                        aria-labelledby="ExitSurveyOverallExperienceRating1">
+                      <span class="p-radio__label" id="ExitSurveyOverallExperienceRating1">Loved it</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyOverallExperienceRating"
+                        aria-labelledby="ExitSurveyOverallExperienceRating2">
+                      <span class="p-radio__label" id="ExitSurveyOverallExperienceRating2">Neutral</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyOverallExperienceRating"
+                        aria-labelledby="ExitSurveyOverallExperienceRating3">
+                      <span class="p-radio__label" id="ExitSurveyOverallExperienceRating3">Hated it</span>
+                    </label>
+                  </div>
+                </div>
+              </fieldset>
+            </li>
+            <li class="p-list__item">
+              <label for="ExitSurveyBestThingAboutExam" id="LblExitSurveyBestThingAboutExam">What is the best thing
+                about your experience? What are we doing right?</label>
+              <input id="ExitSurveyBestThingAboutExam" name="ExitSurveyBestThingAboutExam" maxlength="255"
+                aria-labelledby="LblExitSurveyBestThingAboutExam" type="text" class="is-required" required=""
+                aria-required="true">
+            </li>
+            <li class="p-list__item">
+              <label for="ExitSurveyWorstThingAboutExam" id="LblExitSurveyWorstThingAboutExam">What is the worst thing
+                about your experience? What are we not doing right?</label>
+              <input id="ExitSurveyWorstThingAboutExam" name="ExitSurveyWorstThingAboutExam" maxlength="255"
+                aria-labelledby="LblExitSurveyWorstThingAboutExam" type="text" class="is-required" required=""
+                aria-required="true">
+            </li>
+            <li class="p-list__item">
+              <label for="ExitSurveyDifferenceInExperience" id="LblExitSurveyDifferenceInExperience">Did the experience
+                differ from your expectations (from reading the landing page)?</label>
+              <fieldset id="ExitSurveyDifferenceInExperience" name="ExitSurveyDifferenceInExperience"
+                aria-labelledby="LblExitSurveyDifferenceInExperience InstructExitSurveyDifferenceInExperience">
+                <div class="row">
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyDifferenceInExperience"
+                        aria-labelledby="ExitSurveyDifferenceInExperience1">
+                      <span class="p-radio__label" id="ExitSurveyDifferenceInExperience1">Not at all</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyDifferenceInExperience"
+                        aria-labelledby="ExitSurveyDifferenceInExperience2">
+                      <span class="p-radio__label" id="ExitSurveyDifferenceInExperience2">Somewhat</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyDifferenceInExperience"
+                        aria-labelledby="ExitSurveyDifferenceInExperience3">
+                      <span class="p-radio__label" id="ExitSurveyDifferenceInExperience3">A lot</span>
+                    </label>
+                  </div>
+                </div>
+              </fieldset>
+            </li>
+            <li class="p-list__item">
+              <label for="ExitSurveyPromoterPeer" id="LblExitSurveyPromoterPeer">Would you recommend this exam to your
+                peers?</label>
+              <fieldset id="ExitSurveyPromoterPeer" name="ExitSurveyPromoterPeer"
+                aria-labelledby="LblExitSurveyPromoterPeer InstructExitSurveyPromoterPeer">
+                <div class="row">
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyPromoterPeer"
+                        aria-labelledby="ExitSurveyPromoterPeer1">
+                      <span class="p-radio__label" id="ExitSurveyPromoterPeer1">Absolutely</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyPromoterPeer"
+                        aria-labelledby="ExitSurveyPromoterPeer2">
+                      <span class="p-radio__label" id="ExitSurveyPromoterPeer2">I do not usually recommend these
+                        things</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyPromoterPeer"
+                        aria-labelledby="ExitSurveyPromoterPeer3">
+                      <span class="p-radio__label" id="ExitSurveyPromoterPeer3">I would not recommend it</span>
+                    </label>
+                  </div>
+                </div>
+              </fieldset>
+            </li>
+
+            <li class="p-list__item">
+              <label for="ExitSurveyPromoterManager" id="LblExitSurveyPromoterManager">Would you recommend this exam to
+                your peers?</label>
+              <fieldset id="ExitSurveyPromoterManager" name="ExitSurveyPromoterManager"
+                aria-labelledby="LblExitSurveyPromoterManager InstructExitSurveyPromoterManager">
+                <div class="row">
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyPromoterManager"
+                        aria-labelledby="ExitSurveyPromoterManager1">
+                      <span class="p-radio__label" id="ExitSurveyPromoterManager1">Absolutely</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyPromoterManager"
+                        aria-labelledby="ExitSurveyPromoterManager2">
+                      <span class="p-radio__label" id="ExitSurveyPromoterManager2">I do not usually recommend these
+                        things</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyPromoterManager"
+                        aria-labelledby="ExitSurveyPromoterManager3">
+                      <span class="p-radio__label" id="ExitSurveyPromoterManager3">I would not recommend it</span>
+                    </label>
+                  </div>
+                </div>
+              </fieldset>
+            </li>
+            <!-- <li class="p-list__item">
+              <label class="p-checkbox">
+                <input class="p-checkbox__input" value="yes" aria-labelledby="cube_beta_interest" name="cube_beta_interest" type="checkbox" />
+                <span class="p-checkbox__label" id="cube_beta_interest">I would like to beta test future certifications.</span>
+              </label>
+            </li>
+            <li class="p-list__item">
+              <label class="p-checkbox">
+                <input class="p-checkbox__input" value="yes" aria-labelledby="canonical_research_opt_in" name="canonical_research_opt_in" type="checkbox" />
+                <span class="p-checkbox__label" id="canonical_research_opt_in">I would like to participate in research questionnaires and focus groups.</span>
+              </label>
+            </li>
+            <li class=" p-list__item">
+              <label class="p-checkbox">
+                <input class="p-checkbox__input"  value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
+              </label>
+            </li>
+            <li class="p-list__item">
+              In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.
+            </li> -->
+            {# These are honey pot fields to catch bots #}
+            <li class="u-off-screen">
+              <label class="website" for="website">Website:</label>
+              <input name="website" type="text" class="website" autocomplete="off" value="" id="website"
+                tabindex="-1" />
+            </li>
+            <li class="u-off-screen">
+              <label class="name" for="name">Name:</label>
+              <input name="name" type="text" class="name" autocomplete="off" value="" id="name" tabindex="-1" />
+            </li>
+            {# End of honey pots #}
+          </ul>
+          <ul class="p-list">
+            <li class=" p-list__item">
+              <button type="submit" class="p-button--positive"
+                onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Form', 'eventAction' : 'cloud contact-us', 'eventLabel' : '{{product}}', 'eventValue' : undefined });">Submit</button>
+            </li>
+          </ul>
+          <!-- hidden fields -->
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="{{formid}}" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="{{returnURL}}" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c"
+            value="yes" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign"
+            value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium"
+            value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source"
+            value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content"
+            value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Facebook_Click_ID__c"
+            id="Facebook_Click_ID__c" value="" />
+        </fieldset>
+      </form>
+    </div>
+</section>

--- a/templates/shared/_credentials-exit-survey.html
+++ b/templates/shared/_credentials-exit-survey.html
@@ -16,15 +16,15 @@
               <label for="ExitSurveyRelevanceofShortFormQuestions" id="LblExitSurveyRelevanceofShortFormQuestions">This
                 exam is a
                 prerequisite for more advanced levels of certification and certifies a fundamental level of knowledge in
-                the Linux/OSS community, Ubuntu Desktop, and Ubuntu Server. How relevant are the <strong>Short Form
-                  Questions</strong> in relation to this goal. </label>
+                vendor-neutral Linux as specified in our syllabus. How relevant are the <strong>Short Form
+                  Questions</strong> in relation to this goal? </label>
               <fieldset id="ExitSurveyRelevanceofShortFormQuestions" name="ExitSurveyRelevanceofShortFormQuestions"
                 aria-labelledby="LblExitSurveyRelevanceofShortFormQuestions InstructExitSurveyRelevanceofShortFormQuestions">
                 <div class="row">
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyRelevanceofShortFormQuestions"
-                        value="Not Relevant At All" aria-labelledby="ExitSurveyRelevanceofShortFormQuestions1">
+                        value="Not Relevant At All" aria-labelledby="ExitSurveyRelevanceofShortFormQuestions1" required>
                       <span class="p-radio__label" id="ExitSurveyRelevanceofShortFormQuestions1">Not relevant at
                         all</span>
                     </label>
@@ -58,8 +58,8 @@
 
             <li class="p-list__item">
               <label for="ExitSurveyShortFormQuestionExpectation" id="LblExitSurveyShortFormQuestionExpectation">Were
-                the questions asked what you
-                expected them to be? Choose the statement that feels the most accurate</label>
+                the questions asked what you expected them to be? Choose the statement that feels the most
+                accurate:</label>
               <div class="row">
                 <div class="col-3">
                   <select id="ExitSurveyShortFormQuestionExpectation" name="ExitSurveyShortFormQuestionExpectation"
@@ -74,15 +74,14 @@
             </li>
             <li class="p-list__item">
               <label for="ExitSurveyNumberOfShortFormQuestions" id="LblExitSurveyNumberOfShortFormQuestions">What do you
-                think about the
-                number of short-form questions?</label>
+                think about the number of short-form questions?</label>
               <fieldset id="ExitSurveyNumberOfShortFormQuestions" name="ExitSurveyNumberOfShortFormQuestions"
                 aria-labelledby="LblExitSurveyNumberOfShortFormQuestions InstructExitSurveyNumberOfShortFormQuestions">
                 <div class="row">
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyNumberOfShortFormQuestions"
-                        aria-labelledby="ExitSurveyNumberOfShortFormQuestions1" value="Too many">
+                        aria-labelledby="ExitSurveyNumberOfShortFormQuestions1" value="Too many" required>
                       <span class="p-radio__label" id="ExitSurveyNumberOfShortFormQuestions1">Too many</span>
                     </label>
                   </div>
@@ -114,7 +113,7 @@
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyShortFormDifficulty"
-                        aria-labelledby="ExitSurveyShortFormDifficulty1" value="Too easy">
+                        aria-labelledby="ExitSurveyShortFormDifficulty1" value="Too easy" required>
                       <span class="p-radio__label" id="ExitSurveyShortFormDifficulty1">Too easy</span>
                     </label>
                   </div>
@@ -145,7 +144,7 @@
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyShortFormQuestionTimeAllocated"
-                        aria-labelledby="ExitSurveyShortFormQuestionTimeAllocated1" value="Too short">
+                        aria-labelledby="ExitSurveyShortFormQuestionTimeAllocated1" value="Too short" required>
                       <span class="p-radio__label" id="ExitSurveyShortFormQuestionTimeAllocated1">Too short</span>
                     </label>
                   </div>
@@ -173,16 +172,15 @@
             <li class="p-list__item">
               <label for="ExitSurveyRelevanceofLabQuestions" id="LblExitSurveyRelevanceofLabQuestions">This exam is a
                 prerequisite for more advanced levels of certification and certifies a fundamental level of knowledge in
-                Linux/OSS community, Ubuntu Desktop, and Ubuntu Server. How relevant are the <strong>Lab
-                  Questions</strong> in
-                relation to this goal. </label>
+                vendor-neutral Linux as specified in our syllabus. How relevant are the <strong>Lab Questions</strong>
+                in relation to this goal? </label>
               <fieldset id="ExitSurveyRelevanceofLabQuestions" name="ExitSurveyRelevanceofLabQuestions"
                 aria-labelledby="LblExitSurveyRelevanceofLabQuestions InstructExitSurveyRelevanceofLabQuestions">
                 <div class="row">
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyRelevanceofLabQuestions"
-                        aria-labelledby="ExitSurveyRelevanceofLabQuestions1" value="Not relevant at all">
+                        aria-labelledby="ExitSurveyRelevanceofLabQuestions1" value="Not relevant at all" required>
                       <span class="p-radio__label" id="ExitSurveyRelevanceofLabQuestions1">Not relevant at all</span>
                     </label>
                   </div>
@@ -237,7 +235,7 @@
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyNumberOfLabQuestions"
-                        aria-labelledby="ExitSurveyNumberOfLabQuestions1" value="Too many">
+                        aria-labelledby="ExitSurveyNumberOfLabQuestions1" value="Too many" required>
                       <span class="p-radio__label" id="ExitSurveyNumberOfLabQuestions1">Too many</span>
                     </label>
                   </div>
@@ -268,7 +266,7 @@
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyLabQuestionsDifficulty"
-                        aria-labelledby="ExitSurveyLabQuestionsDifficulty1" value="Too easy">
+                        aria-labelledby="ExitSurveyLabQuestionsDifficulty1" value="Too easy" required>
                       <span class="p-radio__label" id="ExitSurveyLabQuestionsDifficulty1">Too easy</span>
                     </label>
                   </div>
@@ -300,7 +298,7 @@
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyLabQuestionsTimeAllocated"
-                        aria-labelledby="ExitSurveyLabQuestionsTimeAllocated1" value="Too short">
+                        aria-labelledby="ExitSurveyLabQuestionsTimeAllocated1" value="Too short" required>
                       <span class="p-radio__label" id="ExitSurveyLabQuestionsTimeAllocated1">Too short</span>
                     </label>
                   </div>
@@ -411,7 +409,7 @@
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyExamEnvironmentExperience"
-                        aria-labelledby="ExitSurveyExamEnvironmentExperience1" value="Enjoyable">
+                        aria-labelledby="ExitSurveyExamEnvironmentExperience1" value="Enjoyable" required>
                       <span class="p-radio__label" id="ExitSurveyExamEnvironmentExperience1">Enjoyable</span>
                     </label>
                   </div>
@@ -654,7 +652,7 @@
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyReasonablePrice"
-                        aria-labelledby="ExitSurveyReasonablePrice1" value="Free-$20">
+                        aria-labelledby="ExitSurveyReasonablePrice1" value="Free-$20" required>
                       <span class="p-radio__label" id="ExitSurveyReasonablePrice1">Free - $20</span>
                     </label>
                   </div>
@@ -690,7 +688,7 @@
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyMoreExams"
-                        aria-labelledby="ExitSurveyMoreExams1" value="Yes">
+                        aria-labelledby="ExitSurveyMoreExams1" value="Yes" required>
                       <span class="p-radio__label" id="ExitSurveyMoreExams1">Yes</span>
                     </label>
                   </div>
@@ -701,13 +699,6 @@
                       <span class="p-radio__label" id="ExitSurveyMoreExams2">No</span>
                     </label>
                   </div>
-                  <!-- <div class="col-3">
-                    <label class="p-radio--inline">
-                      <input type="radio" class="p-radio__input" name="ExitSurveyMoreExams"
-                        aria-labelledby="ExitSurveyMoreExams3" value="Other">
-                      <span class="p-radio__label" id="ExitSurveyMoreExams3">Other:</span>
-                    </label>
-                  </div> -->
                 </div>
               </fieldset>
             </li>
@@ -726,7 +717,7 @@
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyCompanyInterest"
-                        aria-labelledby="ExitSurveyCompanyInterest1" value="Very Interested">
+                        aria-labelledby="ExitSurveyCompanyInterest1" value="Very Interested" required>
                       <span class="p-radio__label" id="ExitSurveyCompanyInterest1">Very Interested</span>
                     </label>
                   </div>
@@ -762,7 +753,7 @@
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyBenchmarkPlatform"
-                        aria-labelledby="ExitSurveyBenchmarkPlatform1" value="More enjoyable">
+                        aria-labelledby="ExitSurveyBenchmarkPlatform1" value="More enjoyable" required>
                       <span class="p-radio__label" id="ExitSurveyBenchmarkPlatform1">More enjoyable</span>
                     </label>
                   </div>
@@ -792,7 +783,7 @@
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyBenchmarkContent"
-                        aria-labelledby="ExitSurveyBenchmarkContent1" value="More relevant">
+                        aria-labelledby="ExitSurveyBenchmarkContent1" value="More relevant" required>
                       <span class="p-radio__label" id="ExitSurveyBenchmarkContent1">More relevant</span>
                     </label>
                   </div>
@@ -828,7 +819,7 @@
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyOverallExperienceRating"
-                        aria-labelledby="ExitSurveyOverallExperienceRating1" value="Loved it">
+                        aria-labelledby="ExitSurveyOverallExperienceRating1" value="Loved it" required>
                       <span class="p-radio__label" id="ExitSurveyOverallExperienceRating1">Loved it</span>
                     </label>
                   </div>
@@ -872,7 +863,7 @@
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyDifferenceInExperience"
-                        aria-labelledby="ExitSurveyDifferenceInExperience1" value="Not at all">
+                        aria-labelledby="ExitSurveyDifferenceInExperience1" value="Not at all" required>
                       <span class="p-radio__label" id="ExitSurveyDifferenceInExperience1">Not at all</span>
                     </label>
                   </div>
@@ -902,7 +893,7 @@
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyPromoterPeer"
-                        aria-labelledby="ExitSurveyPromoterPeer1" value="Absolutely">
+                        aria-labelledby="ExitSurveyPromoterPeer1" value="Absolutely" required>
                       <span class="p-radio__label" id="ExitSurveyPromoterPeer1">Absolutely</span>
                     </label>
                   </div>
@@ -934,7 +925,7 @@
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyPromoterManager"
-                        aria-labelledby="ExitSurveyPromoterManager1" value="Absolutely">
+                        aria-labelledby="ExitSurveyPromoterManager1" value="Absolutely" required>
                       <span class="p-radio__label" id="ExitSurveyPromoterManager1">Absolutely</span>
                     </label>
                   </div>

--- a/templates/shared/_credentials-exit-survey.html
+++ b/templates/shared/_credentials-exit-survey.html
@@ -361,7 +361,7 @@
             <li class="p-list__item">
               <label for="ExitSurveyExamManagementNegatives" id="ExitSurveyRblreasonForNotLikingPlatform">If you didn't
                 like it, why? Select all that apply:</label>
-              <fieldset id="ExitSurveyExamManagementNegatives" name="ExitSurveyExamManagementNegativess"
+              <fieldset id="ExitSurveyExamManagementNegatives" name="ExitSurveyExamManagementNegatives"
                 aria-labelledby="LblExitSurveyExamManagementNegatives InstructExitSurveyExamManagementNegatives">
                 <div class="row">
                   <div class="col-3">
@@ -395,9 +395,8 @@
                   </div>
                   <div class="col-3">
                     <label class="p-checkbox">
-                      <input class="p-checkbox__input" value="Other" aria-labelledby="BadOther"
-                        name="ExitSurveyExamManagementNegatives" type="checkbox" />
-                      <span class="p-checkbox__label" id="BadOther">Other:</span>
+                      <input type="text" placeholder="Other" aria-placeholder="Other"
+                        name="ExitSurveyExamManagementNegatives">
                     </label>
                   </div>
                 </div>
@@ -436,15 +435,14 @@
             <li class="p-list__item">
               <label for="ExitSurveyExamEnvironmentNegatives" id="ExitSurveyRblreasonForNotLikingPlatform">If you didn't
                 like it, why? Select all that apply:</label>
-              <fieldset id="ExitSurveyExamEnvironmentNegatives" name="ExitSurveyExamEnvironmentNegativess"
+              <fieldset id="ExitSurveyExamEnvironmentNegatives" name="ExitSurveyExamEnvironmentNegatives"
                 aria-labelledby="LblExitSurveyExamEnvironmentNegatives InstructExitSurveyExamEnvironmentNegatives">
                 <div class="row">
                   <div class="col-3">
                     <label class="p-checkbox">
                       <input class="p-checkbox__input" value="Instructions" aria-labelledby="ImproperInstructions"
                         name="ExitSurveyExamEnvironmentNegatives" type="checkbox" />
-                      <span class="p-checkbox__label" id="ImproperInstructions">I couldn't read the instructions
-                        properly</span>
+                      <span class="p-checkbox__label" id="ImproperInstructions">The instructions are unclear</span>
                     </label>
                   </div>
                   <div class="col-3">
@@ -471,9 +469,8 @@
                   </div>
                   <div class="col-3">
                     <label class="p-checkbox">
-                      <input class="p-checkbox__input" value="Other" aria-labelledby="BadOther"
-                        name="ExitSurveyExamEnvironmentNegatives" type="checkbox" />
-                      <span class="p-checkbox__label" id="BadOther">Other:</span>
+                      <input type="text" placeholder="Other" aria-placeholder="Other"
+                        name="ExitSurveyExamEnvironmentNegatives" />
                     </label>
                   </div>
                 </div>
@@ -482,7 +479,7 @@
             <li class="p-list__item">
               <label for="ExitSurveyPlatformBestReasons" id="ExitSurveyLblPlatformBestReasons">What feature did
                 you like most?</label>
-              <fieldset id="ExitSurveyPlatformBestReasons" name="ExitSurveyPlatformBestReasonss"
+              <fieldset id="ExitSurveyPlatformBestReasons" name="ExitSurveyPlatformBestReasons"
                 aria-labelledby="LblExitSurveyPlatformBestReasons InstructExitSurveyPlatformBestReasons">
                 <div class="row">
                   <div class="col-3">
@@ -509,9 +506,8 @@
                   </div>
                   <div class="col-3">
                     <label class="p-checkbox">
-                      <input class="p-checkbox__input" value="Other" aria-labelledby="GoodOther"
-                        name="ExitSurveyPlatformBestReasons" type="checkbox" />
-                      <span class="p-checkbox__label" id="GoodOther">Other:</span>
+                      <input name="ExitSurveyPlatformBestReasons" type="text" aria-placeholder="Other"
+                        placeholder="Other" />
                     </label>
                   </div>
                 </div>
@@ -520,7 +516,7 @@
             <li class="p-list__item">
               <label for="ExitSurveyPlatformWorstReasons" id="ExitSurveyLblPlatformWorstReasons">What feature did
                 you like least?</label>
-              <fieldset id="ExitSurveyPlatformWorstReasons" name="ExitSurveyPlatformWorstReasonss"
+              <fieldset id="ExitSurveyPlatformWorstReasons" name="ExitSurveyPlatformWorstReasons"
                 aria-labelledby="LblExitSurveyPlatformWorstReasons InstructExitSurveyPlatformWorstReasons">
                 <div class="row">
                   <div class="col-3">
@@ -547,9 +543,8 @@
                   </div>
                   <div class="col-3">
                     <label class="p-checkbox">
-                      <input class="p-checkbox__input" value="Other" aria-labelledby="BadOther"
-                        name="ExitSurveyPlatformWorstReasons" type="checkbox" />
-                      <span class="p-checkbox__label" id="BadOther">Other:</span>
+                      <input name="ExitSurveyPlatformWorstReasons" type="text" placeholder="Other"
+                        aria-placeholder="Other" />
                     </label>
                   </div>
                 </div>
@@ -643,9 +638,8 @@
                   </div>
                   <div class="col-3">
                     <label class="p-checkbox">
-                      <input class="p-checkbox__input" value="Other" aria-labelledby="BadOther"
-                        name="ExitSurveyValueKnowledgeReason" type="checkbox" />
-                      <span class="p-checkbox__label" id="BadOther">Other:</span>
+                      <input name="ExitSurveyValueKnowledgeReason" type="text" aria-placeholder="Other"
+                        placeholder="Other" />
                     </label>
                   </div>
                 </div>
@@ -660,29 +654,29 @@
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyReasonablePrice"
-                        aria-labelledby="ExitSurveyReasonablePrice1" value="Free-20$">
-                      <span class="p-radio__label" id="ExitSurveyReasonablePrice1">Free - 20$</span>
+                        aria-labelledby="ExitSurveyReasonablePrice1" value="Free-$20">
+                      <span class="p-radio__label" id="ExitSurveyReasonablePrice1">Free - $20</span>
                     </label>
                   </div>
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyReasonablePrice"
-                        aria-labelledby="ExitSurveyReasonablePrice2" value="20$-50$">
-                      <span class="p-radio__label" id="ExitSurveyReasonablePrice2">20$ - 50$</span>
+                        aria-labelledby="ExitSurveyReasonablePrice2" value="$20-$50">
+                      <span class="p-radio__label" id="ExitSurveyReasonablePrice2">$20 - $50</span>
                     </label>
                   </div>
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyReasonablePrice"
-                        aria-labelledby="ExitSurveyReasonablePrice3" value="50$-100$">
-                      <span class="p-radio__label" id="ExitSurveyReasonablePrice3">50$ - 100$</span>
+                        aria-labelledby="ExitSurveyReasonablePrice3" value="$50-$100">
+                      <span class="p-radio__label" id="ExitSurveyReasonablePrice3">$50 - $100</span>
                     </label>
                   </div>
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyReasonablePrice"
-                        aria-labelledby="ExitSurveyReasonablePrice3" value="more than 100$">
-                      <span class="p-radio__label" id="ExitSurveyReasonablePrice3">> 100$</span>
+                        aria-labelledby="ExitSurveyReasonablePrice3" value="more than $100">
+                      <span class="p-radio__label" id="ExitSurveyReasonablePrice3">> $100</span>
                     </label>
                   </div>
                 </div>
@@ -707,13 +701,13 @@
                       <span class="p-radio__label" id="ExitSurveyMoreExams2">No</span>
                     </label>
                   </div>
-                  <div class="col-3">
+                  <!-- <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyMoreExams"
                         aria-labelledby="ExitSurveyMoreExams3" value="Other">
                       <span class="p-radio__label" id="ExitSurveyMoreExams3">Other:</span>
                     </label>
-                  </div>
+                  </div> -->
                 </div>
               </fieldset>
             </li>

--- a/templates/shared/_credentials-exit-survey.html
+++ b/templates/shared/_credentials-exit-survey.html
@@ -7,23 +7,24 @@
   </div>
   <div class="row">
     <div class="col-12">
-      <form action="/marketo/submit" method="post" id="mktoForm_{{formid}}">
+      <form action="/credentials/exit-survey" method="post">
         <fieldset class="u-no-margin--bottom">
           <h3>Content</h3>
+          <h4>Short Form Questions</h4>
           <ul class="p-list">
             <li class="p-list__item">
               <label for="ExitSurveyRelevanceofShortFormQuestions" id="LblExitSurveyRelevanceofShortFormQuestions">This
                 exam is a
                 prerequisite for more advanced levels of certification and certifies a fundamental level of knowledge in
-                the Linux/OSS community, Ubuntu Desktop, and Ubuntu Server. Choose the statement that feels more
-                accurate in relation to this goal. </label>
+                the Linux/OSS community, Ubuntu Desktop, and Ubuntu Server. How relevant are the <strong>Short Form
+                  Questions</strong> in relation to this goal. </label>
               <fieldset id="ExitSurveyRelevanceofShortFormQuestions" name="ExitSurveyRelevanceofShortFormQuestions"
                 aria-labelledby="LblExitSurveyRelevanceofShortFormQuestions InstructExitSurveyRelevanceofShortFormQuestions">
                 <div class="row">
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyRelevanceofShortFormQuestions"
-                        aria-labelledby="ExitSurveyRelevanceofShortFormQuestions1">
+                        value="Not Relevant At All" aria-labelledby="ExitSurveyRelevanceofShortFormQuestions1">
                       <span class="p-radio__label" id="ExitSurveyRelevanceofShortFormQuestions1">Not relevant at
                         all</span>
                     </label>
@@ -31,7 +32,7 @@
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyRelevanceofShortFormQuestions"
-                        aria-labelledby="ExitSurveyRelevanceofShortFormQuestions4">
+                        value="Not very relevant" aria-labelledby="ExitSurveyRelevanceofShortFormQuestions4">
                       <span class="p-radio__label" id="ExitSurveyRelevanceofShortFormQuestions4">Not very
                         relevant</span>
                     </label>
@@ -39,7 +40,7 @@
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyRelevanceofShortFormQuestions"
-                        aria-labelledby="ExitSurveyRelevanceofShortFormQuestions2">
+                        value="Somewhat relevant" aria-labelledby="ExitSurveyRelevanceofShortFormQuestions2">
                       <span class="p-radio__label" id="ExitSurveyRelevanceofShortFormQuestions2">Somewhat
                         relevant</span>
                     </label>
@@ -47,43 +48,14 @@
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyRelevanceofShortFormQuestions"
-                        aria-labelledby="ExitSurveyRelevanceofShortFormQuestions3">
+                        value="Very relevant" aria-labelledby="ExitSurveyRelevanceofShortFormQuestions3">
                       <span class="p-radio__label" id="ExitSurveyRelevanceofShortFormQuestions3">Very relevant</span>
                     </label>
                   </div>
                 </div>
               </fieldset>
             </li>
-            <li class="p-list__item">
-              <label for="ExitSurveyRelevanceofQuestions" id="LblExitSurveyRelevanceofQuestions">What is your experience
-                with Ubuntu?</label>
-              <fieldset id="ExitSurveyRelevanceofQuestions" name="ExitSurveyRelevanceofQuestions"
-                aria-labelledby="LblExitSurveyRelevanceofQuestions InstructExitSurveyRelevanceofQuestions">
-                <div class="row">
-                  <div class="col-3">
-                    <label class="p-radio--inline">
-                      <input type="radio" class="p-radio__input" name="ExitSurveyRelevanceofQuestions"
-                        aria-labelledby="ExitSurveyRelevanceofQuestions1">
-                      <span class="p-radio__label" id="ExitSurveyRelevanceofQuestions1">Not relevant at all</span>
-                    </label>
-                  </div>
-                  <div class="col-3">
-                    <label class="p-radio--inline">
-                      <input type="radio" class="p-radio__input" name="ExitSurveyRelevanceofQuestions"
-                        aria-labelledby="ExitSurveyRelevanceofQuestions2">
-                      <span class="p-radio__label" id="ExitSurveyRelevanceofQuestions2">Somewhat relevant</span>
-                    </label>
-                  </div>
-                  <div class="col-3">
-                    <label class="p-radio--inline">
-                      <input type="radio" class="p-radio__input" name="ExitSurveyRelevanceofQuestions"
-                        aria-labelledby="ExitSurveyRelevanceofQuestions3">
-                      <span class="p-radio__label" id="ExitSurveyRelevanceofQuestions3">Very relevant</span>
-                    </label>
-                  </div>
-                </div>
-              </fieldset>
-            </li>
+
             <li class="p-list__item">
               <label for="cube_ubuntu_experience" id="Lblcube_ubuntu_experience">Were the questions asked what you
                 expected them to be? Choose the statement that feels the most accurate</label>
@@ -101,28 +73,28 @@
             </li>
             <li class="p-list__item">
               <label for="ExitSurveyNumberOfQuestions" id="LblExitSurveyNumberOfQuestions">What do you think about the
-                number of questions?</label>
+                number of short-form questions?</label>
               <fieldset id="ExitSurveyNumberOfQuestions" name="ExitSurveyNumberOfQuestions"
                 aria-labelledby="LblExitSurveyNumberOfQuestions InstructExitSurveyNumberOfQuestions">
                 <div class="row">
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyNumberOfQuestions"
-                        aria-labelledby="ExitSurveyNumberOfQuestions1">
+                        aria-labelledby="ExitSurveyNumberOfQuestions1" value="Too many">
                       <span class="p-radio__label" id="ExitSurveyNumberOfQuestions1">Too many</span>
                     </label>
                   </div>
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyNumberOfQuestions"
-                        aria-labelledby="ExitSurveyNumberOfQuestions2">
+                        aria-labelledby="ExitSurveyNumberOfQuestions2" value="About the right amount">
                       <span class="p-radio__label" id="ExitSurveyNumberOfQuestions2">About the right amount</span>
                     </label>
                   </div>
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyNumberOfQuestions"
-                        aria-labelledby="ExitSurveyNumberOfQuestions3">
+                        aria-labelledby="ExitSurveyNumberOfQuestions3" value="Too few">
                       <span class="p-radio__label" id="ExitSurveyNumberOfQuestions3">Too few</span>
                     </label>
                   </div>
@@ -131,28 +103,28 @@
             </li>
             <li class="p-list__item">
               <label for="ExitSurveyExamDifficulty" id="LblExitSurveyExamDifficulty">How would you evaluate the exam
-                difficulty level?</label>
+                short-form questions' difficulty level?</label>
               <fieldset id="ExitSurveyExamDifficulty" name="ExitSurveyExamDifficulty"
                 aria-labelledby="LblExitSurveyExamDifficulty InstructExitSurveyExamDifficulty">
                 <div class="row">
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyExamDifficulty"
-                        aria-labelledby="ExitSurveyExamDifficulty1">
+                        aria-labelledby="ExitSurveyExamDifficulty1" value="Too easy">
                       <span class="p-radio__label" id="ExitSurveyExamDifficulty1">Too easy</span>
                     </label>
                   </div>
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyExamDifficulty"
-                        aria-labelledby="ExitSurveyExamDifficulty2">
+                        aria-labelledby="ExitSurveyExamDifficulty2" value="The right difficulty level">
                       <span class="p-radio__label" id="ExitSurveyExamDifficulty2">The right difficulty level</span>
                     </label>
                   </div>
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyExamDifficulty"
-                        aria-labelledby="ExitSurveyExamDifficulty3">
+                        aria-labelledby="ExitSurveyExamDifficulty3" value="Too hard">
                       <span class="p-radio__label" id="ExitSurveyExamDifficulty3">Too hard</span>
                     </label>
                   </div>
@@ -161,28 +133,178 @@
             </li>
             <li class="p-list__item">
               <label for="ExitSurveyTimeAllocated" id="LblExitSurveyTimeAllocated">What do you think about the amount of
-                time allocated for the exam?</label>
+                time allocated for the short-form questions?</label>
               <fieldset id="ExitSurveyTimeAllocated" name="ExitSurveyTimeAllocated"
                 aria-labelledby="LblExitSurveyTimeAllocated InstructExitSurveyTimeAllocated">
                 <div class="row">
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyTimeAllocated"
-                        aria-labelledby="ExitSurveyTimeAllocated1">
+                        aria-labelledby="ExitSurveyTimeAllocated1" value="Too short">
                       <span class="p-radio__label" id="ExitSurveyTimeAllocated1">Too short</span>
                     </label>
                   </div>
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyTimeAllocated"
-                        aria-labelledby="ExitSurveyTimeAllocated2">
+                        aria-labelledby="ExitSurveyTimeAllocated2" value="The right amount of time">
                       <span class="p-radio__label" id="ExitSurveyTimeAllocated2">The right amount of time</span>
                     </label>
                   </div>
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyTimeAllocated"
-                        aria-labelledby="ExitSurveyTimeAllocated3">
+                        aria-labelledby="ExitSurveyTimeAllocated3" value="Too long">
+                      <span class="p-radio__label" id="ExitSurveyTimeAllocated3">Too long</span>
+                    </label>
+                  </div>
+                </div>
+              </fieldset>
+            </li>
+          </ul>
+          <h4>Lab Questions</h4>
+          <ul class="p-list">
+            <li class="p-list__item">
+              <label for="ExitSurveyRelevanceofLabQuestions" id="LblExitSurveyRelevanceofLabQuestions">This exam is a
+                prerequisite for more advanced levels of certification and certifies a fundamental level of knowledge in
+                Linux/OSS community, Ubuntu Desktop, and Ubuntu Server. How relevant are the <strong>Lab
+                  Questions</strong> in
+                relation to this goal. </label>
+              <fieldset id="ExitSurveyRelevanceofLabQuestions" name="ExitSurveyRelevanceofLabQuestions"
+                aria-labelledby="LblExitSurveyRelevanceofLabQuestions InstructExitSurveyRelevanceofLabQuestions">
+                <div class="row">
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyRelevanceofLabQuestions"
+                        aria-labelledby="ExitSurveyRelevanceofLabQuestions1" value="Not relevant at all">
+                      <span class="p-radio__label" id="ExitSurveyRelevanceofLabQuestions1">Not relevant at all</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyRelevanceofLabQuestions"
+                        aria-labelledby="ExitSurveyRelevanceofLabQuestions4" value="Not very">
+                      <span class="p-radio__label" id="ExitSurveyRelevanceofLabQuestions4">Not very
+                        relevant</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyRelevanceofLabQuestions"
+                        aria-labelledby="ExitSurveyRelevanceofLabQuestions2" value="Somewhat relevant">
+                      <span class="p-radio__label" id="ExitSurveyRelevanceofLabQuestions2">Somewhat relevant</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyRelevanceofLabQuestions"
+                        aria-labelledby="ExitSurveyRelevanceofLabQuestions3" value="Very relevant">
+                      <span class="p-radio__label" id="ExitSurveyRelevanceofLabQuestions3">Very relevant</span>
+                    </label>
+                  </div>
+                </div>
+              </fieldset>
+            </li>
+            <li class="p-list__item">
+              <label for="ExitSurveyLabCoverage" id="LblExitSurveyLabCoverage">Did the lab questions cover what
+                you expected them to? Choose the statement that feels the most accurate:
+              </label>
+              <div class="row">
+                <div class="col-3">
+                  <select id="ExitSurveyLabCoverage" name="ExitSurveyLabCoverage"
+                    aria-labelledby="LblExitSurveyLabCoverage" class="is-required" required="">
+                    <option value="" disabled="disabled" selected="">Select...</option>
+                    <option value="Didnot expect these questions">I did not expect these questions at all </option>
+                    <option value="Many were what I wanted">Many questions were what I anticipated them to be</option>
+                    <option value="Exactly what I anticipated">This is exactly what I was expecting</option>
+                  </select>
+                </div>
+              </div>
+            </li>
+            <li class="p-list__item">
+              <label for="ExitSurveyNumberOfQuestions" id="LblExitSurveyNumberOfQuestions">What do you think about the
+                number of questions?</label>
+              <fieldset id="ExitSurveyNumberOfQuestions" name="ExitSurveyNumberOfQuestions"
+                aria-labelledby="LblExitSurveyNumberOfQuestions InstructExitSurveyNumberOfQuestions">
+                <div class="row">
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyNumberOfQuestions"
+                        aria-labelledby="ExitSurveyNumberOfQuestions1" value="Too many">
+                      <span class="p-radio__label" id="ExitSurveyNumberOfQuestions1">Too many</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyNumberOfQuestions"
+                        aria-labelledby="ExitSurveyNumberOfQuestions2" value="About the right amount">
+                      <span class="p-radio__label" id="ExitSurveyNumberOfQuestions2">About the right amount</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyNumberOfQuestions"
+                        aria-labelledby="ExitSurveyNumberOfQuestions3" value="Too few">
+                      <span class="p-radio__label" id="ExitSurveyNumberOfQuestions3">Too few</span>
+                    </label>
+                  </div>
+                </div>
+              </fieldset>
+            </li>
+            <li class="p-list__item">
+              <label for="ExitSurveyExamDifficulty" id="LblExitSurveyExamDifficulty">How would you evaluate the lab
+                questions' difficulty level?</label>
+              <fieldset id="ExitSurveyExamDifficulty" name="ExitSurveyExamDifficulty"
+                aria-labelledby="LblExitSurveyExamDifficulty InstructExitSurveyExamDifficulty">
+                <div class="row">
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyExamDifficulty"
+                        aria-labelledby="ExitSurveyExamDifficulty1" value="Too easy">
+                      <span class="p-radio__label" id="ExitSurveyExamDifficulty1">Too easy</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyExamDifficulty"
+                        aria-labelledby="ExitSurveyExamDifficulty2" value="The right difficulty level">
+                      <span class="p-radio__label" id="ExitSurveyExamDifficulty2">The right difficulty level</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyExamDifficulty"
+                        aria-labelledby="ExitSurveyExamDifficulty3" value="Too hard">
+                      <span class="p-radio__label" id="ExitSurveyExamDifficulty3">Too hard</span>
+                    </label>
+                  </div>
+                </div>
+              </fieldset>
+            </li>
+            <li class="p-list__item">
+              <label for="ExitSurveyTimeAllocated" id="LblExitSurveyTimeAllocated">What do you think about the amount of
+                time allocated for the lab questions?</label>
+              <fieldset id="ExitSurveyTimeAllocated" name="ExitSurveyTimeAllocated"
+                aria-labelledby="LblExitSurveyTimeAllocated InstructExitSurveyTimeAllocated">
+                <div class="row">
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyTimeAllocated"
+                        aria-labelledby="ExitSurveyTimeAllocated1" value="Too short">
+                      <span class="p-radio__label" id="ExitSurveyTimeAllocated1">Too short</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyTimeAllocated"
+                        aria-labelledby="ExitSurveyTimeAllocated2" value="The right amount of time">
+                      <span class="p-radio__label" id="ExitSurveyTimeAllocated2">The right amount of time</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyTimeAllocated"
+                        aria-labelledby="ExitSurveyTimeAllocated3" value="Too long">
                       <span class="p-radio__label" id="ExitSurveyTimeAllocated3">Too long</span>
                     </label>
                   </div>
@@ -196,78 +318,170 @@
           <h3>Platform</h3>
           <ul class="p-list">
             <li class="p-list__item">
-              <label for="ExitSurveyPlatformExperience" id="LblExitSurveyPlatformExperience">How would you rate your
-                experience on the platform? </label>
-              <fieldset id="ExitSurveyPlatformExperience" name="ExitSurveyPlatformExperiences"
-                aria-labelledby="LblExitSurveyPlatformExperience InstructExitSurveyPlatformExperience">
+              <label for="ExitSurveyExamManagementExperience" id="LblExitSurveyExamManagementExperience">How would you
+                rate your experience on the exam management interface (scheduling, exam list page)? </label>
+              <fieldset id="ExitSurveyExamManagementExperience" name="ExitSurveyExamManagementExperiences"
+                aria-labelledby="LblExitSurveyExamManagementExperience InstructExitSurveyExamManagementExperience">
                 <div class="row">
                   <div class="col-3">
                     <label class="p-radio--inline">
-                      <input type="radio" class="p-radio__input" name="ExitSurveyPlatformExperience"
-                        aria-labelledby="ExitSurveyPlatformExperience1">
-                      <span class="p-radio__label" id="ExitSurveyPlatformExperience1">Enjoyable</span>
+                      <input type="radio" class="p-radio__input" name="ExitSurveyExamManagementExperience"
+                        aria-labelledby="ExitSurveyExamManagementExperience1" value="Enjoyable" required>
+                      <span class="p-radio__label" id="ExitSurveyExamManagementExperience1">Enjoyable</span>
                     </label>
                   </div>
                   <div class="col-3">
                     <label class="p-radio--inline">
-                      <input type="radio" class="p-radio__input" name="ExitSurveyPlatformExperience"
-                        aria-labelledby="ExitSurveyPlatformExperience2">
-                      <span class="p-radio__label" id="ExitSurveyPlatformExperience2">Meh</span>
+                      <input type="radio" class="p-radio__input" name="ExitSurveyExamManagementExperience"
+                        aria-labelledby="ExitSurveyExamManagementExperience2" value="Meh">
+                      <span class="p-radio__label" id="ExitSurveyExamManagementExperience2">Meh</span>
                     </label>
                   </div>
                   <div class="col-3">
                     <label class="p-radio--inline">
-                      <input type="radio" class="p-radio__input" name="ExitSurveyPlatformExperience"
-                        aria-labelledby="ExitSurveyPlatformExperience3">
-                      <span class="p-radio__label" id="ExitSurveyPlatformExperience3">Terrible</span>
+                      <input type="radio" class="p-radio__input" name="ExitSurveyExamManagementExperience"
+                        aria-labelledby="ExitSurveyExamManagementExperience3" value="Terrible">
+                      <span class="p-radio__label" id="ExitSurveyExamManagementExperience3">Terrible</span>
                     </label>
                   </div>
                 </div>
               </fieldset>
             </li>
             <li class="p-list__item">
-              <label for="ExitSurveyReasonForNotLikingPlatform" id="ExitSurveyRblreasonForNotLikingPlatform">Were the
-                questions asked what you expected them to be? Choose the statement that feels the most accurate</label>
-              <fieldset id="ExitSurveyReasonForNotLikingPlatform" name="ExitSurveyReasonForNotLikingPlatforms"
-                aria-labelledby="LblExitSurveyReasonForNotLikingPlatform InstructExitSurveyReasonForNotLikingPlatform">
+              <label for="ExitSurveyExamManagementNegatives" id="ExitSurveyRblreasonForNotLikingPlatform">If you didn't
+                like it, why? Select all that apply:</label>
+              <fieldset id="ExitSurveyExamManagementNegatives" name="ExitSurveyExamManagementNegativess"
+                aria-labelledby="LblExitSurveyExamManagementNegatives InstructExitSurveyExamManagementNegatives">
                 <div class="row">
                   <div class="col-3">
                     <label class="p-checkbox">
-                      <input class="p-checkbox__input" value="Platform Confusing" aria-labelledby="PlatformConfusing"
-                        name="ExitSurveyReasonForNotLikingPlatform" type="checkbox" />
-                      <span class="p-checkbox__label" id="PlatformConfusing">The platform was confusing</span>
+                      <input class="p-checkbox__input" value="ConfusingScheduling" aria-labelledby="ConfusingScheduling"
+                        name="ExitSurveyExamManagementNegatives" type="checkbox" />
+                      <span class="p-checkbox__label" id="ConfusingScheduling">The scheduling journey was
+                        confusing</span>
                     </label>
                   </div>
                   <div class="col-3">
                     <label class="p-checkbox">
-                      <input class="p-checkbox__input" value="Platform Slow" aria-labelledby="PlatformSlow"
-                        name="ExitSurveyReasonForNotLikingPlatform" type="checkbox" />
-                      <span class="p-checkbox__label" id="PlatformSlow">The platform was too slow</span>
+                      <input class="p-checkbox__input" value="ConfusingExamList" aria-labelledby="ConfusingExamList"
+                        name="ExitSurveyExamManagementNegatives" type="checkbox" />
+                      <span class="p-checkbox__label" id="ConfusingExamList">The exam list page was confusing</span>
                     </label>
                   </div>
                   <div class="col-3">
                     <label class="p-checkbox">
-                      <input class="p-checkbox__input" value="Platform Crashed" aria-labelledby="PlatformCrashed"
-                        name="ExitSurveyReasonForNotLikingPlatform" type="checkbox" />
-                      <span class="p-checkbox__label" id="PlatformCrashed">The VMs crashed</span>
+                      <input class="p-checkbox__input" value="ConfusingRedirects" aria-labelledby="ConfusingRedirects"
+                        name="ExitSurveyExamManagementNegatives" type="checkbox" />
+                      <span class="p-checkbox__label" id="ConfusingRedirects">The redirecting was confusing</span>
                     </label>
                   </div>
                   <div class="col-3">
                     <label class="p-checkbox">
-                      <input class="p-checkbox__input" value="Other" aria-labelledby="Other"
-                        name="ExitSurveyReasonForNotLikingPlatform" type="checkbox" />
-                      <span class="p-checkbox__label" id="Other">Other:</span>
+                      <input class="p-checkbox__input" value="SiteCrashed" aria-labelledby="SiteCrashed"
+                        name="ExitSurveyExamManagementNegatives" type="checkbox" />
+                      <span class="p-checkbox__label" id="SiteCrashed">The site crashed</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-checkbox">
+                      <input class="p-checkbox__input" value="Other" aria-labelledby="BadOther"
+                        name="ExitSurveyExamManagementNegatives" type="checkbox" />
+                      <span class="p-checkbox__label" id="BadOther">Other:</span>
                     </label>
                   </div>
                 </div>
               </fieldset>
             </li>
             <li class="p-list__item">
-              <label for="ExitSurveyPlatformBestReasons" id="ExitSurveyRblreasonForNotLikingPlatform">Were the questions
-                asked what you expected them to be? Choose the statement that feels the most accurate</label>
+              <label for="ExitSurveyExamEnvironmentExperience" id="LblExitSurveyExamEnvironmentExperience">How would you
+                rate your experience in the exam environment? </label>
+              <fieldset id="ExitSurveyExamEnvironmentExperience" name="ExitSurveyExamEnvironmentExperiences"
+                aria-labelledby="LblExitSurveyExamEnvironmentExperience InstructExitSurveyExamEnvironmentExperience">
+                <div class="row">
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyExamEnvironmentExperience"
+                        aria-labelledby="ExitSurveyExamEnvironmentExperience1" value="Enjoyable">
+                      <span class="p-radio__label" id="ExitSurveyExamEnvironmentExperience1">Enjoyable</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyExamEnvironmentExperience"
+                        aria-labelledby="ExitSurveyExamEnvironmentExperience2" value="Meh">
+                      <span class="p-radio__label" id="ExitSurveyExamEnvironmentExperience2">Meh</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyExamEnvironmentExperience"
+                        aria-labelledby="ExitSurveyExamEnvironmentExperience3" value="Terrible">
+                      <span class="p-radio__label" id="ExitSurveyExamEnvironmentExperience3">Terrible</span>
+                    </label>
+                  </div>
+                </div>
+              </fieldset>
+            </li>
+            <li class="p-list__item">
+              <label for="ExitSurveyExamEnvironmentNegatives" id="ExitSurveyRblreasonForNotLikingPlatform">If you didn't
+                like it, why? Select all that apply:</label>
+              <fieldset id="ExitSurveyExamEnvironmentNegatives" name="ExitSurveyExamEnvironmentNegativess"
+                aria-labelledby="LblExitSurveyExamEnvironmentNegatives InstructExitSurveyExamEnvironmentNegatives">
+                <div class="row">
+                  <div class="col-3">
+                    <label class="p-checkbox">
+                      <input class="p-checkbox__input" value="Instructions" aria-labelledby="ImproperInstructions"
+                        name="ExitSurveyExamEnvironmentNegatives" type="checkbox" />
+                      <span class="p-checkbox__label" id="ImproperInstructions">I couldn't read the instructions
+                        properly</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-checkbox">
+                      <input class="p-checkbox__input" value="Scheduling" aria-labelledby="BadScheduling"
+                        name="ExitSurveyExamEnvironmentNegatives" type="checkbox" />
+                      <span class="p-checkbox__label" id="BadScheduling">Scheduling/Rescheduling</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-checkbox">
+                      <input class="p-checkbox__input" value="Lab Environment" aria-labelledby="BadLabEnvironment"
+                        name="ExitSurveyExamEnvironmentNegatives" type="checkbox" />
+                      <span class="p-checkbox__label" id="BadLabEnvironment">Lab Environment</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-checkbox">
+                      <input class="p-checkbox__input" value="Browser Environment"
+                        aria-labelledby="BadBrowserEnvironment" name="ExitSurveyExamEnvironmentNegatives"
+                        type="checkbox" />
+                      <span class="p-checkbox__label" id="BadBrowserEnvironment">Browser Environment</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-checkbox">
+                      <input class="p-checkbox__input" value="Other" aria-labelledby="BadOther"
+                        name="ExitSurveyExamEnvironmentNegatives" type="checkbox" />
+                      <span class="p-checkbox__label" id="BadOther">Other:</span>
+                    </label>
+                  </div>
+                </div>
+              </fieldset>
+            </li>
+            <li class="p-list__item">
+              <label for="ExitSurveyPlatformBestReasons" id="ExitSurveyLblPlatformBestReasons">What feature did
+                you like most?</label>
               <fieldset id="ExitSurveyPlatformBestReasons" name="ExitSurveyPlatformBestReasonss"
                 aria-labelledby="LblExitSurveyPlatformBestReasons InstructExitSurveyPlatformBestReasons">
                 <div class="row">
+                  <div class="col-3">
+                    <label class="p-checkbox">
+                      <input class="p-checkbox__input" value="InstantProvisioning"
+                        aria-labelledby="GoodInstantProvisioning" name="ExitSurveyPlatformBestReasons"
+                        type="checkbox" />
+                      <span class="p-checkbox__label" id="GoodInstantProvisioning">Taking the exam right away</span>
+                    </label>
+                  </div>
                   <div class="col-3">
                     <label class="p-checkbox">
                       <input class="p-checkbox__input" value="Scheduling" aria-labelledby="Scheduling"
@@ -277,16 +491,9 @@
                   </div>
                   <div class="col-3">
                     <label class="p-checkbox">
-                      <input class="p-checkbox__input" value="Lab Environment" aria-labelledby="GoodLabEnvironment"
-                        name="ExitSurveyPlatformBestReasons" type="checkbox" />
-                      <span class="p-checkbox__label" id="GoodLabEnvironment">Lab Environment</span>
-                    </label>
-                  </div>
-                  <div class="col-3">
-                    <label class="p-checkbox">
-                      <input class="p-checkbox__input" value="Browser Environment"
-                        aria-labelledby="GoodBrowserEnvironment" name="ExitSurveyPlatformBestReasons" type="checkbox" />
-                      <span class="p-checkbox__label" id="GoodBrowserEnvironment">Browser Environment</span>
+                      <input class="p-checkbox__input" value="Desktop Environment"
+                        aria-labelledby="GoodDesktopEnvironment" name="ExitSurveyPlatformBestReasons" type="checkbox" />
+                      <span class="p-checkbox__label" id="GoodDesktopEnvironment">Desktop-like exam environment</span>
                     </label>
                   </div>
                   <div class="col-3">
@@ -300,30 +507,31 @@
               </fieldset>
             </li>
             <li class="p-list__item">
-              <label for="ExitSurveyPlatformWorstReasons" id="ExitSurveyRblreasonForNotLikingPlatform">Were the
-                questions asked what you expected them to be? Choose the statement that feels the most accurate</label>
+              <label for="ExitSurveyPlatformWorstReasons" id="ExitSurveyLblPlatformWorstReasons">What feature did
+                you like least?</label>
               <fieldset id="ExitSurveyPlatformWorstReasons" name="ExitSurveyPlatformWorstReasonss"
                 aria-labelledby="LblExitSurveyPlatformWorstReasons InstructExitSurveyPlatformWorstReasons">
                 <div class="row">
                   <div class="col-3">
                     <label class="p-checkbox">
-                      <input class="p-checkbox__input" value="Scheduling" aria-labelledby="BadScheduling"
+                      <input class="p-checkbox__input" value="InstantProvisioning"
+                        aria-labelledby="BadInstantProvisioning" name="ExitSurveyPlatformWorstReasons"
+                        type="checkbox" />
+                      <span class="p-checkbox__label" id="BadInstantProvisioning">Taking the exam right away</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-checkbox">
+                      <input class="p-checkbox__input" value="BadScheduling" aria-labelledby="BadScheduling"
                         name="ExitSurveyPlatformWorstReasons" type="checkbox" />
                       <span class="p-checkbox__label" id="BadScheduling">Scheduling/Rescheduling</span>
                     </label>
                   </div>
                   <div class="col-3">
                     <label class="p-checkbox">
-                      <input class="p-checkbox__input" value="Lab Environment" aria-labelledby="BadLabEnvironment"
-                        name="ExitSurveyPlatformWorstReasons" type="checkbox" />
-                      <span class="p-checkbox__label" id="BadLabEnvironment">Lab Environment</span>
-                    </label>
-                  </div>
-                  <div class="col-3">
-                    <label class="p-checkbox">
-                      <input class="p-checkbox__input" value="Browser Environment"
-                        aria-labelledby="BadBrowserEnvironment" name="ExitSurveyPlatformWorstReasons" type="checkbox" />
-                      <span class="p-checkbox__label" id="BadBrowserEnvironment">Browser Environment</span>
+                      <input class="p-checkbox__input" value="Desktop Environment"
+                        aria-labelledby="BadDesktopEnvironment" name="ExitSurveyPlatformWorstReasons" type="checkbox" />
+                      <span class="p-checkbox__label" id="BadDesktopEnvironment">Desktop-like exam environment</span>
                     </label>
                   </div>
                   <div class="col-3">
@@ -441,28 +649,28 @@
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyReasonablePrice"
-                        aria-labelledby="ExitSurveyReasonablePrice1">
+                        aria-labelledby="ExitSurveyReasonablePrice1" value="Free-20$">
                       <span class="p-radio__label" id="ExitSurveyReasonablePrice1">Free - 20$</span>
                     </label>
                   </div>
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyReasonablePrice"
-                        aria-labelledby="ExitSurveyReasonablePrice2">
+                        aria-labelledby="ExitSurveyReasonablePrice2" value="20$-50$">
                       <span class="p-radio__label" id="ExitSurveyReasonablePrice2">20$ - 50$</span>
                     </label>
                   </div>
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyReasonablePrice"
-                        aria-labelledby="ExitSurveyReasonablePrice3">
+                        aria-labelledby="ExitSurveyReasonablePrice3" value="50$-100$">
                       <span class="p-radio__label" id="ExitSurveyReasonablePrice3">50$ - 100$</span>
                     </label>
                   </div>
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyReasonablePrice"
-                        aria-labelledby="ExitSurveyReasonablePrice3">
+                        aria-labelledby="ExitSurveyReasonablePrice3" value="more than 100$">
                       <span class="p-radio__label" id="ExitSurveyReasonablePrice3">> 100$</span>
                     </label>
                   </div>
@@ -477,21 +685,21 @@
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyMoreExams"
-                        aria-labelledby="ExitSurveyMoreExams1">
+                        aria-labelledby="ExitSurveyMoreExams1" value="Yes">
                       <span class="p-radio__label" id="ExitSurveyMoreExams1">Yes</span>
                     </label>
                   </div>
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyMoreExams"
-                        aria-labelledby="ExitSurveyMoreExams2">
+                        aria-labelledby="ExitSurveyMoreExams2" value="No">
                       <span class="p-radio__label" id="ExitSurveyMoreExams2">No</span>
                     </label>
                   </div>
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyMoreExams"
-                        aria-labelledby="ExitSurveyMoreExams3">
+                        aria-labelledby="ExitSurveyMoreExams3" value="Other">
                       <span class="p-radio__label" id="ExitSurveyMoreExams3">Other:</span>
                     </label>
                   </div>
@@ -503,6 +711,36 @@
               <input id="ExitSurveyWhyPrice" name="ExitSurveyWhyPrice" maxlength="255"
                 aria-labelledby="LblExitSurveyWhyPrice" type="text" class="is-required" required=""
                 aria-required="true">
+            </li>
+            <li class="p-list__item">
+              <label for="ExitSurveyCompanyInterest" id="LblExitSurveyCompanyInterest">Do you think your company would
+                be interested in including exams like this in training and development programs?</label>
+              <fieldset id="ExitSurveyCompanyInterest" name="ExitSurveyCompanyInterests"
+                aria-labelledby="LblExitSurveyCompanyInterest InstructExitSurveyCompanyInterest">
+                <div class="row">
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyCompanyInterest"
+                        aria-labelledby="ExitSurveyCompanyInterest1" value="Very Interested">
+                      <span class="p-radio__label" id="ExitSurveyCompanyInterest1">Very Interested</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyCompanyInterest"
+                        aria-labelledby="ExitSurveyCompanyInterest2" value="Not sure">
+                      <span class="p-radio__label" id="ExitSurveyCompanyInterest2">Not Sure</span>
+                    </label>
+                  </div>
+                  <div class="col-3">
+                    <label class="p-radio--inline">
+                      <input type="radio" class="p-radio__input" name="ExitSurveyCompanyInterest"
+                        aria-labelledby="ExitSurveyCompanyInterest3" value="Not interested at all">
+                      <span class="p-radio__label" id="ExitSurveyCompanyInterest3">Not interested at all</span>
+                    </label>
+                  </div>
+                </div>
+              </fieldset>
             </li>
           </ul>
         </fieldset>
@@ -519,21 +757,21 @@
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyBenchmarkPlatform"
-                        aria-labelledby="ExitSurveyBenchmarkPlatform1">
+                        aria-labelledby="ExitSurveyBenchmarkPlatform1" value="More enjoyable">
                       <span class="p-radio__label" id="ExitSurveyBenchmarkPlatform1">More enjoyable</span>
                     </label>
                   </div>
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyBenchmarkPlatform"
-                        aria-labelledby="ExitSurveyBenchmarkPlatform2">
+                        aria-labelledby="ExitSurveyBenchmarkPlatform2" value="Similar">
                       <span class="p-radio__label" id="ExitSurveyBenchmarkPlatform2">Similar</span>
                     </label>
                   </div>
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyBenchmarkPlatform"
-                        aria-labelledby="ExitSurveyBenchmarkPlatform3">
+                        aria-labelledby="ExitSurveyBenchmarkPlatform3" value="Less enjoyable">
                       <span class="p-radio__label" id="ExitSurveyBenchmarkPlatform3">Less enjoyable</span>
                     </label>
                   </div>
@@ -549,21 +787,21 @@
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyBenchmarkContent"
-                        aria-labelledby="ExitSurveyBenchmarkContent1">
+                        aria-labelledby="ExitSurveyBenchmarkContent1" value="More relevant">
                       <span class="p-radio__label" id="ExitSurveyBenchmarkContent1">More relevant</span>
                     </label>
                   </div>
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyBenchmarkContent"
-                        aria-labelledby="ExitSurveyBenchmarkContent2">
+                        aria-labelledby="ExitSurveyBenchmarkContent2" value="Similar">
                       <span class="p-radio__label" id="ExitSurveyBenchmarkContent2">Similar</span>
                     </label>
                   </div>
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyBenchmarkContent"
-                        aria-labelledby="ExitSurveyBenchmarkContent3">
+                        aria-labelledby="ExitSurveyBenchmarkContent3" value="Not as relevant">
                       <span class="p-radio__label" id="ExitSurveyBenchmarkContent3">Not as relevant</span>
                     </label>
                   </div>
@@ -585,21 +823,21 @@
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyOverallExperienceRating"
-                        aria-labelledby="ExitSurveyOverallExperienceRating1">
+                        aria-labelledby="ExitSurveyOverallExperienceRating1" value="Loved it">
                       <span class="p-radio__label" id="ExitSurveyOverallExperienceRating1">Loved it</span>
                     </label>
                   </div>
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyOverallExperienceRating"
-                        aria-labelledby="ExitSurveyOverallExperienceRating2">
+                        aria-labelledby="ExitSurveyOverallExperienceRating2" value="Neutral">
                       <span class="p-radio__label" id="ExitSurveyOverallExperienceRating2">Neutral</span>
                     </label>
                   </div>
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyOverallExperienceRating"
-                        aria-labelledby="ExitSurveyOverallExperienceRating3">
+                        aria-labelledby="ExitSurveyOverallExperienceRating3" value="Hated it">
                       <span class="p-radio__label" id="ExitSurveyOverallExperienceRating3">Hated it</span>
                     </label>
                   </div>
@@ -629,21 +867,21 @@
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyDifferenceInExperience"
-                        aria-labelledby="ExitSurveyDifferenceInExperience1">
+                        aria-labelledby="ExitSurveyDifferenceInExperience1" value="Not at all">
                       <span class="p-radio__label" id="ExitSurveyDifferenceInExperience1">Not at all</span>
                     </label>
                   </div>
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyDifferenceInExperience"
-                        aria-labelledby="ExitSurveyDifferenceInExperience2">
+                        aria-labelledby="ExitSurveyDifferenceInExperience2" value="Somewhat">
                       <span class="p-radio__label" id="ExitSurveyDifferenceInExperience2">Somewhat</span>
                     </label>
                   </div>
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyDifferenceInExperience"
-                        aria-labelledby="ExitSurveyDifferenceInExperience3">
+                        aria-labelledby="ExitSurveyDifferenceInExperience3" value="A lot">
                       <span class="p-radio__label" id="ExitSurveyDifferenceInExperience3">A lot</span>
                     </label>
                   </div>
@@ -659,14 +897,14 @@
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyPromoterPeer"
-                        aria-labelledby="ExitSurveyPromoterPeer1">
+                        aria-labelledby="ExitSurveyPromoterPeer1" value="Absolutely">
                       <span class="p-radio__label" id="ExitSurveyPromoterPeer1">Absolutely</span>
                     </label>
                   </div>
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyPromoterPeer"
-                        aria-labelledby="ExitSurveyPromoterPeer2">
+                        aria-labelledby="ExitSurveyPromoterPeer2" value="I do not usually recommend these things">
                       <span class="p-radio__label" id="ExitSurveyPromoterPeer2">I do not usually recommend these
                         things</span>
                     </label>
@@ -674,7 +912,7 @@
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyPromoterPeer"
-                        aria-labelledby="ExitSurveyPromoterPeer3">
+                        aria-labelledby="ExitSurveyPromoterPeer3" value="I would not recommend it">
                       <span class="p-radio__label" id="ExitSurveyPromoterPeer3">I would not recommend it</span>
                     </label>
                   </div>
@@ -691,14 +929,14 @@
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyPromoterManager"
-                        aria-labelledby="ExitSurveyPromoterManager1">
+                        aria-labelledby="ExitSurveyPromoterManager1" value="Absolutely">
                       <span class="p-radio__label" id="ExitSurveyPromoterManager1">Absolutely</span>
                     </label>
                   </div>
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyPromoterManager"
-                        aria-labelledby="ExitSurveyPromoterManager2">
+                        aria-labelledby="ExitSurveyPromoterManager2" value="I do not usually recommend these things">
                       <span class="p-radio__label" id="ExitSurveyPromoterManager2">I do not usually recommend these
                         things</span>
                     </label>
@@ -706,34 +944,14 @@
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyPromoterManager"
-                        aria-labelledby="ExitSurveyPromoterManager3">
+                        aria-labelledby="ExitSurveyPromoterManager3" value="I would not recommend it">
                       <span class="p-radio__label" id="ExitSurveyPromoterManager3">I would not recommend it</span>
                     </label>
                   </div>
                 </div>
               </fieldset>
             </li>
-            <!-- <li class="p-list__item">
-              <label class="p-checkbox">
-                <input class="p-checkbox__input" value="yes" aria-labelledby="cube_beta_interest" name="cube_beta_interest" type="checkbox" />
-                <span class="p-checkbox__label" id="cube_beta_interest">I would like to beta test future certifications.</span>
-              </label>
-            </li>
-            <li class="p-list__item">
-              <label class="p-checkbox">
-                <input class="p-checkbox__input" value="yes" aria-labelledby="canonical_research_opt_in" name="canonical_research_opt_in" type="checkbox" />
-                <span class="p-checkbox__label" id="canonical_research_opt_in">I would like to participate in research questionnaires and focus groups.</span>
-              </label>
-            </li>
-            <li class=" p-list__item">
-              <label class="p-checkbox">
-                <input class="p-checkbox__input"  value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-                <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
-              </label>
-            </li>
-            <li class="p-list__item">
-              In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.
-            </li> -->
+
             {# These are honey pot fields to catch bots #}
             <li class="u-off-screen">
               <label class="website" for="website">Website:</label>

--- a/templates/shared/_credentials-exit-survey.html
+++ b/templates/shared/_credentials-exit-survey.html
@@ -57,12 +57,13 @@
             </li>
 
             <li class="p-list__item">
-              <label for="cube_ubuntu_experience" id="Lblcube_ubuntu_experience">Were the questions asked what you
+              <label for="ExitSurveyShortFormQuestionExpectation" id="LblExitSurveyShortFormQuestionExpectation">Were
+                the questions asked what you
                 expected them to be? Choose the statement that feels the most accurate</label>
               <div class="row">
                 <div class="col-3">
-                  <select id="cube_ubuntu_experience" name="cube_ubuntu_experience"
-                    aria-labelledby="Lblcube_ubuntu_experience" class="is-required" required="">
+                  <select id="ExitSurveyShortFormQuestionExpectation" name="ExitSurveyShortFormQuestionExpectation"
+                    aria-labelledby="LblExitSurveyShortFormQuestionExpectation" class="is-required" required="">
                     <option value="" disabled="disabled" selected="">Select...</option>
                     <option value="Didnot expect these questions">I did not expect these questions at all </option>
                     <option value="Many were what I wanted">Many questions were what I anticipated them to be</option>
@@ -72,90 +73,95 @@
               </div>
             </li>
             <li class="p-list__item">
-              <label for="ExitSurveyNumberOfQuestions" id="LblExitSurveyNumberOfQuestions">What do you think about the
+              <label for="ExitSurveyNumberOfShortFormQuestions" id="LblExitSurveyNumberOfShortFormQuestions">What do you
+                think about the
                 number of short-form questions?</label>
-              <fieldset id="ExitSurveyNumberOfQuestions" name="ExitSurveyNumberOfQuestions"
-                aria-labelledby="LblExitSurveyNumberOfQuestions InstructExitSurveyNumberOfQuestions">
+              <fieldset id="ExitSurveyNumberOfShortFormQuestions" name="ExitSurveyNumberOfShortFormQuestions"
+                aria-labelledby="LblExitSurveyNumberOfShortFormQuestions InstructExitSurveyNumberOfShortFormQuestions">
                 <div class="row">
                   <div class="col-3">
                     <label class="p-radio--inline">
-                      <input type="radio" class="p-radio__input" name="ExitSurveyNumberOfQuestions"
-                        aria-labelledby="ExitSurveyNumberOfQuestions1" value="Too many">
-                      <span class="p-radio__label" id="ExitSurveyNumberOfQuestions1">Too many</span>
+                      <input type="radio" class="p-radio__input" name="ExitSurveyNumberOfShortFormQuestions"
+                        aria-labelledby="ExitSurveyNumberOfShortFormQuestions1" value="Too many">
+                      <span class="p-radio__label" id="ExitSurveyNumberOfShortFormQuestions1">Too many</span>
                     </label>
                   </div>
                   <div class="col-3">
                     <label class="p-radio--inline">
-                      <input type="radio" class="p-radio__input" name="ExitSurveyNumberOfQuestions"
-                        aria-labelledby="ExitSurveyNumberOfQuestions2" value="About the right amount">
-                      <span class="p-radio__label" id="ExitSurveyNumberOfQuestions2">About the right amount</span>
+                      <input type="radio" class="p-radio__input" name="ExitSurveyNumberOfShortFormQuestions"
+                        aria-labelledby="ExitSurveyNumberOfShortFormQuestions2" value="About the right amount">
+                      <span class="p-radio__label" id="ExitSurveyNumberOfShortFormQuestions2">About the right
+                        amount</span>
                     </label>
                   </div>
                   <div class="col-3">
                     <label class="p-radio--inline">
-                      <input type="radio" class="p-radio__input" name="ExitSurveyNumberOfQuestions"
-                        aria-labelledby="ExitSurveyNumberOfQuestions3" value="Too few">
-                      <span class="p-radio__label" id="ExitSurveyNumberOfQuestions3">Too few</span>
+                      <input type="radio" class="p-radio__input" name="ExitSurveyNumberOfShortFormQuestions"
+                        aria-labelledby="ExitSurveyNumberOfShortFormQuestions3" value="Too few">
+                      <span class="p-radio__label" id="ExitSurveyNumberOfShortFormQuestions3">Too few</span>
                     </label>
                   </div>
                 </div>
               </fieldset>
             </li>
             <li class="p-list__item">
-              <label for="ExitSurveyExamDifficulty" id="LblExitSurveyExamDifficulty">How would you evaluate the exam
+              <label for="ExitSurveyShortFormDifficulty" id="LblExitSurveyShortFormDifficulty">How would you evaluate
+                the exam
                 short-form questions' difficulty level?</label>
-              <fieldset id="ExitSurveyExamDifficulty" name="ExitSurveyExamDifficulty"
-                aria-labelledby="LblExitSurveyExamDifficulty InstructExitSurveyExamDifficulty">
+              <fieldset id="ExitSurveyShortFormDifficulty" name="ExitSurveyShortFormDifficulty"
+                aria-labelledby="LblExitSurveyShortFormDifficulty InstructExitSurveyShortFormDifficulty">
                 <div class="row">
                   <div class="col-3">
                     <label class="p-radio--inline">
-                      <input type="radio" class="p-radio__input" name="ExitSurveyExamDifficulty"
-                        aria-labelledby="ExitSurveyExamDifficulty1" value="Too easy">
-                      <span class="p-radio__label" id="ExitSurveyExamDifficulty1">Too easy</span>
+                      <input type="radio" class="p-radio__input" name="ExitSurveyShortFormDifficulty"
+                        aria-labelledby="ExitSurveyShortFormDifficulty1" value="Too easy">
+                      <span class="p-radio__label" id="ExitSurveyShortFormDifficulty1">Too easy</span>
                     </label>
                   </div>
                   <div class="col-3">
                     <label class="p-radio--inline">
-                      <input type="radio" class="p-radio__input" name="ExitSurveyExamDifficulty"
-                        aria-labelledby="ExitSurveyExamDifficulty2" value="The right difficulty level">
-                      <span class="p-radio__label" id="ExitSurveyExamDifficulty2">The right difficulty level</span>
+                      <input type="radio" class="p-radio__input" name="ExitSurveyShortFormDifficulty"
+                        aria-labelledby="ExitSurveyShortFormDifficulty2" value="The right difficulty level">
+                      <span class="p-radio__label" id="ExitSurveyShortFormDifficulty2">The right difficulty level</span>
                     </label>
                   </div>
                   <div class="col-3">
                     <label class="p-radio--inline">
-                      <input type="radio" class="p-radio__input" name="ExitSurveyExamDifficulty"
-                        aria-labelledby="ExitSurveyExamDifficulty3" value="Too hard">
-                      <span class="p-radio__label" id="ExitSurveyExamDifficulty3">Too hard</span>
+                      <input type="radio" class="p-radio__input" name="ExitSurveyShortFormDifficulty"
+                        aria-labelledby="ExitSurveyShortFormDifficulty3" value="Too hard">
+                      <span class="p-radio__label" id="ExitSurveyShortFormDifficulty3">Too hard</span>
                     </label>
                   </div>
                 </div>
               </fieldset>
             </li>
             <li class="p-list__item">
-              <label for="ExitSurveyTimeAllocated" id="LblExitSurveyTimeAllocated">What do you think about the amount of
+              <label for="ExitSurveyShortFormQuestionTimeAllocated"
+                id="LblExitSurveyShortFormQuestionTimeAllocated">What do you think about the amount of
                 time allocated for the short-form questions?</label>
-              <fieldset id="ExitSurveyTimeAllocated" name="ExitSurveyTimeAllocated"
-                aria-labelledby="LblExitSurveyTimeAllocated InstructExitSurveyTimeAllocated">
+              <fieldset id="ExitSurveyShortFormQuestionTimeAllocated" name="ExitSurveyShortFormQuestionTimeAllocated"
+                aria-labelledby="LblExitSurveyShortFormQuestionTimeAllocated InstructExitSurveyShortFormQuestionTimeAllocated">
                 <div class="row">
                   <div class="col-3">
                     <label class="p-radio--inline">
-                      <input type="radio" class="p-radio__input" name="ExitSurveyTimeAllocated"
-                        aria-labelledby="ExitSurveyTimeAllocated1" value="Too short">
-                      <span class="p-radio__label" id="ExitSurveyTimeAllocated1">Too short</span>
+                      <input type="radio" class="p-radio__input" name="ExitSurveyShortFormQuestionTimeAllocated"
+                        aria-labelledby="ExitSurveyShortFormQuestionTimeAllocated1" value="Too short">
+                      <span class="p-radio__label" id="ExitSurveyShortFormQuestionTimeAllocated1">Too short</span>
                     </label>
                   </div>
                   <div class="col-3">
                     <label class="p-radio--inline">
-                      <input type="radio" class="p-radio__input" name="ExitSurveyTimeAllocated"
-                        aria-labelledby="ExitSurveyTimeAllocated2" value="The right amount of time">
-                      <span class="p-radio__label" id="ExitSurveyTimeAllocated2">The right amount of time</span>
+                      <input type="radio" class="p-radio__input" name="ExitSurveyShortFormQuestionTimeAllocated"
+                        aria-labelledby="ExitSurveyShortFormQuestionTimeAllocated2" value="The right amount of time">
+                      <span class="p-radio__label" id="ExitSurveyShortFormQuestionTimeAllocated2">The right amount of
+                        time</span>
                     </label>
                   </div>
                   <div class="col-3">
                     <label class="p-radio--inline">
-                      <input type="radio" class="p-radio__input" name="ExitSurveyTimeAllocated"
-                        aria-labelledby="ExitSurveyTimeAllocated3" value="Too long">
-                      <span class="p-radio__label" id="ExitSurveyTimeAllocated3">Too long</span>
+                      <input type="radio" class="p-radio__input" name="ExitSurveyShortFormQuestionTimeAllocated"
+                        aria-labelledby="ExitSurveyShortFormQuestionTimeAllocated3" value="Too long">
+                      <span class="p-radio__label" id="ExitSurveyShortFormQuestionTimeAllocated3">Too long</span>
                     </label>
                   </div>
                 </div>
@@ -183,7 +189,7 @@
                   <div class="col-3">
                     <label class="p-radio--inline">
                       <input type="radio" class="p-radio__input" name="ExitSurveyRelevanceofLabQuestions"
-                        aria-labelledby="ExitSurveyRelevanceofLabQuestions4" value="Not very">
+                        aria-labelledby="ExitSurveyRelevanceofLabQuestions4" value="Not very relevant">
                       <span class="p-radio__label" id="ExitSurveyRelevanceofLabQuestions4">Not very
                         relevant</span>
                     </label>
@@ -222,90 +228,95 @@
               </div>
             </li>
             <li class="p-list__item">
-              <label for="ExitSurveyNumberOfQuestions" id="LblExitSurveyNumberOfQuestions">What do you think about the
+              <label for="ExitSurveyNumberOfLabQuestions" id="LblExitSurveyNumberOfLabQuestions">What do you think about
+                the
                 number of questions?</label>
-              <fieldset id="ExitSurveyNumberOfQuestions" name="ExitSurveyNumberOfQuestions"
-                aria-labelledby="LblExitSurveyNumberOfQuestions InstructExitSurveyNumberOfQuestions">
+              <fieldset id="ExitSurveyNumberOfLabQuestions" name="ExitSurveyNumberOfLabQuestions"
+                aria-labelledby="LblExitSurveyNumberOfLabQuestions InstructExitSurveyNumberOfLabQuestions">
                 <div class="row">
                   <div class="col-3">
                     <label class="p-radio--inline">
-                      <input type="radio" class="p-radio__input" name="ExitSurveyNumberOfQuestions"
-                        aria-labelledby="ExitSurveyNumberOfQuestions1" value="Too many">
-                      <span class="p-radio__label" id="ExitSurveyNumberOfQuestions1">Too many</span>
+                      <input type="radio" class="p-radio__input" name="ExitSurveyNumberOfLabQuestions"
+                        aria-labelledby="ExitSurveyNumberOfLabQuestions1" value="Too many">
+                      <span class="p-radio__label" id="ExitSurveyNumberOfLabQuestions1">Too many</span>
                     </label>
                   </div>
                   <div class="col-3">
                     <label class="p-radio--inline">
-                      <input type="radio" class="p-radio__input" name="ExitSurveyNumberOfQuestions"
-                        aria-labelledby="ExitSurveyNumberOfQuestions2" value="About the right amount">
-                      <span class="p-radio__label" id="ExitSurveyNumberOfQuestions2">About the right amount</span>
+                      <input type="radio" class="p-radio__input" name="ExitSurveyNumberOfLabQuestions"
+                        aria-labelledby="ExitSurveyNumberOfLabQuestions2" value="About the right amount">
+                      <span class="p-radio__label" id="ExitSurveyNumberOfLabQuestions2">About the right amount</span>
                     </label>
                   </div>
                   <div class="col-3">
                     <label class="p-radio--inline">
-                      <input type="radio" class="p-radio__input" name="ExitSurveyNumberOfQuestions"
-                        aria-labelledby="ExitSurveyNumberOfQuestions3" value="Too few">
-                      <span class="p-radio__label" id="ExitSurveyNumberOfQuestions3">Too few</span>
+                      <input type="radio" class="p-radio__input" name="ExitSurveyNumberOfLabQuestions"
+                        aria-labelledby="ExitSurveyNumberOfLabQuestions3" value="Too few">
+                      <span class="p-radio__label" id="ExitSurveyNumberOfLabQuestions3">Too few</span>
                     </label>
                   </div>
                 </div>
               </fieldset>
             </li>
             <li class="p-list__item">
-              <label for="ExitSurveyExamDifficulty" id="LblExitSurveyExamDifficulty">How would you evaluate the lab
+              <label for="ExitSurveyLabQuestionsDifficulty" id="LblExitSurveyLabQuestionsDifficulty">How would you
+                evaluate the lab
                 questions' difficulty level?</label>
-              <fieldset id="ExitSurveyExamDifficulty" name="ExitSurveyExamDifficulty"
-                aria-labelledby="LblExitSurveyExamDifficulty InstructExitSurveyExamDifficulty">
+              <fieldset id="ExitSurveyLabQuestionsDifficulty" name="ExitSurveyLabQuestionsDifficulty"
+                aria-labelledby="LblExitSurveyLabQuestionsDifficulty InstructExitSurveyLabQuestionsDifficulty">
                 <div class="row">
                   <div class="col-3">
                     <label class="p-radio--inline">
-                      <input type="radio" class="p-radio__input" name="ExitSurveyExamDifficulty"
-                        aria-labelledby="ExitSurveyExamDifficulty1" value="Too easy">
-                      <span class="p-radio__label" id="ExitSurveyExamDifficulty1">Too easy</span>
+                      <input type="radio" class="p-radio__input" name="ExitSurveyLabQuestionsDifficulty"
+                        aria-labelledby="ExitSurveyLabQuestionsDifficulty1" value="Too easy">
+                      <span class="p-radio__label" id="ExitSurveyLabQuestionsDifficulty1">Too easy</span>
                     </label>
                   </div>
                   <div class="col-3">
                     <label class="p-radio--inline">
-                      <input type="radio" class="p-radio__input" name="ExitSurveyExamDifficulty"
-                        aria-labelledby="ExitSurveyExamDifficulty2" value="The right difficulty level">
-                      <span class="p-radio__label" id="ExitSurveyExamDifficulty2">The right difficulty level</span>
+                      <input type="radio" class="p-radio__input" name="ExitSurveyLabQuestionsDifficulty"
+                        aria-labelledby="ExitSurveyLabQuestionsDifficulty2" value="The right difficulty level">
+                      <span class="p-radio__label" id="ExitSurveyLabQuestionsDifficulty2">The right difficulty
+                        level</span>
                     </label>
                   </div>
                   <div class="col-3">
                     <label class="p-radio--inline">
-                      <input type="radio" class="p-radio__input" name="ExitSurveyExamDifficulty"
-                        aria-labelledby="ExitSurveyExamDifficulty3" value="Too hard">
-                      <span class="p-radio__label" id="ExitSurveyExamDifficulty3">Too hard</span>
+                      <input type="radio" class="p-radio__input" name="ExitSurveyLabQuestionsDifficulty"
+                        aria-labelledby="ExitSurveyLabQuestionsDifficulty3" value="Too hard">
+                      <span class="p-radio__label" id="ExitSurveyLabQuestionsDifficulty3">Too hard</span>
                     </label>
                   </div>
                 </div>
               </fieldset>
             </li>
             <li class="p-list__item">
-              <label for="ExitSurveyTimeAllocated" id="LblExitSurveyTimeAllocated">What do you think about the amount of
+              <label for="ExitSurveyLabQuestionsTimeAllocated" id="LblExitSurveyLabQuestionsTimeAllocated">What do you
+                think about the amount of
                 time allocated for the lab questions?</label>
-              <fieldset id="ExitSurveyTimeAllocated" name="ExitSurveyTimeAllocated"
-                aria-labelledby="LblExitSurveyTimeAllocated InstructExitSurveyTimeAllocated">
+              <fieldset id="ExitSurveyLabQuestionsTimeAllocated" name="ExitSurveyLabQuestionsTimeAllocated"
+                aria-labelledby="LblExitSurveyLabQuestionsTimeAllocated InstructExitSurveyLabQuestionsTimeAllocated">
                 <div class="row">
                   <div class="col-3">
                     <label class="p-radio--inline">
-                      <input type="radio" class="p-radio__input" name="ExitSurveyTimeAllocated"
-                        aria-labelledby="ExitSurveyTimeAllocated1" value="Too short">
-                      <span class="p-radio__label" id="ExitSurveyTimeAllocated1">Too short</span>
+                      <input type="radio" class="p-radio__input" name="ExitSurveyLabQuestionsTimeAllocated"
+                        aria-labelledby="ExitSurveyLabQuestionsTimeAllocated1" value="Too short">
+                      <span class="p-radio__label" id="ExitSurveyLabQuestionsTimeAllocated1">Too short</span>
                     </label>
                   </div>
                   <div class="col-3">
                     <label class="p-radio--inline">
-                      <input type="radio" class="p-radio__input" name="ExitSurveyTimeAllocated"
-                        aria-labelledby="ExitSurveyTimeAllocated2" value="The right amount of time">
-                      <span class="p-radio__label" id="ExitSurveyTimeAllocated2">The right amount of time</span>
+                      <input type="radio" class="p-radio__input" name="ExitSurveyLabQuestionsTimeAllocated"
+                        aria-labelledby="ExitSurveyLabQuestionsTimeAllocated2" value="The right amount of time">
+                      <span class="p-radio__label" id="ExitSurveyLabQuestionsTimeAllocated2">The right amount of
+                        time</span>
                     </label>
                   </div>
                   <div class="col-3">
                     <label class="p-radio--inline">
-                      <input type="radio" class="p-radio__input" name="ExitSurveyTimeAllocated"
-                        aria-labelledby="ExitSurveyTimeAllocated3" value="Too long">
-                      <span class="p-radio__label" id="ExitSurveyTimeAllocated3">Too long</span>
+                      <input type="radio" class="p-radio__input" name="ExitSurveyLabQuestionsTimeAllocated"
+                        aria-labelledby="ExitSurveyLabQuestionsTimeAllocated3" value="Too long">
+                      <span class="p-radio__label" id="ExitSurveyLabQuestionsTimeAllocated3">Too long</span>
                     </label>
                   </div>
                 </div>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -46,6 +46,7 @@ from webapp.context import (
 from webapp.shop.flaskparser import UAContractsValidationError
 from webapp.shop.cube.views import (
     cred_self_study,
+    cred_submit_form,
     cred_syllabus_data,
     cred_home,
     cred_schedule,
@@ -912,6 +913,11 @@ app.add_url_rule("/credentials/your-exams", view_func=cred_your_exams)
 app.add_url_rule("/credentials/cancel-exam", view_func=cred_cancel_exam)
 app.add_url_rule("/credentials/assessments", view_func=cred_assessments)
 app.add_url_rule("/credentials/exam", view_func=cred_exam)
+app.add_url_rule(
+    "/credentials/exit-survey",
+    view_func=cred_submit_form,
+    methods=["GET", "POST"],
+)
 
 # Charmed OpenStack docs
 openstack_docs = Docs(

--- a/webapp/shop/cube/views.py
+++ b/webapp/shop/cube/views.py
@@ -368,7 +368,42 @@ def cred_submit_form(**kwargs):
     if flask.request.method == "GET":
         return flask.render_template("credentials/exit-survey.html")
 
-    form_fields = {}
+    form_fields = {
+        "ExitSurveyRelevanceofShortFormQuestions": "",
+        "ExitSurveyShortFormQuestionExpectation": "",
+        "ExitSurveyNumberOfShortFormQuestions": "",
+        "ExitSurveyShortFormDifficulty": "",
+        "ExitSurveyShortFormQuestionTimeAllocated": "",
+        "ExitSurveyRelevanceofLabQuestions": "",
+        "ExitSurveyLabCoverage": "",
+        "ExitSurveyNumberOfLabQuestions": "",
+        "ExitSurveyLabQuestionsDifficulty": "",
+        "ExitSurveyLabQuestionsTimeAllocated": "",
+        "ExitSurveyExamManagementExperience": "",
+        "ExitSurveyExamManagementNegatives": "",
+        "ExitSurveyExamEnvironmentExperience": "",
+        "ExitSurveyExamEnvironmentNegatives": "",
+        "ExitSurveyPlatformBestReasons": "",
+        "ExitSurveyPlatformWorstReasons": "",
+        "ExitSurveyValueKnowledge": "",
+        "ExitSurveyValueKnowledgeReason": "",
+        "ExitSurveyReasonablePrice": "",
+        "ExitSurveyMoreExams": "",
+        "ExitSurveyWhyPrice": "",
+        "ExitSurveyCompanyInterest": "",
+        "ExitSurveyBenchmarkPlatform": "",
+        "ExitSurveyBenchmarkContent": "",
+        "ExitSurveyOverallExperienceRating": "",
+        "ExitSurveyBestThingAboutExam": "",
+        "ExitSurveyWorstThingAboutExam": "",
+        "ExitSurveyDifferenceInExperience": "",
+        "ExitSurveyPromoterPeer": "",
+        "ExitSurveyPromoterManager": "",
+        "formid": "",
+        "returnURL": "",
+        "Consent_to_Processing__c": "",
+        "grecaptcharesponse": "",
+    }
     for key in flask.request.form:
         values = flask.request.form.getlist(key)
         value = ", ".join(values)

--- a/webapp/shop/cube/views.py
+++ b/webapp/shop/cube/views.py
@@ -363,12 +363,19 @@ def cred_syllabus_data(**kawrgs):
     )
 
 
-@shop_decorator(area="cube", permission="user_or_guest", response="html")
+@shop_decorator(area="cube", permission="user", response="html")
 def cred_submit_form(**kwargs):
     if flask.request.method == "GET":
         return flask.render_template("credentials/exit-survey.html")
 
+    sso_user = user_info(flask.session)
+    email = sso_user["email"]
+    first_name, last_name = sso_user["fullname"].rsplit(" ", maxsplit=1)
+
     form_fields = {
+        "firstName": first_name,
+        "lastName": last_name,
+        "email": email,
         "ExitSurveyRelevanceofShortFormQuestions": "",
         "ExitSurveyShortFormQuestionExpectation": "",
         "ExitSurveyNumberOfShortFormQuestions": "",

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -938,6 +938,33 @@ def marketo_submit():
             },
         ).execute()
 
+    if payload["formId"] == "4777":
+        service_account_info = {
+            "token_uri": "https://oauth2.googleapis.com/token",
+            "client_email": os.getenv("GOOGLE_SERVICE_ACCOUNT_EMAIL"),
+            "private_key": os.getenv(
+                "GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY"
+            ).replace("\\n", "\n"),
+            "scopes": [
+                "https://www.googleapis.com/auth/spreadsheets.readonly"
+            ],
+        }
+
+        credentials = service_account.Credentials.from_service_account_info(
+            service_account_info,
+        )
+
+        service = build("sheets", "v4", credentials=credentials)
+
+        sheet = service.spreadsheets()
+        sheet.values().append(
+            spreadsheetId="1L-e0pKXmBo8y_Gv9_jy9P59xO-w4FnZdcTqbGJPMNg0",
+            range="Sheet2",
+            valueInputOption="RAW",
+            body={"values": [[form_fields.__dict__.values()]]},
+        ).execute()
+        return flask.redirect("/thank-you")
+
     # Send enrichment data
     try:
         marketo_api.submit_form(enriched_payload).json()

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -938,33 +938,6 @@ def marketo_submit():
             },
         ).execute()
 
-    if payload["formId"] == "4777":
-        service_account_info = {
-            "token_uri": "https://oauth2.googleapis.com/token",
-            "client_email": os.getenv("GOOGLE_SERVICE_ACCOUNT_EMAIL"),
-            "private_key": os.getenv(
-                "GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY"
-            ).replace("\\n", "\n"),
-            "scopes": [
-                "https://www.googleapis.com/auth/spreadsheets.readonly"
-            ],
-        }
-
-        credentials = service_account.Credentials.from_service_account_info(
-            service_account_info,
-        )
-
-        service = build("sheets", "v4", credentials=credentials)
-
-        sheet = service.spreadsheets()
-        sheet.values().append(
-            spreadsheetId="1L-e0pKXmBo8y_Gv9_jy9P59xO-w4FnZdcTqbGJPMNg0",
-            range="Sheet2",
-            valueInputOption="RAW",
-            body={"values": [[form_fields.__dict__.values()]]},
-        ).execute()
-        return flask.redirect("/thank-you")
-
     # Send enrichment data
     try:
         marketo_api.submit_form(enriched_payload).json()


### PR DESCRIPTION
## Done

- [List of work items including drive-bys - remember to add the why and what of this work.]

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to [/credentials/exit-survey](https://ubuntu-com-12363.demos.haus/credentials/exit-survey)
- Fill out the form
- Filled-out data is stored in [this sheet](https://docs.google.com/spreadsheets/d/1L-e0pKXmBo8y_Gv9_jy9P59xO-w4FnZdcTqbGJPMNg0/edit?usp=sharing)

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/CRED-248

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
