### PR TITLE
Build new Ubuntu 18.04 LTS OCI page

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -597,6 +597,8 @@ ubuntu1804:
       path: /18-04/aws
     - title: IBM
       path: /18-04/ibm
+    - title: OCI
+      path: /18-04/oci
 
 telco:
   title: Telco

--- a/templates/18-04/oci.html
+++ b/templates/18-04/oci.html
@@ -180,6 +180,7 @@
   </div>
   <div class="row">
     <div class="col-9 col-start-large-4">
+      <hr class="is-muted u-no-margin--bottom">
       <div class="row">
         <div class="col-3 col-medium-2 col-start-medium-2">
           <h3 class="p-muted-heading">Support kernels</h3>

--- a/templates/18-04/oci.html
+++ b/templates/18-04/oci.html
@@ -179,32 +179,36 @@
     </div>
   </div>
   <div class="row">
-    <div class="col-3 col-medium-2 col-start-medium-2">
-      <h3 class="p-muted-heading">Support kernels</h3>
-    </div>
-    <div class="col-6 col-medium-3 col-start-medium-4">
-      <p>For continued Linux kernel security, Ubuntu Pro for Ubuntu 18.04 LTS includes support for the below versions:</p>
-      <table>
-        <thead>
-          <tr>
-            <th>Ubuntu release</th>
-            <th>Architecture</th>
-            <th>Kernel version</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>Ubuntu 18.04 LTS</td>
-            <td>arm64, x86-64 (AMD/Intel), and s390x</td>
-            <td>5.4 (HWE)</td>
-          </tr>
-          <tr>
-            <td>Ubuntu 18.04 LTS</td>
-            <td>arm64, x86-64 (AMD/Intel), and s390x</td>
-            <td>4.15 (GA)</td>
-          </tr>
-        </tbody>
-      </table>
+    <div class="col-9 col-start-large-4">
+      <div class="row">
+        <div class="col-3 col-medium-2 col-start-medium-2">
+          <h3 class="p-muted-heading">Support kernels</h3>
+        </div>
+        <div class="col-6 col-medium-3 col-start-medium-4">
+          <p>For continued Linux kernel security, Ubuntu Pro for Ubuntu 18.04 LTS includes support for the below versions:</p>
+          <table>
+            <thead>
+              <tr>
+                <th>Ubuntu release</th>
+                <th>Architecture</th>
+                <th>Kernel version</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Ubuntu 18.04 LTS</td>
+                <td>arm64, x86-64 (AMD/Intel), and s390x</td>
+                <td>5.4 (HWE)</td>
+              </tr>
+              <tr>
+                <td>Ubuntu 18.04 LTS</td>
+                <td>arm64, x86-64 (AMD/Intel), and s390x</td>
+                <td>4.15 (GA)</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
     </div>
   </div>
   <div class="row">

