### PR TITLE
Add form for setting activation keys in marketo

### DIFF
--- a/templates/credentials/beta-activation.html
+++ b/templates/credentials/beta-activation.html
@@ -1,9 +1,8 @@
 {% extends "credentials/base_cred.html" %}
 
-{% block title %}Canonical Credentials -- Schedule an exam{% endblock %}
+{% block title %}Canonical Credentials -- Beta activation{% endblock %}
 
 {% block meta_description %}The Canonical Ubuntu Essentials exams certify knowledge and verify skills in general Linux, Ubuntu Desktop, and Ubuntu Server topics.{% endblock meta_description %}
-{% block meta_copydoc %}https://docs.google.com/document/d/1QuhO-9FEOGLrYp8bErS_9snqdljl7d6tFAUoNQxoVDQ/edit{% endblock meta_copydoc %}
 
 {% block content %}
 

--- a/templates/credentials/beta-activation.html
+++ b/templates/credentials/beta-activation.html
@@ -1,0 +1,27 @@
+{% extends "credentials/base_cred.html" %}
+
+{% block title %}Canonical Credentials -- Schedule an exam{% endblock %}
+
+{% block meta_description %}The Canonical Ubuntu Essentials exams certify knowledge and verify skills in general Linux, Ubuntu Desktop, and Ubuntu Server topics.{% endblock meta_description %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1QuhO-9FEOGLrYp8bErS_9snqdljl7d6tFAUoNQxoVDQ/edit{% endblock meta_copydoc %}
+
+{% block content %}
+
+<section class="p-strip--suru-topped">
+  <div class="row">
+    <h1>Add activation keys</h1>
+    <div class="col-8">
+      <form action="/credentials/beta/activation" method="post">
+        <label class="p-heading--3" for="Emails">Email addresses</label>
+        <p>Add one or more user email addresses below, each on a new line.</p>
+        <textarea id="Emails" name="emails" class="is-required" required aria-required="true" rows="10" placeholder="charlie.changer@example.com"></textarea>
+        <label class="p-heading--3" for="Keys">Activation keys</label>
+        <p>Add one or more activation keys below, each on a new line.</p>
+        <textarea id="Keys" name="keys" class="is-required" required aria-required="true" rows="10" placeholder="abcdef"></textarea>
+        <button type="submit" class="p-button--positive">Submit</button>
+      </form>
+    </div>
+  </div>
+</section>
+
+{% endblock content%}

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -89,6 +89,7 @@ from webapp.shop.cred.views import (
     cred_submit_form,
     cred_syllabus_data,
     cred_your_exams,
+    cred_beta_activation,
     get_activation_keys,
     rotate_activation_key,
 )
@@ -899,6 +900,11 @@ app.add_url_rule(
     "/credentials/keys/activate",
     view_func=activate_activation_key,
     methods=["POST"],
+)
+app.add_url_rule(
+    "/credentials/beta/activation",
+    view_func=cred_beta_activation,
+    methods=["GET", "POST"],
 )
 
 # Charmed OpenStack docs

--- a/webapp/marketo.py
+++ b/webapp/marketo.py
@@ -63,6 +63,5 @@ class MarketoAPI:
             "action": "updateOnly",
             "lookupField": "email",
             "input": leads,
-
         }
         return self.request("POST", "/rest/v1/leads.json", json=data)

--- a/webapp/marketo.py
+++ b/webapp/marketo.py
@@ -51,3 +51,18 @@ class MarketoAPI:
         return self.request(
             "POST", "/rest/v1/leads/submitForm.json", json=data
         )
+
+    def describe_leads(self):
+        return self.request("GET", "/rest/v1/leads/describe.json")
+
+    def get_lead(self, id_):
+        return self.request("GET", f"/rest/v1/leads/{id_}.json")
+
+    def update_leads(self, leads=None):
+        data = {
+            "action": "updateOnly",
+            "lookupField": "email",
+            "input": leads,
+
+        }
+        return self.request("POST", f"/rest/v1/leads.json", json=data)

--- a/webapp/marketo.py
+++ b/webapp/marketo.py
@@ -65,4 +65,4 @@ class MarketoAPI:
             "input": leads,
 
         }
-        return self.request("POST", f"/rest/v1/leads.json", json=data)
+        return self.request("POST", "/rest/v1/leads.json", json=data)

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -18,6 +18,8 @@ from google.oauth2 import service_account
 from googleapiclient.discovery import build
 from werkzeug.exceptions import BadRequest
 
+from ...views import marketo_api
+
 
 TIMEZONE_COUNTRIES = {
     timezone: country
@@ -652,3 +654,25 @@ def activate_activation_key(ua_contracts_api, **kwargs):
             "activationKey": activation_key,
         }
     )
+
+
+@shop_decorator(area="cred", permission="user", response="html")
+@canonical_staff()
+def cred_beta_activation(**_):
+    if flask.request.method == "POST":
+        data = flask.request.form
+
+        emails = data["emails"].split("\n")
+        keys = data["keys"].split("\n")
+
+        leads = []
+        for email, key in zip(emails, keys):
+            leads.append({
+                "email": email,
+                "cred_activation_key": key
+
+            })
+
+        marketo_api.update_leads(leads)
+
+    return flask.render_template("credentials/beta-activation.html")

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -667,11 +667,7 @@ def cred_beta_activation(**_):
 
         leads = []
         for email, key in zip(emails, keys):
-            leads.append({
-                "email": email,
-                "cred_activation_key": key
-
-            })
+            leads.append({"email": email, "cred_activation_key": key})
 
         marketo_api.update_leads(leads)
 


### PR DESCRIPTION
## Done

- Add form for setting activation keys in marketo

## QA

- Visit https://ubuntu-com-12910.demos.haus/credentials/beta/activation
  - Enter one or more email addresses and one or more (fake) activation keys
  - Verify in [Marketo](https://engage-sj.marketo.com/?munchkinId=066-EOV-335#/classic/SL100906930B2LA1) that the "Credentialing activation key" field has been set for the given email addresses

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-4215

## Screenshots

![image](https://github.com/canonical/ubuntu.com/assets/995051/bde99464-778f-439c-bfba-15f207bcfba9)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
