### PR TITLE
WD-1347 Add new Polarfire Risc-v tab

### DIFF
--- a/templates/download/risc-v/index.html
+++ b/templates/download/risc-v/index.html
@@ -13,7 +13,7 @@
     <div class="col-6">
       <h1>Download Ubuntu for RISC-V Platforms</h1>
       <h2 class="p-heading--3">Ubuntu &mdash; now available for multiple RISC-V platforms</h2>
-      <p>Run Ubuntu with your favourite RISC-V boards. Ubuntu recently enabled SiFive Unmatched, StarFive VisionFive, Allwinner Nezha, and Sipeed LicheeRV in 22.10. Download the images for those boards below.</p>
+      <p>Run Ubuntu with your favourite RISC-V boards. Ubuntu recently enabled SiFive Unmatched, StarFive VisionFive, Allwinner Nezha, Sipeed LicheeRV and Microchip Polarfire SoC FPGA Icicle Kit. Download the images for those boards below.</p>
       <p>Pick the OS image to match your hardware, flash it onto SD/microSD card, load it onto your board and away you go.</p>
       <p>
         <a href="/download/contact-us" class="js-invoke-modal p-button">Get in touch</a>
@@ -51,6 +51,9 @@
             <button class="p-tabs__link" role="tab" aria-selected="false" aria-controls="sipeed-licheerv-dock-tab" id="sipeed-licheerv-dock">Sipeed LicheeRV Dock</button>
         </div>
         <div class="p-tabs__item">
+          <button class="p-tabs__link" role="tab" aria-selected="false" aria-controls="microchip-polarfire-soc-fpga-icicle-kit-tab" id="microchip-polarfire-soc-fpga-icicle-kit">Polarfire SoC FPGA Icicle</button>
+        </div>
+        <div class="p-tabs__item">
             <button class="p-tabs__link" role="tab" aria-selected="false" aria-controls="live-installer-tab" id="live-installer">Live installer</button>
         </div>
       </div>
@@ -59,6 +62,7 @@
       {% include "download/risc-v/tab-3.html" %}
       {% include "download/risc-v/tab-4.html" %}
       {% include "download/risc-v/tab-5.html" %}
+      {% include "download/risc-v/tab-6.html" %}
     </div>
   </div>
 </section>

--- a/templates/download/risc-v/tab-1.html
+++ b/templates/download/risc-v/tab-1.html
@@ -28,7 +28,8 @@
 				<li class="p-list__item is-ticked">QEMU</li>
 			</ul>
 		</div>
