### PR TITLE
Update chart.js to include Ubuntu Pro

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -1522,7 +1522,7 @@ export var desktopServerStatus = {
   HARDWARE_AND_MAINTENANCE_UPDATES: "chart__bar--orange",
   MAINTENANCE_UPDATES: "chart__bar--orange-light",
   ESM: "chart__bar--aubergine",
-  MAIN_UNIVERSE: "chart__bar--violet",
+  MAIN_UNIVERSE: "chart__bar--charcoal",
   INTERIM_RELEASE: "chart__bar--grey",
 };
 

--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -87,6 +87,12 @@ export var serverAndDesktopReleases = [
     status: "ESM",
   },
   {
+    startDate: new Date("2016-04-01T00:00:00"),
+    endDate: new Date("2026-04-02T00:00:00"),
+    taskName: "16.04 LTS (Xenial Xerus)",
+    status: "MAIN_UNIVERSE",
+  },
+  {
     startDate: new Date("2018-04-01T00:00:00"),
     endDate: new Date("2023-04-02T00:00:00"),
     taskName: "18.04 LTS (Bionic Beaver)",
@@ -97,6 +103,12 @@ export var serverAndDesktopReleases = [
     endDate: new Date("2028-04-01T00:00:00"),
     taskName: "18.04 LTS (Bionic Beaver)",
     status: "ESM",
+  },
+  {
+    startDate: new Date("2018-04-01T00:00:00"),
+    endDate: new Date("2028-04-01T00:00:00"),
+    taskName: "18.04 LTS (Bionic Beaver)",
+    status: "MAIN_UNIVERSE",
   },
   {
     startDate: new Date("2020-04-01T00:00:00"),
@@ -111,10 +123,22 @@ export var serverAndDesktopReleases = [
     status: "ESM",
   },
   {
+    startDate: new Date("2020-04-01T00:00:00"),
+    endDate: new Date("2030-04-02T00:00:00"),
+    taskName: "20.04 LTS (Focal Fossa)",
+    status: "MAIN_UNIVERSE",
+  },
+  {
     startDate: new Date("2022-04-01T00:00:00"),
     endDate: new Date("2027-04-01T00:00:00"),
     taskName: "22.04 LTS (Jammy Jellyfish)",
     status: "HARDWARE_AND_MAINTENANCE_UPDATES",
+  },
+  {
+    startDate: new Date("2022-04-01T00:00:00"),
+    endDate: new Date("2032-04-01T00:00:00"),
+    taskName: "22.04 LTS (Jammy Jellyfish)",
+    status: "MAIN_UNIVERSE",
   },
   {
     startDate: new Date("2027-04-01T00:00:00"),
@@ -1497,8 +1521,9 @@ export var kubernetesReleases = [
 export var desktopServerStatus = {
   HARDWARE_AND_MAINTENANCE_UPDATES: "chart__bar--orange",
   MAINTENANCE_UPDATES: "chart__bar--orange-light",
-  INTERIM_RELEASE: "chart__bar--grey",
   ESM: "chart__bar--aubergine",
+  MAIN_UNIVERSE: "chart__bar--violet",
+  INTERIM_RELEASE: "chart__bar--grey",
 };
 
 export var kernelStatus = {

--- a/static/js/src/chart.js
+++ b/static/js/src/chart.js
@@ -51,6 +51,15 @@ function addBarsToChart(svg, tasks, taskStatus, x, y, highlightVersion) {
     })
     .attr("y", 0)
     .attr("transform", function (d) {
+      if (d.status === "MAIN_UNIVERSE") {
+        return (
+          "translate(" +
+          x(d.startDate) +
+          "," +
+          (y(d.taskName) - y.bandwidth()) +
+          ")"
+        );
+      }
       return "translate(" + x(d.startDate) + "," + y(d.taskName) + ")";
     })
     .attr("height", function () {
@@ -226,14 +235,22 @@ function formatKeyLabel(key) {
   formattedKey = formattedKey.replace("kub", "Kub");
   formattedKey = formattedKey.replace(
     "Interim release",
-    "Interim release Standard Support"
+    "Interim release Standard Support (9 months)"
   );
   formattedKey = formattedKey.replace(
     "Esm",
-    "Extended Security Maintenance (ESM)"
+    "LTS expanded support for Ubuntu Main (5 years)"
   );
   formattedKey = formattedKey.replace("Cve", "CVE/Critical fixes only");
   formattedKey = formattedKey.replace("Early", "Early preview");
+  formattedKey = formattedKey.replace(
+    "Hardware and maintenance updates",
+    "LTS standard support for Ubuntu Main"
+  );
+  formattedKey = formattedKey.replace(
+    "Main universe",
+    "LTS expanded support for Ubuntu Universe (10 years)"
+  );
   return formattedKey;
 }
 
@@ -275,7 +292,7 @@ export function createChart(
     bottom: 20,
   };
   margin.left = calculateYAxisWidth(taskTypes);
-  var rowHeight = 32;
+  var rowHeight = 34;
   var timeDomainStart;
   var timeDomainEnd;
   var earliestStartDate = d3.min(tasks, (d) => d.startDate);
@@ -312,13 +329,13 @@ export function createChart(
     .scaleBand()
     .domain(taskTypes)
     .rangeRound([0, height - margin.top - margin.bottom])
-    .padding(0.1);
+    .padding(0.6);
 
   var version = d3
     .scaleBand()
     .domain(taskTypes)
     .rangeRound([0, height - margin.top - margin.bottom])
-    .padding(0.1);
+    .padding(0.4);
 
   var xAxis = d3.axisBottom(x);
 
@@ -369,5 +386,5 @@ export function createChart(
   setTimeout(function () {
     emboldenLTSLabels(svg);
     highlightChartRow(svg, highlightVersion);
-  }, 500);
+  }, 0);
 }

--- a/static/sass/_pattern_chart.scss
+++ b/static/sass/_pattern_chart.scss
@@ -32,10 +32,9 @@
   stroke-width: 1px;
 }
 
-
-.chart__bar--violet {
-  fill: #AB83D3;
-  stroke: #AB83D3;
+.chart__bar--charcoal {
+  fill: #333;
+  stroke: #333;
   stroke-width: 1px;
 }
 

--- a/static/sass/_pattern_chart.scss
+++ b/static/sass/_pattern_chart.scss
@@ -32,6 +32,13 @@
   stroke-width: 1px;
 }
 
+
+.chart__bar--violet {
+  fill: #AB83D3;
+  stroke: #AB83D3;
+  stroke-width: 1px;
+}
+
 .chart__label--bold {
   font-weight: bold;
 }

--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -394,38 +394,21 @@
     <div class="u-fixed-width">
       <h2>OpenStack release cycle</h2>
 
-      <p>The <a href="/openstack">OpenStack</a> release cadence follows the Ubuntu release cadence. This means that new versions of OpenStack are released twice a year: in April and in October. Those are shipped with new versions of Ubuntu as packages in the <a href="https://packages.ubuntu.com/">Ubuntu Archive</a>.</p>
+      <p><a href="/openstack">OpenStack</a> release cadence follows Ubuntu release cadence. This means that a new version of OpenStack is released twice a year: in April and in October. Those are shipped with new versions of Ubuntu as packages in the <a href="https://packages.ubuntu.com/">Ubuntu Archive</a>.</p>
 
-      <p>However, since Canonical recommends using only LTS versions of Ubuntu in production environments, this limits available OpenStack versions to one by default. Therefore, Canonical maintains an additional archive &ndash; <a href="https://wiki.ubuntu.com/OpenStack/CloudArchive">Ubuntu Cloud Archive</a> &ndash; to provide access to newer versions of OpenStack on Ubuntu LTS.</p>
+      <p>However, since Canonical recommends using only LTS versions of Ubuntu in production environments, this limits available OpenStack versions to one by default. Therefore, Canonical maintains an additional archive &ndash; <a href="https://wiki.ubuntu.com/OpenStack/CloudArchive">Ubuntu Cloud Archive</a> &ndash; to provide access to non-default versions of OpenStack on Ubuntu LTS.</p>
 
-      <p>As a result, OpenStack versions that are shipped on Ubuntu LTS by default (aka OpenStack LTS versions) benefit from Canonical's commitment around the Ubuntu Archive, including 5 years of standard security maintenance and <a href="/security/esm">Expanded Security Maintenance (ESM)</a> available to <a href="/pro">Ubuntu Pro and Ubuntu Pro (Infra-only)</a> customers. In turn, OpenStack versions which are shipped on Ubuntu LTS through the Ubuntu Cloud Archive are supported by Canonical for 18 months only, except for some versions that are supported for 36 months under Ubuntu Advantage for Infrastructure (UA-I).</p>
+      <p>As a result, OpenStack versions that are shipped on Ubuntu LTS by default (aka OpenStack LTS versions) benefit from Canonical's commitment around the Ubuntu Archive, including 5 years of standard support and Expanded Security Maintenance (ESM). In turn, OpenStack versions which are shipped on Ubuntu LTS through the Ubuntu Cloud Archive are supported by Canonical for 18 months only, except for some versions that are supported for 36 months under Ubuntu Advantage for Infrastructure (UA-I).</p>
 
-      <p>Cloud Archive are maintained by Canonical for 18 months only, except for some versions that are maintained for 36 months under Ubuntu Pro and Ubuntu Pro (Infra-only)</p>
+      <p>Upgrades between consecutive OpenStack versions are fully supported. Users can first upgrade to newer OpenStack versions until the next OpenStack LTS version. Then they can upgrade the underlying Ubuntu operating system. In order to ensure smooth upgrades of OpenStack on Ubuntu, Canonical provides the automation framework based on the <a href="/openstack/features">OpenStack Charms</a> project.</p>
 
-    </div>
-    
-    <div class="u-fixed-width">
-      <h2>Charmed OpenStack</h2>
-      
-      <p>OpenStack clouds deployed through <a href="/openstack/consulting">Private Cloud Build</a> or validated through <a href="/openstack/consulting">Cloud Validation</a> consulting engagement (aka Charmed OpenStack clouds) can also benefit from <a href="/legal/ubuntu-pro-description#uprosd-full-openstack-support">Full OpenStack support</a> under <a>Ubuntu Pro + Support and Ubuntu Pro (Infra-only) + Support</a>. Full OpenStack support is provided for all OpenStack versions available in the Ubuntu Archive and Ubuntu Cloud Archive during their lifespan under standard security maintenance (18, 36 or 60 months depending on the version).</p>
-      
-      <p>The Charmed OpenStack support lifecycle on Ubuntu can be represented this way:</p>
+      <p>The OpenStack support lifecycle on Ubuntu can be represented this way:</p>
     </div>
 
     {% include "/about/openstack-release-cycle.html" %}
 
     <div class="u-fixed-width">
       <p>For more information on supported versions, see <a href="/openstack/docs/supported-versions">Charmed OpenStack documentation</a>.</p>
-    </div>
-
-    <div class="u-fixed-width">
-      <h2>MicroStack</h2>
-
-      <p>OpenStack clouds deployed with <a href="https://microstack.run">MicroStack</a> can also benefit from <a href="/legal/ubuntu-pro-description#uprosd-full-openstack-support">Full OpenStack support</a> under <a>Ubuntu Pro + Support and Ubuntu Pro (Infra-only) + Support</a>. Since MicroStack does not use OpenStack packages directly, but rather uses snaps and open container initiative (OCI) images, its support lifecycle is different from Charmed OpenStack.</p>
-    
-      <p>The first supported version of OpenStack in MicroStack is Antelope. It will be supported until April 2026. Every LTS version of OpenStack will benefit from 10 years of support moving forward. Every second, non LTS version of OpenStack will benefit from 3 years of support moving forward. Only every second version of OpenStack will be supported moving forward. Users will be able to securely upgrade between supported versions of OpenStack using the Skip Level Upgrade Release Process (SLURP) mechanism for 2 years after the next LTS version release.</p>
-    
-      <p>MicroStack support lifecycle on Ubuntu can be represented this way:</p>
     </div>
   </div>
 </section>

--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -77,6 +77,7 @@
               <th scope="col">Released</th>
               <th scope="col">End of Standard Support</th>
               <th scope="col">End of Life</th>
+              <th scope="col">End of Ubuntu Pro Support</th>
             </tr>
           </thead>
           <tbody>
@@ -91,17 +92,20 @@
               <td>Apr 2016</td>
               <td>Apr 2021</td>
               <td>Apr 2026</td>
+              <td>Apr 2026</td>
             </tr>
             <tr>
               <td><strong>18.04 LTS (Bionic Beaver)</strong></td>
               <td>Apr 2018</td>
               <td>Apr 2023</td>
               <td>Apr 2028</td>
+              <td>Apr 2028</td>
             </tr>
             <tr>
               <td><strong>20.04 LTS (Focal Fossa)</strong></td>
               <td>Apr 2020</td>
               <td>Apr 2025</td>
+              <td>Apr 2030</td>
               <td>Apr 2030</td>
             </tr>
             <tr>
@@ -127,6 +131,7 @@
               <td>Apr 2022</td>
               <td>Apr 2027</td>
               <td>Apr 2032</td>
+              <td>Apr 2032</td>
             </tr>
             <tr>
               <td><strong>22.10 (Kinetic Kudu)</strong></td>
@@ -172,9 +177,7 @@
         </tbody>
       </table>
 
-      <p>For each Ubuntu LTS release, Canonical maintains the Base Packages and provides security updates, including kernel livepatching, for a period of ten years. The lifecycle consists of an initial five-year maintenance period, during which maintenance updates are publicly available without an Ubuntu Advantage Subscription, and five years of <a href="/security/esm">Expanded Security Maintenance (ESM)</a>. The full lifecycle is available with an <a href="/pro">Ubuntu Advantage subscription</a> or a <a href="/pro">free personal subscription</a>.</p>
-
-      <p>Customers of Canonical often ask for an expanded security maintenance commitment beyond the Ubuntu Base Packages such as the 'universe' software packages. You can <a href="/support/contact-us">contact us for more information</a>.</p>
+      <p>For each Ubuntu LTS release, Canonical maintains the Base Packages and provides security updates, including kernel livepatching, for a period of ten years. The lifecycle consists of an initial five-year standard security maintenance period, during which maintenance updates are publicly available without a subscription, and five years of <a href="/security/esm">Expanded Security Maintenance (ESM)</a>. Furthermore ESM also covers 10 years of security maintenance for the Universe repository, which is not provided outside of Ubuntu Pro subscription. The full 10 year Ubuntu LTS lifecycle is available with an <a href="/pro">Ubuntu Pro subscription</a> (free for personal use on up to 5 machines).</p>
 
       <div class="u-fixed-width u-hide--small">
         {{
@@ -189,12 +192,10 @@
         }}
       </div>
 
-      <p>Ubuntu LTS releases transition into Expanded Security Maintenance (ESM) phase as the standard, five-year public maintenance window comes to a close. Canonical recommends that users and organisations upgrade to the latest LTS release or <a href="/pro">subscribe to Ubuntu Advantage</a> for continued security coverage with <a href="/security/esm">ESM</a> and <a href="/security/livepatch">kernel livepatching</a>.</p>
-
       <p>To check the subscription status of your system, use this command:</p>
 
       <div class="p-code-snippet">
-        <pre class="p-code-snippet__block--icon"><code>ua status</code></pre>
+        <pre class="p-code-snippet__block--icon"><code>pro status</code></pre>
       </div>
 
       <p>The <a href="https://wiki.ubuntu.com/Releases">Ubuntu Releases wiki</a> has current information on previous and upcoming versions.</p>
@@ -393,21 +394,38 @@
     <div class="u-fixed-width">
       <h2>OpenStack release cycle</h2>
 
-      <p><a href="/openstack">OpenStack</a> release cadence follows Ubuntu release cadence. This means that a new version of OpenStack is released twice a year: in April and in October. Those are shipped with new versions of Ubuntu as packages in the <a href="https://packages.ubuntu.com/">Ubuntu Archive</a>.</p>
+      <p>The <a href="/openstack">OpenStack</a> release cadence follows the Ubuntu release cadence. This means that new versions of OpenStack are released twice a year: in April and in October. Those are shipped with new versions of Ubuntu as packages in the <a href="https://packages.ubuntu.com/">Ubuntu Archive</a>.</p>
 
-      <p>However, since Canonical recommends using only LTS versions of Ubuntu in production environments, this limits available OpenStack versions to one by default. Therefore, Canonical maintains an additional archive &ndash; <a href="https://wiki.ubuntu.com/OpenStack/CloudArchive">Ubuntu Cloud Archive</a> &ndash; to provide access to non-default versions of OpenStack on Ubuntu LTS.</p>
+      <p>However, since Canonical recommends using only LTS versions of Ubuntu in production environments, this limits available OpenStack versions to one by default. Therefore, Canonical maintains an additional archive &ndash; <a href="https://wiki.ubuntu.com/OpenStack/CloudArchive">Ubuntu Cloud Archive</a> &ndash; to provide access to newer versions of OpenStack on Ubuntu LTS.</p>
 
-      <p>As a result, OpenStack versions that are shipped on Ubuntu LTS by default (aka OpenStack LTS versions) benefit from Canonical's commitment around the Ubuntu Archive, including 5 years of standard support and Expanded Security Maintenance (ESM). In turn, OpenStack versions which are shipped on Ubuntu LTS through the Ubuntu Cloud Archive are supported by Canonical for 18 months only, except for some versions that are supported for 36 months under Ubuntu Advantage for Infrastructure (UA-I).</p>
+      <p>As a result, OpenStack versions that are shipped on Ubuntu LTS by default (aka OpenStack LTS versions) benefit from Canonical's commitment around the Ubuntu Archive, including 5 years of standard security maintenance and <a href="/security/esm">Expanded Security Maintenance (ESM)</a> available to <a href="/pro">Ubuntu Pro and Ubuntu Pro (Infra-only)</a> customers. In turn, OpenStack versions which are shipped on Ubuntu LTS through the Ubuntu Cloud Archive are supported by Canonical for 18 months only, except for some versions that are supported for 36 months under Ubuntu Advantage for Infrastructure (UA-I).</p>
 
-      <p>Upgrades between consecutive OpenStack versions are fully supported. Users can first upgrade to newer OpenStack versions until the next OpenStack LTS version. Then they can upgrade the underlying Ubuntu operating system. In order to ensure smooth upgrades of OpenStack on Ubuntu, Canonical provides the automation framework based on the <a href="/openstack/features">OpenStack Charms</a> project.</p>
+      <p>Cloud Archive are maintained by Canonical for 18 months only, except for some versions that are maintained for 36 months under Ubuntu Pro and Ubuntu Pro (Infra-only)</p>
 
-      <p>The OpenStack support lifecycle on Ubuntu can be represented this way:</p>
+    </div>
+    
+    <div class="u-fixed-width">
+      <h2>Charmed OpenStack</h2>
+      
+      <p>OpenStack clouds deployed through <a href="/openstack/consulting">Private Cloud Build</a> or validated through <a href="/openstack/consulting">Cloud Validation</a> consulting engagement (aka Charmed OpenStack clouds) can also benefit from <a href="/legal/ubuntu-pro-description#uprosd-full-openstack-support">Full OpenStack support</a> under <a>Ubuntu Pro + Support and Ubuntu Pro (Infra-only) + Support</a>. Full OpenStack support is provided for all OpenStack versions available in the Ubuntu Archive and Ubuntu Cloud Archive during their lifespan under standard security maintenance (18, 36 or 60 months depending on the version).</p>
+      
+      <p>The Charmed OpenStack support lifecycle on Ubuntu can be represented this way:</p>
     </div>
 
     {% include "/about/openstack-release-cycle.html" %}
 
     <div class="u-fixed-width">
       <p>For more information on supported versions, see <a href="/openstack/docs/supported-versions">Charmed OpenStack documentation</a>.</p>
+    </div>
+
+    <div class="u-fixed-width">
+      <h2>MicroStack</h2>
+
+      <p>OpenStack clouds deployed with <a href="https://microstack.run">MicroStack</a> can also benefit from <a href="/legal/ubuntu-pro-description#uprosd-full-openstack-support">Full OpenStack support</a> under <a>Ubuntu Pro + Support and Ubuntu Pro (Infra-only) + Support</a>. Since MicroStack does not use OpenStack packages directly, but rather uses snaps and open container initiative (OCI) images, its support lifecycle is different from Charmed OpenStack.</p>
+    
+      <p>The first supported version of OpenStack in MicroStack is Antelope. It will be supported until April 2026. Every LTS version of OpenStack will benefit from 10 years of support moving forward. Every second, non LTS version of OpenStack will benefit from 3 years of support moving forward. Only every second version of OpenStack will be supported moving forward. Users will be able to securely upgrade between supported versions of OpenStack using the Skip Level Upgrade Release Process (SLURP) mechanism for 2 years after the next LTS version release.</p>
+    
+      <p>MicroStack support lifecycle on Ubuntu can be represented this way:</p>
     </div>
   </div>
 </section>

--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -76,42 +76,26 @@
               <td>&nbsp;</td>
               <th scope="col">Released</th>
               <th scope="col">End of Standard Support</th>
-              <th scope="col">End of Life</th>
               <th scope="col">End of Ubuntu Pro Support</th>
             </tr>
           </thead>
           <tbody>
             <tr>
-              <td><strong>14.04 LTS (Trusty Tahr)</strong></td>
-              <td>Apr 2014</td>
-              <td>Apr 2019</td>
-              <td>Apr 2024</td>
+              <td><strong>22.10 (Kinetic Kudu)</strong></td>
+              <td>Oct 2022</td>
+              <td>Jul 2023</td>
+              <td>&nbsp;</td>
             </tr>
             <tr>
-              <td><strong>16.04 LTS (Xenial Xerus)</strong></td>
-              <td>Apr 2016</td>
-              <td>Apr 2021</td>
-              <td>Apr 2026</td>
-              <td>Apr 2026</td>
+              <td><strong>22.04 LTS (Jammy Jellyfish)</strong></td>
+              <td>Apr 2022</td>
+              <td>Apr 2027</td>
+              <td>Apr 2032</td>
             </tr>
             <tr>
-              <td><strong>18.04 LTS (Bionic Beaver)</strong></td>
-              <td>Apr 2018</td>
-              <td>Apr 2023</td>
-              <td>Apr 2028</td>
-              <td>Apr 2028</td>
-            </tr>
-            <tr>
-              <td><strong>20.04 LTS (Focal Fossa)</strong></td>
-              <td>Apr 2020</td>
-              <td>Apr 2025</td>
-              <td>Apr 2030</td>
-              <td>Apr 2030</td>
-            </tr>
-            <tr>
-              <td>20.10 (Groovy Gorilla)</td>
-              <td>Oct 2020</td>
-              <td>Jul 2021</td>
+              <td>21.10 (Impish Indri)</td>
+              <td>Oct 2021</td>
+              <td>Jul 2022</td>
               <td>&nbsp;</td>
             </tr>
             <tr>
@@ -121,23 +105,34 @@
               <td>&nbsp;</td>
             </tr>
             <tr>
-              <td>21.10 (Impish Indri)</td>
-              <td>Oct 2021</td>
-              <td>Jul 2022</td>
+              <td>20.10 (Groovy Gorilla)</td>
+              <td>Oct 2020</td>
+              <td>Jul 2021</td>
               <td>&nbsp;</td>
             </tr>
             <tr>
-              <td><strong>22.04 LTS (Jammy Jellyfish)</strong></td>
-              <td>Apr 2022</td>
-              <td>Apr 2027</td>
-              <td>Apr 2032</td>
-              <td>Apr 2032</td>
+              <td><strong>20.04 LTS (Focal Fossa)</strong></td>
+              <td>Apr 2020</td>
+              <td>Apr 2025</td>
+              <td>Apr 2030</td>
             </tr>
             <tr>
-              <td><strong>22.10 (Kinetic Kudu)</strong></td>
-              <td>Oct 2022</td>
-              <td>Jul 2023</td>
-              <td>&nbsp;</td>
+              <td><strong>18.04 LTS (Bionic Beaver)</strong></td>
+              <td>Apr 2018</td>
+              <td>Apr 2023</td>
+              <td>Apr 2028</td>
+            </tr>
+            <tr>
+              <td><strong>16.04 LTS (Xenial Xerus)</strong></td>
+              <td>Apr 2016</td>
+              <td>Apr 2021</td>
+              <td>Apr 2026</td>
+            </tr>
+            <tr>
+              <td><strong>14.04 LTS (Trusty Tahr)</strong></td>
+              <td>Apr 2014</td>
+              <td>Apr 2019</td>
+              <td>Apr 2024</td>
             </tr>
           </tbody>
         </table>

--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -89,7 +89,7 @@
             <tr>
               <td><strong>22.04 LTS (Jammy Jellyfish)</strong></td>
               <td>Apr 2022</td>
-              <td>Apr 2027</td>
+              <td>May 2027</td>
               <td>Apr 2032</td>
             </tr>
             <tr>
@@ -113,13 +113,13 @@
             <tr>
               <td><strong>20.04 LTS (Focal Fossa)</strong></td>
               <td>Apr 2020</td>
-              <td>Apr 2025</td>
+              <td>May 2025</td>
               <td>Apr 2030</td>
             </tr>
             <tr>
               <td><strong>18.04 LTS (Bionic Beaver)</strong></td>
               <td>Apr 2018</td>
-              <td>Apr 2023</td>
+              <td>May 2023</td>
               <td>Apr 2028</td>
             </tr>
             <tr>


### PR DESCRIPTION
## Done

- Updated release chart to include pro as per [mock-up](https://www.figma.com/file/rnBVLtahrGV8NgTHV2Uqez/Release-illustration-draft-brief?type=design&node-id=0-1&t=ZFJKpT3pOQyJ05RS-0)
- Update copy in the Ubuntu release cycle section as per [doc](https://docs.google.com/document/d/1-l3B7AoyDoETaL80UhlfEWCVKmMWPdy3zoF5LpsGcYQ/edit)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: https://ubuntu-com-12871.demos.haus/about/release-cycle
    - Be sure to test on mobile, tablet and desktop screen sizes
- See that the requested updates were made

## Issue / Card

Fixes # https://warthogs.atlassian.net/browse/WD-2642
