### PR TITLE
Remove kafka from /support

### DIFF
--- a/templates/shared/_security-patching-logo-cloud.html
+++ b/templates/shared/_security-patching-logo-cloud.html
@@ -57,10 +57,10 @@
     <span class="p-media-object__image">
       {{
         image(
-        url="https://assets.ubuntu.com/v1/03e7b7ac-apache_kafka_icon_138937.png",
+        url="https://assets.ubuntu.com/v1/a17329f6-ROS.svg",
         alt="",
-        width="100",
-        height="100",
+        width="40",
+        height="40",
         hi_def=True,
         loading="lazy",
         attrs={"class": "p-media-object__image"},
@@ -68,7 +68,7 @@
       }}
     </span>
     <span class="p-media-object__details">
-      <p class="p-media-object__title p-heading--5 u-no-margin--bottom">Kafka</p>
+      <p class="p-media-object__title p-heading--5 u-no-margin--bottom">ROS</p>
     </span>
   </div>
 </div>
@@ -540,24 +540,6 @@
     </span>
     <span class="p-media-object__details">
       <p class="p-media-object__title p-heading--5 u-no-margin--bottom">Anbox Cloud</p>
-    </span>
-  </div>
-  <div class="col-3 col-medium-3 p-media-object">
-    <span class="p-media-object__image">
-      {{
-        image(
-        url="https://assets.ubuntu.com/v1/a17329f6-ROS.svg",
-        alt="",
-        width="40",
-        height="40",
-        hi_def=True,
-        loading="lazy",
-        attrs={"class": "p-media-object__image"},
-        ) | safe
-      }}
-    </span>
-    <span class="p-media-object__details">
-      <p class="p-media-object__title p-heading--5 u-no-margin--bottom">ROS</p>
     </span>
   </div>
 </div>

--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -2,7 +2,7 @@
 
 {% block title %}Enterprise open source support{% endblock %}
 
-{% block meta_description %}Ubuntu Advantage offers a single, per-node packaging of the most comprehensive Linux and open source software, application, security and IaaS support in the industry, with OpenStack support and Kubernetes support included, as well as  for open source applications like Apache Kafka, Cassandra, Elasticsearch, Postgres and more.{% endblock %}
+{% block meta_description %}Ubuntu Pro offers a single, per-node packaging of the most comprehensive Linux and open source software, application, security and IaaS support in the industry, with OpenStack support and Kubernetes support included, as well as for open source applications like Cassandra, Elasticsearch, Postgres and more.{% endblock %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1AU2dwTXpQk2UuEvSuAqRKrbPWYb-LR0ZGvWu6xw95I8/edit#{% endblock meta_copydoc %}
 
@@ -225,7 +225,7 @@
       </li>
       <li class="p-matrix__item">
         <div class="p-matrix__content">
-          <h3 class="p-matrix__title p-heading--4">Kafka, NGINX and PostgreSQL support</h3>
+          <h3 class="p-matrix__title p-heading--4">NGINX and PostgreSQL support</h3>
           <p class="p-matrix__desc">Enterprise-grade security and support for a portfolio of open source database, LMA, messaging and cloud-native applications.</p>
         </div>
       </li>


### PR DESCRIPTION
## Done

-  Remove Kafka logo and mention on the /support page

## QA

- Go to https://ubuntu-com-12766.demos.haus/support
- Check Kafka logo and mention are removed on the page

## Issue / Card

Fixes #https://warthogs.atlassian.net/jira/software/c/projects/WD/boards/801?modal=detail&selectedIssue=WD-3066
