### PR TITLE
Add Google service account creds to /credentials staging & prod

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -183,6 +183,16 @@ production:
         - name: STRIPE_PUBLISHABLE_KEY
           value: pk_live_68aXqowUeX574aGsVck8eiIE
 
+        - name: GOOGLE_SERVICE_ACCOUNT_EMAIL
+          secretKeyRef:
+            key: email
+            name: google-service-account
+
+        - name: GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY
+          secretKeyRef:
+            key: private-key
+            name: google-service-account
+
         - name: TRUEABILITY_URL
           value: https://app.trueability.com
 
@@ -550,6 +560,16 @@ staging:
 
         - name: STRIPE_PUBLISHABLE_KEY
           value: pk_test_yndN9H0GcJffPe0W58Nm64cM00riYG4N46
+
+        - name: GOOGLE_SERVICE_ACCOUNT_EMAIL
+          secretKeyRef:
+            key: email
+            name: google-service-account
+
+        - name: GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY
+          secretKeyRef:
+            key: private-key
+            name: google-service-account
 
         - name: TRUEABILITY_URL
           value: https://app.trueability.com


### PR DESCRIPTION
## Done

An error was being thrown when submitting the exit survey, apparently because the Google service account credentials were not stored in the deployment environment (see https://sentry.is.canonical.com/canonical/ubuntu-com/issues/30635/). This PR adds the credentials for the `/credentials` staging & prod pods in k8s.

## QA

- **Once merged**, visit https://staging.ubuntu.com/credentials/exit-survey
  - Complete the survey and verify that it can be submitted successfully

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
