### PR TITLE
[WIP] WD-4072 Automate Badge Issuing using Credly

### DIFF
--- a/.env
+++ b/.env
@@ -7,7 +7,7 @@ STRIPE_PUBLISHABLE_KEY=pk_test_yndN9H0GcJffPe0W58Nm64cM00riYG4N46
 STORE_MAINTENANCE=false
 BADGR_URL=https://api.test.badgr.com
 TRUEABILITY_URL="https://app.trueability.com"
-CREDLY_SANDBOX_URL="https://sandbox-api.credly.com/v1"
+CREDLY_URL="https://sandbox-api.credly.com/v1"
 
 BADGR_ISSUER="36ZEJnXdTjqobw93BJElog"
 CERTIFIED_BADGE="x9kzmcNhSSyqYhZcQGz0qg"

--- a/.env
+++ b/.env
@@ -7,7 +7,7 @@ STRIPE_PUBLISHABLE_KEY=pk_test_yndN9H0GcJffPe0W58Nm64cM00riYG4N46
 STORE_MAINTENANCE=false
 BADGR_URL=https://api.test.badgr.com
 TRUEABILITY_URL="https://app.trueability.com"
-# TRUEABILITY_API_KEY="YourAPIKey"
+CREDLY_SANDBOX_URL="https://sandbox-api.credly.com/v1"
 
 BADGR_ISSUER="36ZEJnXdTjqobw93BJElog"
 CERTIFIED_BADGE="x9kzmcNhSSyqYhZcQGz0qg"

--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -103,6 +103,9 @@ env:
       key: api-key
       name: trueability
 
+  - name: CANONICAL_LOGIN_URL
+    value: https://login.ubuntu.com/
+
 memoryLimit: 512Mi
 
 extraHosts:
@@ -519,6 +522,24 @@ staging:
         key: api-key
         name: trueability
 
+    - name: TA_WEBHOOK_API_KEY
+      secretKeyRef:
+        key: webhook-secret
+        name: trueability
+
+    - name: CREDLY_URL
+      value: https://sandbox-api.credly.com/v1
+
+    - name: CREDLY_TOKEN
+      secretKeyRef:
+        key: token
+        name: credly
+
+    - name: CREDLY_ORGANIZATION_ID
+      secretKeyRef:
+        key: organization
+        name: credly
+
     - name: CANONICAL_LOGIN_URL
       value: https://login.ubuntu.com/
 
@@ -595,6 +616,24 @@ staging:
           secretKeyRef:
             key: api-key
             name: trueability
+
+        - name: TA_WEBHOOK_API_KEY
+          secretKeyRef:
+            key: webhook-secret
+            name: trueability
+
+        - name: CREDLY_URL
+          value: https://sandbox-api.credly.com/v1
+
+        - name: CREDLY_TOKEN
+          secretKeyRef:
+            key: token
+            name: credly
+
+        - name: CREDLY_ORGANIZATION_ID
+          secretKeyRef:
+            key: organization
+            name: credly
 
     - paths: [/tutorials]
       name: ubuntu-com-tutorials

--- a/static/js/src/advantage/credentials/api/trueability.js
+++ b/static/js/src/advantage/credentials/api/trueability.js
@@ -1,0 +1,7 @@
+export async function getFilteredWebhookResponses(abilityScreenId, page) {
+  let response = await fetch(`/credentials/get_filtered_webhook_responses?ability_screen_id=${abilityScreenId}&page=${page}`, {
+    method: "GET",
+  });
+  const data = await response.json();
+  return data;
+}

--- a/static/js/src/advantage/credentials/api/trueability.js
+++ b/static/js/src/advantage/credentials/api/trueability.js
@@ -1,7 +1,10 @@
 export async function getFilteredWebhookResponses(abilityScreenId, page) {
-  let response = await fetch(`/credentials/get_filtered_webhook_responses?ability_screen_id=${abilityScreenId}&page=${page}`, {
-    method: "GET",
-  });
+  let response = await fetch(
+    `/credentials/get_filtered_webhook_responses?ability_screen_id=${abilityScreenId}&page=${page}`,
+    {
+      method: "GET",
+    }
+  );
   const data = await response.json();
   return data;
 }

--- a/static/js/src/advantage/credentials/app.tsx
+++ b/static/js/src/advantage/credentials/app.tsx
@@ -7,6 +7,7 @@ import { ReactQueryDevtools } from "react-query/devtools";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import CredManage from "./components/CredManage";
 import CredShop from "./components/CredShop";
