### PR TITLE
Update releases.yaml to add 22.04.2

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -12,7 +12,7 @@ lts:
   slug: JammyJellyfish
   name: "Jammy Jellyfish"
   short_version: "22.04"
-  full_version: "22.04.1"
+  full_version: "22.04.2"
   release_date: "April 2022"
   eol: "April 2027"
   release_notes_url: "https://discourse.ubuntu.com/t/jammy-jellyfish-release-notes/24668"
@@ -32,33 +32,33 @@ openstack_lts:
 checksums:
   desktop:
     "22.10": "b98f13cd86839e70cb7757d46840230496b3febea309dd73bd5f81383474e47b *ubuntu-22.10-desktop-amd64.iso"
-    "22.04.1": "c396e956a9f52c418397867d1ea5c0cf1a99a49dcf648b086d2fb762330cc88d *ubuntu-22.04.1-desktop-amd64.iso"
+    "22.04.2": "b98dac940a82b110e6265ca78d1320f1f7103861e922aa1a54e4202686e9bbd3 *ubuntu-22.04.2-desktop-amd64.iso"
     "21.10": "f8d3ab0faeaecb5d26628ae1aa21c9a13e0a242c381aa08157db8624d574b830 *ubuntu-21.10-desktop-amd64.iso"
     "20.04.5": "2980570ea889f3467a04df15c8421ef1dc80ecef7bb37243da97f5714cf3f8ef *ubuntu-20.04.5-desktop-amd64.iso"
   live-server:
     "22.10": "874452797430a94ca240c95d8503035aa145bd03ef7d84f9b23b78f3c5099aed *ubuntu-22.10-live-server-amd64.iso"
-    "22.04.1": "10f19c5b2b8d6db711582e0e27f5116296c34fe4b313ba45f9b201a5007056cb *ubuntu-22.04.1-live-server-amd64.iso"
+    "22.04.2": "5e38b55d57d94ff029719342357325ed3bda38fa80054f9330dc789cd2d43931 *ubuntu-22.04.2-live-server-amd64.iso"
     "21.10": "e84f546dfc6743f24e8b1e15db9cc2d2c698ec57d9adfb852971772d1ce692d4 *ubuntu-21.10-live-server-amd64.iso"
     "20.04.5": "5035be37a7e9abbdc09f0d257f3e33416c1a0fb322ba860d42d74aa75c3468d4 *ubuntu-20.04.5-live-server-amd64.iso"
     "18.04.6": "6c647b1ab4318e8c560d5748f908e108be654bad1e165f7cf4f3c1fc43995934 *ubuntu-18.04.6-live-server-amd64.iso"
   desktop-arm64+raspi:
     "22.10": "c9cf57399a5e3e3a9803740f8107ef52891b7d3ac293106d3257396b75ddf7de *ubuntu-22.10-preinstalled-desktop-arm64+raspi.img.xz"
-    "22.04.1": "680c2c1770b53d90e825fd9a40178f605af47acfff681ad5f68d38094d1c32eb *ubuntu-22.04.1-preinstalled-desktop-arm64+raspi.img.xz"
+    "22.04.2": "c7d39e37455c2ff3def2b125abb046245a9e6fbf8519f711aa22485eabd3bc52 *ubuntu-22.04.2-preinstalled-desktop-arm64+raspi.img.xz"
     "21.10": "5187d507099f26bc4d8218085109af498fae5ff93b40c668f83bab5c7574d954 *ubuntu-21.10-preinstalled-desktop-arm64+raspi.img.xz"
     "21.04": "d89ee327a00b98d7166b1a8cc95d17762aaacd3b4d0fc756c5b6b65df1708f48 *ubuntu-21.04-preinstalled-desktop-arm64+raspi.img.xz"
   server-arm64+raspi:
     "22.10": "170d860a49039499d349eeb69276c997e26ada811f5b4bce761b55a6461914a2 *ubuntu-22.10-preinstalled-server-arm64+raspi.img.xz"
