### PR TITLE
Fix cancelled subscription bug

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.test.tsx
@@ -508,6 +508,28 @@ describe("SubscriptionDetails", () => {
     expect(wrapper.find(".p-chip__value").text()).toBe("Cancelled");
   });
 
+  it("it does display the cancelled label for trial shop purchases", () => {
+    const contract = userSubscriptionFactory.build({
+      type: UserSubscriptionType.Trial,
+      statuses: userSubscriptionStatusesFactory.build({
+        is_trialled: false,
+      }),
+    });
+
+    queryClient.setQueryData("userSubscriptions", [contract]);
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <SubscriptionDetails
+          onCloseModal={jest.fn()}
+          selectedId={contract.id}
+          setHasUnsavedChanges={jest.fn()}
+        />
+      </QueryClientProvider>
+    );
+
+    expect(wrapper.find(".p-chip__value").text()).toBe("Cancelled");
+  });
+
   it("it does not display label for unactionable subs", () => {
     const contract = userSubscriptionFactory.build({
       type: UserSubscriptionType.Legacy,

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.test.tsx
@@ -484,6 +484,30 @@ describe("SubscriptionDetails", () => {
 
     expect(wrapper.find(".p-chip__value").text()).toBe("Auto-renewal off");
   });
+
+  it("it does display the cancelled label for shop purchases", () => {
+    const contract = userSubscriptionFactory.build({
+      type: UserSubscriptionType.Monthly,
+      statuses: userSubscriptionStatusesFactory.build({
+        is_renewed: false,
+        is_cancelled: true,
+      }),
+    });
+
+    queryClient.setQueryData("userSubscriptions", [contract]);
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <SubscriptionDetails
+          onCloseModal={jest.fn()}
+          selectedId={contract.id}
+          setHasUnsavedChanges={jest.fn()}
+        />
+      </QueryClientProvider>
+    );
+
+    expect(wrapper.find(".p-chip__value").text()).toBe("Cancelled");
+  });
+
   it("it does not display label for unactionable subs", () => {
     const contract = userSubscriptionFactory.build({
       type: UserSubscriptionType.Legacy,

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
@@ -160,11 +160,19 @@ export const SubscriptionDetails = forwardRef<HTMLDivElement, Props>(
                           <span className="p-chip__value">Auto-renewal on</span>
                         </button>
                       ) : (
-                        <button className="p-chip--caution">
-                          <span className="p-chip__value">
-                            Auto-renewal off
-                          </span>
-                        </button>
+                        <>
+                          {!subscription.statuses.is_cancelled ? (
+                            <button className="p-chip--caution">
+                              <span className="p-chip__value">
+                                Auto-renewal off
+                              </span>
+                            </button>
+                          ) : (
+                            <button className="p-chip--negative">
+                              <span className="p-chip__value">Cancelled</span>
+                            </button>
+                          )}
+                        </>
                       )}
                     </>
                   ) : null}

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
@@ -176,6 +176,15 @@ export const SubscriptionDetails = forwardRef<HTMLDivElement, Props>(
                       )}
                     </>
                   ) : null}
+                  {subscription.type == "trial" ? (
+                    <>
+                      {!subscription.statuses.is_trialled ? (
+                        <button className="p-chip--negative">
+                          <span className="p-chip__value">Cancelled</span>
+                        </button>
+                      ) : null}
+                    </>
+                  ) : null}
                 </>
               )}
             </header>

--- a/webapp/shop/api/ua_contracts/helpers.py
+++ b/webapp/shop/api/ua_contracts/helpers.py
@@ -267,7 +267,12 @@ def get_user_subscription_statuses(
             subscriptions, subscription_id
         )
 
-        is_cancelled = True if not current_number_of_machines else False
+        is_cancelled = (
+            True
+            if not current_number_of_machines
+            or not statuses["is_subscription_active"]
+            else False
+        )
         statuses["is_cancelled"] = is_cancelled
         statuses["should_present_auto_renewal"] = (
             statuses["is_subscription_active"] and not is_cancelled

--- a/webapp/shop/api/ua_contracts/helpers.py
+++ b/webapp/shop/api/ua_contracts/helpers.py
@@ -257,15 +257,6 @@ def get_user_subscription_statuses(
         statuses["is_subscription_active"] = is_billing_subscription_active(
             subscriptions, subscription_id
         )
-        statuses[
-            "is_subscription_auto_renewing"
-        ] = is_billing_subscription_auto_renewing(
-            subscriptions, subscription_id
-        )
-
-        statuses["is_renewed"] = is_subscription_auto_renewing(
-            subscriptions, subscription_id
-        )
 
         is_cancelled = (
             True
@@ -276,6 +267,17 @@ def get_user_subscription_statuses(
         statuses["is_cancelled"] = is_cancelled
         statuses["should_present_auto_renewal"] = (
             statuses["is_subscription_active"] and not is_cancelled
+        )
+        statuses["is_subscription_auto_renewing"] = (
+            is_billing_subscription_auto_renewing(
+                subscriptions, subscription_id
+            )
+            and not is_cancelled
+        )
+
+        statuses["is_renewed"] = (
+            is_subscription_auto_renewing(subscriptions, subscription_id)
+            and not is_cancelled
         )
 
         # If the subscription is set to auto-renew, we shouldn't alarm the


### PR DESCRIPTION
## Done

- Fix cancelled subscription bug
- This happens because the interface assumes that the users cancels a subscription using the interface, so down-sizing to 0. The condition based on which we'd set a subscription to cancelled is if the number of machines for next billing cycle == 0
- Using the backoffice tool changes the status of a subscription to `deactivated`, but leaves the number of machines for next billing cycle untouched, therefore subscription would still show as active on the u.c.
- Changed so we also take into account the status of the subscription when determining the if the subscription is cancelled or not
- Added Cancelled status indicator

## QA

- Have a fresh account
- Buy a product
- Cancel it using the backoffice tool
- Go to /pro/dashboard on staging, the Edit subscription button will show up
- Got to /pro/dashboard on the demo, the Edit subscription button will not show up

## Issue / Card

Fixes #https://warthogs.atlassian.net/browse/WD-2040

## Screenshot
![image](https://github.com/canonical/ubuntu.com/assets/6387619/4794a3bc-c751-425b-b02d-25a266e4c898)
