### PR TITLE
WD-1242 & WD-1243 Update Ceph logo (`/ceph/managed`) and Ubuntu advantage feature illustration (`/ceph/consulting`)

### DIFF
--- a/templates/ceph/consulting.html
+++ b/templates/ceph/consulting.html
@@ -38,10 +38,10 @@
 		</div>
 		<div class="col-5 u-align--center u-vertically-center u-hide--medium u-hide--small">
       {{ image (
-        url="https://assets.ubuntu.com/v1/83e7ce7c-ubuntu-pro-circular.png",
+        url="https://assets.ubuntu.com/v1/c7cc4e28-ubuntu-advantage-circular.svg",
         alt="",
-        width="250",
-        height="270",
+        width="278",
+        height="300",
         hi_def=True,
         loading="lazy"
         ) | safe

--- a/templates/ceph/managed.html
+++ b/templates/ceph/managed.html
@@ -28,10 +28,10 @@
     </div>
     <div class="col-5 u-hide--medium u-hide--small u-align--center">
 			{{ image (
-				url="https://assets.ubuntu.com/v1/e0461e14-ceph-dark.svg",
+				url="https://assets.ubuntu.com/v1/4fb05534-canonical-ceph-dark.svg",
 				alt="Ceph",
-				width="270",
-				height="110",
+				width="318",
+				height="65",
 				hi_def=True,
 				loading="auto"
 				) | safe


### PR DESCRIPTION
## Done

- Updated the Ceph logo in the header on the "/ceph/managed" page
- Updated the Ubuntu Advantage feature circle illustration in the "Ceph implementation challenges" section on the "/ceph/consulting" page

## QA

- Check https://ubuntu-com-12547.demos.haus/training has the updated header image (reference linked issue and screenshot)

## Issue / Card

- [WD-1232](https://warthogs.atlassian.net/browse/WD-1232)

## Screenshots

![image](https://user-images.githubusercontent.com/48949356/219194641-fe1b3584-1464-4cbe-9978-326b6dd28bd0.png)


[WD-1232]: https://warthogs.atlassian.net/browse/WD-1232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