### PR TITLE
WD-1231 Update observability managed logos

### DIFF
--- a/templates/observability/managed.html
+++ b/templates/observability/managed.html
@@ -394,8 +394,10 @@
 
 <section class="p-strip">
   <div class="row">
-    <div class="col-8">
+    <div class="col-5">
       <h3 class="p-heading--2">Multi-cloud ready</h3>
+    </div>
+    <div class="col-7">
       <p>We manage your monitoring tools anywhere for you. Whether you are running your workloads across multiple clouds or might need to leverage a multi-cloud environment in the future, we can easily scale our managed service to adapt to your IT strategy.</p>
     </div>
     <div class="u-fixed-width">
@@ -403,11 +405,76 @@
         <div class="p-logo-section__items">
           <div class="p-logo-section__item">
             {{
+              image(
+              url="https://assets.ubuntu.com/v1/5d01375a-google-cloud-logo.png",
+              alt="Google Cloud Platform",
+              width="316",
+              height="316",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-logo-section__logo"},
+              ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{
+              image(
+              url="https://assets.ubuntu.com/v1/1a2ca878-kubernetes-logomark-logo.png",
+              alt="Kubernetes",
+              width="316",
+              height="316",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-logo-section__logo"},
+              ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{
               image (
-              url="https://assets.ubuntu.com/v1/901d5a91-Google+Cloud.png",
+              url="https://assets.ubuntu.com/v1/bdadf238-oracle-cloud.png",
+              alt="Oracle cloud",
+              width="316",
+              height="316",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-logo-section__logo"},
+              ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{
+              image (
+              url="https://assets.ubuntu.com/v1/c7b9a434-microsoft-azure-logomark-new.png",
               alt="",
-              width="292",
-              height="290",
+              width="316",
+              height="316",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-logo-section__logo"},
+              ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{
+              image(
+              url="https://assets.ubuntu.com/v1/87b04c6a-vmware-logo.png",
+              alt="VMWARE",
+              width="316",
+              height="316",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{
+              image(
+              url="https://assets.ubuntu.com/v1/6d16204d-openstack-logomark-logo.png",
+              alt="Openstack",
+              width="316",
+              height="316",
               hi_def=True,
               loading="lazy",
               attrs={"class": "p-logo-section__logo"}
@@ -417,90 +484,26 @@
           <div class="p-logo-section__item">
             {{
               image (
-              url="https://assets.ubuntu.com/v1/43d45da9-Anbox-logo-aws.png",
-              alt="",
-              width="310",
-              height="310",
+              url="https://assets.ubuntu.com/v1/505ecea2-maas-logo-stacked.png",
+              alt="MAAS",
+              width="316",
+              height="316",
               hi_def=True,
-              loading="lazy",
+              loading="auto",
               attrs={"class": "p-logo-section__logo"}
               ) | safe
             }}
           </div>
           <div class="p-logo-section__item">
             {{
-              image (
-              url="https://assets.ubuntu.com/v1/fc61db3b-Anbox-logo-azure.png",
-              alt="",
-              width="310",
-              height="310",
+              image(
+              url="https://assets.ubuntu.com/v1/0070b81e-aws-logo.png",
+              alt="AWS",
+              width="316",
+              height="316",
               hi_def=True,
               loading="lazy",
-              attrs={"class": "p-logo-section__logo"}
-              ) | safe
-            }}
-          </div>
-          <div class="p-logo-section__item">
-            {{ image (
-              url="https://assets.ubuntu.com/v1/5daf7029-Openstack_logo.png",
-              alt="",
-              width="292",
-              height="292",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-logo-section__logo"}
-              ) | safe
-            }}
-          </div>
-          <div class="p-logo-section__item">
-            {{
-              image (
-              url="https://assets.ubuntu.com/v1/5dfc272a-vmware_logo.png",
-              alt="",
-              width="292",
-              height="292",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-logo-section__logo"}
-              ) | safe
-            }}
-          </div>
-          <div class="p-logo-section__item">
-            {{
-              image (
-              url="https://assets.ubuntu.com/v1/f1d885ce-Oracle-cloud.png",
-              alt="",
-              width="522",
-              height="161",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-logo-section__logo"}
-              ) | safe
-            }}
-          </div>
-          <div class="p-logo-section__item">
-            {{
-              image (
-              url="https://assets.ubuntu.com/v1/53d93b1d-Anbox-logo-maas.png",
-              alt="",
-              width="310",
-              height="310",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-logo-section__logo"}
-              ) | safe
-            }}
-          </div>
-          <div class="p-logo-section__item">
-            {{
-              image (
-              url="https://assets.ubuntu.com/v1/dba11aee-kubernetes.svg",
-              alt="",
-              width="62",
-              height="60",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-logo-section__logo"}
+              attrs={"class": "p-logo-section__logo"},
               ) | safe
             }}
           </div>


### PR DESCRIPTION
## Done

Update logos observability page

## QA

Check https://ubuntu-com-12562.demos.haus/observability/managed according to https://warthogs.atlassian.net/browse/WD-1236?atlOrigin=eyJpIjoiMjZmMjRiNzQyYTVkNDlhZmFlZjdjZTU0NGM2YjE4YjMiLCJwIjoiaiJ9


## Screenshots
![Screenshot from 2023-02-17 18-12-08](https://user-images.githubusercontent.com/14939793/219745284-b4c514ca-8038-4585-bb0f-e4ff97934b3e.png)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
