### PR TITLE
Update chart data on /kernel/lifecycle

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -386,33 +386,35 @@ export var kernelReleases = [
 
 export var kernelReleases2204 = [
   {
-    startDate: new Date('2023-02-01T00:00:00'),
-    endDate: new Date('2027-04-01T00:00:00'),
-    taskName: 'Ubuntu 22.04.2 LTS',
-    taskVersion: 'Kernel version',
-    status: 'LTS'
+    startDate: new Date("2022-04-23T00:00:00"),
+    endDate: new Date("2027-04-22T00:00:00"),
+    taskName: "Ubuntu 22.04.0 LTS (v5.15)",
+    status: "LTS"
   },
   {
-    startDate: new Date('2022-08-01T00:00:00'),
-    endDate: new Date('2027-04-01T00:00:00'),
-    taskName: 'Ubuntu 22.04.1 LTS',
-    taskVersion: '',
-    status: 'LTS'
+    startDate: new Date("2027-04-22T00:00:00"),
+    endDate: new Date("2032-04-20T00:00:00"),
+    taskName: "Ubuntu 22.04.0 LTS (v5.15)",
+    status: "ESM"
+  },		
+  {
+    startDate: new Date("2022-08-21T00:00:00"),
+    endDate: new Date("2027-04-22T00:00:00"),
+    taskName: "Ubuntu 22.04.1 LTS (v5.15)",
+    status: "LTS"
   },
   {
-    startDate: new Date('2022-04-01T00:00:00'),
-    endDate: new Date('2027-04-01T00:00:00'),
-    taskName: 'Ubuntu 22.04.0 LTS',
-    taskVersion: '',
-    status: 'LTS'
-  },
+    startDate: new Date("2027-04-22T00:00:00"),
+    endDate: new Date("2032-04-21T00:00:00"),
+    taskName: "Ubuntu 22.04.1 LTS (v5.15)",
+    status: "ESM"
+  },		
   {
-    startDate: new Date('2027-04-01T00:00:00'),
-    endDate: new Date('2032-03-30T00:00:00'),
-    taskName: 'Ubuntu 22.04.0 LTS',
-    taskVersion: '',
-    status: 'ESM'
-  },
+    startDate: new Date("2023-02-17T00:00:00"),
+    endDate: new Date("2023-07-22T00:00:00"),
+    taskName: "Ubuntu 22.04.2 LTS (v5.19)",
+    status: "LTS"
+  },		
 ]
 
 export var kernelReleases2004 = [
@@ -849,16 +851,40 @@ export var kernelReleasesALL = [
     status: "LTS",
   },
   {
-    startDate: new Date("2022-05-13T00:00:00"),
-    endDate: new Date("2022-08-11T00:00:00"),
-    taskName: "Ubuntu 20.04.5 LTS (v5.15)",
-    status: "EARLY",
+  startDate: new Date('2022-01-01T00:00:00'),
+  endDate: new Date('2022-04-01T00:00:00'),
+  taskName: 'Ubuntu 22.04.0 LTS (v5.15)',
+  status: 'EARLY'
   },
   {
-    startDate: new Date("2022-08-11T00:00:00"),
-    endDate: new Date("2025-04-22T00:00:00"),
-    taskName: "Ubuntu 20.04.5 LTS (v5.15)",
-    status: "LTS",
+  startDate: new Date('2022-04-01T00:00:00'),
+  endDate: new Date('2027-04-01T00:00:00'),
+  taskName: 'Ubuntu 22.04.0 LTS (v5.15)',
+  status: 'LTS'
+  },
+  {
+  startDate: new Date('2022-05-13T00:00:00'),
+  endDate: new Date('2022-08-11T00:00:00'),
+  taskName: 'Ubuntu 20.04.5 LTS (v5.15)',
+  status: 'EARLY'
+  },
+  {
+  startDate: new Date('2022-08-11T00:00:00'),
+  endDate: new Date('2025-04-22T00:00:00'),
+  taskName: 'Ubuntu 20.04.5 LTS (v5.15)',
+  status: 'LTS'
+  },
+  {
+  startDate: new Date('2022-08-01T00:00:00'),
+  endDate: new Date('2027-04-01T00:00:00'),
+  taskName: 'Ubuntu 22.04.1 LTS (v5.15)',
+  status: 'LTS'
+  },
+  {
+  startDate: new Date('2023-02-01T00:00:00'),
+  endDate: new Date('2023-07-01T00:00:00'),
+  taskName: 'Ubuntu 22.04.2 LTS (v5.19)',
+  status: 'LTS'
   },
 ];
 
@@ -1074,6 +1100,18 @@ export var kernelReleasesLTS = [
     status: "LTS",
   },
   {
+    startDate: new Date('2022-04-01T00:00:00'),
+    endDate: new Date('2024-04-01T00:00:00'),
+    taskName: 'Ubuntu 22.04.0 LTS (v5.15)',
+    status: 'LTS'
+  },
+  {
+    startDate: new Date('2024-04-01T00:00:00'),
+    endDate: new Date('2027-04-01T00:00:00'),
+    taskName: 'Ubuntu 22.04.0 LTS (v5.15)',
+    status: 'CVE'
+  },
+  {
     startDate: new Date("2022-08-11T00:00:00"),
     endDate: new Date("2024-08-10T00:00:00"),
     taskName: "Ubuntu 20.04.5 LTS (v5.15)",
@@ -1084,6 +1122,24 @@ export var kernelReleasesLTS = [
     endDate: new Date("2025-04-22T00:00:00"),
     taskName: "Ubuntu 20.04.5 LTS (v5.15)",
     status: "CVE",
+  },
+  {
+    startDate: new Date('2022-08-01T00:00:00'),
+    endDate: new Date('2024-04-01T00:00:00'),
+    taskName: 'Ubuntu 22.04.1 LTS (v5.15)',
+    status: 'LTS'
+  },
+  {
+    startDate: new Date('2024-04-01T00:00:00'),
+    endDate: new Date('2027-04-01T00:00:00'),
+    taskName: 'Ubuntu 22.04.1 LTS (v5.15)',
+    status: 'CVE'
+  },
+  {
+    startDate: new Date('2023-02-01T00:00:00'),
+    endDate: new Date('2023-07-01T00:00:00'),
+    taskName: 'Ubuntu 22.04.2 LTS (v5.19)',
+    status: 'LTS'
   },
 ];
 
@@ -1543,6 +1599,12 @@ export var kernelVersionNames = [
   "",
 ];
 
