### PR TITLE
Hide error message when value changes

### DIFF
--- a/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
@@ -17,9 +17,10 @@ type Props = {
   quantity: number;
   product: Product;
   action: Action;
+  error: any;
 };
 
-const BuyButton = ({ setError, quantity, product, action }: Props) => {
+const BuyButton = ({ error, setError, quantity, product, action }: Props) => {
   const [isLoading, setIsLoading] = useState(false);
 
   const {
@@ -30,10 +31,44 @@ const BuyButton = ({ setError, quantity, product, action }: Props) => {
     validateForm,
     errors,
   } = useFormikContext<FormValues>();
+
   const { data: userInfo } = useCustomerInfo();
   const useFinishPurchaseMutation = useFinishPurchase();
   const buyAction = values.FreeTrial === "useFreeTrial" ? "trial" : action;
   const queryClient = useQueryClient();
+  useEffect(() => {
+    if (
+      error &&
+      error?.props?.children.includes(
+        "Please make sure all fields are filled in correctly"
+      ) &&
+      document.querySelector(".p-notification--negative")
+    ) {
+      document
+        .querySelector(".p-notification--negative")
+        ?.classList.add("u-hide");
+    } else if (
+      error &&
+      !error?.props?.children.includes(
+        "Please make sure all fields are filled in correctly"
+      ) &&
+      document.querySelector(".p-notification--negative u-hide")
+    ) {
+      document
+        .querySelector(".p-notification--negative u-hide")
+        ?.classList.remove("u-hide");
+    } else if (
+      error &&
+      error?.props?.children.includes(
+        "Please make sure all fields are filled in correctly"
+      ) &&
+      document.querySelector(".p-notification--negative u-hide")
+    ) {
+      document
+        .querySelector(".p-notification--negative u-hide")
+        ?.classList.remove("u-hide");
+    }
+  }, [values]);
 
   const sessionData = {
     gclid: getSessionData("gclid"),
@@ -70,6 +105,9 @@ const BuyButton = ({ setError, quantity, product, action }: Props) => {
 
       if (!(possibleErrors.length === 0)) {
         setError(<>Please make sure all fields are filled in correctly.</>);
+        document
+          .querySelector(".p-notification--negative")
+          ?.classList.remove("u-hide");
         document.querySelector("h1")?.scrollIntoView();
         return;
       }
@@ -106,6 +144,9 @@ const BuyButton = ({ setError, quantity, product, action }: Props) => {
           setIsLoading(false);
           setFieldValue("Description", false);
           setFieldValue("TermsAndConditions", false);
+          document
+            .querySelector(".p-notification--negative")
+            ?.classList.remove("u-hide");
           document.querySelector("h1")?.scrollIntoView();
 
           if (error instanceof Error)
@@ -186,6 +227,9 @@ const BuyButton = ({ setError, quantity, product, action }: Props) => {
       setIsLoading(false);
       setFieldValue("Description", false);
       setFieldValue("TermsAndConditions", false);
+      document
+        .querySelector(".p-notification--negative")
+        ?.classList.remove("u-hide");
       document.querySelector("h1")?.scrollIntoView();
 
       if (

--- a/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
@@ -36,37 +36,15 @@ const BuyButton = ({ error, setError, quantity, product, action }: Props) => {
   const useFinishPurchaseMutation = useFinishPurchase();
   const buyAction = values.FreeTrial === "useFreeTrial" ? "trial" : action;
   const queryClient = useQueryClient();
+  const errorNotification = document.querySelector(".p-notification--negative");
+
   useEffect(() => {
     if (
       error &&
-      error?.props?.children.includes(
-        "Please make sure all fields are filled in correctly"
-      ) &&
-      document.querySelector(".p-notification--negative")
+      errorNotification &&
+      !errorNotification.classList.contains("u-hide")
     ) {
-      document
-        .querySelector(".p-notification--negative")
-        ?.classList.add("u-hide");
-    } else if (
-      error &&
-      !error?.props?.children.includes(
-        "Please make sure all fields are filled in correctly"
-      ) &&
-      document.querySelector(".p-notification--negative u-hide")
-    ) {
-      document
-        .querySelector(".p-notification--negative u-hide")
-        ?.classList.remove("u-hide");
-    } else if (
-      error &&
-      error?.props?.children.includes(
-        "Please make sure all fields are filled in correctly"
-      ) &&
-      document.querySelector(".p-notification--negative u-hide")
-    ) {
-      document
-        .querySelector(".p-notification--negative u-hide")
-        ?.classList.remove("u-hide");
+      errorNotification.classList.add("u-hide");
     }
   }, [values]);
 

--- a/static/js/src/advantage/subscribe/checkout/components/Checkout/Checkout.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Checkout/Checkout.tsx
@@ -32,7 +32,6 @@ const Checkout = ({ product, quantity, action }: Props) => {
   const productCanBeTrialled = product?.canBeTrialled;
   const canTrial = canBeTrialled(productCanBeTrialled, userCanTrial);
   const initialValues = getInitialFormValues(product, canTrial, userInfo);
-
   return (
     <>
       <div className="p-strip">
@@ -132,6 +131,7 @@ const Checkout = ({ product, quantity, action }: Props) => {
                                 quantity={quantity}
                                 action={action}
                                 setError={setError}
+                                error={error}
                               ></BuyButton>
                             </Col>
                           </Row>

--- a/static/js/src/advantage/subscribe/checkout/components/Checkout/Checkout.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Checkout/Checkout.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { Formik } from "formik";
 import {
   Col,
@@ -32,6 +32,18 @@ const Checkout = ({ product, quantity, action }: Props) => {
   const productCanBeTrialled = product?.canBeTrialled;
   const canTrial = canBeTrialled(productCanBeTrialled, userCanTrial);
   const initialValues = getInitialFormValues(product, canTrial, userInfo);
+  const errorNotification = document.querySelector(".p-notification--negative");
+
+  useEffect(() => {
+    if (
+      error &&
+      errorNotification &&
+      errorNotification.classList.contains("u-hide")
+    ) {
+      errorNotification.classList.remove("u-hide");
+    }
+  }, [error]);
+
   return (
     <>
       <div className="p-strip">

--- a/static/js/src/advantage/subscribe/checkout/components/Taxes/Taxes.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Taxes/Taxes.tsx
@@ -72,11 +72,20 @@ const Taxes = ({ setError }: TaxesProps) => {
           onSuccess: () => {
             queryClient.invalidateQueries("preview");
             queryClient.invalidateQueries("customerInfo");
+            if (document.querySelector(".p-notification--negative")) {
+              document
+                .querySelector(".p-notification--negative")
+                ?.classList.add("u-hide");
+            }
           },
           onError: (error) => {
             setFieldValue("Description", false);
             setFieldValue("TermsAndConditions", false);
+            document
+              .querySelector(".p-notification--negative")
+              ?.classList.remove("u-hide");
             document.querySelector("h1")?.scrollIntoView();
+
             Sentry.captureException(error);
             if (error instanceof Error)
               if (error.message.includes("tax_id_invalid")) {
@@ -307,6 +316,11 @@ const Taxes = ({ setError }: TaxesProps) => {
                     setIsEditing(false);
                     setFieldValue("isTaxSaved", true);
                     setFieldTouched("isTaxSaved", false);
+                    if (document.querySelector(".p-notification--negative")) {
+                      document
+                        .querySelector(".p-notification--negative")
+                        ?.classList.add("u-hide");
+                    }
                   }}
                 >
                   Cancel

--- a/static/js/src/advantage/subscribe/checkout/components/UserInfoForm/UserInfoForm.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/UserInfoForm/UserInfoForm.tsx
@@ -98,6 +98,9 @@ const UserInfoForm = ({ setError }: Props) => {
           setFieldValue("Description", false);
           setFieldValue("TermsAndConditions", false);
           setIsButtonDisabled(false);
+          document
+            .querySelector(".p-notification--negative")
+            ?.classList.remove("u-hide");
           document.querySelector("h1")?.scrollIntoView();
 
           if (error instanceof Error)


### PR DESCRIPTION
## Done

- Hide error message when value changes

## QA
- Go to /pro/subscribe 
- Click "Buy now" button
- See the global error message displays at the top and validate message on the fields
- Update some of the fields that show validate message
- See the global error message disappears right after updating field
- Type invalid vat number and check global error message for the vat number displays properly
- Type invalid card number and  check global error message displays properly
- QA with the other error cases as well 

## Issue / Card

Fixes #https://warthogs.atlassian.net/jira/software/c/projects/WD/boards/801?modal=detail&selectedIssue=WD-2941