### PR TITLE
Fix /nvidia redirect

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -942,7 +942,7 @@ blog/topic/(?P<path>.*): /blog/topics/{path}
 blog/topic: /blog
 
 # Marketing redirects to become pages in time
-nvidia: /engage/ubuntu-at-nvidia-gtc-2021
+nvidia: /engage/gtc_nvidia_2021
 
 # Move /securtiy/cve to /security/cves
 security/cve: /security/cves


### PR DESCRIPTION
## Done

- Changes a redirect for `/nvidia` from `/engage/ubuntu-at-nvidia-gtc-2021`  to `/engage/gtc_nvidia_2021`


## QA

- Go to https://ubuntu-com-12377.demos.haus/nvidia and check you are succesfully redirected to `/engage/gtc_nvidia_2021` and the engage page loads

## Issue / Card

Fixes https://github.com/canonical/ubuntu.com/issues/12360
