### PR TITLE
[copy update] WD-3963 remove ROS Support Scope from `/legal/ubuntu-pro-description/ros-esm-service-description`

### DIFF
--- a/templates/legal/ubuntu-pro-description/ros-esm-service-description/index.html
+++ b/templates/legal/ubuntu-pro-description/ros-esm-service-description/index.html
@@ -31,28 +31,6 @@
       </li>
     </ol>
   </li>
-  <li class="p-list__item">
-    <h3 id="ros-support-scope">ROS Support Scope</h3>
-    <p>As a Standard or Advanced customer, you are also entitled to the benefits and services for ROS ESM and the support described below.</p>
-    <ol class="p-list--ordered-legal">
-      <li class="p-list__item">Support requests will follow the Support Services Process as defined in the Ubuntu Pro Service Description.</li>
-      <li class="p-list__item">Support requests will follow the Support Severity Levels definition as defined in the Ubuntu Pro Service Description.</li>
-      <li class="p-list__item">Support requests for third party and abandoned packages will be categorized as Severity Level 4.</li>
-      <li class="p-list__item">
-        <h4>ROS Support Exclusions</h4>
-        <ol class="p-list--ordered-legal">
-          <li class="p-list__item">Canonical does not guarantee a work-around, resolution or resolution time. </li>
-          <li class="p-list__item">Bug fixes for packages in the end of life release as defined in <a href="http://wiki.ros.org/Distributions">ROS release cycles</a>, unless a bug was created by an Expanded Security Maintenance security update.</li>
-          <li class="p-list__item">Support for third party packages that have been abandoned.</li>
-          <li class="p-list__item">Support for the installation and configuration of ROS upstream.</li>
-          <li class="p-list__item">Development support for ROS.</li>
-          <li class="p-list__item">Maintenance, configuration and management of robots.</li>
-          <li class="p-list__item">Configuration files, including YAML/XML-launch.</li>
-          <li class="p-list__item">Support for parts of packages containing URDF/SRDF.</li>
-        </ol>
-      </li>
-    </ol>
-  </li>
 </ol>
 
 {% endblock content %}


### PR DESCRIPTION
## Done

- Remove ROS Support Scope section from `/legal/ubuntu-pro-description/ros-esm-service-description`

## QA

- Check out the [demo here](https://ubuntu-com-12887.demos.haus/legal/ubuntu-pro-description/ros-esm-service-description) and compare it with the changes requested on the [copy doc](https://docs.google.com/document/d/12OGV0hnxPvwY2pT8gbS2vHQp3icndJeaEyqc1G_oIoM/edit).

## Issue / Card

- [WD-3963](https://warthogs.atlassian.net/browse/WD-3963)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-3963]: https://warthogs.atlassian.net/browse/WD-3963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