### PR TITLE
Modernize Launchpad package URLs

### DIFF
--- a/templates/security/cve/cve.html
+++ b/templates/security/cve/cve.html
@@ -141,7 +141,7 @@
                         {% if package["name"] in kenetic_packages or package["name"] in melodic_packages  %}
                           <a href="/robotics/ros-esm">ROS ESM</a>
                         {% else %}
-                          <a href="https://launchpad.net/distros/ubuntu/+source/{{ package["name"] }}">Launchpad</a>,
+                          <a href="https://launchpad.net/ubuntu/+source/{{ package["name"] }}">Launchpad</a>,
                           <a href="https://packages.ubuntu.com/search?suite=all&section=all&arch=any&searchon=sourcenames&keywords={{ package["name"] }}">Ubuntu</a>,
                           <a href="https://tracker.debian.org/{{ package["name"] }}">Debian</a>
                         {% endif %}


### PR DESCRIPTION
`/distros/ubuntu` has been obsolete since 2006.  Use `/ubuntu` instead.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check any CVE page; the Launchpad links point to `/ubuntu/+source/foo` rather than `/distros/ubuntu/+source/foo`, and still work.