### PR TITLE
Update search to include rate limits

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -104,7 +104,7 @@ jobs:
           konf production deploy/site.yaml | kubeval -f -
 
   test-python:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 canonicalwebteam.flask-base==1.1.0
 canonicalwebteam.http==1.0.3
 canonicalwebteam.blog==6.4.0
-canonicalwebteam.search==1.2.7
+canonicalwebteam.search==1.3.0
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.3.1
 canonicalwebteam.discourse==5.0.4

--- a/templates/400.html
+++ b/templates/400.html
@@ -1,4 +1,4 @@
-{% extends "templates/one-column.html" %} {% block title %}404: Page not found{%
+{% extends "templates/one-column.html" %} {% block title %}400: Bad Request{%
 endblock %} {% block content %}
 <div class="p-strip is-deep">
   <div class="row u-equal-height">

--- a/templates/429.html
+++ b/templates/429.html
@@ -1,0 +1,30 @@
+{% extends "templates/one-column.html" %}
+{% block title %}429: Too many requests{% endblock %}
+
+
+{% block content %}
+<div class="p-strip is-deep">
+  <div class="row u-equal-height">
+    <div class="col-6 u-vertically-center u-align--center">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/bcdcf2c8-image-404.svg",
+          alt="",
+          height="365",
+          width="360",
+          hi_def=True,
+          loading="auto"
+        ) | safe
+      }}
+    </div>
+    <div class="col-6 u-vertically-center">
+      <div>
+        <h1>429: Too many requests</h1>
+        <p class="p-heading--4">
+          {{ message }}
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock content %}

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -221,6 +221,15 @@ def deleted_error(error):
     return flask.render_template("410.html", message=error.description), 410
 
 
+@app.errorhandler(429)
+def too_many_requests(error):
+    """
+    Endpoint abuse error
+    """
+    custom_error = f"{error.description}. Please try again tomorrow."
+    return flask.render_template("429.html", message=custom_error), 429
+
+
 @app.errorhandler(SecurityAPIError)
 def security_api_error(error):
     return (
@@ -548,6 +557,7 @@ app.add_url_rule(
         search_engine_id=search_engine_id,
     ),
 )
+
 app.add_url_rule(
     (
         "/appliance/<regex('[a-z-]+'):appliance>/"


### PR DESCRIPTION
## Not to be merged
Review PR for https://github.com/canonical/canonicalwebteam.search/pull/33

## QA

- For QA, I set the limit to 3 times per minute, per endpoint.
- Go to https://ubuntu-com-12514.demos.haus/ search something in the search bar
- Once you are on that page, refresh a couple times or change the search term and you'll get the rate limit (set to 3/minute), after which you'll have to wait one minute to be able to search again.

Only the /search has `3/minute` limit applied, so for other endpoints you won't see th 429 until you reach `500/day`

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
