### PR TITLE
Use CS endpoints for instant provisioning

### DIFF
--- a/templates/credentials/provision.html
+++ b/templates/credentials/provision.html
@@ -51,10 +51,9 @@
       </div>
     </div>
     <form method="post">
+      <input type="number" name="contractItemID" value="{{contract_item_id}}" hidden />
       <button class="p-button--positive" type="submit" name="submit">Start</button>
     </form>
-    <h2>Or schedule for later</h2>
-    <p>Visit the <a href="/credentials/schedule">Scheduling</a> page if you would prefer to schedule your exam for a time in the next one to seven days.</p>
     {% endif %}
   </div>
 </section>

--- a/templates/credentials/provision.html
+++ b/templates/credentials/provision.html
@@ -37,23 +37,14 @@
       <p>Your exam is complete. Please make sure that you have completed the <a href="/credentials/exit-survey">exit survey</a>.</p>
       {% endif %}
     {% elif reservation %}
-    <p>Your exam environment has been scheduled and is awaiting provisioning. <i class="p-icon--spinner u-animation--spin"></i></p>
+    <p>Your exam environment is awaiting provisioning. <i class="p-icon--spinner u-animation--spin"></i></p>
     <div class="p-notification--information">
       <div class="p-notification__content">
         <p class="p-notification__message">During this limited testing cycle, exams could potentially take up to 20 minutes to be provisioned under heavy system load.</p>
       </div>
     </div>
     {% else %}
-    <p>Click Start to begin your exam.</p>
-    <div class="p-notification--information">
-      <div class="p-notification__content">
-        <p class="p-notification__message">During this limited testing cycle, exams could potentially take up to 20 minutes to be provisioned under heavy system load.</p>
-      </div>
-    </div>
-    <form method="post">
-      <input type="number" name="contractItemID" value="{{contract_item_id}}" hidden />
-      <button class="p-button--positive" type="submit" name="submit">Start</button>
-    </form>
+    <p><a href="/credentials/your-exams">Return to your exams&nbsp;&rsaquo;</a></p>
     {% endif %}
   </div>
 </section>

--- a/templates/credentials/schedule.html
+++ b/templates/credentials/schedule.html
@@ -38,7 +38,7 @@ meta_copydoc %}
         <p>You can schedule or reschedule your exam up to 24 hours in advance.</p>
         <input type="date" id="exam-date" name="date" value="{{date}}" min="{{min_date}}" max="{{max_date}}" required />
         <label class="p-heading--4" for="exam-time">Select your preferred time</label>
-        <p>Your exam will take up to three hours to complete. Please make sure to plan accordingly before and after to
+        <p>Your exam will take up to one hour to complete. Please make sure to plan accordingly before and after to
           ensure the best exam experience.</p>
         <input type="time" id="exam-time" name="time" value="{{time}}" required />
         {% if uuid %} <input type="text" id="exam-uuid" name="uuid" value="{{uuid}}" hidden> {% endif %}

--- a/webapp/shop/api/ua_contracts/api.py
+++ b/webapp/shop/api/ua_contracts/api.py
@@ -368,38 +368,19 @@ class UAContractsAPI:
         starts_at,
         country_code,
     ) -> dict:
-        #  return self._request(
-        #      method="get",
-        #      path="v1/cue/schedule",
-        #      json={
-        #          "contractItemID": int(contract_item_id),
-        #          "firstName": first_name,
-        #          "lastName": last_name,
-        #          "timezone": timezone,
-        #          "startsAt": starts_at,
-        #          "countryCode": country_code,
-        #      },
-        #      error_rules=["default"],
-        #  ).json()
-        json_={
-            "contractItemID": int(contract_item_id),
-            "firstName": first_name,
-            "lastName": last_name,
-            "timezone": timezone,
-            "startsAt": starts_at,
-            "countryCode": country_code,
-        }
-        import json
-        print("Request body: ", json.dumps(json_, indent=4))
-
-        response = self._request(
+        return self._request(
             method="get",
             path="v1/cue/schedule",
-            json=json_,
+            json={
+                "contractItemID": int(contract_item_id),
+                "firstName": first_name,
+                "lastName": last_name,
+                "timezone": timezone,
+                "startsAt": starts_at,
+                "countryCode": country_code,
+            },
             error_rules=["default"],
-        )
-        print("API repsonse: ", response)
-        return response.json()
+        ).json()
 
     def delete_assessment_reservation(self, contract_item_id) -> dict:
         self._request(

--- a/webapp/shop/api/ua_contracts/api.py
+++ b/webapp/shop/api/ua_contracts/api.py
@@ -368,19 +368,38 @@ class UAContractsAPI:
         starts_at,
         country_code,
     ) -> dict:
