### PR TITLE
Copy update for pro pricing

### DIFF
--- a/templates/pricing/pro.html
+++ b/templates/pricing/pro.html
@@ -195,6 +195,10 @@
             <td>10</td>
             <td class="u-align--left">Advanced Active Directory policies for Ubuntu Desktop</td>
           </tr>
+          <tr>
+            <td>11</td>
+            <td class="u-align--left">Real-time kernel</td>
+          </tr>
         </tbody>
       </table>
     </div>

--- a/templates/pro/index.html
+++ b/templates/pro/index.html
@@ -478,7 +478,7 @@ https://docs.google.com/document/d/1In4NSnckAtL51_7D_AZCHa6TPnPGXqctXo-5rE77_aY/
         <thead>
           <tr>
             <th class="u-no-padding--left" style="width: 50%;"><a
-                href="https://ubuntu.com/security/certifications">Compliance and hardening</a></th>
+                href="/security/certifications">Compliance and hardening</a></th>
             <th style="width: 15%;">Ubuntu LTS</th>
             <th style="width: 20%;">Ubuntu Pro (Infra-only)</th>
             <th class="u-no-padding--right" style="width: 15%;">Ubuntu Pro</th>
@@ -521,13 +521,20 @@ https://docs.google.com/document/d/1In4NSnckAtL51_7D_AZCHa6TPnPGXqctXo-5rE77_aY/
       <tbody>
         <tr>
           <td class="u-no-padding--left" data-heading="Other features"><a
-              href="https://ubuntu.com/security/livepatch">Kernel Livepatch</a></td>
+              href="/security/livepatch">Kernel Livepatch</a></td>
           <td data-heading="Ubuntu LTS">No</td>
           <td data-heading="Ubuntu Pro (Infra-only)">Yes</td>
           <td class="u-no-padding--right" data-heading="Ubuntu Pro">Yes</td>
         </tr>
         <tr>
-          <td class="u-no-padding--left" data-heading="Other features"><a href="https://ubuntu.com/landscape">Systems
+          <td class="u-no-padding--left" data-heading="Other features"><a
+              href="/blog/real-time-ubuntu-is-now-generally-available">Real-time kernel</a></td>
+          <td data-heading="Ubuntu LTS">No</td>
+          <td data-heading="Ubuntu Pro (Infra-only)">No</td>
+          <td class="u-no-padding--right" data-heading="Ubuntu Pro">Yes</td>
+        </tr>
+        <tr>
+          <td class="u-no-padding--left" data-heading="Other features"><a href="/landscape">Systems
               management at scale with Landscape</a></td>
           <td data-heading="Ubuntu LTS">No</td>
           <td data-heading="Ubuntu Pro (Infra-only)">Yes</td>
@@ -759,7 +766,7 @@ https://docs.google.com/document/d/1In4NSnckAtL51_7D_AZCHa6TPnPGXqctXo-5rE77_aY/
             }}
           </div>
           <div class="col-4 col-medium-3 col-small-2">
-            <p><a href="https://ubuntu.com/azure/pro">
+            <p><a href="/azure/pro">
                 Learn more about Ubuntu Pro on Azure
               </a></p>
           </div>
@@ -779,7 +786,7 @@ https://docs.google.com/document/d/1In4NSnckAtL51_7D_AZCHa6TPnPGXqctXo-5rE77_aY/
             }}
           </div>
           <div class="col-4 col-medium-3 col-small-2">
-            <p><a href="https://ubuntu.com/aws/pro">
+            <p><a href="/aws/pro">
                 Learn more about Ubuntu Pro on AWS
               </a></p>
           </div>
@@ -798,7 +805,7 @@ https://docs.google.com/document/d/1In4NSnckAtL51_7D_AZCHa6TPnPGXqctXo-5rE77_aY/
             }}
           </div>
           <div class="col-4 col-medium-3">
-            <p><a href="https://ubuntu.com/gcp/pro">
+            <p><a href="/gcp/pro">
                 Learn more about Ubuntu Pro on Google Cloud
               </a></p>
           </div>


### PR DESCRIPTION
**_This PR is going to be merged and live at 1PM UK time on 14/02/2023_** 

## Done

- Added `Real-time kernel` on `/pro` and `/pricing/pro`
![image](https://user-images.githubusercontent.com/57550290/218510477-b620b82a-3a15-4122-9aa0-d76198cd838a.png)
![image](https://user-images.githubusercontent.com/57550290/218510605-51c3dc7b-d33d-4059-b3ee-c127d56ab1ff.png)

## QA
- Go to https://ubuntu-com-12536.demos.haus/pro and https://ubuntu-com-12536.demos.haus/pricing/pro
- Compare pages against copy docs below
- [/pro](https://docs.google.com/document/d/1In4NSnckAtL51_7D_AZCHa6TPnPGXqctXo-5rE77_aY/edit)
- [/pro/pricing](https://docs.google.com/document/d/1Ynk0iLa9hjrdich6ATTsybtPbDwW_k4vRI0nk_HNhcI/edit#heading=h.h7757y94aupa)

## Issue / Card

Fixes #https://warthogs.atlassian.net/jira/software/c/projects/WD/boards/801?modal=detail&selectedIssue=WD-2008

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
