### PR TITLE
Update community nav with updated links and CTA

### DIFF
--- a/templates/templates/navigation-community-h.html
+++ b/templates/templates/navigation-community-h.html
@@ -1,89 +1,146 @@
 
-  <div class="dropdown-window__content u-no-padding--top u-no-padding--bottom">
+  <div class="dropdown-window__content u-no-padding--bottom u-no-padding--top">
     <div class="p-strip is-x-shallow u-no-padding--bottom">
-      <div class="row">
-        <div class="col-4">
-          <h4 class="p-heading--4 is-dense u-hide--small">Learn</h4>
-          <h4 class="p-muted-heading u-hide--medium u-hide--large">Learn</h4>
-          <p class="p-p--small u-hide--small">Tutorials cover a wide range of topics. Learn or teach something new to Ubuntu users.</p>
+      <div class="row u-equal-height">
+        <!-- Contribute -->
+        <div class="col-medium-2 col-3 p-card--navigation">
+          <div class="u-hide--small">
+            <h4 class="p-heading-four is-dense">
+              <a href="/community/contribute">Contribute&nbsp;&rsaquo;</a>
+            </h4>
+            <p class="p-p--small">
+                Whether you&apos;re a software developer, systems administrator, artist, writer or something in between, there are numerous ways to contribute to the Ubuntu Community.
+            </p>
+            <a href="/community/contribute" class="p-button--small p-button--positive u-align-text--left">
+              Get Involved
+            </a>
+          </div>
+          <h4 class="u-show--small p-muted-heading u-hide--medium u-hide--large">
+            <a href="/community/contribute">Contribute&nbsp;&rsaquo;</a>
+          </h4>
           <ul class="p-text-list--small is-bordered">
-            <li class="p-list__item"><a href="/tutorials/">Ubuntu Tutorials</a></li>
-            <li class="p-list__item"><a href="https://help.ubuntu.com/">Ubuntu documentation</a></li>
-            <li class="p-list__item"><a href="https://www.youtube.com/user/celebrateubuntu">Ubuntu events on Youtube</a></li>
-            <li class="p-list__item"><a href="https://www.youtube.com/channel/UCSsoSZBAZ3Ivlbt_fxyjIkw">The Juju Cloud Operations Show</a></li>
-            <li class="p-list__item"><a href="/masters-conference">Get inspired by Ubuntu Masters</a></li>
+            <li class="p-list__item"><a href="/community/contribute/software-development">Contribute to Software Development</a></li>
+            <li class="p-list__item"><a href="/community/contribute/documentation">Contribute to Documentation</a></li>
+            <li class="p-list__item"><a href="/community/contribute/art-design">Contribute to Art and Design</a></li>
+            <li class="p-list__item"><a href="/community/contribute/translation-localisation">Contribute to Translation and Localisation</a></li>
+            <li class="p-list__item"><a href="/community/contribute/qa-testing">Contribute to QA and Testing</a></li>
+            <li class="p-list__item"><a href="/community/contribute/donation">Contribute to Donations Funding</a></li>
           </ul>
         </div>
-        <div class="col-4">
-          <h4 class="p-heading--4 is-dense u-hide--small">Meet</h4>
-          <h4 class="p-muted-heading u-hide--medium u-hide--large">Meet</h4>
-          <p class="p-p--small u-hide--small">Find and meet the people who shape the direction of Ubuntu.</p>
+        <!-- Connect -->
+        <div class="col-medium-2 col-3 p-card--navigation">
+          <div class="u-hide--small">
+            <h4 class="p-heading-four is-dense">
+              <a href="https://discourse.ubuntu.com/">Connect&nbsp;&rsaquo;</a>
+            </h4>
+            <p class="p-p--small">
+                The Ubuntu world is active and ever changing. Get up-to-date on all the latest Ubuntu news and join in the conversations at the Ubuntu Community Hub.
+            </p>
+            <a href="https://discourse.ubuntu.com/" class="p-button--small p-button--positive u-align-text--left">
+              Ubuntu Discourse
+            </a>
+          </div>
+          <h4 class="u-show--small p-muted-heading u-hide--medium u-hide--large">
+            <a href="https://discourse.ubuntu.com/">Connect&nbsp;&rsaquo;</a>
+          </h4>
           <ul class="p-text-list--small is-bordered">
