### PR TITLE
Update Trial expiration

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/ExpiryNotification/ExpiryNotification.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/ExpiryNotification/ExpiryNotification.test.tsx
@@ -331,7 +331,9 @@ describe("ExpiryNotification", () => {
       "Your subscription is about to expire."
     );
     expect(wrapper.find(Notification).prop("children")).toBe(
-      "Your trial will end soon."
+      "You have cancelled your Ubuntu Pro trial. " +
+        "At the end of the trial period, this subscription " +
+        "will disappear and you will no longer have access to Pro services."
     );
   });
 

--- a/static/js/src/advantage/react/components/Subscriptions/ExpiryNotification/ExpiryNotification.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/ExpiryNotification/ExpiryNotification.test.tsx
@@ -1,12 +1,11 @@
 import React from "react";
 import { mount } from "enzyme";
-
+import { Notification } from "@canonical/react-components";
+import { UserSubscriptionType } from "advantage/api/enum";
+import { userSubscriptionStatusesFactory } from "advantage/tests/factories/api";
 import ExpiryNotification, {
   ExpiryNotificationSize,
 } from "./ExpiryNotification";
-import { UserSubscriptionType } from "advantage/api/enum";
-import { userSubscriptionStatusesFactory } from "advantage/tests/factories/api";
-import { Notification } from "@canonical/react-components";
 
 describe("ExpiryNotification", () => {
   it("can display an expiring notification", () => {
@@ -175,13 +174,14 @@ describe("ExpiryNotification", () => {
       "Your subscription is about to expire."
     );
     expect(wrapper.find(Notification).prop("children")).toBe(
-      "Click on renew subscription or enable auto-renewals via the renewal settings menu to ensure service continuity."
+      "Check the subscription errors below for more information."
     );
   });
 
   it("is expiring shows legacy message", () => {
     const statuses = userSubscriptionStatusesFactory.build({
       is_expiring: true,
+      is_renewal_actionable: true,
     });
     const onDismiss = jest.fn();
     const wrapper = mount(
@@ -200,10 +200,31 @@ describe("ExpiryNotification", () => {
       "Click on Renew subscription to to ensure service continuity."
     );
   });
+  it("is expiring shows not legacy message if not actionable", () => {
+    const statuses = userSubscriptionStatusesFactory.build({
+      is_expiring: true,
+      is_renewal_actionable: false,
+    });
+    const onDismiss = jest.fn();
+    const wrapper = mount(
+      <ExpiryNotification
+        size={ExpiryNotificationSize.Large}
+        subscriptionType={UserSubscriptionType.Legacy}
+        statuses={statuses}
+        onDismiss={onDismiss}
+      />
+    );
+    expect(wrapper.find("[data-test='is_expiring-large']").exists()).toBe(true);
+    expect(wrapper.find(Notification).prop("title")).toBe(
+      "Your subscription is about to expire."
+    );
+    expect(wrapper.find(Notification).prop("children")).toBe("");
+  });
 
-  it("is in grace period shows default message", () => {
+  it("is in grace period shows legacy message", () => {
     const statuses = userSubscriptionStatusesFactory.build({
       is_in_grace_period: true,
+      is_renewal_actionable: true,
     });
     const onDismiss = jest.fn();
     const wrapper = mount(
@@ -221,13 +242,37 @@ describe("ExpiryNotification", () => {
       "Your subscription has expired."
     );
     expect(wrapper.find(Notification).prop("children")).toBe(
-      "Click on renew subscription or enable auto-renewals via the renewal settings menu to ensure service continuity."
+      "Click on Renew subscription to to ensure service continuity."
     );
   });
 
-  it("is expired shows default message", () => {
+  it("is in grace period shows no message if legacy unactionable", () => {
+    const statuses = userSubscriptionStatusesFactory.build({
+      is_in_grace_period: true,
+      is_renewal_actionable: false,
+    });
+    const onDismiss = jest.fn();
+    const wrapper = mount(
+      <ExpiryNotification
+        size={ExpiryNotificationSize.Large}
+        subscriptionType={UserSubscriptionType.Legacy}
+        statuses={statuses}
+        onDismiss={onDismiss}
+      />
+    );
+    expect(
+      wrapper.find("[data-test='is_in_grace_period-large']").exists()
+    ).toBe(true);
+    expect(wrapper.find(Notification).prop("title")).toBe(
+      "Your subscription has expired."
+    );
+    expect(wrapper.find(Notification).prop("children")).toBe("");
+  });
+
+  it("is expired shows legacy message if actionable", () => {
     const statuses = userSubscriptionStatusesFactory.build({
       is_expired: true,
+      is_renewal_actionable: true,
     });
     const onDismiss = jest.fn();
     const wrapper = mount(
@@ -243,7 +288,96 @@ describe("ExpiryNotification", () => {
       "Your subscription has expired."
     );
     expect(wrapper.find(Notification).prop("children")).toBe(
-      "Click on renew subscription or enable auto-renewals via the renewal settings menu to ensure service continuity."
+      "Click on Renew subscription to to ensure service continuity."
+    );
+  });
+
+  it("is expired shows not legacy message if not actionable", () => {
+    const statuses = userSubscriptionStatusesFactory.build({
+      is_expired: true,
+      is_renewal_actionable: false,
+    });
+    const onDismiss = jest.fn();
+    const wrapper = mount(
+      <ExpiryNotification
+        size={ExpiryNotificationSize.Large}
+        subscriptionType={UserSubscriptionType.Legacy}
+        statuses={statuses}
+        onDismiss={onDismiss}
+      />
+    );
+    expect(wrapper.find("[data-test='is_expired-large']").exists()).toBe(true);
+    expect(wrapper.find(Notification).prop("title")).toBe(
+      "Your subscription has expired."
+    );
+    expect(wrapper.find(Notification).prop("children")).toBe("");
+  });
+
+  it("is expiring shows trial message", () => {
+    const statuses = userSubscriptionStatusesFactory.build({
+      is_expiring: true,
+    });
+    const onDismiss = jest.fn();
+    const wrapper = mount(
+      <ExpiryNotification
+        size={ExpiryNotificationSize.Large}
+        subscriptionType={UserSubscriptionType.Trial}
+        statuses={statuses}
+        onDismiss={onDismiss}
+      />
+    );
+    expect(wrapper.find("[data-test='is_expiring-large']").exists()).toBe(true);
+    expect(wrapper.find(Notification).prop("title")).toBe(
+      "Your subscription is about to expire."
+    );
+    expect(wrapper.find(Notification).prop("children")).toBe(
+      "Your trial will end soon."
+    );
+  });
+
+  it("is in grace period shows trial message", () => {
+    const statuses = userSubscriptionStatusesFactory.build({
+      is_in_grace_period: true,
+    });
+    const onDismiss = jest.fn();
+    const wrapper = mount(
+      <ExpiryNotification
+        size={ExpiryNotificationSize.Large}
+        subscriptionType={UserSubscriptionType.Trial}
+        statuses={statuses}
+        onDismiss={onDismiss}
+      />
+    );
+    expect(
+      wrapper.find("[data-test='is_in_grace_period-large']").exists()
+    ).toBe(true);
+    expect(wrapper.find(Notification).prop("title")).toBe(
+      "Your subscription has expired."
+    );
+    expect(wrapper.find(Notification).prop("children")).toBe(
+      "Your trial has ended."
+    );
+  });
+
+  it("is expired period shows trial message", () => {
+    const statuses = userSubscriptionStatusesFactory.build({
+      is_expired: true,
+    });
+    const onDismiss = jest.fn();
+    const wrapper = mount(
+      <ExpiryNotification
+        size={ExpiryNotificationSize.Large}
+        subscriptionType={UserSubscriptionType.Trial}
+        statuses={statuses}
+        onDismiss={onDismiss}
+      />
+    );
+    expect(wrapper.find("[data-test='is_expired-large']").exists()).toBe(true);
+    expect(wrapper.find(Notification).prop("title")).toBe(
+      "Your subscription has expired."
+    );
+    expect(wrapper.find(Notification).prop("children")).toBe(
+      "Your trial has ended."
     );
   });
 });

--- a/static/js/src/advantage/react/components/Subscriptions/ExpiryNotification/ExpiryNotification.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/ExpiryNotification/ExpiryNotification.test.tsx
@@ -357,7 +357,8 @@ describe("ExpiryNotification", () => {
       "Your subscription has expired."
     );
     expect(wrapper.find(Notification).prop("children")).toBe(
-      "Your trial has ended."
+      "Your trial has expired. " +
+        "This subscription will disappear from your dashboard soon."
     );
   });
 
@@ -379,7 +380,8 @@ describe("ExpiryNotification", () => {
       "Your subscription has expired."
     );
     expect(wrapper.find(Notification).prop("children")).toBe(
-      "Your trial has ended."
+      "Your trial has expired. " +
+        "This subscription will disappear from your dashboard soon."
     );
   });
 });

--- a/static/js/src/advantage/react/components/Subscriptions/ExpiryNotification/ExpiryNotification.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/ExpiryNotification/ExpiryNotification.tsx
@@ -62,7 +62,10 @@ const MESSAGES: Messages = {
           "Enable auto-renewals via the renewal settings menu to ensure service continuity.",
         [UserSubscriptionType.Yearly]:
           "Enable auto-renewals via the renewal settings menu to ensure service continuity.",
-        [UserSubscriptionType.Trial]: "Your trial will end soon.",
+        [UserSubscriptionType.Trial]:
+          "You have cancelled your Ubuntu Pro trial. " +
+          "At the end of the trial period, this subscription " +
+          "will disappear and you will no longer have access to Pro services.",
       },
       title: "Your subscription is about to expire.",
     },
@@ -94,7 +97,9 @@ const MESSAGES: Messages = {
             will remain the same.
           </>
         ),
-        [UserSubscriptionType.Trial]: "Your trial has ended.",
+        [UserSubscriptionType.Trial]:
+          "Your trial has expired. " +
+          "This subscription will disappear from your dashboard soon.",
       },
       title: "Your subscription has expired.",
     },
@@ -126,7 +131,10 @@ const MESSAGES: Messages = {
             will remain the same.
           </>
         ),
-        [UserSubscriptionType.Trial]: "Your trial has ended.",
+        [UserSubscriptionType.Trial]:
+          "You have cancelled your Ubuntu Pro trial. " +
+          "At the end of the trial period, this subscription " +
+          "will disappear and you will no longer have access to Pro services.",
       },
       title: "Your subscription has expired.",
     },

--- a/static/js/src/advantage/react/components/Subscriptions/ExpiryNotification/ExpiryNotification.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/ExpiryNotification/ExpiryNotification.tsx
@@ -132,9 +132,8 @@ const MESSAGES: Messages = {
           </>
         ),
         [UserSubscriptionType.Trial]:
-          "You have cancelled your Ubuntu Pro trial. " +
-          "At the end of the trial period, this subscription " +
-          "will disappear and you will no longer have access to Pro services.",
+          "Your trial has expired. " +
+          "This subscription will disappear from your dashboard soon.",
       },
       title: "Your subscription has expired.",
     },

