### PR TITLE
WD-2072: Add links to Ubuntu Pro and real time kernel from homepage

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -48,10 +48,10 @@
   <div class="row">
     <div class="col-6 col-medium-4">
       <h2>Modern enterprise open&nbsp;source</h2>
-      <p class="p-heading--4">Publisher of Ubuntu.<br /> Security. Support. Managed Services.</p>
+      <p class="p-heading--4">Security, support, and managed services from the publisher of Ubuntu.</p>
       <p>
-        <a class="p-button--positive js-invoke-modal" data-testid="interactive-form-link" href="/contact-us">
-          Contact Canonical
+        <a class="p-button--positive" href="/pro">
+          Get Ubuntu Pro
         </a>
       </p>
     </div>
@@ -138,7 +138,7 @@
       Open source security
     </h2>
     <p class="p-heading--4">
-      More than Linux. <a href="/security/certifications">Security and compliance</a> for the full stack.
+      <a href="/pro">Ubuntu Pro</a> is more than Linux. <a href="/security/certifications">Security and compliance</a> for the full stack.
     </p>
     <p>
       Secure your open source apps. Patch the full stack, from kernel to library and applications, for CVE compliance. Governments and auditors certify Ubuntu for FedRAMP, FISMA and HITECH.
@@ -744,7 +744,7 @@
           FIPS certifiable embedded Linux
         </li>
         <li class="p-list__item is-ticked">
-          Support for real-time compute
+          <a href="/blog/real-time-ubuntu-is-now-generally-available">Support for real-time compute</a>
         </li>
       </ul>
       <ul class="p-inline-list">


### PR DESCRIPTION
## Done

- Add links to Ubuntu Pro and real time kernel from homepage
  -  See changes in this [copydocs](https://docs.google.com/document/d/1ySJxQbqVdeH4Tra0zwBm2Tn0s56kFGnEF7d8xDRTxwU/edit#heading=h.e9djv1qhxxm9)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Make sure all updates look good!

## Issue / Card

Fixes [WD-2072](https://warthogs.atlassian.net/browse/WD-2072)


[WD-2072]: https://warthogs.atlassian.net/browse/WD-2072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