### PR TITLE
WD-1269 update managed apps logos

### DIFF
--- a/templates/managed/apps/index.html
+++ b/templates/managed/apps/index.html
@@ -251,15 +251,15 @@ coverage.{% endblock meta_description %}
 <section class="p-strip">
   <div class="u-fixed-width">
     <div class="p-logo-section">
-      <h2 class="p-logo-section__title u-align--center">Run your apps anywhere</h2>
+      <h2 class="p-logo-section__title u-align--left">Run your apps anywhere</h2>
       <div class="p-logo-section__items">
         <div class="p-logo-section__item">
           {{
             image(
-            url="https://assets.ubuntu.com/v1/42299ebc-google-cloud.png",
+            url="https://assets.ubuntu.com/v1/5d01375a-google-cloud-logo.png",
             alt="Google Cloud Platform",
-            width="68",
-            height="50",
+            width="316",
+            height="316",
             hi_def=True,
             loading="lazy",
             attrs={"class": "p-logo-section__logo"},
@@ -269,10 +269,36 @@ coverage.{% endblock meta_description %}
         <div class="p-logo-section__item">
           {{
             image(
-            url="https://assets.ubuntu.com/v1/dba11aee-kubernetes.svg",
+            url="https://assets.ubuntu.com/v1/1a2ca878-kubernetes-logomark-logo.png",
             alt="Kubernetes",
-            width="62",
-            height="60",
+            width="316",
+            height="316",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"},
+            ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{
+            image (
+            url="https://assets.ubuntu.com/v1/bdadf238-oracle-cloud.png",
+            alt="Oracle cloud",
+            width="316",
+            height="316",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"},
+            ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{
+            image (
+            url="https://assets.ubuntu.com/v1/c7b9a434-microsoft-azure-logomark-new.png",
+            alt="",
+            width="316",
+            height="316",
             hi_def=True,
             loading="lazy",
             attrs={"class": "p-logo-section__logo"},
@@ -282,49 +308,49 @@ coverage.{% endblock meta_description %}
         <div class="p-logo-section__item">
           {{
             image(
-            url="https://assets.ubuntu.com/v1/a82add58-profile-aws.svg",
+            url="https://assets.ubuntu.com/v1/87b04c6a-vmware-logo.png",
+            alt="VMWARE",
+            width="316",
+            height="316",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
+            ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{
+            image(
+            url="https://assets.ubuntu.com/v1/6d16204d-openstack-logomark-logo.png",
+            alt="Openstack",
+            width="316",
+            height="316",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-logo-section__logo"}
+            ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{
+            image (
+            url="https://assets.ubuntu.com/v1/505ecea2-maas-logo-stacked.png",
+            alt="MAAS",
+            width="316",
+            height="316",
+            hi_def=True,
+            loading="auto",
+            attrs={"class": "p-logo-section__logo"}
+            ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{
+            image(
+            url="https://assets.ubuntu.com/v1/0070b81e-aws-logo.png",
             alt="AWS",
-            width="85",
-            height="50",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-logo-section__logo"},
-            ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{
-            image(
-            url="https://assets.ubuntu.com/v1/01cfe6d9-profile-azure.svg",
-            alt="Azure",
-            width="65",
-            height="50",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-logo-section__logo"},
-            ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{
-            image(
-            url="https://assets.ubuntu.com/v1/623e36f9-OpenStack_Logo_Mark+%281%29.svg",
-            alt="OpenStack",
-            width="60",
-            height="50",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-logo-section__logo", "style": "max-height:90px;"},
-            ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{
-            image(
-            url="https://assets.ubuntu.com/v1/d584bd83-logo-vmware.svg",
-            alt="VMware",
-            width="144",
-            height="22",
+            width="316",
+            height="316",
             hi_def=True,
             loading="lazy",
             attrs={"class": "p-logo-section__logo"},


### PR DESCRIPTION
## Done

Update /managed/apps logos

## QA

- Check https://ubuntu-com-12561.demos.haus/managed/apps has the new [updated logos and layout](https://warthogs.atlassian.net/browse/WD-1237?atlOrigin=eyJpIjoiNTZlOWE3YjZiOTY4NGRhODgyNWE1YWJkZTg5MWExOTAiLCJwIjoiaiJ9)

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-1237?atlOrigin=eyJpIjoiNTZlOWE3YjZiOTY4NGRhODgyNWE1YWJkZTg5MWExOTAiLCJwIjoiaiJ9

## Screenshots

![Screenshot from 2023-02-17 17-57-32](https://user-images.githubusercontent.com/14939793/219740311-0b432815-d28c-497c-a6a6-ca8caa249f88.png)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
