### PR TITLE
Update GCP link

### DIFF
--- a/static/js/src/advantage/subscribe/react/components/Form/ProductType/ProductType.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/ProductType/ProductType.tsx
@@ -29,7 +29,7 @@ const PublicCloudInfo = {
     name: "Google Compute Engine",
     CTAName: "GCE marketplace",
     link:
-      "https://console.cloud.google.com/marketplace/browse?q=ubuntu%20pro%20canonical",
+      "https://console.cloud.google.com/marketplace/browse?q=ubuntu%20pro&filter=partner:Canonical%20Group&authuser=1",
   },
   [PublicClouds.oracle]: {
     title: "Oracle",

--- a/templates/pro/index.html
+++ b/templates/pro/index.html
@@ -609,7 +609,7 @@ https://docs.google.com/document/d/1In4NSnckAtL51_7D_AZCHa6TPnPGXqctXo-5rE77_aY/
     </div>
     <div class="u-fixed-width">
       <div class="p-code-snippet">
-        <pre class="p-code-snippet__block"><code>user@xenial-machine:~$ pro security-status
+        <pre class="p-code-snippet__block" tabindex="0"><code>user@xenial-machine:~$ pro security-status
 645 packages installed:
       639 packages from Ubuntu Main/Restricted repository
       3 packages from Ubuntu Universe/Multiverse repository


### PR DESCRIPTION
## Done

- Update GCP link

## QA

- Go to /pro/subscribe
- select this
![image](https://user-images.githubusercontent.com/6387619/220407414-35886717-35cb-4654-bbdf-2f6b1dd95bc7.png)
- link should send you here: https://console.cloud.google.com/marketplace/browse?q=ubuntu%20pro&filter=partner:Canonical%20Group&authuser=1

## Issue / Card

Fixes #https://warthogs.atlassian.net/browse/WD-2151