### PR TITLE
Make select boxes with on change affects accessible

### DIFF
--- a/templates/templates/docs/shared/_docs.html
+++ b/templates/templates/docs/shared/_docs.html
@@ -165,31 +165,13 @@
   selectField.changed = false;
   selectField.onfocus = selectFocussed;
   selectField.onblur = selectUnFocussed;
-  selectField.onchange = selectChanged;
   selectField.onkeyup = selectKeyed;
-  selectField.onclick = selectClicked;
+  selectField.onclick = updatePage;
 })();
 
-function selectChanged(theElement) {
-	var selectField;
-
-	if (theElement && theElement.value) {
-		selectField = theElement;
-	}
-	else {
-		selectField = this;
-	}
-
-	if (!selectField.changed) {
-		return false;
-	}
-
-	window.location.href = selectField.value;
-}
-
-function selectClicked() {
+function updatePage(e) {
 	this.changed = true;
-  window.location.href = this.value;
+  window.location.href =  e.target.value;
 }
 
 function selectFocussed() {
@@ -199,7 +181,7 @@ function selectFocussed() {
 function selectUnFocussed() {
   if (this.value != this.initValue) {
     this.changed = true;
-		selectChanged(this);
+		window.location.href = this.value;
   }
 }
 
@@ -214,9 +196,10 @@ function selectKeyed(e) {
   } else {
     return false;
   }
+
 	if (validConfirmKeys.includes(theKeyPressed) &&  this.value != this.initValue) {
 		this.changed = true;
-		selectChanged(this);
+		window.location.href = this.value;
 	} else if (validCancleKeys.includes(theKeyPressed)) {
 		this.value = this.initValue;
 	} else {

--- a/templates/templates/docs/shared/_docs.html
+++ b/templates/templates/docs/shared/_docs.html
@@ -58,7 +58,7 @@
     <aside class="col-3">
       {% if versions | length > 1 %}
       <label for="version-select" class="u-off-screen">Version selection</label>
-      <select class="js-onchange-select" name="version-select" id="version-select">
+      <select name="version-select" id="version-select">
       {% for version in versions %}
         {% set active = docs_version == version['path'] %}
         <option value="{{ version_paths[version['path']] }}"{% if active %} selected{% endif %}>Version {{ version['version'] }}</option>
@@ -160,7 +160,7 @@
 <script>
 // Allows the 'onchange' listener to be used on a select field, while still being accessible.
 (function initSelect() {
-	var selectField = document.querySelector(".js-onchange-select");
+	var selectField = document.querySelector("#version-select");
 
   selectField.changed = false;
   selectField.onfocus = selectFocussed;

--- a/templates/templates/docs/shared/_docs.html
+++ b/templates/templates/docs/shared/_docs.html
@@ -57,8 +57,8 @@
   <div class="row">
     <aside class="col-3">
       {% if versions | length > 1 %}
-      <label for="version-select" class="u-hide">Version</label>
-      <select name="version-select" id="version-select" onChange="window.location.href=this.value">
+      <label for="version-select" class="u-off-screen">Version selection</label>
+      <select class="js-onchange-select" name="version-select" id="version-select">
       {% for version in versions %}
         {% set active = docs_version == version['path'] %}
         <option value="{{ version_paths[version['path']] }}"{% if active %} selected{% endif %}>Version {{ version['version'] }}</option>
@@ -157,4 +157,64 @@
   </div>
 </div>
 
+<script>
+// Allows the 'onchange' listener to be used on a select field, while still being accessible.
+(function initSelect() {
+	var selectField = document.querySelector(".js-onchange-select");
+
+  selectField.changed = false;
+  selectField.onfocus = selectFocussed;
+  selectField.onchange = selectChanged;
+  selectField.onkeydown = selectKeyed;
+  selectField.onclick = selectClicked;
+})();
+
+function selectChanged(theElement) {
+	var selectField;
+
+	if (theElement && theElement.value) {
+		selectField = theElement;
+	}
+	else {
+		selectField = this;
+	}
+
+	if (!selectField.changed) {
+		return false;
+	}
+
+	window.location.href = selectField.value;
+}
+
+function selectClicked() {
+	this.changed = true;
+  window.location.href = this.value;
+}
+
+function selectFocussed() {
+  this.initValue = this.value;
+}
+
+function selectKeyed(e) {
+	var theEvent;
+	var keyCodeTab = "9";
+	var keyCodeEnter = "13";
+	var keyCodeEsc = "27";
+
+	if (e) {
+    theEvent = e;
+  } else {
+    return false;
+  }
+
+	if ((theEvent.keyCode == keyCodeEnter || theEvent.keyCode == keyCodeTab) &&   this.value != this.initValue) {
+		this.changed = true;
+		selectChanged(this);
+	} else if (theEvent.keyCode == keyCodeEsc) {
+		this.value = this.initValue;
+	} else {
+		this.changed = false;
+	}
+}
+</script>
 {% endblock %}

--- a/templates/templates/docs/shared/_docs.html
+++ b/templates/templates/docs/shared/_docs.html
@@ -165,7 +165,7 @@
   selectField.changed = false;
   selectField.onfocus = selectFocussed;
   selectField.onchange = selectChanged;
-  selectField.onkeydown = selectKeyed;
+  selectField.onkeyup = selectKeyed;
   selectField.onclick = selectClicked;
 })();
 
@@ -196,21 +196,20 @@ function selectFocussed() {
 }
 
 function selectKeyed(e) {
-	var theEvent;
-	var keyCodeTab = "9";
-	var keyCodeEnter = "13";
-	var keyCodeEsc = "27";
+	var theKeyPressed;
+  var validConfirmKeys = [9, "Tab", 13, "Enter"]
+  var validCancleKeys = [27, "Escape", "esc"]
 
 	if (e) {
-    theEvent = e;
+    theKeyPressed = e.key || e.keyCode;
   } else {
     return false;
   }
 
-	if ((theEvent.keyCode == keyCodeEnter || theEvent.keyCode == keyCodeTab) &&   this.value != this.initValue) {
+	if (validConfirmKeys.includes(theKeyPressed) &&  this.value != this.initValue) {
 		this.changed = true;
 		selectChanged(this);
-	} else if (theEvent.keyCode == keyCodeEsc) {
+	} else if (validCancleKeys.includes(theKeyPressed)) {
 		this.value = this.initValue;
 	} else {
 		this.changed = false;

--- a/templates/templates/docs/shared/_docs.html
+++ b/templates/templates/docs/shared/_docs.html
@@ -166,7 +166,7 @@
   selectField.onfocus = selectFocussed;
   selectField.onblur = selectUnFocussed;
   selectField.onkeyup = selectKeyed;
-  selectField.onclick = updatePage;
+  selectField.onchange = updatePage;
 })();
 
 function updatePage(e) {

--- a/templates/templates/docs/shared/_docs.html
+++ b/templates/templates/docs/shared/_docs.html
@@ -164,6 +164,7 @@
 
   selectField.changed = false;
   selectField.onfocus = selectFocussed;
+  selectField.onblur = selectUnFocussed;
   selectField.onchange = selectChanged;
   selectField.onkeyup = selectKeyed;
   selectField.onclick = selectClicked;
@@ -195,7 +196,15 @@ function selectFocussed() {
   this.initValue = this.value;
 }
 
+function selectUnFocussed() {
+  if (this.value != this.initValue) {
+    this.changed = true;
+		selectChanged(this);
+  }
+}
+
 function selectKeyed(e) {
+  e.preventDefault();
 	var theKeyPressed;
   var validConfirmKeys = [9, "Tab", 13, "Enter"]
   var validCancleKeys = [27, "Escape", "esc"]
@@ -205,7 +214,6 @@ function selectKeyed(e) {
   } else {
     return false;
   }
-
 	if (validConfirmKeys.includes(theKeyPressed) &&  this.value != this.initValue) {
 		this.changed = true;
 		selectChanged(this);


### PR DESCRIPTION
## Done

**This script can be added to other sites documentation pages when it is merged**
- When a select input has an 'onchange' listener attached to it, browsing the options using a keyboard will trigger the listener before the user can confirm their selection. this PR implements JS to allow the onchange function to work as normally but also allow people using keyboard navigation to browse the options and use the 'enter' or 'tab' key to confirm their option.
- This addresses the accessibility issues listed in [this document](https://github.com/canonical/ubuntu.com/files/10708064/select.lists.cannot.be.operated.from.the.keyboard.if.they.have.an.onchange.handler.that.performs.navigation.because.the.handler.fires.as.the.user.moves.the.selection.up.and.down.using.the.keyboard.ods)

## QA

- Go to one of the links listed in the document above, for example https://ubuntu-com-12528.demos.haus/security/certifications/docs/fips-faq (they all use the same template, so testing a couple will surfice)
- Navigate to the version select input using your keyboard, once the select is in focus their are two way you can select an option: 
  1. click enter to expand the dropdown, use your arrow keys to navigate to your desired option and click enter or tab. You should see the page reload to the correct version.
  2. Using the arrow keys change the option (with the dropdown still closed), when you have found your desired option click enter. You should see the page reload to the correct version.
- The page should not reload unless you have confirmed a choice with enter or tab.
- Next, try selecting an option using just the mouse and ensure that works as expected.
- Finally, it is advised to go through the keyboard method with your screen reader on the ensure what is read is appropriate and logical.

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-1567
