### PR TITLE
Pass accountID when activating key

### DIFF
--- a/static/js/src/advantage/credentials/api/keys.js
+++ b/static/js/src/advantage/credentials/api/keys.js
@@ -1,4 +1,4 @@
-export async function listAllKeys(contractId) {
+export async function listAllKeys() {
   let response = await fetch(`/credentials/keys/list`, {
     method: "GET",
     headers: {
@@ -25,7 +25,7 @@ export async function rotateKey(activationKey) {
   return data;
 }
 
-export async function activateKey(activationKey) {
+export async function activateKey(activationKey, accountId) {
   let response = await fetch("/credentials/keys/activate", {
     method: "POST",
     headers: {
@@ -34,7 +34,7 @@ export async function activateKey(activationKey) {
     },
     body: JSON.stringify({
       activationKey: activationKey,
-      productID: "cube-admintasks",
+      accountID: accountId,
     }),
   });
   const data = await response.json();

--- a/webapp/shop/advantage/views.py
+++ b/webapp/shop/advantage/views.py
@@ -30,7 +30,7 @@ from webapp.shop.schemas import (
     put_contract_entitlements,
     post_auto_renewal_settings,
     post_offer_schema,
-    account_purhcase,
+    account_purchase,
 )
 
 
@@ -356,7 +356,7 @@ def post_advantage_subscriptions(advantage_mapper, ua_contracts_api, **kwargs):
 
 
 @shop_decorator(area="advantage", response="json")
-@use_kwargs(account_purhcase, location="json")
+@use_kwargs(account_purchase, location="json")
 def post_advantage_purchase(advantage_mapper: AdvantageMapper, **kwargs):
     account_id = kwargs.get("account_id") or flask.session.get(
         "guest_account_id"

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -649,9 +649,11 @@ def rotate_activation_key(ua_contracts_api, **kwargs):
 def activate_activation_key(ua_contracts_api, **kwargs):
     data = flask.request.json
     activation_key = data["activationKey"]
+    account_id = data["accountID"]
     return ua_contracts_api.activate_activation_key(
         {
             "activationKey": activation_key,
+            "accountID": account_id,
         }
     )
 

--- a/webapp/shop/schemas.py
+++ b/webapp/shop/schemas.py
@@ -53,7 +53,7 @@ class PurchaseTotalSchema(Schema):
     total = Int(required=True)
 
 
-account_purhcase = {
+account_purchase = {
     "account_id": String(),
     "customer_info": Nested(CustomerInfo),
     "products": List(Nested(ProductListing)),


### PR DESCRIPTION
## Done

Some keys can be activated only in personal accounts, others - only in paid. By providing `accountID`, we eliminate ambiguity regarding the account getting the entitlement.