### PR TITLE
Add redirect for UA JA legal page

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -589,6 +589,7 @@ legal/ubuntu-advantage/service-description/?: /legal/ubuntu-pro-description
 legal/ubuntu-advantage-service-description: /legal/ubuntu-pro-description
 legal/ubuntu-advantage/ua-terms/?: "/legal/ubuntu-advantage-service-terms"
 legal/ubuntu-advantage-service-terms/?: "/legal/ubuntu-pro-service-terms"
+legal/ubuntu-advantage-service-terms/ja?: "/legal/ubuntu-pro-service-terms/ja"
 legal/ubuntu-advantage/assurance/?: "/legal/ubuntu-pro-assurance"
 legal/ubuntu-advantage-assurance/?: "/legal/ubuntu-pro-assurance"
 legal/ubuntu-advantage/personal/?: "/legal/ubuntu-pro/personal"


### PR DESCRIPTION
## Done

- Add a redirect to cover the Japanese version of the service terms

## QA

- Check the redirect works
