### PR TITLE
Remove /dell from cypress test

### DIFF
--- a/tests/cypress/utils.js
+++ b/tests/cypress/utils.js
@@ -208,17 +208,6 @@ export const interactiveForms = [
     noOfPages: 2,
   },
   {
-    url: "/dell",
-    inputs: [
-      [/First name/, "test"],
-      [/Last name/, "test"],
-      [/Work email/, "test@gmail.com"],
-      [/Mobile\/cell phone number:/, "07777777777"],
-    ],
-    submitBtn: /Let's discuss/,
-    noOfPages: 3,
-  },
-  {
     url: "/desktop/organisations",
     inputs: [
       [/First name/, "test"],


### PR DESCRIPTION
## Done

- According to this [PR](https://github.com/canonical/ubuntu.com/pull/12535/files#diff-67b6532ab2d13a56204a0fa83d6f165fa6982333af3496ca1b8cb59c906d96baR19) interactive form from on `/dell` is replaced with static contact form and it makes cypress test fail
- Remove `/dell` from the list of interactive forms for the Cypress test.

## QA
- All test passed locally
- https://discourse.canonical.com/t/how-to-run-cypress-test-locally-for-forms-on-ubuntu-com/558 if needed

## Issue / Card

Fixes https://github.com/canonical/ubuntu.com/actions/runs/4385219665/jobs/7677660001

