### PR TITLE
Host landscape docs on u.com using discourse module

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -634,7 +634,7 @@ landscape:
     - title: Install
       path: /landscape/install
     - title: Docs
-      path: https://docs.ubuntu.com/landscape/en/
+      path: /landscape/docs
     - title: Forums
       path: https://discourse.ubuntu.com/c/landscape/89
     - title: Log in to Landscape

--- a/templates/advantage/_table.html
+++ b/templates/advantage/_table.html
@@ -147,7 +147,7 @@
               width="16"
               height="16"
             />
-          </td>          
+          </td>
           <td data-heading="Essential" class="u-align--center">
             <img
               src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg"
@@ -175,7 +175,7 @@
         </tr>
         <tr>
           <td data-heading="">
-            <a href="https://docs.ubuntu.com/landscape/en/landscape-install-quickstart">Landscape On-Prem</a> management dashboard
+            <a href="/landscape/docs/quickstart-deployment">Landscape On-Prem</a> management dashboard
           </td>
           <td data-heading="Personal use" class="u-align--center">
             <img
@@ -184,7 +184,7 @@
               width="16"
               height="16"
             />
-          </td>          
+          </td>
           <td data-heading="Essential" class="u-align--center">
             <img
               src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg"
@@ -214,7 +214,7 @@
           <td data-heading="">
             <a href="/landscape">Landscape SaaS</a> management dashboard
           </td>
-          <td data-heading="Personal use" class="u-align--center">-</td>          
+          <td data-heading="Personal use" class="u-align--center">-</td>
           <td data-heading="Essential" class="u-align--center">
             <img
               src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg"
@@ -239,7 +239,7 @@
               height="16"
             />
           </td>
-        </tr>                
+        </tr>
         <tr id="phone-ticket">
           <td data-heading=""><a href="/support">Phone and ticket support</a></td>
           <td data-heading="Personal use" class="u-align--center">-</td>

--- a/templates/landscape/docs/document.html
+++ b/templates/landscape/docs/document.html
@@ -1,0 +1,10 @@
+{% with
+  document=document,
+  nav_items=nav_items,
+  search_action="/landscape/docs/search",
+  siteSearch="https://ubuntu.com/landscape/docs",
+  placeholder="Search on Landscape Docs",
+  navigation=navigation
+%}
+  {% include "templates/docs/shared/_docs.html" %}
+{% endwith %}

--- a/templates/landscape/docs/search-results.html
+++ b/templates/landscape/docs/search-results.html
@@ -1,0 +1,12 @@
+{% with
+    title="Landscape Docs",
+    query=query,
+    results=results,
+    search_action="/landscape/docs/search",
+    siteSearch="https://ubuntu.com/landscape/docs",
+    placeholder="Search on Landscape Docs",
+    search_path="/landscape/docs/search",
+    forum_link="https://discourse.ubuntu.com/c/landscape/89"
+  %}
+    {% include "templates/docs/shared/_search-results.html" %}
+{% endwith %}

--- a/templates/landscape/install.html
+++ b/templates/landscape/install.html
@@ -19,7 +19,7 @@
         </h3>
         <p class="p-stepped-list__content"><code>sudo add-apt-repository --update ppa:landscape/19.10</code></p>
       </li>
-    
+
       <li class="p-stepped-list__item">
         <h3 class="p-stepped-list__title">
           Install Landscape
@@ -27,7 +27,7 @@
         <p class="p-stepped-list__content"><code>sudo apt install landscape-server-quickstart</code></p>
       </li>
     </ol>
-    <p>For additional information, please reference the <a href="https://docs.ubuntu.com/landscape/en/landscape-install-quickstart">Landscape Quickstart deployment documentation&nbsp;&rsaquo;</a></p>
+    <p>For additional information, please reference the <a href="/landscape/docs/quickstart-deployment">Landscape Quickstart deployment documentation&nbsp;&rsaquo;</a></p>
   </div>
 </section>
 {% endblock content %}

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1009,6 +1009,32 @@ app.add_url_rule(
 
 security_certs_docs.init_app(app)
 
+# Landscape docs
+landscape_docs = Docs(
+    parser=DocParser(
+        api=discourse_api,
+        index_topic_id=23070,
+        url_prefix="/landscape/docs",
+    ),
+    document_template="/landscape/docs/document.html",
+    url_prefix="/landscape/docs",
+    blueprint_name="landscape-docs",
+)
+
+# Landscape search
+app.add_url_rule(
+    "/landscape/docs/search",
+    "landscape-docs-search",
+    build_search_view(
+        session=session,
+        site="ubuntu.com/landscape/docs",
+        template_path="/landscape/docs/search-results.html",
+        search_engine_id=search_engine_id,
+    ),
+)
+
+landscape_docs.init_app(app)
+
 app.add_url_rule("/certified", view_func=certified_home)
 app.add_url_rule(
     "/certified/<canonical_id>",


### PR DESCRIPTION
## Done

- Create discourse module to handle requests to /landscape/docs
- Create search module for landscape docs
- Update navigation.yaml to point toward /landscape/docs
- Update any other references to the old landscape docs to point toward u.com/landscape/docs

## QA

- Make sure you have the appropriate discourse & search api keys. These can be found in LastPass.
- Go to https://ubuntu-com-12447.demos.haus/landscape/docs and check that the content is the same content present https://discourse.ubuntu.com/t/landscape-documentation-home/23070 and that the navigation contains the same links
- Test the search works (this one work until is has been indexed by google)

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-1361
