### PR TITLE
Revert /download/amd-xilinx changes

### DIFF
--- a/templates/download/amd-xilinx/index.html
+++ b/templates/download/amd-xilinx/index.html
@@ -52,8 +52,15 @@
             <h2>Download Ubuntu Desktop</h2>
             <h3 class="p-heading--4">Ubuntu Desktop 22.04 LTS</h3>
             <p class="u-sv1">The version of Ubuntu with up to 10 years of long term support, until April 2032.</p>
+            <div class="p-notification--information is-inline">
+              <div class="p-notification__content">
+                <h4 class="p-notification__title">Note:</h4>
+                <p class="p-notification__message">This is a pre-production release for KR260 (<a href="https://support.xilinx.com/s/question/0D52E00007BslVuSAJ/ubuntu-2204-lts-beta-for-kria?language=en_USMPSAY/certified-ubuntu-2004-lts-for-xilinx-devices?language=en_US">see this forum post for details</a>); please check back for a full production release image in Q3 2022.</p>
+              </div>
+            </div>
             <p>
-              <a class="p-button--positive" href="https://people.canonical.com/~platform/images/xilinx/kria-ubuntu-22.04/iot-limerick-kria-classic-desktop-2204-x07-20230302-63.img.xz">Download 64-bit</a>
+              <a class="p-button--positive"
+                 href="https://people.canonical.com/~platform/images/xilinx/kria-ubuntu-22.04/iot-limerick-kria-classic-desktop-2204-x06-20220614-78.img.xz">Download 64-bit</a>
             </p>
             <p>Works on:</p>
             <ul class="p-list">
@@ -98,26 +105,25 @@
             <tbody>
               <tr>
                 <th>
-                  <a href="https://people.canonical.com/~platform/images/xilinx/kria-ubuntu-22.04/iot-limerick-kria-classic-desktop-2204-x07-20230302-63-sysroot.tar.xz">iot-limerick-kria-classic-desktop-2204-x07-20230302-63-sysroot.tar.xz
-</a>
+                  <a href="https://people.canonical.com/~platform/images/xilinx/kria-ubuntu-22.04/iot-limerick-kria-classic-desktop-2204-x06-20220614-78-sysroot.tar.xz">iot-limerick-kria-classic-desktop-2204-x06-20220614-78-sysroot.tar.xz</a>
                 </th>
                 <td colspan="2">Sysroot for cross-compilation</td>
               </tr>
               <tr>
                 <th>
-                  <a href="https://people.canonical.com/~platform/images/xilinx/kria-ubuntu-22.04/iot-limerick-kria-classic-desktop-2204-x07-20230302-63-rootfs.ext4.xz">iot-limerick-kria-classic-desktop-2204-x07-20230302-63-rootfs.ext4.xz</a>
+                  <a href="https://people.canonical.com/~platform/images/xilinx/kria-ubuntu-22.04/iot-limerick-kria-classic-desktop-2204-x06-20220614-78-rootfs.ext4.xz">iot-limerick-kria-classic-desktop-2204-x06-20220614-78-rootfs.ext4.xz</a>
                 </th>
                 <td colspan="2">EXT4 formatted partition containing entire raw rootfs</td>
               </tr>
               <tr>
                 <th>
-                  <a href="https://people.canonical.com/~platform/images/xilinx/kria-ubuntu-22.04/iot-limerick-kria-classic-desktop-2204-x07-20230302-63-rootfs.tar.gz">iot-limerick-kria-classic-desktop-2204-x07-20230302-63-rootfs.tar.gz</a>
+                  <a href="https://people.canonical.com/~platform/images/xilinx/kria-ubuntu-22.04/iot-limerick-kria-classic-desktop-2204-x06-20220614-78-rootfs.tar.gz">iot-limerick-kria-classic-desktop-2204-x06-20220614-78-rootfs.tar.gz</a>
                 </th>
                 <td colspan="2">Raw Root filesystem</td>
               </tr>
               <tr>
                 <th>
-                  <a href="https://people.canonical.com/~platform/images/xilinx/kria-ubuntu-22.04/iot-limerick-kria-classic-desktop-2204-x07-20230302-63-system-boot.tar.gz">iot-limerick-kria-classic-desktop-2204-x07-20230302-63-system-boot.tar.gz</a>
+                  <a href="https://people.canonical.com/~platform/images/xilinx/kria-ubuntu-22.04/iot-limerick-kria-classic-desktop-2204-x06-20220614-78-system-boot.tar.gz">iot-limerick-kria-classic-desktop-2204-x06-20220614-78-system-boot.tar.gz</a>
                 </th>
                 <td colspan="2">FAT Partition Contents</td>
               </tr>


### PR DESCRIPTION
## Done

- The AMD-Xilinx changes in [this issue](https://warthogs.atlassian.net/browse/WD-2709) were mistakenly merged, this PR reverts those changes.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
