### PR TITLE
Attempt to fix builds by adding filelock dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ google-auth-oauthlib==1.0.0
 black
 django-openid-auth==0.17
 time-machine==2.9.0
+filelock==3.12.0


### PR DESCRIPTION
The new version of cachecontrol might have introduced a dependency on
filelock, so we now need to install it.

## QA

See the demo works https://ubuntu-com-12924.demos.haus/