### PR TITLE
use different value for level in certified template

### DIFF
--- a/templates/certified/model-details.html
+++ b/templates/certified/model-details.html
@@ -81,7 +81,7 @@
             {% else %}
             <section>
             {% endif %}
-            {% if release.level == "Enabled" %}
+            {% if release.level == "Certified Pre-Install" %}
               <p class="u-no-margin--bottom">Pre-installed in some regions with a custom Ubuntu image that takes advantage of the system's hardware features and may include additional software. Standard images of Ubuntu may not work well, or at all.</p>
               {% if vendor == "Xilinx" %}
                 <p class="u-no-margin--bottom" style="padding-top:1.4rem;">


### PR DESCRIPTION
The api now returns Certified Pre-Install instead of Enabled. This changes the template to reflect that.

## Done

This change updates the template so that it checks for `Certified Pre-Install` instead of enabled. The api changed the values stored in the database so that the string changed.

## QA

- Go to the https://ubuntu-com-12930.demos.haus//certified/202012-28554 endpoint.  You should see the string about pre-installed systems rather than no string about the image.
