### PR TITLE
Disable when name and organisation name are the same

### DIFF
--- a/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
@@ -55,7 +55,9 @@ const BuyButton = ({
       isLoading ||
       (values.country === "US" && !values.usState) ||
       (values.country === "CA" && !values.caProvince) ||
-      (values.buyingFor === "organisation" && !values.organisationName)
+      (values.buyingFor === "organisation" && !values.organisationName) ||
+      (values.buyingFor === "organisation" &&
+        values.name === values.organisationName)
     ) {
       setIsButtonDisabled(true);
     } else {

--- a/static/js/src/advantage/subscribe/checkout/components/UserInfoForm/UserInfoForm.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/UserInfoForm/UserInfoForm.tsx
@@ -152,6 +152,11 @@ const UserInfoForm = ({ setError, setCardValid }: Props) => {
     let errorMessage;
     if (!value && values.buyingFor === "organisation") {
       errorMessage = "This field is required.";
+    } else if (
+      values.buyingFor === "organisation" &&
+      values.organisationName === values.name
+    ) {
+      errorMessage = 'Please select "I\'m buying for: Myself" option above.';
     }
     return errorMessage;
   };

--- a/static/js/src/advantage/subscribe/checkout/components/UserInfoForm/UserInfoForm.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/UserInfoForm/UserInfoForm.tsx
@@ -309,6 +309,7 @@ const UserInfoForm = ({ setError, setCardValid }: Props) => {
             value="myself"
             label="Myself"
             defaultChecked={values.buyingFor === "myself"}
+            disabled={window.accountId && userInfo?.accountInfo}
           />
           <Field
             as={RadioInput}
@@ -316,6 +317,7 @@ const UserInfoForm = ({ setError, setCardValid }: Props) => {
             value="organisation"
             label="An organisation"
             defaultChecked={values.buyingFor === "organisation"}
+            disabled={window.accountId && userInfo?.accountInfo}
           />
         </div>
       </FormRow>
@@ -325,7 +327,10 @@ const UserInfoForm = ({ setError, setCardValid }: Props) => {
         type="text"
         id="organisationName"
         name="organisationName"
-        disabled={values.buyingFor === "myself"}
+        disabled={
+          values.buyingFor === "myself" ||
+          (window.accountId && userInfo?.accountInfo)
+        }
         label="Organisation:"
         stacked
         validate={validateOrganisationName}

--- a/static/js/src/advantage/subscribe/checkout/components/UserInfoForm/UserInfoForm.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/UserInfoForm/UserInfoForm.tsx
@@ -309,7 +309,7 @@ const UserInfoForm = ({ setError, setCardValid }: Props) => {
             value="myself"
             label="Myself"
             defaultChecked={values.buyingFor === "myself"}
-            disabled={window.accountId && userInfo?.accountInfo}
+            disabled={window.accountId && initialValues.organisationName}
           />
           <Field
             as={RadioInput}
@@ -317,29 +317,33 @@ const UserInfoForm = ({ setError, setCardValid }: Props) => {
             value="organisation"
             label="An organisation"
             defaultChecked={values.buyingFor === "organisation"}
-            disabled={window.accountId && userInfo?.accountInfo}
+            disabled={window.accountId && initialValues.organisationName}
           />
         </div>
       </FormRow>
-      <Field
-        data-testid="field-org-name"
-        as={Input}
-        type="text"
-        id="organisationName"
-        name="organisationName"
-        disabled={
-          values.buyingFor === "myself" ||
-          (window.accountId && userInfo?.accountInfo)
-        }
-        label="Organisation:"
-        stacked
-        validate={validateOrganisationName}
-        error={
-          values.buyingFor === "organisation" &&
-          touched?.organisationName &&
-          errors?.organisationName
-        }
-      />
+      {initialValues.buyingFor === "myself" &&
+      window.accountId &&
+      initialValues.organisationName ? null : (
+        <Field
+          data-testid="field-org-name"
+          as={Input}
+          type="text"
+          id="organisationName"
+          name="organisationName"
+          disabled={
+            values.buyingFor === "myself" ||
+            (window.accountId && initialValues.organisationName)
+          }
+          label="Organisation:"
+          stacked
+          validate={validateOrganisationName}
+          error={
+            values.buyingFor === "organisation" &&
+            touched?.organisationName &&
+            errors?.organisationName
+          }
+        />
+      )}
       <Field
         data-testid="field-address"
         as={Input}

--- a/tests/cypress/integration/pro/checkout_spec.js
+++ b/tests/cypress/integration/pro/checkout_spec.js
@@ -255,7 +255,6 @@ context("Checkout - Your information", () => {
     ).click();
 
     cy.findByLabelText("Name:").type("Abcd", { force: true });
-    cy.findByLabelText("Organisation:").type("Abcd");
     cy.findByLabelText("Address:").type("Abcd");
     cy.findByLabelText("City:").type("Abcd");
     cy.findByLabelText("Postal code:").type("Abcd");
@@ -266,9 +265,8 @@ context("Checkout - Your information", () => {
     ).click();
 
     cy.get('[data-testid="customer-name"]').should("not.have.text", "Abcd");
-    cy.get('[data-testid="organisation-name"]').should("not.have.text", "Abcd");
     cy.get('[data-testid="customer-address"]').should("not.have.text", "Abcd");
-    cy.get('[data-testid="customer-city"]').should("not.have.text", "London");
+    cy.get('[data-testid="customer-city"]').should("not.have.text", "Abcd");
     cy.get('[data-testid="customer-postal-code"]').should(
       "not.have.text",
       "Abcd"


### PR DESCRIPTION
## Done

- Show error and disable buy button when name and organisation name are the same
![image](https://user-images.githubusercontent.com/57550290/220601334-a34c5ae2-b4c6-448e-95f3-5ebc38d4bba5.png)


## QA

- Go to  https://ubuntu-com-12585.demos.haus/pro/subscribe
- Click `An organisation` in Your information section 
- Type the same value as Name field
- Check error message displays and buy button is disabled when name and organisation name are the same

Fixes https://github.com/canonical/commercial-squad/issues/755
