### PR TITLE
Final ubuntu pro ga updates based on pdm suggestions

### DIFF
--- a/templates/ai/index.html
+++ b/templates/ai/index.html
@@ -510,10 +510,10 @@
   <div class="row u-equal-height">
     <div class="col-6 u-vertically-center u-align--center">
       {{ image (
-        url="https://assets.ubuntu.com/v1/71baccc3-ubuntu-advantage-circular.svg",
-        alt="Ubuntu Advantage",
-        width="300",
-        height="324",
+        url="https://assets.ubuntu.com/v1/83e7ce7c-ubuntu-pro-circular.png",
+        alt="",
+        width="250",
+        height="270",
         hi_def=True,
         loading="lazy"
         ) | safe

--- a/templates/ai/services.html
+++ b/templates/ai/services.html
@@ -19,12 +19,12 @@
     </div>
     <div class="col-4 u-hide--medium u-hide--small u-align--center">
       {{ image (
-        url="https://assets.ubuntu.com/v1/71baccc3-ubuntu-advantage-circular.svg",
+        url="https://assets.ubuntu.com/v1/83e7ce7c-ubuntu-pro-circular.png",
         alt="",
-        width="252",
-        height="273",
+        width="250",
+        height="270",
         hi_def=True,
-        loading="auto"
+        loading="lazy"
         ) | safe
       }}
     </div>
@@ -149,7 +149,7 @@
       }}
     </div>
   </section>
-  
+
   <section class="p-strip">
     <div class="row u-vertically-center">
       <div class="col-4 u-hide--medium u-hide--small u-align--center">
@@ -175,7 +175,7 @@
       </div>
     </div>
   </section>
-  
+
   <section class="p-strip--light">
     <div class="row u-vertically-center">
       <div class="col-7">
@@ -226,11 +226,11 @@
         </div>
       </div>
     </div>
-    
+
     <div class="u-fixed-width">
       <hr class="p-separator" />
     </div>
-    
+
     <div class="row">
       <div class="p-logo-section">
         <div class="p-logo-section__items">
@@ -310,14 +310,13 @@
       </div>
     </div>
   </section>
-  
+
   {% include "ai/shared/_learn-more.html" %}
