### PR TITLE
Update logos on /industrial

### DIFF
--- a/templates/industrial/index.html
+++ b/templates/industrial/index.html
@@ -20,6 +20,7 @@
         alt="",
         height="250",
         width="248",
+        loading="auto",
         hi_def=True,
         ) | safe
       }}
@@ -53,7 +54,7 @@
               width="288",
               height="288",
               hi_def=True,
-              loading="auto",
+              loading="lazy",
               attrs={"class": "p-logo-section__logo"}
               ) | safe
             }}
@@ -65,7 +66,7 @@
               width="288",
               height="288",
               hi_def=True,
-              loading="auto",
+              loading="lazy",
               attrs={"class": "p-logo-section__logo"}
               ) | safe
             }}
@@ -77,7 +78,7 @@
               width="288",
               height="288",
               hi_def=True,
-              loading="auto",
+              loading="lazy",
               attrs={"class": "p-logo-section__logo"}
               ) | safe
             }}
@@ -89,7 +90,7 @@
               width="288",
               height="288",
               hi_def=True,
-              loading="auto",
+              loading="lazy",
               attrs={"class": "p-logo-section__logo"}
               ) | safe
             }}
@@ -101,7 +102,7 @@
               width="288",
               height="288",
               hi_def=True,
-              loading="auto",
+              loading="lazy",
               attrs={"class": "p-logo-section__logo"}
               ) | safe
             }}
@@ -113,7 +114,7 @@
               width="288",
               height="288",
               hi_def=True,
-              loading="auto",
+              loading="lazy",
               attrs={"class": "p-logo-section__logo"}
               ) | safe
             }}
@@ -212,7 +213,7 @@
                 width="288",
                 height="288",
                 hi_def=True,
-                loading="auto",
+                loading="lazy",
                 attrs={"class": "p-logo-section__logo"}
                 ) | safe
               }}
@@ -226,7 +227,7 @@
                 width="288",
                 height="288",
                 hi_def=True,
-                loading="auto",
+                loading="lazy",
                 attrs={"class": "p-logo-section__logo"}
                 ) | safe
               }}
@@ -240,7 +241,7 @@
                 width="288",
                 height="288",
                 hi_def=True,
-                loading="auto",
+                loading="lazy",
                 attrs={"class": "p-logo-section__logo"}
                 ) | safe
               }}
@@ -254,7 +255,7 @@
                 width="288",
                 height="288",
                 hi_def=True,
-                loading="auto",
+                loading="lazy",
                 attrs={"class": "p-logo-section__logo"}
                 ) | safe
               }}
@@ -275,6 +276,7 @@
         alt="",
         height="250",
         width="315",
+        loading="lazy",
         hi_def=True,
         ) | safe
       }}
@@ -292,6 +294,7 @@
         alt="",
         height="250",
         width="260",
+        loading="lazy",
         hi_def=True,
         ) | safe
       }}
@@ -312,12 +315,12 @@
           <div class="p-logo-section__item">
             <a href="https://microstack.run/">
               {{ image (
-                url="https://assets.ubuntu.com/v1/f0089726-openstack-logo.png",
-                alt="OpenStack",
+                url="https://assets.ubuntu.com/v1/6d16204d-openstack-logomark-logo (1).png",
+                alt="",
                 width="288",
                 height="288",
                 hi_def=True,
-                loading="auto",
+                loading="lazy",
                 attrs={"class": "p-logo-section__logo"}
                 ) | safe
               }}
@@ -326,12 +329,12 @@
           <div class="p-logo-section__item">
             <a href="https://microk8s.io/">
               {{ image (
-                url="https://assets.ubuntu.com/v1/85cad0f2-microk8s-logo.png",
-                alt="MicroK8s",
+                url="https://assets.ubuntu.com/v1/63988af0-microk8s.svg",
+                alt="",
                 width="288",
                 height="288",
                 hi_def=True,
-                loading="auto",
+                loading="lazy",
                 attrs={"class": "p-logo-section__logo"}
                 ) | safe
               }}
@@ -340,12 +343,12 @@
           <div class="p-logo-section__item">
             <a href="https://linuxcontainers.org/lxd/introduction/">
               {{ image (
-                url="https://assets.ubuntu.com/v1/0c374f1b-lxd-logo.png",
-                alt="LXD",
+                url="https://assets.ubuntu.com/v1/e375d3dc-lxd-logo-stacked.png",
+                alt="",
                 width="288",
                 height="288",
                 hi_def=True,
-                loading="auto",
+                loading="lazy",
                 attrs={"class": "p-logo-section__logo"}
                 ) | safe
               }}
