### PR TITLE
Push shop in maintenanace

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -4,9 +4,13 @@ image: prod-comms.docker-registry.canonical.com/ubuntu.com
 
 env:
   - name: STORE_MAINTENANCE
-    configMapKeyRef:
-      key: maintenance
-      name: ubuntu-com
+    value: false
+
+  - name: STORE_MAINTENANCE_START
+    value: 2023-03-18T21:00:00Z
+
+  - name: STORE_MAINTENANCE_END
+    value: 2023-03-19T00:00:00Z
 
   - name: SEARCH_API_KEY
     secretKeyRef:
@@ -407,9 +411,13 @@ staging:
 
   env:
     - name: STORE_MAINTENANCE
-      configMapKeyRef:
-        key: maintenance
-        name: ubuntu-com
+      value: false
+
+    - name: STORE_MAINTENANCE_START
+      value: 2023-03-18T21:00:00Z
+
+    - name: STORE_MAINTENANCE_END
+      value: 2023-03-19T00:00:00Z
 
     - name: SEARCH_API_KEY
       secretKeyRef:
@@ -749,9 +757,13 @@ staging:
 demo:
   env:
     - name: STORE_MAINTENANCE
-      configMapKeyRef:
-        key: maintenance
-        name: ubuntu-com
+      value: true
+
+    - name: STORE_MAINTENANCE_START
+      value: 2023-03-17T10:00:00Z
+
+    - name: STORE_MAINTENANCE_END
+      value: 2023-03-17T11:05:00Z
 
     - name: SEARCH_API_KEY
       secretKeyRef:

--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -7,10 +7,10 @@ env:
     value: false
 
   - name: STORE_MAINTENANCE_START
-    value: 2023-03-18T21:00:00Z
+    value: 2023-03-16T21:00:00Z
 
   - name: STORE_MAINTENANCE_END
-    value: 2023-03-19T00:00:00Z
+    value: 2023-03-17T00:00:00Z
 
   - name: SEARCH_API_KEY
     secretKeyRef:
@@ -414,10 +414,10 @@ staging:
       value: false
 
     - name: STORE_MAINTENANCE_START
-      value: 2023-03-18T21:00:00Z
+      value: 2023-03-16T21:00:00Z
 
     - name: STORE_MAINTENANCE_END
-      value: 2023-03-19T00:00:00Z
+      value: 2023-03-17T00:00:00Z
 
     - name: SEARCH_API_KEY
       secretKeyRef:
@@ -757,13 +757,13 @@ staging:
 demo:
   env:
     - name: STORE_MAINTENANCE
-      value: true
+      value: false
 
     - name: STORE_MAINTENANCE_START
-      value: 2023-03-17T10:00:00Z
+      value: 2023-03-16T21:00:00Z
 
     - name: STORE_MAINTENANCE_END
-      value: 2023-03-17T12:30:00Z
+      value: 2023-03-17T00:00:00Z
 
     - name: SEARCH_API_KEY
       secretKeyRef:

--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -763,7 +763,7 @@ demo:
       value: 2023-03-17T10:00:00Z
 
     - name: STORE_MAINTENANCE_END
-      value: 2023-03-17T11:05:00Z
+      value: 2023-03-17T11:45:00Z
 
     - name: SEARCH_API_KEY
       secretKeyRef:

--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -763,7 +763,7 @@ demo:
       value: 2023-03-17T10:00:00Z
 
     - name: STORE_MAINTENANCE_END
-      value: 2023-03-17T11:45:00Z
+      value: 2023-03-17T12:30:00Z
 
     - name: SEARCH_API_KEY
       secretKeyRef:

--- a/templates/account/maintenance-check.html
+++ b/templates/account/maintenance-check.html
@@ -1,0 +1,18 @@
+{% extends "templates/one-column.html" %}
+{% block title %}Ubuntu Pro for Infrastructure: maintenance{% endblock %}
+
+
+{% block content %}
+<div class="p-strip is-deep">
+  <div class="row">
+    <div class="col-12">
+      <h1 class="p-heading--2">Maintenance check</h1>
+      <ul class="p-list">
+        <li class="p-list__item">
+          Shop is not in maintenance!
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+{% endblock content %}

