### PR TITLE
Remove unnecessary aria-hidden label from side navigation in /tutorials

### DIFF
--- a/templates/tutorials/tutorial.html
+++ b/templates/tutorials/tutorial.html
@@ -23,7 +23,7 @@
     <button type="button" class="l-tutorial__nav-toggle p-icon--menu u-hide u-show--small" aria-controls="menu-tutorial" aria-expanded="false">
       Toggle tutorial menu
     </button>
-    <ol class="l-tutorial__nav p-stepped-list u-hide--small" id="menu-tutorial" aria-hidden="true">
+    <ol class="l-tutorial__nav p-stepped-list u-hide--small" id="menu-tutorial">
       {% for section in document.sections %}
         <li class="p-stepped-list__item l-tutorial__nav-item">
           <p class="p-stepped-list__title l-tutorial__nav-title u-no-margin--bottom">


### PR DESCRIPTION
## Done

- This PR addressed the a11y issue raised in [this document](https://github.com/canonical/ubuntu.com/files/10708620/An.element.with.aria-hidden.true.contains.focusable.content.ods) all of these cases occurred in /tutorials and were all addressed by removing an aria-hidden label from the base template.

## QA

- Go to the of the links listed in the document (one or two will suffice as the root cause was in the tutorial.html template), for example https://ubuntu-com-12529.demos.haus/tutorials/how-to-build-your-own-ami-from-ubuntu-pro-using-packer#2-getting-everything-ready and check that the side navigation is accessible with your keyboard.

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-1571
