### PR TITLE
Change /pro/tutorial command to match latest version of Pro client.

### DIFF
--- a/templates/pro/tutorial.html
+++ b/templates/pro/tutorial.html
@@ -112,14 +112,12 @@ meta_copydoc %}
       <p>I can see that I am running version 27.13.1, so no need to update. If you run a previous version of the client,
         you have two options:</p>
       <ul class="p-list--divided has-bullets">
-        <li class="p-list__item">You could wait for the pro client update, which is now released and phased to get to
-          all Ubuntu machines, or
+        <li class="p-list__item">You could wait for the pro client update, which is now released and phased to get to all Ubuntu machines, or
         </li>
-        <li class="p-list__item">Consider bypassing the update phasing and install the client version 27.13.1 using the
-          following command:
+        <li class="p-list__item">Consider bypassing the update phasing and install the latest client version using the following command:
           <div class="p-code-snippet">
             <pre
-              class="p-code-snippet__block">$ sudo apt install ubuntu-advantage-tools=27.13.1~$(lsb_release -rs).1</pre>
+              class="p-code-snippet__block">$ sudo apt install ubuntu-advantage-tools</pre>
           </div>
         </li>
       </ul>


### PR DESCRIPTION
## Done

Change /pro/tutorial command to match latest version of Pro client.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/pro/tutorial
- Check the last bit of text on step 1 is now:
```
Consider bypassing the update phasing and install the latest client version using the following command:
$ sudo apt install ubuntu-advantage-tools
```