### PR TITLE
Add temp fix for 'Ubuntu Advantage' reference in global nav

### DIFF
--- a/static/js/src/navigation.js
+++ b/static/js/src/navigation.js
@@ -299,3 +299,19 @@ if (accountContainer && accountContainerSmall) {
       );
     });
 }
+
+// TEMP FIX - PETE F 15.05.23
+// UPDATES 'UBUNTU ADVANTAGE' TO 'UBUNTU PRO' IN THE MEGANAV UNTIL
+// WE MERGE THE NEW MEGANAV
+function replaceUbuntuAdvantage() {
+  const globalNav = document.querySelector("#canonical-global-nav");
+  const targetElementsArray = globalNav.querySelectorAll("[href='https://ubuntu.com/support']");
+  targetElementsArray.forEach(function(element) {
+    if (element.children.length) {
+      element.querySelector("h4").innerText = "Ubuntu Pro ›";
+    } else {
+      element.innerText = "Ubuntu Pro";
+    }
+  })
+}
+replaceUbuntuAdvantage()

--- a/static/js/src/navigation.js
+++ b/static/js/src/navigation.js
@@ -305,13 +305,15 @@ if (accountContainer && accountContainerSmall) {
 // WE MERGE THE NEW MEGANAV
 function replaceUbuntuAdvantage() {
   const globalNav = document.querySelector("#canonical-global-nav");
-  const targetElementsArray = globalNav.querySelectorAll("[href='https://ubuntu.com/support']");
-  targetElementsArray.forEach(function(element) {
+  const targetElementsArray = globalNav.querySelectorAll(
+    "[href='https://ubuntu.com/support']"
+  );
+  targetElementsArray.forEach(function (element) {
     if (element.children.length) {
       element.querySelector("h4").innerText = "Ubuntu Pro ›";
     } else {
       element.innerText = "Ubuntu Pro";
     }
-  })
+  });
 }
-replaceUbuntuAdvantage()
+replaceUbuntuAdvantage();


### PR DESCRIPTION
## Done

- Adds a hacky JS fix for 'Ubuntu Advantage' in global nav

## QA

- Check global nav doesn't reference Ubuntu Advantage



## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
