### PR TITLE
Make cancel button use formik initial values

### DIFF
--- a/static/js/src/advantage/subscribe/checkout/components/Checkout/Checkout.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Checkout/Checkout.tsx
@@ -66,7 +66,7 @@ const Checkout = ({ product, quantity, action }: Props) => {
             <Formik
               onSubmit={() => {}}
               initialValues={initialValues}
-              enableReinitialize={false}
+              enableReinitialize={!error}
             >
               <>
                 <Col emptyLarge={7} size={6}>

--- a/static/js/src/advantage/subscribe/checkout/components/Taxes/Taxes.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Taxes/Taxes.tsx
@@ -18,7 +18,6 @@ import {
 import { getLabel } from "advantage/subscribe/react/utils/utils";
 import postCustomerTaxInfo from "../../hooks/postCustomerTaxInfo";
 import useCalculateTaxes from "../../hooks/useCalculateTaxes";
-import useCustomerInfo from "../../hooks/useCustomerInfo";
 import { FormValues, Product } from "../../utils/types";
 
 type TaxesProps = {
@@ -31,18 +30,15 @@ type TaxesProps = {
 const Taxes = ({ product, quantity, setTaxSaved, setError }: TaxesProps) => {
   const {
     values,
+    initialValues,
     errors,
     touched,
     setFieldValue,
     setErrors: setFormikErrors,
   } = useFormikContext<FormValues>();
-  const [isEditing, setIsEditing] = useState(!values.country);
-
+  const [isEditing, setIsEditing] = useState(!initialValues.country);
   const queryClient = useQueryClient();
-  const { data: userInfo } = useCustomerInfo();
-
-  const savedCountry = !!userInfo?.customerInfo?.address?.country;
-  const isGuest = !userInfo?.customerInfo?.email;
+  const isGuest = !initialValues.email;
 
   useEffect(() => {
     if (errors.VATNumber) {
@@ -52,11 +48,13 @@ const Taxes = ({ product, quantity, setTaxSaved, setError }: TaxesProps) => {
   }, [errors]);
 
   useEffect(() => {
+    const savedCountry = !!initialValues.country;
+
     if (savedCountry) {
       setIsEditing(!savedCountry);
       setTaxSaved(savedCountry);
     }
-  }, [savedCountry]);
+  }, [initialValues]);
 
   const taxMutation = useCalculateTaxes({
     marketplace: values.marketplace,
@@ -183,7 +181,9 @@ const Taxes = ({ product, quantity, setTaxSaved, setError }: TaxesProps) => {
         </Col>
         <Col size={8}>
           <p>
-            <strong>{getLabel(values.country ?? "", countries)}</strong>
+            <strong data-testid="country">
+              {getLabel(values.country ?? "", countries)}
+            </strong>
           </p>
         </Col>
       </Row>
@@ -196,7 +196,9 @@ const Taxes = ({ product, quantity, setTaxSaved, setError }: TaxesProps) => {
             </Col>
             <Col size={8}>
               <p>
-                <strong>{getLabel(values.usState, USStates)}</strong>
+                <strong data-testid="us-state">
+                  {getLabel(values.usState, USStates)}
+                </strong>
               </p>
             </Col>
           </Row>
@@ -211,7 +213,9 @@ const Taxes = ({ product, quantity, setTaxSaved, setError }: TaxesProps) => {
             </Col>
             <Col size={8}>
               <p>
-                <strong>{getLabel(values.caProvince, caProvinces)}</strong>
+                <strong data-testid="ca-province">
+                  {getLabel(values.caProvince, caProvinces)}
+                </strong>
               </p>
             </Col>
           </Row>
@@ -226,7 +230,9 @@ const Taxes = ({ product, quantity, setTaxSaved, setError }: TaxesProps) => {
             </Col>
             <Col size={8}>
               <p>
-                <strong>{values.VATNumber ? values.VATNumber : "None"}</strong>
+                <strong data-testid="vat-number">
+                  {values.VATNumber ? values.VATNumber : "None"}
+                </strong>
               </p>
             </Col>
           </Row>
@@ -265,6 +271,7 @@ const Taxes = ({ product, quantity, setTaxSaved, setError }: TaxesProps) => {
       )}
       {values.country === "CA" && (
         <Field
+          data-testid="select-ca-province"
           as={Select}
           id="caProvinces"
           name="caProvince"
@@ -278,6 +285,7 @@ const Taxes = ({ product, quantity, setTaxSaved, setError }: TaxesProps) => {
       )}
       {vatCountries.includes(values.country ?? "") && (
         <Field
+          data-testid="field-vat-number"
           as={Input}
           type="text"
           id="VATNumber"
@@ -304,30 +312,10 @@ const Taxes = ({ product, quantity, setTaxSaved, setError }: TaxesProps) => {
             {window.accountId ? (
               <ActionButton
                 onClick={() => {
-                  if (touched?.country) {
-                    setFieldValue(
-                      "country",
-                      userInfo?.customerInfo?.address?.country
-                    );
-                  }
-                  if (touched?.usState) {
-                    setFieldValue(
-                      "usState",
-                      userInfo?.customerInfo?.address?.state
-                    );
-                  }
-                  if (touched?.caProvince) {
-                    setFieldValue(
-                      "caProvince",
-                      userInfo?.customerInfo?.address?.state
-                    );
-                  }
-                  if (touched?.VATNumber) {
-                    setFieldValue(
-                      "VATNumber",
-                      userInfo?.customerInfo?.taxID?.value
-                    );
-                  }
+                  setFieldValue("country", initialValues.country);
+                  setFieldValue("usState", initialValues.usState);
+                  setFieldValue("caProvince", initialValues.caProvince);
+                  setFieldValue("VATNumber", initialValues.VATNumber);
                   setIsEditing(false);
                   setTaxSaved(true);
                 }}

--- a/static/js/src/advantage/subscribe/checkout/components/UserInfoForm/UserInfoForm.test.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/UserInfoForm/UserInfoForm.test.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { Formik } from "formik";
+import { Elements } from "@stripe/react-stripe-js";
+import { loadStripe } from "@stripe/stripe-js";
+import { fireEvent, render, screen } from "@testing-library/react";
+import UserInfoForm from "./UserInfoForm";
+
+describe("UserInfoFormTests", () => {
+  let queryClient: QueryClient;
+  const stripePromise = loadStripe(window.stripePublishableKey ?? "");
+
+  beforeEach(async () => {
+    queryClient = new QueryClient();
+  });
+
+  it("cancel button resets user info values", () => {
+    global.window = Object.create(window);
+    Object.defineProperty(window, "accountId", { value: "ABCDEF" });
+
+    const intialValues = {
+      name: "Joe",
+      organisationName: "Canonical",
+      buyingFor: "organisation",
+      address: "Adrs Street",
+      city: "Citty",
+      postalCode: "AB12 3CD",
+      defaultPaymentMethod: {
+        brand: "visa",
+        country: "US",
+        expMonth: 4,
+        expYear: 2024,
+        id: "pm_ABCDEF",
+        last4: "4242",
+      },
+    };
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Formik initialValues={intialValues} onSubmit={jest.fn()}>
+          <Elements stripe={stripePromise}>
+            <UserInfoForm setError={jest.fn()} setCardValid={jest.fn()} />
+          </Elements>
+        </Formik>
+      </QueryClientProvider>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+    fireEvent.change(screen.getByTestId("field-customer-name"), {
+      target: { value: "Doe" },
+    });
+    fireEvent.change(screen.getByTestId("field-org-name"), {
+      target: { value: "Canonical 2" },
+    });
+    fireEvent.change(screen.getByTestId("field-address"), {
+      target: { value: "Address" },
+    });
+    fireEvent.change(screen.getByTestId("field-city"), {
+      target: { value: "City" },
+    });
+    fireEvent.change(screen.getByTestId("field-post-code"), {
+      target: { value: "ZX09 8YT" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(screen.getByTestId("customer-name")).toHaveTextContent("Joe");
+    expect(screen.getByTestId("organisation-name")).toHaveTextContent(
+      "Canonical"
+    );
+    expect(screen.getByTestId("customer-address")).toHaveTextContent(
+      "Adrs Street"
+    );
+    expect(screen.getByTestId("customer-city")).toHaveTextContent("Citty");
+    expect(screen.getByTestId("customer-postal-code")).toHaveTextContent(
+      "AB12 3CD"
+    );
+  });
+});

--- a/static/js/src/advantage/subscribe/checkout/components/UserInfoForm/UserInfoForm.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/UserInfoForm/UserInfoForm.tsx
@@ -13,7 +13,6 @@ import { CardElement } from "@stripe/react-stripe-js";
 import { checkoutEvent } from "advantage/ecom-events";
 import { getErrorMessage } from "advantage/error-handler";
 import registerPaymentMethod from "../../hooks/postCustomerInfo";
-import useCustomerInfo from "../../hooks/useCustomerInfo";
 import { FormValues } from "../../utils/types";
 import FormRow from "../FormRow";
 import PaymentMethodSummary from "./PaymentMethodSummary";
@@ -34,16 +33,15 @@ const UserInfoForm = ({ setError, setCardValid }: Props) => {
     errors,
     touched,
     values,
+    initialValues,
     setErrors: setFormikErrors,
     setFieldValue,
     isSubmitting,
   } = useFormikContext<FormValues>();
   const queryClient = useQueryClient();
-  const { data: userInfo } = useCustomerInfo();
-  const defaultPaymentMethod = userInfo?.customerInfo?.defaultPaymentMethod;
   const paymentMethodMutation = registerPaymentMethod();
   const [isEditing, setIsEditing] = useState(
-    !window.accountId || !defaultPaymentMethod
+    !window.accountId || !initialValues.defaultPaymentMethod
   );
   const [isButtonDisabled, setIsButtonDisabled] = useState(false);
   const [cardFieldHasFocus, setCardFieldFocus] = useState(false);
@@ -58,7 +56,7 @@ const UserInfoForm = ({ setError, setCardValid }: Props) => {
   };
 
   useEffect(() => {
-    if (defaultPaymentMethod && !isEditing) {
+    if (initialValues.defaultPaymentMethod && !isEditing) {
       setCardValid(true);
     } else {
       setCardValid(false);
@@ -169,7 +167,9 @@ const UserInfoForm = ({ setError, setCardValid }: Props) => {
             </Col>
             <Col size={8}>
               <p>
-                <strong>{values.organisationName}</strong>
+                <strong data-testid="organisation-name">
+                  {values.organisationName}
+                </strong>
               </p>
             </Col>
           </Row>
@@ -182,7 +182,7 @@ const UserInfoForm = ({ setError, setCardValid }: Props) => {
         </Col>
         <Col size={8}>
           <p>
-            <strong>{values.name}</strong>
+            <strong data-testid="customer-name">{values.name}</strong>
           </p>
         </Col>
       </Row>
@@ -193,7 +193,7 @@ const UserInfoForm = ({ setError, setCardValid }: Props) => {
         </Col>
         <Col size={8}>
           <p>
-            <strong>{values.address}</strong>
+            <strong data-testid="customer-address">{values.address}</strong>
           </p>
         </Col>
       </Row>
@@ -204,7 +204,7 @@ const UserInfoForm = ({ setError, setCardValid }: Props) => {
         </Col>
         <Col size={8}>
           <p>
-            <strong>{values.city}</strong>
+            <strong data-testid="customer-city">{values.city}</strong>
           </p>
         </Col>
       </Row>
@@ -215,7 +215,9 @@ const UserInfoForm = ({ setError, setCardValid }: Props) => {
         </Col>
         <Col size={8}>
           <p>
-            <strong>{values.postalCode}</strong>
+            <strong data-testid="customer-postal-code">
+              {values.postalCode}
+            </strong>
           </p>
         </Col>
       </Row>
@@ -284,6 +286,7 @@ const UserInfoForm = ({ setError, setCardValid }: Props) => {
         </div>
       </FormRow>
       <Field
+        data-testid="field-customer-name"
         as={Input}
         type="text"
         id="name"
@@ -312,6 +315,7 @@ const UserInfoForm = ({ setError, setCardValid }: Props) => {
         </div>
       </FormRow>
       <Field
+        data-testid="field-org-name"
         as={Input}
         type="text"
         id="organisationName"
@@ -327,6 +331,7 @@ const UserInfoForm = ({ setError, setCardValid }: Props) => {
         }
       />
       <Field
+        data-testid="field-address"
         as={Input}
         type="text"
         id="address"
@@ -337,6 +342,7 @@ const UserInfoForm = ({ setError, setCardValid }: Props) => {
         error={touched?.address && errors?.address}
       />
       <Field
+        data-testid="field-city"
         as={Input}
         type="text"
         id="city"
@@ -347,6 +353,7 @@ const UserInfoForm = ({ setError, setCardValid }: Props) => {
         error={touched?.city && errors?.city}
       />
       <Field
+        data-testid="field-post-code"
         as={Input}
         type="text"
         id="postalCode"
@@ -362,7 +369,7 @@ const UserInfoForm = ({ setError, setCardValid }: Props) => {
   return (
     <Row>
       {isEditing ? editMode : displayMode}
-      {window.accountId && defaultPaymentMethod ? (
+      {window.accountId && initialValues.defaultPaymentMethod ? (
         <>
           <hr />
           <div
@@ -372,39 +379,15 @@ const UserInfoForm = ({ setError, setCardValid }: Props) => {
             {isEditing ? (
               <ActionButton
                 onClick={() => {
-                  if (touched?.buyingFor) {
-                    setFieldValue(
-                      "buyingFor",
-                      userInfo?.accountInfo?.name ? "organisation" : "myself"
-                    );
-                  }
-                  if (touched?.organisationName) {
-                    setFieldValue(
-                      "organisationName",
-                      userInfo?.accountInfo?.name
-                    );
-                  }
-                  if (touched?.name) {
-                    setFieldValue("name", userInfo?.customerInfo?.name);
-                  }
-                  if (touched?.address) {
-                    setFieldValue(
-                      "address",
-                      userInfo?.customerInfo?.address?.line1
-                    );
-                  }
-                  if (touched?.city) {
-                    setFieldValue(
-                      "city",
-                      userInfo?.customerInfo?.address?.city
-                    );
-                  }
-                  if (touched?.postalCode) {
-                    setFieldValue(
-                      "postalCode",
-                      userInfo?.customerInfo?.address?.postal_code
-                    );
-                  }
+                  setFieldValue("buyingFor", initialValues.buyingFor);
+                  setFieldValue(
+                    "organisationName",
+                    initialValues.organisationName
+                  );
+                  setFieldValue("name", initialValues.name);
+                  setFieldValue("address", initialValues.address);
+                  setFieldValue("city", initialValues.city);
+                  setFieldValue("postalCode", initialValues.postalCode);
                   setIsEditing(false);
                 }}
               >

--- a/static/js/src/advantage/subscribe/checkout/utils/helpers.ts
+++ b/static/js/src/advantage/subscribe/checkout/utils/helpers.ts
@@ -15,6 +15,7 @@ export function getInitialFormValues(
     name: customerName ?? "",
     buyingFor: buyingFor,
     organisationName: accountName ?? "",
+    defaultPaymentMethod: userInfo?.customerInfo?.defaultPaymentMethod,
     address: userInfo?.customerInfo?.address?.line1 ?? "",
     postalCode: userInfo?.customerInfo?.address?.postal_code ?? "",
     country: userInfo?.customerInfo?.address?.country ?? "",

--- a/static/js/src/advantage/subscribe/checkout/utils/types.ts
+++ b/static/js/src/advantage/subscribe/checkout/utils/types.ts
@@ -35,6 +35,7 @@ export interface FormValues {
   name?: string;
   buyingFor?: "organisation" | "myself";
   organisationName?: string;
+  defaultPaymentMethod?: DefaultPaymentMethod;
   address?: string;
   postalCode?: string;
   country?: string;

--- a/tests/cypress/integration/pro/checkout_spec.js
+++ b/tests/cypress/integration/pro/checkout_spec.js
@@ -14,7 +14,7 @@ const ENDPOINTS = {
   postInvoice: "/account/purchase/*/invoices/*",
 };
 
-context("Checkout - Step 1", () => {
+context("Checkout - Region and taxes", () => {
   it("guest: it should show correct non-VAT price", () => {
     cy.visit("/pro/subscribe");
     cy.acceptCookiePolicy();
@@ -163,6 +163,122 @@ context("Checkout - Step 1", () => {
     // Assert
     cy.get('[data-testid="tax"]').should("exist");
     cy.get('[data-testid="total"]').should("exist");
+  });
+
+  it("user: clicks cancel should reset fields", () => {
+    cy.visit("/pro/subscribe");
+    cy.acceptCookiePolicy();
+    cy.selectProducts();
+
+    cy.login();
+    cy.wait(2000);
+
+    cy.scrollTo("bottom");
+    cy.findByRole("button", { name: "Buy now" }).click();
+
+    // Redirected to checkout
+    cy.location().should((loc) => {
+      expect(loc.pathname).to.equal("/account/checkout");
+    });
+
+    cy.wait(2000);
+
+    // Click 1st Edit button
+    cy.get(
+      ":nth-child(1) > .p-stepped-list__content > .row > .u-align--right > .p-action-button"
+    ).click();
+    cy.findByLabelText("Country/Region:").select(1); // France
+    cy.findByLabelText("VAT number:").clear().type("ABDCDEFG");
+
+    // Click cancel button
+    cy.get(
+      ":nth-child(1) > .p-stepped-list__content > :nth-child(1) > .u-align--right > :nth-child(1)"
+    ).click();
+
+    cy.get('[data-testid="country"]').should("have.text", "United Kingdom");
+    cy.get('[data-testid="vat-number"]').should("have.text", "None");
+
+    // Click 1st Edit button
+    cy.get(
+      ":nth-child(1) > .p-stepped-list__content > .row > .u-align--right > .p-action-button"
+    ).click();
+    cy.findByLabelText("Country/Region:").select(5); // USA
+    cy.findByLabelText("State:").select("Alabama");
+
+    // Click cancel button
+    cy.get(
+      ":nth-child(1) > .p-stepped-list__content > :nth-child(1) > .u-align--right > :nth-child(1)"
+    ).click();
+
+    cy.get('[data-testid="country"]').should("have.text", "United Kingdom");
+    cy.get('[data-testid="vat-number"]').should("have.text", "None");
+
+    // Click 1st Edit button
+    cy.get(
+      ":nth-child(1) > .p-stepped-list__content > .row > .u-align--right > .p-action-button"
+    ).click();
+    cy.findByLabelText("Country/Region:").select("Canada");
+    cy.findByLabelText("Province:").select("Alberta");
+
+    // Click cancel button
+    cy.get(
+      ":nth-child(1) > .p-stepped-list__content > :nth-child(1) > .u-align--right > :nth-child(1)"
+    ).click();
+
+    cy.get('[data-testid="country"]').should("have.text", "United Kingdom");
+    cy.get('[data-testid="vat-number"]').should("have.text", "None");
+  });
+});
+
+context("Checkout - Your information", () => {
+  it("user: clicks cancel should reset fields", () => {
+    cy.visit("/pro/subscribe");
+    cy.acceptCookiePolicy();
+    cy.selectProducts();
+
+    cy.login();
+    cy.wait(2000);
+
+    cy.scrollTo("bottom");
+    cy.findByRole("button", { name: "Buy now" }).click();
+
+    // Redirected to checkout
+    cy.location().should((loc) => {
+      expect(loc.pathname).to.equal("/account/checkout");
+    });
+
+    cy.wait(2000);
+
+    // Click 1st Edit button
+    cy.get(
+      ":nth-child(3) > .p-stepped-list__content > :nth-child(1) > .u-align--right > .p-action-button"
+    ).click();
+
+    cy.findByLabelText("Name:").type("Abcd", { force: true });
+    cy.findByLabelText("Organisation:").type("Abcd");
+    cy.findByLabelText("Address:").type("Abcd");
+    cy.findByLabelText("City:").type("Abcd");
+    cy.findByLabelText("Postal code:").type("Abcd");
+
+    // Click cancel button
+    cy.get(
+      ":nth-child(3) > .p-stepped-list__content > :nth-child(1) > .u-align--right > :nth-child(1)"
+    ).click();
+
+    cy.get('[data-testid="customer-name"]').should("have.text", "Peter");
+    cy.get('[data-testid="organisation-name"]').should(
+      "have.text",
+      "Canonical"
+    );
+    cy.get('[data-testid="customer-address"]').should(
+      "have.text",
+      "Address Road"
+    );
+    cy.get('[data-testid="customer-city"]').should("have.text", "London");
+    cy.get('[data-testid="customer-postal-code"]').should(
+      "have.text",
+      "Post Code"
+    );
   });
 });
 

--- a/tests/cypress/integration/pro/checkout_spec.js
+++ b/tests/cypress/integration/pro/checkout_spec.js
@@ -265,19 +265,13 @@ context("Checkout - Your information", () => {
       ":nth-child(3) > .p-stepped-list__content > :nth-child(1) > .u-align--right > :nth-child(1)"
     ).click();
 
-    cy.get('[data-testid="customer-name"]').should("have.text", "Peter");
-    cy.get('[data-testid="organisation-name"]').should(
-      "have.text",
-      "Canonical"
-    );
-    cy.get('[data-testid="customer-address"]').should(
-      "have.text",
-      "Address Road"
-    );
-    cy.get('[data-testid="customer-city"]').should("have.text", "London");
+    cy.get('[data-testid="customer-name"]').should("not.have.text", "Abcd");
+    cy.get('[data-testid="organisation-name"]').should("not.have.text", "Abcd");
+    cy.get('[data-testid="customer-address"]').should("not.have.text", "Abcd");
+    cy.get('[data-testid="customer-city"]').should("not.have.text", "London");
     cy.get('[data-testid="customer-postal-code"]').should(
-      "have.text",
-      "Post Code"
+      "not.have.text",
+      "Abcd"
     );
   });
 });

--- a/tests/cypress/support/pro/commands.js
+++ b/tests/cypress/support/pro/commands.js
@@ -68,14 +68,6 @@ Cypress.Commands.add("fillInCustomerInfo", () => {
   cy.findByLabelText("City:").type("Citty");
 });
 
-Cypress.Commands.add("fillInCustomerInfo", () => {
-  cy.findByLabelText("Name:").type("Joe Doe", { force: true });
-  cy.findByLabelText("Organisation:").type("AB Studios");
-  cy.findByLabelText("Address:").type("Address Road");
-  cy.findByLabelText("Postal code:").type("AB0 0AB");
-  cy.findByLabelText("City:").type("Citty");
-});
-
 Cypress.Commands.add("acceptTerms", () => {
   cy.findByLabelText(/I agree to the Ubuntu Pro service terms/).click({
     // Need to use { force: true } because the actual input element (radio button)


### PR DESCRIPTION
## Done

- Make cancel button from `Taxes` and `UserInfoForm` components reset to the Fromik initailValues.

## QA

- Are tests passings?
- Edit `Taxes` or `UserInfoForm` sections, click cancel, are the values resetting?

## Issue / Card

Fixes #https://warthogs.atlassian.net/browse/WD-2173