### PR TITLE
404 fixes

### DIFF
--- a/templates/kubernetes/docs/1.23/charm-vsphere-integrator.md
+++ b/templates/kubernetes/docs/1.23/charm-vsphere-integrator.md
@@ -231,4 +231,4 @@ EOY
 
 [interface]: https://github.com/juju-solutions/interface-vsphere-integration
 [Charmed Kubernetes]: https://jaas.ai/charmed-kubernetes
-[vmware documentation]: https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/existing.html
+[vmware documentation]: https://docs.vmware.com/en/VMware-vSphere-Container-Storage-Plug-in/index.html

--- a/templates/kubernetes/docs/1.26/components.md
+++ b/templates/kubernetes/docs/1.26/components.md
@@ -37,7 +37,7 @@ Other information about this release can be found on the following pages:
 ## What's new
 
 For a list of new features, changes, deprecations, and bug fixes in this
-release, please see the [Release notes](release-notes).
+release, please see the [release notes](release-notes).
 
 ## Core charms
 
@@ -57,7 +57,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
 
 
 ## CNI charms
-These are the CNI charms also supported by Charmed Kubernetes ( calico is the default CNI and is included in the core charms above)
+These are the CNI charms also supported by Charmed Kubernetes (Calico is the default CNI and is included in the core charms above)
 
 |charm | summary | source | docs | bugs |
 |-|-|-|-|-|

--- a/templates/kubernetes/docs/1.26/components.md
+++ b/templates/kubernetes/docs/1.26/components.md
@@ -37,7 +37,7 @@ Other information about this release can be found on the following pages:
 ## What's new
 
 For a list of new features, changes, deprecations, and bug fixes in this
-release, please see the [release notes](release-notes).
+release, please see the [Release notes](release-notes).
 
 ## Core charms
 
@@ -57,7 +57,7 @@ release. These charms are maintained by the Charmed Kubernetes team.
 
 
 ## CNI charms
-These are the CNI charms also supported by Charmed Kubernetes (calico is the default CNI and is included in the core charms above)
+These are the CNI charms also supported by Charmed Kubernetes ( calico is the default CNI and is included in the core charms above)
 
 |charm | summary | source | docs | bugs |
 |-|-|-|-|-|
@@ -103,7 +103,7 @@ These charms are also maintained and supported by the Charmed Kubernetes team to
 | [kubernetes-e2e](https://charmhub.io/kubernetes-e2e) | End-to-end (e2e) tests for Kubernetes | [source](https://github.com/charmed-kubernetes/charm-kubernetes-e2e.git) | [docs](https://charmhub.io/kubernetes-e2e/docs)  | [bugs](https://bugs.launchpad.net/charm-kubernetes-e2e) |
 | [kubernetes-metrics-server](https://charmhub.io/kubernetes-metrics-server) | Exposes core Kubernetes metrics via metrics API | [source](https://github.com/charmed-kubernetes/kubernetes-metrics-server-operator.git) | [docs](https://charmhub.io/kubernetes-metrics-server/docs)  | [bugs](https://bugs.launchpad.net/charmed-kubernetes) |
 | [metallb-controller](https://charmhub.io/metallb-controller) | Controller charm for the metallb loadbalancer | [source](https://github.com/charmed-kubernetes/metallb-operator.git) | [docs](https://charmhub.io/metallb-controller/docs)  | [bugs](https://bugs.launchpad.net/operator-metallb) |
-| [metallb-speaker](https://charmhub.io/metallb-speaker) | Speaker charm for the metallb loadbalancer | [source](https://github.com/charmed-kubernetes/metallb-operator.git) | [docs](https://charmhub.io/metallb-speaker/docs)  | [bugs](https://bugs.launchpad.net/operator-metallb') |
+| [metallb-speaker](https://charmhub.io/metallb-speaker) | Speaker charm for the metallb loadbalancer | [source](https://github.com/charmed-kubernetes/metallb-operator.git) | [docs](https://charmhub.io/metallb-speaker/docs)  | [bugs](https://bugs.launchpad.net/operator-metallb) |
 
 ## Images
 

--- a/templates/kubernetes/docs/equinix.md
+++ b/templates/kubernetes/docs/equinix.md
@@ -431,7 +431,7 @@ Hello Kubernetes!
 
 
 [asset-ceph-radosgw-overlay]: https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/overlays/ceph-radosgw.yaml
-[asset-equinix-overlay]: https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/overlays/equinix-overaly.yaml
+[asset-equinix-overlay]: https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/overlays/equinix-overlay.yaml
 [equinix-facilities]: https://metal.equinix.com/developers/docs/locations/facilities/
 [equinix-configuration]: https://github.com/equinix/cloud-provider-equinix-metal#configuration
 [quickstart]: /kubernetes/docs/quickstart

--- a/templates/kubernetes/docs/security.md
+++ b/templates/kubernetes/docs/security.md
@@ -101,7 +101,7 @@ To test your cluster, please see the
 [Kubernetes Security documentation]: https://kubernetes.io/docs/concepts/security/overview/
 [Machine auth]: https://juju.is/docs/olm/accessing-individual-machines-with-ssh
 [juju-users]: https://juju.is/docs/olm/working-with-multiple-users
-[juju-user-types]: https://juju.is/docs/user-types-and-abilities
+[juju-user-types]: https://juju.is/docs/olm/manage-users
 [CIS compliance]: /kubernetes/docs/cis-compliance
 [k8s-auth]: /kubernetes/docs/auth
 [k8s-aws-iam]: /kubernetes/docs/aws-iam-auth


### PR DESCRIPTION
## Done

- some link fixes for k8s docs

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes

Some of the output from the linkchecker appears to be bogus/out of date btw