-    "22.04.1": "5d0661eef1a0b89358159f3849c8f291be2305e5fe85b7a16811719e6e8ad5d1 *ubuntu-22.04.1-preinstalled-server-arm64+raspi.img.xz"
+    "22.04.2": "22705473ab9c1ca19012fe2d42f917218b823d1a815dabb8a240681c51d143a5 *ubuntu-22.04.2-preinstalled-server-arm64+raspi.img.xz"
     "21.10": "126f940d3b270a6c1fc5a183ac8a3d193805fead4f517296a7df9d3e7d691a03 *ubuntu-21.10-preinstalled-server-arm64+raspi.img.xz"
     "20.04.5": "44b98acd3fd4379c6b194696520b6aecb2f596b601e43e9b6934c83f0aa61026 *ubuntu-20.04.5-preinstalled-server-arm64+raspi.img.xz"
   server-armhf+raspi:
     "22.10": "a869ade13fb1a983da95eb92093e640692a930d01354d63f05571234ca0cd6b5 *ubuntu-22.10-preinstalled-server-armhf+raspi.img.xz"
-    "22.04.1": "342fb581ce11208c26f35675acafdc3d56ac2838b1297a508e602f88606903f1 *ubuntu-22.04.1-preinstalled-server-armhf+raspi.img.xz"
+    "22.04.2": "45b2fb10f63fa2e820d0bd34693d86a507499f6efae1f4848af6601ebfaf8745 *ubuntu-22.04.2-preinstalled-server-armhf+raspi.img.xz"
     "21.10": "341593c9607ed20744cd86941d94d73e3ba4f74e8ef2633eec63ce9b0cfac5a1 *ubuntu-21.10-preinstalled-server-armhf+raspi.img.xz"
     "20.04.5": "065c41846ddf7a1c636a1aac5a7d49ebcee819b141f9d57fd586c5f84b9b7942 *ubuntu-20.04.5-preinstalled-server-armhf+raspi.img.xz"
   server-riscv64:
     "22.10": "858feb7f96e94ad904624262ee4a669caebafd012a2812e19e0dd21be9b6faa6 *ubuntu-22.10-preinstalled-server-riscv64+unmatched.img.xz"
-    "22.04.1": "a4cf79456e09c7c03c96ef4b0924dd54ab1706d86af09d29a7c117855e80eac6 *ubuntu-22.04.1-preinstalled-server-riscv64+unmatched.img.xz"
+    "22.04.2": "7a31a92f6a17e497bc8d5e72b2862ed0eb6cc68ca3a4efb1893ddcbfda13e9bd *ubuntu-22.04.2-preinstalled-server-riscv64+unmatched.img.xz"
     "21.10": "8067892fa627eb219b31dc629f31f3bda6b015dfeabf2fdc9b0ed150bf7984b8 *ubuntu-21.10-preinstalled-server-riscv64+unmatched.img.xz"
   core-22-arm64+raspi:
     "22": "374697bd7324f10ff3c00007b75ca42885aff161cbddb63b1d14bc1551e69ce2 *ubuntu-core-22-arm64+raspi.img.xz"

--- a/templates/download/risc-v/tab-1.html
+++ b/templates/download/risc-v/tab-1.html
@@ -12,15 +12,15 @@
 			<p>
 				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/22.10/release/ubuntu-22.10-preinstalled-server-riscv64+unmatched.img.xz">Download 64-bit</a>
 			</p>			
-			<h3 class="p-heading--4">Ubuntu Server 22.04.1</h3>
+			<h3 class="p-heading--4">Ubuntu Server 22.04.2</h3>
 			<div class="p-notification--information is-inline">
 				<div class="p-notification__content">
 					<h4 class="p-notification__title">Note:</h4>
-					<p class="p-notification__message">It is an early RISC-V developer access through Ubuntu 22.04.1 and this is a preinstalled image, if you have a NVMe drive, we advise you to use the Ubuntu Server live installer which can be found <a href="https://cdimage.ubuntu.com/releases/22.04.1/release/ubuntu-22.04.1-live-server-riscv64.img.gz">here</a>.</p>
+					<p class="p-notification__message">It is an early RISC-V developer access through Ubuntu 22.04.2 and this is a preinstalled image, if you have a NVMe drive, we advise you to use the Ubuntu Server live installer which can be found <a href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-live-server-riscv64.img.gz">here</a>.</p>
 				</div>
 			</div>
 			<p>
