### PR TITLE
Pro pricing: Change "No support" text to "Self-Support"

### DIFF
--- a/templates/pricing/pro.html
+++ b/templates/pricing/pro.html
@@ -144,7 +144,7 @@
 
           <tr>
             <td>Knowledge base access</td>
-            <td>no</td>
+            <td>yes</td>
             <td>yes</td>
             <td>yes</td>
           </tr>

--- a/templates/pricing/pro.html
+++ b/templates/pricing/pro.html
@@ -38,7 +38,7 @@
         <thead>
           <tr>
             <th style="width: 40%;"></th>
-            <th>No support<br><span class="u-text--muted">(software only)</span></th>
+            <th>Self-Support<br><span class="u-text--muted">(software only)</span></th>
             <th>With Infra support<br><span class="u-text--muted">(24/7)</span></th>
             <th>With full support <br><span class="u-text--muted">(24/7)</span></th>
           </tr>
@@ -70,7 +70,7 @@
         <thead>
           <tr>
             <th style="width: 40%;"></th>
-            <th>No support<br><span class="u-text--muted">(software only)</span></th>
+            <th>Self-Support<br><span class="u-text--muted">(software only)</span></th>
             <th>With Infra support<br><span class="u-text--muted">(24/7)</span></th>
             <th>With full support <br><span class="u-text--muted">(24/7)</span></th>
           </tr>
@@ -170,7 +170,7 @@
         <thead>
           <tr>
             <th style="width: 40%;"></th>
-            <th>No support<br><span class="u-text--muted">(software only)</span></th>
+            <th>Self-Support<br><span class="u-text--muted">(software only)</span></th>
             <th>With Infra support<br><span class="u-text--muted">(24/7)</span></th>
             <th>With full support <br><span class="u-text--muted">(24/7)</span></th>
           </tr>
@@ -571,7 +571,7 @@
           <thead>
             <tr>
               <th>Feature</th>
-              <th class="u-align--right">No Support</th>
+              <th class="u-align--right">Self-Support</th>
               <th class="u-align--right">Weekday support</th>
               <th class="u-align--right">24/7 support</th>
             </tr>


### PR DESCRIPTION
## Done

- Change "No support" text to "Self-Support".
- Change "Knowledge base access" to 'yes' for self-support customers.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- Go to /pricing/pro and check the copy changes are good.

## Issue / Card

Fixes #12465
