### PR TITLE
[Sunbeam GA launch] Update OpenStack cheat sheet

### DIFF
--- a/templates/openstack/openstack-cheat-sheet.html
+++ b/templates/openstack/openstack-cheat-sheet.html
@@ -19,16 +19,17 @@
           <li class="p-list__item is-ticked"> Cinder </li>
         </ul>
       <p>Get the following OpenStack cheat sheet for free. No registration needed!</p>
-      <p><a href="https://assets.ubuntu.com/v1/8d3130a1-OpenStack.cheat.sheet.1.pdf" class="p-button--positive">Get the OpenStack cheat sheet</a></p>
+      <p><a href="https://assets.ubuntu.com/v1/2950553c-OpenStack%20cheat%20sheet%20-%20revised%20v3.pdf" class="p-button--positive">Get the OpenStack cheat sheet</a></p>
     </div>
     <div class="col-6 u-vertically-center u-hide--medium u-hide--small u-align--center u-hide--medium">
-      {{ image (
-        url="https://assets.ubuntu.com/v1/7bf0af87-Openstack-cheatsheet-grfx.png",
+      {{ 
+        image (
+        url="https://assets.ubuntu.com/v1/970dede6-Openstack cheat-sheet mock-up copy.png",
         alt="",
-        width="1504",
-        height="1085",
+        width="1621",
+        height="1180",
         hi_def=True,
-        loading="auto",
+        loading="auto"
         ) | safe
       }}
     </div>


### PR DESCRIPTION
## Done

- Updated cheat sheet pdf and visual as per ticket request

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: https://ubuntu-com-12955.demos.haus/openstack/openstack-cheat-sheet
    - Be sure to test on mobile, tablet and desktop screen sizes
- See that the assets have been updated

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-3616