### PR TITLE
Fix renewal number of machines

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/RenewalButton/RenewalButton.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/RenewalButton/RenewalButton.tsx
@@ -33,7 +33,7 @@ export default function RenewalButton({
 
   const shopCheckoutData = {
     product: product,
-    quantity: subscription.number_of_machines,
+    quantity: subscription.current_number_of_machines,
     action: action,
   };
 

--- a/webapp/shop/api/ua_contracts/builders.py
+++ b/webapp/shop/api/ua_contracts/builders.py
@@ -199,8 +199,12 @@ def build_final_user_subscriptions(
         aggregated_values = get_items_aggregated_values(items, type)
         number_of_machines = aggregated_values.get("number_of_machines")
         end_date = aggregated_values.get("end_date")
-        current_number_of_machines = get_current_number_of_machines(
-            subscriptions, subscription_id, listing
+        current_number_of_machines = (
+            get_current_number_of_machines(
+                subscriptions, subscription_id, listing
+            )
+            if type in ["trial", "monthly", "yearly"]
+            else number_of_machines
         )
         price_info = get_price_info(number_of_machines, items, listing)
         product_name = (


### PR DESCRIPTION
## Done

- Renewal button for is setting the wrong number of machines to the checkout. This one fixes it.

## Issue / Card

Fixes #https://warthogs.atlassian.net/browse/WD-2320