### PR TITLE
Adjust footer size on small screens

### DIFF
--- a/static/sass/_pattern_footer.scss
+++ b/static/sass/_pattern_footer.scss
@@ -1,12 +1,16 @@
 // Footer pattern styling
 @mixin footer-title {
   color: $color-mid-dark;
-  line-height: 1.5;
+  line-height: 1.25;
   margin-bottom: 0;
 
   @media only screen and (max-width: $breakpoint-small) {
     cursor: pointer;
   }
+
+  @media only screen and (min-width: $breakpoint-small) {
+    line-height: 1.5;
+  } 
 }
 
 @mixin ubuntu-p-footer {
@@ -97,7 +101,7 @@
     background-size: 13px 13px;
     border-top: 1px solid $color-mid-light;
     color: $color-dark;
-    font-size: 1.2rem;
+    font-size: 1rem;
     font-weight: 300;
     margin-top: 0;
     max-width: inherit;
@@ -172,6 +176,7 @@
     padding: $sp-small 0 $sp-small $sp-x-large;
     position: relative;
     z-index: 2;
+    line-height: 2.3;
 
     @media only screen and (min-width: $breakpoint-small) {
       display: none;
@@ -183,7 +188,6 @@
   }
 
   .p-footer--secondary {
-    padding: $sp-large $sp-small 0;
 
     @media only screen and (min-width: $breakpoint-small) {
       padding: 0;
@@ -191,6 +195,7 @@
 
     @media only screen and (max-width: $breakpoint-small - 1px) {
       margin-top: 0;
+      padding: $sp-large $sp-small 0 $sp-medium !important;
     }
 
     a:hover {
@@ -225,13 +230,15 @@
         border-top: 1px solid $color-mid-light;
         color: $color-dark;
         display: block;
-        font-size: 1.2rem;
+        font-size: 1rem;
         padding: $sp-medium;
+        line-height: 1.25;
 
         @media only screen and (min-width: $breakpoint-small) {
           border: 0;
           font-size: 0.8125rem;
           padding: 0;
+          line-height: 1.5rem;
         }
       }
     }
@@ -295,6 +302,10 @@
     @media only screen and (min-width: $breakpoint-large) {
       margin-top: $sp-x-small;
     }
+  }
+
+  .p-footer--secondary .p-inline-list {
+
   }
 
   .p-footer--secondary .p-inline-list__item {

--- a/static/sass/_pattern_footer.scss
+++ b/static/sass/_pattern_footer.scss
@@ -10,7 +10,7 @@
 
   @media only screen and (min-width: $breakpoint-small) {
     line-height: 1.5;
-  } 
+  }
 }
 
 @mixin ubuntu-p-footer {
@@ -171,12 +171,12 @@
     border-bottom: 1px solid $color-mid-dark;
     display: block;
     left: auto;
+    line-height: 2.3;
     margin-bottom: -1px;
     max-width: inherit;
     padding: $sp-small 0 $sp-small $sp-x-large;
     position: relative;
     z-index: 2;
-    line-height: 2.3;
 
     @media only screen and (min-width: $breakpoint-small) {
       display: none;
@@ -188,7 +188,6 @@
   }
 
   .p-footer--secondary {
-
     @media only screen and (min-width: $breakpoint-small) {
       padding: 0;
     }
@@ -231,14 +230,14 @@
         color: $color-dark;
         display: block;
         font-size: 1rem;
-        padding: $sp-medium;
         line-height: 1.25;
+        padding: $sp-medium;
 
         @media only screen and (min-width: $breakpoint-small) {
           border: 0;
           font-size: 0.8125rem;
-          padding: 0;
           line-height: 1.5rem;
+          padding: 0;
         }
       }
     }

--- a/static/sass/_pattern_footer.scss
+++ b/static/sass/_pattern_footer.scss
@@ -102,7 +102,7 @@
     border-top: 1px solid $color-mid-light;
     color: $color-dark;
     font-size: 1rem;
-    font-weight: 300;
+    font-weight: 400;
     margin-top: 0;
     max-width: inherit;
 
@@ -183,7 +183,7 @@
     }
 
     a {
-      color: $color-brand;
+      color: $color-x-dark;
     }
   }
 
@@ -213,7 +213,7 @@
 
         li {
           a {
-            color: $color-mid-dark;
+            color: $color-dark;
           }
         }
       }
@@ -306,6 +306,7 @@
 
   .p-footer--secondary .p-inline-list__item {
     display: block;
+    margin-top: 0.5rem;
 
     @media only screen and (min-width: $breakpoint-small) {
       display: inline-block;

--- a/static/sass/_pattern_footer.scss
+++ b/static/sass/_pattern_footer.scss
@@ -183,7 +183,7 @@
     }
 
     a {
-      color: $color-mid-dark;
+      color: $color-brand;
     }
   }
 
@@ -302,10 +302,6 @@
     @media only screen and (min-width: $breakpoint-large) {
       margin-top: $sp-x-small;
     }
-  }
-
-  .p-footer--secondary .p-inline-list {
-
   }
 
   .p-footer--secondary .p-inline-list__item {


### PR DESCRIPTION
## Done

Some suggested improvements for the Ubuntu.com footer on small screens: 

- Reduced the size (font and line-height) of footer accordions to take up less space on small devices 
- Increased the size of 'back to top' button - to more closely resemble the other accordions and improve accessibility of this [touch target](https://accessibility.digital.gov/ux/touch-targets/#:~:text=Make%20touch%20targets%20at%20least,extend%20padding%20past%20the%20icon)
- Changed colour of 'back to top' button to help differentiate between itself and newly resized accordions. It might look better if the arrow image was also orange, but I couldn't access the svg to change it 
- Added left-side padding to secondary footer content, as previously it started against the border
- Adjusted all breakpoints so the above changes only apply to small screens
 

## QA

- Open demo 
- In demo, inspect Ubuntu.com homepage in live server on small screen (<629px) and scroll down to footer
- Open live Ubuntu.com website in separate tab for comparison 
- In demo, see the above changes that have been made


## Screenshots

Before:

<img width="466" alt="Ubuntu footer #1" src="https://github.com/canonical/ubuntu.com/assets/95416961/9d471c74-b447-4c9a-bd72-b4dd9f25b896">

<img width="462" alt="Ubuntu footer #2" src="https://github.com/canonical/ubuntu.com/assets/95416961/6284f259-ce0d-4353-8bba-30540fe24b8d">

After: 

<img width="461" alt="Ubuntu footer #3" src="https://github.com/canonical/ubuntu.com/assets/95416961/305ab927-1103-42cd-bfc8-700da0da9b3a">

<img width="461" alt="Ubuntu footer #4" src="https://github.com/canonical/ubuntu.com/assets/95416961/3d53d1f4-66ec-44d9-95d7-e8a0566a74c1">


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
