### PR TITLE
Add plausible on the checkout page 

### DIFF
--- a/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
@@ -11,6 +11,7 @@ import useCustomerInfo from "../../hooks/useCustomerInfo";
 import useFinishPurchase from "../../hooks/useFinishPurchase";
 import usePollPurchaseStatus from "../../hooks/usePollPurchaseStatus";
 import { Action, FormValues, Product } from "../../utils/types";
+import { currencyFormatter } from "advantage/react/utils";
 
 type Props = {
   setError: React.Dispatch<React.SetStateAction<React.ReactNode>>;
@@ -78,6 +79,18 @@ const BuyButton = ({ setError, quantity, product, action }: Props) => {
     if (!(Object.keys(errors).length === 0)) {
       return;
     }
+
+    window.plausible("pro-purchase", {
+      props: {
+        country: values.country,
+        product: product?.name,
+        quantity: quantity,
+        total: currencyFormatter.format(product?.price?.value / 100),
+        VAT: values.VATNumber,
+        "buying-for": values.buyingFor,
+        action: buyAction,
+      },
+    });
 
     // empty the product selector state persisted in the local storage
     // after the user chooses to make a purchase

--- a/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
@@ -80,19 +80,6 @@ const BuyButton = ({ setError, quantity, product, action }: Props) => {
       return;
     }
 
-    window.plausible("pro-purchase", {
-      props: {
-        country: values.country,
-        product: product?.name,
-        quantity: quantity,
-        total:
-          values.totalPrice &&
-          currencyFormatter.format(values?.totalPrice / 100),
-        "buying-for": values.buyingFor,
-        action: buyAction,
-      },
-    });
-
     // empty the product selector state persisted in the local storage
     // after the user chooses to make a purchase
     // to prevent page refreshes from causing accidental double purchasing
@@ -115,6 +102,19 @@ const BuyButton = ({ setError, quantity, product, action }: Props) => {
             setPendingPurchaseID(purchaseId);
             window.currentPaymentId = purchaseId;
           }
+
+          window.plausible("pro-purchase", {
+            props: {
+              country: values.country,
+              product: product?.name,
+              quantity: quantity,
+              total:
+                values.totalPrice &&
+                currencyFormatter.format(values?.totalPrice / 100),
+              "buying-for": values.buyingFor,
+              action: buyAction,
+            },
+          });
         },
         onError: (error) => {
           setIsLoading(false);

--- a/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
@@ -10,10 +10,8 @@ import { getErrorMessage } from "advantage/error-handler";
 import useCustomerInfo from "../../hooks/useCustomerInfo";
 import useFinishPurchase from "../../hooks/useFinishPurchase";
 import usePollPurchaseStatus from "../../hooks/usePollPurchaseStatus";
-import { Action, FormValues, Product, TaxInfo } from "../../utils/types";
+import { Action, FormValues, Product } from "../../utils/types";
 import { currencyFormatter } from "advantage/react/utils";
-import usePreview from "../../hooks/usePreview";
-import useCalculate from "../../hooks/useCalculate";
 
 type Props = {
   setError: React.Dispatch<React.SetStateAction<React.ReactNode>>;
@@ -37,25 +35,6 @@ const BuyButton = ({ setError, quantity, product, action }: Props) => {
   const useFinishPurchaseMutation = useFinishPurchase();
   const buyAction = values.FreeTrial === "useFreeTrial" ? "trial" : action;
   const queryClient = useQueryClient();
-  const { data: calculate } = useCalculate({
-    quantity: quantity,
-    marketplace: product.marketplace,
-    productListingId: product.longId,
-    country: values.country,
-    VATNumber: values.VATNumber,
-    isTaxSaved: values.isTaxSaved,
-  });
-
-  const { data: preview } = usePreview({
-    quantity,
-    product,
-    action,
-  });
-  const priceData: TaxInfo | undefined = preview || calculate;
-  const discount =
-    (product?.price?.value * ((product?.price?.discount ?? 0) / 100)) / 100;
-  const total = (priceData?.total ?? 0) / 100;
-  const defaultTotal = (product?.price?.value * quantity) / 100 - discount;
 
   const sessionData = {
     gclid: getSessionData("gclid"),
@@ -106,9 +85,9 @@ const BuyButton = ({ setError, quantity, product, action }: Props) => {
         country: values.country,
         product: product?.name,
         quantity: quantity,
-        total: priceData
-          ? currencyFormatter.format(total)
-          : currencyFormatter.format(defaultTotal),
+        total:
+          values.totalPrice &&
+          currencyFormatter.format(values?.totalPrice / 100),
         "buying-for": values.buyingFor,
         action: buyAction,
       },

--- a/static/js/src/advantage/subscribe/checkout/hooks/useCalculate.tsx
+++ b/static/js/src/advantage/subscribe/checkout/hooks/useCalculate.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from "react-query";
 import { UserSubscriptionMarketplace } from "advantage/api/enum";
-import { TaxInfo } from "../utils/types";
+import { FormValues, TaxInfo } from "../utils/types";
+import { useFormikContext } from "formik";
 
 type useCalculateProps = {
   marketplace: UserSubscriptionMarketplace;
@@ -19,6 +20,7 @@ const useCalculate = ({
   VATNumber,
   isTaxSaved,
 }: useCalculateProps) => {
+  const { setFieldValue } = useFormikContext<FormValues>();
   const { isLoading, isError, isSuccess, data, error, isFetching } = useQuery(
     ["calculate"],
     async () => {
@@ -52,7 +54,7 @@ const useCalculate = ({
       }
 
       const data: TaxInfo = res;
-
+      setFieldValue("totalPrice", data.total);
       return data;
     },
     {

--- a/static/js/src/advantage/subscribe/checkout/hooks/usePreview.tsx
+++ b/static/js/src/advantage/subscribe/checkout/hooks/usePreview.tsx
@@ -1,6 +1,13 @@
 import { useQuery } from "react-query";
-import { Action, PaymentPayload, Product, TaxInfo } from "../utils/types";
+import {
+  Action,
+  FormValues,
+  PaymentPayload,
+  Product,
+  TaxInfo,
+} from "../utils/types";
 import useCustomerInfo from "./useCustomerInfo";
+import { useFormikContext } from "formik";
 
 type Props = {
   quantity: number;
@@ -10,7 +17,7 @@ type Props = {
 
 const usePreview = ({ quantity, product, action }: Props) => {
   const { isError: isUserInfoError } = useCustomerInfo();
-
+  const { setFieldValue } = useFormikContext<FormValues>();
   const { isLoading, isError, isSuccess, data, error, isFetching } = useQuery(
     ["preview", product],
     async () => {
@@ -70,6 +77,7 @@ const usePreview = ({ quantity, product, action }: Props) => {
         end_of_cycle: res.end_of_cycle,
       };
 
+      setFieldValue("totalPrice", data.total);
       return data;
     },
     {

--- a/static/js/src/advantage/subscribe/checkout/utils/helpers.ts
+++ b/static/js/src/advantage/subscribe/checkout/utils/helpers.ts
@@ -32,6 +32,7 @@ export function getInitialFormValues(
     isTaxSaved: !!userInfo?.customerInfo?.address?.country,
     isCardValid: !!userInfo?.customerInfo?.defaultPaymentMethod,
     isInfoSaved: !!userInfo?.customerInfo?.defaultPaymentMethod,
+    totalPrice: undefined,
   };
 }
 

--- a/static/js/src/advantage/subscribe/checkout/utils/types.ts
+++ b/static/js/src/advantage/subscribe/checkout/utils/types.ts
@@ -52,6 +52,7 @@ export interface FormValues {
   isTaxSaved: boolean;
   isCardValid: boolean;
   isInfoSaved: boolean;
+  totalPrice: undefined | number;
 }
 
 export type marketplace = "canonical-ua" | "canonical-cube" | "blender";

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -15,7 +15,7 @@
   <script src="{{ versioned_static('js/dist/main.js') }}" defer></script>
   <script src="{{ versioned_static('js/src/infer-preferred-language.js')}}"></script>
 
-  <script defer data-domain="ubuntu.com" data-include="/pro, /pro/dashboard, /pro/subscribe" src="https://plausible.io/js/script.exclusions.js"></script>
+  <script defer data-domain="ubuntu.com" data-include="/pro, /pro/dashboard, /pro/subscribe, /account/checkout" src="https://plausible.io/js/script.exclusions.js"></script>
   <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
 
   <link rel="stylesheet" type="text/css" media="screen" href="{{ versioned_static('css/styles.css') }}">


### PR DESCRIPTION
## Done

- Add plausible on the checkout page

## QA

- Go to the /account/checkout page, fill in all fields properly and click buy button. 
- Go to https://plausible.io/ubuntu.com
- Check country, product, quantity,   total, buying-for, action are tracked properly under purchase prop on the plausible dashboard

## Issue / Card

Fixes #https://warthogs.atlassian.net/jira/software/c/projects/WD/boards/801?modal=detail&selectedIssue=WD-3393
