### PR TITLE
(feat) Data Fabric Docs landing page take 3 

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -103,6 +103,16 @@ env:
       key: api-key
       name: trueability
 
+  - name: CHARMHUB_DISCOURSE_API_KEY
+    secretKeyRef:
+      key: charmhub-api-key
+      name: discourse-api
+
+  - name: CHARMHUB_DISCOURSE_API_USERNAME
+    secretKeyRef:
+      key: charmhub-api-username
+      name: discourse-api
+
 memoryLimit: 512Mi
 
 extraHosts:
@@ -522,6 +532,16 @@ staging:
     - name: CANONICAL_LOGIN_URL
       value: https://login.ubuntu.com/
 
+    - name: CHARMHUB_DISCOURSE_API_KEY
+      secretKeyRef:
+        key: charmhub-api-key
+        name: discourse-api
+
+    - name: CHARMHUB_DISCOURSE_API_USERNAME
+      secretKeyRef:
+        key: charmhub-api-username
+        name: discourse-api
+
   routes:
     - paths: [/blog]
       name: ubuntu-com-blog
@@ -866,3 +886,13 @@ demo:
 
     - name: CANONICAL_LOGIN_URL
       value: https://login.ubuntu.com/
+
+    - name: CHARMHUB_DISCOURSE_API_KEY
+      secretKeyRef:
+        key: charmhub-api-key
+        name: discourse-api
+
+    - name: CHARMHUB_DISCOURSE_API_USERNAME
+      secretKeyRef:
+        key: charmhub-api-username
+        name: discourse-api

--- a/navigation.yaml
+++ b/navigation.yaml
@@ -365,6 +365,8 @@ data:
       path: /data/mongodb
     - title: OpenSearch
       path: /data/opensearch
+    - title: Docs
+      path: /data/docs
 
 download:
   title: Downloads

--- a/templates/data/docs/index.html
+++ b/templates/data/docs/index.html
@@ -1,0 +1,78 @@
+{% extends "data/base_data.html" %}
+
+{% block title %}Canonical Charmed Data Fabric Suite{% endblock %}
+
+{% block meta_description %}Canonical Data Fabric Suite - Documentation Hub. Innovate at scale on any cloud. Advanced open source solutions for data on IaaS and Kubernetes with flexible, enterprise-grade support.{% endblock meta_description %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1zidLwSBOsNPIznRO2DfFGU1N3xxnCBKRmQku-X-fc_U/edit#{% endblock meta_copydoc %}
+
+{% block content %}
+
+<section>
+<div class="p-strip--suru is-dark">
+  <div class="row u-equal-height">
+    <div class="col-7">
+      <h1>
+        Canonical Data Fabric Suite
+      </h1>
+      <h2 class="u-sv3">
+        Documentation Hub
+      </h2>
+      <p>Canonical's Data Fabric Suite has been engineered to deliver a rock solid operational foundation for your critical data infrastructure.</p>
+      <p class="u-sv3">It offers flexible support for your database servers and other data fabric enablers, with up to 10 years of software maintenance and break-fix support on selected releases. The Canonical Data Fabric Suite is a comprehensive offering for reliable data processing at any scale.</p>
+    </div>
+    <div class="col-5 u-vertically-center u-hide--medium u-hide--small u-align--center">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/55eda3ae-Servers+-white.svg",
+        alt="",
+        width="300",
+        height="135",
+        hi_def=True,
+        loading="auto|lazy"
+        ) | safe
+      }}
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-4 u-equal-height">
+      <div class="p-card">
+        <h2 class="p-card__title p-heading--3">Charmed Spark</h2>
+        <p class="p-card__content u-sv3">Access resources for deploying, operating and using Apache Spark<sup>&reg;</sup> on Kubernetes with Charmed Spark.</p>
+	<p class="p-card__content"><a href="/data/docs/spark-k8s" class="p-button--positive">Access docs</a></p>
+      </div>
+    </div>
+    <div class="col-4 u-equal-height">
+      <div class="p-card">
+        <h2 class="p-card__title p-heading--3">Charmed PostgreSQL</h2>
+        <p class="p-card__content u-sv3">Access resources for deploying and operating PostgreSQL on Kubernetes with Charmed PostgreSQL.</p>
+	<p class="p-card__content"><a href="/data/docs/postgresql-k8s" class="p-button--positive">Access docs</a></p>
+      </div>
+    </div>
+    <div class="col-4 u-equal-height">
+      <div class="p-card">
+        <h2 class="p-card__title p-heading--3">Charmed MongoDB</h2>
+        <p class="p-card__content u-sv3">Access resources for deploying and operating the MongoDB database on IaaS using Charmed MongoDB.</p>
+        <p class="p-card__content"><a href="/data/docs/mongodb-vm" class="p-button--positive">Access docs</a></p>
+      </div>
+    </div>
+  </div>
+</div>
+</section>
+
+<section class="p-strip">
+  <div class="row">
+    <div class="col-7">
+      <h2>Enterprise-class Support</h2>
+      <p>Streamline your operations with Canonical. Flexible support options in the data centre and on the cloud.</p>
+      <p><a href="#get-in-touch" class="p-button--positive js-invoke-modal" data-testid="interactive-form-link">Get in touch</a></p>
+    </div>
+  </div>
+</section>
+
+
+{% with first_item="_server_download", second_item="_server_contact_us", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
+
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/data-docs.html" data-form-id="4908" data-lp-id="3828" data-return-url="https://ubuntu.com/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+</div>
+
+{% endblock content %}

--- a/templates/data/docs/mongodb-vm/document.html
+++ b/templates/data/docs/mongodb-vm/document.html
@@ -1,0 +1,10 @@
+{% with
+  document=document,
+  nav_items=nav_items,
+  search_action="/data/docs/mongodb-vm/search",
+  siteSearch="https://ubuntu.com/data/docs/mongodb-vm",
+  placeholder="Search Charmed MongoDB on IaaS docs",
+  navigation=navigation
+%}
+  {% include "templates/docs/shared/_docs.html" %}
+{% endwith %}

--- a/templates/data/docs/mongodb-vm/search-results.html
+++ b/templates/data/docs/mongodb-vm/search-results.html
@@ -6,7 +6,7 @@
     siteSearch="https://ubuntu.com/data/docs/mongodb-vm",
     placeholder="Search Charmed MongoDB on IaaS Docs",
     search_path="/data/docs/mongodb-vm/search",
-    forum_link="https://discourse.charmhub.io/t/charmed-mongodb-docs/7663"
+    forum_link="https://discourse.charmhub.io/c/charm/41"
   %}
     {% include "templates/docs/shared/_search-results.html" %}
 {% endwith %}