-		<div class="col-6 u-hide--medium u-hide--small u-align--center">
+		<div class="col-2 u-hide--medium u-hide--small">&nbsp;</div>
+		<div class="col-4 u-hide--medium u-hide--small u-align--center u-vertically-center">
 			{{ image (
 				url="https://assets.ubuntu.com/v1/37c094a9-SiFive+Unmatched+Board.jpg",
 				alt="",
@@ -40,8 +41,10 @@
 			  }}
 		</div>
 	</div>
-	<div class="u-fixed-width">
-		<h4>First time installing Ubuntu on QEMU/Unmatched?</h4>
-		<p>Please see the <a href="https://wiki.ubuntu.com/RISC-V">wiki.ubuntu.com/RISC-V</a> for more information.</p>
+	<div class="row">
+		<div class="col-6 u-vertically-center u-no-padding">
+			<h4>First time installing Ubuntu on QEMU/Unmatched?</h4>
+			<p>Please see the <a href="https://wiki.ubuntu.com/RISC-V">wiki.ubuntu.com/RISC-V</a> for more information.</p>
+		</div>
 	</div>
 </div>

--- a/templates/download/risc-v/tab-2.html
+++ b/templates/download/risc-v/tab-2.html
@@ -27,7 +27,8 @@
 				<li class="p-list__item is-ticked">The VisionFive board</li>
 			</ul>
 		</div>
-		<div class="col-6 u-hide--medium u-hide--small u-align--center">
+		<div class="col-2 u-hide--medium u-hide--small">&nbsp;</div>
+		<div class="col-4 u-hide--medium u-hide--small u-align--center">
 			{{ image (
 				url="https://assets.ubuntu.com/v1/470a2398-StarFive+VisionFive+Board-NoBg.png",
 				alt="",
@@ -39,8 +40,10 @@
 			  }}
 		</div>
 	</div>
-	<div class="u-fixed-width">
-		<h4>First time installing Ubuntu on the VisionFive?</h4>
-		<p>Please see the <a href="https://discourse.ubuntu.com/t/ubuntu-on-the-visionfive-and-the-nezha-boards/29858	">How to install Ubuntu on the VisionFive</a> for more information.</p>
+	<div class="row">
+		<div class="col-6 u-vertically-center u-no-padding">
+			<h4>First time installing Ubuntu on the VisionFive?</h4>
+			<p>Please see the <a href="https://discourse.ubuntu.com/t/ubuntu-on-the-visionfive-and-the-nezha-boards/29858	">How to install Ubuntu on the VisionFive</a> for more information.</p>
+		</div>
 	</div>
 </div>

--- a/templates/download/risc-v/tab-3.html
+++ b/templates/download/risc-v/tab-3.html
@@ -27,7 +27,8 @@
 				<li class="p-list__item is-ticked">The Nezha board</li>
 			</ul>
 		</div>
-		<div class="col-6 u-hide--medium u-hide--small u-align--center">
+		<div class="col-2 u-hide--medium u-hide--small">&nbsp;</div>
+		<div class="col-4 u-hide--medium u-hide--small u-align--center">
 			{{ image (
 				url="https://assets.ubuntu.com/v1/0cc9bac3-Allwinner+Nezha+Board.png",
 				alt="",
@@ -39,8 +40,10 @@
 			  }}
 		</div>
 	</div>
-	<div class="u-fixed-width">
-		<h4>First time installing Ubuntu on the Nezha?</h4>
-		<p>Please see the <a href="https://discourse.ubuntu.com/t/ubuntu-on-the-visionfive-and-the-nezha-boards/29858">How to install Ubuntu on the Nezha</a> for more information.</p>
+	<div class="row u-vertically-center u-no-padding">
+		<div class="col-6">
+			<h4>First time installing Ubuntu on the Nezha?</h4>
+			<p>Please see <a href="https://wiki.ubuntu.com/RISC-V/Nezha%20D1">How to install Ubuntu on the Nezha Guide</a> for more information.</p>
+		</div>
 	</div>
 </div>

--- a/templates/download/risc-v/tab-4.html
+++ b/templates/download/risc-v/tab-4.html
@@ -12,12 +12,23 @@
 			<p>
 				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/22.10/release/ubuntu-22.10-preinstalled-server-riscv64+licheerv.img.xz">Download 64-bit</a>
 			</p>
+			<h3 class="p-heading--4">Ubuntu Server 22.04.2</h3>
+			<div class="p-notification--information is-inline">
+				<div class="p-notification__content">
+					<h4 class="p-notification__title">Note:</h4>
+					<p class="p-notification__message">It is an early RISC-V developer access through Ubuntu 22.04.2.</p>
+				</div>
+			</div>
+			<p>
+				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+licheerv.img.xz">Download 64-bit</a>
+			</p>
 			<p>Works on:</p>
 			<ul class="p-list">
 				<li class="p-list__item is-ticked">The LicheeRV Dock board</li>
 			</ul>
 		</div>
-		<div class="col-6 u-hide--medium u-hide--small u-align--center">
+		<div class="col-2 u-hide--medium u-hide--small">&nbsp;</div>
+		<div class="col-4 u-hide--medium u-hide--small u-align--center">
 			{{ image (
 				url="https://assets.ubuntu.com/v1/b151abd7-Sipeed+LicheeRV+-+Edited-2.png",
 				alt="",
@@ -29,8 +40,10 @@
 			}}
 		</div>
 	</div>
-	<div class="u-fixed-width">
-		<h4>First time installing Ubuntu on the LicheeRV Dock?</h4>
-		<p>Please see the <a href="https://wiki.ubuntu.com/RISC-V/LicheeRV">How to install Ubuntu on the LicheeRV Dock guide</a> for more information.</p>
+	<div class="row u-vertically-center u-no-padding">
+		<div class="col-6">
+			<h4>First time installing Ubuntu on the LicheeRV Dock?</h4>
+			<p>Please see the <a href="https://wiki.ubuntu.com/RISC-V/LicheeRV">How to install Ubuntu on the LicheeRV Dock guide</a> for more information.</p>
+		</div>
 	</div>
 </div>

--- a/templates/download/risc-v/tab-5.html
+++ b/templates/download/risc-v/tab-5.html
@@ -1,47 +1,40 @@
-<div tabindex="0" role="tabpanel" id="live-installer-tab" aria-labelledby="live-installer" aria-hidden="true">
+<div tabindex="0" role="tabpanel" id="microchip-polarfire-soc-fpga-icicle-kit-tab" aria-labelledby="live-installer" aria-hidden="true">
 	<div class="row u-vertically-center u-no-padding">
 		<div class="col-6">
-			<h2>Download Ubuntu Server Live Installer</h2>
-			<h3 class="p-heading--4">Ubuntu Server 22.10</h3>
-			<div class="p-notification--information is-inline">
-				<div class="p-notification__content">
-					<h4 class="p-notification__title">Note:</h4>
-					<p class="p-notification__message">It is an early RISC-V developer access through Ubuntu 22.10. This image works on the SiFive Unmatched Board and on QEMU.</p>
-				</div>
-			</div>
-			<p>
-				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/22.10/release/ubuntu-22.10-live-server-riscv64.img.gz">Download 64-bit</a>
-			</p>			
+			<h2>Download Ubuntu Server</h2>
 			<h3 class="p-heading--4">Ubuntu Server 22.04.2</h3>
 			<div class="p-notification--information is-inline">
 				<div class="p-notification__content">
 					<h4 class="p-notification__title">Note:</h4>
-					<p class="p-notification__message">It is an early RISC-V developer access through Ubuntu 22.04.2. This image works on the SiFive Unmatched Board and on QEMU.</p>
+					<p class="p-notification__message">It is an early RISC-V developer access through Ubuntu 22.04.2.</p>
 				</div>
 			</div>
 			<p>
-				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-live-server-riscv64.img.gz">Download 64-bit</a>
-			</p>
+				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+icicle.img.xz">Download 64-bit</a>
+			</p>			
 			<p>Works on:</p>
 			<ul class="p-list">
-				<li class="p-list__item is-ticked">The Unmatched board</li>
-				<li class="p-list__item is-ticked">QEMU</li>
+				<li class="p-list__item is-ticked">The Microchip Polarfire SoC FPGA Icicle Kit with <a href="https://github.com/polarfire-soc/hart-software-services/releases/tag/v2022.10">HSS v2022.10</a></li>
 			</ul>
 		</div>
-		<div class="col-6 u-hide--medium u-hide--small u-align--center">
-			{{ image (
-				url="https://assets.ubuntu.com/v1/37c094a9-SiFive+Unmatched+Board.jpg",
+		<div class="col-2 u-hide--medium u-hide--small">&nbsp;</div>
+		<div class="col-4 u-hide--medium u-hide--small u-align--center">
+			{{
+				image (
+				url="https://assets.ubuntu.com/v1/40eacb41-Microchip+PolarFire.png",
 				alt="",
-				width="720",
-				height="480",
+				width="800",
+				height="414",
 				hi_def=True,
-				loading="auto"
+				loading="lazy"
 				) | safe
-			}}
+			  }}
 		</div>
 	</div>
-	<div class="u-fixed-width">
-		<h4>First time installing Ubuntu on QEMU/Unmatched?</h4>
-		<p>Please see the <a href="https://discourse.ubuntu.com/t/ubuntu-installation-on-the-sifive-hifive-unmatched-board-using-a-server-install-image/27804">Ubuntu installation on the SiFive HiFive Unmatched board using a server install image - RISC-V-docs</a> and <a href="https://discourse.ubuntu.com/t/ubuntu-installation-on-a-risc-v-virtual-machine-using-a-server-install-image-and-qemu/27636">Ubuntu installation on a RISC-V virtual machine using a server install image and QEMU</a> for more information.</p>
+	<div class="row u-vertically-center u-no-padding">
+		<div class="col-6">
+			<h4>First time installing Ubuntu on the Microchip Polarfire SoC FPGA Icicle Kit?</h4>
+			<p>Please see <a href="https://wiki.ubuntu.com/RISC-V/PolarFire%20SoC%20FPGA%20Icicle%20Kit">How to install Ubuntu on the Microchip Polarfire SoC FPGA Icicle Kit</a> for more information.</p>
+		</div>
 	</div>
 </div>

--- a/templates/download/risc-v/tab-6.html
+++ b/templates/download/risc-v/tab-6.html
@@ -1,0 +1,60 @@
+<div tabindex="0" role="tabpanel" id="live-installer-tab" aria-labelledby="live-installer" aria-hidden="true">
+	<div class="row u-vertically-center u-no-padding">
+		<div class="col-6">
+			<h2>Download Ubuntu Server Live Installer</h2>
+			<h3 class="p-heading--4">Ubuntu Server 22.10</h3>
+			<div class="p-notification--information is-inline">
+				<div class="p-notification__content">
+					<h4 class="p-notification__title">Note:</h4>
+					<p class="p-notification__message">It is an early RISC-V developer access through Ubuntu 22.10. This image works on the SiFive Unmatched Board and on QEMU.</p>
+				</div>
+			</div>
+			<p>
+				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/22.10/release/ubuntu-22.10-live-server-riscv64.img.gz">Download 64-bit</a>
+			</p>			
+			<h3 class="p-heading--4">Ubuntu Server 22.04.2</h3>
+			<div class="p-notification--information is-inline">
+				<div class="p-notification__content">
+					<h4 class="p-notification__title">Note:</h4>
+					<p class="p-notification__message">It is an early RISC-V developer access through Ubuntu 22.04.2. This image works on the SiFive Unmatched Board and on QEMU.</p>
+				</div>
+			</div>
+			<p>
+				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-live-server-riscv64.img.gz">Download 64-bit</a>
+			</p>
+			<p>Works on:</p>
+			<ul class="p-list">
+				<li class="p-list__item is-ticked">The Unmatched board</li>
+				<li class="p-list__item is-ticked">QEMU</li>
+			</ul>
+		</div>
+		<div class="col-2 u-hide--medium u-hide--small">&nbsp;</div>
+		<div class="col-4 u-hide--medium u-hide--small u-align--center">
+			{{ image (
+				url="https://assets.ubuntu.com/v1/37c094a9-SiFive+Unmatched+Board.jpg",
+				alt="",
+				width="720",
+				height="480",
+				hi_def=True,
+				loading="auto"
+				) | safe
+			}}
+			{{
+				image (
+				url="https://assets.ubuntu.com/v1/308d48cd-Qemu-logo.png",
+				alt="",
+				width="377",
+				height="120",
+				hi_def=True,
+				loading="auto|lazy"
+				) | safe
+			  }}
+		</div>
+	</div>
+	<div class="row u-vertically-center u-no-padding">
+		<div class="col-6">
+			<h4>First time installing Ubuntu on QEMU/Unmatched?</h4>
+			<p>Please see the <a href="https://discourse.ubuntu.com/t/ubuntu-installation-on-the-sifive-hifive-unmatched-board-using-a-server-install-image/27804">Ubuntu installation on the SiFive HiFive Unmatched board using a server install image - RISC-V-docs</a> and <a href="https://discourse.ubuntu.com/t/ubuntu-installation-on-a-risc-v-virtual-machine-using-a-server-install-image-and-qemu/27636">Ubuntu installation on a RISC-V virtual machine using a server install image and QEMU</a> for more information.</p>
+		</div>
+	</div>
+</div>


### PR DESCRIPTION
# Deploy on 7th of March

## Done

Add new Polarfire Risc-v tab

## QA

- Go to  https://ubuntu-com-12611.demos.haus/download/risc-v
- Click on the new Polarfire tab. Check against [copy docs](https://docs.google.com/document/d/1kkJeq9HdH3iWV35HwihcJd3CxZw9Jy21W66lJl8VbWs/edit?disco=AAAArW4QcRQ)
   - Only new  Microchip Polarfire change at the top
   - New tab 5 for Microchip Polarfire. 

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-2154?atlOrigin=eyJpIjoiZmVlMTRlZDNmZDlmNGQzZWFlODdiYTYzNjM2ZjU5OWEiLCJwIjoiaiJ9


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
