### PR TITLE
Add Snapcraft 101 to /training

### DIFF
--- a/templates/training/contact-us.html
+++ b/templates/training/contact-us.html
@@ -90,7 +90,17 @@ returnURL="/training/thank-you?product=juju-administrator-training-onsite" %}
 intro_text="Fill in your details below and a member of our training team will be in touch.",
 formid="1448",
 lpId="2661",
-returnURL="/training/thank-you?product=juju-administrator-training-onsite" %}
+returnURL="/training/thank-you?product=charm-developer-training-onsite" %}
+{% include "shared/_cloud-contact-us-form.html" %}
+{% endwith %}
+
+{% elif product == 'snapcraft-101' %}
+
+{% with h1="Contact us about our Snapcraft 101 training course",
+intro_text="Fill in your details below and a member of our training team will be in touch.",
+formid="1448",
+lpId="2661",
+returnURL="/training/thank-you?product=snapcraft-101" %}
 {% include "shared/_cloud-contact-us-form.html" %}
 {% endwith %}
 

--- a/templates/training/contact-us.html
+++ b/templates/training/contact-us.html
@@ -98,7 +98,7 @@ returnURL="/training/thank-you?product=charm-developer-training-onsite" %}
 
 {% with h1="Contact us about our Snapcraft 101 training course",
 intro_text="Fill in your details below and a member of our training team will be in touch.",
-formid="1448",
+formid="4843",
 lpId="2661",
 returnURL="/training/thank-you?product=snapcraft-101" %}
 {% include "shared/_cloud-contact-us-form.html" %}

--- a/templates/training/index.html
+++ b/templates/training/index.html
@@ -19,7 +19,7 @@
         <p>Train your sysadmins and devops engineers to become <a href="/openstack">Charmed OpenStack</a> or Charmed Kubernetes experts. Canonical runs training programmes to suit all environments and all levels of experience. Explore, prototype and design with cloud technologies so you can get the most out of your environment. All classes and materials are provided in English.</p>
       </div>
     </div>
