### PR TITLE
[copy update] /download/risc-v

### DIFF
--- a/templates/download/risc-v/index.html
+++ b/templates/download/risc-v/index.html
@@ -48,6 +48,7 @@
         <li><button class="p-tabs__item" id="sipeed-licheerv-dock" role="tab" aria-selected="false" aria-controls="sipeed-licheerv-dock-tab">Sipeed LicheeRV Dock</button></li>
         <li><button class="p-tabs__item" id="microchip-polarfire-soc-fpga-icicle-kit" role="tab" aria-selected="false" aria-controls="microchip-polarfire-soc-fpga-icicle-kit-tab">Polarfire SoC FPGA Icicle</button></li>
         <li><button class="p-tabs__item" id="qemu" role="tab" aria-selected="false" aria-controls="qemu-tab">QEMU emulator</button></li>
+        <li><button class="p-tabs__item" id="starfive-visionfive-2" role="tab" aria-selected="false" aria-controls="starfive-visionfive-2-tab">StarFive VisionFive 2</button></li>
       </ul>
     </div>
     <div class="col-9 col-medium-4">
@@ -57,6 +58,7 @@
       {% include "download/risc-v/tab-4.html" %}
       {% include "download/risc-v/tab-5.html" %}
       {% include "download/risc-v/tab-6.html" %}
+      {% include "download/risc-v/tab-7.html" %}
     </div>
   </div>
 </section>

--- a/templates/download/risc-v/index.html
+++ b/templates/download/risc-v/index.html
@@ -44,11 +44,11 @@
       <ul class="js-tabbed-content p-tabs--vertical is-risc-v" role="tablist" aria-label="Robotics features">
         <li><button class="p-tabs__item" id="quemu-sifive-image" role="tab" aria-selected="true" tab-index="-1" aria-controls="quemu-sifive-image-tab">SiFive Unmatched</button></li>
         <li><button class="p-tabs__item" id="starfive-visionfive-board" role="tab" aria-selected="false" aria-controls="starfive-visionfive-board-tab">StarFive VisionFive</button></li>
+        <li><button class="p-tabs__item" id="starfive-visionfive-2" role="tab" aria-selected="false" aria-controls="starfive-visionfive-2-tab">StarFive VisionFive 2</button></li>
         <li><button class="p-tabs__item" id="allwinner-nezha" role="tab" aria-selected="false" aria-controls="allwinner-nezha-tab">AllWinner Nezha</button></li>
         <li><button class="p-tabs__item" id="sipeed-licheerv-dock" role="tab" aria-selected="false" aria-controls="sipeed-licheerv-dock-tab">Sipeed LicheeRV Dock</button></li>
         <li><button class="p-tabs__item" id="microchip-polarfire-soc-fpga-icicle-kit" role="tab" aria-selected="false" aria-controls="microchip-polarfire-soc-fpga-icicle-kit-tab">Polarfire SoC FPGA Icicle</button></li>
         <li><button class="p-tabs__item" id="qemu" role="tab" aria-selected="false" aria-controls="qemu-tab">QEMU emulator</button></li>
-        <li><button class="p-tabs__item" id="starfive-visionfive-2" role="tab" aria-selected="false" aria-controls="starfive-visionfive-2-tab">StarFive VisionFive 2</button></li>
       </ul>
     </div>
     <div class="col-9 col-medium-4">

--- a/templates/download/risc-v/tab-1.html
+++ b/templates/download/risc-v/tab-1.html
@@ -36,7 +36,7 @@
 				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-live-server-riscv64.img.gz">Download 22.04.2 live installer</a>
 			</p>
 			<h4>First time installing Ubuntu on QEMU/Unmatched?</h4>
-			<p><a href="https://wiki.ubuntu.com/RISC-V/SiFive%20HiFive%20Unmatched">How to install Ubuntu on SiFive HiFive Unmatched</a></p>
+			<p><a href="https://wiki.ubuntu.com/RISC-V/SiFive%20HiFive%20Unmatched">Check out how to install Ubuntu on SiFive HiFive Unmatched</a></p>
 		</div>
 	</div>
 </div>

--- a/templates/download/risc-v/tab-1.html
+++ b/templates/download/risc-v/tab-1.html
@@ -2,11 +2,12 @@
   <div class="row">
     <div class="col-6">
       <div class="p-strip is-shallow u-no-padding--top">
