### PR TITLE
Add pages to install and manage lxd

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -420,7 +420,7 @@ lxd:
     - title: Manage
       path: /lxd/manage
     - title: Docs
-      path: https://linuxcontainers.org/lxd/docs/latest
+      path: https://documentation.ubuntu.com/lxd/
     - title: Forum
       path: https://discourse.ubuntu.com/c/lxd/126
 

--- a/navigation.yaml
+++ b/navigation.yaml
@@ -415,6 +415,14 @@ lxd:
   children:
     - title: Overview
       path: /lxd
+    - title: Install
+      path: /lxd/install
+    - title: Manage
+      path: /lxd/manage
+    - title: Docs
+      path: https://documentation.ubuntu.com/lxd/
+    - title: Forum
+      path: https://discourse.ubuntu.com/c/lxd/126
 
 observability:
   title: Observability

--- a/navigation.yaml
+++ b/navigation.yaml
@@ -420,7 +420,7 @@ lxd:
     - title: Manage
       path: /lxd/manage
     - title: Docs
-      path: https://documentation.ubuntu.com/lxd/
+      path: https://linuxcontainers.org/lxd/docs/latest
     - title: Forum
       path: https://discourse.ubuntu.com/c/lxd/126
 

--- a/templates/appliance/lxd/_next-steps.html
+++ b/templates/appliance/lxd/_next-steps.html
@@ -32,7 +32,7 @@
         <pre>lxc remote add appliance IP-ADDRESS
 lxc list appliance:</pre>
         <p>
-          And you're away. For more information check out the <a href="https://linuxcontainers.org">LXD website</a> or read our <a href="https://discuss.linuxcontainers.org/t/lxd-cluster-on-raspberry-pi-4/9076">tutorial on turning the LXD Ubuntu Appliance into your own homelab</a>.
+          And you're away. For more information check out the <a href="https://ubuntu.com/lxd">LXD website</a> or read our <a href="https://discuss.linuxcontainers.org/t/lxd-cluster-on-raspberry-pi-4/9076">tutorial on turning the LXD Ubuntu Appliance into your own homelab</a>.
         </p>
         <div class="p-notification" id="notification">
           <div class="p-notification__content">

--- a/templates/appliance/lxd/_next-steps.html
+++ b/templates/appliance/lxd/_next-steps.html
@@ -32,7 +32,7 @@
         <pre>lxc remote add appliance IP-ADDRESS
 lxc list appliance:</pre>
         <p>
-          And you're away. For more information check out the <a href="https://ubuntu.com/lxd">LXD website</a> or read our <a href="https://discuss.linuxcontainers.org/t/lxd-cluster-on-raspberry-pi-4/9076">tutorial on turning the LXD Ubuntu Appliance into your own homelab</a>.
+          And you're away. For more information check out the <a href="/lxd">LXD website</a> or read our <a href="https://discuss.linuxcontainers.org/t/lxd-cluster-on-raspberry-pi-4/9076">tutorial on turning the LXD Ubuntu Appliance into your own homelab</a>.
         </p>
         <div class="p-notification" id="notification">
           <div class="p-notification__content">

--- a/templates/appliance/lxd/index.md
+++ b/templates/appliance/lxd/index.md
@@ -26,7 +26,7 @@ context:
       url: "https://lxd.readthedocs.io"
     2:
       title: "LXD website"
-      url: "https://linuxcontainers.org/"
+      url: "https://ubuntu.com/lxd"
     3:
       title: "License - Apache-2.0"
       url: "https://www.apache.org/licenses/LICENSE-2.0"

--- a/templates/containers/index.html
+++ b/templates/containers/index.html
@@ -137,6 +137,6 @@
   </div>
 </section>
 