--- a/templates/data/docs/mongodb-vm/search-results.html
+++ b/templates/data/docs/mongodb-vm/search-results.html
@@ -1,0 +1,13 @@
+{% with
+    title="Charmed MongoDB on IaaS Docs",
+    query=query,
+    results=results,
+    search_action="/data/docs/mongodb-vm/search",
+    siteSearch="https://ubuntu.com/data/docs/mongodb-vm",
+    placeholder="Search Charmed MongoDB on IaaS Docs",
+    search_path="/data/docs/mongodb-vm/search",
+    forum_link="https://discourse.charmhub.io/t/charmed-mongodb-docs/7663"
+  %}
+    {% include "templates/docs/shared/_search-results.html" %}
+{% endwith %}
+

--- a/templates/data/docs/postgresql-k8s/document.html
+++ b/templates/data/docs/postgresql-k8s/document.html
@@ -1,0 +1,10 @@
+{% with
+  document=document,
+  nav_items=nav_items,
+  search_action="/data/docs/postgresql-k8s/search",
+  siteSearch="https://ubuntu.com/data/docs/postgresql-k8s",
+  placeholder="Search Charmed PostgreSQL on K8s docs",
+  navigation=navigation
+%}
+  {% include "templates/docs/shared/_docs.html" %}
+{% endwith %}

--- a/templates/data/docs/postgresql-k8s/search-results.html
+++ b/templates/data/docs/postgresql-k8s/search-results.html
@@ -2,7 +2,7 @@
     title="Charmed PostgreSQL on K8s Docs",
     query=query,
     results=results,
-    search_action="/data/docs/posgresql-k8s/search",
+    search_action="/data/docs/postgresql-k8s/search",
     siteSearch="https://ubuntu.com/data/docs/postgresql-k8s",
     placeholder="Search Charmed PostgreSQL on K8s Docs",
     search_path="/data/docs/spark/search",

--- a/templates/data/docs/postgresql-k8s/search-results.html
+++ b/templates/data/docs/postgresql-k8s/search-results.html
@@ -1,0 +1,13 @@
+{% with
+    title="Charmed PostgreSQL on K8s Docs",
+    query=query,
+    results=results,
+    search_action="/data/docs/posgresql-k8s/search",
+    siteSearch="https://ubuntu.com/data/docs/postgresql-k8s",
+    placeholder="Search Charmed PostgreSQL on K8s Docs",
+    search_path="/data/docs/spark/search",
+    forum_link="https://discourse.charmhub.io/t/spark-client-snap-documentation/8963"
+  %}
+    {% include "templates/docs/shared/_search-results.html" %}
+{% endwith %}
+

--- a/templates/data/docs/postgresql-k8s/search-results.html
+++ b/templates/data/docs/postgresql-k8s/search-results.html
@@ -6,7 +6,7 @@
     siteSearch="https://ubuntu.com/data/docs/postgresql-k8s",
     placeholder="Search Charmed PostgreSQL on K8s Docs",
     search_path="/data/docs/spark/search",
-    forum_link="https://discourse.charmhub.io/t/spark-client-snap-documentation/8963"
+    forum_link="https://discourse.charmhub.io/c/charm/41"
   %}
     {% include "templates/docs/shared/_search-results.html" %}
 {% endwith %}

--- a/templates/data/docs/spark-k8s/document.html
+++ b/templates/data/docs/spark-k8s/document.html
@@ -1,0 +1,10 @@
+{% with
+  document=document,
+  nav_items=nav_items,
+  search_action="/data/docs/spark-k8s/search",
+  siteSearch="https://ubuntu.com/data/docs/spark-k8s",
+  placeholder="Search Charmed Spark docs",
+  navigation=navigation
+%}
+  {% include "templates/docs/shared/_docs.html" %}
+{% endwith %}

--- a/templates/data/docs/spark-k8s/search-results.html
+++ b/templates/data/docs/spark-k8s/search-results.html
@@ -1,0 +1,13 @@
+{% with
+    title="Charmed Spark on K8s Docs",
+    query=query,
+    results=results,
+    search_action="/data/docs/spark-k8s/search",
+    siteSearch="https://ubuntu.com/data/docs/spark-k8s",
+    placeholder="Search Charmed Spark on K8s Docs",
+    search_path="/data/docs/spark-k8s/search",
+    forum_link="https://discourse.charmhub.io/t/spark-client-snap-documentation/8963"
+  %}
+    {% include "templates/docs/shared/_search-results.html" %}
+{% endwith %}
+

--- a/templates/data/docs/spark-k8s/search-results.html
+++ b/templates/data/docs/spark-k8s/search-results.html
@@ -6,7 +6,7 @@
     siteSearch="https://ubuntu.com/data/docs/spark-k8s",
     placeholder="Search Charmed Spark on K8s Docs",
     search_path="/data/docs/spark-k8s/search",
-    forum_link="https://discourse.charmhub.io/t/spark-client-snap-documentation/8963"
+    forum_link="https://discourse.charmhub.io/c/charm/41"
   %}
     {% include "templates/docs/shared/_search-results.html" %}
 {% endwith %}

--- a/templates/data/kafka/index.html
+++ b/templates/data/kafka/index.html
@@ -11,7 +11,7 @@
 <section class="p-strip--suru-bottomed">
   <div class="row u-vertically-center">
     <div class="col-7">
-      <h1>Canonical Charmed Data Platform</h1>
+      <h1>Canonical Data Fabric Suite</h1>
       <h2>Apache Kafka<sup>&reg;</sup></h2>
       <p>Streamline your Apache Kafka<sup>&reg;</sup> operations with Canonical. 24/7 supported in the data centre and on the cloud.</p>
       <p>
@@ -74,7 +74,7 @@
 <section class="p-strip">
   <div class="row">
     <div class="col-7">
-      <h2>Scale your Apache Kafka<sup>&reg;</sup> deployments today</h2>
+      <h2>Scale Apache Kafka<sup>&reg;</sup> deployments today</h2>
       <p>Canonical offers a compliant, scalable and comprehensive full stack solution for Apache Kafka, including:</p>
       <ul>
         <li>Complete support for upstream Apache Kafka</li>

--- a/templates/data/spark/index.html
+++ b/templates/data/spark/index.html
@@ -55,19 +55,34 @@
   </div>
   <div class="row">
     <div class="col-4">
-      <h2 class="p-heading--4">No friction</h2>
-      <p>Get started fast &mdash; the open source solution is free to use in any environment, in the data centre and in the cloud.</p>
-      <p><a href="https://snapcraft.io/spark-client" class="p-button">Try our Spark solution now</a></p>
+      <p>
+        <div class="col-5 u-vertically-center u-hide--medium u-hide--small u-align--center">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/40d4f11a-servers.svg",
+            alt="",
+            width="218",
+            height="150",
+            hi_def=True,
+            loading="auto|lazy"
+            ) | safe
+          }}
+        </div>
+      </p>
     </div>
     <div class="col-4">
       <h2 class="p-heading--4">Expressway operations</h2>
