### PR TITLE
[copy update] WD-3595 update HPE logo on `/server`

### DIFF
--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -112,7 +112,7 @@
         </div>
         <div class="p-logo-section__item">
           {{ image (
-            url="https://assets.ubuntu.com/v1/11814428-hp-logo.png",
+            url="https://assets.ubuntu.com/v1/a9b3cc95-hpe.png",
             alt="Hewlett Packard",
             width="288",
             height="288",


### PR DESCRIPTION
## Done

- Update the HPE logo

## QA

- Check out the [demo here](https://ubuntu-com-12882.demos.haus/server) and compare it with the asset specified in the [copy doc](https://docs.google.com/document/d/1vxLhtbjgPs9PCNEhr7fbhEoErCPMXYFfU4UTKH7Kbq4/edit)

## Issue / Card

- [WD-3595](https://warthogs.atlassian.net/browse/WD-3595)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-3595]: https://warthogs.atlassian.net/browse/WD-3595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