-        <h2>Ubuntu Server <br class="u-hide--small">preinstalled image</h2>
+        <h2>SiFive Unmatched</h2>
+        <h3>Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
       </div>
       <div class="p-notification--information is-inline">
         <div class="p-notification__content">
-          <h4 class="p-notification__title">Note:</h4>
+          <p class="p-notification__title">Note:</p>
           <p class="p-notification__message">If you have an NVMe drive, we advise you to use the Ubuntu Server live installer.</p>
         </div>
       </div>
@@ -30,13 +31,12 @@
   <div class="row">
     <div class="col-6">
       <hr class="u-no-margin--bottom">
-      <h3 class="p-heading--2 u-sv3">Ubuntu Server live installer</h3>
+      <h3 class="u-sv3">Ubuntu Server live installer</h3>
 			<p>
 				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-live-server-riscv64.img.gz">Download 23.04 live installer</a>
 				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-live-server-riscv64.img.gz">Download 22.04.2 live installer</a>
 			</p>
-			<h4>First time installing Ubuntu on QEMU/Unmatched?</h4>
-			<p><a href="https://wiki.ubuntu.com/RISC-V/SiFive%20HiFive%20Unmatched">Check out how to install Ubuntu on SiFive HiFive Unmatched</a></p>
+			<p><a href="https://wiki.ubuntu.com/RISC-V/SiFive%20HiFive%20Unmatched">How to install Ubuntu on SiFive HiFive Unmatched</a></p>
 		</div>
 	</div>
 </div>

--- a/templates/download/risc-v/tab-2.html
+++ b/templates/download/risc-v/tab-2.html
@@ -8,7 +8,8 @@
 				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+visionfive.img.xz">Download 23.04</a>
 				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+visionfive.img.xz">Download 22.04.2</a>
 			</p>
