### PR TITLE
Typo: add 20.04 to FIPS kernel Variants

### DIFF
--- a/templates/kernel/variants.html
+++ b/templates/kernel/variants.html
@@ -148,8 +148,8 @@
       <h2 id="additional-kernel-variants">Additional kernel variants</h2>
       <p>In addition to those kernel variants, Canonical offers FIPS certified kernels:</p>
       <ul>
-        <li>FIPS &mdash; Certified GA kernel for Ubuntu 16.04, 18.04, and 20.04</li>
-        <li>FIPS &mdash; compliant GA kernel with critical security and patch updates for Ubuntu 16.04, 18.04, and 20.04</li>
+        <li>FIPS &mdash; Certified GA kernel for Ubuntu 16.04, 18.04 and 20.04</li>
+        <li>FIPS &mdash; compliant GA kernel with critical security and patch updates for Ubuntu 16.04, 18.04 and 20.04</li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
## Done

Fixed typo by adding 20.04 to the list of FIPS kernels

Hope this isn't too small of a change. 

Please let me know if there is something I can do differently or better to contribute more effectively. 
