### PR TITLE
add title attributes to iframe elements

### DIFF
--- a/templates/appliance/shared/_base_appliance_index.html
+++ b/templates/appliance/shared/_base_appliance_index.html
@@ -79,7 +79,7 @@
     <div class="col-10">
       <div class="u-embedded-media u-no-margin--top" style="margin-bottom: 1rem;">
         {% if "youtu" in screenshots.1 %}
-        <iframe class="u-embedded-media__element" src="{{ screenshots.1 }}" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+        <iframe title="Screenshots" class="u-embedded-media__element" src="{{ screenshots.1 }}" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
         {% else %}
         <img src="{{ screenshots.1 }}" class="p-image--shadowed" alt="{{ appliance_name }} screenshots">
         {% endif %}

--- a/templates/blog/product-cards/_raspberry-pi_2010-livestream.html
+++ b/templates/blog/product-cards/_raspberry-pi_2010-livestream.html
@@ -4,7 +4,7 @@
   <h3>
     <a href="/engage/raspberry-pi-livestream">Ubuntu Desktop for Raspberry Pi</a>
   </h3>
-  <iframe width="560" height="315" src="https://www.youtube.com/embed/0pT4-RcTERU" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  <iframe title="20.10 launch" width="560" height="315" src="https://www.youtube.com/embed/0pT4-RcTERU" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
   <p>Watch the live event of the 20.10 launch the and find out all the news about the new Ubuntu Desktop image for Raspberry Pi.</p>
   <p><a href="/engage/raspberry-pi-livestream">Discover more&nbsp;&rsaquo;</a></p>
 </div>

--- a/templates/ceph/index.html
+++ b/templates/ceph/index.html
@@ -41,7 +41,7 @@
       <p>If you do not have the in house expertise to operate your own storage infrastructure Charmed Ceph is available as a managed service.</p>
     </div>
     <div class="col-6">
-      <iframe src="https://player.vimeo.com/video/405859468" width="500" height="300" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>
+      <iframe title="Enabling global genomic research with Ceph storage" src="https://player.vimeo.com/video/405859468" width="500" height="300" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>
     </div>
   </div>
 

--- a/templates/credentials/exam.html
+++ b/templates/credentials/exam.html
@@ -8,7 +8,7 @@
 {% block content %}
 
 <section class="p-strip--suru-topped u-no-padding">
-  <iframe class="u-no-margin" id="exam-iframe" onload="setIframeHeight()" scrolling="no" width="100%" src="{{ url }}"></iframe>
+  <iframe title="Exam" class="u-no-margin" id="exam-iframe" onload="setIframeHeight()" scrolling="no" width="100%" src="{{ url }}"></iframe>
 </section>
 
 <script>

--- a/templates/engage/base.html
+++ b/templates/engage/base.html
@@ -135,7 +135,7 @@
 <!-- Youtube webinars -->
 <section class="p-strip is-shallow" id="youtube-section">
   <div class="row" id="webinar">
-    <iframe width="560" height="315" src="https://www.youtube.com/embed/{{ metadata['youtube_id'] }}" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+    <iframe title="Webinar" width="560" height="315" src="https://www.youtube.com/embed/{{ metadata['youtube_id'] }}" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
   </div>
 </section>
 {% endif %}
@@ -144,7 +144,7 @@
 <!-- Vimeo webinars -->
 <section class="p-strip is-shallow" id="vimeo-section">
   <div class="row" id="webinar">
-    <iframe src="https://player.vimeo.com/video/{{ metadata['vimeo_id'] }}" width="560" height="315" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>
+    <iframe title="Webinar" src="https://player.vimeo.com/video/{{ metadata['vimeo_id'] }}" width="560" height="315" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>
   </div>
 </section>
 {% endif %}

--- a/templates/engage/unlisted/custom-ubuntu-pro-image-on-azure.html
+++ b/templates/engage/unlisted/custom-ubuntu-pro-image-on-azure.html
@@ -50,7 +50,7 @@
 
       <h2>Arrange onboarding</h2>
 
-      <iframe src="https://calendly.com/niklas-brag/30min-1?hide_gdpr_banner=1" height="1000px" width="1000px"></iframe>
+      <iframe title="Book a slot" src="https://calendly.com/niklas-brag/30min-1?hide_gdpr_banner=1" height="1000px" width="1000px"></iframe>
     </div>
   </div>
 </section>

--- a/templates/engage/unlisted/shell-onboarding.html
+++ b/templates/engage/unlisted/shell-onboarding.html
@@ -85,7 +85,7 @@
 
 <section class="p-strip is-shallow" id="vimeo-section">
   <div class="row" id="webinar">
