### PR TITLE
WD-1710 `/desktop/organisations` logo replacements

### DIFF
--- a/templates/desktop/organisations.html
+++ b/templates/desktop/organisations.html
@@ -36,116 +36,78 @@
       <h2 class="u-sv2">Secure enterprise management with Ubuntu Pro Desktop</h2>
     </div>
   </div>
-  <div class="row u-sv3">
-    <div class="col-4">
-      <div class="u-hide--small u-hide--medium">
-        {{ image (
-          url="https://assets.ubuntu.com/v1/b4cabb3f-68747470733a2f2f696d616765732e7a656e68756275736572636f6e74656e742e636f6d2f3562393738373431393663303830316165643138633461312f65663636653130652d393435662d343565622d393163302d636662633965356564303263.svg",
-          alt="",
-          width="100",
-          height="100",
-          hi_def=True,
-          loading="lazy"
-          ) | safe
-        }}
-      </div>
-      <h3>Secure open-source stack</h3>
-      <div>
-        <p>Receive 10 years of security patches for Ubuntu LTS releases with Expanded Security Maintenance (<a href="/security/esm">ESM</a>) and coverage for over 23,000 packages in the Ubuntu Universe repository. Minimise downtime with Kernel <a href="/security/livepatch">Livepatch</a>.</p>
-        <p><a href="/pro">Learn more about Ubuntu Pro&nbsp;&rsaquo;</a></p>
-      </div>
+  <div class="row u-equal-height">
+    <div class="col-4 p-card col-medium-3">
+      <h4>Secure open-source stack</h4>
+      <hr />
+      <p>
+        Receive 10 years of security patches for Ubuntu LTS releases with Expanded Security Maintenance (<a href="/security/esm">ESM</a>) and coverage for over 23,000 packages in the Ubuntu Universe repository. Minimise downtime with Kernel <a href="/security/livepatch">Livepatch</a>.
+      </p>
+      <p>
+        <a href="/pro">
+          Learn more about Ubuntu Pro
+        </a>
+      </p>
     </div>
-    <div class="col-4">
-      <div class="u-hide--small u-hide--medium">
-        {{ image (
-          url="https://assets.ubuntu.com/v1/50c0306d-image-picto-landscape.svg",
-          alt="",
-          width="100",
-          height="100",
-          hi_def=True,
-          loading="lazy"
-          ) | safe
-        }}
-      </div>
-      <h3>Landscape Fleet Management</h3>
-      <div>
-        <p>Software updates, configuration management, policy compliance, and permission control for your entire physical and virtual fleet. Landscape is easy to use and smoothly integrates with other tooling through a robust API.</p>
-        <p><a href="https://landscape.canonical.com/">Learn more about Landscape&nbsp;&rsaquo;</a></p>
-      </div>
+    <div class="col-4 p-card col-medium-3">
+      <h4>Landscape Fleet Management</h4>
+      <hr />
+      <p>
+        Software updates, configuration management, policy compliance, and permission control for your entire physical and virtual fleet. Landscape is easy to use and smoothly integrates with other tooling through a robust API.
+      </p>
+      <p>
+        <a href="https://landscape.canonical.com/">
+          Learn more about Landscape
+        </a>
+      </p>
     </div>
-    <div class="col-4">
-      <div class="u-hide--small u-hide--medium u-sv1">
-        {{ image (
-          url="https://assets.ubuntu.com/v1/e7bcb9fa-4b9bad4c100c73cc2c1c839f3eb5ec03_active-directory-logo.png",
-          alt="",
-          width="405",
-          height="100",
-          hi_def=True,
-          loading="lazy"
-          ) | safe
-        }}
-      </div>
-      <h3>Advanced Active Directory Policies</h3>
-      <div>
-        <p>Increase your management capabilities with full Group Policy Object support, remote script execution and privilege management.</p>
-        <p><a href="/engage/New-Active-Directory-integration-features">Learn more about Active Directory integration&nbsp;&rsaquo;</a></p>
-      </div>
+    <div class="col-4 p-card col-medium-3">
+      <h4>Advanced Active Directory Policies</h4>
+      <hr />
+      <p>
+        Increase your management capabilities with full Group Policy Object support, remote script execution and privilege management.
+      </p>
+      <p>
+        <a href="/engage/New-Active-Directory-integration-features">
+          Learn more about Active <br/>Directory integration
+        </a>
+      </p>
     </div>
