### PR TITLE
UI tweaks for Credentials

### DIFF
--- a/templates/credentials/index.html
+++ b/templates/credentials/index.html
@@ -107,7 +107,7 @@
             ) | safe
           }}
         <div class="p-matrix__content">
-          <h3 class="p-matrix__title">CUE.01: Desktop QuickCert</h3>
+          <h3 class="p-matrix__title">CUE.02: Desktop QuickCert</h3>
           <div class="p-matrix__desc">
             <p>Demonstrate your knowledge of Ubuntu Desktop administrative essentials. Topics include package management, system installation, data gathering, and managing printing and displays.</p>
             <a href="/credentials/syllabus?exam=CUE%3A%20Desktop" class="p-button">Syllabus</a>
@@ -127,7 +127,7 @@
           ) | safe
           }}
         <div class="p-matrix__content">
-          <h3 class="p-matrix__title">CUE.01: Server QuickCert</h3>
+          <h3 class="p-matrix__title">CUE.03: Server QuickCert</h3>
           <div class="p-matrix__desc">
             <p>Illustrate your knowledge of common Ubuntu Server administrative tasks and troubleshooting. Topics include job control, performance tuning, services management, and Bash scripting.</p>
             <a href="/credentials/syllabus?exam=CUE%3A%20Server" class="p-button">Syllabus</a>

--- a/templates/credentials/redeem.html
+++ b/templates/credentials/redeem.html
@@ -17,7 +17,7 @@ meta_copydoc %}
     </div>
     <div class="p-notification__meta">
       <div class="p-notification__actions">
-        <a class="p-notification__action" href="/credentials">Go back to credentials</a>
+        <a class="p-notification__action" href="/credentials/your-exams">Go to your exams&nbsp;›</a>
       </div>
     </div>
   </div>
@@ -29,7 +29,7 @@ meta_copydoc %}
     </div>
     <div class="p-notification__meta">
       <div class="p-notification__actions">
-        <a class="p-notification__action" href="/credentials/schedule">Schedule an exam</a>
+        <a class="p-notification__action" href="/credentials/schedule">Go to your exams&nbsp;›</a>
       </div>
     </div>
   </div>

--- a/templates/credentials/self-study.html
+++ b/templates/credentials/self-study.html
@@ -29,7 +29,7 @@
               <a class="p-side-navigation__link" href="#general-resources">General Resources</a>
             </li>
           </ul>
-          <h3 class="p-side-navigation__heading">CUE: Linux resources</h3>
+          <h3 class="p-side-navigation__heading">CUE.01: Linux resources</h3>
           <ul class="p-side-navigation__list">
             <li class="p-side-navigation__item">
               <a class="p-side-navigation__link" href="#linux-tutorials">Tutorials</a>
@@ -38,7 +38,7 @@
               <a class="p-side-navigation__link" href="#linux-documentation">Documentation</a>
             </li>
           </ul>
-          <h3 class="p-side-navigation__heading">CUE: Desktop resources</h3>
+          <h3 class="p-side-navigation__heading">CUE.02: Desktop resources</h3>
           <ul class="p-side-navigation__list">
             <li class="p-side-navigation__item">
               <a class="p-side-navigation__link" href="#desktop-tutorials">Tutorials</a>
@@ -47,7 +47,7 @@
               <a class="p-side-navigation__link" href="#desktop-documentation">Documentation</a>
             </li>
           </ul>
-          <h3 class="p-side-navigation__heading">CUE: Server resources</h3>
+          <h3 class="p-side-navigation__heading">CUE.03: Server resources</h3>
           <ul class="p-side-navigation__list">
             <li class="p-side-navigation__item">
               <a class="p-side-navigation__link" href="#server-tutorials">Tutorials</a>
@@ -96,7 +96,7 @@
           <a href="https://ubuntu.com/blog/tag/conference">Canonical conference materials</a>
         </li>
       </ul>