-            <li class="p-list__item"><a href="https://discourse.ubuntu.com/">Ubuntu Discourse</a></li>
-            <li class="p-list__item"><a href="https://askubuntu.com/">Ask Ubuntu &mdash; our StackExchange</a></li>
-            <li class="p-list__item"><a href="http://loco.ubuntu.com/teams/">Join your Local Community team</a></li>
+            <li class="p-list__item"><a href="/blog">Ubuntu Blog</a></li>
+            <li class="p-list__item"><a href="https://planet.ubuntu.com/">Ubuntu Planet</a></li>
+            <li class="p-list__item"><a href="https://wiki.ubuntu.com/UbuntuWeeklyNewsletter">Ubuntu Weekly Newsletter</a></li>
+
+          </ul>
+        </div>
+        <!-- Support -->
+        <div class="col-medium-2 col-3 p-card--navigation">
+          <div class="u-hide--small">
+            <h4 class="p-heading-four is-dense">
+              <a href="/community/support">Support&nbsp;&rsaquo;</a>
+            </h4>
+            <p class="p-p--small">
+              The Ubuntu Community provides a number of resources to help support new and experienced users, provide spaces for discussion, and help troubleshoot common technical issues.
+            </p>
+            <a href="/community/support" class="p-button--small p-button--positive u-align-text--left">
+              Get Support
+            </a>
+          </div>
+          <h4 class="u-show--small p-muted-heading u-hide--medium u-hide--large">
+            <a href="/community/support">Support&nbsp;&rsaquo;</a>
+          </h4>
+          <ul class="p-text-list--small is-bordered">
+            <li class="p-list__item u-show--small u-hide--medium u-hide--large"><a href="/community/support">Get Support</a></li>
+            <li class="p-list__item"><a href="https://docs.ubuntu.com">Ubuntu Documentation</a></li>
+            <li class="p-list__item"><a href="https://wiki.ubuntu.com/IRC/ChannelList">Chat on IRC</a></li>
             <li class="p-list__item"><a href="https://ubuntuforums.org/">Ubuntu Forums</a></li>
-            <li class="p-list__item"><a href="https://help.ubuntu.com/community/InternetRelayChat">Chat on IRC</a></li>
+            <li class="p-list__item"><a href="https://askubuntu.com/">Ask Ubuntu</a></li>
+            <li class="p-list__item"><a href="https://answers.launchpad.net/">Launchpad Answers</a></li>
+            <li class="p-list__item"><a href="https://lists.ubuntu.com/">Mailing Lists</a></li>
           </ul>
         </div>
-        <div class="col-4">
-          <h4 class="p-heading--4 is-dense u-hide--small">Ethos</h4>
-          <h4 class="p-muted-heading u-hide--medium u-hide--large">Ethos</h4>
-          <p class="p-p--small u-hide--small">The mission of Ubuntu is to bring the benefits of free software to the widest possible audience.</p>
+        <!-- Governance -->
+        <div class="col-medium-2 col-3 p-card--navigation">
+          <div class="u-hide--small">
+            <h4 class="p-heading-four is-dense">
+              <a href="/community/governance">Governance&nbsp;&rsaquo;</a>
+            </h4>
+            <p class="p-p--small">
+              Ubuntu is made up of multiple governing bodies that work together to deliver the world&apos;s best free software. Discover their mission to ensure the health and prosperity of our community.
+            </p>
+            <a href="/community/governance" class="p-button--small p-button--positive u-align-text--left">
+              Explore Now
+            </a>
+          </div>
+          <h4 class="u-show--small p-muted-heading u-hide--medium u-hide--large">
+            <a href="/community/governance">Governance&nbsp;&rsaquo;</a>
+          </h4>
           <ul class="p-text-list--small is-bordered">
-            <li class="p-list__item"><a href="/community/mission">Our mission</a></li>
-            <li class="p-list__item"><a href="/community/code-of-conduct">Ubuntu Code of Conduct</a></li>
+            <li class="p-list__item u-show--small u-hide--medium u-hide--large"><a href="/community/governance">Explore Now</a></li>
+            <li class="p-list__item"><a href="/community/governance/mission">Our Mission</a></li>
+            <li class="p-list__item"><a href="/community/governance/code-of-conduct">Ubuntu Code of Conduct</a></li>
+            <li class="p-list__item"><a href="/community/governance/diversity">Diversity Policy</a></li>
+            <li class="p-list__item"><a href="/community/governance/teams">Ubuntu Councils and Teams</a></li>
+            <li class="p-list__item"><a href="https://loco.ubuntu.com/">LoCos</a></li>
           </ul>
         </div>
       </div>
