### PR TITLE
Disable buy button when user info is edit mode

### DIFF
--- a/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
@@ -32,6 +32,7 @@ const BuyButton = ({ setError, quantity, product, action }: Props) => {
 
   useEffect(() => {
     if (
+      !values.isInfoSaved ||
       !values.isTaxSaved ||
       !values.isCardValid ||
       !values.email ||

--- a/static/js/src/advantage/subscribe/checkout/components/UserInfoForm/UserInfoForm.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/UserInfoForm/UserInfoForm.tsx
@@ -59,6 +59,12 @@ const UserInfoForm = ({ setError }: Props) => {
     setFieldValue("isCardValid", !isEditing);
   }, [isEditing]);
 
+  useEffect(() => {
+    if (!initialValues.email || !window.accountId) {
+      setFieldValue("isInfoSaved", true);
+    }
+  }, []);
+
   const onSaveClick = () => {
     checkoutEvent(window.GAFriendlyProduct, "2");
     setIsButtonDisabled(true);

--- a/static/js/src/advantage/subscribe/checkout/components/UserInfoForm/UserInfoForm.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/UserInfoForm/UserInfoForm.tsx
@@ -51,6 +51,7 @@ const UserInfoForm = ({ setError }: Props) => {
       onSaveClick();
     } else {
       setIsEditing(true);
+      setFieldValue("isInfoSaved", false);
     }
   };
 
@@ -61,6 +62,7 @@ const UserInfoForm = ({ setError }: Props) => {
   const onSaveClick = () => {
     checkoutEvent(window.GAFriendlyProduct, "2");
     setIsButtonDisabled(true);
+    setFieldValue("isInfoSaved", true);
 
     paymentMethodMutation.mutate(
       { formData: values },
@@ -398,6 +400,7 @@ const UserInfoForm = ({ setError }: Props) => {
                   setFieldValue("city", initialValues.city);
                   setFieldValue("postalCode", initialValues.postalCode);
                   setIsEditing(false);
+                  setFieldValue("isInfoSaved", true);
                 }}
               >
                 Cancel

--- a/static/js/src/advantage/subscribe/checkout/utils/helpers.ts
+++ b/static/js/src/advantage/subscribe/checkout/utils/helpers.ts
@@ -31,6 +31,7 @@ export function getInitialFormValues(
     marketplace: product.marketplace,
     isTaxSaved: !!userInfo?.customerInfo?.address?.country,
     isCardValid: !!userInfo?.customerInfo?.defaultPaymentMethod,
+    isInfoSaved: !!userInfo?.customerInfo?.defaultPaymentMethod,
   };
 }
 

--- a/static/js/src/advantage/subscribe/checkout/utils/types.ts
+++ b/static/js/src/advantage/subscribe/checkout/utils/types.ts
@@ -51,6 +51,7 @@ export interface FormValues {
   FreeTrial: string;
   isTaxSaved: boolean;
   isCardValid: boolean;
+  isInfoSaved: boolean;
 }
 
 export type marketplace = "canonical-ua" | "canonical-cube" | "blender";


### PR DESCRIPTION
## Done

- Disable buy button if editting user info

## QA

- Log in with account that has purchase history 
- Click Edit button in Your information section 
- Check buy button is disabled/active depending on the edit/save button 

## Issue / Card

Fixes #https://warthogs.atlassian.net/jira/software/c/projects/WD/boards/801?modal=detail&selectedIssue=WD-2407
