### PR TITLE
Add chinese tw language filter

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -1375,6 +1375,10 @@
     if (window.ActiveXObject) {
       xhr = new ActiveXObject('Microsoft.XMLHTTP');
     }
+    var fetchUserCountry = new XMLHttpRequest();
+    if (window.ActiveXObject) {
+      fetchUserCountry = new ActiveXObject('Microsoft.XMLHTTP');
+    }
 
     xhr.onreadystatechange = function() {
       if (xhr.readyState == XMLHttpRequest.DONE) {
@@ -1382,23 +1386,37 @@
           var takeovers = JSON.parse(xhr.responseText);
 
           // Get the selected takeovers based on the primary language
-          var currentUserCountry = "{{ current_user_country }}"
-          var selectedTakeovers = takeovers.filter(function(item) {
-            if (item.target_country && item.target_country == currentUserCountry) {
-              return true
-            } else if (item.lang === primaryParentLanguage || item.lang === "") {
-              return true
-            } else {
-              return false
-            }
-          })
+          if (
+            fetchUserCountry.readyState == XMLHttpRequest.DONE &&
+            fetchUserCountry.status == 200
+          ) {
+            var userCountry = JSON.parse(fetchUserCountry.responseText).country_code;
+            var selectedTakeovers = takeovers.filter(function (item) {
+              if (item.target_country && item.target_country == userCountry) {
+                return true;
+              } else if (item.lang === primaryParentLanguage || item.lang === "") {
+                return true;
+              } else {
+                return false;
+              }
+            });
+          } else {
+            var selectedTakeovers = takeovers.filter(function (item) {
+              if (item.lang === primaryParentLanguage || item.lang === "") {
+                return true;
+              } else {
+                return false;
+              }
+            });
+          }
 
           if (selectedTakeovers && selectedTakeovers.length > 0) {
             var selectedIndex = null;
 
-            if (window.localStorage.getItem('selected_takeover_index') !== null) {
+            if (window.localStorage.getItem("selected_takeover_index") !== null) {
               // If we previously visited a takeover, increment the number to show the next takeover
-              var nextIndex = parseInt(window.localStorage.getItem('selected_takeover_index')) + 1
+              var nextIndex =
+                parseInt(window.localStorage.getItem("selected_takeover_index")) + 1;
               selectedIndex = nextIndex < selectedTakeovers.length ? nextIndex : 0;
             } else {
               // Otherwise, randomly choose one of the takeovers and store it for next time
@@ -1407,8 +1425,10 @@
             showTakeover(selectedTakeovers, selectedIndex);
 
             // Store the current takeover index
-            localStorage.setItem('selected_takeover_index', selectedIndex)
+            localStorage.setItem("selected_takeover_index", selectedIndex);
           }
+
+
         } else {
           takeoverAnimation.className = takeoverAnimation.className.replace(" is-loading", "");
           takeoverAnimation.className +=  " is-loaded";
@@ -1418,6 +1438,8 @@
 
     xhr.open("GET", "/takeovers.json", true);
     xhr.send();
+    fetchUserCountry.open("GET", "/user-country.json", true);
+    fetchUserCountry.send();
     takeoverAnimation.className +=  " is-loading";
   }
 

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -1382,8 +1382,15 @@
           var takeovers = JSON.parse(xhr.responseText);
 
           // Get the selected takeovers based on the primary language
+          var currentUserCountry = "{{ current_user_country }}"
           var selectedTakeovers = takeovers.filter(function(item) {
-            return item.lang === primaryParentLanguage || item.lang === ""
+            if (item.target_country && item.target_country == currentUserCountry) {
+              return true
+            } else if (item.lang === primaryParentLanguage || item.lang === "") {
+              return true
+            } else {
+              return false
+            }
           })
 
           if (selectedTakeovers && selectedTakeovers.length > 0) {

--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -31,6 +31,7 @@
         <label for="language-selector">Select language:</label>
         <select name="language-selector" id="language-selector" class="u-no-margin--bottom">
           <option value="all">All languages</option>
+          <option value="zh-TW">Chinese (Traditional)</option>
           <option value="de">Deutsch</option>
           <option value="en">English</option>
           <option value="es">Espa&ntilde;ol</option>

--- a/templates/engage/shared/_zh-TW_engage_form.html
+++ b/templates/engage/shared/_zh-TW_engage_form.html
@@ -1,0 +1,67 @@
+<!-- MARKETO FORM -->
+<form action="/marketo/submit" method="post" id="mktoForm_{{ id }}" onSubmit='if (typeof fbq === "function"){fbq("trackCustom", "Download"); }'>
+  <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
+    <ul class="p-list">
+      <li class="p-list__item">
+        <label for="firstName">First name:</label>
+        <input required id="firstName" name="firstName" maxlength="255" type="text" value="">
+      </li>
+      <li>
+        <label for="lastName">Last name:</label>
+        <input required id="lastName" name="lastName" maxlength="255" type="text">
+      </li>
+      <li>
+        <label for="email">Work email:</label>
+        <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" value="">
+      </li>
+      <li>
+        <label for="company">Company name:</label>
+        <input required id="company" name="company" maxlength="255" type="text">
+      </li>
+      <li>
+        <label for="jobTitle">Job title:</label>
+        <input required id="jobTitle" name="title" maxlength="255" type="text">
+      </li>
+      <li>
+        <label for="phone">Mobile/cell phone number:</label>
+        <input required id="phone" name="phone" maxlength="255" type="tel">
+      </li>
+      <li>
+        <label class="p-checkbox">
+          <input class="p-checkbox__input" name="canonicalUpdatesOptIn" aria-labelledby="canonicalUpdatesOptIn" value="yes" type="checkbox">
+          <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
+        </label>
+      </li>
+      <li>
+        <p>In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.
+          <input name="RichText" aria-label="RichText" type="hidden">
+        </p>
+      </li>
+      {# These are honey pot fields to catch bots #}
+      <li class="u-off-screen">
+        <label class="website" for="website">Website:</label>
+        <input name="website" type="text" class="website" autocomplete="off" value="" id="website" tabindex="-1" />
+      </li>
+      <li class="u-off-screen">
+        <label class="name" for="name">Name:</label>
+        <input name="name" type="text" class="name" autocomplete="off" value="" id="name" tabindex="-1" />
+      </li>
+      {# End of honey pots #}
+      <li>
+        <input name="Consent_to_Processing__c" aria-label="Consent" value="Yes" type="hidden">
+      </li>
+      <li>
+        <button type="submit" class="u-no-margin--bottom {% if cta_class %}{{ cta_class }}{% endif %}" >{% if cta %}{{ cta }}{% else %}Download the whitepaper{% endif %}</button>
+        <input name="formid" aria-label="formid" value="{{ id }}" type="hidden">
+        <input type="hidden" name="returnURL" aria-label="returnURL" value="{{ returnURL }}" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="{{utm_campaign}}" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="{{utm_medium}}" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="{{utm_source}}" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Facebook_Click_ID__c" id="Facebook_Click_ID__c" value="" />
+      </li>
+    </ul>
+  </fieldset>
+</form>

--- a/templates/engage/shared/_zh-TW_thank-you.html
+++ b/templates/engage/shared/_zh-TW_thank-you.html
@@ -1,0 +1,94 @@
+{% extends "engage/base_engage.html" %}
+
+{% block title %}Download {{ resource_name }} {% endblock %}
+
+{% block head_extra%}<meta name="robots" content="noindex" />{% endblock %}
+
+{% block content %}
+<style>
+  .global-nav .global-nav__header-logo-anchor {
+    padding-left: 0 !important;
+  }
+</style>
+<section class="p-strip p-engage-banner--grad">
+  <div class="u-fixed-width navigation-logo-engage">
+    <a href="/">
+      {{
+        image(
+            url="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg",
+            alt="Ubuntu",
+            width="143",
+            height="32",
+            hi_def=True,
+            loading="auto",
+        ) | safe
+      }}
+    </a>
+  </div>
+  <div class="row">
+    <div class="col-8">
+      <h1>
+        Thank you
+      </h1>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="u-fixed-width">
+  {% if 'pages.ubuntu.com' or 'assets.ubuntu.com' in resource_url %}
+    {% if form_details and "access_to_content" in metadata and metadata.access_to_content == "true" %}
+    
+      <h3>We've emailed a copy of {{ resource_name }} to {{ form_details.email }}</h3>
+      <p>
+        <a class="p-button--positive" href="{{ request_url }}">Back to last page</a>
+        <a class="p-button" href="/contact-us">Contact us</a>
+      </p>
+      <p>
+        Not received it? Check your spam folder and that you've used the right email address.
+      </p>
+      <p>
+        <a href="{{ request_url }}">Or try resending it</a>
+      </p>
+
+    {% else %}
+      {% if "thank_you_text" in metadata %}
+        <p>{{ metadata["thank_you_text"] }}</p>
+      {% else %}
+        <p>The {{ resource_name }} is now ready to download.</p>
+      {% endif %}
+      {% if "contact_form_only" not in metadata and metadata.contact_form_only != "true" or ("access_to_content" in metadata and metadata.access_to_content == "true") %}
+        <p>
+          <a class="p-button--positive" href="{{ resource_url }}">Download</a>
+        </p>
+      {% endif %}
+    {% endif %}
+      
+  {% else %}
+    <p>
+      Sorry, we do not recognise this download request.  Please let us know by <a href="https://github.com/canonical-websites/www.ubuntu.com/issues/new?body=Bad+resource+download+link+from {{ request.url | urlencode }}">filing and issue on GitHub</a>. And let us know what you excepted to download.
+    </p>
+  {% endif %}
+  </div>
+</section>
+
+{% if related | length > 0 %}
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-8">
+      <h2 class="p-heading--3">You may also be interested in &hellip;</h2>
+    </div>
+  </div>
+  <div class="row p-divider">
+    {% for page in related %}
+    <div class="col-4 p-divider__block">
+      <!-- THREE ADDITIONAL CTAs -->
+      <h4>{{page["topic_name"]}}</h4>
+      <p>{{page["subtitle"]}}</p>
+      <p><a href="{{page['path']}}">See more&nbsp;&rsaquo;</a></p>
+    </div>
+    {% endfor %}
+  </div>
+</section>
+{% endif %}
+{% endblock content %}

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -41,7 +41,6 @@ from webapp.context import (
     months_list,
     get_navigation,
     releases,
-    get_user_country_by_ip,
 )
 
 from webapp.shop.flaskparser import UAContractsValidationError
@@ -86,6 +85,7 @@ from webapp.views import (
     mirrors_query,
     build_tutorials_query,
     openstack_engage,
+    get_user_country_by_ip,
 )
 
 from webapp.shop.views import (
@@ -304,7 +304,6 @@ def context():
         "CAPTCHA_TESTING_API_KEY": CAPTCHA_TESTING_API_KEY,
         "http_host": flask.request.host,
         "is_maintenance": strtobool(os.getenv("STORE_MAINTENANCE", "false")),
-        "current_user_country": get_user_country_by_ip(),
     }
 
 
@@ -710,6 +709,8 @@ app.add_url_rule(
 
 core_services_guide.init_app(app)
 
+
+app.add_url_rule("/user-country.json", view_func=get_user_country_by_ip)
 
 # All other routes
 template_finder_view = TemplateFinder.as_view("template_finder")

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -41,6 +41,7 @@ from webapp.context import (
     months_list,
     get_navigation,
     releases,
+    get_user_country_by_ip,
 )
 
 from webapp.shop.flaskparser import UAContractsValidationError
@@ -303,6 +304,7 @@ def context():
         "CAPTCHA_TESTING_API_KEY": CAPTCHA_TESTING_API_KEY,
         "http_host": flask.request.host,
         "is_maintenance": strtobool(os.getenv("STORE_MAINTENANCE", "false")),
+        "current_user_country": get_user_country_by_ip(),
     }
 
 

--- a/webapp/context.py
+++ b/webapp/context.py
@@ -5,7 +5,6 @@ import calendar
 import logging
 import json
 from urllib.parse import parse_qs, urlencode
-from geolite2 import geolite2
 
 # Packages
 import flask
@@ -18,7 +17,6 @@ from canonicalwebteam.http import CachedSession
 logger = logging.getLogger(__name__)
 
 api_session = CachedSession(fallback_cache_duration=3600)
-ip_reader = geolite2.reader()
 
 # Read navigation.yaml
 with open("navigation.yaml") as navigation_file:
@@ -138,13 +136,3 @@ def get_json_feed(url, offset=0, limit=None):
         return False
 
     return content[offset:end]
-
-
-def get_user_country_by_ip():
-    client_ip = flask.request.headers.get(
-        "X-Real-IP", flask.request.remote_addr
-    )
-    ip_location = ip_reader.get(client_ip)
-    if not ip_location:
-        return None
-    return ip_location["country"]["iso_code"]

--- a/webapp/context.py
+++ b/webapp/context.py
@@ -5,6 +5,7 @@ import calendar
 import logging
 import json
 from urllib.parse import parse_qs, urlencode
+from geolite2 import geolite2
 
 # Packages
 import flask
@@ -17,7 +18,7 @@ from canonicalwebteam.http import CachedSession
 logger = logging.getLogger(__name__)
 
 api_session = CachedSession(fallback_cache_duration=3600)
-
+ip_reader = geolite2.reader()
 
 # Read navigation.yaml
 with open("navigation.yaml") as navigation_file:
@@ -137,3 +138,13 @@ def get_json_feed(url, offset=0, limit=None):
         return False
 
     return content[offset:end]
+
+
+def get_user_country_by_ip():
+    client_ip = flask.request.headers.get(
+        "X-Real-IP", flask.request.remote_addr
+    )
+    ip_location = ip_reader.get(client_ip)
+    if not ip_location:
+        return None
+    return ip_location["country"]["iso_code"]

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -962,3 +962,25 @@ def thank_you():
     return flask.render_template(
         "thank-you.html", referrer=flask.request.args.get("referrer")
     )
+
+
+def get_user_country_by_ip():
+    client_ip = flask.request.headers.get(
+        "X-Real-IP", flask.request.remote_addr
+    )
+    ip_location = ip_reader.get("84.247.0.146")
+
+    if not ip_location:
+        country_code = None
+    else:
+        country_code = ip_location["country"]["iso_code"]
+
+    response = flask.jsonify(
+        {
+            "client_ip": client_ip,
+            "country_code": country_code,
+        }
+    )
+    response.cache_control.private = True
+
+    return response


### PR DESCRIPTION
## Done

- Add language filter for Chinese (traditional) according to [the brief](https://docs.google.com/document/d/1sPw5bsPhZHaSOIdUAYhGaXK9Q0FSVAkimW-XeO_OhEE/edit#heading=h.meo0azuz09li)
- Translations will not be done according to TJ, so defaulting to English
- Phone number prefix, we are planning to use geolocation for it.

## QA

- Go to https://ubuntu-com-12408.demos.haus/engage
- Click on the language filter and select the new filter "Chinese (Traditional)" as requested in the brief
- Fill up the form with test data and submit.

## Issue / Card

Fixes https://github.com/canonical/web-squad/issues/6309

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
