### PR TITLE
Reorder logos

### DIFF
--- a/templates/certified/shared/_partners.html
+++ b/templates/certified/shared/_partners.html
@@ -156,6 +156,42 @@
 <div class="row">
   <div class="col-small-1 col-medium-1 col-1">
     {{ image (
+      url="https://assets.ubuntu.com/v1/2b253402-advantech-logo.png",
+      alt="Advantech",
+      attrs={"class":"p-logo-section__logo"},
+      width="280",
+      height="280",
+      hi_def=False,
+      loading="lazy",
+      ) | safe
+    }}
+  </div>
+  <div class="col-small-1 col-medium-1 col-1">
+    {{ image (
+      url="https://assets.ubuntu.com/v1/1d02aa46-aaeon-logo.png",
+      alt="Aaeon",
+      attrs={"class":"p-logo-section__logo"},
+      width="280",
+      height="280",
+      hi_def=False,
+      loading="lazy",
+      ) | safe
+    }}
+  </div>
+  <div class="col-small-1 col-medium-1 col-1">
+    {{ image (
+      url="https://assets.ubuntu.com/v1/9e488802-dfi-logo.png",
+      alt="DFI",
+      attrs={"class":"p-logo-section__logo"},
+      width="280",
+      height="280",
+      hi_def=False,
+      loading="lazy"
+      ) | safe
+    }}
+  </div>
+  <div class="col-small-1 col-medium-1 col-1">
+    {{ image (
       url="https://assets.ubuntu.com/v1/0f4ef2b8-adlink-logo.png",
       alt="Adlink",
       attrs={"class":"p-logo-section__logo"},
@@ -192,32 +228,8 @@
   </div>
   <div class="col-small-1 col-medium-1 col-1">
     {{ image (
-      url="https://assets.ubuntu.com/v1/1d02aa46-aaeon-logo.png",
-      alt="Aaeon",
-      attrs={"class":"p-logo-section__logo"},
-      width="280",
-      height="280",
-      hi_def=False,
-      loading="lazy",
-      ) | safe
-    }}
-  </div>
-  <div class="col-small-1 col-medium-1 col-1">
-    {{ image (
       url="https://assets.ubuntu.com/v1/8fdc3ebf-raspberry-pi-logo.png",
       alt="Rapsberry Pi",
-      attrs={"class":"p-logo-section__logo"},
-      width="280",
-      height="280",
-      hi_def=False,
-      loading="lazy",
-      ) | safe
-    }}
-  </div>
-  <div class="col-small-1 col-medium-1 col-1">
-    {{ image (
-      url="https://assets.ubuntu.com/v1/2b253402-advantech-logo.png",
-      alt="Advantech",
       attrs={"class":"p-logo-section__logo"},
       width="280",
       height="280",
@@ -242,18 +254,6 @@
     {{ image (
       url="https://assets.ubuntu.com/v1/6513cff5-axiomtek-logo.png",
       alt="Axiomtek",
-      attrs={"class":"p-logo-section__logo"},
-      width="280",
-      height="280",
-      hi_def=False,
-      loading="lazy"
-      ) | safe
-    }}
-  </div>
-  <div class="col-small-1 col-medium-1 col-1">
-    {{ image (
-      url="https://assets.ubuntu.com/v1/9e488802-dfi-logo.png",
-      alt="DFI",
       attrs={"class":"p-logo-section__logo"},
       width="280",
       height="280",


### PR DESCRIPTION
## Done

- Follow up of [this pr](https://github.com/canonical/ubuntu.com/pull/12720), stakeholder has asked to reorder the logos so that  Advantech / Aaeon / DFI are the first 3 logos in the second row.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: https://ubuntu-com-12732.demos.haus/certified/why-certify
    - Be sure to test on mobile, tablet and desktop screen sizes
- See that the requested change was made

## Screenshots
![Screenshot from 2023-03-29 16-45-04](https://user-images.githubusercontent.com/17607612/228576393-aada7a60-ffba-49f0-8056-e7cdeefc4316.png)
