### PR TITLE
Update k8s table data

### DIFF
--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -440,6 +440,12 @@
           </thead>
           <tbody>
             <tr>
+              <td><strong>1.26.x</strong></td>
+              <td align='right'>Dec 2022</td>
+              <td align='right'>Dec 2023</td>
+              <td align='right'>Aug 2024</td>
+            </tr>
+            <tr>
               <td><strong>1.25.x</strong></td>
               <td align='right'>Sep 2022</td>
               <td align='right'>Aug 2023</td>


### PR DESCRIPTION
Previously I submitted this [PR](https://github.com/canonical/ubuntu.com/pull/12395) to update the k8s release cycle information. This updated the chart, but I mistakenly forgot to update the table data that appears for small screen sizes. This PR adds the 1.26 table data for that table. Sorry about that. 

## Done
- Update kubernetes release table data for 1.26

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
