### PR TITLE
Update visuals for Credentials

### DIFF
--- a/templates/credentials/index.html
+++ b/templates/credentials/index.html
@@ -50,7 +50,7 @@
       <h3 class="p-heading--5 u-no-margin--bottom">Real-life hands-on testing</h3>
       <p class="u-sv2">Exam questions simulate a real life problem or task that can be part of the day to day of a professional working in an Ubuntu environment. Real-world environments provide a familiar setting to showcase your problem-solving skills.</p>
       <hr class="is-fixed-width u-no-margin--bottom">
-      <h3 class="p-heading--5 u-no-margin--bottom">The smartest way to build up your certification</h3>
+      <h3 class="p-heading--5 u-no-margin--bottom">Intelligently designed to suit your schedule</h3>
       <p>Your career path: now with stepping stones! Our modular program features simple, laser-focused building blocks, or QuickCerts (QC) to help you take the exams most relevant to you while simultaneously earning badges toward more advanced credential tracks. Earn the badges you need without spending time and energy you don’t have.</p>
     </div>
   </div>

--- a/templates/credentials/index.html
+++ b/templates/credentials/index.html
@@ -7,7 +7,7 @@
 
 {% block content %}
 
-<section class="p-strip--suru-topped">
+<section class="p-strip--image is-dark is-deep" style="background-image: url(https://assets.ubuntu.com/v1/4a1f9f33-suru-cut.png); background-position: 100% 60%">
   <div class="row u-equal-height">
     <div class="col-6">
       <h1>Canonical Credentials</h1>
@@ -15,13 +15,22 @@
       <p>Find the shortest path to your passion. Develop and certify your skills on the world's most popular Linux OS.</p>
       <p><i>Sign-ups for the CUE.01: Linux beta are now closed. Please check back for future announcements and beta opportunities.</i></p>
     </div>
