### PR TITLE
1.26+ck1 docs changes

### DIFF
--- a/templates/kubernetes/docs/1.26/release-notes.md
+++ b/templates/kubernetes/docs/1.26/release-notes.md
@@ -14,6 +14,30 @@ layout: [base, ubuntu-com]
 toc: False
 ---
 
+# 1.26+ck1 Bugfix release
+ 
+### January 16, 2022 - `charmed-kubernetes --channel 1.26/stable` 
+ 
+The release bundle can also be [downloaded here](https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/releases/1.26/bundle.yaml).
+ 
+ ## Fixes
+ 
+ Notable fixes in this release include:
+- Kubernetes Control Plane / Octavia [LP#1990494](https://bugs.launchpad.net/bugs/1990494)
+   Resolves an issue which made it impossible to delete a kubernetes service when octavia loadbalancers are detected
+- Kubernetes Control Plane / Octavia [LP#1995746](https://bugs.launchpad.net/bugs/1995746)
+   Adds support to disable openstack loadbalancer integration
+- Kubernetes Control Plane / Ceph [LP#1998257](https://bugs.launchpad.net/bugs/1998257)
+   Resolves an issue where the `csi-rbdplugin` pod cannot start if the control-plane unit is running in a LXD machine.
+- Containerd [#LP2002593](https://bugs.launchpad.net/bugs/2002593)
+   Resolves issue with flooding `/var/log/syslog` with messages about a deprecation of `io.containerd.runc.v1`
+- CoreDNS [LP#2002698](https://bugs.launchpad.net/bugs/2002698)
+   Upgrade of the coredns image from `1.6.7` to `1.10.0`
+- ops.lib-manifest library [LP#1999427](https://bugs.launchpad.net/bugs/1999427)
+   Resolves an issue where a charm hook fails rather than retrying when the kubernetes-api is available.
+- SRIOV CNI/Network Device Plugin [LP#2002186](https://bugs.launchpad.net/bugs/2002186)
+   Add support for control-plane node toleration for SRIOV daemonsets
+
 ## 1.26
 
 ### December 15, 2022 - `charmed-kubernetes --channel 1.26/stable` 

--- a/templates/kubernetes/docs/1.26/upgrading.md
+++ b/templates/kubernetes/docs/1.26/upgrading.md
@@ -69,6 +69,15 @@ deprecated APIs.
 </div>
 
 
+## Upgrading the Machine's Series (required for machines currently running 18.04(Bionic))
+
+All of the charms support [upgrading the machine's series via Juju](https://juju.is/docs/olm/manage-machines#heading--upgrade-the-ubuntu-series-of-a-machine).
+As each machine is upgraded, the applications on that machine will be stopped and the unit will
+go into a `blocked` status until the upgrade is complete. For the worker units, pods will be drained
+from the node and onto one of the other nodes at the start of the upgrade, and the node will be removed
+from the pool until the upgrade is complete.
+
+
 ## Infrastructure updates
 
 The applications which run alongside the core Kubernetes components can be upgraded
@@ -344,16 +353,6 @@ juju run-action kubernetes-worker/0 upgrade
 juju run-action kubernetes-worker/1 upgrade
 ...
 ```
-
-<a id='upgrading-series'> </a>
-
-## Upgrading the Machine's Series
-
-All of the charms support [upgrading the machine's series via Juju](https://juju.is/docs/olm/manage-machines#heading--upgrade-the-ubuntu-series-of-a-machine).
-As each machine is upgraded, the applications on that machine will be stopped and the unit will
-go into a `blocked` status until the upgrade is complete. For the worker units, pods will be drained
-from the node and onto one of the other nodes at the start of the upgrade, and the node will be removed
-from the pool until the upgrade is complete.
 
 <a id='verify-upgrade'> </a>
 

--- a/templates/kubernetes/docs/logging.md
+++ b/templates/kubernetes/docs/logging.md
@@ -294,7 +294,7 @@ view.
 [k8-logs]: https://kubernetes.io/docs/concepts/cluster-administration/logging/
 [logging-egf-overlay]: https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/overlays/logging-egf-overlay.yaml
 [graylog-vhost]: https://raw.githubusercontent.com/charmed-kubernetes/kubernetes-docs/master/assets/graylog-vhost.tmpl
-[graylog-dashboards]: http://docs.graylog.org/en/3.0/pages/dashboards.html
+[graylog-dashboards]: https://go2docs.graylog.org/5-0/search.htm?q=dashboard
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">

--- a/templates/kubernetes/docs/operations.md
+++ b/templates/kubernetes/docs/operations.md
@@ -105,7 +105,7 @@ The kubernetes-worker charm supports deploying an NGINX ingress controller.
 Ingress allows access from the Internet to containers running web
 services inside the cluster.
 
-First allow the Internet access to the kubernetes-worker charm with with the
+First allow the Internet access to the kubernetes-worker charm with the
 following Juju command:
 
 ```

--- a/templates/kubernetes/docs/release-notes.md
+++ b/templates/kubernetes/docs/release-notes.md
@@ -14,6 +14,44 @@ toc: False
 ---
 
 <!-- AUTOGENERATE RELEASE NOTES HERE -->
+# 1.26+ck1 Bugfix release
+
+### January 16, 2022 - `charmed-kubernetes --channel 1.26/stable` 
+
+The release bundle can also be [downloaded here](https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/releases/1.26/bundle.yaml).
+
+
+## Fixes
+
+Notable fixes in this release include:
+
+- Kubernetes Control Plane / Octavia [LP#1990494](https://bugs.launchpad.net/bugs/1990494)
+
+  Resolves an issue which made it impossible to delete a kubernetes service when octavia loadbalancers are detected
+
+- Kubernetes Control Plane / Octavia [LP#1995746](https://bugs.launchpad.net/bugs/1995746)
+
+  Adds support to disable openstack loadbalancer integration
+
+- Kubernetes Control Plane / Ceph [LP#1998257](https://bugs.launchpad.net/bugs/1998257)
+
+  Resolves an issue where the `csi-rbdplugin` pod cannot start if the control-plane unit is running in a LXD machine.
+
+- Containerd [#LP2002593](https://bugs.launchpad.net/bugs/2002593)
+  
+  Resolves issue with flooding `/var/log/syslog` with messages about a deprecation of `io.containerd.runc.v1`
+
+- CoreDNS [LP#2002698](https://bugs.launchpad.net/bugs/2002698)
+
+  Upgrade of the coredns image from `1.6.7` to `1.10.0`
+
+- ops.lib-manifest library [LP#1999427](https://bugs.launchpad.net/bugs/1999427)
+
+  Resolves an issue where a charm hook fails rather than retrying when the kubernetes-api is available.
+
+- SRIOV CNI/Network Device Plugin [LP#2002186](https://bugs.launchpad.net/bugs/2002186)
+
+  Add support for control-plane node toleration for SRIOV daemonsets
 
 # 1.26
 
@@ -92,9 +130,9 @@ A list of issues to be fixed in the first 1.26 maintenance release can be found 
     aws-k8s-storage/0*         error        idle                54.80.73.214                    hook failed: "update-status"
   ```
 
-  When the affected charms (see bug link above) are deployed on a cloud with a `kube-api-loadbalancer`, the load-balancer
+  When the affected charms are deployed on a cloud with a `kube-api-loadbalancer`, the load-balancer
   can respond to client requests with a 502 Gateway Error, amongst other error statuses not produced
-  by the API server itself.  The charm's Kubernetes client library raises an unhandled exception in
+  by the API server itself.  The charm's kubernetes client library raises an unhandled exception in
   this case. This results is the charm being in an error state which is easily resolved by running
 
   ```bash

--- a/templates/kubernetes/docs/upgrading.md
+++ b/templates/kubernetes/docs/upgrading.md
@@ -22,9 +22,9 @@ toc: False
   </div>
   <div class="p-notification__meta">
     <div class="p-notification__actions">
+      <a class='p-notification__action' href='/kubernetes/docs/1.26/upgrading'>Upgrade to 1.26 </a>
+      <a class='p-notification__action' href='/kubernetes/docs/1.25/upgrading'>Upgrade to 1.25 </a>
       <a class='p-notification__action' href='/kubernetes/docs/1.24/upgrading'>Upgrade to 1.24 </a>
-      <a class='p-notification__action' href='/kubernetes/docs/1.23/upgrading'>Upgrade to 1.23 </a>
-      <a class='p-notification__action' href='/kubernetes/docs/1.22/upgrading'>Upgrade to 1.22 </a>
     </div>
   </div>
 </div>

--- a/templates/kubernetes/docs/vsphere-integration.md
+++ b/templates/kubernetes/docs/vsphere-integration.md
@@ -4,7 +4,7 @@ markdown_includes:
   nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
   title: "Charmed Kubernetes on vSphere"
-  description: Running Charmed Kubernetes on vSphere using the integrator.
+  description: Running Charmed Kubernetes on vSphere using the out-of-tree provider.
 keywords: vsphere, integrator
 tags: [install]
 sidebar: k8smain-sidebar
@@ -14,22 +14,79 @@ toc: False
 ---
 
 **Charmed Kubernetes** will install and run on vSphere virtual servers.
-With the  addition of the `vsphere-integrator`, your cluster will also be able
+With the  addition of the `vsphere-cloud-provider` and the `vsphere-integrator`, your cluster will also be able
 to directly use native vSphere features such as storage.
 
 <div class="p-notification--information is-inline">
   <div class="p-notification__content">
     <span class="p-notification__title">Note:</span>
-    <p class="p-notification__message">These instructions for deploying Charmed Kubernetes with the vSphere integrator assume that Juju has been configured appropriately for your vSphere server. For reference, the configuration options may be found in the <a href="https://juju.is/docs/olm/vmware-vsphere" >Juju documentation</a>.</p>
+    <p class="p-notification__message">These instructions for deploying Charmed Kubernetes with the vSphere Cloud Provider assume that Juju has been configured appropriately for your vSphere server. For reference, the configuration options may be found in the <a href="https://juju.is/docs/olm/vmware-vsphere" >Juju documentation</a>.</p>
   </div>
 </div>
+
+## Upgrading from 1.25 to 1.26
+
+<div class="p-notification--caution is-inline">
+  <div markdown="1" class="p-notification__content">
+    <span class="p-notification__title">Note:</span>
+    <p class="p-notification__message">vSphere CSI Migration requires vSphere 7.0u2. If you have in-tree vSphere volumes you should update to this version. On the other hand, if you do not need to migrate in-tree vSphere volumes you can use vSphere 67u3 and above. More information about the requirements may be found in the <a href="https://docs.vmware.com/en/VMware-vSphere-Container-Storage-Plug-in/2.0/vmware-vsphere-csp-getting-started/GUID-D4AAD99E-9128-40CE-B89C-AD451DA8379D.html#GUID-E59B13F5-6F49-4619-9877-DF710C365A1E" >vSphere documentation</a>.</p>
+  </div>
+</div>
+
+vSphere has migrated to the out-of-tree provider and the legacy in-tree provider is marked for
+deprecation. Nevertheless, it is possible to migrate the workload volumes provisioned with the
+in-tree provider to the new out-of-tree provider. Follow the instructions below to prepare to
+migrate the volumes:
+
+
+### 1. Enable privileged containers support
+
+The new out-of-tree provider requires privileged containers. Please ensure that your Kubernetes
+cluster supports this. You can enable this feature using:
+
+```bash
+juju config kubernetes-control-plane allow-privileged=true
+```
+
+### 2. Install vSphere Cloud Provider
+Install the vSphere Cloud Provider charm and relate it to the required components. Follow the
+instructions in the [vsphere-cloud-provider][] charm documentation.
+
+### 3. Prepare kube-controller and kubelet
+
+<div class="p-notification--information is-inline">
+  <div class="p-notification__content">
+    <span class="p-notification__title">Note:</span>
+    <p class="p-notification__message">In case you have other flags enabled on these components, remember to add the following flags to the existing configuration.</p>
+  </div>
+</div>
+
+
+To enable volume migration you must add the CSIMigration and CSIMigrationvSphere flags in
+kube-controller and kubelet options of the Kubernetes Control Plane. You can do this via
+Juju using:
+
+```bash
+juju config kubernetes-control-plane controller-manager-extra-args="feature-gates=CSIMigration=true,CSIMigrationvSphere=true"
+juju config kubernetes-control-plane kubelet-extra-config="{featureGates: {CSIMigration: true,CSIMigrationvSphere: true}}"
+```
+
+### 4. vSphere in-tree volume migrations
+
+Now you can follow the instructions in the vSphere documentation about [Migrating In-Tree vSphere volumes][].
+
+## vSphere Cloud Provider
+
+The `vsphere-cloud-provider` charm allows **Charmed Kubernetes** to connect to the vSphere API 
+via the out-of-tree cloud provider. This allow your cluster to manage parts of the vSphere infrastructure, 
+such as virtual disks.
 
 ## vSphere integrator
 
 The `vsphere-integrator` charm simplifies working with **Charmed Kubernetes** on
 vSphere servers. Using the credentials provided to **Juju**, it acts as a proxy between
-Charmed Kubernetes and the underlying cloud, granting permissions to
-dynamically create, for example, storage.
+Charmed Kubernetes and the underlying cloud. This charm integrates with the `vsphere-cloud-provider` 
+charm to share the credentials required for its operation.
 
 ### Model configuration
 
@@ -42,23 +99,31 @@ juju model-config datastore=mydatastore primary-network=mynetwork
 ### Installing
 
 If you install **Charmed Kubernetes** [using the Juju bundle][install],
-you can add the vsphere-integrator at the same time by using the following
+you can add both `vsphere-cloud-provider` and `vsphere-integrator` at the same time by using the following
 overlay file ([download it here][asset-vsphere-overlay]):
 
 ```yaml
 description: Charmed Kubernetes overlay to add native vSphere support.
 applications:
+  kubernetes-control-plane:
+    options:
+      allow-privileged: "true"
   vsphere-integrator:
-    annotations:
-      gui-x: "600"
-      gui-y: "300"
     charm: vsphere-integrator
     num_units: 1
     trust: true
+  vsphere-cloud-provider:
+    charm: vsphere-cloud-provider
 relations:
-  - ['vsphere-integrator', 'kubernetes-control-plane']
-  - ['vsphere-integrator', 'kubernetes-worker']
-  ```
+- - vsphere-cloud-provider:certificates
+  - easyrsa:client
+- - vsphere-cloud-provider:kube-control
+  - kubernetes-control-plane:kube-control
+- - vsphere-cloud-provider:external-cloud-provider
+  - kubernetes-control-plane:external-cloud-provider
+- - vsphere-cloud-provider:vsphere-integration
+  - vsphere-integrator:clients
+```
 
 To use this overlay with the **Charmed Kubernetes** bundle, it is specified
 during deploy like this:
@@ -76,7 +141,7 @@ juju scp kubernetes-control-plane/0:config ~/.kube/config
 <div class="p-notification--caution is-inline">
   <div class="p-notification__content">
     <span class="p-notification__title">Resource usage:</span>
-    <p class="p-notification__message">By relating to this charm, other charms can directly allocate resources, such as managed disks and load balancers, which could lead to cloud charges and
+    <p class="p-notification__message">By relating to these charms, other charms can directly allocate resources, such as managed disks and load balancers, which could lead to cloud charges and
     count against quotas. Because these resources are not managed by Juju, they
     will not be automatically deleted when the models or applications are
     destroyed, nor will they show up in Juju's status or GUI. It is therefore up
@@ -129,22 +194,20 @@ back to the credential data it received via `juju trust`.
 
 ## Storage
 
-The vSphere integrator can make use of vSphere-backed storage for Kubernetes.
+The vSphere charms can make use of vSphere-backed storage for Kubernetes.
 The steps below create a busybox pod with a persistent volume claim backed by
 vSphere's PersistentDisk as an example.
 
 
-### 1. Create a storage class using the `kubernetes.io/vsphere-volume` provisioner:
+### 1. Create a storage class using the `csi.vsphere.vmware.com` provisioner:
 
 ```bash
 kubectl create -f - <<EOY
-apiVersion: storage.k8s.io/v1
 kind: StorageClass
+apiVersion: storage.k8s.io/v1
 metadata:
   name: mystorage
-provisioner: kubernetes.io/vsphere-volume
-parameters:
-  diskformat: zeroedthick
+provisioner: csi.vsphere.vmware.com
 EOY
 ```
 
@@ -194,15 +257,15 @@ spec:
 EOY
 ```
 
-For more configuration options and details of the permissions which the integrator uses,
-please see the [vSphere integrator charm page][vsphere-integrator].
+For more configuration options and details of the permissions which the cloud provider uses,
+please see the [vSphere Cloud Provider charm page][vsphere-cloud-provider].
 
 <!-- LINKS -->
 
 [asset-vsphere-overlay]: https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/overlays/vsphere-overlay.yaml
-
+[Migrating In-Tree vSphere volumes]: https://docs.vmware.com/en/VMware-vSphere-Container-Storage-Plug-in/2.0/vmware-vsphere-csp-getting-started/GUID-968D421F-D464-4E22-8127-6CB9FF54423F.html
 [storage]: /kubernetes/docs/storage
-[vsphere-integrator]: https://charmhub.io/vsphere-integrator/docs
+[vsphere-cloud-provider]: https://charmhub.io/vsphere-cloud-provider/docs
 [vsphere-juju]: https://juju.is/docs/olm/vmware-vsphere
 [install]: /kubernetes/docs/install-manual
 [vmware documentation]: https://docs.vmware.com/en/VMware-vSphere-Container-Storage-Plug-in/index.html


### PR DESCRIPTION
## Done

- Release notes for 1.26+ck1
- changes for vsphere integrator/provider
- link updates

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
