### PR TITLE
WD-1708 replaces Canonical OpenStack, Kubernetes and Ceph logos in `/managed`

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1154,7 +1154,7 @@ hr.p-separator.is-shallow {
     row-gap: 2rem;
 
     @media (max-width: $threshold-6-12-col) {
-      row-gap: 0rem;
+      row-gap: 0;
     }
   }
 }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1143,3 +1143,18 @@ hr.p-separator.is-shallow {
 .no-border::after {
   content: none !important;
 }
+
+// Custom styles for /managed/index
+// Extend row with increaded row gap
+.row--r-gap3 {
+  @extend %vf-row;
+  @include vf-b-row-reset;
+
+  @supports (display: grid) {
+    row-gap: 2rem;
+
+    @media (max-width: $threshold-6-12-col) {
+      row-gap: 0rem;
+    }
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1145,7 +1145,7 @@ hr.p-separator.is-shallow {
 }
 
 // Custom styles for /managed/index
-// Extend row with increaded row gap
+// Extend row with increased row gap
 .row--r-gap3 {
   @extend %vf-row;
   @include vf-b-row-reset;

--- a/templates/managed/index.html
+++ b/templates/managed/index.html
@@ -442,21 +442,22 @@
           <p><a class="p-button--positive" href="/openstack/managed">Managed OpenStack</a></p>
         </div>
 
-        <div class="col-4 u-sv3">
-          {{
-          image(
-          url="https://assets.ubuntu.com/v1/990738e2-kubernetes-cloud.svg",
-          alt="Kubernetes cloud",
-          width="263",
-          height="150",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class":"u-hide--small"},
-          ) | safe
-          }}
-          <h3 class="p-heading--4"><a href="/kubernetes/managed">Kubernetes</a></h3>
+        <div class="col-4 u-sv3 p-card">
+          <div class="u-sv1">
+            {{
+              image(
+              url="https://assets.ubuntu.com/v1/f996fd9f-canonical-kubernetes.svg",
+              alt="Canonical Kubernetes",
+              width="271",
+              height="42",
+              hi_def=True,
+              loading="lazy",
+              ) | safe
+            }}
+          </div>
+          <hr />
           <p>Deploy Kubernetes on bare metal, public cloud or on top of your OpenStack, and maintain your focus on developing your cloud native applications.</p>
-          <p><a class="p-button--positive" href="/kubernetes/managed">Managed Kubernetes&nbsp;&rsaquo;</a></p>
+          <p><a class="p-button--positive" href="/kubernetes/managed">Managed Kubernetes</a></p>
         </div>
 
         <div class="col-4 u-sv3">
@@ -473,7 +474,7 @@
           }}
           <h3 class="p-heading--4"><a href="/ceph/managed">Ceph</a></h3>
           <p>As easy as the public cloud, just more economical. Fully managed open-source software-defined storage, with a proven reference architecture, that can be customised for your needs.</p>
-          <p><a class="p-button--positive" href="/ceph/managed">Managed Ceph&nbsp;&rsaquo;</a></p>
+          <p><a class="p-button--positive" href="/ceph/managed">Managed Ceph</a></p>
         </div>
 
         <div class="col-4 u-sv3">
@@ -490,7 +491,7 @@
           }}
           <h3 class="p-heading--4"><a href="/managed/apps">Applications</a></h3>
           <p>Focus on your application layer and offload the dependencies with Canonical's managed platform services that provide predictable pricing from the industry leaders in Open Source.</p>
-          <p><a class="p-button--positive" href="/managed/apps">Managed Applications&nbsp;&rsaquo;</a></p>
+          <p><a class="p-button--positive" href="/managed/apps">Managed Applications</a></p>
         </div>
 
         <div class="col-4 u-sv3">
@@ -507,7 +508,7 @@
           }}
           <h3 class="p-heading--4"><a href="/observability/managed">Observability</a></h3>
           <p>Best-in-class open-source monitoring tools for your cloud native applications and infrastructure. Reliable, powerful and always there when you need them.</p>
-          <p><a class="p-button--positive" href="/observability/managed">Managed observability&nbsp;&rsaquo;</a></p>
+          <p><a class="p-button--positive" href="/observability/managed">Managed observability</a></p>
         </div>
       </div>
     </div>

--- a/templates/managed/index.html
+++ b/templates/managed/index.html
@@ -425,19 +425,20 @@
     <div class="u-fixed-width">
       <h2 class="u-sv3">Learn more about Managed IT Services</h2>
       <div class="row">
-        <div class="col-4 u-sv3">
-          {{
-          image(
-          url="https://assets.ubuntu.com/v1/dcb2963c-openstack+cloud+outlines.svg",
-          alt="",
-          width="263",
-          height="150",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class":"u-hide--small"},
-          ) | safe
-          }}
-          <h3 class="p-heading--4"><a href="/openstack/managed">Openstack</a></h3>
+        <div class="col-4 u-sv3 p-card">
+          <div class="u-sv1">
+            {{
+              image(
+              url="https://assets.ubuntu.com/v1/9504c76c-canonical-openstack.svg",
+              alt="Canonical OpenStack",
+              width="263",
+              height="42",
+              hi_def=True,
+              loading="lazy",
+              ) | safe
+            }}
+          </div>
+          <hr />
           <p>Cut your cloud operational costs by up to 50% and build a business centric IT department focused on driving your business. </p>
           <p><a class="p-button--positive" href="/openstack/managed">Managed OpenStack</a></p>
         </div>

