### PR TITLE
Add redeem button for activation keys in management view

### DIFF
--- a/static/js/src/advantage/credentials/components/CredManage/CredManage.tsx
+++ b/static/js/src/advantage/credentials/components/CredManage/CredManage.tsx
@@ -323,17 +323,15 @@ const CredManage = () => {
                     {
                       content: (
                         <>
-                          <Tooltip message="Copy Key" position="right">
-                            <p>
-                              {keyitem["key"]} &emsp;
-                              <a
-                                onClick={() => {
-                                  copyToClipboard(keyitem.key);
-                                }}
-                              >
-                                <i className="p-icon--copy"></i>
-                              </a>
-                            </p>
+                          <span>{keyitem["key"]} &emsp;</span>
+                          <Tooltip message="Copy Key" position="btm-center">
+                            <a
+                              onClick={() => {
+                                copyToClipboard(keyitem.key);
+                              }}
+                            >
+                              <i className="p-icon--copy"></i>
+                            </a>
                           </Tooltip>
                         </>
                       ),
@@ -345,9 +343,12 @@ const CredManage = () => {
                           {keyitem["activatedBy"] ? (
                             <p>{keyitem["activatedBy"]} &emsp;</p>
                           ) : (
-                            <Tooltip message="Refresh Key" position="right">
-                              <p>
-                                N/A &emsp;
+                            <>
+                              <span>N/A &emsp;</span>
+                              <Tooltip
+                                message="Refresh Key"
+                                position="btm-center"
+                              >
                                 <a
                                   onClick={() => {
                                     rotateActivationKeys([keyitem.key]);
@@ -355,8 +356,19 @@ const CredManage = () => {
                                 >
                                   <i className="p-icon--restart"></i>
                                 </a>
-                              </p>
-                            </Tooltip>
+                              </Tooltip>
+                              <span>&emsp;</span>
+                              <Tooltip
+                                message="Redeem Key"
+                                position="btm-center"
+                              >
+                                <a
+                                  href={`/credentials/redeem/${keyitem["key"]}?action=confirm`}
+                                >
+                                  <i className="p-icon--video-play"></i>
+                                </a>
+                              </Tooltip>
+                            </>
                           )}
                         </>
                       ),

--- a/templates/credentials/redeem_with_form.html
+++ b/templates/credentials/redeem_with_form.html
@@ -18,7 +18,7 @@ Ubuntu Desktop, and Ubuntu Server topics.{% endblock meta_description %}
             <label for="activation-key">Enter your key</label>
           </div>
           <div class="col-3">
-            <input type="text" name="activation-key" id="activation-key" autocomplete="off" required>
+            <input type="text" name="activation-key" id="activation-key" autocomplete="off" value="{{ activation_key if activation_key }}" required>
           </div>
         </div>
         <div class="p-form__group row">

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -580,6 +580,7 @@ def cred_shop(**kwargs):
 @shop_decorator(area="cube", permission="user", response="html")
 def cred_redeem_code(ua_contracts_api, advantage_mapper, **kwargs):
     exam = None
+    action = flask.request.args.get("action")
 
     if flask.request.method == "POST":
         activation_key = flask.request.form.get("activation-key")
@@ -587,8 +588,10 @@ def cred_redeem_code(ua_contracts_api, advantage_mapper, **kwargs):
     else:
         activation_key = kwargs.get("code")
 
-    if not activation_key:
-        return flask.render_template("/credentials/redeem_with_form.html")
+    if not activation_key or action == "confirm":
+        return flask.render_template(
+            "/credentials/redeem_with_form.html", activation_key=activation_key
+        )
 
     try:
         activation_response = ua_contracts_api.activate_activation_key(
@@ -601,11 +604,11 @@ def cred_redeem_code(ua_contracts_api, advantage_mapper, **kwargs):
             product_tags=["cue"],
         )
         contract_id = exam_contracts[-1]["id"]
-        if flask.request.args.get("action") == "schedule":
+        if action == "schedule":
             return flask.redirect(
                 f"/credentials/schedule?contractItemID={contract_id}"
             )
-        if flask.request.args.get("action") == "take":
+        if action == "take":
             return flask.redirect(
                 f"/credentials/provision?contractItemID={contract_id}"
             )

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -10,7 +10,7 @@ from webapp.shop.api.ua_contracts.api import (
 )
 
 from webapp.shop.decorators import shop_decorator, canonical_staff
-from webapp.shop.utils import get_user_first_last_name
+from webapp.shop.utils import get_exam_contract_id, get_user_first_last_name
 from webapp.login import user_info
 from webapp.views import get_user_country_by_ip
 
@@ -603,7 +603,7 @@ def cred_redeem_code(ua_contracts_api, advantage_mapper, **kwargs):
         exam_contracts = ua_contracts_api.get_annotated_contract_items(
             product_tags=["cue"],
         )
-        contract_id = exam_contracts[-1]["id"]
+        contract_id = get_exam_contract_id(exam_contracts[-1])
         if action == "schedule":
             return flask.redirect(
                 f"/credentials/schedule?contractItemID={contract_id}"

--- a/webapp/shop/utils.py
+++ b/webapp/shop/utils.py
@@ -5,6 +5,10 @@ import flask
 from webapp.login import user_info
 
 
+def get_exam_contract_id(contract) -> int:
+    return contract.get("id") or contract["contractItem"]["id"]
+
+
 def get_user_first_last_name() -> Tuple[str, str]:
     sso_user = user_info(flask.session)
     name = sso_user["fullname"].rsplit(" ", maxsplit=1)


### PR DESCRIPTION
## Done

- Add button that leads to /credentials/redeem with the activation key pre-populated

## QA

- If necessary, purchase activation key(s) for staging in Backoffice
- Visit https://ubuntu-com-12961.demos.haus/credentials/shop/manage
- Find an unassigned key in the list and click the "Redeem key" button
  - Verify that you land on https://ubuntu-com-12961.demos.haus/credentials/redeem and that the key field is pre-populated

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-4070

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
