### PR TITLE
Keep URL parameters after SSO authentication

### DIFF
--- a/webapp/shop/decorators.py
+++ b/webapp/shop/decorators.py
@@ -104,7 +104,7 @@ def shop_decorator(area=None, permission=None, response="json", redirect=None):
 
             if permission == "user" and response == "html":
                 if not user_token:
-                    redirect_path = redirect or flask.request.path
+                    redirect_path = redirect or flask.request.full_path
 
                     return flask.redirect(f"/login?next={redirect_path}")
 


### PR DESCRIPTION
## Done
As the title says, with this change URL parameters will be preserved during the login flow for shop pages. This is going to be handy for Ubuntu Pro pages where users login in the middle a flows and it's important to keep the URL parameters that are set before logging in.

## QA
- Go to https://staging.ubuntu.com/pro/dashboard?params=true
- Check that after SSO the parameters are gone.
- Go to https://ubuntu-com-12436.demos.haus/pro/dashboard?params=true
- Check that after SSO the parameters are kept.