### PR TITLE
Fix techinical user error

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.test.tsx
@@ -445,7 +445,9 @@ describe("SubscriptionDetails", () => {
     const contract = userSubscriptionFactory.build({
       type: UserSubscriptionType.Monthly,
       statuses: userSubscriptionStatusesFactory.build({
+        is_subscription_active: true,
         is_renewed: true,
+        is_cancelled: false,
       }),
     });
 
@@ -467,6 +469,7 @@ describe("SubscriptionDetails", () => {
     const contract = userSubscriptionFactory.build({
       type: UserSubscriptionType.Monthly,
       statuses: userSubscriptionStatusesFactory.build({
+        is_subscription_active: true,
         is_renewed: false,
       }),
     });
@@ -535,7 +538,9 @@ describe("SubscriptionDetails", () => {
     const contract = userSubscriptionFactory.build({
       type: UserSubscriptionType.Trial,
       statuses: userSubscriptionStatusesFactory.build({
+        is_subscription_active: true,
         is_renewed: true,
+        is_cancelled: false,
       }),
     });
 

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
@@ -155,37 +155,49 @@ export const SubscriptionDetails = forwardRef<HTMLDivElement, Props>(
                   {subscription.type == "monthly" ||
                   subscription.type == "yearly" ? (
                     <>
-                      {subscription.statuses.is_renewed ? (
-                        <button className="p-chip--positive">
-                          <span className="p-chip__value">Auto-renewal on</span>
-                        </button>
-                      ) : (
+                      {subscription.statuses.is_subscription_active &&
+                      !subscription.statuses.is_cancelled ? (
                         <>
-                          {!subscription.statuses.is_cancelled ? (
+                          {subscription.statuses.is_renewed ? (
+                            <button className="p-chip--positive">
+                              <span className="p-chip__value">
+                                Auto-renewal on
+                              </span>
+                            </button>
+                          ) : null}
+                          {!subscription.statuses.is_renewed ? (
                             <button className="p-chip--caution">
                               <span className="p-chip__value">
                                 Auto-renewal off
                               </span>
                             </button>
-                          ) : (
-                            <button className="p-chip--negative">
-                              <span className="p-chip__value">Cancelled</span>
-                            </button>
-                          )}
+                          ) : null}
                         </>
-                      )}
-                    </>
-                  ) : null}
-                  {subscription.type == "trial" ? (
-                    <>
+                      ) : null}
                       {subscription.statuses.is_cancelled ? (
                         <button className="p-chip--negative">
                           <span className="p-chip__value">Cancelled</span>
                         </button>
                       ) : null}
-                      {subscription.statuses.is_renewed ? (
-                        <button className="p-chip--positive">
-                          <span className="p-chip__value">Auto-renewal on</span>
+                    </>
+                  ) : null}
+                  {subscription.type == "trial" ? (
+                    <>
+                      {subscription.statuses.is_subscription_active ? (
+                        <>
+                          {subscription.statuses.is_renewed &&
+                          subscription.statuses.is_cancelled ? (
+                            <button className="p-chip--positive">
+                              <span className="p-chip__value">
+                                Auto-renewal on
+                              </span>
+                            </button>
+                          ) : null}
+                        </>
+                      ) : null}
+                      {subscription.statuses.is_cancelled ? (
+                        <button className="p-chip--negative">
+                          <span className="p-chip__value">Cancelled</span>
                         </button>
                       ) : null}
                     </>

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
@@ -186,7 +186,7 @@ export const SubscriptionDetails = forwardRef<HTMLDivElement, Props>(
                       {subscription.statuses.is_subscription_active ? (
                         <>
                           {subscription.statuses.is_renewed &&
-                          subscription.statuses.is_cancelled ? (
+                          !subscription.statuses.is_cancelled ? (
                             <button className="p-chip--positive">
                               <span className="p-chip__value">
                                 Auto-renewal on

--- a/webapp/shop/api/ua_contracts/helpers.py
+++ b/webapp/shop/api/ua_contracts/helpers.py
@@ -242,7 +242,7 @@ def get_user_subscription_statuses(
         statuses["has_pending_purchases"] = True
         return statuses
 
-    if type == "trial":
+    if type == "trial" and account.role != "technical":
         active_trial = [
             subscription
             for subscription in subscriptions
@@ -273,7 +273,7 @@ def get_user_subscription_statuses(
             and not statuses["is_cancelled"]
         )
 
-    if type in ["yearly", "monthly"]:
+    if type in ["yearly", "monthly"] and account.role != "technical":
         statuses["is_subscription_active"] = is_billing_subscription_active(
             subscriptions, subscription_id
         )


### PR DESCRIPTION
## Done

- Fix technical getting the `Cancelled` label incorrectly

## QA

- Login with user 1: buy a product
- Make user 2 a technical user of the account
- Login with user 2: you will not see cancelled label.

## Issue / Card

Fixes #https://warthogs.atlassian.net/browse/WD-4720
