### PR TITLE
Force focus to iframe containing TA exam

### DIFF
--- a/templates/credentials/exam.html
+++ b/templates/credentials/exam.html
@@ -25,6 +25,18 @@
 
   // window.onresize = setIframeHeight;
 
+  const refocusIframe = () => {
+    const iframe = document.getElementById("exam-iframe");
+    const focused = document.activeElement;
+    if (focused && focused !== document.body) {
+      return;
+    }
+
+    iframe.contentWindow.focus();
+  }
+
+  document.addEventListener('click', refocusIframe);
+  document.addEventListener('keydown', refocusIframe);
 </script>
 
 {% endblock content%}


### PR DESCRIPTION
## Done

- Force focus to the iframe as a potential fix for the keyboard issues that some users have reported in the exam environment. See the [Guacamole FAQ](https://guacamole.apache.org/faq/#iframes) for context.

## QA

- Once deployed, monitor user feedback to see if keyboard issues persist

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/CRED-321

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
