### PR TITLE
update dummy cypress account credentials

### DIFF
--- a/.github/workflows/cypress-pr.yaml
+++ b/.github/workflows/cypress-pr.yaml
@@ -30,7 +30,9 @@ jobs:
       - name: Cypress run
         uses: cypress-io/github-action@v2
         with:
-          env: UBUNTU_USERNAME=peter.makowski+cy@canonical.com,UBUNTU_PASSWORD=jibfdq5hmq
+          # This is a dummy account that contains no sensitive information and is only used for testing
+          # This is to workaround the fact that GitHub secrets cannot be used in pull requests from forks
+          env: UBUNTU_USERNAME=peter.makowski+dummy-cypress-account@canonical.com,UBUNTU_PASSWORD=9BKfSNo2&2Zs
           build: yarn run build
           start: yarn run serve
           wait-on: "http://0.0.0.0:8001/_status/check"


### PR DESCRIPTION
## Done

- update dummy cypress account credentials

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
