### PR TITLE
WD-4286 certified UX improvements

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -633,8 +633,8 @@ certification:
       path: /certified/desktops
     - title: Servers
       path: /certified/servers
-    - title: Devices
-      path: /certified/devices
+    - title: IoT
+      path: /certified/iot
     - title: SoCs
       path: /certified/socs
 

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -126,15 +126,15 @@ category/product/ubuntu-light/?: http://lubuntu.net/
 # old certification.ubuntu.com redirects
 certified/desktop/?: "/certified?category=Desktop&category=Laptop"
 certified/server/?: "/certified?category=Server"
-certified/iot/?: "/certified?category=Device"
 certified/soc/?: "/certified?category=SoC"
 certified/hardware/(?P<canonical_id>.*): "/certified/{canonical_id}"
 certified/catalog/search/?: "/certified"
 certified/desktop/models/?: "/certified?category=Desktop&category=Laptop"
 certified/server/models/?: "/certified?category=Server"
-certified/iot/models/?: "/certified?category=Device"
+certified/iot/models/?: "/certified/iot"
 certified/soc/models/?: "/certified?category=SoC"
 certified/why-certified/?: "/certified/why-certify"
+certified/devices/?: "/certified/iot"
 certification/?: "/certified"
 
 cc/?: "/security/certifications"

--- a/templates/certified/desktops.html
+++ b/templates/certified/desktops.html
@@ -8,7 +8,7 @@
 
 <section class="p-strip--suru-topped is-bordered">
   <div class="u-fixed-width">
-    <a href="/certified?q=">&lsaquo; Certified hardware</a>
+    <a href="/certified">&lsaquo; Certified hardware</a>
   </div>
   <br />
   <div class="row">

--- a/templates/certified/devices.html
+++ b/templates/certified/devices.html
@@ -8,12 +8,12 @@
 
 <section class="p-strip--suru-topped is-bordered">
   <div class="u-fixed-width">
-    <a href="/certified?q=">&lsaquo; Certified hardware</a>
+    <a href="/certified">&lsaquo; Certified hardware</a>
   </div>
   <br />
   <div class="row">
     <div class="col-8">
-      <h1>Ubuntu certified devices</h1>
+      <h1>Ubuntu certified IoT devices</h1>
       <p>IoT vendors rely on Ubuntu for their devices, from drones and robots to edge gateways and development boards. Ubuntu Core delivers bullet-proof security, reliable updates and access to a rich ecosystem on 32 and 64-bit ARM and X86 platforms.      </p>
     </div>
     <div class="col-4 u-vertically-center u-align--center u-hide--small u-hide--medium">

--- a/templates/certified/index.html
+++ b/templates/certified/index.html
@@ -116,7 +116,7 @@
             loading="auto"
             ) | safe
           }}