--- a/templates/account/status.html
+++ b/templates/account/status.html
@@ -1,0 +1,35 @@
+{% extends "templates/one-column.html" %}
+{% block title %}Ubuntu Pro for Infrastructure: maintenance{% endblock %}
+
+
+{% block content %}
+<div class="p-strip is-deep">
+  <div class="row">
+    <div class="col-12">
+      {% if maintenance_scheduled or is_in_maintenance %}
+        <div class="p-notification--caution">
+          <div class="p-notification__content">
+            <h5 class="p-notification__title">Maintenance scheduled</h5>
+            <p class="p-notification__message">
+              From <strong>{{start_date}}</strong> to <strong>{{end_date}}</strong> (UTC) the shop will be down. <br> 
+              Current UTC time: <strong>{{time_now}}</strong>
+            </p>
+          </div>
+        </div>
+      {% endif %}
+      <h1 class="p-heading--2">Status</h1>
+      <ul class="p-list">
+        {% if not is_in_maintenance %}
+          <li class="p-list__item is-ticked">
+            Shop is up!
+          </li>
+        {% else %}
+          <li class="p-list__item">
+            Shop is down!
+          </li>
+        {% endif %}
+      </ul>
+    </div>
+  </div>
+</div>
+{% endblock content %}

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -8,7 +8,7 @@
 
 {% if user_info %}
   <section class="p-strip--suru-topped u-no-padding--bottom">
-    {% if is_maintenance %}
+    {% if is_in_maintenance %}
     <div class="row">
       <div class="col-12">
         <div class="p-notification--caution">
@@ -38,7 +38,9 @@
       {% if not is_technical %}
         <div class="col-7 u-vertically-center u-align--right">
           <div>
