### PR TITLE
Update /subscription-centre with pdm suggestions

### DIFF
--- a/subscriptions.yaml
+++ b/subscriptions.yaml
@@ -38,7 +38,7 @@ Ubuntu & Linux:
   - Ubuntu on AWS
   - Ubuntu on GCP
   - Linux kernel
-  - Ubutnu 22.04 
+  - Ubutnu 22.04
   - Ubuntu 20.04
   - Ubuntu 18.04
   - Ubuntu 16.04
@@ -73,7 +73,7 @@ Enterprise Administration:
   - Ubuntu Pro
   - Credentials and certs
 
-Cloud and Infrastructure:
+Cloud & Infrastructure:
   - Data centre
   - Private cloud
   - Public cloud

--- a/templates/subscription-centre/index.html
+++ b/templates/subscription-centre/index.html
@@ -15,11 +15,11 @@
   </div>
   <div class="row">
     <div class="col-4">
-      <h1 class="p-heading--2">Subscription centre</h1>
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+      <h1 class="p-heading--2 u-no-margin--bottom u-sv1">Subscription centre</h1>
+      <p class="p-heading--4">Tailor your email preferences</p>
     </div>
     <div class="col-8">
-      <div class="p-search-and-filter" id="subscription-centre-search" style="margin-bottom:1rem;">
+      <div class="p-search-and-filter" id="subscription-centre-search" style="margin-bottom:1rem;" aria-hidden="true" hidden>
         <button class="p-search-and-filter__clear" aria-hidden="true" hidden=""><i class="p-icon--close"></i></button>
         <div class="p-search-and-filter__search-container" aria-expanded="true" data-active="true" data-empty="false">
           <div class="p-search-and-filter__box" data-overflowing="false">
@@ -38,9 +38,10 @@
       </div>
 
       <form id="subscription-centre" method="post">
+        <p>Select your areas of interest below to regularly receive informative emails about relevant product announcements, webinars and events, case studies, and more. You can update your preferences here anytime.</p>
         <label class="p-checkbox">
           <input id="general-updates" type="checkbox" aria-labelledby="generalUpdates" class="p-checkbox__input" name="generalUpdates" value="true" {% if updatesOptIn %}checked{% endif %}>
-          <span class="p-checkbox__label">Include regular updates about Canonical's products and services, including webinar and event invites</span>
+          <span class="p-checkbox__label">I agree to receive information about Canonical's products and services</span>
         </label>
         <hr class="p-separator is-shallow">
         <div class="p-accordion">
@@ -165,7 +166,7 @@
 
       return subsArray;
     };
-    
+
     // Searches for matching strings and renders the matches in the search dropdown
     const handleSearch = (e) => {
       const searchVal = e.target.value.trim().toLowerCase();
@@ -229,6 +230,7 @@
     const handleClearBtn = (e) => {
       if (!checkValidEventType(e)) return;
       hideResultsDropdown(true);
+      hideCancleBtn(true);
       clearResults();
       searchInput.value = "";
     };

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -984,6 +984,8 @@ def get_user_country_by_ip():
     response.cache_control.private = True
 
     return response
+
+
 def subscription_centre():
     sfdcLeadId = flask.request.args.get("id")
     return_url = flask.request.form.get("returnURL")


### PR DESCRIPTION
## Done

- Includes some of the updates detailed in the conversation on [this pr](https://github.com/canonical/ubuntu.com/pull/12345) I haven't tackled all of them in this PR as some require discussion or design input
- The comments I addressed are the following:
3. Spelling: Can "Cloud and Infrastructure" be changed to "Cloud & Infrastructure" so that it aligns with the other headers? Furthermore there is an "Ubutnu" in Ubuntu & Linux
6. Optin box: please change the text to: "I agree to receive information about Canonical’s products and services."
7. Can we hide the search bar for our MVP to go live? We're not really satisfied with it yet but might want to bring it back later on
8. Can we keep the subtitle we had in the old subscription center? (example: https://pages.ubuntu.com/Subscription-preferences.html?mkt_unsubscribe=1) So under "Subscription center" we would like to add "Tailor your email preferences"
9. Above the optin box and instead of the search bar, can you place the following: Select your areas of interest below to regularly receive informative emails about relevant product announcements, webinars and events, case studies, and more. You can update your preferences here anytime. (see added screenshot of how this could look)
![image](https://user-images.githubusercontent.com/58276363/212356159-d2f88128-a2ea-4a2c-9da2-e56f20f31c67.png)

Please reach out if anything is not clear.


## QA

- Go to /subscription-centre?id= and use [this id](https://pastebin.canonical.com/p/XFptDSWB8K/) compare against the changes detailed above.

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-1272

