### PR TITLE
Add document title to document template

### DIFF
--- a/templates/templates/docs/shared/_docs.html
+++ b/templates/templates/docs/shared/_docs.html
@@ -98,6 +98,8 @@
     </aside>
 
     <main class="col-9">
+      <h1>{{ document.title }}</h1>
+
       {{ document.body_html | safe }}
 
       <div class="p-strip">


### PR DESCRIPTION
To bring ubuntu.com inline with other sites where the document title is pulled from the discourse topic title.

This will lead to duplicate titles until https://github.com/canonical/discourse-update-titles is run, so should be well coordinated on release.

Fixes https://warthogs.atlassian.net/browse/WD-2170

## QA

Go to:

https://ubuntu-com-12587.demos.haus/core/docs
https://ubuntu-com-12587.demos.haus/openstack/docs
https://ubuntu-com-12587.demos.haus/landscape/docs
https://ubuntu-com-12587.demos.haus/server/docs
https://ubuntu-com-12587.demos.haus/ceph/docs
https://ubuntu-com-12587.demos.haus/security/livepatch/docs
https://ubuntu-com-12587.demos.haus/security/certifications/docs

Check you see duplicate titles! Maybe try removing one of the duplicate titles, check it looks ok.
