### PR TITLE
Update tables to have appropriate th elements across the site

### DIFF
--- a/templates/gov/index.html
+++ b/templates/gov/index.html
@@ -272,7 +272,7 @@
           }}
         </div>
         <div class="p-logo-section__item">
-          {{ 
+          {{
             image (
             url="https://assets.ubuntu.com/v1/67f81bfe-intel-new-logo.png",
             alt="Intel",
@@ -343,7 +343,7 @@
 <section class="p-strip">
   <div class="u-fixed-width">
     <h2 class="u-sv2" id="certification-specs">Ubuntu Advantage, Ubuntu Pro, Ubuntu Pro FIPS specs</h2>
-    <table>
+    <table role="presentation">
       <tr>
         <td><strong>FIPS 140-2 certified</strong></td>
         <td>
@@ -430,7 +430,7 @@
 <section class="p-strip u-no-padding--top">
   <div class="u-fixed-width">
     <h2>Security, accessibility and reliability</h2>
-    <table>
+    <table role="presentation">
       <tr>
         <td><strong>Security Patching</strong></td>
         <td>

--- a/templates/legal/companies.html
+++ b/templates/legal/companies.html
@@ -19,8 +19,8 @@
       <table class="p-table">
         <thead>
           <tr>
-            <td>Company</td>
-            <td>Registered address</td>
+            <th>Company</th>
+            <th>Registered address</th>
           </tr>
         </thead>
         <tbody>

--- a/templates/managed/apps/_managed-apps-logo-section.html
+++ b/templates/managed/apps/_managed-apps-logo-section.html
@@ -1,0 +1,83 @@
+<section class="p-strip is-deep u-hide--small">
+  <div class="row u-equal-height">
+    <div class="col-12">
+      <div class="p-logo-section">
+        <h2 class="p-logo-section__title u-align--center">Managed on:</h2>
+        <div class="p-logo-section__items">
+          <div class="p-logo-section__item">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/f4749569-kubernetes-logomark-logo.png",
+              alt="Kubernetes",
+              width="288",
+              height="288",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/d174f7bf-google-cloud-logo.png",
+              alt="Goggle Cloud",
+              width="288",
+              height="288",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/de681426-aws-logo.png",
+              alt="Amazon Web Services",
+              width="288",
+              height="288",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/6ef81e08-microsoft-azure-new-logo.png",
+              alt="Microsoft Azure",
+              width="288",
+              height="288",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/f0089726-openstack-logo.png",
+              alt="OpenStack",
+              width="288",
+              height="288",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/68d3206a-vmware-logo.png",
+              alt="VMware",
+              width="288",
+              height="288",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/templates/managed/apps/kafka.html
+++ b/templates/managed/apps/kafka.html
@@ -33,89 +33,7 @@
   </div>
 </section>
 
-<section class="p-strip is-deep">
-  <div class="row u-equal-height">
-    <div class="col-12">
-      <div class="p-logo-section">
-        <h2 class="p-logo-section__title u-align--center">Managed on:</h2>
-        <div class="p-logo-section__items">
-          <div class="p-logo-section__item">
-            {{
-              image(
-                url="https://assets.ubuntu.com/v1/11d594e7-K8s+logo+white+outline.svg",
-                alt="Kubernetes",
-                width="266",
-                height="259",
-                hi_def=True,
-                attrs={"class": "p-logo-section__logo"},
-              ) | safe
-            }}
-          </div>
-          <div class="p-logo-section__item">
-            {{
-              image(
-                url="https://assets.ubuntu.com/v1/6e176d9a-Google+Cloud+stacked.svg",
-                alt="Google Cloud",
-                width="150",
-                height="125",
-                hi_def=True,
-                attrs={"class": "p-logo-section__logo"},
-              ) | safe
-            }}
-          </div>
-          <div class="p-logo-section__item">
-            {{
-              image(
-                url="https://assets.ubuntu.com/v1/8e5cc412-AWS.svg",
-                alt="AWS",
-                width="107",
-                height="64",
-                hi_def=True,
-                attrs={"class": "p-logo-section__logo"},
-              ) | safe
-            }}
-          </div>
-          <div class="p-logo-section__item">
-            {{
-              image(
-                url="https://assets.ubuntu.com/v1/01cfe6d9-profile-azure.svg",
-                alt="Microsoft Azure",
-                width="125",
-                height="100",
-                hi_def=True,
-                attrs={"class": "p-logo-section__logo is-wide"},
-              ) | safe
-            }}
-          </div>
-          <div class="p-logo-section__item">
-            {{
-              image(
-                url="https://assets.ubuntu.com/v1/623e36f9-OpenStack_Logo_Mark+%281%29.svg",
-                alt="OpenStack",
-                width="60",
-                height="50",
-                hi_def=True,
-                attrs={"class": "p-logo-section__logo"},
-              ) | safe
-            }}
-          </div>
-          <div class="p-logo-section__item">
-            {{
-              image(
-                url="https://assets.ubuntu.com/v1/244981d4-vmware_logo.svg",
-                alt="VMWare",
-                width="130",
-                height="21",
-                hi_def=True,
-                attrs={"class": "p-logo-section__logo is-wide"},
-              ) | safe
-            }}
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</section>
+{% include "managed/apps/_managed-apps-logo-section.html" %}
 
 <section class="p-strip--light">
   <div class="row u-equal-height">
@@ -168,7 +86,7 @@
               width="32",
               height="32",
               hi_def=True,
-              attrs={"class": "p-heading-icon__img"},
+              attrs={"class": "p-heading-icon__img u-hide--small u-hide--medium"},
             ) | safe
           }}
           <p class="p-heading--4">Webinar</p>
@@ -195,7 +113,7 @@
           width="274",
           height="200",
           hi_def=True,
-          attrs={"style":"height: 80px; width: auto;"},
+          attrs={"style":"height: 80px; width: auto;", "class": "u-hide--small u-hide--medium"},
         ) | safe
       }}
       <h4>Secure</h4>