-      <p><a href="https://wiki.ubuntu.com/RISC-V/StarFive%20VisionFive">How to install Ubuntu on the VisionFive</a></p>
+			<h4>First time installing Ubuntu on StarFive VisionFive?</h4>
+			<p><a href="https://wiki.ubuntu.com/RISC-V/StarFive%20VisionFive">Check out how to install Ubuntu on the VisionFive</a></p>
 		</div>
 		<div class="col-3 u-hide--medium u-hide--small p-strip is-shallow u-no-padding--bottom">
 			{{ image (

--- a/templates/download/risc-v/tab-2.html
+++ b/templates/download/risc-v/tab-2.html
@@ -2,14 +2,14 @@
 	<div class="row">
 		<div class="col-6">
 			<div class="p-strip is-shallow u-no-padding--top">
-				<h3 class="p-heading--2">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
+				<h2>StarFive VisionFive</h2>
+				<h3>Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
 			</div>
 			<p>
 				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+visionfive.img.xz">Download 23.04</a>
 				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+visionfive.img.xz">Download 22.04.2</a>
 			</p>
-			<h4>First time installing Ubuntu on StarFive VisionFive?</h4>
-			<p><a href="https://wiki.ubuntu.com/RISC-V/StarFive%20VisionFive">Check out how to install Ubuntu on the VisionFive</a></p>
+			<p><a href="https://wiki.ubuntu.com/RISC-V/StarFive%20VisionFive">How to install Ubuntu on the VisionFive</a></p>
 		</div>
 		<div class="col-3 u-hide--medium u-hide--small p-strip is-shallow u-no-padding--bottom">
 			{{ image (

--- a/templates/download/risc-v/tab-3.html
+++ b/templates/download/risc-v/tab-3.html
@@ -1,24 +1,25 @@
-<div tabindex="0" role="tabpanel" id="allwinner-nezha-tab" aria-labelledby="allwinner-nezha" aria-hidden="true">
+<div tabindex="0" role="tabpanel" id="starfive-visionfive-2-tab" aria-labelledby="starfive-visionfive-2" aria-hidden="true">
 	<div class="row">
 		<div class="col-6">
-			<h3 class="p-heading--2 u-sv3">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
+			<div class="p-strip is-shallow u-no-padding--top">
+        <h2>StarFive VisionFive 2</h2>
+				<h3>Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
+			</div>
 			<p>
-				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+nezha.img.xz">Download 23.04</a>
-				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+nezha.img.xz">Download 22.04.2</a>
+				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+visionfive2.img.xz">Download 23.04</a>
 			</p>
-			<h4>First time installing Ubuntu on AllWinner Nezha?</h4>
-			<p><a href="https://wiki.ubuntu.com/RISC-V/Nezha%20D1">Check out how to install Ubuntu on the Nezha</a></p>
+			<p><a href="https://wiki.ubuntu.com/RISC-V/StarFive%20VisionFive%202">How to install Ubuntu on the VisionFive 2</a></p>
 		</div>
 		<div class="col-3 u-hide--medium u-hide--small p-strip is-shallow u-no-padding--bottom">
-			{{ image (
-				url="https://assets.ubuntu.com/v1/0cc9bac3-Allwinner+Nezha+Board.png",
-				alt="",
-				width="600",
-				height="400",
-				hi_def=True,
-				loading="auto"
-				) | safe
-			  }}
+      {{ image (
+          url="https://assets.ubuntu.com/v1/3579cbd3-starfive-visionfive-2.jpg",
+          alt="",
+          width="500",
+          height="400",
+          hi_def=True,
+          loading="lazy"
+          ) | safe
+        }}
 		</div>
 	</div>
 </div>

--- a/templates/download/risc-v/tab-3.html
+++ b/templates/download/risc-v/tab-3.html
@@ -6,7 +6,8 @@
 				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+nezha.img.xz">Download 23.04</a>
 				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+nezha.img.xz">Download 22.04.2</a>
 			</p>
-      <p><a href="https://wiki.ubuntu.com/RISC-V/Nezha%20D1">How to install Ubuntu on the Nezha Guide</a></p>
+			<h4>First time installing Ubuntu on AllWinner Nezha?</h4>
+			<p><a href="https://wiki.ubuntu.com/RISC-V/Nezha%20D1">Check out how to install Ubuntu on the Nezha</a></p>
 		</div>
 		<div class="col-3 u-hide--medium u-hide--small p-strip is-shallow u-no-padding--bottom">
 			{{ image (

--- a/templates/download/risc-v/tab-4.html
+++ b/templates/download/risc-v/tab-4.html
@@ -1,24 +1,24 @@
-<div tabindex="0" role="tabpanel" id="sipeed-licheerv-dock-tab" aria-labelledby="allwinner-nezha" aria-hidden="true">
+<div tabindex="0" role="tabpanel" id="allwinner-nezha-tab" aria-labelledby="allwinner-nezha" aria-hidden="true">
 	<div class="row">
 		<div class="col-6">
-			<h3 class="p-heading--2 u-sv3">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
+      <h2>AllWiner Nezha</h2>
+			<h3>Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
 			<p>
-				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+licheerv.img.xz">Download 23.04</a>
-				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+licheerv.img.xz">Download 22.04.2</a>
+				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+nezha.img.xz">Download 23.04</a>
+				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+nezha.img.xz">Download 22.04.2</a>
 			</p>
-			<h4>First time installing Ubuntu on LicheeRV Dock?</h4>
-			<p><a href="https://wiki.ubuntu.com/RISC-V/LicheeRV">Check out how to install Ubuntu on the LicheeRV Dock</a></p>
+			<p><a href="https://wiki.ubuntu.com/RISC-V/Nezha%20D1">How to install Ubuntu on the Nezha</a></p>
 		</div>
 		<div class="col-3 u-hide--medium u-hide--small p-strip is-shallow u-no-padding--bottom">
 			{{ image (
-				url="https://assets.ubuntu.com/v1/b151abd7-Sipeed+LicheeRV+-+Edited-2.png",
+				url="https://assets.ubuntu.com/v1/0cc9bac3-Allwinner+Nezha+Board.png",
 				alt="",
-				width="900",
-				height="700",
+				width="600",
+				height="400",
 				hi_def=True,
 				loading="auto"
 				) | safe
-			}}
+			  }}
 		</div>
 	</div>
 </div>

--- a/templates/download/risc-v/tab-4.html
+++ b/templates/download/risc-v/tab-4.html
@@ -6,7 +6,8 @@
 				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+licheerv.img.xz">Download 23.04</a>
 				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+licheerv.img.xz">Download 22.04.2</a>
 			</p>
-      <p><a href="https://wiki.ubuntu.com/RISC-V/LicheeRV">How to install Ubuntu on the LicheeRV Dock guide</a></p>
+			<h4>First time installing Ubuntu on LicheeRV Dock?</h4>
+			<p><a href="https://wiki.ubuntu.com/RISC-V/LicheeRV">Check out how to install Ubuntu on the LicheeRV Dock guide</a></p>
 		</div>
 		<div class="col-3 u-hide--medium u-hide--small p-strip is-shallow u-no-padding--bottom">
 			{{ image (

--- a/templates/download/risc-v/tab-4.html
+++ b/templates/download/risc-v/tab-4.html
@@ -7,7 +7,7 @@
 				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+licheerv.img.xz">Download 22.04.2</a>
 			</p>
 			<h4>First time installing Ubuntu on LicheeRV Dock?</h4>
-			<p><a href="https://wiki.ubuntu.com/RISC-V/LicheeRV">Check out how to install Ubuntu on the LicheeRV Dock guide</a></p>
+			<p><a href="https://wiki.ubuntu.com/RISC-V/LicheeRV">Check out how to install Ubuntu on the LicheeRV Dock</a></p>
 		</div>
 		<div class="col-3 u-hide--medium u-hide--small p-strip is-shallow u-no-padding--bottom">
 			{{ image (

--- a/templates/download/risc-v/tab-5.html
+++ b/templates/download/risc-v/tab-5.html
@@ -10,7 +10,8 @@
 			<ul class="p-list">
 				<li class="p-list__item is-ticked">The Microchip Polarfire SoC FPGA Icicle Kit with <a href="https://github.com/polarfire-soc/hart-software-services/releases/tag/v2022.10">HSS v2022.10</a></li>
 			</ul>
-      <p><a href="https://wiki.ubuntu.com/RISC-V/PolarFire%20SoC%20FPGA%20Icicle%20Kit">How to install Ubuntu on the Microchip Polarfire SoC FPGA Icicle Kit</a></p>
+			<h4>First time installing Ubuntu on Microchip Polorfire?</h4>
+			<p><a href="https://wiki.ubuntu.com/RISC-V/PolarFire%20SoC%20FPGA%20Icicle%20Kit">How to install Ubuntu on the Microchip Polarfire SoC FPGA Icicle Kit</a></p>
 		</div>
 		<div class="col-3 u-hide--medium u-hide--small p-strip is-shallow u-no-padding--bottom">
 			{{

--- a/templates/download/risc-v/tab-5.html
+++ b/templates/download/risc-v/tab-5.html
@@ -1,29 +1,24 @@
-<div tabindex="0" role="tabpanel" id="microchip-polarfire-soc-fpga-icicle-kit-tab" aria-labelledby="live-installer" aria-hidden="true">
+<div tabindex="0" role="tabpanel" id="sipeed-licheerv-dock-tab" aria-labelledby="allwinner-nezha" aria-hidden="true">
 	<div class="row">
 		<div class="col-6">
-			<h3 class="p-heading--2 u-sv3">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
+      <h2>Sipeed LicheeRV Dock</h2>
+			<h3 class="u-sv3">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
 			<p>
-				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+icicle.img.xz">Download 23.04</a>
-				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+icicle.img.xz">Download 22.04.2</a>
+				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+licheerv.img.xz">Download 23.04</a>
+				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+licheerv.img.xz">Download 22.04.2</a>
 			</p>
-			<p>Works on:</p>
-			<ul class="p-list">
-				<li class="p-list__item is-ticked">The Microchip Polarfire SoC FPGA Icicle Kit with <a href="https://github.com/polarfire-soc/hart-software-services/releases/tag/v2022.10">HSS v2022.10</a></li>
-			</ul>
-			<h4>First time installing Ubuntu on Microchip Polorfire?</h4>
-			<p><a href="https://wiki.ubuntu.com/RISC-V/PolarFire%20SoC%20FPGA%20Icicle%20Kit">Check out how to install Ubuntu on the Microchip Polarfire SoC FPGA Icicle Kit</a></p>
+			<p><a href="https://wiki.ubuntu.com/RISC-V/LicheeRV">How to install Ubuntu on the LicheeRV Dock</a></p>
 		</div>
 		<div class="col-3 u-hide--medium u-hide--small p-strip is-shallow u-no-padding--bottom">
-			{{
-				image (
-				url="https://assets.ubuntu.com/v1/40eacb41-Microchip+PolarFire.png",
+			{{ image (
+				url="https://assets.ubuntu.com/v1/b151abd7-Sipeed+LicheeRV+-+Edited-2.png",
 				alt="",
-				width="800",
-				height="414",
+				width="900",
+				height="700",
 				hi_def=True,
-				loading="lazy"
+				loading="auto"
 				) | safe
-			  }}
+			}}
 		</div>
 	</div>
 </div>

--- a/templates/download/risc-v/tab-5.html
+++ b/templates/download/risc-v/tab-5.html
@@ -11,7 +11,7 @@
 				<li class="p-list__item is-ticked">The Microchip Polarfire SoC FPGA Icicle Kit with <a href="https://github.com/polarfire-soc/hart-software-services/releases/tag/v2022.10">HSS v2022.10</a></li>
 			</ul>
 			<h4>First time installing Ubuntu on Microchip Polorfire?</h4>
-			<p><a href="https://wiki.ubuntu.com/RISC-V/PolarFire%20SoC%20FPGA%20Icicle%20Kit">How to install Ubuntu on the Microchip Polarfire SoC FPGA Icicle Kit</a></p>
+			<p><a href="https://wiki.ubuntu.com/RISC-V/PolarFire%20SoC%20FPGA%20Icicle%20Kit">Check out how to install Ubuntu on the Microchip Polarfire SoC FPGA Icicle Kit</a></p>
 		</div>
 		<div class="col-3 u-hide--medium u-hide--small p-strip is-shallow u-no-padding--bottom">
 			{{

--- a/templates/download/risc-v/tab-6.html
+++ b/templates/download/risc-v/tab-6.html
@@ -1,35 +1,29 @@
-<div tabindex="0" role="tabpanel" id="qemu-tab" aria-labelledby="qemu" aria-hidden="true">
+<div tabindex="0" role="tabpanel" id="microchip-polarfire-soc-fpga-icicle-kit-tab" aria-labelledby="live-installer" aria-hidden="true">
 	<div class="row">
 		<div class="col-6">
-			<h3 class="p-heading--2 u-sv3">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
-			<p class="u-sv3">
-				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+unmatched.img.xz">Download 23.04</a>
-				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+unmatched.img.xz">Download 22.04.2</a>
+      <h2>Microchip Polarfire SoC <br class="u-hide--small">FPGA Icicle Kit</h2>
+			<h3 class="u-sv3">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
+			<p>
+				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+icicle.img.xz">Download 23.04</a>
+				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+icicle.img.xz">Download 22.04.2</a>
 			</p>
-    </div>
+			<p>Works on:</p>
+			<ul class="p-list">
+				<li class="p-list__item is-ticked">The Microchip Polarfire SoC FPGA Icicle Kit with <a href="https://github.com/polarfire-soc/hart-software-services/releases/tag/v2022.10">HSS v2022.10</a></li>
+			</ul>
+			<p><a href="https://wiki.ubuntu.com/RISC-V/PolarFire%20SoC%20FPGA%20Icicle%20Kit">How to install Ubuntu on the Microchip Polarfire SoC FPGA Icicle Kit</a></p>
+		</div>
 		<div class="col-3 u-hide--medium u-hide--small p-strip is-shallow u-no-padding--bottom">
 			{{
 				image (
-				url="https://assets.ubuntu.com/v1/308d48cd-Qemu-logo.png",
+				url="https://assets.ubuntu.com/v1/40eacb41-Microchip+PolarFire.png",
 				alt="",
-				width="377",
-				height="120",
+				width="800",
+				height="414",
 				hi_def=True,
 				loading="lazy"
 				) | safe
 			  }}
-		</div>
-	</div>
-	<div class="row">
-		<div class="col-6">
-      <hr class="u-no-margin--bottom">
-      <h3 class="p-heading--2 u-sv3">Ubuntu Server live installer</h3>
-			<p>
-				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-live-server-riscv64.img.gz">Download 23.04 live installer</a>
-				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-live-server-riscv64.img.gz">Download 22.04.2 live installer</a>
-			</p>
-			<h4>First time installing Ubuntu on Ubuntu on QEMU?</h4>
-			<p><a href="https://wiki.ubuntu.com/RISC-V/QEMU">Check out how to install Ubuntu on QEMU RISC-V</a></p>
 		</div>
 	</div>
 </div>

--- a/templates/download/risc-v/tab-6.html
+++ b/templates/download/risc-v/tab-6.html
@@ -15,7 +15,7 @@
 				width="377",
 				height="120",
 				hi_def=True,
-				loading="auto|lazy"
+				loading="lazy"
 				) | safe
 			  }}
 		</div>
@@ -28,7 +28,8 @@
 				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-live-server-riscv64.img.gz">Download 23.04 live installer</a>
 				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-live-server-riscv64.img.gz">Download 22.04.2 live installer</a>
 			</p>
-			<p><a href="https://wiki.ubuntu.com/RISC-V/QEMU">How to install Ubuntu on QEMU RISC-V</a></p>
+			<h4>First time installing Ubuntu on Ubuntu on QEMU?</h4>
+			<p><a href="https://wiki.ubuntu.com/RISC-V/QEMU">Check out how to install Ubuntu on QEMU RISC-V</a></p>
 		</div>
 	</div>
 </div>

--- a/templates/download/risc-v/tab-7.html
+++ b/templates/download/risc-v/tab-7.html
@@ -1,25 +1,35 @@
-<div tabindex="0" role="tabpanel" id="starfive-visionfive-2-tab" aria-labelledby="starfive-visionfive-2" aria-hidden="true">
+<div tabindex="0" role="tabpanel" id="qemu-tab" aria-labelledby="qemu" aria-hidden="true">
 	<div class="row">
 		<div class="col-6">
-			<div class="p-strip is-shallow u-no-padding--top">
-				<h3 class="p-heading--2">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
-			</div>
-			<p>
-				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+visionfive2.img.xz">Download 23.04</a>
+      <h2>QEMU emulator</h2>
+			<h3 class="u-sv3">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
+			<p class="u-sv3">
+				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+unmatched.img.xz">Download 23.04</a>
+				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+unmatched.img.xz">Download 22.04.2</a>
 			</p>
-			<h4>First time installing Ubuntu on StarFive VisionFive?</h4>
-			<p><a href="https://wiki.ubuntu.com/RISC-V/StarFive%20VisionFive%202">Check out how to install Ubuntu on the VisionFive 2</a></p>
-		</div>
+    </div>
 		<div class="col-3 u-hide--medium u-hide--small p-strip is-shallow u-no-padding--bottom">
-            {{ image (
-                url="https://assets.ubuntu.com/v1/3579cbd3-starfive-visionfive-2.jpg",
-                alt="",
-                width="500",
-                height="400",
-                hi_def=True,
-                loading="lazy"
-                ) | safe
-              }}
+			{{
+				image (
+				url="https://assets.ubuntu.com/v1/308d48cd-Qemu-logo.png",
+				alt="",
+				width="377",
+				height="120",
+				hi_def=True,
+				loading="lazy"
+				) | safe
+			  }}
+		</div>
+	</div>
+	<div class="row">
+		<div class="col-6">
+      <hr class="u-no-margin--bottom">
+      <h3 class="u-sv3">Ubuntu Server live installer</h3>
+			<p>
+				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-live-server-riscv64.img.gz">Download 23.04 live installer</a>
+				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-live-server-riscv64.img.gz">Download 22.04.2 live installer</a>
+			</p>
+			<p><a href="https://wiki.ubuntu.com/RISC-V/QEMU">How to install Ubuntu on QEMU RISC-V</a></p>
 		</div>
 	</div>
 </div>

--- a/templates/download/risc-v/tab-7.html
+++ b/templates/download/risc-v/tab-7.html
@@ -1,0 +1,25 @@
+<div tabindex="0" role="tabpanel" id="starfive-visionfive-2-tab" aria-labelledby="starfive-visionfive-2" aria-hidden="true">
+	<div class="row">
+		<div class="col-6">
+			<div class="p-strip is-shallow u-no-padding--top">
+				<h3 class="p-heading--2">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
+			</div>
+			<p>
+				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+visionfive2.img.xz">Download 23.04</a>
+			</p>
+			<h4>First time installing Ubuntu on StarFive VisionFive?</h4>
+			<p><a href="https://wiki.ubuntu.com/RISC-V/StarFive%20VisionFive%202">Check out how to install Ubuntu on the VisionFive 2</a></p>
+		</div>
+		<div class="col-3 u-hide--medium u-hide--small p-strip is-shallow u-no-padding--bottom">
+            {{ image (
+                url="https://assets.ubuntu.com/v1/3579cbd3-starfive-visionfive-2.jpg",
+                alt="",
+                width="500",
+                height="400",
+                hi_def=True,
+                loading="lazy"
+                ) | safe
+              }}
+		</div>
+	</div>
+</div>


### PR DESCRIPTION
## Done

- Updated copy as per [doc](https://docs.google.com/document/d/1kkJeq9HdH3iWV35HwihcJd3CxZw9Jy21W66lJl8VbWs/edit#)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: https://ubuntu-com-12842.demos.haus/download/risc-v
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check each tab and see that the requested changes have been made

## Issue / Card

Fixes # Follow up of https://warthogs.atlassian.net/browse/WD-3078