-  </div>
-  <div class="row">
-    <div class="col-4">
-      <div class="u-hide--small u-hide--medium">
-        {{ image (
-          url="https://assets.ubuntu.com/v1/ec3f53f7-extended-security-maintenance.svg",
-          alt="",
-          width="100",
-          height="100",
-          hi_def=True,
-          loading="lazy"
-          ) | safe
-        }}
-      </div>
-      <h3>Compliance, certification and hardening</h3>
-      <div>
-        <p>Ubuntu Pro delivers security and compliance for even the most sensitive workloads with <a href="/security/certifications#fips">FIPS 140-2 certified modules</a>, <a href="/security/certifications#cis">CIS hardening</a> and <a href="/security/certifications#common-criteria">Common Criteria EAL2</a> certification available.</p>
-        <p><a href="/security">Learn more about Ubuntu's security practices&nbsp;&rsaquo;</a></p>
-      </div>
+    <div class="col-4 p-card col-medium-3">
+      <h4>Compliance, certification and hardening</h4>
+      <hr />
+      <p>
+        Ubuntu Pro delivers security and compliance for even the most sensitive workloads with <a href="/security/certifications#fips">FIPS 140-2 certified modules</a>, <a href="/security/certifications#cis">CIS hardening</a> and <a href="/security/certifications#common-criteria">Common Criteria EAL2</a> certification available.
+      </p>
+      <p>
+        <a href="/security">
+          Learn more about Ubuntu's security practices
+        </a>
+      </p>
     </div>
-    <div class="col-4">
-      <div class="u-hide--small u-hide--medium">
-        {{ image (
-          url="https://assets.ubuntu.com/v1/7cafcb2c-Managed-apps.svg",
-          alt="",
-          width="197",
-          height="100",
-          hi_def=True,
-          loading="lazy"
-          ) | safe
-        }}
-      </div>
-      <h3>Certified hardware</h3>
-      <div>
-        <p>Ubuntu Desktop is certified across a wide range of laptops, desktops, and workstations, including the HP Z series and Dell  XPS and Precision lines.</p>
-        <p><a href="/certified">Learn more about Ubuntu certified hardware&nbsp;&rsaquo;</a></p>
-      </div>
+    <div class="col-4 p-card col-medium-3">
+      <h4>Certified hardware</h4>
+      <hr />
+      <p>
+        Ubuntu Desktop is certified across a wide range of laptops, desktops, and workstations, including the HP Z series and Dell  XPS and Precision lines.
+      </p>
+      <p>
+        <a href="/certified">
+          Learn more about Ubuntu certified hardware
+        </a>
+      </p>
     </div>
-    <div class="col-4">
-      <div class="u-hide--small u-hide--medium">
-        {{ image (
-          url="https://assets.ubuntu.com/v1/e9d3cf66-We+support+your+operations.svg",
-          alt="",
-          width="100",
-          height="100",
-          hi_def=True,
-          loading="lazy"
-          ) | safe
-        }}
-      </div>
-      <h3>Weekday or 24/7 Support</h3>
-      <div>
-        <p>UAdvanced support customers get direct 24/7 access to our enterprise open source support team through our web portal, knowledge base or via phone.</p>
-        <p><a href="/desktop/contact-us" class="js-invoke-modal p-button">Contact us</a></p>
-      </div>
+    <div class="col-4 p-card col-medium-3">
+      <h4>Weekday or 24/7 Support</h4>
+      <hr />
+      <p>
+        UAdvanced support customers get direct 24/7 access to our enterprise open source support team through our web portal, knowledge base or via phone.
+      </p>
+      <p>
+        <a href="/desktop/contact-us" class="js-invoke-modal p-button">
+          Contact us
+        </a>
+      </p>
     </div>
   </div>
 </section>
@@ -259,189 +221,199 @@
 
 <section class="p-strip">
   <div class="u-fixed-width">
