### PR TITLE
Add links for K8s preview 

### DIFF
--- a/templates/kubernetes/docs/1.27/release-notes.md
+++ b/templates/kubernetes/docs/1.27/release-notes.md
@@ -71,7 +71,7 @@ Offered as a technical preview, the suite of Volcano charms deploys on either
 MicroK8s or Charmed Kubernetes, and can be used to more effectively schedule
 ML/AI workloads which need to ensure effective queuing of jobs requiring GPU
 resources. The charm ships with v1.7.0 of Volcano and will follow future
-upstream releases.
+upstream releases. See the [Volcano documentation](/kubernetes/docs/volcano) for more information.
 
 ### Cluster API Providers
 
@@ -88,7 +88,8 @@ infrastructure provider.
 
 While the user experience surrounding certain Juju-related interactions is still
 being improved, Charmed Kubernetes can be deployed using the familiar Cluster
-API workflow using the providers in their current state.
+API workflow using the providers in their current state. For the current 
+instructions, see the [Juju cluster API provider repository](https://github.com/charmed-kubernetes/cluster-api-provider-juju).
 
 ## Component Versions
 

--- a/templates/kubernetes/docs/release-notes.md
+++ b/templates/kubernetes/docs/release-notes.md
@@ -72,7 +72,8 @@ Offered as a technical preview, the suite of Volcano charms deploys on either
 MicroK8s or Charmed Kubernetes, and can be used to more effectively schedule
 ML/AI workloads which need to ensure effective queuing of jobs requiring GPU
 resources. The charm ships with v1.7.0 of Volcano and will follow future
-upstream releases.
+upstream releases. See the [Volcano documentation](/kubernetes/docs/volcano) for more information.
+
 
 ### Cluster API Providers
 
@@ -89,7 +90,8 @@ infrastructure provider.
 
 While the user experience surrounding certain Juju-related interactions is still
 being improved, Charmed Kubernetes can be deployed using the familiar Cluster
-API workflow using the providers in their current state.
+API workflow using the providers in their current state. For the current 
+instructions, see the [Juju cluster API provider repository](https://github.com/charmed-kubernetes/cluster-api-provider-juju).
 
 ## Component Versions
 


### PR DESCRIPTION
## Done

- Added two links to release notes

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