@@ -385,7 +388,7 @@
               width="288",
               height="288",
               hi_def=True,
-              loading="auto",
+              loading="lazy",
               attrs={"class": "p-logo-section__logo"}
               ) | safe
             }}
@@ -397,7 +400,7 @@
               width="288",
               height="288",
               hi_def=True,
-              loading="auto",
+              loading="lazy",
               attrs={"class": "p-logo-section__logo"}
               ) | safe
             }}
@@ -418,6 +421,7 @@
         height="250",
         width="248",
         hi_def=True,
+        loading="lazy",
         ) | safe
       }}
     </div>
@@ -435,6 +439,7 @@
         height="250",
         width="178",
         hi_def=True,
+        loading="lazy",
         ) | safe
       }}
     </div>
@@ -458,7 +463,7 @@
                 width="288",
                 height="288",
                 hi_def=True,
-                loading="auto",
+                loading="lazy",
                 attrs={"class": "p-logo-section__logo"}
                 ) | safe
               }}
@@ -471,7 +476,7 @@
               width="288",
               height="288",
               hi_def=True,
-              loading="auto",
+              loading="lazy",
               attrs={"class": "p-logo-section__logo"}
               ) | safe
             }}
@@ -483,7 +488,7 @@
               width="288",
               height="288",
               hi_def=True,
-              loading="auto",
+              loading="lazy",
               attrs={"class": "p-logo-section__logo"}
               ) | safe
             }}
@@ -515,6 +520,7 @@
         height="88",
         width="88",
         hi_def=True,
+        loading="lazy",
         ) | safe
       }}
     </div>
@@ -523,18 +529,20 @@
 </section>
 
 <div class="p-strip--light u-no-padding--bottom">
-  <div class="row">
+  <div class="u-fixed-width">
     <h2 class="u-sv3">Where the journey starts</h2>
-  </div><div class="row">
-    <div class="col-6">
-      <div class="u-sv3">
+  </div>
+  <div class="row">
+    <div class="col-6 u-sv4">
+      <div class="u-sv3 u-hide--small u-hide--medium">
         {{
           image(
-          url="https://assets.ubuntu.com/v1/6dd24c11-ubuntu-advantage-linear.svg",
+          url="https://assets.ubuntu.com/v1/c391f52d-ubuntu-pro-linear.svg",
           alt="",
           height="150",
           width="294",
           hi_def=True,
+          loading="lazy",
           ) | safe
         }}
       </div>
@@ -546,8 +554,8 @@
       </a></p>
     </div>
 
-    <div class="col-6">
-      <div class="u-sv3">
+    <div class="col-6 u-sv4">
+      <div class="u-sv3 u-hide--small u-hide--medium">
         {{
           image(
           url="https://assets.ubuntu.com/v1/a46ea917-3+-+Leverage+snaps+to+build+a+lean+custom+production+image.svg",
@@ -555,6 +563,7 @@
           height="150",
           width="232",
           hi_def=True,
+          loading="lazy",
           ) | safe
         }}
       </div>
@@ -564,19 +573,16 @@
         Learn more&nbsp;&rsaquo;
       </a></p>
     </div>
-  </div>
-</div>
-<div class="p-strip--light">
-  <div class="row">
-    <div class="col-6">
-      <div class="u-sv3">
+    <div class="col-6 u-sv4">
+      <div class="u-sv3 u-hide--small u-hide--medium">
         {{
           image(
-          url="https://assets.ubuntu.com/v1/32961c5b-Charmed+Kubernetes+partners.svg",
+          url="https://assets.ubuntu.com/v1/df555852-ubuntu-servers.svg",
           alt="",
           height="150",
           width="218",
           hi_def=True,
+          loading="lazy",
           ) | safe
         }}
       </div>
@@ -587,20 +593,19 @@
         Learn more&nbsp;&rsaquo;
       </a></p>
     </div>
-    <div class="col-6">
-
-      <div class="u-sv3">
+    <div class="col-6 u-sv4">
+      <div class="u-sv3 u-hide--small u-hide--medium">
         {{
           image(
-          url="https://assets.ubuntu.com/v1/9d42b2ab-3B-embedded-linux_AW.svg",
+          url="https://assets.ubuntu.com/v1/a238ab28-embedded-linux-aw.svg",
           alt="",
           height="150",
           width="263",
           hi_def=True,
+          loading="lazy",
           ) | safe
         }}
       </div>
