### PR TITLE
Upgrade d3 CDNs

### DIFF
--- a/templates/16-04/_release-chart-1604.html
+++ b/templates/16-04/_release-chart-1604.html
@@ -93,5 +93,5 @@
     </table>
   </div>
 </div>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/6.7.0/d3.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.8.2/d3.min.js"></script>
 <script src="{{ versioned_static('js/dist/release-chart.js') }}"></script>

--- a/templates/about/index.html
+++ b/templates/about/index.html
@@ -94,6 +94,6 @@
   </div>
 </section>
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/6.7.0/d3.min.js" defer></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.8.2/d3.min.js" defer></script>
 <script src="{{ versioned_static('js/dist/release-chart.js') }}" defer></script>
 {% endblock content %}

--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -528,7 +528,7 @@
   </div>
 </section>
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/6.7.0/d3.min.js" defer></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.8.2/d3.min.js" defer></script>
 <script src="{{ versioned_static('js/dist/release-chart.js') }}" defer></script>
 <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
 

--- a/templates/cpu-compatibility/index.html
+++ b/templates/cpu-compatibility/index.html
@@ -252,7 +252,7 @@
   </div>
 </section>
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/6.7.0/d3.min.js" defer></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.8.2/d3.min.js" defer></script>
 <script src="{{ versioned_static('js/dist/release-chart.js') }}" defer></script>
 
 {% endblock content %}

--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -714,7 +714,7 @@ meta_copydoc %}
 {% include "shared/_latest_news_strip.html" %}
 {% endwith %}
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/6.7.0/d3.min.js" defer></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.8.2/d3.min.js" defer></script>
 <script src="{{ versioned_static('js/dist/release-chart.js') }}" defer></script>
 <script src="https://assets.ubuntu.com/v1/3c99518b-d3-version3.5.6.min.js"></script>
 <script src="{{ versioned_static('js/src/developer-chart.js')}}"></script>

--- a/templates/desktop/statistics.html
+++ b/templates/desktop/statistics.html
@@ -388,7 +388,7 @@ Ubuntu 18.04 LTS.{% endblock %}
 
 {% with first_item="_desktop_contact_us", second_item="_support", third_item="_desktop_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/6.7.0/d3.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.8.2/d3.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/d3-geo/1.9.1/d3-geo.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/d3-array/1.2.2/d3-array.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/d3-geo-projection/2.4.0/d3-geo-projection.min.js">

--- a/templates/openstack/why-openstack.html
+++ b/templates/openstack/why-openstack.html
@@ -170,6 +170,6 @@ https://docs.google.com/document/d/1StqylVToo1URkhLvNfl17vZ52H35fXCVOR1aMKG1aGU/
 <!-- Set default Marketo information for contact form below-->
 <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/openstack" data-form-id="4578" data-lp-id="2086" data-return-url="https://ubuntu.com/openstack/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/6.7.0/d3.min.js" defer></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.8.2/d3.min.js" defer></script>
 <script src="{{ versioned_static('js/dist/release-chart.js') }}" defer></script>
 {% endblock content %}

--- a/templates/shared/_kernel-support-schedule.html
+++ b/templates/shared/_kernel-support-schedule.html
@@ -572,7 +572,7 @@
   </div>
 </section>
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/6.7.0/d3.min.js" defer></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.8.2/d3.min.js" defer></script>
 <script src="{{ versioned_static('js/dist/release-chart.js') }}" defer></script>
 <script src="{{ versioned_static('js/dist/tabotronic.js') }}" defer></script>
 

--- a/templates/shared/_release_schedule.html
+++ b/templates/shared/_release_schedule.html
@@ -110,5 +110,5 @@
   </div>
 </div>
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/6.7.0/d3.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.8.2/d3.min.js"></script>
 <script src="{{ versioned_static('js/dist/release-chart.js') }}"></script>


### PR DESCRIPTION
## Done


Another PR to make the renovate PR lighter: https://github.com/canonical/ubuntu.com/pull/12389
- Upgrade CDNs for d3

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- THis is the list of pages updated, make sure they look the same!

https://ubuntu-com-12580.demos.haus/16-04
https://ubuntu.com/16-04

https://ubuntu-com-12580.demos.haus/about
https://ubuntu.com/about

https://ubuntu-com-12580.demos.haus/about/release-cycle
https://ubuntu.com/about/release-cycle

https://ubuntu-com-12580.demos.haus/cpu-compatibility
https://ubuntu.com/cpu-compatibility

https://ubuntu-com-12580.demos.haus/desktop/developers
https://ubuntu.com/desktop/developers

https://ubuntu-com-12580.demos.haus/desktop/statistic
https://ubuntu.com/desktop/statistics

https://ubuntu-com-12580.demos.haus/openstack/why-openstack
https://ubuntu.com/openstack/why-openstack

https://ubuntu-com-12580.demos.haus/kernel/lifecycle
https://ubuntu.com/kernel/lifecycle

https://ubuntu-com-12580.demos.haus/server
https://ubuntu.com/server