### PR TITLE
Add mobile number input validation on `kubernetes#get-in-touch` form

### DIFF
--- a/templates/shared/forms/interactive/kubernetes.html
+++ b/templates/shared/forms/interactive/kubernetes.html
@@ -36,7 +36,7 @@
               </li>
               <li class="p-list__item">
                 <label for="phone">Mobile/cell phone number:</label>
-                <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
+                <input required id="phone" name="phone" maxlength="20" type="tel" pattern="^[0-9]*$" required="required" />
               </li>
               <li class="p-list__item">
                 <label class="p-checkbox">


### PR DESCRIPTION
## Done

* Added regex pattern in **Mobile/cell phone number** input field of [kubernetes#get-in-touch](https://ubuntu.com/kubernetes#get-in-touch) form.
* Changed maxLength from 255 to 20

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #12691 

## Screenshots

Now requires valid number before form submission👇
<img width="315" alt="Screenshot 2023-04-10 135558" src="https://user-images.githubusercontent.com/89641167/230865169-d406d51e-5020-4f86-8029-10c3abc361e7.png">


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
