### PR TITLE
Add #success to return-url on landscape/managed

### DIFF
--- a/templates/managed/apps/index.html
+++ b/templates/managed/apps/index.html
@@ -16,7 +16,7 @@ coverage.{% endblock meta_description %}
       <h1>Performant open source with Managed Apps</h1>
       <p class="p-heading--4">One vendor, easy deployment, guaranteed uptime</p>
       <p>
-        <a href="/managed/contact-us" class="p-button--positive js-invoke-modal" data-testid="interactive-form-link" data-form-location="/shared/forms/interactive/managed-apps.html" data-form-id="3545" data-lp-id="3828" data-return-url="https://ubuntu.com/managed/thank-you#success" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">Free deployment assessment</a>
+        <a href="/managed/contact-us" class="p-button--positive js-invoke-modal" data-testid="interactive-form-link" data-form-location="/shared/forms/interactive/managed-apps.html" data-form-id="3545" data-lp-id="3828" data-return-url="https://ubuntu.com/managed/apps#success" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">Free deployment assessment</a>
       </p>
     </div>
     <div class="col-6 u-embedded-media u-align--center">

--- a/templates/managed/apps/index.html
+++ b/templates/managed/apps/index.html
@@ -16,7 +16,7 @@ coverage.{% endblock meta_description %}
       <h1>Performant open source with Managed Apps</h1>
       <p class="p-heading--4">One vendor, easy deployment, guaranteed uptime</p>
       <p>
-        <a href="/managed/contact-us" class="p-button--positive js-invoke-modal" data-testid="interactive-form-link" data-form-location="/shared/forms/interactive/managed-apps.html" data-form-id="3545" data-lp-id="3828" data-return-url="https://ubuntu.com/managed/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">Free deployment assessment</a>
+        <a href="/managed/contact-us" class="p-button--positive js-invoke-modal" data-testid="interactive-form-link" data-form-location="/shared/forms/interactive/managed-apps.html" data-form-id="3545" data-lp-id="3828" data-return-url="https://ubuntu.com/managed/thank-you#success" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">Free deployment assessment</a>
       </p>
     </div>
     <div class="col-6 u-embedded-media u-align--center">


### PR DESCRIPTION
## Done

- Add #success to return-url on landscape/managed as cypress check was failing

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
