### PR TITLE
Fix reported broken links on the site

### DIFF
--- a/.github/workflows/live-links.yaml
+++ b/.github/workflows/live-links.yaml
@@ -37,6 +37,8 @@ jobs:
             https://ubuntu.com/security
             http://www.brendangregg.com
             http://www.adlinktech.com/en/index
+            */flags.png
+            */flags@2x.png
 
           [output]
           status=0

--- a/static/files/sitemap.xml
+++ b/static/files/sitemap.xml
@@ -36,12 +36,6 @@
         <priority>0.5</priority>
       </url>
       <url>
-        <loc>https://ubuntu.com/pro/maintenance</loc>
-        <lastmod>2020-11-17T13:53:25Z</lastmod>
-        <changefreq>hourly</changefreq>
-        <priority>0.333333333333333</priority>
-      </url>
-      <url>
         <loc>https://ubuntu.com/pro/subscribe</loc>
         <lastmod>2021-02-10T09:25:50Z</lastmod>
         <changefreq>hourly</changefreq>
@@ -1692,7 +1686,7 @@
         <priority>0.333333333333333</priority>
       </url>
       <url>
-        <loc>https://ubuntu.com/legal/ubuntu-advantage-service-description/ja</loc>
+        <loc>https://ubuntu.com/legal/ubuntu-pro-description/ja</loc>
         <lastmod>2020-12-09T09:58:56Z</lastmod>
         <changefreq>hourly</changefreq>
         <priority>0.25</priority>

--- a/templates/legal/data-privacy/contact.md
+++ b/templates/legal/data-privacy/contact.md
@@ -51,7 +51,7 @@ You can also ask us to stop using your information for newsletters, news or prod
 
 ## Your right to complain
 
-If you have a complaint about our use of your information, you can contact the Information Commissioner's Office via their website at [ico.org.uk/concerns/](https://ico.org.uk/concerns/) or write to them at:
+If you have a complaint about our use of your information, you can contact the Information Commissioner's Office via their website at [ico.org.uk/make-a-complaint/](https://ico.org.uk/make-a-complaint/) or write to them at:
 
 <div style="margin:2rem;">
 Information Commissioner's Office<br />

--- a/templates/legal/data-privacy/index.html
+++ b/templates/legal/data-privacy/index.html
@@ -297,7 +297,7 @@
       </div>
       <p>Alternatively you can use the relevant <a href="/contact-us">contact us</a> form.</p>
       <h2 id="your-right-to-complain">Your right to complain</h2>
-      <p>If you have a complaint about our use of your information, you can contact the Information Commissioner's Office via their website at <a href="https://ico.org.uk/concerns/">ico.org.uk/concerns/</a> or write to them at:</p>
+      <p>If you have a complaint about our use of your information, you can contact the Information Commissioner's Office via their website at <a href="https://ico.org.uk/make-a-complaint/">ico.org.uk/make-a-complaint/</a> or write to them at:</p>
       <div style="margin: 2rem;">
         <p>
           Information Commissioner's Office<br />

--- a/templates/legal/data-privacy/newsletter.md
+++ b/templates/legal/data-privacy/newsletter.md
@@ -52,7 +52,7 @@ You can also ask us to stop using your information for newsletters, news or prod
 
 ## Your right to complain
 
-If you have a complaint about our use of your information, you can contact the Information Commissioner's Office via their website at [ico.org.uk/concerns/](https://ico.org.uk/concerns/) or write to them at:
+If you have a complaint about our use of your information, you can contact the Information Commissioner's Office via their website at [ico.org.uk/make-a-complaint/](https://ico.org.uk/make-a-complaint/) or write to them at:
 
 <div style="margin:2rem;">
 Information Commissioner's Office<br />

--- a/templates/legal/data-privacy/sso.md
+++ b/templates/legal/data-privacy/sso.md
@@ -65,7 +65,7 @@ Please note that if you ask us to remove your SSO and/or Ubuntu One account you 
 
 ## Your right to complain
 
-If you have a complaint about our use of your information, you can contact the Information Commissioner's Office via their website at [ico.org.uk/concerns/](https://ico.org.uk/concerns/) or write to them at:
+If you have a complaint about our use of your information, you can contact the Information Commissioner's Office via their website at [ico.org.uk/make-a-complaint/](https://ico.org.uk/make-a-complaint/) or write to them at:
 
 <div style="margin:2rem;">
 Information Commissioner's Office<br />

--- a/templates/legal/data-privacy/webinar.md
+++ b/templates/legal/data-privacy/webinar.md
@@ -49,7 +49,7 @@ You can also ask us to stop using your information for news or product updates â
 
 ## Your right to complain
 
-If you have a complaint about our use of your information, you can contact the Information Commissioner's Office via their website at [ico.org.uk/concerns/](https://ico.org.uk/concerns/) or write to them at:
+If you have a complaint about our use of your information, you can contact the Information Commissioner's Office via their website at [ico.org.uk/make-a-complaint/](https://ico.org.uk/make-a-complaint/) or write to them at:
 
 <div style="margin:2rem;">
 Information Commissioner's Office<br />

--- a/templates/legal/ubuntu-pro-description/_toc.html
+++ b/templates/legal/ubuntu-pro-description/_toc.html
@@ -135,7 +135,7 @@
 
     <ul class="p-side-navigation__list">
       <li class="p-side-navigation__item--title"><a class="p-side-navigation__link" href="#embedded-services">Embedded Services</a></li>
-    </ul>    
+    </ul>
 
     <ul class="p-side-navigation__list">
       <li class="p-side-navigation__item--title"><a class="p-side-navigation__link" href="#uprosd-definitions">Definitions</a></li>
@@ -154,7 +154,7 @@
 
     <ul class="p-side-navigation__list">
       <li class="p-side-navigation__item--title"><span class="p-side-navigation__text">Japanese translation</span></li>
-      <li class="p-side-navigation__item"><a class="p-side-navigation__link" href="/legal/ubuntu-advantage-service-description/ja">UA サービス範囲&nbsp;&rsaquo;</a></li>
+      <li class="p-side-navigation__item"><a class="p-side-navigation__link" href="/legal/ubuntu-pro-description/ja">UA サービス範囲&nbsp;&rsaquo;</a></li>
     </ul>
   </nav>
 </div>


### PR DESCRIPTION
## Done
- Added to the ignore list for linkchecker to ignore the flag image which is a 3rd party package
- Updated the advantage links in the sitemap
- Updated a link to ico.org.uk across the site

## QA
- Check the changes will fix the errors reported here: https://github.com/canonical/ubuntu.com/actions/runs/3965586863/jobs/6795456091
