### PR TITLE
Filter Reservations by SSO user email

### DIFF
--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -138,6 +138,7 @@ def cred_schedule(ua_contracts_api, trueability_api, **_):
 
 @shop_decorator(area="cred", permission="user", response="html")
 def cred_your_exams(ua_contracts_api, trueability_api, **_):
+    sso_user_email = user_info(flask.session)["email"]
     exam_contracts = ua_contracts_api.get_exam_contracts()
     exams_in_progress = []
     exams_scheduled = []
@@ -155,6 +156,10 @@ def cred_your_exams(ua_contracts_api, trueability_api, **_):
                     exam_contract["cueContext"]["reservation"]["IDs"][-1]
                 )
                 r = response["assessment_reservation"]
+
+                user_email = r.get("user", {}).get("email")
+                if user_email != sso_user_email:
+                    continue
 
                 timezone = r["user"]["time_zone"]
                 tz_info = pytz.timezone(timezone)


### PR DESCRIPTION
## Done

- For different users under the same contract account, it was possible to see exams that had been scheduled for other users. We now filter out Reservations that don't match the SSO user's email address on /credentials/your-exams.

Fixes https://warthogs.atlassian.net/browse/CRED-321

## QA

- Check out this feature branch
- Run the site locally against the production Contracts Service (set `CONTRACTS_API_URL=https://contracts.canonical.com/` in `.env.local`)
- Visit http://localhost:8001/credentials/your-exams
  - Verify that you can only view Scheduled, In progress, or Complete exams that you have scheduled/provisioned/taken

## Screenshots

![cred-my-exams](https://user-images.githubusercontent.com/995051/222139670-74a00fd8-c4c6-406b-9f36-14c96bbc3bfc.png)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
