### PR TITLE
Build /18-04/aws

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -593,6 +593,8 @@ ubuntu1804:
       path: /18-04/azure
     - title: GCP
       path: /18-04/gcp
+    - title: AWS
+      path: /18-04/aws
 
 telco:
   title: Telco

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1341,3 +1341,7 @@ hr.p-separator.is-shallow {
     }
   }
 }
+
+.bordered-thumbnail {
+  border: 1px solid $colors--light-theme--border-low-contrast;
+}

--- a/templates/18-04/aws.html
+++ b/templates/18-04/aws.html
@@ -55,12 +55,12 @@
   </div>
   <div class="row">
     <div class="col-6 col-medium-3 col-start-large-7 col-start-medium-4">
-      <hr class="is-muted u-no-margin--bottom" />
-      <h3 class="p-heading--5">Watch the 18.04 End of Standard Support webinar:</h3>
-      <p>Ubuntu 18.04 LTS 'Bionic Beaver', one of the most popular Ubuntu releases, reaches the end of the standard, five-year maintenance window for Long-Term Support (LTS) releases on 31 May 2023. Learn more about your options in this webinar.</p>
+      <div class="p-strip is-shallow">
+        <hr class="is-muted">
+      </div>
       <a href="/engage/18-04-lts-end-of-support-webinar">
         {{ image (
-          url="https://assets.ubuntu.com/v1/94fae5f3-20.04-migration-webinar.png",
+          url="https://assets.ubuntu.com/v1/a8ecc110-ubuntu-18.04-end-standard-support.png",
           alt="",
           width="1350",
           height="758",
@@ -69,6 +69,8 @@
           ) | safe
         }}
       </a>      
+      <h3 class="p-heading--5">Watch the 18.04 End of Standard Support webinar:</h3>
+      <p>Ubuntu 18.04 LTS 'Bionic Beaver', one of the most popular Ubuntu releases, reaches the end of the standard, five-year maintenance window for Long-Term Support (LTS) releases on 31 May 2023. Learn more about your options in this webinar.</p>
     </div>
   </div>
 </section>
@@ -88,9 +90,9 @@
   </div>
   <div class="row">
     <div class="col-6 col-medium-3 col-start-large-7 col-start-medium-4">
-      <hr class="is-muted u-no-margin--bottom" />
-      <h3 class="p-heading--5">Watch the 20.04 migration webinar:</h3>
-      <p>This webinar explores all the factors that should be taken into account to deliver successful migration at the right pace, covering the most popular infrastructure components such as OpenStack, Kubernetes and Ceph.</p>
+      <div class="p-strip is-shallow">
+        <hr class="is-muted">
+      </div>
       <a href="/engage/migrating-to-20.04">
         {{ image (
           url="https://assets.ubuntu.com/v1/94fae5f3-20.04-migration-webinar.png",
@@ -102,6 +104,8 @@
           ) | safe
         }}
       </a>   
+      <h3 class="p-heading--5">Watch the 20.04 migration webinar:</h3>
+      <p>This webinar explores all the factors that should be taken into account to deliver successful migration at the right pace, covering the most popular infrastructure components such as OpenStack, Kubernetes and Ceph.</p>
     </div>
   </div>
 </section>

--- a/templates/18-04/aws.html
+++ b/templates/18-04/aws.html
@@ -20,7 +20,7 @@
     </div>
     <div class="col-6 col-start-large-7">
       <h1 class="p-heading--2">
-        <strong>Ubuntu 18.04 LTS <br class="u-hide--small">(Bionic Beaver) on Aamazon Web Services (AWS)</strong>
+        <strong>Ubuntu 18.04 LTS <br class="u-hide--small">(Bionic Beaver) on Amazon Web Services (AWS)</strong>
       </h1>
       <p class="p-heading--2">Out of standard support. <br class="u-hide--small">Upgrade to Ubuntu Pro</p>
       <p>Ubuntu 18.04 LTS (Bionic Beaver) was released on 23 April 2018, introducing improved UEFI Secure Boot and broader Kernel Livepatch coverage for enhanced security on Amazon Web Services.</p>
