### PR TITLE
[copy update] WD-3926 remove all walmart logos

### DIFF
--- a/templates/azure/index.html
+++ b/templates/azure/index.html
@@ -47,18 +47,6 @@
         <div class="p-logo-section__items u-no-margin--bottom">
           <div class="p-logo-section__item">
             {{ image (
-              url="https://assets.ubuntu.com/v1/92cf9e91-walmart-logo.png",
-              alt="Walmart",
-              width="288",
-              height="288",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-logo-section__logo"}
-              ) | safe
-            }}
-          </div>
-          <div class="p-logo-section__item">
-            {{ image (
               url="https://assets.ubuntu.com/v1/6cd78b57-at%26t-logo.png",
               alt="AT&T",
               width="288",

--- a/templates/embedding/index.html
+++ b/templates/embedding/index.html
@@ -87,19 +87,6 @@
         <div class="p-logo-section__item">
           {{
             image(
-                url="https://assets.ubuntu.com/v1/3161e6ba-logo-walmart.svg",
-                alt="Walmart",
-                width="250",
-                height="60",
-                hi_def=True,
-                loading="lazy",
-                attrs={"class": "p-logo-section__logo"},
-            ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{
-            image(
                 url="https://assets.ubuntu.com/v1/03a06060-logo-deutschetelekom.svg",
                 alt="Deutsche Telekom",
                 width="250",

--- a/templates/landscape/index.html
+++ b/templates/landscape/index.html
@@ -201,19 +201,6 @@
         <div class="p-logo-section__item">
           {{
             image (
-            url="https://assets.ubuntu.com/v1/bc54a1da-Walmart.png",
-            alt="Walmart",
-            width="292",
-            height="290",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-logo-section__logo"}
-            ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{
-            image (
             url="https://assets.ubuntu.com/v1/c6e197c4-deutsche-telekom-logo.png",
             alt="Deutsche Telekom",
             width="288",
@@ -224,8 +211,6 @@
             ) | safe
           }}
         </div>
-      </div>
-      <div class="p-logo-section__items">
         <div class="p-logo-section__item">
           {{
             image (
@@ -239,6 +224,8 @@
             ) | safe
           }}
         </div>
+      </div>
+      <div class="p-logo-section__items">
         <div class="p-logo-section__item">
           {{
             image (

--- a/templates/openstack/shared/_openstack_clients.html
+++ b/templates/openstack/shared/_openstack_clients.html
@@ -57,19 +57,6 @@
       <div class="p-logo-section__item">
         {{
           image(
-            url="https://assets.ubuntu.com/v1/b3315d88-walmart.svg",
-            alt="Walmart",
-            height="34",
-            width="144",
-            hi_def=True,
-            attrs={"class": "p-logo-section__logo"},
-            loading="lazy",
-          ) | safe
-        }}
-      </div>
-      <div class="p-logo-section__item">
-        {{
-          image(
             url="https://assets.ubuntu.com/v1/73135672-ntt-logo.svg",
             alt="NTT",
             height="53",

--- a/templates/openstack/support.html
+++ b/templates/openstack/support.html
@@ -53,19 +53,6 @@
           }}
         </div>
         <div class="p-logo-section__item">
-          {{
-            image(
-            url="https://assets.ubuntu.com/v1/c911ed42-walmart_logo.svg",
-            alt="Walmart",
-            width="131",
-            height="32",
-            hi_def=True,
-            loading="auto",
-            attrs={"class": "p-logo-section__logo"},
-            ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
           {{ image (
             url="https://assets.ubuntu.com/v1/d8841399-Wellcome_Sanger_Institute_Logo_Landscape_Digital_RGB_Full_Colour.svg",
             alt="Wellcome Sanger Institute",

--- a/templates/security/index.html
+++ b/templates/security/index.html
@@ -239,19 +239,6 @@
         <div class="p-logo-section__item">
           {{
             image(
-              url="https://assets.ubuntu.com/v1/b3315d88-walmart.svg",
-              alt="Walmart",
-              height="34",
-              width="144",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-logo-section__logo"}
-            ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{
-            image(
               url="https://assets.ubuntu.com/v1/03a06060-logo-deutschetelekom.svg",
               alt="Deutsche Telekom",
               height="32",

--- a/templates/security/livepatch.html
+++ b/templates/security/livepatch.html
@@ -203,19 +203,6 @@ meta_copydoc %}
         <div class="p-logo-section__item">
           {{
           image(
-          url="https://assets.ubuntu.com/v1/ff209af1-2018-logo-walmart.svg",
-          alt="Walmart",
-          width="145",
-          height="145",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class": "p-logo-section__logo"},
-          ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{
-          image(
           url="https://assets.ubuntu.com/v1/d199354d-2018-logo-deutsche-telekom.svg",
           alt="Deutcshe Telecom",
           width="145",

--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -64,18 +64,6 @@
         </div>
         <div class="p-logo-section__item">
           {{ image (
-            url="https://assets.ubuntu.com/v1/92cf9e91-walmart-logo.png",
-            alt="Walmart",
-            width="288",
-            height="288",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-logo-section__logo"},
-            ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{ image (
             url="https://assets.ubuntu.com/v1/c6e197c4-deutsche-telekom-logo.png",
             alt="Deutsche Telekom",
             width="288",


### PR DESCRIPTION
## Done

- Removed all Walmart logos from u.com

## QA

- Check out the [demo here](https://ubuntu-com-12880.demos.haus/) and make sure the pages updated correspond with the checklist on [the task](https://warthogs.atlassian.net/browse/WD-3926).
  List of pages affect:
  - [x] [/azure](https://ubuntu-com-12880.demos.haus/azure)
  - [x] [/embedding](https://ubuntu-com-12880.demos.haus/embedding)
  - [x] [/support](https://ubuntu-com-12880.demos.haus/support)
  - [x] [/openstack/support](https://ubuntu-com-12880.demos.haus/openstack/support)
  - [x] [/landscape](https://ubuntu-com-12880.demos.haus/landscape)
  - [x] [/security](https://ubuntu-com-12880.demos.haus/security)
  - [x] [/security/livepatch](https://ubuntu-com-12880.demos.haus/security/livepatch)
  - [x] [/rfp](https://ubuntu-com-12880.demos.haus/rfp)

## Issue / Card

- [WD-3926](https://warthogs.atlassian.net/browse/WD-3926)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-3926]: https://warthogs.atlassian.net/browse/WD-3926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