### PR TITLE
[copy update] WD-4719 fix typo on `/security/livepatch`

### DIFF
--- a/templates/security/livepatch.html
+++ b/templates/security/livepatch.html
@@ -291,7 +291,7 @@ meta_copydoc %}
       <div class="p-card col-6">
         <h3 class="p-card__title">Free for personal use</h3>
         <hr>
-        <p>All you need is an Ubuntu One Account. Free for up to 3 machines.</p>
+        <p>All you need is an Ubuntu One Account. Free for up to 5 machines.</p>
         <br>
         <a href="/pro" class="p-button--positive">Get your free subscription</a>
       </div>


### PR DESCRIPTION
## Done

- Fix typo --> "3 machines" to "5 machines"

## QA

- Check out the [demo here](url) and compare it with the change requested on the [copy doc](https://docs.google.com/document/d/1g_Ip5MzlBRpbM2wULpSnsR5XaHJVWgLPLdq8_7fCHrs/edit).

## Issue / Card

- [WD-4719](https://warthogs.atlassian.net/browse/WD-4719)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
