### PR TITLE
Update logos on /appliance/hardware

### DIFF
--- a/templates/appliance/hardware.html
+++ b/templates/appliance/hardware.html
@@ -31,17 +31,17 @@
             attrs={"style": "margin-bottom: .85rem;"},
           ) | safe
         }}
-        <p class="p-heading--4">PC and Server Family</p>
+        <p class="p-heading--4" style="margin-right:0;">PC and Server Family</p>
       </a>
     </div>
     <div class="col-4 p-divider__block u-align--center">
       <a href="/appliance/vm">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/05caa6c5-Multipass-mark.svg?h=136",
+            url="https://assets.ubuntu.com/v1/ead64879-multipass-logo.svg",
             alt="",
             height="136",
-            width="136",
+            width="130",
             hi_def=True,
             loading="auto",
             attrs={"style": "margin-bottom: 1rem; margin-top: 0.75rem;"},

--- a/templates/appliance/shared/_featured_appliances.html
+++ b/templates/appliance/shared/_featured_appliances.html
@@ -108,10 +108,10 @@
       <div class="u-hide--small">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/ac9a0e00-lxd_primary.svg",
+            url="https://assets.ubuntu.com/v1/73cc5217-lxd-logo.svg",
             alt="",
-            height="32",
-            width="97",
+            height="26",
+            width="120",
             hi_def=True,
             loading="lazy",
             attrs={"class": "u-align--left", "style": "margin-top: 1rem;"},


### PR DESCRIPTION
## Done

- Updates logos on /appliance/hardware based on [the issue](https://warthogs.atlassian.net/browse/WD-1729)

## QA

- Go to https://ubuntu-com-12609.demos.haus/appliance/hardware and make sure the page matches the 'replacement' images found in the issue

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-1729