### PR TITLE
[page refresh] /download/risc-v

### DIFF
--- a/static/sass/_pattern_tabs.scss
+++ b/static/sass/_pattern_tabs.scss
@@ -54,6 +54,17 @@
         @include vf-highlight-bar($color-brand, left);
       }
     }
+
+    &.is-risc-v {
+      margin-left: 0;
+      padding-left: 0;
+
+      .p-tabs__item {
+        &[aria-selected="true"] {
+          @include vf-highlight-bar($color-dark, left);
+        }
+      }
+    }
   }
 
   // Override the highlighted tab colour for pages that need to use the brand

--- a/templates/download/risc-v/index.html
+++ b/templates/download/risc-v/index.html
@@ -8,23 +8,25 @@
 
 {% block content %}
 
-<section class="p-strip">
-  <div class="row u-equal-height">
-    <div class="col-3 col-medium-6">
-      {{
-        image (
-        url="https://assets.ubuntu.com/v1/4d5b8d51-riscv-color.svg",
-        alt="",
-        width="300",
-        height="48",
-        hi_def=True,
-        loading="auto",
-        attrs={"style": "padding-top: 1rem"},
-        ) | safe
-      }}
+<section class="p-strip is-deep">
+  <div class="row">
+    <div class="col-3 col-medium-2">
+      <div class="p-strip is-shallow u-no-padding--top">
+        {{
+          image (
+          url="https://assets.ubuntu.com/v1/4d5b8d51-riscv-color.svg",
+          alt="",
+          width="200",
+          height="32",
+          hi_def=True,
+          loading="auto",
+          attrs={"style": "padding-top: 1rem"},
+          ) | safe
+        }}
+      </div>
   </div>
-  <div class="col-9 col-meidum-6">
-    <h1><strong>Download Ubuntu for RISC-V Platforms</strong></h1>
+  <div class="col-9 col-medium-4">
+    <h1 class="p-heading--2"><strong>Download Ubuntu for RISC-V Platforms</strong></h1>
     <p>Run Ubuntu with your favourite RISC-V boards. Pick the OS image to match your hardware, flash it onto SD/microSD card, load it onto your board and away you go.</p>
     <p>All images are 64-bit developer preview builds of Ubuntu Server.</p>
     <p>
@@ -34,11 +36,11 @@
   </div>
 </section>
 
-<section class="p-strip is-shallow">
-  <hr class="is-fixed-width">
+<section class="p-strip is-deep u-no-padding--top">
+  <hr class="is-fixed-width u-no-margin--bottom">
   <div class="row">
-    <div class="col-3 col-medium-6">
-      <h2 class="p-text--small-caps u-sv2">Choose a board</h2>
+    <div class="col-3 col-medium-2">
+      <div class="p-strip is-shallow u-no-padding--top"><h2 class="p-text--small-caps">Choose a board</h2></div>
       <ul class="js-tabbed-content p-tabs--vertical is-risc-v u-hide--small u-hide--medium" role="tablist" aria-label="Robotics features">
         <li><button class="p-tabs__item" id="quemu-sifive-image" role="tab" aria-selected="true" tab-index="-1" aria-controls="quemu-sifive-image-tab">SiFive Unmatched</button></li>
         <li><button class="p-tabs__item" id="starfive-visionfive-board" role="tab" aria-selected="false" aria-controls="starfive-visionfive-board-tab">StarFive VisionFive</button></li>
@@ -48,7 +50,7 @@
         <li><button class="p-tabs__item" id="qemu" role="tab" aria-selected="false" aria-controls="qemu-tab">QEMU emulator</button></li>
       </ul>
     </div>
-    <div class="col-9 col-medium-6">
+    <div class="col-9 col-medium-4">
       {% include "download/risc-v/tab-1.html" %}
       {% include "download/risc-v/tab-2.html" %}
       {% include "download/risc-v/tab-3.html" %}

--- a/templates/download/risc-v/index.html
+++ b/templates/download/risc-v/index.html
@@ -41,7 +41,7 @@
   <div class="row">
     <div class="col-3 col-medium-2">
       <div class="p-strip is-shallow u-no-padding--top"><h2 class="p-text--small-caps">Choose a board</h2></div>