@@ -212,7 +130,7 @@
           width="100",
           height="100",
           hi_def=True,
-          attrs={"style":"height: 80px; width: auto;"},
+          attrs={"style":"height: 80px; width: auto;", "class": "u-hide--small u-hide--medium"},
         ) | safe
       }}
       <h4>Reliable</h4>
@@ -229,7 +147,7 @@
           width="152",
           height="100",
           hi_def=True,
-          attrs={"style":"height: 80px; width: auto;"},
+          attrs={"style":"height: 80px; width: auto;", "class": "u-hide--small u-hide--medium"},
         ) | safe
       }}
       <h4>Optimised</h4>
@@ -258,7 +176,7 @@
                 height="100",
                 hi_def=True,
                 loading="lazy",
-                attrs={"class": "p-heading-icon__img"},
+                attrs={"class": "p-heading-icon__img u-hide--small u-hide--medium"},
                 ) | safe
               }}
               <h4 class="p-heading-icon__title" style="padding-top: .5rem;">Regain focus</h4>
@@ -281,7 +199,7 @@
                 height="100",
                 hi_def=True,
                 loading="lazy",
-                attrs={"class": "p-heading-icon__img"},
+                attrs={"class": "p-heading-icon__img u-hide--small u-hide--medium"},
                 ) | safe
               }}
               <h4 class="p-heading-icon__title" style="padding-top: .5rem;">Reliable and robust</h4>
@@ -304,7 +222,7 @@
                 height="100",
                 hi_def=True,
                 loading="lazy",
-                attrs={"class": "p-heading-icon__img"},
+                attrs={"class": "p-heading-icon__img u-hide--small u-hide--medium"},
                 ) | safe
               }}
               <h4 class="p-heading-icon__title" style="padding-top: .5rem;">Predictable pricing</h4>
@@ -328,7 +246,7 @@
                 height="100",
                 hi_def=True,
                 loading="lazy",
-                attrs={"class": "p-heading-icon__img"},
+                attrs={"class": "p-heading-icon__img u-hide--small u-hide--medium"},
                 ) | safe
               }}
               <h4 class="p-heading-icon__title" style="padding-top: .5rem;">Accelerate to market</hh43>
@@ -377,7 +295,7 @@
             <a href="/engage/kafka-in-production">Watch the webinar&nbsp;&rsaquo;</a>
           </p>
         </div>
-        <div class="col-5 u-hide--small u-vertically-center u-align--center">
+        <div class="col-5 u-hide--small u-hide--medium u-vertically-center u-align--center">
           {{
             image(
             url="https://assets.ubuntu.com/v1/7cafcb2c-Managed-apps.svg",


### PR DESCRIPTION
## Done

- Using [this document](https://github.com/canonical/ubuntu.com/files/10731404/Identify.row.and.column.headers.in.data.tables.using.th.elements.and.mark.layout.tables.with.role.presentation.ods) I worked through the pages and added the appropriate `<th>` elements. A lot of the page were wordpress blogs that required editing the original wordpress document
- Some fly-by changes on some of the pages I worked on

Going forward I am still seeking a solution to more incorrectly formatted tables being added to wordpress. Unlike github there are not pipelines that can be used to ensure proper formatting. One solution would be to create a new/edit an existing guiide to include this as a step but would not be very reliable. Suggestions are very much welcome.


## QA

demo: https://ubuntu-com-12538.demos.haus/
- Go to each page on the list  (everyone page should be checked as they each required individual changes) and check that each table has the appropriate headings. ie. the heading boxes should be `<th>` tags and if the table is purely for decorative purposes should include `role="presentation"`

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-1563