### PR TITLE
Update the cancel return URL from PayPal

### DIFF
--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -240,7 +240,7 @@
             <input type="hidden" name="rm" value="1">
             
             <input type="hidden" name="return" value="http://{{ http_host }}/download/desktop/thank-you">
-            <input type="hidden" name="cancel_return" value="http://{{ http_host }}/download/desktop/thank-you">
+            <input type="hidden" name="cancel_return" value="http://{{ http_host }}/download/desktop">
             
             <input type="hidden" name="bn" value="PP-BuyNowBF:btn_buynowCC_LG.gif:NonHosted">
             <button type="submit" class="js-contribute-submit p-button--positive u-no-margin--bottom" tabindex="9">Contribute with PayPal</button>


### PR DESCRIPTION
## Done

Updated the cancel PayPal URL to prevent confusion when a user cancels and returns to the site.

## QA

- Download a version of the download
- Click Contribute with PayPal
- Click the cancel and return to the site link
- See you no longer return to the thank you page

## Issue / Card

Fixes #3244