+export var kernelReleaseNames2204 = [
+  "Ubuntu 22.04.0 LTS (v5.15)",
+  "Ubuntu 22.04.1 LTS (v5.15)",
+  "Ubuntu 22.04.2 LTS (v5.19)",
+];
+
 export var kernelReleaseNames2004 = [
   "Ubuntu 20.04.0 LTS (v5.4)",
   "Ubuntu 20.04.1 LTS (v5.4)",
@@ -1603,8 +1665,8 @@ export var kernelReleaseNamesALL = [
   "Ubuntu 20.04.2 LTS (v5.8)",
   "Ubuntu 20.04.3 LTS (v5.11)",
   "Ubuntu 20.04.4 LTS (v5.13)",
-  "Ubuntu 20.04.5 LTS (v5.15)",
   "Ubuntu 22.04.0 LTS (v5.15)",
+  "Ubuntu 20.04.5 LTS (v5.15)",
   "Ubuntu 22.04.1 LTS (v5.15)",
   "Ubuntu 22.04.2 LTS (v5.19)"
 ];
@@ -1633,7 +1695,10 @@ export var kernelReleaseNamesLTS = [
   "Ubuntu 20.04.2 LTS (v5.8)",
   "Ubuntu 20.04.3 LTS (v5.11)",
   "Ubuntu 20.04.4 LTS (v5.13)",
+  "Ubuntu 22.04.0 LTS (v5.15)",
   "Ubuntu 20.04.5 LTS (v5.15)",
+  "Ubuntu 22.04.1 LTS (v5.15)",
+  "Ubuntu 22.04.2 LTS (v5.19)"
 ];
 
 export var openStackReleaseNames = [

--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -138,25 +138,25 @@ export var serverAndDesktopReleases = [
 
 export var kernelReleases = [
   {
-    startDate: new Date('2023-02-01T00:00:00'),
-    endDate: new Date('2027-04-01T00:00:00'),
-    taskName: 'Ubuntu 22.04.2 LTS',
-    taskVersion: 'Kernel version',
-    status: 'LTS'
+    startDate: new Date("2023-02-01T00:00:00"),
+    endDate: new Date("2027-04-01T00:00:00"),
+    taskName: "Ubuntu 22.04.2 LTS",
+    taskVersion: "Kernel version",
+    status: "LTS",
   },
   {
-    startDate: new Date('2022-10-01T00:00:00'),
-    endDate: new Date('2023-07-01T00:00:00'),
-    taskName: 'Ubuntu 22.10',
-    taskVersion: '',
-    status: 'INTERIM_RELEASE'
+    startDate: new Date("2022-10-01T00:00:00"),
+    endDate: new Date("2023-07-01T00:00:00"),
+    taskName: "Ubuntu 22.10",
+    taskVersion: "",
+    status: "INTERIM_RELEASE",
   },
   {
-    startDate: new Date('2022-08-01T00:00:00'),
-    endDate: new Date('2027-04-01T00:00:00'),
-    taskName: 'Ubuntu 22.04.1 LTS',
-    taskVersion: '',
-    status: 'LTS'
+    startDate: new Date("2022-08-01T00:00:00"),
+    endDate: new Date("2027-04-01T00:00:00"),
+    taskName: "Ubuntu 22.04.1 LTS",
+    taskVersion: "",
+    status: "LTS",
   },
   {
     startDate: new Date("2022-08-01T00:00:00"),
@@ -389,33 +389,33 @@ export var kernelReleases2204 = [
     startDate: new Date("2022-04-23T00:00:00"),
     endDate: new Date("2027-04-22T00:00:00"),
     taskName: "Ubuntu 22.04.0 LTS (v5.15)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2027-04-22T00:00:00"),
     endDate: new Date("2032-04-20T00:00:00"),
     taskName: "Ubuntu 22.04.0 LTS (v5.15)",
-    status: "ESM"
-  },		
+    status: "ESM",
+  },
   {
     startDate: new Date("2022-08-21T00:00:00"),
     endDate: new Date("2027-04-22T00:00:00"),
     taskName: "Ubuntu 22.04.1 LTS (v5.15)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2027-04-22T00:00:00"),
     endDate: new Date("2032-04-21T00:00:00"),
     taskName: "Ubuntu 22.04.1 LTS (v5.15)",
-    status: "ESM"
-  },		
+    status: "ESM",
+  },
   {
     startDate: new Date("2023-02-17T00:00:00"),
     endDate: new Date("2023-07-22T00:00:00"),
     taskName: "Ubuntu 22.04.2 LTS (v5.19)",
-    status: "LTS"
-  },		
-]
+    status: "LTS",
+  },
+];
 
 export var kernelReleases2004 = [
   {
@@ -851,40 +851,40 @@ export var kernelReleasesALL = [
     status: "LTS",
   },
   {
-  startDate: new Date('2022-01-01T00:00:00'),
-  endDate: new Date('2022-04-01T00:00:00'),
-  taskName: 'Ubuntu 22.04.0 LTS (v5.15)',
-  status: 'EARLY'
+    startDate: new Date("2022-01-01T00:00:00"),
+    endDate: new Date("2022-04-01T00:00:00"),
+    taskName: "Ubuntu 22.04.0 LTS (v5.15)",
+    status: "EARLY",
   },
   {
-  startDate: new Date('2022-04-01T00:00:00'),
-  endDate: new Date('2027-04-01T00:00:00'),
-  taskName: 'Ubuntu 22.04.0 LTS (v5.15)',
-  status: 'LTS'
+    startDate: new Date("2022-04-01T00:00:00"),
+    endDate: new Date("2027-04-01T00:00:00"),
+    taskName: "Ubuntu 22.04.0 LTS (v5.15)",
+    status: "LTS",
   },
   {
-  startDate: new Date('2022-05-13T00:00:00'),
-  endDate: new Date('2022-08-11T00:00:00'),
-  taskName: 'Ubuntu 20.04.5 LTS (v5.15)',
-  status: 'EARLY'
+    startDate: new Date("2022-05-13T00:00:00"),
+    endDate: new Date("2022-08-11T00:00:00"),
+    taskName: "Ubuntu 20.04.5 LTS (v5.15)",
+    status: "EARLY",
   },
   {
-  startDate: new Date('2022-08-11T00:00:00'),
-  endDate: new Date('2025-04-22T00:00:00'),
-  taskName: 'Ubuntu 20.04.5 LTS (v5.15)',
-  status: 'LTS'
+    startDate: new Date("2022-08-11T00:00:00"),
+    endDate: new Date("2025-04-22T00:00:00"),
+    taskName: "Ubuntu 20.04.5 LTS (v5.15)",
+    status: "LTS",
   },
   {
-  startDate: new Date('2022-08-01T00:00:00'),
-  endDate: new Date('2027-04-01T00:00:00'),
-  taskName: 'Ubuntu 22.04.1 LTS (v5.15)',
-  status: 'LTS'
+    startDate: new Date("2022-08-01T00:00:00"),
+    endDate: new Date("2027-04-01T00:00:00"),
+    taskName: "Ubuntu 22.04.1 LTS (v5.15)",
+    status: "LTS",
   },
   {
-  startDate: new Date('2023-02-01T00:00:00'),
-  endDate: new Date('2023-07-01T00:00:00'),
-  taskName: 'Ubuntu 22.04.2 LTS (v5.19)',
-  status: 'LTS'
+    startDate: new Date("2023-02-01T00:00:00"),
+    endDate: new Date("2023-07-01T00:00:00"),
+    taskName: "Ubuntu 22.04.2 LTS (v5.19)",
+    status: "LTS",
   },
 ];
 
@@ -1100,16 +1100,16 @@ export var kernelReleasesLTS = [
     status: "LTS",
   },
   {
-    startDate: new Date('2022-04-01T00:00:00'),
-    endDate: new Date('2024-04-01T00:00:00'),
-    taskName: 'Ubuntu 22.04.0 LTS (v5.15)',
-    status: 'LTS'
+    startDate: new Date("2022-04-01T00:00:00"),
+    endDate: new Date("2024-04-01T00:00:00"),
+    taskName: "Ubuntu 22.04.0 LTS (v5.15)",
+    status: "LTS",
   },
   {
-    startDate: new Date('2024-04-01T00:00:00'),
-    endDate: new Date('2027-04-01T00:00:00'),
-    taskName: 'Ubuntu 22.04.0 LTS (v5.15)',
-    status: 'CVE'
+    startDate: new Date("2024-04-01T00:00:00"),
+    endDate: new Date("2027-04-01T00:00:00"),
+    taskName: "Ubuntu 22.04.0 LTS (v5.15)",
+    status: "CVE",
   },
   {
     startDate: new Date("2022-08-11T00:00:00"),
@@ -1124,22 +1124,22 @@ export var kernelReleasesLTS = [
     status: "CVE",
   },
   {
-    startDate: new Date('2022-08-01T00:00:00'),
-    endDate: new Date('2024-04-01T00:00:00'),
-    taskName: 'Ubuntu 22.04.1 LTS (v5.15)',
-    status: 'LTS'
+    startDate: new Date("2022-08-01T00:00:00"),
+    endDate: new Date("2024-04-01T00:00:00"),
+    taskName: "Ubuntu 22.04.1 LTS (v5.15)",
+    status: "LTS",
   },
   {
-    startDate: new Date('2024-04-01T00:00:00'),
-    endDate: new Date('2027-04-01T00:00:00'),
-    taskName: 'Ubuntu 22.04.1 LTS (v5.15)',
-    status: 'CVE'
+    startDate: new Date("2024-04-01T00:00:00"),
+    endDate: new Date("2027-04-01T00:00:00"),
+    taskName: "Ubuntu 22.04.1 LTS (v5.15)",
+    status: "CVE",
   },
   {
-    startDate: new Date('2023-02-01T00:00:00'),
-    endDate: new Date('2023-07-01T00:00:00'),
-    taskName: 'Ubuntu 22.04.2 LTS (v5.19)',
-    status: 'LTS'
+    startDate: new Date("2023-02-01T00:00:00"),
+    endDate: new Date("2023-07-01T00:00:00"),
+    taskName: "Ubuntu 22.04.2 LTS (v5.19)",
+    status: "LTS",
   },
 ];
 
@@ -1668,7 +1668,7 @@ export var kernelReleaseNamesALL = [
   "Ubuntu 22.04.0 LTS (v5.15)",
   "Ubuntu 20.04.5 LTS (v5.15)",
   "Ubuntu 22.04.1 LTS (v5.15)",
-  "Ubuntu 22.04.2 LTS (v5.19)"
+  "Ubuntu 22.04.2 LTS (v5.19)",
 ];
 
 export var kernelReleaseNamesLTS = [
@@ -1698,7 +1698,7 @@ export var kernelReleaseNamesLTS = [
   "Ubuntu 22.04.0 LTS (v5.15)",
   "Ubuntu 20.04.5 LTS (v5.15)",
   "Ubuntu 22.04.1 LTS (v5.15)",
-  "Ubuntu 22.04.2 LTS (v5.19)"
+  "Ubuntu 22.04.2 LTS (v5.19)",
 ];
 
 export var openStackReleaseNames = [

--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -1556,6 +1556,9 @@ export var desktopServerReleaseNames = [
 ];
 
 export var kernelReleaseNames = [
+  "Ubuntu 22.04.2 LTS",
+  "Ubuntu 22.10",
+  "Ubuntu 22.04.1 LTS",
   "Ubuntu 20.04.5 LTS",
   "Ubuntu 22.04.0 LTS",
   "Ubuntu 20.04.4 LTS",
@@ -1578,7 +1581,10 @@ export var kernelReleaseNames = [
 ];
 
 export var kernelVersionNames = [
+  "5.19 kernel",
+  "",
   "5.15 kernel",
+  "",
   "",
   "5.13 kernel",
   "",

--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -138,6 +138,27 @@ export var serverAndDesktopReleases = [
 
 export var kernelReleases = [
   {
+    startDate: new Date('2023-02-01T00:00:00'),
+    endDate: new Date('2027-04-01T00:00:00'),
+    taskName: 'Ubuntu 22.04.2 LTS',
+    taskVersion: 'Kernel version',
+    status: 'LTS'
+  },
+  {
+    startDate: new Date('2022-10-01T00:00:00'),
+    endDate: new Date('2023-07-01T00:00:00'),
+    taskName: 'Ubuntu 22.10',
+    taskVersion: '',
+    status: 'INTERIM_RELEASE'
+  },
+  {
+    startDate: new Date('2022-08-01T00:00:00'),
+    endDate: new Date('2027-04-01T00:00:00'),
+    taskName: 'Ubuntu 22.04.1 LTS',
+    taskVersion: '',
+    status: 'LTS'
+  },
+  {
     startDate: new Date("2022-08-01T00:00:00"),
     endDate: new Date("2025-04-30T00:00:00"),
     taskName: "Ubuntu 20.04.5 LTS",
@@ -362,6 +383,37 @@ export var kernelReleases = [
     status: "ESM",
   },
 ];
+
+export var kernelReleases2204 = [
+  {
+    startDate: new Date('2023-02-01T00:00:00'),
+    endDate: new Date('2027-04-01T00:00:00'),
+    taskName: 'Ubuntu 22.04.2 LTS',
+    taskVersion: 'Kernel version',
+    status: 'LTS'
+  },
+  {
+    startDate: new Date('2022-08-01T00:00:00'),
+    endDate: new Date('2027-04-01T00:00:00'),
+    taskName: 'Ubuntu 22.04.1 LTS',
+    taskVersion: '',
+    status: 'LTS'
+  },
+  {
+    startDate: new Date('2022-04-01T00:00:00'),
+    endDate: new Date('2027-04-01T00:00:00'),
+    taskName: 'Ubuntu 22.04.0 LTS',
+    taskVersion: '',
+    status: 'LTS'
+  },
+  {
+    startDate: new Date('2027-04-01T00:00:00'),
+    endDate: new Date('2032-03-30T00:00:00'),
+    taskName: 'Ubuntu 22.04.0 LTS',
+    taskVersion: '',
+    status: 'ESM'
+  },
+]
 
 export var kernelReleases2004 = [
   {
@@ -1552,6 +1604,9 @@ export var kernelReleaseNamesALL = [
   "Ubuntu 20.04.3 LTS (v5.11)",
   "Ubuntu 20.04.4 LTS (v5.13)",
   "Ubuntu 20.04.5 LTS (v5.15)",
+  "Ubuntu 22.04.0 LTS (v5.15)",
+  "Ubuntu 22.04.1 LTS (v5.15)",
+  "Ubuntu 22.04.2 LTS (v5.19)"
 ];
 
 export var kernelReleaseNamesLTS = [

--- a/static/js/src/chart.js
+++ b/static/js/src/chart.js
@@ -278,12 +278,14 @@ export function createChart(
   var rowHeight = 32;
   var timeDomainStart;
   var timeDomainEnd;
+  var earliestStartDate = d3.min(tasks, (d) => d.startDate);
+  var latestEndDate = d3.max(tasks, (d) => d.endDate);
   if (removePadding) {
-    timeDomainStart = tasks[0].startDate;
-    timeDomainEnd = tasks[tasks.length - 1].endDate;
+    timeDomainStart = earliestStartDate;
+    timeDomainEnd = latestEndDate;
   } else {
-    timeDomainStart = d3.timeYear.offset(tasks[0].startDate, -1);
-    timeDomainEnd = d3.timeYear.offset(tasks[tasks.length - 1].endDate, +1);
+    timeDomainStart = d3.timeYear.offset(earliestStartDate, -1);
+    timeDomainEnd = d3.timeYear.offset(latestEndDate, +1);
   }
   var height = taskTypes.length * rowHeight;
   var containerWidth = document.querySelector(chartSelector).clientWidth;

--- a/static/js/src/release-chart.js
+++ b/static/js/src/release-chart.js
@@ -219,7 +219,7 @@ function clearCharts() {
   }
 }
 
-var mediumBreakpoint = 875;
+var mediumBreakpoint = 620;
 
 // A bit of a hack, but chart doesn't load with full year axis on first load,
 // It has to be loaded once, and then again

--- a/static/js/src/release-chart.js
+++ b/static/js/src/release-chart.js
@@ -5,6 +5,7 @@ import {
   serverAndDesktopReleases,
   kernelReleases,
   kernelReleaseSchedule,
+  kernelReleases2204,
   kernelReleases2004,
   kernelReleases1804,
   kernelReleases1604,
@@ -25,6 +26,7 @@ import {
   kernelReleaseNames,
   kernelVersionNames,
   kernelReleaseScheduleNames,
+  kernelReleaseNames2204,
   kernelReleaseNames2004,
   kernelReleaseNames1804,
   kernelReleaseNames1604,
@@ -72,6 +74,14 @@ function buildCharts() {
       kernelStatus,
       kernelReleases,
       kernelVersionNames
+    );
+  }
+  if (document.querySelector("#kernel2204")) {
+    createChart(
+      "#kernel2204",
+      kernelReleaseNames2204,
+      kernelStatus,
+      kernelReleases2204
     );
   }
   if (document.querySelector("#kernel2004")) {
@@ -166,6 +176,10 @@ function clearCharts() {
   const kernelEol = document.querySelector("#kernel-eol");
   if (kernelEol) {
     kernelEol.innerHTML = "";
+  }
+  const kernel2204 = document.querySelector("#kernel2204");
+  if (kernel2204) {
+    kernel2204.innerHTML = "";
   }
   const kernel2004 = document.querySelector("#kernel2004");
   if (kernel2004) {

--- a/static/js/src/tabbed-content.js
+++ b/static/js/src/tabbed-content.js
@@ -112,7 +112,7 @@
       tabContent.forEach((content) => {
         if (tabElement === tab) {
           tabElement.setAttribute("aria-selected", true);
-          content.classList.remove("u-hide");   
+          content.classList.remove("u-hide");
           if (triggerReload) {
             window.dispatchEvent(new Event("resize"));
           }
@@ -159,7 +159,6 @@
     });
   };
 
-
   /**
     Check to see if a given script has been loaded on the page.
   
@@ -176,15 +175,15 @@
   */
   const isScriptIncluded = (scriptName) => {
     var scripts = document.scripts;
-    
+
     for (var i = 0; i < scripts.length; i++) {
       if (scripts[i].src.includes(scriptName)) {
         return true;
       }
     }
-    
+
     return false;
-  }
+  };
   const targetScript = "release-chart.js";
   const triggerReload = isScriptIncluded(targetScript);
 

--- a/static/js/src/tabbed-content.js
+++ b/static/js/src/tabbed-content.js
@@ -112,22 +112,25 @@
       tabContent.forEach((content) => {
         if (tabElement === tab) {
           tabElement.setAttribute("aria-selected", true);
-          content.removeAttribute("hidden");
+          content.classList.remove("u-hide");   
+          if (triggerReload) {
+            window.dispatchEvent(new Event("resize"));
+          }
         } else {
           tabElement.setAttribute("aria-selected", false);
-          content.setAttribute("hidden", true);
+          content.classList.add("u-hide");
         }
       });
     });
   };
 
   /**
-      Attaches events to tab links within a given parent element,
-      and sets the active tab if the current hash matches the id
-      of an element controlled by a tab link
-      @param {String} selector class name of the element
-      containing the tabs we want to attach events to
-    */
+    Attaches events to tab links within a given parent element,
+    and sets the active tab if the current hash matches the id
+    of an element controlled by a tab link
+    @param {String} selector class name of the element
+    containing the tabs we want to attach events to
+  */
   const initTabs = (selector) => {
     var tabContainers = [].slice.call(document.querySelectorAll(selector));
 
@@ -155,6 +158,35 @@
       }
     });
   };
+
+
+  /**
+    Check to see if a given script has been loaded on the page.
+  
+    If a chart is on a tab that isn't visible, it isn't built,
+    because its width depends on a parent element's width, which
+    is zero when the tab is not visible.
+   
+    Charts aren't responsive and need to be redrawn if the window
+    is resized, so they listen for that event and trigger the redraw
+    when it fires.
+   
+    @param {String} scriptName name of the script to check exists
+    on the page
+  */
+  const isScriptIncluded = (scriptName) => {
+    var scripts = document.scripts;
+    
+    for (var i = 0; i < scripts.length; i++) {
+      if (scripts[i].src.includes(scriptName)) {
+        return true;
+      }
+    }
+    
+    return false;
+  }
+  const targetScript = "release-chart.js";
+  const triggerReload = isScriptIncluded(targetScript);
 
   document.addEventListener("DOMContentLoaded", () => {
     initTabs(".js-tabbed-content");

--- a/static/js/src/tabotronic.js
+++ b/static/js/src/tabotronic.js
@@ -33,6 +33,10 @@
       panel.classList.add("u-hide");
     });
     panelElement.classList.remove("u-hide");
+    // Hack to fix a graph sizing bug:
+    // The size is defined by the container, but on hidden tabs it falls back 
+    // on the next parent which is smaller than the container it is in when
+    // not hidden
     if (panelElement.querySelector("svg[class='chart']")) {
       window.dispatchEvent(new Event("resize"));
     }

--- a/static/js/src/tabotronic.js
+++ b/static/js/src/tabotronic.js
@@ -34,7 +34,7 @@
     });
     panelElement.classList.remove("u-hide");
     // Hack to fix a graph sizing bug:
-    // The size is defined by the container, but on hidden tabs it falls back 
+    // The size is defined by the container, but on hidden tabs it falls back
     // on the next parent which is smaller than the container it is in when
     // not hidden
     if (panelElement.querySelector("svg[class='chart']")) {

--- a/static/sass/_pattern_tabs.scss
+++ b/static/sass/_pattern_tabs.scss
@@ -55,7 +55,7 @@
       }
     }
 
-    &.is-risc-v {
+    &.is-black {
       margin-left: 0;
       padding-left: 0;
 
@@ -64,6 +64,18 @@
           @include vf-highlight-bar($color-dark, left);
         }
       }
+    }
+
+    &.on-paper {
+      .p-tabs__item {
+        background-color: #f7f7f7;
+
+        &[aria-selected="true"] {
+          @include vf-highlight-bar($color-brand, left);
+          background-color: white;
+        }
+      }
+
     }
   }
 

--- a/static/sass/_pattern_tabs.scss
+++ b/static/sass/_pattern_tabs.scss
@@ -72,10 +72,10 @@
 
         &[aria-selected="true"] {
           @include vf-highlight-bar($color-brand, left);
+
           background-color: white;
         }
       }
-
     }
   }
 

