### PR TITLE
Fix d3 graphs and data across site

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -373,13 +373,13 @@ export var kernelReleases2004 = [
   {
     startDate: new Date("2022-08-11T00:00:00"),
     endDate: new Date("2025-04-22T00:00:00"),
-    taskName: "Ubuntu 20.04.5 LTS",
+    taskName: "Ubuntu 20.04.5 LTS (v5.15)",
     status: "LTS",
   },
   {
     startDate: new Date("2025-04-22T00:00:00"),
     endDate: new Date("2030-04-21T00:00:00"),
-    taskName: "Ubuntu 20.04.5 LTS",
+    taskName: "Ubuntu 20.04.5 LTS (v5.15)",
     status: "ESM",
   },
   {
@@ -805,13 +805,13 @@ export var kernelReleasesALL = [
   {
     startDate: new Date("2022-05-13T00:00:00"),
     endDate: new Date("2022-08-11T00:00:00"),
-    taskName: "Ubuntu 20.04.5 LTS",
+    taskName: "Ubuntu 20.04.5 LTS (v5.15)",
     status: "EARLY",
   },
   {
     startDate: new Date("2022-08-11T00:00:00"),
     endDate: new Date("2025-04-22T00:00:00"),
-    taskName: "Ubuntu 20.04.5 LTS",
+    taskName: "Ubuntu 20.04.5 LTS (v5.15)",
     status: "LTS",
   },
 ];
@@ -1030,13 +1030,13 @@ export var kernelReleasesLTS = [
   {
     startDate: new Date("2022-08-11T00:00:00"),
     endDate: new Date("2024-08-10T00:00:00"),
-    taskName: "Ubuntu 20.04.5 LTS",
+    taskName: "Ubuntu 20.04.5 LTS (v5.15)",
     status: "LTS",
   },
   {
     startDate: new Date("2024-08-10T00:00:00"),
     endDate: new Date("2025-04-22T00:00:00"),
-    taskName: "Ubuntu 20.04.5 LTS",
+    taskName: "Ubuntu 20.04.5 LTS (v5.15)",
     status: "CVE",
   },
 ];

--- a/static/js/src/desktop-statistics.js
+++ b/static/js/src/desktop-statistics.js
@@ -828,7 +828,7 @@ function buildCharts() {
         top: 20,
         right: 20,
         bottom: 70,
-        left: -5,
+        left: 0,
       },
     });
   } else {
@@ -843,7 +843,7 @@ function buildCharts() {
           top: 20,
           right: 40,
           bottom: 20,
-          left: 200,
+          left: 240,
         },
       }
     );
@@ -852,7 +852,13 @@ function buildCharts() {
       dummyData.languageList.dataset,
       {
         sort: "ascending",
-      }
+        margin: {
+          top: 20,
+          right: 50,
+          bottom: 20,
+          left: 100,
+        },
+      },
     );
   }
 }

--- a/static/js/src/desktop-statistics.js
+++ b/static/js/src/desktop-statistics.js
@@ -858,7 +858,7 @@ function buildCharts() {
           bottom: 20,
           left: 100,
         },
-      },
+      }
     );
   }
 }

--- a/templates/desktop/statistics.html
+++ b/templates/desktop/statistics.html
@@ -195,13 +195,13 @@ Ubuntu 18.04 LTS.{% endblock %}
   <div class="row p-mobile-flex-col u-equal-height p-divider">
     <div class="col-6 p-divider__block">
       <h4>Number of CPUs</h4>
-      <svg id="number-of-cpus" height="200"></svg>
+      <svg id="number-of-cpus" height="210"></svg>
       <p>The Central Processing Unit (CPU) carries out the basic algorithmic, logical, control, and input/output
         functions. Having multiple CPUs allows a computer to perform more tasks in parallel.</p>
     </div>
     <div class="col-6 p-divider__block">
       <h4>Size of RAM (GB)</h4>
-      <svg id="size-of-ram" height="200"></svg>
+      <svg id="size-of-ram" height="210"></svg>
       <p>The more memory, the more power the computer has to carry out functions. Some users reported having RAM
         upwards of 96GB!</p>
     </div>
@@ -218,7 +218,7 @@ Ubuntu 18.04 LTS.{% endblock %}
         inferred from the number and size of partitions of a disk.</p>
     </div>
     <div class="col-6 u-align--center">
-      <svg id="physical-disk" height="200"></svg>
+      <svg id="physical-disk" height="220"></svg>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- Updates chart-data.js to fill in missing data, this fixes the floating bar found on /kernel/lifecycle, specifically the 'All releases', 'All LTS releases', '20.04' tabs
- Updates margin sizing in desktop-statistics.js & inline width style in /desktop/statistics.html to fix the following graphs on /dektop/statistics: 'What language do they use?', 'Number of CPUs', 'Size of RAM (GB)', 'Physical disk (GB)', 'Partition type', 'What physical disks do people have?'

## QA

- Go to https://ubuntu-com-12584.demos.haus/kernel/lifecycle and see that the floating bar has moved to the appropriate column on the graphs detailed above. 
- Go to https://ubuntu-com-12584.demos.haus/desktop/statistics and see that the overflow issue is fixed on the graphs detailed above.
- Make sure to change screen size and ensure I haven't broken something else

## Issue / Card

Fixes https://github.com/canonical/ubuntu.com/issues/12583

## Screenshots

I have given one example from each page to save space in this PR, please check out the live page to see each individual one.

Example from /kernel/lifestyle
![image](https://user-images.githubusercontent.com/58276363/220570717-83c17fdc-4f5e-4fe1-8630-0e2d68939ff6.png)

Example from /desktop/statistics
![image](https://user-images.githubusercontent.com/58276363/220571316-8cb9297d-a7f4-49cf-a8bf-5270f6be91c4.png)

