### PR TITLE
Update /16-04 table mobile view ESM to 2026

### DIFF
--- a/templates/16-04/_release-chart-1604.html
+++ b/templates/16-04/_release-chart-1604.html
@@ -13,80 +13,80 @@
       <tbody>
         <tr>
           <td><strong>Ubuntu 22.04 LTS</strong></td>
-          <td>April 2022</td>
-          <td>April 2027</td>
+          <td>April 2022</td>
+          <td>April 2027</td>
           <td></td>
         </tr>
         <tr>
           <td>Ubuntu 21.10</td>
-          <td>October 2021</td>
-          <td>July 2022</td>
+          <td>October 2021</td>
+          <td>July 2022</td>
           <td></td>
         </tr>
         <tr>
           <td>Ubuntu 21.04</td>
-          <td>April 2021</td>
-          <td>January 2022</td>
+          <td>April 2021</td>
+          <td>January 2022</td>
           <td></td>
         </tr>
         <tr>
           <td>Ubuntu 20.10</td>
-          <td>October 2020</td>
-          <td>July 2021</td>
+          <td>October 2020</td>
+          <td>July 2021</td>
           <td></td>
         </tr>
         <tr>
           <td><strong>Ubuntu 20.04 LTS</strong></td>
-          <td>April 2020</td>
-          <td>April 2025</td>
-          <td>April 2030</td>
+          <td>April 2020</td>
+          <td>April 2025</td>
+          <td>April 2030</td>
         </tr>
         <tr>
           <td>Ubuntu 19.10</td>
-          <td>October 2019</td>
-          <td>July 2020</td>
+          <td>October 2019</td>
+          <td>July 2020</td>
           <td></td>
         </tr>
         <tr>
           <td>Ubuntu 19.04</td>
-          <td>April 2019</td>
-          <td>January 2020</td>
+          <td>April 2019</td>
+          <td>January 2020</td>
           <td></td>
         </tr>
         <tr>
           <td>Ubuntu 18.10</td>
-          <td>October 2018</td>
-          <td>July 2019</td>
+          <td>October 2018</td>
+          <td>July 2019</td>
           <td></td>
         </tr>
         <tr>
           <td><strong>Ubuntu 18.04 LTS</strong></td>
-          <td>April 2018</td>
-          <td>April 2023</td>
-          <td>April 2028</td>
+          <td>April 2018</td>
+          <td>April 2023</td>
+          <td>April 2028</td>
         </tr>
         <tr>
           <td><strong>Ubuntu 16.04 LTS</strong></td>
-          <td>April 2016</td>
-          <td>April 2021</td>
-          <td>April 2024</td>
+          <td>April 2016</td>
+          <td>April 2021</td>
+          <td>April 2026</td>
         </tr>
         <tr>
           <td><strong>Ubuntu 14.04 LTS</strong></td>
-          <td>April 2014</td>
-          <td>April 2019</td>
-          <td>April 2022</td>
+          <td>April 2014</td>
+          <td>April 2019</td>
+          <td>April 2022</td>
         </tr>
         <tr>
           <td><strong>Ubuntu 12.04 LTS</strong></td>
-          <td>April 2012</td>
-          <td>April 2017</td>
-          <td>April 2019</td>
+          <td>April 2012</td>
+          <td>April 2017</td>
+          <td>April 2019</td>
         </tr>
         <tr>
           <td><strong>Ubuntu 10.04 LTS</strong></td>
-          <td>April 2010</td>
-          <td>April 2015</td>
+          <td>April 2010</td>
+          <td>April 2015</td>
           <td></td>
         </tr>
       </tbody>

--- a/templates/16-04/index.html
+++ b/templates/16-04/index.html
@@ -11,7 +11,7 @@
       <h1>Ubuntu 16.04 LTS <br class="u-hide--small">(Xenial Xerus)</h1>
       <p>Ubuntu 16.04 LTS (Xenial Xerus) was released on 21 April 2016 and introduced us to snaps, a more secure app format, with faster and simpler updates, as well as LXD, the pure-container hypervisor and OpenStack Mitaka. </p>
       <h2 class="p-heading--4">Is Ubuntu 16.04 LTS still supported?</h2>
-      <p class="u-sv2">Yes, Ubuntu 16.04 LTS is supported until 2026 through Canonical’s Expanded Security Maintenance (ESM) product. Xenial entered the ESM period in April 2021, with security patches for five additional years, beyond the five years of standard support.</p>
+      <p class="u-sv2">Yes, Ubuntu 16.04 LTS is supported until 2026 through Canonical's Expanded Security Maintenance (ESM) product. Xenial entered the ESM period in April 2021, with security patches for five additional years, beyond the five years of standard support.</p>
       <p>
         <a href="/pro" class="p-button--positive">Get started with ESM for Ubuntu 16.04 LTS</a>
       </p>


### PR DESCRIPTION
## Done

- Updates the mobile view table on /16-04 to show the ESM deadline as 2026 (previously it showed 2024)

## QA

- Go https://ubuntu-com-12572.demos.haus/16-40 and check all reference to its ESM show 2026

## Issue / Card

Fixes https://github.com/canonical/ubuntu.com/issues/12541
