### PR TITLE
Add country field to en whitepaper download forms

### DIFF
--- a/templates/engage/shared/_en_engage_form.html
+++ b/templates/engage/shared/_en_engage_form.html
@@ -27,7 +27,10 @@
         <label for="phone">Mobile/cell phone number:</label>
         <input required id="phone" name="phone" maxlength="255" type="tel">
       </li>
+
+      {% include "shared/forms/_country.html" %}
       <li>
+        
         <label class="p-checkbox">
           <input class="p-checkbox__input" name="canonicalUpdatesOptIn" aria-labelledby="canonicalUpdatesOptIn" value="yes" type="checkbox">
           <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -844,8 +844,8 @@ def marketo_submit():
 
     enrichment_fields = None
 
+    # Enrichment data for global enrichment form (id:4198)
     if "email" in form_fields:
-        # Enrichment data for global enrichment form (id:4198)
         enrichment_fields = {
             "email": form_fields["email"],
             "acquisition_url": referrer,
@@ -856,6 +856,12 @@ def marketo_submit():
             "preferredLanguage"
         ]
         form_fields.pop("preferredLanguage")
+    
+    if "country" in form_fields:
+        enrichment_fields["country"] = form_fields[
+            "country"
+        ]
+        form_fields.pop("country")
 
     payload = {
         "formId": form_fields.pop("formid"),

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -856,11 +856,9 @@ def marketo_submit():
             "preferredLanguage"
         ]
         form_fields.pop("preferredLanguage")
-    
+
     if "country" in form_fields:
-        enrichment_fields["country"] = form_fields[
-            "country"
-        ]
+        enrichment_fields["country"] = form_fields["country"]
         form_fields.pop("country")
 
     payload = {


### PR DESCRIPTION
## Done

- Add country field to en whitepaper download forms

## QA

- Go to any whitepaper download page, for example: https://ubuntu-com-12847.demos.haus/engage/driving-open-source-together-with-canonical-and-intel
- With the network tab open, fill in the form and submit it.
- Check that the form submits correctly and has 'country' in the payload.
- Go to the associated marketo list and check the lead was recieved, in the example above it is: https://engage-sj.marketo.com/?munchkinId=066-EOV-335#/classic/SL100940043B2LA1
## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-2703
