### PR TITLE
Fix magic attach button/link issue

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
@@ -81,7 +81,7 @@ export const SubscriptionDetails = forwardRef<HTMLDivElement, Props>(
         if (
           subscription?.current_number_of_machines &&
           (subscription?.current_number_of_machines ?? 0) <
-            (subscription?.number_of_machines ?? 0)
+          (subscription?.number_of_machines ?? 0)
         ) {
           setNotification({
             severity: "caution",
@@ -153,7 +153,7 @@ export const SubscriptionDetails = forwardRef<HTMLDivElement, Props>(
                     </>
                   ) : null}
                   {subscription.type == "monthly" ||
-                  subscription.type == "yearly" ? (
+                    subscription.type == "yearly" ? (
                     <>
                       {subscription.statuses.is_renewed ? (
                         <button className="p-chip--positive">
@@ -182,7 +182,7 @@ export const SubscriptionDetails = forwardRef<HTMLDivElement, Props>(
             {isFree ? null : (
               <>
                 {subscription.statuses.has_access_to_support &&
-                subscription.type !== UserSubscriptionType.Trial ? (
+                  subscription.type !== UserSubscriptionType.Trial ? (
                   <Button
                     appearance="positive"
                     className="p-subscriptions__details-action"
@@ -196,7 +196,6 @@ export const SubscriptionDetails = forwardRef<HTMLDivElement, Props>(
                 ) : null}
                 {subscription.marketplace == "canonical-ua" ? (
                   <Button
-                    appearance="neutral"
                     className="p-subscriptions__details-action"
                     data-test="attach-button"
                     disabled={editing}

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
@@ -81,7 +81,7 @@ export const SubscriptionDetails = forwardRef<HTMLDivElement, Props>(
         if (
           subscription?.current_number_of_machines &&
           (subscription?.current_number_of_machines ?? 0) <
-          (subscription?.number_of_machines ?? 0)
+            (subscription?.number_of_machines ?? 0)
         ) {
           setNotification({
             severity: "caution",
@@ -153,7 +153,7 @@ export const SubscriptionDetails = forwardRef<HTMLDivElement, Props>(
                     </>
                   ) : null}
                   {subscription.type == "monthly" ||
-                    subscription.type == "yearly" ? (
+                  subscription.type == "yearly" ? (
                     <>
                       {subscription.statuses.is_renewed ? (
                         <button className="p-chip--positive">
@@ -182,7 +182,7 @@ export const SubscriptionDetails = forwardRef<HTMLDivElement, Props>(
             {isFree ? null : (
               <>
                 {subscription.statuses.has_access_to_support &&
-                  subscription.type !== UserSubscriptionType.Trial ? (
+                subscription.type !== UserSubscriptionType.Trial ? (
                   <Button
                     appearance="positive"
                     className="p-subscriptions__details-action"


### PR DESCRIPTION
## Done

- [List of work items including drive-bys - remember to add the why and what of this work.]

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- visit [/pro/subscriptions](https://ubuntu-com-12480.demos.haus/pro/subscriptions)
    - if you do not have an ubuntu pro subscription, buy one
- A button should appear saying "Attach a machine"
- It should not be a link

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
