### PR TITLE
Fix page title

### DIFF
--- a/templates/landscape/managed.html
+++ b/templates/landscape/managed.html
@@ -1,6 +1,6 @@
 {% extends "landscape/base_landscape.html" %}
 
-{% block title %}Install Landscape{% endblock %}
+{% block title %} Managed Landscape {% endblock %}
 {% block meta_description %} Managed Landscape is for customers that need the flexibility of self-hosted Landscape, and the convenience and assurance of a software as a service solution. {% endblock meta_description %}
 {% block meta_copydoc %} https://docs.google.com/document/d/1MycPWcmMveCZxrGtn7ASc0myWNxPzLTciHfQIA6kPZ4/edit# {% endblock meta_copydoc %}
 


### PR DESCRIPTION
## Done

- Fix page title "Install Landscape" -> "Managed Landscape"

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/landscape/managed
- Check that title has been updated