-  
+
   {% with first_item="_cloud_bootstack", second_item="_cloud_ubuntu_advantage", third_item="_kubeflow_news_signup" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
-  
+
   <!-- Set default Marketo information for contact form below-->
   <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/kubeflow" data-form-id="3231" data-lp-id="6279" data-return-url="https://ubuntu.com/ai/thank-you?product=ai-managed" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
   </div>
-  
+
   {% endblock content %}
-  

--- a/templates/aws/workspaces.html
+++ b/templates/aws/workspaces.html
@@ -78,6 +78,21 @@
   <div class="u-fixed-width">
     <p><a class="p-button--positive" href="https://aws.amazon.com/workspaces/pricing/?nc=sn&loc=3">Ubuntu Desktop on Amazon WorkSpaces pricing</a></p>
   </div>
+
+  <section class="p-strip--light">
+    <div class="u-fixed-width">
+      <h2>Getting Started with Ubuntu WorkSpaces</h2>
+    </div>
+    <div class="row">
+      <div class="col-6 embedded-media">
+        <iframe class="embedded-media__element" width="560" height="315" src="https://www.youtube.com/embed/oaVOJDIcBto" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+      </div>
+      <div class="col-6">
+        <p>Ubuntu WorkSpaces can be quickly provisioned on top of your existing directory services. Simply select your preferred Ubuntu bundle and associate users to each workstation.</p>
+        <p>Ubuntu WorkSpaces can be additionally customised after creation and are accessible from ChromeOS, iOS, Linux and the Web.</p>
+      </div>
+    </div>
+  </section>
 </section>
 
 {% endblock content %}

--- a/templates/ceph/consulting.html
+++ b/templates/ceph/consulting.html
@@ -37,15 +37,15 @@
 			<p><a href="/ceph/what-is-ceph">Learn more about Ceph&nbsp;&rsaquo;</a></p>
 		</div>
 		<div class="col-5 u-align--center u-vertically-center u-hide--medium u-hide--small">
-			{{ image (
-				url="https://assets.ubuntu.com/v1/71baccc3-ubuntu-advantage-circular.svg",
-				alt="ubuntu advantage circular",
-				width="278",
-				height="300",
-				hi_def=True,
-				loading="lazy"
-			) | safe
-			}}
+      {{ image (
+        url="https://assets.ubuntu.com/v1/83e7ce7c-ubuntu-pro-circular.png",
+        alt="",
+        width="250",
+        height="270",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
 		</div>
   </div>
 </section>

--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -658,15 +658,14 @@ meta_copydoc %}
       <p><a href="/desktop/organisations">Ubuntu Desktop for organisations&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-5 u-align--center u-hide--medium u-hide--small">
-      {{
-      image(
-      url="https://assets.ubuntu.com/v1/71baccc3-ubuntu-advantage-circular.svg",
-      alt="",
-      height="350",
-      width="350",
-      hi_def=True,
-      loading="lazy"
-      ) | safe
+      {{ image (
+        url="https://assets.ubuntu.com/v1/83e7ce7c-ubuntu-pro-circular.png",
+        alt="",
+        width="250",
+        height="270",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
       }}
     </div>
   </div>

--- a/templates/desktop/organisations.html
+++ b/templates/desktop/organisations.html
@@ -586,8 +586,8 @@
       {{ image (
         url="https://assets.ubuntu.com/v1/83e7ce7c-ubuntu-pro-circular.png",
         alt="",
-        width="231",
-        height="250",
+        width="250",
+        height="270",
         hi_def=True,
         loading="lazy"
         ) | safe

--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -197,8 +197,8 @@
       {{ image (
         url="https://assets.ubuntu.com/v1/83e7ce7c-ubuntu-pro-circular.png",
         alt="",
-        width="231",
-        height="250",
+        width="250",
+        height="270",
         hi_def=True,
         loading="lazy"
         ) | safe
@@ -241,8 +241,9 @@
     <hr class="p-separator">
   </div>
   <div class="row">
-    <div class="col-4 u-align--center u-hide--small u-hide--medium">
+    <div class="col-4 u-align--center u-vertically-center u-hide--small u-hide--medium">
       {{ image (
+<<<<<<< HEAD
         url="https://assets.ubuntu.com/v1/ce518a18-CoF-2022_solid+O.svg",
         alt="",
         width="156",
@@ -256,6 +257,12 @@
         alt="",
         width="150",
         height="169",
+=======
+        url="https://assets.ubuntu.com/v1/8b5cbeea-Windows_11+Ubuntu .png",
+        alt="",
+        width="375",
+        height="110",
+>>>>>>> d6334aac8 (Final ubuntu pro ga updates based on pdm suggestions)
         hi_def=True,
         loading="lazy"
         ) | safe

--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -243,26 +243,10 @@
   <div class="row">
     <div class="col-4 u-align--center u-vertically-center u-hide--small u-hide--medium">
       {{ image (
-<<<<<<< HEAD
-        url="https://assets.ubuntu.com/v1/ce518a18-CoF-2022_solid+O.svg",
-        alt="",
-        width="156",
-        height="150",
-        hi_def=True,
-        loading="lazy"
-        ) | safe
-      }}
-      {{ image (
-        url="https://assets.ubuntu.com/v1/1046696f-windows-11-logo-2023.png",
-        alt="",
-        width="150",
-        height="169",
-=======
         url="https://assets.ubuntu.com/v1/8b5cbeea-Windows_11+Ubuntu .png",
         alt="",
         width="375",
         height="110",
->>>>>>> d6334aac8 (Final ubuntu pro ga updates based on pdm suggestions)
         hi_def=True,
         loading="lazy"
         ) | safe

--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -73,7 +73,7 @@
       <h3 class="p-heading--4"><a href="/tutorials/upgrading-ubuntu-desktop">Upgrade Ubuntu Desktop</a></h3>
       <hr>
       <p>If you're already running Ubuntu, you can upgrade in a few clicks from the Software Updater.</p>
-    </div>            
+    </div>
   </div>
 </section>
 
@@ -120,10 +120,10 @@
     </div>
     <div class="col-6 u-vertically-center u-align--center u-hide--medium">
       {{ image (
-        url="https://assets.ubuntu.com/v1/71baccc3-ubuntu-advantage-circular.svg",
+        url="https://assets.ubuntu.com/v1/83e7ce7c-ubuntu-pro-circular.png",
         alt="",
-        width="231",
-        height="250",
+        width="250",
+        height="270",
         hi_def=True,
         loading="lazy"
         ) | safe
@@ -132,7 +132,7 @@
   </div>
   <div class="u-fixed-width">
     <p>For more information, download our whitepaper:</p>
-    <p><a href="/engage/adopting-secure-enterprise-linux-desktop">Adopting a secure enterprise Linux desktop</a></p>
+    <p><a href="/engage/adopting-secure-enterprise-linux-desktop" class="p-button">Adopting a secure enterprise Linux desktop</a></p>
   </div>
   <div class="u-fixed-width">
     <p><a class="p-button--positive" href="/pro">Register today</a></p>
@@ -147,7 +147,7 @@
         <p>Contributions require JavaScript. Please enable JavaScript if you want to contribute.</p>
       </noscript>
       <form class="p-card contribute__options" action="https://www.paypal.com/cgi-bin/webscr" id="contributions-form" method="post" target="_top">
-        
+
         <section id="community-projects" class="u-sv3">
           <label for="amount-community">
             <p class="p-heading--4">Community projects</p>
@@ -161,7 +161,7 @@
             I support LoCo teams, UbuCons and other events, upstream projects and all the good work the community does.
           </p>
         </section>
-        
+
         <section id="ubuntu-desktop" class="u-sv3">
           <label for="amount-desktop">
             <p class="p-heading--4">Ubuntu Desktop</p>
@@ -175,7 +175,7 @@
             Make the desktop even more amazing.
           </p>
         </section>
-        
+
         <section id="tip-to-canonical" class="u-sv3">
           <label for="amount-canonical">
             <p class="p-heading--4">Tip to Canonical</p>
@@ -189,7 +189,7 @@
             Hats off for making Ubuntu possible. Keep it up.
           </p>
         </section>
-        
+
         <section id="ubuntu-for-things" class="u-sv3">
           <label for="amount-things">
             <p class="p-heading--4">Ubuntu for IoT</p>
@@ -203,7 +203,7 @@
             I want a secure, upgradeable Internet of Things, powered by Ubuntu.
           </p>
         </section>
-        
+
         <section id="ubuntu-for-cloud" class="u-sv3">
           <label for="amount-cloud">
             <p class="p-heading--4">Ubuntu Server & Cloud</p>
@@ -217,7 +217,7 @@
             I want Ubuntu Server running my servers, cloud and as a guest everywhere.
           </p>
         </section>
-        
+
         <div class="p-media-object u-no-margin--bottom u-sv3 u-vertically-center">
           <img alt="T-shirt" src="https://assets.ubuntu.com/v1/b26d26e5-t-shirt.png?w=78" width="78" class="p-media-object__image js-equivalent-image">
           <div class="p-media-object__details">
@@ -225,9 +225,9 @@
             <p class="p-media-object__content u-no-margin--bottom js-equivalent-description">Peace, Love and Linux t-shirt</p>
           </div>
         </div>
-        
+
         <hr class="u-sv3" />
-        
+
         <div class="row">
           <div class="col-4">
             <p>Your contribution&nbsp;<span class="p-card" style="padding: .5rem;">&#36;<span class="js-total-amount">16</span></span></p>
@@ -242,10 +242,10 @@
             <input type="hidden" name="no_note" value="1">
             <input type="hidden" name="no_shipping" value="1">
             <input type="hidden" name="rm" value="1">
-            
+
             <input type="hidden" name="return" value="http://{{ http_host }}/download/desktop/thank-you">
             <input type="hidden" name="cancel_return" value="http://{{ http_host }}/download/desktop">
-            
+
             <input type="hidden" name="bn" value="PP-BuyNowBF:btn_buynowCC_LG.gif:NonHosted">
             <button type="submit" class="js-contribute-submit p-button--positive u-no-margin--bottom" tabindex="9">Contribute with PayPal</button>
           </div>
@@ -265,21 +265,21 @@
                   <input type="checkbox" aria-labelledby="insightscloudserver" class="p-checkbox__input" name="insightscloudserver" value="true" />
                   <span class="p-checkbox__label" id="insightscloudserver">Cloud and Server</span>
                 </label>
-                
+
               </li>
               <li class="p-list__item u-clearfix">
                 <label class="p-checkbox">
                   <input type="checkbox" aria-labelledby="insightsdesktop" class="p-checkbox__input" name="insightsdesktop" value="true" />
                   <span class="p-checkbox__label" id="insightsdesktop">Desktop</span>
                 </label>
-                
+
               </li>
               <li class="p-list__item u-clearfix">
                 <label class="p-checkbox">
                   <input type="checkbox" aria-labelledby="insightsiot" class="p-checkbox__input" name="insightsiot" value="true" />
                   <span class="p-checkbox__label" id="insightsiot">Internet of Things</span>
                 </label>
-                
+
               </li>
               <li class="p-list__item u-clearfix">
                 <label class="p-checkbox">
@@ -321,8 +321,8 @@
             <p>
               <small>In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/newsletter">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</small>
             </p>
-            
-            
+
+
             <div>
               <span class="p-card--content">
                 <button type="submit" class="u-no-margin--bottom">Subscribe now</button>
@@ -368,7 +368,7 @@
     <div class="col-3 p-divider__block">
       <p><a href="/blog/linux-gaming-tutorial-raspberry-pi-minecraft-server-on-ubuntu-desktop">Raspberry Pi Tutorial: Host a Minecraft server on Ubuntu Desktop</a></p>
       <p><em>by <a href="/blog/author/local-optimum">Oliver Smith</a> on 9 December 2021</em></p>
-    </div>            
+    </div>
   </div>
 </section>
 
@@ -384,11 +384,11 @@
 <script defer>
   var architecture = '{{ architecture }}';
   var version = '{{ version }}';
-  
+
   if (version && architecture && architecture != 'amd64+mac') {
     var GAlabel = version + '-desktop-' + architecture;
     var imagePath = version + '/ubuntu-' + version + '-desktop-' + architecture + '.iso';
-    
+
     window.initImageDownload(imagePath, GAlabel);
   }
 </script>

--- a/templates/embedding/index.html
+++ b/templates/embedding/index.html
@@ -19,12 +19,12 @@
     </div>
     <div class="col-6 u-hide--small u-hide--medium u-align--center">
       {{ image (
-        url="https://assets.ubuntu.com/v1/71baccc3-ubuntu-advantage-circular.svg",
+        url="https://assets.ubuntu.com/v1/83e7ce7c-ubuntu-pro-circular.png",
         alt="",
-        width="278",
-        height="300",
+        width="250",
+        height="270",
         hi_def=True,
-        loading="auto"
+        loading="lazy"
         ) | safe
       }}
     </div>
@@ -212,7 +212,7 @@
       <p>Embedding contracts include the rights required to deliver solutions based on Canonical offerings and to use the Ubuntu trademarks.</p>
     </div>
     <div class="col-3 u-hide--small u-hide--medium u-align--center">
-      {{ 
+      {{
         image (
         url="https://assets.ubuntu.com/v1/253da317-image-document-ubuntudocs.svg",
         alt="",
@@ -229,7 +229,7 @@
 <section class="p-strip--light">
   <div class="row">
     <div class="col-3 u-hide--small u-hide--medium u-align--center u-vertically-center">
-      {{ 
+      {{
         image (
         url="https://assets.ubuntu.com/v1/b0af9ede-UA_24-7_Support.svg",
         alt="",
@@ -264,7 +264,7 @@
       </ul>
     </div>
     <div class="col-3 u-hide--small u-hide--medium u-align--center u-vertically-center">
-      {{ 
+      {{
         image (
         url="https://assets.ubuntu.com/v1/d127abd7-safety+reliability.svg",
         alt="",
@@ -281,7 +281,7 @@
 <section class="p-strip--light">
   <div class="row">
     <div class="col-6 u-hide--small u-hide--medium u-align--center u-vertically-center">
-      {{ 
+      {{
         image (
         url="https://assets.ubuntu.com/v1/c4b290c8-Contact+us.svg",
         alt="",
@@ -324,7 +324,7 @@
 
     if (extraCommentsText.value) {
       textarea.value += extraCommentsLabel + " " + extraCommentsText.value
-    }  
+    }
 }
 </script>
 {% endblock content %}

--- a/templates/landscape/index.html
+++ b/templates/landscape/index.html
@@ -17,9 +17,8 @@
       </p>
     </div>
     <div class="col-6 u-hide--small u-hide--medium u-align--center">
-      {{ 
-        image (
-        url="https://assets.ubuntu.com/v1/71baccc3-ubuntu-advantage-circular.svg",
+      {{ image (
+        url="https://assets.ubuntu.com/v1/83e7ce7c-ubuntu-pro-circular.png",
         alt="",
         width="250",
         height="270",
@@ -100,7 +99,7 @@
       <div class="p-card--highlighted">
         <h3 class="p-heading--1">2 months</h3>
         <p>Investment payback period</p>
-      </div>    
+      </div>
     </div>
   </div>
   <div class="u-fixed-width">
@@ -111,7 +110,7 @@
 <section class="p-strip">
   <div class="row">
     <div class="col-4 u-hide--small u-hide--medium u-vertically-center u-align--center">
-      {{ 
+      {{
         image (
         url="https://assets.ubuntu.com/v1/db86a8d0-Capgemini_logo.svg",
         alt="",
@@ -151,7 +150,7 @@
       </p>
     </div>
     <div class="col-4 u-hide--small u-hide--medium u-vertically-center u-align--center">
-      {{ 
+      {{
         image (
         url="https://assets.ubuntu.com/v1/6dd24c11-ubuntu-advantage-linear.svg",
         alt="",
@@ -173,7 +172,7 @@
       </p>
       <div class="p-logo-section__items">
         <div class="p-logo-section__item">
-          {{ 
+          {{
             image (
             url="https://assets.ubuntu.com/v1/b637b55f-logo-bloomberg.png",
             alt="Bloomberg",
@@ -186,7 +185,7 @@
           }}
         </div>
         <div class="p-logo-section__item">
-          {{ 
+          {{
             image (
             url="https://assets.ubuntu.com/v1/e7dd8cc4-logo-at%26t.png",
             alt="AT&T",
@@ -199,7 +198,7 @@
           }}
         </div>
         <div class="p-logo-section__item">
-          {{ 
+          {{
             image (
             url="https://assets.ubuntu.com/v1/bc54a1da-Walmart.png",
             alt="Walmart",
@@ -212,7 +211,7 @@
           }}
         </div>
         <div class="p-logo-section__item">
-          {{ 
+          {{
             image (
             url="https://assets.ubuntu.com/v1/c6e197c4-deutsche-telekom-logo.png",
             alt="Deutsche Telekom",
@@ -227,7 +226,7 @@
       </div>
       <div class="p-logo-section__items">
         <div class="p-logo-section__item">
-          {{ 
+          {{
             image (
             url="https://assets.ubuntu.com/v1/d7356bae-ebay-logo.png",
             alt="Ebay",
@@ -240,7 +239,7 @@
           }}
         </div>
         <div class="p-logo-section__item">
-          {{ 
+          {{
             image (
             url="https://assets.ubuntu.com/v1/4a09336c-logo-cisco.png",
             alt="Cisco",
@@ -253,7 +252,7 @@
           }}
         </div>
         <div class="p-logo-section__item">
-          {{ 
+          {{
             image (
             url="https://assets.ubuntu.com/v1/673fa219-logo-ntt.png",
             alt="NTT",
@@ -266,7 +265,7 @@
           }}
         </div>
         <div class="p-logo-section__item">
-          {{ 
+          {{
             image (
             url="https://assets.ubuntu.com/v1/698f7a58-best-buy-logo.png",
             alt="Best Buy",

--- a/templates/pricing/desktops.html
+++ b/templates/pricing/desktops.html
@@ -266,10 +266,10 @@
     </div>
     <div class="col-5 u-align--center u-hide--medium u-hide--small">
       {{ image (
-        url="https://assets.ubuntu.com/v1/71baccc3-ubuntu-advantage-circular.svg",
+        url="https://assets.ubuntu.com/v1/83e7ce7c-ubuntu-pro-circular.png",
         alt="",
-        height="350",
-        width="350",
+        width="250",
+        height="270",
         hi_def=True,
         loading="lazy"
         ) | safe


### PR DESCRIPTION
## Done

- There were two main requests from Oliver:
[ x ] update all the old support logos with the [new one](https://assets.ubuntu.com/v1/83e7ce7c-ubuntu-pro-circular.png)
[ x ] convert the link `Adopting a secure enterprise Linux desktop` on /download/desktop/thank-you to a button to match /download/desktop

## QA

- Check the above changes have been applied

