### PR TITLE
Create Marketo lead if it doesn't exist

### DIFF
--- a/webapp/marketo.py
+++ b/webapp/marketo.py
@@ -60,7 +60,7 @@ class MarketoAPI:
 
     def update_leads(self, leads=None):
         data = {
-            "action": "updateOnly",
+            "action": "createOrUpdate",
             "lookupField": "email",
             "input": leads,
         }


### PR DESCRIPTION
## Done

- When adding Credentials activation keys to Marketo, create the lead if it doesn't already exist in Marketo

## QA

-

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-4703


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
