### PR TITLE
WD-3167 Add the discourse terms legal page

### DIFF
--- a/templates/legal/partner-portal-terms.md
+++ b/templates/legal/partner-portal-terms.md
@@ -6,6 +6,7 @@ context:
   update_date: "Version - February 2019"
   copydoc: https://docs.google.com/document/d/1CqJbwC3KpEJeJaCUVjAIN0y6ZLmoc7gVlFyc-BeFMYw/edit#
 ---
+
 # Partner Portal terms and conditions
 
 ## Intellectual property

--- a/templates/legal/terms-and-policies/discourse-terms.md
+++ b/templates/legal/terms-and-policies/discourse-terms.md
@@ -1,0 +1,76 @@
+---
+wrapper_template: "legal/_base_legal_markdown.html"
+context:
+  title: "Canonical Ubuntu Community Discourse Forum Terms of Service"
+  description: "Ubuntu and Canonical Legal - Canonical Ubuntu Community Discourse Forum Terms of Service"
+  update_date: "Version - April 2023"
+  copydoc: https://docs.google.com/document/d/1Yv4bItPlNPS4oOSvUsUavT3qD6NmVrf_EjQNVFLx40w/edit
+---
+
+# Ubuntu Community Discourse Forum terms and conditions
+
+## Canonical's terms and conditions
+
+These terms and conditions cover your registration and use of the Ubuntu Community Discourse Forum (“**Forum**”), provided by Canonical Group Limited, registered in England, company number 06870835 (“**Canonical**”, “**us**”, “**we**” or “**our**”) to you as an individual or an entity (“**you**” or “**your**”). Your registration and use of the Forum will be governed by these terms and conditions along with Canonical's Privacy Policy and Privacy Notice. Please read these terms and conditions carefully before you register for a Forum account. If you register for a Forum account and use the Forum on behalf of a company or other entity, you represent that you have the full legal authority to bind the company to these terms and conditions and you are agreeing to these terms and conditions on behalf of that company. To register for a Forum account and use the Forum, you must be at least 13 years old. If you are between age 13 and 18, you confirm that you have your parent's or legal guardian's consent and that they have read and agreed to these terms.
+
+## Intellectual property
+
+[Canonical's intellectual property rights policy](/legal/intellectual-property-policy) governs your use of Canonical's intellectual property.
+
+## Copyright
+
+The website HTML, text, images, audio, video, software or other content that is made available on the Forum or otherwise hosted by Canonical are the property of someone - the author in the case of content produced elsewhere and reproduced here with permission, or Canonical or its content suppliers. Before you use this content in some way please take care to ensure that you have the relevant rights and permissions from the copyright holder.
+
+You are welcome to display on your computer, download and print pages from the Forum for personal, education and non-commercial use only. You must retain copyright, trademark and other notices unaltered on any copies or printouts you make. Certain materials available on this Forum are “open source” materials subject to the GNU General Public Licence (“GPL”) or other open-source licence and are so marked. Use of those materials is governed by the individual applicable licence.
+
+## Trademarks
+
+Any trademarks, logos and service marks displayed on the Forum are the property of their owners, whether Canonical or third parties. For example, Linux is a registered trademark of Linus Torvalds; Debian is a trademark of Software in the Public Interest, Inc; Windows is a trademark of Microsoft Corporation.
+
+Canonical owns a number of trademarks, including UBUNTU, KUBUNTU, EDUBUNTU, and XUBUNTU, and use of these is subject to compliance with [Canonical's intellectual property rights' policy](/legal/intellectual-property-policy).
+
+### Collection and use of credential information
+
+You provide Canonical with your name and password(s) and IP address (credentials) in order to register for the Forum and to authenticate while using the Forum.
+
+Canonical collects and stores your credentials when you register and when you enter them in the web authentication dialog and use them, and authentication cookies, to provide authentication to the Forum when you access this.
+
+By using the Forum you consent to:
+
+- the collection and use of your credentials in this way;
+- the use of authentication cookies; and
+- the storage of your credentials and the authentication cookies on your computer.
+- Canonical will not access or use your credentials or authentication cookies in any other way.
+
+## Privacy policy
+
+Our collection and use of your personal information is governed by the [Ubuntu Community Discourse Privacy Notice](/legal/data-privacy/community-discourse) and [Canonical privacy policy](/legal/data-privacy).
+
+## Links and third-party content
+
+This Forum and any other websites hosted by Canonical may contain links to other websites and resources and third party content, for example, useful background information. Canonical is not responsible for such content, or that of any linked websites. You will not remove or alter any third party's copyright or trademark notices or other identifier, except as allowed by the third-party's licence of that content. Should you reasonably believe that any third-party content you access through the Forum is in breach of any law, regulation or third party's rights, you should notify Canonical in writing at the address below. In doing so, please:
+
+- identify the material which you believe to be infringing;
+- identify what you believe this material infringes and why;
+- provide your name, email address, address and telephone number;
+- confirm that you believe in good faith that this material is infringing a law or third party's rights and that, to the best of your knowledge, the information you are providing is correct;
+- identify if you are acting on behalf of the third party whose rights may have been infringed;
+- provide your physical or electronic signature.
+
+### Ceasing use
+
+You may cease using the Forum at any time. If you cease using the Forum, please ensure that you have followed the required steps to delete your Forum account.
+
+### Changes
+
+Although most changes are likely to be minor, Canonical may change these terms and conditions from time to time, and at Canonical's sole discretion. Please check this page from time to time for any changes to these terms and conditions as we will not be able to notify you directly.
+
+## Disclaimer
+
+The Forum and any other websites hosted by Canonical and all information, products and services on them are provided on an "as is" basis, without warranty of any kind, either express or implied. Your use of this Forum and any other websites hosted by Canonical is at your own risk. Canonical disclaims all warranties, express or implied, including without limitation, warranties of merchantability and fitness for a particular purpose.
+
+Canonical disclaims liability for any direct, indirect, incidental, special, consequential, exemplary, punitive or other damages, or lost profits, that may result directly or indirectly from the use of this Forum and any other websites hosted by Canonical and any material that is downloaded or obtained through them.
+
+This includes, without limitation, any damage to computer systems, hardware or software, loss of data, or any other performance failures, any errors, bugs, viruses or other defects that result from, or are associated with the use of this and any other websites hosted by Canonical.
+
+Yes, it gives most of us a headache to read all of this, but it's important so thank you for your patience and now, enjoy the Ubuntu Community Discourse Forum!

--- a/templates/legal/terms-and-policies/index.html
+++ b/templates/legal/terms-and-policies/index.html
@@ -36,7 +36,7 @@
       <p>These terms and conditions cover both Ubuntu and Canonical. They govern the content of our websites, including things like the use of images and text.</p>
       <p><a href="/legal/terms">View website terms and conditions&nbsp;&rsaquo;</a></p>
     </div>
-    
+
     <div class="col-6 p-card">
       <h3>Privacy</h3>
       <p>Your privacy is extremely important. Our privacy policy explains what data we collect from you via both our websites and our software &mdash; and what we do with&nbsp;it.</p>
@@ -138,11 +138,17 @@
       <p>The terms for use of our Snap Store and services delivered via snapcraft.io.</p>
       <p><a href="/legal/terms-and-policies/snap-store-terms">View Snap Store terms&nbsp;&rsaquo;</a></p>
     </div>
-    
+
     <div class="col-6 p-card">
       <h3>Canonical Credentials Terms of Service</h3>
       <p>The terms governing use of Canonical's Credentials service.</p>
       <p><a href="/legal/terms-and-policies/credentials-terms">View Canonical Credentials terms&nbsp;&rsaquo;</a></p>
+    </div>
+
+    <div class="col-6 p-card">
+      <h3>Canonical Ubuntu Community Discourse Forum Terms of Service</h3>
+      <p>The terms governing use of Canonical's Ubuntu Community Discourse Forum.</p>
+      <p><a href="/legal/terms-and-policies/discourse-terms">View Canonical Ubuntu Community Discourse Forum terms&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Done

- Added the discourse terms page to the legal section based on this [copy doc](https://docs.google.com/document/d/1Yv4bItPlNPS4oOSvUsUavT3qD6NmVrf_EjQNVFLx40w/edit#).
- Added a section linking to the page on the main terms and policies page based on this [copy doc](https://docs.google.com/document/d/1p3ZWroZ3nkw8XJJdPvPxSlWGYcLZLT8UbUVuppBcyHk/edit#heading=h.twzeocg9szb2).

## QA

- Open the demo
- Find the legal section
- Click on Terms and policies in the secondary nav
- Scroll to the bottom and check the "Canonical Ubuntu Community Discourse Forum Terms of Service" box matches the copy doc above
- Click on it and check the page content matches the copy doc above