+import CredWebhookResponses from "./components/CredWebhookResponses";
 
 const oneHour = 1000 * 60 * 60;
 const queryClient = new QueryClient({
@@ -39,6 +40,10 @@ function App() {
           <Routes>
             <Route path="/" element={<CredShop />} />
             <Route path="/manage" element={<CredManage />} />
+            <Route
+              path="/webhook_responses"
+              element={<CredWebhookResponses />}
+            />
           </Routes>
         </Router>
         <ReactQueryDevtools initialIsOpen={false} />

--- a/static/js/src/advantage/credentials/components/CredWebhookResponses/CredWebhookResponses.tsx
+++ b/static/js/src/advantage/credentials/components/CredWebhookResponses/CredWebhookResponses.tsx
@@ -1,0 +1,113 @@
+import { MainTable } from "@canonical/react-components";
+import { getFilteredWebhookResponses } from "advantage/credentials/api/trueability";
+import React, { useEffect, useState } from "react";
+import { useQuery } from "react-query";
+import { useSearchParams } from "react-router-dom";
+
+type Webhook = {
+  ability_screen_id: string;
+  on_transition_to: string;
+};
+type WebhookResponse = {
+  id: string;
+  created_at: Date;
+  sent_at: Date;
+  webhook: Webhook;
+  response_status: string;
+};
+
+const CredWebhookResponses = () => {
+  const [searchParams] = useSearchParams();
+  const page = parseInt(searchParams.get("page") || "1");
+  console.log(page);
+  const { data } = useQuery(["WebhookResponses"], async () => {
+    return getFilteredWebhookResponses("4190", page);
+  });
+  const [tableData, changeTableData] = useState<WebhookResponse[]>(data);
+
+  useEffect(() => {
+    if (data && data["webhook_responses"]) {
+      changeTableData(data["webhook_responses"]);
+    }
+    console.log(data);
+  }, [data]);
+
+  return (
+    <section className="u-fixed-width">
+      <MainTable
+        headers={[
+          { content: "Created At", sortKey: "created_at" },
+          { content: "Id", sortKey: "id" },
+          { content: "Sent At", sortKey: "sent_at" },
+          { content: "Ability Screen Id", sortKey: "ability_screen_id" },
+          { content: "Response Status", sortKey: "response_status" },
+          { content: "Transition", sortKey: "on_transition_to" },
+        ]}
+        rows={
+          tableData &&
+          tableData.map((keyitem: WebhookResponse) => {
+            return {
+              columns: [
+                {
+                  content: keyitem.created_at.toString(),
+                },
+                {
+                  content: keyitem.id,
+                },
+                {
+                  content: keyitem.sent_at.toString(),
+                },
+                {
+                  content: keyitem.webhook.ability_screen_id,
+                },
+                {
+                  content: keyitem.response_status,
+                },
+                {
+                  content: keyitem.webhook.on_transition_to,
+                },
+              ],
+            };
+          })
+        }
+        sortable
+        responsive
+      />
+      {data && (
+        <nav className="p-pagination" aria-label="Pagination">
+          <ol className="p-pagination__items">
+            <li className="p-pagination__item">
+              <a
+                className="p-pagination__link--previous"
+                href={
+                  data["meta"]["prev_page"]
+                    ? `/credentials/shop/webhook_responses?page=${data["meta"]["prev_page"]}`
+                    : "#"
+                }
+                title="Previous page"
+              >
+                <i className="p-icon--chevron-down"></i>
+                <span>Previous page</span>
+              </a>
+            </li>
+            <li className="p-pagination__item">
+              <a
+                className="p-pagination__link--next"
+                href={
+                  data["meta"]["next_page"]
+                    ? `/credentials/shop/webhook_responses?page=${data["meta"]["next_page"]}`
+                    : "#"
+                }
+                title="Next page"
+              >
+                <span>Next page</span>
+                <i className="p-icon--chevron-down"></i>
+              </a>
+            </li>
+          </ol>
+        </nav>
+      )}
+    </section>
+  );
+};
+export default CredWebhookResponses;

--- a/static/js/src/advantage/credentials/components/CredWebhookResponses/index.tsx
+++ b/static/js/src/advantage/credentials/components/CredWebhookResponses/index.tsx
@@ -1,0 +1,1 @@
+export { default } from "./CredWebhookResponses";

--- a/templates/credentials/your-badges.html
+++ b/templates/credentials/your-badges.html
@@ -39,12 +39,12 @@ meta_copydoc %}
                 width="100"/>
             </a>
           </td>
-          <td>{{ badge[""] }}</td>
+          <td>{{ badge["badge_template"]["name"] }}</td>
           <td>{{ badge["issued_at_date"] }}</td>
           {% if badge["state"]=="pending" %}
-          <td><a href="{{ badge['accept_badge_url'] }}"><button class="p-button--positive">Accept Badge</button></a></td>
+          <td><a href="{{ badge['accept_badge_url'] }}" target="_blank"><button class="p-button--positive">Accept Badge</button></a></td>
           {% else %}
-          <td><a href="{{ badge['badge_template']['url'] }}"><button class="p-button--positive">View Badge</button></a></td>
+          <td><a href="{{ badge['badge_template']['url'] }}" target="_blank"><button class="p-button--positive">View Badge</button></a></td>
           {% endif %}
         </tr>
         {% endfor %}

--- a/templates/credentials/your-badges.html
+++ b/templates/credentials/your-badges.html
@@ -21,8 +21,8 @@ meta_copydoc %}
       <thead>
         <tr>
           <th>Badge</th>
+          <th>Exam</th>
           <th>Date of Issue</th>
-          <th>Status</th>
           <th>Actions</th>
         </tr>
       </thead>
@@ -39,10 +39,12 @@ meta_copydoc %}
                 width="100"/>
             </a>
           </td>
