### PR TITLE
Add tutorial link to /pro page

### DIFF
--- a/templates/pro/index.html
+++ b/templates/pro/index.html
@@ -635,7 +635,7 @@ https://docs.google.com/document/d/1In4NSnckAtL51_7D_AZCHa6TPnPGXqctXo-5rE77_aY/
       {% endif %}
     </div>
 </section>
-<section class="p-strip is-x-deep">
+<section class="p-strip is-x-deep u-no-padding--bottom">
   <hr class="is-fixed-width u-no-margin--bottom">
   <div class="u-fixed-width">
     <div class="row">
@@ -669,6 +669,11 @@ https://docs.google.com/document/d/1In4NSnckAtL51_7D_AZCHa6TPnPGXqctXo-5rE77_aY/
         Learn more at https://ubuntu.com/pro
       </code></pre>
     </div>
+  </div>
+</section>
+<section class="p-strip is-x-deep">
+  <div class="u-fixed-width">
+    <h2><a href="/pro/tutorial">Or check the tutorial to activate Ubuntu Pro.&nbsp;&rsaquo;</a></h2>
   </div>
 </section>
 <section class="p-strip is-x-deep u-no-padding--top">


### PR DESCRIPTION
## Done

Link to the pro tutorial from the pro page

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/pro
- Make sure there is a link to the tutorials page after the `Curious to know how much Ubuntu Pro can do for you?` section.
