### PR TITLE
Update flavours.html

### DIFF
--- a/templates/desktop/flavours.html
+++ b/templates/desktop/flavours.html
@@ -206,7 +206,7 @@
         </div>
         <div>
           <p>Ubuntu Cinnamon combines Ubuntu with the intuitive Cinnamon desktop. Built upon the legacy of GNOME 2, Ubuntu Cinnamon provides a traditionally modern experience crafted for professional and home users alike. The hassle free desktop allows for deep personalization options and add-ons for a little extra spice.</p>
-          <p><a href="https://ubuntucinnamon.org/download/" class="p-button--positive">Get Ubuntu Cinnamon</a></p>
+          <p><a href="https://ubuntucinnamon.org/" class="p-button--positive">Get Ubuntu Cinnamon</a></p>
           <p><a href="https://t.me/ubuntucinnamon">Join the Ubuntu Cinnamon community&nbsp;&rsaquo;</a></p>
           <p><a href="https://twitter.com/UbuntuCinnamon">Follow Ubuntu Cinnamon&nbsp;&rsaquo;</a></p>
         </div>


### PR DESCRIPTION
Updated the broken Ubuntu Cinnammon link

## Done

- Changed https://ubuntucinnamon.org/download/ to https://ubuntucinnamon.org/

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to the flavours page https://ubuntu.com/desktop/flavours
- Click 'Get Ubuntu Cinnammon'

## Issue / Card

Fixes #12849 

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
