### PR TITLE
Fix typo remove duplicated "now" from Ubuntu Pro tutorial

### DIFF
--- a/templates/pro/tutorial.html
+++ b/templates/pro/tutorial.html
@@ -407,7 +407,7 @@ Subscription: Ubuntu Pro - free personal subscription</pre>
     <div class="col-9">
       <h2>Congratulations - your machine is now upgraded to Ubuntu Pro</h2>
 
-      <p>Well done! Your machine now has now access to Ubuntu Pro repositories. That means that every time you update
+      <p>Well done! Your machine now has access to Ubuntu Pro repositories. That means that every time you update
         your software, you will be pulling from the Ubuntu Pro’s Expanded Security Maintenance repositories. You can get
         it through all the usual paths; nothing new to learn. You can use unattended-upgrades, the Software Updater on
         the Desktop, or <code>apt upgrade</code> command in the CLI.</p>


### PR DESCRIPTION
## Done

Fixed Typo in step 5 of the  Ubuntu Pro tutorial Removed duplicated "now" 

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #12738 

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
