### PR TITLE
Correct price of managed ceph on bare metal.

### DIFF
--- a/templates/pricing/pro.html
+++ b/templates/pricing/pro.html
@@ -539,7 +539,7 @@
             <tr>
               <td><a href="/ceph">Managed Ceph</a> on bare metal</td>
               <td class="u-align--right">&nbsp;</td>
-              <td class="u-align--right">&dollar;3,985</td>
+              <td class="u-align--right">&dollar;3,485</td>
             </tr>
             <tr>
               <td>Combined offering - managed on-demand K8s on fully managed OpenStack</td>


### PR DESCRIPTION
## Done

Correct price of managed ceph on bare metal to match what is on the copydoc.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/pricing/pro
- Make sure the change matches what is on the copydoc.