-    <h2>Ubuntu delivers the best of open source</h2>
-    <p>Drive innovation in high-growth areas such as data science and machine learning with support for the latest libraries and apps  in addition to critical workflow tools like <a href="https://multipass.run/">Multipass</a>, <a href="https://jaas.ai/">Juju</a>, <a href="/lxd">LXD</a> and <a href="https://microk8s.io/">MicroK8s</a>.</p>
-    <div class="p-logo-section">
-      <div class="p-logo-section__items">
-        <div class="p-logo-section__item">
-          {{ image (
-            url="https://assets.ubuntu.com/v1/57dd2115-TensorFlow-logo.svg",
-            alt="",
-            width="145",
-            height="145",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-logo-section__logo"}
-            ) | safe
-          }}
+    <div class="p-strip u-no-padding-top">
+      <div class="row">
+        <div class="col-5">
+          <h2>Ubuntu delivers the best <br/>of open source</h2>
         </div>
-        <div class="p-logo-section__item">
-          {{ image (
-            url="https://assets.ubuntu.com/v1/d540aea5-OpenCV-logo.png",
-            alt="",
-            width="288",
-            height="288",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-logo-section__logo"}
-            ) | safe
-          }}
+        <div class="col-6">
+          <p>Drive innovation in high-growth areas such as data science and machine learning with support for the latest libraries and apps  in addition to critical workflow tools like <a href="https://multipass.run/">Multipass</a>, <a href="https://jaas.ai/">Juju</a>, <a href="/lxd">LXD</a> and <a href="https://microk8s.io/">MicroK8s</a>.</p>
         </div>
