### PR TITLE
Ignore local JS errors in OpenStack docs

### DIFF
--- a/.github/workflows/openstack-charm-guide-docs-links.yaml
+++ b/.github/workflows/openstack-charm-guide-docs-links.yaml
@@ -31,6 +31,7 @@ jobs:
             https://openstack\.org/projects
             https://openstack\.org/projects\/openstack-faq
             ^.*\.css
+            ^.*\.js
 
           [output]
           status=0


### PR DESCRIPTION
## Done

Ignore local JS errors in OpenStack docs because they are errors we can not control when scanning a 3rd party website
