### PR TITLE
Update Community Support Link

### DIFF
--- a/templates/support/community-support.html
+++ b/templates/support/community-support.html
@@ -30,7 +30,7 @@
   <div class="row u-equal-height">
     <div class="col-4 p-card">
       <h3><a href="/community/support">Find community support</a></h3>
-      <p><a href="https://askubuntu.com/">Ask Ubuntu</a> and <a href="https://ubuntuforums.org/">Ubuntu Forums</a> are great sources of answers to common questions about installing, troubleshooting and optimising Ubuntu. For more info on support forums, including IRC channels, see <a href="/community/support">our Discourse site</a>.</p>
+      <p><a href="https://askubuntu.com/">Ask Ubuntu</a> and <a href="https://ubuntuforums.org/">Ubuntu Forums</a> are great sources of answers to common questions about installing, troubleshooting and optimising Ubuntu. For more info on support forums, including IRC channels, see <a href="/community/support">our community docs</a>.</p>
     </div>
     <div class="col-4 p-card">
       <h3><a href="https://help.ubuntu.com/">Read the docs</a></h3>

--- a/templates/support/community-support.html
+++ b/templates/support/community-support.html
@@ -29,7 +29,7 @@
 <div class="p-strip is-deep">
   <div class="row u-equal-height">
     <div class="col-4 p-card">
-      <h3><a href="https://ubuntu.com/community/support">Find community support</a></h3>
+      <h3><a href="/community/support">Find community support</a></h3>
       <p><a href="https://askubuntu.com/">Ask Ubuntu</a> and <a href="https://ubuntuforums.org/">Ubuntu Forums</a> are great sources of answers to common questions about installing, troubleshooting and optimising Ubuntu. For more info on support forums, including IRC channels, see <a href="https://discourse.ubuntu.com/t/community-support/709">our Discourse site</a>.</p>
     </div>
     <div class="col-4 p-card">

--- a/templates/support/community-support.html
+++ b/templates/support/community-support.html
@@ -29,7 +29,7 @@
 <div class="p-strip is-deep">
   <div class="row u-equal-height">
     <div class="col-4 p-card">
-      <h3><a href="https://discourse.ubuntu.com/t/community-support/709">Find community support</a></h3>
+      <h3><a href="https://ubuntu.com/community/support">Find community support</a></h3>
       <p><a href="https://askubuntu.com/">Ask Ubuntu</a> and <a href="https://ubuntuforums.org/">Ubuntu Forums</a> are great sources of answers to common questions about installing, troubleshooting and optimising Ubuntu. For more info on support forums, including IRC channels, see <a href="https://discourse.ubuntu.com/t/community-support/709">our Discourse site</a>.</p>
     </div>
     <div class="col-4 p-card">

--- a/templates/support/community-support.html
+++ b/templates/support/community-support.html
@@ -30,7 +30,7 @@
   <div class="row u-equal-height">
     <div class="col-4 p-card">
       <h3><a href="/community/support">Find community support</a></h3>
-      <p><a href="https://askubuntu.com/">Ask Ubuntu</a> and <a href="https://ubuntuforums.org/">Ubuntu Forums</a> are great sources of answers to common questions about installing, troubleshooting and optimising Ubuntu. For more info on support forums, including IRC channels, see <a href="https://discourse.ubuntu.com/t/community-support/709">our Discourse site</a>.</p>
+      <p><a href="https://askubuntu.com/">Ask Ubuntu</a> and <a href="https://ubuntuforums.org/">Ubuntu Forums</a> are great sources of answers to common questions about installing, troubleshooting and optimising Ubuntu. For more info on support forums, including IRC channels, see <a href="/community/support">our Discourse site</a>.</p>
     </div>
     <div class="col-4 p-card">
       <h3><a href="https://help.ubuntu.com/">Read the docs</a></h3>


### PR DESCRIPTION
Replace old Community Support link with new Discourse Docs generated page.

## Done

- Replaced link to old Community Support Discourse topic link with new Discourse docs generated Community Support page.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
