### PR TITLE
Show spinner while purchase is processed

### DIFF
--- a/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import { useQueryClient } from "react-query";
 import { useFormikContext } from "formik";
 import { getSessionData } from "utils/getSessionData";
@@ -18,11 +18,18 @@ type Props = {
   quantity: number;
   product: Product;
   action: Action;
+  isLoading: boolean;
+  setIsLoading: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
-const BuyButton = ({ setError, quantity, product, action }: Props) => {
-  const [isLoading, setIsLoading] = useState(false);
-
+const BuyButton = ({
+  setError,
+  quantity,
+  product,
+  action,
+  isLoading,
+  setIsLoading,
+}: Props) => {
   const {
     values,
     setFieldValue,
@@ -85,7 +92,7 @@ const BuyButton = ({ setError, quantity, product, action }: Props) => {
     // to prevent page refreshes from causing accidental double purchasing
     localStorage.removeItem("ua-subscribe-state");
     setIsLoading(true);
-
+    document.querySelector(".global-nav")?.scrollIntoView();
     useFinishPurchaseMutation.mutate(
       {
         formData: values,

--- a/static/js/src/advantage/subscribe/checkout/components/Checkout/Checkout.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Checkout/Checkout.tsx
@@ -32,6 +32,7 @@ const Checkout = ({ product, quantity, action }: Props) => {
   const productCanBeTrialled = product?.canBeTrialled;
   const canTrial = canBeTrialled(productCanBeTrialled, userCanTrial);
   const initialValues = getInitialFormValues(product, canTrial, userInfo);
+  const [isLoading, setIsLoading] = useState(false);
 
   return (
     <>
@@ -49,7 +50,7 @@ const Checkout = ({ product, quantity, action }: Props) => {
               {error}
             </Notification>
           ) : null}
-          {isUserInfoLoading ? (
+          {isLoading || isUserInfoLoading ? (
             <>
               {" "}
               <Col size={12}>
@@ -60,7 +61,8 @@ const Checkout = ({ product, quantity, action }: Props) => {
                 </div>
               </Col>
             </>
-          ) : (
+          ) : null}
+          {!isUserInfoLoading && (
             <Formik
               onSubmit={() => {}}
               initialValues={initialValues}
@@ -68,7 +70,11 @@ const Checkout = ({ product, quantity, action }: Props) => {
                 !isGuest && !!userInfo?.customerInfo?.defaultPaymentMethod
               }
             >
-              <>
+              <div
+                style={{
+                  display: isLoading || isUserInfoLoading ? "none" : "block",
+                }}
+              >
                 <Col emptyLarge={7} size={6}>
                   <p>* indicates a mandatory field</p>
                 </Col>
@@ -134,6 +140,8 @@ const Checkout = ({ product, quantity, action }: Props) => {
                                 quantity={quantity}
                                 action={action}
                                 setError={setError}
+                                isLoading={isLoading}
+                                setIsLoading={setIsLoading}
                               ></BuyButton>
                             </Col>
                           </Row>
@@ -142,7 +150,7 @@ const Checkout = ({ product, quantity, action }: Props) => {
                     },
                   ]}
                 />
-              </>
+              </div>
             </Formik>
           )}
         </Row>


### PR DESCRIPTION
## Done

- Show spinner while form submitting is processed after clicking buy button.

## QA

- Go to /pro/subscribe
- Select products and buy products
- Check spinner displays properly while form submitting is processed after clicking buy button.
- Check thank you page shows after purchase is successful
- Check notification message shows on the checkout page after purchase is failed.

## Issue / Card

Fixes #