-            <a class="p-button--positive" href="/pro/subscribe">Buy new subscription</a>
+            {% if not is_in_maintenance %}
+              <a class="p-button--positive" href="/pro/subscribe">Buy new subscription</a>
+            {% endif %}
             <a class="p-button" href="/account/invoices">Invoices</a>
             <a class="p-button" href="/account/payment-methods">Payment methods</a>
           </div>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -113,6 +113,7 @@ from webapp.shop.views import (
     support,
     checkout,
     get_shop_status_page,
+    maintenance_check,
 )
 
 from webapp.shop.advantage.views import (
@@ -536,6 +537,12 @@ app.add_url_rule(
     view_func=get_shop_status_page,
     methods=["GET"],
 )
+app.add_url_rule(
+    "/pro/maintenance-check",
+    view_func=maintenance_check,
+    methods=["GET"],
+)
+
 # end of shop
 
 app.add_url_rule(

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -3,7 +3,6 @@ A Flask application for ubuntu.com
 """
 
 # Packages
-from distutils.util import strtobool
 import os
 import talisker.requests
 import flask
@@ -113,6 +112,7 @@ from webapp.shop.views import (
     post_purchase_calculate,
     support,
     checkout,
+    get_shop_status_page,
 )
 
 from webapp.shop.advantage.views import (
@@ -325,7 +325,6 @@ def context():
         "utm_source": flask.request.args.get("utm_source", ""),
         "CAPTCHA_TESTING_API_KEY": CAPTCHA_TESTING_API_KEY,
         "http_host": flask.request.host,
-        "is_maintenance": strtobool(os.getenv("STORE_MAINTENANCE", "false")),
         "schedule_banner": schedule_banner,
     }
 
@@ -531,6 +530,11 @@ app.add_url_rule(
     "/account/<marketplace>/purchase/calculate",
     view_func=post_purchase_calculate,
     methods=["POST"],
+)
+app.add_url_rule(
+    "/pro/status",
+    view_func=get_shop_status_page,
+    methods=["GET"],
 )
 # end of shop
 

--- a/webapp/shop/advantage/views.py
+++ b/webapp/shop/advantage/views.py
@@ -69,7 +69,7 @@ def pro_page_view(advantage_mapper, **kwargs):
 
 
 @shop_decorator(area="advantage", permission="user", response="html")
-def advantage_view(advantage_mapper, **kwargs):
+def advantage_view(advantage_mapper, is_in_maintenance, **kwargs):
     is_technical = False
     try:
         advantage_mapper.get_purchase_account("canonical-ua")
@@ -80,15 +80,22 @@ def advantage_view(advantage_mapper, **kwargs):
         is_technical = True
 
     return flask.render_template(
-        "advantage/index.html", is_technical=is_technical
+        "advantage/index.html",
+        is_technical=is_technical,
+        is_in_maintenance=is_in_maintenance,
     )
 
 
 @shop_decorator(area="advantage", permission="user", response="json")
 @use_kwargs({"email": String()}, location="query")
-def get_user_subscriptions(advantage_mapper, **kwargs):
+def get_user_subscriptions(advantage_mapper, is_in_maintenance, **kwargs):
     email = kwargs.get("email")
-    user_subscriptions = advantage_mapper.get_user_subscriptions(email)
+
+    user_subscriptions = advantage_mapper.get_user_subscriptions(
+        email=email,
+        is_in_maintenance=is_in_maintenance,
+    )
+
     return flask.jsonify(to_dict(user_subscriptions))
 
 

--- a/webapp/shop/api/ua_contracts/helpers.py
+++ b/webapp/shop/api/ua_contracts/helpers.py
@@ -227,7 +227,7 @@ def get_user_subscription_statuses(
         statuses["has_access_to_support"] = True
         statuses["has_access_to_token"] = True
 
-    if type == "free" or strtobool(os.getenv("STORE_MAINTENANCE", "false")):
+    if type == "free":
         return statuses
 
     if renewal is None or (renewal and renewal.status != "closed"):

--- a/webapp/shop/api/ua_contracts/helpers.py
+++ b/webapp/shop/api/ua_contracts/helpers.py
@@ -1,5 +1,3 @@
-from distutils.util import strtobool
-import os
 from datetime import datetime
 from typing import Dict, List, Optional
 

--- a/webapp/shop/decorators.py
+++ b/webapp/shop/decorators.py
@@ -1,6 +1,9 @@
 from distutils.util import strtobool
 import os
 from functools import wraps
+from datetime import datetime
+from dateutil.parser import parse
+import pytz
 
 import flask
 import talisker.requests
@@ -55,6 +58,11 @@ SERVICES = {
     },
 }
 
+MAINTENANCE_URLS = [
+    # "/pro/status",
+    "/pro/subscribe",
+]
+
 
 def shop_decorator(area=None, permission=None, response="json", redirect=None):
     permission = permission if permission in PERMISSION_LIST else None
@@ -76,9 +84,14 @@ def shop_decorator(area=None, permission=None, response="json", redirect=None):
                     flask.session[metadata_key] = value
 
             # shop under maintenance
-            if flask.request.path == "/pro/subscribe" and strtobool(
-                os.getenv("STORE_MAINTENANCE", "false")
-            ):
+            maintenance = strtobool(os.getenv("STORE_MAINTENANCE", "false"))
+            maintenance_start = parse(os.getenv("STORE_MAINTENANCE_START"))
+            maintenance_end = parse(os.getenv("STORE_MAINTENANCE_END"))
+            time_now = datetime.utcnow().replace(tzinfo=pytz.utc)
+            is_in_timeframe = maintenance_start <= time_now < maintenance_end
+            is_in_maintenance = maintenance and is_in_timeframe
+
+            if flask.request.path in MAINTENANCE_URLS and is_in_maintenance:
                 return flask.render_template("advantage/maintenance.html")
 
             # if logged in, get rid of guest token
@@ -129,6 +142,7 @@ def shop_decorator(area=None, permission=None, response="json", redirect=None):
                 trueability_api=get_trueability_api_instance(
                     area, trueability_session
                 ),
+                is_in_maintenance=is_in_maintenance,  # temporarily hard-coded
                 *args,
                 **kwargs,
             )

--- a/webapp/shop/decorators.py
+++ b/webapp/shop/decorators.py
@@ -59,8 +59,8 @@ SERVICES = {
 }
 
 MAINTENANCE_URLS = [
-    # "/pro/status",
-    "/pro/subscribe",
+    # "/pro/subscribe",
+    "/pro/maintenance-check",
 ]
 
 
@@ -85,10 +85,18 @@ def shop_decorator(area=None, permission=None, response="json", redirect=None):
 
             # shop under maintenance
             maintenance = strtobool(os.getenv("STORE_MAINTENANCE", "false"))
-            maintenance_start = parse(os.getenv("STORE_MAINTENANCE_START"))
-            maintenance_end = parse(os.getenv("STORE_MAINTENANCE_END"))
-            time_now = datetime.utcnow().replace(tzinfo=pytz.utc)
-            is_in_timeframe = maintenance_start <= time_now < maintenance_end
+            is_in_timeframe = False
+            store_maintenance_start = os.getenv("STORE_MAINTENANCE_START")
+            store_maintenance_end = os.getenv("STORE_MAINTENANCE_END")
+
+            if store_maintenance_start and store_maintenance_end:
+                maintenance_start = parse(os.getenv("STORE_MAINTENANCE_START"))
+                maintenance_end = parse(os.getenv("STORE_MAINTENANCE_END"))
+                time_now = datetime.utcnow().replace(tzinfo=pytz.utc)
+                is_in_timeframe = (
+                    maintenance_start <= time_now < maintenance_end
+                )
+
             is_in_maintenance = maintenance and is_in_timeframe
 
             if flask.request.path in MAINTENANCE_URLS and is_in_maintenance:
@@ -142,7 +150,7 @@ def shop_decorator(area=None, permission=None, response="json", redirect=None):
                 trueability_api=get_trueability_api_instance(
                     area, trueability_session
                 ),
-                is_in_maintenance=is_in_maintenance,  # temporarily hard-coded
+                is_in_maintenance=False,  # temporarily hard-coded
                 *args,
                 **kwargs,
             )

--- a/webapp/shop/views.py
+++ b/webapp/shop/views.py
@@ -367,15 +367,16 @@ def checkout(**kwargs):
 
 
 @shop_decorator(area="account", response="html")
-def get_shop_status_page(is_in_maintenance, **kwargs):
+def get_shop_status_page(**kwargs):
     maintenance = strtobool(os.getenv("STORE_MAINTENANCE", "false"))
     start_date = parse(os.getenv("STORE_MAINTENANCE_START"))
     end_date = parse(os.getenv("STORE_MAINTENANCE_END"))
     time_now = datetime.utcnow().replace(tzinfo=pytz.utc)
+    is_in_timeframe = start_date <= time_now < end_date
 
     return flask.render_template(
         "account/status.html",
-        is_in_maintenance=is_in_maintenance,
+        is_in_maintenance=(maintenance and is_in_timeframe),
         maintenance_scheduled=(maintenance and (start_date > time_now)),
         start_date=start_date.strftime("%-d %B %Y at %H:%M"),
         end_date=end_date.strftime("%-d %B %Y at %H:%M"),

--- a/webapp/shop/views.py
+++ b/webapp/shop/views.py
@@ -1,5 +1,10 @@
 # Packages
+from distutils.util import strtobool
+import os
 import flask
+from datetime import datetime
+from dateutil.parser import parse
+import pytz
 from requests.exceptions import HTTPError
 from webapp.shop.api.ua_contracts.advantage_mapper import AdvantageMapper
 
@@ -358,4 +363,21 @@ def support(**kwargs):
 def checkout(**kwargs):
     return flask.render_template(
         "account/checkout.html",
+    )
+
+
+@shop_decorator(area="account", response="html")
+def get_shop_status_page(is_in_maintenance, **kwargs):
+    maintenance = strtobool(os.getenv("STORE_MAINTENANCE", "false"))
+    start_date = parse(os.getenv("STORE_MAINTENANCE_START"))
+    end_date = parse(os.getenv("STORE_MAINTENANCE_END"))
+    time_now = datetime.utcnow().replace(tzinfo=pytz.utc)
+
+    return flask.render_template(
+        "account/status.html",
+        is_in_maintenance=is_in_maintenance,
+        maintenance_scheduled=(maintenance and (start_date > time_now)),
+        start_date=start_date.strftime("%-d %B %Y at %H:%M"),
+        end_date=end_date.strftime("%-d %B %Y at %H:%M"),
+        time_now=time_now.strftime("%-d %B %Y %H:%M"),
     )

--- a/webapp/shop/views.py
+++ b/webapp/shop/views.py
@@ -381,3 +381,10 @@ def get_shop_status_page(is_in_maintenance, **kwargs):
         end_date=end_date.strftime("%-d %B %Y at %H:%M"),
         time_now=time_now.strftime("%-d %B %Y %H:%M"),
     )
+
+
+@shop_decorator(area="account", response="html")
+def maintenance_check(**kwargs):
+    return flask.render_template(
+        "account/maintenance-check.html",
+    )


### PR DESCRIPTION
## Done

- Implement maintenance feature. This is a semi-version, that will allow us to test just of the /pro/maintenance-check page. 
- Two new pages added: 
  - /pro/status to check the status of the shop and future scheduled maintenances
  - /pro/maintenance-check a page to help us test the semi-version
- Maintenance feature is controlled by the following env varaibles:
```ymal
    - name: STORE_MAINTENANCE
      value: false

    - name: STORE_MAINTENANCE_START
      value: 2023-03-16T21:00:00Z

    - name: STORE_MAINTENANCE_END
      value: 2023-03-17T00:00:00Z
```
- to turn the shop on `STORE_MAINTENANCE` must be `true` and now must be between the two dates

Full version compared to the semi-version will also:
- turn off /pro/subscribe
- Hide the Buy subscription button on /pro/dashboard
- Hide resizing features on /pro/dashboard 
- Display a warning about /pro/dashboard about the maintenance


## QA

- All tests should pass
- Go to /pro/subscribe it should be available
- Go to /pro/dashboard and you should be able to:
  - See the resize features
  - See the Buy Subscription feature
  - See no warning that the shop is in maintenance
- Go to /pro/status it should say that shop is up
- Go to /pro/maintenance-check should say that shop is not in maintenance

## Issue / Card

Fixes #https://warthogs.atlassian.net/browse/WD-2705