-        return self._request(
+        #  return self._request(
+        #      method="get",
+        #      path="v1/cue/schedule",
+        #      json={
+        #          "contractItemID": int(contract_item_id),
+        #          "firstName": first_name,
+        #          "lastName": last_name,
+        #          "timezone": timezone,
+        #          "startsAt": starts_at,
+        #          "countryCode": country_code,
+        #      },
+        #      error_rules=["default"],
+        #  ).json()
+        json_={
+            "contractItemID": int(contract_item_id),
+            "firstName": first_name,
+            "lastName": last_name,
+            "timezone": timezone,
+            "startsAt": starts_at,
+            "countryCode": country_code,
+        }
+        import json
+        print("Request body: ", json.dumps(json_, indent=4))
+
+        response = self._request(
             method="get",
             path="v1/cue/schedule",
-            json={
-                "contractItemID": int(contract_item_id),
-                "firstName": first_name,
-                "lastName": last_name,
-                "timezone": timezone,
-                "startsAt": starts_at,
-                "countryCode": country_code,
-            },
+            json=json_,
             error_rules=["default"],
-        ).json()
+        )
+        print("API repsonse: ", response)
+        return response.json()
 
     def delete_assessment_reservation(self, contract_item_id) -> dict:
         self._request(

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -330,9 +330,7 @@ def cred_provision(ua_contracts_api, trueability_api, **_):
     else:
         error = "Exam not found"
 
-    if flask.request.method == "POST" and not reservation_uuid:
-        data = flask.request.form
-        contract_item_id = data["contractItemID"]
+    if not reservation_uuid:
         tz_info = pytz.timezone("UTC")
         starts_at = tz_info.localize(datetime.utcnow() + timedelta(seconds=70))
         first_name, last_name = sso_user["fullname"].rsplit(" ", maxsplit=1)
@@ -359,9 +357,7 @@ def cred_provision(ua_contracts_api, trueability_api, **_):
         response = trueability_api.get_assessment_reservation(reservation_uuid)
 
         if "error" in response:
-            error = response.get(
-                "message", "An error occurred while fetching your exam."
-            )
+            error = response.get("message", "No exam booking could be found.")
         else:
             reservation = response["assessment_reservation"]
             assessment = reservation["assessment"]

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -205,13 +205,13 @@ def cred_your_exams(ua_contracts_api, trueability_api, **_):
                         "text": "Schedule",
                         "href": "/credentials/schedule?"
                         f"contractItemID={contract_item_id}",
-                        "button_class": "p-button",
+                        "button_class": "p-button--positive",
                     },
                     {
                         "text": "Take now",
                         "href": "/credentials/provision?"
                         f"contractItemID={contract_item_id}",
-                        "button_class": "p-button",
+                        "button_class": "p-button--positive",
                     },
                 ]
                 exams.append({"name": name, "actions": actions})

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -187,6 +187,7 @@ def cred_your_exams(ua_contracts_api, trueability_api, **_):
                             },
                         ]
                     )
+
                 exams.append(
                     {
                         "name": name,
@@ -301,7 +302,7 @@ def cred_exam(trueability_api, **_):
 @shop_decorator(area="cred", permission="user", response="html")
 @canonical_staff()
 def cred_provision(ua_contracts_api, trueability_api, **_):
-    contract_item_id = flask.request.args.get("contractItemID")
+    contract_item_id = flask.request.args.get("contractItemID", type=int)
 
     if contract_item_id is None:
         return flask.redirect("/credentials/your-exams")
@@ -318,7 +319,7 @@ def cred_provision(ua_contracts_api, trueability_api, **_):
 
     exam_contract = None
     for item in exam_contracts:
-        if int(contract_item_id) == item["id"]:
+        if contract_item_id == item["id"]:
             exam_contract = item
             break
 
@@ -361,6 +362,13 @@ def cred_provision(ua_contracts_api, trueability_api, **_):
         else:
             reservation = response["assessment_reservation"]
             assessment = reservation["assessment"]
+
+    if assessment and assessment.get("state") in [
+        "notified",
+        "released",
+        "in_progress",
+    ]:
+        return flask.redirect(f"/credentials/exam?id={ assessment['id'] }")
 
     return flask.render_template(
         "/credentials/provision.html",

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -308,7 +308,7 @@ def cred_provision(ua_contracts_api, trueability_api, **_):
         return flask.redirect("/credentials/your-exams")
 
     sso_user = user_info(flask.session)
-    country_code = get_user_country_by_ip().json["country_code"] or "DE"
+    country_code = get_user_country_by_ip().json["country_code"] or "GB"
 
     reservation_uuid = None
     assessment = None

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -333,7 +333,7 @@ def cred_provision(ua_contracts_api, trueability_api, **_):
 
     if not reservation_uuid:
         tz_info = pytz.timezone("UTC")
-        starts_at = tz_info.localize(datetime.utcnow() + timedelta(seconds=70))
+        starts_at = tz_info.localize(datetime.utcnow() + timedelta(minutes=10))
         first_name, last_name = sso_user["fullname"].rsplit(" ", maxsplit=1)
 
         response = ua_contracts_api.post_assessment_reservation(

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -333,7 +333,7 @@ def cred_provision(ua_contracts_api, trueability_api, **_):
 
     if not reservation_uuid:
         tz_info = pytz.timezone("UTC")
-        starts_at = tz_info.localize(datetime.utcnow() + timedelta(minutes=10))
+        starts_at = tz_info.localize(datetime.utcnow() + timedelta(seconds=20))
         first_name, last_name = sso_user["fullname"].rsplit(" ", maxsplit=1)
 
         response = ua_contracts_api.post_assessment_reservation(

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -11,6 +11,7 @@ from webapp.shop.api.ua_contracts.api import (
 
 from webapp.shop.decorators import shop_decorator, canonical_staff
 from webapp.login import user_info
+from webapp.views import get_user_country_by_ip
 
 from google.oauth2 import service_account
 from googleapiclient.discovery import build
@@ -308,6 +309,7 @@ def cred_provision(ua_contracts_api, trueability_api, **_):
     sso_user = user_info(flask.session)
     sso_user_email = sso_user["email"]
     ability_screen_id = 4194
+    country_code = get_user_country_by_ip().json['country_code'] or "DE"
 
     reservation_uuid = None
     assessment = None
@@ -358,7 +360,7 @@ def cred_provision(ua_contracts_api, trueability_api, **_):
                 last_name,
                 tz_info.zone,
                 starts_at.isoformat(),
-                "DE",
+                country_code,
             )
 
             #  print(json.dumps(response, indent=4))


### PR DESCRIPTION
## Done

- Instantly-provisioned exams are scheduled through the CS contracts service rather than directly using the TA API

~~**Note:** Instantly-provisioned exams are currently scheduled for 10 mins into the future to due to TA platform limitations. We will remove this window once TA has implemented the necessary patch.~~

## QA

- Obtain a CUE activation key using the Backoffice tool (or get one from Morgan)
- Visit https://ubuntu-com-12518.demos.haus/credentials/redeem/[activation-key] to redeem your key
- Visit https://ubuntu-com-12518.demos.haus/credentials/your-exams
  - Verify that your exam is listed
  - Click the "Take now" button
  - Verify that the exam is built and that you are redirected to the exam environment

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/CRED-289

## Screenshots

![cred-cs-provision](https://user-images.githubusercontent.com/995051/217834166-5711440a-182a-42cb-a59c-14ddd0315eba.png)

![cred-beta-provisioning](https://user-images.githubusercontent.com/995051/219058097-56ce5a95-c4d9-4b18-8205-314b0819f001.png)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
