### PR TITLE
WD-3412 - Add Real-time Ubuntu Beta optimised for Intel SoCs

### DIFF
--- a/templates/download/iot/intel-iot.html
+++ b/templates/download/iot/intel-iot.html
@@ -93,12 +93,10 @@
   </div>
 </section>
 
-<section class="p-strip u-no-padding--bottom">
+<section class="p-strip is-bordered">
   <div class="row">
-    <div class="col-6">
+    <div class="col-8">
       <h2>Real-time Ubuntu Beta optimised for Intel SoCs</h2>
-    </div>
-    <div class="col-6">
       <p>Optimised <a href="/blog/real-time-ubuntu-is-now-generally-available">real-time Ubuntu</a> is now available on 12th Gen Intel&reg; Core&trade; processors in Beta.</p>
       <p>Coupled with Intel&reg; Time Coordinated Computing (Intel&reg; TCC) and Time Sensitive Networking (IEEE TSN), the real-time Ubuntu kernel delivers industrial-grade performance to the time-bound workloads of industrial enterprises.</p>
       <p><a href="https://register.gotowebinar.com/register/8712572348523284318?source=Canonical">Watch the joint webinar by Canonical and Intel on how real-time Ubuntu on Intel accelerates industrial transformation</a></p>
@@ -115,7 +113,6 @@
 </section>
 
 <section class="p-strip is-bordered">
-  <hr class="is-fixed-width">
   <div class="u-fixed-width u-sv3">
     <h2>Ubuntu optimised for next-gen Intel SoCs</h2>
     <p>Intel's portfolio of edge-ready compute and connectivity technologies make it easy to deploy edge applications quickly. Enhanced for IoT, they enable processing at the edge to get critical insights and business value from your data with compute resources where you need them most.</p>

--- a/templates/download/iot/intel-iot.html
+++ b/templates/download/iot/intel-iot.html
@@ -146,7 +146,7 @@
       </thead>
       <tbody>
         <tr>
-          <th>13th Gen Intel® Core™ processors (former codename Raptor Lake S, Raptor Lake P)</th>
+          <th>13th Gen Intel&reg; Core&trade; processors (former codename Raptor Lake S, Raptor Lake P, PS)</th>
           <td class="u-align--center" data-heading="Ubuntu Core 22">-</td>
           <td class="u-align--center" data-heading="Ubuntu Desktop 22.04">
             <p>
@@ -165,11 +165,11 @@
         </tr>
         <tr>
           <th>
-            Intel Atom® X6000E Series and Intel® Pentium® and Celeron® N and J Series Processors <br/>(former codename Elkhart Lake)
+            Intel Atom&reg; X6000E Series Processors (former codename Elkhart Lake)
           </th>
           <td class="u-align--center" data-heading="Ubuntu Core 22">
             <p>
-              <a href="https://cdimage.ubuntu.com/releases/jammy/release/inteliot/ubuntu-core-22-amd64+intel-iot.img.xz.zsync" class="p-button is-dense">
+              <a href="http://cdimage.ubuntu.com/releases/jammy/release/inteliot/ubuntu-core-22-amd64+intel-iot.img.xz" class="p-button is-dense">
                 Download
               </a>
             </p>
@@ -190,34 +190,36 @@
           </td>
         </tr>
         <tr>
-          <th>11th Gen Intel® Core™ processors <br/>(former codename Tiger Lake)</th>
+          <th>
+            Intel Atom® X7000E Series Processors (former codename Alder Lake N)
+          </th>
           <td class="u-align--center" data-heading="Ubuntu Core 22">
             <p>
-              <a href="https://cdimage.ubuntu.com/releases/jammy/release/inteliot/ubuntu-core-22-amd64+intel-iot.img.xz.zsync" class="p-button is-dense">
+              <a href="http://cdimage.ubuntu.com/releases/jammy/release/inteliot/ubuntu-core-22-amd64+intel-iot.img.xz" class="p-button is-dense">
                 Download
               </a>
             </p>
           </td>
           <td class="u-align--center" data-heading="Ubuntu Desktop 22.04">
             <p>