-      <ul class="js-tabbed-content p-tabs--vertical is-risc-v u-hide--small" role="tablist" aria-label="Robotics features">
+      <ul class="js-tabbed-content p-tabs--vertical is-risc-v" role="tablist" aria-label="Robotics features">
         <li><button class="p-tabs__item" id="quemu-sifive-image" role="tab" aria-selected="true" tab-index="-1" aria-controls="quemu-sifive-image-tab">SiFive Unmatched</button></li>
         <li><button class="p-tabs__item" id="starfive-visionfive-board" role="tab" aria-selected="false" aria-controls="starfive-visionfive-board-tab">StarFive VisionFive</button></li>
         <li><button class="p-tabs__item" id="allwinner-nezha" role="tab" aria-selected="false" aria-controls="allwinner-nezha-tab">AllWinner Nezha</button></li>

--- a/templates/download/risc-v/index.html
+++ b/templates/download/risc-v/index.html
@@ -8,55 +8,47 @@
 
 {% block content %}
 
-<section class="p-strip--suru-topped">
-  <div class="row u-vertically-center">
-    <div class="col-6">
-      <h1>Download Ubuntu for RISC-V Platforms</h1>
-      <h2 class="p-heading--3">Ubuntu &mdash; now available for multiple RISC-V platforms</h2>
-      <p>Run Ubuntu with your favourite RISC-V boards. Ubuntu recently enabled SiFive Unmatched, StarFive VisionFive, Allwinner Nezha, Sipeed LicheeRV and Microchip Polarfire SoC FPGA Icicle Kit. Download the images for those boards below.</p>
-      <p>Pick the OS image to match your hardware, flash it onto SD/microSD card, load it onto your board and away you go.</p>
-      <p>
-        <a href="/download/contact-us" class="js-invoke-modal p-button">Get in touch</a>
-      </p>
-    </div>
-    <div class="col-6 u-hide--medium u-hide--small u-align--center">
-        {{
-            image (
-            url="https://assets.ubuntu.com/v1/4d5b8d51-riscv-color.svg",
-            alt="",
-            width="300",
-            height="48",
-            hi_def=True,
-            loading="auto"
-            ) | safe
-          }}
-    </div>
+<section class="p-strip">
+  <div class="row u-equal-height">
+    <div class="col-3 col-medium-6">
+      {{
+        image (
+        url="https://assets.ubuntu.com/v1/4d5b8d51-riscv-color.svg",
+        alt="",
+        width="300",
+        height="48",
+        hi_def=True,
+        loading="auto",
+        attrs={"style": "padding-top: 1rem"},
+        ) | safe
+      }}
+  </div>
+  <div class="col-9 col-meidum-6">
+    <h1><strong>Download Ubuntu for RISC-V Platforms</strong></h1>
+    <p>Run Ubuntu with your favourite RISC-V boards. Pick the OS image to match your hardware, flash it onto SD/microSD card, load it onto your board and away you go.</p>
+    <p>All images are 64-bit developer preview builds of Ubuntu Server.</p>
+    <p>
+      <a href="/download/contact-us" class="js-invoke-modal p-button">Get in touch</a>
+    </p>
+  </div>
   </div>
 </section>
 
 <section class="p-strip is-shallow">
