### PR TITLE
Use geo-lookup to preset the country code for mobile number inputs ac…

### DIFF
--- a/static/js/src/intlTelInput.js
+++ b/static/js/src/intlTelInput.js
@@ -19,8 +19,9 @@ function setupIntlTelInput(phoneInput) {
         throw new Error(response.status);
       }
       const JSONObject = await response.json();
-      const countryCode = (JSONObject && JSONObject.country_code) ? JSONObject.country_code : "UK";
-      success(countryCode)
+      const countryCode =
+        JSONObject && JSONObject.country_code ? JSONObject.country_code : "UK";
+      success(countryCode);
     },
   });
 }

--- a/static/js/src/intlTelInput.js
+++ b/static/js/src/intlTelInput.js
@@ -12,6 +12,16 @@ function setupIntlTelInput(phoneInput) {
     utilsScript,
     separateDialCode: true,
     hiddenInput: inputName,
+    initialCountry: "auto",
+    geoIpLookup: async function fetchUserIp(success, failure) {
+      const response = await fetch("/user-country.json");
+      if (!response.ok) {
+        throw new Error(response.status);
+      }
+      const JSONObject = await response.json();
+      const countryCode = (JSONObject && JSONObject.country_code) ? JSONObject.country_code : "UK";
+      success(countryCode)
+    },
   });
 }
 

--- a/static/js/src/intlTelInput.js
+++ b/static/js/src/intlTelInput.js
@@ -20,7 +20,8 @@ function setupIntlTelInput(phoneInput) {
       }
       const JSONObject = await response.json();
       const countryCode =
-        JSONObject && JSONObject.country_code ? JSONObject.country_code : "UK";
+        JSONObject && JSONObject.country_code ? JSONObject.country_code : "gb";
+
       success(countryCode);
     },
   });

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -968,7 +968,7 @@ def get_user_country_by_ip():
     client_ip = flask.request.headers.get(
         "X-Real-IP", flask.request.remote_addr
     )
-    ip_location = ip_reader.get("84.247.0.146")
+    ip_location = ip_reader.get(client_ip)
 
     if not ip_location:
         country_code = None


### PR DESCRIPTION
## Done

- Implements geo-location on form mobie input, this presets the country-code to that based on their IP. It uses the IP api that was implemented in [this pr](https://github.com/canonical/ubuntu.com/pull/12298)

## QA

- Go to any form and check that the country-code for the mobile input is preset to whatever country your ip is for.

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-1476