--- a/templates/managed/index.html
+++ b/templates/managed/index.html
@@ -424,8 +424,8 @@
   <div class="row">
     <div class="u-fixed-width">
       <h2 class="u-sv3">Learn more about Managed IT Services</h2>
-      <div class="row">
-        <div class="col-4 u-sv3 p-card">
+      <div class="row--r-gap3">
+        <div class="col-4 p-card">
           <div class="u-sv1">
             {{
               image(
@@ -443,7 +443,7 @@
           <p><a class="p-button--positive" href="/openstack/managed">Managed OpenStack</a></p>
         </div>
 
-        <div class="col-4 u-sv3 p-card">
+        <div class="col-4 p-card">
           <div class="u-sv1">
             {{
               image(
@@ -461,7 +461,7 @@
           <p><a class="p-button--positive" href="/kubernetes/managed">Managed Kubernetes</a></p>
         </div>
 
-        <div class="col-4 u-sv3 p-card">
+        <div class="col-4 p-card">
           <div class="u-sv1">
             {{
               image (
@@ -479,36 +479,16 @@
           <p><a class="p-button--positive" href="/ceph/managed">Managed Ceph</a></p>
         </div>
 
-        <div class="col-4 u-sv3">
-          {{
-          image(
-          url="https://assets.ubuntu.com/v1/317680dc-CLOUD+APPS.svg",
-          alt="Kubernetes cloud",
-          width="278",
-          height="150",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class":"u-hide--small"},
-          ) | safe
-          }}
-          <h3 class="p-heading--4"><a href="/managed/apps">Applications</a></h3>
+        <div class="col-4 p-card">
+          <h3>Managed Applications</h3>
+          <hr />
           <p>Focus on your application layer and offload the dependencies with Canonical's managed platform services that provide predictable pricing from the industry leaders in Open Source.</p>
           <p><a class="p-button--positive" href="/managed/apps">Managed Applications</a></p>
         </div>
 
-        <div class="col-4 u-sv3">
-          {{
-          image (
-          url="https://assets.ubuntu.com/v1/3336fc49-observability-cloud.svg",
-          alt="",
-          width="263",
-          height="150",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class": "u-hide--small"},
-          ) | safe
-          }}
-          <h3 class="p-heading--4"><a href="/observability/managed">Observability</a></h3>
+        <div class="col-4 p-card">
+          <h3>Managed Observability</h3>
+          <hr />
           <p>Best-in-class open-source monitoring tools for your cloud native applications and infrastructure. Reliable, powerful and always there when you need them.</p>
           <p><a class="p-button--positive" href="/observability/managed">Managed observability</a></p>
         </div>

--- a/templates/managed/index.html
+++ b/templates/managed/index.html
@@ -461,19 +461,20 @@
           <p><a class="p-button--positive" href="/kubernetes/managed">Managed Kubernetes</a></p>
         </div>
 
-        <div class="col-4 u-sv3">
-          {{
-          image (
-          url="https://assets.ubuntu.com/v1/e0461e14-ceph-dark.svg",
-          alt="",
-          width="324",
-          height="135",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class":"u-hide--small"},
-          ) | safe
-          }}
-          <h3 class="p-heading--4"><a href="/ceph/managed">Ceph</a></h3>
+        <div class="col-4 u-sv3 p-card">
+          <div class="u-sv1">
+            {{
+              image (
+              url="https://assets.ubuntu.com/v1/dfd3bd7a-canonical-ceph.svg",
+              alt="Canonical Ceph",
+              width="199",
+              height="42",
+              hi_def=True,
+              loading="lazy",
+              ) | safe
+            }}
+          </div>
+          <hr />
           <p>As easy as the public cloud, just more economical. Fully managed open-source software-defined storage, with a proven reference architecture, that can be customised for your needs.</p>
           <p><a class="p-button--positive" href="/ceph/managed">Managed Ceph</a></p>
         </div>


### PR DESCRIPTION
## Done

- Replaced logos for Canonical OpenStack, Kubernetes and Ceph.
- Reformated the grid items to be cards and increased the row-gap.

## QA

- Navigate to https://ubuntu-com-12618.demos.haus/managed and reference [WD-1708](https://warthogs.atlassian.net/browse/WD-1708) and screenshot section.

## Issue / Card

- [WD-1708](https://warthogs.atlassian.net/browse/WD-1708)

## Screenshots

Previous look:
![image](https://user-images.githubusercontent.com/48949356/221923580-7f064239-f954-46e5-86e1-9ff7f46af7e4.png)

New look:
![image](https://user-images.githubusercontent.com/48949356/221923706-826a2ce5-8479-4a31-83c3-295e97b7d23d.png)



## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-1708]: https://warthogs.atlassian.net/browse/WD-1708?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WD-1708]: https://warthogs.atlassian.net/browse/WD-1708?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