### PR TITLE
Update /desktop/flavours with new flavour information

### DIFF
--- a/templates/desktop/flavours.html
+++ b/templates/desktop/flavours.html
@@ -16,9 +16,9 @@
     </div>
     <div class="col-6 u-align--center u-vertically-center u-hide--small u-hide--medium">
       {{ image (
-        url="https://assets.ubuntu.com/v1/dc0b7c84-ubuntu+flavours.png",
+        url="https://assets.ubuntu.com/v1/e84a9007-ubuntu-flavours-23.png",
         alt="",
-        width="1072",
+        width="1296",
         height="460",
         hi_def=True,
         loading="auto"
@@ -35,8 +35,8 @@
         <div class="p-heading-icon__header">
           {{
             image(
-              url="https://assets.ubuntu.com/v1/267e8693-Kubuntu_logo.svg",
-              alt="Kubuntu icon",
+              url="https://assets.ubuntu.com/v1/a2f090ef-edubuntu-logo.svg",
+              alt="Edubuntu icon",
               height="64",
               width="64",
               hi_def=True,
@@ -44,18 +44,17 @@
               attrs={"class": "p-heading-icon__img"}
             ) | safe
           }}
-          <h3 class="p-heading-icon__title">Kubuntu</h3>
+          <h3 class="p-heading-icon__title">Edubuntu</h3>
         </div>
-        <p>Kubuntu unites Ubuntu with KDE and the Plasma desktop, bringing you a full set of applications including productivity, office, email, graphics, photography, and music applications ready to use at startup with extensive additional software installed from not one, but two desktop package managers. </p>
-        <p>Built using the Qt toolkit, Kubuntu is fast, slick and beautiful. Kubuntu is mobile-ready, enabling easy integration between your PC desktop and phone or tablet with KDE Connect.</p>
-        <p><a href="https://kubuntu.org/getkubuntu/" class="p-button--positive">Get Kubuntu</a></p>
-        <p><a href="https://www.kubuntuforums.net/forum">Join the Kubuntu community&nbsp;&rsaquo;</a>
-        <p><a href="https://twitter.com/kubuntu">Follow Kubuntu&nbsp;&rsaquo;</a></p>
+        <p>Edubuntu is an official flavor of Ubuntu crafted for use in the education world. Teachers and students will have access to a huge ecosystem of learning software and educational tools built on a familiar and usable desktop. Edubuntu provides a fast, stable, secure and privacy conscious option for schools, universities and other places of learning.</p>
+        <p><a href="https://edubuntu.org/" class="p-button--positive">Get Edubuntu</a></p>
+        <p><a href="https://ubuntuforums.org/forumdisplay.php?f=329&pp=20&prefixid=edubuntu">Join the Edubuntu community&nbsp;&rsaquo;</a></p>
+        <p><a href="https://twitter.com/edubuntuproject">Follow Edubuntu&nbsp;&rsaquo;</a></p>
       </div>
   </div>
   <div class="col-6 u-vertically-center u-align--center u-hide--small u-hide--medium">
     {{ image (
-      url="https://assets.ubuntu.com/v1/7c6fa2da-kubuntu-2204-screenshot.png",
+      url="https://assets.ubuntu.com/v1/54331fa0-edubuntu-2304-screenshot.png",
       alt="",
       width="2560",
       height="1440",
@@ -70,10 +69,10 @@
   <div class="row">
     <div class="col-6 u-vertically-center u-align--center u-hide--small u-hide--medium">
       {{ image (
-        url="https://assets.ubuntu.com/v1/8d50725a-lubuntu-2204-screenshot.png",
+        url="https://assets.ubuntu.com/v1/7c6fa2da-kubuntu-2204-screenshot.png",
         alt="",
-        width="1920",
-        height="1080",
+        width="2560",
+        height="1440",
         hi_def=True,
         loading="lazy"
         ) | safe
@@ -84,10 +83,40 @@
         <div class="p-heading-icon__header">
           {{
             image(
+              url="https://assets.ubuntu.com/v1/267e8693-Kubuntu_logo.svg",
+              alt="Kubuntu icon",
+              height="64",
+              width="64",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-heading-icon__img"}
+            ) | safe
+          }}
+          <h3 class="p-heading-icon__title">Kubuntu</h3>
+        </div>
+        <div>
+        <p>Kubuntu unites Ubuntu with KDE and the Plasma desktop, bringing you a full set of applications including productivity, office, email, graphics, photography, and music applications ready to use at startup with extensive additional software installed from not one, but two desktop package managers. </p>
+        <p>Built using the Qt toolkit, Kubuntu is fast, slick and beautiful. Kubuntu is mobile-ready, enabling easy integration between your PC desktop and phone or tablet with KDE Connect.</p>
+        <p><a href="https://kubuntu.org/getkubuntu/" class="p-button--positive">Get Kubuntu</a></p>
+        <p><a href="https://www.kubuntuforums.net/forum">Join the Kubuntu community&nbsp;&rsaquo;</a>
+        <p><a href="https://twitter.com/kubuntu">Follow Kubuntu&nbsp;&rsaquo;</a></p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-6">
+      <div class="p-heading-icon">
+        <div class="p-heading-icon__header">
+          {{
+            image(
               url="https://assets.ubuntu.com/v1/6ac4ba34-lubuntu-logo.svg",
               alt="Lubuntu icon",
-              height="32",
-              width="32",
+              height="64",
+              width="64",
               hi_def=True,
               loading="lazy",
               attrs={"class": "p-heading-icon__img"}
@@ -103,6 +132,57 @@
         </div>
       </div>
     </div>
+    <div class="col-6 u-vertically-center u-align--center u-hide--small u-hide--medium">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/8d50725a-lubuntu-2204-screenshot.png",
+        alt="",
+        width="1920",
+        height="1080",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="row">
+    <div class="col-6 u-vertically-center u-align--center u-hide--small u-hide--medium">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/eb97c55b-Ubuntu_Budgie.png",
+        alt="",
+        width="1920",
+        height="1080",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+    <div class="col-6">
+      <div class="p-heading-icon">
+        <div class="p-heading-icon__header">
+          {{
+            image(
+              url="https://assets.ubuntu.com/v1/49e647f4-budgie-remix-logo-medium.svg",
+              alt="Budgie icon",
+              height="64",
+              width="64",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-heading-icon__img"}
+            ) | safe
+          }}
+          <h3 class="p-heading-icon__title">Ubuntu Budgie</h3>
+        </div>
+          <p>Ubuntu Budgie is a proud official Ubuntu flavour. We combine the simplicity and elegance of the Budgie desktop environment with the power and familiarity of an Ubuntu based operative system.</p>
+          <p>The result is a modern and fast desktop distribution with great defaults, yet fully customizable.</p>
+          <p><a href="https://ubuntubudgie.org/downloads/" class="p-button--positive">Get Ubuntu Budgie</a></p>
+          <p><a href="https://discourse.ubuntubudgie.org/">Join the Ubuntu Budgie community&nbsp;&rsaquo;</a></p>
+          <p><a href="https://twitter.com/ubuntubudgie">Follow Ubuntu Budgie&nbsp;&rsaquo;</a></p>
+        </div>
+      </div>
+    </div>
   </div>
 </section>
 
@@ -113,29 +193,28 @@
         <div class="p-heading-icon__header">
           {{
             image(
-              url="https://assets.ubuntu.com/v1/49e647f4-budgie-remix-logo-medium.svg",
-              alt="Budgie icon",
-              height="32",
-              width="32",
+              url="https://assets.ubuntu.com/v1/504cc54e-ubuntu-cinnamon-logo.svg",
+              alt="Cinnamon icon",
+              height="64",
+              width="64",
               hi_def=True,
               loading="lazy",
               attrs={"class": "p-heading-icon__img"}
             ) | safe
           }}
-          <h3 class="p-heading-icon__title">Ubuntu Budgie</h3>
+          <h3 class="p-heading-icon__title">Ubuntu Cinnamon</h3>
         </div>
         <div>
-          <p>Ubuntu Budgie is a proud official Ubuntu flavour. We combine the simplicity and elegance of the Budgie desktop environment with the power and familiarity of an Ubuntu based operative system.</p>
-          <p>The result is a modern and fast desktop distribution with great defaults, yet fully customizable.</p>
-          <p><a href="https://ubuntubudgie.org/downloads/" class="p-button--positive">Get Ubuntu Budgie</a></p>
-          <p><a href="https://discourse.ubuntubudgie.org/">Join the Ubuntu Budgie community&nbsp;&rsaquo;</a></p>
-          <p><a href="https://twitter.com/ubuntubudgie">Follow Ubuntu Budgie&nbsp;&rsaquo;</a></p>
+          <p>Ubuntu Cinnamon combines Ubuntu with the intuitive Cinnamon desktop. Built upon the legacy of GNOME 2, Ubuntu Cinnamon provides a traditionally modern experience crafted for professional and home users alike. The hassle free desktop allows for deep personalization options and add-ons for a little extra spice.</p>
+          <p><a href="https://ubuntucinnamon.org/download/" class="p-button--positive">Get Ubuntu Cinnamon</a></p>
+          <p><a href="https://t.me/ubuntucinnamon">Join the Ubuntu Cinnamon community&nbsp;&rsaquo;</a></p>
+          <p><a href="https://twitter.com/UbuntuCinnamon">Follow Ubuntu Cinnamon&nbsp;&rsaquo;</a></p>
         </div>
       </div>
     </div>
     <div class="col-6 u-vertically-center u-align--center u-hide--small u-hide--medium">
       {{ image (
-        url="https://assets.ubuntu.com/v1/eb97c55b-Ubuntu_Budgie.png",
+        url="https://assets.ubuntu.com/v1/70b28e5e-ubuntu-cinnamon-2304-screenshot.png",
         alt="",
         width="1920",
         height="1080",
@@ -167,8 +246,8 @@
             image(
               url="https://assets.ubuntu.com/v1/a9914e3f-ubuntu-kylin.svg",
               alt="Kylin icon",
-              height="32",
-              width="32",
+              height="64",
+              width="64",
               hi_def=True,
               loading="lazy",
               attrs={"class": "p-heading-icon__img"}
@@ -195,8 +274,8 @@
             image(
               url="https://assets.ubuntu.com/v1/b89d0c93-mate.svg",
               alt="MATE icon",
-              height="32",
-              width="32",
+              height="64",
+              width="64",
               hi_def=True,
               loading="lazy",
               attrs={"class": "p-heading-icon__img"}
@@ -246,8 +325,8 @@
             image(
               url="https://assets.ubuntu.com/v1/4a512076-ubuntustudio.svg",
               alt="Studio icon",
-              height="32",
-              width="32",
+              height="64",
+              width="64",
               hi_def=True,
               loading="lazy",
               attrs={"class": "p-heading-icon__img"}
@@ -272,9 +351,9 @@
         <div class="p-heading-icon__header">
           {{ image (
             url="https://assets.ubuntu.com/v1/219d06b0-ubuntu-unity-logo.png",
-            alt="",
-            width="32",
-            height="32",
+            alt="Unity Icon",
+            width="64",
+            height="64",
             hi_def=True,
             loading="lazy",
             attrs={"class": "p-heading-icon__img"}
@@ -323,8 +402,8 @@
             image(
               url="https://assets.ubuntu.com/v1/36e8f12b-Xubuntu_logo.svg",
               alt="Xbuntu icon",
-              height="32",
-              width="32",
+              height="64",
+              width="64",
               hi_def=True,
               loading="lazy",
               attrs={"class": "p-heading-icon__img"}


### PR DESCRIPTION
Update of the Ubuntu desktop flavours page to include sections for new official flavours: Edubuntu and Ubuntu Cinnamon.

## Done

- Uploaded new flavour assets into asset manager.
- Updated flavour banner image with new flavour icons.
- Added new sections and associated content for new flavours - Edubuntu and Ubuntu Cinnamon
- Updated section classes to maintain page theming.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes

## Issue / Card

Fixes # https://warthogs.atlassian.net/browse/WD-3027

