### PR TITLE
Update logos on /pricing/devices

### DIFF
--- a/templates/pricing/devices.html
+++ b/templates/pricing/devices.html
@@ -18,7 +18,7 @@
 <section class="p-strip--light">
   <div class="u-fixed-width">
     <h2>Get to market quickly with IoT services</h2>
-    <p>Time to market is crucial. Canonical will validate or enable your hardware, package your apps, set up your app store and prepare your device image. It’s everything you need to get your device to market fast. App store and over-the-air security updates guaranteed. You can also choose from our extensive list of <a href="/certified?category=Device">certified boards and boxes</a>.</p>
+    <p>Time to market is crucial. Canonical will validate or enable your hardware, package your apps, set up your app store and prepare your device image. It's everything you need to get your device to market fast. App store and over-the-air security updates guaranteed. You can also choose from our extensive list of <a href="/certified?category=Device">certified boards and boxes</a>.</p>
 
     <h3>IoT and device professional services packages</h3>
 
@@ -125,7 +125,7 @@
 <section class="p-strip--light">
   <div class="u-fixed-width">
     <h2>SoC, board and device enablement</h2>
-    <p class="p-heading--4">Give your SoC, board or device a custom kernel that’s proven compatible with the public Ubuntu LTS kernel, for wide application compatibility and developer productivity.</p>
+    <p class="p-heading--4">Give your SoC, board or device a custom kernel that's proven compatible with the public Ubuntu LTS kernel, for wide application compatibility and developer productivity.</p>
   </div>
 
   <div class="row u-equal-height u-sv3">
@@ -175,10 +175,10 @@
     </div>
     <div class="col-4 u-hide--small u-hide--medium u-align--center u-vertically-center">
       {{ image (
-        url="https://assets.ubuntu.com/v1/706b259a-ubuntu_certified_hex.svg",
+        url="https://assets.ubuntu.com/v1/f76dd871-ubuntu-certified.png",
         alt="",
-        width="120",
-        height="150",
+        width="158",
+        height="224",
         hi_def=True,
         loading="lazy"
         ) | safe


### PR DESCRIPTION
## Done

- Update logos on /pricing/devices based on [this issue](https://warthogs.atlassian.net/browse/WD-1717)

## QA

- Go to https://ubuntu-com-12645.demos.haus/pricing/devices and check it used the same logos as in the issue

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-1717
