### PR TITLE
Fixed the broken pricing desktops navigation item

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -486,7 +486,7 @@ pricing:
     - title: Consulting
       path: /pricing/consulting
     - title: Desktops
-      path: /pricing/desktops
+      path: /pricing/desktop
     - title: Devices
       path: /pricing/devices
 


### PR DESCRIPTION
## Done

- Fixed the broken navigation item

## QA

- Open the demo
- Go to /pricing
- Click "Desktops" in the subnav
- Check it works now
