### PR TITLE
Add id "free" to header in /pro page for anchor link

### DIFF
--- a/templates/pro/index.html
+++ b/templates/pro/index.html
@@ -568,7 +568,7 @@ https://docs.google.com/document/d/1In4NSnckAtL51_7D_AZCHa6TPnPGXqctXo-5rE77_aY/
   <hr class="is-fixed-width u-no-margin--bottom">
   <div class="row p-strip is-shallow u-no-padding--top">
     <div class="col-6 col-medium-3">
-      <h3 class="p-heading--2">Free for personal use</h3>
+      <h3 id="free" class="p-heading--2">Free for personal use</h3>
     </div>
     <div class="col-6 col-medium-3">
       <p>Anyone can use Ubuntu Pro for free on up to 5 machines, or 50 if you are <a


### PR DESCRIPTION
## Done

Added an "id" attribute with the value of "free" to the header element **Free for personal use** in the `/pro` page. This allows users to visit the page directly to the section with the id "free" by appending "#free" to the URL.
* Previously users had to visit https://ubuntu.com/pro and search for the text free with your web browser's search tool
* Now users can directly visit https://ubuntu.com/pro#free

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #12516 

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