--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -420,7 +420,6 @@
       <p>The release cycles of Charmed Kubernetes and MicroK8s are tightly synchronised to the release of upstream Kubernetes<sup>&reg;</sup>. The current release and two prior releases are supported (N-2), subject to changes in the upstream release cycle. Canonical also provides expanded security maintenance (ESM) for N-4 Kubernetes releases in the stable release channel.</p>
 
       <p>For <a href="/support">Ubuntu Advantage</a> support, users must upgrade to remain in the N-2 support window.</p>
-
       <p>ESM support includes fixes to high and critical CVEs related to Kubernetes charms, limited to the LTS Ubuntu releases in the current N-4 support window. Upstream updates and fixes to Kubernetes binaries or container images are absorbed by Charmed Kubernetes and Microk8s.</p>
 
       <p>The Canonical Kubernetes support lifecycle can be represented this way:</p>
@@ -537,29 +536,5 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.8.2/d3.min.js" defer></script>
 <script src="{{ versioned_static('js/dist/release-chart.js') }}" defer></script>
 <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
-
-<script>
-  const tabs = document.querySelectorAll('.p-tabs__link');
-
-  // If a chart is on a tab that isn't visible, it isn't built,
-  // because its width depends on a parent element's width, which
-  // is zero when the tab is not visible.
-  //
-  // Charts aren't responsive and need to be redrawn if the window
-  // is resized, so they listen for that event and trigger the redraw
-  // when it fires.
-  //
-  // By triggering that same event, we can force the charts to be redrawn
-  // when a tab is made visible.
-  tabs.forEach(tab => {
-    tab.addEventListener('click', () => {
-      window.dispatchEvent(new Event('resize'));
-    })
-
-    tab.addEventListener('focus', () => {
-      window.dispatchEvent(new Event('resize'));
-    })
-  })
-</script>
 
 {% endblock content %}

--- a/templates/core/features/index.html
+++ b/templates/core/features/index.html
@@ -280,7 +280,7 @@
           </div>
         </div>
 
-        <div tabindex="0" role="tabpanel" id="snapd-tab" aria-labelledby="snapd-tab-cta" hidden="hidden">
+        <div tabindex="0" role="tabpanel" id="snapd-tab" aria-labelledby="snapd-tab-cta" aria-hidden="hidden">
           <div class="row u-equal-height">
             <div class="col-8 p-divider__block">
             <h3>Snapd</h3>
@@ -308,7 +308,7 @@
           </div>
         </div>
 
-        <div tabindex="0" role="tabpanel" id="snapcraft-tab" aria-labelledby="snapcraft-tab-cta" hidden="hidden">
+        <div tabindex="0" role="tabpanel" id="snapcraft-tab" aria-labelledby="snapcraft-tab-cta" aria-hidden="hidden">
           <div class="row u-equal-height">
             <div class="col-8 p-divider__block">
               <h3>Snapcraft</h3>

--- a/templates/download/amd-xilinx/index.html
+++ b/templates/download/amd-xilinx/index.html
@@ -202,7 +202,7 @@
         </div>
       </div>
       <!-- tab 2: Ubuntu for Zynq UltraScale+ MPSoC Development Boards -->
-      <div tabindex="0" role="tabpanel" id="zynq-ultrascale-tab" aria-labelledby="zynq-ultrascale" hidden="true">
+      <div tabindex="0" role="tabpanel" id="zynq-ultrascale-tab" aria-labelledby="zynq-ultrascale" aria-hidden="true">
         <div class="row u-vertically-center u-no-padding">
           <div class="col-6">
             <h2>Download Ubuntu Desktop</h2>

--- a/templates/download/risc-v/index.html
+++ b/templates/download/risc-v/index.html
@@ -41,7 +41,7 @@
   <div class="row">
     <div class="col-3 col-medium-2">
       <div class="p-strip is-shallow u-no-padding--top"><h2 class="p-text--small-caps">Choose a board</h2></div>
-      <ul class="js-tabbed-content p-tabs--vertical is-risc-v" role="tablist" aria-label="Robotics features">
+      <ul class="js-tabbed-content p-tabs--vertical is-black" role="tablist" aria-label="Robotics features">
         <li><button class="p-tabs__item" id="quemu-sifive-image" role="tab" aria-selected="true" tab-index="-1" aria-controls="quemu-sifive-image-tab">SiFive Unmatched</button></li>
         <li><button class="p-tabs__item" id="starfive-visionfive-board" role="tab" aria-selected="false" aria-controls="starfive-visionfive-board-tab">StarFive VisionFive</button></li>
         <li><button class="p-tabs__item" id="starfive-visionfive-2" role="tab" aria-selected="false" aria-controls="starfive-visionfive-2-tab">StarFive VisionFive 2</button></li>

--- a/templates/download/risc-v/tab-2.html
+++ b/templates/download/risc-v/tab-2.html
@@ -1,4 +1,4 @@
-<div tabindex="0" role="tabpanel" id="starfive-visionfive-board-tab" aria-labelledby="starfive-visionfive-board" hidden="true">
+<div tabindex="0" role="tabpanel" id="starfive-visionfive-board-tab" aria-labelledby="starfive-visionfive-board" aria-hidden="true">
 	<div class="row">
 		<div class="col-6">
 			<div class="p-strip is-shallow u-no-padding--top">

--- a/templates/kernel/lifecycle.html
+++ b/templates/kernel/lifecycle.html
@@ -97,8 +97,8 @@
   </div>
 </section>
 
-{% with selected_tab="support-all-tab" %}
-  {% include "shared/_kernel-support-schedule.html" %}
-{% endwith %}
+{% include "shared/_kernel-support-schedule.html" %}
+
+<script src="{{ versioned_static('js/dist/tabotronic.js') }}" defer></script>
 
 {% endblock %}

--- a/templates/openstack/install.html
+++ b/templates/openstack/install.html
@@ -37,7 +37,7 @@
   </div>
 </section>
 
-<section class="p-strip--light is-bordered">
+<section class="p-strip--light u-no-padding--bottom">
   <div class="u-fixed-width">
     <h2>Single-node, multi-node or large-scale cluster?</h2>
     <p><strong>Choose the OpenStack installation option that suits you best:</strong></p>
@@ -55,69 +55,29 @@
       </div>
     </div>
   </div>
