### PR TITLE
update /why-certified to /why-certify

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -599,8 +599,8 @@ certification:
   children:
     - title: Overview
       path: /certified
-    - title: Why Certified?
-      path: /certified/why-certified
+    - title: Why certify?
+      path: /certified/why-certify
     - title: Laptops
       path: /certified/laptops
     - title: Desktops

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -135,6 +135,7 @@ certified/desktop/models/?: "/certified?category=Desktop&category=Laptop"
 certified/server/models/?: "/certified?category=Server"
 certified/iot/models/?: "/certified?category=Device"
 certified/soc/models/?: "/certified?category=SoC"
+certified/why-certified/?: "/certified/why-certify"
 certification/?: "/certified"
 
 cc/?: "/security/certifications"

--- a/templates/certified/index.html
+++ b/templates/certified/index.html
@@ -393,7 +393,7 @@
       <h2 class="u-no-padding--top">Are you interested <br class="u-hide--medium u-hide--large">in <br class="u-hide--medium u-hide--small">certifying <br class="u-hide--medium u-hide--large">your hardware?</h2>
       <hr />
       <p>Drive differentiation for your hardware by certifying with the world's most widely used Linux. Our certification programme increases customer confidence that your products integrate seamlessly with Ubuntu.</p>
-      <a href="/certified/why-certified" class="p-button--positive">Discover the benefits</a>
+      <a href="/certified/why-certify" class="p-button--positive">Discover the benefits</a>
     </div>
   </div>
 </section>

--- a/templates/certified/why-certify.html
+++ b/templates/certified/why-certify.html
@@ -1,7 +1,7 @@
 {% extends "templates/base.html" %}
 
 
-{% block title %}Why Certified? | Certified hardware{% endblock %}
+{% block title %}Why certify? | Certified hardware{% endblock %}
 
 {% block meta_description %}Ubuntu Certified Hardware has passed our extensive testing and review process, ensuring that Ubuntu runs optimally out of the box, ready for your organisation. Canonical provides continuous support throughout the lifecycle of the Ubuntu release to ensure quality, functionality, and maintenance for up to 10 years{% endblock %}
 

--- a/templates/credentials/index.html
+++ b/templates/credentials/index.html
@@ -32,7 +32,7 @@
 
 <section class="p-strip--light">
   <div class="u-fixed-width">
-    <h2 class="u-sv2">Why Certify?</h2>
+    <h2 class="u-sv2">Why certify?</h2>
     <p>Ubuntu is the world's most popular open source OS for both development and deployment, from the data centre to the cloud to the Internet of things. So whether you are trying to pave your way into the tech field, or looking to upgrade your career or prove your skills, Canonical Credentials is here for you! This program is designed to help you demonstrate your expertise to countless enterprise organisations who are more likely than not using Ubuntu software today.</p>
     <ul class="p-matrix">
       <li class="p-matrix__item">

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1037,7 +1037,7 @@ app.add_url_rule(
     view_func=certified_socs,
 )
 app.add_url_rule(
-    "/certified/why-certified",
+    "/certified/why-certify",
     view_func=certified_why,
 )
 

--- a/webapp/certified/views.py
+++ b/webapp/certified/views.py
@@ -562,7 +562,7 @@ def certified_socs():
 
 
 def certified_why():
-    view = create_category_views("Why", "certified/why-certified.html")
+    view = create_category_views("Why", "certified/why-certify.html")
     return view
 
 


### PR DESCRIPTION
## Done

- moved the page at /certified/why-certified to /certified/why-certify
- updated any internal links to reflect the above change
- added a redirect

## QA

- visit https://ubuntu-com-12375.demos.haus/certified
- Click "Why certify?" in the subnav, you should be taken to https://ubuntu-com-12375.demos.haus/certified/why-certify
- try to visit https://ubuntu-com-12375.demos.haus/certified/why-certified
- you should be redirected to https://ubuntu-com-12375.demos.haus/certified/why-certify

## Issue / Card

Fixes [comment raised in JIRA](https://warthogs.atlassian.net/browse/WD-738?focusedCommentId=124087)