+          <td>{{ badge[""] }}</td>
           <td>{{ badge["issued_at_date"] }}</td>
-          <td>{{ badge["state"] }}</td>
           {% if badge["state"]=="pending" %}
           <td><a href="{{ badge['accept_badge_url'] }}"><button class="p-button--positive">Accept Badge</button></a></td>
+          {% else %}
+          <td><a href="{{ badge['badge_template']['url'] }}"><button class="p-button--positive">View Badge</button></a></td>
           {% endif %}
         </tr>
         {% endfor %}

--- a/templates/credentials/your-badges.html
+++ b/templates/credentials/your-badges.html
@@ -1,0 +1,54 @@
+{% extends "credentials/base_cred.html" %}
+
+{% block title %}Canonical Credentials -- Your Badges{% endblock %}
+
+{% block meta_description %}The Canonical Ubuntu Essentials exams certify knowledge and verify skills in general Linux,
+Ubuntu Desktop, and Ubuntu Server topics.{% endblock meta_description %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1QuhO-9FEOGLrYp8bErS_9snqdljl7d6tFAUoNQxoVDQ/edit{% endblock
+meta_copydoc %}
+
+{% block content %}
+
+<section class="p-strip">
+  <div class="row">
+    <div class="col-12">
+      <h1>Your badges</h1>
+      <p>The table below shows the badges you have earned.</p>
+    </div>
+  </div>
+  <div class="row">
+    <table aria-label="Badges earned">
+      <thead>
+        <tr>
+          <th>Badge</th>
+          <th>Date of Issue</th>
+          <th>Status</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+
+        {% for badge in badges %}
+        <tr>
+          <td>
+            <a href="{{ badge['badge_template']['url'] }}" target="_blank">
+              <img
+                src="{{ badge['image_url'] }}"
+                alt="{{ badge['image']['id'] }}"
+                height="100"
+                width="100"/>
+            </a>
+          </td>
+          <td>{{ badge["issued_at_date"] }}</td>
+          <td>{{ badge["state"] }}</td>
+          {% if badge["state"]=="pending" %}
+          <td><a href="{{ badge['accept_badge_url'] }}"><button class="p-button--positive">Accept Badge</button></a></td>
+          {% endif %}
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</section>
+
+{% endblock content %}

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -91,6 +91,9 @@ from webapp.shop.cred.views import (
     cred_your_exams,
     cred_beta_activation,
     get_activation_keys,
+    get_filtered_webhook_responses,
+    get_webhook_response,
+    issue_badges,
     rotate_activation_key,
 )
 from webapp.shop.views import (
@@ -906,6 +909,22 @@ app.add_url_rule(
     view_func=cred_beta_activation,
     methods=["GET", "POST"],
 )
+app.add_url_rule(
+    "/credentials/get_filtered_webhook_responses",
+    view_func=get_filtered_webhook_responses,
+    methods=["GET"],
+)
+app.add_url_rule(
+    "/credentials/get_webhook_response",
+    view_func=get_webhook_response,
+    methods=["GET"],
+)
+app.add_url_rule(
+    "/credentials/assessment_passed",
+    view_func=issue_badges,
+    methods=["POST"],
+)
+
 
 # Charmed OpenStack docs
 openstack_docs = Docs(

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -93,6 +93,7 @@ from webapp.shop.cred.views import (
     get_activation_keys,
     get_filtered_webhook_responses,
     get_issued_badges,
+    get_my_issued_badges,
     get_webhook_response,
     issue_badges,
     rotate_activation_key,
@@ -929,6 +930,12 @@ app.add_url_rule(
 app.add_url_rule(
     "/credentials/get_issued_badges",
     view_func=get_issued_badges,
+    methods=["GET"],
+)
+
+app.add_url_rule(
+    "/credentials/your-badges",
+    view_func=get_my_issued_badges,
     methods=["GET"],
 )
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -92,6 +92,7 @@ from webapp.shop.cred.views import (
     cred_beta_activation,
     get_activation_keys,
     get_filtered_webhook_responses,
+    get_issued_badges,
     get_webhook_response,
     issue_badges,
     rotate_activation_key,
@@ -925,6 +926,11 @@ app.add_url_rule(
     methods=["POST"],
 )
 
+app.add_url_rule(
+    "/credentials/get_issued_badges",
+    view_func=get_issued_badges,
+    methods=["GET"],
+)
 
 # Charmed OpenStack docs
 openstack_docs = Docs(

--- a/webapp/shop/api/credly/api.py
+++ b/webapp/shop/api/credly/api.py
@@ -1,6 +1,6 @@
 from requests.auth import HTTPBasicAuth
 from requests import Session
-import datetime
+from datetime import datetime, timezone
 
 
 class CredlyAPI:
@@ -33,7 +33,8 @@ class CredlyAPI:
     ):
         uri = f"{self.base_url}{path}"
         headers["Content-type"] = "application/json"
-        auth = HTTPBasicAuth("user", "pass")
+        auth = HTTPBasicAuth(self.auth_token, "")
+        print(self.auth_token)
 
         response = self.session.request(
             method,
@@ -71,8 +72,8 @@ class CredlyAPI:
         uri = f"/organizations/{self.org_id}/badges"
         body = {
             "recipient_email": email,
-            "issued_at": datetime.datetime.now().strftime(
-                "%Y-%m-% d %H:%M:%S %z"
+            "issued_at": datetime.now(timezone.utc).strftime(
+                "%Y-%m-%d %H:%M:%S %z"
             ),
             "badge_template_id": self.badge_template_dict[ability_screen_id],
             "issued_to_first_name": first_name,

--- a/webapp/shop/api/credly/api.py
+++ b/webapp/shop/api/credly/api.py
@@ -53,7 +53,6 @@ class CredlyAPI:
                 data=data,
                 json=json,
                 retry=False,
-                auth=auth,
             )
 
         return response

--- a/webapp/shop/api/credly/api.py
+++ b/webapp/shop/api/credly/api.py
@@ -1,0 +1,82 @@
+from requests.auth import HTTPBasicAuth
+from requests import Session
+import datetime
+
+
+class CredlyAPI:
+    def __init__(
+        self,
+        base_url: str,
+        org_id: str,
+        auth_token: str,
+        session: Session,
+    ):
+        self.base_url = base_url
+        self.org_id = org_id
+        self.session = session
+        self.auth_token = auth_token
+        self.badge_template_dict = {
+            4190: "3d3a19a1-324c-48fa-aa55-60f66c0dcca6",
+            4194: "3d3a19a1-324c-48fa-aa55-60f66c0dcca6",
+            4223: "3d3a19a1-324c-48fa-aa55-60f66c0dcca6",
+        }
+
+    def make_request(
+        self,
+        method: str,
+        path: str,
+        headers: dict = {},
+        data: dict = {},
+        json: dict = {},
+        retry: bool = True,
+        allow_redirects: bool = True,
+    ):
+        uri = f"{self.base_url}{path}"
+        headers["Content-type"] = "application/json"
+        auth = HTTPBasicAuth("user", "pass")
+
+        response = self.session.request(
+            method,
+            uri,
+            headers=headers,
+            data=data,
+            json=json,
+            allow_redirects=allow_redirects,
+            auth=auth,
+        )
+
+        if retry and response.status_code == 401:
+            response = self.make_request(
+                method,
+                path,
+                headers=headers,
+                data=data,
+                json=json,
+                retry=False,
+                auth=auth,
+            )
+
+        return response
+
+    def get_issued_badges(self):
+        uri = f"/organizations/{self.org_id}/badges"
+        return self.make_request("GET", uri).json()
+
+    def issue_new_badge(
+        self,
+        email: str,
+        first_name: str,
+        last_name: str,
+        ability_screen_id: int,
+    ):
+        uri = f"/organizations/{self.org_id}/badges"
+        body = {
+            "recipient_email": email,
+            "issued_at": datetime.datetime.now().strftime(
+                "%Y-%m-% d %H:%M:%S %z"
+            ),
+            "badge_template_id": self.badge_template_dict[ability_screen_id],
+            "issued_to_first_name": first_name,
+            "issued_to_last_name": last_name,
+        }
+        return self.make_request("POST", uri, json=body).json()

--- a/webapp/shop/api/credly/api.py
+++ b/webapp/shop/api/credly/api.py
@@ -1,6 +1,7 @@
 from requests.auth import HTTPBasicAuth
 from requests import Session
 from datetime import datetime, timezone
+from urllib.parse import quote_plus
 
 
 class CredlyAPI:
@@ -58,8 +59,15 @@ class CredlyAPI:
 
         return response
 
-    def get_issued_badges(self):
-        uri = f"/organizations/{self.org_id}/badges"
+    def get_issued_badges(self, filter: dict = {}):
+        print(filter)
+        filter_params = ""
+        for k, v in filter.items():
+            filter_params += f"{k}::{quote_plus(v)}"
+        if filter:
+            uri = f"/organizations/{self.org_id}/badges?filter={filter_params}"
+        else:
+            uri = f"/organizations/{self.org_id}/badges"
         return self.make_request("GET", uri).json()
 
     def issue_new_badge(

--- a/webapp/shop/api/trueability/api.py
+++ b/webapp/shop/api/trueability/api.py
@@ -218,3 +218,22 @@ class TrueAbilityAPI:
     def get_system_status(self):
         uri = "/api/v1/system_status"
         return self.make_request("GET", uri).json()
+    
+    def get_webhook_response(self, webhook_id: int):
+        uri = f"/api/v1/webhook_responses/{webhook_id}"
+        return self.make_request("GET", uri).json()
+
+    def get_filtered_webhook_responses(
+        self, ability_screen_id: str = None, page: int = 1
+    ):
+        uri = (
+            f"{self.base_url}"
+            "/api/v1/webhook_responses"
+            f"?ability_screen_id={ability_screen_id}"
+            f"&page={page}"
+        )
+        headers = {"X-API_KEY": self.api_key}
+        response = self.session.request(
+            method="GET", url=uri, headers=headers
+        ).json()
+        return response

--- a/webapp/shop/api/trueability/api.py
+++ b/webapp/shop/api/trueability/api.py
@@ -218,7 +218,7 @@ class TrueAbilityAPI:
     def get_system_status(self):
         uri = "/api/v1/system_status"
         return self.make_request("GET", uri).json()
-    
+
     def get_webhook_response(self, webhook_id: int):
         uri = f"/api/v1/webhook_responses/{webhook_id}"
         return self.make_request("GET", uri).json()

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -724,7 +724,7 @@ def get_webhook_response(trueability_api, **kwargs):
     return flask.jsonify(webhook_responses)
 
 
-@shop_decorator(area="cred", permission="user", response=json)
+@shop_decorator(area="cred", permission="guest", response=json)
 def issue_badges(trueability_api, credly_api, **kwargs):
     req = flask.request.json
     webhook_response = req["webhook_response"]

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -746,7 +746,7 @@ def get_my_issued_badges(credly_api, **kwargs):
 def issue_badges(trueability_api, credly_api, **kwargs):
     webhook_response = flask.request.json
     api_key = flask.request.headers.get("X-API-KEY")
-    if not api_key or api_key != os.getenv(""):
+    if not api_key or api_key != os.getenv("TA_WEBHOOK_API_KEY"):
         return flask.jsonify({"status": "Invalid API Key"}), 401
     assessment_score = webhook_response["assessment"]["score"]
     print(assessment_score)

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -695,9 +695,12 @@ def get_filtered_webhook_responses(trueability_api, **kwargs):
         page=ta_page,
     )
     ta_webhook_responses = webhook_responses["webhook_responses"]
-    ta_webhook_responses = ta_webhook_responses[
-        page * per_page % ta_results_per_page
-        - per_page : page * per_page % ta_results_per_page
+    ta_webhook_responses = [
+        ta_webhook_responses[i]
+        for i in range(
+            page * per_page % ta_results_per_page - per_page,
+            page * per_page % ta_results_per_page,
+        )
     ]
     page_metadata = {}
     page_metadata["current_page"] = page

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -749,7 +749,6 @@ def issue_badges(trueability_api, credly_api, **kwargs):
     if not api_key or api_key != os.getenv("TA_WEBHOOK_API_KEY"):
         return flask.jsonify({"status": "Invalid API Key"}), 401
     assessment_score = webhook_response["assessment"]["score"]
-    print(assessment_score)
     if assessment_score >= 0.5:
         assessment_user = webhook_response["assessment"]["user"]["email"]
         first_name, last_name = webhook_response["assessment"]["user"][

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -726,16 +726,15 @@ def get_webhook_response(trueability_api, **kwargs):
 
 @shop_decorator(area="cred", permission="guest", response=json)
 def issue_badges(trueability_api, credly_api, **kwargs):
-    req = flask.request.json
-    webhook_response = req["webhook_response"]
-    assessment_id = webhook_response["associated_object_id"]
-    assessment = trueability_api.get_assessment(assessment_id)
-    assessment_score = assessment["assessment"]["score"]
-    if assessment_score >= 0.75:
-        assessment_user = assessment["assessment"]["user"]["email"]
-        first_name, last_name = get_user_first_last_name()
+    webhook_response = flask.request.json
+    assessment_score = webhook_response["assessment"]["score"]
+    print(assessment_score)
+    if assessment_score >= 0.5:
+        assessment_user = webhook_response["assessment"]["user"]["email"]
+        first_name, last_name = webhook_response["assessment"]["user"]["full_name"].rsplit(" ",1)
+        ability_screen_id = webhook_response["assessment"]["ability_screen_variant"]["ability_screen_id"]
         credly_api.issue_new_badge(
-            email=assessment_user, first_name=first_name, last_name=last_name
+            email=assessment_user, first_name=first_name, last_name=last_name, ability_screen_id=ability_screen_id
         )
         return flask.jsonify({"status": "badge_issued"}), 200
     return flask.jsonify({"status": "badge_not_issued"}), 200

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -724,11 +724,22 @@ def get_webhook_response(trueability_api, **kwargs):
     return flask.jsonify(webhook_responses)
 
 
-@canonical_staff
+@canonical_staff()
 @shop_decorator(area="cred", permission="user", response=json)
 def get_issued_badges(credly_api, **kwargs):
     badges = credly_api.get_issued_badges()
-    return flask.jsonify(badges)
+    return flask.jsonify(badges["data"])
+
+
+@shop_decorator(area="cred", permission="user", response=html)
+def get_my_issued_badges(credly_api, **kwargs):
+    sso_user_email = user_info(flask.session)["email"]
+    response = credly_api.get_issued_badges(
+        filter={"recipient_email": sso_user_email}
+    )
+    return flask.render_template(
+        "credentials/your-badges.html", badges=response["data"]
+    )
 
 
 @shop_decorator(area="cred", permission="guest", response=json)
@@ -762,4 +773,6 @@ def issue_badges(trueability_api, credly_api, **kwargs):
                 ),
                 200,
             )
+        else:
+            return (flask.jsonify(new_badge), 418)
     return flask.jsonify({"status": "badge_not_issued"}), 200

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -731,10 +731,28 @@ def issue_badges(trueability_api, credly_api, **kwargs):
     print(assessment_score)
     if assessment_score >= 0.5:
         assessment_user = webhook_response["assessment"]["user"]["email"]
-        first_name, last_name = webhook_response["assessment"]["user"]["full_name"].rsplit(" ",1)
-        ability_screen_id = webhook_response["assessment"]["ability_screen_variant"]["ability_screen_id"]
-        credly_api.issue_new_badge(
-            email=assessment_user, first_name=first_name, last_name=last_name, ability_screen_id=ability_screen_id
+        first_name, last_name = webhook_response["assessment"]["user"][
+            "full_name"
+        ].rsplit(" ", 1)
+        ability_screen_id = webhook_response["assessment"][
+            "ability_screen_variant"
+        ]["ability_screen_id"]
+        new_badge = credly_api.issue_new_badge(
+            email=assessment_user,
+            first_name=first_name,
+            last_name=last_name,
+            ability_screen_id=ability_screen_id,
         )
-        return flask.jsonify({"status": "badge_issued"}), 200
+        if "data" in new_badge and "accept_badge_url" in new_badge["data"]:
+            return (
+                flask.jsonify(
+                    {
+                        "status": "badge_issued",
+                        "accept_badge_url": new_badge["data"][
+                            "accept_badge_url"
+                        ],
+                    }
+                ),
+                200,
+            )
     return flask.jsonify({"status": "badge_not_issued"}), 200

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -749,7 +749,7 @@ def issue_badges(trueability_api, credly_api, **kwargs):
     if not api_key or api_key != os.getenv("TA_WEBHOOK_API_KEY"):
         return flask.jsonify({"status": "Invalid API Key"}), 401
     assessment_score = webhook_response["assessment"]["score"]
-    cutoff_score = webhook_response["ability_screen"]["cutoff_score"]
+    cutoff_score = webhook_response["assessment"]["ability_screen"]["cutoff_score"]
     if assessment_score >= cutoff_score:
         assessment_user = webhook_response["assessment"]["user"]["email"]
         first_name, last_name = webhook_response["assessment"]["user"][

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -681,7 +681,7 @@ def cred_beta_activation(**_):
     return flask.render_template("credentials/beta-activation.html")
 
 
-@shop_decorator(area="cred", permission="user", response=json)
+@shop_decorator(area="cred", permission="user", response="json")
 def get_filtered_webhook_responses(trueability_api, **kwargs):
     ability_screen_id = flask.request.args.get("ability_screen_id", None)
     page = flask.request.args.get("page", 1)
@@ -715,7 +715,7 @@ def get_filtered_webhook_responses(trueability_api, **kwargs):
     )
 
 
-@shop_decorator(area="cred", permission="user", response=json)
+@shop_decorator(area="cred", permission="user", response="json")
 def get_webhook_response(trueability_api, **kwargs):
     webhook_id = flask.request.args.get("webhook_id", None)
     webhook_responses = trueability_api.get_webhook_response(
@@ -724,14 +724,14 @@ def get_webhook_response(trueability_api, **kwargs):
     return flask.jsonify(webhook_responses)
 
 
-@canonical_staff()
 @shop_decorator(area="cred", permission="user", response=json)
+@canonical_staff()
 def get_issued_badges(credly_api, **kwargs):
     badges = credly_api.get_issued_badges()
     return flask.jsonify(badges["data"])
 
 
-@shop_decorator(area="cred", permission="user", response=html)
+@shop_decorator(area="cred", permission="user", response="html")
 def get_my_issued_badges(credly_api, **kwargs):
     sso_user_email = user_info(flask.session)["email"]
     response = credly_api.get_issued_badges(
@@ -742,7 +742,7 @@ def get_my_issued_badges(credly_api, **kwargs):
     )
 
 
-@shop_decorator(area="cred", permission="guest", response=json)
+@shop_decorator(area="cred", permission="guest", response="json")
 def issue_badges(trueability_api, credly_api, **kwargs):
     webhook_response = flask.request.json
     assessment_score = webhook_response["assessment"]["score"]

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -749,7 +749,9 @@ def issue_badges(trueability_api, credly_api, **kwargs):
     if not api_key or api_key != os.getenv("TA_WEBHOOK_API_KEY"):
         return flask.jsonify({"status": "Invalid API Key"}), 401
     assessment_score = webhook_response["assessment"]["score"]
-    cutoff_score = webhook_response["assessment"]["ability_screen"]["cutoff_score"]
+    cutoff_score = webhook_response["assessment"]["ability_screen"][
+        "cutoff_score"
+    ]
     if assessment_score >= cutoff_score:
         assessment_user = webhook_response["assessment"]["user"]["email"]
         first_name, last_name = webhook_response["assessment"]["user"][

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -724,6 +724,13 @@ def get_webhook_response(trueability_api, **kwargs):
     return flask.jsonify(webhook_responses)
 
 
+@canonical_staff
+@shop_decorator(area="cred", permission="user", response=json)
+def get_issued_badges(credly_api, **kwargs):
+    badges = credly_api.get_issued_badges()
+    return flask.jsonify(badges)
+
+
 @shop_decorator(area="cred", permission="guest", response=json)
 def issue_badges(trueability_api, credly_api, **kwargs):
     webhook_response = flask.request.json

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -745,6 +745,9 @@ def get_my_issued_badges(credly_api, **kwargs):
 @shop_decorator(area="cred", permission="guest", response="json")
 def issue_badges(trueability_api, credly_api, **kwargs):
     webhook_response = flask.request.json
+    api_key = flask.request.headers.get("X-API-KEY")
+    if not api_key or api_key != os.getenv(""):
+        return flask.jsonify({"status": "Invalid API Key"}), 401
     assessment_score = webhook_response["assessment"]["score"]
     print(assessment_score)
     if assessment_score >= 0.5:

--- a/webapp/shop/decorators.py
+++ b/webapp/shop/decorators.py
@@ -244,9 +244,7 @@ def get_credly_api_instance(area, credly_session) -> CredlyAPI:
         return None
 
     return CredlyAPI(
-        base_url=os.getenv(
-            "CREDLY_SANDBOX_URL", "https://sandbox-api.credly.com/v1"
-        ),
+        base_url=os.getenv("CREDLY_URL", "https://sandbox-api.credly.com/v1"),
         auth_token=os.getenv("CREDLY_TOKEN", ""),
         org_id=os.getenv(
             "CREDLY_ORGANIZATION_ID", "069adc37-b51e-45ee-8c9d-4a2c89ce6622"

--- a/webapp/shop/decorators.py
+++ b/webapp/shop/decorators.py
@@ -11,6 +11,7 @@ import talisker.requests
 from webapp.shop.api.ua_contracts.api import UAContractsAPI
 from webapp.shop.api.ua_contracts.advantage_mapper import AdvantageMapper
 from webapp.shop.api.badgr.api import BadgrAPI
+from webapp.shop.api.credly.api import CredlyAPI
 from webapp.shop.api.trueability.api import TrueAbilityAPI
 from webapp.login import user_info
 from requests import Session
@@ -72,6 +73,7 @@ def shop_decorator(area=None, permission=None, response="json", redirect=None):
     session = talisker.requests.get_session()
     badgr_session = init_badgr_session(area)
     trueability_session = init_trueability_session(area)
+    credly_session = init_credly_session(area)
 
     def decorator(func):
         @wraps(func)
@@ -155,6 +157,7 @@ def shop_decorator(area=None, permission=None, response="json", redirect=None):
                 trueability_api=get_trueability_api_instance(
                     area, trueability_session
                 ),
+                credly_api=get_credly_api_instance(area, credly_session),
                 is_in_maintenance=is_in_maintenance,
                 is_community_member=is_community_member,
                 *args,
@@ -194,6 +197,17 @@ def init_badgr_session(area) -> Session:
     return badgr_session
 
 
+def init_credly_session(area) -> Session:
+    if area != "cred":
+        return None
+
+    credly_session = Session()
+    talisker.requests.configure(credly_session)
+
+    return credly_session
+
+
+
 def init_trueability_session(area) -> Session:
     if area != "cred":
         return None
@@ -224,6 +238,20 @@ def get_badgr_api_instance(area, badgr_session) -> BadgrAPI:
         os.getenv("BADGR_PASSWORD"),
         badgr_session,
     )
+
+def get_credly_api_instance(area, credly_session) -> CredlyAPI:
+    if area != "cred":
+        return None
+
+    return CredlyAPI(
+        os.getenv("CREDLY_SANDBOX_URL", "https://sandbox-api.credly.com/v1"),
+        os.getenv("CREDLY_TOKEN", "dO26vW6KiCFv1sZHg1xWt5IhrehfKeYVfNrW"),
+        os.getenv(
+            "CREDLY_ORGANIZATION_ID", "069adc37-b51e-45ee-8c9d-4a2c89ce6622"
+        ),
+        credly_session,
+    )
+
 
 
 def get_trueability_api_instance(area, trueability_session) -> TrueAbilityAPI:

--- a/webapp/shop/decorators.py
+++ b/webapp/shop/decorators.py
@@ -207,7 +207,6 @@ def init_credly_session(area) -> Session:
     return credly_session
 
 
-
 def init_trueability_session(area) -> Session:
     if area != "cred":
         return None
@@ -239,19 +238,21 @@ def get_badgr_api_instance(area, badgr_session) -> BadgrAPI:
         badgr_session,
     )
 
+
 def get_credly_api_instance(area, credly_session) -> CredlyAPI:
     if area != "cred":
         return None
 
     return CredlyAPI(
-        os.getenv("CREDLY_SANDBOX_URL", "https://sandbox-api.credly.com/v1"),
-        os.getenv("CREDLY_TOKEN", "dO26vW6KiCFv1sZHg1xWt5IhrehfKeYVfNrW"),
-        os.getenv(
+        base_url=os.getenv(
+            "CREDLY_SANDBOX_URL", "https://sandbox-api.credly.com/v1"
+        ),
+        auth_token=os.getenv("CREDLY_TOKEN", ""),
+        org_id=os.getenv(
             "CREDLY_ORGANIZATION_ID", "069adc37-b51e-45ee-8c9d-4a2c89ce6622"
         ),
-        credly_session,
+        session=credly_session,
     )
-
 
 
 def get_trueability_api_instance(area, trueability_session) -> TrueAbilityAPI:


### PR DESCRIPTION
## Done

- [List of work items including drive-bys - remember to add the why and what of this work.]

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
### Proper QA
- Take the sample exam on TA 
    - Pass the said exam
    - After a few hours, a badge should appear in /credentials/your-badges page
### Easier QA
- Visit https://app.trueability.com/m/ability_screens/4190/webhooks/202/test
    - Response should be {"status":"badge_not_issued"}, 403
    - This means that the website is accepting the webhooks
- Now call the [same endpoint](https://ubuntu-com-12946.demos.haus/credentials/assessment_passed) using cURL/Postman.  
    `{
    "assessment":{
        "score":0.75,
        "user":{
            "full_name":"John Doe",
            "email":"john.doe@xyz.com"
        },
        "ability_screen":{
            "cutoff_score": 0.6
        },
        "ability_screen_variant":{
            "ability_screen_id":4190
        }
    }
}`  
    - A badge should be issued from Credly
    - Verify new badge in [/your-badges](https://ubuntu-com-12946.demos.haus/credentials/your-badges)

## Issue / Card

Fixes [WD-4072](https://warthogs.atlassian.net/browse/WD-4072)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-4072]: https://warthogs.atlassian.net/browse/WD-4072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