### PR TITLE
Ensure all inputs across site have aria-labelling

### DIFF
--- a/static/js/src/advantage/subscribe/react/components/Form/Quantity/Quantity.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Quantity/Quantity.tsx
@@ -49,6 +49,7 @@ const Quantity = () => {
             value={quantity}
             pattern="\d+"
             style={{ minWidth: "unset", width: "4rem" }}
+            aria-label="For how many machines"
           />
         </Col>
       </Row>

--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -129,7 +129,6 @@
       <div class="row">
         <div class="col-8">
           <h3>Are you building a robot on top of Ubuntu and looking for a partner? Talk to us!</h3>
-
           <p>
             <a href="/internet-of-things/contact-us?product=robotics" class="p-button--positive">
               Contact Us

--- a/templates/blog/newsletter-form.html
+++ b/templates/blog/newsletter-form.html
@@ -2,43 +2,43 @@
   <header class="blog-p-card__header">
     <h5 class="p-muted-heading u-no-margin--bottom">Newsletter signup</h5>
   </header>
-  
+
   <div class="blog-p-card__content">
     <form action="/marketo/submit" method="post" id="mktoForm_1212" onsubmit="ga('send', 'Newsletter', 'Signup', 'New homepage newsletter signup');">
       <h3 class="p-card--title p-heading--4">Select topics you're <br />interested in</h3>
-      
+
       <ul class="p-list">
         <li class="p-list__item u-clearfix">
           <label class="p-checkbox">
             <input type="checkbox" aria-labelledby="insightscloudserver" class="p-checkbox__input" name="insightscloudserver" value="true" />
             <span class="p-checkbox__label" id="insightscloudserver">Cloud and Server</span>
           </label>
-          
+
         </li>
-        
+
         <li class="p-list__item u-clearfix">
           <label class="p-checkbox">
             <input type="checkbox" aria-labelledby="insightsdesktop" class="p-checkbox__input" name="insightsdesktop" value="true" />
             <span class="p-checkbox__label" id="insightsdesktop">Desktop</span>
           </label>
-          
+
         </li>
-        
+
         <li class="p-list__item u-clearfix">
           <label class="p-checkbox">
             <input type="checkbox" aria-labelledby="insightsiot" class="p-checkbox__input" name="insightsiot" value="true" />
             <span class="p-checkbox__label" id="insightsiot">Internet of Things</span>
           </label>
-          
+
         </li>
-        
+
         <li class="p-list__item u-clearfix">
           <label class="p-checkbox">
             <input class="p-checkbox__input" aria-labelledby="insightsrobotics" name="insightsrobotics" value="true" type="checkbox">
             <span class="p-checkbox__label" id="insightsrobotics">Robotics</span>
           </label>
         </li>
-        
+
         <li class="p-list__item u-clearfix">
           <label class="p-checkbox">
             <input class="p-checkbox__input" aria-labelledby="insightstutorials" name="insightstutorials" value="true" type="checkbox">
@@ -62,18 +62,18 @@
         </li>
         {# End of honey pots #}
       </ul>
-      
+
       <div>
         <label>
           <span class="u-no-margin--top">Work email: <span>*</span></span>
           <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"/>
         </label>
       </div>
-      
+
       <div>
         <label class="p-checkbox">
           <input class="p-checkbox__input u-no-margin--top" name="canonicalUpdatesOptIn" aria-labelledby="CanonicalUpdatesOptIn" value="yes" type="checkbox" />
-          <span class="p-checkbox__label" for="CanonicalUpdatesOptIn">
+          <span class="p-checkbox__label" id="CanonicalUpdatesOptIn">
             <small>I agree to receive information about Canonical's products and services.</small>
           </span>
         </label>
@@ -81,12 +81,12 @@
       <p>
         <small>In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/newsletter">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</small>
       </p>
-      
+
       <div>
         <span class="p-card--content">
           <button type="submit" class="u-no-margin--bottom">Subscribe now</button>
         </span>
-        
+
         <input value="1212" name="formid" type="hidden">
         <input type="hidden" name="Consent_to_Processing__c" value="yes" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="/blog#success" />

--- a/templates/certified/index.html
+++ b/templates/certified/index.html
@@ -58,7 +58,8 @@
       <form class="p-form p-form--inline" style="width: 100%;">
         <div class="p-form__group" style="flex-grow: 1;">
           <div class="p-form__control" style="width: 100%;">
-            <input type="text" name="q" id="text" value="{{ query or '' }}" placeholder="Search" aria-label="Search" autocomplete="off" required>
+            <label for="certified-hardware-search" class="u-off-screen">Search in Ubuntu certified hardware</label>
+            <input type="text" name="q" id="certified-hardware-search" value="{{ query or '' }}" placeholder="Search" autocomplete="off" required>
           </div>
         </div>
         <button type="submit" class="p-button--positive">Search</button>

--- a/templates/certified/search-results.html
+++ b/templates/certified/search-results.html
@@ -13,7 +13,8 @@
     </div>
     <div class="u-fixed-width">
       <div class="p-search-box">
-        <input class="p-search-box__input" type="text" name="q" value="{{ query or '' }}" placeholder="Search">
+        <label for="certified-hardware-search" class="u-off-screen">Search in Ubuntu certified hardware</label>
+        <input class="p-search-box__input" type="text" name="q" value="{{ query or '' }}" placeholder="Search" id="certified-hardware-search">
         <button type="submit" class="p-search-box__button"><i class="p-icon--search">Submit</i></button>
       </div>
     </div>
@@ -80,8 +81,8 @@
                   <section class="p-accordion__panel is-dense" id="tab1-section" aria-hidden="false" aria-labelledby="tab1">
                     {% for category_filter in category_filters %}
                     <label class="p-checkbox">
-                      <input type="checkbox" aria-labelledby="{{ category_filter }}" class="p-checkbox__input js-enable-apply-filters category-filter" id="category-filter-{{ loop.index }}" name="category" value="{{ category_filter }}" {% if category and category_filter in category %}checked{% endif %}>
-                      <span class="p-checkbox__label" id="{{ category_filter }}">{{ category_filter }}</span>
+                      <input type="checkbox" aria-labelledby="{{ category_filter|replace(" ", "-") }}" class="p-checkbox__input js-enable-apply-filters category-filter" id="category-filter-{{ loop.index }}" name="category" value="{{ category_filter }}" {% if category and category_filter in category %}checked{% endif %}>
+                      <span class="p-checkbox__label" id="{{ category_filter|replace(" ", "-") }}">{{ category_filter }}</span>
                     </label>
                     {% endfor %}
                   </section>
@@ -99,8 +100,8 @@
                   <section class="p-accordion__panel is-collapsed is-dense" id="tab2-section" aria-hidden="false" aria-labelledby="tab2">
                     {% for vendor_filter in vendor_filters %}
                     <label class="p-checkbox">
-                      <input type="checkbox" aria-labelledby="{{ vendor_filter }}" class="p-checkbox__input js-enable-apply-filters vendor-filter" id="vendor-filter-{{ loop.index }}" name="vendor" value="{{ vendor_filter }}" {% if vendors and vendor_filter in vendors %}checked{% endif %}>
-                      <span class="p-checkbox__label" id="{{ vendor_filter }}">{{ vendor_filter }}</span>
+                      <input type="checkbox" aria-labelledby="{{ vendor_filter|replace(" ", "-") }}" class="p-checkbox__input js-enable-apply-filters vendor-filter" id="vendor-filter-{{ loop.index }}" name="vendor" value="{{ vendor_filter }}" {% if vendors and vendor_filter in vendors %}checked{% endif %}>
+                      <span class="p-checkbox__label" id="{{ vendor_filter|replace(" ", "-") }}">{{ vendor_filter }}</span>
                     </label>
                     {% endfor %}
                   </section>
@@ -123,8 +124,8 @@
                   <section class="p-accordion__panel is-collapsed is-dense" id="tab3-section" aria-hidden="false" aria-labelledby="tab3">
                     {% for release_filter in release_filters %}
                     <label class="p-checkbox">
-                      <input type="checkbox" aria-labelledby="{{ release_filter }}" class="p-checkbox__input js-enable-apply-filters release-filter" id="release-filter-{{ loop.index }}" name="release" value="{{ release_filter }}" {% if releases and release_filter in releases%}checked{% endif %}>
-                      <span class="p-checkbox__label" id="{{ release_filter }}">{{ release_filter }}</span>
+                      <input type="checkbox" aria-labelledby="{{ release_filter|replace(" ", "-") }}" class="p-checkbox__input js-enable-apply-filters release-filter" id="release-filter-{{ loop.index }}" name="release" value="{{ release_filter }}" {% if releases and release_filter in releases%}checked{% endif %}>
+                      <span class="p-checkbox__label" id="{{ release_filter|replace(" ", "-") }}">{{ release_filter }}</span>
                     </label>
                     {% endfor %}
                   </section>

--- a/templates/certified/shared/category-search-results.html
+++ b/templates/certified/shared/category-search-results.html
@@ -5,7 +5,8 @@
     </div>
     <div class="u-fixed-width">
       <div class="p-search-box">
-        <input class="p-search-box__input" type="text" name="q" value="{{ query or '' }}" placeholder="{{ placeholder or '' }}">
+        <label for="certified-search" class="u-off-screen">{{ placeholder or "Search in certified"}}</label>
+        <input class="p-search-box__input" id="certified-search" type="text" name="q" value="{{ query or '' }}" placeholder="{{ placeholder or '' }}">
         <button type="submit" class="p-search-box__button"><i class="p-icon--search">Submit</i></button>
       </div>
     </div>
@@ -73,8 +74,8 @@
                   <section class="p-accordion__panel is-dense" id="tab1-section" aria-hidden="false" aria-labelledby="tab1">
                     {% for category_filter in category_filters %}
                     <label class="p-checkbox">
-                      <input type="checkbox" aria-labelledby="{{ category_filter }}" class="p-checkbox__input js-enable-apply-filters" name="category" value="{{ category_filter }}" {% if category and category_filter in category %}checked{% endif %}>
-                      <span class="p-checkbox__label">{{ category_filter }}</span>
+                      <input type="checkbox" aria-labelledby="{{ category_filter|replace(" ", "-") }}" class="p-checkbox__input js-enable-apply-filters" name="category" value="{{ category_filter }}" {% if category and category_filter in category %}checked{% endif %}>
+                      <span class="p-checkbox__label" id="{{ category_filter|replace(" ", "-") }}">{{ category_filter }}</span>
                     </label>
                     {% endfor %}
                   </section>
@@ -93,8 +94,8 @@
                   <section class="p-accordion__panel {% if vendor_filters | length > 5 %}is-collapsed{% endif %} is-dense" id="tab2-section" aria-hidden="false" aria-labelledby="tab2">
                     {% for vendor_filter in vendor_filters %}
                     <label class="p-checkbox">
-                      <input type="checkbox" aria-labelledby="{{ vendor_filter }}" class="p-checkbox__input js-enable-apply-filters" name="vendor" value="{{ vendor_filter }}" {% if vendors and vendor_filter in vendors %}checked{% endif %}>
-                      <span class="p-checkbox__label">{{ vendor_filter }}</span>
+                      <input type="checkbox" aria-labelledby="{{ vendor_filter|replace(" ", "-") }}" class="p-checkbox__input js-enable-apply-filters" name="vendor" value="{{ vendor_filter }}" {% if vendors and vendor_filter in vendors %}checked{% endif %}>
+                      <span class="p-checkbox__label" id="{{ vendor_filter|replace(" ", "-") }}">{{ vendor_filter }}</span>
                     </label>
                     {% endfor %}
                   </section>
@@ -120,8 +121,8 @@
                   <section class="p-accordion__panel {% if release_filters | length > 5 %}is-collapsed{% endif %} is-dense" id="tab3-section" aria-hidden="false" aria-labelledby="tab3">
                     {% for release_filter in release_filters %}
                     <label class="p-checkbox">
-                      <input type="checkbox" aria-labelledby="{{ release_filter }}" class="p-checkbox__input js-enable-apply-filters" name="release" value="{{ release_filter }}" {% if releases and release_filter in releases%}checked{% endif %}>
-                      <span class="p-checkbox__label">{{ release_filter }}</span>
+                      <input type="checkbox" aria-labelledby="{{ release_filter|replace(" ", "-") }}" class="p-checkbox__input js-enable-apply-filters" name="release" value="{{ release_filter }}" {% if releases and release_filter in releases%}checked{% endif %}>
+                      <span class="p-checkbox__label" id="{{ release_filter|replace(" ", "-") }}">{{ release_filter }}</span>
                     </label>
                     {% endfor %}
                   </section>

--- a/templates/download/iot/intel-iot.html
+++ b/templates/download/iot/intel-iot.html
@@ -1,7 +1,7 @@
 {% extends "download/iot/_base_iot.html" %}
 
 {% block title %}Download Ubuntu for Intel IoT platforms | Download{% endblock %}
-{% block meta_description %}​Canonical and Intel have partnered to provide Ubuntu Desktop and Ubuntu Core on Intel's IoT platforms: Atom&reg; X6000E Series, Intel&reg; Pentium&reg; and Celeron&reg; N and J Series and 11th Gen Intel&reg; Core&trade; processors.{% endblock meta_description %}
+{% block meta_description %}Canonical and Intel have partnered to provide Ubuntu Desktop and Ubuntu Core on Intel's IoT platforms: Atom&reg; X6000E Series, Intel&reg; Pentium&reg; and Celeron&reg; N and J Series and 11th Gen Intel&reg; Core&trade; processors.{% endblock meta_description %}
 {% block meta_image %}https://assets.ubuntu.com/v1/fc79371c-__++_++_+grad+_+en+_+800x418.jpeg{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1hxKzPs6e6JQaa9tBqfZ55GAXrVnEryEWBja8HlXy-lc/edit{% endblock meta_copydoc %}
 

--- a/templates/shared/contextual_footers/_download_iot_iotg_newsletter.html
+++ b/templates/shared/contextual_footers/_download_iot_iotg_newsletter.html
@@ -5,7 +5,7 @@
     <ul class="p-list u-clearfix">
       <li class="p-list__item">
         <label for="email">Your email:</label>
-        <input id="email" name="email" maxlength="255"S type="email"  aria-required="true" >
+        <input id="email" name="email" maxlength="255" type="email"  aria-required="true" >
       </li>
       <li class="p-list__item">
         <label class="p-checkbox">

--- a/templates/shared/contextual_footers/_download_iot_iotg_newsletter.html
+++ b/templates/shared/contextual_footers/_download_iot_iotg_newsletter.html
@@ -4,8 +4,8 @@
     <h3>Sign up to receive information about product updates</h3>
     <ul class="p-list u-clearfix">
       <li class="p-list__item">
-        <label for="Email">Your email:</label>
-        <input id="email" name="email" maxlength="255" aria-labelledby="LblEmail InstructEmail" type="email"  aria-required="true" >
+        <label for="email">Your email:</label>
+        <input id="email" name="email" maxlength="255"S type="email"  aria-required="true" >
       </li>
       <li class="p-list__item">
         <label class="p-checkbox">


### PR DESCRIPTION
## Done

- Using [this document](https://github.com/canonical/ubuntu.com/files/10695213/The.aria-controls.attribute.must.point.to.IDs.of.elements.in.the.same.document.1.ods) as reference I updated input fields to have appropriate aria-labels
- Fields highlighted green have been completed. Fields highlighted in orange, I could not identify any a11y issue related to aria-labelling. Fields in red are not tackled in this PR, these changes can be found in [this issue](https://warthogs.atlassian.net/browse/WD-1894)

## QA

- I advise installing an a11y extension to help with the process, I used [wave](https://wave.webaim.org/) for this PR. This will allow you to check if a page is breaking any a11y rules. You can expect many rules to be broken as this PR only tackles aria-labels.
- Many pages in the list overlap, such as `/blog` or `/certified` so there is no need to check all of them.
- Go to an individual page from each bubble (/blog, /certified/server, /certified/devices, etc) in the document above and check that there are no aria-label related rules being broken.
- Go to each page and activate your screen reader, using your key board navigate the page and ensure the what is being read makes sense.

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-1559
