### PR TITLE
Show expiry message for subscriptions activated by keys

### DIFF
--- a/static/js/src/advantage/api/enum.ts
+++ b/static/js/src/advantage/api/enum.ts
@@ -31,7 +31,7 @@ export enum UserSubscriptionType {
   Monthly = "monthly",
   Trial = "trial",
   Legacy = "legacy",
-  Key_activated = "key_activated",
+  KeyActivated = "key_activated",
 }
 
 export enum UserSubscriptionMachineType {

--- a/static/js/src/advantage/api/enum.ts
+++ b/static/js/src/advantage/api/enum.ts
@@ -31,6 +31,7 @@ export enum UserSubscriptionType {
   Monthly = "monthly",
   Trial = "trial",
   Legacy = "legacy",
+  Key_activated = "key_activated",
 }
 
 export enum UserSubscriptionMachineType {

--- a/static/js/src/advantage/react/components/Subscriptions/ExpiryNotification/ExpiryNotification.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/ExpiryNotification/ExpiryNotification.tsx
@@ -66,6 +66,8 @@ const MESSAGES: Messages = {
           "You have cancelled your Ubuntu Pro trial. " +
           "At the end of the trial period, this subscription " +
           "will disappear and you will no longer have access to Pro services.",
+        [UserSubscriptionType.Key_activated]:
+          "Contact OEM to renew and ensure service continuity.",
       },
       title: "Your subscription is about to expire.",
     },

--- a/static/js/src/advantage/react/components/Subscriptions/ExpiryNotification/ExpiryNotification.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/ExpiryNotification/ExpiryNotification.tsx
@@ -66,8 +66,8 @@ const MESSAGES: Messages = {
           "You have cancelled your Ubuntu Pro trial. " +
           "At the end of the trial period, this subscription " +
           "will disappear and you will no longer have access to Pro services.",
-        [UserSubscriptionType.Key_activated]:
-          "Contact OEM to renew and ensure service continuity.",
+        [UserSubscriptionType.KeyActivated]:
+          "Contact the OEM to renew and ensure service continuity.",
       },
       title: "Your subscription is about to expire.",
     },

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/DetailsContent.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/DetailsContent.tsx
@@ -88,7 +88,7 @@ const DetailsContent = ({ selectedId, setHasUnsavedChanges }: Props) => {
     size: 2,
     title: "Billing",
     value:
-      isFree || subscription.type == "key_activated"
+      isFree || subscription.type == UserSubscriptionType.KeyActivated
         ? "None"
         : getPeriodDisplay(subscription.period),
   };

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/DetailsContent.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/DetailsContent.tsx
@@ -87,7 +87,10 @@ const DetailsContent = ({ selectedId, setHasUnsavedChanges }: Props) => {
   const billingCol: Feature = {
     size: 2,
     title: "Billing",
-    value: isFree ? "None" : getPeriodDisplay(subscription.period),
+    value:
+      isFree || subscription.type == "key_activated"
+        ? "None"
+        : getPeriodDisplay(subscription.period),
   };
 
   const cost = getSubscriptionCost(subscription);

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/ListCard/ListCard.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/ListCard/ListCard.tsx
@@ -75,7 +75,9 @@ const ListCard = ({
               className="p-text--small-caps u-text--muted p-subscriptions__list-card-period"
               data-test="card-type"
             >
-              {subscription.type}
+              {subscription.type === UserSubscriptionType.KeyActivated
+                ? "key activated"
+                : subscription.type}
             </span>
           )}
         </div>

--- a/webapp/shop/api/ua_contracts/builders.py
+++ b/webapp/shop/api/ua_contracts/builders.py
@@ -165,8 +165,7 @@ def build_legacy_item_groups(user_summary: List) -> List:
                     item.product_listing_id is None
                     or item.subscription_id is None
                 ):
