### PR TITLE
Update noOfpages

### DIFF
--- a/tests/cypress/utils.js
+++ b/tests/cypress/utils.js
@@ -240,7 +240,7 @@ export const interactiveForms = [
       [/Work email/, "test@gmail.com"],
     ],
     submitBtn: /Let's discuss/,
-    noOfPages: 3,
+    noOfPages: 2,
   },
   {
     url: "/gcp",


### PR DESCRIPTION
## Done
- The form on https://ubuntu.com/financial-services#get-in-touch seems to be updated by this [PR](https://github.com/canonical/ubuntu.com/pull/12486) but the cypress test for this form hasn't been updated. 
- Updated the number of pages `3` to `2` on `/tests/cypress/utils.js`

## QA
- Refer to this checks failure log https://github.com/canonical/ubuntu.com/actions/runs/4104370403/jobs/7079764936
- If needed, https://discourse.canonical.com/t/how-to-run-cypress-test-locally-for-forms-on-ubuntu-com/558 
