### PR TITLE
Add download button for un-certified xilinx boards details pages

### DIFF
--- a/templates/certified/model-details.html
+++ b/templates/certified/model-details.html
@@ -82,7 +82,12 @@
             <section>
             {% endif %}
             {% if release.level == "Enabled" %}
-              <p class="u-no-margin--bottom">Pre-installed in some regions with a custom Ubuntu image that takes advantage of the system’s hardware features and may include additional software. Standard images of Ubuntu may not work well, or at all.</p>
+              <p class="u-no-margin--bottom">Pre-installed in some regions with a custom Ubuntu image that takes advantage of the system's hardware features and may include additional software. Standard images of Ubuntu may not work well, or at all.</p>
+              {% if vendor == "Xilinx" %}
+                <p class="u-no-margin--bottom" style="padding-top:1.4rem;">
+                  <a href="/download/amd-xilinx" class="p-button">Download</a>
+                </p>
+              {% endif %}
             {% elif release.level == "Certified" %}
               <p>The {{ vendor }} {{ name }} with the components described below has been awarded the status of certified for Ubuntu.</p>
               <p class="u-no-margin--bottom">
@@ -109,7 +114,7 @@
                 {% for hardware_subtitle, values in release["components"].items() %}
                   <tr>
                     <th colspan="2" class="u-text--muted">{{ hardware_subtitle }}</th>
-                    <td colspan="8">{% for value in values %} 
+                    <td colspan="8">{% for value in values %}
                       <p style="margin-bottom: 0.5rem;">{{ value.name }}{% if value.bus in ["usb", "pci"] %} {{ value.bus }} ({{ value.identifier }}{% if value.subsystem != '' %} {{ value.subsystem }}{% endif %}){% endif %}</p>
                       {% endfor %}
                     </td>


### PR DESCRIPTION
## Done

- Add download button for un-certified xilinx boards details pages, based on [this conversation thread](https://chat.canonical.com/canonical/pl/hnpqjthn9fdd5xcfbxirbyu74e) and further conversations in matter most. The summarize, Felica wanted to include a download button in the detail section for Xilinx board that were not certified, this link would go to the general u.com/download/amd-xilinx page

## QA

- Go to  https://ubuntu-com-12445.demos.haus/certified/202008-28164
- There should be two boards described, the first one not certified, the second  certified. 
- Check that both boards descriptions reflect this difference.
- Check that both have a download button leading to /download/amd-xilinx (they should go to the same place)
- Find another board that is **not** certified and check that there is no download button. This change should only effect Xilinx boards.

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-1403