### PR TITLE
WD-1233 update illustrations in  `/telco/vnf`

### DIFF
--- a/templates/telco/vnf.html
+++ b/templates/telco/vnf.html
@@ -27,10 +27,10 @@
       </div>
       <div class="col-5 u-hide--medium u-hide--small u-align--center">
         {{ image (
-          url="https://assets.ubuntu.com/v1/669390e0-openstack-cloud.svg",
+          url="https://assets.ubuntu.com/v1/0231333e-charmed-openstack-cloud.svg",
           alt="",
           width="263",
-          height="150",
+          height="151",
           hi_def=True,
           loading="auto"
           ) | safe

--- a/templates/telco/vnf.html
+++ b/templates/telco/vnf.html
@@ -148,7 +148,7 @@
     </div>
     <div class="col-6 u-align--center u-hide--small u-hide--medium u-vertically-center">
       {{ image (
-        url="https://assets.ubuntu.com/v1/03019c46-Openstack-extendable-containers-layers.svg",
+        url="https://assets.ubuntu.com/v1/9c58d3a7-Openstack-extendable-containers-layers.svg",
         alt="",
         width="389",
         height="330",


### PR DESCRIPTION
## Done

On the "/telco/vnf" page
- Updated the header illustration 
- Updated the illustration in the "Extendable Containers Layer" section

## QA

- Check https://ubuntu-com-12553.demos.haus/telco/vnf has the updated header image (reference linked issue and screenshots)

## Issue / Card

- [WD-1233](https://warthogs.atlassian.net/browse/WD-1233)

## Screenshots
The new header illustration
![image](https://user-images.githubusercontent.com/48949356/219597043-77051128-c6cd-4635-8824-99740c6890bc.png)

The illustration in the "Extendable Containers Layer" section
![image](https://user-images.githubusercontent.com/48949356/219597273-80fc3158-27aa-4203-a33c-9502f221490c.png)


[WD-1233]: https://warthogs.atlassian.net/browse/WD-1233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