### PR TITLE
WIP : Separate getPurchaseAccountStatus in a separate hook

### DIFF
--- a/static/js/src/advantage/api/contracts.js
+++ b/static/js/src/advantage/api/contracts.js
@@ -59,7 +59,7 @@ export async function getCustomerInfo(accountId) {
   );
 
   let data = await response.json();
-  return data;
+  return data.customerInfo;
 }
 
 export async function getUserInfo() {

--- a/static/js/src/advantage/subscribe/checkout/components/Checkout/Checkout.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Checkout/Checkout.tsx
@@ -8,6 +8,7 @@ import {
   Spinner,
 } from "@canonical/react-components";
 import useCustomerInfo from "../../hooks/useCustomerInfo";
+import useAccountInfo from "../../hooks/useAccountInfo";
 import { canBeTrialled, getInitialFormValues } from "../../utils/helpers";
 import { Action, marketplaceDisplayName, Product } from "../../utils/types";
 import BuyButton from "../BuyButton";
@@ -26,12 +27,19 @@ type Props = {
 
 const Checkout = ({ product, quantity, action }: Props) => {
   const [error, setError] = useState<React.ReactNode>(null);
+  const { data: accountInfo } = useAccountInfo();
   const { data: userInfo, isLoading: isUserInfoLoading } = useCustomerInfo();
+
   const isGuest = !userInfo?.customerInfo?.email;
   const userCanTrial = window.canTrial;
   const productCanBeTrialled = product?.canBeTrialled;
   const canTrial = canBeTrialled(productCanBeTrialled, userCanTrial);
-  const initialValues = getInitialFormValues(product, canTrial, userInfo);
+  const initialValues = getInitialFormValues(
+    product,
+    canTrial,
+    userInfo,
+    accountInfo
+  );
 
   return (
     <>

--- a/static/js/src/advantage/subscribe/checkout/hooks/useAccountInfo.tsx
+++ b/static/js/src/advantage/subscribe/checkout/hooks/useAccountInfo.tsx
@@ -1,0 +1,40 @@
+import { useQuery } from "react-query";
+import { getPurchaseAccountStatus } from "advantage/api/contracts";
+
+const useAccountInfo = () => {
+  const { isLoading, isError, isSuccess, data, error } = useQuery(
+    "accountInfo",
+    async () => {
+      console.log("window.marketplace", window.marketplace);
+      const accountStatusReq = await getPurchaseAccountStatus(
+        window.marketplace
+      );
+
+      if (!accountStatusReq.account) {
+        window.canTrial = true;
+      } else {
+        window.accountId = accountStatusReq.account.id;
+        const lastPurchaseIds = accountStatusReq.last_purchase_ids;
+        const canTrial = accountStatusReq.can_trial;
+        window.previousPurchaseIds = lastPurchaseIds?.[window.marketplace];
+        window.canTrial = canTrial;
+      }
+      const data: any = {
+        accountInfo: accountStatusReq,
+      };
+      return data;
+    },
+    {
+      retry: false,
+    }
+  );
+
+  return {
+    isLoading: isLoading,
+    isError: isError,
+    isSuccess: isSuccess,
+    data: data,
+    error: error,
+  };
+};
+export default useAccountInfo;

--- a/static/js/src/advantage/subscribe/checkout/hooks/useCustomerInfo.tsx
+++ b/static/js/src/advantage/subscribe/checkout/hooks/useCustomerInfo.tsx
@@ -1,8 +1,5 @@
 import { useQuery } from "react-query";
-import {
-  getCustomerInfo,
-  getPurchaseAccountStatus,
-} from "advantage/api/contracts";
+import { getCustomerInfo } from "advantage/api/contracts";
 import { LoginSession, UserInfo } from "../utils/types";
 
 const useCustomerInfo = () => {
@@ -20,19 +17,6 @@ const useCustomerInfo = () => {
         }
 
         window.loginSession = response;
-        const accountStatusReq = await getPurchaseAccountStatus(
-          window.marketplace
-        );
-
-        if (!accountStatusReq.account) {
-          window.canTrial = true;
-        } else {
-          window.accountId = accountStatusReq.account.id;
-          const lastPurchaseIds = accountStatusReq.last_purchase_ids;
-          const canTrial = accountStatusReq.can_trial;
-          window.previousPurchaseIds = lastPurchaseIds?.[window.marketplace];
-          window.canTrial = canTrial;
-        }
       }
 
       if (window.accountId) {

--- a/static/js/src/advantage/subscribe/checkout/utils/helpers.ts
+++ b/static/js/src/advantage/subscribe/checkout/utils/helpers.ts
@@ -1,9 +1,10 @@
-import { FormValues, Product, UserInfo } from "./types";
+import { AccountInfo, FormValues, Product, UserInfo } from "./types";
 
 export function getInitialFormValues(
   product: Product,
   canTrial: boolean,
-  userInfo?: UserInfo
+  userInfo?: UserInfo,
+  accountInfo?: AccountInfo
 ): FormValues {
   const accountName = userInfo?.accountInfo?.name;
   const customerName = userInfo?.customerInfo.name;

--- a/static/js/src/advantage/subscribe/checkout/utils/types.ts
+++ b/static/js/src/advantage/subscribe/checkout/utils/types.ts
@@ -24,6 +24,12 @@ export interface UserInfo {
   };
 }
 
+export interface AccountInfo {
+  accountInfo?: {
+    name?: string;
+  };
+}
+
 export interface Data {
   accountId?: string;
   paymentMethod?: PaymentMethod.Card;


### PR DESCRIPTION
## Done

- Separate getPurchaseAccountStatus in a separate hook

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
