### PR TITLE
Update ASRock logo on /certified

### DIFF
--- a/templates/certified/shared/_partners.html
+++ b/templates/certified/shared/_partners.html
@@ -228,13 +228,13 @@
   </div>
   <div class="col-small-1 col-medium-1 col-1">
     {{ image (
-      url="https://assets.ubuntu.com/v1/d94e3a65-asrock.svg",
-      alt="ASRock",
+      url="https://assets.ubuntu.com/v1/cae3c13c-asrockIndustrial.png",
+      alt="AS Rock",
       attrs={"class":"p-logo-section__logo"},
       width="280",
       height="280",
       hi_def=False,
-      loading="lazy",
+      loading="lazy"
       ) | safe
     }}
   </div>


### PR DESCRIPTION
## Done

- Updates the ASRock logo to the most recent one found [here](https://assets.ubuntu.com/v1/cae3c13c-asrockIndustrial.png) based on the changed request in [this jira issue](https://warthogs.atlassian.net/browse/WD-1171)

**Note**: part of the request was to have the name 'ASRock Incorporation iEP-5000G' updated to 'ASRock Industrial' on the detail page. Due to how these pages are built, removing the model number (iEP-5000G) is not practical and we agreed to keep it. The update to 'ASRock Industrial' has been requested and will be made on directly to the database.

## QA

- Go to /certified and /certified/why-certify and check the ASRock logo matches the one linked above
- Visit [this](/certified/202209-30659) hardware details page and check the vendor name is 'ASRock Industrial'

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-1171
