### PR TITLE
Add data-testid on base_index.html

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -99,7 +99,7 @@
       </p>
       <ul class="p-inline-list">
         <li class="p-inline-list__item">
-          <a href="/contact-us" class="js-invoke-modal">
+          <a href="/contact-us" class="js-invoke-modal" data-testid="interactive-form-link">
             Let's talk open source&nbsp;&rsaquo;
           </a>
         </li>


### PR DESCRIPTION
## Done
- `data-testid` seems to be removed in `base_index.html` for some reason and because of that, cypress test for forms is failing on `/`
- Added `data-testid` in `base_index.html`

## QA
- All passed locally 
<img width="747" alt="image" src="https://user-images.githubusercontent.com/57550290/221886581-b06e4000-dd45-4021-a2c9-6e5e871d7e69.png">

- https://discourse.canonical.com/t/how-to-run-cypress-test-locally-for-forms-on-ubuntu-com/558 if needed

Fixes https://github.com/canonical/ubuntu.com/actions/runs/4293744211