### PR TITLE
WD-3147 - Add real-time kernel product card

### DIFF
--- a/templates/blog/product-cards.html
+++ b/templates/blog/product-cards.html
@@ -1,6 +1,10 @@
 <div id="product-card">
+    {# Real-time Linux tag cards #}
+  {% if article.tags and 4296 in article.tags %}
+    {% include "blog/product-cards/_real-time_linux.html" %}
+
     {# Multi-cloud tag cards #}
-  {% if article.tags and 2976 in article.tags %}
+  {% elif article.tags and 2976 in article.tags %}
     {% include "blog/product-cards/_multi_cloud.html" %}
 
     {# Hybrid-cloud tag cards #}

--- a/templates/blog/product-cards/_real-time_linux.html
+++ b/templates/blog/product-cards/_real-time_linux.html
@@ -1,0 +1,10 @@
+<div class="p-card js-product-card u-hide">
+  <h3>
+    <a href="/kernel/real-time/contact-us">
+      Talk to us about real-time Ubuntu
+    </a>
+  </h3>
+  <p>
+    Interested in running real-time Ubuntu in production? Tell us more about your needs
+  </p>
+</div>


### PR DESCRIPTION
## Done

- Specify the product card for blog posts with the "real-time Linux" tag.

## QA

- Check out any of these blog posts in the demo:
  - [Real-time Ubuntu is now generally available | Ubuntu](https://ubuntu-com-12829.demos.haus/blog/real-time-ubuntu-is-now-generally-available)
  - [Real-time Ubuntu 22.04 LTS Beta – Now Available | Ubuntu](https://ubuntu-com-12829.demos.haus/blog/real-time-ubuntu-released)
  - [An intro to real-time Linux with Ubuntu | Ubuntu](https://ubuntu-com-12829.demos.haus/blog/real-time-linux-qa)
  - [What is real-time Linux? Part I | Ubuntu](https://ubuntu-com-12829.demos.haus/blog/what-is-real-time-linux-i)
  - [What is real-time Linux? Part II | Ubuntu](https://ubuntu-com-12829.demos.haus/what-is-real-time-linux-ii)
  - [What is real-time Linux? Part III | Ubuntu](https://ubuntu-com-12829.demos.haus/blog/what-is-real-time-linux-part-iii) - this doesn't have the appropriate tag so it will not show here. I will reach to PDM to add it.

- Verify that the product card (first card on the right) looks like the screenshot below and that it corresponds with the details presented in the task: [WD-3147](https://warthogs.atlassian.net/browse/WD-3147)

## Issue / Card

- [WD-3147](https://warthogs.atlassian.net/browse/WD-3147)

## Screenshots

![image](https://user-images.githubusercontent.com/48949356/234801809-21144a49-e992-4612-927c-8061d3574f8a.png)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-3147]: https://warthogs.atlassian.net/browse/WD-3147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WD-3147]: https://warthogs.atlassian.net/browse/WD-3147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