-  <div class="u-fixed-width">
-    <div class="p-tabs">
-      <div class="p-tabs__list js-tabbed-content" role="tablist" aria-label="Install RISC-V">
-        <div class="p-tabs__item">
-          <button class="p-tabs__link" role="tab" aria-selected="true" aria-controls="quemu-sifive-image-tab" id="quemu-sifive-image" tabindex="-1">SiFive Unmatched, QEMU</button>
-        </div>
-        <div class="p-tabs__item">
-          <button class="p-tabs__link" role="tab" aria-selected="false" aria-controls="starfive-visionfive-board-tab" id="starfive-visionfive-board">StarFive VisionFive</button>
-        </div>
-        <div class="p-tabs__item">
-            <button class="p-tabs__link" role="tab" aria-selected="false" aria-controls="allwinner-nezha-tab" id="allwinner-nezha">AllWinner Nezha</button>
-        </div>
-        <div class="p-tabs__item">
-            <button class="p-tabs__link" role="tab" aria-selected="false" aria-controls="sipeed-licheerv-dock-tab" id="sipeed-licheerv-dock">Sipeed LicheeRV Dock</button>
-        </div>
-        <div class="p-tabs__item">
-          <button class="p-tabs__link" role="tab" aria-selected="false" aria-controls="microchip-polarfire-soc-fpga-icicle-kit-tab" id="microchip-polarfire-soc-fpga-icicle-kit">Polarfire SoC FPGA Icicle</button>
-        </div>
-        <div class="p-tabs__item">
-            <button class="p-tabs__link" role="tab" aria-selected="false" aria-controls="qemu-tab" id="qemu">QEMU</button>
-        </div>
-      </div>
+  <hr class="is-fixed-width">
+  <div class="row">
+    <div class="col-3 col-medium-6">
+      <h2 class="p-text--small-caps u-sv2">Choose a board</h2>
+      <ul class="js-tabbed-content p-tabs--vertical is-risc-v u-hide--small u-hide--medium" role="tablist" aria-label="Robotics features">
+        <li><button class="p-tabs__item" id="quemu-sifive-image" role="tab" aria-selected="true" tab-index="-1" aria-controls="quemu-sifive-image-tab">SiFive Unmatched</button></li>
+        <li><button class="p-tabs__item" id="starfive-visionfive-board" role="tab" aria-selected="false" aria-controls="starfive-visionfive-board-tab">StarFive VisionFive</button></li>
+        <li><button class="p-tabs__item" id="allwinner-nezha" role="tab" aria-selected="false" aria-controls="allwinner-nezha-tab">AllWinner Nezha</button></li>
+        <li><button class="p-tabs__item" id="sipeed-licheerv-dock" role="tab" aria-selected="false" aria-controls="sipeed-licheerv-dock-tab">Sipeed LicheeRV Dock</button></li>
+        <li><button class="p-tabs__item" id="microchip-polarfire-soc-fpga-icicle-kit" role="tab" aria-selected="false" aria-controls="microchip-polarfire-soc-fpga-icicle-kit-tab">Polarfire SoC FPGA Icicle</button></li>
+        <li><button class="p-tabs__item" id="qemu" role="tab" aria-selected="false" aria-controls="qemu-tab">QEMU emulator</button></li>
+      </ul>
+    </div>
+    <div class="col-9 col-medium-6">
       {% include "download/risc-v/tab-1.html" %}
       {% include "download/risc-v/tab-2.html" %}
       {% include "download/risc-v/tab-3.html" %}

--- a/templates/download/risc-v/index.html
+++ b/templates/download/risc-v/index.html
@@ -41,7 +41,7 @@
   <div class="row">
     <div class="col-3 col-medium-2">
       <div class="p-strip is-shallow u-no-padding--top"><h2 class="p-text--small-caps">Choose a board</h2></div>
-      <ul class="js-tabbed-content p-tabs--vertical is-risc-v u-hide--small u-hide--medium" role="tablist" aria-label="Robotics features">
+      <ul class="js-tabbed-content p-tabs--vertical is-risc-v u-hide--small" role="tablist" aria-label="Robotics features">
         <li><button class="p-tabs__item" id="quemu-sifive-image" role="tab" aria-selected="true" tab-index="-1" aria-controls="quemu-sifive-image-tab">SiFive Unmatched</button></li>
         <li><button class="p-tabs__item" id="starfive-visionfive-board" role="tab" aria-selected="false" aria-controls="starfive-visionfive-board-tab">StarFive VisionFive</button></li>
         <li><button class="p-tabs__item" id="allwinner-nezha" role="tab" aria-selected="false" aria-controls="allwinner-nezha-tab">AllWinner Nezha</button></li>

--- a/templates/download/risc-v/tab-1.html
+++ b/templates/download/risc-v/tab-1.html
@@ -1,46 +1,40 @@
 <div tabindex="0" role="tabpanel" id="quemu-sifive-image-tab" aria-labelledby="quemu-sifive-image">
