### PR TITLE
Change machine number for renewals

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/RenewalButton/RenewalButton.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/RenewalButton/RenewalButton.tsx
@@ -16,6 +16,9 @@ export default function RenewalButton({
   editing,
   action,
 }: Props) {
+  const price = subscription.renewal_id
+    ? Number(subscription.price) / subscription.current_number_of_machines
+    : Number(subscription.price) / subscription.number_of_machines;
   const product: Product = {
     longId: subscription.renewal_id ?? subscription.listing_id ?? "",
     period:
@@ -26,7 +29,7 @@ export default function RenewalButton({
     id: subscription.id,
     name: subscription.product_name ?? "",
     price: {
-      value: Number(subscription.price) / subscription.number_of_machines,
+      value: price,
     },
     canBeTrialled: false,
   };

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/DetailsContent.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/DetailsContent.tsx
@@ -1,3 +1,5 @@
+import React, { ReactNode } from "react";
+import classNames from "classnames";
 import {
   Button,
   CodeSnippet,
@@ -8,7 +10,7 @@ import {
   Spinner,
   Tooltip,
 } from "@canonical/react-components";
-import classNames from "classnames";
+import { UserSubscriptionType } from "advantage/api/enum";
 import { useContractToken, useUserSubscriptions } from "advantage/react/hooks";
 import { selectSubscriptionById } from "advantage/react/hooks/useUserSubscriptions";
 import {
@@ -16,15 +18,12 @@ import {
   getMachineTypeDisplay,
   getPeriodDisplay,
   getSubscriptionCost,
-  isFreeSubscription,
   isBlenderSubscription,
+  isFreeSubscription,
 } from "advantage/react/utils";
 import { sendAnalyticsEvent } from "advantage/react/utils/sendAnalyticsEvent";
-import React, { ReactNode } from "react";
-
-import DetailsTabs from "../DetailsTabs";
 import { SelectedId } from "../../Content/types";
-import { UserSubscriptionType } from "advantage/api/enum";
+import DetailsTabs from "../DetailsTabs";
 
 type Props = {
   selectedId?: SelectedId;
@@ -138,7 +137,7 @@ const DetailsContent = ({ selectedId, setHasUnsavedChanges }: Props) => {
             ? // Don't show the billing column for legacy subscriptions.
               []
             : [billingCol]),
-          ...(cost
+          ...(cost && subscription.type !== UserSubscriptionType.Legacy
             ? // Don't show the cost column if it's empty.
               [costCol]
             : []),

--- a/tests/shop/advantage/helpers.py
+++ b/tests/shop/advantage/helpers.py
@@ -171,6 +171,7 @@ def make_renewal(
     new_contract_start: str = None,
     price: int = None,
     currency: str = None,
+    number_of_machines: int = None,
 ) -> Renewal:
     return Renewal(
         id=id or "rAaBbCcDdEeFfGg",
@@ -182,6 +183,7 @@ def make_renewal(
         new_contract_start=new_contract_start or "2020-01-01T10:00:00Z",
         price=price or 10000,
         currency=currency or "USD",
+        number_of_machines=number_of_machines or 1,
     )
 
 

--- a/tests/shop/advantage/helpers.py
+++ b/tests/shop/advantage/helpers.py
@@ -196,6 +196,7 @@ def make_legacy_contract_item(
     reason: str = None,
     value: int = None,
     renewal: Renewal = None,
+    number_of_machines: int = None,
 ) -> ContractItem:
     default_renewal = Renewal(
         id="rAaBbCcDdEeFfGg",
@@ -207,6 +208,7 @@ def make_legacy_contract_item(
         new_contract_start="2020-01-01T10:00:00Z",
         price=10000,
         currency="USD",
+        number_of_machines=number_of_machines or 1,
     )
 
     return ContractItem(

--- a/tests/shop/advantage/test_parsers.py
+++ b/tests/shop/advantage/test_parsers.py
@@ -327,6 +327,7 @@ class TestParsers(unittest.TestCase):
             new_contract_start="2021-01-01T00:00:00Z",
             price=11000,
             currency="USD",
+            number_of_machines=1,
         )
 
         self.assertEqual(to_dict(expectation), to_dict(parsed_renewal))
@@ -411,6 +412,7 @@ class TestParsers(unittest.TestCase):
                     new_contract_start="2015-01-01T00:00:00Z",
                     price=5000,
                     currency="USD",
+                    number_of_machines=1,
                 ),
             ),
         ]

--- a/tests/shop/advantage/test_parsers.py
+++ b/tests/shop/advantage/test_parsers.py
@@ -327,7 +327,7 @@ class TestParsers(unittest.TestCase):
             new_contract_start="2021-01-01T00:00:00Z",
             price=11000,
             currency="USD",
-            number_of_machines=1,
+            number_of_machines=3,
         )
 
         self.assertEqual(to_dict(expectation), to_dict(parsed_renewal))

--- a/tests/shop/advantage/test_parsers.py
+++ b/tests/shop/advantage/test_parsers.py
@@ -412,7 +412,7 @@ class TestParsers(unittest.TestCase):
                     new_contract_start="2015-01-01T00:00:00Z",
                     price=5000,
                     currency="USD",
-                    number_of_machines=1,
+                    number_of_machines=5,
                 ),
             ),
         ]

--- a/webapp/shop/api/ua_contracts/builders.py
+++ b/webapp/shop/api/ua_contracts/builders.py
@@ -203,8 +203,10 @@ def build_final_user_subscriptions(
             get_current_number_of_machines(
                 subscriptions, subscription_id, listing
             )
-            if type in ["trial", "monthly", "yearly"]
-            else number_of_machines
+            if type != "legacy"
+            else (
+                renewal.number_of_machines if renewal else number_of_machines
+            )
         )
         price_info = get_price_info(number_of_machines, items, listing)
         product_name = (

--- a/webapp/shop/api/ua_contracts/parsers.py
+++ b/webapp/shop/api/ua_contracts/parsers.py
@@ -97,9 +97,11 @@ def parse_renewal(raw_renewal: Dict = None) -> Renewal:
     renewal_items = raw_renewal.get("renewalItems")
     price = 0
     currency = "usd"
+    number_of_machines = 0
     for item in renewal_items:
         price = price + item.get("priceTotal").get("value")
         currency = item.get("priceTotal").get("currency")
+        number_of_machines = item.get("allowance").get("value")
 
     return Renewal(
         id=raw_renewal.get("id"),
@@ -111,6 +113,7 @@ def parse_renewal(raw_renewal: Dict = None) -> Renewal:
         new_contract_start=raw_renewal.get("newContractStart"),
         price=price,
         currency=currency,
+        number_of_machines=number_of_machines,
     )
 
 

--- a/webapp/shop/api/ua_contracts/primitives.py
+++ b/webapp/shop/api/ua_contracts/primitives.py
@@ -16,6 +16,7 @@ class Renewal:
         new_contract_start: str,
         price: int,
         currency: str,
+        number_of_machines: int,
     ):
         self.id = id
         self.contract_id = contract_id
@@ -26,6 +27,7 @@ class Renewal:
         self.price = price
         self.currency = currency
         self.new_contract_start = new_contract_start
+        self.number_of_machines = number_of_machines
 
 
 class ContractItem:


### PR DESCRIPTION
## Done

- Update renewals to renew the number of machines from the renewal object rather than the number of machines they had before

Fixes https://warthogs.atlassian.net/browse/WD-2478