### PR TITLE
Schedule shop for maintenance

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -7,10 +7,10 @@ env:
     value: true
 
   - name: STORE_MAINTENANCE_START
-    value: 2023-03-17T16:00:00Z
+    value: 2023-03-18T21:00:00Z
 
   - name: STORE_MAINTENANCE_END
-    value: 2023-03-17T16:30:00Z
+    value: 2023-03-19T01:00:00Z
 
   - name: SEARCH_API_KEY
     secretKeyRef:
@@ -313,10 +313,10 @@ production:
           value: true
 
         - name: STORE_MAINTENANCE_START
-          value: 2023-03-17T16:00:00Z
+          value: 2023-03-18T21:00:00Z
 
         - name: STORE_MAINTENANCE_END
-          value: 2023-03-17T16:30:00Z
+          value: 2023-03-19T01:00:00Z
 
         - name: SEARCH_API_KEY
           secretKeyRef:
@@ -423,10 +423,10 @@ staging:
       value: true
 
     - name: STORE_MAINTENANCE_START
-      value: 2023-03-17T16:00:00Z
+      value: 2023-03-18T21:00:00Z
 
     - name: STORE_MAINTENANCE_END
-      value: 2023-03-17T16:30:00Z
+      value: 2023-03-19T01:00:00Z
 
     - name: SEARCH_API_KEY
       secretKeyRef:
@@ -704,10 +704,10 @@ staging:
           value: true
 
         - name: STORE_MAINTENANCE_START
-          value: 2023-03-17T16:00:00Z
+          value: 2023-03-18T21:00:00Z
 
         - name: STORE_MAINTENANCE_END
-          value: 2023-03-17T16:30:00Z
+          value: 2023-03-19T01:00:00Z
 
         - name: SEARCH_API_KEY
           secretKeyRef:
@@ -778,10 +778,10 @@ demo:
       value: true
 
     - name: STORE_MAINTENANCE_START
-      value: 2023-03-17T16:00:00Z
+      value: 2023-03-18T21:00:00Z
 
     - name: STORE_MAINTENANCE_END
-      value: 2023-03-17T16:30:00Z
+      value: 2023-03-19T01:00:00Z
 
     - name: SEARCH_API_KEY
       secretKeyRef:

--- a/webapp/shop/decorators.py
+++ b/webapp/shop/decorators.py
@@ -59,7 +59,7 @@ SERVICES = {
 }
 
 MAINTENANCE_URLS = [
-    # "/pro/subscribe",
+    "/pro/subscribe",
     "/pro/maintenance-check",
 ]
 
@@ -150,7 +150,7 @@ def shop_decorator(area=None, permission=None, response="json", redirect=None):
                 trueability_api=get_trueability_api_instance(
                     area, trueability_session
                 ),
-                is_in_maintenance=False,  # temporarily hard-coded
+                is_in_maintenance=is_in_maintenance,
                 *args,
                 **kwargs,
             )


### PR DESCRIPTION
## Done

- Change to the full maintenance feature:
  - `MAINTENANCE_URLS` is the list of urls that will show the maintenance view when maintenance is on.
  - un-hardcode `is_in_maintenance` we make use of this value to hide specific features(fx: resizing, or buy buttons)
- Schedule it