-    <div class="col-4 col-start-large-9 u-hide--small u-hide--medium u-vertically-center">
+  </div>
+</section>
+<section class="p-strip--light is-deep">
+  <div class="row">
+    <div class="col-6">
+      <h2 class="u-sv2">Why certify?</h2>
+      <p>Ubuntu is the world's most popular open source OS for both development and deployment, from the data centre to the cloud to the Internet of things. So whether you are trying to pave your way into the tech field, or looking to upgrade your career or prove your skills, Canonical Credentials is here for you!</p>
+      <p>This program is designed to help you demonstrate your expertise to countless enterprise organisations who are more likely than not using Ubuntu software today.</p>
+    </div>
+    <div class="col-6 col-start-large-9 u-hide--small u-hide--medium u-vertically-center">
       {{
         image (
-        url="https://assets.ubuntu.com/v1/7bf909cc-Admin.svg",
+        url="https://assets.ubuntu.com/v1/92959538-Rosette.svg",
         alt="Canonical Ubuntu Essentials badge",
-        width="175",
-        height="205",
+        width="141",
+        height="320",
         hi_def=True,
         loading="auto"
         ) | safe
@@ -29,112 +38,57 @@
     </div>
   </div>
 </section>
-
-<section class="p-strip--light">
-  <div class="u-fixed-width">
-    <h2 class="u-sv2">Why certify?</h2>
-    <p>Ubuntu is the world's most popular open source OS for both development and deployment, from the data centre to the cloud to the Internet of things. So whether you are trying to pave your way into the tech field, or looking to upgrade your career or prove your skills, Canonical Credentials is here for you!</p>
-    <p>This program is designed to help you demonstrate your expertise to countless enterprise organisations who are more likely than not using Ubuntu software today.</p>
-    <ul class="p-matrix">
-      <li class="p-matrix__item">
-        <div class="p-matrix__content">
-          <h3 class="p-matrix__title">Validate your knowledge</h3>
-          <div class="p-matrix__desc">
-            <p>Challenge yourself, expand your skill set, and test your knowledge. Take exams developed with expert oversight, strict methodology, and industry best practices. Earn official Canonical Ubuntu badges that certify your knowledge and recognise your professional skills.</p>
-          </div>
-        </div>
-      </li>
-      <li class="p-matrix__item">
-        <div class="p-matrix__content">
-          <h3 class="p-matrix__title">Real-life hands-on testing</h3>
-          <div class="p-matrix__desc">
-            <p>Exam questions simulate a real life problem or task that can be part of the day to day of a professional working in an Ubuntu environment. Real-world environments provide a familiar setting to showcase your problem-solving skills.</p>
-          </div>
-        </div>
-      </li>
-      <li class="p-matrix__item">
-        <div class="p-matrix__content">
-          <h3 class="p-matrix__title">Intelligently designed to suit your schedule</h3>
-          <div class="p-matrix__desc">
-            <p>Your career path: now with stepping stones! Our modular program features simple, laser-focused building blocks, or QuickCerts (QC) to help you take the exams most relevant to you while simultaneously earning badges toward more advanced credential tracks. Earn the badges you need without spending time and energy you don’t have.</p>
-          </div>
-        </div>
-      </li>
-    </ul>
+<section class="p-strip">
+  <div class="row">
+    <div class="col-6">
+      <h2 class="u-sv2">What's included?</h2>
+    </div>
+    <div class="col-6">
+      <h3 class="p-heading--5 u-no-margin--bottom">Validate your knowledge</h3>
+      <p class="u-sv2">Challenge yourself, expand your skill set, and test your knowledge. The official Canonical Ubuntu badges will certify your knowledge and recognise you as an industry expert.</p>
+      <hr class="is-fixed-width u-no-margin--bottom">
+      <h3 class="p-heading--5 u-no-margin--bottom">Real-life hands-on testing</h3>
+      <p class="u-sv2">Exam questions simulate a real life problem or task that can be part of the day to day of a professional working in an Ubuntu environment. Real-world environments provide a familiar setting to showcase your problem-solving skills.</p>
+      <hr class="is-fixed-width u-no-margin--bottom">
+      <h3 class="p-heading--5 u-no-margin--bottom">The smartest way to build up your certification</h3>
+      <p>Your career path: now with stepping stones! Our modular program features simple, laser-focused building blocks, or QuickCerts (QC) to help you take the exams most relevant to you while simultaneously earning badges toward more advanced credential tracks. Earn the badges you need without spending time and energy you don’t have.</p>
+    </div>
   </div>
 </section>
-
-<section class="p-strip" id="syllabus">
+<section class="p-strip--light" id="syllabus">
   <div class="row">
-    <div class="col-12">
+    <div class="col-6">
       <h2>The future is almost here...</h2>
+    </div>
+    <div class="col-6">
       <p>Help establish the certification programme today and be at the forefront of the programme of tomorrow. Be the first to hear about upcoming exams and new credentials in the upcoming year!</p>
     </div>
   </div>
-  <div class="u-fixed-width">
-    <h3 class="u-sv2">Complete Canonical Ubuntu Essentials Syllabus &ndash; at a glance</h3>
-    <ul class="p-matrix">
-      <li class="p-matrix__item">
-          {{
-            image (
-            url="https://assets.ubuntu.com/v1/43f7d2a3-Commands.svg",
-            alt="CUE.01: Linux badge",
-            width="51",
-            height="60",
-            hi_def=True,
-            attrs={"class":"p-matrix__img"},
-            loading="auto"
-            ) | safe
-          }}
-        <div class="p-matrix__content">
-          <h3 class="p-matrix__title">CUE.01: Linux QuickCert</h3>
-          <div class="p-matrix__desc">
-            <p>Prove your knowledge of the Linux community, history, and philosophy. Topics include common Linux commands, open source and software licensing, and basic knowledge of Linux architecture and file hierarchy.</p>
-            <a href="/credentials/syllabus?exam=CUE%3A%20Linux" class="p-button">Syllabus</a>
-          </div>
-        </div>
-      </li>
-      <li class="p-matrix__item">
-          {{
-            image (
-            url="https://assets.ubuntu.com/v1/093b57b6-Devices+%26+files.svg",
-            alt="CUE.01: Desktop badge",
-            width="51",
-            height="60",
-            hi_def=True,
-            attrs={"class":"p-matrix__img"},
-            loading="auto"
-            ) | safe
-          }}
-        <div class="p-matrix__content">
-          <h3 class="p-matrix__title">CUE.02: Desktop QuickCert</h3>
-          <div class="p-matrix__desc">
-            <p>Demonstrate your knowledge of Ubuntu Desktop administrative essentials. Topics include package management, system installation, data gathering, and managing printing and displays.</p>
-            <a href="/credentials/syllabus?exam=CUE%3A%20Desktop" class="p-button">Syllabus</a>
-          </div>
-        </div>
-      </li>
-      <li class="p-matrix__item">
-        {{
-          image (
-          url="https://assets.ubuntu.com/v1/64422ff3-Virtualisation.svg",
-          alt="CUE.01: Server badge",
-          width="51",
-          height="60",
-          hi_def=True,
-          attrs={"class":"p-matrix__img"},
-          loading="auto"
-          ) | safe
-          }}
-        <div class="p-matrix__content">
-          <h3 class="p-matrix__title">CUE.03: Server QuickCert</h3>
-          <div class="p-matrix__desc">
-            <p>Illustrate your knowledge of common Ubuntu Server administrative tasks and troubleshooting. Topics include job control, performance tuning, services management, and Bash scripting.</p>
-            <a href="/credentials/syllabus?exam=CUE%3A%20Server" class="p-button">Syllabus</a>
-          </div>
-        </div>
-      </li>
-    </ul>
+</section>
+<section class="p-strip">
+  <div class="row">
+    <div class="col-6">
+      <h2 class="u-sv2">Complete Canonical Ubuntu Essentials Syllabus</h2>
+    </div>
+    <div class="col-6">
+      <div class="u-sv4">
+        <h3 class="p-heading--5 u-no-margin--bottom">CUE.01: Linux QuickCert</h3>
+        <p>Prove your knowledge of the Linux community, history, and philosophy. Topics include common Linux commands, open source and software licensing, and basic knowledge of Linux architecture and file hierarchy.</p>
+        <a href="/credentials/syllabus?exam=CUE.01%3A%20Linux">Syllabus&nbsp;›</a>
+      </div>
+      <div class="u-sv4">
+        <hr class="is-fixed-width u-no-margin--bottom">
+        <h3 class="p-heading--5 u-no-margin--bottom">CUE.02: Desktop QuickCert</h3>
+        <p>Demonstrate your knowledge of Ubuntu Desktop administrative essentials. Topics include package management, system installation, data gathering, and managing printing and displays.</p>
+        <a href="/credentials/syllabus?exam=CUE.02%3A%20Desktop">Syllabus&nbsp;›</a>
+      </div>
+      <div class="u-sv4">
+        <hr class="is-fixed-width u-no-margin--bottom">
+        <h3 class="p-heading--5 u-no-margin--bottom">CUE.03: Server QuickCert</h3>
+        <p>Illustrate your knowledge of common Ubuntu Server administrative tasks and troubleshooting. Topics include job control, performance tuning, services management, and Bash scripting.</p>
+        <a href="/credentials/syllabus?exam=CUE.03%3A%20Server">Syllabus&nbsp;›</a>
+      </div>
+    </div>
   </div>
 </section>
 

--- a/templates/credentials/syllabus.html
+++ b/templates/credentials/syllabus.html
@@ -7,6 +7,17 @@
 
 {% block content %}
 
+<style>
+  .p-tabs {
+    padding-top: 1.5rem;
+    background-color: #f7f7f7;
+  }
+
+  .p-tabs__link {
+    background: transparent;
+  }
+</style>
+
 <section class="p-strip--image is-dark" style="background-image: url(https://assets.ubuntu.com/v1/4a1f9f33-suru-cut.png); background-position: 100% 60%">
   <div class="row u-equal-height">
     <div class="col-6">
@@ -15,28 +26,33 @@
     </div>
   </div>
 </section>
-<section class="p-strip--light u-no-padding--top">
-  <div class="u-fixed-width">
-    <div class="p-tabs">
-      <div class="p-tabs__list" role="tablist" aria-label="CUE Syllabus">
+<div>
+  <div class="p-tabs">
+    <div class="row">
+      <div class="p-tabs__list u-no-margin--bottom" role="tablist" aria-label="CUE Syllabus">
         {% for exam in syllabus_data %}
         <div class="p-tabs__item">
           <button class="p-tabs__link" role="tab" aria-controls="{{exam['exam_name']}}-tab" id="{{exam['exam_name']}}" {% if (exam_name and exam_name!=exam["exam_name"]) or (not exam_name and loop.index!=1) %}aria-selected="false"{% else %}aria-selected="true"{% endif %}>{{exam["exam_name"]}}</button>
         </div>
         {% endfor %}
       </div>
+    </div>
+  </div>
+</div>
+<section class="p-strip u-no-padding--top">
+  <div class="u-fixed-width">
       {% for exam in syllabus_data %}
       <div tabindex="0" role="tabpanel" id="{{exam['exam_name']}}-tab" aria-labelledby="{{exam['exam_name']}}" {% if (exam_name and exam_name!=exam["exam_name"]) or (not exam_name and loop.index!=1) %}hidden="hidden"{% endif %}>
-        <div class="row u-sv4">
+        <div class="row" style="padding: 4rem 0rem;">
           <div class="col-3">
             <p class="p-heading--5">OVERVIEW</p>
           </div>
           <div class="col-6">
-            <p>{{exam['exam_description']}}</p>
+            <p class="u-no-margin--bottom">{{exam['exam_description']}}</p>
           </div>
         </div>
         {% for chapter in exam["syllabus"] %}
-        <hr class="is-fixed-width u-no-margin--bottom">
+        <hr class="u-no-margin--bottom">
         <div class="row u-sv4">
           <div class="col-3 col-medium-1">
             <p class="p-step-counter">

--- a/templates/credentials/syllabus.html
+++ b/templates/credentials/syllabus.html
@@ -7,27 +7,15 @@
 
 {% block content %}
 
-<section class="p-strip--suru-topped">
+<section class="p-strip--image is-dark" style="background-image: url(https://assets.ubuntu.com/v1/4a1f9f33-suru-cut.png); background-position: 100% 60%">
   <div class="row u-equal-height">
     <div class="col-6">
       <h1> Certification Syllabus</h1>
       <p class="p-heading--4">Each of our QuickCerts is specifically designed to be relevant to what matters in the industry today.</p>
     </div>
-    <div class="col-4 col-start-large-9 u-hide--small u-vertically-center">
-      {{
-        image (
-        url="https://assets.ubuntu.com/v1/7bf909cc-Admin.svg",
-        alt="Canonical Ubuntu Essentials badge",
-        width="175",
-        height="205",
-        hi_def=True,
-        loading="auto"
-        ) | safe
-      }}
-    </div>
   </div>
 </section>
-<section class="p-strip--light">
+<section class="p-strip--light u-no-padding--top">
   <div class="u-fixed-width">
     <div class="p-tabs">
       <div class="p-tabs__list" role="tablist" aria-label="CUE Syllabus">
@@ -39,18 +27,32 @@
       </div>
       {% for exam in syllabus_data %}
       <div tabindex="0" role="tabpanel" id="{{exam['exam_name']}}-tab" aria-labelledby="{{exam['exam_name']}}" {% if (exam_name and exam_name!=exam["exam_name"]) or (not exam_name and loop.index!=1) %}hidden="hidden"{% endif %}>
-        <p>{{exam['exam_description']}}</p>
-        <ol class="p-stepped-list">
-          {% for chapter in exam["syllabus"] %}
-          <li class="p-stepped-list__item"><h3 class="p-stepped-list__title">{{chapter['chapter_title']}}</h3>
+        <div class="row u-sv4">
+          <div class="col-3">
+            <p class="p-heading--5">OVERVIEW</p>
+          </div>
+          <div class="col-6">
+            <p>{{exam['exam_description']}}</p>
+          </div>
+        </div>
+        {% for chapter in exam["syllabus"] %}
+        <hr class="is-fixed-width u-no-margin--bottom">
+        <div class="row u-sv4">
+          <div class="col-3 col-medium-1">
+            <p class="p-step-counter">
+            {{ loop.index }}
+            </p>
+          </div>
+          <div class="col-6 col-medium-5">
+            <h2>{{chapter['chapter_title']}}</h2>
             <ol class="p-stepped-list__content">
               {% for section in chapter['chapter_sections'] %}
               <li>{{section}}</li>
               {% endfor %}
             </ol>
-          </li>
-          {% endfor %}
-        </ol>
+          </div>
+        </div>
+        {% endfor %}
       </div>
       {% endfor %}
     </div>


### PR DESCRIPTION
## Done

- Update visuals for /credentials and /credentials/syllabus

## QA

- Visit https://ubuntu-com-12725.demos.haus/credentials
  - Compare against [visual design](https://www.figma.com/file/ZTdYjh2H2nT9rRo9BYHv4G/CUE?node-id=113-2264&t=Y4r2FlET4SRQ33zB-0)
- Visit https://ubuntu-com-12725.demos.haus/credentials/syllabus
  - Compare against [visual design](https://www.figma.com/file/ZTdYjh2H2nT9rRo9BYHv4G/CUE?node-id=153-919&t=Y4r2FlET4SRQ33zB-0)

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/CRED-298

## Screenshots

![cred-beta-visuals-credentials](https://user-images.githubusercontent.com/995051/228558052-fdb15265-cc88-46f6-978d-f0807042aabe.png)

![cred-beta-visuals-syllabus](https://user-images.githubusercontent.com/995051/228558070-f59d32ee-53f8-445f-b3f1-a57c52f04583.png)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
