### PR TITLE
Update for partial-extra-point-release 20.04.6

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -19,7 +19,7 @@ lts:
 previous_lts:
   name: "Focal Fossa"
   short_version: "20.04"
-  full_version: "20.04.5"
+  full_version: "20.04.6"
   release_date: "April 2020"
   eol: "April 2025"
 previous_previous_lts:
@@ -34,12 +34,12 @@ checksums:
     "22.10": "b98f13cd86839e70cb7757d46840230496b3febea309dd73bd5f81383474e47b *ubuntu-22.10-desktop-amd64.iso"
     "22.04.2": "b98dac940a82b110e6265ca78d1320f1f7103861e922aa1a54e4202686e9bbd3 *ubuntu-22.04.2-desktop-amd64.iso"
     "21.10": "f8d3ab0faeaecb5d26628ae1aa21c9a13e0a242c381aa08157db8624d574b830 *ubuntu-21.10-desktop-amd64.iso"
-    "20.04.5": "2980570ea889f3467a04df15c8421ef1dc80ecef7bb37243da97f5714cf3f8ef *ubuntu-20.04.5-desktop-amd64.iso"
+    "20.04.6": "510ce77afcb9537f198bc7daa0e5b503b6e67aaed68146943c231baeaab94df1 *ubuntu-20.04.6-desktop-amd64.iso"
   live-server:
     "22.10": "874452797430a94ca240c95d8503035aa145bd03ef7d84f9b23b78f3c5099aed *ubuntu-22.10-live-server-amd64.iso"
     "22.04.2": "5e38b55d57d94ff029719342357325ed3bda38fa80054f9330dc789cd2d43931 *ubuntu-22.04.2-live-server-amd64.iso"
     "21.10": "e84f546dfc6743f24e8b1e15db9cc2d2c698ec57d9adfb852971772d1ce692d4 *ubuntu-21.10-live-server-amd64.iso"
-    "20.04.5": "5035be37a7e9abbdc09f0d257f3e33416c1a0fb322ba860d42d74aa75c3468d4 *ubuntu-20.04.5-live-server-amd64.iso"
+    "20.04.6": "b8f31413336b9393ad5d8ef0282717b2ab19f007df2e9ed5196c13d8f9153c8b *ubuntu-20.04.6-live-server-amd64.iso"
     "18.04.6": "6c647b1ab4318e8c560d5748f908e108be654bad1e165f7cf4f3c1fc43995934 *ubuntu-18.04.6-live-server-amd64.iso"
   desktop-arm64+raspi:
     "22.10": "c9cf57399a5e3e3a9803740f8107ef52891b7d3ac293106d3257396b75ddf7de *ubuntu-22.10-preinstalled-desktop-arm64+raspi.img.xz"


### PR DESCRIPTION
Only affects desktop and server installers. Others need to stay on 20.04.5.

## Done

- [List of work items including drive-bys - remember to add the why and what of this work.]

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
