### PR TITLE
WD-2509 Replace the intel logo on the automotive page

### DIFF
--- a/templates/automotive/index.html
+++ b/templates/automotive/index.html
@@ -357,13 +357,12 @@
           </div>
           <div class="p-logo-section__item">
             {{ image (
-              url="https://assets.ubuntu.com/v1/627f7bed-intel-old-logo.png",
+              url="https://assets.ubuntu.com/v1/67f81bfe-intel-new-logo.png",
               alt="",
               width="288",
               height="288",
               hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-logo-section__logo"}
+              loading="lazy"
               ) | safe
             }}
           </div>


### PR DESCRIPTION
## Done

- Replace the intel logo on the automotive page

## QA

- Check the new logo matches the one in [the copy doc](https://docs.google.com/document/d/10jSLdwz2Ks7gnEMXlKWzrpsY6TQFxISUgnQo4y3yOrA/edit#)