-				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/22.04.1/release/ubuntu-22.04.1-preinstalled-server-riscv64+unmatched.img.xz">Download 64-bit</a>
+				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+unmatched.img.xz">Download 64-bit</a>
 			</p>
 			<p>Works on:</p>
 			<ul class="p-list">

--- a/templates/download/risc-v/tab-2.html
+++ b/templates/download/risc-v/tab-2.html
@@ -12,15 +12,15 @@
 			<p>
 				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/22.10/release/ubuntu-22.10-preinstalled-server-riscv64+visionfive.img.xz">Download 64-bit</a>
 			</p>			
-			<h3 class="p-heading--4">Ubuntu Server 22.04.1</h3>
+			<h3 class="p-heading--4">Ubuntu Server 22.04.2</h3>
 			<div class="p-notification--information is-inline">
 				<div class="p-notification__content">
 					<h4 class="p-notification__title">Note:</h4>
-					<p class="p-notification__message">It is an early RISC-V developer access through Ubuntu 22.04.1.</p>
+					<p class="p-notification__message">It is an early RISC-V developer access through Ubuntu 22.04.2.</p>
 				</div>
 			</div>
 			<p>
-				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/22.04.1/release/ubuntu-22.04.1-preinstalled-server-riscv64+visionfive.img.xz">Download 64-bit</a>
+				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+visionfive.img.xz">Download 64-bit</a>
 			</p>
 			<p>Works on:</p>
 			<ul class="p-list">

--- a/templates/download/risc-v/tab-3.html
+++ b/templates/download/risc-v/tab-3.html
@@ -12,15 +12,15 @@
 			<p>
 				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/22.10/release/ubuntu-22.10-preinstalled-server-riscv64+nezha.img.xz">Download 64-bit</a>
 			</p>	
-			<h3 class="p-heading--4">Ubuntu Server 22.04.1</h3>
+			<h3 class="p-heading--4">Ubuntu Server 22.04.2</h3>
 			<div class="p-notification--information is-inline">
 				<div class="p-notification__content">
 					<h4 class="p-notification__title">Note:</h4>
-					<p class="p-notification__message">It is an early RISC-V developer access through Ubuntu 22.04.1.</p>
+					<p class="p-notification__message">It is an early RISC-V developer access through Ubuntu 22.04.2</p>
 				</div>
 			</div>
 			<p>
-				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/22.04.1/release/ubuntu-22.04.1-preinstalled-server-riscv64+nezha.img.xz">Download 64-bit</a>
+				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+nezha.img.xz">Download 64-bit</a>
 			</p>
 			<p>Works on:</p>
 			<ul class="p-list">

--- a/templates/download/risc-v/tab-5.html
+++ b/templates/download/risc-v/tab-5.html
@@ -12,15 +12,15 @@
 			<p>
 				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/22.10/release/ubuntu-22.10-live-server-riscv64.img.gz">Download 64-bit</a>
 			</p>			
-			<h3 class="p-heading--4">Ubuntu Server 22.04.1</h3>
+			<h3 class="p-heading--4">Ubuntu Server 22.04.2</h3>
 			<div class="p-notification--information is-inline">
 				<div class="p-notification__content">
 					<h4 class="p-notification__title">Note:</h4>
-					<p class="p-notification__message">It is an early RISC-V developer access through Ubuntu 22.04.1. This image works on the SiFive Unmatched Board and on QEMU.</p>
+					<p class="p-notification__message">It is an early RISC-V developer access through Ubuntu 22.04.2. This image works on the SiFive Unmatched Board and on QEMU.</p>
 				</div>
 			</div>
 			<p>
-				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/22.04.1/release/ubuntu-22.04.1-live-server-riscv64.img.gz">Download 64-bit</a>
+				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-live-server-riscv64.img.gz">Download 64-bit</a>
 			</p>
 			<p>Works on:</p>
 			<ul class="p-list">


### PR DESCRIPTION
## Done

- Update releases.yaml file to include the new 22.04.2 release.
- [x] Update sha256 sums for the release

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Check that there are no mentions of 22.04.1
