### PR TITLE
Hide images for small and medium screens on /certified

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -104,7 +104,7 @@ jobs:
           konf production deploy/site.yaml | kubeval -f -
 
   test-python:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2

--- a/templates/certified/desktops.html
+++ b/templates/certified/desktops.html
@@ -14,9 +14,9 @@
   <div class="row">
     <div class="col-8">
       <h1>Ubuntu certified desktops</h1>
-      <p>Many of the world’s biggest PC manufacturers certify their desktops for Ubuntu.</p>
+      <p>Many of the world's biggest PC manufacturers certify their desktops for Ubuntu.</p>
     </div>
-    <div class="col-4 u-vertically-center u-align--center">
+    <div class="col-4 u-vertically-center u-align--center u-hide--small u-hide--medium">
       {{ image (
         url="https://assets.ubuntu.com/v1/21efb2ec-desktop.svg",
         alt="",

--- a/templates/certified/devices.html
+++ b/templates/certified/devices.html
@@ -16,7 +16,7 @@
       <h1>Ubuntu certified devices</h1>
       <p>IoT vendors rely on Ubuntu for their devices, from drones and robots to edge gateways and development boards. Ubuntu Core delivers bullet-proof security, reliable updates and access to a rich ecosystem on 32 and 64-bit ARM and X86 platforms.      </p>
     </div>
-    <div class="col-4 u-vertically-center u-align--center">
+    <div class="col-4 u-vertically-center u-align--center u-hide--small u-hide--medium">
       {{ image (
         url="https://assets.ubuntu.com/v1/f9f8ace9-gateway.svg",
         alt="",

--- a/templates/certified/laptops.html
+++ b/templates/certified/laptops.html
@@ -14,9 +14,9 @@
   <div class="row">
     <div class="col-8">
       <h1>Ubuntu certified laptops</h1>
-      <p>Many of the world’s biggest PC manufacturers certify their laptops for Ubuntu.</p>
+      <p>Many of the world's biggest PC manufacturers certify their laptops for Ubuntu.</p>
     </div>
-    <div class="col-4 u-vertically-center u-align--center">
+    <div class="col-4 u-vertically-center u-align--center u-hide--small u-hide--medium">
       {{ image (
         url="https://assets.ubuntu.com/v1/4b732966-Laptop.svg",
         alt="",

--- a/templates/certified/servers.html
+++ b/templates/certified/servers.html
@@ -17,7 +17,7 @@
       <p>Using Ubuntu Server speeds up the ability to deploy physical infrastructure on bare metal as it is in the cloud.</p>
       <p>Deploying on certified servers saves you time in choosing and testing what hardware you will use from a single server instance to the largest scale-out data-center environments.</p>
     </div>
-    <div class="col-4 u-vertically-center u-align--center">
+    <div class="col-4 u-vertically-center u-align--center u-hide--small u-hide--medium">
       {{ image (
         url="https://assets.ubuntu.com/v1/fdf83d49-Server.svg",
         alt="",

--- a/templates/certified/socs.html
+++ b/templates/certified/socs.html
@@ -16,7 +16,7 @@
       <h1>Ubuntu certified SoCs</h1>
       <p>Low-power small-footprint System on a Chip (SoC) hardware is redefining the future of sustainable data centers.</p>
     </div>
-    <div class="col-4 u-vertically-center u-align--center">
+    <div class="col-4 u-vertically-center u-align--center u-hide--small u-hide--medium">
       {{ image (
         url="https://assets.ubuntu.com/v1/4e0399a1-chip.svg",
         alt="",


### PR DESCRIPTION
## Done

- Adds the `u-hide` utility style to various images under certified

## QA

- Go to https://ubuntu-com-12373.demos.haus/certified and visit each dedicated page (laptops, desktops, etc.) and check that the header images are hidden on small and medium screens.

## Issue / Card

Fixes https://github.com/canonical/ubuntu.com/issues/12369
