### PR TITLE
Update list activation keys for contract endpoint path

### DIFF
--- a/webapp/shop/api/ua_contracts/api.py
+++ b/webapp/shop/api/ua_contracts/api.py
@@ -417,7 +417,7 @@ class UAContractsAPI:
     def list_activation_keys(self, contract_id: str) -> dict:
         return self._request(
             method="get",
-            path=f"v1/keys/list/{contract_id}",
+            path=f"v1/contracts/{contract_id}/keys",
             error_rules=["default"],
         ).json()
 


### PR DESCRIPTION
## Done

Commercial Systems has updated the path to list activation keys for a contract. The changes on our side will be deployed on Wed, Apr 5th. Given this page is Canonical-only, we don't see much point in `try` / `except` dances when back-porting from an older to a newer endpoint.