### PR TITLE
Update references from Ubuntu Advantage subscription to Ubuntu Pro

### DIFF
--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -172,7 +172,7 @@
         </tbody>
       </table>
 
-      <p>For each Ubuntu LTS release, Canonical maintains the Base Packages and provides security updates, including kernel livepatching, for a period of ten years. The lifecycle consists of an initial five-year maintenance period, during which maintenance updates are publicly available without an Ubuntu Advantage Subscription, and five years of <a href="/security/esm">Expanded Security Maintenance (ESM)</a>. The full lifecycle is available with an <a href="/pro">Ubuntu Advantage subscription</a> or a <a href="/pro">free personal subscription</a>.</p>
+      <p>For each Ubuntu LTS release, Canonical maintains the Base Packages and provides security updates, including kernel livepatching, for a period of ten years. The lifecycle consists of an initial five-year maintenance period, during which maintenance updates are publicly available without an Ubuntu Pro Subscription, and five years of <a href="/security/esm">Expanded Security Maintenance (ESM)</a>. The full lifecycle is available with an <a href="/pro">Ubuntu Pro subscription</a> or a <a href="/pro">free personal subscription</a>.</p>
 
       <p>Customers of Canonical often ask for an expanded security maintenance commitment beyond the Ubuntu Base Packages such as the 'universe' software packages. You can <a href="/support/contact-us">contact us for more information</a>.</p>
 
@@ -189,7 +189,7 @@
         }}
       </div>
 
-      <p>Ubuntu LTS releases transition into Expanded Security Maintenance (ESM) phase as the standard, five-year public maintenance window comes to a close. Canonical recommends that users and organisations upgrade to the latest LTS release or <a href="/pro">subscribe to Ubuntu Advantage</a> for continued security coverage with <a href="/security/esm">ESM</a> and <a href="/security/livepatch">kernel livepatching</a>.</p>
+      <p>Ubuntu LTS releases transition into Expanded Security Maintenance (ESM) phase as the standard, five-year public maintenance window comes to a close. Canonical recommends that users and organisations upgrade to the latest LTS release or <a href="/pro">subscribe to Ubuntu Pro</a> for continued security coverage with <a href="/security/esm">ESM</a> and <a href="/security/livepatch">kernel livepatching</a>.</p>
 
       <p>To check the subscription status of your system, use this command:</p>
 
@@ -397,7 +397,7 @@
 
       <p>However, since Canonical recommends using only LTS versions of Ubuntu in production environments, this limits available OpenStack versions to one by default. Therefore, Canonical maintains an additional archive &ndash; <a href="https://wiki.ubuntu.com/OpenStack/CloudArchive">Ubuntu Cloud Archive</a> &ndash; to provide access to non-default versions of OpenStack on Ubuntu LTS.</p>
 
-      <p>As a result, OpenStack versions that are shipped on Ubuntu LTS by default (aka OpenStack LTS versions) benefit from Canonical's commitment around the Ubuntu Archive, including 5 years of standard support and Expanded Security Maintenance (ESM). In turn, OpenStack versions which are shipped on Ubuntu LTS through the Ubuntu Cloud Archive are supported by Canonical for 18 months only, except for some versions that are supported for 36 months under Ubuntu Advantage for Infrastructure (UA-I).</p>
+      <p>As a result, OpenStack versions that are shipped on Ubuntu LTS by default (aka OpenStack LTS versions) benefit from Canonical's commitment around the Ubuntu Archive, including 5 years of standard support and Expanded Security Maintenance (ESM). In turn, OpenStack versions which are shipped on Ubuntu LTS through the Ubuntu Cloud Archive are supported by Canonical for 18 months only, except for some versions that are supported for 36 months under Ubuntu Pro for Infrastructure (UA-I).</p>
 
       <p>Upgrades between consecutive OpenStack versions are fully supported. Users can first upgrade to newer OpenStack versions until the next OpenStack LTS version. Then they can upgrade the underlying Ubuntu operating system. In order to ensure smooth upgrades of OpenStack on Ubuntu, Canonical provides the automation framework based on the <a href="/openstack/features">OpenStack Charms</a> project.</p>
 
@@ -419,7 +419,7 @@
 
       <p>The release cycles of Charmed Kubernetes and MicroK8s are tightly synchronised to the release of upstream Kubernetes<sup>&reg;</sup>. The current release and two prior releases are supported (N-2), subject to changes in the upstream release cycle. Canonical also provides expanded security maintenance (ESM) for N-4 Kubernetes releases in the stable release channel.</p>
 
-      <p>For <a href="/support">Ubuntu Advantage</a> support, users must upgrade to remain in the N-2 support window.</p>
+      <p>For <a href="/support">Ubuntu Pro</a> support, users must upgrade to remain in the N-2 support window.</p>
 
       <p>ESM support includes fixes to high and critical CVEs related to Kubernetes charms, limited to the LTS Ubuntu releases in the current N-4 support window. Upstream updates and fixes to Kubernetes binaries or container images are absorbed by Charmed Kubernetes and Microk8s.</p>
 


### PR DESCRIPTION
## Done

Updated all references from the old "Ubuntu Advantage Subscription" service name to the new "Ubuntu Pro" service name.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/about/release-cycle

## Issue / Card
Fixes #12652 