### PR TITLE
Add page for Apache Spark solution offer

### DIFF
--- a/templates/data/kafka/index.html
+++ b/templates/data/kafka/index.html
@@ -78,7 +78,6 @@
       <p>Canonical offers a compliant, scalable and comprehensive full stack solution for Apache Kafka, including:</p>
       <ul>
         <li>Complete support for upstream Apache Kafka</li>
-        <li>Rich feature set including Kafka, Kafka Connect and Karapace schema registry</li>
         <li>Fully automated Kafka deployment and operations founded on enterprise-proven Ubuntu LTS</li>
         <li>Expert deployment and integration services available when you need them</li>
         <li>Full managed service options on-premise or in your cloud for peace of mind</li>

--- a/templates/data/kafka/index.html
+++ b/templates/data/kafka/index.html
@@ -4,7 +4,7 @@
 
 {% block meta_description %}Streamline your Apache Kafka® operations with Canonical. 24/7 supported, full stack solution – in the data centre and on the cloud.{% endblock meta_description %}
 
-{% block meta_copydoc %}https://docs.google.com/document/d/1n6T7kbXECxd_bx2u8M5-bulLrCdySvDo2WcsEYmVRkE/edit{% endblock meta_copydoc %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1bfo97XdFdKlzrMcMoRxiTdzt_bPVndx6j55IPsapuAE/edit{% endblock meta_copydoc %}
 
 {% block content %}
 
@@ -12,8 +12,8 @@
   <div class="row u-vertically-center">
     <div class="col-7">
       <h1>Canonical Charmed Data Platform</h1>
-      <h2>Apache Kafka®</h2>
-      <p>Streamline your Apache Kafka® operations with Canonical. 24/7 supported in the data centre and on the cloud.</p>
+      <h2>Apache Kafka<sup>&reg;</sup></h2>
+      <p>Streamline your Apache Kafka<sup>&reg;</sup> operations with Canonical. 24/7 supported in the data centre and on the cloud.</p>
       <p>
         <a href="/data/kafka#get-in-touch" class="p-button--positive js-invoke-modal" data-testid="interactive-form-link">Get in touch</a>
       </p>
@@ -39,7 +39,7 @@
       </h2>
       <ul>
         <li>The full stack system for streaming data processing</li>
-        <li>Accelerate deployment and operation of your Apache Kafka® clusters</li>
+	<li>Accelerate deployment and operation of your Apache Kafka<sup>&reg;</sup> clusters</li>
         <li>Part of the Canonical Charmed Data Platform ecosystem</li>
       </ul>
     </div>
@@ -74,7 +74,7 @@
 <section class="p-strip">
   <div class="row">
     <div class="col-7">
-      <h2>Scale your Apache Kafka® deployments today</h2>
+      <h2>Scale your Apache Kafka<sup>&reg;</sup> deployments today</h2>
       <p>Canonical offers a compliant, scalable and comprehensive full stack solution for Apache Kafka, including:</p>
       <ul>
         <li>Complete support for upstream Apache Kafka</li>
@@ -102,8 +102,8 @@
   <div class="row">
     <div class="col-7">
       <h2>Managed Apps</h2>
-      <h3>Jumpstart Apache Kafka®</h3>
-      <p>Canonical can offer managed services with a guaranteed SLA for Apache Kafka® and a range of open source data intensive applications.</p>
+      <h3>Jumpstart Apache Kafka<sup>&reg;</sup></h3>
+      <p>Canonical can offer managed services with a guaranteed SLA for Apache Kafka<sup>&reg;</sup> and a range of open source data intensive applications.</p>
       <p><a href="/managed/apps" class="p-button">Find out more</a></p>
     </div>
   </div>
@@ -114,7 +114,7 @@
 <section class="p-strip--light">
   <div class="row">
     <div class="col-7">
-      <p>Apache®, Apache Kafka, Kafka®, and the Kafka logo are either registered trademarks or trademarks of the Apache Software Foundation in the United States and/or other countries.</p>
+      <p>Apache<sup>&reg;</sup>, Apache Kafka, Kafka<sup>&reg;</sup>, and the Kafka logo are either registered trademarks or trademarks of the Apache Software Foundation in the United States and/or other countries.</p>
     </div>
   </div>
 </section>

--- a/templates/data/spark/index.html
+++ b/templates/data/spark/index.html
@@ -11,9 +11,9 @@
 <section class="p-strip--suru-bottomed">
   <div class="row u-vertically-center">
     <div class="col-7">
