### PR TITLE
Update engage page tempalate to hide header images on medium screens

### DIFF
--- a/templates/engage/base.html
+++ b/templates/engage/base.html
@@ -73,7 +73,7 @@
       {% endif %}
     </div>
     {% if metadata["image"] != '' %}
-    <div class="col-5 u-hide--small u-vertically-center u-align--center">
+    <div class="col-5 u-hide--small u-hide--medium u-vertically-center u-align--center">
       <img src="{{metadata['image']}}" alt="" width="{{metadata['image_width']}}"/>
     </div>
     {% endif %}


### PR DESCRIPTION
## Done

- Update engage page tempalate to hide header images on medium screens

## QA

- Go to any engage page and check images are hidden on both small and medium screens

## Issue / Card

Fixes https://github.com/canonical/ubuntu.com/issues/12406