### PR TITLE
Update openstack-release-cycle chart data

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -1064,6 +1064,36 @@ export var kernelReleaseSchedule = [
 
 export var openStackReleases = [
   {
+    startDate: new Date("2024-04-01T00:00:00"),
+    endDate: new Date("2027-04-01T00:00:00"),
+    taskName: "OpenStack C",
+    status: "MATCHING_OPENSTACK_RELEASE_SUPPORT",
+  },
+  {
+    startDate: new Date("2023-10-01T00:00:00"),
+    endDate: new Date("2025-04-01T00:00:00"),
+    taskName: "OpenStack Bobcat",
+    status: "MATCHING_OPENSTACK_RELEASE_SUPPORT",
+  },
+  {
+    startDate: new Date("2023-04-01T00:00:00"),
+    endDate: new Date("2024-10-01T00:00:00"),
+    taskName: "OpenStack Antelope",
+    status: "MATCHING_OPENSTACK_RELEASE_SUPPORT",
+  },
+  {
+    startDate: new Date("2024-10-01T00:00:00"),
+    endDate: new Date("2026-04-01T00:00:00"),
+    taskName: "OpenStack Antelope",
+    status: "EXTENDED_SUPPORT_FOR_CUSTOMERS",
+  },
+  {
+    startDate: new Date("2022-10-01T00:00:00"),
+    endDate: new Date("2024-04-01T00:00:00"),
+    taskName: "OpenStack Zed",
+    status: "MATCHING_OPENSTACK_RELEASE_SUPPORT",
+  },
+  {
     startDate: new Date("2022-04-01T00:00:00"),
     endDate: new Date("2027-04-01T00:00:00"),
     taskName: "OpenStack Yoga LTS",
@@ -1594,6 +1624,10 @@ export var kernelReleaseNamesLTS = [
 ];
 
 export var openStackReleaseNames = [
+  "OpenStack C",
+  "OpenStack Bobcat",
+  "OpenStack Antelope",
+  "OpenStack Zed",
   "OpenStack Yoga LTS",
   "Ubuntu 22.04 LTS",
   "OpenStack Yoga",

--- a/templates/about/openstack-release-cycle.html
+++ b/templates/about/openstack-release-cycle.html
@@ -14,6 +14,34 @@
       </thead>
       <tbody>
         <tr>
+          <td>OpenStack C</td>
+          <td>&nbsp;</td>
+          <td>Apr 2024</td>
+          <td>Apr 2027</td>
+          <td>&nbsp;</td>
+        </tr>
+        <tr>
+          <td>OpenStack Bobcat</td>
+          <td>&nbsp;</td>
+          <td>Oct 2023</td>
+          <td>Apr 2025</td>
+          <td>&nbsp;</td>
+        </tr>
+        <tr>
+          <td>OpenStack Antelope</td>
+          <td>&nbsp;</td>
+          <td>Apr 2023</td>
+          <td>Oct 2024</td>
+          <td>Apr 2026</td>
+        </tr>
+        <tr>
+          <td>OpenStack Zed</td>
+          <td>&nbsp;</td>
+          <td>Oct 2022</td>
+          <td>Apr 2024</td>
+          <td>&nbsp;</td>
+        </tr>
+        <tr>
           <td>OpenStack Yoga LTS</td>
           <td>&nbsp;</td>
           <td>Apr 2022</td>
@@ -46,7 +74,7 @@
           <td>&nbsp;</td>
         </tr>
         <tr>
-          <td>OpenStack W</td>
+          <td>OpenStack Wallaby</td>
           <td>&nbsp;</td>
           <td>Apr 2021</td>
           <td>Oct 2022</td>


### PR DESCRIPTION
## Done

- Update openstack-release-cycle chart data, based on the updated [spreadsheet](https://docs.google.com/spreadsheets/d/1KIuOAa620yseE0uhIl67u2SlS0bWlPI_d98bvYM2Yl8/edit#gid=1483484944)

## QA

- Go to [the demo](https://ubuntu-com-12844.demos.haus/about/release-cycle#openstack-release-cycle) and check that the 'openstack-releases-cycle' chart matches the data in the [spreadsheet](https://docs.google.com/spreadsheets/d/1KIuOAa620yseE0uhIl67u2SlS0bWlPI_d98bvYM2Yl8/edit#gid=1483484944)
- Check the data in 'cahrt-data.js' is accurate

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-3155
