### PR TITLE
Update logos on /appliance

### DIFF
--- a/templates/appliance/index.html
+++ b/templates/appliance/index.html
@@ -45,10 +45,10 @@
     <div class="col-5 u-hide--medium u-hide--small u-align--center u-vertically-center">
       {{
         image(
-        url="https://assets.ubuntu.com/v1/9d42b2ab-3B-embedded-linux_AW.svg",
+        url="https://assets.ubuntu.com/v1/6ec5c97f-embedded-linux_AW.svg",
         alt="",
         height="114",
-        width="200",
+        width="189",
         hi_def=True,
         loading="auto"
         ) | safe


### PR DESCRIPTION
## Done

- Update logos on /appliance based on [this issue](https://warthogs.atlassian.net/browse/WD-1718)

## QA

- Go to https://ubuntu-com-12644.demos.haus/appliance and check the logos match the ones provided in the issue

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-1718
