### PR TITLE
Fix country-code dropdown not overlapping fieldsets

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -3,7 +3,7 @@
 // allow use of math.div
 @use "sass:math";
 
-//settings
+// settings
 @import "global-settings";
 @import "settings_colors";
 

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -225,6 +225,7 @@ select {
 fieldset {
   border: 1px solid $color-mid-light;
   border-radius: $sp-xx-small $sp-xx-small 0 0;
+  overflow: visible;
 }
 
 fieldset + fieldset {


### PR DESCRIPTION
## Done

- Set `fieldset: visible` to stop the dropdown causing the field set to scroll for overflow, as can be seen in [this issue](https://github.com/canonical/ubuntu.com/issues/12625)

## QA

- Go to a contact-us form with a number input near the edge of a field set, ex. download/contact-us
- Check it does not need to be scrolled to see the full container

Before:
![image](https://user-images.githubusercontent.com/58276363/224001914-06cfe756-3ef9-4134-a576-7c0397303205.png)
After:
![image](https://user-images.githubusercontent.com/58276363/224001966-482a0b0b-c95d-416e-ab1f-e046f9096ed9.png)

## Issue / Card

Fixes https://github.com/canonical/ubuntu.com/issues/12625