-	<div class="row u-vertically-center u-no-padding">
-		<div class="col-6">
-			<h2>SiFive Unmatched</h2>
-			<h3 class="p-heading--4">Ubuntu Server preinstalled image</h3>
-			<div class="p-notification--information is-inline">
-				<div class="p-notification__content">
-					<h4 class="p-notification__title">Note:</h4>
-					<p class="p-notification__message">If you have an NVMe drive, we advise you to use the Ubuntu Server live installer.</p>
-				</div>
-			</div>
-			<p>
-				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+unmatched.img.xz">Download 23.04</a>
-				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+unmatched.img.xz">Download 22.04.2</a>
-			</p>
-			<h3 class="p-heading--4">Ubuntu Server live installer</h3>
+  <div class="row">
+    <div class="col-6">
+      <h2>Ubuntu Server <br class="u-hide--small">preinstalled image</h2>
+      <div class="p-notification--information is-inline">
+        <div class="p-notification__content">
+          <h4 class="p-notification__title">Note:</h4>
+          <p class="p-notification__message">If you have an NVMe drive, we advise you to use the Ubuntu Server live installer.</p>
+        </div>
+      </div>
+      <p class="u-sv3">
+        <a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+unmatched.img.xz">Download 23.04</a>
+        <a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+unmatched.img.xz">Download 22.04.2</a>
+      </p>
+    </div>
+    <div class="col-3 u-hide--medium u-hide--small">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/37c094a9-SiFive+Unmatched+Board.jpg",
+        alt="",
+        width="720",
+        height="480",
+        hi_def=True,
+        loading="auto"
+        ) | safe
+        }}
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <hr class="u-no-margin--bottom">
+      <h3 class="p-heading--2 u-sv3">Ubuntu Server live installer</h3>
 			<p>
 				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+unmatched.img.xz">Download 23.04 live installer</a>
 				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+unmatched.img.xz">Download 22.04.2 live installer</a>
 			</p>
-			<p>Works on:</p>
-			<ul class="p-list">
-				<li class="p-list__item is-ticked">The Unmatched board</li>
-				<li class="p-list__item is-ticked">QEMU</li>
-			</ul>
-		</div>
-		<div class="col-2 u-hide--medium u-hide--small">&nbsp;</div>
-		<div class="col-4 u-hide--medium u-hide--small u-align--center u-vertically-center">
-			{{ image (
-				url="https://assets.ubuntu.com/v1/37c094a9-SiFive+Unmatched+Board.jpg",
-				alt="",
-				width="720",
-				height="480",
-				hi_def=True,
-				loading="auto"
-				) | safe
-			  }}
-		</div>
-	</div>
-	<div class="row">
-		<div class="col-6 u-vertically-center u-no-padding">
 			<h4>First time installing Ubuntu on QEMU/Unmatched?</h4>
-			<p>Please see <a href="https://wiki.ubuntu.com/RISC-V/SiFive%20HiFive%20Unmatched">How to install Ubuntu on SiFive HiFive Unmatched</a> for more information.</p>
+			<p><a href="https://wiki.ubuntu.com/RISC-V/SiFive%20HiFive%20Unmatched">How to install Ubuntu on SiFive HiFive Unmatched</a></p>
 		</div>
 	</div>
 </div>

--- a/templates/download/risc-v/tab-1.html
+++ b/templates/download/risc-v/tab-1.html
@@ -1,7 +1,9 @@
 <div tabindex="0" role="tabpanel" id="quemu-sifive-image-tab" aria-labelledby="quemu-sifive-image">
   <div class="row">
     <div class="col-6">
-      <h2>Ubuntu Server <br class="u-hide--small">preinstalled image</h2>
+      <div class="p-strip is-shallow u-no-padding--top">
+        <h2>Ubuntu Server <br class="u-hide--small">preinstalled image</h2>
+      </div>
       <div class="p-notification--information is-inline">
         <div class="p-notification__content">
           <h4 class="p-notification__title">Note:</h4>
@@ -13,7 +15,7 @@
         <a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+unmatched.img.xz">Download 22.04.2</a>
       </p>
     </div>
