### PR TITLE
Update logos on /appliance/vm

### DIFF
--- a/templates/appliance/vm.html
+++ b/templates/appliance/vm.html
@@ -18,13 +18,13 @@
         Try out Ubuntu Appliance images in an isolated virtual machine on your PC or Mac with Multipass.  You can navigate through the setup instructions and interact with the software before taking the next step and installing it on a Raspberry Pi or a PC.
       </p>
     </div>
-    <div class="col-4 u-hide-small u-align--center u-vertically-center">
+    <div class="col-4 u-hide-small u-hide--medium u-align--center u-vertically-center">
       {{
         image(
-        url="https://assets.ubuntu.com/v1/648b93e0-Multipass-stacked.svg",
+        url="https://assets.ubuntu.com/v1/1899e099-multipass-logo-light.svg",
         alt="",
-        width="240",
-        height="164",
+        width="333",
+        height="55",
         hi_def=True,
         loading="auto",
         ) | safe


### PR DESCRIPTION
## Done

- Updates logos on /appliance/vm based on [this issue](https://warthogs.atlassian.net/browse/WD-1731)

## QA

- Go to https://ubuntu-com-12610.demos.haus/appliance/vm and check that it matches the 'replacement' image from the issue

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-1731
