### PR TITLE
Exit survey error fixed

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -922,6 +922,7 @@ app.add_url_rule("/credentials/exam", view_func=cred_exam)
 app.add_url_rule(
     "/credentials/exit-survey",
     view_func=cred_submit_form,
+    methods=["GET", "POST"],
 )
 app.add_url_rule(
     "/credentials/provision",


### PR DESCRIPTION
## Done

- [List of work items including drive-bys - remember to add the why and what of this work.]

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to [/credentials/exit-survey](https://ubuntu-com-12422.demos.haus/credentials/exit-survey)
- Submit the form
- Check it does not show 405 error

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
