### PR TITLE
Typo fix on /pricing/devices

### DIFF
--- a/templates/pricing/devices.html
+++ b/templates/pricing/devices.html
@@ -29,7 +29,7 @@
         <hr class="u-sv1">
         <p>Let our Linux experts help you ensure the success of your application packaging on Ubuntu.</p>
 
-        <p>Enjoy Snap Craft 101 training, snap store services, device fees and support for one year for up to 1,000 devices; deployment services (excluding proxy deployments); and either the packaging of up to three  application snaps (subject to approval) or equivalent consulting hours for clients that wish to do the packaging themselves with help from our top-notch Linux experts.</p>
+        <p>Enjoy Snapcraft 101 training, snap store services, device fees and support for one year for up to 1,000 devices; deployment services (excluding proxy deployments); and either the packaging of up to three  application snaps (subject to approval) or equivalent consulting hours for clients that wish to do the packaging themselves with help from our top-notch Linux experts.</p>
       </div>
 
       <div class="p-card col-3">


### PR DESCRIPTION
## Done

- Update 'Snap Craft' to 'Snapcraft' on /pricing/devices

## QA

- Ege has told me there is no need for a review as this is such a minor change. See issue below

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-4622