-      <div class="u-fixed-width"><hr></div>
-      <div class="row">
-        <div class="col-4">
-          <h4 class="p-heading--4 is-dense u-hide--small">Contribute</h4>
-          <h4 class="p-muted-heading u-hide--medium u-hide--large">Contribute</h4>
-          <ul class="p-text-list--small is-bordered">
-            <li class="p-list__item"><a href="https://discourse.ubuntu.com/t/translations/32">Translate Ubuntu into your language</a></li>
-            <li class="p-list__item"><a href="https://wiki.ubuntu.com/DocumentationTeam/SystemDocumentation">Improve the documentation</a></li>
-            <li class="p-list__item"><a href="/download/desktop/thank-you">Donate to the project</a></li>
-          </ul>
-        </div>
-        <div class="col-4">
-          <h4 class="p-heading--4 is-dense u-hide--small">Follow</h4>
-          <h4 class="p-muted-heading u-hide--medium u-hide--large">Follow</h4>
-          <ul class="p-text-list--small is-bordered">
-            <li class="p-list__item"><a href="https://twitter.com/ubuntu">Ubuntu on Twitter</a></li>
-            <li class="p-list__item"><a href="https://facebook.com/ubuntulinux">Facebook</a></li>
-          </ul>
-        </div>
-        <div class="col-4">
-          <h4 class="p-heading--4 is-dense u-hide--small">Governance</h4>
-          <h4 class="p-muted-heading u-hide--medium u-hide--large">Governance</h4>
-          <ul class="p-text-list--small is-bordered">
-            <li class="p-list__item"><a href="/community/governance">Project Governance</a></li>
-            <li class="p-list__item"><a href="https://discourse.ubuntu.com/t/what-is-the-ubuntu-community-council/706">Community Council</a></li>
-            <li class="p-list__item"><a href="/community/diversity">Diversity policy</a></li>
-          </ul>
-        </div>
+    </div>
+  </div>
+  <div class="dropdown-window__content">
+    <div class="u-fixed-width">
+      <hr>
+    </div>
+    <div class="row">
+      <div class="col-3">
+        <h4 class="p-muted-heading--small">Watch</h4>
       </div>
-      <div class="u-fixed-width"><hr></div>
-      <div class="u-sv3">
-        <div class="row">
-          <div class="col-2">
-            <h4 class="p-muted-heading--small">Connect</h4>
-          </div>
-          <div class="col-10">
-            <ul class="p-inline-list--middot is-x-dense">
-              <li class="p-inline-list__item"><a href="/blog">Blog</a></li>
-              <li class="p-inline-list__item"><a href="https://wiki.ubuntu.com/UbuntuWeeklyNewsletter">Weekly Newsletter</a></li>
-              <li class="p-inline-list__item"><a href="http://discourse.ubuntu.com/">Discourse</a></li>
-              <li class="p-inline-list__item"><a href="http://planet.ubuntu.com/">Planet</a></li>
-              <li class="p-inline-list__item"><a href="https://wiki.ubuntu.com/Teams">Teams</a></li>
-              <li class="p-inline-list__item"><a href="http://loco.ubuntu.com/teams/">LoCos</a></li>
-              <li class="p-inline-list__item"><a href="https://lists.ubuntu.com/">Lists</a></li>
-              <li class="p-inline-list__item"><a href="https://help.ubuntu.com/community/InternetRelayChat">IRC</a></li>
-            </ul>
-          </div>
-        </div>
+      <div class="col-9">
+        <ul class="p-inline-list--middot is-x-dense">
+          <li class="p-inline-list__item"><a href="https://www.youtube.com/UbuntuOnAir">UbuntuOnAir</a></li>
+          <li class="p-inline-list__item"><a href="https://www.youtube.com/@jujucharms">The JuJu Cloud Operations Show</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="u-fixed-width"><hr class="p-hr--subtle p-hr--dense"></div>
+    <div class="row">
+      <div class="col-3">
+        <h4 class="p-muted-heading--small">Learn</h4>
+      </div>
+      <div class="col-9">
+        <ul class="p-inline-list--middot is-x-dense">
+          <li class="p-inline-list__item"><a href="/tutorials">Ubuntu Tutorials</a></li>
+          <li class="p-inline-list__item"><a href="/masters-conference">Learn from Ubuntu Masters</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="u-fixed-width"><hr class="p-hr--subtle p-hr--dense"></div>
+    <div class="row">
+      <div class="col-3">
+        <h4 class="p-muted-heading--small">Follow</h4>
+      </div>
+      <div class="col-9">
+        <ul class="p-inline-list--middot is-x-dense">
+          <li class="p-inline-list__item"><a href="https://twitter.com/ubuntu">Ubuntu on Twitter</a></li>
+          <li class="p-inline-list__item"><a href="https://facebook.com/ubuntulinux">Ubuntu Facebook</a></li>
+        </ul>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Update community navigation menu with four column layout, links to new community docs and call-to-action button elements.

## Done

- Change navigation menu to four column layout
- Reorganize and update hrefs where appropriate
- Created new Call-To-Action button elements for high priority hrefs

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes https://warthogs.atlassian.net/jira/software/c/projects/CT/boards/531?modal=detail&selectedIssue=CT-438

## Screenshots

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