-      <h2>CUE: Linux resources</h2>
+      <h2>CUE.01: Linux resources</h2>
       <p>Before embarking on the CUE: Linux exam, it would be helpful to be familiar with the topics covered by the following resources.</p>
       <h3 id="linux-tutorials">Tutorials</h3>
       <ul>
@@ -120,7 +120,7 @@
         </li>
       </ul>
 
-      <h2>CUE: Desktop resources</h2>
+      <h2>CUE.02: Desktop resources</h2>
       <p>The following resources may prove useful when studying for the CUE: Desktop exam.</p>
       <h3 id="desktop-tutorials">Tutorials</h3>
       <ul>
@@ -172,7 +172,7 @@
           <a href="https://help.ubuntu.com/community/CorporateUbuntu">Corporate Ubuntu</a>
         </li>
       </ul>
-      <h2>CUE: Server resources</h2>
+      <h2>CUE.03: Server resources</h2>
       <p>The following resources are recommended for prospective CUE: Server candidates.</p>
       <h3 id="server-tutorials">Tutorials</h3>
       <ul>

--- a/webapp/shop/cred/syllabus.json
+++ b/webapp/shop/cred/syllabus.json
@@ -1,6 +1,6 @@
 [
   {
-    "exam_name": "CUE: Linux",
+    "exam_name": "CUE.01: Linux",
     "exam_description": "Prove your knowledge of the Linux community, history, and philosophy. Topics include common Linux commands, open source and software licensing, and basic knowledge of Linux architecture and file hierarchy.",
     "syllabus": [
       {
@@ -33,7 +33,7 @@
     ]
   },
   {
-    "exam_name": "CUE: Desktop",
+    "exam_name": "CUE.02: Desktop",
     "exam_description": "Demonstrate your knowledge of Ubuntu Desktop administrative essentials. Focus on package management, system installation, data gathering, and managing printing and displays.",
     "syllabus": [
       {
@@ -111,7 +111,7 @@
     ]
   },
   {
-    "exam_name": "CUE: Server",
+    "exam_name": "CUE.03: Server",
     "exam_description": "Illustrate your knowledge of common Ubuntu Server administrative tasks and troubleshooting. Topics include job control, performance tuning, services management, and Bash scripting.",
     "syllabus": [
       {

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -25,7 +25,10 @@ TIMEZONE_COUNTRIES = {
 }
 TIMEZONE_COUNTRIES["Asia/Calcutta"] = "IN"
 
-EXAM_NAMES = {"cue-test": "CUE: Linux Beta"}
+EXAM_NAMES = {
+    "cue-test": "CUE: Linux Beta",
+    "cue-linux-essentials": "CUE.01: Linux",
+}
 
 RESERVATION_STATES = {
     "created": "Scheduled",


### PR DESCRIPTION
## Done

- Fix CUE exam names (CUE.01: Linux, CUE.02: Desktop, CUE.03: Server)
- Direct the user to /credentials/your-exams if there is an error redeeming an activation key
- Map "cue-linux-essentials" to "CUE.01: Linux" on /credentials/your-exams

## QA

- Visit https://ubuntu-com-12680.demos.haus/credentials
  - Verify that the exams are titled "CUE.01: Linux QuickCert", "CUE.02: Desktop QuickCert", and "CUE.03: Server QuickCert"
- Visit https://ubuntu-com-12680.demos.haus/credentials/redeem/invalidkey
  - Verify that "Go to your exams ›" links to https://ubuntu-com-12680.demos.haus/credentials/your-exams

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/CRED-326

## Screenshots

![image](https://user-images.githubusercontent.com/995051/225337287-4b88b991-67fd-4ca9-afde-92b221586ca3.png)

![image](https://user-images.githubusercontent.com/995051/225337872-0c8b4fa1-f7f6-4ff7-aa1a-873cdf90e842.png)

![image](https://user-images.githubusercontent.com/995051/225337600-7e1c551b-2117-4361-a54c-49a2aa0627fa.png)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
