### PR TITLE
Add blog slug renames redirects

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -954,6 +954,9 @@ server/guide: /server/docs
 blog/topic/(?P<path>.*): /blog/topics/{path}
 blog/topic: /blog
 
+# Blog slug renames
+/blog/cloud-repatriation: /blog/cloud-repatriation-reasons
+
 # Move /securtiy/cve to /security/cves
 security/cve: /security/cves
 security/cve/sitemap(?P<suffix>.*).xml: /security/cves/sitemap{suffix}.xml


### PR DESCRIPTION
## Done

- Add a redirect to fix a blog slug rename 

## QA

- /blog/cloud-repatriation should redirect to: /blog/cloud-repatriation-reasons