+      <p>Get started fast &mdash; the open source solution is free to use in any environment, in the data centre and on the cloud.</p>
+      <p><a href="/data/docs/spark-k8s" class="p-button">Learn more</a></p>
+    </div>
+    <!--div class="col-4">
+      <h2 class="p-heading--4">Expressway operations</h2>
       <p>Rapidly deploy your Apache Spark<sup>&reg;</sup> applications with the integrated, full stack solution from Canonical.</p>
       <p><a href="https://juju.is/" class="p-button">Learn more about our solutions</a></p>
-    </div>
+    </div -->
     <div class="col-4">
       <h2 class="p-heading--4">Fully supported</h2>
       <p>24/7 support and professional services are available to ensure your initiatives are always on track.</p>
-      <p><a href="/data/spark#get-in-touch" class="p-button">Contact sales</a></p>
+      <p><a href="/data/spark#get-in-touch" class="p-button">Contact us</a></p>
     </div>
   </div>
 </section>
@@ -100,6 +115,17 @@
 
 <section class="p-strip--light">
   <div class="row">
+    <div class="col-5 u-hide--medium u-hide--small u-align--center u-vertically-center">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/c0bf7b88-opensearch-consulting-services-illustration.svg",
+        alt="",
+        width="350",
+        height="200",
+        hi_def=True,
+        loading="auto|lazy"
+        ) | safe
+      }}
+    </div>
     <div class="col-7">
       <h2>Expert services</h2>
       <p>A production-grade, fully supported Spark environment deployed and operational, no fuss.</p>