-    <div class="col-3 u-hide--medium u-hide--small">
+    <div class="col-3 u-hide--medium u-hide--small p-strip is-shallow u-no-padding--bottom">
       {{ image (
         url="https://assets.ubuntu.com/v1/37c094a9-SiFive+Unmatched+Board.jpg",
         alt="",

--- a/templates/download/risc-v/tab-1.html
+++ b/templates/download/risc-v/tab-1.html
@@ -32,8 +32,8 @@
       <hr class="u-no-margin--bottom">
       <h3 class="p-heading--2 u-sv3">Ubuntu Server live installer</h3>
 			<p>
-				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+unmatched.img.xz">Download 23.04 live installer</a>
-				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+unmatched.img.xz">Download 22.04.2 live installer</a>
+				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-live-server-riscv64.img.gz">Download 23.04 live installer</a>
+				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-live-server-riscv64.img.gz">Download 22.04.2 live installer</a>
 			</p>
 			<h4>First time installing Ubuntu on QEMU/Unmatched?</h4>
 			<p><a href="https://wiki.ubuntu.com/RISC-V/SiFive%20HiFive%20Unmatched">How to install Ubuntu on SiFive HiFive Unmatched</a></p>

--- a/templates/download/risc-v/tab-2.html
+++ b/templates/download/risc-v/tab-2.html
@@ -1,19 +1,14 @@
 <div tabindex="0" role="tabpanel" id="starfive-visionfive-board-tab" aria-labelledby="starfive-visionfive-board" hidden="true">
-	<div class="row u-vertically-center u-no-padding">
+	<div class="row">
 		<div class="col-6">
-			<h2>StarFive VisionFive</h2>
-			<h3 class="p-heading--4">Ubuntu Server preinstalled image</h3>
+			<h3 class="p-heading--2 u-sv3">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
 			<p>
 				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+visionfive.img.xz">Download 23.04</a>
 				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+visionfive.img.xz">Download 22.04.2</a>
 			</p>
-			<p>Works on:</p>
-			<ul class="p-list">
-				<li class="p-list__item is-ticked">The VisionFive board</li>
-			</ul>
+      <p><a href="https://wiki.ubuntu.com/RISC-V/StarFive%20VisionFive">How to install Ubuntu on the VisionFive</a></p>
 		</div>
-		<div class="col-2 u-hide--medium u-hide--small">&nbsp;</div>
-		<div class="col-4 u-hide--medium u-hide--small u-align--center">
+		<div class="col-3 u-hide--medium u-hide--small">
 			{{ image (
 				url="https://assets.ubuntu.com/v1/470a2398-StarFive+VisionFive+Board-NoBg.png",
 				alt="",
@@ -23,12 +18,6 @@
 				loading="auto"
 				) | safe
 			  }}
-		</div>
-	</div>
-	<div class="row">
-		<div class="col-6 u-vertically-center u-no-padding">
-			<h4>First time installing Ubuntu on the VisionFive?</h4>
-			<p>Please see the <a href="https://wiki.ubuntu.com/RISC-V/StarFive%20VisionFive">How to install Ubuntu on the VisionFive</a> for more information.</p>
 		</div>
 	</div>
 </div>

--- a/templates/download/risc-v/tab-2.html
+++ b/templates/download/risc-v/tab-2.html
@@ -1,14 +1,16 @@
 <div tabindex="0" role="tabpanel" id="starfive-visionfive-board-tab" aria-labelledby="starfive-visionfive-board" hidden="true">
 	<div class="row">
 		<div class="col-6">
-			<h3 class="p-heading--2 u-sv3">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
+			<div class="p-strip is-shallow u-no-padding--top">
+				<h3 class="p-heading--2">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
+			</div>
 			<p>
 				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+visionfive.img.xz">Download 23.04</a>
 				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+visionfive.img.xz">Download 22.04.2</a>
 			</p>
       <p><a href="https://wiki.ubuntu.com/RISC-V/StarFive%20VisionFive">How to install Ubuntu on the VisionFive</a></p>
 		</div>
-		<div class="col-3 u-hide--medium u-hide--small">
+		<div class="col-3 u-hide--medium u-hide--small p-strip is-shallow u-no-padding--bottom">
 			{{ image (
 				url="https://assets.ubuntu.com/v1/470a2398-StarFive+VisionFive+Board-NoBg.png",
 				alt="",

--- a/templates/download/risc-v/tab-3.html
+++ b/templates/download/risc-v/tab-3.html
@@ -7,7 +7,6 @@
 				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+nezha.img.xz">Download 22.04.2</a>
 			</p>
       <p><a href="https://wiki.ubuntu.com/RISC-V/Nezha%20D1">How to install Ubuntu on the Nezha Guide</a></p>
-
 		</div>
 		<div class="col-3 u-hide--medium u-hide--small p-strip is-shallow u-no-padding--bottom">
 			{{ image (

--- a/templates/download/risc-v/tab-3.html
+++ b/templates/download/risc-v/tab-3.html
@@ -1,19 +1,15 @@
 <div tabindex="0" role="tabpanel" id="allwinner-nezha-tab" aria-labelledby="allwinner-nezha" aria-hidden="true">
-	<div class="row u-vertically-center u-no-padding">
+	<div class="row">
 		<div class="col-6">
-			<h2>AllWinner Nezha</h2>
-			<h3 class="p-heading--4">Ubuntu Server preinstalled image</h3>
+			<h3 class="p-heading--2 u-sv3">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
 			<p>
 				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+nezha.img.xz">Download 23.04</a>
 				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+nezha.img.xz">Download 22.04.2</a>
 			</p>
-			<p>Works on:</p>
-			<ul class="p-list">
-				<li class="p-list__item is-ticked">The Nezha board</li>
-			</ul>
+      <p><a href="https://wiki.ubuntu.com/RISC-V/Nezha%20D1">How to install Ubuntu on the Nezha Guide</a></p>
+
 		</div>
-		<div class="col-2 u-hide--medium u-hide--small">&nbsp;</div>
-		<div class="col-4 u-hide--medium u-hide--small u-align--center">
+		<div class="col-3 u-hide--medium u-hide--small">
 			{{ image (
 				url="https://assets.ubuntu.com/v1/0cc9bac3-Allwinner+Nezha+Board.png",
 				alt="",
@@ -23,12 +19,6 @@
 				loading="auto"
 				) | safe
 			  }}
-		</div>
-	</div>
-	<div class="row u-vertically-center u-no-padding">
-		<div class="col-6">
-			<h4>First time installing Ubuntu on the Nezha?</h4>
-			<p>Please see <a href="https://wiki.ubuntu.com/RISC-V/Nezha%20D1">How to install Ubuntu on the Nezha Guide</a> for more information.</p>
 		</div>
 	</div>
 </div>

--- a/templates/download/risc-v/tab-3.html
+++ b/templates/download/risc-v/tab-3.html
@@ -9,7 +9,7 @@
       <p><a href="https://wiki.ubuntu.com/RISC-V/Nezha%20D1">How to install Ubuntu on the Nezha Guide</a></p>
 
 		</div>
-		<div class="col-3 u-hide--medium u-hide--small">
+		<div class="col-3 u-hide--medium u-hide--small p-strip is-shallow u-no-padding--bottom">
 			{{ image (
 				url="https://assets.ubuntu.com/v1/0cc9bac3-Allwinner+Nezha+Board.png",
 				alt="",

--- a/templates/download/risc-v/tab-4.html
+++ b/templates/download/risc-v/tab-4.html
@@ -9,7 +9,7 @@
       <p><a href="https://wiki.ubuntu.com/RISC-V/LicheeRV">How to install Ubuntu on the LicheeRV Dock guide</a></p>
 
 		</div>
-		<div class="col-3 u-hide--medium u-hide--small">
+		<div class="col-3 u-hide--medium u-hide--small p-strip is-shallow u-no-padding--bottom">
 			{{ image (
 				url="https://assets.ubuntu.com/v1/b151abd7-Sipeed+LicheeRV+-+Edited-2.png",
 				alt="",

--- a/templates/download/risc-v/tab-4.html
+++ b/templates/download/risc-v/tab-4.html
@@ -1,18 +1,15 @@
 <div tabindex="0" role="tabpanel" id="sipeed-licheerv-dock-tab" aria-labelledby="allwinner-nezha" aria-hidden="true">
-	<div class="row u-vertically-center u-no-padding">
+	<div class="row">
 		<div class="col-6">
-			<h2>Sipeed LicheeRV Dock</h2>
+			<h3 class="p-heading--2 u-sv3">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
 			<p>
 				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+licheerv.img.xz">Download 23.04</a>
 				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+licheerv.img.xz">Download 22.04.2</a>
 			</p>
-			<p>Works on:</p>
-			<ul class="p-list">
-				<li class="p-list__item is-ticked">The LicheeRV Dock board</li>
-			</ul>
+      <p><a href="https://wiki.ubuntu.com/RISC-V/LicheeRV">How to install Ubuntu on the LicheeRV Dock guide</a></p>
+
 		</div>
-		<div class="col-2 u-hide--medium u-hide--small">&nbsp;</div>
-		<div class="col-4 u-hide--medium u-hide--small u-align--center">
+		<div class="col-3 u-hide--medium u-hide--small">
 			{{ image (
 				url="https://assets.ubuntu.com/v1/b151abd7-Sipeed+LicheeRV+-+Edited-2.png",
 				alt="",
@@ -22,12 +19,6 @@
 				loading="auto"
 				) | safe
 			}}
-		</div>
-	</div>
-	<div class="row u-vertically-center u-no-padding">
-		<div class="col-6">
-			<h4>First time installing Ubuntu on the LicheeRV Dock?</h4>
-			<p>Please see the <a href="https://wiki.ubuntu.com/RISC-V/LicheeRV">How to install Ubuntu on the LicheeRV Dock guide</a> for more information.</p>
 		</div>
 	</div>
 </div>

--- a/templates/download/risc-v/tab-4.html
+++ b/templates/download/risc-v/tab-4.html
@@ -7,7 +7,6 @@
 				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+licheerv.img.xz">Download 22.04.2</a>
 			</p>
       <p><a href="https://wiki.ubuntu.com/RISC-V/LicheeRV">How to install Ubuntu on the LicheeRV Dock guide</a></p>
-
 		</div>
 		<div class="col-3 u-hide--medium u-hide--small p-strip is-shallow u-no-padding--bottom">
 			{{ image (

--- a/templates/download/risc-v/tab-5.html
+++ b/templates/download/risc-v/tab-5.html
@@ -12,7 +12,7 @@
 			</ul>
       <p><a href="https://wiki.ubuntu.com/RISC-V/PolarFire%20SoC%20FPGA%20Icicle%20Kit">How to install Ubuntu on the Microchip Polarfire SoC FPGA Icicle Kit</a></p>
 		</div>
-		<div class="col-3 u-hide--medium u-hide--small">
+		<div class="col-3 u-hide--medium u-hide--small p-strip is-shallow u-no-padding--bottom">
 			{{
 				image (
 				url="https://assets.ubuntu.com/v1/40eacb41-Microchip+PolarFire.png",

--- a/templates/download/risc-v/tab-5.html
+++ b/templates/download/risc-v/tab-5.html
@@ -1,8 +1,7 @@
 <div tabindex="0" role="tabpanel" id="microchip-polarfire-soc-fpga-icicle-kit-tab" aria-labelledby="live-installer" aria-hidden="true">
-	<div class="row u-vertically-center u-no-padding">
+	<div class="row">
 		<div class="col-6">
-			<h2>Microchip Polarfire SoC FPGA Icicle Kit</h2>
-			<h3 class="p-heading--4">Ubuntu Server preinstalled image</h3>
+			<h3 class="p-heading--2 u-sv3">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
 			<p>
 				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+icicle.img.xz">Download 23.04</a>
 				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+icicle.img.xz">Download 22.04.2</a>
@@ -11,9 +10,9 @@
 			<ul class="p-list">
 				<li class="p-list__item is-ticked">The Microchip Polarfire SoC FPGA Icicle Kit with <a href="https://github.com/polarfire-soc/hart-software-services/releases/tag/v2022.10">HSS v2022.10</a></li>
 			</ul>
+      <p><a href="https://wiki.ubuntu.com/RISC-V/PolarFire%20SoC%20FPGA%20Icicle%20Kit">How to install Ubuntu on the Microchip Polarfire SoC FPGA Icicle Kit</a></p>
 		</div>
-		<div class="col-2 u-hide--medium u-hide--small">&nbsp;</div>
-		<div class="col-4 u-hide--medium u-hide--small u-align--center">
+		<div class="col-3 u-hide--medium u-hide--small">
 			{{
 				image (
 				url="https://assets.ubuntu.com/v1/40eacb41-Microchip+PolarFire.png",
@@ -24,12 +23,6 @@
 				loading="lazy"
 				) | safe
 			  }}
-		</div>
-	</div>
-	<div class="row u-vertically-center u-no-padding">
-		<div class="col-6">
-			<h4>First time installing Ubuntu on the Microchip Polarfire SoC FPGA Icicle Kit?</h4>
-			<p>Please see <a href="https://wiki.ubuntu.com/RISC-V/PolarFire%20SoC%20FPGA%20Icicle%20Kit">How to install Ubuntu on the Microchip Polarfire SoC FPGA Icicle Kit</a> for more information.</p>
 		</div>
 	</div>
 </div>

--- a/templates/download/risc-v/tab-6.html
+++ b/templates/download/risc-v/tab-6.html
@@ -1,25 +1,13 @@
 <div tabindex="0" role="tabpanel" id="qemu-tab" aria-labelledby="qemu" aria-hidden="true">
-	<div class="row u-vertically-center u-no-padding">
+	<div class="row">
 		<div class="col-6">
-			<h2>QEMU emulator</h2>
-			<h3 class="p-heading--4">Ubuntu Server preinstalled image</h3>
-			<p>
+			<h3 class="p-heading--2 u-sv3">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
+			<p class="u-sv3">
 				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-live-server-riscv64.img.gz">Download 23.04</a>
 				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-live-server-riscv64.img.gz">Download 22.04.2</a>
 			</p>
-			<h3 class="p-heading--4">Ubuntu Server live installer</h3>
-			<p>
-				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-live-server-riscv64.img.gz">Download 23.04 live installer</a>
-				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-live-server-riscv64.img.gz">Download 22.04.2 live installer</a>
-			</p>
-			<p>Works on:</p>
-			<ul class="p-list">
-				<li class="p-list__item is-ticked">The Unmatched board</li>
-				<li class="p-list__item is-ticked">QEMU</li>
-			</ul>
-		</div>
-		<div class="col-2 u-hide--medium u-hide--small">&nbsp;</div>
-		<div class="col-4 u-hide--medium u-hide--small u-align--center">
+    </div>
+		<div class="col-3 u-hide--medium u-hide--small">
 			{{
 				image (
 				url="https://assets.ubuntu.com/v1/308d48cd-Qemu-logo.png",
@@ -32,10 +20,15 @@
 			  }}
 		</div>
 	</div>
-	<div class="row u-vertically-center u-no-padding">
+	<div class="row">
 		<div class="col-6">
-			<h4>First time installing Ubuntu on QEMU/Unmatched?</h4>
-			<p>Please see the <a href="https://wiki.ubuntu.com/RISC-V/QEMU">How to install Ubuntu on QEMU RISC-V</a> for more information.</p>
+      <hr class="u-no-margin--bottom">
+      <h3 class="p-heading--2 u-sv3">Ubuntu Server live installer</h3>
+			<p>
+				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-live-server-riscv64.img.gz">Download 23.04 live installer</a>
+				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-live-server-riscv64.img.gz">Download 22.04.2 live installer</a>
+			</p>
+			<p><a href="https://wiki.ubuntu.com/RISC-V/QEMU">How to install Ubuntu on QEMU RISC-V</a></p>
 		</div>
 	</div>
 </div>

--- a/templates/download/risc-v/tab-6.html
+++ b/templates/download/risc-v/tab-6.html
@@ -3,8 +3,8 @@
 		<div class="col-6">
 			<h3 class="p-heading--2 u-sv3">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
 			<p class="u-sv3">
-				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-live-server-riscv64.img.gz">Download 23.04</a>
-				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-live-server-riscv64.img.gz">Download 22.04.2</a>
+				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+unmatched.img.xz">Download 23.04</a>
+				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+unmatched.img.xz">Download 22.04.2</a>
 			</p>
     </div>
 		<div class="col-3 u-hide--medium u-hide--small p-strip is-shallow u-no-padding--bottom">

--- a/templates/download/risc-v/tab-6.html
+++ b/templates/download/risc-v/tab-6.html
@@ -7,7 +7,7 @@
 				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-live-server-riscv64.img.gz">Download 22.04.2</a>
 			</p>
     </div>
-		<div class="col-3 u-hide--medium u-hide--small">
+		<div class="col-3 u-hide--medium u-hide--small p-strip is-shallow u-no-padding--bottom">
 			{{
 				image (
 				url="https://assets.ubuntu.com/v1/308d48cd-Qemu-logo.png",


### PR DESCRIPTION
## Done

- Applied redesign as per [mock-up](https://www.figma.com/file/WsMLgH1TXcU1mZ7YjqZRDY/u.com%2Fdownload%2Frisc-v?node-id=1-479&t=FINyqxY91oUUwEOf-0)
- Updated copy as per [doc](https://docs.google.com/document/d/1kkJeq9HdH3iWV35HwihcJd3CxZw9Jy21W66lJl8VbWs/edit#)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: https://ubuntu-com-12821.demos.haus/download/risc-v
    - Be sure to test on mobile, tablet and desktop screen sizes
- See that the requested copy changes were made and that the page matches the design

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-3078