### PR TITLE
Update copy on /landscape

### DIFF
--- a/templates/landscape/index.html
+++ b/templates/landscape/index.html
@@ -3,7 +3,7 @@
 {% block title %}Landscape{% endblock %}
 {% block meta_description %}Landscape is the leading management and administration tool for all versions of Ubuntu, anywhere.{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1Q5KPVOn3yaexgSbkZHmXHmWzT5WG3ocYAPthweMwDz4/edit{% endblock meta_copydoc %}
-{% block meta_image %}https://assets.ubuntu.com/v1/6b9a0b06-landscape-metatag.svg{% endblock meta_image %}
+{% block meta_image %}https://assets.ubuntu.com/v1/ea7adcf4-Canonical+Landscape+dark+text.svg{% endblock meta_image %}
 
 {% block content %}
 
@@ -147,16 +147,16 @@
         <li class="p-list__item is-ticked">Kernel Livepatching for all your machines</li>
       </ul>
       <p>
-        <a href="/support">Learn more about Ubuntu Advantage&nbsp;&rsaquo;</a>
+        <a href="/pro">Learn more about Ubuntu Pro&nbsp;&rsaquo;</a>
       </p>
     </div>
     <div class="col-4 u-hide--small u-hide--medium u-vertically-center u-align--center">
       {{
         image (
-        url="https://assets.ubuntu.com/v1/6dd24c11-ubuntu-advantage-linear.svg",
+        url="https://assets.ubuntu.com/v1/c391f52d-ubuntu-pro-linear.svg",
         alt="",
-        width="394",
-        height="198",
+        width="393",
+        height="200",
         hi_def=True,
         loading="lazy"
         ) | safe
@@ -169,7 +169,7 @@
   <div class="u-fixed-width">
     <div class="p-logo-section">
       <p class="p-logo-section__title u-align--center">
-        A SELECTION OF UBUNTU ADVANTAGE CUSTOMERS
+        A selection of Ubuntu Pro customers
       </p>
       <div class="p-logo-section__items">
         <div class="p-logo-section__item">

--- a/templates/landscape/index.html
+++ b/templates/landscape/index.html
@@ -3,7 +3,7 @@
 {% block title %}Landscape{% endblock %}
 {% block meta_description %}Landscape is the leading management and administration tool for all versions of Ubuntu, anywhere.{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1Q5KPVOn3yaexgSbkZHmXHmWzT5WG3ocYAPthweMwDz4/edit{% endblock meta_copydoc %}
-{% block meta_image %}https://assets.ubuntu.com/v1/ea7adcf4-Canonical+Landscape+dark+text.svg{% endblock meta_image %}
+{% block meta_image %}https://assets.ubuntu.com/v1/6b9a0b06-landscape-metatag.svg{% endblock meta_image %}
 
 {% block content %}
 


### PR DESCRIPTION
## Done

- Update copy on /landscape based on [copydoc](https://docs.google.com/document/d/1Q5KPVOn3yaexgSbkZHmXHmWzT5WG3ocYAPthweMwDz4/edit)
- Updates an illustrations

## QA

- Check the https://ubuntu-com-12701.demos.haus/landscape matches the changes on the [copydoc](https://docs.google.com/document/d/1Q5KPVOn3yaexgSbkZHmXHmWzT5WG3ocYAPthweMwDz4/edit)
- Check all illustrations use the newest Ubuntu logo

## Issue / Card

FIxes https://warthogs.atlassian.net/browse/WD-2448
