### PR TITLE
Pro Dashboard - show full documentation for free subscriptions.

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.test.tsx
@@ -118,9 +118,7 @@ describe("DetailsTabs", () => {
     wrapper.find("[data-test='docs-tab']").simulate("click");
     const docsLinks = wrapper.find("[data-test='doc-link']");
     expect(docsLinks.length).toBe(1);
-    expect(docsLinks.at(0).text()).toBe(
-      "Ubuntu Pro (esm-apps --beta) tutorial"
-    );
+    expect(docsLinks.at(0).text()).toBe("Ubuntu Pro (esm-apps) tutorial");
   });
 
   it("reorders FIPS, CC-EAL, and CIS to the end", () => {
@@ -157,9 +155,7 @@ describe("DetailsTabs", () => {
     // Switch to the docs tab:
     wrapper.find("[data-test='docs-tab']").simulate("click");
     const docsLinks = wrapper.find("[data-test='doc-link']");
-    expect(docsLinks.at(0).text()).toBe(
-      "Ubuntu Pro (esm-apps --beta) tutorial"
-    );
+    expect(docsLinks.at(0).text()).toBe("Ubuntu Pro (esm-apps) tutorial");
     expect(docsLinks.at(1).text()).toBe("Livepatch");
     expect(docsLinks.at(2).text()).toBe("FIPS setup instructions");
     expect(docsLinks.at(3).text()).toBe("CC-EAL2 setup instructions");
@@ -190,8 +186,6 @@ describe("DetailsTabs", () => {
     // Switch to the docs tab:
     wrapper.find("[data-test='docs-tab']").simulate("click");
     const docsLinks = wrapper.find("[data-test='doc-link']");
-    expect(docsLinks.at(0).text()).toBe(
-      "Ubuntu Pro (esm-apps --beta) tutorial"
-    );
+    expect(docsLinks.at(0).text()).toBe("Ubuntu Pro (esm-apps) tutorial");
   });
 });

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.tsx
@@ -94,7 +94,7 @@ const generateDocLinks = (
         case EntitlementType.EsmApps:
         case EntitlementType.EsmInfra:
           link = {
-            label: "Ubuntu Pro (esm-apps --beta) tutorial",
+            label: "Ubuntu Pro (esm-apps) tutorial",
             url: "/pro/beta",
           };
           break;
@@ -147,25 +147,20 @@ const DetailsTabs = ({
   const featuresDisplay = filterAndFormatEntitlements(
     subscription.entitlements
   );
+
+  const isBlender = isBlenderSubscription(subscription);
+  const isFree = isFreeSubscription(subscription);
+
   const [activeTab, setActiveTab] = useState<ActiveTab>(
-    featuresDisplay.included.length > 0
+    !isFree && featuresDisplay.included.length > 0
       ? ActiveTab.FEATURES
       : ActiveTab.DOCUMENTATION
   );
+
   let content: ReactNode | null;
 
-  const isBlender = isBlenderSubscription(subscription);
-
-  const isFree = isFreeSubscription(subscription);
   // Display tutorial link for the free subscription.
-  const docs = isFree
-    ? [
-        {
-          label: "Ubuntu Pro (esm-apps --beta) tutorial",
-          url: "/pro/beta",
-        },
-      ]
-    : generateDocLinks(subscription.entitlements);
+  const docs = generateDocLinks(subscription.entitlements);
   const setTab = (tab: ActiveTab) => {
     setActiveTab(tab);
     sendAnalyticsEvent({
@@ -239,7 +234,7 @@ const DetailsTabs = ({
       <Tabs
         className="p-tabs--brand"
         links={[
-          ...(featuresDisplay.included.length > 0
+          ...(!isFree && featuresDisplay.included.length > 0
             ? // Don't show the Features tab if there are no included features.
               [
                 {

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/components/FeaturesTab/FeaturesTab.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/components/FeaturesTab/FeaturesTab.tsx
@@ -140,7 +140,7 @@ const FeaturesTab = ({ subscription, setHasUnsavedChanges }: Props) => {
                       featuresFormState[label]?.isDisabled ? (
                         <Tooltip
                           tooltipClassName="p-subscriptions-tooltip"
-                          message="ESM Apps is in beta for your contract. To enable it on a machine, run `sudo pro enable esm-apps --beta`."
+                          message="ESM Apps is in beta for your contract. To enable it on a machine, run `sudo pro enable esm-apps`."
                         >
                           <Button
                             type="button"

--- a/static/js/src/advantage/tests/factories/api.ts
+++ b/static/js/src/advantage/tests/factories/api.ts
@@ -13,6 +13,7 @@ import {
   UserSubscriptionPeriod,
   UserSubscriptionMarketplace,
   UserSubscriptionType,
+  SupportLevel,
 } from "advantage/api/enum";
 
 export const userSubscriptionEntitlementFactory = Factory.define<UserSubscriptionEntitlement>(
@@ -87,7 +88,16 @@ export const freeSubscriptionFactory = Factory.define<UserSubscription>(
     contract_id: `mUuVO7AyCYZzvjY3JaBWF0x8vv5S684ZTeXMnJ${sequence}`,
     currency: "USD",
     end_date: null,
-    entitlements: [],
+    entitlements: [
+      {
+        type: EntitlementType.EsmApps,
+        is_available: true,
+        is_editable: true,
+        is_in_beta: false,
+        enabled_by_default: true,
+        support_level: SupportLevel.Standard,
+      },
+    ],
     listing_id: null,
     machine_type: UserSubscriptionMachineType.Physical,
     marketplace: UserSubscriptionMarketplace.Free,

--- a/webapp/shop/api/ua_contracts/builders.py
+++ b/webapp/shop/api/ua_contracts/builders.py
@@ -228,7 +228,7 @@ def build_final_user_subscriptions(
 
         entitlements = (
             apply_entitlement_rules(contract.entitlements)
-            if marketplace == "canonical-ua"
+            if marketplace in ["canonical-ua", "free"]
             else []
         )
 


### PR DESCRIPTION
## Done

- Show documentation for all entitlements on free subscriptions.
- Remove outdated reference to `esm-apps --beta`.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- Go to /pro/dashboard
- Check free subscriptions have documentation links to all the features they are entitled too.
- Check we removed `--beta` from `esm-apps` command
