### PR TITLE
Remove `u-show--small` class

### DIFF
--- a/templates/templates/navigation-enterprise-h.html
+++ b/templates/templates/navigation-enterprise-h.html
@@ -19,7 +19,7 @@
             <a href="/openstack/managed">Fully managed OpenStack&nbsp;&rsaquo;</a>
           </h4>
           <ul class="p-text-list--small is-bordered">
-            <li class="p-list__item u-show--small u-hide--medium u-hide--large"><a href="/openstack">Get OpenStack</a></li>
+            <li class="p-list__item u-hide--medium u-hide--large"><a href="/openstack">Get OpenStack</a></li>
             <li class="p-list__item"><a href="/openstack/managed">Fully managed OpenStack</a></li>
             <li class="p-list__item"><a href="/openstack/consulting">Design and deliver private clouds</a></li>
             <li class="p-list__item"><a href="/openstack/features">OpenStack features</a></li>
@@ -78,7 +78,7 @@
             <a href="/internet-of-things">Internet of Things&nbsp;&rsaquo;</a>
           </h4>
           <ul class="p-text-list--small is-bordered">
-            <li class="p-list__item u-show--small u-hide--medium u-hide--large"><a href="/internet-of-things">Build your IoT on Ubuntu</a></li>
+            <li class="p-list__item u-hide--medium u-hide--large"><a href="/internet-of-things">Build your IoT on Ubuntu</a></li>
             <li class="p-list__item"><a href="/core/services">Launch a product with our IoT Professional Services</a></li>
             <li class="p-list__item"><a href="/core">Ubuntu Core - embedded &amp; secure</a></li>
             <li class="p-list__item"><a href="/appliance">Appliance images</a></li>
@@ -109,7 +109,7 @@
             <a href="/support">Support and services&nbsp;&rsaquo;</a>
           </h4>
           <ul class="p-text-list--small is-bordered">
-            <li class="p-list__item u-show--small u-hide--medium u-hide--large"><a href="/support">Get support</a></li>
+            <li class="p-list__item u-hide--medium u-hide--large"><a href="/support">Get support</a></li>
             <li class="p-list__item"><a href="/pro">Ubuntu Pro</a></li>
             <li class="p-list__item"><a href="/livepatch">Livepatch security updates</a></li>
             <li class="p-list__item"><a href="/landscape">Landscape remote management</a></li>


### PR DESCRIPTION
## Done

- Remove `u-show--small` class from the lists that have both `p-list__item` and `u-show--small` classes

## QA

- Go to navigation on ubnutu.com on small screens and click "Enterprise"
- See the [issue](https://github.com/canonical/ubuntu.com/issues/12859) and check it's fixed. 

## Issue / Card

Fixes https://github.com/canonical/ubuntu.com/issues/12859