-  <div class="u-fixed-width">
-    <div tabindex="0" role="tabpanel" aria-labelledby="single-node-deployment">
-      <div class="row">
-        <div class="col-6">
-          <ul class="p-list">
-            <li class="p-list__item is-ticked">One physical machine needed</li>
-            <li class="p-list__item is-ticked">Uses MicroStack &ndash; OpenStack in a snap</li>
-            <li class="p-list__item is-ticked">Core services included</li>
-            <li class="p-list__item is-ticked">All services on a single node</li>
-          </ul>
-        </div>
-        <div class="col-6">
-          <ul class="p-list">
-            <li class="p-list__item is-ticked">Opinionated OpenStack</li>
-            <li class="p-list__item is-ticked">Straightforward installation</li>
-            <li class="p-list__item is-ticked">OpenStack "on-rails"</li>
-          </ul>
-        </div>
-      </div>
-    </div>
-    <div tabindex="0" role="tabpanel" aria-labelledby="multi-node-deployment" hidden="true">
-      <div class="row">
-        <div class="col-6">
-          <ul class="p-list">
-            <li class="p-list__item is-ticked">At least two physical machines needed</li>
-            <li class="p-list__item is-ticked">Uses MicroStack &ndash; OpenStack in a snap</li>
-            <li class="p-list__item is-ticked">Core services included</li>
-            <li class="p-list__item is-ticked">One control node, many compute/storage nodes</li>
-          </ul>
-        </div>
-        <div class="col-6">
-          <ul class="p-list">
-            <li class="p-list__item is-ticked">Opinionated OpenStack</li>
-            <li class="p-list__item is-ticked">Straightforward installation</li>
-            <li class="p-list__item is-ticked">OpenStack "on-rails"</li>
-          </ul>
-        </div>
-      </div>
-    </div>
-      <div tabindex="0" role="tabpanel" aria-labelledby="large-scale-deployment" hidden="true">
-        <div class="row">
-          <div class="col-6">
-            <ul class="p-list">
-              <li class="p-list__item is-ticked">At least six physical machines needed</li>
-              <li class="p-list__item is-ticked">Uses <a href="https://docs.openstack.org/charm-guide/latest/">OpenStack Charms</a></li>
-              <li class="p-list__item is-ticked">Core and additional services included</li>
-              <li class="p-list__item is-ticked">Architectural freedom, full HA option</li>
-            </ul>
-          </div>
-          <div class="col-6">
-            <ul class="p-list">
-              <li class="p-list__item is-ticked">Composable OpenStack</li>
-              <li class="p-list__item is-ticked">Fully automated installation and day-2 operations</li>
-              <li class="p-list__item is-ticked">Enterprise private cloud</li>
-            </ul>
-          </div>
-        </div>
-      </div>
-    </div>
-  </section>
+</section>
 
-<section class="p-strip is-bordered" id="single-node-deployment">
-  <div class="u-fixed-width">
+<section tabindex="0" role="tabpanel" id="single-node-deployment">
+  <div class="p-strip--light is-bordered u-no-padding--top">
+    <div class="row">
+      <div class="col-6">
+        <ul class="p-list">
+          <li class="p-list__item is-ticked">One physical machine needed</li>
+          <li class="p-list__item is-ticked">Uses MicroStack &ndash; OpenStack in a snap</li>
+          <li class="p-list__item is-ticked">Core services included</li>
+          <li class="p-list__item is-ticked">All services on a single node</li>
+        </ul>
+      </div>
+      <div class="col-6">
+        <ul class="p-list">
+          <li class="p-list__item is-ticked">Opinionated OpenStack</li>
+          <li class="p-list__item is-ticked">Straightforward installation</li>
+          <li class="p-list__item is-ticked">OpenStack "on-rails"</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+  <div class="p-strip u-fixed-width">
     <h2>Single-node OpenStack deployment</h2>
     <p class="u-sv3">These instructions use <a href="https://snapcraft.io/microstack">MicroStack</a> &dash; OpenStack in a snap, MicroStack is a pure upstream OpenStack distribution designed for small scale and edge deployments, that can be installed and maintained with a minimal effort.</p>
     <div class="p-notification is-inline">
@@ -128,13 +88,32 @@
     </div>
 
     {{ single_node | safe }}
-
+    
     <p>To learn more about MicroStack, visit <a href="https://microstack.run">https://microstack.run</a>.</p>
   </div>
 </section>
 
-<section class="p-strip is-bordered" id="multi-node-deployment" hidden="true">
-  <div class="u-fixed-width">
+<section tabindex="0" role="tabpanel" id="multi-node-deployment" aria-hidden="true">
+  <div class="p-strip--light is-bordered u-no-padding--top">
+    <div class="row">
+      <div class="col-6">
+        <ul class="p-list">
+          <li class="p-list__item is-ticked">At least two physical machines needed</li>
+          <li class="p-list__item is-ticked">Uses MicroStack &ndash; OpenStack in a snap</li>
+          <li class="p-list__item is-ticked">Core services included</li>
+          <li class="p-list__item is-ticked">One control node, many compute/storage nodes</li>
+        </ul>
+      </div>
+      <div class="col-6">
+        <ul class="p-list">
+          <li class="p-list__item is-ticked">Opinionated OpenStack</li>
+          <li class="p-list__item is-ticked">Straightforward installation</li>
+          <li class="p-list__item is-ticked">OpenStack "on-rails"</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+  <div class="p-strip u-fixed-width">
     <h2>Multi-node OpenStack deployment</h2>
     <p>These instructions use <a href="https://snapcraft.io/microstack">MicroStack</a> &dash; in a snap. MicroStack is a pure upstream OpenStack distribution, designed for small scale and edge deployments, that can be installed and maintained with a minimal effort.</p>
     <div class="p-notification is-inline">
@@ -149,9 +128,28 @@
   <p>To learn more about MicroStack, visit <a href="https://microstack.run">https://microstack.run</a>.</p>
 </section>
 
-<section class="p-strip is-bordered" id="large-scale-deployment" hidden="true">
-  <div class="u-fixed-width">
-    <div tabindex="0" role="tabpanel" id="large-scale-deployment" aria-labelledby="large-scale-deployment" hidden="hidden">
+<section tabindex="0" role="tabpanel" id="large-scale-deployment" aria-labelledby="large-scale-deployment" aria-hidden="hidden">
+  <div class="p-strip--light is-bordered u-no-padding--top">
+    <div class="row">
+      <div class="col-6">
+        <ul class="p-list">
+          <li class="p-list__item is-ticked">At least six physical machines needed</li>
+          <li class="p-list__item is-ticked">Uses <a href="https://docs.openstack.org/charm-guide/latest/">OpenStack Charms</a></li>
+          <li class="p-list__item is-ticked">Core and additional services included</li>
+          <li class="p-list__item is-ticked">Architectural freedom, full HA option</li>
+        </ul>
+      </div>
+      <div class="col-6">
+        <ul class="p-list">
+          <li class="p-list__item is-ticked">Composable OpenStack</li>
+          <li class="p-list__item is-ticked">Fully automated installation and day-2 operations</li>
+          <li class="p-list__item is-ticked">Enterprise private cloud</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+  <div class="p-strip u-fixed-width">
+    <div>
       <h2>Large-scale deployment</h2>
       <p>
         These instructions use <a href="https://docs.openstack.org/charm-guide/latest/">OpenStack Charms</a>. OpenStack Charms are the foundation of Canonical’s <a href="https://ubuntu.com/openstack">Charmed OpenStack</a> distribution which is an enterprise private cloud, designed to run mission-critical workloads.

--- a/templates/shared/_kernel-support-schedule.html
+++ b/templates/shared/_kernel-support-schedule.html
@@ -27,19 +27,19 @@
         </thead>
         <tbody>
           <tr>
-            <td><strong>Ubuntu 22.04.0 LTS</strong></td>
+            <td><strong>Ubuntu 22.04.0 LTS (v5.15)</strong></td>
             <td>Apr 2022</td>
             <td>Apr 2027</td>
             <td>Apr 2032</td>
           </tr>
           <tr>
-            <td><strong>Ubuntu 22.04.1 LTS</strong></td>
+            <td><strong>Ubuntu 22.04.1 LTS (v5.15)</strong></td>
             <td>Aug 2022</td>
             <td>Apr 2027</td>
             <td>Apr 2032</td>
           </tr>
           <tr>
-            <td><strong>Ubuntu 22.04.2 LTS</strong></td>
+            <td><strong>Ubuntu 22.04.2 LTS (v5.19)</strong></td>
             <td>Feb 2023</td>
             <td>Jul 2023</td>
             <td>&nbsp;</td>
@@ -61,37 +61,37 @@
         </thead>
         <tbody>
           <tr>
-            <td><strong>Ubuntu 20.04.5 LTS</strong></td>
+            <td><strong>Ubuntu 20.04.5 LTS (v5.15)</strong></td>
             <td>Aug 2022</td>
             <td>Apr 2025</td>
             <td>Apr 2030</td>
           </tr>
           <tr>
-            <td><strong>Ubuntu 20.04.4 LTS</strong></td>
+            <td><strong>Ubuntu 20.04.4 LTS (v5.13)</strong></td>
             <td>Feb 2022</td>
             <td>Aug 2022</td>
             <td>&nbsp;</td>
           </tr>
           <tr>
-            <td><strong>Ubuntu 20.04.3 LTS</strong></td>
+            <td><strong>Ubuntu 20.04.3 LTS (v5.11)</strong></td>
             <td>Aug 2021</td>
             <td>Feb 2022</td>
             <td>&nbsp;</td>
           </tr>
           <tr>
-            <td><strong>Ubuntu 20.04.2 LTS</strong></td>
+            <td><strong>Ubuntu 20.04.2 LTS (v5.8)</strong></td>
             <td>Feb 2021</td>
             <td>Aug 2021</td>
             <td>&nbsp;</td>
           </tr>
           <tr>
-            <td><strong>Ubuntu 20.04.1 LTS</strong></td>
+            <td><strong>Ubuntu 20.04.1 LTS (v5.4)</strong></td>
             <td>Jul 2020</td>
             <td>Apr 2025</td>
             <td>Apr 2030</td>
           </tr>
           <tr>
-            <td><strong>Ubuntu 20.04.0 LTS</strong></td>
+            <td><strong>Ubuntu 20.04.0 LTS (v5.4)</strong></td>
             <td>Apr 2020</td>
             <td>Apr 2025</td>
             <td>Apr 2030</td>
@@ -113,7 +113,7 @@
         </thead>
         <tbody>
           <tr>
-            <td><strong>Ubuntu 18.04.5 LTS</strong></td>
+            <td><strong>Ubuntu 18.04.5 LTS (v5.4)</strong></td>
             <td>Aug 2020</td>
             <td>Apr 2023</td>
             <td>Apr 2028</td>
@@ -371,37 +371,37 @@
             <td>Jul 2020</td>
           </tr>
           <tr>
-            <td><strong>Ubuntu 20.04.0 LTS</strong></td>
+            <td><strong>Ubuntu 20.04.0 LTS (v5.4)</strong></td>
             <td>Apr 2020</td>
             <td>Apr 2022</td>
             <td>Apr 2025</td>
           </tr>
           <tr>
-            <td><strong>Ubuntu 20.04.1 LTS</strong></td>
+            <td><strong>Ubuntu 20.04.1 LTS (v5.4)</strong></td>
             <td>Jul 2020</td>
             <td>Apr 2022</td>
             <td>Apr 2025</td>
           </tr>
           <tr>
-            <td><strong>Ubuntu 18.04.5 LTS</strong></td>
+            <td><strong>Ubuntu 18.04.5 LTS (v5.4)</strong></td>
             <td>Aug 2020</td>
             <td>Apr 2022</td>
             <td>Apr 2023</td>
           </tr>
           <tr>
-            <td><strong>Ubuntu 20.04.2 LTS</strong></td>
+            <td><strong>Ubuntu 20.04.2 LTS (v5.8)</strong></td>
             <td>Feb 2021</td>
             <td>&nbsp;</td>
             <td>Aug 2021</td>
           </tr>
           <tr>