-{% with first_item="_containers_juju", second_item="_cloud_lxd", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
+{% with first_item="_containers_juju", second_item="_cloud_lxd_vs_docker", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 {% endblock content %}

--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -197,7 +197,6 @@
       <h3>Run system containers with LXD</h3>
       <p>When running Linux on Linux, consider LXD system containers instead of VMs for optimizing resources. LXD runs a full OS inside containers, providing all the benefits of a VM without the usual overhead.</p>
       <p><a href="/lxd">Learn more about LXD&nbsp;&rsaquo;</a></p>
-      <p><a href="https://linuxcontainers.org/lxd/try-it/">Try LXD with an online demo tool&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-4 p-divider__block u-vertically-center u-align--center u-hide--small u-hide--medium">
       {{ image (

--- a/templates/industrial/index.html
+++ b/templates/industrial/index.html
@@ -341,7 +341,7 @@
             </a>
           </div>
           <div class="p-logo-section__item">
-            <a href="https://ubuntu.com/lxd">
+            <a href="/lxd">
               {{ image (
                 url="https://assets.ubuntu.com/v1/e375d3dc-lxd-logo-stacked.png",
                 alt="",

--- a/templates/industrial/index.html
+++ b/templates/industrial/index.html
@@ -341,7 +341,7 @@
             </a>
           </div>
           <div class="p-logo-section__item">
-            <a href="https://linuxcontainers.org/lxd/introduction/">
+            <a href="https://ubuntu.com/lxd">
               {{ image (
                 url="https://assets.ubuntu.com/v1/e375d3dc-lxd-logo-stacked.png",
                 alt="",

--- a/templates/kubernetes/_install-lxd.html
+++ b/templates/kubernetes/_install-lxd.html
@@ -7,7 +7,7 @@
       Install LXD
     </h4>
     <div class="p-stepped-list__content">
-      <p><a href="https://ubuntu.com/lxd">LXD</a> is a system container and VM hypervisor that allows you to create a local cloud. It can be installed via a snap package.</p>
+      <p><a href="/lxd">LXD</a> is a system container and VM hypervisor that allows you to create a local cloud. It can be installed via a snap package.</p>
       <div class="p-code-snippet">
         <pre class="p-code-snippet__block--icon"><code>sudo snap install lxd --classic</code></pre>
       </div>

--- a/templates/kubernetes/_install-lxd.html
+++ b/templates/kubernetes/_install-lxd.html
@@ -7,7 +7,7 @@
       Install LXD
     </h4>
     <div class="p-stepped-list__content">
-      <p><a href="https://linuxcontainers.org/">LXD</a> is a system container and VM hypervisor that allows you to create a local cloud. It can be installed via a snap package.</p>
+      <p><a href="https://ubuntu.com/lxd">LXD</a> is a system container and VM hypervisor that allows you to create a local cloud. It can be installed via a snap package.</p>
       <div class="p-code-snippet">
         <pre class="p-code-snippet__block--icon"><code>sudo snap install lxd --classic</code></pre>
       </div>

--- a/templates/kubernetes/charmed-k8s.html
+++ b/templates/kubernetes/charmed-k8s.html
@@ -238,7 +238,7 @@
       <ul class="p-list">
         <li class="p-list__item is-ticked">Use the Linux Containers Daemon, LXD, for pure-container guests in OpenStack.</li>
         <li class="p-list__item is-ticked">Faster to launch, with zero latency and amazing quality of service, LXD guests are the bridge between traditional VMs and next-generation Kubernetes.</li>
-        <p><a href="https://ubuntu.com/lxd">Visit the LXD website&nbsp;&rsaquo;</a></p>
+        <p><a href="/lxd">Visit the LXD website&nbsp;&rsaquo;</a></p>
       </ul>
     </div>
   </div>

--- a/templates/kubernetes/charmed-k8s.html
+++ b/templates/kubernetes/charmed-k8s.html
@@ -238,7 +238,7 @@
       <ul class="p-list">
         <li class="p-list__item is-ticked">Use the Linux Containers Daemon, LXD, for pure-container guests in OpenStack.</li>
         <li class="p-list__item is-ticked">Faster to launch, with zero latency and amazing quality of service, LXD guests are the bridge between traditional VMs and next-generation Kubernetes.</li>
-        <p><a href="https://linuxcontainers.org/">Visit the LXD website&nbsp;&rsaquo;</a></p>
+        <p><a href="https://ubuntu.com/lxd">Visit the LXD website&nbsp;&rsaquo;</a></p>
       </ul>
     </div>
   </div>

--- a/templates/kubernetes/docs/inclusive-naming.md
+++ b/templates/kubernetes/docs/inclusive-naming.md
@@ -62,7 +62,7 @@ transition the names of the default branches to `main`.
 
 <!-- LINKS -->
 
-[LXD-image]: https://linuxcontainers.org/lxd/docs/master/image-handling
+[LXD-image]: https://documentation.ubuntu.com/lxd/en/latest/image-handling
 [kubernetes-control-plane]: https://charmhub.io/kubernetes-control-plane/docs
 [etcd]: /kubernetes/docs/charm-etcd
 [upgrading]: /kubernetes/docs/upgrading

--- a/templates/kubernetes/docs/inclusive-naming.md
+++ b/templates/kubernetes/docs/inclusive-naming.md
@@ -62,7 +62,7 @@ transition the names of the default branches to `main`.
 
 <!-- LINKS -->
 
-[LXD-image]: https://documentation.ubuntu.com/lxd/en/latest/image-handling
+[LXD-image]: https://linuxcontainers.org/lxd/docs/latest/image-handling
 [kubernetes-control-plane]: https://charmhub.io/kubernetes-control-plane/docs
 [etcd]: /kubernetes/docs/charm-etcd
 [upgrading]: /kubernetes/docs/upgrading

--- a/templates/kubernetes/docs/inclusive-naming.md
+++ b/templates/kubernetes/docs/inclusive-naming.md
@@ -62,7 +62,7 @@ transition the names of the default branches to `main`.
 
 <!-- LINKS -->
 
-[LXD-image]: https://linuxcontainers.org/lxd/docs/latest/image-handling
+[LXD-image]: https://documentation.ubuntu.com/lxd/en/latest/image-handling
 [kubernetes-control-plane]: https://charmhub.io/kubernetes-control-plane/docs
 [etcd]: /kubernetes/docs/charm-etcd
 [upgrading]: /kubernetes/docs/upgrading

--- a/templates/kubernetes/docs/install-local.md
+++ b/templates/kubernetes/docs/install-local.md
@@ -247,7 +247,7 @@ juju config kubernetes-worker sysctl="{ fs.inotify.max_user_watches=1048576 }"
 
 <!-- LINKS -->
 
-[lxd-home]: https://linuxcontainers.org/
+[lxd-home]: https://ubuntu.com/lxd
 [lxd-profile]: https://github.com/charmed-kubernetes/charm-kubernetes-worker/blob/main/lxd-profile.yaml
 [Juju]: https://jaas.ai
 [snap]: https://snapcraft.io/docs/installing-snapd

--- a/templates/kubernetes/docs/install-offline.md
+++ b/templates/kubernetes/docs/install-offline.md
@@ -258,7 +258,7 @@ is covered in the [proxy documentation][].
 
 
 <!-- LINKS -->
-[LXD-image]: https://linuxcontainers.org/lxd/docs/master/image-handling
+[LXD-image]: https://documentation.ubuntu.com/lxd/en/latest/image-handling
 [maas-images]: https://maas.io/docs/how-to-use-standard-images
 [simplestreams]: https://juju.is/docs/olm/cloud-image-metadata
 [bundles]: /kubernetes/docs/supported-versions
@@ -285,7 +285,7 @@ is covered in the [proxy documentation][].
 [sideload]: https://docs.ubuntu.com/snap-store-proxy/en/airgap#usage
 [proxy documentation]: /kubernetes/docs/proxies
 [registry]: /kubernetes/docs/docker-registry
-[LXD]: https://linuxcontainers.org/lxd/introduction/
+[LXD]: https://ubuntu.com/lxd
 [local-install]: /kubernetes/docs/install-local
 
 <!-- FEEDBACK -->

--- a/templates/kubernetes/docs/install-offline.md
+++ b/templates/kubernetes/docs/install-offline.md
@@ -258,7 +258,7 @@ is covered in the [proxy documentation][].
 
 
 <!-- LINKS -->
-[LXD-image]: https://linuxcontainers.org/lxd/docs/latest/image-handling
+[LXD-image]: https://documentation.ubuntu.com/lxd/en/latest/image-handling
 [maas-images]: https://maas.io/docs/how-to-use-standard-images
 [simplestreams]: https://juju.is/docs/olm/cloud-image-metadata
 [bundles]: /kubernetes/docs/supported-versions

--- a/templates/kubernetes/docs/install-offline.md
+++ b/templates/kubernetes/docs/install-offline.md
@@ -258,7 +258,7 @@ is covered in the [proxy documentation][].
 
 
 <!-- LINKS -->
-[LXD-image]: https://documentation.ubuntu.com/lxd/en/latest/image-handling
+[LXD-image]: https://linuxcontainers.org/lxd/docs/latest/image-handling
 [maas-images]: https://maas.io/docs/how-to-use-standard-images
 [simplestreams]: https://juju.is/docs/olm/cloud-image-metadata
 [bundles]: /kubernetes/docs/supported-versions

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -268,7 +268,7 @@
       <h2 class="p-logo-section__title u-align--left">Fully-support Kubernetes clouds</h2>
       <div class="p-logo-section__items">
         <div class="p-logo-section__item">
-          <a href="https://linuxcontainers.org/">
+          <a href="https://ubuntu.com/lxd">
             {{
               image (
               url="https://assets.ubuntu.com/v1/e375d3dc-lxd-logo-stacked.png",

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -268,7 +268,7 @@
       <h2 class="p-logo-section__title u-align--left">Fully-support Kubernetes clouds</h2>
       <div class="p-logo-section__items">
         <div class="p-logo-section__item">
-          <a href="https://ubuntu.com/lxd">
+          <a href="/lxd">
             {{
               image (
               url="https://assets.ubuntu.com/v1/e375d3dc-lxd-logo-stacked.png",

--- a/templates/legal/websites.html
+++ b/templates/legal/websites.html
@@ -80,9 +80,6 @@
           <a href="https://launchpad.net">launchpad.net</a>
         </li>
         <li class="p-list__item">
-          <a href="https://linuxcontainers.org">linuxcontainers.org</a>
-        </li>
-        <li class="p-list__item">
           <a href="https://lists.ubuntu.com">lists.ubuntu.com</a>
         </li>
         <li class="p-list__item">

--- a/templates/lxd/index.html
+++ b/templates/lxd/index.html
@@ -163,7 +163,7 @@
         ) | safe
       }}
       </div>
-      <a href="https://linuxcontainers.org/lxd/docs/latest">Read the documentation&nbsp;&rsaquo;</a>
+      <a href="https://documentation.ubuntu.com/lxd">Read the documentation&nbsp;&rsaquo;</a>
     </div>
     <div class="col-4">
       <div class="u-sv1 u-hide--medium u-hide--small">

--- a/templates/lxd/index.html
+++ b/templates/lxd/index.html
@@ -15,7 +15,7 @@
       <p class="p-heading--4">Fast, dense, and secure container and VM management at any scale </p>
       <p> LXD provides a unified user experience for managing system containers and virtual machines. For more demanding workloads, LXD can be set up in a cluster environment to run containers, VMs, or a combination of the two on a set of machines. LXD has direct hardware access, minimising overhead and matching the density and efficiency of containers.</p>
       <p>
-        <a class="p-button--positive js-invoke-modal" href="/lxd#get-in-touch">Get in touch</a>
+        <a class="p-button--positive js-invoke-modal" href="/containers/contact-us?product=containers-lxd">Get in touch</a>
       </p>
     </div>
     <div class="col-6 u-hide--medium u-hide--small u-align--center">

--- a/templates/lxd/index.html
+++ b/templates/lxd/index.html
@@ -15,8 +15,7 @@
       <p class="p-heading--4">Fast, dense, and secure container and VM management at any scale </p>
       <p> LXD provides a unified user experience for managing system containers and virtual machines. For more demanding workloads, LXD can be set up in a cluster environment to run containers, VMs, or a combination of the two on a set of machines. LXD has direct hardware access, minimising overhead and matching the density and efficiency of containers.</p>
       <p>
-        <a class="p-button--positive" href="https://linuxcontainers.org/lxd/try-it/">Try LXD Online</a>
-        <a class="p-button js-invoke-modal" href="/lxd#get-in-touch">Get in touch</a>
+        <a class="p-button--positive js-invoke-modal" href="/lxd#get-in-touch">Get in touch</a>
       </p>
     </div>
     <div class="col-6 u-hide--medium u-hide--small u-align--center">
@@ -149,67 +148,10 @@
     </ul>
   </div>
 </section>
-<section class="p-strip">
-  <div class="u-fixed-width">
-    <h2>Install LXD in 4 easy steps</h2>
-    <ol class="p-stepped-list--detailed">
-      <li class="p-stepped-list__item">
-        <h3 class="p-stepped-list__title">Install LXD as a snap</h3>
-        <div class="p-stepped-list__content">
-          <p>If you are running Ubuntu 16.04 or later, just run:</p>
-          <pre><code>snap install lxd</code></pre>
-        </div>
-      </li>
-      <li class="p-stepped-list__item">
-        <h3 class="p-stepped-list__title">Configure LXD</h3>
-        <div class="p-stepped-list__content">
-          <p>Run the following command and either accept the defaults or choose different options when prompted:</p>
-          <pre><code>lxd init</code></pre>
-        </div>
-      </li>
-      <li class="p-stepped-list__item">
-        <h3 class="p-stepped-list__title">Install the OS you’d like to use in your container or VM</h3>
-        <div class="p-stepped-list__content">
-          <h4>Container</h4>
-            <p>Command: <pre><code>lxc launch &lt;image_server&gt;:&lt;image_name&gt; &lt;instance_name&gt;</code></pre></p>
-            <p>Example: <pre><code>lxc launch ubuntu:22.04 ubuntu-container</code></pre></p>
-          <h4>VM</h4>
-            <p>Command: <pre><code>lxc launch &lt;image_server&gt;:&lt;image_name&gt; &lt;instance_name&gt; --vm</code></pre></p>
-            <p>Example: <pre><code>lxc launch ubuntu:22.04 ubuntu-container-vm --vm</code></pre></p>
-            <p>Check the <a href="https://images.linuxcontainers.org/">community image server</a> for other Linux distributions.</p>
-        </div>
-      </li>
-      <li class="p-stepped-list__item">
-        <h3 class="p-stepped-list__title">Run commands</h3>
-        <div class="p-stepped-list__content">
-          <p>You now have your instance up and running! You’re all set to experiment with any commands you need.</p>
-          <p>Command: <pre><code>lxc exec &lt;instance_name&gt; -- &lt;command&gt;</code></pre></p>
-          <p>Example: <pre><code>lxc exec ubuntu-container -- apt-get update</code></pre></p>
-          <p>For a list of available commands and options, just run lxc</p>
-        </div>
-      </li>
-    </ol>
-    <p>For other installation options, please check our <a href="https://linuxcontainers.org/lxd/docs/master/installing/">documentation</a>.</p>
-  </div>
-</section>
 <section class="p-strip--light">
   <div class="row">
     <h2 class="u-sv3">Join the LXD community</h2>
-    <div class="col-3">
-      <div class="u-sv1 u-hide--medium u-hide--small">
-      {{ image (
-        url="https://assets.ubuntu.com/v1/dead5f08-containers.svg",
-        alt="",
-        width="52",
-        height="60",
-        hi_def=True,
-        loading="lazy"
-        ) | safe
-      }}
-      </div>
-      <a href="https://linuxcontainers.org/lxd/try-it/">Try LXD online demo&nbsp;&rsaquo;</a>
-    </div>
-    <div class="col-3">
+    <div class="col-4">
       <div class="u-sv1 u-hide--medium u-hide--small">
       {{ image (
         url="https://assets.ubuntu.com/v1/df54bb6a-document-open-icon.svg",
@@ -221,9 +163,9 @@
         ) | safe
       }}
       </div>
-      <a href="https://linuxcontainers.org/lxd/docs/master/">Read the documentation&nbsp;&rsaquo;</a>
+      <a href="https://documentation.ubuntu.com/lxd">Read the documentation&nbsp;&rsaquo;</a>
     </div>
-    <div class="col-3">
+    <div class="col-4">
       <div class="u-sv1 u-hide--medium u-hide--small">
       {{ image (
         url="https://assets.ubuntu.com/v1/3aef5bf9-forum-icon.svg",
@@ -235,9 +177,9 @@
         ) | safe
       }}
       </div>
-      <a href="https://discuss.linuxcontainers.org/">Discuss with other users&nbsp;&rsaquo;</a>
+      <a href="https://discourse.ubuntu.com/c/lxd/126">Discuss with other users&nbsp;&rsaquo;</a>
     </div>
-    <div class="col-3">
+    <div class="col-4">
       <div class="u-sv1 u-hide--medium u-hide--small">
       {{ image (
         url="https://assets.ubuntu.com/v1/3769b4a7-webinar-icon.svg",
@@ -256,7 +198,7 @@
 <section class="p-strip is-bordered">
   <div class="row">
     <div class="col-6">
-      <h2 class="u-sv2">Enhance your experience with best-in-class open-source tools</h2>
+      <h2 class="u-sv2">Enhance your experience with best-in-class open source tools</h2>
     </div>
   </div>
   <div class="row">

--- a/templates/lxd/index.html
+++ b/templates/lxd/index.html
@@ -163,7 +163,7 @@
         ) | safe
       }}
       </div>
-      <a href="https://documentation.ubuntu.com/lxd">Read the documentation&nbsp;&rsaquo;</a>
+      <a href="https://linuxcontainers.org/lxd/docs/latest">Read the documentation&nbsp;&rsaquo;</a>
     </div>
     <div class="col-4">
       <div class="u-sv1 u-hide--medium u-hide--small">

--- a/templates/lxd/install.html
+++ b/templates/lxd/install.html
@@ -68,7 +68,7 @@
         </div>
       </li>
     </ol>
-    <p>For other installation options, please check our <a href="https://linuxcontainers.org/lxd/docs/latest/installing/">documentation</a>.</p>
+    <p>For other installation options, please check our <a href="https://documentation.ubuntu.com/lxd/en/latest/installing/">documentation</a>.</p>
   </div>
 </section>
 
@@ -77,7 +77,7 @@
     <div class="col-6">
       <h3 class="p-heading--4">Firewall issues</h3>
       <p>You might see issues with your firewall blocking network access for your instances, or connectivity issues because you run LXD and Docker on the same host.</p>
-      <p>See <a href="https://linuxcontainers.org/lxd/docs/latest/howto/network_bridge_firewalld/#network-bridge-firewall">How to configure your firewall</a> for information on how to resolve such issues.</p>
+      <p>See <a href="https://documentation.ubuntu.com/lxd/en/latest/howto/network_bridge_firewalld/#network-bridge-firewall">How to configure your firewall</a> for information on how to resolve such issues.</p>
     </div>
   </div>
 </section>
@@ -90,24 +90,24 @@
     <div class="col-6 p-card">
       <h3 class="p-card__title p-heading--4">Instances</h3>
       <p>LXD supports two types of instances: system containers and virtual machines.</p>
-      <a href="https://linuxcontainers.org/lxd/docs/latest/explanation/containers_and_vms/">Learn more</a>
+      <a href="https://documentation.ubuntu.com/lxd/en/latest/explanation/containers_and_vms/">Learn more</a>
     </div>
     <div class="col-6 p-card">
       <h3 class="p-card__title p-heading--4">Images</h3>
       <p>LXD uses an image-based workflow, providing images for a large number of Linux distributions.</p>
-      <a href="https://linuxcontainers.org/lxd/docs/latest/image-handling/">Learn more</a>
+      <a href="https://documentation.ubuntu.com/lxd/en/latest/image-handling/">Learn more</a>
     </div>
   </div>
   <div class="row u-equal-height">
     <div class="col-6 p-card">
       <h3 class="p-card__title p-heading--4">Security</h3>
       <p>Security is at the forefront of everything we do and there are various things to consider to keep your LXD installation secure.</p>
-      <a href="https://linuxcontainers.org/lxd/docs/latest/explanation/security/">Learn more</a>
+      <a href="https://documentation.ubuntu.com/lxd/en/latest/explanation/security/">Learn more</a>
     </div>
     <div class="col-6 p-card">
       <h3 class="p-card__title p-heading--4">Contribute</h3>
       <p>We welcome and value contributions from the community.</p>
-      <a href="https://linuxcontainers.org/lxd/docs/latest/contributing/">Learn more</a>
+      <a href="https://documentation.ubuntu.com/lxd/en/latest/contributing/">Learn more</a>
     </div>
   </div>
 </section>

--- a/templates/lxd/install.html
+++ b/templates/lxd/install.html
@@ -1,0 +1,135 @@
+{% extends "lxd/base_lxd.html" %}
+
+{% block title %}Install LXD{% endblock %}
+
+{% block meta_description %}Try LXD on your laptop, workstation or server. Set up a single instance LXD for testing and development, or run it in a clustering mode for highly-available production environments.{% endblock meta_description %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1LKlXAc39dy69dSCc7PE6WqV2qkCSeXmicKGS4lFicDE/edit{% endblock meta_copydoc %}
+
+{% block content %}
+
+<section class="p-strip--suru-topped">
+  <div class="row u-equal-height u-vertically-center">
+    <div class="col-6">
+      <h1>Install LXD</h1>
+      <p>Try LXD on your laptop, workstation or server. Set up a single instance LXD for testing and development, or run it in a clustering mode for highly-available production environments.</p>
+      <p>Looking for help running LXD?</p>
+      <p>
+        <a class="p-button--positive js-invoke-modal" href="/lxd#get-in-touch">Get in touch</a>
+      </p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="u-fixed-width">
+    <h2>Install LXD in 4 easy steps</h2>
+    <ol class="p-stepped-list--detailed">
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">Install LXD as a snap</h3>
+        <div class="p-stepped-list__content">
+          <p>To install LXD as a snap, just run:</p>
+          <pre><code>snap install lxd</code></pre>
+        </div>
+      </li>
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">Configure LXD</h3>
+        <div class="p-stepped-list__content">
+          <p>Run the following command and either accept the defaults or choose different options when prompted:</p>
+          <pre><code>lxd init</code></pre>
+        </div>
+      </li>
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">Install the OS you’d like to use in your container or VM</h3>
+        <div class="p-stepped-list__content">
+          <h4>Container</h4>
+            <p>Command: <pre><code>lxc launch &lt;image_server&gt;:&lt;image_name&gt; &lt;instance_name&gt;</code></pre></p>
+            <p>Example: <pre><code>lxc launch ubuntu:22.04 ubuntu-container</code></pre></p>
+          <h4>VM</h4>
+            <p>Command: <pre><code>lxc launch &lt;image_server&gt;:&lt;image_name&gt; &lt;instance_name&gt; --vm</code></pre></p>
+            <p>Example: <pre><code>lxc launch ubuntu:22.04 ubuntu-vm --vm</code></pre></p>
+            <p>Check the <a href="https://images.linuxcontainers.org/">community image server</a> for other Linux distributions.</p>
+        </div>
+      </li>
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">Run commands</h3>
+        <div class="p-stepped-list__content">
+          <p>You now have your instance up and running! You’re all set to experiment with any commands you need.</p>
+          <p>Command: <pre><code>lxc exec &lt;instance_name&gt; -- &lt;command&gt;</code></pre></p>
+          <p>Example: <pre><code>lxc exec ubuntu-container -- apt-get update</code></pre></p>
+          <p>For a list of available commands and options, just run <pre><code>lxc</code></pre></p>
+        </div>
+      </li>
+    </ol>
+    <p>For other installation options, please check our <a href="https://documentation.ubuntu.com/lxd/en/latest/installing/">documentation</a>.</p>
+  </div>
+</section>
+
+<section class="p-strip is-bordered">
+  <div class="row">
+    <div class="col-6">
+      <h3 class="p-heading--4">Firewall issues</h3>
+      <p>You might see issues with your firewall blocking network access for your instances, or connectivity issues because you run LXD and Docker on the same host.</p>
+      <p>See <a href="https://documentation.ubuntu.com/lxd/en/latest/howto/network_bridge_firewalld/#network-bridge-firewall">How to configure your firewall</a> for information on how to resolve such issues.</p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-bordered">
+  <div class="row">
+    <h2 class="p-heading--3">Familiarise yourself with the basics</h2>
+  </div>
+  <div class="row u-equal-height">
+    <div class="col-6 p-card">
+      <h3 class="p-card__title p-heading--4">Instances</h3>
+      <p>LXD supports two types of instances: system containers and virtual machines.</p>
+      <a href="https://documentation.ubuntu.com/lxd/en/latest/explanation/containers_and_vms/">Learn more</a>
+    </div>
+    <div class="col-6 p-card">
+      <h3 class="p-card__title p-heading--4">Images</h3>
+      <p>LXD uses an image-based workflow, providing images for a large number of Linux distributions.</p>
+      <a href="https://documentation.ubuntu.com/lxd/en/latest/image-handling/">Learn more</a>
+    </div>
+  </div>
+  <div class="row u-equal-height">
+    <div class="col-6 p-card">
+      <h3 class="p-card__title p-heading--4">Security</h3>
+      <p>Security is at the forefront of everything we do and there are various things to consider to keep your LXD installation secure.</p>
+      <a href="https://documentation.ubuntu.com/lxd/en/latest/explanation/security/">Learn more</a>
+    </div>
+    <div class="col-6 p-card">
+      <h3 class="p-card__title p-heading--4">Contribute</h3>
+      <p>We welcome and value contributions from the community.</p>
+      <a href="https://documentation.ubuntu.com/lxd/en/latest/contributing/">Learn more</a>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-bordered">
+  <div class="row u-sv3">
+    <div class="col-5 u-vertically-center u-align--center u-hide--small u-hide--medium">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/c4b290c8-Contact+us.svg",
+        alt="",
+        width="211",
+        height="150",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+    <div class="col-7">
+      <h2>Need more help with LXD?</h2>
+      <p>Let our LXD experts help you take the next step.</p>
+      <p>
+        <a class="p-button--positive js-invoke-modal" href="/lxd#get-in-touch">Get in touch</a>
+      </p>
+    </div>
+  </div>
+</section>
+
+<!-- Set default Marketo information for contact form below-->
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/lxd" data-form-id="4446" data-lp-id="" data-return-url="/lxd" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+</div>
+
+{% endblock content %}

--- a/templates/lxd/install.html
+++ b/templates/lxd/install.html
@@ -61,7 +61,7 @@
         </div>
       </li>
     </ol>
-    <p>For other installation options, please check our <a href="https://documentation.ubuntu.com/lxd/en/latest/installing/">documentation</a>.</p>
+    <p>For other installation options, please check our <a href="https://linuxcontainers.org/lxd/docs/latest/installing/">documentation</a>.</p>
   </div>
 </section>
 
@@ -70,7 +70,7 @@
     <div class="col-6">
       <h3 class="p-heading--4">Firewall issues</h3>
       <p>You might see issues with your firewall blocking network access for your instances, or connectivity issues because you run LXD and Docker on the same host.</p>
-      <p>See <a href="https://documentation.ubuntu.com/lxd/en/latest/howto/network_bridge_firewalld/#network-bridge-firewall">How to configure your firewall</a> for information on how to resolve such issues.</p>
+      <p>See <a href="https://linuxcontainers.org/lxd/docs/latest/howto/network_bridge_firewalld/#network-bridge-firewall">How to configure your firewall</a> for information on how to resolve such issues.</p>
     </div>
   </div>
 </section>
@@ -83,24 +83,24 @@
     <div class="col-6 p-card">
       <h3 class="p-card__title p-heading--4">Instances</h3>
       <p>LXD supports two types of instances: system containers and virtual machines.</p>
-      <a href="https://documentation.ubuntu.com/lxd/en/latest/explanation/containers_and_vms/">Learn more</a>
+      <a href="https://linuxcontainers.org/lxd/docs/latest/explanation/containers_and_vms/">Learn more</a>
     </div>
     <div class="col-6 p-card">
       <h3 class="p-card__title p-heading--4">Images</h3>
       <p>LXD uses an image-based workflow, providing images for a large number of Linux distributions.</p>
-      <a href="https://documentation.ubuntu.com/lxd/en/latest/image-handling/">Learn more</a>
+      <a href="https://linuxcontainers.org/lxd/docs/latest/image-handling/">Learn more</a>
     </div>
   </div>
   <div class="row u-equal-height">
     <div class="col-6 p-card">
       <h3 class="p-card__title p-heading--4">Security</h3>
       <p>Security is at the forefront of everything we do and there are various things to consider to keep your LXD installation secure.</p>
-      <a href="https://documentation.ubuntu.com/lxd/en/latest/explanation/security/">Learn more</a>
+      <a href="https://linuxcontainers.org/lxd/docs/latest/explanation/security/">Learn more</a>
     </div>
     <div class="col-6 p-card">
       <h3 class="p-card__title p-heading--4">Contribute</h3>
       <p>We welcome and value contributions from the community.</p>
-      <a href="https://documentation.ubuntu.com/lxd/en/latest/contributing/">Learn more</a>
+      <a href="https://linuxcontainers.org/lxd/docs/latest/contributing/">Learn more</a>
     </div>
   </div>
 </section>

--- a/templates/lxd/install.html
+++ b/templates/lxd/install.html
@@ -15,7 +15,7 @@
       <p>Try LXD on your laptop, workstation or server. Set up a single instance LXD for testing and development, or run it in a clustering mode for highly-available production environments.</p>
       <p>Looking for help running LXD?</p>
       <p>
-        <a class="p-button--positive js-invoke-modal" href="/lxd#get-in-touch">Get in touch</a>
+        <a class="p-button--positive js-invoke-modal" href="/containers/contact-us?product=containers-lxd">Get in touch</a>
       </p>
     </div>
   </div>
@@ -122,7 +122,7 @@
       <h2>Need more help with LXD?</h2>
       <p>Let our LXD experts help you take the next step.</p>
       <p>
-        <a class="p-button--positive js-invoke-modal" href="/lxd#get-in-touch">Get in touch</a>
+        <a class="p-button--positive js-invoke-modal" href="/containers/contact-us?product=containers-lxd">Get in touch</a>
       </p>
     </div>
   </div>

--- a/templates/lxd/install.html
+++ b/templates/lxd/install.html
@@ -43,11 +43,15 @@
         <h3 class="p-stepped-list__title">Install the OS you’d like to use in your container or VM</h3>
         <div class="p-stepped-list__content">
           <h4>Container</h4>
-            <p>Command: <pre><code>lxc launch &lt;image_server&gt;:&lt;image_name&gt; &lt;instance_name&gt;</code></pre></p>
-            <p>Example: <pre><code>lxc launch ubuntu:22.04 ubuntu-container</code></pre></p>
+            <p>Command:</p>
+            <pre><code>lxc launch &lt;image_server&gt;:&lt;image_name&gt; &lt;instance_name&gt;</code></pre>
+            <p>Example:</p>
+            <pre><code>lxc launch ubuntu:22.04 ubuntu-container</code></pre>
           <h4>VM</h4>
-            <p>Command: <pre><code>lxc launch &lt;image_server&gt;:&lt;image_name&gt; &lt;instance_name&gt; --vm</code></pre></p>
-            <p>Example: <pre><code>lxc launch ubuntu:22.04 ubuntu-vm --vm</code></pre></p>
+            <p>Command:</p>
+            <pre><code>lxc launch &lt;image_server&gt;:&lt;image_name&gt; &lt;instance_name&gt; --vm</code></pre>
+            <p>Example:</p>
+            <pre><code>lxc launch ubuntu:22.04 ubuntu-vm --vm</code></pre>
             <p>Check the <a href="https://images.linuxcontainers.org/">community image server</a> for other Linux distributions.</p>
         </div>
       </li>
@@ -55,9 +59,12 @@
         <h3 class="p-stepped-list__title">Run commands</h3>
         <div class="p-stepped-list__content">
           <p>You now have your instance up and running! You’re all set to experiment with any commands you need.</p>
-          <p>Command: <pre><code>lxc exec &lt;instance_name&gt; -- &lt;command&gt;</code></pre></p>
-          <p>Example: <pre><code>lxc exec ubuntu-container -- apt-get update</code></pre></p>
-          <p>For a list of available commands and options, just run <pre><code>lxc</code></pre></p>
+          <p>Command:</p>
+          <pre><code>lxc exec &lt;instance_name&gt; -- &lt;command&gt;</code></pre>
+          <p>Example:</p>
+          <pre><code>lxc exec ubuntu-container -- apt-get update</code></pre>
+          <p>For a list of available commands and options, just run</p>
+          <pre><code>lxc</code></pre>
         </div>
       </li>
     </ol>

--- a/templates/lxd/manage.html
+++ b/templates/lxd/manage.html
@@ -184,10 +184,10 @@
     <div class="row">
       <div class="col-5 u-vertically-center u-align--center u-hide--small u-hide--medium">
         {{ image (
-          url="https://assets.ubuntu.com/v1/ab22825a-ansible+logo.png",
+          url="https://assets.ubuntu.com/v1/c3e59d4f-Ansible_logo.svg",
           alt="",
-          width="252",
-          height="253",
+          width="130",
+          height="157",
           hi_def=True,
           loading="lazy"
           ) | safe
@@ -238,8 +238,8 @@
         {{ image (
           url="https://assets.ubuntu.com/v1/b690b29b-bolt-logo-dark.png",
           alt="",
-          width="250",
-          height="95",
+          width="170",
+          height="64",
           hi_def=True,
           loading="lazy"
           ) | safe

--- a/templates/lxd/manage.html
+++ b/templates/lxd/manage.html
@@ -33,12 +33,12 @@
     <div class="col-6 p-card">
     <h2 class="p-heading--3">LXD CLI</h2>
       <p>LXD offers an intuitive and crisp CLI for easy operations. To control LXD, you typically use two different commands: lxd and lxc. The lxd command is used to control the daemon and is typically used only for initialisation and debugging. The lxc command is the command-line client that you use to interact with your instances. See lxc --help for an overview of all available subcommands.</p>
-      <a href="https://linuxcontainers.org/lxd/docs/latest/explanation/lxd_lxc/">Get started with the LXD CLI</a>
+      <a href="https://documentation.ubuntu.com/lxd/en/latest/explanation/lxd_lxc/">Get started with the LXD CLI</a>
     </div>
     <div class="col-6 p-card">
       <h2 class="p-card__title p-heading--3">LXD REST API</h2>
       <p>All communication between LXD and its clients happens using a RESTful API over HTTP. This means you can easily integrate LXD with any other tool you use for managing your infrastructure, and you can easily set up scripts as needed. LXD implements a single REST API for both local and remote access.</p>
-      <a href="https://linuxcontainers.org/lxd/docs/latest/rest-api/">Learn more about the LXD REST API</a>
+      <a href="https://documentation.ubuntu.com/lxd/en/latest/rest-api/">Learn more about the LXD REST API</a>
     </div>
   </div>
 </section>
@@ -203,7 +203,7 @@
           <li class="p-list__item is-ticked">A <a href="https://docs.ansible.com/ansible/latest/collections/community/general/lxd_container_module.html">plugin</a> to create and manage LXD containers</li>
           <li class="p-list__item is-ticked">A <a href="https://docs.ansible.com/ansible/latest/collections/community/general/lxd_profile_module.html">plugin</a> to manage LXD profiles</li>
         </ul>
-        <p>To manage LXD in Ansible, you need a LXD server (see <a href="https://linuxcontainers.org/lxd/docs/latest/getting_started/">Getting started</a>).</p>
+        <p>To manage LXD in Ansible, you need a LXD server (see <a href="https://documentation.ubuntu.com/lxd/en/latest/getting_started/">Getting started</a>).</p>
       </div>
     </div>
   </div>
@@ -216,7 +216,7 @@
         <p><a href="https://terraform.io/">Terraform</a> is an open source infrastructure-as-code software tool for configuration and service management.</p>
         <p>The LXD integration allows Terraform to deploy instances on LXD servers with support for local and remote deployments.</p>
         <p>Take a look at the <a href="https://registry.terraform.io/providers/terraform-lxd/lxd/latest/docs">Terraform documentation on LXD</a> for more information.</p>
-        <p>To manage LXD in Terraform, you need a LXD server  (see <a href="https://linuxcontainers.org/lxd/docs/latest/getting_started/">Getting started</a>).</p>
+        <p>To manage LXD in Terraform, you need a LXD server  (see <a href="https://documentation.ubuntu.com/lxd/en/latest/getting_started/">Getting started</a>).</p>
       </div>
       <div class="col-5 u-vertically-center u-align--center u-hide--small u-hide--medium">
         {{ image (
@@ -250,7 +250,7 @@
         <p><a href="https://puppet.com/docs/bolt/latest/bolt.html">Bolt</a> is an open source orchestration tool that automates the manual work it takes to maintain your infrastructure.</p>
         <p>The LXD transport allows for interacting with LXD instances.</p>
         <p>For more information, see the <a href="https://puppet.com/docs/bolt/latest/bolt_transports_reference.html#lxd">Puppet Bolt Documentation on LXD</a>.</p>
-        <p>To manage LXD in Puppet Bolt, you need a LXD server (see <a href="https://linuxcontainers.org/lxd/docs/latest/getting_started/">Getting started</a>).</p>
+        <p>To manage LXD in Puppet Bolt, you need a LXD server (see <a href="https://documentation.ubuntu.com/lxd/en/latest/getting_started/">Getting started</a>).</p>
       </div>
     </div>
   </div>
@@ -262,8 +262,8 @@
         <p><a href="https://www.packer.io/">Packer</a> is an open source tool for creating identical machine images for multiple platforms.</p>
         <p>With Packer's LXD builder, it's possible to re-use your existing cloud image building pipeline and with the LXD builder, build a LXD container image.</p>
         <p>Take a look at the <a href="https://www.packer.io/docs/builders/lxd">Packer documentation on LXD</a> for more information.</p>
-        <p>Additionally our guides about <a href="https://linuxcontainers.org/lxd/docs/latest/images/">images</a> and <a href="https://linuxcontainers.org/lxd/docs/latest/howto/instances_configure/">instance configuration</a> might contain useful information regarding image choice, configuration options etc.</p>
-        <p>To create LXD images in Packer, you need a LXD server (see <a href="https://linuxcontainers.org/lxd/docs/latest/getting_started/">Getting started</a>).</p>
+        <p>Additionally our guides about <a href="https://documentation.ubuntu.com/lxd/en/latest/images/">images</a> and <a href="https://documentation.ubuntu.com/lxd/en/latest/howto/instances_configure/">instance configuration</a> might contain useful information regarding image choice, configuration options etc.</p>
+        <p>To create LXD images in Packer, you need a LXD server (see <a href="https://documentation.ubuntu.com/lxd/en/latest/getting_started/">Getting started</a>).</p>
       </div>
       <div class="col-5 u-vertically-center u-align--center u-hide--small u-hide--medium">
         {{ image (

--- a/templates/lxd/manage.html
+++ b/templates/lxd/manage.html
@@ -52,7 +52,7 @@
     </div>
     <div class="col-6 u-vertically-center u-align--center u-hide--small u-hide--medium">
       {{ image (
-        url="https://lh4.googleusercontent.com/oURP8ffnOR44PGUCGaTlD1rRtfVN3oBkPxuLpuvvI4vrYt_093UhOiDTwIihUtlfPWTEA_48rMqZL1wB832Pa4I5AppqTl4EHbcTPRf3V-fxFQaae2jdYcA7-ntt-vOl6wgTYl1hi54RTifHPnOgnIY",
+        url="https://assets.ubuntu.com/v1/4db28649-lxd-ui-with-vm.png",
         alt="",
         width="489",
         height="250",

--- a/templates/lxd/manage.html
+++ b/templates/lxd/manage.html
@@ -48,7 +48,7 @@
     <div class="col-6">
       <h2>LXD graphical user interface</h2>
       <p>An official LXD UI tool is now available as an experimental feature. The UI supports most of the functionalities surrounding managing instances. More features coming soon.</p>
-      <p><a href="https://ubuntu.com/blog/lxd_ui">Read more about the current state of the UI and future plans</a></p>
+      <p><a href="/blog/lxd_ui">Read more about the current state of the UI and future plans</a></p>
     </div>
     <div class="col-6 u-vertically-center u-align--center u-hide--small u-hide--medium">
       {{ image (

--- a/templates/lxd/manage.html
+++ b/templates/lxd/manage.html
@@ -33,12 +33,12 @@
     <div class="col-6 p-card">
     <h2 class="p-heading--3">LXD CLI</h2>
       <p>LXD offers an intuitive and crisp CLI for easy operations. To control LXD, you typically use two different commands: lxd and lxc. The lxd command is used to control the daemon and is typically used only for initialisation and debugging. The lxc command is the command-line client that you use to interact with your instances. See lxc --help for an overview of all available subcommands.</p>
-      <a href="https://documentation.ubuntu.com/lxd/en/latest/explanation/lxd_lxc/">Get started with the LXD CLI</a>
+      <a href="https://linuxcontainers.org/lxd/docs/latest/explanation/lxd_lxc/">Get started with the LXD CLI</a>
     </div>
     <div class="col-6 p-card">
       <h2 class="p-card__title p-heading--3">LXD REST API</h2>
       <p>All communication between LXD and its clients happens using a RESTful API over HTTP. This means you can easily integrate LXD with any other tool you use for managing your infrastructure, and you can easily set up scripts as needed. LXD implements a single REST API for both local and remote access.</p>
-      <a href="https://documentation.ubuntu.com/lxd/en/latest/rest-api/">Learn more about the LXD REST API</a>
+      <a href="https://linuxcontainers.org/lxd/docs/latest/rest-api/">Learn more about the LXD REST API</a>
     </div>
   </div>
 </section>
@@ -203,7 +203,7 @@
           <li class="p-list__item is-ticked">A <a href="https://docs.ansible.com/ansible/latest/collections/community/general/lxd_container_module.html">plugin</a> to create and manage LXD containers</li>
           <li class="p-list__item is-ticked">A <a href="https://docs.ansible.com/ansible/latest/collections/community/general/lxd_profile_module.html">plugin</a> to manage LXD profiles</li>
         </ul>
-        <p>To manage LXD in Ansible, you need a LXD server (see <a href="https://documentation.ubuntu.com/lxd/en/latest/getting_started/">Getting started</a>).</p>
+        <p>To manage LXD in Ansible, you need a LXD server (see <a href="https://linuxcontainers.org/lxd/docs/latest/getting_started/">Getting started</a>).</p>
       </div>
     </div>
   </div>
@@ -216,7 +216,7 @@
         <p><a href="https://terraform.io/">Terraform</a> is an open source infrastructure-as-code software tool for configuration and service management.</p>
         <p>The LXD integration allows Terraform to deploy instances on LXD servers with support for local and remote deployments.</p>
         <p>Take a look at the <a href="https://registry.terraform.io/providers/terraform-lxd/lxd/latest/docs">Terraform documentation on LXD</a> for more information.</p>
-        <p>To manage LXD in Terraform, you need a LXD server  (see <a href="https://documentation.ubuntu.com/lxd/en/latest/getting_started/">Getting started</a>).</p>
+        <p>To manage LXD in Terraform, you need a LXD server  (see <a href="https://linuxcontainers.org/lxd/docs/latest/getting_started/">Getting started</a>).</p>
       </div>
       <div class="col-5 u-vertically-center u-align--center u-hide--small u-hide--medium">
         {{ image (
@@ -250,7 +250,7 @@
         <p><a href="https://puppet.com/docs/bolt/latest/bolt.html">Bolt</a> is an open source orchestration tool that automates the manual work it takes to maintain your infrastructure.</p>
         <p>The LXD transport allows for interacting with LXD instances.</p>
         <p>For more information, see the <a href="https://puppet.com/docs/bolt/latest/bolt_transports_reference.html#lxd">Puppet Bolt Documentation on LXD</a>.</p>
-        <p>To manage LXD in Puppet Bolt, you need a LXD server (see <a href="https://documentation.ubuntu.com/lxd/en/latest/getting_started/">Getting started</a>).</p>
+        <p>To manage LXD in Puppet Bolt, you need a LXD server (see <a href="https://linuxcontainers.org/lxd/docs/latest/getting_started/">Getting started</a>).</p>
       </div>
     </div>
   </div>
@@ -262,8 +262,8 @@
         <p><a href="https://www.packer.io/">Packer</a> is an open source tool for creating identical machine images for multiple platforms.</p>
         <p>With Packer's LXD builder, it's possible to re-use your existing cloud image building pipeline and with the LXD builder, build a LXD container image.</p>
         <p>Take a look at the <a href="https://www.packer.io/docs/builders/lxd">Packer documentation on LXD</a> for more information.</p>
-        <p>Additionally our guides about <a href="https://documentation.ubuntu.com/lxd/en/latest/images/">images</a> and <a href="https://documentation.ubuntu.com/lxd/en/latest/howto/instances_configure/">instance configuration</a> might contain useful information regarding image choice, configuration options etc.</p>
-        <p>To create LXD images in Packer, you need a LXD server (see <a href="https://documentation.ubuntu.com/lxd/en/latest/getting_started/">Getting started</a>).</p>
+        <p>Additionally our guides about <a href="https://linuxcontainers.org/lxd/docs/latest/images/">images</a> and <a href="https://linuxcontainers.org/lxd/docs/latest/howto/instances_configure/">instance configuration</a> might contain useful information regarding image choice, configuration options etc.</p>
+        <p>To create LXD images in Packer, you need a LXD server (see <a href="https://linuxcontainers.org/lxd/docs/latest/getting_started/">Getting started</a>).</p>
       </div>
       <div class="col-5 u-vertically-center u-align--center u-hide--small u-hide--medium">
         {{ image (

--- a/templates/lxd/manage.html
+++ b/templates/lxd/manage.html
@@ -1,0 +1,310 @@
+{% extends "lxd/base_lxd.html" %}
+
+{% block title %}Manage LXD{% endblock %}
+
+{% block meta_description %}When using LXD, you have several ways to manage your server configuration and your instances: with a simple command line tool, directly through the REST API, through the web UI or by using third-party tools and integrations.{% endblock meta_description %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1doGyKYSTOsX8dHvQ6W9W2U_pHQY6yfiq1bqSAJyredQ/edit{% endblock meta_copydoc %}
+
+{% block content %}
+
+<section class="p-strip--suru-topped">
+  <div class="row u-sv3">
+    <div class="col-7">
+      <h1>Manage LXD</h1>
+      <p>When using LXD, you have several ways to manage your server configuration and your instances: with a simple command line tool,  directly through the REST API, through the web UI or by using third-party tools and integrations.</p>
+    </div>
+    <div class="col-5 u-vertically-center u-align--center u-hide--small u-hide--medium">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/89024427-Developer-convenience-2.svg",
+        alt="",
+        width="300",
+        height="172",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+  </div>
+</section>
+
+<section class="p-strip--light">
+  <div class="row u-equal-height">
+    <div class="col-6 p-card">
+    <h2 class="p-heading--3">LXD CLI</h2>
+      <p>LXD offers an intuitive and crisp CLI for easy operations. To control LXD, you typically use two different commands: lxd and lxc. The lxd command is used to control the daemon and is typically used only for initialisation and debugging. The lxc command is the command-line client that you use to interact with your instances. See lxc --help for an overview of all available subcommands.</p>
+      <a href="https://documentation.ubuntu.com/lxd/en/latest/explanation/lxd_lxc/">Get started with the LXD CLI</a>
+    </div>
+    <div class="col-6 p-card">
+      <h2 class="p-card__title p-heading--3">LXD REST API</h2>
+      <p>All communication between LXD and its clients happens using a RESTful API over HTTP. This means you can easily integrate LXD with any other tool you use for managing your infrastructure, and you can easily set up scripts as needed. LXD implements a single REST API for both local and remote access.</p>
+      <a href="https://documentation.ubuntu.com/lxd/en/latest/rest-api/">Learn more about the LXD REST API</a>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-bordered">
+  <div class="row u-sv3">
+    <div class="col-6">
+      <h2>LXD graphical user interface</h2>
+      <p>An official LXD UI tool is now available as an experimental feature. The UI supports most of the functionalities surrounding managing instances. More features coming soon.</p>
+      <p><a href="https://ubuntu.com/blog/lxd_ui">Read more about the current state of the UI and future plans</a></p>
+    </div>
+    <div class="col-6 u-vertically-center u-align--center u-hide--small u-hide--medium">
+      {{ image (
+        url="https://lh4.googleusercontent.com/oURP8ffnOR44PGUCGaTlD1rRtfVN3oBkPxuLpuvvI4vrYt_093UhOiDTwIihUtlfPWTEA_48rMqZL1wB832Pa4I5AppqTl4EHbcTPRf3V-fxFQaae2jdYcA7-ntt-vOl6wgTYl1hi54RTifHPnOgnIY",
+        alt="",
+        width="489",
+        height="250",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+  </div>
+  <div class="u-fixed-width">
+    <h3>Try LXD UI</h3>
+    <ol class="p-stepped-list--detailed">
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">Enable the UI</h3>
+        <div class="p-stepped-list__content">
+          <p>The LXD UI is packaged together with the LXD snap, but it is still considered an experimental feature that needs to be enabled with:</p>
+          <pre><code>snap set lxd ui.enable=true</code></pre>
+          <pre><code>snap restart --reload lxd</code></pre>
+        </div>
+      </li>
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">Expose LXD server to the host</h3>
+        <div class="p-stepped-list__content">
+          <p>To access the UI, you need to make sure your LXD server is exposed to the host. You can enable this with:</p>
+          <pre><code>lxc config set core.https_address :8443</code></pre>
+        </div>
+      </li>
+      <li class="p-stepped-list__item">
+        <h3 class="p-stepped-list__title">Set up the authentication certificates</h3>
+        <div class="p-stepped-list__content">
+          <p>Access the UI in your browser by entering the server address (for example, https://192.0.2.10:8443) and follow the authentication steps presented in the UI.</p>
+        </div>
+      </li>
+    </ol>
+  </div>
+</section>
+
+<section>
+  <div class="p-strip--light">
+    <div class="row">
+      <h2>Third-party integrations</h2>
+    </div>
+    <div class="row">
+      <div class="col-6">
+        <p>Besides using LXD natively, you can also use LXD within external tools.</p>
+        <p>LXD integrations are available for the following tools:</p>
+
+        <ul class="p-list is-split">
+          <li class="p-list__item is-ticked">
+            <a href="#juju">Juju</a>
+          </li>
+          <li class="p-list__item is-ticked">
+            <a href="#maas">MAAS</a>
+          </li>
+          <li class="p-list__item is-ticked">
+            <a href="#ansible">Ansible</a>
+          </li>
+          <li class="p-list__item is-ticked">
+            <a href="#terraform">Terraform</a>
+          </li>
+          <li class="p-list__item is-ticked">
+            <a href="#puppet-bolt">Puppet Bolt</a>
+          </li>
+          <li class="p-list__item is-ticked">
+            <a href="#packer">Packer</a>
+          </li>
+        </ul>
+      </div>
+      <div class="col-6 u-vertically-center u-align--center u-hide--small u-hide--medium">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/f880a3bd-Enterprise%2Bsupport.svg",
+          alt="",
+          width="200",
+          height="200",
+          hi_def=True,
+          loading="lazy"
+          ) | safe
+        }}
+      </div>
+    </div>
+  </div>
+
+  <div class="p-strip is-shallow">
+    <div class="row">
+      <div class="col-5 u-vertically-center u-align--center u-hide--small u-hide--medium">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/16a67f91-Canonical%20Juju.svg",
+          alt="",
+          width="250",
+          height="131",
+          hi_def=True,
+          loading="lazy"
+          ) | safe
+        }}
+      </div>
+      <div class="col-7">
+        <h3 id="juju">Juju</h3>
+        <p><a href="https://juju.is/">Juju</a> is an open source orchestration engine for software operators that enables the deployment, integration and lifecycle management of applications at any scale, on any infrastructure.</p>
+        <p>Juju can be used to deploy a variety of workloads across many different clouds and virtualisation providers. It supports both deploying workloads against a LXD server or cluster and using LXD on the machines it's deploying to separate otherwise colocated services.</p>
+        <p>Take a look at the Step-by-Step Guide for LXD in the <a href="https://juju.is/docs/olm/lxd">Juju documentation</a>.</p>
+      </div>
+    </div>
+  </div>
+
+  <div class="p-strip--light is-shallow">
+    <div class="row">
+      <div class="col-7">
+        <h3 id="maas">MAAS</h3>
+        <p><a href="https://maas.io/">MAAS</a> is an open source server provisioning software tool for your data centre.</p>
+        <p>Self-service, remote installation of Windows, CentOS, ESXi and Ubuntu on real servers turns your data centre into a bare metal cloud.</p>
+        <p>MAAS integrates with LXD to provide easy creation of virtual machines. It can automatically deploy and configure LXD as part of the deployment of a physical machine or can be connected to an existing LXD deployment to dynamically create virtual machines on it.</p>
+        <p>Read about how <a href="https://maas.io/how-it-works">MAAS works</a> and try MAAS and LXD in the <a href="https://maas.io/tutorials/build-a-maas-and-lxd-environment-in-30-minutes-with-multipass-on-ubuntu">MAAS hands on tutorial</a>.</p>
+      </div>
+      <div class="col-5 u-vertically-center u-align--center u-hide--small u-hide--medium">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/e45b7f3f-Canonical%20MAAS.svg",
+          alt="",
+          width="300",
+          height="121",
+          hi_def=True,
+          loading="lazy"
+          ) | safe
+        }}
+      </div>
+    </div>
+  </div>
+
+  <div class="p-strip is-shallow">
+    <div class="row">
+      <div class="col-5 u-vertically-center u-align--center u-hide--small u-hide--medium">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/ab22825a-ansible+logo.png",
+          alt="",
+          width="252",
+          height="253",
+          hi_def=True,
+          loading="lazy"
+          ) | safe
+        }}
+      </div>
+      <div class="col-7">
+        <h3 id="ansible">Ansible</h3>
+        <p><a href="https://www.ansible.com/">Ansible</a> is an open source software provisioning, configuration management and application-deployment tool.</p>
+        <p>The main integrations between Ansible and LXD are:</p>
+        <ul class="p-list is-split">
+          <li class="p-list__item is-ticked">A <a href="https://docs.ansible.com/ansible/latest/collections/community/general/lxd_connection.html#ansible-collections-community-general-lxd-connection">connection plugin</a> allowing Ansible to manage a LXD instance just as any other Linux system</li>
+          <li class="p-list__item is-ticked">An <a href="https://docs.ansible.com/ansible/latest/collections/community/general/lxd_inventory.html">inventory plugin</a> to detect LXD instances</li>
+          <li class="p-list__item is-ticked">A <a href="https://docs.ansible.com/ansible/latest/collections/community/general/lxd_container_module.html">plugin</a> to create and manage LXD containers</li>
+          <li class="p-list__item is-ticked">A <a href="https://docs.ansible.com/ansible/latest/collections/community/general/lxd_profile_module.html">plugin</a> to manage LXD profiles</li>
+        </ul>
+        <p>To manage LXD in Ansible, you need a LXD server (see <a href="https://documentation.ubuntu.com/lxd/en/latest/getting_started/">Getting started</a>).</p>
+      </div>
+    </div>
+  </div>
+
+
+  <div class="p-strip--light is-shallow">
+    <div class="row">
+      <div class="col-7">
+        <h3 id="terraform">Terraform</h3>
+        <p><a href="https://terraform.io/">Terraform</a> is an open source infrastructure-as-code software tool for configuration and service management.</p>
+        <p>The LXD integration allows Terraform to deploy instances on LXD servers with support for local and remote deployments.</p>
+        <p>Take a look at the <a href="https://registry.terraform.io/providers/terraform-lxd/lxd/latest/docs">Terraform documentation on LXD</a> for more information.</p>
+        <p>To manage LXD in Terraform, you need a LXD server  (see <a href="https://documentation.ubuntu.com/lxd/en/latest/getting_started/">Getting started</a>).</p>
+      </div>
+      <div class="col-5 u-vertically-center u-align--center u-hide--small u-hide--medium">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/3f10732f-terraform-logo.svg",
+          alt="",
+          width="300",
+          height="72",
+          hi_def=True,
+          loading="lazy"
+          ) | safe
+        }}
+      </div>
+    </div>
+  </div>
+
+  <div class="p-strip is-shallow">
+    <div class="row">
+      <div class="col-5 u-vertically-center u-align--center u-hide--small u-hide--medium">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/b690b29b-bolt-logo-dark.png",
+          alt="",
+          width="250",
+          height="95",
+          hi_def=True,
+          loading="lazy"
+          ) | safe
+        }}
+      </div>
+      <div class="col-7">
+        <h3 id="puppet-bolt">Bolt</h3>
+        <p><a href="https://puppet.com/docs/bolt/latest/bolt.html">Bolt</a> is an open source orchestration tool that automates the manual work it takes to maintain your infrastructure.</p>
+        <p>The LXD transport allows for interacting with LXD instances.</p>
+        <p>For more information, see the <a href="https://puppet.com/docs/bolt/latest/bolt_transports_reference.html#lxd">Puppet Bolt Documentation on LXD</a>.</p>
+        <p>To manage LXD in Puppet Bolt, you need a LXD server (see <a href="https://documentation.ubuntu.com/lxd/en/latest/getting_started/">Getting started</a>).</p>
+      </div>
+    </div>
+  </div>
+
+  <div class="p-strip--light is-shallow">
+    <div class="row">
+      <div class="col-7">
+        <h3 id="packer">Packer</h3>
+        <p><a href="https://www.packer.io/">Packer</a> is an open source tool for creating identical machine images for multiple platforms.</p>
+        <p>With Packer's LXD builder, it's possible to re-use your existing cloud image building pipeline and with the LXD builder, build a LXD container image.</p>
+        <p>Take a look at the <a href="https://www.packer.io/docs/builders/lxd">Packer documentation on LXD</a> for more information.</p>
+        <p>Additionally our guides about <a href="https://documentation.ubuntu.com/lxd/en/latest/images/">images</a> and <a href="https://documentation.ubuntu.com/lxd/en/latest/howto/instances_configure/">instance configuration</a> might contain useful information regarding image choice, configuration options etc.</p>
+        <p>To create LXD images in Packer, you need a LXD server (see <a href="https://documentation.ubuntu.com/lxd/en/latest/getting_started/">Getting started</a>).</p>
+      </div>
+      <div class="col-5 u-vertically-center u-align--center u-hide--small u-hide--medium">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/a4aefced-packer-logo.svg",
+          alt="",
+          width="250",
+          height="95",
+          hi_def=True,
+          loading="lazy"
+          ) | safe
+        }}
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-bordered">
+  <div class="row u-sv3">
+    <div class="col-5 u-vertically-center u-align--center u-hide--small u-hide--medium">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/c4b290c8-Contact+us.svg",
+        alt="",
+        width="211",
+        height="150",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
+    <div class="col-7">
+      <h2>Need more help with LXD?</h2>
+      <p>Let our LXD experts help you take the next step.</p>
+      <p>
+        <a class="p-button--positive js-invoke-modal" href="/lxd#get-in-touch">Get in touch</a>
+      </p>
+    </div>
+  </div>
+</section>
+
+<!-- Set default Marketo information for contact form below-->
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/lxd" data-form-id="4446" data-lp-id="" data-return-url="/lxd" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+</div>
+
+{% endblock content %}

--- a/templates/lxd/manage.html
+++ b/templates/lxd/manage.html
@@ -297,7 +297,7 @@
       <h2>Need more help with LXD?</h2>
       <p>Let our LXD experts help you take the next step.</p>
       <p>
-        <a class="p-button--positive js-invoke-modal" href="/lxd#get-in-touch">Get in touch</a>
+        <a class="p-button--positive js-invoke-modal" href="/containers/contact-us?product=containers-lxd">Get in touch</a>
       </p>
     </div>
   </div>

--- a/templates/shared/contextual_footers/_cloud_lxd_vs_docker.html
+++ b/templates/shared/contextual_footers/_cloud_lxd_vs_docker.html
@@ -1,0 +1,5 @@
+<div class="col-4 p-divider__block">
+  <h3 class="p-heading--4">LXD vs. Docker</h3>
+  <p>LXD <a href="/blog/what-are-linux-containers">system containers</a> run a complete filesystem with background processes, making it different from the application containers such as Docker.</p>
+  <p><a href="/blog/lxd-vs-docker">Learn more about the difference</a></p>
+</div>

--- a/templates/templates/navigation-developer-h.html
+++ b/templates/templates/navigation-developer-h.html
@@ -208,7 +208,7 @@
             <li class="p-inline-list__item"><a href="https://netplan.io">netplan</a></li>
             <li class="p-inline-list__item"><a href="https://juju.is">Juju</a></li>
             <li class="p-inline-list__item"><a href="https://snapcraft.io">Snapcraft</a></li>
-            <li class="p-inline-list__item"><a href="http://linuxcontainers.org">LXD</a></li>
+            <li class="p-inline-list__item"><a href="https://ubuntu.com/lxd">LXD</a></li>
             <li class="p-inline-list__item"><a href="https://multipass.run">Multipass</a></li>
           </ul>
         </div>

--- a/templates/templates/navigation-developer-h.html
+++ b/templates/templates/navigation-developer-h.html
@@ -208,7 +208,7 @@
             <li class="p-inline-list__item"><a href="https://netplan.io">netplan</a></li>
             <li class="p-inline-list__item"><a href="https://juju.is">Juju</a></li>
             <li class="p-inline-list__item"><a href="https://snapcraft.io">Snapcraft</a></li>
-            <li class="p-inline-list__item"><a href="https://ubuntu.com/lxd">LXD</a></li>
+            <li class="p-inline-list__item"><a href="/lxd">LXD</a></li>
             <li class="p-inline-list__item"><a href="https://multipass.run">Multipass</a></li>
           </ul>
         </div>


### PR DESCRIPTION
## Done

- added lxd/install and lxd/manage pages

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- check /lxd, /lxd/install and /lxd/manage

## Issue / Card

Fixes WD-4823