### PR TITLE
Increase rate limit to 2000 per day

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -410,6 +410,7 @@ app.add_url_rule(
         session=session,
         template_path="search.html",
         search_engine_id=search_engine_id,
+        request_limit="2000/day",
     ),
 )
 
@@ -652,6 +653,7 @@ app.add_url_rule(
         site="ubuntu.com/server/docs",
         template_path="/server/docs/search-results.html",
         search_engine_id=search_engine_id,
+        request_limit="2000/day",
     ),
 )
 
@@ -679,6 +681,7 @@ app.add_url_rule(
         site="ubuntu.com/community",
         template_path="/community/docs/search-results.html",
         search_engine_id=search_engine_id,
+        request_limit="2000/day",
     ),
 )
 
@@ -732,6 +735,7 @@ app.add_url_rule(
         site="ubuntu.com/ceph/docs",
         template_path="ceph/docs/search-results.html",
         search_engine_id=search_engine_id,
+        request_limit="2000/day",
     ),
 )
 
@@ -753,6 +757,7 @@ app.add_url_rule(
         site="ubuntu.com/core/docs",
         template_path="/core/docs/search-results.html",
         search_engine_id=search_engine_id,
+        request_limit="2000/day",
     ),
 )
 core_docs.init_app(app)
@@ -917,6 +922,7 @@ app.add_url_rule(
         site="ubuntu.com/openstack/docs",
         template_path="openstack/docs/search-results.html",
         search_engine_id=search_engine_id,
+        request_limit="2000/day",
     ),
 )
 
@@ -943,6 +949,7 @@ app.add_url_rule(
         site="ubuntu.com/security/livepatch/docs",
         template_path="/security/livepatch/docs/search-results.html",
         search_engine_id=search_engine_id,
+        request_limit="2000/day",
     ),
 )
 
@@ -969,6 +976,7 @@ app.add_url_rule(
         site="ubuntu.com/security/certifications/docs",
         template_path="/security/certifications/docs/search-results.html",
         search_engine_id=search_engine_id,
+        request_limit="2000/day",
     ),
 )
 
@@ -995,6 +1003,7 @@ app.add_url_rule(
         site="ubuntu.com/landscape/docs",
         template_path="/landscape/docs/search-results.html",
         search_engine_id=search_engine_id,
+        request_limit="2000/day",
     ),
 )
 
@@ -1021,6 +1030,7 @@ app.add_url_rule(
         site="ubuntu.com/robotics/docs",
         template_path="/robotics/docs/search-results.html",
         search_engine_id=search_engine_id,
+        request_limit="2000/day",
     ),
 )
 


### PR DESCRIPTION
## Done

Increase rate limit to 2000 per day.

## QA

- Check that search works:
      - https://ubuntu-com-12831.demos.haus/server/docs
      - https://ubuntu-com-12831.demos.haus/ceph/docs
      - https://ubuntu-com-12831.demos.haus/security/livepatch/docs
      - https://ubuntu-com-12831.demos.haus/security/certifications/docs
      - https://ubuntu-com-12831.demos.haus/landscape/docs
      - https://ubuntu-com-12831.demos.haus/robotics/docs
      - https://ubuntu-com-12831.demos.haus/community/

- Not sure we can QA this to 2000 queries to make it fail, but we can already see the rate limit works.



## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
