### PR TITLE
Add workspaces tutorial video to /aws/workspaces

### DIFF
--- a/templates/aws/workspaces.html
+++ b/templates/aws/workspaces.html
@@ -15,7 +15,7 @@
         <p>IT organisations benefit from rapid deployment, configuration and scalability for their managed Ubuntu Desktops whilst their applications and data remain secured in the AWS cloud, even when their developers are working remotely.</p>
         <a href="https://aws.amazon.com/workspaces/pricing/?nc=sn&loc=3" class="p-button--positive">Launch Today</a>
       </div>
-      <div class="col-5 u-align--center u-vertically-center u-hide--medium u-hide--small">
+      <div class="col-5 u-align--center u-vertically-center u-align--center u-hide--medium u-hide--small">
         {{
           image(
             url="https://assets.ubuntu.com/v1/55bb92be-aws_workspaces.png",
@@ -74,9 +74,25 @@
       <p>Read more about <a href="/desktop/organisations">Ubuntu Desktop for organisations</a></p>
     </div>
   </div>
-
   <div class="u-fixed-width">
     <p><a class="p-button--positive" href="https://aws.amazon.com/workspaces/pricing/?nc=sn&loc=3">Ubuntu Desktop on Amazon WorkSpaces pricing</a></p>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="u-fixed-width">
+    <h2>Getting Started with Ubuntu WorkSpaces</h2>
+  </div>
+  <div class="row">
+    <div class="col-6 u-vertically-center">
+      <div class="u-embedded-media">
+        <iframe class="u-embedded-media__element" width="560" height="315" src="https://www.youtube.com/embed/oaVOJDIcBto" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+      </div>
+    </div>
+    <div class="col-6">
+      <p>Ubuntu WorkSpaces can be quickly provisioned on top of your existing directory services. Simply select your preferred Ubuntu bundle and associate users to each workstation.</p>
+      <p>Ubuntu WorkSpaces can be additionally customised after creation and are accessible from ChromeOS, iOS, Linux and the Web.</p>
+    </div>
   </div>
 </section>
 


### PR DESCRIPTION
## Done

- Add workspaces tutorial video to /aws/workspaces,  based on [copydoc](https://docs.google.com/document/d/1qC22TM6KZTlxK3CScf-RQ4RUiMUhIBcjSWGur-dbYVA/edit#)

## QA

- Go to https://ubuntu-com-12442.demos.haus/aws/workspaces compare against copydoc
- Check the video plays when clicked and can be opened into full screen

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-1364
