### PR TITLE
Update OpenStack install methods

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -598,7 +598,7 @@ def openstack_install():
         blueprint_name="openstack-install-docs",
     )
 
-    singlenode_topic = openstack_install_docs.parser.api.get_topic(21427)
+    singlenode_topic = openstack_install_docs.parser.api.get_topic(35230)
     singlenode_topic_soup = BeautifulSoup(
         singlenode_topic["post_stream"]["posts"][0]["cooked"],
         features="html.parser",
@@ -608,7 +608,7 @@ def openstack_install():
     )
     openstack_install_docs.parser._replace_lightbox(singlenode_topic_soup)
 
-    multinode_topic = openstack_install_docs.parser.api.get_topic(18259)
+    multinode_topic = openstack_install_docs.parser.api.get_topic(35727)
     multinode_topic_soup = BeautifulSoup(
         multinode_topic["post_stream"]["posts"][0]["cooked"],
         features="html.parser",


### PR DESCRIPTION
The Discourse-based MicroStack documentation was very recently given a face-lift due to the launch of MicroStack with Sunbeam. The "single-node" and "multi-node" install methods on https://ubuntu.com/openstack/install need to reflect that because the content is sourced from Discourse.

![image](https://github.com/canonical/ubuntu.com/assets/6303808/e05d6166-5188-48c7-ad96-e08f9114139f)

The new Discourse topic IDs on https://discourse.ubuntu.com/ are:

- single-node: [35230](https://discourse.ubuntu.com/t/single-node-quickstart/35230)
- multi-node: [35727](https://discourse.ubuntu.com/t/multi-node/35727)