### PR TITLE
Update to vanilla-3.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "typescript": "4.5.4",
     "url-polyfill": "1.1.12",
     "url-search-params-polyfill": "8.1.1",
-    "vanilla-framework": "^3.12.1",
+    "vanilla-framework": "^3.13.0",
     "yup": "0.32.11"
   },
   "resolutions": {

--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -37,6 +37,7 @@ $ubuntu-logo-width--mobile: $ubuntu-logo-svg-width + 2 * $sph--large;
         align-items: stretch;
         display: flex;
         justify-content: center;
+        margin: 0;
         order: 2;
 
         .p-navigation__dropdown-link {

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1285,3 +1285,10 @@ hr.p-separator.is-shallow {
     }
   }
 }
+
+// XXX Pete 03/04/2023
+// Fixes bug with `is-split` on lists, remove when this vanilla issue is fixed:
+// https: //github.com/canonical/vanilla-framework/issues/4719
+[class*=p-list].is-split .p-list__item {
+  display: inline-block;
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1289,6 +1289,6 @@ hr.p-separator.is-shallow {
 // XXX Pete 03/04/2023
 // Fixes bug with `is-split` on lists, remove when this vanilla issue is fixed:
 // https: //github.com/canonical/vanilla-framework/issues/4719
-[class*=p-list].is-split .p-list__item {
+[class*="p-list"].is-split .p-list__item {
   display: inline-block;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8605,10 +8605,10 @@ vanilla-framework@3.0.1:
     postcss-cli "9.1.0"
     sass "1.45.2"
 
-vanilla-framework@^3.12.1:
-  version "3.12.1"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-3.12.1.tgz#b438f76816d1bb558eeea87e56987d755bf264ec"
-  integrity sha512-IbCb7gblPY1A1f89+mcyPvEC+2Zd1z2A0fB+L7tabXuBn/eu6eL8EAq1WY0Jc5hK3hws/YPyrhBzgUVAw2fglg==
+vanilla-framework@^3.13.0:
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-3.13.0.tgz#264f6f33e6926e6d1019e7659660f36fa20cd4b4"
+  integrity sha512-L6Z+8q4nbUTl12yCDJ/TqdWRugFeCaPMxUV7o0qrI1/bmuOLGpDaVPhGOcBPIO+uzIxANICVABXvk0qvzAClxA==
   dependencies:
     "@canonical/cookie-policy" "3.4.0"
     "@canonical/latest-news" "1.4.1"


### PR DESCRIPTION
## Done

[This PR](https://github.com/canonical/ubuntu.com/pull/12667) already exists, but I wanted to get the vanilla update live asap as it is required for [this PR](https://github.com/canonical/ubuntu.com/pull/12675) that is due to go live today

- Updates to vanilla-3.13.0. This is a separate PR

## QA

- Check the changes made to the nav 