-    <div class="col-5 u-hide--small">
+    <div class="col-5 u-hide--small u-hide--medium">
       {{
         image(
         url="https://assets.ubuntu.com/v1/652d2f5f-ubuntu-openstack-k8s-medals.svg",
@@ -70,7 +70,7 @@
           <dt class="p-inline-definition-list__title">Availability</dt>
           <dd class="p-inline-definition-list__item">Private groups only</dd>
         </dl>
-        <p><a href="/training/contact-us?product=openstack-training-onsite"  data-form-location="/shared/forms/interactive/support-openstack" data-form-id="1223" data-lp-id="1973" data-return-url="https://ubuntu.com/training/thank-you?product=openstack-training-onsite" data-lp-url="https://ubuntu.com/training/thank-you?product=openstack-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
+        <p><a href="/training/contact-us?product=openstack-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
       </div>
     </div>
   </div>
@@ -93,7 +93,7 @@
           <dt class="p-inline-definition-list__title">Location</dt>
           <dd class="p-inline-definition-list__item">Your premises</dd>
         </dl>
-        <p><a href="/training/contact-us?product=openstack-training-onsite" data-form-location="/shared/forms/interactive/support-openstack" data-form-id="1223" data-lp-id="1973" data-return-url="https://ubuntu.com/training/thank-you?product=openstack-training-onsite" data-lp-url="https://ubuntu.com/training/thank-you?product=openstack-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
+        <p><a href="/training/contact-us?product=openstack-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
       </div>
     </div>
   </div>
@@ -126,7 +126,7 @@
           <dt class="p-inline-definition-list__title">Availability</dt>
           <dd class="p-inline-definition-list__item">Private groups only</dd>
         </dl>
-        <p><a href="/training/contact-us?product=openstack-training-onsite" data-form-location="/shared/forms/interactive/support-openstack" data-form-id="1223" data-lp-id="1973" data-return-url="https://ubuntu.com/training/thank-you?product=openstack-training-onsite" data-lp-url="https://ubuntu.com/training/thank-you?product=openstack-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
+        <p><a href="/training/contact-us?product=openstack-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
       </div>
     </div>
   </div>
@@ -154,7 +154,7 @@
           <dt class="p-inline-definition-list__title">Availability</dt>
           <dd class="p-inline-definition-list__item">Private groups only</dd>
         </dl>
-        <p><a href="/training/contact-us?product=openstack-training-server-admin" data-form-location="/shared/forms/interactive/support-openstack" data-form-id="1448" data-lp-id="2661" data-return-url="https://ubuntu.com/training/thank-you?product=openstack-training-server-admin" data-lp-url="https://ubuntu.com/training/thank-you?product=openstack-training-server-admin">Contact us to book yours&nbsp;&rsaquo;</a></p>
+        <p><a href="/training/contact-us?product=openstack-training-server-admin">Contact us to book yours&nbsp;&rsaquo;</a></p>
       </div>
     </div>
   </div>
@@ -179,7 +179,7 @@
           <dt class="p-inline-definition-list__title">Availability</dt>
           <dd class="p-inline-definition-list__item">Private groups only</dd>
         </dl>
-        <p><a href="/training/contact-us?product=openstack-training-server-admin" data-form-location="/shared/forms/interactive/support-openstack" data-form-id="1448" data-lp-id="2661" data-return-url="https://ubuntu.com/training/thank-you?product=openstack-training-server-admin" data-lp-url="https://ubuntu.com/training/thank-you?product=openstack-training-server-admin">Contact us to book yours&nbsp;&rsaquo;</a></p>
+        <p><a href="/training/contact-us?product=openstack-training-server-admin">Contact us to book yours&nbsp;&rsaquo;</a></p>
       </div>
     </div>
   </div>
@@ -214,7 +214,7 @@
           <dt class="p-inline-definition-list__title">Availability</dt>
           <dd class="p-inline-definition-list__item">Private groups only</dd>
         </dl>
-        <p><a href="/training/contact-us?product=kubernetes-training-onsite"  data-form-location="/shared/forms/interactive/kubernetes" data-form-id="1223" data-lp-id="1973" data-return-url="https://ubuntu.com/training/thank-you?product=kubernetes-training-onsite" data-lp-url="https://ubuntu.com/training/thank-you?product=kubernetes-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
+        <p><a href="/training/contact-us?product=kubernetes-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
       </div>
     </div>
   </div>
@@ -238,7 +238,7 @@
           <dt class="p-inline-definition-list__title">Location</dt>
           <dd class="p-inline-definition-list__item">Your premises</dd>
         </dl>
-        <p><a href="/training/contact-us?product=/training/contact-us?product=kubernetes-training-onsite" data-form-location="/shared/forms/interactive/kubernetes" data-form-id="1223" data-lp-id="1973" data-return-url="https://ubuntu.com/training/thank-you?product=kubernetes-training-onsite" data-lp-url="https://ubuntu.com/training/thank-you?product=kubernetes-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
+        <p><a href="/training/contact-us?product=/training/contact-us?product=kubernetes-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
       </div>
     </div>
   </div>
@@ -273,7 +273,7 @@
           <dt class="p-inline-definition-list__title">Availability</dt>
           <dd class="p-inline-definition-list__item">Private groups only</dd>
         </dl>
-        <p><a href="/training/contact-us?product=kubeflow-training-onsite"  data-form-location="/shared/forms/interactive/kubeflow" data-form-id="1223" data-lp-id="1973" data-return-url="https://ubuntu.com/training/thank-you?product=kubeflow-training-onsite" data-lp-url="https://ubuntu.com/training/thank-you?product=kubeflow-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
+        <p><a href="/training/contact-us?product=kubeflow-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
       </div>
     </div>
   </div>
@@ -308,7 +308,7 @@
           <dt class="p-inline-definition-list__title">Availability</dt>
           <dd class="p-inline-definition-list__item">Private groups only</dd>
         </dl>
-        <p><a href="/training/contact-us?product=maas-training-onsite"  data-form-location="/shared/forms/interactive/kubernetes" data-form-id="1223" data-lp-id="1973" data-return-url="https://ubuntu.com/training/thank-you?product=maas-training-onsite" data-lp-url="https://ubuntu.com/training/thank-you?product=maas-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
+        <p><a href="/training/contact-us?product=maas-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
       </div>
     </div>
   </div>
@@ -343,7 +343,7 @@
           <dt class="p-inline-definition-list__title">Availability</dt>
           <dd class="p-inline-definition-list__item">Private groups only</dd>
         </dl>
-        <p><a href="/training/contact-us?product=ceph-training-onsite"  data-form-location="/shared/forms/interactive/kubernetes" data-form-id="1223" data-lp-id="1973" data-return-url="https://ubuntu.com/training/thank-you?product=ceph-training-onsite" data-lp-url="https://ubuntu.com/training/thank-you?product=ceph-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
+        <p><a href="/training/contact-us?product=ceph-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
       </div>
     </div>
   </div>
@@ -378,7 +378,7 @@
           <dt class="p-inline-definition-list__title">Availability</dt>
           <dd class="p-inline-definition-list__item">Private groups only</dd>
         </dl>
-        <p><a href="/training/contact-us?product=landscape-training-onsite"  data-form-location="/shared/forms/interactive/kubernetes" data-form-id="1223" data-lp-id="1973" data-return-url="https://ubuntu.com/training/thank-you?product=landscape-training-onsite" data-lp-url="https://ubuntu.com/training/thank-you?product=landscape-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
+        <p><a href="/training/contact-us?product=landscape-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
       </div>
     </div>
   </div>
@@ -412,7 +412,7 @@
           <dt class="p-inline-definition-list__title">Availability</dt>
           <dd class="p-inline-definition-list__item">Private groups only</dd>
         </dl>
-        <p><a href="/training/contact-us?product=juju-administrator-training-onsite"  data-form-location="/shared/forms/interactive/kubernetes" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=juju-administrator-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=juju-administrator-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
+        <p><a href="/training/contact-us?product=juju-administrator-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
       </div>
     </div>
   </div>
@@ -446,7 +446,7 @@
           <dt class="p-inline-definition-list__title">Availability</dt>
           <dd class="p-inline-definition-list__item">Private groups only</dd>
         </dl>
-        <p><a href="/training/contact-us?product=charm-developer-training-onsite"  data-form-location="/shared/forms/interactive/kubernetes" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=charm-developer-training-onsite" data-lp-url="https://www.ubuntu.com/training/thank-you?product=charm-developer-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
+        <p><a href="/training/contact-us?product=charm-developer-training-onsite">Contact us to book yours&nbsp;&rsaquo;</a></p>
       </div>
     </div>
   </div>
@@ -480,7 +480,7 @@
           <dt class="p-inline-definition-list__title">Availability</dt>
           <dd class="p-inline-definition-list__item">Private groups only</dd>
         </dl>
-        <p><a href="/training/contact-us?product=snapcraft-101" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=snapcraft-101" data-lp-url="https://www.ubuntu.com/training/thank-you?product=snapcraft-101">Contact us to book yours&nbsp;&rsaquo;</a></p>
+        <p><a href="/training/contact-us?product=snapcraft-101">Contact us to book yours&nbsp;&rsaquo;</a></p>
       </div>
     </div>
   </div>

--- a/templates/training/index.html
+++ b/templates/training/index.html
@@ -452,7 +452,41 @@
   </div>
 </section>
 
-<section class="p-strip--light">
+<section class="p-strip--light is-bordered" itemscope itemtype="https://schema.org/Product">
+  <div class="row">
+    <div class="col-7">
+      <h2 itemprop="name">Snapcraft 101</h2>
+    </div>
+  </div>
+
+  <div>
+    <div class="u-fixed-width">
+      <hr />
+    </div>
+
+    <div class="row p-divider">
+      <div class="col-7 p-divider__block">
+        <p itemprop="description">A hands-on workshop to learn how to create, build, publish and maintain your own snaps using Snapcraft and deploy them on Ubuntu Core. The workshop alternates short instructor-led discussions with task-focused practical labs. At the end of the two day workshop, your development team will be fully capable of deploying and maintaining your own snaps.</p>
+        <p><a href="https://assets.ubuntu.com/v1/f44d287e-Snapcraft 101 Outline.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a></p>
+      </div>
+      <div class="col-5 p-divider__block">
+        <dl class="p-inline-definition-list">
+          <dt class="p-inline-definition-list__title">Duration</dt>
+          <dd class="p-inline-definition-list__item">2 days</dd>
+          <dt class="p-inline-definition-list__title">Cost</dt>
+          <dd class="p-inline-definition-list__item" itemprop="offers" itemscope itemtype="https://schema.org/Offer">USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="5000">5,000</span> up to 15 attendees</dd>
+          <dt class="p-inline-definition-list__title">Location</dt>
+          <dd class="p-inline-definition-list__item">Remote</dd>
+          <dt class="p-inline-definition-list__title">Availability</dt>
+          <dd class="p-inline-definition-list__item">Private groups only</dd>
+        </dl>
+        <p><a href="/training/contact-us?product=snapcraft-101" data-form-id="1223" data-lp-id="1973" data-return-url="https://www.ubuntu.com/training/thank-you?product=snapcraft-101" data-lp-url="https://www.ubuntu.com/training/thank-you?product=snapcraft-101">Contact us to book yours&nbsp;&rsaquo;</a></p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
   <div class="row u-equal-height">
     <div class="col-7">
       <h2>Questions about training?</h2>

--- a/templates/training/thank-you.html
+++ b/templates/training/thank-you.html
@@ -26,6 +26,8 @@
   {% with thanks_context="enquiring about our Juju Administrator training course" %}{% include "shared/_thank_you.html" %} {% endwith %}
 {% elif product == 'charm-developer-training-onsite' %}
   {% with thanks_context="enquiring about our Charm Developer training course" %}{% include "shared/_thank_you.html" %} {% endwith %}
+{% elif product == 'snapcraft-101' %}
+  {% with thanks_context="enquiring about our Snapcraft 101 training course" %}{% include "shared/_thank_you.html" %} {% endwith %}
 {% else %}
   {% with thanks_context="enquiring about training" %}{% include "shared/_thank_you.html" %}{% endwith %}
 {% endif %}


### PR DESCRIPTION
## Done

- Add new section to /training for Snapcraft 101, based on [copydoc](https://docs.google.com/document/d/1gyxy75qXC5Ta08o6Vnm13yK6aeN4qOnsETB2gZ4e0ZY/edit#)

## QA

- Go to /training and compare against [copydoc](https://docs.google.com/document/d/1gyxy75qXC5Ta08o6Vnm13yK6aeN4qOnsETB2gZ4e0ZY/edit#)
- Click 'contact us' prompt and see a custom snapcraft 101 contact us page.
- Fill in the form and see you are directed to a custom snapcraft 101 thank you

## Issue / Card

Fixes https://github.com/canonical/web-squad/issues/6341
