### PR TITLE
Cache git.launchpad.net requests for ROS ESM package lists

### DIFF
--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -14,6 +14,7 @@ from mistune import Markdown
 from sortedcontainers import SortedDict
 
 # Local
+from webapp.context import api_session
 from webapp.security.api import SecurityAPI
 
 markdown_parser = Markdown(
@@ -487,7 +488,7 @@ def cve(cve_id):
 # This is a temporary fix. To be removed pending redesign
 # Parses given URL to create a list of package names
 def list_package_names(url):
-    source = session.get(url).text
+    source = api_session.get(url).text
     soup = bs.BeautifulSoup(source, "lxml")
     raw_string = soup.code(string=True)[0].split()
     package_list = list(raw_string)


### PR DESCRIPTION
## Done

This avoids flooding the git service with two requests for every CVE page load.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- http://0.0.0.0:8001/security/CVE-2015-9541 still shows an entry for pyside2 in ROS ESM; the first request shows "Caching b/c of expires header. expires in 300 seconds", and subsequent requests show "The response is \"fresh\", returning cached response".

## Issue / Card

Fixes #12784.