### PR TITLE
fix: cypress marketo form interception

### DIFF
--- a/tests/cypress/forms/forms_spec.js
+++ b/tests/cypress/forms/forms_spec.js
@@ -5,21 +5,26 @@ import {
   formsWithEmailTestId,
 } from "../utils";
 
-beforeEach(() => {
-  cy.intercept({
-    method: "POST",
-    url: "/marketo/submit",
-  }).as("captureLead");
-});
-
-afterEach(() => {
-  cy.wait("@captureLead").then(({ request, response }) => {
-    expect(request.method).to.equal("POST");
-    expect(response.statusCode).to.equal(302);
-  });
-});
-
 context("Static marketo forms", () => {
+  beforeEach(() => {
+    cy.intercept({ hostname: "www.google-analytics.com" }, { statusCode: 503 });
+    cy.intercept({ hostname: "www.googletagmanager.com" }, { statusCode: 503 });
+    cy.intercept({
+      method: "POST",
+      url: "/marketo/submit",
+    }).as("captureLead");
+  });
+
+  afterEach(() => {
+    cy.wait("@captureLead")
+      .should("not.be.undefined")
+      .should("include.all.keys", ["request", "response"])
+      .then(({ request, response }) => {
+        expect(request.method).to.equal("POST");
+        expect(response.statusCode).to.equal(302);
+      });
+  });
+
   it("should check each contact form on /contact-us pages with standard form", () => {
     cy.visit("/");
     cy.acceptCookiePolicy();
@@ -60,18 +65,36 @@ context("Static marketo forms", () => {
     cy.findByText(/Let’s discuss/).click();
     cy.findByRole("heading", { name: /Thank you/ });
   });
-
 });
 
 context("Interactive marketo forms", () => {
-  it(
-    "should check each interactive contact modal",
-    { scrollBehavior: "center" },
-    () => {
-      cy.visit("/");
-      cy.acceptCookiePolicy();
+  beforeEach(() => {
+    cy.intercept({ hostname: "www.google-analytics.com" }, { statusCode: 503 });
+    cy.intercept({ hostname: "www.googletagmanager.com" }, { statusCode: 503 });
+    cy.intercept({
+      method: "POST",
+      url: "/marketo/submit",
+    }).as("captureLead");
+  });
 
-      interactiveForms.forEach((form) => {
+  afterEach(() => {
+    cy.wait("@captureLead")
+      .should("not.be.undefined")
+      .should("include.all.keys", ["request", "response"])
+      .then(({ request, response }) => {
+        expect(request.method).to.equal("POST");
+        expect(response.statusCode).to.equal(302);
+      });
+  });
+
+  interactiveForms.forEach((form) => {
+    it(
+      `should check each interactive contact modal on ${form.url}`,
+      { scrollBehavior: "center" },
+      () => {
+        cy.visit("/");
+        cy.acceptCookiePolicy();
+
         cy.visit(form.url);
         cy.findByTestId("interactive-form-link").click();
         cy.findByRole("dialog").within(() => {
@@ -84,9 +107,9 @@ context("Interactive marketo forms", () => {
           cy.findByText(form.submitBtn).click();
         });
         cy.url().should("include", "#success");
-      });
-    }
-  );
+      }
+    );
+  });
 
   // wrote separate test for some pages as there are same email inputs in the modal and in the page.
   it(
@@ -228,6 +251,25 @@ context("Interactive marketo forms", () => {
 });
 
 context("engage forms", () => {
+  beforeEach(() => {
+    cy.intercept({ hostname: "www.google-analytics.com" }, { statusCode: 503 });
+    cy.intercept({ hostname: "www.googletagmanager.com" }, { statusCode: 503 });
+    cy.intercept({
+      method: "POST",
+      url: "/marketo/submit",
+    }).as("captureLead");
+  });
+
+  afterEach(() => {
+    cy.wait("@captureLead")
+      .should("not.be.undefined")
+      .should("include.all.keys", ["request", "response"])
+      .then(({ request, response }) => {
+        expect(request.method).to.equal("POST");
+        expect(response.statusCode).to.equal(302);
+      });
+  });
+
   it("should check forms on engage pages", () => {
     cy.visit("/engage/dockerandros");
     cy.acceptCookiePolicy();


### PR DESCRIPTION
## Done

- fix: cypress marketo form interception
  - define beforeEach/afterEach separately for each individual context
  - add google analytics intercept (to make sure we don't submit events in tests)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]


## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
