### PR TITLE
Update copy on /landscape/pricing

### DIFF
--- a/templates/contact-us/form/index.html
+++ b/templates/contact-us/form/index.html
@@ -45,6 +45,16 @@
     returnURL="/contact-us/form/thank-you" %}
     {% include "shared/_pro-contact-us-form.html" %}
   {% endwith %}
+
+{% elif product == 'landscape' %}
+  {% with h1="Talk to our Landscape team",
+    intro_text="If you want to learn more about Landscape or our professional services options, meet with us and discuss your needs with one of our advisors.",
+    formid="4473",
+    lpId="",
+    returnURL="/landscape/pricing" %}
+    {% include "shared/_cloud-contact-us-form.html" %}
+  {% endwith %}
+
 {% else %}
 
 {% with h1="Contact Canonical",

--- a/templates/landscape/pricing.html
+++ b/templates/landscape/pricing.html
@@ -1,7 +1,7 @@
 {% extends "landscape/base_landscape.html" %}
 
 {% block title %}Compare Landscape editions{% endblock %}
-{% block meta_description %}Features and pricing for Landscape SaaS and self hosted Landscape{% endblock meta_description %}
+{% block meta_description %}Features and pricing for each Landscape edition: Landscape SaaS, self hosted Landscape, and Managed Landscape{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1pESmRniuiaDHkbzY_60GlOJdCiH2pZ9erI9KV49eDyM/edit#{% endblock meta_copydoc %}
 
 {% block content %}
@@ -15,7 +15,8 @@
         <tr>
           <th style="font-size: 20px;">Feature</th>
           <th class="u-align--center"><span style="font-size: 20px;">Landscape SaaS</span> <br> No server software to maintain</th>
-          <th class="u-align--center"><span style="font-size: 20px;">Self-hosted Landscape</span> <br>Runs behind your firewall</th>
+          <th class="u-align--center"><span style="font-size: 20px;">Self-hosted Landscape</span> <br>Runs on-prem or in any cloud</th>
+          <th class="u-align--center"><span style="font-size: 20px;">Managed Landscape</span> <br>Runs on public clouds</th>
         </tr>
       </thead>
       <tbody>
@@ -23,9 +24,11 @@
           <td>Software and inventory management</td>
           <td class="u-align--center"><i class="p-icon--success">Included</i></td>
           <td class="u-align--center"><i class="p-icon--success">Included</i></td>
+          <td class="u-align--center"><i class="p-icon--success">Included</i></td>
         </tr>
         <tr>
           <td>Security patches and notices</td>
+          <td class="u-align--center"><i class="p-icon--success">Included</i></td>
           <td class="u-align--center"><i class="p-icon--success">Included</i></td>
           <td class="u-align--center"><i class="p-icon--success">Included</i></td>
         </tr>
@@ -33,9 +36,11 @@
           <td>System monitoring and custom reporting</td>
           <td class="u-align--center"><i class="p-icon--success">Included</i></td>
           <td class="u-align--center"><i class="p-icon--success">Included</i></td>
+          <td class="u-align--center"><i class="p-icon--success">Included</i></td>
         </tr>
         <tr>
           <td>Inventory management</td>
+          <td class="u-align--center"><i class="p-icon--success">Included</i></td>
           <td class="u-align--center"><i class="p-icon--success">Included</i></td>
           <td class="u-align--center"><i class="p-icon--success">Included</i></td>
         </tr>
@@ -43,9 +48,17 @@
           <td>Compliance management</td>
           <td class="u-align--center"><i class="p-icon--success">Included</i></td>
           <td class="u-align--center"><i class="p-icon--success">Included</i></td>
+          <td class="u-align--center"><i class="p-icon--success">Included</i></td>
         </tr>
         <tr>
           <td>Role based access control</td>
+          <td class="u-align--center"><i class="p-icon--success">Included</i></td>
+          <td class="u-align--center"><i class="p-icon--success">Included</i></td>
+          <td class="u-align--center"><i class="p-icon--success">Included</i></td>
+        </tr>
+        <tr>
+          <td>Manage all guest machines of a virtualisation host (KVM, VMWare, LXD, etc.)</td>
+          <td class="u-align--center"><i class="p-icon--success">Included</i></td>
           <td class="u-align--center"><i class="p-icon--success">Included</i></td>
           <td class="u-align--center"><i class="p-icon--success">Included</i></td>
         </tr>
@@ -53,52 +66,57 @@
           <td>SSO with UbuntuOne</td>
           <td class="u-align--center"><i class="p-icon--success">Included</i></td>
           <td class="u-align--center"><i class="p-icon--success">Included</i></td>
+          <td class="u-align--center"><i class="p-icon--success">Included</i></td>
         </tr>
         <tr>
           <td>3rd party SSO integration</td>
           <td></td>
+          <td class="u-align--center"><i class="p-icon--success">Included</i></td>
           <td class="u-align--center"><i class="p-icon--success">Included</i></td>
         </tr>
         <tr>
           <td>Custom software repositories</td>
           <td class="u-align--center"></td>
           <td class="u-align--center"><i class="p-icon--success">Included</i></td>
+          <td class="u-align--center"><i class="p-icon--success">Included</i></td>
         </tr>
         <tr>
           <td>Private repository hosting</td>
           <td></td>
           <td class="u-align--center"><i class="p-icon--success">Included</i></td>
+          <td class="u-align--center"><i class="p-icon--success">Included</i></td>
         </tr>
         <tr>
-          <td>Unlimited Virtual Machine guests</td>
+          <td>Managed by Canonical</td>
+          <td class="u-align--center"><i class="p-icon--success">Included</i></td>
           <td></td>
           <td class="u-align--center"><i class="p-icon--success">Included</i></td>
         </tr>
         <tr>
-          <td>Unlimited Ubuntu KVM guest support</td>
+          <td>Manage 40,000 machines with an SLA</td>
+          <td></td>
           <td></td>
           <td class="u-align--center"><i class="p-icon--success">Included</i></td>
         </tr>
         <tr>
-          <td>Unlimited Ubuntu LXD guest support</td>
-          <td></td>
-          <td class="u-align--center"><i class="p-icon--success">Included</i></td>
-        </tr>
-        <tr>
-          <td>Air gapped</td>
+          <td>Works in air gapped environments</td>
           <td></td>
           <td class="u-align--center"><i class="p-icon--success">Included</i></td>
         </tr>
         <tr>
           <td>Pricing</td>
-          <td><a href="/pro/subscribe">Pricing calculator for Ubuntu Pro</a></td>
+          <td>Landscape SaaS is included with a paid Ubuntu Pro subscription.</td>
           <td>Free for up to 10 machines for personal use, or evaluation purposes.<br /><br />Beyond the free tier, <a href="/pro">Ubuntu Pro</a> is required for more than 10 machines on self-hosted Landscape</td>
+          <td>Canonical's standard <a href="/managed/apps">Managed Apps</a> pricing applies</td>
         </tr>
-        <tr>
-          <td></td>
-          <td>Landscape SaaS is included with <a href="/pro">Ubuntu Pro</a></td>
-          <td><a href="/landscape/install">Set up your self-hosted Landscape</a></td>
-        </tr>
+        <tfoot>
+          <tr>
+            <td></td>
+          <td><a href="/pro/subscribe">Pricing calculator for Ubuntu Pro</a></td>
+            <td><a href="/landscape/install">Set up your self-hosted Landscape</a></td>
+            <td><a href="/contact-us/form?product=landscape" class="p-button--positive is-dense js-invoke-modal">Contact us</a> to get started</td>
+          </tr>
+        </tfoot>
       </tbody>
     </table>
   </div>
@@ -110,7 +128,7 @@
       <div>
         <h2>Speak to a member of our team</h2>
         <p>If you want to learn more about Landscape or our professional services options, contact us to discuss your needs.</p>
-        <p><a href="#get-in-touch" class="p-button--positive js-invoke-modal">Contact us</a></p>
+        <p><a href="/contact-us/form?product=landscape" class="p-button--positive js-invoke-modal">Contact us</a></p>
       </div>
     </div>
     <div class="col-5 u-hide--small u-hide--medium u-align--right">


### PR DESCRIPTION
## Done

- Updates copy on https://ubuntu-com-12670.demos.haus/landscape/pricing based on [copydoc](https://docs.google.com/document/d/1pESmRniuiaDHkbzY_60GlOJdCiH2pZ9erI9KV49eDyM/edit#)
- Adds a fallback form for when JS is no enabled

## QA

- Go to https://ubuntu-com-12670.demos.haus/landscape/pricing and compare against [copydoc](https://docs.google.com/document/d/1pESmRniuiaDHkbzY_60GlOJdCiH2pZ9erI9KV49eDyM/edit#)
- Disable JS and click a contact-us button, see that you are redirected to a static form with the same form id (4473) as the modal form.

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-2530
