### PR TITLE
WD-3849 remove walmart logo

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -399,18 +399,6 @@
         </div>
         <div class="p-logo-section__item">
           {{ image (
-            url="https://assets.ubuntu.com/v1/92cf9e91-walmart-logo.png",
-            alt="Walmart",
-            width="288",
-            height="288",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-logo-section__logo"}
-            ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{ image (
             url="https://assets.ubuntu.com/v1/2b6c1718-bmp-paribas-logo.png",
             alt="BNP Paribas",
             width="288",


### PR DESCRIPTION
## Done

- Remove the Walmart logo from the home page

## QA

- Check out the [demo here](url) and compare it with the [copy doc](https://docs.google.com/document/d/1ySJxQbqVdeH4Tra0zwBm2Tn0s56kFGnEF7d8xDRTxwU/edit).

## Issue / Card

- [WD-3849](https://warthogs.atlassian.net/browse/WD-3849)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
