### PR TITLE
Temporarily replace canonical logo

### DIFF
--- a/static/js/src/navigation.js
+++ b/static/js/src/navigation.js
@@ -317,3 +317,15 @@ function replaceUbuntuAdvantage() {
   });
 }
 replaceUbuntuAdvantage();
+
+// TEMP FIX - PETE F 03.07.23
+// REPLACES CANONICAL LOGO WITH CANONICAL LINK UNTIL
+// WE MERGE THE NEW MEGANAV
+function replaceGlobalNavLogo() {
+  const globalNavLogo = document.querySelector(".global-nav__header-logo");
+  if (globalNavLogo){
+    globalNavLogo.innerHTML = `<a href="https://canonical.com/" style="color:white;">Canonical</a>`
+  }
+}
+
+replaceGlobalNavLogo()

--- a/static/js/src/navigation.js
+++ b/static/js/src/navigation.js
@@ -318,7 +318,7 @@ function replaceUbuntuAdvantage() {
 }
 replaceUbuntuAdvantage();
 
-// TEMP FIX - PETE F 03.07.23
+// TEMP FIX - MPT 03.07.23
 // REPLACES CANONICAL LOGO WITH CANONICAL LINK UNTIL
 // WE MERGE THE NEW MEGANAV
 function replaceGlobalNavLogo() {


### PR DESCRIPTION
## Done

- Replace the Canonical logo in the meganav with Canonical link

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- See that the logo is gone and there instead a string "Canonical" which links to the c.com homepage

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-4616