-            <td><strong>Ubuntu 20.04.3 LTS</strong></td>
+            <td><strong>Ubuntu 20.04.3 LTS (v5.11)</strong></td>
             <td>Aug 2021</td>
             <td>&nbsp;</td>
             <td>Feb 2022</td>
           </tr>
           <tr>
-            <td><strong>Ubuntu 20.04.4 LTS</strong></td>
+            <td><strong>Ubuntu 20.04.4 LTS (v5.13)</strong></td>
             <td>Feb 2022</td>
             <td>&nbsp;</td>
             <td>Jul 2022</td>

--- a/templates/shared/_kernel-support-schedule.html
+++ b/templates/shared/_kernel-support-schedule.html
@@ -4,7 +4,7 @@
   </div>
   <div class="row">
   <div class="col-3">
-      <ul class="p-tabs--vertical on-paper js-tabbed-content" role="tablist" style="margin-top:1.5rem;">
+      <ul class="p-tabs--vertical on-paper js-tabbed-content u-no-margin--left u-no-padding--left" role="tablist" style="margin-top:1.5rem;">
         <li><button class="p-tabs__item" role="tab" id="support-all-tab" aria-controls="support-all">All releases</button></li>
         <li><button class="p-tabs__item" role="tab" id="support-lts-tab" aria-selected="false" aria-controls="support-lts">All LTS releases</button></li>
         <li><button class="p-tabs__item" role="tab" id="support-22-04-tab" aria-selected="false" aria-controls="support-22-04">22.04 LTS</button></li>

--- a/templates/shared/_kernel-support-schedule.html
+++ b/templates/shared/_kernel-support-schedule.html
@@ -13,6 +13,9 @@
               <a href="#support-lts" class="p-tabs__link" role="tab" id="support-lts-tab" {% if selected_tab == "support-lts-tab" %}aria-selected="true"{% endif %}aria-controls="support-lts">All LTS releases</a>
             </li>
             <li class="p-tabs__item" role="presentation">
+              <a href="#support-22-04" class="p-tabs__link" role="tab" id="support-22-04-tab" {% if selected_tab == "support-22-04-tab" %}aria-selected="true"{% endif %}aria-controls="support-22-04">22.04 LTS</a>
+            </li>
+            <li class="p-tabs__item" role="presentation">
               <a href="#support-20-04" class="p-tabs__link" role="tab" id="support-20-04-tab" {% if selected_tab == "support-20-04-tab" %}aria-selected="true"{% endif %}aria-controls="support-20-04">20.04 LTS</a>
             </li>
             <li class="p-tabs__item" role="presentation">
@@ -27,6 +30,40 @@
             </li>
           </ul>
         </nav>
+
+        <div class="p-tabs__content" id="support-22-04" role="tabpanel" aria-labelledby="support-22-04-tab">
+          <div class="u-hide--small" id="kernel2204"></div>
+          <table class="u-hide--medium u-hide--large">
+            <thead>
+              <tr>
+                <td>&nbsp;</td>
+                <th scope="col">Released</th>
+                <th scope="col">End of Life</th>
+                <th scope="col">Expanded security maintenance</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><strong>Ubuntu 22.04.0 LTS</strong></td>
+                <td>Apr 2022</td>
+                <td>Apr 2027</td>
+                <td>Apr 2032</td>
+              </tr>
+              <tr>
+                <td><strong>Ubuntu 22.04.1 LTS</strong></td>
+                <td>Aug 2022</td>
+                <td>Apr 2027</td>
+                <td>Apr 2032</td>
+              </tr>
+              <tr>
+                <td><strong>Ubuntu 22.04.2 LTS</strong></td>
+                <td>Feb 2023</td>
+                <td>Jul 2023</td>
+                <td>&nbsp;</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
 
         <div class="p-tabs__content" id="support-20-04" role="tabpanel" aria-labelledby="support-20-04-tab">
           <div class="u-hide--small" id="kernel2004"></div>
@@ -387,11 +424,29 @@
                 <td>Jul 2022</td>
               </tr>
               <tr>
+                <td><strong>Ubuntu 22.04.0 LTS (v5.15)</strong></td>
+                <td>Apr 2022</td>
+                <td>Apr 2024</td>
+                <td>Apr 2027</td>
+              </tr>
+              <tr>
                 <td><strong>Ubuntu 20.04.5 LTS (v5.15)</strong></td>
                 <td>Aug 2022</td>
                 <td>Aug 2024</td>
                 <td>Apr 2025</td>
               </tr>
+              <tr>
+                <td><strong>Ubuntu 22.04.1 LTS (v5.15)</strong></td>
+                <td>Aug 2022</td>
+                <td>Apr 2024</td>
+                <td>Apr 2027</td>
+              </tr>
+              <tr>
+                <td><strong>Ubuntu 22.04.2 LTS (v5.19)</strong></td>
+                <td>Feb 2023</td>
+                <td>&nbsp;</td>
+                <td>Jul 2023</td>
+                </tr>
             </tbody>
           </table>
         </div>
@@ -523,46 +578,64 @@
                 <td>Jul 2020</td>
               </tr>
               <tr>
-                <td><strong>Ubuntu 20.04.0 LTS</strong></td>
+                <td><strong>Ubuntu 20.04.0 LTS (v5.4)</strong></td>
                 <td>Jan 2020</td>
                 <td>Apr 2020</td>
                 <td>Apr 2025</td>
               </tr>
               <tr>
-                <td><strong>Ubuntu 20.04.1 LTS</strong></td>
+                <td><strong>Ubuntu 20.04.1 LTS (v5.4)</strong></td>
                 <td>Apr 2020</td>
                 <td>Jul 2020</td>
                 <td>Apr 2025</td>
               </tr>
               <tr>
-                <td><strong>Ubuntu 18.04.5 LTS</strong></td>
+                <td><strong>Ubuntu 18.04.5 LTS (v5.4)</strong></td>
                 <td>May 2020</td>
                 <td>Aug 2020</td>
                 <td>Apr 2023</td>
               </tr>
               <tr>
-                <td><strong>Ubuntu 20.04.2 LTS</strong></td>
+                <td><strong>Ubuntu 20.04.2 LTS (v5.8)</strong></td>
                 <td>&nbsp;</td>
                 <td>Feb 2021</td>
                 <td>Aug 2021</td>
               </tr>
               <tr>
-                <td><strong>Ubuntu 20.04.3 LTS</strong></td>
+                <td><strong>Ubuntu 20.04.3 LTS (v5.11)</strong></td>
                 <td>&nbsp;</td>
                 <td>Aug 2021</td>
                 <td>Feb 2022</td>
               </tr>
               <tr>
-                <td><strong>Ubuntu 20.04.4 LTS</strong></td>
+                <td><strong>Ubuntu 20.04.4 LTS (v5.13)</strong></td>
                 <td>&nbsp;</td>
                 <td>Feb 2022</td>
                 <td>Aug 2022</td>
               </tr>
               <tr>
+                <td><strong>Ubuntu 22.04.0 LTS (v5.15)</strong></td>
+                <td>Jan 2022</td>
+                <td>Apr 2022</td>
+                <td>Apr 2027</td>
+                </tr>
+              <tr>
                 <td><strong>Ubuntu 20.04.5 LTS (v5.15)</strong></td>
                 <td>May 2022</td>
                 <td>Aug 2022</td>
                 <td>Apr 2025</td>
+              </tr>
+              <tr>
+                <td><strong>Ubuntu 22.04.1 LTS (v5.15)</strong></td>
+                <td>&nbsp;</td>
+                <td>Aug 2022</td>
+                <td>Apr 2027</td>
+              </tr>
+              <tr>
+                <td><strong>Ubuntu 22.04.2 LTS (v5.19)</strong></td>
+                <td>&nbsp;</td>
+                <td>Feb 2023</td>
+                <td>Jul 2023</td>
               </tr>
             </tbody>
           </table>

--- a/templates/shared/_kernel-support-schedule.html
+++ b/templates/shared/_kernel-support-schedule.html
@@ -1,651 +1,631 @@
 <section class="p-strip--light is-bordered">
+  <div class="u-fixed-width">
+    <h2>Kernel release schedule</h2>
+  </div>
   <div class="row">
-    <div class="col-8">
-      <h2>Kernel release schedule</h2>
+  <div class="col-3">
+      <ul class="p-tabs--vertical on-paper js-tabbed-content" role="tablist" style="margin-top:1.5rem;">
+        <li><button class="p-tabs__item" role="tab" id="support-all-tab" aria-controls="support-all">All releases</button></li>
+        <li><button class="p-tabs__item" role="tab" id="support-lts-tab" aria-selected="false" aria-controls="support-lts">All LTS releases</button></li>
+        <li><button class="p-tabs__item" role="tab" id="support-22-04-tab" aria-selected="false" aria-controls="support-22-04">22.04 LTS</button></li>
+        <li><button class="p-tabs__item" role="tab" id="support-20-04-tab" aria-selected="false" aria-controls="support-20-04">20.04 LTS</button></li>
+        <li><button class="p-tabs__item" role="tab" id="support-18-04-tab" aria-selected="false"  aria-controls="support-18-04">18.04 LTS</button></li>
+        <li><button class="p-tabs__item" role="tab" id="support-16-04-tab" aria-selected="false"  aria-controls="support-16-04">16.04 LTS</button></li>
+        <li><button class="p-tabs__item" role="tab" id="support-14-04-tab" aria-selected="false" aria-controls="support-14-04">14.04 LTS</button></li>
+      </ul>
+    </div>
+    <div class="col-9" tabindex="0" id="support-22-04" role="tabpanel" aria-labelledby="support-22-04-tab">
+      <div class="u-hide--small" id="kernel2204"></div>
+      <table class="u-hide--medium u-hide--large">
+        <thead>
+          <tr>
+            <td>&nbsp;</td>
+            <th scope="col">Released</th>
+            <th scope="col">End of Life</th>
+            <th scope="col">Expanded security maintenance</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>Ubuntu 22.04.0 LTS</strong></td>
+            <td>Apr 2022</td>
+            <td>Apr 2027</td>
+            <td>Apr 2032</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 22.04.1 LTS</strong></td>
+            <td>Aug 2022</td>
+            <td>Apr 2027</td>
+            <td>Apr 2032</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 22.04.2 LTS</strong></td>
+            <td>Feb 2023</td>
+            <td>Jul 2023</td>
+            <td>&nbsp;</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
 
