### PR TITLE
Remove extraneous field from the /engage/fr form

### DIFF
--- a/templates/engage/shared/_fr_engage_form.html
+++ b/templates/engage/shared/_fr_engage_form.html
@@ -28,11 +28,6 @@
         <input required id="title" name="title" maxlength="255" type="text"/>
       </li>
       <li class="p-list__item">
-        <label for="Comments_from_lead__c">Décrivez vos besoins de support :</label>
-        <textarea required id="Comments_from_lead__c" name="Comments_from_lead__c" rows="4" maxlength="2000"></textarea>
-      </li>
-
-      <li class="p-list__item">
         <label class="p-checkbox">
           <input class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
           <span class="p-checkbox__label" id="canonicalUpdatesOptIn">J'accepte de recevoir des informations sur les produits et services de Canonical.</span>


### PR DESCRIPTION
## Done

- Removed extra "comment" field from the /engage/fr form template, when we need this field, it should be added on an ad-hoc basis and not in the template mostly used for whitepapers.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
