### PR TITLE
/download/risc-v redesign

### DIFF
--- a/static/js/src/risc-v.js
+++ b/static/js/src/risc-v.js
@@ -1,0 +1,19 @@
+// Toggles show board based on selection on small screens
+
+const boards = document.querySelectorAll(`[role=tabpanel]`);
+const dropdownSelect = document.getElementById("boardSelect");
+
+dropdownSelect.addEventListener("change", (event) => {
+    selectBoard();
+})
+
+function selectBoard() {
+  boards.forEach(board => {
+    if (board.id === dropdownSelect.value) {
+      board.classList.remove("u-hide")
+      board.focus();
+    } else {
+      board.classList.add("u-hide");
+    }
+  })
+}

--- a/static/js/src/risc-v.js
+++ b/static/js/src/risc-v.js
@@ -4,16 +4,16 @@ const boards = document.querySelectorAll(`[role=tabpanel]`);
 const dropdownSelect = document.getElementById("boardSelect");
 
 dropdownSelect.addEventListener("change", (event) => {
-    selectBoard();
-})
+  selectBoard();
+});
 
 function selectBoard() {
-  boards.forEach(board => {
+  boards.forEach((board) => {
     if (board.id === dropdownSelect.value) {
-      board.classList.remove("u-hide")
+      board.classList.remove("u-hide");
       board.focus();
     } else {
       board.classList.add("u-hide");
     }
-  })
+  });
 }

