### PR TITLE
Update /pro/subscribe page 

### DIFF
--- a/static/js/src/advantage/subscribe/react/UAPurchase.tsx
+++ b/static/js/src/advantage/subscribe/react/UAPurchase.tsx
@@ -4,14 +4,16 @@ import ProductSummary from "./components/ProductSummary";
 import { FormContext } from "advantage/subscribe/react/utils/FormContext";
 import {
   IoTDevices,
+  ProductUsers,
   isIoTDevice,
   isPublicCloud,
 } from "advantage/subscribe/react/utils/utils";
 const UAPurchase = () => {
-  const { productType, iotDevice } = useContext(FormContext);
+  const { productType, iotDevice, productUser } = useContext(FormContext);
   const disabled =
-    isPublicCloud(productType) ||
-    (isIoTDevice(productType) && iotDevice === IoTDevices.core);
+    productUser === ProductUsers.organisation &&
+    (isPublicCloud(productType) ||
+      (isIoTDevice(productType) && iotDevice === IoTDevices.core));
 
   return (
     <>

--- a/static/js/src/advantage/subscribe/react/components/Form/Feature/Feature.test.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Feature/Feature.test.tsx
@@ -7,6 +7,7 @@ import {
   IoTDevices,
   ProductListings,
   ProductTypes,
+  LTSVersions,
 } from "advantage/subscribe/react/utils/utils";
 import { productListFixture } from "advantage/subscribe/react/utils/test/Mocks";
 
@@ -33,6 +34,19 @@ test("Feature sections disables Infra + Apps if destkop is selected", () => {
   );
 
   expect(screen.getByTestId("infra-only")).toBeDisabled();
+});
+
+test("Ubuntu pro is disabled if 14.04 server is selected", () => {
+  render(
+    <FormProvider
+      initialType={ProductTypes.physical}
+      initialVersion={LTSVersions.trusty}
+    >
+      <Feature />
+    </FormProvider>
+  );
+
+  expect(screen.getByTestId("pro")).toBeDisabled();
 });
 
 test("The section is disabled if a public cloud is selected", () => {

--- a/static/js/src/advantage/subscribe/react/components/Form/Feature/Feature.test.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Feature/Feature.test.tsx
@@ -36,7 +36,7 @@ test("Feature sections disables Infra + Apps if destkop is selected", () => {
   expect(screen.getByTestId("infra-only")).toBeDisabled();
 });
 
-test("Ubuntu pro is disabled if 14.04 server is selected", () => {
+test("Ubuntu pro is disabled if physical & 14.04 server is selected", () => {
   render(
     <FormProvider
       initialType={ProductTypes.physical}
@@ -47,6 +47,32 @@ test("Ubuntu pro is disabled if 14.04 server is selected", () => {
   );
 
   expect(screen.getByTestId("pro")).toBeDisabled();
+});
+
+test("Ubuntu pro is disabled if desktops & 14.04 server is selected", () => {
+  render(
+    <FormProvider
+      initialType={ProductTypes.desktop}
+      initialVersion={LTSVersions.trusty}
+    >
+      <Feature />
+    </FormProvider>
+  );
+
+  expect(screen.getByTestId("pro")).toBeDisabled();
+});
+
+test("Ubuntu pro infra only is not disabled if desktop and 14.04 server is selected", () => {
+  render(
+    <FormProvider
+      initialType={ProductTypes.desktop}
+      initialVersion={LTSVersions.trusty}
+    >
+      <Feature />
+    </FormProvider>
+  );
+
+  expect(screen.getByTestId("infra-only")).not.toBeDisabled();
 });
 
 test("The section is disabled if a public cloud is selected", () => {

--- a/static/js/src/advantage/subscribe/react/components/Form/Feature/Feature.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Feature/Feature.tsx
@@ -1,11 +1,15 @@
 import React, { useContext } from "react";
 import classNames from "classnames";
 import { Col, RadioInput, Row } from "@canonical/react-components";
-import { Features, ProductTypes } from "advantage/subscribe/react/utils/utils";
+import {
+  Features,
+  ProductTypes,
+  LTSVersions,
+} from "advantage/subscribe/react/utils/utils";
 import { FormContext } from "advantage/subscribe/react/utils/FormContext";
 
 const Feature = () => {
-  const { productType, feature, setFeature } = useContext(FormContext);
+  const { productType, feature, setFeature, version } = useContext(FormContext);
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setFeature(event.target.value as Features);
@@ -16,6 +20,7 @@ const Feature = () => {
   };
 
   const infraOnlyDisabled = ProductTypes.desktop === productType;
+  const proDisabled = version === LTSVersions.trusty;
 
   return (
     <div
@@ -114,6 +119,7 @@ const Feature = () => {
           >
             <label className="p-radio u-align-text--center">
               <input
+                data-testid="pro"
                 className="p-radio__input"
                 autoComplete="off"
                 type="radio"
@@ -121,6 +127,7 @@ const Feature = () => {
                 value={Features.pro}
                 checked={feature === Features.pro}
                 onChange={handleChange}
+                disabled={proDisabled}
               />
               <span className="p-radio__label" id={`pro-label`}>
                 <RadioInput
@@ -129,6 +136,7 @@ const Feature = () => {
                   checked={feature === Features.pro}
                   value={Features.pro}
                   onChange={handleChange}
+                  disabled={proDisabled}
                 />
                 <div className="included">
                   <i className="p-icon--success"></i>Included
@@ -185,6 +193,7 @@ const Feature = () => {
           value={Features.pro}
           checked={feature === Features.pro}
           onChange={handleChange}
+          disabled={proDisabled}
         />
         <RadioInput
           label="Ubuntu Pro (Infra-only)"

--- a/static/js/src/advantage/subscribe/react/components/Form/Feature/Feature.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Feature/Feature.tsx
@@ -19,7 +19,9 @@ const Feature = () => {
     );
   };
 
-  const infraOnlyDisabled = ProductTypes.desktop === productType;
+  const infraOnlyDisabled =
+    productType === ProductTypes.desktop && version !== LTSVersions.trusty;
+
   const proDisabled = version === LTSVersions.trusty;
 
   return (

--- a/static/js/src/advantage/subscribe/react/components/Form/Form.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Form.tsx
@@ -8,11 +8,13 @@ import Version from "./Version";
 import { FormContext } from "advantage/subscribe/react/utils/FormContext";
 import {
   IoTDevices,
+  ProductUsers,
   isIoTDevice,
   isPublicCloud,
 } from "advantage/subscribe/react/utils/utils";
+import ProductUser from "./ProductUser/ProductUser";
 const Form = () => {
-  const { productType, iotDevice } = useContext(FormContext);
+  const { productType, iotDevice, productUser } = useContext(FormContext);
   const disabled =
     isPublicCloud(productType) ||
     (isIoTDevice(productType) && iotDevice === IoTDevices.core);
@@ -21,69 +23,84 @@ const Form = () => {
     <form className="product-selector">
       <Strip includeCol={false}>
         <Col size={6}>
-          <h2>What are you setting up?</h2>
+          <h2>Who will be using this subscription?</h2>
         </Col>
         <Col size={6}>
-          <ProductType />
+          <ProductUser />
         </Col>
       </Strip>
-      {!disabled && (
+      {productUser !== ProductUsers.myself ? (
         <>
           <Row>
             <hr />
           </Row>
           <Strip includeCol={false}>
             <Col size={6}>
-              <h2>For how many machines?</h2>
+              <h2>What are you setting up?</h2>
             </Col>
             <Col size={6}>
-              <Quantity />
+              <ProductType />
             </Col>
           </Strip>
-          <Row>
-            <hr />
-          </Row>
+          {!disabled && (
+            <>
+              <Row>
+                <hr />
+              </Row>
+              <Strip includeCol={false}>
+                <Col size={6}>
+                  <h2>For how many machines?</h2>
+                </Col>
+                <Col size={6}>
+                  <Quantity />
+                </Col>
+              </Strip>
+              <Row>
+                <hr />
+              </Row>
 
-          <Strip includeCol={false}>
-            <Col size={6}>
-              <h2>What Ubuntu LTS version are you running?</h2>
-              <p style={{ marginLeft: "3.6rem" }}>
-                {" "}
-                Ubuntu Advantage is available for Ubuntu 14.04 and higher.
-                <br />{" "}
-                <a href="/contact-us/form?product=pro">
-                  Are you using an older version?
-                </a>
-              </p>
-            </Col>
-            <Col size={6}>
-              <Version />
-            </Col>
-          </Strip>
-          <Row>
-            <hr />
-          </Row>
-          <Strip includeCol={false}>
-            <Col size={12}>
-              <h2>What security coverage do you need?</h2>
-            </Col>
-            <Col size={12}>
-              <Feature />
-            </Col>
-          </Strip>
-          <Row>
-            <hr />
-          </Row>
-          <Strip includeCol={false}>
-            <Col size={12}>
-              <h2>Do you also need phone and ticket support?</h2>
-            </Col>
-            <Col size={12}>
-              <Support />
-            </Col>
-          </Strip>
+              <Strip includeCol={false}>
+                <Col size={6}>
+                  <h2>What Ubuntu LTS version are you running?</h2>
+                  <p style={{ marginLeft: "3.6rem" }}>
+                    {" "}
+                    Ubuntu Advantage is available for Ubuntu 14.04 and higher.
+                    <br />{" "}
+                    <a href="/contact-us/form?product=pro">
+                      Are you using an older version?
+                    </a>
+                  </p>
+                </Col>
+                <Col size={6}>
+                  <Version />
+                </Col>
+              </Strip>
+              <Row>
+                <hr />
+              </Row>
+              <Strip includeCol={false}>
+                <Col size={12}>
+                  <h2>What security coverage do you need?</h2>
+                </Col>
+                <Col size={12}>
+                  <Feature />
+                </Col>
+              </Strip>
+              <Row>
+                <hr />
+              </Row>
+              <Strip includeCol={false}>
+                <Col size={12}>
+                  <h2>Do you also need phone and ticket support?</h2>
+                </Col>
+                <Col size={12}>
+                  <Support />
+                </Col>
+              </Strip>
+            </>
+          )}
         </>
-      )}
+      ) : null}
     </form>
   );
 };

--- a/static/js/src/advantage/subscribe/react/components/Form/Form.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Form.tsx
@@ -49,6 +49,11 @@ const Form = () => {
               <h2>What Ubuntu LTS version are you running?</h2>
             </Col>
             <Col size={6}>
+              <p>
+                {" "}
+                Ubuntu Advantage is available for Ubuntu 14.04 and higher.
+                <br /> <a>Are you using an older version?</a>
+              </p>
               <Version />
             </Col>
           </Strip>

--- a/static/js/src/advantage/subscribe/react/components/Form/Form.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Form.tsx
@@ -47,13 +47,16 @@ const Form = () => {
           <Strip includeCol={false}>
             <Col size={6}>
               <h2>What Ubuntu LTS version are you running?</h2>
-            </Col>
-            <Col size={6}>
-              <p>
+              <p style={{ marginLeft: "3.6rem" }}>
                 {" "}
                 Ubuntu Advantage is available for Ubuntu 14.04 and higher.
-                <br /> <a>Are you using an older version?</a>
+                <br />{" "}
+                <a href="/contact-us/form?product=pro">
+                  Are you using an older version?
+                </a>
               </p>
+            </Col>
+            <Col size={6}>
               <Version />
             </Col>
           </Strip>

--- a/static/js/src/advantage/subscribe/react/components/Form/ProductType/ProductType.test.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/ProductType/ProductType.test.tsx
@@ -17,8 +17,9 @@ test("Type selector doesn't display the public cloud section by default", () => 
       <ProductType />
     </FormProvider>
   );
-
-  expect(screen.queryByText(/^You can buy/)).not.toBeInTheDocument();
+  expect(
+    screen.queryByText(/^Solutions for Ubuntu 18.04 LTS instances/)
+  ).not.toBeInTheDocument();
 });
 
 test("Type selector displays the public cloud section if a public cloud is selected", async () => {

--- a/static/js/src/advantage/subscribe/react/components/Form/ProductType/ProductType.test.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/ProductType/ProductType.test.tsx
@@ -30,9 +30,11 @@ test("Type selector displays the public cloud section if a public cloud is selec
 
   await userEvent.click(screen.getByText("Public cloud instances"));
 
-  expect(screen.getByText(/^Visit AWS marketplace/)).toHaveAttribute(
+  expect(
+    screen.getByText(/launch new Ubuntu Pro instances on the AWS Marketplace/)
+  ).toHaveAttribute(
     "href",
-    "https://aws.amazon.com/marketplace/search/results?page=1&filters=VendorId&VendorId=e6a5002c-6dd0-4d1e-8196-0a1d1857229b&searchTerms=ubuntu+pro"
+    "https://aws.amazon.com/marketplace/search/results?page=1&filters=VendorId&VendorId=e6a5002c-6dd0-4d1e-8196-0a1d1857229b&searchTerms=ubuntu+pro+ec2"
   );
 });
 

--- a/static/js/src/advantage/subscribe/react/components/Form/ProductType/ProductType.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/ProductType/ProductType.tsx
@@ -12,7 +12,7 @@ import {
 const PublicCloudInfo = {
   [PublicClouds.aws]: {
     title: "AWS",
-    name: "AWS Marketplace",
+    name: "AWS",
     CTA: [
       {
         CTAName: "in-place upgrade to Ubuntu Pro",
@@ -37,7 +37,7 @@ const PublicCloudInfo = {
           EC2 Console
         </a>{" "}
         at a per-second, per-machine rate. If you have a running Ubuntu LTS
-        instance in AWS, you can also In-place upgrade that instance to a Ubuntu
+        instance in AWS, you can also in-place upgrade that instance to a Ubuntu
         Pro. If you need tech support as well,{" "}
         <a href="/aws#get-in-touch">contact us</a>.
       </>
@@ -45,12 +45,12 @@ const PublicCloudInfo = {
   },
   [PublicClouds.azure]: {
     title: "Azure",
-    name: "Azure Marketplace",
+    name: "Azure",
     CTA: [
       {
-        CTAName: "in-place upgrade to Ubuntu Pro",
+        CTAName: "Ubuntu Pro in Azure marketplace",
         link:
-          "https://azuremarketplace.microsoft.com/en-us/marketplace/apps?search=Ubuntu%20Pro&page=1",
+          "https://azuremarketplace.microsoft.com/en-us/marketplace/apps?search=ubuntu%20pro%20canonical&page=1",
         appearance: "positive",
       },
       {
@@ -73,7 +73,7 @@ const PublicCloudInfo = {
   },
   [PublicClouds.gcp]: {
     title: "GCP",
-    name: "Google Compute Engine",
+    name: "Google Cloud",
     CTA: [
       {
         CTAName: "in-place upgrade to Ubuntu Pro",
@@ -94,7 +94,7 @@ const PublicCloudInfo = {
           launch new Ubuntu Pro instances on the Google Compute Engine
         </a>{" "}
         at an hourly, per-machine rate. If you have a running Ubuntu LTS
-        instance in Google Cloud, you can also In-place upgrade that instance to
+        instance in Google Cloud, you can also in-place upgrade that instance to
         a Ubuntu Pro. If you need tech support as well,{" "}
         <a href="/gcp#get-in-touch">contact us</a>.{" "}
       </>
@@ -104,7 +104,7 @@ const PublicCloudInfo = {
   },
   [PublicClouds.oracle]: {
     title: "Oracle",
-    name: "Oracle",
+    name: "Oracle Cloud",
     CTA: [
       {
         CTAName: "Contact us",
@@ -127,7 +127,7 @@ const PublicCloudInfo = {
   },
   [PublicClouds.ibm]: {
     title: "IBM",
-    name: "IBM",
+    name: "IBM Cloud",
     CTA: [
       {
         CTAName: "Contact us",
@@ -266,7 +266,7 @@ const ProductType = () => {
       </div>
 
       <p>
-        <strong>{PublicCloudInfo[publicCloud]?.title}</strong>
+        <strong>{PublicCloudInfo[publicCloud]?.name}</strong>
       </p>
       <p>{PublicCloudInfo[publicCloud]?.describe}</p>
       {PublicCloudInfo[publicCloud]?.CTA.map((cta) => (
@@ -356,7 +356,7 @@ const ProductType = () => {
             checked={productType === ProductTypes.physical}
           />
         </Col>
-        {productType === "physical" && (
+        {productType === ProductTypes.physical && (
           <Col size={12} style={{ marginLeft: "35px" }}>
             <p>
               <strong>Unlimited VMs on selected hypervisors</strong>
@@ -390,6 +390,13 @@ const ProductType = () => {
             checked={productType === ProductTypes.desktop}
           />
         </Col>
+        {productType === ProductTypes.desktop && (
+          <Col size={12} style={{ marginLeft: "35px" }}>
+            <p>
+              A subscription limited to single-user machine Desktop use-cases.
+            </p>
+          </Col>
+        )}
         <Col size={12}>
           <RadioInput
             label="IoT and devices"

--- a/static/js/src/advantage/subscribe/react/components/Form/ProductType/ProductType.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/ProductType/ProductType.tsx
@@ -13,29 +13,129 @@ const PublicCloudInfo = {
   [PublicClouds.aws]: {
     title: "AWS",
     name: "AWS Marketplace",
-    CTAName: "AWS marketplace",
-    link:
-      "https://aws.amazon.com/marketplace/search/results?page=1&filters=VendorId&VendorId=e6a5002c-6dd0-4d1e-8196-0a1d1857229b&searchTerms=ubuntu+pro",
+    CTA: [
+      {
+        CTAName: "In-place upgrade to Ubuntu Pro",
+        link:
+          "/blog/upgrade-your-existing-ubuntu-lts-instances-to-ubuntu-pro-in-aws",
+        appearance: "positive",
+      },
+      {
+        CTAName: "Solutions for Ubuntu 18.04 LTS instances",
+        link: "/18-04/aws",
+        appearance: "",
+      },
+    ],
+    describe: (
+      <>
+        You can{" "}
+        <a href="https://aws.amazon.com/marketplace/search/results?page=1&filters=VendorId&VendorId=e6a5002c-6dd0-4d1e-8196-0a1d1857229b&searchTerms=ubuntu+pro+ec2">
+          launch new Ubuntu Pro instances on the AWS Marketplace
+        </a>{" "}
+        and the{" "}
+        <a href="/blog/ubuntu-pro-is-now-part-of-the-aws-ec2-console">
+          EC2 Console
+        </a>{" "}
+        at a per-second, per-machine rate. If you have a running Ubuntu LTS
+        instance in AWS, you can also In-place upgrade that instance to a Ubuntu
+        Pro. If you need tech support as well,{" "}
+        <a href="/aws#get-in-touch">contact us</a>.
+      </>
+    ),
   },
   [PublicClouds.azure]: {
     title: "Azure",
     name: "Azure Marketplace",
-    CTAName: "Azure marketplace",
-    link:
-      "https://azuremarketplace.microsoft.com/en-us/marketplace/apps?search=Ubuntu%20Pro&page=1",
+    CTA: [
+      {
+        CTAName: "In-place upgrade to Ubuntu Pro",
+        link:
+          "https://azuremarketplace.microsoft.com/en-us/marketplace/apps?search=Ubuntu%20Pro&page=1",
+        appearance: "positive",
+      },
+      {
+        CTAName: "Solutions for Ubuntu 18.04 LTS instances",
+        link: "/18-04/azure",
+        appearance: "",
+      },
+    ],
+    describe: (
+      <>
+        You can{" "}
+        <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps?search=Ubuntu%20Pro&page=1">
+          launch new Ubuntu Pro instances on the Azure Marketplace
+        </a>{" "}
+        at an hourly, per-machine rate. If you need tech support as well, or to
+        add Ubuntu Pro entitlements to existing Ubuntu LTS instances, please{" "}
+        <a href="/azure#get-in-touch">contact us</a>.
+      </>
+    ),
   },
   [PublicClouds.gcp]: {
     title: "GCP",
     name: "Google Compute Engine",
-    CTAName: "GCE marketplace",
+    CTA: [
+      {
+        CTAName: "In-place upgrade to Ubuntu Pro",
+        link:
+          "https://cloud.google.com/compute/docs/images/premium/ubuntu-pro/upgrade-from-ubuntu",
+        appearance: "positive",
+      },
+      {
+        CTAName: "Solutions for Ubuntu 18.04 LTS instances",
+        link: "/18-04/gcp",
+        appearance: "",
+      },
+    ],
+    describe: (
+      <>
+        You can{" "}
+        <a href="https://console.cloud.google.com/marketplace/browse?q=ubuntu%20pro&filter=partner:Canonical%20Group&authuser=1&pli=1">
+          launch new Ubuntu Pro instances on the Google Compute Engine
+        </a>{" "}
+        at an hourly, per-machine rate. If you have a running Ubuntu LTS
+        instance in Google Cloud, you can also In-place upgrade that instance to
+        a Ubuntu Pro. If you need tech support as well,{" "}
+        <a href="/gcp#get-in-touch">contact us</a>.{" "}
+      </>
+    ),
     link:
       "https://console.cloud.google.com/marketplace/browse?q=ubuntu%20pro&filter=partner:Canonical%20Group&authuser=1",
   },
   [PublicClouds.oracle]: {
     title: "Oracle",
     name: "Oracle",
-    CTAName: "Oracle marketplace",
-    link: "",
+    CTA: [
+      {
+        CTAName: "Solutions for Ubuntu 18.04 LTS instances",
+        link: "/18-04/oci",
+        appearance: "positive",
+      },
+    ],
+    describe: (
+      <>
+        Please <a href="/security/esm#get-in-touch">contact us</a> to purchase a
+        subscription that you can attach to your Oracle Cloud Infrastructure
+        instance.
+      </>
+    ),
+  },
+  [PublicClouds.ibm]: {
+    title: "IBM Cloud",
+    name: "IBM",
+    CTA: [
+      {
+        CTAName: "Solutions for Ubuntu 18.04 LTS instances",
+        link: "/18-04/ibm",
+        appearance: "positive",
+      },
+    ],
+    describe: (
+      <>
+        Please <a href="/security/esm#get-in-touch">contact us</a> to purchase a
+        subscription that you can attach to your IBM Cloud instance.
+      </>
+    ),
   },
 };
 const ProductType = () => {
@@ -118,24 +218,57 @@ const ProductType = () => {
           >
             {PublicCloudInfo[PublicClouds.gcp].title}
           </button>
+          <button
+            className="p-segmented-control__button"
+            role="tab"
+            aria-selected={publicCloud === PublicClouds.oracle}
+            aria-controls={PublicClouds.oracle}
+            id={PublicClouds.oracle}
+            onClick={(e) => {
+              e.preventDefault();
+              setPublicCloud(PublicClouds.oracle);
+              localStorage.setItem(
+                "pro-selector-publicCloud",
+                JSON.stringify(PublicClouds.oracle)
+              );
+            }}
+          >
+            {PublicCloudInfo[PublicClouds.ibm].title}
+          </button>
+          <button
+            className="p-segmented-control__button"
+            role="tab"
+            aria-selected={publicCloud === PublicClouds.ibm}
+            aria-controls={PublicClouds.ibm}
+            id={PublicClouds.ibm}
+            onClick={(e) => {
+              e.preventDefault();
+              setPublicCloud(PublicClouds.ibm);
+              localStorage.setItem(
+                "pro-selector-publicCloud",
+                JSON.stringify(PublicClouds.ibm)
+              );
+            }}
+          >
+            {PublicCloudInfo[PublicClouds.oracle].title}
+          </button>
         </div>
       </div>
 
       <p>
         <strong>{PublicCloudInfo[publicCloud]?.title}</strong>
       </p>
-      <p>
-        You can buy Ubuntu Pro on the {PublicCloudInfo[publicCloud]?.name} at an
-        hourly, per-machine rate. If you need tech support as well,{" "}
-        <a href="/support/contact-us">contact us</a>.
-      </p>
-      <Button
-        appearance="positive"
-        element="a"
-        href={PublicCloudInfo[publicCloud]?.link}
-      >
-        Visit {PublicCloudInfo[publicCloud]?.CTAName}
-      </Button>
+      <p>{PublicCloudInfo[publicCloud]?.describe}</p>
+      {PublicCloudInfo[publicCloud]?.CTA.map((cta) => (
+        <Button
+          appearance={cta.appearance}
+          element="a"
+          href={cta.link}
+          key={cta.CTAName}
+        >
+          {cta.CTAName}
+        </Button>
+      ))}
     </>
   );
 

--- a/static/js/src/advantage/subscribe/react/components/Form/ProductType/ProductType.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/ProductType/ProductType.tsx
@@ -62,7 +62,7 @@ const PublicCloudInfo = {
     describe: (
       <>
         You can{" "}
-        <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps?search=Ubuntu%20Pro&page=1">
+        <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps?search=ubuntu%20pro%20canonical&page=1">
           launch new Ubuntu Pro instances on the Azure Marketplace
         </a>{" "}
         at an hourly, per-machine rate. If you need tech support as well, or to
@@ -107,9 +107,14 @@ const PublicCloudInfo = {
     name: "Oracle",
     CTA: [
       {
+        CTAName: "Contact us",
+        link: "/security/esm#get-in-touch",
+        appearance: "positive",
+      },
+      {
         CTAName: "Solutions for Ubuntu 18.04 LTS instances",
         link: "/18-04/oci",
-        appearance: "positive",
+        appearance: "",
       },
     ],
     describe: (
@@ -121,13 +126,18 @@ const PublicCloudInfo = {
     ),
   },
   [PublicClouds.ibm]: {
-    title: "IBM Cloud",
+    title: "IBM",
     name: "IBM",
     CTA: [
       {
+        CTAName: "Contact us",
+        link: "/security/esm#get-in-touch",
+        appearance: "positive",
+      },
+      {
         CTAName: "Solutions for Ubuntu 18.04 LTS instances",
         link: "/18-04/ibm",
-        appearance: "positive",
+        appearance: "",
       },
     ],
     describe: (
@@ -233,7 +243,7 @@ const ProductType = () => {
               );
             }}
           >
-            {PublicCloudInfo[PublicClouds.ibm].title}
+            {PublicCloudInfo[PublicClouds.oracle].title}
           </button>
           <button
             className="p-segmented-control__button"
@@ -250,7 +260,7 @@ const ProductType = () => {
               );
             }}
           >
-            {PublicCloudInfo[PublicClouds.oracle].title}
+            {PublicCloudInfo[PublicClouds.ibm].title}
           </button>
         </div>
       </div>

--- a/static/js/src/advantage/subscribe/react/components/Form/ProductType/ProductType.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/ProductType/ProductType.tsx
@@ -15,13 +15,13 @@ const PublicCloudInfo = {
     name: "AWS Marketplace",
     CTA: [
       {
-        CTAName: "In-place upgrade to Ubuntu Pro",
+        CTAName: "in-place upgrade to Ubuntu Pro",
         link:
           "/blog/upgrade-your-existing-ubuntu-lts-instances-to-ubuntu-pro-in-aws",
         appearance: "positive",
       },
       {
-        CTAName: "Solutions for Ubuntu 18.04 LTS instances",
+        CTAName: "More info for Ubuntu 18.04 LTS users",
         link: "/18-04/aws",
         appearance: "",
       },
@@ -48,13 +48,13 @@ const PublicCloudInfo = {
     name: "Azure Marketplace",
     CTA: [
       {
-        CTAName: "In-place upgrade to Ubuntu Pro",
+        CTAName: "in-place upgrade to Ubuntu Pro",
         link:
           "https://azuremarketplace.microsoft.com/en-us/marketplace/apps?search=Ubuntu%20Pro&page=1",
         appearance: "positive",
       },
       {
-        CTAName: "Solutions for Ubuntu 18.04 LTS instances",
+        CTAName: "More info for Ubuntu 18.04 LTS users",
         link: "/18-04/azure",
         appearance: "",
       },
@@ -76,13 +76,13 @@ const PublicCloudInfo = {
     name: "Google Compute Engine",
     CTA: [
       {
-        CTAName: "In-place upgrade to Ubuntu Pro",
+        CTAName: "in-place upgrade to Ubuntu Pro",
         link:
           "https://cloud.google.com/compute/docs/images/premium/ubuntu-pro/upgrade-from-ubuntu",
         appearance: "positive",
       },
       {
-        CTAName: "Solutions for Ubuntu 18.04 LTS instances",
+        CTAName: "More info for Ubuntu 18.04 LTS users",
         link: "/18-04/gcp",
         appearance: "",
       },

--- a/static/js/src/advantage/subscribe/react/components/Form/ProductType/ProductType.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/ProductType/ProductType.tsx
@@ -393,7 +393,7 @@ const ProductType = () => {
         {productType === ProductTypes.desktop && (
           <Col size={12} style={{ marginLeft: "35px" }}>
             <p>
-              A subscription limited to single-user machine Desktop use-cases.
+              A subscription limited to single-user machine Desktop use-cases
             </p>
           </Col>
         )}

--- a/static/js/src/advantage/subscribe/react/components/Form/ProductUser/ProductUser.test.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/ProductUser/ProductUser.test.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import userEvent from "@testing-library/user-event";
+import { FormProvider } from "advantage/subscribe/react/utils/FormContext";
+import ProductUser from "./ProductUser";
+import { ProductListings } from "advantage/subscribe/react/utils/utils";
+import { productListFixture } from "advantage/subscribe/react/utils/test/Mocks";
+
+beforeAll(() => {
+  global.window.productList = productListFixture as ProductListings;
+});
+
+test("Should not display step 2,3,4,5,6 when 'myself' is selected in the first step", async () => {
+  render(
+    <FormProvider>
+      <ProductUser />
+    </FormProvider>
+  );
+
+  await userEvent.click(screen.getByText("Myself"));
+
+  expect(screen.queryByText(/What are you setting up/)).not.toBeInTheDocument();
+  expect(screen.queryByText(/For how many machines/)).not.toBeInTheDocument();
+  expect(
+    screen.queryByText(/What Ubuntu LTS version are you running/)
+  ).not.toBeInTheDocument();
+  expect(
+    screen.queryByText(/What security coverage do you need/)
+  ).not.toBeInTheDocument();
+  expect(
+    screen.queryByText(/Do you also need phone and ticket support/)
+  ).not.toBeInTheDocument();
+});

--- a/static/js/src/advantage/subscribe/react/components/Form/ProductUser/ProductUser.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/ProductUser/ProductUser.tsx
@@ -28,11 +28,9 @@ const ProductUser = () => {
             checked={productUser === ProductUsers.organisation}
           />
         </Col>
-        {productUser === "organisation" && (
-          <Col size={12} style={{ marginLeft: "35px" }}>
-            <p>Enterprise subscriptions for commercial use.</p>
-          </Col>
-        )}
+        <Col size={12} style={{ marginLeft: "35px" }}>
+          <p>Enterprise subscriptions for commercial use.</p>
+        </Col>
         <Col size={12}>
           <RadioInput
             label="Myself"
@@ -42,17 +40,15 @@ const ProductUser = () => {
             checked={productUser === ProductUsers.myself}
           />
         </Col>
-        {productUser === "myself" && (
-          <Col size={12} style={{ marginLeft: "35px" }}>
-            <p>
-              Free, personal subscription for 5 machines for you or any business
-              you own, or 50 machines for active{" "}
-              <a href="/community/membership">Ubuntu Community members</a>. If
-              you need phone support or need to cover more than 5 machines,
-              please select &quot;My organisation&quot;.
-            </p>
-          </Col>
-        )}
+        <Col size={12} style={{ marginLeft: "35px" }}>
+          <p>
+            Free, personal subscription for 5 machines for you or any business
+            you own, or 50 machines for active{" "}
+            <a href="/community/membership">Ubuntu Community members</a>. If you
+            need phone support or need to cover more than 5 machines, please
+            select &quot;My organisation&quot;.
+          </p>
+        </Col>
       </Row>
     </>
   );

--- a/static/js/src/advantage/subscribe/react/components/Form/ProductUser/ProductUser.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/ProductUser/ProductUser.tsx
@@ -1,0 +1,64 @@
+import React, { useContext } from "react";
+import { Col, RadioInput, Row } from "@canonical/react-components";
+import { FormContext } from "advantage/subscribe/react/utils/FormContext";
+import { ProductUsers } from "advantage/subscribe/react/utils/utils";
+
+const ProductUser = () => {
+  const { productUser, setProductUser } = useContext(FormContext);
+
+  const handleProductUserChange = (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    setProductUser(event.target.value as ProductUsers);
+    localStorage.setItem(
+      "pro-selector-productUser",
+      JSON.stringify(event.target.value as ProductUsers)
+    );
+  };
+
+  return (
+    <>
+      <Row>
+        <Col size={12}>
+          <RadioInput
+            label="My organisation"
+            name="user"
+            value={ProductUsers.organisation}
+            onChange={handleProductUserChange}
+            checked={productUser === ProductUsers.organisation}
+          />
+        </Col>
+        {productUser === "organisation" && (
+          <Col size={12} style={{ marginLeft: "35px" }}>
+            <p>
+              {" "}
+              Enterprise subscriptions for commercial use. If you need to cover
+              up to 5 machines with no support, it's free for personal use or
+              for a business you own. In that case please select "Myself".{" "}
+            </p>
+          </Col>
+        )}
+        <Col size={12}>
+          <RadioInput
+            label="Myself"
+            name="user"
+            value={ProductUsers.myself}
+            onChange={handleProductUserChange}
+            checked={productUser === ProductUsers.myself}
+          />
+        </Col>
+        {productUser === "myself" && (
+          <Col size={12} style={{ marginLeft: "35px" }}>
+            <p>
+              Free, personal subscription for up to 5 machines, or 50 machines
+              for active{" "}
+              <a href="/community/membership">Ubuntu Community members</a>.
+            </p>
+          </Col>
+        )}
+      </Row>
+    </>
+  );
+};
+
+export default ProductUser;

--- a/static/js/src/advantage/subscribe/react/components/Form/ProductUser/ProductUser.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/ProductUser/ProductUser.tsx
@@ -31,10 +31,10 @@ const ProductUser = () => {
         {productUser === "organisation" && (
           <Col size={12} style={{ marginLeft: "35px" }}>
             <p>
-              {" "}
               Enterprise subscriptions for commercial use. If you need to cover
-              up to 5 machines with no support, it's free for personal use or
-              for a business you own. In that case please select "Myself".{" "}
+              up to 5 machines with no support, it&rsquo;s free for personal use
+              or for a business you own. In that case please select
+              &quot;Myself&quot;.
             </p>
           </Col>
         )}
@@ -54,7 +54,7 @@ const ProductUser = () => {
               for active{" "}
               <a href="/community/membership">Ubuntu Community members</a>. If
               you need phone support or need to cover more than 5 machines,
-              please select "My organisation".
+              please select &quot;My organisation&quot;.
             </p>
           </Col>
         )}

--- a/static/js/src/advantage/subscribe/react/components/Form/ProductUser/ProductUser.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/ProductUser/ProductUser.tsx
@@ -52,7 +52,9 @@ const ProductUser = () => {
             <p>
               Free, personal subscription for up to 5 machines, or 50 machines
               for active{" "}
-              <a href="/community/membership">Ubuntu Community members</a>.
+              <a href="/community/membership">Ubuntu Community members</a>. If
+              you need phone support or need to cover more than 5 machines,
+              please select "My organisation".
             </p>
           </Col>
         )}

--- a/static/js/src/advantage/subscribe/react/components/Form/ProductUser/ProductUser.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/ProductUser/ProductUser.tsx
@@ -30,12 +30,7 @@ const ProductUser = () => {
         </Col>
         {productUser === "organisation" && (
           <Col size={12} style={{ marginLeft: "35px" }}>
-            <p>
-              Enterprise subscriptions for commercial use. If you need to cover
-              up to 5 machines with no support, it&rsquo;s free for personal use
-              or for a business you own. In that case please select
-              &quot;Myself&quot;.
-            </p>
+            <p>Enterprise subscriptions for commercial use.</p>
           </Col>
         )}
         <Col size={12}>
@@ -50,8 +45,8 @@ const ProductUser = () => {
         {productUser === "myself" && (
           <Col size={12} style={{ marginLeft: "35px" }}>
             <p>
-              Free, personal subscription for up to 5 machines, or 50 machines
-              for active{" "}
+              Free, personal subscription for 5 machines for you or any business
+              you own, or 50 machines for active{" "}
               <a href="/community/membership">Ubuntu Community members</a>. If
               you need phone support or need to cover more than 5 machines,
               please select &quot;My organisation&quot;.

--- a/static/js/src/advantage/subscribe/react/components/Form/ProductUser/ProductUser.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/ProductUser/ProductUser.tsx
@@ -29,7 +29,7 @@ const ProductUser = () => {
           />
         </Col>
         <Col size={12} style={{ marginLeft: "35px" }}>
-          <p>Enterprise subscriptions for commercial use.</p>
+          <p>Enterprise subscriptions for commercial use</p>
         </Col>
         <Col size={12}>
           <RadioInput
@@ -46,7 +46,7 @@ const ProductUser = () => {
             you own, or 50 machines for active{" "}
             <a href="/community/membership">Ubuntu Community members</a>. If you
             need phone support or need to cover more than 5 machines, please
-            select &quot;My organisation&quot;.
+            select &quot;My organisation&quot;
           </p>
         </Col>
       </Row>

--- a/static/js/src/advantage/subscribe/react/components/Form/ProductUser/index.ts
+++ b/static/js/src/advantage/subscribe/react/components/Form/ProductUser/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ProductUser";

--- a/static/js/src/advantage/subscribe/react/components/Form/Version/Version.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Version/Version.tsx
@@ -10,7 +10,7 @@ import {
 } from "advantage/subscribe/react/utils/utils";
 
 const livepatch =
-  "Kernel Livepatch  to apply kernel patches at run time without the need for an immediate reboot";
+  "Kernel Livepatch to apply kernel patches at run time without the need for an immediate reboot";
 const landscape = "Ubuntu systems management with Landscape";
 const knowledgeBase = "Access to the Knowledge base";
 const realtimeKernel = "Real-time kernel";
@@ -28,6 +28,11 @@ const FIPSComingSoon = (
     <StatusLabel appearance="positive">Coming soon</StatusLabel>
   </>
 );
+const CIS = (
+  <>
+    Ubuntu Security Guide (USG) for certified CIS benchmark tooling & automation
+  </>
+);
 const CISComingSoon = (
   <>
     Ubuntu Security Guide (USG) for certified CIS benchmark tooling & automation
@@ -35,7 +40,10 @@ const CISComingSoon = (
   </>
 );
 const CommonCriteria = "Common Criteria EAL2";
-const ESMEndDate = "Extended Security Maintenance (ESM) until ";
+const ESMEndDate =
+  "Expanded Security Maintenance (ESM) for packages in 'main' repository until";
+const DesktopESMEndDate =
+  "Expanded Security Maintenance (ESM) for packages in 'main' and 'universe' repositories until";
 const AAD =
   "Advanced Active Directory integration including native GPO policy support, custom script execution and privilege management";
 
@@ -46,7 +54,7 @@ const PhysicalServerVersionDetails: {
     `${ESMEndDate} 2032`,
     livepatch,
     FIPSComingSoon,
-    CISComingSoon,
+    CIS,
     KVMDrivers,
     landscape,
     knowledgeBase,
@@ -94,49 +102,45 @@ const DesktopVersionDetails: {
   [key in LTSVersions]: Array<React.ReactNode>;
 } = {
   [LTSVersions.jammy]: [
-    `${ESMEndDate} 2032`,
+    `${DesktopESMEndDate} 2032`,
     AAD,
     livepatch,
     FIPSComingSoon,
     CISComingSoon,
-    KVMDrivers,
     landscape,
     knowledgeBase,
+    realtimeKernel,
   ],
   [LTSVersions.focal]: [
-    `${ESMEndDate} 2030`,
+    `${DesktopESMEndDate} 2030`,
     AAD,
     livepatch,
     FIPS,
     CISBenchmarkAndAutomation,
-    KVMDrivers,
     landscape,
     knowledgeBase,
   ],
   [LTSVersions.bionic]: [
-    `${ESMEndDate} 2028`,
+    `${DesktopESMEndDate} 2028`,
     livepatch,
     FIPS,
     CISBenchmark,
     CommonCriteria,
-    KVMDrivers,
     landscape,
     knowledgeBase,
   ],
   [LTSVersions.xenial]: [
-    `${ESMEndDate} 2026`,
+    `${DesktopESMEndDate} 2026`,
     livepatch,
     FIPS,
     CISBenchmark,
     CommonCriteria,
-    KVMDrivers,
     landscape,
     knowledgeBase,
   ],
   [LTSVersions.trusty]: [
     `${ESMEndDate} 2024`,
     livepatch,
-    KVMDrivers,
     landscape,
     knowledgeBase,
   ],

--- a/static/js/src/advantage/subscribe/react/components/Form/Version/Version.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Version/Version.tsx
@@ -33,12 +33,6 @@ const CIS = (
     Ubuntu Security Guide (USG) for certified CIS benchmark tooling & automation
   </>
 );
-const CISComingSoon = (
-  <>
-    Ubuntu Security Guide (USG) for certified CIS benchmark tooling & automation
-    <StatusLabel appearance="positive">Coming soon</StatusLabel>
-  </>
-);
 const CommonCriteria = "Common Criteria EAL2";
 const ESMEndDate =
   "Expanded Security Maintenance (ESM) for packages in 'main' repository until";
@@ -106,7 +100,7 @@ const DesktopVersionDetails: {
     AAD,
     livepatch,
     FIPSComingSoon,
-    CISComingSoon,
+    CIS,
     landscape,
     knowledgeBase,
     realtimeKernel,

--- a/static/js/src/advantage/subscribe/react/components/PaymentButton/PaymentButton.tsx
+++ b/static/js/src/advantage/subscribe/react/components/PaymentButton/PaymentButton.tsx
@@ -1,11 +1,13 @@
 import React, { useContext } from "react";
 import { Button } from "@canonical/react-components";
 import { FormContext } from "../../utils/FormContext";
+import { ProductUsers } from "../../utils/utils";
 
 export default function PaymentButton() {
   const {
     quantity,
     product,
+    productUser,
     productType,
     version,
     support,
@@ -22,30 +24,42 @@ export default function PaymentButton() {
 
   return (
     <>
-      <Button
-        appearance="positive"
-        onClick={(e) => {
-          e.preventDefault();
-          window.plausible("pro-selector", {
-            props: {
-              "product-type": productType,
-              quantity: quantity,
-              version: version,
-              feature: feature,
-              support: support,
-              sla: sla,
-              period: period,
-            },
-          });
-          localStorage.setItem(
-            "shop-checkout-data",
-            JSON.stringify(shopCheckoutData)
-          );
-          location.href = "/account/checkout";
-        }}
-      >
-        Buy now
-      </Button>
+      {productUser === ProductUsers.myself ? (
+        <Button
+          appearance="positive"
+          onClick={(e) => {
+            e.preventDefault();
+            location.href = "/pro/dashboard";
+          }}
+        >
+          Register
+        </Button>
+      ) : (
+        <Button
+          appearance="positive"
+          onClick={(e) => {
+            e.preventDefault();
+            window.plausible("pro-selector", {
+              props: {
+                "product-type": productType,
+                quantity: quantity,
+                version: version,
+                feature: feature,
+                support: support,
+                sla: sla,
+                period: period,
+              },
+            });
+            localStorage.setItem(
+              "shop-checkout-data",
+              JSON.stringify(shopCheckoutData)
+            );
+            location.href = "/account/checkout";
+          }}
+        >
+          Buy now
+        </Button>
+      )}
     </>
   );
 }

--- a/static/js/src/advantage/subscribe/react/components/ProductSummary/ProductSummary.test.tsx
+++ b/static/js/src/advantage/subscribe/react/components/ProductSummary/ProductSummary.test.tsx
@@ -1,30 +1,56 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
-import userEvent from "@testing-library/user-event";
 import { FormProvider } from "advantage/subscribe/react/utils/FormContext";
 import ProductSummary from "./ProductSummary";
-import { ProductListings } from "advantage/subscribe/react/utils/utils";
+import {
+  ProductListings,
+  ProductTypes,
+  ProductUsers,
+} from "advantage/subscribe/react/utils/utils";
 import { productListFixture } from "advantage/subscribe/react/utils/test/Mocks";
-import ProductUser from "../Form/ProductUser/ProductUser";
 
 beforeAll(() => {
   global.window.productList = productListFixture as ProductListings;
 });
 
-test("Should show register button and person subscription terms of service when 'myself' is selected ", async () => {
+test("Should show Buy now button and full service description link when 'organisation' is selected ", async () => {
   render(
-    <FormProvider>
-      <ProductUser />
+    <FormProvider initialUser={ProductUsers.organisation}>
       <ProductSummary />
     </FormProvider>
   );
 
-  await userEvent.click(screen.getByText("Myself"));
+  expect(
+    screen.getAllByText("See full service description")[0]
+  ).toHaveAttribute("href", "/legal/ubuntu-pro-description");
+  expect(screen.getAllByText("Buy now")[0]).toBeInTheDocument();
+});
+
+test("Should show register button and person subscription terms of service when 'myself' is selected ", async () => {
+  render(
+    <FormProvider initialUser={ProductUsers.myself}>
+      <ProductSummary />
+    </FormProvider>
+  );
 
   expect(screen.getByTestId("personal-subscription")).toHaveAttribute(
     "href",
     "/legal/ubuntu-pro/personal"
   );
   expect(screen.getAllByText("Register")[0]).toBeInTheDocument();
+});
+
+test("Type selector displays the public cloud section if a public cloud is selected", async () => {
+  render(
+    <FormProvider
+      initialUser={ProductUsers.organisation}
+      initialType={ProductTypes.publicCloud}
+    >
+      <ProductSummary />
+    </FormProvider>
+  );
+  expect(screen.getByTestId("summary-section")).toHaveClass(
+    "p-shop-cart--hidden"
+  );
 });

--- a/static/js/src/advantage/subscribe/react/components/ProductSummary/ProductSummary.test.tsx
+++ b/static/js/src/advantage/subscribe/react/components/ProductSummary/ProductSummary.test.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import userEvent from "@testing-library/user-event";
+import { FormProvider } from "advantage/subscribe/react/utils/FormContext";
+import ProductSummary from "./ProductSummary";
+import { ProductListings } from "advantage/subscribe/react/utils/utils";
+import { productListFixture } from "advantage/subscribe/react/utils/test/Mocks";
+import ProductUser from "../Form/ProductUser/ProductUser";
+
+beforeAll(() => {
+  global.window.productList = productListFixture as ProductListings;
+});
+
+test("Should show register button and person subscription terms of service when 'myself' is selected ", async () => {
+  render(
+    <FormProvider>
+      <ProductUser />
+      <ProductSummary />
+    </FormProvider>
+  );
+
+  await userEvent.click(screen.getByText("Myself"));
+
+  expect(screen.getByTestId("personal-subscription")).toHaveAttribute(
+    "href",
+    "/legal/ubuntu-pro/personal"
+  );
+  expect(screen.getAllByText("Register")[0]).toBeInTheDocument();
+});

--- a/static/js/src/advantage/subscribe/react/components/ProductSummary/ProductSummary.tsx
+++ b/static/js/src/advantage/subscribe/react/components/ProductSummary/ProductSummary.tsx
@@ -44,6 +44,7 @@ const ProductSummary = () => {
           isHidden ? "p-shop-cart--hidden" : ""
         }`}
         id="summary-section"
+        data-testid="summary-section"
       >
         <Row className="u-sv3">
           <Col size={6} className="p-text--small-caps">

--- a/static/js/src/advantage/subscribe/react/components/ProductSummary/ProductSummary.tsx
+++ b/static/js/src/advantage/subscribe/react/components/ProductSummary/ProductSummary.tsx
@@ -3,15 +3,18 @@ import { Col, Row, Select, StatusLabel } from "@canonical/react-components";
 import { FormContext } from "advantage/subscribe/react/utils/FormContext";
 import {
   IoTDevices,
+  isIoTDevice,
   isMonthlyAvailable,
+  isPublicCloud,
   Periods,
-  ProductTypes,
+  ProductUsers,
 } from "../../utils/utils";
 import { currencyFormatter } from "advantage/react/utils";
 import PaymentButton from "../PaymentButton";
 
 const ProductSummary = () => {
   const {
+    productUser,
     quantity,
     period,
     setPeriod,
@@ -27,10 +30,12 @@ const ProductSummary = () => {
     );
   };
   const isHidden =
-    !product ||
-    !quantity ||
-    quantity < 1 ||
-    (productType === ProductTypes.iotDevice && iotDevice === IoTDevices.core);
+    productUser === ProductUsers.organisation &&
+    (!product ||
+      !quantity ||
+      +quantity < 1 ||
+      isPublicCloud(productType) ||
+      (isIoTDevice(productType) && iotDevice === IoTDevices.core));
 
   return (
     <>
@@ -55,43 +60,58 @@ const ProductSummary = () => {
           </Col>
           <hr />
           <Col size={6}>
-            <p className="p-heading--2">{product?.name}</p>
-            <a href="/legal/ubuntu-pro-description">
-              See full service description
-            </a>
+            <p className="p-heading--2">
+              {productUser === ProductUsers.myself
+                ? "Ubuntu Pro"
+                : product?.name}
+            </p>
+            {productUser === ProductUsers.myself ? (
+              <a href="/legal/ubuntu-pro/personal">
+                See personal subscription <br /> terms of service
+              </a>
+            ) : (
+              <a href="/legal/ubuntu-pro-description">
+                See full service description
+              </a>
+            )}
           </Col>
           <Col size={2} className="u-align--right p-heading--2">
-            {quantity}
+            {productUser === ProductUsers.myself ? 5 : quantity}
           </Col>
           <Col size={2} style={{ lineHeight: "4rem" }}>
-            {isMonthlyAvailable(product) ? (
-              <>
-                <Select
-                  name="billing-period"
-                  className="u-no-margin--bottom"
-                  defaultValue={period}
-                  options={[
-                    {
-                      label: "Billed Annually",
-                      value: Periods.yearly,
-                    },
-                    {
-                      label: "Billed Monthly",
-                      value: Periods.monthly,
-                    },
-                  ]}
-                  onChange={handlePeriodChange}
-                />
-              </>
-            ) : (
-              "Billed Yearly"
-            )}
+            {productUser !== ProductUsers.myself ? (
+              isMonthlyAvailable(product) ? (
+                <>
+                  <Select
+                    name="billing-period"
+                    className="u-no-margin--bottom"
+                    defaultValue={period}
+                    options={[
+                      {
+                        label: "Billed Annually",
+                        value: Periods.yearly,
+                      },
+                      {
+                        label: "Billed Monthly",
+                        value: Periods.monthly,
+                      },
+                    ]}
+                    onChange={handlePeriodChange}
+                  />
+                </>
+              ) : (
+                "Billed Yearly"
+              )
+            ) : null}
           </Col>
           <Col size={2} className="u-align--right">
             <p className="p-heading--2">
-              {currencyFormatter.format(
-                ((product?.price.value ?? 0) / 100) * (Number(quantity) ?? 0)
-              )}
+              {productUser === ProductUsers.myself
+                ? `Free`
+                : currencyFormatter.format(
+                    ((product?.price.value ?? 0) / 100) *
+                      (Number(quantity) ?? 0)
+                  )}
             </p>{" "}
             <p className="p-text--small">
               per {period === Periods.yearly ? "year" : "month"}
@@ -106,7 +126,7 @@ const ProductSummary = () => {
             emptyLarge={9}
             style={{ display: "flex", alignItems: "center" }}
           >
-            {product?.canBeTrialled ? (
+            {product?.canBeTrialled && productUser !== ProductUsers.myself ? (
               <StatusLabel appearance="positive">
                 Free trial available
               </StatusLabel>
@@ -124,35 +144,41 @@ const ProductSummary = () => {
         <Row className="u-sv3">
           <Col size={12}>
             <p>
-              {quantity} subscription{quantity > 1 ? "s" : ""} for
+              {quantity} subscription{+quantity > 1 ? "s" : ""} for
             </p>
           </Col>
           <Col size={12}>
-            <p className="p-heading--2">{product?.name}</p>
+            <p className="p-heading--2">
+              {productUser === ProductUsers.myself
+                ? "Ubuntu Pro"
+                : product?.name}
+            </p>
           </Col>
           <Col size={12}>
-            {isMonthlyAvailable(product) ? (
-              <>
-                <Select
-                  name="billing-period"
-                  className="u-no-margin--bottom"
-                  defaultValue={period}
-                  options={[
-                    {
-                      label: "Billed Annually",
-                      value: Periods.yearly,
-                    },
-                    {
-                      label: "Billed Monthly",
-                      value: Periods.monthly,
-                    },
-                  ]}
-                  onChange={handlePeriodChange}
-                />
-              </>
-            ) : (
-              "Billed Yearly"
-            )}
+            {productUser !== ProductUsers.myself ? (
+              isMonthlyAvailable(product) ? (
+                <>
+                  <Select
+                    name="billing-period"
+                    className="u-no-margin--bottom"
+                    defaultValue={period}
+                    options={[
+                      {
+                        label: "Billed Annually",
+                        value: Periods.yearly,
+                      },
+                      {
+                        label: "Billed Monthly",
+                        value: Periods.monthly,
+                      },
+                    ]}
+                    onChange={handlePeriodChange}
+                  />
+                </>
+              ) : (
+                "Billed Yearly"
+              )
+            ) : null}
           </Col>
           <Col size={1} small={2}>
             <p className="p-heading--2">
@@ -160,9 +186,15 @@ const ProductSummary = () => {
                 ((product?.price.value ?? 0) / 100) * (Number(quantity) ?? 0)
               )}
             </p>
-            <a href="/legal/ubuntu-pro-description">
-              See full service description
-            </a>
+            {productUser === ProductUsers.myself ? (
+              <a href="/legal/ubuntu-pro/personal">
+                See personal subscription <br /> terms of service
+              </a>
+            ) : (
+              <a href="/legal/ubuntu-pro-description">
+                See full service description
+              </a>
+            )}
           </Col>
           <Col size={1} small={2}>
             <p>per {period === Periods.yearly ? "year" : "month"}</p>
@@ -173,7 +205,7 @@ const ProductSummary = () => {
           <Col size={12}>
             <PaymentButton />
           </Col>
-          {product?.canBeTrialled ? (
+          {product?.canBeTrialled && productUser !== ProductUsers.myself ? (
             <Col size={12}>
               <StatusLabel appearance="positive">
                 Free trial available

--- a/static/js/src/advantage/subscribe/react/components/ProductSummary/ProductSummary.tsx
+++ b/static/js/src/advantage/subscribe/react/components/ProductSummary/ProductSummary.tsx
@@ -187,7 +187,10 @@ const ProductSummary = () => {
               )}
             </p>
             {productUser === ProductUsers.myself ? (
-              <a href="/legal/ubuntu-pro/personal">
+              <a
+                href="/legal/ubuntu-pro/personal"
+                data-testid="personal-subscription"
+              >
                 See personal subscription <br /> terms of service
               </a>
             ) : (

--- a/static/js/src/advantage/subscribe/react/utils/FormContext.tsx
+++ b/static/js/src/advantage/subscribe/react/utils/FormContext.tsx
@@ -158,10 +158,15 @@ export const FormProvider = ({
   }, [productType, support]);
 
   useEffect(() => {
-    if (productType === ProductTypes.desktop) {
+    if (
+      productType === ProductTypes.desktop &&
+      version !== LTSVersions.trusty
+    ) {
       setFeature(Features.pro);
+    } else if (version === LTSVersions.trusty) {
+      setFeature(Features.infra);
     }
-  }, [productType, feature]);
+  }, [productType, feature, version]);
 
   useEffect(() => {
     const product = getProduct(productType, feature, support, sla, period);

--- a/static/js/src/advantage/subscribe/react/utils/FormContext.tsx
+++ b/static/js/src/advantage/subscribe/react/utils/FormContext.tsx
@@ -8,11 +8,14 @@ import {
   Periods,
   Product,
   ProductTypes,
+  ProductUsers,
   SLA,
   Support,
 } from "./utils";
 
 interface FormContext {
+  productUser: ProductUsers;
+  setProductUser: React.Dispatch<React.SetStateAction<ProductUsers>>;
   productType: ProductTypes;
   setProductType: React.Dispatch<React.SetStateAction<ProductTypes>>;
   version: LTSVersions;
@@ -33,6 +36,8 @@ interface FormContext {
 }
 
 export const defaultValues: FormContext = {
+  productUser: ProductUsers.organisation,
+  setProductUser: () => {},
   productType: ProductTypes.physical,
   setProductType: () => {},
   version: LTSVersions.jammy,
@@ -55,6 +60,7 @@ export const defaultValues: FormContext = {
 export const FormContext = createContext<FormContext>(defaultValues);
 
 interface FormProviderProps {
+  initialUser?: ProductUsers;
   initialType?: ProductTypes;
   initialVersion?: LTSVersions;
   initialFeature?: Features;
@@ -67,6 +73,7 @@ interface FormProviderProps {
 }
 
 export const FormProvider = ({
+  initialUser = defaultValues.productUser,
   initialType = defaultValues.productType,
   initialVersion = defaultValues.version,
   initialFeature = defaultValues.feature,
@@ -77,6 +84,7 @@ export const FormProvider = ({
   initialIoTDevice = defaultValues.iotDevice,
   children,
 }: FormProviderProps) => {
+  const localProductUser = localStorage.getItem("pro-selector-productUser");
   const localProductType = localStorage.getItem("pro-selector-productType");
   const localVersion = localStorage.getItem("pro-selector-version");
   const localQuantity = localStorage.getItem("pro-selector-quantity");
@@ -86,6 +94,9 @@ export const FormProvider = ({
   const localPeriod = localStorage.getItem("pro-selector-period");
   const localIoTDevice = localStorage.getItem("pro-selector-iotDevice");
 
+  const [productUser, setProductUser] = useState<ProductUsers>(
+    localProductUser ? JSON.parse(localProductUser) : initialUser
+  );
   const [productType, setProductType] = useState<ProductTypes>(
     localProductType ? JSON.parse(localProductType) : initialType
   );
@@ -173,6 +184,8 @@ export const FormProvider = ({
   return (
     <FormContext.Provider
       value={{
+        productUser,
+        setProductUser,
         productType,
         setProductType,
         version,

--- a/static/js/src/advantage/subscribe/react/utils/utils.ts
+++ b/static/js/src/advantage/subscribe/react/utils/utils.ts
@@ -122,6 +122,7 @@ export enum PublicClouds {
   azure = "azure",
   gcp = "gcp",
   oracle = "oracle",
+  ibm = "ibm",
 }
 
 export enum LTSVersions {

--- a/static/js/src/advantage/subscribe/react/utils/utils.ts
+++ b/static/js/src/advantage/subscribe/react/utils/utils.ts
@@ -104,6 +104,11 @@ export type BuyButtonProps = {
   setStep: React.Dispatch<React.SetStateAction<number>>;
 };
 
+export enum ProductUsers {
+  organisation = "organisation",
+  myself = "myself",
+}
+
 export enum ProductTypes {
   physical = "physical",
   virtual = "virtual",


### PR DESCRIPTION
## Done
1. Disable Ubuntu Pro in the step 4 "What security coverage do you need?" when server 14.04 is selected
2. Add public cloud instances and update copy doc according to this [doc](https://docs.google.com/document/d/1UqL8YJH9ywvOXnrt3syY0U8fiOakfAGWmLS9uerwAWk/edit)
2. Add "Who will be using this subscription?" step according to this [figma](https://www.figma.com/file/FEK76z86SxEzzRUzSOcpKe/Pro-Shop-update---Personal-vs-Enterprise-subscription?type=design&node-id=20-8&mode=design)

## QA
- go to /pro/subscribe
1. 
- Select "myself"  in the Step 1 "Who will be using this subscription?" and check all other steps are not visible and in the summary it says "ubuntu pro", quantity 5, total free, button says register. 
- Select "my organisation" and check all other steps are working as it was before
2. 
- Select "my organisation"  in the Step 1 
- Select `Physical servers with unlimited VMs` in the Step 2
- Select `14.04 LTS` in the step 4
- See Ubuntu Pro is disabled in the step 5 "What security coverage do you need?" 
3.
- Select "my organisation"  in the Step 1 
- Select `Public cloud instances` in the Step 2
- See public cloud instances buttons are updated properly according to this [doc]

## Issue / Card

Fixes #https://warthogs.atlassian.net/jira/software/c/projects/WD/boards/801?modal=detail&selectedIssue=WD-4588
and https://warthogs.atlassian.net/browse/WD-4519