-      <h1>Accelerate AI/ML innovation anywhere with Apache Spark®</h1>
-      <h2>Everything you need to run Spark®</h2>
-      <p>Get 24/7 cover wherever you run your operations - run behind the firewall in your own data centre, or on the cloud – with a fully integrated, supported solution for Apache Spark® from Canonical.</p>
+      <h1>Accelerate AI/ML innovation anywhere with Apache Spark<sup>&reg;</sup></h1>
+      <h4 class="p-heading--4">Everything you need to run Spark<sup>&reg;</sup></h4>
+      <p>Get 24/7 cover wherever you run your operations - run behind the firewall in your own data centre, or on the cloud – with a fully integrated, supported solution for Apache Spark<sup>&reg;</sup> from Canonical.</p>
       <p>The one-stop solution for data engineering at scale.</p>
       <p>
         <a href="/data/spark#get-in-touch" class="p-button--positive js-invoke-modal" data-testid="interactive-form-link">Contact us to learn more</a>
@@ -36,10 +36,10 @@
   <div class="row">
     <div class="col-8">
       <h2 class="u-sv3">
-        Canonical’s complete, integrated and fully supported open source solution for data engineering and machine learning at scale.
+        Canonical's complete, integrated and fully supported open source solution for data engineering and machine learning at scale.
       </h2>
       <ul>
-        <li>A complete, integrated, full-stack solution for Apache Spark®</li>
+        <li>A complete, integrated, full-stack solution for Apache Spark<sup>&reg;</sup></li>
         <li>Accelerate the time to value of your innovation projects</li>
         <li>Founded on Kubernetes and Ubuntu</li>
       </ul>
@@ -55,17 +55,17 @@
   </div>
   <div class="row">
     <div class="col-4">
-      <h3>No friction</h3>
+      <h4 class="p-heading--4">No friction</h4>
       <p>Get started fast &mdash; the open source solution is free to use in any environment, in the data centre and in the cloud.</p>
       <p><a href="https://snapcraft.io/spark-client" class="p-button">Try our Spark solution now</a></p>
     </div>
     <div class="col-4">
-      <h3>Expressway operations</h3>
-      <p>Rapidly deploy your Apache Spark® applications with the integrated, full stack solution from Canonical.</p>
+      <h4 class="p-heading--4">Expressway operations</h4>
+      <p>Rapidly deploy your Apache Spark<sup>&reg;</sup> applications with the integrated, full stack solution from Canonical.</p>
       <p><a href="https://juju.is/" class="p-button">Learn more about our solutions</a></p>
     </div>
     <div class="col-4">
-      <h3>Fully supported</h3>
+      <h4 class="p-heading--4">Fully supported</h4>
       <p>24/7 support and professional services are available to ensure your initiatives are always on track.</p>
       <p><a href="/data/spark#get-in-touch" class="p-button">Contact sales</a></p>
     </div>
@@ -75,10 +75,10 @@
 <section class="p-strip">
   <div class="row">
     <div class="col-7">
-      <h2>The best choice for Apache Spark®, anywhere</h2>
+      <h2>The best choice for Apache Spark<sup>&reg;</sup>, anywhere</h2>
       <p>Canonical’s scalable and comprehensive full stack system for Apache Spark covers:</p>
       <ul>
-        <li>Security fixes and support for upstream Apache Spark.</li>
+        <li>Security fixes and support for upstream Apache Spark<sup>&reg;</sup>.</li>
         <li>Integrated, 24/7 supported solution founded on enterprise-proven Ubuntu Server LTS and Charmed Kubernetes.</li>
         <li>Expert consulting services available when you need them.</li>
       </ul>
@@ -118,7 +118,7 @@
 <section class="p-strip--light">
   <div class="row">
     <div class="col-7">
-      <p>Apache®, Apache Spark, Spark®, and the Spark logo are either registered trademarks or trademarks of the Apache Software Foundation in the United States and/or other countries.</p>
+      <p>Apache<sup>&reg;</sup>, Apache Spark, Spark<sup>&reg;</sup>, and the Spark logo are either registered trademarks or trademarks of the Apache Software Foundation in the United States and/or other countries.</p>
     </div>
   </div>
 </section>