--- a/static/js/src/advantage/react/components/Subscriptions/ExpiryNotification/ExpiryNotification.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/ExpiryNotification/ExpiryNotification.tsx
@@ -1,13 +1,12 @@
+import React, { ReactNode } from "react";
+import type { NotificationProps } from "@canonical/react-components";
 import {
   Notification,
   NotificationSeverity,
   PropsWithSpread,
 } from "@canonical/react-components";
-import type { NotificationProps } from "@canonical/react-components";
-import React, { ReactNode } from "react";
-
-import { UserSubscriptionStatuses } from "advantage/api/types";
 import { UserSubscriptionType } from "advantage/api/enum";
+import { UserSubscriptionStatuses } from "advantage/api/types";
 
 export enum ExpiryNotificationSize {
   Small = "small",
@@ -56,14 +55,14 @@ const MESSAGES: Messages = {
   [StatusKey.IsExpiring]: {
     [ExpiryNotificationSize.Large]: {
       message: {
-        default:
-          "Click on renew subscription or enable auto-renewals via the renewal settings menu to ensure service continuity.",
+        default: "Check the subscription errors below for more information.",
         [UserSubscriptionType.Legacy]:
           "Click on Renew subscription to to ensure service continuity.",
         [UserSubscriptionType.Monthly]:
           "Enable auto-renewals via the renewal settings menu to ensure service continuity.",
         [UserSubscriptionType.Yearly]:
           "Enable auto-renewals via the renewal settings menu to ensure service continuity.",
+        [UserSubscriptionType.Trial]: "Your trial will end soon.",
       },
       title: "Your subscription is about to expire.",
     },
@@ -76,8 +75,9 @@ const MESSAGES: Messages = {
   [StatusKey.IsExpired]: {
     [ExpiryNotificationSize.Large]: {
       message: {
-        default:
-          "Click on renew subscription or enable auto-renewals via the renewal settings menu to ensure service continuity.",
+        default: "Check the subscription errors below for more information.",
+        [UserSubscriptionType.Legacy]:
+          "Click on Renew subscription to to ensure service continuity.",
         [UserSubscriptionType.Monthly]: (
           <>
             If you don&apos;t renew it, it will disappear from your dashboard in
@@ -94,6 +94,7 @@ const MESSAGES: Messages = {
             will remain the same.
           </>
         ),
+        [UserSubscriptionType.Trial]: "Your trial has ended.",
       },
       title: "Your subscription has expired.",
     },
@@ -106,8 +107,9 @@ const MESSAGES: Messages = {
   [StatusKey.IsInGracePeriod]: {
     [ExpiryNotificationSize.Large]: {
       message: {
-        default:
-          "Click on renew subscription or enable auto-renewals via the renewal settings menu to ensure service continuity.",
+        default: "Check the subscription errors below for more information.",
+        [UserSubscriptionType.Legacy]:
+          "Click on Renew subscription to to ensure service continuity.",
         [UserSubscriptionType.Monthly]: (
           <>
             If you don&apos;t renew it, it will disappear from your dashboard in
@@ -124,6 +126,7 @@ const MESSAGES: Messages = {
             will remain the same.
           </>
         ),
+        [UserSubscriptionType.Trial]: "Your trial has ended.",
       },
       title: "Your subscription has expired.",
     },
@@ -153,13 +156,25 @@ const ExpiryNotification = ({
     // status.
     statusesToShow = [highestStatus];
   }
+
   const notifications = statusesToShow.map((statusKey) => {
     const notification = MESSAGES[statusKey][size];
+    let children = notification?.message["default"];
+
+    if (subscriptionType && notification?.message[subscriptionType]) {
+      children = notification?.message[subscriptionType];
+    }
+
+    if (
+      subscriptionType &&
+      subscriptionType == "legacy" &&
+      !statuses["is_renewal_actionable"]
+    ) {
+      children = "";
+    }
+
     return {
-      children:
-        subscriptionType && notification?.message[subscriptionType]
-          ? notification?.message[subscriptionType]
-          : notification?.message["default"],
+      children: children,
       key: `${statusKey}-${size}`,
       // Display a title for large notifications.
       title: size === ExpiryNotificationSize.Large ? notification?.title : null,

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.test.tsx
@@ -512,7 +512,29 @@ describe("SubscriptionDetails", () => {
     const contract = userSubscriptionFactory.build({
       type: UserSubscriptionType.Trial,
       statuses: userSubscriptionStatusesFactory.build({
-        is_trialled: false,
+        is_cancelled: false,
+      }),
+    });
+
+    queryClient.setQueryData("userSubscriptions", [contract]);
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <SubscriptionDetails
+          onCloseModal={jest.fn()}
+          selectedId={contract.id}
+          setHasUnsavedChanges={jest.fn()}
+        />
+      </QueryClientProvider>
+    );
+
+    expect(wrapper.find(".p-chip__value").text()).toBe("Auto-renewal on");
+  });
+
+  it("it does display the auto-renewal label for trial shop purchases", () => {
+    const contract = userSubscriptionFactory.build({
+      type: UserSubscriptionType.Trial,
+      statuses: userSubscriptionStatusesFactory.build({
+        is_renewed: true,
       }),
     });
 

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.test.tsx
@@ -512,7 +512,8 @@ describe("SubscriptionDetails", () => {
     const contract = userSubscriptionFactory.build({
       type: UserSubscriptionType.Trial,
       statuses: userSubscriptionStatusesFactory.build({
-        is_cancelled: false,
+        is_cancelled: true,
+        is_renewed: false,
       }),
     });
 
@@ -527,7 +528,7 @@ describe("SubscriptionDetails", () => {
       </QueryClientProvider>
     );
 
-    expect(wrapper.find(".p-chip__value").text()).toBe("Auto-renewal on");
+    expect(wrapper.find(".p-chip__value").text()).toBe("Cancelled");
   });
 
   it("it does display the auto-renewal label for trial shop purchases", () => {
@@ -549,7 +550,7 @@ describe("SubscriptionDetails", () => {
       </QueryClientProvider>
     );
 
-    expect(wrapper.find(".p-chip__value").text()).toBe("Cancelled");
+    expect(wrapper.find(".p-chip__value").text()).toBe("Auto-renewal on");
   });
 
   it("it does not display label for unactionable subs", () => {

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
@@ -21,7 +21,9 @@ import {
 import { sendAnalyticsEvent } from "advantage/react/utils/sendAnalyticsEvent";
 import { SelectedId } from "../Content/types";
 import ExpiryNotification from "../ExpiryNotification";
-import { ExpiryNotificationSize } from "../ExpiryNotification/ExpiryNotification";
+import {
+  ExpiryNotificationSize,
+} from "../ExpiryNotification/ExpiryNotification";
 import RenewalButton from "../RenewalButton";
 import SubscriptionCancel from "../SubscriptionCancel";
 import SubscriptionEdit from "../SubscriptionEdit";
@@ -178,9 +180,14 @@ export const SubscriptionDetails = forwardRef<HTMLDivElement, Props>(
                   ) : null}
                   {subscription.type == "trial" ? (
                     <>
-                      {!subscription.statuses.is_trialled ? (
+                      {subscription.statuses.is_cancelled ? (
                         <button className="p-chip--negative">
                           <span className="p-chip__value">Cancelled</span>
+                        </button>
+                      ) : null}
+                      {subscription.statuses.is_renewed ? (
+                        <button className="p-chip--positive">
+                          <span className="p-chip__value">Auto-renewal on</span>
                         </button>
                       ) : null}
                     </>

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
@@ -21,9 +21,7 @@ import {
 import { sendAnalyticsEvent } from "advantage/react/utils/sendAnalyticsEvent";
 import { SelectedId } from "../Content/types";
 import ExpiryNotification from "../ExpiryNotification";
-import {
-  ExpiryNotificationSize,
-} from "../ExpiryNotification/ExpiryNotification";
+import { ExpiryNotificationSize } from "../ExpiryNotification/ExpiryNotification";
 import RenewalButton from "../RenewalButton";
 import SubscriptionCancel from "../SubscriptionCancel";
 import SubscriptionEdit from "../SubscriptionEdit";

--- a/tests/shop/advantage/test_helpers.py
+++ b/tests/shop/advantage/test_helpers.py
@@ -3,36 +3,36 @@ import unittest
 from freezegun import freeze_time
 
 from tests.shop.advantage.helpers import (
-    make_subscription,
-    make_listing,
+    make_account,
     make_contract_item,
     make_free_trial_contract,
-    make_shop_contract,
-    make_subscription_item,
     make_legacy_contract_item,
+    make_listing,
     make_renewal,
-    make_account,
+    make_shop_contract,
+    make_subscription,
+    make_subscription_item,
 )
-from webapp.shop.api.ua_contracts.models import Entitlement
 from webapp.shop.api.ua_contracts.helpers import (
+    apply_entitlement_rules,
+    extract_last_purchase_ids,
     get_current_number_of_machines,
+    get_date_statuses,
     get_items_aggregated_values,
     get_machine_type,
-    is_trialling_user_subscription,
     get_pending_purchases,
-    has_pending_purchases,
-    is_user_subscription_cancelled,
-    get_date_statuses,
-    get_user_subscription_statuses,
-    extract_last_purchase_ids,
     get_price_info,
-    set_listings_trial_status,
-    apply_entitlement_rules,
-    to_dict,
+    get_user_subscription_statuses,
     group_shop_items,
+    has_pending_purchases,
     is_billing_subscription_active,
     is_billing_subscription_auto_renewing,
+    is_trialling_user_subscription,
+    is_user_subscription_cancelled,
+    set_listings_trial_status,
+    to_dict,
 )
+from webapp.shop.api.ua_contracts.models import Entitlement
 
 
 class TestHelpers(unittest.TestCase):
@@ -842,9 +842,11 @@ class TestHelpers(unittest.TestCase):
                             started_with_trial=True,
                             in_trial=True,
                             status="active",
+                            id="abc",
                         )
                     ],
                     "machine": 1,
+                    "subscription_id": "abc",
                 },
                 "expectations": {
                     "is_upsizeable": False,
@@ -858,7 +860,7 @@ class TestHelpers(unittest.TestCase):
                     "is_renewable": False,
                     "is_renewal_actionable": False,
                     "has_pending_purchases": False,
-                    "is_subscription_active": False,
+                    "is_subscription_active": True,
                     "is_subscription_auto_renewing": False,
                     "should_present_auto_renewal": False,
                     "has_access_to_support": True,

--- a/webapp/shop/api/ua_contracts/builders.py
+++ b/webapp/shop/api/ua_contracts/builders.py
@@ -97,6 +97,7 @@ def build_trial_item_groups(
                             "listing": listing,
                             "marketplace": listing.marketplace,
                             "subscriptions": user_details.get("subscriptions"),
+                            "subscription_id": item.subscription_id,
                             "type": "trial",
                         }
                     )

--- a/webapp/shop/api/ua_contracts/helpers.py
+++ b/webapp/shop/api/ua_contracts/helpers.py
@@ -253,6 +253,16 @@ def get_user_subscription_statuses(
 
         statuses["is_trialled"] = True if active_trial else False
 
+        statuses[
+            "is_subscription_auto_renewing"
+        ] = is_billing_subscription_auto_renewing(
+            subscriptions, subscription_id
+        )
+
+        # If the subscription is set to auto-renew don't expire
+        if statuses["is_subscription_auto_renewing"]:
+            statuses["is_expiring"] = False
+
     if type in ["yearly", "monthly"]:
         statuses["is_subscription_active"] = is_billing_subscription_active(
             subscriptions, subscription_id
@@ -280,8 +290,7 @@ def get_user_subscription_statuses(
             and not is_cancelled
         )
 
-        # If the subscription is set to auto-renew, we shouldn't alarm the
-        # user.
+        # If the subscription is set to auto-renew don't expire
         if statuses["is_subscription_auto_renewing"]:
             statuses["is_expiring"] = False
 

--- a/webapp/shop/api/ua_contracts/helpers.py
+++ b/webapp/shop/api/ua_contracts/helpers.py
@@ -262,6 +262,16 @@ def get_user_subscription_statuses(
         # If the subscription is set to auto-renew don't expire
         if statuses["is_subscription_auto_renewing"]:
             statuses["is_expiring"] = False
+        statuses["is_subscription_active"] = is_billing_subscription_active(
+            subscriptions, subscription_id
+        )
+
+        statuses["is_cancelled"] = not statuses["is_subscription_active"]
+
+        statuses["is_renewed"] = (
+            is_subscription_auto_renewing(subscriptions, subscription_id)
+            and not statuses["is_cancelled"]
+        )
 
     if type in ["yearly", "monthly"]:
         statuses["is_subscription_active"] = is_billing_subscription_active(


### PR DESCRIPTION
## Done

- Fix bug where trial would show that it's expiring even if auto-renewal is turned on for the subscription.
- Update renewal warnings.

## QA

- Get branch locally
- Buy a trial
- Edit: file `webapp/shop/api/ua_contracts/helpers.py` line 335
From: `"is_expiring": is_expiring,` to `"is_expiring": True,` so time wise the subscription should be expiring, but the auto-renewal logic overrides the `is_expiring` status to `False`, because subscription is set to auto renew.
- Expiration warning will not show up

## Issue / Card

Fixes #https://warthogs.atlassian.net/browse/WD-2659

## Screenshots

Trial is expiring warnings now:
![image](https://github.com/canonical/ubuntu.com/assets/6387619/3571de3f-6613-4a8a-aee3-aedb1ae0fcf3)
Trial is expired warnings now:
![image](https://github.com/canonical/ubuntu.com/assets/6387619/37086c01-013a-4d50-818a-2fd47e625ad5)

Trial is expiring warnings before:
![image](https://github.com/canonical/ubuntu.com/assets/6387619/5254291b-0806-47ca-9567-93d62c88134d)

Note: The top notification error message has been updated to point the user to check individual subscription to know how to fix the renewal warnings (if possible). 