@@ -49,7 +49,7 @@
     <div class="col-6 col-medium-3">
       <p>You can either <a href="#upgrade-install">migrate to the next LTS</a> or <a href="#upgrade-pro">upgrade to Ubuntu Pro</a> to expand your security maintenance.</p>
       <p>With Ubuntu Pro, the 18.04 LTS will be fully supported until 2028. Ubuntu Pro is free for personal and small-scale commercial use on up to 5 machines. Paid plans with transparent, per-machine pricing are available for large-scale deployments.</p>
-      <p><a href="/blog/upgrade-your-existing-ubuntu-lts-instances-to-ubuntu-pro-in-aws" class="p-button--positive">Upgrade to ubuntu Pro on AWS</a></p>
+      <p><a href="/blog/upgrade-your-existing-ubuntu-lts-instances-to-ubuntu-pro-in-aws" class="p-button--positive">Upgrade to Ubuntu Pro on AWS</a></p>
       <p><a href="/aws/pro">Get started with Ubuntu Pro on AWS&nbsp;&rsaquo;</a></p>
     </div>
   </div>
@@ -119,7 +119,7 @@
     <div class="col-6 col-medium-3">
       <p>If your workload is ephemeral or easy to redeploy, for example, if it is regularly rebuilt in a CI/CD, you can launch fresh instances of Ubuntu Pro 18.04 LTS from the AWS Marketplace or using <a href="https://aws.amazon.com/marketplace/pp/prodview-322njmk4u5jam">AWS CLI</a></p>
       <p>When a redeploy is not viable, you can upgrade your Ubuntu LTS instances to Ubuntu Pro using AWS License Manager and benefit from a PAYG subscription model with optional savings plans from AWS. <a href="/tutorials/how-to-upgrade-ubuntu-lts-to-ubuntu-pro-on-aws-using-aws-license-manager#1-overview">Learn more about the process with this step-by-step guide</a>.</p>
-      <p><a href="/blog/upgrade-your-existing-ubuntu-lts-instances-to-ubuntu-pro-in-aws" class="p-button--positive">Upgrade to ubuntu Pro on AWS</a></p>
+      <p><a href="/blog/upgrade-your-existing-ubuntu-lts-instances-to-ubuntu-pro-in-aws" class="p-button--positive">Upgrade to Ubuntu Pro on AWS</a></p>
       <p><a href="/aws/pro">Get started with Ubuntu Pro on AWS&nbsp;&rsaquo;</a></p>
     </div>
   </div>
@@ -133,7 +133,7 @@
     </div>
     <div class="col-6 col-medium-3">
       <p><a href="/security/esm">Expanded Security Maintenance</a>(ESM) peovides extended Linux kernel and open source security updates for Ubuntu.</p>
-      <p>ESM is free on up to five machines and for broader enterprise use through an <a href="/pro">Ubuntu Pro susbcription</a> or an <a href="/blog/upgrade-your-existing-ubuntu-lts-instances-to-ubuntu-pro-in-aws">Ubuntu Pro upgrade on AWS. The subscription also includes additional services such as FIPS-compliant modules and the Ubuntu Livepatch Service to apply critical kernel patches without unplanned downtime.</a></p>
+      <p>ESM is free on up to five machines and for broader enterprise use through an <a href="/pro">Ubuntu Pro susbcription</a> or an <a href="/blog/upgrade-your-existing-ubuntu-lts-instances-to-ubuntu-pro-in-aws">Ubuntu Pro upgrade on AWS</a>. The subscription also includes additional services such as FIPS-compliant modules and the Ubuntu Livepatch Service to apply critical kernel patches without unplanned downtime.</p>
       <p><a href="/aws/pro">Learn more about Ubuntu Livepatch&nbsp;&rsaquo;</a></p>
     </div>
   </div>

--- a/templates/18-04/aws.html
+++ b/templates/18-04/aws.html
@@ -242,6 +242,7 @@
         <span class="p-pull-quote__citation">Andy Parker, Engineering Manager, TIM</span>
         <a href="/engage/case-study-acuris">Read the case study&nbsp;&rsaquo;</a>
       </blockquote>
+      <hr class="is-muted">
       <p><a href="/security/esm#get-in-touch">Get in touch</a> if you need advice on the best path for your company.</p>
     </div>
   </div>

