### PR TITLE
Add link to Ubuntu Pro 22.04 LTS on GCP marketplace

### DIFF
--- a/templates/gcp/index.html
+++ b/templates/gcp/index.html
@@ -73,6 +73,7 @@
           <li class="p-list__item is-ticked">Integration with GCP security and compliance features</li>
           <li class="p-list__item is-ticked">10-year lifetime</li>
         </ul>
+        <p><a class="p-button--positive u-no-margin--bottom" href="https://console.cloud.google.com/marketplace/product/canonical-public/ubuntu-pro-2204-jammy">Launch Ubuntu Pro 22.04 LTS</a></p>
         <p><a href="/gcp/pro">More about Ubuntu Pro for GCP&nbsp;&rsaquo;</a></p>
       </div>
     </div>


### PR DESCRIPTION
## Done

- add link Ubuntu Pro 22.04 LTS on GCP marketplace

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/gcp
- Make sure it matches the updates from https://docs.google.com/document/d/1Gvt9tNFDZkqkBcP0k79C6ueTJCmNZvwoXQoU19WEa8E/edit

## Issue / Card

Fixes WD-1967