--- a/templates/18-04/oci.html
+++ b/templates/18-04/oci.html
@@ -1,0 +1,296 @@
+{% extends "18-04/base_18-04.html" %}
+
+{% block title %}Ubuntu 18.04 LTS (Bionic Beaver){% endblock %}
+{% block meta_description %}Ubuntu 18.04 LTS (Bionic Beaver) is out of standard support on 31 May 2023. Ubuntu Pro provides continued support and security coverage for Ubuntu 18.04 LTS for an additional 5 years, until 2028.{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1Kdq2tmLk4aA6wceyhS9gmmmyfCU8Ralw0MOts6HtmOM{% endblock meta_copydoc %}
+
+{% block content %}
+<section class="p-strip">
+  <div class="row">
+    <div class="col-5 u-hide--small u-hide--medium">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/bb580eec-Bionic+Beaver_18.04.svg",
+        alt="Bionic Beaver 18.04",
+        width="793",
+        height="443",
+        hi_def=True,
+        loading="auto"
+        ) | safe
+      }}
+    </div>
+    <div class="col-6 col-start-large-7">
+      <h1 class="p-heading--2">
+        <strong>Ubuntu 18.04 LTS <br class="u-hide--small">(Bionic Beaver) on Oracle Cloud Infrastructure (OCI)</strong>
+      </h1>
+      <p class="p-heading--2">Out of standard support. <br class="u-hide--small">Upgrade to Ubuntu Pro</p>
+      <p>Ubuntu 18.04 LTS (Bionic Beaver) was released on 23 April 2018 and is one of the most popular Ubuntu releases. It has been <a href="https://docs.oracle.com/en-us/iaas/images/ubuntu-1804/">available on Oracle Cloud Infrastructure (OCI) since May 2018</a>.</p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip u-no-padding--top">
+  <hr class="is-fixed-width">
+  <div class="row">
+    <div class="col-6 col-medium-3">
+      <h2>Reaching end of standard support on 31 May 2023</h2>
+    </div>
+    <div class="col-6 col-medium-3">
+      <p>Transitioning to the latest Ubuntu release, such as Ubuntu 22.04 LTS, is important for performance, hardware enablement and new technology benefits and is recommended for new instances. But it might be a more complex process for existing deployments.</p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip u-no-padding--top">
+  <div class="row">
+    <hr class="is-muted u-no-margin--bottom" />
+    <div class="col-6 col-medium-3">
+      <h2>What are your options?</h3>
+    </div>
+    <div class="col-6 col-medium-3">
+      <p>
+        You can either migrate to the next LTS or upgrade to Ubuntu Pro to expand your security maintenance.  
+      </p>
+      <p>
+        With Ubuntu Pro, the 18.04 LTS will be fully supported until 2028. Ubuntu Pro is free for personal and small-scale commercial use on up to 5 machines. Paid plans with transparent, per-machine pricing are available for large-scale deployments.
+      </p>
+      <p>
+        <a href="/security/esm#get-in-touch">Contact us to talk about Ubuntu Pro for OCI instances&nbsp;&rsaquo;</a>
+      </p>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-6 col-medium-3 col-start-large-7 col-start-medium-4">
+      <div class="p-strip is-shallow">
+        <hr class="is-muted">
+      </div>
+      <a href="/engage/18-04-lts-end-of-support-webinar">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/f52739bc-18.04_LTS_End_of_Standard_Support.png",
+          alt="",
+          width="1350",
+          height="758",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "bordered-thumbnail"}
+          ) | safe
+        }}
+      </a>
+      <h3 class="p-heading--5"><a href="/engage/18-04-lts-end-of-support-webinar">Watch the 18.04 End of Standard Support webinar&nbsp;&rsaquo;</a></h3>
+      <p>Ubuntu 18.04 LTS ‘Bionic Beaver‘, one of the most popular Ubuntu releases, reaches the end of the standard, five-year maintenance window for Long-Term Support (LTS) releases on 31 May 2023. Join us to learn more about your options.</p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip u-no-padding--top">
+  <div class="row">
+    <hr class="is-muted u-no-margin--bottom">
+  </div>
+  <div class="row">
+    <div class="col-6 col-medium-3">
+      <h2>
+        Security updates for <br class="u-hide--small u-hide--medium" />Ubuntu 18.04 LTS, with Ubuntu Pro
+      </h2>
+    </div>
+    <div class="col-6 col-medium-3">
+      <div class="p-strip is-shallow u-no-padding--top">
+        <p>
+          The Ubuntu Security Team is dedicated to providing timely security updates for all packages on Ubuntu 18.04 LTS for x86-64 and arm64 architectures.
+        </p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip u-no-padding--top">
+  <div class="row">
+    <hr class="is-muted u-no-margin--bottom" />
+    <div class="col-6 col-medium-3">
+      <h2>Upgrading to Ubuntu 20.04 LTS, <br class="u-hide--small"/>or Ubuntu 22.04 LTS fresh install</h2>
+    </div>
+    <div class="col-6 col-medium-3">
+      <p>
+        Where it makes sense, you should transition workloads to later Ubuntu releases. You can either upgrade existing Ubuntu 18.04 LTS instances to Ubuntu 20.04 LTS or redeploy your workload onto a <a href="https://docs.oracle.com/en-us/iaas/images/ubuntu-2204/">fresh Ubuntu 22.04 LTS instance</a>. There is no direct upgrade path from Ubuntu 18.04 LTS to Ubuntu 22.04 LTS, so you can either move to Ubuntu 20.04 LTS and then to Ubuntu 22.04 LTS, or redeploy onto Ubuntu 22.04 LTS.
+      </p>
+      <p><a href="/server/docs/upgrade-introduction">Ubuntu Server upgrade guide&nbsp;&rsaquo;</a></p>
+      <div class="p-strip is-shallow">
+        <hr class="is-muted">
+      </div>
+      <a href="/engage/migrating-to-20.04">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/2aceaa9c-Migrating_to_20.04_LTS.png",
+          alt="",
+          width="1350",
+          height="758",
+          hi_def=True,
+          loading="lazy",
+          attrs={"class": "bordered-thumbnail"}
+          ) | safe
+        }}
+      </a>
+      <h3 class="p-heading--5"><a href="/engage/migrating-to-20.04">Watch the 20.04 migration webinar&nbsp;&rsaquo;</a></h3>
+      <p>
+        This webinar explores all the factors that should be taken into account to deliver successful migration at the right pace, covering the most popular infrastructure components such as OpenStack, Kubernetes and Ceph.
+      </p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip u-no-padding--top">
+  <div class="row">
+    <hr class="is-muted u-no-margin--bottom">
+  </div>
+  <div class="row">
+    <div class="col-6 col-medium-3">
+      <h2>
+        Expanded Security Maintenance (ESM) for 18.04 LTS
+      </h2>
+    </div>
+    <div class="col-6 col-medium-3">
+      <div class="p-strip is-shallow u-no-padding--top">
+        <p>
+          <a href="/security/esm">Expanded Security Maintenance</a> (ESM) provides extended Linux kernel and open source security updates for Ubuntu. 
+        </p>
+        <p>
+          ESM is free on up to five machines and for broader enterprise use through an <a href="/pro">Ubuntu Pro subscription</a>. The subscription also includes additional services such as FIPS-compliant modules and the Ubuntu Livepatch Service to apply critical kernel patches without unplanned downtime.
+        </p>
+        <p><a href="/security/livepatch">Learn more about Ubuntu Livepatch&nbsp;&rsaquo;</a></p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip u-no-padding--top">
+  <div class="row">
+    <hr class="is-muted u-no-margin--bottom">
+    <div class="col-6 col-medium-3">
+      <h2>
+        What do you get with Ubuntu Pro <br class="u-hide--small" />for 18.04 LTS?
+      </h2>
+    </div>
+    <div class="col-6 col-medium-3">
+      <div class="p-strip is-shallow u-no-padding--top">
+        <p>
+          Standard Security Maintenance of an Ubuntu LTS release covers binary packages that reside in the <a href="/community/Repositories/Ubuntu">Main Ubuntu repository</a> for a period of five years. For continued security beyond the standard five-year maintenance period, Ubuntu Pro delivers security maintenance to a wide range of binary packages that are commonly used in cloud and server workloads on 64-bit x86 AMD/Intel architectures for a period of five years beyond the end of standard support.
+        </p>
+        <p>
+          Additionally, Ubuntu Pro can also cover all packages in the <a href="https://help.ubuntu.com/community/Repositories/Ubuntu">Ubuntu Universe repository</a>, until April 2028.
+        </p>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-3 col-medium-2 col-start-medium-2">
+      <h3 class="p-muted-heading">Support kernels</h3>
+    </div>
+    <div class="col-6 col-medium-3 col-start-medium-4">
+      <p>For continued Linux kernel security, Ubuntu Pro for Ubuntu 18.04 LTS includes support for the below versions:</p>
+      <table>
+        <thead>
+          <tr>
+            <th>Ubuntu release</th>
+            <th>Architecture</th>
+            <th>Kernel version</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Ubuntu 18.04 LTS</td>
+            <td>arm64, x86-64 (AMD/Intel), and s390x</td>
+            <td>5.4 (HWE)</td>
+          </tr>
+          <tr>
+            <td>Ubuntu 18.04 LTS</td>
+            <td>arm64, x86-64 (AMD/Intel), and s390x</td>
+            <td>4.15 (GA)</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-9 col-start-large-4">
+      <hr class="is-muted u-no-margin--bottom">
+      <div class="row">
+        <div class="col-3 col-medium-2 col-start-medium-2">
+          <h3 class="p-muted-heading">Infrastructure packages</h3>
+        </div>
+        <div class="col-6 col-medium-3 col-start-medium-4">
+          <p>For Ubuntu 18.04 LTS, where technically feasible, Canonical provides extended security maintenance to all binary packages that reside in the Ubuntu Main Repository.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-9 col-start-large-4">
+      <hr class="is-muted u-no-margin--bottom">
+      <div class="row">
+        <div class="col-3 col-medium-2 col-start-medium-2">
+          <h3 class="p-muted-heading">Application packages</h3>
+        </div>
+        <div class="col-6 col-medium-3 col-start-medium-4">
+          <p>Canonical provides application extended security maintenance to the binary packages that reside in Main and Universe. A few commonly-used packages include:</p>
+          <ul class="p-list--divided">
+            <li class="p-list__item has-bullet">MySQL – 5.7</li>
+            <li class="p-list__item has-bullet">Python – 2.7</li>
+            <li class="p-list__item has-bullet">PostgreSQL – 10</li>
+            <li class="p-list__item has-bullet">Ruby – 2.5</li>
+            <li class="p-list__item has-bullet">Nodejs – 8.10</li>
+            <li class="p-list__item has-bullet">PHP – 7.2</li>
+            <li class="p-list__item has-bullet">ROS – Melodic</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip u-no-padding--top">
+  <div class="u-fixed-width">
+    <hr class="p-rule">
+  </div>
+  <div class="row">
+    <div class="col-6 col-medium-3">
+      <h2 id="ubuntu-pro">Upgrading to Ubuntu Pro on Oracle OCI</h2>
+    </div>
+    <div class="col-6 col-medium-3">
+      <p>
+        You can upgrade your Ubuntu 18.04 LTS instances on OCI to Ubuntu Pro using an activation token from Canonical. You can apply this to your existing instances with no disruption to your workloads.
+      </p>
+      <p>
+        <a href="/security/esm#get-in-touch">Contact us to talk about Ubuntu Pro for OCI instances&nbsp;&rsaquo;</a>
+      </p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip u-no-padding--top">
+  <hr class="is-fixed-width" />
+  <div class="row">
+    <div class="col-6 col-medium-3">
+      <h2>What customers say <br class="u-hide--small">about ESM</h2>
+    </div>
+    <div class="col-6 col-medium-3">
+      <blockquote class="p-pull-quote">
+        <p class="p-pull-quote__quote">ESM literally saved our lives. It's allowing us to upgrade from 14.04 LTS at our own pace. It's taken the pressure off, and it also means we can tackle the Ubuntu upgrades at the same time as we roll out the new version of our platform.</p>
+        <span class="p-pull-quote__citation">Zivago Lee, Director of DevOps Engineering, Interana</span>
+        <a href="/engage/interana-casestudy">Read the case study&nbsp;&rsaquo;</a>
+      </blockquote>
+      <blockquote class="p-pull-quote">
+        <p class="p-pull-quote__quote">ESM has given us the space to plan what comes next. It's helping us get into a position where we can have a more sustainable infrastructure.</p>
+        <span class="p-pull-quote__citation">Andy Parker, Engineering Manager, TIM</span>
+        <a href="/engage/case-study-acuris">Read the case study&nbsp;&rsaquo;</a>
+      </blockquote>
+      <hr class="is-muted u-no-margin--bottom">
+      <p><a href="/security/esm#get-in-touch">Get in touch</a> if you need advice on the best path for your company.</p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-deep">
+  <div class="u-fixed-width">
+    <hr class="is-muted u-no-margin--bottom" />
+    <p class="p-heading--2">Latest Ubuntu 18.04 LTS news from <a href="/blog/tag/ubuntu-18-04">our blog&nbsp;&rsaquo;</a></p>
+  </div>
+</section>
+
+{% endblock content %}

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -199,9 +199,16 @@ class TestRoutes(VCRTestCase):
         """
         response = self.client.get("/security/certifications/docs")
         self.assertEqual(response.status_code, 200)
-
         soup = BeautifulSoup(response.data, "html.parser")
         self.assertIsNotNone(soup.find("meta", {"name": "description"}))
+
+    def test_18_04_bubble(self):
+        """
+        When given the 18-04 page,
+        we should return a 200 status code
+        """
+        response = self.client.get("/18-04/oci")
+        self.assertEqual(response.status_code, 200)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Done

- Built as per [doc](https://docs.google.com/document/d/1Kdq2tmLk4aA6wceyhS9gmmmyfCU8Ralw0MOts6HtmOM)
- Design is meant to match the rest of the pages in the 18-04 bubble, please compare against those

## QA

- Check https://ubuntu-com-12917.demos.haus/18-04/oci against [copy doc](https://docs.google.com/document/d/1Kdq2tmLk4aA6wceyhS9gmmmyfCU8Ralw0MOts6HtmOM)
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-4152

