### PR TITLE
Add meta lang block in jinja2 templates

### DIFF
--- a/templates/engage/de_why-openstack.html
+++ b/templates/engage/de_why-openstack.html
@@ -1,6 +1,7 @@
 {% extends "openstack/_base_openstack.html" %}
 
 {% block title %}Warum OpenStack | Ubuntu{% endblock %}
+{% block meta_lang %}de{% endblock %}
 
 {% block meta_description %}
 OpenStack ist die weltweit führende Open-Source-Cloud-Plattform für den Aufbau kostengünstiger Infrastrukturen. Entdecken Sie, wo Sie mit der Nutzung von OpenStack für Ihr Unternehmen beginnen können.

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -1,6 +1,6 @@
 <!doctype html>
 
-<html prefix="og: http://ogp.me/ns#" class="{% block extra_html_class %}{% endblock %}" lang="en" dir="ltr">
+<html prefix="og: http://ogp.me/ns#" class="{% block extra_html_class %}{% endblock %}" lang="{% block meta_lang %}en{% endblock %}" dir="ltr">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
## Done

- Add block meta_lang to allow pages to change the lang of a specific page. The default is always english
- Update http://0.0.0.0:8001/engage/de/warum-openstack to have de lang set

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/engage/de/warum-openstack
- Open inspector: make sure that `lang="de"`
- Go on any other page, the lang should be `en`

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-2625