-        <div class="p-logo-section__item">
-          {{ image (
-            url="https://assets.ubuntu.com/v1/6019771d-logo-docker.svg",
-            alt="",
-            width="97",
-            height="97",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-logo-section__logo"}
-            ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{ image (
-            url="https://assets.ubuntu.com/v1/3def7411-kubeflow-logo.png",
-            alt="Kubeflow",
-            width="288",
-            height="288",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-logo-section__logo"}
-            ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{ image (
-            url="https://assets.ubuntu.com/v1/5ad2c156-edgex-logo.png",
-            alt="",
-            width="288",
-            height="288",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-logo-section__logo"}
-            ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{ image (
-            url="https://assets.ubuntu.com/v1/f41c87c6-pytorch-logo.png",
-            alt="",
-            width="288",
-            height="288",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-logo-section__logo"}
-            ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{ image (
-            url="https://assets.ubuntu.com/v1/19487741-acrn-logo.png",
-            alt="",
-            width="288",
-            height="288",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-logo-section__logo"}
-            ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{ image (
-            url="https://assets.ubuntu.com/v1/1e5e8699-2018-logo-open-vSwitch.svg",
-            alt="",
-            width="146",
-            height="146",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-logo-section__logo"}
-            ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{ image (
-            url="https://assets.ubuntu.com/v1/c1b1d4a9-ros-logo.png",
-            alt="ROS",
-            width="288",
-            height="288",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-logo-section__logo"}
-            ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{ image (
-            url="https://assets.ubuntu.com/v1/e1899663-flutter-logo.png",
-            alt="Flutter",
-            width="288",
-            height="288",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-logo-section__logo"}
-            ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{ image (
-            url="https://assets.ubuntu.com/v1/389dee91-openvino-logo.png",
-            alt="",
-            width="288",
-            height="288",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-logo-section__logo"}
-            ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{ image (
-            url="https://assets.ubuntu.com/v1/0c374f1b-lxd-logo.png",
-            alt="",
-            width="288",
-            height="288",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-logo-section__logo"}
-            ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{ image (
-            url="https://assets.ubuntu.com/v1/b96a2a65-Multipass+logo_rgb.svg",
-            alt="",
-            width="300",
-            height="55",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-logo-section__logo"}
-            ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{ image (
-            url="https://assets.ubuntu.com/v1/7fe3f290-2019-logo-jaas.svg",
-            alt="",
-            width="145",
-            height="145",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-logo-section__logo"}
-            ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{ image (
-            url="https://assets.ubuntu.com/v1/89fdda84-microk8s-logo.svg",
-            alt="",
-            width="145",
-            height="144",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-logo-section__logo"}
-            ) | safe
-          }}
+      </div>
+    </div>
+    <div class="row">
+      <div class="p-logo-section">
+        <div class="p-logo-section__items">
+          <div class="p-logo-section__item">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/be56a944-tensor-flow-logo.png",
+              alt="TensorFlow",
+              width="158",
+              height="158",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/96c4727f-OpenCV-logo.png",
+              alt="OpenCV",
+              width="158",
+              height="158",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/5154773b-docker-logo-horizontal.png",
+              alt="Docker",
+              width="158",
+              height="158",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/94ae6189-edgexfoundry-logo.png",
+              alt="EdgeX Foundry",
+              width="158",
+              height="158",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/a20afc7d-kubeflow-logo.png",
+              alt="Kubeflow",
+              width="158",
+              height="158",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/835a5d08-Juju.png",
+              alt="Canonical Juju",
+              width="158",
+              height="158",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/75145268-acrn-logo.png",
+              alt="Acrn",
+              width="158",
+              height="158",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/eac2a3ad-openvino-logo.png",
+              alt="OpenVINO",
+              width="158",
+              height="158",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/1d3e5eaf-flutter-logo.png",
+              alt="Flutter",
+              width="158",
+              height="158",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/49e6dfc2-ros-logo.png",
+              alt="ROS",
+              width="158",
+              height="158",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/a984834a-LXD.png",
+              alt="Canonical LXD",
+              width="158",
+              height="158",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/d60029cc-pytorch-logo.png",
+              alt="Pytorch",
+              width="158",
+              height="158",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/1ad80137-Multipass.png",
+              alt="Canonical Multipass",
+              width="158",
+              height="158",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/083fd46b-open-v-switch.png",
+              alt="Open vSwitch",
+              width="158",
+              height="158",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/3f49251c-MicroK8s.png",
+              alt="Canonical MicroK8s",
+              width="158",
+              height="158",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
+          </div>
         </div>
       </div>
     </div>
@@ -456,10 +428,10 @@
   <div class="row">
     <div class="col-7 u-vertically-center u-hide--small u-hide--medium">
       {{ image (
-        url="https://assets.ubuntu.com/v1/938872cc-Screenshot+from+2022-04-20+11-53-34.png",
-        alt="",
-        width="1236",
-        height="298",
+        url="https://assets.ubuntu.com/v1/750a8ab6-ubuntu-for-datascience.svg",
+        alt="Ubuntu for datascience",
+        width="538",
+        height="133",
         hi_def=True,
         loading="lazy"
         ) | safe

--- a/templates/desktop/organisations.html
+++ b/templates/desktop/organisations.html
@@ -101,7 +101,7 @@
       <h4>Weekday or 24/7 Support</h4>
       <hr />
       <p>
-        UAdvanced support customers get direct 24/7 access to our enterprise open source support team through our web portal, knowledge base or via phone.
+        Advanced support customers get direct 24/7 access to our enterprise open source support team through our web portal, knowledge base or via phone.
       </p>
       <p>
         <a href="/desktop/contact-us" class="js-invoke-modal p-button">
@@ -224,7 +224,7 @@
     <div class="p-strip u-no-padding-top">
       <div class="row">
         <div class="col-5">
-          <h2>Ubuntu delivers the best <br/>of open source</h2>
+          <h2>Ubuntu delivers the best <br class="u-hide--medium u-hide--small"/>of open source</h2>
         </div>
         <div class="col-6">
           <p>Drive innovation in high-growth areas such as data science and machine learning with support for the latest libraries and apps  in addition to critical workflow tools like <a href="https://multipass.run/">Multipass</a>, <a href="https://jaas.ai/">Juju</a>, <a href="/lxd">LXD</a> and <a href="https://microk8s.io/">MicroK8s</a>.</p>


### PR DESCRIPTION
## Done

- Remove logos in the "Secure enterprise management with Ubuntu Pro Desktop" section.
- Logo replacements in the "Ubuntu delivers the best of open source" section.
- Update Ubuntu for Data science illustration.

## QA

- Check the demo here: https://ubuntu-com-12650.demos.haus/desktop/organisations
- Compare with the screenshots in the task [here](https://warthogs.atlassian.net/browse/WD-1710).

## Issue / Card

- [WD-1710](https://warthogs.atlassian.net/browse/WD-1710)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-1710]: https://warthogs.atlassian.net/browse/WD-1710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