### PR TITLE
WD-3958 Remove the Tesla logo from HCP use-cases

### DIFF
--- a/templates/hpc/use-cases.html
+++ b/templates/hpc/use-cases.html
@@ -29,18 +29,6 @@
       <div class="p-logo-section__items">
         <div class="p-logo-section__item">
           {{ image (
-            url="https://assets.ubuntu.com/v1/d3ee88a5-2018-logo-tesla.svg",
-            alt="",
-            width="145",
-            height="145",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-logo-section__logo"},
-            ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{ image (
             url="https://assets.ubuntu.com/v1/654fe8a7-firmus-logo.png",
             alt="",
             width="288",


### PR DESCRIPTION
## Done

- Remove the Tesla logo from HCP use-cases page

## QA

- Open the demo
- Visit /hpc/use-cases and see the Tesla logo is not on the page

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-3958