--- a/templates/data/spark/index.html
+++ b/templates/data/spark/index.html
@@ -1,0 +1,129 @@
+{% extends "data/base_data.html" %}
+
+{% block title %}Canonical Charmed Data Platform{% endblock %}
+
+{% block meta_description %}Accelerate innovation with the full-stack solution for Apache Spark® from Canonical. 24/7 supported Spark – in the data centre and on the cloud.{% endblock meta_description %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1sM8pgyM-N8VK8fyHgMsW21PdXUiqYrdRkPkipIljNd0/edit{% endblock meta_copydoc %}
+
+{% block content %}
+
+<section class="p-strip--suru-bottomed">
+  <div class="row u-vertically-center">
+    <div class="col-7">
+      <h1>Accelerate AI/ML innovation anywhere with Apache Spark®</h1>
+      <h2>Everything you need to run Spark®</h2>
+      <p>Get 24/7 cover wherever you run your operations - run behind the firewall in your own data centre, or on the cloud – with a fully integrated, supported solution for Apache Spark® from Canonical.</p>
+      <p>The one-stop solution for data engineering at scale.</p>
+      <p>
+        <a href="/data/spark#get-in-touch" class="p-button--positive js-invoke-modal" data-testid="interactive-form-link">Contact us to learn more</a>
+      </p>
+    </div>
+    <div class="col-5 u-hide--medium u-hide--small u-align--center u-vertically-center">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/5ecd8306-Apache_Spark_logo.svg",
+        alt="",
+        width="500",
+        height="260",
+        hi_def=True,
+        loading="auto"
+        ) | safe
+      }}
+    </div>
+  </div>
+</section>
+<section class="p-strip is-deep">
+  <div class="row">
+    <div class="col-8">
+      <h2 class="u-sv3">
+        Canonical’s complete, integrated and fully supported open source solution for data engineering and machine learning at scale.
+      </h2>
+      <ul>
+        <li>A complete, integrated, full-stack solution for Apache Spark®</li>
+        <li>Accelerate the time to value of your innovation projects</li>
+        <li>Founded on Kubernetes and Ubuntu</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="u-fixed-width">
+    <h2 class="u-sv3">
+      Accelerate your innovation projects at any scale
+    </h2>
+  </div>
+  <div class="row">
+    <div class="col-4">
+      <h3>No friction</h3>
+      <p>Get started fast &mdash; the open source solution is free to use in any environment, in the data centre and in the cloud.</p>
+      <p><a href="https://snapcraft.io/spark-client" class="p-button">Try our Spark solution now</a></p>
+    </div>
+    <div class="col-4">
+      <h3>Expressway operations</h3>
+      <p>Rapidly deploy your Apache Spark® applications with the integrated, full stack solution from Canonical.</p>
+      <p><a href="https://juju.is/" class="p-button">Learn more about our solutions</a></p>
+    </div>
+    <div class="col-4">
+      <h3>Fully supported</h3>
+      <p>24/7 support and professional services are available to ensure your initiatives are always on track.</p>
+      <p><a href="/data/spark#get-in-touch" class="p-button">Contact sales</a></p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="row">
+    <div class="col-7">
+      <h2>The best choice for Apache Spark®, anywhere</h2>
+      <p>Canonical’s scalable and comprehensive full stack system for Apache Spark covers:</p>
+      <ul>
+        <li>Security fixes and support for upstream Apache Spark.</li>
+        <li>Integrated, 24/7 supported solution founded on enterprise-proven Ubuntu Server LTS and Charmed Kubernetes.</li>
+        <li>Expert consulting services available when you need them.</li>
+      </ul>
+      <p><a href="/data/spark#get-in-touch" class="p-button--positive js-invoke-modal">Contact Sales</a></p>
+    </div>
+    <div class="col-5 u-hide--medium u-hide--small u-align--center u-vertically-center">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/e8568793-contact+us.svg",
+        alt="",
+        width="144",
+        height="150",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-7">
+      <h2>Expert services</h2>
+      <p>A production-grade, fully supported Spark environment deployed and operational, no fuss.</p>
+      <ul>
+        <li>Integrated solution on Charmed Kubernetes, Azure, and AWS.</li>
+	<li>A cost-effective strategy to jumpstart your data engineering projects.</li>
+	<li>Covers solution architecure design, solution deployment and integration into your IT landscape.</li>
+      </ul>
+      <p><a href="/data/spark#get-in-touch" class="p-button">Learn more about our services</a></p>
+    </div>
+  </div>
+</section>
+
+{% with first_item="_server_download", second_item="_server_contact_us", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
+
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-7">
+      <p>Apache®, Apache Spark, Spark®, and the Spark logo are either registered trademarks or trademarks of the Apache Software Foundation in the United States and/or other countries.</p>
+    </div>
+  </div>
+</section>
+
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/spark.html" data-form-id="4908" data-lp-id="3828" data-return-url="https://ubuntu.com/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+</div>
+
+{% endblock content %}

--- a/templates/data/spark/index.html
+++ b/templates/data/spark/index.html
@@ -12,7 +12,7 @@
   <div class="row u-vertically-center">
     <div class="col-7">
       <h1>Accelerate AI/ML innovation anywhere with Apache Spark<sup>&reg;</sup></h1>
-      <h4 class="p-heading--4">Everything you need to run Spark<sup>&reg;</sup></h4>
+      <h2 class="p-heading--4">Everything you need to run Spark<sup>&reg;</sup></h2>
       <p>Get 24/7 cover wherever you run your operations - run behind the firewall in your own data centre, or on the cloud – with a fully integrated, supported solution for Apache Spark<sup>&reg;</sup> from Canonical.</p>
       <p>The one-stop solution for data engineering at scale.</p>
       <p>
@@ -55,7 +55,7 @@
   </div>
   <div class="row">
     <div class="col-4">
-      <h4 class="p-heading--4">No friction</h4>
+      <h2 class="p-heading--4">No friction</h2>
       <p>Get started fast &mdash; the open source solution is free to use in any environment, in the data centre and in the cloud.</p>
       <p><a href="https://snapcraft.io/spark-client" class="p-button">Try our Spark solution now</a></p>
     </div>
@@ -76,7 +76,7 @@
   <div class="row">
     <div class="col-7">
       <h2>The best choice for Apache Spark<sup>&reg;</sup>, anywhere</h2>
-      <p>Canonical’s scalable and comprehensive full stack system for Apache Spark covers:</p>
+      <p>Canonical's scalable and comprehensive full stack system for Apache Spark covers:</p>
       <ul>
         <li>Security fixes and support for upstream Apache Spark<sup>&reg;</sup>.</li>
         <li>Integrated, 24/7 supported solution founded on enterprise-proven Ubuntu Server LTS and Charmed Kubernetes.</li>
@@ -105,8 +105,8 @@
       <p>A production-grade, fully supported Spark environment deployed and operational, no fuss.</p>
       <ul>
         <li>Integrated solution on Charmed Kubernetes, Azure, and AWS.</li>
-	<li>A cost-effective strategy to jumpstart your data engineering projects.</li>
-	<li>Covers solution architecure design, solution deployment and integration into your IT landscape.</li>
+        <li>A cost-effective strategy to jumpstart your data engineering projects.</li>
+        <li>Covers solution architecure design, solution deployment and integration into your IT landscape.</li>
       </ul>
       <p><a href="/data/spark#get-in-touch" class="p-button">Learn more about our services</a></p>
     </div>

--- a/templates/data/spark/index.html
+++ b/templates/data/spark/index.html
@@ -75,7 +75,7 @@
 <section class="p-strip">
   <div class="row">
     <div class="col-7">
-      <h2>The best choice for Apache Spark<sup>&reg;</sup>, anywhere</h2>
+      <h2>The best choice for Apache Spark<sup>&reg;</sup> anywhere</h2>
       <p>Canonical's scalable and comprehensive full stack system for Apache Spark covers:</p>
       <ul>
         <li>Security fixes and support for upstream Apache Spark<sup>&reg;</sup>.</li>

--- a/templates/data/spark/index.html
+++ b/templates/data/spark/index.html
@@ -60,12 +60,12 @@
       <p><a href="https://snapcraft.io/spark-client" class="p-button">Try our Spark solution now</a></p>
     </div>
     <div class="col-4">
-      <h4 class="p-heading--4">Expressway operations</h4>
+      <h2 class="p-heading--4">Expressway operations</h2>
       <p>Rapidly deploy your Apache Spark<sup>&reg;</sup> applications with the integrated, full stack solution from Canonical.</p>
       <p><a href="https://juju.is/" class="p-button">Learn more about our solutions</a></p>
     </div>
     <div class="col-4">
-      <h4 class="p-heading--4">Fully supported</h4>
+      <h2 class="p-heading--4">Fully supported</h2>
       <p>24/7 support and professional services are available to ensure your initiatives are always on track.</p>
       <p><a href="/data/spark#get-in-touch" class="p-button">Contact sales</a></p>
     </div>

--- a/templates/shared/forms/interactive/spark.html
+++ b/templates/shared/forms/interactive/spark.html
@@ -1,0 +1,106 @@
+<div class="p-modal" id="contact-modal">
+  <div class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
+    <header class="p-modal__header" style="display: block; border-bottom: 0;">
+      <button class="p-modal__close" aria-label="Close active modal" style="margin-left: -1rem">Close</button>
+      <h2 class="p-modal__title u-sv1" id="modal-title">Talk to our Apache Spark solution architects</h2>
+    </header>
+    <div class="js-pagination js-pagination--1">
+      <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form p-form p-form--stacked">
+        <div class="u-sv2">
+          <h3 class="p-heading--5">Tell us more about your Spark use case</h3>
+          <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" aria-label="Anything you'd like to communicate about your needs or interests?" rows="3" placeholder="Anything you'd like to communicate about your needs or interests?"></textarea>
+        </div>
+        <div class="row u-no-padding">
+          <div class="col-6">
+            <h3 class="p-heading--5">How should we get in touch?</h3>
+            <ul class="p-list">
+              <li class="p-list__item">
+                <label for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
+              </li>
+              <li class="p-list__item">
+                <label for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
+              </li>
+              <li class="p-list__item">
+                <label for="company">Company name:</label>
+                <input required id="company" name="company" maxlength="255" type="text">
+              </li>
+              <li class="p-list__item">
+                <label for="title">Job title:</label>
+                <input data-testid="form-jobTitle" required id="title" name="title" maxlength="255" type="text">
+              </li>
+              <li class="p-list__item">
+                <label for="email">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
+              </li>
+              <li class="p-list__item">
+                <label for="phone">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
+              </li>
+              <li class="p-list__item">
+                <label class="p-checkbox">
+                  <input class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
+                  <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
+                </label>
+              </li>
+              <li class="p-list__item">In submitting this form, I confirm that I have read and agree to Canonical's <a href="/legal/terms-and-policies/privacy-policy">Privacy Policy</a>.</li>
+              {# These are honey pot fields to catch bots #}
+              <li class="u-off-screen">
+                <label class="website" for="website">Website:</label>
+                <input name="website" type="text" class="website" autocomplete="off" value="" id="website" tabindex="-1" />
+              </li>
+              <li class="u-off-screen">
+                <label class="name" for="name">Name:</label>
+                <input name="name" type="text" class="name" autocomplete="off" value="" id="name" tabindex="-1" />
+              </li>
+              {# End of honey pots #}
+            </ul>
+            
+            <div class="u-hide">
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Facebook_Click_ID__c" id="Facebook_Click_ID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
+            </div>
+            
+            <div class="pagination">
+              <button type="submit" class="pagination__link--next p-button--positive" aria-label="Submit">Let's discuss</button>
+            </div>
+          </div>
+        </div>
+      </form>
+    </div>
+    
+    <div class="js-pagination js-pagination--2 u-hide">
+      <div class="row u-no-padding">
+        <div class="u-equal-height">
+          <div class="col-7">
+            <h3 class="p-heading--2">Thank you for enquiring about our solution for Apache Spark</h3>
+            <p class="p-heading--4">A member of our team will be in touch within one working day.</p>
+          </div>
+          <div class="col-5 u-vertically-center u-hide--medium u-hide--small u-align--center">
+            {{
+              image(
+              url="https://assets.ubuntu.com/v1/cbae9a60-thank_you_orange_cmyk.svg",
+              alt="smile",
+              width="200",
+              height="200",
+              hi_def=True,
+              loading="auto",
+              ) | safe
+            }}
+          </div>
+        </div>
+      </div>
+      <a class="js-close p-button" href="">Close</a>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Done

- driveby: Correction to scope of Apache Kafka offer
- feature: New page for Apache Spark offer
- feature: Contact form for Apache Spark offer
- feature: integration contact form / page / marketo
- note: adjusted copydoc to change one of the images which was using the old logo. Substituted the image in the page and the copydoc. 

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: https://ubuntu-com-12552.demos.haus/data/spark 
    - Be sure to test on mobile, tablet and desktop screen sizes

## Issue / Card

https://warthogs.atlassian.net/browse/DATAPM-713, https://warthogs.atlassian.net/browse/WD-2075, https://warthogs.atlassian.net/browse/WD-2074

## Screenshots

Sorry no screenshot, but you can run `./run` and navigate to `/data/spark` to review

