### PR TITLE
fix: adding /data/spark page to site navigation structure

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -357,6 +357,8 @@ data:
   children:
     - title: Kafka
       path: /data/kafka
+    - title: Spark
+      path: /data/spark
 
 download:
   title: Downloads


### PR DESCRIPTION
## Done

- fix for omission of the page /data/spark from the submenu

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card


## Screenshots

![image](https://user-images.githubusercontent.com/3254480/220371346-878f2ac7-874d-45b1-a3da-6657dfc0482e.png)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
