### PR TITLE
Render table of contents above documentation when headings have anchors tags

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,8 @@ canonicalwebteam.blog==6.4.0
 canonicalwebteam.search==1.2.7
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.3.1
-canonicalwebteam.discourse==5.0.1
+#canonicalwebteam.discourse==5.0.1
+git+https://github.com/canonical/canonicalwebteam.discourse@wd-2017#egg=canonicalwebteam.discourse
 python-dateutil==2.8.2
 pytz==2020.5
 maxminddb-geolite2==2018.703

--- a/templates/templates/docs/shared/_docs.html
+++ b/templates/templates/docs/shared/_docs.html
@@ -98,6 +98,30 @@
     </aside>
 
     <main class="col-9">
+      {% if document.headings_map %}
+        <p><strong>Contents:</strong></p>
+        <ol class="p-list--nested-counter">
+          {% for heading in document.headings_map %}
+          <li>
+            <a href="#{{heading.heading_slug}}">
+              {{ heading.heading_text }}
+            </a>
+            {% if heading.children %}
+              <ol>
+                {% for sub_heading in heading.children %}
+                  <li>
+                    <a href="#{{sub_heading.heading_slug}}">
+                      {{ sub_heading.heading_text }}
+                    </a>
+                  </li>
+                {% endfor %}
+              </ol>
+            {% endif %}
+          </li>
+          {% endfor %}
+        </ol>
+      {% endif %}
+
       {{ document.body_html | safe }}
 
       <div class="p-strip">


### PR DESCRIPTION
## Done

- Renders a table of contents above documentation based on a list received from the discourse module.
- If the object is empty no table of contents will be displayed.
- This using a patch the the discourse module that has not yet been merged, so the requirements.txt file has been updated to point toward that PR and the original ref commented out. This should be reverted before this PR is merged.
`#canonicalwebteam.discourse==5.0.1
git+https://github.com/canonical/canonicalwebteam.discourse@wd-2017#egg=canonicalwebteam.discourse`

## QA

*our [current version of discourse(2.6)](https://meta.discourse.org/t/discourse-version-2-6/151394) will not natively add anchor tags to to heading, but will in [discourse-2.7](https://meta.discourse.org/t/discourse-version-2-7/166607) onward. There is an open [RT filed here](https://portal.admin.canonical.com/C156056/) to upgrade*
-  Visit /core/docs/test-topic, a topic I created with the same anchor style found in discourse-2.7 onward, and see a table of contents containing h2 and h3 tag titles and links to those headings in the document.
- Visit a page with no anchor tags, /core/docs/preseeding and see that no table of contents is rendered

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-2015
