### PR TITLE
/pro - call get_user_subscriptions for pro marketplace only

### DIFF
--- a/webapp/shop/advantage/views.py
+++ b/webapp/shop/advantage/views.py
@@ -41,14 +41,12 @@ def pro_page_view(advantage_mapper, **kwargs):
     subscriptions so we can display a contact form, otherwise renders the page
     without any form. Anonymous requests don't see the form either.
     """
-
     show_beta_request = False
-
     user = user_info(flask.session)
     if user:
         try:
             subscriptions = advantage_mapper.get_user_subscriptions(
-                user["email"]
+                email=None, marketplaces=["canonical-ua"]
             )
             for subscription in subscriptions:
                 if (
@@ -57,12 +55,11 @@ def pro_page_view(advantage_mapper, **kwargs):
                 ):
                     show_beta_request = True
                     break
-        except Exception as exception:
+        except Exception:
             flask.current_app.extensions["sentry"].captureException(
-                exception,
                 extra={
                     "message": "Could not get user subscriptions on pro page"
-                },
+                }
             )
 
     return flask.render_template(


### PR DESCRIPTION
## Done

Call get_user_subscriptions for pro marketplace only and capture the exception properly.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- @nottrobin to got to /pro and not see a 500.

## Issue / Card

Fixes #12511