-      <div class="js-tab-container" {% if selected_tab %}data-js-selected-tab="{{ selected_tab }}"{% endif %}>
-        <nav class="p-tabs">
-          <ul class="p-tabs__list" role="tablist">
-            <li class="p-tabs__item" role="presentation">
-              <a href="#support-all" class="p-tabs__link" role="tab" id="support-all-tab" {% if selected_tab == "support-all-tab" %}aria-selected="true"{% endif %} aria-controls="support-all">All releases</a>
-            </li>
-            <li class="p-tabs__item" role="presentation">
-              <a href="#support-lts" class="p-tabs__link" role="tab" id="support-lts-tab" {% if selected_tab == "support-lts-tab" %}aria-selected="true"{% endif %}aria-controls="support-lts">All LTS releases</a>
-            </li>
-            <li class="p-tabs__item" role="presentation">
-              <a href="#support-22-04" class="p-tabs__link" role="tab" id="support-22-04-tab" {% if selected_tab == "support-22-04-tab" %}aria-selected="true"{% endif %}aria-controls="support-22-04">22.04 LTS</a>
-            </li>
-            <li class="p-tabs__item" role="presentation">
-              <a href="#support-20-04" class="p-tabs__link" role="tab" id="support-20-04-tab" {% if selected_tab == "support-20-04-tab" %}aria-selected="true"{% endif %}aria-controls="support-20-04">20.04 LTS</a>
-            </li>
-            <li class="p-tabs__item" role="presentation">
-              <a href="#support-18-04" class="p-tabs__link" role="tab" id="support-18-04-tab" {% if selected_tab == "support-18-04-tab" %}aria-selected="true"{% endif %} aria-controls="support-18-04">18.04 LTS</a>
-            </li>
-            <li class="p-tabs__item" role="presentation">
-              <a href="#support-16-04" class="p-tabs__link" role="tab" id="support-16-04-tab" {% if selected_tab == "support-16-04-tab" %}aria-selected="true"{% endif %} aria-controls="support-16-04">16.04 LTS</a>
-            </li>
-            <li class="p-tabs__item" role="presentation">
-              <a href="#support-14-04" class="p-tabs__link" role="tab" id="support-14-04-tab"
-              {% if selected_tab == "support-14-04-tab" %}aria-selected="true"{% endif %}  aria-controls="support-14-04">14.04 LTS</a>
-            </li>
-          </ul>
-        </nav>
+    <div class="col-9" tabindex="0" id="support-20-04" role="tabpanel" aria-labelledby="support-20-04-tab">
+      <div class="u-hide--small" id="kernel2004"></div>
+      <table class="u-hide--medium u-hide--large">
+        <thead>
+          <tr>
+            <td>&nbsp;</td>
+            <th scope="col">Released</th>
+            <th scope="col">End of Life</th>
+            <th scope="col">Expanded security maintenance</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>Ubuntu 20.04.5 LTS</strong></td>
+            <td>Aug 2022</td>
+            <td>Apr 2025</td>
+            <td>Apr 2030</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 20.04.4 LTS</strong></td>
+            <td>Feb 2022</td>
+            <td>Aug 2022</td>
+            <td>&nbsp;</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 20.04.3 LTS</strong></td>
+            <td>Aug 2021</td>
+            <td>Feb 2022</td>
+            <td>&nbsp;</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 20.04.2 LTS</strong></td>
+            <td>Feb 2021</td>
+            <td>Aug 2021</td>
+            <td>&nbsp;</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 20.04.1 LTS</strong></td>
+            <td>Jul 2020</td>
+            <td>Apr 2025</td>
+            <td>Apr 2030</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 20.04.0 LTS</strong></td>
+            <td>Apr 2020</td>
+            <td>Apr 2025</td>
+            <td>Apr 2030</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
 
-        <div class="p-tabs__content" id="support-22-04" role="tabpanel" aria-labelledby="support-22-04-tab">
-          <div class="u-hide--small" id="kernel2204"></div>
-          <table class="u-hide--medium u-hide--large">
-            <thead>
-              <tr>
-                <td>&nbsp;</td>
-                <th scope="col">Released</th>
-                <th scope="col">End of Life</th>
-                <th scope="col">Expanded security maintenance</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td><strong>Ubuntu 22.04.0 LTS</strong></td>
-                <td>Apr 2022</td>
-                <td>Apr 2027</td>
-                <td>Apr 2032</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 22.04.1 LTS</strong></td>
-                <td>Aug 2022</td>
-                <td>Apr 2027</td>
-                <td>Apr 2032</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 22.04.2 LTS</strong></td>
-                <td>Feb 2023</td>
-                <td>Jul 2023</td>
-                <td>&nbsp;</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+    <div class="col-9" tabindex="0" id="support-18-04" role="tabpanel" aria-labelledby="support-18-04-tab">
+      <div class="u-hide--small" id="kernel1804"></div>
+      <table class="u-hide--medium u-hide--large">
+        <thead>
+          <tr>
+            <td>&nbsp;</td>
+            <th scope="col">Released</th>
+            <th scope="col">End of Life</th>
+            <th scope="col">Expanded security maintenance</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>Ubuntu 18.04.5 LTS</strong></td>
+            <td>Aug 2020</td>
+            <td>Apr 2023</td>
+            <td>Apr 2028</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 18.04.4 LTS (v5.3)</strong></td>
+            <td>Feb 2020</td>
+            <td>Aug 2020</td>
+            <td>&nbsp;</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 18.04.3 LTS  (v5.0)</strong></td>
+            <td>Aug 2019</td>
+            <td>Feb 2020</td>
+            <td>&nbsp;</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 18.04.2 LTS (v4.18)</strong></td>
+            <td>Feb 2019</td>
+            <td>Aug 2019</td>
+            <td>&nbsp;</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 18.04.1 LTS (v4.15)</strong></td>
+            <td>Jul 2018</td>
+            <td>Apr 2023</td>
+            <td>Apr 2028</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 18.04.0 LTS (v4.15)</strong></td>
+            <td>Apr 2018</td>
+            <td>Apr 2023</td>
+            <td>Apr 2028</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
 
-        <div class="p-tabs__content" id="support-20-04" role="tabpanel" aria-labelledby="support-20-04-tab">
-          <div class="u-hide--small" id="kernel2004"></div>
-          <table class="u-hide--medium u-hide--large">
-            <thead>
-              <tr>
-                <td>&nbsp;</td>
-                <th scope="col">Released</th>
-                <th scope="col">End of Life</th>
-                <th scope="col">Expanded security maintenance</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td><strong>Ubuntu 20.04.5 LTS</strong></td>
-                <td>Aug 2022</td>
-                <td>Apr 2025</td>
-                <td>Apr 2030</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 20.04.4 LTS</strong></td>
-                <td>Feb 2022</td>
-                <td>Aug 2022</td>
-                <td>&nbsp;</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 20.04.3 LTS</strong></td>
-                <td>Aug 2021</td>
-                <td>Feb 2022</td>
-                <td>&nbsp;</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 20.04.2 LTS</strong></td>
-                <td>Feb 2021</td>
-                <td>Aug 2021</td>
-                <td>&nbsp;</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 20.04.1 LTS</strong></td>
-                <td>Jul 2020</td>
-                <td>Apr 2025</td>
-                <td>Apr 2030</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 20.04.0 LTS</strong></td>
-                <td>Apr 2020</td>
-                <td>Apr 2025</td>
-                <td>Apr 2030</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+    <div class="col-9" tabindex="0" id="support-16-04" role="tabpanel" aria-labelledby="support-16-04-tab">
+      <div class="u-hide--small" id="kernel1604"></div>
+      <table class="u-hide--medium u-hide--large">
+        <thead>
+          <tr>
+            <td>&nbsp;</td>
+            <th scope="col">Released</th>
+            <th scope="col">End of Life</th>
+            <th scope="col">Expanded security maintenance</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>Ubuntu 16.04.5 LTS (v4.15)</strong></td>
+            <td>Aug 2018</td>
+            <td>Apr 2021</td>
+            <td>Apr 2024</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 16.04.4 LTS (v4.13)</strong></td>
+            <td>Feb 2018</td>
+            <td>Jul 2018</td>
+            <td>&nbsp;</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 16.04.3 LTS (v4.10)</strong></td>
+            <td>Aug 2017</td>
+            <td>Jan 2018</td>
+            <td>&nbsp;</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 16.04.2 LTS (v4.8)</strong></td>
+            <td>Feb 2017</td>
+            <td>Jul 2017</td>
+            <td>&nbsp;</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 16.04.1 LTS (v4.4)</strong></td>
+            <td>Aug 2016</td>
+            <td>Apr 2021</td>
+            <td>Apr 2024</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 16.04.0 LTS (v4.4)</strong></td>
+            <td>Apr 2016</td>
+            <td>Apr 2021</td>
+            <td>Apr 2024</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
 
-        <div class="p-tabs__content" id="support-18-04" role="tabpanel" aria-labelledby="support-18-04-tab">
-          <div class="u-hide--small" id="kernel1804"></div>
-          <table class="u-hide--medium u-hide--large">
-            <thead>
-              <tr>
-                <td>&nbsp;</td>
-                <th scope="col">Released</th>
-                <th scope="col">End of Life</th>
-                <th scope="col">Expanded security maintenance</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td><strong>Ubuntu 18.04.5 LTS</strong></td>
-                <td>Aug 2020</td>
-                <td>Apr 2023</td>
-                <td>Apr 2028</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 18.04.4 LTS (v5.3)</strong></td>
-                <td>Feb 2020</td>
-                <td>Aug 2020</td>
-                <td>&nbsp;</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 18.04.3 LTS  (v5.0)</strong></td>
-                <td>Aug 2019</td>
-                <td>Feb 2020</td>
-                <td>&nbsp;</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 18.04.2 LTS (v4.18)</strong></td>
-                <td>Feb 2019</td>
-                <td>Aug 2019</td>
-                <td>&nbsp;</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 18.04.1 LTS (v4.15)</strong></td>
-                <td>Jul 2018</td>
-                <td>Apr 2023</td>
-                <td>Apr 2028</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 18.04.0 LTS (v4.15)</strong></td>
-                <td>Apr 2018</td>
-                <td>Apr 2023</td>
-                <td>Apr 2028</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+    <div class="col-9" tabindex="0" id="support-14-04" role="tabpanel" aria-labelledby="support-14-04-tab">
+      <div class="u-hide--small" id="kernel1404"></div>
+      <table class="u-hide--medium u-hide--large">
+        <thead>
+          <tr>
+            <td>&nbsp;</td>
+            <th scope="col">Released</th>
+            <th scope="col">End of Life</th>
+            <th scope="col">Expanded security maintenance</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>Ubuntu 14.04.5 LTS (v4.4)</strong></td>
+            <td>Aug 2016</td>
+            <td>Apr 2019</td>
+            <td>Apr 2022</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 14.04.4 LTS (v4.2)</strong></td>
+            <td>Feb 2016</td>
+            <td>Jul 2016</td>
+            <td>&nbsp;</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 14.04.3 LTS (v3.19)</strong></td>
+            <td>Aug 2015</td>
+            <td>Jul 2016</td>
+            <td>&nbsp;</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 14.04.2 LTS (v3.16)</strong></td>
+            <td>Feb 2015</td>
+            <td>Jul 2016</td>
+            <td>&nbsp;</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 14.04.1 LTS (v3.13)</strong></td>
+            <td>Aug 2014</td>
+            <td>Apr 2019</td>
+            <td>Apr 2022</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 14.04.0 LTS (v3.13)</strong></td>
+            <td>Apr 2014</td>
+            <td>Apr 2019</td>
+            <td>Apr 2022</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
 
