### PR TITLE
Remove / prefixes; Fix /pricing/desktops 404

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -957,24 +957,27 @@ security/cve: /security/cves
 security/cve/sitemap(?P<suffix>.*).xml: /security/cves/sitemap{suffix}.xml
 
 # Shop redirects
-/advantage/purchase-account: "/account/purchase-account"
-/advantage/customer-info/(?P<account_id>.*): "/account/customer-info/{account_id}"
-/advantage/customer-info: "/account/customer-info"
-/advantage/customer-info-anon: "/account/customer-info-anon"
-/advantage/purchases/(?P<purchase_id>.*): /account/purchases/{purchase_id}
-/advantage/(?P<tx_type>.*)/(?P<tx_id>.*)/invoices/(?P<invoice_id>.*): "/account/{tx_type}/{tx_id}/invoices/{invoice_id}"
-/advantage/last-purchase-ids/(?P<account_id>.*): "/account/last-purchase-ids/{account_id}"
-/advantage/attach: "/pro/attach"
+advantage/purchase-account: "/account/purchase-account"
+advantage/customer-info/(?P<account_id>.*): "/account/customer-info/{account_id}"
+advantage/customer-info: "/account/customer-info"
+advantage/customer-info-anon: "/account/customer-info-anon"
+advantage/purchases/(?P<purchase_id>.*): /account/purchases/{purchase_id}
+advantage/(?P<tx_type>.*)/(?P<tx_id>.*)/invoices/(?P<invoice_id>.*): "/account/{tx_type}/{tx_id}/invoices/{invoice_id}"
+advantage/last-purchase-ids/(?P<account_id>.*): "/account/last-purchase-ids/{account_id}"
+advantage/attach: "/pro/attach"
 
-/advantage: "/pro"
-/advantage/(?P<path>.*): "/pro/{path}"
-/pro/get-in-touch: "/pro#get-in-touch"
-/pro/beta: "/pro/tutorial"
+advantage: "/pro"
+advantage/(?P<path>.*): "/pro/{path}"
+pro/get-in-touch: "/pro#get-in-touch"
+pro/beta: "/pro/tutorial"
 
 # USN redirects
-/security/notices/months(/.*)?/?: /security/notices
-/security/notices/releases(/.*)?/?: /security/notices
-/security/notices/usn/atom.xml: /security/notices/atom.xml
-/security/notices/usn/rss.xml: /security/notices/rss.xml
-/security/notices/usn/(usn-|USN-)(?P<usn_id>.*)/?: /security/notices/USN-{usn_id}
-/security/notices/(usn/)?(?P<usn_id>[\d]{4}-[\d]{1,2})/?: /security/notices/USN-{usn_id}
+security/notices/months(/.*)?/?: /security/notices
+security/notices/releases(/.*)?/?: /security/notices
+security/notices/usn/atom.xml: /security/notices/atom.xml
+security/notices/usn/rss.xml: /security/notices/rss.xml
+security/notices/usn/(usn-|USN-)(?P<usn_id>.*)/?: /security/notices/USN-{usn_id}
+security/notices/(usn/)?(?P<usn_id>[\d]{4}-[\d]{1,2})/?: /security/notices/USN-{usn_id}
+
+# Fix search results https://github.com/canonical/ubuntu.com/issues/12510
+pricing/desktops: "/pricing/desktop"


### PR DESCRIPTION
Redirect /pricing/desktops to /pricing/desktop (which actually exists) to fix erroneous search results.

Fixes #12510 

QA
--

Go to https://ubuntu-com-12512.demos.haus/pricing/desktops, check you end up on https://ubuntu-com-12512.demos.haus/pricing/desktop.

For good measure, also check:

https://ubuntu-com-12512.demos.haus/advantage -> /pro
https://ubuntu-com-12512.demos.haus/pro/beta -> /pro/tutorial
https://ubuntu-com-12512.demos.haus/advantage/attach -> /pro/attach