-    <iframe src="https://player.vimeo.com/video/670718263" width="560" height="315" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>
+    <iframe title="Webinar" src="https://player.vimeo.com/video/670718263" width="560" height="315" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>
   </div>
 </section>
 {% endblock content %}

--- a/templates/hpc/index.html
+++ b/templates/hpc/index.html
@@ -21,7 +21,7 @@
       </div>
       <div class="col-5 u-hide--small u-align--center">
         <div class="u-embedded-media">
-          <iframe class="u-embedded-media__element" src="https://www.youtube.com/embed/tGIobcyKViI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+          <iframe title="What is HPC?" class="u-embedded-media__element" src="https://www.youtube.com/embed/tGIobcyKViI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
         </div>
       </div>
     </div>

--- a/templates/hpc/use-cases.html
+++ b/templates/hpc/use-cases.html
@@ -17,7 +17,7 @@
     </div>
     <div class="col-6 u-align--center">
       <div class="u-embedded-media">
-        <iframe class="u-embedded-media__element" src="https://www.youtube.com/embed/tGIobcyKViI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" 	allowfullscreen></iframe>
+        <iframe title="What is HPC?" class="u-embedded-media__element" src="https://www.youtube.com/embed/tGIobcyKViI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" 	allowfullscreen></iframe>
       </div>
     </div>
   </div>

--- a/templates/kubeconeurope2020/index.html
+++ b/templates/kubeconeurope2020/index.html
@@ -25,7 +25,7 @@
         Watch Ubuntu's original KubeCon demos on multi-cloud Kubernetes
       </h5>
       <div class="u-embedded-media">
-        <iframe class="u-embedded-media__element" src="https://www.youtube.com/embed/videoseries?list=PLwFSk464RMxn0sHgaX59Q82fIplLSnrdH" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+        <iframe title="Virtual Kubecon Europe 2020" class="u-embedded-media__element" src="https://www.youtube.com/embed/videoseries?list=PLwFSk464RMxn0sHgaX59Q82fIplLSnrdH" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
       </div>
       <div style="padding-top: 2rem;">
         <p class="p-button--positive p-button--inline" onclick="LC_API.open_chat_window();return false">

--- a/templates/managed/apps/index.html
+++ b/templates/managed/apps/index.html
@@ -548,7 +548,7 @@ coverage.{% endblock meta_description %}
       <p><a href="/engage/managed-apps-webinar">Watch the full webinar on demand now&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-6">
-      <iframe src="https://player.vimeo.com/video/456162146" width="500" height="300" frameborder="0"
+      <iframe title="How does Canonical's managed service for cloud applications help reduce costs?" src="https://player.vimeo.com/video/456162146" width="500" height="300" frameborder="0"
         allow="autoplay; fullscreen" allowfullscreen></iframe>
     </div>
   </div>

--- a/templates/masters-conference/index.html
+++ b/templates/masters-conference/index.html
@@ -15,7 +15,7 @@
     </div>
     <div class="col-6 u-hide--small u-align--right">
       <div class="u-embedded-media">
-        <iframe class="u-embedded-media__element" src="https://player.vimeo.com/video/425889911" width="504" height="280" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>
+        <iframe title="Master conference intro" class="u-embedded-media__element" src="https://player.vimeo.com/video/425889911" width="504" height="280" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>
       </div>
     </div>
   </div>
@@ -28,7 +28,7 @@
   <div class="row u-equal-height">
     <div class="col-6">
       <div class="u-embedded-media u-vertically-center--direct" style="margin-left: auto; margin-right: auto; max-width: 100%; width: 466px;">
-        <iframe width="560" height="315" src="https://www.youtube.com/embed/sRuVBMclM_k" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+        <iframe title="SQL server on Kubernetes" width="560" height="315" src="https://www.youtube.com/embed/sRuVBMclM_k" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
       </div>
     </div>
     <div class="col-6">
@@ -50,7 +50,7 @@
     </div>
     <div class="col-6">
       <div class="u-embedded-media u-vertically-center--direct" style="margin-left: auto; margin-right: auto; max-width: 100%; width: 466px;">
-        <iframe width="560" height="315" src="https://www.youtube.com/embed/Rv54iqchy5M" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+        <iframe title="Industry 4.0 needs a complete automation solution" width="560" height="315" src="https://www.youtube.com/embed/Rv54iqchy5M" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
       </div>
     </div>
   </div>
@@ -60,7 +60,7 @@
   <div class="row u-equal-height">
     <div class="col-6">
       <div class="u-embedded-media u-vertically-center--direct" style="margin-left: auto; margin-right: auto; max-width: 100%; width: 466px;">
-        <iframe width="560" height="315" src="https://www.youtube.com/embed/2DOcm4yMvMw" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+        <iframe title="Plugging the Boothole" width="560" height="315" src="https://www.youtube.com/embed/2DOcm4yMvMw" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
       </div>
     </div>
     <div class="col-6">
