### PR TITLE
activation keys list is empty in /credentials/shop/manage

### DIFF
--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -599,12 +599,11 @@ def get_activation_keys(ua_contracts_api, advantage_mapper, **kwargs):
     account = advantage_mapper.get_purchase_account()
     contracts = advantage_mapper.get_activation_key_contracts(account.id)
 
-    contract_id = None
+    keys = []
     for contract in contracts:
-        if contract.name == "CUE TEST key":
-            contract_id = contract.id
+        contract_id = contract.id
+        keys.extend(ua_contracts_api.list_activation_keys(contract_id))
 
-    keys = ua_contracts_api.list_activation_keys(contract_id)
     return flask.jsonify(keys)
 
 


### PR DESCRIPTION
## Done

- Keys are not listed in /credentials/shop/manage
## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- test on local and set the environment to production
- go to /credentials/shop/manage
- Should see a list of keys 

## Issue / Card

Fixes #[CRED-346](https://warthogs.atlassian.net/browse/CRED-346)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[CRED-346]: https://warthogs.atlassian.net/browse/CRED-346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