-        <div class="p-tabs__content" id="support-16-04" role="tabpanel" aria-labelledby="support-16-04-tab">
-          <div class="u-hide--small" id="kernel1604"></div>
-          <table class="u-hide--medium u-hide--large">
-            <thead>
-              <tr>
-                <td>&nbsp;</td>
-                <th scope="col">Released</th>
-                <th scope="col">End of Life</th>
-                <th scope="col">Expanded security maintenance</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td><strong>Ubuntu 16.04.5 LTS (v4.15)</strong></td>
-                <td>Aug 2018</td>
-                <td>Apr 2021</td>
-                <td>Apr 2024</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 16.04.4 LTS (v4.13)</strong></td>
-                <td>Feb 2018</td>
-                <td>Jul 2018</td>
-                <td>&nbsp;</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 16.04.3 LTS (v4.10)</strong></td>
-                <td>Aug 2017</td>
-                <td>Jan 2018</td>
-                <td>&nbsp;</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 16.04.2 LTS (v4.8)</strong></td>
-                <td>Feb 2017</td>
-                <td>Jul 2017</td>
-                <td>&nbsp;</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 16.04.1 LTS (v4.4)</strong></td>
-                <td>Aug 2016</td>
-                <td>Apr 2021</td>
-                <td>Apr 2024</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 16.04.0 LTS (v4.4)</strong></td>
-                <td>Apr 2016</td>
-                <td>Apr 2021</td>
-                <td>Apr 2024</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+    <div class="col-9" tabindex="0" id="support-lts" role="tabpanel" aria-labelledby="support-lts-tab">
+      <div class="u-hide--small" id="kernellts"></div>
+      <table class="u-hide--medium u-hide--large">
+        <thead>
+          <tr>
+            <td>&nbsp;</td>
+            <th scope="col">Released</th>
+            <th scope="col">CVE/Critical fixes only</th>
+            <th scope="col">End of Life</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>Ubuntu 14.04.0 LTS (v3.13)</strong></td>
+            <td>Apr 2014</td>
+            <td>Apr 2016</td>
+            <td>Apr 2019</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 14.04.1 LTS (v3.13)</strong></td>
+            <td>Aug 2014</td>
+            <td>Apr 2016</td>
+            <td>Apr 2019</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 14.04.2 LTS (v3.16)</strong></td>
+            <td>Feb 2015</td>
+            <td>May 2015</td>
+            <td>Jul 2016</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 14.04.3 LTS (v3.19)</strong></td>
+            <td>Aug 2015</td>
+            <td>&nbsp;</td>
+            <td>Jul 2016</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 14.04.4 LTS (v4.2)</strong></td>
+            <td>Feb 2016</td>
+            <td>&nbsp;</td>
+            <td>Jul 2016</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 16.04.0 LTS (v4.4)</strong></td>
+            <td>Apr 2016</td>
+            <td>Apr 2018</td>
+            <td>Mar 2023</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 14.04.5 LTS (v4.4)</strong></td>
+            <td>Aug 2016</td>
+            <td>Apr 2018</td>
+            <td>Apr 2019</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 16.04.1 LTS (v4.4)</strong></td>
+            <td>Aug 2016</td>
+            <td>Apr 2018</td>
+            <td>Apr 2021</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 16.04.2 LTS (v4.8)</strong></td>
+            <td>Feb 2017</td>
+            <td>&nbsp;</td>
+            <td>Jul 2017</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 16.04.3 LTS (v4.10)</strong></td>
+            <td>Aug 2017</td>
+            <td>&nbsp;</td>
+            <td>Jan 2018</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 16.04.4 LTS (v4.13)</strong></td>
+            <td>Feb 2018</td>
+            <td>&nbsp;</td>
+            <td>Jul 2018</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 18.04.0 LTS (v4.15)</strong></td>
+            <td>Apr 2018</td>
+            <td>Apr 2020</td>
+            <td>Mar 2025</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 18.04.1 LTS (v4.15)</strong></td>
+            <td>Jul 2018</td>
+            <td>Apr 2020</td>
+            <td>Apr 2023</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 16.04.5 LTS (v4.15)</strong></td>
+            <td>Aug 2018</td>
+            <td>Apr 2020</td>
+            <td>Apr 2021</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 18.04.2 LTS (v4.18)</strong></td>
+            <td>Feb 2019</td>
+            <td>&nbsp;</td>
+            <td>Jul 2019</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 18.04.3 LTS (v5.0)</strong></td>
+            <td>Aug 2019</td>
+            <td>&nbsp;</td>
+            <td>Jan 2020</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 18.04.4 LTS (v5.3)</strong></td>
+            <td>Feb 2020</td>
+            <td>&nbsp;</td>
+            <td>Jul 2020</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 20.04.0 LTS</strong></td>
+            <td>Apr 2020</td>
+            <td>Apr 2022</td>
+            <td>Apr 2025</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 20.04.1 LTS</strong></td>
+            <td>Jul 2020</td>
+            <td>Apr 2022</td>
+            <td>Apr 2025</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 18.04.5 LTS</strong></td>
+            <td>Aug 2020</td>
+            <td>Apr 2022</td>
+            <td>Apr 2023</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 20.04.2 LTS</strong></td>
+            <td>Feb 2021</td>
+            <td>&nbsp;</td>
+            <td>Aug 2021</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 20.04.3 LTS</strong></td>
+            <td>Aug 2021</td>
+            <td>&nbsp;</td>
+            <td>Feb 2022</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 20.04.4 LTS</strong></td>
+            <td>Feb 2022</td>
+            <td>&nbsp;</td>
+            <td>Jul 2022</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 22.04.0 LTS (v5.15)</strong></td>
+            <td>Apr 2022</td>
+            <td>Apr 2024</td>
+            <td>Apr 2027</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 20.04.5 LTS (v5.15)</strong></td>
+            <td>Aug 2022</td>
+            <td>Aug 2024</td>
+            <td>Apr 2025</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 22.04.1 LTS (v5.15)</strong></td>
+            <td>Aug 2022</td>
+            <td>Apr 2024</td>
+            <td>Apr 2027</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 22.04.2 LTS (v5.19)</strong></td>
+            <td>Feb 2023</td>
+            <td>&nbsp;</td>
+            <td>Jul 2023</td>
+            </tr>
+        </tbody>
+      </table>
+    </div>
 