-          <span><a href="/certified/devices">IoT</a></span>
+          <span><a href="/certified/iot">IoT</a></span>
         </li>
         <li class="p-list__item">
           {{ image (

--- a/templates/certified/laptops.html
+++ b/templates/certified/laptops.html
@@ -8,7 +8,7 @@
 
 <section class="p-strip--suru-topped is-bordered">
   <div class="u-fixed-width">
-    <a href="/certified?q=">&lsaquo; Certified hardware</a>
+    <a href="/certified">&lsaquo; Certified hardware</a>
   </div>
   <br />
   <div class="row">

--- a/templates/certified/search-results.html
+++ b/templates/certified/search-results.html
@@ -9,11 +9,15 @@
 <form class="js-search-results">
   <section class="p-strip--suru-topped">
     <div class="u-fixed-width">
-      <h1 class="u-sv3">Ubuntu certified hardware</h1>
+      <a href="/certified">&lsaquo; Certified hardware</a>
+    </div>
+    <br />
+    <div class="u-fixed-width">
+      <h1 class="u-sv3">Search Ubuntu certified hardware</h1>
     </div>
     <div class="u-fixed-width">
       <div class="p-search-box">
-        <label for="certified-hardware-search" class="u-off-screen">Search in Ubuntu certified hardware</label>
+        <label for="certified-hardware-search" class="u-off-screen">Search Ubuntu certified hardware</label>
         <input class="p-search-box__input" type="text" name="q" value="{{ query or '' }}" placeholder="Search" id="certified-hardware-search">
         <button type="submit" class="p-search-box__button"><i class="p-icon--search">Submit</i></button>
       </div>

--- a/templates/certified/servers.html
+++ b/templates/certified/servers.html
@@ -8,7 +8,7 @@
 
 <section class="p-strip--suru-topped is-bordered">
   <div class="u-fixed-width">
-    <a href="/certified?q=">&lsaquo; Certified hardware</a>
+    <a href="/certified">&lsaquo; Certified hardware</a>
   </div>
   <br />
   <div class="row">

--- a/templates/certified/shared/category-search-results.html
+++ b/templates/certified/shared/category-search-results.html
@@ -1,9 +1,6 @@
 <form class="js-search-results">
   <section class="p-strip">
     <div class="u-fixed-width">
-      <h2>{{ title }}</h2>
-    </div>
-    <div class="u-fixed-width">
       <div class="p-search-box">
         <label for="certified-search" class="u-off-screen">{{ placeholder or "Search in certified"}}</label>
         <input class="p-search-box__input" id="certified-search" type="text" name="q" value="{{ query or '' }}" placeholder="{{ placeholder or '' }}">

--- a/templates/certified/socs.html
+++ b/templates/certified/socs.html
@@ -8,7 +8,7 @@
 
 <section class="p-strip--suru-topped is-bordered">
   <div class="u-fixed-width">
-    <a href="/certified?q=">&lsaquo; Certified hardware</a>
+    <a href="/certified">&lsaquo; Certified hardware</a>
   </div>
   <br />
   <div class="row">

--- a/templates/certified/why-certify.html
+++ b/templates/certified/why-certify.html
@@ -134,7 +134,7 @@
 
             <p>Canonical's certification programme offers you peace of mind: all your Internet of Things devices will remain secure and regularly updated.</p>
 
-            <p><a href="/certified/devices">Explore certified IoT</a></p>
+            <p><a href="/certified/iot">Explore certified IoT</a></p>
           </div>
         </div>
       </div>

--- a/templates/core/features/secure-boot.html
+++ b/templates/core/features/secure-boot.html
@@ -70,7 +70,7 @@
     </div>
     <div class="p-card col-6 u-vertically-center">
       <h3 class="p-card__title">Free for pre-certified boards</h3>
-      <p class="p-card__content">Secure boot is available out of the box on <a href="/certified/devices">certified devices</a> at no additional cost. An enablement fee is required to fully certify Ubuntu Core on non-certified boards.</p>
+      <p class="p-card__content">Secure boot is available out of the box on <a href="/certified/iot">certified devices</a> at no additional cost. An enablement fee is required to fully certify Ubuntu Core on non-certified boards.</p>
     </div>
   </div>
 </section>

--- a/templates/dell/index.html
+++ b/templates/dell/index.html
@@ -211,7 +211,7 @@
           <a href="/certified/servers?q=&limit=20&vendor=Dell+Technologies">Servers</a>
         </li>
         <li class="p-inline-list__item">
-          <a href="/certified/devices?q=&limit=20&vendor=Dell">Devices</a>
+          <a href="/certified/iot?q=&limit=20&vendor=Dell">IoT</a>
         </li>
       </ul>
 		</div>

--- a/templates/download/iot/intel-iot.html
+++ b/templates/download/iot/intel-iot.html
@@ -414,7 +414,7 @@
   <div class="u-fixed-width">
     <h2>Hardware Certification Program</h2>
     <p>Canonical partners with leading device manufacturers to validate the same Ubuntu image across a wide variety of boards offering a great out-of-the-box experience for your customised needs. Stay tuned for more features coming soon!</p>
-    <a href="/certified/devices">Further information on Ubuntu certified devices&nbsp;&rsaquo;</a>
+    <a href="/certified/iot">Further information on Ubuntu certified devices&nbsp;&rsaquo;</a>
   </div>
 </section>
 

--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -521,7 +521,7 @@
 <section class="p-strip--light">
   <div class="u-fixed-width">
     <h2>Which image should I pick?</h2>
-    <p>If you are wondering which download to pick, here are a few pointers on the options. For information on previous versions of Ubuntu, visit our <a href="/certified/devices?q=&limit=20&vendor=Raspberry+Pi+Foundation">certified hardware</a> section to get more insight into Raspberry Pi compatibility.</p>
+    <p>If you are wondering which download to pick, here are a few pointers on the options. For information on previous versions of Ubuntu, visit our <a href="/certified/iot?q=&limit=20&vendor=Raspberry+Pi+Foundation">certified hardware</a> section to get more insight into Raspberry Pi compatibility.</p>
   </div>
   <div class="row u-equal-height">
     <div class="col-6 p-card">

--- a/templates/internet-of-things/smart-displays.html
+++ b/templates/internet-of-things/smart-displays.html
@@ -255,7 +255,7 @@
     <div class="col-8">
       <h2>Ready for all boards, frameworks, and applications</h2>
       <p>Minimise your costs and time to market: Ubuntu Frame is compatible with the most popular boards and silicon.</p>
-      <p>Check the <a href="/certified/devices">full list of Ubuntu certified hardware</a> and find the right one for your application.</p>
+      <p>Check the <a href="/certified/iot">full list of Ubuntu certified hardware</a> and find the right one for your application.</p>
     </div>
   </div>
   <div class="row u-equal-height">

--- a/templates/robotics/index.html
+++ b/templates/robotics/index.html
@@ -545,7 +545,7 @@
     </div>
   </div>
   <div class="u-fixed-width">
-    <p>Or check the <a href="/certified/devices">full list of Ubuntu certified hardware</a> and find the right one for your application.</p>
+    <p>Or check the <a href="/certified/iot">full list of Ubuntu certified hardware</a> and find the right one for your application.</p>
   </div>
 </section>
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1104,7 +1104,7 @@ app.add_url_rule(
     view_func=certified_servers,
 )
 app.add_url_rule(
-    "/certified/devices",
+    "/certified/iot",
     view_func=certified_devices,
 )
 app.add_url_rule(


### PR DESCRIPTION
## Done

UX improvements for /certified
https://warthogs.atlassian.net/jira/software/c/projects/WD/boards/932?modal=detail&selectedIssue=WD-4286

## QA

- Check out this feature branch

Category pages “‹ Certified Hardware” s links to /certified:
- https://ubuntu-com-13004.demos.haus/certified/desktops
- https://ubuntu-com-13004.demos.haus/certified/laptops
- https://ubuntu-com-13004.demos.haus/certified/iot
- https://ubuntu-com-13004.demos.haus/certified/socs

-Remove the H2 header (e.g. “All certified desktops”), it’s redundant.
- Added H1 header to generic results page https://ubuntu-com-13004.demos.haus/certified?q=

- Change “Devices” in the bubble navigation for “IoT”. This change involves renaming all /certified/devices paths to /certified/iot


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
