### PR TITLE
WD-4214 Revert the discourse module to last known working version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ canonicalwebteam.blog==6.4.0
 canonicalwebteam.search==1.3.0
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.3.1
-canonicalwebteam.discourse==5.4.1
+canonicalwebteam.discourse==5.2.4
 python-dateutil==2.8.2
 pytz==2022.7.1
 maxminddb-geolite2==2018.703


### PR DESCRIPTION
## Done
- Revert the discourse module to the last known working version

## QA

- Open the demo and check the docs set:
- /ceph/docs
- /server/docs
- /community/
- /core/docs/
- etc.

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-4214
