### PR TITLE
Added new product card

### DIFF
--- a/templates/blog/product-cards.html
+++ b/templates/blog/product-cards.html
@@ -3,6 +3,10 @@
   {% if article.tags and 2976 in article.tags %}
     {% include "blog/product-cards/_multi_cloud.html" %}
 
+    {# Ubuntu 18.04 tag cards #}
+  {% elif article.tags and 3486 in article.tags %}
+    {% include "blog/product-cards/_ubuntu_18.04_end_of_support.html" %}
+
     {# Hybrid-cloud tag cards #}
   {% elif article.tags and 3150 in article.tags %}
     {% include "blog/product-cards/_hybrid_cloud.html" %}

--- a/templates/blog/product-cards/_ubuntu_18.04_end_of_support.html
+++ b/templates/blog/product-cards/_ubuntu_18.04_end_of_support.html
@@ -1,6 +1,6 @@
 <div class="p-card js-product-card u-hide">
     <h3>
-      <a href="/18-04-end-of-standard-support">Time to prepare for Ubuntu 18.04 LTS End of Standard Support</a>
+      <a href="/18-04">Time to prepare for Ubuntu 18.04 LTS End of Standard Support</a>
     </h3>
     <p>Bionic Beaver will reach the end of the standard, five-year maintenance window for Long-Term Support (LTS) releases on 31 May 2023. Migrate to the latest LTS or get extended coverage until 2028 with Ubuntu Pro.</p>
     <p><a href="/18-04-end-of-standard-support">Learn more&nbsp;&rsaquo;</a></p>

--- a/templates/blog/product-cards/_ubuntu_18.04_end_of_support.html
+++ b/templates/blog/product-cards/_ubuntu_18.04_end_of_support.html
@@ -3,5 +3,5 @@
       <a href="/18-04">Time to prepare for Ubuntu 18.04 LTS End of Standard Support</a>
     </h3>
     <p>Bionic Beaver will reach the end of the standard, five-year maintenance window for Long-Term Support (LTS) releases on 31 May 2023. Migrate to the latest LTS or get extended coverage until 2028 with Ubuntu Pro.</p>
-    <p><a href="/18-04-end-of-standard-support">Learn more&nbsp;&rsaquo;</a></p>
+    <p><a href="/18-04">Learn more&nbsp;&rsaquo;</a></p>
   </div>

--- a/templates/blog/product-cards/_ubuntu_18.04_end_of_support.html
+++ b/templates/blog/product-cards/_ubuntu_18.04_end_of_support.html
@@ -1,0 +1,7 @@
+<div class="p-card js-product-card u-hide">
+    <h3>
+      <a href="/18-04-end-of-standard-support">Time to prepare for Ubuntu 18.04 LTS End of Standard Support</a>
+    </h3>
+    <p>Bionic Beaver will reach the end of the standard, five-year maintenance window for Long-Term Support (LTS) releases on 31 May 2023. Migrate to the latest LTS or get extended coverage until 2028 with Ubuntu Pro.</p>
+    <p><a href="/18-04-end-of-standard-support">Learn more&nbsp;&rsaquo;</a></p>
+  </div>


### PR DESCRIPTION
## Done

- Added a new product card _ubuntu_18.04_end_of_support for pages with the tag "ubuntu 18.04"

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
