### PR TITLE
WD-1756 update logos in `/robotics/what-is-ros` and `/robotics/ros-esm` header illustration

### DIFF
--- a/templates/robotics/ros-esm.html
+++ b/templates/robotics/ros-esm.html
@@ -11,7 +11,7 @@
 
 <section class="p-strip--suru-shape-light is-deep">
   <div class="row">
-    <div class="col-9">
+    <div class="col-7">
       <h1 class="p-heading--2 u-no-margin--bottom"><strong>ROS Expanded Security Maintenance</strong></h1>
       <h2 class="u-no-padding--top u-text--muted">Same great ROS. More security updates.</h2>
       <ul class="p-inline-list">
@@ -25,12 +25,12 @@
         </li>
       </ul>
     </div>
-    <div class="col-2 u-align--center u-vertically-center u-hide--medium u-hide--small">
+    <div class="col-4 u-align--center u-vertically-center u-hide--medium u-hide--small">
       {{ image (
         url="https://assets.ubuntu.com/v1/81061ede-ESM+for+ROS_12 1.svg",
         alt="",
-        width="262",
-        height="300",
+        width="157",
+        height="190",
         hi_def=True,
         loading="auto"
         ) | safe

--- a/templates/robotics/what-is-ros.html
+++ b/templates/robotics/what-is-ros.html
@@ -24,7 +24,7 @@
         </a>
       </p>
     </div>
-    <div class="col-6 u-hide--small u-vertically-center u-align--center">
+    <div class="col-6 u-hide--small u-hide--medium u-vertically-center u-align--center">
       <div>
         {{
           image(
@@ -210,7 +210,7 @@
       <p><a class="p-button--positive" href="https://roscon.ros.org/2020/">Come to ROSCon</a></p>
       <p><a href="/robotics/community">Learn more about the community&nbsp;&rsaquo;</a></p>
     </div>
-    <div class="col-4 u-hide--small">
+    <div class="col-4 u-hide--medium u-hide--small">
       {{
         image(
           url="https://assets.ubuntu.com/v1/69237fec-ROS-10-years.png",


### PR DESCRIPTION
## Done

- Update the Open Robotics header illustration to use the new logo.
- Update ROS-ESM header illustration to use the new logo.
- A couple fly-bys too.

## QA

- Check out the demo here: https://ubuntu-com-12682.demos.haus/robotics/what-is-ros
  - Compare with the screenshots in the task [here](https://warthogs.atlassian.net/browse/WD-1756).
- Check out the demo here: https://ubuntu-com-12682.demos.haus/robotics/ros-esm
  - Compare with the screenshots in the task [here](https://warthogs.atlassian.net/browse/WD-1754).

## Issue / Card

- [WD-1756](https://warthogs.atlassian.net/browse/WD-1756)
- [WD-1754](https://warthogs.atlassian.net/browse/WD-1754)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-1756]: https://warthogs.atlassian.net/browse/WD-1756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[WD-1754]: https://warthogs.atlassian.net/browse/WD-1754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