### PR TITLE
Update 18-04 eol banner link to new blog post

### DIFF
--- a/templates/shared/_18-04-eol-banner.html
+++ b/templates/shared/_18-04-eol-banner.html
@@ -2,7 +2,7 @@
   <div class="p-notification--information is-inline">
     <div class="p-notification__content">
       <h5 class="p-notification__title">Ubuntu 18.04 LTS is moving out of standard support in April 2023.</h5>
-      <p class="p-notification__message">If you are a {% if product  %}{{ product }}{% else %}device manufacturer{% endif %}, <a href="https://canonical.com/blog/ubuntu-18-04-lts-end-of-life-keep-your-fleet-of-devices-up-and-running">learn your options&nbsp;&rsaquo;</a></p>
+      <p class="p-notification__message">If you are a {% if product  %}{{ product }}{% else %}device manufacturer{% endif %}, <a href="https://canonical.com/blog/ubuntu-18-04-eol-for-devices">learn your options&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Done

- Updates 18-04 eol banner link to new blog post (they changed the name post-deployment, breaking the link we had set up)

## QA

- Go to https://ubuntu-com-12495.demos.haus/embedded or https://ubuntu-com-12495.demos.haus/robotics and check the link in the banner leads to https://canonical.com/blog/ubuntu-18-04-eol-for-devices

