### PR TITLE
WD-4338 Update /download/cloud to remove Ubuntu Advantage

### DIFF
--- a/templates/download/cloud/index.html
+++ b/templates/download/cloud/index.html
@@ -9,7 +9,7 @@
   <div class="row u-equal-height">
     <div class="col-8">
       <h1>Optimised Ubuntu on&nbsp;public&nbsp;clouds</h1>
-      <p>Ubuntu builds optimised and certified server images for partners like Amazon AWS, Microsoft Azure, Google Cloud Platform, IBM Cloud and Oracle. In addition, Canonical offers Ubuntu Advantage, enterprise-grade commercial support, on these images.</p>
+      <p>Ubuntu builds optimised and certified server images for partners like Amazon AWS, Microsoft Azure, Google Cloud Platform, IBM Cloud and Oracle. In addition, Canonical offers Ubuntu Pro, enterprise-grade commercial support, on these images.</p>
     </div>
     <div class="col-4 u-align--center u-vertically-center u-hide--medium u-hide--small">
       {{
@@ -107,6 +107,8 @@
       <ul class="p-list">
         <li class="p-list__item u-no-margin--top"><a href="https://cloud.google.com/sdk/docs/quickstart-debian-ubuntu">Guide to using GCP</a></li>
         <li class="p-list__item"><a href="https://console.cloud.google.com/launcher/browse?q=ubuntu&filter=category:os&filter=price:free">Get started on GCP</a></li>
+        <li class="p-list__item"><a href="https://console.cloud.google.com/marketplace/product/ubuntu-os-cloud/ubuntu-focal">Launch Ubuntu on GCP</a></li>
+        <li class="p-list__item"><a href="https://console.cloud.google.com/marketplace/product/ubuntu-os-pro-cloud/ubuntu-pro-focal">Launch Ubuntu Pro on GCP</a></li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
## Done

- Updated the copy on the /download/cloud page to match [the copy doc](https://docs.google.com/document/d/1kp7QQXst1EbCjZjzWZP3YZwfmG0EIXLfQoRUVaMEZng/edit#)
- I did not, add the datasheets as that would probably require design and is of our scope for the ticket.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-4338
