### PR TITLE
Update IoT images

### DIFF
--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -20,7 +20,7 @@
     <div class="col-5 col-start-large-8 u-hide--medium u-hide--small u-align--center">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/049b4cc6-ubuntu+core+18+circular+white.svg",
+          url="https://assets.ubuntu.com/v1/79356618-ubuntu+core+18+circular+white.svg",
           alt="",
           width="350",
           height="350",
@@ -192,20 +192,9 @@
   </div>
 </section>
 
-<section class="p-strip--light">
+<section class="p-strip">
   <div class="row u-equal-height">
-    <div class="col-5 u-align--center u-vertically-center u-hide--medium u-hide--small">
-      {{
-        image(
-          url="https://assets.ubuntu.com/v1/805f2b3a-core_black-orange_st_hex.svg",
-          alt="",
-          width="150",
-          height="200",
-          hi_def=True,
-        ) | safe
-      }}
-    </div>
-    <div class="col-6 col-start-large-7">
+    <div class="col-6" style="border-right: 1px solid #f7f7f7">
       <h2>Ubuntu Core</h2>
       <p>Ubuntu Core is a version of Ubuntu optimised for IoT-native embedded systems.</p>
       <ul class="p-list">
@@ -217,6 +206,17 @@
         <li class="p-list__item is-ticked">10 years of long term support and security updates</li>
       </ul>
       <p><a href="/core">Learn more about Ubuntu Core&nbsp;&rsaquo;</a></p>
+    </div>
+    <div class="col-5 u-align--center u-vertically-center u-hide--medium u-hide--small">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/5faf50ed-ubuntu-core-new.svg",
+          alt="",
+          width="230",
+          height="55",
+          hi_def=True,
+        ) | safe
+      }}
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

Replaced image in the banner with the new one (new circle of friends)
Replaced Ubuntu Core logo

## QA

- Check https://ubuntu-com-12545.demos.haus/internet-of-things has the updated images (reference Screenshots section)


## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-1250?atlOrigin=eyJpIjoiMThiNjE4MTdjN2YwNGY1NGExNzA2ZmJmMTMxNjk2YTEiLCJwIjoiaiJ9

## Screenshots

![Screenshot from 2023-02-15 14-02-44](https://user-images.githubusercontent.com/14939793/219048787-66320705-08e5-4060-bc36-8ad8677ba7bf.png)
![Screenshot from 2023-02-15 14-02-52](https://user-images.githubusercontent.com/14939793/219048814-aa61a5fd-809d-4c5d-b4f9-e50602b503d0.png)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
