### PR TITLE
Improve performance of engage pages submit

### DIFF
--- a/templates/engage/thank-you.html
+++ b/templates/engage/thank-you.html
@@ -72,23 +72,4 @@
   </div>
 </section>
 
-{% if related | length > 0 %}
-<section class="p-strip--light">
-  <div class="row">
-    <div class="col-8">
-      <h2 class="p-heading--3">You may also be interested in &hellip;</h2>
-    </div>
-  </div>
-  <div class="row p-divider">
-    {% for page in related %}
-    <div class="col-4 p-divider__block">
-      <!-- THREE ADDITIONAL CTAs -->
-      <h4>{{page["topic_name"]}}</h4>
-      <p>{{page["subtitle"]}}</p>
-      <p><a href="{{page['path']}}">See more&nbsp;&rsaquo;</a></p>
-    </div>
-    {% endfor %}
-  </div>
-</section>
-{% endif %}
 {% endblock content %}

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -510,7 +510,6 @@ def engage_thank_you(engage_pages):
             path = f"/engage/{page}"
 
         metadata = engage_pages.get_engage_page(path)
-        all_engage_pages = engage_pages.get_index()
         if not metadata:
             flask.abort(404)
 
@@ -524,26 +523,6 @@ def engage_thank_you(engage_pages):
             return flask.abort(404)
 
         language = metadata["language"]
-        # Filter engage pages by language and tags
-        total_num_related = 3
-        related = []
-        for item in all_engage_pages:
-            # Skip related engage page
-            # missing metadata
-            if "language" not in item:
-                continue
-
-            check_match = match_tags(
-                item["tags"].split(","), metadata["tags"].split(",")
-            )
-
-            # Match language and match tags
-            if item["language"] == language and check_match:
-                related.append(item)
-            if len(related) > total_num_related:
-                # we can only fit 3 related posts, no need to finish the loop
-                break
-
         if language and language != "en":
             template_language = f"engage/shared/_{language}_thank-you.html"
         else:
@@ -560,7 +539,6 @@ def engage_thank_you(engage_pages):
             metadata=metadata,
             resource_name=metadata["type"],
             resource_url=metadata["resource_url"],
-            related=related,
             form_details=form_details,
         )
 


### PR DESCRIPTION
## Done

Improve performance of engage pages.

I put some timestamps in various places before and after the submit, I found about 5 seconds difference between the start of the marketo endpoint and then return to the thank-you page. Another 5 secs roughly for rendering the thank-you page, so I focused on improving the rendering part of the thank-you page. Changing marketo/submit endpoint could bring breaking changes, so I tried not to do that, but the other 5 seconds delay is contained within this endpoint.

So this PR should decrease by half the time it takes to submit.

## QA

- Go to https://ubuntu-com-12911.demos.haus/engage, pick a whitepaper
- Fill in the form with test data and submit. Compare it with prod, it should be faster now

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
