### PR TITLE
Cred: Add more materials for Linux resources

### DIFF
--- a/templates/credentials/self-study.html
+++ b/templates/credentials/self-study.html
@@ -118,6 +118,18 @@
         <li>
           <a href="https://help.ubuntu.com/community/InputDevices">Input devices</a>
         </li>
+        <li>
+          <a href="/server/docs/security-users">User Management</a>
+        </li>
+        <li>
+          <a href="https://help.ubuntu.com/community/FilePermissions">Understanding and Using File Permissions</a>
+        </li>
+        <li>
+          <a href="https://help.ubuntu.com/stable/ubuntu-help/nautilus-file-properties-permissions">Set file permissions</a>
+        </li>
+        <li>
+          <a href="https://help.ubuntu.com/community/SSH/OpenSSH/Keys">SSH Key Pairs</a>
+        </li>
       </ul>
 
       <h2>CUE.02: Desktop resources</h2>
@@ -132,9 +144,6 @@
         </li>
         <li>
           <a href="https://ubuntu.com/tutorials/upgrading-ubuntu-desktop">Upgrade Ubuntu desktop</a>
-        </li>
-        <li>
-          <a href="https://ubuntu.com/tutorials/use-the-concept-of-domains-roles-users-and-groups-to-manage-identities">Use the concept of domains, roles, users and groups to manage identities</a>
         </li>
         <li>
           <a href="https://ubuntu.com/tutorials/create-a-usb-stick-on-ubuntu">Create a bootable USB stick on Ubuntu</a>


### PR DESCRIPTION
## Done
Cred: Add more materials for Linux resources

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/credentials/self-study
- Make sure the links specified on the ticket were added.

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/CRED-385
