### PR TITLE
Update /landscape subnav

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -649,14 +649,14 @@ landscape:
       path: /landscape
     - title: Features
       path: /landscape/features
+    - title: Managed
+      path: /landscape/managed
     - title: Pricing
       path: /landscape/pricing
     - title: Install
       path: /landscape/install
     - title: Docs
       path: /landscape/docs
-    - title: Forums
-      path: https://discourse.ubuntu.com/c/landscape/89
     - title: Log in to Landscape
       path: https://landscape.canonical.com/login/authenticate
 


### PR DESCRIPTION
## Done

- Added /landscape/managed link to subnav and remove "Forums" link

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/landscape
    - Be sure to test on mobile, tablet and desktop screen sizes
- See that the link is located between "Features" and "Pricing" and check that it routes correctly
- See that external link "Forums" has been removed from the subnav