-                    if (item.reason == "key_activated" and
-                       contract.product_id != "cue-linux-essentials"):
+                    if item.reason == "key_activated":
                         legacy_item_groups.append(
                             {
                                 "account": user_details.get("account"),
@@ -176,8 +175,9 @@ def build_legacy_item_groups(user_summary: List) -> List:
                                 "item_id": item.id,
                                 "listing": None,
                                 "marketplace": "canonical-ua",
-                                "subscriptions":
-                                    user_details.get("subscriptions"),
+                                "subscriptions": user_details.get(
+                                    "subscriptions"
+                                ),
                                 "type": "key_activated",
                             }
                         )
@@ -191,8 +191,9 @@ def build_legacy_item_groups(user_summary: List) -> List:
                                 "item_id": item.id,
                                 "listing": None,
                                 "marketplace": "canonical-ua",
-                                "subscriptions":
-                                    user_details.get("subscriptions"),
+                                "subscriptions": user_details.get(
+                                    "subscriptions"
+                                ),
                                 "type": "legacy",
                             }
                         )

--- a/webapp/shop/api/ua_contracts/builders.py
+++ b/webapp/shop/api/ua_contracts/builders.py
@@ -165,19 +165,36 @@ def build_legacy_item_groups(user_summary: List) -> List:
                     item.product_listing_id is None
                     or item.subscription_id is None
                 ):
-                    legacy_item_groups.append(
-                        {
-                            "account": user_details.get("account"),
-                            "contract": contract,
-                            "items": [item],
-                            "renewal": item.renewal,
-                            "item_id": item.id,
-                            "listing": None,
-                            "marketplace": "canonical-ua",
-                            "subscriptions": user_details.get("subscriptions"),
-                            "type": "legacy",
-                        }
-                    )
+                    if item.reason == "key_activated":
+                        legacy_item_groups.append(
+                            {
+                                "account": user_details.get("account"),
+                                "contract": contract,
+                                "items": [item],
+                                "renewal": item.renewal,
+                                "item_id": item.id,
+                                "listing": None,
+                                "marketplace": "canonical-ua",
+                                "subscriptions":
+                                    user_details.get("subscriptions"),
+                                "type": "key_activated",
+                            }
+                        )
+                    else:
+                        legacy_item_groups.append(
+                            {
+                                "account": user_details.get("account"),
+                                "contract": contract,
+                                "items": [item],
+                                "renewal": item.renewal,
+                                "item_id": item.id,
+                                "listing": None,
+                                "marketplace": "canonical-ua",
+                                "subscriptions":
+                                    user_details.get("subscriptions"),
+                                "type": "legacy",
+                            }
+                        )
 
     return legacy_item_groups
 

--- a/webapp/shop/api/ua_contracts/builders.py
+++ b/webapp/shop/api/ua_contracts/builders.py
@@ -165,7 +165,8 @@ def build_legacy_item_groups(user_summary: List) -> List:
                     item.product_listing_id is None
                     or item.subscription_id is None
                 ):
-                    if item.reason == "key_activated":
+                    if (item.reason == "key_activated" and
+                       contract.product_id != "cue-linux-essentials"):
                         legacy_item_groups.append(
                             {
                                 "account": user_details.get("account"),


### PR DESCRIPTION
## Done

- Created `key_activated` in subscription type 
- Added expiry message saying  "Contact OEM to renew and ensure service continuity." so it shows when subscription is expiring.  

## QA
- Go to `/webapp/shop/api/ua_contracts/helpers.pyhelpers.py` 
- Line 352 change  "is_expiring" to True
- 
- Run ubuntu.com locally
- Activate a key on /pro/activate
- Go to /pro/dashboard
- Check expiry message

## Issue / Card

Fixes #https://warthogs.atlassian.net/jira/software/c/projects/WD/boards/801?modal=detail&selectedIssue=WD-4619

## Screenshot
![image](https://github.com/canonical/ubuntu.com/assets/57550290/100483eb-fcdf-4a69-b557-a1cde9167b0c)
