### PR TITLE
Update Google cloud pro page #WD-1968

### DIFF
--- a/templates/gcp/pro.html
+++ b/templates/gcp/pro.html
@@ -11,9 +11,7 @@
       <h1>Ubuntu Pro for Google Cloud</h1>
       <p class="p-heading--3">For production. For professionals.</p>
       <p>Ubuntu Pro for GCP is a premium image delivering the most comprehensive security and GCP compliance features. Ubuntu Pro is suitable for small and large-scale Linux enterprise operations offering pay-as-you-go billing on your existing GCP invoice.</p>
-      <h3 class="p-heading--4">Ubuntu Pro 22.04 LTS
-        <span class="p-status-label--rounded">Latest</span>
-      </h3>
+      <h3 class="p-heading--4">Ubuntu Pro 22.04 LTS</h3>
       <p>Delivers additional layer of security and compliance services and security patches covering a wider range of packages, until 2032.</p>
       <p><a href="https://console.cloud.google.com/marketplace/product/canonical-public/ubuntu-pro-2204-jammy" class="p-button--positive">Launch now</a></p>
     </div>

--- a/templates/gcp/pro.html
+++ b/templates/gcp/pro.html
@@ -5,12 +5,17 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/1zR1m6CH1POU5tnzNzgNYanG2_EGQtKVNR3_dPew1pf4/edit{% endblock meta_copydoc %}
 
 {% block content %}
-<section class="p-strip--suru-topped u-no-padding--bottom">
+<section class="p-strip--suru-topped is-bordered">
   <div class="row u-equal-height">
     <div class="col-7 col-medium-4">
       <h1>Ubuntu Pro for Google Cloud</h1>
       <p class="p-heading--3">For production. For professionals.</p>
       <p>Ubuntu Pro for GCP is a premium image delivering the most comprehensive security and GCP compliance features. Ubuntu Pro is suitable for small and large-scale Linux enterprise operations offering pay-as-you-go billing on your existing GCP invoice.</p>
+      <h3 class="p-heading--4">Ubuntu Pro 22.04 LTS
+        <span class="p-status-label--rounded">Latest</span>
+      </h3>
+      <p>Delivers additional layer of security and compliance services and security patches covering a wider range of packages, until 2032.</p>
+      <p><a href="https://console.cloud.google.com/marketplace/product/canonical-public/ubuntu-pro-2204-jammy" class="p-button--positive">Launch now</a></p>
     </div>
     <div class="col-5 u-align--center u-vertically-center u-hide--medium u-hide--small">
       {{
@@ -27,7 +32,10 @@
   </div>
 </section>
 
-<section class="p-strip is-shallow u-sv3">
+<section class="p-strip u-sv3">
+  <div class="u-fixed-width">
+    <h2>Previous Releases</h2>
+  </div>
   <div class="row p-divider">
     <div class="col-4 p-divider__block">
       <h3 class="p-heading--4">Ubuntu Pro 20.04 LTS</h3>


### PR DESCRIPTION
## Done

Updated Google cloud pro pages.

## QA

- Compare https://ubuntu-com-12551.demos.haus/gcp/pro with [copy docs](https://docs.google.com/document/d/1zR1m6CH1POU5tnzNzgNYanG2_EGQtKVNR3_dPew1pf4/edit)

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-1968?atlOrigin=eyJpIjoiNjI5ZjU5YzI3OGY2NDRiY2I0OTQzMmEwYmMwZGIwZGEiLCJwIjoiaiJ9


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