@@ -103,7 +103,7 @@
     </div>
     <div class="col-6">
       <div class="u-embedded-media u-vertically-center--direct" style="margin-left: auto; margin-right: auto; max-width: 100%; width: 466px;">
-        <iframe class="u-embedded-media__element" width="560" height="315" src="https://www.youtube-nocookie.com/embed/SGrRqCuiT90" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+        <iframe title="Mastering multicloud for HPC systems" class="u-embedded-media__element" width="560" height="315" src="https://www.youtube-nocookie.com/embed/SGrRqCuiT90" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
       </div>
     </div>
   </div>
@@ -114,7 +114,7 @@
   <div class="row u-equal-height">
     <div class="col-6">
       <div class="u-embedded-media u-vertically-center--direct" style="margin-left: auto; margin-right: auto; max-width: 100%; width: 466px;">
-        <iframe class="u-embedded-media__element" width="560" height="315" src="https://www.youtube-nocookie.com/embed/8u-sM4xpfZE" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+        <iframe title="Streamlined provisioning of IoT devices" class="u-embedded-media__element" width="560" height="315" src="https://www.youtube-nocookie.com/embed/8u-sM4xpfZE" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
       </div>
     </div>
     <div class="col-6">
@@ -163,7 +163,7 @@
     </div>
     <div class="col-6">
       <div class="u-embedded-media u-vertically-center--direct" style="margin-left: auto; margin-right: auto; max-width: 100%; width: 466px;">
-        <iframe class="u-embedded-media__element" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Ma1hzMf6YO0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+        <iframe title="The open (source) road to smarter robots" class="u-embedded-media__element" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Ma1hzMf6YO0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
       </div>
     </div>
   </section>
@@ -178,7 +178,7 @@
     <div class="row u-equal-height p-reverse-cols--small">
       <div class="col-6">
         <div class="u-embedded-media u-vertically-center--direct" style="margin-left: auto; margin-right: auto; max-width: 100%; width: 466px;">
-          <iframe class="u-embedded-media__element" width="560" height="315" src="https://www.youtube-nocookie.com/embed/WvZB3xn1bWg" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+          <iframe title="Scaling Years of Growth in One Week" class="u-embedded-media__element" width="560" height="315" src="https://www.youtube-nocookie.com/embed/WvZB3xn1bWg" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
         </div>
       </div>
       <div class="col-6">
@@ -210,7 +210,7 @@
       </div>
       <div class="col-6">
         <div class="u-embedded-media u-vertically-center--direct" style="margin-left: auto; margin-right: auto; max-width: 100%; width: 466px;">
-          <iframe class="u-embedded-media__element" width="560" height="315" src="https://www.youtube-nocookie.com/embed/txNszs1AJf4" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+          <iframe title="An introudction to edge computing for computer vision and robotics" class="u-embedded-media__element" width="560" height="315" src="https://www.youtube-nocookie.com/embed/txNszs1AJf4" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
         </div>
       </div>
     </div>
@@ -222,7 +222,7 @@
     <div class="row u-equal-height p-reverse-cols--small">
       <div class="col-6">
         <div class="u-embedded-media u-vertically-center--direct" style="margin-left: auto; margin-right: auto; max-width: 100%; width: 466px;">
-          <iframe class="u-embedded-media__element" width="560" height="315" src="https://www.youtube-nocookie.com/embed/dSZqax12Q7A" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+          <iframe title="Building the data centre" class="u-embedded-media__element" width="560" height="315" src="https://www.youtube-nocookie.com/embed/dSZqax12Q7A" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
         </div>
       </div>
       <div class="col-6">
@@ -246,7 +246,7 @@
     <div class="row u-equal-height p-reverse-cols--small">
       <div class="col-6">
         <div class="u-embedded-media u-vertically-center--direct" style="margin-left: auto; margin-right: auto; max-width: 100%; width: 466px;">
-          <iframe class="u-embedded-media__element" width="560" height="315" src="https://www.youtube-nocookie.com/embed/7pmXdG8-7WU" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+          <iframe title="Netflix talks about Extended BPF" class="u-embedded-media__element" width="560" height="315" src="https://www.youtube-nocookie.com/embed/7pmXdG8-7WU" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
         </div>
       </div>
 
@@ -295,7 +295,7 @@
 
       <div class="col-6">
         <div class="u-embedded-media u-vertically-center--direct" style="margin-left: auto; margin-right: auto; max-width: 100%; width: 466px;">
-          <iframe class="u-embedded-media__element" width="560" height="315" src="https://www.youtube-nocookie.com/embed/IUgODRm9Soc" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+          <iframe title="Adobe meets huge demand with a lean approach" class="u-embedded-media__element" width="560" height="315" src="https://www.youtube-nocookie.com/embed/IUgODRm9Soc" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
         </div>
       </div>
     </div>
