### PR TITLE
WD-1712, WD-1714 Replace logos in `/download/*`

### DIFF
--- a/templates/appliance/shared/_featured_appliances.html
+++ b/templates/appliance/shared/_featured_appliances.html
@@ -108,7 +108,7 @@
       <div class="u-hide--small">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/73cc5217-lxd-logo.svg",
+            url="https://assets.ubuntu.com/v1/73cc5217-lxd-logo-26.svg",
             alt="",
             height="26",
             width="120",

--- a/templates/download/cloud/index.html
+++ b/templates/download/cloud/index.html
@@ -14,10 +14,10 @@
     <div class="col-4 u-align--center u-vertically-center u-hide--medium u-hide--small">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/a9580e02-ubuntu-cloud-medium.svg",
-          alt="",
-          width="350",
-          height="200",
+          url="https://assets.ubuntu.com/v1/f0028afb-ubuntu-cloud.svg",
+          alt="ubuntu cloud illustration",
+          width="303",
+          height="198",
           hi_def=True,
         ) | safe
       }}

--- a/templates/download/iot/index.html
+++ b/templates/download/iot/index.html
@@ -171,7 +171,7 @@
             url="https://assets.ubuntu.com/v1/0bdfaf89-ubuntu-core-logo-45.svg",
             alt="Canonical Ubuntu Core logo",
             width="315",
-            height="46",
+            height="45",
             hi_def=True,
             loading="lazy"
           ) | safe

--- a/templates/download/iot/index.html
+++ b/templates/download/iot/index.html
@@ -155,8 +155,8 @@
   </section>
 
   <section id="core" class="p-strip--light">
-    <div class="row u-equal-height">
-      <div class="col-8">
+    <div class="row u-equal-height p-divider">
+      <div class="col-7">
         <h3 class="p-heading--2">Ubuntu Core</h3>
         <p>
           Ubuntu Core is a lean, strictly confined and fully transactional operating system. We designed it from the ground up, to focus on security and simplified maintenance, for appliances and large device networks. Ubuntu Core is powered by snaps - the universal Linux packaging format.
@@ -165,13 +165,13 @@
           <a class="p-button is-inline" style="margin-left: 0;" href="/core">Learn more about Ubuntu Core</a><br class="u-hide--large u-hide--medium" /><a href="/download/kvm">Install on your workstation in a KVM&nbsp;&rsaquo;</a>
         </p>
       </div>
-      <div class="col-4 u-vertically-center u-hide--medium u-hide--small u-align--center">
+      <div class="col-5 p-divider__block u-vertically-center u-hide--medium u-hide--small u-align--center">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/805f2b3a-core_black-orange_st_hex.svg",
-            alt="Ubuntu Core",
-            width="125",
-            height="168",
+            url="https://assets.ubuntu.com/v1/0bdfaf89-ubuntu-core-logo-45.svg",
+            alt="Canonical Ubuntu Core logo",
+            width="315",
+            height="46",
             hi_def=True,
             loading="lazy"
           ) | safe

--- a/templates/pricing/shared/_enablement-strip.html
+++ b/templates/pricing/shared/_enablement-strip.html
@@ -32,12 +32,11 @@
 
 
     <div class="col-2 col-start-large-10 u-hide--small u-hide--medium">
-      {{
-        image(
-        url="https://assets.ubuntu.com/v1/706b259a-ubuntu_certified_hex.svg",
-        alt="Ubuntu certified",
-        width="127",
-        height="159",
+      {{ image (
+        url="https://assets.ubuntu.com/v1/f76dd871-ubuntu-certified.png",
+        alt="Ubuntu certified logo",
+        width="158",
+        height="224",
         hi_def=True,
         loading="lazy",
         attrs={"class": "col-2 col-start-large-10 u-hide--small"},


### PR DESCRIPTION
## Done

- `/download/iot`
  - Replaced: 
    - Ubunutu core logo
    - Canonical LXD logo
    - Ubuntu Certified logo 
 
- `/download/cloud`
  - Replaced:
    - Ubuntu cloud logo

## QA

- Navigate to https://ubuntu-com-12613.demos.haus/download/iot and compare with images in [WD-1712](https://warthogs.atlassian.net/browse/WD-1712)
- Navigate to https://ubuntu-com-12613.demos.haus/download/cloud and compare with the image in [WD-1714](https://warthogs.atlassian.net/browse/WD-1714)

## Issue / Card
- [WD-1712](https://warthogs.atlassian.net/browse/WD-1712)
- [WD-1714](https://warthogs.atlassian.net/browse/WD-1714)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-1712]: https://warthogs.atlassian.net/browse/WD-1712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WD-1712]: https://warthogs.atlassian.net/browse/WD-1712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[WD-1714]: https://warthogs.atlassian.net/browse/WD-1714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WD-1714]: https://warthogs.atlassian.net/browse/WD-1714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