### PR TITLE
Fix free trial step

### DIFF
--- a/static/js/src/advantage/subscribe/checkout/components/Checkout/Checkout.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Checkout/Checkout.tsx
@@ -30,13 +30,10 @@ const Checkout = ({ product, quantity, action }: Props) => {
   const [isTaxSaved, setTaxSaved] = useState<boolean>(false);
   const { data: userInfo, isLoading: isUserInfoLoading } = useCustomerInfo();
   const isGuest = !userInfo?.customerInfo?.email;
-
-  const initialValues = getInitialFormValues(
-    product,
-    action,
-    userInfo,
-    window.accountId
-  );
+  const userCanTrial = window.canTrial;
+  const productCanBeTrialled = product?.canBeTrialled;
+  const canTrial = canBeTrialled(productCanBeTrialled, userCanTrial);
+  const initialValues = getInitialFormValues(product, canTrial, userInfo);
 
   return (
     <>
@@ -117,7 +114,7 @@ const Checkout = ({ product, quantity, action }: Props) => {
                         />
                       ),
                     },
-                    ...(canBeTrialled(product, action)
+                    ...(canTrial
                       ? [
                           {
                             title: "Free trial",

--- a/static/js/src/advantage/subscribe/checkout/utils/helpers.ts
+++ b/static/js/src/advantage/subscribe/checkout/utils/helpers.ts
@@ -1,48 +1,20 @@
-import { Action, Data, FormValues, Product, UserInfo } from "./types";
-
-export function getUserInfoFromVariables(
-  data: Data,
-  variables: FormValues
-): UserInfo {
-  return {
-    customerInfo: {
-      email: variables.email,
-      name: variables.name,
-      address: {
-        line1: variables.address,
-        postal_code: variables.postalCode,
-        country: variables.country,
-        city: variables.city,
-        state:
-          variables.country === "US" ? variables.usState : variables.caProvince,
-      },
-      defaultPaymentMethod: {
-        id: data?.paymentMethodId ?? "",
-        brand: data?.paymentMethod?.brand ?? "",
-        last4: data?.paymentMethod?.last4 ?? "",
-        expMonth: data?.paymentMethod?.exp_month ?? 0,
-        expYear: data?.paymentMethod?.exp_year ?? 0,
-      },
-      taxID: { value: variables.VATNumber },
-    },
-    accountInfo: {
-      name: variables.organisationName,
-    },
-  };
-}
+import { FormValues, Product, UserInfo } from "./types";
 
 export function getInitialFormValues(
   product: Product,
-  action: Action,
-  userInfo?: UserInfo,
-  accountId?: string
+  canTrial: boolean,
+  userInfo?: UserInfo
 ): FormValues {
+  const accountName = userInfo?.accountInfo?.name;
+  const customerName = userInfo?.customerInfo.name;
+  const buyingFor =
+    customerName && accountName === customerName ? "myself" : "organisation";
+
   return {
     email: userInfo?.customerInfo?.email ?? "",
-    name: userInfo?.customerInfo?.name ?? "",
-    buyingFor:
-      !accountId || userInfo?.accountInfo?.name ? "organisation" : "myself",
-    organisationName: userInfo?.accountInfo?.name ?? "",
+    name: customerName ?? "",
+    buyingFor: buyingFor,
+    organisationName: accountName ?? "",
     address: userInfo?.customerInfo?.address?.line1 ?? "",
     postalCode: userInfo?.customerInfo?.address?.postal_code ?? "",
     country: userInfo?.customerInfo?.address?.country ?? "",
@@ -54,21 +26,22 @@ export function getInitialFormValues(
     TermsAndConditions: false,
     MarketingOptIn: false,
     Description: false,
+    FreeTrial: canTrial ? "useFreeTrial" : "payNow",
     marketplace: product.marketplace,
-    FreeTrial: canBeTrialled(product, action) ? "useFreeTrial" : "payNow",
   };
 }
 
-export const canBeTrialled = (product: Product, action: Action) => {
-  if (action != "purchase") {
+export const canBeTrialled = (
+  productCanBeTrialled?: boolean,
+  userCanTrial?: boolean
+) => {
+  if (productCanBeTrialled == undefined) {
     return false;
   }
 
-  let canTrial = product.canBeTrialled;
-
-  if (window.canTrial !== undefined) {
-    canTrial = window.canTrial;
+  if (userCanTrial == undefined) {
+    return productCanBeTrialled;
   }
 
-  return canTrial;
+  return userCanTrial && productCanBeTrialled;
 };


### PR DESCRIPTION
## Done

- Fix Free trial step. If a user has never made a purchase before then the checkout would show the free trial step even though the product is not triallable. Now we take both the `product.canBeTrialled` and the user account status when displaying that step.

## QA

- Have an clean account that has never made a UA purchase before therefore would be allowed to trial
- Go to https://staging.ubuntu.com/pro/subscribe
- Login
- Select a product that cannot be trialled
- Proceed to checkout, you will see the free trial step incorrectly
- Do the same with the demo, the free trial step will not be there

## Issue / Card

Fixes #https://warthogs.atlassian.net/browse/WD-2165