--- a/templates/18-04/aws.html
+++ b/templates/18-04/aws.html
@@ -60,12 +60,13 @@
       </div>
       <a href="/engage/18-04-lts-end-of-support-webinar">
         {{ image (
-          url="https://assets.ubuntu.com/v1/a8ecc110-ubuntu-18.04-end-standard-support.png",
+          url="https://assets.ubuntu.com/v1/f52739bc-18.04_LTS_End_of_Standard_Support.png",
           alt="",
           width="1350",
           height="758",
           hi_def=True,
-          loading="lazy"
+          loading="lazy",
+          attrs={"class": "bordered-thumbnail"},
           ) | safe
         }}
       </a>      
@@ -95,12 +96,13 @@
       </div>
       <a href="/engage/migrating-to-20.04">
         {{ image (
-          url="https://assets.ubuntu.com/v1/94fae5f3-20.04-migration-webinar.png",
+          url="https://assets.ubuntu.com/v1/2aceaa9c-Migrating_to_20.04_LTS.png",
           alt="",
           width="1350",
           height="758",
           hi_def=True,
-          loading="lazy"
+          loading="lazy",
+          attrs={"class": "bordered-thumbnail"},
           ) | safe
         }}
       </a>   

--- a/templates/18-04/aws.html
+++ b/templates/18-04/aws.html
@@ -1,0 +1,252 @@
+{% extends "18-04/base_18-04.html" %}
+
+{% block title %}Ubuntu 18.04 LTS (Bionic Beaver){% endblock %}
+{% block meta_description %}Ubuntu 18.04 LTS (Bionic Beaver) is out of standard support on 31 May 2023. Ubuntu Pro provides continued support and security coverage for Ubuntu 18.04 LTS for additional 5 years, until 2028.{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1mZliSIg5yruIqcTbQwr_D2MNIonmlqnYdrUQzOmIqvE/edit#{% endblock meta_copydoc %}
+
+{% block content %}
+<section class="p-strip">
+  <div class="row">
+    <div class="col-5 u-hide--small u-hide--medium">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/bb580eec-Bionic+Beaver_18.04.svg",
+        alt="Bionic Beaver 18.04",
+        width="793",
+        height="443",
+        hi_def=True,
+        loading="auto"
+        ) | safe
+      }}
+    </div>
+    <div class="col-6 col-start-large-7">
+      <h1 class="p-heading--2">
+        <strong>Ubuntu 18.04 LTS <br class="u-hide--small">(Bionic Beaver) on Aamazon Web Services (AWS)</strong>
+      </h1>
+      <p class="p-heading--2">Out of standard support. <br class="u-hide--small">Upgrade to Ubuntu Pro</p>
+      <p>Ubuntu 18.04 LTS (Bionic Beaver) was released on 23 April 2018, introducing improved UEFI Secure Boot and broader Kernel Livepatch coverage for enhanced security on Amazon Web Services.</p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip u-no-padding--top">
+  <hr class="is-fixed-width" />
+  <div class="row">
+    <div class="col-6 col-medium-3">
+      <h2>Reaching end of standard support on 31 May 2023</h2>
+    </div>
+    <div class="col-6 col-medium-3">
+      <p>Transitioning to the latest Ubuntu release, such as Ubuntu 22.04 LTS, is important for performance, hardware enablement and new technology benefits and is recommended for new instances. But it might be a more complex process for existing deployments.</p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip u-no-padding--top">
+  <hr class="is-fixed-width" />
+  <div class="row">
+    <div class="col-6 col-medium-3">
+      <h3 class="p-heading--2">What are your options?</h3>
+    </div>
+    <div class="col-6 col-medium-3">
+      <p>You can either <a href="#upgrade-install">migrate to the next LTS</a> or <a href="#upgrade-pro">upgrade to Ubuntu Pro</a> to expand your security maintenance.</p>
+      <p>With Ubuntu Pro, the 18.04 LTS will be fully supported until 2028. Ubuntu Pro is free for personal and small-scale commercial use on up to 5 machines. Paid plans with transparent, per-machine pricing are available for large-scale deployments.</p>
+      <p><a href="/blog/upgrade-your-existing-ubuntu-lts-instances-to-ubuntu-pro-in-aws" class="p-button--positive">Upgrade to ubuntu Pro on AWS</a></p>
+      <p><a href="/aws/pro">Get started with Ubuntu Pro on AWS&nbsp;&rsaquo;</a></p>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-6 col-medium-3 col-start-large-7 col-start-medium-4">
+      <hr class="is-muted u-no-margin--bottom" />
+      <h3 class="p-heading--5">Watch the 18.04 End of Standard Support webinar:</h3>
+      <p>Ubuntu 18.04 LTS 'Bionic Beaver', one of the most popular Ubuntu releases, reaches the end of the standard, five-year maintenance window for Long-Term Support (LTS) releases on 31 May 2023. Learn more about your options in this webinar.</p>
+      <a href="/engage/18-04-lts-end-of-support-webinar">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/94fae5f3-20.04-migration-webinar.png",
+          alt="",
+          width="1350",
+          height="758",
+          hi_def=True,
+          loading="lazy"
+          ) | safe
+        }}
+      </a>      
+    </div>
+  </div>
+</section>
+
+<section class="p-strip u-no-padding--top">
+  <hr class="is-fixed-width" />
+  <div class="row">
+    <div class="col-6 col-medium-3">
+      <h3 class="p-heading--2" id="upgrade-install">Upgrading to Ubuntu 20.04 LTS, or Ubuntu 22.04 LTS fresh install</h3>
+    </div>
+    <div class="col-6 col-medium-3">
+      <p>Where it makes sense, you should transition workloads to later Ubuntu releases. You can either upgrade existing Ubuntu 18.04 LTS instances to <a href="https://aws.amazon.com/marketplace/pp/prodview-iftkyuwv2sjxi">Ubuntu 20.04 LTS</a> or redeploy your workload onto a fresh Ubuntu 22.04 LTS instance available on the <a href="https://us-east-1.console.aws.amazon.com/ec2/home?region=us-east-1#LaunchInstances:">AWS EC2 Quick Launch</a> menu or via <a href="https://aws.amazon.com/marketplace/pp/prodview-f2if34z3a4e3i">AWS Marketplace</a>. There is no direct upgrade path from Ubuntu 18.04 LTS to Ubuntu 22.04 LTS, so you can either move to Ubuntu 20.04 LTS and then to Ubuntu 22.04 LTS, or redeploy onto Ubuntu 22.04 LTS.</p>
+      <p>
+        <a href="/server/docs/upgrade-introduction">Ubuntu Server upgrade guide&nbsp;&rsaquo;</a>
+      </p>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-6 col-medium-3 col-start-large-7 col-start-medium-4">
+      <hr class="is-muted u-no-margin--bottom" />
+      <h3 class="p-heading--5">Watch the 20.04 migration webinar:</h3>
+      <p>This webinar explores all the factors that should be taken into account to deliver successful migration at the right pace, covering the most popular infrastructure components such as OpenStack, Kubernetes and Ceph.</p>
+      <a href="/engage/migrating-to-20.04">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/94fae5f3-20.04-migration-webinar.png",
+          alt="",
+          width="1350",
+          height="758",
+          hi_def=True,
+          loading="lazy"
+          ) | safe
+        }}
+      </a>   
+    </div>
+  </div>
+</section>
+
+<section class="p-strip u-no-padding--top">
+  <hr class="is-fixed-width" />
+  <div class="row">
+    <div class="col-6 col-medium-3">
+      <h3 class="p-heading--2" id="upgrade-pro">Upgrading to Ubuntu Pro</h3>
+    </div>
+    <div class="col-6 col-medium-3">
+      <p>If your workload is ephemeral or easy to redeploy, for example, if it is regularly rebuilt in a CI/CD, you can launch fresh instances of Ubuntu Pro 18.04 LTS from the AWS Marketplace or using <a href="https://aws.amazon.com/marketplace/pp/prodview-322njmk4u5jam">AWS CLI</a></p>
+      <p>When a redeploy is not viable, you can upgrade your Ubuntu LTS instances to Ubuntu Pro using AWS License Manager and benefit from a PAYG subscription model with optional savings plans from AWS. <a href="/tutorials/how-to-upgrade-ubuntu-lts-to-ubuntu-pro-on-aws-using-aws-license-manager#1-overview">Learn more about the process with this step-by-step guide</a>.</p>
+      <p><a href="/blog/upgrade-your-existing-ubuntu-lts-instances-to-ubuntu-pro-in-aws" class="p-button--positive">Upgrade to ubuntu Pro on AWS</a></p>
+      <p><a href="/aws/pro">Get started with Ubuntu Pro on AWS&nbsp;&rsaquo;</a></p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip u-no-padding--top">
+  <hr class="is-fixed-width" />
+  <div class="row">
+    <div class="col-6 col-medium-3">
+      <h3 class="p-heading--2" id="upgrade-pro">Expanded Security Maintenance (ESM) for 18.04 LTS</h3>
+    </div>
+    <div class="col-6 col-medium-3">
+      <p><a href="/security/esm">Expanded Security Maintenance</a>(ESM) peovides extended Linux kernel and open source security updates for Ubuntu.</p>
+      <p>ESM is free on up to five machines and for broader enterprise use through an <a href="/pro">Ubuntu Pro susbcription</a> or an <a href="/blog/upgrade-your-existing-ubuntu-lts-instances-to-ubuntu-pro-in-aws">Ubuntu Pro upgrade on AWS. The subscription also includes additional services such as FIPS-compliant modules and the Ubuntu Livepatch Service to apply critical kernel patches without unplanned downtime.</a></p>
+      <p><a href="/aws/pro">Learn more about Ubuntu Livepatch&nbsp;&rsaquo;</a></p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip u-no-padding--top">
+  <div class="row">
+    <hr class="is-muted u-no-margin--bottom">
+    <div class="col-6 col-medium-3">
+      <h2>What do you get with Ubuntu Pro <br class="u-hide--small" />for 18.04 LTS?</h2>
+    </div>
+    <div class="col-6 col-medium-3">
+      <div class="p-strip is-shallow u-no-padding--top">
+        <p>Standard Security Maintenance of an Ubuntu LTS release covers binary packages that reside in the Main Ubuntu repository for a period of five years. For continued security beyond the standard five-year maintenance period, Ubuntu Pro delivers security maintenance to a wide range of binary packages that are commonly used in cloud and server workloads on 64-bit x86 AMD/Intel architectures for a period of five years beyond the end of standard support.</p>
+        <p>Additionally, Ubuntu Pro can also cover all packages in the Ubuntu Universe repository, until April 2028.</p>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-9 col-start-large-4">
+      <hr class="is-muted u-no-margin--bottom" />
+      <div class="row">
+        <div class="col-3 col-medium-2 col-start-medium-2">
+          <h3 class="p-muted-heading">Support kernels</h3>
+        </div>
+        <div class="col-6 col-medium-3 col-start-medium-4">
+          <p>For continued Linux kernel security, Ubuntu Pro for Ubuntu 18.04 LTS includes support for the below versions:</p>
+          <table>
+            <thead>
+              <tr>
+                <th>Ubuntu release</th>
+                <th>Architecture</th>
+                <th>Kernel version</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Ubuntu 18.04 LTS</td>
+                <td>arm64, x86-64 (AMD/Intel), and s390x</td>
+                <td>5.4 (HWE)</td>
+              </tr>
+              <tr>
+                <td>Ubuntu 18.04 LTS</td>
+                <td>arm64, x86-64 (AMD/Intel), and s390x</td>
+                <td>4.15 (GA)</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-9 col-start-large-4">
+      <hr class="is-muted u-no-margin--bottom" />
+      <div class="row">
+        <div class="col-3 col-medium-2 col-start-medium-2">
+          <h3 class="p-muted-heading">Infrastructure packages</h3>
+        </div>
+        <div class="col-6 col-medium-3 col-start-medium-4">
+          <p>For Ubuntu 18.04 LTS, where technically feasible, Canonical provides extended security maintenance to all binary packages that reside in the Ubuntu Main Repository.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-9 col-start-large-4">
+      <hr class="is-muted u-no-margin--bottom" />
+      <div class="row">
+        <div class="col-3 col-medium-2 col-start-medium-2">
+          <h3 class="p-muted-heading">Application packages</h3>
+        </div>
+        <div class="col-6 col-medium-3 col-start-medium-4">
+          <p>Canonical provides application extended security maintenance to the binary packages that reside in Main and Universe. A few commonly-used packages include:</p>
+          <ul class="p-list--divided">
+            <li class="p-list__item has-bullet">MySQL &ndash; 5.7</li>
+            <li class="p-list__item has-bullet">Python &ndash; 2.7</li>
+            <li class="p-list__item has-bullet">PostgreSQL &ndash; 10</li>
+            <li class="p-list__item has-bullet">Ruby &ndash; 2.5</li>
+            <li class="p-list__item has-bullet">Nodejs &ndash; 8.10</li>
+            <li class="p-list__item has-bullet">PHP &ndash; 7.2</li>
+            <li class="p-list__item has-bullet">ROS &ndash; Melodic</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip u-no-padding--top">
+  <div class="row">
+    <hr class="is-muted u-no-margin--bottom" />
+    <div class="col-6 col-medium-3">
+      <h2>What customers say <br class="u-hide--small">about ESM</h2>
+    </div>
+    <div class="col-6 col-medium-3">
+      <blockquote class="p-pull-quote">
+        <p class="p-pull-quote__quote">ESM literally saved our lives. It's allowing us to upgrade from 14.04 LTS at our own pace. It's taken the pressure off, and it also means we can tackle the Ubuntu upgrades at the same time as we roll out the new version of our platform.</p>
+        <span class="p-pull-quote__citation">Zivago Lee, Director of DevOps Engineering, Interana</span>
+        <a href="/engage/interana-casestudy">Read the case study&nbsp;&rsaquo;</a>
+      </blockquote>
+      <blockquote class="p-pull-quote">
+        <p class="p-pull-quote__quote">ESM has given us the space to plan what comes next. It's helping us get into a position where we can have a more sustainable infrastructure.</p>
+        <span class="p-pull-quote__citation">Andy Parker, Engineering Manager, TIM</span>
+        <a href="/engage/case-study-acuris">Read the case study&nbsp;&rsaquo;</a>
+      </blockquote>
+      <p><a href="/security/esm#get-in-touch">Get in touch</a> if you need advice on the best path for your company.</p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-deep">
+  <div class="u-fixed-width">
+    <hr class="is-muted u-no-margin--bottom" />
+    <p class="p-heading--2">Latest Ubuntu 18.04 LTS news from <a href="/blog/tag/ubuntu-18-04">our blog&nbsp;&rsaquo;</a></p>
+  </div>
+</section>
+
+
+{% endblock content %}

--- a/templates/18-04/aws.html
+++ b/templates/18-04/aws.html
@@ -69,7 +69,7 @@
           ) | safe
         }}
       </a>      
-      <h3 class="p-heading--5">Watch the 18.04 End of Standard Support webinar:</h3>
+      <h3 class="p-heading--5"><a href="/engage/18-04-lts-end-of-support-webinar">Watch the 18.04 End of Standard Support webinar&nbsp;&rsaquo;</a></h3>
       <p>Ubuntu 18.04 LTS 'Bionic Beaver', one of the most popular Ubuntu releases, reaches the end of the standard, five-year maintenance window for Long-Term Support (LTS) releases on 31 May 2023. Learn more about your options in this webinar.</p>
     </div>
   </div>
@@ -104,7 +104,7 @@
           ) | safe
         }}
       </a>   
-      <h3 class="p-heading--5">Watch the 20.04 migration webinar:</h3>
+      <h3 class="p-heading--5"><a href="/engage/migrating-to-20.04">Watch the 20.04 migration webinar&nbsp;&rsaquo;</a></h3>
       <p>This webinar explores all the factors that should be taken into account to deliver successful migration at the right pace, covering the most popular infrastructure components such as OpenStack, Kubernetes and Ceph.</p>
     </div>
   </div>


### PR DESCRIPTION
## Done

- Built as per [doc](https://docs.google.com/document/d/1mZliSIg5yruIqcTbQwr_D2MNIonmlqnYdrUQzOmIqvE/edit#)
- Design is meant to match the rest of the pages in the 18-04 bubble, please compare against those

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: https://ubuntu-com-12915.demos.haus/18-04/aws
    - Be sure to test on mobile, tablet and desktop screen sizes
- See that the copy matches the doc
- See that the design matches the other 18-04 pages

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-4155
