### PR TITLE
Demo ceph docs versioning

### DIFF
--- a/templates/templates/docs/shared/_docs.html
+++ b/templates/templates/docs/shared/_docs.html
@@ -61,7 +61,7 @@
       <select name="version-select" id="version-select" onChange="window.location.href=this.value">
       {% for version in versions %}
         {% set active = docs_version == version['path'] %}
-        <option value="{{ version_paths[version['path']] }}"{% if active %} selected{% endif %}>Version {{ version['version'] }}</option>
+        <option value="{{ version_paths[version['path']] }}"{% if active %} selected{% endif %}>{{ version['version'] }}</option>
       {% endfor %}
       <select>
       {% endif %}

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -849,7 +849,7 @@ app.add_url_rule(
 # Ceph docs
 ceph_docs = Docs(
     parser=DocParser(
-        api=discourse_api, index_topic_id=17250, url_prefix="/ceph/docs"
+        api=discourse_api, index_topic_id=34324, url_prefix="/ceph/docs"
     ),
     document_template="/ceph/docs/document.html",
     url_prefix="/ceph/docs",


### PR DESCRIPTION
A demo of Ceph docs with a versions table, to show how it would work.

This is for @pmatulis.

I've followed the instructions in https://discourse.canonical.com/t/creating-discourse-based-documentation-pages/159 for setting up the version table.

