### PR TITLE
/certified/why-certify - Update logo list

### DIFF
--- a/templates/certified/shared/_partners.html
+++ b/templates/certified/shared/_partners.html
@@ -286,4 +286,16 @@
       ) | safe
     }}
   </div>
+  <div class="col-small-1 col-medium-1 col-1">
+    {{ image (
+      url="https://assets.ubuntu.com/v1/8ae36e4b-iei-logo.png",
+      alt="iEi",
+      attrs={"class":"p-logo-section__logo"},
+      width="280",
+      height="280",
+      hi_def=False,
+      loading="lazy"
+      ) | safe
+    }}
+  </div>
 </div>

--- a/templates/certified/shared/_partners.html
+++ b/templates/certified/shared/_partners.html
@@ -238,4 +238,52 @@
       ) | safe
     }}
   </div>
+  <div class="col-small-1 col-medium-1 col-1">
+    {{ image (
+      url="https://assets.ubuntu.com/v1/6513cff5-axiomtek-logo.png",
+      alt="Axiomtek",
+      attrs={"class":"p-logo-section__logo"},
+      width="280",
+      height="280",
+      hi_def=False,
+      loading="lazy"
+      ) | safe
+    }}
+  </div>
+  <div class="col-small-1 col-medium-1 col-1">
+    {{ image (
+      url="https://assets.ubuntu.com/v1/9e488802-dfi-logo.png",
+      alt="DFI",
+      attrs={"class":"p-logo-section__logo"},
+      width="280",
+      height="280",
+      hi_def=False,
+      loading="lazy"
+      ) | safe
+    }}
+  </div>
+  <div class="col-small-1 col-medium-1 col-1">
+    {{ image (
+      url="https://assets.ubuntu.com/v1/4bd534af-eurotech-logo.png",
+      alt="Eurotech",
+      attrs={"class":"p-logo-section__logo"},
+      width="280",
+      height="280",
+      hi_def=False,
+      loading="lazy"
+      ) | safe
+    }}
+  </div>
+  <div class="col-small-1 col-medium-1 col-1">
+    {{ image (
+      url="https://assets.ubuntu.com/v1/6c63f194-onlogic-logo.png",
+      alt="Onlogic",
+      attrs={"class":"p-logo-section__logo"},
+      width="280",
+      height="280",
+      hi_def=False,
+      loading="lazy"
+      ) | safe
+    }}
+  </div>
 </div>


### PR DESCRIPTION
## Done

- Added new logos [as requested](https://warthogs.atlassian.net/browse/WD-2758)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: https://ubuntu-com-12720.demos.haus/certified/why-certify
    - Be sure to test on mobile, tablet and desktop screen sizes
- See that the requested logos were added

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-2758
