### PR TITLE
test: read dummy ubuntu credentials from GitHub secrets

### DIFF
--- a/.github/workflows/cypress-main.yaml
+++ b/.github/workflows/cypress-main.yaml
@@ -1,4 +1,4 @@
-name: Cypress checks / main
+name: Cypress checks / forms
 env:
   SECRET_KEY: insecure_test_key
   PORT: 8001

--- a/.github/workflows/cypress-pr.yaml
+++ b/.github/workflows/cypress-pr.yaml
@@ -1,4 +1,4 @@
-name: Cypress checks / PR
+name: Cypress checks / all
 env:
   SECRET_KEY: insecure_test_key
   PORT: 8001
@@ -7,8 +7,13 @@ env:
   CAPTCHA_TESTING_API_KEY: 6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
   MARKETO_API_CLIENT: ${{secrets.MARKETO_API_CLIENT}}
   MARKETO_API_SECRET: ${{secrets.MARKETO_API_SECRET}}
+  UBUNTU_USERNAME: ${{secrets.UBUNTU_USERNAME}}
+  UBUNTU_PASSWORD: ${{secrets.UBUNTU_PASSWORD}}
 
-on: pull_request
+on:
+  push:
+    branches:
+      - main
 
 jobs:
   run-cypress:
@@ -30,7 +35,7 @@ jobs:
       - name: Cypress run
         uses: cypress-io/github-action@v2
         with:
-          env: UBUNTU_USERNAME=peter.makowski+cy@canonical.com,UBUNTU_PASSWORD=jibfdq5hmq
+          env: UBUNTU_USERNAME=${{ secrets.UBUNTU_USERNAME }},UBUNTU_PASSWORD=${{ secrets.UBUNTU_PASSWORD }}
           build: yarn run build
           start: yarn run serve
           wait-on: "http://0.0.0.0:8001/_status/check"


### PR DESCRIPTION
## Done

- read UBUNTU_USERNAME and UBUNTU_PASSWORD from GitHub secrets
(this has the unfortunate side effect of having to run the test only after merge as secrets cannot be read from from pull requests)
- update cypress PR tests to run on after merge

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
