### PR TITLE
fix ubuntu pro typos on /esm

### DIFF
--- a/templates/security/esm.html
+++ b/templates/security/esm.html
@@ -384,7 +384,7 @@
           <div class="p-esm-chart__right-col" style="background-color: #000">
             <div class="p-esm-chart__right-col-lts">
               <div style="background: #E95420;">
-                <p style="margin-bottom: 0; padding-top: 0;">Ubuntu Pro LTS</p>
+                <p style="margin-bottom: 0; padding-top: 0;">Ubuntu LTS</p>
               </div>
             </div>
           </div>
@@ -559,7 +559,7 @@
       </div>
       <div class="col-6">
         <p>If you are running Ubuntu 16.04 LTS images on the public cloud and are looking for continued security coverage with ESM, it is recommended to launch new, Ubuntu Pro images for <a href="/azure/pro">Azure</a>, <a href="/aws/pro">AWS</a> and <a href="/gcp/pro">Google Cloud</a>. Ubuntu Pro images are paid, premium images that are optimised and priced for the cloud, with security and compliance features built-in.</p>
-        <p>Learn more about Ubuntu Pro 16.04 LTS on <a href="/16-04/azure">Azure</a> | <a href="/aws/pro">AWS</a> | <a href="/gcp/pro">Google Cloud</a></p>
+        <p>Learn more about Ubuntu 16.04 LTS on <a href="/16-04/azure">Azure</a> | <a href="/aws/pro">AWS</a> | <a href="/gcp/pro">Google Cloud</a></p>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Done

- Fixed two typos on /esm that inaccurately listed "Ubuntu Pro 16.04 LTS" as a thing that exists

## QA

- Visit /esm
- See that it addresses [the issue in the copy doc](https://docs.google.com/document/d/1RBZX3PJPvODxRlcnIS10Ii4SkIMH5Fm74EmsMQ0cnic/edit?disco=AAAAmOQBiAk)

## Issue / Card

Fixes https://github.com/canonical/web-squad/issues/6293
