### PR TITLE
Replace anbox cloud new logo

### DIFF
--- a/templates/shared/_security-patching-logo-cloud.html
+++ b/templates/shared/_security-patching-logo-cloud.html
@@ -528,10 +528,10 @@
     <span class="p-media-object__image">
       {{
         image(
-        url="https://assets.ubuntu.com/v1/ee29de9e-Anbox_favicon_64px.png",
+        url="https://assets.ubuntu.com/v1/8c0d8057-Anbox-logomark.svg",
         alt="",
-        width="40",
-        height="40",
+        width="48",
+        height="46",
         hi_def=True,
         loading="lazy",
         attrs={"class": "p-media-object__image"},


### PR DESCRIPTION
## Done

Update Anbox cloud logo on support page

## QA

- Go to https://ubuntu-com-12544.demos.haus/support check that Anbox cloud logo has been updated.

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-1247?atlOrigin=eyJpIjoiMDk4NzRiMzc0MjdjNGUwOGI4ZjQ2NjZkNTRiYmVmODQiLCJwIjoiaiJ9

## Screenshots

![Screenshot from 2023-02-15 13-46-42](https://user-images.githubusercontent.com/14939793/219044627-666f878f-a07a-4f47-902f-91feec5b14b1.png)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