-
       <h2 class="p-heading--4">Ubuntu Core</h2>
       <p>Ubuntu Core is an ultra-secure embedded Ubuntu, optimised for mission critical IoT appliances. Benefit from OTA software updates and security maintenance for 10 years.</p>
       <a href="/core">
@@ -637,6 +642,7 @@
         height="31",
         width="163",
         hi_def=True,
+        loading="lazy",
         ) | safe
       }}
     </div>
@@ -671,6 +677,7 @@
         height="34",
         width="112",
         hi_def=True,
+        loading="lazy",
         ) | safe
       }}
     </div>
@@ -678,66 +685,63 @@
 </section>
 
 <section class="p-strip">
-  <div class="row">
-    <div class="col-12">
-      <h2>Ready for the next steps?</h2>
+  <div class="u-fixed-width u-sv3">
+    <h2>Ready for the next steps?</h2>
+  </div>
+  <div class="row p-divider">
+    <div class="col-4 p-divider__block">
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/f22f6ded-get-in-touch_chat.svg",
+        alt="",
+        height="50",
+        width="50",
+        hi_def=True,
+        loading="lazy",
+        ) | safe
+      }}
+      <p class="p-heading--4"><a href="">Get an immediate answer to your questions&nbsp;&rsaquo;</a></p>
+    </div>
+    <div class="col-4 p-divider__block">
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/e9d3cf66-We+support+your+operations.svg",
+        alt="",
+        height="50",
+        width="50",
+        hi_def=True,
+        loading="lazy",
+        ) | safe
+      }}
+      <p class="p-heading--4"><a href="">Tell us what you have in mind&nbsp;&rsaquo;</a></p>
+    </div>
+    <div class="col-4 p-divider__block">
+      {{
+        image(
+        url="https://assets.ubuntu.com/v1/24a03775-Contact+us.svg",
+        alt="",
+        height="50",
+        width="70",
+        hi_def=True,
+        loading="lazy",
+        ) | safe
+      }}
+      <p class="p-heading--4"><a href="">Schedule a call with our industry 4.0 experts&nbsp;&rsaquo;</a></p>
     </div>
   </div>
-  <div class="p-strip">
-    <div class="row p-divider">
-      <div class="col-4 p-divider__block">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/f22f6ded-get-in-touch_chat.svg",
-          alt="",
-          height="50",
-          width="50",
-          hi_def=True,
-          ) | safe
-        }}
-        <p class="p-heading--4"><a href="">Get an immediate answer to your questions&nbsp;&rsaquo;</a></p>
-      </div>
-      <div class="col-4 p-divider__block">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/e9d3cf66-We+support+your+operations.svg",
-          alt="",
-          height="50",
-          width="50",
-          hi_def=True,
-          ) | safe
-        }}
-        <p class="p-heading--4"><a href="">Tell us what you have in mind&nbsp;&rsaquo;</a></p>
-      </div>
-      <div class="col-4 p-divider__block">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/24a03775-Contact+us.svg",
-          alt="",
-          height="50",
-          width="70",
-          hi_def=True,
-          ) | safe
-        }}
-        <p class="p-heading--4"><a href="">Schedule a call with our industry 4.0 experts&nbsp;&rsaquo;</a></p>
-      </div>
+  <hr class="p-separator is-fixed-width u-hide--small u-hide--medium">
+  <div class="row">
+    <div class="col-12">
+      <h2>Tell us your story</h2>
     </div>
-
-    <div class="u-fixed-width">
-      <hr class="p-separator" />
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <p>The Ubuntu platform enables industry 4.0 digital transformation. We would love to be part of your success.</p>
+      <p><a class="js-invoke-modal p-button--positive" href="/internet-of-things/contact-us?product=industry">Get in touch</a></p>
     </div>
-    <div class="row">
-      <div class="col-12">
-        <h2>Tell us your story</h2>
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-6">
-        <p>The Ubuntu platform enables industry 4.0 digital transformation. We would love to be part of your success.</p>
-        <p><a class="js-invoke-modal p-button--positive" href="/internet-of-things/contact-us?product=industry">Get in touch</a></p>
-      </div>
-    </div>
-  </section>
+  </div>
+</section>
 
   <!-- Set default Marketo information for contact form below-->
   <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/embedded" data-form-id="1266" data-lp-id="2551" data-return-url="https://ubuntu.com/internet-of-things/thank-you?product=iot" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">


### PR DESCRIPTION
## Done

- Update logos on /industrial based on [this issue](https://warthogs.atlassian.net/browse/WD-1732)
- Minor code and design changes

## QA

- Go to /industrial
- Check that all logos on the page use the new Ubuntu logo

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-1732