@@ -307,7 +307,7 @@
     <div class="row u-equal-height p-reverse-cols--small">
       <div class="col-6">
         <div class="u-embedded-media u-vertically-center--direct" style="margin-left: auto; margin-right: auto; max-width: 100%; width: 466px;">
-          <iframe class="u-embedded-media__element" width="560" height="315" src="https://www.youtube-nocookie.com/embed/SwlU4U-BWRo" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+          <iframe title="How Roblox went from Windows to Ubuntu in 7 days for edge compute nodes" class="u-embedded-media__element" width="560" height="315" src="https://www.youtube-nocookie.com/embed/SwlU4U-BWRo" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
         </div>
       </div>
 

--- a/templates/security/livepatch.html
+++ b/templates/security/livepatch.html
@@ -24,7 +24,7 @@ meta_copydoc %}
       </div>
       <div class="col-5 u-vertically-center">
         <div class="u-embedded-media">
-          <iframe class="u-embedded-media__element" width="560" height="315" src="https://www.youtube.com/embed/IOLQQZVYbbg" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+          <iframe title="Livepatch: provide uninterrupted service" class="u-embedded-media__element" width="560" height="315" src="https://www.youtube.com/embed/IOLQQZVYbbg" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
         </div>
       </div>
     </div>

--- a/templates/shared/_share_this.html
+++ b/templates/shared/_share_this.html
@@ -1,5 +1,5 @@
 <div class="share-this">
-	<iframe src="https://www.facebook.com/plugins/like.php?href=http%3A%2F%2Fwww.ubuntu.com%2Fubuntu&amp;send=false&amp;layout=button_count&amp;show_faces=false&amp;action=like&amp;colorscheme=light&amp;font&amp;height=20" style="border:none; overflow:hidden; height:21px; padding-right:23px;"></iframe>
+	<iframe title="Share on Facebook" src="https://www.facebook.com/plugins/like.php?href=http%3A%2F%2Fwww.ubuntu.com%2Fubuntu&amp;send=false&amp;layout=button_count&amp;show_faces=false&amp;action=like&amp;colorscheme=light&amp;font&amp;height=20" style="border:none; overflow:hidden; height:21px; padding-right:23px;"></iframe>
 	<div class="g-plusone" data-size="medium"></div>
     <script>
       window.___gcfg = {lang: 'en-GB'};

--- a/templates/templates/_product.html
+++ b/templates/templates/_product.html
@@ -44,7 +44,7 @@
       <div class="u-fixed-width">
         <h2>{% block video_title %}{% endblock %}</h2>
         <div class="u-embedded-media">
-          <iframe class="u-embedded-media__element" width="453" height="255" src="{% block video_url %}{% endblock %}" frameborder="0" allowfullscreen></iframe>
+          <iframe title="{% block video_title %}{% endblock %}" class="u-embedded-media__element" width="453" height="255" src="{% block video_url %}{% endblock %}" frameborder="0" allowfullscreen></iframe>
         </div>
       </div>
     </section>

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -68,7 +68,7 @@
 <body class="{% block body_class %}{% endblock %}">
   <!-- google tag manager -->
   <noscript>
-    <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K92JCQ" height="0" width="0" style="display:none;visibility:hidden"></iframe>
+    <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K92JCQ" height="0" width="0" style="display:none;visibility:hidden" title="Google Tag Manager"></iframe>
   </noscript>
   <!-- end google tag manager -->
 

--- a/templates/templates/base_no_nav.html
+++ b/templates/templates/base_no_nav.html
@@ -44,7 +44,7 @@
   <body style="padding-top: 0;">
     <!-- google tag manager -->
     <noscript>
-      <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K92JCQ" height="0" width="0" style="display:none;visibility:hidden"></iframe>
+      <iframe title="Google Tag Manager" src="https://www.googletagmanager.com/ns.html?id=GTM-K92JCQ" height="0" width="0" style="display:none;visibility:hidden"></iframe>
     </noscript>
     <!-- end google tag manager -->
 


### PR DESCRIPTION
## Done

- Added `title` attributes to all `iframe` elements

## QA

- Check out this feature branch
- Search the codebase for "<iframe", and see that all iframe elements it finds have an appropriate `title` attribute

## Issue / Card

Fixes https://github.com/canonical/ubuntu.com/issues/11891 as far as we're able to, many of the pages listed in the [spreadsheet given in the issue](https://docs.google.com/spreadsheets/d/1TwEIjvujOjqFcAr3IuEAb_VeFA6_dUZnnQyOFC59V1o/edit?usp=sharing) include a Bright Talk embed, and it isn't possible for us to add a title attribute to that.
