### PR TITLE
Display offer discount on checkout

### DIFF
--- a/static/js/src/advantage/offers/components/Offer/Offer.test.tsx
+++ b/static/js/src/advantage/offers/components/Offer/Offer.test.tsx
@@ -33,7 +33,6 @@ describe("Offer", () => {
       ],
       total: 340000,
     });
-    console.log("offer", offer);
     render(<Offer offer={offer} />);
     expect(screen.getByText("Test")).toBeInTheDocument();
     expect(screen.getByText("$400.00")).toBeInTheDocument();

--- a/static/js/src/advantage/offers/components/Offer/Offer.tsx
+++ b/static/js/src/advantage/offers/components/Offer/Offer.tsx
@@ -24,6 +24,7 @@ const Offer = ({ offer }: Props) => {
     name: names.join(", "),
     price: {
       value: Number(total),
+      discount: Number(discount),
     },
     canBeTrialled: false,
   };

--- a/static/js/src/advantage/subscribe/checkout/components/Summary/Summary.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Summary/Summary.tsx
@@ -41,10 +41,13 @@ function Summary({ quantity, product, action }: Props) {
   const planType = action !== "offer" ? "Plan type" : "Products";
   const productName =
     action !== "offer" ? product?.name : product?.name.replace(", ", "<br>");
+  const discount =
+    (product?.price?.value * ((product?.price?.discount ?? 0) / 100)) / 100;
+  const defaultTotal = (product?.price?.value * quantity) / 100 - discount;
 
   let totalSection = (
     <>
-      {priceData?.subtotal && action === "offer" && product?.price?.discount && (
+      {product?.price?.discount && (
         <>
           <Row>
             <Col size={4}>
@@ -52,13 +55,7 @@ function Summary({ quantity, product, action }: Props) {
             </Col>
             <Col size={8}>
               <p data-testid="discount">
-                <strong>
-                  &minus;{" "}
-                  {currencyFormatter.format(
-                    (product?.price?.value * (product?.price?.discount / 100)) /
-                      100
-                  )}
-                </strong>
+                <strong>&minus; {currencyFormatter.format(discount)}</strong>
               </p>
             </Col>
           </Row>
@@ -72,13 +69,9 @@ function Summary({ quantity, product, action }: Props) {
         <Col size={8}>
           <p data-testid="subtotal">
             <strong>
-              {priceData?.subtotal &&
-              action === "offer" &&
-              product?.price?.discount
+              {priceData
                 ? currencyFormatter.format(total)
-                : currencyFormatter.format(
-                    ((product?.price?.value ?? 0) * quantity) / 100
-                  )}
+                : currencyFormatter.format(defaultTotal)}
             </strong>
           </p>
         </Col>
@@ -89,7 +82,7 @@ function Summary({ quantity, product, action }: Props) {
   if (taxAmount && total) {
     totalSection = (
       <>
-        {priceData && action === "offer" && product?.price?.discount && (
+        {product?.price?.discount && (
           <>
             <Row>
               <Col size={4}>
@@ -97,14 +90,7 @@ function Summary({ quantity, product, action }: Props) {
               </Col>
               <Col size={8}>
                 <p data-testid="discount">
-                  <strong>
-                    &minus;{" "}
-                    {currencyFormatter.format(
-                      (product?.price?.value *
-                        (product?.price?.discount / 100)) /
-                        100
-                    )}
-                  </strong>
+                  <strong>&minus; {currencyFormatter.format(discount)}</strong>
                 </p>
               </Col>
             </Row>

--- a/static/js/src/advantage/subscribe/checkout/components/Summary/Summary.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Summary/Summary.tsx
@@ -43,25 +43,75 @@ function Summary({ quantity, product, action }: Props) {
     action !== "offer" ? product?.name : product?.name.replace(", ", "<br>");
 
   let totalSection = (
-    <Row>
-      <Col size={4}>
-        <p>Total:</p>
-      </Col>
-      <Col size={8}>
-        <p data-testid="subtotal">
-          <strong>
-            {currencyFormatter.format(
-              ((product?.price?.value ?? 0) * (Number(quantity) ?? 0)) / 100
-            )}
-          </strong>
-        </p>
-      </Col>
-    </Row>
+    <>
+      {priceData?.subtotal &&
+        action === "offer" &&
+        priceData?.subtotal !== product?.price?.value && (
+          <>
+            <Row>
+              <Col size={4}>
+                <p>Discount:</p>
+              </Col>
+              <Col size={8}>
+                <p data-testid="discount">
+                  <strong>
+                    &minus;{" "}
+                    {currencyFormatter.format(
+                      ((product?.price?.value - priceData.subtotal) *
+                        quantity) /
+                        100
+                    )}
+                  </strong>
+                </p>
+              </Col>
+            </Row>
+            <hr />
+          </>
+        )}
+      <Row>
+        <Col size={4}>
+          <p>Total:</p>
+        </Col>
+        <Col size={8}>
+          <p data-testid="subtotal">
+            <strong>
+              {currencyFormatter.format(
+                ((product?.price?.value ?? 0) * quantity) / 100
+              )}
+            </strong>
+          </p>
+        </Col>
+      </Row>
+    </>
   );
 
   if (taxAmount && total) {
     totalSection = (
       <>
+        {priceData &&
+          action === "offer" &&
+          product?.price?.value !== priceData.total && (
+            <>
+              <Row>
+                <Col size={4}>
+                  <p>Discount:</p>
+                </Col>
+                <Col size={8}>
+                  <p data-testid="discount">
+                    <strong>
+                      -{" "}
+                      {currencyFormatter.format(
+                        ((product?.price?.value - priceData.total) * quantity) /
+                          100 +
+                          taxAmount
+                      )}
+                    </strong>
+                  </p>
+                </Col>
+              </Row>
+              <hr />
+            </>
+          )}
         {priceData?.end_of_cycle && (
           <>
             <Row>
@@ -83,7 +133,12 @@ function Summary({ quantity, product, action }: Props) {
           </Col>
           <Col size={8}>
             <p data-testid="tax">
-              <strong>{currencyFormatter.format(taxAmount)}</strong>
+              <strong>
+                {priceData &&
+                  action === "offer" &&
+                  product?.price?.value !== priceData.total && <>&#43;</>}
+                {currencyFormatter.format(taxAmount)}
+              </strong>
             </p>
           </Col>
         </Row>
@@ -102,19 +157,41 @@ function Summary({ quantity, product, action }: Props) {
     );
   } else if (priceData?.end_of_cycle) {
     totalSection = (
-      <Row>
-        <Col size={4}>
-          <p>
-            Total
-            {priceData?.end_of_cycle && " for this period"}
-          </p>
-        </Col>
-        <Col size={8}>
-          <p>
-            <strong>{currencyFormatter.format(total)}</strong>
-          </p>
-        </Col>
-      </Row>
+      <>
+        {action === "offer" && product?.price?.value !== priceData.total && (
+          <>
+            <Row>
+              <Col size={4}>
+                <p>Discount:</p>
+              </Col>
+              <Col size={8}>
+                <p data-testid="discount">
+                  <strong>
+                    {currencyFormatter.format(
+                      ((product?.price?.value - priceData.total) * quantity) /
+                        100
+                    )}
+                  </strong>
+                </p>
+              </Col>
+            </Row>
+            <hr />
+          </>
+        )}
+        <Row>
+          <Col size={4}>
+            <p>
+              Total
+              {priceData?.end_of_cycle && " for this period"}
+            </p>
+          </Col>
+          <Col size={8}>
+            <p>
+              <strong>{currencyFormatter.format(total)}</strong>
+            </p>
+          </Col>
+        </Row>
+      </>
     );
   }
   return (
@@ -132,20 +209,6 @@ function Summary({ quantity, product, action }: Props) {
             data-testid="name"
             dangerouslySetInnerHTML={{ __html: productName ?? "" }}
           />
-        </Col>
-      </Row>
-      <hr />
-      <Row>
-        <Col size={4}>
-          <p>{units}:</p>
-        </Col>
-        <Col size={8}>
-          <p data-testid="machines">
-            <strong>
-              {quantity} x{" "}
-              {currencyFormatter.format((product?.price?.value ?? 0) / 100)}
-            </strong>
-          </p>
         </Col>
       </Row>
       <hr />
@@ -187,6 +250,20 @@ function Summary({ quantity, product, action }: Props) {
             </p>
           </Col>
         )}
+      </Row>
+      <hr />
+      <Row>
+        <Col size={4}>
+          <p>{units}:</p>
+        </Col>
+        <Col size={8}>
+          <p data-testid="machines">
+            <strong>
+              {quantity} x{" "}
+              {currencyFormatter.format((product?.price?.value ?? 0) / 100)}
+            </strong>
+          </p>
+        </Col>
       </Row>
       <hr />
       {!isSummaryLoading ? (

--- a/static/js/src/advantage/subscribe/checkout/components/Summary/Summary.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Summary/Summary.tsx
@@ -44,30 +44,27 @@ function Summary({ quantity, product, action }: Props) {
 
   let totalSection = (
     <>
-      {priceData?.subtotal &&
-        action === "offer" &&
-        priceData?.subtotal !== product?.price?.value && (
-          <>
-            <Row>
-              <Col size={4}>
-                <p>Discount:</p>
-              </Col>
-              <Col size={8}>
-                <p data-testid="discount">
-                  <strong>
-                    &minus;{" "}
-                    {currencyFormatter.format(
-                      ((product?.price?.value - priceData.subtotal) *
-                        quantity) /
-                        100
-                    )}
-                  </strong>
-                </p>
-              </Col>
-            </Row>
-            <hr />
-          </>
-        )}
+      {priceData?.subtotal && action === "offer" && product?.price?.discount && (
+        <>
+          <Row>
+            <Col size={4}>
+              <p>Discount:</p>
+            </Col>
+            <Col size={8}>
+              <p data-testid="discount">
+                <strong>
+                  &minus;{" "}
+                  {currencyFormatter.format(
+                    (product?.price?.value * (product?.price?.discount / 100)) /
+                      100
+                  )}
+                </strong>
+              </p>
+            </Col>
+          </Row>
+          <hr />
+        </>
+      )}
       <Row>
         <Col size={4}>
           <p>Total:</p>
@@ -75,9 +72,13 @@ function Summary({ quantity, product, action }: Props) {
         <Col size={8}>
           <p data-testid="subtotal">
             <strong>
-              {currencyFormatter.format(
-                ((product?.price?.value ?? 0) * quantity) / 100
-              )}
+              {priceData?.subtotal &&
+              action === "offer" &&
+              product?.price?.discount
+                ? currencyFormatter.format(total)
+                : currencyFormatter.format(
+                    ((product?.price?.value ?? 0) * quantity) / 100
+                  )}
             </strong>
           </p>
         </Col>
@@ -88,30 +89,28 @@ function Summary({ quantity, product, action }: Props) {
   if (taxAmount && total) {
     totalSection = (
       <>
-        {priceData &&
-          action === "offer" &&
-          product?.price?.value !== priceData.total && (
-            <>
-              <Row>
-                <Col size={4}>
-                  <p>Discount:</p>
-                </Col>
-                <Col size={8}>
-                  <p data-testid="discount">
-                    <strong>
-                      -{" "}
-                      {currencyFormatter.format(
-                        ((product?.price?.value - priceData.total) * quantity) /
-                          100 +
-                          taxAmount
-                      )}
-                    </strong>
-                  </p>
-                </Col>
-              </Row>
-              <hr />
-            </>
-          )}
+        {priceData && action === "offer" && product?.price?.discount && (
+          <>
+            <Row>
+              <Col size={4}>
+                <p>Discount:</p>
+              </Col>
+              <Col size={8}>
+                <p data-testid="discount">
+                  <strong>
+                    &minus;{" "}
+                    {currencyFormatter.format(
+                      (product?.price?.value *
+                        (product?.price?.discount / 100)) /
+                        100
+                    )}
+                  </strong>
+                </p>
+              </Col>
+            </Row>
+            <hr />
+          </>
+        )}
         {priceData?.end_of_cycle && (
           <>
             <Row>
@@ -133,12 +132,7 @@ function Summary({ quantity, product, action }: Props) {
           </Col>
           <Col size={8}>
             <p data-testid="tax">
-              <strong>
-                {priceData &&
-                  action === "offer" &&
-                  product?.price?.value !== priceData.total && <>&#43;</>}
-                {currencyFormatter.format(taxAmount)}
-              </strong>
+              <strong>{currencyFormatter.format(taxAmount)}</strong>
             </p>
           </Col>
         </Row>
@@ -158,7 +152,7 @@ function Summary({ quantity, product, action }: Props) {
   } else if (priceData?.end_of_cycle) {
     totalSection = (
       <>
-        {action === "offer" && product?.price?.value !== priceData.total && (
+        {action === "offer" && product?.price?.discount && (
           <>
             <Row>
               <Col size={4}>
@@ -167,8 +161,10 @@ function Summary({ quantity, product, action }: Props) {
               <Col size={8}>
                 <p data-testid="discount">
                   <strong>
+                    &minus;{" "}
                     {currencyFormatter.format(
-                      ((product?.price?.value - priceData.total) * quantity) /
+                      (product?.price?.value *
+                        (product?.price?.discount / 100)) /
                         100
                     )}
                   </strong>

--- a/static/js/src/advantage/subscribe/checkout/utils/types.ts
+++ b/static/js/src/advantage/subscribe/checkout/utils/types.ts
@@ -70,6 +70,7 @@ export interface Product {
   name: string;
   price: {
     value: number;
+    discount?: null | number;
   };
   canBeTrialled?: boolean;
 }


### PR DESCRIPTION
## Done

- Display discount on checkout
<img width="620" alt="image" src="https://user-images.githubusercontent.com/57550290/223392594-ab82ace0-171e-4320-b52a-95316816de19.png">


## QA

- Go to /pro/offers
- Click an offer that provides a discount
- Check offer discount price displays in summary and total is correct
- Check the case when user is guest as well
## Issue / Card

Fixes #https://warthogs.atlassian.net/jira/software/c/projects/WD/boards/801?modal=detail&selectedIssue=WD-1940