--- a/templates/shared/forms/interactive/data-docs.html
+++ b/templates/shared/forms/interactive/data-docs.html
@@ -1,0 +1,106 @@
+<div class="p-modal" id="contact-modal">
+  <div class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
+    <header class="p-modal__header" style="display: block; border-bottom: 0;">
+      <button class="p-modal__close" aria-label="Close active modal" style="margin-left: -1rem">Close</button>
+      <h2 class="p-modal__title u-sv1" id="modal-title">Talk to our solution architects</h2>
+    </header>
+    <div class="js-pagination js-pagination--1">
+      <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form p-form p-form--stacked">
+        <div class="u-sv2">
+          <h3 class="p-heading--5">Tell us more about your use case</h3>
+          <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" aria-label="Anything you'd like to communicate about your needs or interests?" rows="3" placeholder="Anything you'd like to communicate about your needs or interests?"></textarea>
+        </div>
+        <div class="row u-no-padding">
+          <div class="col-6">
+            <h3 class="p-heading--5">How should we get in touch?</h3>
+            <ul class="p-list">
+              <li class="p-list__item">
+                <label for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
+              </li>
+              <li class="p-list__item">
+                <label for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
+              </li>
+              <li class="p-list__item">
+                <label for="company">Company name:</label>
+                <input required id="company" name="company" maxlength="255" type="text">
+              </li>
+              <li class="p-list__item">
+                <label for="title">Job title:</label>
+                <input data-testid="form-jobTitle" required id="title" name="title" maxlength="255" type="text">
+              </li>
+              <li class="p-list__item">
+                <label for="email">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
+              </li>
+              <li class="p-list__item">
+                <label for="phone">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
+              </li>
+              <li class="p-list__item">
+                <label class="p-checkbox">
+                  <input class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
+                  <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
+                </label>
+              </li>
+              <li class="p-list__item">In submitting this form, I confirm that I have read and agree to Canonical's <a href="/legal/terms-and-policies/privacy-policy">Privacy Policy</a>.</li>
+              {# These are honey pot fields to catch bots #}
+              <li class="u-off-screen">
+                <label class="website" for="website">Website:</label>
+                <input name="website" type="text" class="website" autocomplete="off" value="" id="website" tabindex="-1" />
+              </li>
+              <li class="u-off-screen">
+                <label class="name" for="name">Name:</label>
+                <input name="name" type="text" class="name" autocomplete="off" value="" id="name" tabindex="-1" />
+              </li>
+              {# End of honey pots #}
+            </ul>
+            
+            <div class="u-hide">
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Facebook_Click_ID__c" id="Facebook_Click_ID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
+            </div>
+            
+            <div class="pagination">
+              <button type="submit" class="pagination__link--next p-button--positive" aria-label="Submit">Let's discuss</button>
+            </div>
+          </div>
+        </div>
+      </form>
+    </div>
+    
+    <div class="js-pagination js-pagination--2 u-hide">
+      <div class="row u-no-padding">
+        <div class="u-equal-height">
+          <div class="col-7">
+            <h3 class="p-heading--2">Thank you for enquiring about our Data Fabric suite</h3>
+            <p class="p-heading--4">A member of our team will be in touch within one working day.</p>
+          </div>
+          <div class="col-5 u-vertically-center u-hide--medium u-hide--small u-align--center">
+            {{
+              image(
+              url="https://assets.ubuntu.com/v1/cbae9a60-thank_you_orange_cmyk.svg",
+              alt="smile",
+              width="200",
+              height="200",
+              hi_def=True,
+              loading="auto",
+              ) | safe
+            }}
+          </div>
+        </div>
+      </div>
+      <a class="js-close p-button" href="">Close</a>
+    </div>
+  </div>
+</div>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -2,182 +2,152 @@
 A Flask application for ubuntu.com
 """
 
-# Packages
 import os
-import requests
-import talisker.requests
-import flask
-from datetime import datetime
-from webapp.context import schedule_banner
-from canonicalwebteam.flask_base.app import FlaskBase
-from canonicalwebteam.templatefinder import TemplateFinder
 
-from canonicalwebteam.search import build_search_view
-from canonicalwebteam import image_template
-from canonicalwebteam.blog import build_blueprint, BlogViews, BlogAPI
+import requests
+import flask
+import talisker.requests
+from canonicalwebteam.blog import BlogAPI, BlogViews, build_blueprint
 from canonicalwebteam.discourse import (
     DiscourseAPI,
-    Docs,
     DocParser,
+    Docs,
     EngagePages,
-    Tutorials,
     TutorialParser,
+    Tutorials,
 )
+from canonicalwebteam.flask_base.app import FlaskBase
+from canonicalwebteam.search import build_search_view
+from canonicalwebteam.templatefinder import TemplateFinder
 
-# Local
-from webapp.shop.api.ua_contracts.api import (
-    UAContractsAPIError,
-    UAContractsAPIErrorView,
-    UnauthorizedError,
-    UnauthorizedErrorView,
+from webapp.certified.views import (
+    certified_component_details,
+    certified_desktops,
+    certified_devices,
+    certified_hardware_details,
+    certified_home,
+    certified_laptops,
+    certified_model_details,
+    certified_servers,
+    certified_socs,
+    certified_vendors,
+    certified_why,
 )
-from webapp.security.api import SecurityAPIError
-from webapp.context import (
-    current_year,
-    descending_years,
-    format_date,
-    get_json_feed,
-    modify_query,
-    month_name,
-    months_list,
-    get_navigation,
-    releases,
+from webapp.handlers import init_handlers
+from webapp.login import login_handler, logout
+from webapp.security.views import (
+    cve,
+    cve_index,
+    cves_sitemap,
+    notice,
+    notices,
+    notices_feed,
+    notices_sitemap,
+    single_cves_sitemap,
+    single_notices_sitemap,
 )
-
-from webapp.shop.flaskparser import UAContractsValidationError
+from webapp.shop.advantage.views import (
+    accept_renewal,
+    activate_magic_attach,
+    advantage_account_users_view,
+    advantage_shop_view,
+    advantage_thanks_view,
+    advantage_view,
+    blender_shop_view,
+    blender_thanks_view,
+    cancel_advantage_subscriptions,
+    cancel_trial,
+    delete_account_user_role,
+    get_account_offers,
+    get_account_users,
+    get_advantage_offers,
+    get_annotated_subscriptions,
+    get_contract_token,
+    get_renewal,
+    get_user_subscriptions,
+    magic_attach_view,
+    post_account_user_role,
+    post_advantage_purchase,
+    post_advantage_subscriptions,
+    post_auto_renewal_settings,
+    post_offer,
+    pro_page_view,
+    put_account_user_role,
+    put_contract_entitlements,
+)
 from webapp.shop.cred.views import (
     activate_activation_key,
+    cred_assessments,
+    cred_cancel_exam,
+    cred_exam,
+    cred_home,
+    cred_provision,
     cred_redeem_code,
+    cred_schedule,
     cred_self_study,
     cred_shop,
+    cred_sign_up,
     cred_submit_form,
     cred_syllabus_data,
-    cred_sign_up,
-    cred_home,
-    cred_schedule,
     cred_your_exams,
-    cred_cancel_exam,
-    cred_assessments,
-    cred_exam,
-    cred_provision,
     get_activation_keys,
     rotate_activation_key,
 )
-
+from webapp.shop.views import (
+    account_view,
+    checkout,
+    download_invoice,
+    ensure_purchase_account,
+    get_customer_info,
+    get_last_purchase_ids,
+    get_purchase,
+    get_purchase_account_status,
+    get_purchase_v2,
+    get_shop_status_page,
+    invoices_view,
+    maintenance_check,
+    payment_methods_view,
+    post_anonymised_customer_info,
+    post_customer_info,
+    post_payment_methods,
+    post_purchase_calculate,
+    post_retry_purchase,
+    support,
+)
 from webapp.views import (
     BlogCustomGroup,
     BlogCustomTopic,
     BlogRedirects,
     BlogSitemapIndex,
     BlogSitemapPage,
-    build_engage_page,
-    build_tutorials_index,
-    download_server_steps,
-    download_thank_you,
+    account_query,
     appliance_install,
     appliance_portfolio,
+    build_engage_index,
+    build_engage_page,
+    build_tutorials_index,
+    build_tutorials_query,
+    download_server_steps,
+    download_thank_you,
+    engage_thank_you,
+    french_why_openstack,
+    german_why_openstack,
+    get_user_country_by_ip,
+    json_asset_query,
+    marketo_submit,
+    mirrors_query,
+    openstack_engage,
+    openstack_install,
     releasenotes_redirect,
     show_template,
-    build_engage_index,
-    engage_thank_you,
-    unlisted_engage_page,
     sitemap_index,
-    account_query,
-    json_asset_query,
     sixteen_zero_four,
-    openstack_install,
-    marketo_submit,
-    thank_you,
-    mirrors_query,
-    build_tutorials_query,
-    openstack_engage,
-    get_user_country_by_ip,
+    spanish_why_openstack,
     subscription_centre,
+    thank_you,
+    unlisted_engage_page,
 )
 
-from webapp.shop.views import (
-    account_view,
-    get_purchase_account_status,
-    invoices_view,
-    download_invoice,
-    payment_methods_view,
-    post_payment_methods,
-    ensure_purchase_account,
-    get_customer_info,
-    post_customer_info,
-    post_anonymised_customer_info,
-    get_purchase,
-    get_purchase_v2,
-    post_retry_purchase,
-    get_last_purchase_ids,
-    post_purchase_calculate,
-    support,
-    checkout,
-    get_shop_status_page,
-    maintenance_check,
-)
-
-from webapp.shop.advantage.views import (
-    accept_renewal,
-    activate_magic_attach,
-    advantage_view,
-    advantage_account_users_view,
-    advantage_shop_view,
-    advantage_thanks_view,
-    get_renewal,
-    magic_attach_view,
-    post_advantage_subscriptions,
-    post_auto_renewal_settings,
-    cancel_advantage_subscriptions,
-    get_account_offers,
-    get_user_subscriptions,
-    get_annotated_subscriptions,
-    get_contract_token,
-    cancel_trial,
-    get_account_users,
-    delete_account_user_role,
-    post_account_user_role,
-    pro_page_view,
-    put_account_user_role,
-    put_contract_entitlements,
-    blender_thanks_view,
-    blender_shop_view,
-    post_offer,
-    get_advantage_offers,
-    post_advantage_purchase,
-)
-
-from webapp.login import login_handler, logout, user_info, empty_session
-from webapp.security.views import (
-    notice,
-    notices,
-    notices_feed,
-    cve_index,
-    cve,
-    single_notices_sitemap,
-    notices_sitemap,
-    single_cves_sitemap,
-    cves_sitemap,
-)
-
-from webapp.certified.views import (
-    certified_home,
-    certified_model_details,
-    certified_hardware_details,
-    certified_component_details,
-    certified_vendors,
-    certified_desktops,
-    certified_laptops,
-    certified_servers,
-    certified_devices,
-    certified_socs,
-    certified_why,
-)
-
-
-CAPTCHA_TESTING_API_KEY = os.getenv(
-    "CAPTCHA_TESTING_API_KEY", "6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if"
-)
 DISCOURSE_API_KEY = os.getenv("DISCOURSE_API_KEY")
 DISCOURSE_API_USERNAME = os.getenv("DISCOURSE_API_USERNAME")
 
@@ -197,9 +167,7 @@ app = FlaskBase(
 )
 
 sentry = app.extensions["sentry"]
-
 session = talisker.requests.get_session()
-
 charmhub_session = requests.Session()
 talisker.requests.configure(charmhub_session)
 
@@ -211,143 +179,18 @@ discourse_api = DiscourseAPI(
     get_topics_query_id=2,
 )
 
-charmhub_discourse_api = api=DiscourseAPI(
+charmhub_discourse_api = DiscourseAPI(
     base_url="https://discourse.charmhub.io/",
     session=charmhub_session,
+    api_key=CHARMHUB_DISCOURSE_API_KEY,
+    api_username=CHARMHUB_DISCOURSE_API_USERNAME,
     get_topics_query_id=2,
 )
 
 # Web tribe websites custom search ID
 search_engine_id = "adb2397a224a1fe55"
 
-
-# Error pages
-@app.errorhandler(400)
-def bad_request_error(error):
-    return flask.render_template("400.html", message=error.description), 400
-
-
-@app.errorhandler(403)
-def forbidden_error(error):
-    return flask.render_template("403.html", message=error.description), 403
-
-
-@app.errorhandler(410)
-def deleted_error(error):
-    return flask.render_template("410.html", message=error.description), 410
-
-
-@app.errorhandler(429)
-def too_many_requests(error):
-    """
-    Endpoint abuse error
-    """
-    custom_error = f"{error.description}. Please try again tomorrow."
-    return flask.render_template("429.html", message=custom_error), 429
-
-
-@app.errorhandler(SecurityAPIError)
-def security_api_error(error):
-    return (
-        flask.render_template(
-            "security-error-500.html",
-            message=error.response.json().get("message"),
-        ),
-        500,
-    )
-
-
-@app.errorhandler(UAContractsValidationError)
-def ua_contracts_validation_error(error):
-    sentry.captureException(
-        extra={
-            "user_info": user_info(flask.session),
-            "request_url": error.request.url,
-            "request_body": error.request.json,
-            "response_body": error.response.messages,
-        }
-    )
-
-    return flask.jsonify({"errors": error.response.messages}), 422
-
-
-@app.errorhandler(UAContractsAPIError)
-@app.errorhandler(UnauthorizedError)
-def ua_contracts_api_error(error):
-    sentry.captureException(
-        extra={
-            "user_info": user_info(flask.session),
-            "request_url": error.request.url,
-            "request_headers": error.request.headers,
-            "response_headers": error.response.headers,
-            "response_body": error.response.json(),
-        }
-    )
-
-    if error.response.status_code == 401:
-        empty_session(flask.session)
-
-    return (
-        flask.jsonify({"errors": error.response.json()["message"]}),
-        error.response.status_code or 500,
-    )
-
-
-@app.errorhandler(UAContractsAPIErrorView)
-@app.errorhandler(UnauthorizedErrorView)
-def ua_contracts_api_error_view(error):
-    sentry.captureException(
-        extra={
-            "user_info": user_info(flask.session),
-            "request_url": error.request.url,
-            "request_headers": error.request.headers,
-            "response_headers": error.response.headers,
-            "response_body": error.response.json(),
-        }
-    )
-
-    if error.response.status_code == 401:
-        empty_session(flask.session)
-
-        return flask.redirect(flask.request.url)
-
-    return flask.render_template("500.html"), 500
-
-
-# Template context
-@app.context_processor
-def context():
-    return {
-        "current_year": current_year,
-        "descending_years": descending_years,
-        "format_date": format_date,
-        "get_json_feed": get_json_feed,
-        "modify_query": modify_query,
-        "month_name": month_name,
-        "months_list": months_list,
-        "get_navigation": get_navigation,
-        "get_stripe_publishable_key": os.getenv(
-            "STRIPE_PUBLISHABLE_KEY",
-            "pk_live_68aXqowUeX574aGsVck8eiIE",
-        ),
-        "product": flask.request.args.get("product", ""),
-        "request": flask.request,
-        "releases": releases(),
-        "user_info": user_info(flask.session),
-        "utm_campaign": flask.request.args.get("utm_campaign", ""),
-        "utm_content": flask.request.args.get("utm_content", ""),
-        "utm_medium": flask.request.args.get("utm_medium", ""),
-        "utm_source": flask.request.args.get("utm_source", ""),
-        "CAPTCHA_TESTING_API_KEY": CAPTCHA_TESTING_API_KEY,
-        "http_host": flask.request.host,
-        "schedule_banner": schedule_banner,
-    }
-
-
-@app.context_processor
-def utility_processor():
-    return {"image": image_template}
-
+init_handlers(app, sentry)
 
 # Routes
 # ===
@@ -693,7 +536,15 @@ app.add_url_rule(
 # Custom engage page in German
 app.add_url_rule(
     "/engage/de/warum-openstack",
-    view_func=lambda: flask.render_template("engage/de_why-openstack.html"),
+    view_func=german_why_openstack,
+)
+app.add_url_rule(
+    "/engage/fr/pourquoi-openstack",
+    view_func=french_why_openstack,
+)
+app.add_url_rule(
+    "/engage/es/por-que-openstack",
+    view_func=spanish_why_openstack,
 )
 app.add_url_rule(engage_path, view_func=build_engage_index(engage_pages))
 app.add_url_rule(
@@ -794,33 +645,6 @@ template_finder_view._exclude_xframe_options_header = True
 app.add_url_rule("/", view_func=template_finder_view)
 app.add_url_rule("/<path:subpath>", view_func=template_finder_view)
 
-# Server docs
-url_prefix = "/server/docs"
-server_docs = Docs(
-    parser=DocParser(
-        api=discourse_api,
-        index_topic_id=11322,
-        url_prefix=url_prefix,
-    ),
-    document_template="/server/docs/document.html",
-    url_prefix=url_prefix,
-    blueprint_name="server-docs",
-)
-
-# Server docs search
-app.add_url_rule(
-    "/server/docs/search",
-    "server-docs-search",
-    build_search_view(
-        session=session,
-        site="ubuntu.com/server/docs",
-        template_path="/server/docs/search-results.html",
-        search_engine_id=search_engine_id,
-    ),
-)
-
-server_docs.init_app(app)
-
 # Data Platform Spark on K8s docs
 data_spark_k8s_docs = Docs(
     parser=DocParser(
@@ -898,6 +722,33 @@ app.add_url_rule(
 )
 
 data_postgresql_k8s_docs.init_app(app)
+
+# Server docs
+url_prefix = "/server/docs"
+server_docs = Docs(
+    parser=DocParser(
+        api=discourse_api,
+        index_topic_id=11322,
+        url_prefix=url_prefix,
+    ),
+    document_template="/server/docs/document.html",
+    url_prefix=url_prefix,
+    blueprint_name="server-docs",
+)
+
+# Server docs search
+app.add_url_rule(
+    "/server/docs/search",
+    "server-docs-search",
+    build_search_view(
+        session=session,
+        site="ubuntu.com/server/docs",
+        template_path="/server/docs/search-results.html",
+        search_engine_id=search_engine_id,
+    ),
+)
+
+server_docs.init_app(app)
 
 # Community docs
 url_prefix = "/community"
@@ -1242,6 +1093,32 @@ app.add_url_rule(
 
 landscape_docs.init_app(app)
 
+# Robotics docs
+robotics_docs = Docs(
+    parser=DocParser(
+        api=discourse_api,
+        index_topic_id=34683,
+        url_prefix="/robotics/docs",
+    ),
+    document_template="/robotics/docs/document.html",
+    url_prefix="/robotics/docs",
+    blueprint_name="robotics-docs",
+)
+
+# Robotics search
+app.add_url_rule(
+    "/robotics/docs/search",
+    "robotics-docs-search",
+    build_search_view(
+        session=session,
+        site="ubuntu.com/robotics/docs",
+        template_path="/robotics/docs/search-results.html",
+        search_engine_id=search_engine_id,
+    ),
+)
+
+robotics_docs.init_app(app)
+
 app.add_url_rule("/certified", view_func=certified_home)
 app.add_url_rule(
     "/certified/<canonical_id>",
@@ -1296,36 +1173,3 @@ app.add_url_rule(
     view_func=subscription_centre,
     methods=["GET", "POST"],
 )
-
-
-@app.after_request
-def cache_headers(response):
-    """
-    Set cache expiry to 60 seconds for homepage and blog page
-    """
-
-    disable_cache_on = (
-        "/account",
-        "/advantage",
-        "/pro",
-        "/credentials",
-        "/core/build",
-        "/account.json",
-    )
-
-    if flask.request.path.startswith(disable_cache_on):
-        response.cache_control.no_store = True
-
-    return response
-
-
-def date_has_passed(date_str):
-    try:
-        date = datetime.strptime(date_str, "%Y-%m-%d")
-        present = datetime.now()
-        return present > date
-    except ValueError:
-        return False
-
-
-app.add_template_filter(date_has_passed)

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -2,153 +2,187 @@
 A Flask application for ubuntu.com
 """
 
+# Packages
 import os
-
-import flask
+import requests
 import talisker.requests
-from canonicalwebteam.blog import BlogAPI, BlogViews, build_blueprint
-from canonicalwebteam.discourse import (
-    DiscourseAPI,
-    DocParser,
-    Docs,
-    EngagePages,
-    TutorialParser,
-    Tutorials,
-)
+import flask
+from datetime import datetime
+from webapp.context import schedule_banner
 from canonicalwebteam.flask_base.app import FlaskBase
-from canonicalwebteam.search import build_search_view
 from canonicalwebteam.templatefinder import TemplateFinder
 
-from webapp.certified.views import (
-    certified_component_details,
-    certified_desktops,
-    certified_devices,
-    certified_hardware_details,
-    certified_home,
-    certified_laptops,
-    certified_model_details,
-    certified_servers,
-    certified_socs,
-    certified_vendors,
-    certified_why,
+from canonicalwebteam.search import build_search_view
+from canonicalwebteam import image_template
+from canonicalwebteam.blog import build_blueprint, BlogViews, BlogAPI
+from canonicalwebteam.discourse import (
+    DiscourseAPI,
+    Docs,
+    DocParser,
+    EngagePages,
+    Tutorials,
+    TutorialParser,
 )
-from webapp.handlers import init_handlers
-from webapp.login import login_handler, logout
-from webapp.security.views import (
-    cve,
-    cve_index,
-    cves_sitemap,
-    notice,
-    notices,
-    notices_feed,
-    notices_sitemap,
-    single_cves_sitemap,
-    single_notices_sitemap,
+
+# Local
+from webapp.shop.api.ua_contracts.api import (
+    UAContractsAPIError,
+    UAContractsAPIErrorView,
+    UnauthorizedError,
+    UnauthorizedErrorView,
 )
-from webapp.shop.advantage.views import (
-    accept_renewal,
-    activate_magic_attach,
-    advantage_account_users_view,
-    advantage_shop_view,
-    advantage_thanks_view,
-    advantage_view,
-    blender_shop_view,
-    blender_thanks_view,
-    cancel_advantage_subscriptions,
-    cancel_trial,
-    delete_account_user_role,
-    get_account_offers,
-    get_account_users,
-    get_advantage_offers,
-    get_annotated_subscriptions,
-    get_contract_token,
-    get_renewal,
-    get_user_subscriptions,
-    magic_attach_view,
-    post_account_user_role,
-    post_advantage_purchase,
-    post_advantage_subscriptions,
-    post_auto_renewal_settings,
-    post_offer,
-    pro_page_view,
-    put_account_user_role,
-    put_contract_entitlements,
+from webapp.security.api import SecurityAPIError
+from webapp.context import (
+    current_year,
+    descending_years,
+    format_date,
+    get_json_feed,
+    modify_query,
+    month_name,
+    months_list,
+    get_navigation,
+    releases,
 )
+
+from webapp.shop.flaskparser import UAContractsValidationError
 from webapp.shop.cred.views import (
     activate_activation_key,
-    cred_assessments,
-    cred_cancel_exam,
-    cred_exam,
-    cred_home,
-    cred_provision,
     cred_redeem_code,
-    cred_schedule,
     cred_self_study,
     cred_shop,
-    cred_sign_up,
     cred_submit_form,
     cred_syllabus_data,
+    cred_sign_up,
+    cred_home,
+    cred_schedule,
     cred_your_exams,
+    cred_cancel_exam,
+    cred_assessments,
+    cred_exam,
+    cred_provision,
     get_activation_keys,
     rotate_activation_key,
 )
-from webapp.shop.views import (
-    account_view,
-    checkout,
-    download_invoice,
-    ensure_purchase_account,
-    get_customer_info,
-    get_last_purchase_ids,
-    get_purchase,
-    get_purchase_account_status,
-    get_purchase_v2,
-    get_shop_status_page,
-    invoices_view,
-    maintenance_check,
-    payment_methods_view,
-    post_anonymised_customer_info,
-    post_customer_info,
-    post_payment_methods,
-    post_purchase_calculate,
-    post_retry_purchase,
-    support,
-)
+
 from webapp.views import (
     BlogCustomGroup,
     BlogCustomTopic,
     BlogRedirects,
     BlogSitemapIndex,
     BlogSitemapPage,
-    account_query,
-    appliance_install,
-    appliance_portfolio,
-    build_engage_index,
     build_engage_page,
     build_tutorials_index,
-    build_tutorials_query,
     download_server_steps,
     download_thank_you,
-    engage_thank_you,
-    french_why_openstack,
-    german_why_openstack,
-    get_user_country_by_ip,
-    json_asset_query,
-    marketo_submit,
-    mirrors_query,
-    openstack_engage,
-    openstack_install,
+    appliance_install,
+    appliance_portfolio,
     releasenotes_redirect,
     show_template,
-    sitemap_index,
-    sixteen_zero_four,
-    spanish_why_openstack,
-    subscription_centre,
-    thank_you,
+    build_engage_index,
+    engage_thank_you,
     unlisted_engage_page,
+    sitemap_index,
+    account_query,
+    json_asset_query,
+    sixteen_zero_four,
+    openstack_install,
+    marketo_submit,
+    thank_you,
+    mirrors_query,
+    build_tutorials_query,
+    openstack_engage,
+    get_user_country_by_ip,
+    subscription_centre,
 )
 
+from webapp.shop.views import (
+    account_view,
+    get_purchase_account_status,
+    invoices_view,
+    download_invoice,
+    payment_methods_view,
+    post_payment_methods,
+    ensure_purchase_account,
+    get_customer_info,
+    post_customer_info,
+    post_anonymised_customer_info,
+    get_purchase,
+    get_purchase_v2,
+    post_retry_purchase,
+    get_last_purchase_ids,
+    post_purchase_calculate,
+    support,
+    checkout,
+    get_shop_status_page,
+    maintenance_check,
+)
+
+from webapp.shop.advantage.views import (
+    accept_renewal,
+    activate_magic_attach,
+    advantage_view,
+    advantage_account_users_view,
+    advantage_shop_view,
+    advantage_thanks_view,
+    get_renewal,
+    magic_attach_view,
+    post_advantage_subscriptions,
+    post_auto_renewal_settings,
+    cancel_advantage_subscriptions,
+    get_account_offers,
+    get_user_subscriptions,
+    get_annotated_subscriptions,
+    get_contract_token,
+    cancel_trial,
+    get_account_users,
+    delete_account_user_role,
+    post_account_user_role,
+    pro_page_view,
+    put_account_user_role,
+    put_contract_entitlements,
+    blender_thanks_view,
+    blender_shop_view,
+    post_offer,
+    get_advantage_offers,
+    post_advantage_purchase,
+)
+
+from webapp.login import login_handler, logout, user_info, empty_session
+from webapp.security.views import (
+    notice,
+    notices,
+    notices_feed,
+    cve_index,
+    cve,
+    single_notices_sitemap,
+    notices_sitemap,
+    single_cves_sitemap,
+    cves_sitemap,
+)
+
+from webapp.certified.views import (
+    certified_home,
+    certified_model_details,
+    certified_hardware_details,
+    certified_component_details,
+    certified_vendors,
+    certified_desktops,
+    certified_laptops,
+    certified_servers,
+    certified_devices,
+    certified_socs,
+    certified_why,
+)
+
+
+CAPTCHA_TESTING_API_KEY = os.getenv(
+    "CAPTCHA_TESTING_API_KEY", "6LfYBloUAAAAAINm0KzbEv6TP0boLsTEzpdrB8if"
+)
 DISCOURSE_API_KEY = os.getenv("DISCOURSE_API_KEY")
 DISCOURSE_API_USERNAME = os.getenv("DISCOURSE_API_USERNAME")
+
+CHARMHUB_DISCOURSE_API_KEY = os.getenv("CHARMHUB_DISCOURSE_API_KEY")
+CHARMHUB_DISCOURSE_API_USERNAME = os.getenv("CHARMHUB_DISCOURSE_API_USERNAME")
 
 # Set up application
 # ===
@@ -163,7 +197,12 @@ app = FlaskBase(
 )
 
 sentry = app.extensions["sentry"]
+
 session = talisker.requests.get_session()
+
+charmhub_session = requests.Session()
+talisker.requests.configure(charmhub_session)
+
 discourse_api = DiscourseAPI(
     base_url="https://discourse.ubuntu.com/",
     session=session,
@@ -172,10 +211,143 @@ discourse_api = DiscourseAPI(
     get_topics_query_id=2,
 )
 
+charmhub_discourse_api = api=DiscourseAPI(
+    base_url="https://discourse.charmhub.io/",
+    session=charmhub_session,
+    get_topics_query_id=2,
+)
+
 # Web tribe websites custom search ID
 search_engine_id = "adb2397a224a1fe55"
 
-init_handlers(app, sentry)
+
+# Error pages
+@app.errorhandler(400)
+def bad_request_error(error):
+    return flask.render_template("400.html", message=error.description), 400
+
+
+@app.errorhandler(403)
+def forbidden_error(error):
+    return flask.render_template("403.html", message=error.description), 403
+
+
+@app.errorhandler(410)
+def deleted_error(error):
+    return flask.render_template("410.html", message=error.description), 410
+
+
+@app.errorhandler(429)
+def too_many_requests(error):
+    """
+    Endpoint abuse error
+    """
+    custom_error = f"{error.description}. Please try again tomorrow."
+    return flask.render_template("429.html", message=custom_error), 429
+
+
+@app.errorhandler(SecurityAPIError)
+def security_api_error(error):
+    return (
+        flask.render_template(
+            "security-error-500.html",
+            message=error.response.json().get("message"),
+        ),
+        500,
+    )
+
+
+@app.errorhandler(UAContractsValidationError)
+def ua_contracts_validation_error(error):
+    sentry.captureException(
+        extra={
+            "user_info": user_info(flask.session),
+            "request_url": error.request.url,
+            "request_body": error.request.json,
+            "response_body": error.response.messages,
+        }
+    )
+
+    return flask.jsonify({"errors": error.response.messages}), 422
+
+
+@app.errorhandler(UAContractsAPIError)
+@app.errorhandler(UnauthorizedError)
+def ua_contracts_api_error(error):
+    sentry.captureException(
+        extra={
+            "user_info": user_info(flask.session),
+            "request_url": error.request.url,
+            "request_headers": error.request.headers,
+            "response_headers": error.response.headers,
+            "response_body": error.response.json(),
+        }
+    )
+
+    if error.response.status_code == 401:
+        empty_session(flask.session)
+
+    return (
+        flask.jsonify({"errors": error.response.json()["message"]}),
+        error.response.status_code or 500,
+    )
+
+
+@app.errorhandler(UAContractsAPIErrorView)
+@app.errorhandler(UnauthorizedErrorView)
+def ua_contracts_api_error_view(error):
+    sentry.captureException(
+        extra={
+            "user_info": user_info(flask.session),
+            "request_url": error.request.url,
+            "request_headers": error.request.headers,
+            "response_headers": error.response.headers,
+            "response_body": error.response.json(),
+        }
+    )
+
+    if error.response.status_code == 401:
+        empty_session(flask.session)
+
+        return flask.redirect(flask.request.url)
+
+    return flask.render_template("500.html"), 500
+
+
+# Template context
+@app.context_processor
+def context():
+    return {
+        "current_year": current_year,
+        "descending_years": descending_years,
+        "format_date": format_date,
+        "get_json_feed": get_json_feed,
+        "modify_query": modify_query,
+        "month_name": month_name,
+        "months_list": months_list,
+        "get_navigation": get_navigation,
+        "get_stripe_publishable_key": os.getenv(
+            "STRIPE_PUBLISHABLE_KEY",
+            "pk_live_68aXqowUeX574aGsVck8eiIE",
+        ),
+        "product": flask.request.args.get("product", ""),
+        "request": flask.request,
+        "releases": releases(),
+        "user_info": user_info(flask.session),
+        "utm_campaign": flask.request.args.get("utm_campaign", ""),
+        "utm_content": flask.request.args.get("utm_content", ""),
+        "utm_medium": flask.request.args.get("utm_medium", ""),
+        "utm_source": flask.request.args.get("utm_source", ""),
+        "CAPTCHA_TESTING_API_KEY": CAPTCHA_TESTING_API_KEY,
+        "http_host": flask.request.host,
+        "schedule_banner": schedule_banner,
+    }
+
+
+@app.context_processor
+def utility_processor():
+    return {"image": image_template}
+
 
 # Routes
 # ===
@@ -521,15 +693,7 @@ app.add_url_rule(
 # Custom engage page in German
 app.add_url_rule(
     "/engage/de/warum-openstack",
-    view_func=german_why_openstack,
-)
-app.add_url_rule(
-    "/engage/fr/pourquoi-openstack",
-    view_func=french_why_openstack,
-)
-app.add_url_rule(
-    "/engage/es/por-que-openstack",
-    view_func=spanish_why_openstack,
+    view_func=lambda: flask.render_template("engage/de_why-openstack.html"),
 )
 app.add_url_rule(engage_path, view_func=build_engage_index(engage_pages))
 app.add_url_rule(
@@ -656,6 +820,84 @@ app.add_url_rule(
 )
 
 server_docs.init_app(app)
+
+# Data Platform Spark on K8s docs
+data_spark_k8s_docs = Docs(
+    parser=DocParser(
+        api=charmhub_discourse_api,
+        index_topic_id=8963,
+        url_prefix="/data/docs/spark-k8s",
+    ),
+    document_template="/data/docs/spark-k8s/document.html",
+    url_prefix="/data/docs/spark-k8s",
+    blueprint_name="data-docs-spark-k8s",
+)
+
+# Data Platform Spark on K8s docs search
+app.add_url_rule(
+    "/data/docs/spark-k8s/search",
+    "data-docs-spark-k8s-search",
+    build_search_view(
+        session=session,
+        site="ubuntu.com/data/docs/spark-k8s",
+        template_path="/data/docs/spark-k8s/search-results.html",
+        search_engine_id=search_engine_id,
+    ),
+)
+
+data_spark_k8s_docs.init_app(app)
+
+# Data Platform MongoDB on IaaS docs
+data_mongodb_vm_docs = Docs(
+    parser=DocParser(
+        api=charmhub_discourse_api,
+        index_topic_id=7663,
+        url_prefix="/data/docs/mongodb-vm",
+    ),
+    document_template="/data/docs/mongodb-vm/document.html",
+    url_prefix="/data/docs/mongodb-vm",
+    blueprint_name="data-docs-mongodb-vm",
+)
+
+# Data Platform MongoDB on IaaS docs search
+app.add_url_rule(
+    "/data/docs/mongodb-vm/search",
+    "data-docs-mongodb-vm-search",
+    build_search_view(
+        session=session,
+        site="ubuntu.com/data/docs/mongodb-vm",
+        template_path="/data/docs/mongodb-vm/search-results.html",
+        search_engine_id=search_engine_id,
+    ),
+)
+
+data_mongodb_vm_docs.init_app(app)
+
+# Data Platform PosgreSQL on K8s docs
+data_postgresql_k8s_docs = Docs(
+    parser=DocParser(
+        api=charmhub_discourse_api,
+        index_topic_id=9307,
+        url_prefix="/data/docs/postgresql-k8s",
+    ),
+    document_template="/data/docs/postgresql-k8s/document.html",
+    url_prefix="/data/docs/postgresql-k8s",
+    blueprint_name="data-docs-postgresql-k8s",
+)
+
+# Data Platform PostgreSQL on K8s docs search
+app.add_url_rule(
+    "/data/docs/postgresql-k8s/search",
+    "data-docs-postgresql-k8s-search",
+    build_search_view(
+        session=session,
+        site="ubuntu.com/data/docs/postgresql-k8s",
+        template_path="/data/docs/postgresql-k8s/search-results.html",
+        search_engine_id=search_engine_id,
+    ),
+)
+
+data_postgresql_k8s_docs.init_app(app)
 
 # Community docs
 url_prefix = "/community"
@@ -1000,32 +1242,6 @@ app.add_url_rule(
 
 landscape_docs.init_app(app)
 
-# Robotics docs
-robotics_docs = Docs(
-    parser=DocParser(
-        api=discourse_api,
-        index_topic_id=34683,
-        url_prefix="/robotics/docs",
-    ),
-    document_template="/robotics/docs/document.html",
-    url_prefix="/robotics/docs",
-    blueprint_name="robotics-docs",
-)
-
-# Robotics search
-app.add_url_rule(
-    "/robotics/docs/search",
-    "robotics-docs-search",
-    build_search_view(
-        session=session,
-        site="ubuntu.com/robotics/docs",
-        template_path="/robotics/docs/search-results.html",
-        search_engine_id=search_engine_id,
-    ),
-)
-
-robotics_docs.init_app(app)
-
 app.add_url_rule("/certified", view_func=certified_home)
 app.add_url_rule(
     "/certified/<canonical_id>",
@@ -1080,3 +1296,36 @@ app.add_url_rule(
     view_func=subscription_centre,
     methods=["GET", "POST"],
 )
+
+
+@app.after_request
+def cache_headers(response):
+    """
+    Set cache expiry to 60 seconds for homepage and blog page
+    """
+
+    disable_cache_on = (
+        "/account",
+        "/advantage",
+        "/pro",
+        "/credentials",
+        "/core/build",
+        "/account.json",
+    )
+
+    if flask.request.path.startswith(disable_cache_on):
+        response.cache_control.no_store = True
+
+    return response
+
+
+def date_has_passed(date_str):
+    try:
+        date = datetime.strptime(date_str, "%Y-%m-%d")
+        present = datetime.now()
+        return present > date
+    except ValueError:
+        return False
+
+
+app.add_template_filter(date_has_passed)


### PR DESCRIPTION
## Done

- Add initial /data/docs landing page
- Add integration with charmhub discourse for charmed spark, mongodb and postgres documentation
- (driveby) fix Spark page layout
- Fix branding on Kafka page to align with /data/docs and current Data Fabric branding