### PR TITLE
Add secondary call to action in /pro

### DIFF
--- a/templates/pro/index.html
+++ b/templates/pro/index.html
@@ -18,6 +18,7 @@ https://docs.google.com/document/d/1In4NSnckAtL51_7D_AZCHa6TPnPGXqctXo-5rE77_aY/
     </h1>
     <p class="p-heading--2">The most comprehensive subscription<br /> for open-source software security</p>
     <a href="/pro/subscribe" class="p-button--positive">Get Ubuntu Pro now</a>
+    <a href="/pro/dashboard" class="p-button">Register for personal use</a>
   </div>
 </section>
 


### PR DESCRIPTION
## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/pro
- Make sure it adds the call to action as specified on the ticket.

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-2179

