### PR TITLE
Fix broken template in /ubuntu-pro-service-terms/2019-02-11

### DIFF
--- a/templates/legal/ubuntu-pro-service-terms/2019-02-11.md
+++ b/templates/legal/ubuntu-pro-service-terms/2019-02-11.md
@@ -1,5 +1,5 @@
 ---
-wrapper_template: "legal/ubuntu-advantage-service-terms/_base_uast_markdown.html"
+wrapper_template: "legal/ubuntu-pro-service-terms/_base_uast_markdown.html"
 context:
   title: "Short form services agreement | 2019-02-11"
   description: "Ubuntu and Canonical Legal - Short form services agreement"


### PR DESCRIPTION
## Done

- Fixes broken wrapper template link. The wrapper template file had been renamed to pro, but the reference link had not

## QA

- Go to /legal/ubuntu-pro-service-terms/2019-02-11 and check that you can access the page

## Issue / Card

Fixes https://github.com/canonical/ubuntu.com/issues/12539
