### PR TITLE
Fix deep spacing

### DIFF
--- a/templates/pro/tutorial.html
+++ b/templates/pro/tutorial.html
@@ -14,7 +14,7 @@ meta_copydoc %}
     </div>
   </div>
 </section>
-<section class="p-strip is-deep u-no-padding--top">
+<section class="p-strip u-no-padding--top">
   <hr class="is-fixed-width u-no-margin--bottom">
   <div class="row">
     <div class="col-3 col-medium-1">
@@ -83,7 +83,7 @@ meta_copydoc %}
     </div>
   </div>
 </section>
-<section class="p-strip is-deep u-no-padding--top">
+<section class="p-strip u-no-padding--top">
   <hr class="is-fixed-width u-no-margin--bottom">
   <div class="row">
     <div class="col-3 col-medium-1">
@@ -129,7 +129,7 @@ meta_copydoc %}
     </div>
   </div>
 </section>
-<section class="p-strip is-deep u-no-padding--top">
+<section class="p-strip u-no-padding--top">
   <hr class="is-fixed-width u-no-margin--bottom">
   <div class="row">
     <div class="col-3 col-medium-1">
@@ -224,7 +224,7 @@ to learn more about that package.</pre>
       <div class="p-code-snippet">
         <pre class="p-code-snippet__block">
 $ pro fix CVE-2021-3583
-CVE-2021-3583: 
+CVE-2021-3583:
 A flaw was found in Ansible, where a user's controller is vulnerable to
 template injection. This issue can occur through facts used in the template
 if the user is trying to put templates in multi-line YAML strings and the
@@ -244,7 +244,7 @@ Choose: [S]ubscribe at ubuntu.com [A]ttach existing token [C]ancel</pre>
     </div>
   </div>
 </section>
-<section class="p-strip is-deep u-no-padding--top">
+<section class="p-strip u-no-padding--top">
   <hr class="is-fixed-width u-no-margin--bottom">
   <div class="row">
     <div class="col-3 col-medium-1">
@@ -330,7 +330,7 @@ Choose: [S]ubscribe at ubuntu.com [A]ttach existing token [C]ancel</pre>
     </div>
   </div>
 </section>
-<section class="p-strip is-deep u-no-padding--top">
+<section class="p-strip u-no-padding--top">
   <hr class="is-fixed-width u-no-margin--bottom">
   <div class="row">
     <div class="col-3 col-medium-1">
@@ -360,7 +360,7 @@ Ubuntu Pro: ESM Infra enabled
 Enabling default service livepatch
 Canonical livepatch enabled.
 Unable to determine current instance-id
-This machine is now attached to 'Ubuntu Pro - free personal subscription'            
+This machine is now attached to 'Ubuntu Pro - free personal subscription'
 
 SERVICE          ENTITLED  STATUS    DESCRIPTION
 esm-apps         <span class="token string">yes</span>       <span class="token string">enabled</span>   Expanded Security Maintenance for Applications
@@ -396,7 +396,7 @@ Subscription: Ubuntu Pro - free personal subscription</pre>
   </div>
 </section>
 
-<section class="p-strip is-deep u-no-padding--top">
+<section class="p-strip u-no-padding--top">
   <hr class="is-fixed-width u-no-margin--bottom">
   <div class="row">
     <div class="col-3">
@@ -419,7 +419,7 @@ Subscription: Ubuntu Pro - free personal subscription</pre>
   </div>
 </section>
 
-<section class="p-strip is-deep u-no-padding--top">
+<section class="p-strip u-no-padding--top">
   <hr class="is-fixed-width u-no-margin--bottom">
   <div class="row">
     <div class="col-3">
@@ -441,7 +441,7 @@ Subscription: Ubuntu Pro - free personal subscription</pre>
   </div>
 </section>
 
-<section class="p-strip is-deep u-no-padding--top">
+<section class="p-strip u-no-padding--top">
   <hr class="is-fixed-width u-no-margin--bottom">
   <div class="row">
     <div class="col-3">

--- a/templates/pro/tutorial.html
+++ b/templates/pro/tutorial.html
@@ -254,10 +254,10 @@ Choose: [S]ubscribe at ubuntu.com [A]ttach existing token [C]ancel</pre>
     </div>
     <div class="col-9 col-medium-5">
       <h2>Get your free Ubuntu Pro subscription</h2>
-      <ol class="p-list--divided has-bullets">
+      <ol class="p-list--divided">
         <li class="p-list__item">
           <div class="u-max-width p-strip is-shallow u-no-padding--top">
-            <h3 class="p-heading--5 u-sv-1 u-no-margin--bottom">
+            <h3 class="p-heading--5 u-sv-1 u-no-margin--bottom u-no-padding--top">
               Create an Ubuntu One account
             </h3>
             <p>
@@ -272,7 +272,7 @@ Choose: [S]ubscribe at ubuntu.com [A]ttach existing token [C]ancel</pre>
           </div>
         </li>
         <li class="p-list__item">
-          <h3 class="p-heading--5 u-sv-1 u-no-margin--bottom">
+          <h3 class="p-heading--5 u-sv-1 u-no-margin--bottom u-no-padding--top">
             Confirm the email address
           </h3>
           <p>
@@ -313,7 +313,7 @@ Choose: [S]ubscribe at ubuntu.com [A]ttach existing token [C]ancel</pre>
         </li>
         <li class="p-list__item">
           <div class="p-strip is-shallow u-no-padding--top">
-            <h3 class="p-heading--5 u-sv-1 u-no-margin--bottom">
+            <h3 class="p-heading--5 u-sv-1 u-no-margin--bottom u-no-padding--top">
               Retrieve the token:
             </h3>
             <div class="p-strip is-shallow u-no-padding--top">
@@ -345,7 +345,7 @@ Choose: [S]ubscribe at ubuntu.com [A]ttach existing token [C]ancel</pre>
           Ubuntu LTS, and type the following command:</p>
       </div>
       <div class="p-code-snippet">
-        <pre class="p-code-snippet__block--icon"><code>$ sudo pro attach [YOUR_TOKEN]</code></pre>
+        <pre class="p-code-snippet__block--icon"><code>sudo pro attach [YOUR_TOKEN]</code></pre>
       </div>
       <p>
         You should see some of the Ubuntu Pro services automatically enabling, while others will remain disabled until

--- a/templates/security/esm.html
+++ b/templates/security/esm.html
@@ -581,13 +581,12 @@
     </div>
   </section>
 
-  <section class="p-strip is-deep u-no-padding--top">
-    <hr class="is-fixed-width"/>
-    <div class="p-strip is-deep">
+  <hr class="is-fixed-width u-no-margin--bottom"/>
+
+  <section class="p-strip is-deep">
       <div class="u-fixed-width">
         <h2>Secure your Ubuntu estate.<br /><a href="/support/contact-us?product=contextual-footer-landscape" class="js-invoke-modal" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'support contact-us', 'eventLabel' : 'Contact us', 'eventValue' : undefined });">Get in touch to discuss ESM</a></h2>
       </div>
-    </div>
   </section>
 
 


### PR DESCRIPTION
## Done

Couple fixes related to increased deep spacing size coming soon to Vanilla.

- Remove some unnecessary deep strips in couple places

Drive-bys:

- fix numbered list spacing on pro tutorial page
- remove double prompt from CLI example

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