-              <a href="https://cdimage.ubuntu.com/releases/jammy/release/inteliot/ubuntu-22.04-desktop-amd64+intel-iot.iso" class="p-button is-dense">
+              <a href="http://cdimage.ubuntu.com/releases/jammy/release/inteliot/ubuntu-22.04-desktop-amd64+intel-iot.iso" class="p-button is-dense">
                 Download
               </a>
             </p>
           </td>
           <td class="u-align--center" data-heading="Ubuntu Server 22.04">
             <p>
-              <a href="https://cdimage.ubuntu.com/releases/jammy/release/inteliot/ubuntu-22.04-live-server-amd64+intel-iot.iso" class="p-button is-dense">
+              <a href="http://cdimage.ubuntu.com/releases/jammy/release/inteliot/ubuntu-22.04-live-server-amd64+intel-iot.iso" class="p-button is-dense">
                 Download
               </a>
             </p>
           </td>
         </tr>
         <tr>
-          <th>12th Gen Intel® Core™ processors <br/>(former codename Alder Lake S, P, N)</th>
+          <th>11th Gen Intel® Core™ processors <br/>(former codename Tiger Lake-UP3)</th>
           <td class="u-align--center" data-heading="Ubuntu Core 22">
             <p>
-              <a href="https://cdimage.ubuntu.com/releases/jammy/release/inteliot/ubuntu-core-22-amd64+intel-iot.img.xz.zsync" class="p-button is-dense">
+              <a href="http://cdimage.ubuntu.com/releases/jammy/release/inteliot/ubuntu-core-22-amd64+intel-iot.img.xz" class="p-button is-dense">
                 Download
               </a>
             </p>
@@ -238,7 +240,31 @@
           </td>
         </tr>
         <tr>
-          <th>Intel® Xeon® D processors <br/>(former codename Ice Lake)</th>
+          <th>12th Gen Intel® Core™ processors <br/>(former codename Alder Lake S, P, PS)</th>
+          <td class="u-align--center" data-heading="Ubuntu Core 22">
+            <p>
+              <a href="http://cdimage.ubuntu.com/releases/jammy/release/inteliot/ubuntu-core-22-amd64+intel-iot.img.xz" class="p-button is-dense">
+                Download
+              </a>
+            </p>
+          </td>
+          <td class="u-align--center" data-heading="Ubuntu Desktop 22.04">
+            <p>
+              <a href="https://cdimage.ubuntu.com/releases/jammy/release/inteliot/ubuntu-22.04-desktop-amd64+intel-iot.iso" class="p-button is-dense">
+                Download
+              </a>
+            </p>
+          </td>
+          <td class="u-align--center" data-heading="Ubuntu Server 22.04">
+            <p>
+              <a href="https://cdimage.ubuntu.com/releases/jammy/release/inteliot/ubuntu-22.04-live-server-amd64+intel-iot.iso" class="p-button is-dense">
+                Download
+              </a>
+            </p>
+          </td>
+        </tr>
+        <tr>
+          <th>Intel&reg; Xeon® D processors <br/>(former codename Ice Lake-D)</th>
           <td class="u-align--center" data-heading="Ubuntu Core 22">-</td>
           <td class="u-align--center" data-heading="Ubuntu Desktop 22.04">
             <p>
@@ -270,7 +296,7 @@
       <tbody>
         <tr>
           <th>
-            Intel Atom® X6000E Series and Intel® Pentium® and Celeron® N and J Series Processors <br/>(former codename Elkhart Lake)
+            Intel Atom&reg; X6000E Series Processors <br/>(former codename Elkhart Lake)
           </th>
           <td class="u-align--center" data-heading="Ubuntu Core 20">
             <p>
@@ -295,7 +321,7 @@
           </td>
         </tr>
         <tr>
