### PR TITLE
Check if tab content contains an D3 chart and trigger resize event if yes

### DIFF
--- a/static/js/src/tabotronic.js
+++ b/static/js/src/tabotronic.js
@@ -33,6 +33,9 @@
       panel.classList.add("u-hide");
     });
     panelElement.classList.remove("u-hide");
+    if (panelElement.querySelector("svg[class='chart']")) {
+      window.dispatchEvent(new Event("resize"));
+    }
     panelElement.scrollIntoView();
   }
 


### PR DESCRIPTION
## Done

- Check if tab content contains an D3 chart and trigger resize event if yes
- I added the check into tabtronic.js as this is only an issue that occurs when a d3 chart is held within tabs. This is because the d3 script check the size of the container that holds the chart, if the container is hidden that chart has a width of 0, so d3 will infer the size from the closest `col`

## QA

- Go to https://ubuntu-com-12662.demos.haus/kernel/lifecycle and check that the charts are the same size between tabs

## Issue / Card

Fixes https://github.com/canonical/ubuntu.com/issues/12590
