### PR TITLE
Update k8s chart data for 1.27 release

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -1384,6 +1384,18 @@ export var kubernetesReleases = [
     taskName: "Kubernetes 1.26",
     status: "CANONICAL_KUBERNETES_EXTENDED_SECURITY_MAINTENANCE",
   },
+  {
+    startDate: new Date("2023-04-21T00:00:00"),
+    endDate: new Date("2024-04-21T00:00:00"),
+    taskName: "Kubernetes 1.27",
+    status: "CANONICAL_KUBERNETES_SUPPORT",
+  },
+  {
+    startDate: new Date("2024-04-21T00:00:00"),
+    endDate: new Date("2024-12-06T00:00:00"),
+    taskName: "Kubernetes 1.27",
+    status: "CANONICAL_KUBERNETES_EXTENDED_SECURITY_MAINTENANCE",
+  },
 ];
 
 export var desktopServerStatus = {
@@ -1601,6 +1613,7 @@ export var openStackReleaseNames = [
 ];
 
 export var kubernetesReleaseNames = [
+  "Kubernetes 1.27",
   "Kubernetes 1.26",
   "Kubernetes 1.25",
   "Kubernetes 1.24",

--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -440,6 +440,12 @@
           </thead>
           <tbody>
             <tr>
+              <td><strong>1.27.x</strong></td>
+              <td align='right'>April 2023</td>
+              <td align='right'>April 2024</td>
+              <td align='right'>Dec 2024</td>
+            </tr>
+            <tr>
               <td><strong>1.26.x</strong></td>
               <td align='right'>Dec 2022</td>
               <td align='right'>Dec 2023</td>


### PR DESCRIPTION
## Done

- Adds k8s 1.27 release information to chart and table

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
