### PR TITLE
WD-1730 replace illustrations with new logo in `/automotive`

### DIFF
--- a/templates/automotive/index.html
+++ b/templates/automotive/index.html
@@ -53,7 +53,7 @@
     <div class="col-6 u-hide--medium u-hide--small u-align--center">
       {{
         image(
-        url="https://assets.ubuntu.com/v1/2bd31151-Automotive-in-car-cockpit-sized.svg",
+        url="https://assets.ubuntu.com/v1/35136622-Automotive-car-dashboard.svg",
         alt="",
         height="250",
         width="429",
@@ -270,7 +270,7 @@
     </div>
     <div class="col-6 u-hide--medium u-hide--small u-align--center">
       {{ image (
-        url="https://assets.ubuntu.com/v1/af98e3d6-automotive_car-network.svg",
+        url="https://assets.ubuntu.com/v1/35df0fa1-automotive_car-network.svg",
         alt="",
         height="210",
         width="360",
@@ -286,7 +286,7 @@
   <div class="row u-vertically-center u-sv3">
     <div class="col-6 u-hide--medium u-hide--small u-align--center">
       {{ image (
-        url="https://assets.ubuntu.com/v1/9c4d4439-Automotive-car-chassi-new.svg",
+        url="https://assets.ubuntu.com/v1/6386f75e-Automotive-car-chassi-new.svg",
         alt="",
         width="408",
         height="250",
@@ -576,7 +576,7 @@
   <div class="row u-vertically-center u-sv3">
     <div class="col-6 u-hide--medium u-hide--small u-align--center">
       {{ image (
-        url="https://assets.ubuntu.com/v1/cef9fb09-automotive-business-software.svg",
+        url="https://assets.ubuntu.com/v1/fe49f22c-automotive-business-software.svg",
         alt="",
         width="420",
         height="320",


### PR DESCRIPTION
## Done

- Replace automotive car dashboard illustration
- Replace automotive car network illustration
- Replace automotive car chassi illustration
- Replace business software illustration

## QA

- Navigate to https://ubuntu-com-12623.demos.haus/automotive
- Compare with images in [WD-1730](https://warthogs.atlassian.net/browse/WD-1730).

## Issue / Card

- [WD-1730](https://warthogs.atlassian.net/browse/WD-1730)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-1730]: https://warthogs.atlassian.net/browse/WD-1730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WD-1730]: https://warthogs.atlassian.net/browse/WD-1730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