### PR TITLE
Fix bug when parsing first name and last name from Ubuntu One account

### DIFF
--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -10,6 +10,7 @@ from webapp.shop.api.ua_contracts.api import (
 )
 
 from webapp.shop.decorators import shop_decorator, canonical_staff
+from webapp.shop.utils import get_user_first_last_name
 from webapp.login import user_info
 from webapp.views import get_user_country_by_ip
 
@@ -62,7 +63,6 @@ def cred_schedule(ua_contracts_api, trueability_api, **_):
 
     if flask.request.method == "POST":
         data = flask.request.form
-        sso_user = user_info(flask.session)
 
         timezone = data["timezone"]
         tz_info = pytz.timezone(timezone)
@@ -71,7 +71,7 @@ def cred_schedule(ua_contracts_api, trueability_api, **_):
             datetime.strptime(scheduled_time, "%Y-%m-%dT%H:%M")
         )
         contract_item_id = data["contractItemID"]
-        first_name, last_name = sso_user["fullname"].rsplit(" ", maxsplit=1)
+        first_name, last_name = get_user_first_last_name()
         country_code = TIMEZONE_COUNTRIES[timezone]
 
         response = ua_contracts_api.post_assessment_reservation(
@@ -359,9 +359,7 @@ def cred_provision(ua_contracts_api, trueability_api, **_):
     if contract_item_id is None:
         return flask.redirect("/credentials/your-exams")
 
-    sso_user = user_info(flask.session)
     country_code = get_user_country_by_ip().json["country_code"] or "GB"
-
     reservation_uuid = None
     assessment = None
     reservation = None
@@ -386,7 +384,7 @@ def cred_provision(ua_contracts_api, trueability_api, **_):
     if not reservation_uuid:
         tz_info = pytz.timezone("UTC")
         starts_at = tz_info.localize(datetime.utcnow() + timedelta(seconds=20))
-        first_name, last_name = sso_user["fullname"].rsplit(" ", maxsplit=1)
+        first_name, last_name = get_user_first_last_name()
 
         response = ua_contracts_api.post_assessment_reservation(
             contract_item_id,
@@ -450,7 +448,7 @@ def cred_submit_form(**_):
 
     sso_user = user_info(flask.session)
     email = sso_user["email"]
-    first_name, last_name = sso_user["fullname"].rsplit(" ", maxsplit=1)
+    first_name, last_name = get_user_first_last_name()
 
     form_fields = {
         "firstName": first_name,

--- a/webapp/shop/utils.py
+++ b/webapp/shop/utils.py
@@ -1,0 +1,14 @@
+from typing import Tuple
+
+import flask
+
+from webapp.login import user_info
+
+
+def get_user_first_last_name() -> Tuple[str, str]:
+    sso_user = user_info(flask.session)
+    name = sso_user["fullname"].rsplit(" ", maxsplit=1)
+    first_name = name[0] if len(name) > 0 else ""
+    last_name = name[1] if len(name) > 1 else ""
+
+    return first_name, last_name


### PR DESCRIPTION
## Done

When retrieving the user's first and last name from the user session, an error would be thrown if the user's profile didn't contain two names separated by a space in the "Full name" field of the [Ubuntu One account settings](https://login.ubuntu.com/) (see [error in Sentry](https://sentry.is.canonical.com/canonical/ubuntu-com/issues/31953/?query=%2Fcredentials%2Fprovision)). We add a new function, `get_user_first_last_name()`, to safely parse this information, and return an empty string for the first and/or last name if not provided.

## QA

- Visit https://login.ubuntu.com/ and modify the "Full name" field under "Personal details" to contain only your first name (no last name), then save your settings
- Visit https://ubuntu-com-12683.demos.haus/credentials/your-exams and schedule or reschedule an exam that you have activated. (You can purchase a test key in the staging Backoffice and then redeem it if you have no activated exams.)
  - Verify that you are able to schedule/reschedule without an error being thrown

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/CRED-355

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
