### PR TITLE
404-fixes

### DIFF
--- a/templates/kubernetes/docs/1.23/charm-kubernetes-master.md
+++ b/templates/kubernetes/docs/1.23/charm-kubernetes-master.md
@@ -698,7 +698,7 @@ The DNS add-on allows pods to have DNS names in addition to IP addresses.
 The Kubernetes cluster DNS server (based on the SkyDNS library) supports
 forward lookups (A records), service lookups (SRV records) and reverse IP
 address lookups (PTR records). More information about the DNS can be obtained
-from the [Kubernetes DNS admin guide](http://kubernetes.io/docs/admin/dns/).
+from the [Kubernetes DNS admin guide](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/).
 
 # Actions
 

--- a/templates/kubernetes/docs/1.24/upgrading.md
+++ b/templates/kubernetes/docs/1.24/upgrading.md
@@ -343,7 +343,7 @@ juju run-action kubernetes-worker/1 upgrade
 
 ## Upgrading the Machine's Series
 
-All of the charms support [upgrading the machine's series via Juju](https://juju.is/docs/upgrading-series).
+All of the charms support [upgrading the machine's series via Juju](https://juju.is/docs/olm/manage-machines#heading--upgrade-the-ubuntu-series-of-a-machine).
 As each machine is upgraded, the applications on that machine will be stopped and the unit will
 go into a `blocked` status until the upgrade is complete. For the worker units, pods will be drained
 from the node and onto one of the other nodes at the start of the upgrade, and the node will be removed

--- a/templates/kubernetes/docs/1.26/release-notes.md
+++ b/templates/kubernetes/docs/1.26/release-notes.md
@@ -30,7 +30,7 @@ Notable fixes in this release include:
 
   Restrict non-root access to etcd snap data directory.
 
-- Kubernetes Control Plane [LP#2007174](https://bugs.launchpad.net/bugs/2007174)
+- Kubernetes Control Plane 
 
   Restrict non-root access to the script responsible for synchronizing control-plane leader files to followers.
 


### PR DESCRIPTION
## Done

- some annoying 404 fixes for older versions of the K8s docs

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
