### PR TITLE
6315: New Core 22 release notes and 12th gen download link on /download/iot/intel-iot

### DIFF
--- a/templates/download/iot/intel-iot.html
+++ b/templates/download/iot/intel-iot.html
@@ -100,7 +100,7 @@
     <p><strong>Download Ubuntu for your Intel hardware.</strong> Below you will find links for the production-grade family of Ubuntu images, along with release notes and installation instructions.</p>
     <p><a href="https://assets.ubuntu.com/v1/a492a35c-LookoutCanyon_ReleaseNotes_22.04_221115_V1.1.pdf">Release notes for Ubuntu Desktop and Server 22.04&nbsp;&rsaquo;</a></p>
     <p><a href="https://assets.ubuntu.com/v1/fd2fa325-LookoutCanyon_ReleaseNotes_20.04_221115_V1.1.pdf">Release notes for Ubuntu Desktop and Server 20.04&nbsp;&rsaquo;</a></p>    
-    <p><a href="https://assets.ubuntu.com/v1/e1201039-LookoutCanyon_ReleaseNotes_UC22_221130.pdf">Release notes for Ubuntu Core 22&nbsp;&rsaquo;</a></p>
+    <p><a href="https://assets.ubuntu.com/v1/b3b43e13-LookoutCanyon_ReleaseNotes_UC22_221130%20_V1.1.pdf">Release notes for Ubuntu Core 22&nbsp;&rsaquo;</a></p>
     <p><a href="https://assets.ubuntu.com/v1/c657029e-LookoutCanyon_ReleaseNotes_UC20_221130.pdf">Release notes for Ubuntu Core 20&nbsp;&rsaquo;</a></p>    
     <table class="p-table--mobile-card" aria-label="Ubuntu 22.04 for intel downloads">
       <thead>
@@ -126,7 +126,7 @@
         </tr>
         <tr>
           <th>12th Gen Intel® Core™ processors <br/>(former codename Alder Lake S, P)</th>
-          <td class="u-align--center" data-heading="Ubuntu Core 22"><p><button class="p-button is-dense" disabled="">Coming soon</button></p></td>
+          <td class="u-align--center" data-heading="Ubuntu Core 22"><p><a href="https://cdimage.ubuntu.com/ubuntu-core/22/stable/20221021.3/ubuntu-core-22-amd64+intel-iot.img.xz" class="p-button is-dense">Download</a></p></td>
           <td class="u-align--center" data-heading="Ubuntu Desktop 22.04"><p><a href="https://cdimage.ubuntu.com/jammy/daily-live/manual/jammy-desktop-amd64+intel-iot.iso" class="p-button is-dense">Download</a></p></td>
           <td class="u-align--center" data-heading="Ubuntu Server 22.04"><p><a href="https://cdimage.ubuntu.com/ubuntu-server/jammy/daily-live/manual/jammy-live-server-amd64+intel-iot.iso" class="p-button is-dense">Download</a></p></td>
         </tr>


### PR DESCRIPTION
Changes from [copy doc](https://docs.google.com/document/d/1hxKzPs6e6JQaa9tBqfZ55GAXrVnEryEWBja8HlXy-lc/edit#).

- Replace Core 22 release notes with new link
- Add 12th Gen download link for Core 22

Fixes #12421

## QA

Open https://ubuntu-com-12421.demos.haus/download/iot/intel-iot, check the new links for the release notes and download match those mentioned in [the copy doc](https://docs.google.com/document/d/1hxKzPs6e6JQaa9tBqfZ55GAXrVnEryEWBja8HlXy-lc/edit#).