### PR TITLE
Add redirects to schedule/provision from activate key view

### DIFF
--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -522,13 +522,14 @@ def cred_redeem_code(ua_contracts_api, advantage_mapper, **kwargs):
         exam_contracts = ua_contracts_api.get_exam_contracts()
         contract_id = exam_contracts[-1]["id"]
         if flask.request.args.get("action") == "schedule":
-            flask.redirect(
+            return flask.redirect(
                 f"/credentials/schedule?contractItemID={contract_id}"
             )
-        else:
-            flask.redirect(
+        if flask.request.args.get("action") == "take":
+            return flask.redirect(
                 f"/credentials/provision?contractItemID={contract_id}"
             )
+        return flask.redirect("/credentials/your-exams")
     except UAContractsAPIErrorView as error:
         activation_response = json.loads(error.response.text)
         return flask.render_template(

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -519,10 +519,16 @@ def cred_redeem_code(ua_contracts_api, advantage_mapper, **kwargs):
                 "productID": product_id,
             }
         )
-        return flask.render_template(
-            "/credentials/redeem.html",
-            activation_response=activation_response,
-        )
+        exam_contracts = ua_contracts_api.get_exam_contracts()
+        contract_id = exam_contracts[-1]["id"]
+        if flask.request.args.get("action") == "schedule":
+            flask.redirect(
+                f"/credentials/schedule?contractItemID={contract_id}"
+            )
+        else:
+            flask.redirect(
+                f"/credentials/provision?contractItemID={contract_id}"
+            )
     except UAContractsAPIErrorView as error:
         activation_response = json.loads(error.response.text)
         return flask.render_template(


### PR DESCRIPTION
## Done

- [List of work items including drive-bys - remember to add the why and what of this work.]

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to /credentials/redeem/{activationKey}?action={"schedule"/"take"}
  - Should not show a confirmation view and directly take to the respective pages. 


## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
