### PR TITLE
Fixes for instant provisioning

### DIFF
--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -158,7 +158,9 @@ def cred_your_exams(ua_contracts_api, trueability_api, **kwargs):
         for exam_contract in exam_contracts:
             name = exam_contract["cueContext"]["courseID"]
             name = EXAM_NAMES.get(name, name)
-            contract_item_id = exam_contract["id"]
+            contract_item_id = (
+                exam_contract.get("id") or exam_contract["contractItem"]["id"]
+            )
             if "reservation" in exam_contract["cueContext"]:
                 response = trueability_api.get_assessment_reservation(
                     exam_contract["cueContext"]["reservation"]["IDs"][-1]
@@ -380,7 +382,7 @@ def cred_provision(ua_contracts_api, trueability_api, **_):
 
     exam_contract = None
     for item in exam_contracts:
-        if contract_item_id == item["id"]:
+        if contract_item_id == (item.get("id") or item["contractItem"]["id"]):
             exam_contract = item
             break
 


### PR DESCRIPTION
## Done

- Call `get_annotated_contract_items()` to fetch exam contracts
- Catch exception and show error if exam reservation fails
- Support looking up the contract ID on both staging and production for /credentials/your-exams and /credentials/provision

## QA

- Make sure you have redeemed/activated at least one exam (on staging)
- Visit https://ubuntu-com-12899.demos.haus/credentials/your-exams
  - Verify that the page loads and lists your exams
- Click on "Take now" on one of your exams
  - Verify that your exam provisions without errors

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-4071

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
