### PR TITLE
Add community dicourse page and link to privacy policy

### DIFF
--- a/templates/legal/data-privacy/community-discourse.md
+++ b/templates/legal/data-privacy/community-discourse.md
@@ -1,0 +1,58 @@
+---
+wrapper_template: "legal/_base_legal_markdown.html"
+context:
+  title: "Privacy notice – Ubuntu Community Discourse"
+  description: This privacy notice tells you about the information collected from you when you register for an Ubuntu Community Discourse account. Ubuntu Community Discourse is a forum where Ubuntu contributors can coordinate their contributions to Ubuntu and closely related products. In collecting this information, we are acting as a data controller and, by law, we are required to provide you with information about us, about why and how we use your data, and about the rights you have over your data.
+  copydoc: https://docs.google.com/document/d/15DqAWthYZvF9aOeBu-O1UA_jjCplkl1lJsIeV_dER-g/edit#
+---
+
+<h4 class="p-muted-heading">Version - March 2023</h4>
+<hr style="margin-bottom: 2rem;" />
+
+# Privacy notice – Ubuntu Community Discourse
+
+This privacy notice tells you about the information collected from you when you register for an Ubuntu Community Discourse account. Ubuntu Community Discourse is a forum where Ubuntu contributors can coordinate their contributions to Ubuntu and closely related products. In collecting this information, we are acting as a data controller and, by law, we are required to provide you with information about us, about why and how we use your data, and about the rights you have over your data. For more information, please see our <a href="/legal/data-privacy">privacy policy</a>.
+
+## Who are we?
+
+We are Canonical Group Limited. Our address is The Office Group, St Dunstans House, 4th floor, 201 Borough High St, London SE1 1JA. You can contact us by post at the above address or by email to <a href="mailto:dataprotection@canonical.com">dataprotection@canonical.com</a> for the attention of “Legal”.
+
+We are not required to have a data protection officer, so any enquiries about our use of your personal data should be addressed to the contact details above.
+
+## What personal data do we collect?
+
+When you register an Ubuntu Community Discourse account, we ask you for your name and your email address and related information. We may also record your IP address in order to provide you with certain content or aspects of the service.
+
+## Why do we collect this information?
+
+Your information will be used by us for the provision of services in the creation of an Ubuntu Community Discourse account. The Ubuntu Community Discourse account is then used to access the Ubuntu Community Discourse forum.
+
+## What do we do with your information?
+
+Your information is stored in our database and may be processed outside of the European Economic Area. It is shared with the third parties only as reasonably required for Canonical to process and store your data in accordance with this notice, or to provide you with access to third party content and/or services.
+
+## How long do we keep your information for?
+
+We keep your information for as long as you retain an Ubuntu Community Discourse account and thereafter for so long as reasonably required in accordance with our record retention policy.
+
+## Your rights over your information
+
+By law, you can ask us what information we hold about you, and you can ask us to correct it if it is inaccurate.
+
+You can also ask for it to be erased and you can ask for us to give you a copy of the information. If you ask us to remove your Ubuntu Community Discourse account you will no longer be able to post on the Ubuntu Community Discourse forum.
+
+## Your right to complain
+
+If you have a complaint about our use of your information, you can contact the Information Commissioner’s Office via their website at <a href="https://ico.org.uk/concerns/">ico.org.uk/concerns/</a> or write to them at:
+
+<div style="margin: 2rem;">
+  <p>
+    Information Commissioner's Office<br />
+    Wycliffe House<br />
+    Water Lane<br />
+    Wilmslow<br />
+    Cheshire<br />
+    SK9 5AF<br />
+    United Kingdom
+  </p>
+</div>

--- a/templates/legal/data-privacy/index.html
+++ b/templates/legal/data-privacy/index.html
@@ -41,6 +41,7 @@
         <li class="p-list__item"><a href="/legal/data-privacy/unilateral-nda">Confidentiality agreement privacy notice&nbsp;&rsaquo;</a></li>
         <li class="p-list__item"><a href="/legal/data-privacy/credentials">Canonical Credentials privacy notice&nbsp;&rsaquo;</a></li>
         <li class="p-list__item"><a href="/legal/data-privacy/recruitment">Recruitment privacy notice&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a href="/legal/data-privacy/community-discourse">Ubuntu Community Discourse&nbsp;&rsaquo;</a></li>
       </ul>
       <h2 id="information-we-collect-from-you">Information we collect from you</h2>
       <ul class="p-list">


### PR DESCRIPTION
## Done

- Create new `/legal/data-privacy/community-discourse` page, based on [copydoc](https://docs.google.com/document/d/15DqAWthYZvF9aOeBu-O1UA_jjCplkl1lJsIeV_dER-g/edit#)
- Updates `/legal/data-privacy` to reflect the [copydoc](https://docs.google.com/document/d/1AlOE2_-BqZNP4hiiuf8kZney8g1zvqAlDYl2u3X6m6I/edit)

## QA

- Go to https://ubuntu-com-12703.demos.haus/legal/data-privacy and navigate to https://ubuntu-com-12703.demos.haus/legal/data-privacy/community-discourse using the link on the page titled 'Ubuntu Community Discourse'
- Check that the page matches the [copydoc](https://docs.google.com/document/d/15DqAWthYZvF9aOeBu-O1UA_jjCplkl1lJsIeV_dER-g/edit#)

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-2657
