### PR TITLE
Add isTaxSaved and isCardValid to Formik values

### DIFF
--- a/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
@@ -15,18 +15,9 @@ type Props = {
   quantity: number;
   product: Product;
   action: Action;
-  isCardValid: boolean;
-  isTaxSaved: boolean;
 };
 
-const BuyButton = ({
-  setError,
-  quantity,
-  product,
-  action,
-  isCardValid,
-  isTaxSaved,
-}: Props) => {
+const BuyButton = ({ setError, quantity, product, action }: Props) => {
   const [isLoading, setIsLoading] = useState(false);
   const [isButtonDisabled, setIsButtonDisabled] = useState(true);
 
@@ -41,8 +32,8 @@ const BuyButton = ({
 
   useEffect(() => {
     if (
-      !isTaxSaved ||
-      !isCardValid ||
+      !values.isTaxSaved ||
+      !values.isCardValid ||
       !values.email ||
       !values.name ||
       !values.address ||
@@ -63,7 +54,7 @@ const BuyButton = ({
     } else {
       setIsButtonDisabled(false);
     }
-  }, [values, isLoading, isCardValid, isTaxSaved]);
+  }, [values, isLoading]);
 
   const sessionData = {
     gclid: getSessionData("gclid"),

--- a/static/js/src/advantage/subscribe/checkout/components/Checkout/Checkout.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Checkout/Checkout.tsx
@@ -26,8 +26,6 @@ type Props = {
 
 const Checkout = ({ product, quantity, action }: Props) => {
   const [error, setError] = useState<React.ReactNode>(null);
-  const [isCardValid, setCardValid] = useState<boolean>(false);
-  const [isTaxSaved, setTaxSaved] = useState<boolean>(false);
   const { data: userInfo, isLoading: isUserInfoLoading } = useCustomerInfo();
   const isGuest = !userInfo?.customerInfo?.email;
   const userCanTrial = window.canTrial;
@@ -82,7 +80,6 @@ const Checkout = ({ product, quantity, action }: Props) => {
                         <Taxes
                           product={product}
                           quantity={quantity}
-                          setTaxSaved={setTaxSaved}
                           setError={setError}
                         />
                       ),
@@ -107,12 +104,7 @@ const Checkout = ({ product, quantity, action }: Props) => {
                       : []),
                     {
                       title: "Your information",
-                      content: (
-                        <UserInfoForm
-                          setCardValid={setCardValid}
-                          setError={setError}
-                        />
-                      ),
+                      content: <UserInfoForm setError={setError} />,
                     },
                     ...(canTrial
                       ? [
@@ -133,8 +125,6 @@ const Checkout = ({ product, quantity, action }: Props) => {
                                 product={product}
                                 quantity={quantity}
                                 action={action}
-                                isCardValid={isCardValid}
-                                isTaxSaved={isTaxSaved}
                                 setError={setError}
                               ></BuyButton>
                             </Col>

--- a/static/js/src/advantage/subscribe/checkout/components/Taxes/Taxes.test.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Taxes/Taxes.test.tsx
@@ -20,12 +20,7 @@ describe("TaxesTests", () => {
       <QueryClientProvider client={queryClient}>
         <Formik initialValues={{}} onSubmit={jest.fn()}>
           <Elements stripe={stripePromise}>
-            <Taxes
-              product={UAProduct}
-              quantity={1}
-              setTaxSaved={jest.fn()}
-              setError={jest.fn()}
-            />
+            <Taxes product={UAProduct} quantity={1} setError={jest.fn()} />
           </Elements>
         </Formik>
       </QueryClientProvider>
@@ -40,12 +35,7 @@ describe("TaxesTests", () => {
       <QueryClientProvider client={queryClient}>
         <Formik initialValues={{}} onSubmit={jest.fn()}>
           <Elements stripe={stripePromise}>
-            <Taxes
-              product={UAProduct}
-              quantity={1}
-              setError={jest.fn()}
-              setTaxSaved={jest.fn()}
-            />
+            <Taxes product={UAProduct} quantity={1} setError={jest.fn()} />
           </Elements>
         </Formik>
       </QueryClientProvider>
@@ -62,12 +52,7 @@ describe("TaxesTests", () => {
       <QueryClientProvider client={queryClient}>
         <Formik initialValues={{}} onSubmit={jest.fn()}>
           <Elements stripe={stripePromise}>
-            <Taxes
-              product={UAProduct}
-              quantity={1}
-              setError={jest.fn()}
-              setTaxSaved={jest.fn()}
-            />
+            <Taxes product={UAProduct} quantity={1} setError={jest.fn()} />
           </Elements>
         </Formik>
       </QueryClientProvider>
@@ -86,12 +71,7 @@ describe("TaxesTests", () => {
       <QueryClientProvider client={queryClient}>
         <Formik initialValues={{}} onSubmit={jest.fn()}>
           <Elements stripe={stripePromise}>
-            <Taxes
-              product={UAProduct}
-              quantity={1}
-              setError={jest.fn()}
-              setTaxSaved={jest.fn()}
-            />
+            <Taxes product={UAProduct} quantity={1} setError={jest.fn()} />
           </Elements>
         </Formik>
       </QueryClientProvider>
@@ -117,12 +97,7 @@ describe("TaxesTests", () => {
       <QueryClientProvider client={queryClient}>
         <Formik initialValues={intialValues} onSubmit={jest.fn()}>
           <Elements stripe={stripePromise}>
-            <Taxes
-              product={UAProduct}
-              quantity={1}
-              setError={jest.fn()}
-              setTaxSaved={jest.fn()}
-            />
+            <Taxes product={UAProduct} quantity={1} setError={jest.fn()} />
           </Elements>
         </Formik>
       </QueryClientProvider>
@@ -136,12 +111,7 @@ describe("TaxesTests", () => {
       <QueryClientProvider client={queryClient}>
         <Formik initialValues={{}} onSubmit={jest.fn()}>
           <Elements stripe={stripePromise}>
-            <Taxes
-              product={UAProduct}
-              quantity={1}
-              setError={jest.fn()}
-              setTaxSaved={jest.fn()}
-            />
+            <Taxes product={UAProduct} quantity={1} setError={jest.fn()} />
           </Elements>
         </Formik>
       </QueryClientProvider>
@@ -163,12 +133,7 @@ describe("TaxesTests", () => {
       <QueryClientProvider client={queryClient}>
         <Formik initialValues={intialValues} onSubmit={jest.fn()}>
           <Elements stripe={stripePromise}>
-            <Taxes
-              product={UAProduct}
-              quantity={1}
-              setError={jest.fn()}
-              setTaxSaved={jest.fn()}
-            />
+            <Taxes product={UAProduct} quantity={1} setError={jest.fn()} />
           </Elements>
         </Formik>
       </QueryClientProvider>

--- a/static/js/src/advantage/subscribe/checkout/components/Taxes/Taxes.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Taxes/Taxes.tsx
@@ -23,11 +23,10 @@ import { FormValues, Product } from "../../utils/types";
 type TaxesProps = {
   product: Product;
   quantity: number;
-  setTaxSaved: React.Dispatch<React.SetStateAction<boolean>>;
   setError: React.Dispatch<React.SetStateAction<React.ReactNode>>;
 };
 
-const Taxes = ({ product, quantity, setTaxSaved, setError }: TaxesProps) => {
+const Taxes = ({ product, quantity, setError }: TaxesProps) => {
   const {
     values,
     initialValues,
@@ -43,7 +42,7 @@ const Taxes = ({ product, quantity, setTaxSaved, setError }: TaxesProps) => {
   useEffect(() => {
     if (errors.VATNumber) {
       setIsEditing(true);
-      setTaxSaved(false);
+      setFieldValue("isTaxSaved", false);
     }
   }, [errors]);
 
@@ -52,7 +51,7 @@ const Taxes = ({ product, quantity, setTaxSaved, setError }: TaxesProps) => {
 
     if (savedCountry) {
       setIsEditing(!savedCountry);
-      setTaxSaved(savedCountry);
+      setFieldValue("isTaxSaved", savedCountry);
     }
   }, [initialValues]);
 
@@ -80,7 +79,7 @@ const Taxes = ({ product, quantity, setTaxSaved, setError }: TaxesProps) => {
           Sentry.captureException(error);
         },
       });
-      setTaxSaved(true);
+      setFieldValue("isTaxSaved", true);
     } else {
       postCustomerTaxInfoMutation.mutate(
         {
@@ -128,13 +127,13 @@ const Taxes = ({ product, quantity, setTaxSaved, setError }: TaxesProps) => {
           },
         }
       );
-      setTaxSaved(true);
+      setFieldValue("isTaxSaved", true);
     }
   };
 
   const onEditClick = () => {
     setIsEditing(true);
-    setTaxSaved(false);
+    setFieldValue("isTaxSaved", false);
   };
 
   const validateRequired = (value: string) => {
@@ -317,7 +316,7 @@ const Taxes = ({ product, quantity, setTaxSaved, setError }: TaxesProps) => {
                   setFieldValue("caProvince", initialValues.caProvince);
                   setFieldValue("VATNumber", initialValues.VATNumber);
                   setIsEditing(false);
-                  setTaxSaved(true);
+                  setFieldValue("isTaxSaved", true);
                 }}
               >
                 Cancel

--- a/static/js/src/advantage/subscribe/checkout/components/UserInfoForm/UserInfoForm.test.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/UserInfoForm/UserInfoForm.test.tsx
@@ -39,7 +39,7 @@ describe("UserInfoFormTests", () => {
       <QueryClientProvider client={queryClient}>
         <Formik initialValues={intialValues} onSubmit={jest.fn()}>
           <Elements stripe={stripePromise}>
-            <UserInfoForm setError={jest.fn()} setCardValid={jest.fn()} />
+            <UserInfoForm setError={jest.fn()} />
           </Elements>
         </Formik>
       </QueryClientProvider>

--- a/static/js/src/advantage/subscribe/checkout/components/UserInfoForm/UserInfoForm.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/UserInfoForm/UserInfoForm.tsx
@@ -25,10 +25,9 @@ type Error = {
 
 type Props = {
   setError: React.Dispatch<React.SetStateAction<React.ReactNode>>;
-  setCardValid: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
-const UserInfoForm = ({ setError, setCardValid }: Props) => {
+const UserInfoForm = ({ setError }: Props) => {
   const {
     errors,
     touched,
@@ -57,9 +56,9 @@ const UserInfoForm = ({ setError, setCardValid }: Props) => {
 
   useEffect(() => {
     if (initialValues.defaultPaymentMethod && !isEditing) {
-      setCardValid(true);
+      setFieldValue("isCardValid", true);
     } else {
-      setCardValid(false);
+      setFieldValue("isCardValid", false);
     }
   }, [isEditing]);
 
@@ -278,10 +277,10 @@ const UserInfoForm = ({ setError, setCardValid }: Props) => {
             }}
             onChange={(e) => {
               if (e.complete && !e.error) {
-                setCardValid(true);
+                setFieldValue("isCardValid", true);
                 setCardFieldError(null);
               } else {
-                setCardValid(false);
+                setFieldValue("isCardValid", false);
                 if (e.error) {
                   setCardFieldError(e.error);
                 }

--- a/static/js/src/advantage/subscribe/checkout/utils/helpers.ts
+++ b/static/js/src/advantage/subscribe/checkout/utils/helpers.ts
@@ -29,6 +29,8 @@ export function getInitialFormValues(
     Description: false,
     FreeTrial: canTrial ? "useFreeTrial" : "payNow",
     marketplace: product.marketplace,
+    isTaxSaved: false,
+    isCardValid: false,
   };
 }
 

--- a/static/js/src/advantage/subscribe/checkout/utils/types.ts
+++ b/static/js/src/advantage/subscribe/checkout/utils/types.ts
@@ -49,6 +49,8 @@ export interface FormValues {
   Description: boolean;
   marketplace: UserSubscriptionMarketplace;
   FreeTrial: string;
+  isTaxSaved: boolean;
+  isCardValid: boolean;
 }
 
 export type marketplace = "canonical-ua" | "canonical-cube" | "blender";


### PR DESCRIPTION
## Done

- Removed `isTaxSaved`, `setTaxSave`, `isCardValid`, `setCardValid` states
- Added `isTaxSaved` and `isCardValid` to Formik values

## QA

-  Checkout this branch and run locally
-  Go to `/pro/subscribe`
- `console.log(values)` in `Taxes.tsx` and `UserInfoForm.tsx` 
- Check  `isTaxSaved` is updated properly when Save/Edit button clicked in the tax section 
- Check `isCardValid` value is updated properly when valid/wrong payment card entered

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-2196
