### PR TITLE
Improve error handling for user-country.json

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -968,10 +968,17 @@ def get_user_country_by_ip():
     )
     ip_location = ip_reader.get(client_ip)
 
-    if not ip_location:
-        country_code = None
-    else:
+    try:
         country_code = ip_location["country"]["iso_code"]
+    except KeyError:
+        # geolite2 can't identify IP address
+        country_code = None
+    except Exception as error:
+        # Errors not documented in the geolite2 module
+        country_code = None
+        flask.current_app.extensions["sentry"].captureException(
+            extra={"ip_location object": ip_location, "error": error}
+        )
 
     response = flask.jsonify(
         {


### PR DESCRIPTION
## Done

Getting some [sentry errors](https://sentry.is.canonical.com/canonical/ubuntu-com/issues/10208/?query=is%3Aunresolved), but not sure when this happens, can't replicate locally or reproduce it. So I'm adding some additional error information to help troubleshoot this, if this happens again.

## QA

Basically test that everything is working as usual

- Test https://ubuntu-com-12493.demos.haus/engage forms are still doing the geolocation of international prefix correctly
- Test that homepage takeovers is working as usual (refresh a few times)

## Issue / Card

Fixes https://sentry.is.canonical.com/canonical/ubuntu-com/issues/10208/?query=is%3Aunresolved

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
