### PR TITLE
Fix missing commas HPC page

### DIFF
--- a/templates/hpc/index.html
+++ b/templates/hpc/index.html
@@ -387,7 +387,7 @@
                 width="171",
                 height="150",
                 hi_def=True,
-                loading="lazy"
+                loading="lazy",
                 attrs={"class": "p-heading-icon__img"}
                 ) | safe
               }}
@@ -410,7 +410,7 @@
                 width="171",
                 height="150",
                 hi_def=True,
-                loading="lazy"
+                loading="lazy",
                 attrs={"class": "p-heading-icon__img"}
                 ) | safe
               }}


### PR DESCRIPTION
## Done

Due to missing commas, /hpc page is failing

## QA

- Check https://ubuntu-com-12824.demos.haus/hpc works now
- Or checkout this PR and pull the code. Go to http://localhost:8001/hpc

## Issue

Fixes https://github.com/canonical/ubuntu.com/issues/12822

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
