### PR TITLE
Add appropriate labels to all form elements

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1099,10 +1099,3 @@ hr.p-separator.is-shallow {
 .no-border::after {
   content: none !important;
 }
-
-.u-label-sizing {
-  margin-bottom: 0.6rem;
-  margin-top: 0;
-  max-width: 40rem;
-  padding-top: 0.4rem;
-}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1099,3 +1099,10 @@ hr.p-separator.is-shallow {
 .no-border::after {
   content: none !important;
 }
+
+.u-label-sizing {
+  margin-bottom: 0.6rem;
+  margin-top: 0;
+  max-width: 40rem;
+  padding-top: 0.4rem;
+}

--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -152,7 +152,7 @@
           <div class="p-slider__wrapper">
             <label for="amount-community" class="u-off-screen">Contribution to community projects in US dollars</label>
             <input class="p-slider" min="0" max="125" value="3" step="1" id="amount-community" type="range">
-            <label for="amount-community-input" class="u-off-screen">Contribution amount to community projects</label>
+            <label for="amount-community-input" class="u-off-screen">Contribution amount to community projects in US dollars</label>
             <input class="p-slider__input" style="min-width: 4rem;" min="0" max="125" id="amount-community-input" name="amount_4" value="3" tabindex="4" type="number">
             <input type="hidden" name="item_name_4" value="Community projects">
           </div>

--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -147,13 +147,12 @@
         <p>Contributions require JavaScript. Please enable JavaScript if you want to contribute.</p>
       </noscript>
       <form class="p-card contribute__options" action="https://www.paypal.com/cgi-bin/webscr" id="contributions-form" method="post" target="_top">
-
         <section id="community-projects" class="u-sv3">
-          <label for="amount-community">
-            <p class="p-heading--4">Community projects</p>
-          </label>
+          <p class="p-heading--4">Community projects</p>
           <div class="p-slider__wrapper">
+            <label for="amount-community" class="u-off-screen">Contribution to community projects in US dollars</label>
             <input class="p-slider" min="0" max="125" value="3" step="1" id="amount-community" type="range">
+            <label for="amount-community-input" class="u-off-screen">Contribution amount to community projects</label>
             <input class="p-slider__input" style="min-width: 4rem;" min="0" max="125" id="amount-community-input" name="amount_4" value="3" tabindex="4" type="number">
             <input type="hidden" name="item_name_4" value="Community projects">
           </div>
@@ -163,11 +162,11 @@
         </section>
 
         <section id="ubuntu-desktop" class="u-sv3">
-          <label for="amount-desktop">
-            <p class="p-heading--4">Ubuntu Desktop</p>
-          </label>
+          <p class="p-heading--4">Ubuntu Desktop</p>
           <div class="p-slider__wrapper">
+            <label for="amount-desktop" class="u-off-screen">Contribution to desktop projects in US dollars</label>
             <input class="p-slider" min="0" max="125" value="3" step="1" id="amount-desktop" type="range">
+            <label for="amount-desktop-input" class="u-off-screen">Contribution to desktop projects in US dollars</label>
             <input class="p-slider__input" style="min-width: 4rem;" min="0" max="125" id="amount-desktop-input" name="amount_1" value="3" tabindex="1" type="number">
             <input type="hidden" name="item_name_1" value="Ubuntu Desktop">
           </div>
@@ -177,11 +176,11 @@
         </section>
 
         <section id="tip-to-canonical" class="u-sv3">
-          <label for="amount-canonical">
-            <p class="p-heading--4">Tip to Canonical</p>
-          </label>
+          <p class="p-heading--4">Tip to Canonical</p>
           <div class="p-slider__wrapper">
+            <label for="amount-canonical" class="u-off-screen">Contribution to canonical projects in US dollars</label>
             <input class="p-slider" min="0" max="125" value="3" step="1" id="amount-canonical" type="range">
+            <label for="amount-canonical-input" class="u-off-screen">Contribution to canonical projects in US dollars</label>
             <input class="p-slider__input" style="min-width: 4rem;" min="0" max="125" id="amount-canonical-input" name="amount_5" value="3" tabindex="5" type="number">
             <input type="hidden" name="item_name_5" value="Tip to Canonical">
           </div>
@@ -191,11 +190,11 @@
         </section>
 
         <section id="ubuntu-for-things" class="u-sv3">
-          <label for="amount-things">
-            <p class="p-heading--4">Ubuntu for IoT</p>
-          </label>
+          <p class="p-heading--4">Ubuntu for IoT</p>
           <div class="p-slider__wrapper">
+            <label for="amount-things" class="u-off-screen">Contribution to IOT projects in US dollars</label>
             <input class="p-slider" min="0" max="125" value="3" step="1" id="amount-things" type="range">
+            <label for="amount-things-input" class="u-off-screen">Contribution to IOT projects in US dollars</label>
             <input class="p-slider__input" style="min-width: 4rem;" min="0" max="125" id="amount-things-input" name="amount_3" value="3" tabindex="3" type="number">
             <input type="hidden" name="item_name_3" value="Ubuntu for things">
           </div>
@@ -205,11 +204,11 @@
         </section>
 
         <section id="ubuntu-for-cloud" class="u-sv3">
-          <label for="amount-cloud">
-            <p class="p-heading--4">Ubuntu Server & Cloud</p>
-          </label>
+          <p class="p-heading--4">Ubuntu Server & Cloud</p>
           <div class="p-slider__wrapper">
+            <label for="amount-cloud" class="u-off-screen">Contribution to server and cloud projects in US dollars</label>
             <input class="p-slider" min="0" max="125" value="3" step="1" id="amount-cloud" type="range">
+            <label for="amount-cloud-input" class="u-off-screen">Contribution to server and cloud projects in US dollars</label>
             <input class="p-slider__input" style="min-width: 4rem;" min="0" max="125" id="amount-cloud-input" name="amount_2" value="3" tabindex="2" type="number">
             <input type="hidden" name="item_name_2" value="Ubuntu for cloud computing">
           </div>

--- a/templates/download/intel-nuc-desktop.html
+++ b/templates/download/intel-nuc-desktop.html
@@ -40,20 +40,20 @@
     <ol class="p-stepped-list--detailed">
       <li class="p-stepped-list__item">
         <h3 class="p-stepped-list__title">
-          
+
           Download Ubuntu Desktop
         </h3>
         <div class="p-stepped-list__content">
           <p>Download the correct Ubuntu image for your device:</p>
           <ul class="u-no-margin--left u-no-margin--top">
-            <li><a href="http://people.canonical.com/~platform/images/nuc/pc-dawson-xenial-amd64-m4-20180507-32.iso"> Dawson Canyon and June Canyon NUC – Ubuntu Desktop 16.04 LTS image</a>
+            <li><a href="http://people.canonical.com/~platform/images/nuc/pc-dawson-xenial-amd64-m4-20180507-32.iso"> Dawson Canyon and June Canyon NUC &ndash; Ubuntu Desktop 16.04 LTS image</a>
             <br>Certified for the Dawson Canyon NUC models: NUC7i7DNHE, NUC7i7DNKE, NUC7i7DNBE, NUC7i5DNHE, NUC7i5DNKE, NUC7i5DNBE NUC7i3DNHE, NUC7i3DNKE, NUC7i3DNBE and for the June Canyon NUC models: NUC7PJYH and NUC7CJYH.</li>
           </ul>
         </div>
       </li>
       <li class="p-stepped-list__item">
         <h3 class="p-stepped-list__title">
-          
+
           Flash the USB drive
         </h3>
         <div class="p-stepped-list__content">
@@ -62,7 +62,7 @@
       </li>
       <li class="p-stepped-list__item">
         <h3 class="p-stepped-list__title">
-          
+
           Install Ubuntu Desktop
         </h3>
         <div class="p-stepped-list__content">

--- a/templates/download/server/s390x.html
+++ b/templates/download/server/s390x.html
@@ -27,6 +27,7 @@
       <!-- MARKETO FORM -->
       <form class="p-form u-no-margin--top" action="/marketo/submit" method="post" id="mktoForm_1400">
         <fieldset style="border: 1px solid #c0c0c0;">
+          <legend class="u-off-screen">Contact information</legend>
           <ul class="p-list u-no-margin--bottom">
             <li class="p-list__item">
               <label for="firstName" aria-label="FirstName">First name: <span>*</span></label>
@@ -79,7 +80,7 @@
                 <option value="z14/Emperor II - 2 drawers (up to 69 cores)"> - 2 drawers (up to 69 cores)</option>
                 <option value="z14/Emperor II - 3 drawers (up to 105 cores)"> - 3 drawers (up to 105 cores)</option>
                 <option value="z14/Emperor II - 4 drawer (up to 170 cores)"> - 4 drawer (up to 170 cores)</option>
-                
+
                 <option value="z15/T02/LinuxONE III LY2" disabled>z15/T02/LinuxONE III LY2</option>
                 <option value="z15/T02/LinuxONE III LY2 - 1/2 drawer (up to 65 cores)"> - 1/2 drawer (up to 65 cores)</option>
 

--- a/templates/download/shared/_get-ebook-security.html
+++ b/templates/download/shared/_get-ebook-security.html
@@ -32,6 +32,7 @@
       <!-- MARKETO FORM -->
       <form action="/marketo/submit" method="post" id="mktoForm_1917">
         <fieldset style="border: 0;">
+          <legend class="u-off-screen">Contact information</legend>
           <ul class="p-list">
             <li class="p-list__item">
               <label for="firstName">First name:</label>

--- a/templates/download/shared/_get_ebook_maas.html
+++ b/templates/download/shared/_get_ebook_maas.html
@@ -36,6 +36,7 @@
       <!-- MARKETO FORM -->
       <form action="/marketo/submit" method="post" id="mktoForm_1862">
         <fieldset style="border: 0;">
+          <legend class="u-off-screen">Contact information</legend>
           <ul class="p-list">
             <li class="p-list__item">
               <label for="1-FirstName">First name:</label>
@@ -85,7 +86,7 @@
               <input name="name" type="text" class="name" autocomplete="off" value="" id="name" tabindex="-1" />
             </li>
             {# End of honey pots #}
-            
+
             <li class="p-list__item">
               <button type="submit" class="p-button--positive" aria-label="Submit">Download the eBook</button>
               <input type="hidden" name="formid" value="1862" aria-label="">

--- a/templates/engage/shared/_de_engage_form.html
+++ b/templates/engage/shared/_de_engage_form.html
@@ -1,6 +1,7 @@
 <!-- MARKETO FORM -->
 <form action="/marketo/submit" method="post" id="mktoForm_{{ id }}" onSubmit='if (typeof fbq === "function"){fbq("trackCustom", "Download"); }'>
   <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
+    <legend class="u-off-screen">Kontaktinformationen</legend>
     <ul class="p-list u-no-margin--bottom">
       <li class="p-list__item">
         <label for="firstName">Vorname:</label>

--- a/templates/engage/shared/_en_engage_form.html
+++ b/templates/engage/shared/_en_engage_form.html
@@ -1,6 +1,7 @@
 <!-- MARKETO FORM -->
 <form action="/marketo/submit" method="post" id="mktoForm_{{ id }}" onSubmit='if (typeof fbq === "function"){fbq("trackCustom", "Download"); }'>
   <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
+    <legend class="u-off-screen">Contact information</legend>
     <ul class="p-list">
       <li class="p-list__item">
         <label for="firstName">First name:</label>

--- a/templates/engage/shared/_es_engage_form.html
+++ b/templates/engage/shared/_es_engage_form.html
@@ -1,6 +1,7 @@
 <!-- MARKETO FORM -->
 <form action="/marketo/submit" method="post" id="mktoForm_{{ id }}" onSubmit='if (typeof fbq === "function"){fbq("trackCustom", "Download"); }'>
   <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
+    <legend class="u-off-screen">Información del contacto</legend>
     <ul class="p-list">
       <li class="p-list__item">
         <label for="firstName">Nombre:</label>
@@ -51,7 +52,7 @@
         <label class="name" for="name">Name:</label>
         <input name="name" type="text" class="name" autocomplete="off" value="" id="name" tabindex="-1" />
       </li>
-      {# End of honey pots #}       
+      {# End of honey pots #}
       <li>
         <input name="Consent_to_Processing__c" aria-label="Consent" value="Yes" type="hidden">
       </li>

--- a/templates/engage/shared/_fr_engage_form.html
+++ b/templates/engage/shared/_fr_engage_form.html
@@ -1,6 +1,7 @@
 <form action="/marketo/submit" method="post" id="mktoForm_{{ id }}" onSubmit='if (typeof fbq === "function"){fbq("trackCustom", "Download"); }'>
   <fieldset>
-    <h3>Prenons contact</h3>
+    <legend class="u-off-screen">Prenons contact</legend>
+    <h2 class="p-heading--3">Prenons contact</h2>
     <ul class="p-list u-no-margin--bottom">
       <li class="p-list__item">
         <label for="firstName">Prénom :</label>

--- a/templates/engage/shared/_it_engage_form.html
+++ b/templates/engage/shared/_it_engage_form.html
@@ -1,6 +1,7 @@
 <!-- MARKETO FORM -->
 <form action="/marketo/submit" method="post" id="mktoForm_{{ id }}" onSubmit='if (typeof fbq === "function"){fbq("trackCustom", "Download"); }'>
   <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
+    <legend class="u-off-screen">Informazioni sui contatti</legend>
     <ul class="p-list">
       <li class="p-list__item">
         <label for="firstName">Nome:</label>

--- a/templates/engage/shared/_pt_engage_form.html
+++ b/templates/engage/shared/_pt_engage_form.html
@@ -1,6 +1,7 @@
 <!-- MARKETO FORM -->
 <form action="/marketo/submit" method="post" id="mktoForm_{{ id }}" onSubmit='if (typeof fbq === "function"){fbq("trackCustom", "Download"); }'>
   <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
+    <legend class="u-off-screen">Informações de contato</legend>
     <ul class="p-list">
       <li class="p-list__item">
         <label for="firstName">Primeiro Nome:</label>

--- a/templates/engage/shared/_ru_engage_form.html
+++ b/templates/engage/shared/_ru_engage_form.html
@@ -1,6 +1,7 @@
 <!-- MARKETO FORM -->
 <form action="/marketo/submit" method="post" id="mktoForm_{{ id }}" onSubmit='if (typeof fbq === "function"){fbq("trackCustom", "Download"); }'>
     <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
+        <legend class="u-off-screen">Контактная информация</legend>
         <ul class="p-list">
         <li class="p-list__item">
             <label for="firstName">Имя:</label>

--- a/templates/engage/shared/_zh-TW_engage_form.html
+++ b/templates/engage/shared/_zh-TW_engage_form.html
@@ -1,6 +1,7 @@
 <!-- MARKETO FORM -->
 <form action="/marketo/submit" method="post" id="mktoForm_{{ id }}" onSubmit='if (typeof fbq === "function"){fbq("trackCustom", "Download"); }'>
   <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
+    <legend class="u-off-screen">Contact information</legend>
     <ul class="p-list">
       <li class="p-list__item">
         <label for="firstName">First name:</label>

--- a/templates/legal/confidentiality-agreement.html
+++ b/templates/legal/confidentiality-agreement.html
@@ -142,11 +142,13 @@
                   <input type="hidden" name="csrfmiddlewaretoken" value="d7952e7df2133d5703f3001be27d982e">
                 </div>
                 <fieldset id="tfa_22" class="section">
+                  <legend class="u-off-screen">Organisation details</legend>
                   <h3>Organisation details</h3>
                   <label id="tfa_9-L" for="tfa_9" class="label preField">Individual or organisation name <span>*</span></label>
                   <input type="text" id="tfa_9" name="tfa_9" value="" placeholder="" class="calc-OrgName required">
                 </fieldset>
                 <fieldset id="tfa_Yourcontactdetai1" class="section">
+                  <legend class="u-off-screen">Your details</legend>
                   <h3>Your details</h3>
                   <ul class="p-list">
                     <li class="p-list__item">

--- a/templates/legal/contributors/agreement.html
+++ b/templates/legal/contributors/agreement.html
@@ -236,8 +236,8 @@ defer></script>
           <div class="codesection" id="code-237277"></div>
           <form method="post" action="https://www.tfaforms.com/responses/processor" class="hintsTooltip labelsAbove" id="237277" role="form">
             <div class="oneField field-container-D    " id="tfa_Agreementtype1-D" role="radiogroup" aria-labelledby="tfa_Agreementtype1-L" data-tfa-labelledby="-L tfa_Agreementtype1-L">
-              <h2>
-                <label id="tfa_Agreementtype1-L" class="label preField reqMark">Agreement type</label>
+              <h2  id="tfa_Agreementtype1-L" class="label preField reqMark">
+                Agreement type
               </h2>
               <div class="inputWrapper">
                 <span id="tfa_Agreementtype1" class="choices  required" aria-required="true">

--- a/templates/legal/data-privacy/enquiry.html
+++ b/templates/legal/data-privacy/enquiry.html
@@ -96,7 +96,7 @@
 
         <fieldset>
           <legend class="u-off-screen">Company information</legend>
-          <h2 class="p-headind--3">Company information</h2>
+          <h2 class="p-heading--3">Company information</h2>
           <ul class="p-list">
             <li class="p-list__item">
               <label for="tfa_29">

--- a/templates/legal/data-privacy/enquiry.html
+++ b/templates/legal/data-privacy/enquiry.html
@@ -17,7 +17,8 @@
 
       <form method="post" action="https://www.tfaforms.com/responses/processor" class="hintsBelow labelsLeftAligned" id="tfa_0" enctype="multipart/form-data">
         <fieldset>
-          <h3 id="tfa_16-L">Your contact details</h3>
+          <legend class="u-off-screen">Your contact details</legend>
+          <h2 id="tfa_16-L" class="p-heading--3">Your contact details</h2>
           <ul class="p-list">
             <li class="p-list__item">
               <label for="tfa_1">
@@ -94,7 +95,8 @@
         </fieldset>
 
         <fieldset>
-          <h3>Company information</h3>
+          <legend class="u-off-screen">Company information</legend>
+          <h2 class="p-headind--3">Company information</h2>
           <ul class="p-list">
             <li class="p-list__item">
               <label for="tfa_29">
@@ -150,6 +152,7 @@
         </fieldset>
 
         <fieldset>
+          <legend class="u-off-screen">Additional information</legend>
           <ul class="p-list">
             <li class="p-list__item">
               <label for="tfa_40">
@@ -188,6 +191,7 @@
         </fieldset>
 
         <fieldset>
+          <legend class="u-off-screen">Privacy policy</legend>
           <p>Data collected from this survey will be handled in accordance with Canonical's <a href="/legal/data-privacy/contact">privacy notice</a> and <a href="/legal/data-privacy">privacy policy</a>.</p>
           <ul class="p-list">
             <li>

--- a/templates/openstack/install.html
+++ b/templates/openstack/install.html
@@ -127,7 +127,7 @@
       </div>
     </div>
 
-      {{single_node | safe}}
+    {{ single_node | safe }}
 
     <p>To learn more about MicroStack, visit <a href="https://microstack.run">https://microstack.run</a>.</p>
   </div>

--- a/templates/security/cve/_version-and-status-row.html
+++ b/templates/security/cve/_version-and-status-row.html
@@ -26,7 +26,7 @@
   </div>
   <div class="col-3">
     {% if show_labels %}
-      <div class="u-label-sizing">&nbsp;</div>
+      <div style="margin-bottom:0.6rem;margin-top:0;max-width:40rem;padding-top:0.4rem;">&nbsp;</div>
     {% endif %}
     <button class="js-remove-row" {% if index == 0 %}disabled{% endif %} aria-label="remove">&minus;</button>
     <button class="js-add-row" disabled aria-label="add">&plus;</button>

--- a/templates/security/cve/_version-and-status-row.html
+++ b/templates/security/cve/_version-and-status-row.html
@@ -16,7 +16,7 @@
   </div>
   <div class="col-3">
     {% if show_labels %}
-      <label for="version">Status</label>
+      <label for="status">Status</label>
     {% endif %}
     <select name="status" class="js-status-input" {% if show_labels %}id="status"{% endif %}>
       {% with statuses=statuses, index=index %}
@@ -26,9 +26,9 @@
   </div>
   <div class="col-3">
     {% if show_labels %}
-      <label>&nbsp;</label>
+      <div class="u-label-sizing">&nbsp;</div>
     {% endif %}
-    <button class="js-remove-row" {% if index == 0 %}disabled{% endif %}>&minus;</button>
-    <button class="js-add-row" disabled>&plus;</button>
+    <button class="js-remove-row" {% if index == 0 %}disabled{% endif %} aria-label="remove">&minus;</button>
+    <button class="js-add-row" disabled aria-label="add">&plus;</button>
   </div>
 </div>

--- a/templates/security/notices.html
+++ b/templates/security/notices.html
@@ -69,13 +69,13 @@
       </div>
       <div class="col-4 p-form p-form--inline">
         <div class="p-form__group">
-          <label class="p-form__label">Sort by:</label>
-          <select class="p-form__control u-no-margin--bottom js-order-select">
+          <label class="p-form__label" for="sort-by">Sort by:</label>
+          <select class="p-form__control u-no-margin--bottom js-order-select" id="sort-by">
             <option value="newest" {% if request.args.order == 'newest'%} selected {% endif %}>Newest</option>
             <option value="oldest" {% if request.args.order == 'oldest'%} selected {% endif %}>Oldest</option>
           </select>
         </div>
-      </div>  
+      </div>
     </div>
     <div class="u-fixed-width" style="margin-bottom: 2rem; margin-top: 2rem;">
       <hr class="u-hide--small"/>
@@ -87,7 +87,7 @@
         <h2>Latest Notices</h2>
       {% endif %}
       {% if notices %}
-        {% for notice in notices %} 
+        {% for notice in notices %}
           {% include "security/_notice-brief.html" %}
         {% endfor %}
       {% else %}
@@ -122,7 +122,7 @@
   var release = document.querySelector(".js-release");
   var submit = document.querySelector(".js-submit");
 
-  // Submit form on order select change 
+  // Submit form on order select change
   if (orderSelect != null) {
     orderSelect.onchange = function(event) {
       orderInput.value = event.target.value;

--- a/templates/shared/_client-contact-us-form.html
+++ b/templates/shared/_client-contact-us-form.html
@@ -9,7 +9,8 @@
     <div class="col-8">
       <form action="/marketo/submit" method="post" id="mktoForm_{{formid}}">
         <fieldset class="u-no-margin--bottom">
-          <h3>About you</h3>
+          <legend class="u-off-screen">About you</legend>
+          <h2 class="p-heading--3">About you</h2>
           <ul class="p-list">
             <li class="p-list__item">
               <label for="firstName">First name:</label>
@@ -30,9 +31,10 @@
             {% include "shared/forms/_country.html" %}
           </ul>
         </fieldset>
-        
+
         <fieldset class="u-no-margin--bottom">
-          <h3>About your company</h3>
+          <legend class="u-off-screen">About your company</legend>
+          <h2 class="p-heading--3">About your company</h2>
           <ul class="p-list">
             <li class="p-list__item">
               <label for="company">Company name:</label>
@@ -42,12 +44,13 @@
               <label for="job-title">Job title:</label>
               <input required id="job-title" name="title" maxlength="255" type="text" />
             </li>
-            
+
           </ul>
         </fieldset>
-        
+
         <fieldset class="u-no-margin--bottom">
-          <h3>Your comments</h3>
+          <legend class="u-off-screen">Your comments</legend>
+          <h2 class="p-heading--3">Your comments</h2>
           <ul class="p-list">
             <li class="p-list__item">
               <label for="Comments_from_lead__c">What would you like to talk to us about?</label>

--- a/templates/shared/_cloud-contact-us-form.html
+++ b/templates/shared/_cloud-contact-us-form.html
@@ -9,7 +9,8 @@
     <div class="col-8">
       <form action="/marketo/submit" method="post" id="mktoForm_{{formid}}">
         <fieldset class="u-no-margin--bottom">
-          <h3>About you</h3>
+          <legend class="u-off-screen">About you</legend>
+          <h2 class="p-heading--3">About you</h2>
           <ul class="p-list">
             <li class="p-list__item">
               <label for="firstName">First name:</label>
@@ -32,6 +33,7 @@
           </ul>
         </fieldset>
         <fieldset class="u-no-margin--bottom">
+          <legend class="u-off-screen">About your company</legend>
           <h3>About your company</h3>
           <ul class="p-list">
             <li class="p-list__item">
@@ -45,6 +47,7 @@
           </ul>
         </fieldset>
         <fieldset class="u-no-margin--bottom">
+          <legend class="u-off-screen">Your comments</legend>
           <h3>Your comments</h3>
           <ul class="p-list">
             <li class="p-list__item">
@@ -54,6 +57,7 @@
           </ul>
         </fieldset>
         <fieldset class="u-no-margin--bottom">
+          <legend class="u-off-screen">Privacy policy</legend>
           <ul class="p-list">
             <li class="p-list__item">
               <label class="p-checkbox">
@@ -94,7 +98,7 @@
         </fieldset>
       </form>
     </div>
-    
+
     <div class="col-4">
       <div class="p-card">
         <h3 class="p-card__title">Any questions? Call us</h3>

--- a/templates/shared/_pro-contact-us-form.html
+++ b/templates/shared/_pro-contact-us-form.html
@@ -9,13 +9,15 @@
     <div class="col-8">
       <form action="/marketo/submit" method="post" id="mktoForm_{{formid}}" onsubmit="getCustomFields()">
         <fieldset class="u-no-margin--bottom">
-          <h3>Tell us about your project</h3>
-          <textarea id="about-your-project" aria-label="Tell us about your project and team"
-            placeholder="What do you want to achieve, which applications and languages do you use, and what’s your team's setup?"
+          <legend class="u-off-screen">Tell us about your project and team</legend>
+          <h2 class="p-heading--3">Tell us about your project</h2>
+          <textarea id="about-your-project"
+            placeholder="What do you want to achieve, which applications and languages do you use, and what's your team's setup?"
             rows="3"></textarea>
         </fieldset>
         <fieldset class="u-no-margin--bottom" id="ubuntu-versions">
-          <h3>If you use Ubuntu, which version(s) are you using?</h3>
+          <legend class="u-off-screen">If you use Ubuntu, which version or versions are you using?</legend>
+          <h2 class="p-heading--3">If you use Ubuntu, which version(s) are you using?</h2>
           <div class="row u-no-padding">
             <div class="col-4 u-sv3">
               <strong>LTS within standard support</strong>
@@ -82,7 +84,8 @@
           </div>
         </fieldset>
         <fieldset class="u-no-margin--bottom" id="how-do-you-consume-open-source">
-          <h3>How do you consume open source?</h3>
+          <legend class="u-off-screen">How do you consume open source?</legend>
+          <h2 class="p-heading--3">How do you consume open source?</h2>
           <div class="row u-no-padding">
             <div class="col-4 u-sv3 u-no-padding--bottom">
               <label class="p-checkbox">
@@ -104,13 +107,14 @@
               </label>
               <label class="p-checkbox">
                 <input type="checkbox" aria-labelledby="i-dont-know" class="p-checkbox__input" value="I don't know">
-                <span class="p-checkbox__label" id="i-dont-know">I don’t know</span>
+                <span class="p-checkbox__label" id="i-dont-know">I don't know</span>
               </label>
             </div>
           </div>
         </fieldset>
         <fieldset class="u-no-margin--bottom" id="hardening-requirements">
-          <h3>Do you have specific compliance or hardening requirements?</h3>
+          <legend class="u-off-screen">Do you have specific compliance or hardening requirements?</legend>
+          <h2 class="p-heading--3">Do you have specific compliance or hardening requirements?</h2>
           <div class="row u-no-padding">
             <div class="col-4 u-sv3">
               <label class="p-checkbox">
@@ -151,7 +155,8 @@
           </div>
         </fieldset>
         <fieldset class="u-no-margin--bottom" id="responsible-for-tracking">
-          <h3>Who is responsible for tracking, testing and applying CVE patches in a timely manner?</h3>
+          <legend class="u-off-screen">Who is responsible for tracking, testing and applying CVE patches in a timely manner?</legend>
+          <h2 class="p-heading--3">Who is responsible for tracking, testing and applying CVE patches in a timely manner?</h2>
           <div class="row u-no-padding">
             <div class="col-4 u-sv3">
               <label class="p-checkbox">
@@ -172,18 +177,20 @@
               </label>
               <label class="p-checkbox">
                 <input type="checkbox" aria-labelledby="i-dont-know" class="p-checkbox__input" value="I don't know">
-                <span class="p-checkbox__label" id="i-dont-know">I don’t know</span>
+                <span class="p-checkbox__label" id="i-dont-know">I don't know</span>
               </label>
             </div>
           </div>
         </fieldset>
         <fieldset class="u-no-margin--bottom">
-          <h3>What advice are you looking for?</h3>
+          <legend class="u-off-screen">What advice are you looking for?</legend>
+          <h2 class="p-heading--3">What advice are you looking for?</h2>
           <textarea id="advice" aria-label="Tell us about your challenge and your goals"
             placeholder="Tell us about your challenge and your goals" rows="3"></textarea>
         </fieldset>
         <fieldset class="u-no-margin--bottom">
-          <h3>About you</h3>
+          <legend class="u-off-screen">About you</legend>
+          <h2 class="p-heading--3">About you</h2>
           <ul class="p-list">
             <li class="p-list__item">
               <label for="firstName">First name:</label>
@@ -207,7 +214,8 @@
           </ul>
         </fieldset>
         <fieldset class="u-no-margin--bottom">
-          <h3>About your company</h3>
+          <legend class="u-off-screen">About your company</legend>
+          <h2 class="p-heading--3">About your company</h2>
           <ul class="p-list">
             <li class="p-list__item">
               <label for="company">Company name:</label>
@@ -220,6 +228,7 @@
           </ul>
         </fieldset>
         <fieldset class="u-no-margin--bottom">
+          <legend class="u-off-screen">Privacy policy</legend>
           <ul class="p-list">
             <li class="p-list__item">
               <label class="p-checkbox">
@@ -281,11 +290,11 @@
 
     <div class="col-4">
       <div class="p-card">
-        <h3 class="p-card__title">Any questions? Call us</h3>
+        <h2 class="p-heading--3 p-card__title">Any questions? Call us</h2>
         {% include "shared/_call-sales-long.html" %}
       </div>
       <div class="p-card">
-        <h3 class="p-card__title">Need help with Ubuntu?</h3>
+        <h2 class="p-heading--3 p-card__title">Need help with Ubuntu?</h2>
         <p>If you are just looking for some free support for yourself, you can try:</p>
         <ul class="p-list--divided">
           <li class="p-list__item"><a href="https://askubuntu.com/">Ask Ubuntu</a></li>

--- a/templates/shared/_telco-contact-us.html
+++ b/templates/shared/_telco-contact-us.html
@@ -9,6 +9,7 @@
     <div class="col-8">
       <form action="/marketo/submit" method="post" id="mktoForm_{{formid}}">
         <fieldset class="u-no-margin--bottom">
+          <legend class="u-off-screen">What is your main business?</legend>
           <h3 class="p-heading--5">What is your main business?</h3>
           <ul class="row u-no-padding">
             <li class="col-4 u-sv3">
@@ -64,6 +65,7 @@
         </fieldset>
 
         <fieldset class="u-no-margin--bottom">
+          <legend class="u-off-screen">What are the priority use cases you want to talk about?</legend>
           <h3 class="p-heading--5">What are the priority use cases you want to talk about?</h3>
           <ul class="row u-no-padding">
             <li class="col-4 u-sv3">
@@ -147,6 +149,7 @@
         </fieldset>
 
         <fieldset>
+          <legend class="u-off-screen">Tell us about you and your team (Optional)</legend>
           <h3 class="p-heading--5">Tell us about you and your team (Optional)</h3>
           <textarea id="tellUsMore" aria-label="Tell us more about you and your team?" rows="3" placeholder="What are you working on right now? What is your underlying infrastructure? How advanced are you with cloud native network functions? Do you use Ubuntu?"></textarea>
         </div>
@@ -155,6 +158,7 @@
       <div class="row">
         <div class="col-8">
           <fieldset class="u-no-margin--bottom">
+          <legend class="u-off-screen">How should we get in touch?</legend>
             <h3 class="p-heading--5">How should we get in touch?</h3>
             <div class="row u-no-padding">
               <div class="col-6">
@@ -191,6 +195,7 @@
           </fieldset>
 
           <fieldset class="u-no-margin--bottom">
+          <legend class="u-off-screen">Your comments and privacy policy</legend>
             <h3>Your comments</h3>
             <ul class="p-list">
               <li class="p-list__item">

--- a/templates/shared/forms/interactive/openstack.html
+++ b/templates/shared/forms/interactive/openstack.html
@@ -6,7 +6,7 @@
     </header>
     <div class="js-pagination js-pagination--1">
       <div class="u-sv3 js-formfield">
-        <h3 class="p-heading--5">Tell us about your project and team</h3>
+        <label class="p-heading--5" for="about-your-project-or-interest">Tell us about your project and team</label>
         <textarea id="about-your-project-or-interest" name="sector-specific-requirements" aria-label="Tell us about your project and team" placeholder="Where are you located? What is the scale of your project (number of servers, number of VMs, etc.)? Have you already purchased hardware for this project? Do you already have OpenStack deployed? Where are your workloads running right now? Is this initiative for a specific workload or for the business as a whole?" rows="3"></textarea>
       </div>
       <div class="js-formfield">
@@ -17,83 +17,83 @@
               <input type="checkbox" aria-labelledby="priority-workloads-Telco-NFV" class="p-checkbox__input">
               <span class="p-checkbox__label" id="priority-workloads-Telco-NFV">Telco NFV</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="priority-workloads-Kubernetes" class="p-checkbox__input">
               <span class="p-checkbox__label" id="priority-workloads-Kubernetes">Kubernetes</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="priority-workloads-Serverless" class="p-checkbox__input">
               <span class="p-checkbox__label" id="priority-workloads-Serverless">Serverless</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="priority-workloads-High-performance-computing" class="p-checkbox__input">
               <span class="p-checkbox__label" id="priority-workloads-High-performance-computing">High performance computing</span>
             </label>
-            
+
           </div>
           <div class="col-3 u-sv3">
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="priority-workloads-Databases" class="p-checkbox__input">
               <span class="p-checkbox__label" id="priority-workloads-Databases">Databases</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="priority-workloads-Data-warehouses" class="p-checkbox__input">
               <span class="p-checkbox__label" id="priority-workloads-Data-warehouses">Data warehouses</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="priority-workloads-Data-lake" class="p-checkbox__input">
               <span class="p-checkbox__label" id="priority-workloads-Data-lake">Data lake</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="priority-workloads-Cloud-storage" class="p-checkbox__input">
               <span class="p-checkbox__label" id="priority-workloads-Cloud-storage">Cloud storage</span>
             </label>
-            
+
           </div>
           <div class="col-3 u-sv3">
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="priority-workloads-AI-ML" class="p-checkbox__input">
               <span class="p-checkbox__label" id="priority-workloads-AI-ML">AI/ML</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="priority-workloads-Big-data-analytics" class="p-checkbox__input">
               <span class="p-checkbox__label" id="priority-workloads-Big-data-analytics">Big data analytics</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="priority-workloads-CI-CD" class="p-checkbox__input">
               <span class="p-checkbox__label" id="priority-workloads-CI-CD">CI/CD</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="priority-workloads-Developer-VMs" class="p-checkbox__input">
               <span class="p-checkbox__label" id="priority-workloads-Developer-VMs">Developer VMs</span>
             </label>
-            
+
           </div>
           <div class="col-3 u-sv3">
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="priority-workloads-Web-applications" class="p-checkbox__input">
               <span class="p-checkbox__label" id="priority-workloads-Web-applications">Web applications</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="priority-workloads-Media-streaming" class="p-checkbox__input">
               <span class="p-checkbox__label" id="priority-workloads-Media-streaming">Media streaming</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="priority-workloads-Video-transcoding" class="p-checkbox__input">
               <span class="p-checkbox__label" id="priority-workloads-Video-transcoding">Video transcoding</span>
             </label>
-            
+
             <div class="js-other-container">
               <label class="p-checkbox">
                 <input class="p-checkbox__input js-other-container__checkbox" type="checkbox" aria-labelledby="priority-workloads-other">
@@ -113,32 +113,32 @@
               <input type="checkbox" aria-labelledby="platform-preferences-CPU-Intel" class="p-checkbox__input">
               <span class="p-checkbox__label" id="platform-preferences-CPU-Intel">Intel</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="platform-preferences-CPU-AMD" class="p-checkbox__input">
               <span class="p-checkbox__label" id="platform-preferences-CPU-AMD">AMD</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="platform-preferences-CPU-ARM" class="p-checkbox__input">
               <span class="p-checkbox__label" id="platform-preferences-CPU-ARM">ARM</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="platform-preferences-CPU-POWER" class="p-checkbox__input">
               <span class="p-checkbox__label" id="platform-preferences-CPU-POWER">POWER</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="platform-preferences-CPU-Z" class="p-checkbox__input">
               <span class="p-checkbox__label" id="platform-preferences-CPU-Z">Z</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="platform-preferences-CPU-Undecided" class="p-checkbox__input">
               <span class="p-checkbox__label" id="platform-preferences-CPU-Undecided">Undecided</span>
             </label>
-            
+
           </div>
           <div class="col-3 u-sv3">
             <p class="js-sub-section">Servers</p>
@@ -146,37 +146,37 @@
               <input type="checkbox" aria-labelledby="platform-preferences-Servers-Gigabyte" class="p-checkbox__input">
               <span class="p-checkbox__label" id="platform-preferences-Servers-Gigabyte">Gigabyte</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="platform-preferences-Servers-Lenovo" class="p-checkbox__input">
               <span class="p-checkbox__label" id="platform-preferences-Servers-Lenovo">Lenovo</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="platform-preferences-Servers-Dell" class="p-checkbox__input">
               <span class="p-checkbox__label" id="platform-preferences-Servers-Dell">Dell</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="platform-preferences-Servers-HPE" class="p-checkbox__input">
               <span class="p-checkbox__label" id="platform-preferences-Servers-HPE">HPE</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="platform-preferences-Servers-Huawei" class="p-checkbox__input">
               <span class="p-checkbox__label" id="platform-preferences-Servers-Huawei">Huawei</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="platform-preferences-Servers-Cisco" class="p-checkbox__input">
               <span class="p-checkbox__label" id="platform-preferences-Servers-Cisco">Cisco</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="platform-preferences-Servers-Undecided" class="p-checkbox__input">
               <span class="p-checkbox__label" id="platform-preferences-Servers-Undecided">Undecided</span>
             </label>
-            
+
             <div class="js-other-container">
               <label class="p-checkbox">
                 <input class="p-checkbox__input js-other-container__checkbox" type="checkbox" aria-labelledby="platform-preferences-servers-other">
@@ -191,27 +191,27 @@
               <input type="checkbox" aria-labelledby="platform-preferences-Networking-OVN" class="p-checkbox__input">
               <span class="p-checkbox__label" id="platform-preferences-Networking-OVN">OVN</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="platform-preferences-Networking-OVS" class="p-checkbox__input">
               <span class="p-checkbox__label" id="platform-preferences-Networking-OVS">OVS</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="platform-preferences-Networking-Cisco" class="p-checkbox__input">
               <span class="p-checkbox__label" id="platform-preferences-Networking-Cisco">Cisco</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="platform-preferences-Networking-Juniper" class="p-checkbox__input">
               <span class="p-checkbox__label" id="platform-preferences-Networking-Juniper">Juniper</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="platform-preferences-Networking-Undecided" class="p-checkbox__input">
               <span class="p-checkbox__label" id="platform-preferences-Networking-Undecided">Undecided</span>
             </label>
-            
+
             <div class="js-other-container">
               <label class="p-checkbox">
                 <input class="p-checkbox__input js-other-container__checkbox" type="checkbox" aria-labelledby="platform-preferences-networking-other">
@@ -226,17 +226,17 @@
               <input type="checkbox" aria-labelledby="platform-preferences-Storage-Ceph" class="p-checkbox__input">
               <span class="p-checkbox__label" id="platform-preferences-Storage-Ceph">Ceph</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="platform-preferences-Storage-iSCSI" class="p-checkbox__input">
               <span class="p-checkbox__label" id="platform-preferences-Storage-iSCSI">iSCSI</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="platform-preferences-Storage-Undecided" class="p-checkbox__input">
               <span class="p-checkbox__label" id="platform-preferences-Storage-Undecided">Undecided</span>
             </label>
-            
+
             <div class="js-other-container">
               <label class="p-checkbox">
                 <input class="p-checkbox__input js-other-container__checkbox" type="checkbox" aria-labelledby="platform-preferences-storage-other">
@@ -255,28 +255,28 @@
               <input type="checkbox" aria-labelledby="platform-preferences-Architecture-Hyper-converged" class="p-checkbox__input">
               <span class="p-checkbox__label" id="platform-preferences-Architecture-Hyper-converged">Hyper-converged</span>
             </label>
-            
+
           </div>
           <div class="col-3">
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="platform-preferences-Architecture-Converged" class="p-checkbox__input">
               <span class="p-checkbox__label" id="platform-preferences-Architecture-Converged">Converged</span>
             </label>
-            
+
           </div>
           <div class="col-3">
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="platform-preferences-Architecture-Fully-Disaggregated" class="p-checkbox__input">
               <span class="p-checkbox__label" id="platform-preferences-Architecture-Fully-Disaggregated">Fully Disaggregated</span>
             </label>
-            
+
           </div>
           <div class="col-3">
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="platform-preferences-Architecture-Undecided" class="p-checkbox__input">
               <span class="p-checkbox__label" id="platform-preferences-Architecture-Undecided">Undecided</span>
             </label>
-            
+
           </div>
         </div>
       </div>
@@ -284,7 +284,7 @@
         <a class="p-button--positive pagination__link--next" href="">Next</a>
       </div>
     </div>
-    
+
     <div class="js-pagination js-pagination--2 u-hide">
       <div class="js-formfield">
         <h3 class="p-heading--5">Which OpenStack capabilities matter to you?</h3>
@@ -294,121 +294,121 @@
               <input type="checkbox" aria-labelledby="openstack-capabilities-matter-VMs-coordination" class="p-checkbox__input">
               <span class="p-checkbox__label" id="openstack-capabilities-matter-VMs-coordination">VMs coordination</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="openstack-capabilities-matter-Containers-coordination" class="p-checkbox__input">
               <span class="p-checkbox__label" id="openstack-capabilities-matter-Containers-coordination">Containers coordination</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="openstack-capabilities-matter-Workload-HA" class="p-checkbox__input">
               <span class="p-checkbox__label" id="openstack-capabilities-matter-Workload-HA">Workload HA</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="openstack-capabilities-matter-Ephemeral-storage" class="p-checkbox__input">
               <span class="p-checkbox__label" id="openstack-capabilities-matter-Ephemeral-storage">Ephemeral storage</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="openstack-capabilities-matter-Block-storage" class="p-checkbox__input">
               <span class="p-checkbox__label" id="openstack-capabilities-matter-Block-storage">Block storage</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="openstack-capabilities-matter-Object-storage" class="p-checkbox__input">
               <span class="p-checkbox__label" id="openstack-capabilities-matter-Object-storage">Object storage</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="openstack-capabilities-matter-Shared-file-system" class="p-checkbox__input">
               <span class="p-checkbox__label" id="openstack-capabilities-matter-Shared-file-system">Shared file system</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="openstack-capabilities-matter-Identity-management" class="p-checkbox__input">
               <span class="p-checkbox__label" id="openstack-capabilities-matter-Identity-management">Identity management</span>
             </label>
-            
+
           </div>
           <div class="col-4 u-sv3">
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="openstack-capabilities-matter-DNSaaS" class="p-checkbox__input">
               <span class="p-checkbox__label" id="openstack-capabilities-matter-DNSaaS">DNSaaS</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="openstack-capabilities-matter-LBaaS" class="p-checkbox__input">
               <span class="p-checkbox__label" id="openstack-capabilities-matter-LBaaS">LBaaS</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="openstack-capabilities-matter-SR-IOV" class="p-checkbox__input">
               <span class="p-checkbox__label" id="openstack-capabilities-matter-SR-IOV">SR-IOV</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="openstack-capabilities-matter-DPDK" class="p-checkbox__input">
               <span class="p-checkbox__label" id="openstack-capabilities-matter-DPDK">DPDK</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="openstack-capabilities-matter-EPA" class="p-checkbox__input">
               <span class="p-checkbox__label" id="openstack-capabilities-matter-EPA">EPA</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="openstack-capabilities-matter-NUMA" class="p-checkbox__input">
               <span class="p-checkbox__label" id="openstack-capabilities-matter-NUMA">NUMA</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="openstack-capabilities-matter-FPGA" class="p-checkbox__input">
               <span class="p-checkbox__label" id="openstack-capabilities-matter-FPGA">FPGA</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="openstack-capabilities-matter-SmartNICs" class="p-checkbox__input">
               <span class="p-checkbox__label" id="openstack-capabilities-matter-SmartNICs">SmartNICs</span>
             </label>
-            
+
           </div>
           <div class="col-4 u-sv3">
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="openstack-capabilities-matter-Automation" class="p-checkbox__input">
               <span class="p-checkbox__label" id="openstack-capabilities-matter-Automation">Automation</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="openstack-capabilities-matter-Secret-management" class="p-checkbox__input">
               <span class="p-checkbox__label" id="openstack-capabilities-matter-Secret-management">Secret management</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="openstack-capabilities-matter-HSM" class="p-checkbox__input">
               <span class="p-checkbox__label" id="openstack-capabilities-matter-HSM">HSM</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="openstack-capabilities-matter-GPGPU" class="p-checkbox__input">
               <span class="p-checkbox__label" id="openstack-capabilities-matter-GPGPU">GPGPU</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="openstack-capabilities-matter-Telemetry" class="p-checkbox__input">
               <span class="p-checkbox__label" id="openstack-capabilities-matter-Telemetry">Telemetry</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="openstack-capabilities-matter-Billing" class="p-checkbox__input">
               <span class="p-checkbox__label" id="openstack-capabilities-matter-Billing">Billing</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="openstack-capabilities-matter-Dashboard" class="p-checkbox__input">
               <span class="p-checkbox__label" id="openstack-capabilities-matter-Dashboard">Dashboard</span>
             </label>
-            
+
             <div class="js-other-container">
               <label class="p-checkbox">
                 <input class="p-checkbox__input js-other-container__checkbox" type="checkbox" aria-labelledby="openstack-capabilities-matter-other">
@@ -427,106 +427,106 @@
               <input type="checkbox" aria-labelledby="most-helpful-Workload-analysis" class="p-checkbox__input">
               <span class="p-checkbox__label" id="most-helpful-Workload-analysis">Workload analysis</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="most-helpful-Architecture-design" class="p-checkbox__input">
               <span class="p-checkbox__label" id="most-helpful-Architecture-design">Architecture design</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="most-helpful-Hardware-guidance" class="p-checkbox__input">
               <span class="p-checkbox__label" id="most-helpful-Hardware-guidance">Hardware guidance</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="most-helpful-Performance-tuning" class="p-checkbox__input">
               <span class="p-checkbox__label" id="most-helpful-Performance-tuning">Performance tuning</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="most-helpful-Ecosystem-integration" class="p-checkbox__input">
               <span class="p-checkbox__label" id="most-helpful-Ecosystem-integration">Ecosystem integration</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="most-helpful-Compliance-certification" class="p-checkbox__input">
               <span class="p-checkbox__label" id="most-helpful-Compliance-certification">Compliance certification</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="most-helpful-Cost-estimates" class="p-checkbox__input">
               <span class="p-checkbox__label" id="most-helpful-Cost-estimates">Cost estimates</span>
             </label>
-            
+
           </div>
           <div class="col-4 u-sv3">
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="most-helpful-OpenStack-deployment" class="p-checkbox__input">
               <span class="p-checkbox__label" id="most-helpful-OpenStack-deployment">OpenStack deployment</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="most-helpful-Performance-benchmarking" class="p-checkbox__input">
               <span class="p-checkbox__label" id="most-helpful-Performance-benchmarking">Performance benchmarking</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="most-helpful-Backup-and-recovery" class="p-checkbox__input">
               <span class="p-checkbox__label" id="most-helpful-Backup-and-recovery">Backup and recovery</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="most-helpful-Disaster-recovery-plans" class="p-checkbox__input">
               <span class="p-checkbox__label" id="most-helpful-Disaster-recovery-plans">Disaster recovery plans</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="most-helpful-Observability-stack" class="p-checkbox__input">
               <span class="p-checkbox__label" id="most-helpful-Observability-stack">Observability stack</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="most-helpful-OpenStack-training" class="p-checkbox__input">
               <span class="p-checkbox__label" id="most-helpful-OpenStack-training">OpenStack training</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="most-helpful-Workload-migration" class="p-checkbox__input">
               <span class="p-checkbox__label" id="most-helpful-Workload-migration">Workload migration</span>
             </label>
-            
+
           </div>
           <div class="col-4 u-sv3">
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="most-helpful-Upgrade-to-new-version" class="p-checkbox__input">
               <span class="p-checkbox__label" id="most-helpful-Upgrade-to-new-version">Upgrade to new version</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="most-helpful-Enterprise-support" class="p-checkbox__input">
               <span class="p-checkbox__label" id="most-helpful-Enterprise-support">Enterprise support</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="most-helpful-Fully-managed-private-cloud" class="p-checkbox__input">
               <span class="p-checkbox__label" id="most-helpful-Fully-managed-private-cloud">Fully-managed private cloud</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="most-helpful-Security-updates" class="p-checkbox__input">
               <span class="p-checkbox__label" id="most-helpful-Security-updates">Security updates</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="most-helpful-Security-audit" class="p-checkbox__input">
               <span class="p-checkbox__label" id="most-helpful-Security-audit">Security audit</span>
             </label>
-            
+
             <label class="p-checkbox">
               <input type="checkbox" aria-labelledby="most-helpful-Hybrid-multi-cloud" class="p-checkbox__input">
               <span class="p-checkbox__label" id="most-helpful-Hybrid-multi-cloud">Hybrid/multi-cloud</span>
             </label>
-            
+
             <div class="js-other-container">
               <label class="p-checkbox">
                 <input class="p-checkbox__input js-other-container__checkbox" type="checkbox" aria-labelledby="most-helpful-other">
@@ -542,7 +542,7 @@
         <a class="p-button--positive pagination__link--next" href="">Next</a>
       </div>
     </div>
-    
+
     <div class="js-pagination js-pagination--3 u-hide">
       <h3 class="p-heading--5">How should we get in touch?</h3>
       <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
@@ -583,7 +583,7 @@
               </li>
               {# End of honey pots #}
             </ul>
-            
+
             <div class="u-hide">
               <h3>Your comments</h3>
               <ul class="p-list">
@@ -612,10 +612,10 @@
               <button type="submit" class="pagination__link--next p-button--positive" aria-label="Submit">Let's discuss your requirements</button>
             </div>
           </div>
-        </div> 
-      </form>  
+        </div>
+      </form>
     </div>
-    
+
     <div class="js-pagination js-pagination--4 u-hide">
       <div class="row u-no-padding">
         <div class="u-equal-height">

--- a/templates/shared/forms/interactive/robotics_ros.html
+++ b/templates/shared/forms/interactive/robotics_ros.html
@@ -2,7 +2,7 @@
   <div class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
     <header class="p-modal__header" style="display: block; border-bottom: 0;">
       <button class="p-modal__close" aria-label="Close active modal" style="margin-left: -1rem">Close</button>
-      <h2 class="p-modal__title u-sv1" id="modal-title">Let’s get your robot rolling</h2>
+      <h2 class="p-modal__title u-sv1" id="modal-title">Let's get your robot rolling</h2>
     </header>
     <div class="js-pagination js-pagination--1">
       <p id="modal-description" class="u-no-max-width u-no-margin--bottom">Tell us about your project so we can bring the right team to the conversation. If the form  doesn't address your questions, please press next and submit your inquiry in the  text area.</p>
@@ -12,15 +12,15 @@
         <div class="row u-no-padding">
           <div class="col-2 u-sv3">
             <label class="p-radio">
-  <input class="p-radio__input" type="radio" aria-labelledby="enterprise-support-for-ROS-yes" name="enterprise-support-for-ROS" value="Yes">
-  <span class="p-radio__label" id="enterprise-support-for-ROS-yes">Yes</span>
-</label>
+              <input class="p-radio__input" type="radio" aria-labelledby="enterprise-support-for-ROS-yes" name="enterprise-support-for-ROS" value="Yes">
+              <span class="p-radio__label" id="enterprise-support-for-ROS-yes">Yes</span>
+            </label>
           </div>
           <div class="col-2 u-sv3">
             <label class="p-radio">
-  <input class="p-radio__input" type="radio" aria-labelledby="enterprise-support-for-ROS-no" name="enterprise-support-for-ROS" value="No">
-  <span class="p-radio__label" id="enterprise-support-for-ROS-no">No</span>
-</label>
+              <input class="p-radio__input" type="radio" aria-labelledby="enterprise-support-for-ROS-no" name="enterprise-support-for-ROS" value="No">
+              <span class="p-radio__label" id="enterprise-support-for-ROS-no">No</span>
+            </label>
           </div>
         </div>
       </div>
@@ -30,15 +30,15 @@
         <div class="row u-no-padding">
           <div class="col-2 u-sv3">
             <label class="p-radio">
-  <input class="p-radio__input" type="radio" aria-labelledby="Hardware-Enablement-and-Certification-yes" name="Hardware-Enablement-and-Certification" value="Yes">
-  <span class="p-radio__label" id="Hardware-Enablement-and-Certification-yes">Yes</span>
-</label>
+              <input class="p-radio__input" type="radio" aria-labelledby="Hardware-Enablement-and-Certification-yes" name="Hardware-Enablement-and-Certification" value="Yes">
+              <span class="p-radio__label" id="Hardware-Enablement-and-Certification-yes">Yes</span>
+            </label>
           </div>
           <div class="col-2 u-sv3">
             <label class="p-radio">
-  <input class="p-radio__input" type="radio" aria-labelledby="Hardware-Enablement-and-Certification-no" name="Hardware-Enablement-and-Certification" value="No">
-  <span class="p-radio__label" id="Hardware-Enablement-and-Certification-no">No</span>
-</label>
+              <input class="p-radio__input" type="radio" aria-labelledby="Hardware-Enablement-and-Certification-no" name="Hardware-Enablement-and-Certification" value="No">
+              <span class="p-radio__label" id="Hardware-Enablement-and-Certification-no">No</span>
+            </label>
           </div>
         </div>
       </div>
@@ -48,15 +48,15 @@
         <div class="row u-no-padding">
           <div class="col-2 u-sv3">
             <label class="p-radio">
-  <input class="p-radio__input" type="radio" aria-labelledby="Brand-Store-and-our-management-solution-yes" name="Brand-Store-and-our-management-solution" value="Yes">
-  <span class="p-radio__label" id="Brand-Store-and-our-management-solution-yes">Yes</span>
-</label>
+              <input class="p-radio__input" type="radio" aria-labelledby="Brand-Store-and-our-management-solution-yes" name="Brand-Store-and-our-management-solution" value="Yes">
+              <span class="p-radio__label" id="Brand-Store-and-our-management-solution-yes">Yes</span>
+            </label>
           </div>
           <div class="col-2 u-sv3">
             <label class="p-radio">
-  <input class="p-radio__input" type="radio" aria-labelledby="Brand-Store-and-our-management-solution-no" name="Brand-Store-and-our-management-solution" value="No">
-  <span class="p-radio__label" id="Brand-Store-and-our-management-solution-no">No</span>
-</label>
+              <input class="p-radio__input" type="radio" aria-labelledby="Brand-Store-and-our-management-solution-no" name="Brand-Store-and-our-management-solution" value="No">
+              <span class="p-radio__label" id="Brand-Store-and-our-management-solution-no">No</span>
+            </label>
           </div>
         </div>
       </div>
@@ -66,21 +66,21 @@
         <div class="row u-no-padding">
           <div class="col-2 u-sv3">
             <label class="p-radio">
-  <input class="p-radio__input" type="radio" aria-labelledby="support-getting-to-market-yes" name="support-getting-to-market" value="Yes">
-  <span class="p-radio__label" id="support-getting-to-market-yes">Yes</span>
-</label>
+              <input class="p-radio__input" type="radio" aria-labelledby="support-getting-to-market-yes" name="support-getting-to-market" value="Yes">
+              <span class="p-radio__label" id="support-getting-to-market-yes">Yes</span>
+            </label>
           </div>
           <div class="col-2 u-sv3">
             <label class="p-radio">
-  <input class="p-radio__input" type="radio" aria-labelledby="support-getting-to-market-no" name="support-getting-to-market" value="No">
-  <span class="p-radio__label" id="support-getting-to-market-no">No</span>
-</label>
+              <input class="p-radio__input" type="radio" aria-labelledby="support-getting-to-market-no" name="support-getting-to-market" value="No">
+              <span class="p-radio__label" id="support-getting-to-market-no">No</span>
+            </label>
           </div>
         </div>
       </div>
 
       <div class="u-sv3 js-formfield">
-        <h3 class="p-heading--5">What can we help you with?</h3>
+        <label class="p-heading--5" for="open-question">What can we help you with?</label>
         <textarea id="open-question" name="open-question" aria-label="What can we help you with?" placeholder="What type of robotics project or product are you working on? Manufacturing? Industrial automation? " rows="3"></textarea>
       </div>
 
@@ -123,10 +123,10 @@
               <li class="p-list__item">
                 <label class="p-checkbox">
                   <input class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-                  <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical’s products and services.</span>
+                  <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
                 </label>
               </li>
-              <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical’s Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
+              <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
               {# These are honey pot fields to catch bots #}
               <li class="u-off-screen">
                 <label class="website" for="website">Website:</label>


### PR DESCRIPTION
## Done

- I went through [this document](https://github.com/canonical/ubuntu.com/files/10677373/HTML.form.control.has.no.accessible.name.ods) provided through our a11y audit and updated the forms where appropriate. A lot of pages share the same form.
- There is one field in red which is not tackled in this PR and will require upstream changes, these changes can be found in [this issue](https://warthogs.atlassian.net/browse/WD-1894)

## QA

- I advise installing a a11y extension to help with the process, I used [wave](https://wave.webaim.org/) for this PR. This will allow you to check if a page is breaking any a11y rules. You can expect many rules to be broken as this PR only tackles form labels.
- Go to each individual page listed in the document above and check that there are no label/form related rules being broken.
- Go to each page and activate your screen reader, make sure the form groups and labels are being read.

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-1562