-          <th>11th Gen Intel® Core™ processors <br/>(former codename Tiger Lake)</th>
+          <th>11th Gen Intel® Core™ processors <br/>(former codename Tiger Lake-UP3)</th>
           <td class="u-align--center" data-heading="Ubuntu Core 20">
             <p>
               <a href="https://cdimage.ubuntu.com/releases/focal/release/inteliotg/ubuntu-core-20-amd64+intel-iot.img.xz" class="p-button is-dense">

--- a/templates/download/iot/intel-iot.html
+++ b/templates/download/iot/intel-iot.html
@@ -12,7 +12,7 @@
     <div class="col-7">
       <h1>Download Ubuntu for Intel IoT platforms</h1>
       <p class="p-heading--4">Accelerate industrial compute with Ubuntu on Intel processors</p>
-      <p>The entire family of industrial-grade Ubuntu images optimsed for Intel IoT hardware, from Core to Desktop and Server, are available for download across a wide range of Intel platforms.</p>
+      <p>The entire family of industrial-grade Ubuntu images optimised for Intel IoT hardware, from Core to Desktop and Server, are available for download across a wide range of Intel platforms.</p>
     </div>
     <div class="col-5 u-hide--medium u-hide--small u-align--center">
       {{
@@ -93,7 +93,29 @@
   </div>
 </section>
 
+<section class="p-strip u-no-padding--bottom">
+  <div class="row">
+    <div class="col-6">
+      <h2>Real-time Ubuntu Beta optimised for Intel SoCs</h2>
+    </div>
+    <div class="col-6">
+      <p>Optimised <a href="/blog/real-time-ubuntu-is-now-generally-available">real-time Ubuntu</a> is now available on 12th Gen Intel&reg; Core&trade; processors in Beta.</p>
+      <p>Coupled with Intel&reg; Time Coordinated Computing (Intel&reg; TCC) and Time Sensitive Networking (IEEE TSN), the real-time Ubuntu kernel delivers industrial-grade performance to the time-bound workloads of industrial enterprises.</p>
+      <p><a href="https://register.gotowebinar.com/register/8712572348523284318?source=Canonical">Watch the joint webinar by Canonical and Intel on how real-time Ubuntu on Intel accelerates industrial transformation</a></p>
+      <p>Real-time Ubuntu on Intel SoCs is available via <a href="/pro">Ubuntu Pro</a>, Canonical's enterprise security and compliance subscription, covering all aspects of open infrastructure. With an <a href="/pro/dashboard">Ubuntu Pro subscription</a>, launching the kernel is as easy as:</p>
+      <div class="p-code-snippet">
+        <pre class="p-code-snippet__block--icon"><code>pro attach &lt;token&gt;</code></pre>
+        <pre class="p-code-snippet__block--icon"><code>pro enable realtime-kernel --access-only</code></pre>
+        <pre class="p-code-snippet__block--icon"><code>apt install ubuntu-intel-iot-realtime</code></pre>
+      </div>
+      <p>Are you interested in running real-time Ubuntu on Intel SoCs?</p>
+      <p><a href="/kernel/real-time/contact-us" class="p-button--positive">Get in touch</a></p>
+    </div>
+  </div>
+</section>
+
 <section class="p-strip is-bordered">
+  <hr class="is-fixed-width">
   <div class="u-fixed-width u-sv3">
     <h2>Ubuntu optimised for next-gen Intel SoCs</h2>
     <p>Intel's portfolio of edge-ready compute and connectivity technologies make it easy to deploy edge applications quickly. Enhanced for IoT, they enable processing at the edge to get critical insights and business value from your data with compute resources where you need them most.</p>


### PR DESCRIPTION
## Done
- Added the new "Add Real-time Ubuntu Beta optimised for Intel SoCs" content
- Updated the download links and some content

## QA
- Open the demo and go to /download/iot/intel-iot
- Ensure the copy matches [the copydoc](https://docs.google.com/document/d/1hxKzPs6e6JQaa9tBqfZ55GAXrVnEryEWBja8HlXy-lc/edit#)

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-3412

