### PR TITLE
WD-2135: Limit run-image job to 15 minutes

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -6,6 +6,7 @@ env:
 jobs:
   run-image:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
 
     steps:


### PR DESCRIPTION
The run-image job can take 6 hours to fail. Let's [limit][2] it to 15 minutes to limit the harm this can do.

Fixes https://github.com/canonical/ubuntu.com/issues/12558

[2]: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes