### PR TITLE
WD-1788 Add the datasheet link to the hero section of the ROS ESM page

### DIFF
--- a/templates/robotics/ros-esm.html
+++ b/templates/robotics/ros-esm.html
@@ -27,7 +27,7 @@
         </a>
       </p>
       <p>
-        Read the whitepaper &hyphen; <a href="/engage/ros-support">ROS support with ROS ESM&nbsp;&rsaquo;</a>
+        <a href="https://pages.ubuntu.com/rs/066-EOV-335/images/ROS%20datasheet%202023.pdf">Read the datasheet&nbsp;&rsaquo;</a>
       </p>
     </div>
     <div class="col-4 u-align--center u-vertically-center u-hide--medium u-hide--small">


### PR DESCRIPTION
## Done

- Add the datasheet link to the hero section of the ROS ESM page
- **The rest of the page is not ready to be updated yet**

## QA

- Check the copy and link matches the request in the [copy doc](https://docs.google.com/document/d/1oiz_006n9U1Ya50wdSkKIyj_jsxSr92FdCpkDU4kpHs/edit#)

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-1788