--- a/static/js/src/tabbed-content.js
+++ b/static/js/src/tabbed-content.js
@@ -58,6 +58,7 @@
       @param {Array} tabs an array of tabs within a container
     */
   const attachEvents = (tabs, persistURLHash) => {
+    console.log(tabs)
     tabs.forEach(function (tab, index) {
       tab.addEventListener("keyup", function (e) {
         let compatibleKeys = IEKeys;
@@ -105,6 +106,7 @@
       @param {Array} tabs an array of tabs within a container
     */
   const setActiveTab = (tab, tabs) => {
+    console.log(tab)
     tabs.forEach((tabElement) => {
       var tabContent = document.querySelectorAll(
         "#" + tabElement.getAttribute("aria-controls")

--- a/static/js/src/tabbed-content.js
+++ b/static/js/src/tabbed-content.js
@@ -58,7 +58,6 @@
       @param {Array} tabs an array of tabs within a container
     */
   const attachEvents = (tabs, persistURLHash) => {
-    console.log(tabs)
     tabs.forEach(function (tab, index) {
       tab.addEventListener("keyup", function (e) {
         let compatibleKeys = IEKeys;
@@ -106,7 +105,6 @@
       @param {Array} tabs an array of tabs within a container
     */
   const setActiveTab = (tab, tabs) => {
-    console.log(tab)
     tabs.forEach((tabElement) => {
       var tabContent = document.querySelectorAll(
         "#" + tabElement.getAttribute("aria-controls")

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1384,10 +1384,16 @@ hr.p-separator.is-shallow {
   background-color: #fff;
 }
 
-.risc-v-strip {
+.risc-v-container {
   @extend .p-strip--light;
+  @extend .u-aspect-ratio--3-2;
 
-  margin-top: 0.5rem;
-  padding-bottom: 1rem;
-  padding-top: 1rem;
+  margin-top: $spv--small;
+  padding-bottom: $spv--large;
+  padding-top: $spv--large;
+
+  .risc-v-image {
+    height: 13rem;
+    width: auto;
+  }
 }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1383,3 +1383,9 @@ hr.p-separator.is-shallow {
 
   background-color: #fff;
 }
+
+.risc-v-strip {
+  @extend .p-strip--light; 
+  margin-top: .5rem;
+  padding: 1rem 0 1rem 0;
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1385,7 +1385,9 @@ hr.p-separator.is-shallow {
 }
 
 .risc-v-strip {
-  @extend .p-strip--light; 
-  margin-top: .5rem;
-  padding: 1rem 0 1rem 0;
+  @extend .p-strip--light;
+
+  margin-top: 0.5rem;
+  padding-bottom: 1rem;
+  padding-top: 1rem;
 }

--- a/templates/download/risc-v/index.html
+++ b/templates/download/risc-v/index.html
@@ -41,7 +41,7 @@
   <div class="row">
     <div class="col-3 col-medium-2">
       <div class="p-strip is-shallow u-no-padding--top"><h2 class="p-text--small-caps">Choose a board</h2></div>
-      <ul class="js-tabbed-content p-tabs--vertical is-balck" role="tablist" aria-label="Robotics features">
+      <ul class="js-tabbed-content p-tabs--vertical is-risc-v u-hide--small" role="tablist" aria-label="Robotics features">
         <li><button class="p-tabs__item" id="allwinner-nezha" role="tab" aria-selected="true" aria-controls="allwinner-nezha-tab">AllWinner Nezha</button></li>
         <li><button class="p-tabs__item" id="microchip-polarfire-soc-fpga-icicle-kit" role="tab" aria-selected="false" aria-controls="microchip-polarfire-soc-fpga-icicle-kit-tab">Polarfire SoC FPGA Icicle</button></li>
         <li><button class="p-tabs__item" id="qemu" role="tab" aria-selected="false" aria-controls="qemu-tab">QEMU emulator</button></li>
@@ -50,6 +50,17 @@
         <li><button class="p-tabs__item" id="starfive-visionfive-board" role="tab" aria-selected="false" aria-controls="starfive-visionfive-board-tab">StarFive VisionFive</button></li>
         <li><button class="p-tabs__item" id="starfive-visionfive-2" role="tab" aria-selected="false" aria-controls="starfive-visionfive-2-tab">StarFive VisionFive 2</button></li>
       </ul>
+      <form class="u-hide--large u-hide--medium">
+        <select name="boardSelect" id="boardSelect">
+          <option value="" disabled="disabled" selected="">AllWinner Nezha</option>
+          <option value="1">Polarfire SoC FPGA Icicle</option>
+          <option value="2">QEMU emulator</option>
+          <option value="3">SiFive Unmatched</option>
+          <option value="4">Sipeed LicheeRV Dock</option>
+          <option value="4">StarFive VisionFive</option>
+          <option value="4">StarFive VisionFive 2</option>
+        </select>
+      </form>
     </div>
     <div class="col-9 col-medium-4">
       {% include "download/risc-v/tab-1.html" %}
@@ -67,5 +78,16 @@
 <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/risc-v" data-form-id="4532" data-lp-id="" data-return-url="https://ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html"></div>
 
 <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
+
+<script>
+  
+    const options = document.querySelectorAll("option");
+    options.forEach(option => {
+      console.log(option.innerHTML)
+    })
+
+
+  
+</script>
 
 {% endblock content %}

--- a/templates/download/risc-v/index.html
+++ b/templates/download/risc-v/index.html
@@ -41,7 +41,7 @@
   <div class="row">
     <div class="col-3 col-medium-2">
       <div class="p-strip is-shallow u-no-padding--top"><h2 class="p-text--small-caps">Choose a board</h2></div>
-      <ul class="js-tabbed-content p-tabs--vertical is-risc-v u-hide--small" role="tablist" aria-label="Robotics features">
+      <ul class="js-tabbed-content p-tabs--vertical is-black u-hide--small" role="tablist" aria-label="Robotics features">
         <li><button class="p-tabs__item" id="allwinner-nezha" role="tab" aria-selected="true" aria-controls="allwinner-nezha-tab">AllWinner Nezha</button></li>
         <li><button class="p-tabs__item" id="microchip-polarfire-soc-fpga-icicle-kit" role="tab" aria-selected="false" aria-controls="microchip-polarfire-soc-fpga-icicle-kit-tab">Polarfire SoC FPGA Icicle</button></li>
         <li><button class="p-tabs__item" id="qemu" role="tab" aria-selected="false" aria-controls="qemu-tab">QEMU emulator</button></li>
@@ -51,14 +51,14 @@
         <li><button class="p-tabs__item" id="starfive-visionfive-2" role="tab" aria-selected="false" aria-controls="starfive-visionfive-2-tab">StarFive VisionFive 2</button></li>
       </ul>
       <form class="u-hide--large u-hide--medium">
-        <select name="boardSelect" id="boardSelect">
-          <option value="" disabled="disabled" selected="">AllWinner Nezha</option>
-          <option value="1">Polarfire SoC FPGA Icicle</option>
-          <option value="2">QEMU emulator</option>
-          <option value="3">SiFive Unmatched</option>
-          <option value="4">Sipeed LicheeRV Dock</option>
-          <option value="4">StarFive VisionFive</option>
-          <option value="4">StarFive VisionFive 2</option>
+        <select name="boardSelect" id="boardSelect" onchange="selectBoard()">
+          <option value="allwinner-nezha-tab" selected="">AllWinner Nezha</option>
+          <option value="microchip-polarfire-soc-fpga-icicle-kit-tab">Polarfire SoC FPGA Icicle</option>
+          <option value="qemu-tab">QEMU emulator</option>
+          <option value="quemu-sifive-image-tab">SiFive Unmatched</option>
+          <option value="sipeed-licheerv-dock-tab">Sipeed LicheeRV Dock</option>
+          <option value="starfive-visionfive-board-tab">StarFive VisionFive</option>
+          <option value="starfive-visionfive-2-tab">StarFive VisionFive 2</option>
         </select>
       </form>
     </div>
@@ -80,14 +80,17 @@
 <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
 
 <script>
-  
-    const options = document.querySelectorAll("option");
-    options.forEach(option => {
-      console.log(option.innerHTML)
+  function selectBoard(){
+    const selected = document.getElementById("boardSelect").value;
+    const boards = document.querySelectorAll(`[role=tabpanel]`)
+    boards.forEach(board => {
+      if (board.id === selected){
+        board.classList.remove("u-hide")
+      } else {
+        board.classList.add("u-hide")
+      }
     })
-
-
-  
+  }
 </script>
 
 {% endblock content %}

--- a/templates/download/risc-v/index.html
+++ b/templates/download/risc-v/index.html
@@ -4,7 +4,7 @@
 
 {% block meta_description %}Use Ubuntu on RISC-V platforms for the familiar developer experience and an accelerated path to production{% endblock meta_description %}
 
-{% block meta_copydoc%}https://docs.google.com/document/d/1kkJeq9HdH3iWV35HwihcJd3CxZw9Jy21W66lJl8VbWs/edit#{% endblock meta_copydoc %}
+{% block meta_copydoc%} https://docs.google.com/document/d/1kkJeq9HdH3iWV35HwihcJd3CxZw9Jy21W66lJl8VbWs/ {% endblock meta_copydoc %}
 
 {% block content %}
 
@@ -41,14 +41,14 @@
   <div class="row">
     <div class="col-3 col-medium-2">
       <div class="p-strip is-shallow u-no-padding--top"><h2 class="p-text--small-caps">Choose a board</h2></div>
-      <ul class="js-tabbed-content p-tabs--vertical is-black" role="tablist" aria-label="Robotics features">
-        <li><button class="p-tabs__item" id="quemu-sifive-image" role="tab" aria-selected="true" tab-index="-1" aria-controls="quemu-sifive-image-tab">SiFive Unmatched</button></li>
-        <li><button class="p-tabs__item" id="starfive-visionfive-board" role="tab" aria-selected="false" aria-controls="starfive-visionfive-board-tab">StarFive VisionFive</button></li>
-        <li><button class="p-tabs__item" id="starfive-visionfive-2" role="tab" aria-selected="false" aria-controls="starfive-visionfive-2-tab">StarFive VisionFive 2</button></li>
-        <li><button class="p-tabs__item" id="allwinner-nezha" role="tab" aria-selected="false" aria-controls="allwinner-nezha-tab">AllWinner Nezha</button></li>
-        <li><button class="p-tabs__item" id="sipeed-licheerv-dock" role="tab" aria-selected="false" aria-controls="sipeed-licheerv-dock-tab">Sipeed LicheeRV Dock</button></li>
+      <ul class="js-tabbed-content p-tabs--vertical is-balck" role="tablist" aria-label="Robotics features">
+        <li><button class="p-tabs__item" id="allwinner-nezha" role="tab" aria-selected="true" aria-controls="allwinner-nezha-tab">AllWinner Nezha</button></li>
         <li><button class="p-tabs__item" id="microchip-polarfire-soc-fpga-icicle-kit" role="tab" aria-selected="false" aria-controls="microchip-polarfire-soc-fpga-icicle-kit-tab">Polarfire SoC FPGA Icicle</button></li>
         <li><button class="p-tabs__item" id="qemu" role="tab" aria-selected="false" aria-controls="qemu-tab">QEMU emulator</button></li>
+        <li><button class="p-tabs__item" id="quemu-sifive-image" role="tab" aria-selected="false" aria-controls="quemu-sifive-image-tab">SiFive Unmatched</button></li>
+        <li><button class="p-tabs__item" id="sipeed-licheerv-dock" role="tab" aria-selected="false" aria-controls="sipeed-licheerv-dock-tab">Sipeed LicheeRV Dock</button></li>
+        <li><button class="p-tabs__item" id="starfive-visionfive-board" role="tab" aria-selected="false" aria-controls="starfive-visionfive-board-tab">StarFive VisionFive</button></li>
+        <li><button class="p-tabs__item" id="starfive-visionfive-2" role="tab" aria-selected="false" aria-controls="starfive-visionfive-2-tab">StarFive VisionFive 2</button></li>
       </ul>
     </div>
     <div class="col-9 col-medium-4">

--- a/templates/download/risc-v/index.html
+++ b/templates/download/risc-v/index.html
@@ -51,7 +51,7 @@
         <li><button class="p-tabs__item" id="starfive-visionfive-2" role="tab" aria-selected="false" aria-controls="starfive-visionfive-2-tab">StarFive VisionFive 2</button></li>
       </ul>
       <form class="u-hide--large u-hide--medium">
-        <select name="boardSelect" id="boardSelect" onchange="selectBoard()">
+        <select name="boardSelect" id="boardSelect">
           <option value="allwinner-nezha-tab" selected="">AllWinner Nezha</option>
           <option value="microchip-polarfire-soc-fpga-icicle-kit-tab">Polarfire SoC FPGA Icicle</option>
           <option value="qemu-tab">QEMU emulator</option>
@@ -79,18 +79,6 @@
 
 <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
 
-<script>
-  function selectBoard(){
-    const selected = document.getElementById("boardSelect").value;
-    const boards = document.querySelectorAll(`[role=tabpanel]`)
-    boards.forEach(board => {
-      if (board.id === selected){
-        board.classList.remove("u-hide")
-      } else {
-        board.classList.add("u-hide")
-      }
-    })
-  }
-</script>
+<script src="{{ versioned_static('js/src/risc-v.js') }}"></script>
 
 {% endblock content %}

--- a/templates/download/risc-v/tab-1.html
+++ b/templates/download/risc-v/tab-1.html
@@ -3,7 +3,7 @@
     <div class="col-3">
       <h2 class="u-hide--small">AllWinner Nezha</h2>
     </div>
-    <div class="col-6 p-strip--light is-shallow u-vertically-center u-align--center">
+    <div class="col-6 risc-v-strip is-shallow u-vertically-center u-align--center">
       {{ image (
         url="https://assets.ubuntu.com/v1/5207975e-0cc9bac3-Allwinner+Nezha+Board.png",
         alt="",

--- a/templates/download/risc-v/tab-1.html
+++ b/templates/download/risc-v/tab-1.html
@@ -3,20 +3,21 @@
     <div class="col-3">
       <h2 class="u-hide--small">AllWinner Nezha</h2>
     </div>
-    <div class="col-6 risc-v-strip is-shallow u-vertically-center u-align--center">
+    <div class="col-6 risc-v-container u-vertically-center u-align--center">
       {{ image (
         url="https://assets.ubuntu.com/v1/5207975e-0cc9bac3-Allwinner+Nezha+Board.png",
         alt="",
         width="400",
         height="240",
         hi_def=True,
-        loading="lazy"
+        loading="auto",
+        attrs={"class": "risc-v-image"}
         ) | safe
       }}
     </div>
   </div>
-  <div class="row p-strip is-shallow u-no-padding--top">
-    <hr class="is-fixed-width col-9">
+  <div class="row p-strip u-no-padding--top">
+    <hr class="col-9">
     <div class="col-3">
       <h3 class="p-heading--5 u-no-padding--top">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
     </div>

--- a/templates/download/risc-v/tab-1.html
+++ b/templates/download/risc-v/tab-1.html
@@ -1,22 +1,9 @@
 <div tabindex="0" role="tabpanel" id="quemu-sifive-image-tab" aria-labelledby="quemu-sifive-image">
-  <div class="row">
-    <div class="col-6">
-      <div class="p-strip is-shallow u-no-padding--top">
-        <h2>SiFive Unmatched</h2>
-        <h3>Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
-      </div>
-      <div class="p-notification--information is-inline">
-        <div class="p-notification__content">
-          <p class="p-notification__title">Note:</p>
-          <p class="p-notification__message">If you have an NVMe drive, we advise you to use the Ubuntu Server live installer.</p>
-        </div>
-      </div>
-      <p class="u-sv3">
-        <a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+unmatched.img.xz">Download 23.04</a>
-        <a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+unmatched.img.xz">Download 22.04.2</a>
-      </p>
+  <div class="row p-strip--light is-shallow" style="margin-top: 3.5rem;">
+    <div class="col-3 u-vertically-center">
+      <h2 style="padding-left: 10%;">SiFive Unmatched</h2> 
     </div>
-    <div class="col-3 u-hide--medium u-hide--small p-strip is-shallow u-no-padding--bottom">
+    <div class="col-6 u-hide--medium u-hide--small p-strip is-shallow u-no-padding--bottom u-vertically-center">
       {{ image (
         url="https://assets.ubuntu.com/v1/37c094a9-SiFive+Unmatched+Board.jpg",
         alt="",
@@ -28,14 +15,32 @@
         }}
     </div>
   </div>
-  <div class="row">
+  <div class="row p-strip is-shallow">
+    <hr class="is-fixed-width u-no-margin--bottom col-9">
+    <div class="col-3">
+      <div class="p-strip is-shallow u-no-padding--top">
+        <h3 class="p-heading--5">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
+      </div>
+    </div>
     <div class="col-6">
-      <hr class="u-no-margin--bottom">
-      <h3 class="u-sv3">Ubuntu Server live installer</h3>
+      <p class="p-notification__message"><i class="p-icon--information"></i> If you have an NVMe drive, we advise you to use the Ubuntu Server live installer.</p>
+      <p class="u-sv3">
+        <a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+unmatched.img.xz">Download 23.04</a>
+        <a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+unmatched.img.xz">Download 22.04.2</a>
+      </p>
+    </div>
+  </div>
+  <div class="row">
+    <hr class="u-fixed-width col-9">
+    <div class="col-3">
+      <h3 class="u-no-padding--top p-heading--5">Ubuntu Server live installer</h3>
+    </div>
+    <div class="col-6">
 			<p>
 				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-live-server-riscv64.img.gz">Download 23.04 live installer</a>
 				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-live-server-riscv64.img.gz">Download 22.04.2 live installer</a>
 			</p>
+      <hr class="u-no-margin--bottom">
 			<p><a href="https://wiki.ubuntu.com/RISC-V/SiFive%20HiFive%20Unmatched">How to install Ubuntu on SiFive HiFive Unmatched</a></p>
 		</div>
 	</div>

--- a/templates/download/risc-v/tab-1.html
+++ b/templates/download/risc-v/tab-1.html
@@ -1,7 +1,7 @@
 <div tabindex="0" role="tabpanel" id="allwinner-nezha-tab" aria-labelledby="allwinner-nezha" aria-hidden="true">
   <div class="row p-strip is-shallow u-no-padding--top">
     <div class="col-3">
-      <h2>AllWinner Nezha</h2>
+      <h2 class="u-hide--small">AllWinner Nezha</h2>
     </div>
     <div class="col-6 p-strip--light is-shallow u-vertically-center u-align--center">
       {{ image (

--- a/templates/download/risc-v/tab-1.html
+++ b/templates/download/risc-v/tab-1.html
@@ -1,47 +1,31 @@
-<div tabindex="0" role="tabpanel" id="quemu-sifive-image-tab" aria-labelledby="quemu-sifive-image">
-  <div class="row p-strip--light is-shallow" style="margin-top: 3.5rem;">
-    <div class="col-3 u-vertically-center">
-      <h2 style="padding-left: 10%;">SiFive Unmatched</h2> 
+<div tabindex="0" role="tabpanel" id="allwinner-nezha-tab" aria-labelledby="allwinner-nezha" aria-hidden="true">
+  <div class="row p-strip is-shallow u-no-padding--top">
+    <div class="col-3">
+      <h2>AllWinner Nezha</h2>
     </div>
-    <div class="col-6 u-hide--medium u-hide--small p-strip is-shallow u-no-padding--bottom u-vertically-center">
+    <div class="col-6 p-strip--light is-shallow u-vertically-center u-align--center">
       {{ image (
-        url="https://assets.ubuntu.com/v1/37c094a9-SiFive+Unmatched+Board.jpg",
+        url="https://assets.ubuntu.com/v1/5207975e-0cc9bac3-Allwinner+Nezha+Board.png",
         alt="",
-        width="720",
-        height="480",
+        width="400",
+        height="240",
         hi_def=True,
-        loading="auto"
+        loading="lazy"
         ) | safe
-        }}
+      }}
     </div>
   </div>
-  <div class="row p-strip is-shallow">
-    <hr class="is-fixed-width u-no-margin--bottom col-9">
+  <div class="row p-strip is-shallow u-no-padding--top">
+    <hr class="is-fixed-width col-9">
     <div class="col-3">
-      <div class="p-strip is-shallow u-no-padding--top">
-        <h3 class="p-heading--5">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
-      </div>
+      <h3 class="p-heading--5 u-no-padding--top">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
     </div>
     <div class="col-6">
-      <p class="p-notification__message"><i class="p-icon--information"></i> If you have an NVMe drive, we advise you to use the Ubuntu Server live installer.</p>
-      <p class="u-sv3">
-        <a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+unmatched.img.xz">Download 23.04</a>
-        <a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+unmatched.img.xz">Download 22.04.2</a>
-      </p>
-    </div>
-  </div>
-  <div class="row">
-    <hr class="u-fixed-width col-9">
-    <div class="col-3">
-      <h3 class="u-no-padding--top p-heading--5">Ubuntu Server live installer</h3>
-    </div>
-    <div class="col-6">
-			<p>
-				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-live-server-riscv64.img.gz">Download 23.04 live installer</a>
-				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-live-server-riscv64.img.gz">Download 22.04.2 live installer</a>
+      <p>
+				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+nezha.img.xz">Download 23.04</a>
+				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+nezha.img.xz">Download 22.04.2</a>
 			</p>
-      <hr class="u-no-margin--bottom">
-			<p><a href="https://wiki.ubuntu.com/RISC-V/SiFive%20HiFive%20Unmatched">How to install Ubuntu on SiFive HiFive Unmatched</a></p>
-		</div>
-	</div>
+			<p><a href="https://wiki.ubuntu.com/RISC-V/Nezha%20D1">How to install Ubuntu on the Nezha</a></p>
+    </div>
+  </div>
 </div>

--- a/templates/download/risc-v/tab-2.html
+++ b/templates/download/risc-v/tab-2.html
@@ -1,9 +1,9 @@
-<div tabindex="0" role="tabpanel" id="microchip-polarfire-soc-fpga-icicle-kit-tab" aria-labelledby="live-installer" hidden="false">
+<div tabindex="0" role="tabpanel" id="microchip-polarfire-soc-fpga-icicle-kit-tab" aria-labelledby="live-installer" aria-hidden="true">
 	<div class="row p-strip is-shallow u-no-padding--top">
     <div class="col-3">
       <h2 class="u-hide--small">Microchip Polarfire SoC <br>FPGA Icicle Kit</h2>
     </div>
-    <div class="col-6 p-strip--light is-shallow u-vertically-center u-align--center">
+    <div class="col-6 risc-v-strip is-shallow u-vertically-center u-align--center">
       {{ 
         image (
         url="https://assets.ubuntu.com/v1/0f48dfd1-Microchip+PolarFire.png",

--- a/templates/download/risc-v/tab-2.html
+++ b/templates/download/risc-v/tab-2.html
@@ -1,26 +1,32 @@
-<div tabindex="0" role="tabpanel" id="starfive-visionfive-board-tab" aria-labelledby="starfive-visionfive-board" aria-hidden="true">
-	<div class="row">
-		<div class="col-6">
-			<div class="p-strip is-shallow u-no-padding--top">
-				<h2>StarFive VisionFive</h2>
-				<h3>Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
-			</div>
-			<p>
-				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+visionfive.img.xz">Download 23.04</a>
-				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+visionfive.img.xz">Download 22.04.2</a>
-			</p>
-			<p><a href="https://wiki.ubuntu.com/RISC-V/StarFive%20VisionFive">How to install Ubuntu on the VisionFive</a></p>
-		</div>
-		<div class="col-3 u-hide--medium u-hide--small p-strip is-shallow u-no-padding--bottom">
+<div tabindex="0" role="tabpanel" id="starfive-visionfive-board-tab" aria-labelledby="starfive-visionfive-board" hidden="true">
+	<div class="row p-strip--light is-shallow" style="margin-top: 3.5rem;">
+    <div class="col-3 u-vertically-center">
+      <h2 style="padding-left: 10%;">StarFive VisionFive</h2> 
+    </div>
+    <div class="col-6 u-hide--medium u-hide--small p-strip is-shallow u-no-padding--bottom u-vertically-center">
 			{{ image (
 				url="https://assets.ubuntu.com/v1/470a2398-StarFive+VisionFive+Board-NoBg.png",
 				alt="",
-				width="1056",
-				height="854",
+				width="739",
+				height="598",
 				hi_def=True,
 				loading="auto"
 				) | safe
 			  }}
 		</div>
-	</div>
+  </div>
+  <div class="row p-strip is-shallow">
+    <hr class="is-fixed-width col-9">
+    <div class="col-3">
+      <h3 class="p-heading--5">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
+    </div>
+    <div class="col-6">
+      <p>
+        <a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+visionfive.img.xz">Download 23.04</a>
+        <a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+visionfive.img.xz">Download 22.04.2</a>
+      </p>
+      <hr class="u-no-margin--bottom">
+      <p><a href="https://wiki.ubuntu.com/RISC-V/StarFive%20VisionFive">How to install Ubuntu on the VisionFive</a></p>
+    </div>
+  </div>
 </div>

--- a/templates/download/risc-v/tab-2.html
+++ b/templates/download/risc-v/tab-2.html
@@ -1,32 +1,37 @@
-<div tabindex="0" role="tabpanel" id="starfive-visionfive-board-tab" aria-labelledby="starfive-visionfive-board" hidden="true">
-	<div class="row p-strip--light is-shallow" style="margin-top: 3.5rem;">
-    <div class="col-3 u-vertically-center">
-      <h2 style="padding-left: 10%;">StarFive VisionFive</h2> 
+<div tabindex="0" role="tabpanel" id="microchip-polarfire-soc-fpga-icicle-kit-tab" aria-labelledby="live-installer" aria-hidden="true">
+	<div class="row p-strip is-shallow u-no-padding--top">
+    <div class="col-3">
+      <h2>Microchip Polarfire SoC <br class="u-hide--small">FPGA Icicle Kit</h2>
     </div>
-    <div class="col-6 u-hide--medium u-hide--small p-strip is-shallow u-no-padding--bottom u-vertically-center">
-			{{ image (
-				url="https://assets.ubuntu.com/v1/470a2398-StarFive+VisionFive+Board-NoBg.png",
-				alt="",
-				width="739",
-				height="598",
-				hi_def=True,
-				loading="auto"
-				) | safe
-			  }}
-		</div>
+    <div class="col-6 p-strip--light is-shallow u-vertically-center u-align--center">
+      {{ 
+        image (
+        url="https://assets.ubuntu.com/v1/0f48dfd1-Microchip+PolarFire.png",
+        alt="",
+        width="400",
+        height="207",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
   </div>
-  <div class="row p-strip is-shallow">
+  <div class="row p-strip is-shallow u-no-padding--top">
     <hr class="is-fixed-width col-9">
     <div class="col-3">
-      <h3 class="p-heading--5">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
+      <h3 class="p-heading--5 u-no-padding--top">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
     </div>
     <div class="col-6">
+      <p>Works on:</p>
+			<ul class="p-list">
+				<li class="p-list__item is-ticked">The Microchip Polarfire SoC FPGA Icicle Kit with <a href="https://github.com/polarfire-soc/hart-software-services/releases/tag/v2022.10">HSS v2022.10</a></li>
+			</ul>
+      <hr class="is-fixed-width col-6">
       <p>
-        <a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+visionfive.img.xz">Download 23.04</a>
-        <a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+visionfive.img.xz">Download 22.04.2</a>
-      </p>
-      <hr class="u-no-margin--bottom">
-      <p><a href="https://wiki.ubuntu.com/RISC-V/StarFive%20VisionFive">How to install Ubuntu on the VisionFive</a></p>
+				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+icicle.img.xz">Download 23.04</a>
+				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+icicle.img.xz">Download 22.04.2</a>
+			</p>
+      <p><a href="https://wiki.ubuntu.com/RISC-V/PolarFire%20SoC%20FPGA%20Icicle%20Kit">How to install Ubuntu on the Microchip Polarfire SoC FPGA Icicle Kit</a></p>
     </div>
   </div>
 </div>

--- a/templates/download/risc-v/tab-2.html
+++ b/templates/download/risc-v/tab-2.html
@@ -1,7 +1,7 @@
-<div tabindex="0" role="tabpanel" id="microchip-polarfire-soc-fpga-icicle-kit-tab" aria-labelledby="live-installer" aria-hidden="true">
+<div tabindex="0" role="tabpanel" id="microchip-polarfire-soc-fpga-icicle-kit-tab" aria-labelledby="live-installer" hidden="false">
 	<div class="row p-strip is-shallow u-no-padding--top">
     <div class="col-3">
-      <h2>Microchip Polarfire SoC <br class="u-hide--small">FPGA Icicle Kit</h2>
+      <h2 class="u-hide--small">Microchip Polarfire SoC <br>FPGA Icicle Kit</h2>
     </div>
     <div class="col-6 p-strip--light is-shallow u-vertically-center u-align--center">
       {{ 

--- a/templates/download/risc-v/tab-2.html
+++ b/templates/download/risc-v/tab-2.html
@@ -3,7 +3,7 @@
     <div class="col-3">
       <h2 class="u-hide--small">Microchip Polarfire SoC <br>FPGA Icicle Kit</h2>
     </div>
-    <div class="col-6 risc-v-strip is-shallow u-vertically-center u-align--center">
+    <div class="col-6 risc-v-container u-vertically-center u-align--center">
       {{ 
         image (
         url="https://assets.ubuntu.com/v1/0f48dfd1-Microchip+PolarFire.png",
@@ -11,13 +11,14 @@
         width="400",
         height="207",
         hi_def=True,
-        loading="lazy"
+        loading="lazy",
+        attrs={"class": "risc-v-image"}
         ) | safe
       }}
     </div>
   </div>
-  <div class="row p-strip is-shallow u-no-padding--top">
-    <hr class="is-fixed-width col-9">
+  <div class="row p-strip u-no-padding--top">
+    <hr class="col-9">
     <div class="col-3">
       <h3 class="p-heading--5 u-no-padding--top">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
     </div>

--- a/templates/download/risc-v/tab-2.html
+++ b/templates/download/risc-v/tab-2.html
@@ -1,4 +1,4 @@
-<div tabindex="0" role="tabpanel" id="microchip-polarfire-soc-fpga-icicle-kit-tab" aria-labelledby="live-installer" aria-hidden="true">
+<div tabindex="0" role="tabpanel" id="microchip-polarfire-soc-fpga-icicle-kit-tab" aria-labelledby="microchip-polarfire-soc-fpga-icicle-kit" aria-hidden="true">
 	<div class="row p-strip is-shallow u-no-padding--top">
     <div class="col-3">
       <h2 class="u-hide--small">Microchip Polarfire SoC <br>FPGA Icicle Kit</h2>

--- a/templates/download/risc-v/tab-3.html
+++ b/templates/download/risc-v/tab-3.html
@@ -1,25 +1,31 @@
 <div tabindex="0" role="tabpanel" id="starfive-visionfive-2-tab" aria-labelledby="starfive-visionfive-2" aria-hidden="true">
-	<div class="row">
-		<div class="col-6">
-			<div class="p-strip is-shallow u-no-padding--top">
-        <h2>StarFive VisionFive 2</h2>
-				<h3>Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
-			</div>
-			<p>
-				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+visionfive2.img.xz">Download 23.04</a>
-			</p>
-			<p><a href="https://wiki.ubuntu.com/RISC-V/StarFive%20VisionFive%202">How to install Ubuntu on the VisionFive 2</a></p>
-		</div>
-		<div class="col-3 u-hide--medium u-hide--small p-strip is-shallow u-no-padding--bottom">
+	<div class="row p-strip--light is-shallow" style="margin-top: 3.5rem;">
+    <div class="col-3 u-vertically-center">
+      <h2 style="padding-left: 10%;">StarFive VisionFive 2</h2> 
+    </div>
+    <div class="col-6 u-hide--medium u-hide--small p-strip is-shallow u-no-padding--bottom u-vertically-center">
       {{ image (
-          url="https://assets.ubuntu.com/v1/3579cbd3-starfive-visionfive-2.jpg",
-          alt="",
-          width="500",
-          height="400",
-          hi_def=True,
-          loading="lazy"
-          ) | safe
-        }}
+        url="https://assets.ubuntu.com/v1/f63441ac-risc-v_star-five-board.png",
+        alt="",
+        width="500",
+        height="400",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
 		</div>
-	</div>
+  </div>
+  <div class="row p-strip is-shallow">
+    <hr class="is-fixed-width col-9">
+    <div class="col-3">
+      <h3 class="p-heading--5">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
+    </div>
+    <div class="col-6">
+      <p>
+				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+visionfive2.img.xz">Download 23.04</a>
+      </p>
+      <hr class="u-no-margin--bottom">
+      <p><a href="https://wiki.ubuntu.com/RISC-V/StarFive%20VisionFive%202">How to install Ubuntu on the VisionFive</a></p>
+    </div>
+  </div>
 </div>

--- a/templates/download/risc-v/tab-3.html
+++ b/templates/download/risc-v/tab-3.html
@@ -1,7 +1,7 @@
 <div tabindex="0" role="tabpanel" id="qemu-tab" aria-labelledby="qemu" aria-hidden="true">
   <div class="row p-strip is-shallow u-no-padding--top">
     <div class="col-3">
-      <h2>QEMU emulator</h2>
+      <h2 class="u-hide--small">QEMU emulator</h2>
     </div>
     <div class="col-6 p-strip--light is-shallow u-vertically-center u-align--center">
       {{

--- a/templates/download/risc-v/tab-3.html
+++ b/templates/download/risc-v/tab-3.html
@@ -12,7 +12,6 @@
 				height="120",
 				hi_def=True,
 				loading="lazy",
-        attrs={"class": "risc-v-image"}
 				) | safe
 			  }}
     </div>

--- a/templates/download/risc-v/tab-3.html
+++ b/templates/download/risc-v/tab-3.html
@@ -3,7 +3,7 @@
     <div class="col-3">
       <h2 class="u-hide--small">QEMU emulator</h2>
     </div>
-    <div class="col-6 risc-v-strip is-shallow u-vertically-center u-align--center">
+    <div class="col-6 risc-v-container u-vertically-center u-align--center">
       {{
 				image (
 				url="https://assets.ubuntu.com/v1/308d48cd-Qemu-logo.png",
@@ -11,13 +11,14 @@
 				width="377",
 				height="120",
 				hi_def=True,
-				loading="lazy"
+				loading="lazy",
+        attrs={"class": "risc-v-image"}
 				) | safe
 			  }}
     </div>
   </div>
-  <div class="row p-strip is-shallow u-no-padding--top">
-    <hr class="is-fixed-width col-9">
+  <div class="row p-strip u-no-padding--top">
+    <hr class="col-9">
     <div class="col-3">
       <h3 class="p-heading--5 u-no-padding--top">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
     </div>
@@ -28,7 +29,7 @@
 			</p>
     </div>
   </div>
-  <div class="row p-strip is-shallow u-no-padding--top">
+  <div class="row p-strip u-no-padding--top">
     <hr class="is-fixed-width col-9">
     <div class="col-3">
       <h3 class="p-heading--5 u-no-padding--top">Ubuntu Server <br class="u-hide--small">live installer</h3>

--- a/templates/download/risc-v/tab-3.html
+++ b/templates/download/risc-v/tab-3.html
@@ -3,7 +3,7 @@
     <div class="col-3">
       <h2 class="u-hide--small">QEMU emulator</h2>
     </div>
-    <div class="col-6 p-strip--light is-shallow u-vertically-center u-align--center">
+    <div class="col-6 risc-v-strip is-shallow u-vertically-center u-align--center">
       {{
 				image (
 				url="https://assets.ubuntu.com/v1/308d48cd-Qemu-logo.png",

--- a/templates/download/risc-v/tab-3.html
+++ b/templates/download/risc-v/tab-3.html
@@ -1,31 +1,44 @@
-<div tabindex="0" role="tabpanel" id="starfive-visionfive-2-tab" aria-labelledby="starfive-visionfive-2" aria-hidden="true">
-	<div class="row p-strip--light is-shallow" style="margin-top: 3.5rem;">
-    <div class="col-3 u-vertically-center">
-      <h2 style="padding-left: 10%;">StarFive VisionFive 2</h2> 
+<div tabindex="0" role="tabpanel" id="qemu-tab" aria-labelledby="qemu" aria-hidden="true">
+  <div class="row p-strip is-shallow u-no-padding--top">
+    <div class="col-3">
+      <h2>QEMU emulator</h2>
     </div>
-    <div class="col-6 u-hide--medium u-hide--small p-strip is-shallow u-no-padding--bottom u-vertically-center">
-      {{ image (
-        url="https://assets.ubuntu.com/v1/f63441ac-risc-v_star-five-board.png",
-        alt="",
-        width="500",
-        height="400",
-        hi_def=True,
-        loading="lazy"
-        ) | safe
-      }}
-		</div>
+    <div class="col-6 p-strip--light is-shallow u-vertically-center u-align--center">
+      {{
+				image (
+				url="https://assets.ubuntu.com/v1/308d48cd-Qemu-logo.png",
+				alt="",
+				width="377",
+				height="120",
+				hi_def=True,
+				loading="lazy"
+				) | safe
+			  }}
+    </div>
   </div>
-  <div class="row p-strip is-shallow">
+  <div class="row p-strip is-shallow u-no-padding--top">
     <hr class="is-fixed-width col-9">
     <div class="col-3">
-      <h3 class="p-heading--5">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
+      <h3 class="p-heading--5 u-no-padding--top">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
+    </div>
+    <div class="col-6">
+      <p class="u-sv3">
+				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+unmatched.img.xz">Download 23.04</a>
+				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+unmatched.img.xz">Download 22.04.2</a>
+			</p>
+    </div>
+  </div>
+  <div class="row p-strip is-shallow u-no-padding--top">
+    <hr class="is-fixed-width col-9">
+    <div class="col-3">
+      <h3 class="p-heading--5 u-no-padding--top">Ubuntu Server <br class="u-hide--small">live installer</h3>
     </div>
     <div class="col-6">
       <p>
-				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+visionfive2.img.xz">Download 23.04</a>
-      </p>
-      <hr class="u-no-margin--bottom">
-      <p><a href="https://wiki.ubuntu.com/RISC-V/StarFive%20VisionFive%202">How to install Ubuntu on the VisionFive</a></p>
+				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-live-server-riscv64.img.gz">Download 23.04 live installer</a>
+				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-live-server-riscv64.img.gz">Download 22.04.2 live installer</a>
+			</p>
+      <p><a href="https://wiki.ubuntu.com/RISC-V/QEMU">How to install Ubuntu on QEMU RISC-V</a></p>
     </div>
   </div>
 </div>

--- a/templates/download/risc-v/tab-4.html
+++ b/templates/download/risc-v/tab-4.html
@@ -1,7 +1,7 @@
 <div tabindex="0" role="tabpanel" id="quemu-sifive-image-tab" aria-labelledby="quemu-sifive-image">
   <div class="row p-strip is-shallow u-no-padding--top">
     <div class="col-3">
-      <h2>SiFive Unmatched</h2>
+      <h2 class="u-hide--small">SiFive Unmatched</h2>
     </div>
     <div class="col-6 p-strip--light is-shallow u-vertically-center u-align--center">
       {{ image (

--- a/templates/download/risc-v/tab-4.html
+++ b/templates/download/risc-v/tab-4.html
@@ -3,20 +3,21 @@
     <div class="col-3">
       <h2 class="u-hide--small">SiFive Unmatched</h2>
     </div>
-    <div class="col-6 risc-v-strip is-shallow u-vertically-center u-align--center">
+    <div class="col-6 risc-v-container u-vertically-center u-align--center">
       {{ image (
         url="https://assets.ubuntu.com/v1/37c094a9-SiFive+Unmatched+Board.jpg",
         alt="",
         width="504",
         height="286",
         hi_def=True,
-        loading="auto"
+        loading="auto",
+        attrs={"class": "risc-v-image"}
         ) | safe
         }}
     </div>
   </div>
-  <div class="row p-strip is-shallow u-no-padding--top">
-    <hr class="is-fixed-width u-no-margin--bottom col-9">
+  <div class="row p-strip u-no-padding--top">
+    <hr class="col-9">
     <div class="col-3">
       <h3 class="p-heading--5">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
     </div>
@@ -28,8 +29,8 @@
       </p>
     </div>
   </div>
-  <div class="row p-strip is-shallow u-no-padding--top">
-    <hr class="is-fixed-width col-9">
+  <div class="row p-strip u-no-padding--top">
+    <hr class="col-9">
     <div class="col-3">
       <h3 class="p-heading--5">Ubuntu Server <br class="u-hide--small">live installer</h3>
     </div>

--- a/templates/download/risc-v/tab-4.html
+++ b/templates/download/risc-v/tab-4.html
@@ -1,32 +1,44 @@
-<div tabindex="0" role="tabpanel" id="allwinner-nezha-tab" aria-labelledby="allwinner-nezha" aria-hidden="true">
-	<div class="row p-strip--light is-shallow" style="margin-top: 3.5rem;">
-    <div class="col-3 u-vertically-center">
-      <h2 style="padding-left: 10%;">AllWiner Nezha</h2> 
+<div tabindex="0" role="tabpanel" id="quemu-sifive-image-tab" aria-labelledby="quemu-sifive-image">
+  <div class="row p-strip is-shallow u-no-padding--top">
+    <div class="col-3">
+      <h2>SiFive Unmatched</h2>
     </div>
-    <div class="col-6 u-hide--medium u-hide--small p-strip is-shallow u-no-padding--bottom u-vertically-center">
+    <div class="col-6 p-strip--light is-shallow u-vertically-center u-align--center">
       {{ image (
-        url="https://assets.ubuntu.com/v1/5207975e-0cc9bac3-Allwinner+Nezha+Board.png",
+        url="https://assets.ubuntu.com/v1/37c094a9-SiFive+Unmatched+Board.jpg",
         alt="",
-        width="500",
-        height="300",
+        width="504",
+        height="286",
         hi_def=True,
-        loading="lazy"
+        loading="auto"
         ) | safe
-      }}
-		</div>
+        }}
+    </div>
   </div>
-  <div class="row p-strip is-shallow">
-    <hr class="is-fixed-width col-9">
+  <div class="row p-strip is-shallow u-no-padding--top">
+    <hr class="is-fixed-width u-no-margin--bottom col-9">
     <div class="col-3">
       <h3 class="p-heading--5">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
     </div>
     <div class="col-6">
+      <p class="p-notification__message"><i class="p-icon--information"></i> If you have an NVMe drive, we advise you to use the Ubuntu Server live installer.</p>
+      <p class="u-sv3">
+        <a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+unmatched.img.xz">Download 23.04</a>
+        <a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+unmatched.img.xz">Download 22.04.2</a>
+      </p>
+    </div>
+  </div>
+  <div class="row p-strip is-shallow u-no-padding--top">
+    <hr class="is-fixed-width col-9">
+    <div class="col-3">
+      <h3 class="p-heading--5">Ubuntu Server <br class="u-hide--small">live installer</h3>
+    </div>
+    <div class="col-6">
       <p>
-				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+nezha.img.xz">Download 23.04</a>
-				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+nezha.img.xz">Download 22.04.2</a>
+				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-live-server-riscv64.img.gz">Download 23.04 live installer</a>
+				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-live-server-riscv64.img.gz">Download 22.04.2 live installer</a>
 			</p>
-      <hr class="u-no-margin--bottom">
-			<p><a href="https://wiki.ubuntu.com/RISC-V/Nezha%20D1">How to install Ubuntu on the Nezha</a></p>
+			<p><a href="https://wiki.ubuntu.com/RISC-V/SiFive%20HiFive%20Unmatched">How to install Ubuntu on SiFive HiFive Unmatched</a></p>
     </div>
   </div>
 </div>

--- a/templates/download/risc-v/tab-4.html
+++ b/templates/download/risc-v/tab-4.html
@@ -3,7 +3,7 @@
     <div class="col-3">
       <h2 class="u-hide--small">SiFive Unmatched</h2>
     </div>
-    <div class="col-6 p-strip--light is-shallow u-vertically-center u-align--center">
+    <div class="col-6 risc-v-strip is-shallow u-vertically-center u-align--center">
       {{ image (
         url="https://assets.ubuntu.com/v1/37c094a9-SiFive+Unmatched+Board.jpg",
         alt="",

--- a/templates/download/risc-v/tab-4.html
+++ b/templates/download/risc-v/tab-4.html
@@ -1,24 +1,32 @@
 <div tabindex="0" role="tabpanel" id="allwinner-nezha-tab" aria-labelledby="allwinner-nezha" aria-hidden="true">
-	<div class="row">
-		<div class="col-6">
-      <h2>AllWiner Nezha</h2>
-			<h3>Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
-			<p>
+	<div class="row p-strip--light is-shallow" style="margin-top: 3.5rem;">
+    <div class="col-3 u-vertically-center">
+      <h2 style="padding-left: 10%;">AllWiner Nezha</h2> 
+    </div>
+    <div class="col-6 u-hide--medium u-hide--small p-strip is-shallow u-no-padding--bottom u-vertically-center">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/5207975e-0cc9bac3-Allwinner+Nezha+Board.png",
+        alt="",
+        width="500",
+        height="300",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+		</div>
+  </div>
+  <div class="row p-strip is-shallow">
+    <hr class="is-fixed-width col-9">
+    <div class="col-3">
+      <h3 class="p-heading--5">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
+    </div>
+    <div class="col-6">
+      <p>
 				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+nezha.img.xz">Download 23.04</a>
 				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+nezha.img.xz">Download 22.04.2</a>
 			</p>
+      <hr class="u-no-margin--bottom">
 			<p><a href="https://wiki.ubuntu.com/RISC-V/Nezha%20D1">How to install Ubuntu on the Nezha</a></p>
-		</div>
-		<div class="col-3 u-hide--medium u-hide--small p-strip is-shallow u-no-padding--bottom">
-			{{ image (
-				url="https://assets.ubuntu.com/v1/0cc9bac3-Allwinner+Nezha+Board.png",
-				alt="",
-				width="600",
-				height="400",
-				hi_def=True,
-				loading="auto"
-				) | safe
-			  }}
-		</div>
-	</div>
+    </div>
+  </div>
 </div>

--- a/templates/download/risc-v/tab-4.html
+++ b/templates/download/risc-v/tab-4.html
@@ -19,7 +19,7 @@
   <div class="row p-strip u-no-padding--top">
     <hr class="col-9">
     <div class="col-3">
-      <h3 class="p-heading--5">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
+      <h3 class="p-heading--5 u-no-padding--top">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
     </div>
     <div class="col-6">
       <p class="p-notification__message"><i class="p-icon--information"></i> If you have an NVMe drive, we advise you to use the Ubuntu Server live installer.</p>
@@ -32,7 +32,7 @@
   <div class="row p-strip u-no-padding--top">
     <hr class="col-9">
     <div class="col-3">
-      <h3 class="p-heading--5">Ubuntu Server <br class="u-hide--small">live installer</h3>
+      <h3 class="p-heading--5 u-no-padding--top">Ubuntu Server <br class="u-hide--small">live installer</h3>
     </div>
     <div class="col-6">
       <p>

--- a/templates/download/risc-v/tab-5.html
+++ b/templates/download/risc-v/tab-5.html
@@ -1,7 +1,7 @@
 <div tabindex="0" role="tabpanel" id="sipeed-licheerv-dock-tab" aria-labelledby="allwinner-nezha" aria-hidden="true">
-	<div class="row">
-		<div class="col-6">
-      <h2>Sipeed LicheeRV Dock</h2>
+	<div class="row p-strip--light is-shallow" style="margin-top: 3.5rem;">
+		<div class="col-3 u-vertically-center">
+			<h2>Sipeed LicheeRV Dock</h2>
 			<h3 class="u-sv3">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
 			<p>
 				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+licheerv.img.xz">Download 23.04</a>

--- a/templates/download/risc-v/tab-5.html
+++ b/templates/download/risc-v/tab-5.html
@@ -1,24 +1,32 @@
-<div tabindex="0" role="tabpanel" id="sipeed-licheerv-dock-tab" aria-labelledby="allwinner-nezha" aria-hidden="true">
-	<div class="row p-strip--light is-shallow" style="margin-top: 3.5rem;">
-		<div class="col-3 u-vertically-center">
-			<h2>Sipeed LicheeRV Dock</h2>
-			<h3 class="u-sv3">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
-			<p>
+<div tabindex="0" role="tabpanel" id="sipeed-licheerv-dock-tab" aria-labelledby="sipeed-licheerv-dock" aria-hidden="true">
+	<div class="row p-strip is-shallow u-no-padding--top">
+    <div class="col-3">
+      <h2>Sipeed LicheeRV Dock</h2>
+    </div>
+    <div class="col-6 p-strip--light is-shallow u-vertically-center u-align--center">
+      {{ 
+        image (
+        url="https://assets.ubuntu.com/v1/4c609299-Sipeed+LicheeRV+-+Edited.png",
+        alt="",
+        width="400",
+        height="400",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+  </div>
+  <div class="row p-strip is-shallow u-no-padding--top">
+    <hr class="is-fixed-width col-9">
+    <div class="col-3">
+      <h3 class="p-heading--5 u-no-padding--top">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
+    </div>
+    <div class="col-6">
+      <p>
 				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+licheerv.img.xz">Download 23.04</a>
 				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+licheerv.img.xz">Download 22.04.2</a>
 			</p>
 			<p><a href="https://wiki.ubuntu.com/RISC-V/LicheeRV">How to install Ubuntu on the LicheeRV Dock</a></p>
-		</div>
-		<div class="col-3 u-hide--medium u-hide--small p-strip is-shallow u-no-padding--bottom">
-			{{ image (
-				url="https://assets.ubuntu.com/v1/b151abd7-Sipeed+LicheeRV+-+Edited-2.png",
-				alt="",
-				width="900",
-				height="700",
-				hi_def=True,
-				loading="auto"
-				) | safe
-			}}
-		</div>
-	</div>
+    </div>
+  </div>
 </div>

--- a/templates/download/risc-v/tab-5.html
+++ b/templates/download/risc-v/tab-5.html
@@ -3,7 +3,7 @@
     <div class="col-3">
       <h2 class="u-hide--small">Sipeed LicheeRV Dock</h2>
     </div>
-    <div class="col-6 risc-v-strip is-shallow u-vertically-center u-align--center">
+    <div class="col-6 risc-v-container u-vertically-center u-align--center">
       {{ 
         image (
         url="https://assets.ubuntu.com/v1/4c609299-Sipeed+LicheeRV+-+Edited.png",
@@ -11,13 +11,14 @@
         width="400",
         height="400",
         hi_def=True,
-        loading="lazy"
+        loading="lazy",
+        attrs={"class": "risc-v-image"}
         ) | safe
       }}
     </div>
   </div>
-  <div class="row p-strip is-shallow u-no-padding--top">
-    <hr class="is-fixed-width col-9">
+  <div class="row p-strip u-no-padding--top">
+    <hr class="col-9">
     <div class="col-3">
       <h3 class="p-heading--5 u-no-padding--top">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
     </div>

--- a/templates/download/risc-v/tab-5.html
+++ b/templates/download/risc-v/tab-5.html
@@ -3,7 +3,7 @@
     <div class="col-3">
       <h2 class="u-hide--small">Sipeed LicheeRV Dock</h2>
     </div>
-    <div class="col-6 p-strip--light is-shallow u-vertically-center u-align--center">
+    <div class="col-6 risc-v-strip is-shallow u-vertically-center u-align--center">
       {{ 
         image (
         url="https://assets.ubuntu.com/v1/4c609299-Sipeed+LicheeRV+-+Edited.png",

--- a/templates/download/risc-v/tab-5.html
+++ b/templates/download/risc-v/tab-5.html
@@ -1,7 +1,7 @@
 <div tabindex="0" role="tabpanel" id="sipeed-licheerv-dock-tab" aria-labelledby="sipeed-licheerv-dock" aria-hidden="true">
 	<div class="row p-strip is-shallow u-no-padding--top">
     <div class="col-3">
-      <h2>Sipeed LicheeRV Dock</h2>
+      <h2 class="u-hide--small">Sipeed LicheeRV Dock</h2>
     </div>
     <div class="col-6 p-strip--light is-shallow u-vertically-center u-align--center">
       {{ 

--- a/templates/download/risc-v/tab-6.html
+++ b/templates/download/risc-v/tab-6.html
@@ -3,20 +3,21 @@
     <div class="col-3">
       <h2 class="u-hide--small">StarFive VisionFive</h2>
     </div>
-    <div class="col-6 risc-v-strip is-shallow u-vertically-center u-align--center">
+    <div class="col-6 risc-v-container u-vertically-center u-align--center">
       {{ image (
 				url="https://assets.ubuntu.com/v1/470a2398-StarFive+VisionFive+Board-NoBg.png",
 				alt="",
 				width="370",
 				height="299",
 				hi_def=True,
-				loading="lazy"
+				loading="lazy",
+        attrs={"class": "risc-v-image"}
 				) | safe
 			  }}
     </div>
   </div>
-  <div class="row p-strip is-shallow u-no-padding--top">
-    <hr class="is-fixed-width col-9">
+  <div class="row p-strip u-no-padding--top">
+    <hr class="col-9">
     <div class="col-3">
       <h3 class="p-heading--5 u-no-padding--top">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
     </div>

--- a/templates/download/risc-v/tab-6.html
+++ b/templates/download/risc-v/tab-6.html
@@ -1,7 +1,7 @@
 <div tabindex="0" role="tabpanel" id="starfive-visionfive-board-tab" aria-labelledby="starfive-visionfive-board" hidden="true">
 	<div class="row p-strip is-shallow u-no-padding--top">
     <div class="col-3">
-      <h2>StarFive VIsionFive</h2>
+      <h2 class="u-hide--small">StarFive VisionFive</h2>
     </div>
     <div class="col-6 p-strip--light is-shallow u-vertically-center u-align--center">
       {{ image (
@@ -10,7 +10,7 @@
 				width="370",
 				height="299",
 				hi_def=True,
-				loading="auto"
+				loading="lazy"
 				) | safe
 			  }}
     </div>
@@ -26,7 +26,6 @@
         <a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+visionfive.img.xz">Download 22.04.2</a>
       </p>
       <p><a href="https://wiki.ubuntu.com/RISC-V/StarFive%20VisionFive">How to install Ubuntu on the VisionFive</a></p>
-    </div>
     </div>
   </div>
 </div>

--- a/templates/download/risc-v/tab-6.html
+++ b/templates/download/risc-v/tab-6.html
@@ -1,29 +1,32 @@
-<div tabindex="0" role="tabpanel" id="microchip-polarfire-soc-fpga-icicle-kit-tab" aria-labelledby="live-installer" aria-hidden="true">
-	<div class="row p-strip--light is-shallow" style="margin-top: 3.5rem;">
-		<div class="col-6">
-      <h2>Microchip Polarfire SoC <br class="u-hide--small">FPGA Icicle Kit</h2>
-			<h3 class="u-sv3">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
-			<p>
-				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+icicle.img.xz">Download 23.04</a>
-				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+icicle.img.xz">Download 22.04.2</a>
-			</p>
-			<p>Works on:</p>
-			<ul class="p-list">
-				<li class="p-list__item is-ticked">The Microchip Polarfire SoC FPGA Icicle Kit with <a href="https://github.com/polarfire-soc/hart-software-services/releases/tag/v2022.10">HSS v2022.10</a></li>
-			</ul>
-			<p><a href="https://wiki.ubuntu.com/RISC-V/PolarFire%20SoC%20FPGA%20Icicle%20Kit">How to install Ubuntu on the Microchip Polarfire SoC FPGA Icicle Kit</a></p>
-		</div>
-		<div class="col-3 u-hide--medium u-hide--small p-strip is-shallow u-no-padding--bottom">
-			{{
-				image (
-				url="https://assets.ubuntu.com/v1/40eacb41-Microchip+PolarFire.png",
+<div tabindex="0" role="tabpanel" id="starfive-visionfive-board-tab" aria-labelledby="starfive-visionfive-board" hidden="true">
+	<div class="row p-strip is-shallow u-no-padding--top">
+    <div class="col-3">
+      <h2>StarFive VIsionFive</h2>
+    </div>
+    <div class="col-6 p-strip--light is-shallow u-vertically-center u-align--center">
+      {{ image (
+				url="https://assets.ubuntu.com/v1/470a2398-StarFive+VisionFive+Board-NoBg.png",
 				alt="",
-				width="800",
-				height="414",
+				width="370",
+				height="299",
 				hi_def=True,
-				loading="lazy"
+				loading="auto"
 				) | safe
 			  }}
-		</div>
-	</div>
+    </div>
+  </div>
+  <div class="row p-strip is-shallow u-no-padding--top">
+    <hr class="is-fixed-width col-9">
+    <div class="col-3">
+      <h3 class="p-heading--5 u-no-padding--top">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
+    </div>
+    <div class="col-6">
+      <p>
+        <a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+visionfive.img.xz">Download 23.04</a>
+        <a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+visionfive.img.xz">Download 22.04.2</a>
+      </p>
+      <p><a href="https://wiki.ubuntu.com/RISC-V/StarFive%20VisionFive">How to install Ubuntu on the VisionFive</a></p>
+    </div>
+    </div>
+  </div>
 </div>

--- a/templates/download/risc-v/tab-6.html
+++ b/templates/download/risc-v/tab-6.html
@@ -1,9 +1,9 @@
-<div tabindex="0" role="tabpanel" id="starfive-visionfive-board-tab" aria-labelledby="starfive-visionfive-board" hidden="true">
+<div tabindex="0" role="tabpanel" id="starfive-visionfive-board-tab" aria-labelledby="starfive-visionfive-board" aria-hidden="true">
 	<div class="row p-strip is-shallow u-no-padding--top">
     <div class="col-3">
       <h2 class="u-hide--small">StarFive VisionFive</h2>
     </div>
-    <div class="col-6 p-strip--light is-shallow u-vertically-center u-align--center">
+    <div class="col-6 risc-v-strip is-shallow u-vertically-center u-align--center">
       {{ image (
 				url="https://assets.ubuntu.com/v1/470a2398-StarFive+VisionFive+Board-NoBg.png",
 				alt="",

--- a/templates/download/risc-v/tab-6.html
+++ b/templates/download/risc-v/tab-6.html
@@ -1,5 +1,5 @@
 <div tabindex="0" role="tabpanel" id="microchip-polarfire-soc-fpga-icicle-kit-tab" aria-labelledby="live-installer" aria-hidden="true">
-	<div class="row">
+	<div class="row p-strip--light is-shallow" style="margin-top: 3.5rem;">
 		<div class="col-6">
       <h2>Microchip Polarfire SoC <br class="u-hide--small">FPGA Icicle Kit</h2>
 			<h3 class="u-sv3">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>

--- a/templates/download/risc-v/tab-7.html
+++ b/templates/download/risc-v/tab-7.html
@@ -1,35 +1,31 @@
-<div tabindex="0" role="tabpanel" id="qemu-tab" aria-labelledby="qemu" aria-hidden="true">
-	<div class="row p-strip--light is-shallow" style="margin-top: 3.5rem;">
-		<div class="col-6">
-      <h2>QEMU emulator</h2>
-			<h3 class="u-sv3">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
-			<p class="u-sv3">
-				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+unmatched.img.xz">Download 23.04</a>
-				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+unmatched.img.xz">Download 22.04.2</a>
-			</p>
+<div tabindex="0" role="tabpanel" id="starfive-visionfive-2-tab" aria-labelledby="starfive-visionfive-2" aria-hidden="true">
+	<div class="row p-strip is-shallow u-no-padding--top">
+    <div class="col-3">
+      <h2>StarFive VisionFive 2</h2>
     </div>
-		<div class="col-3 u-hide--medium u-hide--small p-strip is-shallow u-no-padding--bottom">
-			{{
-				image (
-				url="https://assets.ubuntu.com/v1/308d48cd-Qemu-logo.png",
-				alt="",
-				width="377",
-				height="120",
-				hi_def=True,
-				loading="lazy"
-				) | safe
-			  }}
-		</div>
-	</div>
-	<div class="row">
-		<div class="col-6">
+    <div class="col-6 p-strip--light is-shallow u-vertically-center u-align--center">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/f63441ac-risc-v_star-five-board.png",
+        alt="",
+        width="500",
+        height="400",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+  </div>
+  <div class="row p-strip is-shallow u-no-padding--top">
+    <hr class="is-fixed-width col-9">
+    <div class="col-3">
+      <h3 class="p-heading--5">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
+    </div>
+    <div class="col-6">
+      <p>
+				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+visionfive2.img.xz">Download 23.04</a>
+      </p>
       <hr class="u-no-margin--bottom">
-      <h3 class="u-sv3">Ubuntu Server live installer</h3>
-			<p>
-				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-live-server-riscv64.img.gz">Download 23.04 live installer</a>
-				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-live-server-riscv64.img.gz">Download 22.04.2 live installer</a>
-			</p>
-			<p><a href="https://wiki.ubuntu.com/RISC-V/QEMU">How to install Ubuntu on QEMU RISC-V</a></p>
-		</div>
-	</div>
+      <p><a href="https://wiki.ubuntu.com/RISC-V/StarFive%20VisionFive%202">How to install Ubuntu on the VisionFive</a></p>
+    </div>
+  </div>
 </div>

--- a/templates/download/risc-v/tab-7.html
+++ b/templates/download/risc-v/tab-7.html
@@ -1,7 +1,7 @@
 <div tabindex="0" role="tabpanel" id="starfive-visionfive-2-tab" aria-labelledby="starfive-visionfive-2" aria-hidden="true">
 	<div class="row p-strip is-shallow u-no-padding--top">
     <div class="col-3">
-      <h2>StarFive VisionFive 2</h2>
+      <h2 class="u-hide--small">StarFive VisionFive 2</h2>
     </div>
     <div class="col-6 p-strip--light is-shallow u-vertically-center u-align--center">
       {{ image (

--- a/templates/download/risc-v/tab-7.html
+++ b/templates/download/risc-v/tab-7.html
@@ -3,12 +3,12 @@
     <div class="col-3">
       <h2 class="u-hide--small">StarFive VisionFive 2</h2>
     </div>
-    <div class="col-6 p-strip--light is-shallow u-vertically-center u-align--center">
+    <div class="col-6 risc-v-strip is-shallow u-vertically-center u-align--center">
       {{ image (
         url="https://assets.ubuntu.com/v1/f63441ac-risc-v_star-five-board.png",
         alt="",
-        width="500",
-        height="400",
+        width="400",
+        height="300",
         hi_def=True,
         loading="lazy"
         ) | safe

--- a/templates/download/risc-v/tab-7.html
+++ b/templates/download/risc-v/tab-7.html
@@ -1,5 +1,5 @@
 <div tabindex="0" role="tabpanel" id="qemu-tab" aria-labelledby="qemu" aria-hidden="true">
-	<div class="row">
+	<div class="row p-strip--light is-shallow" style="margin-top: 3.5rem;">
 		<div class="col-6">
       <h2>QEMU emulator</h2>
 			<h3 class="u-sv3">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>

--- a/templates/download/risc-v/tab-7.html
+++ b/templates/download/risc-v/tab-7.html
@@ -3,28 +3,26 @@
     <div class="col-3">
       <h2 class="u-hide--small">StarFive VisionFive 2</h2>
     </div>
-    <div class="col-6 risc-v-strip is-shallow u-vertically-center u-align--center">
+    <div class="col-6 risc-v-container u-vertically-center u-align--center">
       {{ image (
         url="https://assets.ubuntu.com/v1/f63441ac-risc-v_star-five-board.png",
         alt="",
         width="400",
         height="300",
         hi_def=True,
-        loading="lazy"
+        loading="lazy",
+        attrs={"class": "risc-v-image"}
         ) | safe
       }}
     </div>
   </div>
-  <div class="row p-strip is-shallow u-no-padding--top">
-    <hr class="is-fixed-width col-9">
+  <div class="row p-strip u-no-padding--top">
+    <hr class="col-9">
     <div class="col-3">
-      <h3 class="p-heading--5">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
+      <h3 class="p-heading--5 u-no-padding--top">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
     </div>
     <div class="col-6">
-      <p>
-				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+visionfive2.img.xz">Download 23.04</a>
-      </p>
-      <hr class="u-no-margin--bottom">
+      <p><a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+visionfive2.img.xz">Download 23.04</a></p>
       <p><a href="https://wiki.ubuntu.com/RISC-V/StarFive%20VisionFive%202">How to install Ubuntu on the VisionFive</a></p>
     </div>
   </div>


### PR DESCRIPTION
## Done

- Applied redesign as per [mock-up](https://www.figma.com/file/WsMLgH1TXcU1mZ7YjqZRDY/u.com%2Fdownload%2Frisc-v?type=design&node-id=1-479&t=CjoQFe70UKFQNHyE-0)
- Added functionality for small screen dropdown select

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: https://ubuntu-com-12870.demos.haus/download/risc-v
- Check against design
    - Be sure to test on mobile, tablet and desktop screen sizes

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-3875