-        <div class="p-tabs__content" id="support-14-04" role="tabpanel" aria-labelledby="support-14-04-tab">
-          <div class="u-hide--small" id="kernel1404"></div>
-          <table class="u-hide--medium u-hide--large">
-            <thead>
-              <tr>
-                <td>&nbsp;</td>
-                <th scope="col">Released</th>
-                <th scope="col">End of Life</th>
-                <th scope="col">Expanded security maintenance</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td><strong>Ubuntu 14.04.5 LTS (v4.4)</strong></td>
-                <td>Aug 2016</td>
-                <td>Apr 2019</td>
-                <td>Apr 2022</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 14.04.4 LTS (v4.2)</strong></td>
-                <td>Feb 2016</td>
-                <td>Jul 2016</td>
-                <td>&nbsp;</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 14.04.3 LTS (v3.19)</strong></td>
-                <td>Aug 2015</td>
-                <td>Jul 2016</td>
-                <td>&nbsp;</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 14.04.2 LTS (v3.16)</strong></td>
-                <td>Feb 2015</td>
-                <td>Jul 2016</td>
-                <td>&nbsp;</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 14.04.1 LTS (v3.13)</strong></td>
-                <td>Aug 2014</td>
-                <td>Apr 2019</td>
-                <td>Apr 2022</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 14.04.0 LTS (v3.13)</strong></td>
-                <td>Apr 2014</td>
-                <td>Apr 2019</td>
-                <td>Apr 2022</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-
-        <div class="p-tabs__content" id="support-lts" role="tabpanel" aria-labelledby="support-lts-tab">
-          <div class="u-hide--small" id="kernellts"></div>
-          <table class="u-hide--medium u-hide--large">
-            <thead>
-              <tr>
-                <td>&nbsp;</td>
-                <th scope="col">Released</th>
-                <th scope="col">CVE/Critical fixes only</th>
-                <th scope="col">End of Life</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td><strong>Ubuntu 14.04.0 LTS (v3.13)</strong></td>
-                <td>Apr 2014</td>
-                <td>Apr 2016</td>
-                <td>Apr 2019</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 14.04.1 LTS (v3.13)</strong></td>
-                <td>Aug 2014</td>
-                <td>Apr 2016</td>
-                <td>Apr 2019</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 14.04.2 LTS (v3.16)</strong></td>
-                <td>Feb 2015</td>
-                <td>May 2015</td>
-                <td>Jul 2016</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 14.04.3 LTS (v3.19)</strong></td>
-                <td>Aug 2015</td>
-                <td>&nbsp;</td>
-                <td>Jul 2016</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 14.04.4 LTS (v4.2)</strong></td>
-                <td>Feb 2016</td>
-                <td>&nbsp;</td>
-                <td>Jul 2016</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 16.04.0 LTS (v4.4)</strong></td>
-                <td>Apr 2016</td>
-                <td>Apr 2018</td>
-                <td>Mar 2023</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 14.04.5 LTS (v4.4)</strong></td>
-                <td>Aug 2016</td>
-                <td>Apr 2018</td>
-                <td>Apr 2019</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 16.04.1 LTS (v4.4)</strong></td>
-                <td>Aug 2016</td>
-                <td>Apr 2018</td>
-                <td>Apr 2021</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 16.04.2 LTS (v4.8)</strong></td>
-                <td>Feb 2017</td>
-                <td>&nbsp;</td>
-                <td>Jul 2017</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 16.04.3 LTS (v4.10)</strong></td>
-                <td>Aug 2017</td>
-                <td>&nbsp;</td>
-                <td>Jan 2018</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 16.04.4 LTS (v4.13)</strong></td>
-                <td>Feb 2018</td>
-                <td>&nbsp;</td>
-                <td>Jul 2018</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 18.04.0 LTS (v4.15)</strong></td>
-                <td>Apr 2018</td>
-                <td>Apr 2020</td>
-                <td>Mar 2025</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 18.04.1 LTS (v4.15)</strong></td>
-                <td>Jul 2018</td>
-                <td>Apr 2020</td>
-                <td>Apr 2023</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 16.04.5 LTS (v4.15)</strong></td>
-                <td>Aug 2018</td>
-                <td>Apr 2020</td>
-                <td>Apr 2021</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 18.04.2 LTS (v4.18)</strong></td>
-                <td>Feb 2019</td>
-                <td>&nbsp;</td>
-                <td>Jul 2019</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 18.04.3 LTS (v5.0)</strong></td>
-                <td>Aug 2019</td>
-                <td>&nbsp;</td>
-                <td>Jan 2020</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 18.04.4 LTS (v5.3)</strong></td>
-                <td>Feb 2020</td>
-                <td>&nbsp;</td>
-                <td>Jul 2020</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 20.04.0 LTS</strong></td>
-                <td>Apr 2020</td>
-                <td>Apr 2022</td>
-                <td>Apr 2025</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 20.04.1 LTS</strong></td>
-                <td>Jul 2020</td>
-                <td>Apr 2022</td>
-                <td>Apr 2025</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 18.04.5 LTS</strong></td>
-                <td>Aug 2020</td>
-                <td>Apr 2022</td>
-                <td>Apr 2023</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 20.04.2 LTS</strong></td>
-                <td>Feb 2021</td>
-                <td>&nbsp;</td>
-                <td>Aug 2021</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 20.04.3 LTS</strong></td>
-                <td>Aug 2021</td>
-                <td>&nbsp;</td>
-                <td>Feb 2022</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 20.04.4 LTS</strong></td>
-                <td>Feb 2022</td>
-                <td>&nbsp;</td>
-                <td>Jul 2022</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 22.04.0 LTS (v5.15)</strong></td>
-                <td>Apr 2022</td>
-                <td>Apr 2024</td>
-                <td>Apr 2027</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 20.04.5 LTS (v5.15)</strong></td>
-                <td>Aug 2022</td>
-                <td>Aug 2024</td>
-                <td>Apr 2025</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 22.04.1 LTS (v5.15)</strong></td>
-                <td>Aug 2022</td>
-                <td>Apr 2024</td>
-                <td>Apr 2027</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 22.04.2 LTS (v5.19)</strong></td>
-                <td>Feb 2023</td>
-                <td>&nbsp;</td>
-                <td>Jul 2023</td>
-                </tr>
-            </tbody>
-          </table>
-        </div>
-
-        <div class="p-tabs__content" id="support-all" role="tabpanel" aria-labelledby="support-all-tab">
-          <div class="u-hide--small" id="kernelall"></div>
-          <table class="u-hide--medium u-hide--large">
-            <thead>
-              <tr>
-                <td>&nbsp;</td>
-                <th scope="col">Early preview</th>
-                <th scope="col">Released</th>
-                <th scope="col">End of Life</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td><strong>Ubuntu 14.04.0 LTS (v3.13)</strong></td>
-                <td>Jan 2014</td>
-                <td>Apr 2014</td>
-                <td>Apr 2019</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 14.04.1 LTS (v3.13)</strong></td>
-                <td>May 2014</td>
-                <td>Aug 2014</td>
-                <td>Apr 2019</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 14.04.2 LTS (v3.16)</strong></td>
-                <td>&nbsp;</td>
-                <td>Feb 2015</td>
-                <td>Jul 2016</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 14.04.3 LTS (v3.19)</strong></td>
-                <td>&nbsp;</td>
-                <td>Aug 2015</td>
-                <td>Jul 2016</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 14.04.4 LTS (v4.2)</strong></td>
-                <td>&nbsp;</td>
-                <td>Feb 2016</td>
-                <td>Jul 2016</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 16.04.0 LTS (v4.4)</strong></td>
-                <td>Jan 2016</td>
-                <td>Apr 2016</td>
-                <td>Apr 2021</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 14.04.5 LTS (v4.4)</strong></td>
-                <td>May 2016</td>
-                <td>Aug 2016</td>
-                <td>Apr 2019</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 16.04.1 LTS (v4.4)</strong></td>
-                <td>May 2016</td>
-                <td>Aug 2016</td>
-                <td>Apr 2021</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 16.04.2 LTS (v4.8)</strong></td>
-                <td>&nbsp;</td>
-                <td>Feb 2017</td>
-                <td>Jul 2017</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 16.04.3 LTS (v4.10)</strong></td>
-                <td>&nbsp;</td>
-                <td>Aug 2017</td>
-                <td>Jan 2018</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 16.04.4 LTS (v4.13)</strong></td>
-                <td>&nbsp;</td>
-                <td>Feb 2018</td>
-                <td>Jul 2018</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 18.04.0 LTS (v4.15)</strong></td>
-                <td>Jan 2018</td>
-                <td>Apr 2018</td>
-                <td>Apr 2023</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 18.04.1 LTS (v4.15)</strong></td>
-                <td>Apr 2018</td>
-                <td>Jul 2018</td>
-                <td>Apr 2023</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 16.04.5 LTS (v4.15)</strong></td>
-                <td>May 2018</td>
-                <td>Aug 2018</td>
-                <td>Apr 2021</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 18.04.2 LTS (v4.18)</strong></td>
-                <td>&nbsp;</td>
-                <td>Feb 2019</td>
-                <td>Aug 2019</td>
-              </tr>
-              <tr>
-                <td>Ubuntu 19.04 (v5.0)</td>
-                <td>&nbsp;</td>
-                <td>Apr 2019</td>
-                <td>Jan 2020</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 18.04.3 LTS (v5.0)</strong></td>
-                <td>&nbsp;</td>
-                <td>Aug 2019</td>
-                <td>Feb 2020</td>
-              </tr>
-              <tr>
-                <td>Ubuntu 19.10 (v5.3)</td>
-                <td>&nbsp;</td>
-                <td>Oct 2019</td>
-                <td>Jul 2020</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 18.04.4 LTS (v5.3)</strong></td>
-                <td>&nbsp;</td>
-                <td>Feb 2020</td>
-                <td>Jul 2020</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 20.04.0 LTS (v5.4)</strong></td>
-                <td>Jan 2020</td>
-                <td>Apr 2020</td>
-                <td>Apr 2025</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 20.04.1 LTS (v5.4)</strong></td>
-                <td>Apr 2020</td>
-                <td>Jul 2020</td>
-                <td>Apr 2025</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 18.04.5 LTS (v5.4)</strong></td>
-                <td>May 2020</td>
-                <td>Aug 2020</td>
-                <td>Apr 2023</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 20.04.2 LTS (v5.8)</strong></td>
-                <td>&nbsp;</td>
-                <td>Feb 2021</td>
-                <td>Aug 2021</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 20.04.3 LTS (v5.11)</strong></td>
-                <td>&nbsp;</td>
-                <td>Aug 2021</td>
-                <td>Feb 2022</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 20.04.4 LTS (v5.13)</strong></td>
-                <td>&nbsp;</td>
-                <td>Feb 2022</td>
-                <td>Aug 2022</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 22.04.0 LTS (v5.15)</strong></td>
-                <td>Jan 2022</td>
-                <td>Apr 2022</td>
-                <td>Apr 2027</td>
-                </tr>
-              <tr>
-                <td><strong>Ubuntu 20.04.5 LTS (v5.15)</strong></td>
-                <td>May 2022</td>
-                <td>Aug 2022</td>
-                <td>Apr 2025</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 22.04.1 LTS (v5.15)</strong></td>
-                <td>&nbsp;</td>
-                <td>Aug 2022</td>
-                <td>Apr 2027</td>
-              </tr>
-              <tr>
-                <td><strong>Ubuntu 22.04.2 LTS (v5.19)</strong></td>
-                <td>&nbsp;</td>
-                <td>Feb 2023</td>
-                <td>Jul 2023</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      </div>
+    <div class="col-9" tabindex="0" id="support-all" role="tabpanel" aria-labelledby="support-all-tab">
+      <div class="u-hide--small" id="kernelall"></div>
+      <table class="u-hide--medium u-hide--large">
+        <thead>
+          <tr>
+            <td>&nbsp;</td>
+            <th scope="col">Early preview</th>
+            <th scope="col">Released</th>
+            <th scope="col">End of Life</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>Ubuntu 14.04.0 LTS (v3.13)</strong></td>
+            <td>Jan 2014</td>
+            <td>Apr 2014</td>
+            <td>Apr 2019</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 14.04.1 LTS (v3.13)</strong></td>
+            <td>May 2014</td>
+            <td>Aug 2014</td>
+            <td>Apr 2019</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 14.04.2 LTS (v3.16)</strong></td>
+            <td>&nbsp;</td>
+            <td>Feb 2015</td>
+            <td>Jul 2016</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 14.04.3 LTS (v3.19)</strong></td>
+            <td>&nbsp;</td>
+            <td>Aug 2015</td>
+            <td>Jul 2016</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 14.04.4 LTS (v4.2)</strong></td>
+            <td>&nbsp;</td>
+            <td>Feb 2016</td>
+            <td>Jul 2016</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 16.04.0 LTS (v4.4)</strong></td>
+            <td>Jan 2016</td>
+            <td>Apr 2016</td>
+            <td>Apr 2021</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 14.04.5 LTS (v4.4)</strong></td>
+            <td>May 2016</td>
+            <td>Aug 2016</td>
+            <td>Apr 2019</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 16.04.1 LTS (v4.4)</strong></td>
+            <td>May 2016</td>
+            <td>Aug 2016</td>
+            <td>Apr 2021</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 16.04.2 LTS (v4.8)</strong></td>
+            <td>&nbsp;</td>
+            <td>Feb 2017</td>
+            <td>Jul 2017</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 16.04.3 LTS (v4.10)</strong></td>
+            <td>&nbsp;</td>
+            <td>Aug 2017</td>
+            <td>Jan 2018</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 16.04.4 LTS (v4.13)</strong></td>
+            <td>&nbsp;</td>
+            <td>Feb 2018</td>
+            <td>Jul 2018</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 18.04.0 LTS (v4.15)</strong></td>
+            <td>Jan 2018</td>
+            <td>Apr 2018</td>
+            <td>Apr 2023</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 18.04.1 LTS (v4.15)</strong></td>
+            <td>Apr 2018</td>
+            <td>Jul 2018</td>
+            <td>Apr 2023</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 16.04.5 LTS (v4.15)</strong></td>
+            <td>May 2018</td>
+            <td>Aug 2018</td>
+            <td>Apr 2021</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 18.04.2 LTS (v4.18)</strong></td>
+            <td>&nbsp;</td>
+            <td>Feb 2019</td>
+            <td>Aug 2019</td>
+          </tr>
+          <tr>
+            <td>Ubuntu 19.04 (v5.0)</td>
+            <td>&nbsp;</td>
+            <td>Apr 2019</td>
+            <td>Jan 2020</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 18.04.3 LTS (v5.0)</strong></td>
+            <td>&nbsp;</td>
+            <td>Aug 2019</td>
+            <td>Feb 2020</td>
+          </tr>
+          <tr>
+            <td>Ubuntu 19.10 (v5.3)</td>
+            <td>&nbsp;</td>
+            <td>Oct 2019</td>
+            <td>Jul 2020</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 18.04.4 LTS (v5.3)</strong></td>
+            <td>&nbsp;</td>
+            <td>Feb 2020</td>
+            <td>Jul 2020</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 20.04.0 LTS (v5.4)</strong></td>
+            <td>Jan 2020</td>
+            <td>Apr 2020</td>
+            <td>Apr 2025</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 20.04.1 LTS (v5.4)</strong></td>
+            <td>Apr 2020</td>
+            <td>Jul 2020</td>
+            <td>Apr 2025</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 18.04.5 LTS (v5.4)</strong></td>
+            <td>May 2020</td>
+            <td>Aug 2020</td>
+            <td>Apr 2023</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 20.04.2 LTS (v5.8)</strong></td>
+            <td>&nbsp;</td>
+            <td>Feb 2021</td>
+            <td>Aug 2021</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 20.04.3 LTS (v5.11)</strong></td>
+            <td>&nbsp;</td>
+            <td>Aug 2021</td>
+            <td>Feb 2022</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 20.04.4 LTS (v5.13)</strong></td>
+            <td>&nbsp;</td>
+            <td>Feb 2022</td>
+            <td>Aug 2022</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 22.04.0 LTS (v5.15)</strong></td>
+            <td>Jan 2022</td>
+            <td>Apr 2022</td>
+            <td>Apr 2027</td>
+            </tr>
+          <tr>
+            <td><strong>Ubuntu 20.04.5 LTS (v5.15)</strong></td>
+            <td>May 2022</td>
+            <td>Aug 2022</td>
+            <td>Apr 2025</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 22.04.1 LTS (v5.15)</strong></td>
+            <td>&nbsp;</td>
+            <td>Aug 2022</td>
+            <td>Apr 2027</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 22.04.2 LTS (v5.19)</strong></td>
+            <td>&nbsp;</td>
+            <td>Feb 2023</td>
+            <td>Jul 2023</td>
+          </tr>
+        </tbody>
+      </table>
     </div>
   </div>
 </section>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.8.2/d3.min.js" defer></script>
 <script src="{{ versioned_static('js/dist/release-chart.js') }}" defer></script>
-<script src="{{ versioned_static('js/dist/tabotronic.js') }}" defer></script>
-
+<script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>


### PR DESCRIPTION
## Done

- Updates chart data on /kernel/lifecycle based on [spreadsheet data](https://docs.google.com/spreadsheets/d/1KIuOAa620yseE0uhIl67u2SlS0bWlPI_d98bvYM2Yl8/edit#gid=281992953) & some other data for other charts that were broken
- Updates `createChart` to use the earliest and latest dates to scale the graph domain
- Updates tabbed-content.js to use the `u-hide` class instead of `hidden`
- Updates pages that used `tabbed-content.js` to work with refactor
- updates `_pattern_tabs.scss` to have a 'on-paper' vertical tab pattern
- Fixes tabs on `openstack/install`


## QA

- Each graph is build of a different tab in the [spreadsheet](https://docs.google.com/spreadsheets/d/1KIuOAa620yseE0uhIl67u2SlS0bWlPI_d98bvYM2Yl8/edit#gid=281992953), compare the data with each graph tab in [the demo](https://ubuntu-com-12858.demos.haus/kernel/lifecycle) as follows
[Kernel all](https://docs.google.com/spreadsheets/d/1KIuOAa620yseE0uhIl67u2SlS0bWlPI_d98bvYM2Yl8/edit#gid=703230516) -> `All releases`
[Kernel lts](https://docs.google.com/spreadsheets/d/1KIuOAa620yseE0uhIl67u2SlS0bWlPI_d98bvYM2Yl8/edit#gid=281992953) -> `All LTS Releases`
[Kernel 22.04](https://docs.google.com/spreadsheets/d/1KIuOAa620yseE0uhIl67u2SlS0bWlPI_d98bvYM2Yl8/edit#gid=1844838308) -> `22.04`

- check out the other pages I made changes to from the description and files changed and check everything works as before

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-2248