### PR TITLE
WD-1232 update `/training` header illustration

### DIFF
--- a/templates/training/index.html
+++ b/templates/training/index.html
@@ -22,9 +22,9 @@
     <div class="col-5 u-hide--small u-hide--medium">
       {{
         image(
-        url="https://assets.ubuntu.com/v1/652d2f5f-ubuntu-openstack-k8s-medals.svg",
+        url="https://assets.ubuntu.com/v1/de99fe54-ubuntu-juju-k8s-medals.svg",
         alt="",
-        width="400",
+        width="401",
         height="237",
         hi_def=True,
         loading="auto",


### PR DESCRIPTION
## Done

- Updated the header illustration on the "/training" page

## QA

- Check https://ubuntu-com-12546.demos.haus/training has the updated header image (reference Screenshots section)

## Issue / Card

Fixes #

## Screenshots

![image](https://user-images.githubusercontent.com/48949356/219194641-fe1b3584-1464-4cbe-9978-326b6dd28bd0.png)
