### PR TITLE
WD-4878 - Clickable diagram on the Nvidia page

### DIFF
--- a/templates/nvidia/index.html
+++ b/templates/nvidia/index.html
@@ -34,16 +34,18 @@
 			<p><a href="https://assets.ubuntu.com/v1/49180a1d-AI%20enterprise%20solution%20powered%20by%20Canonical%20and%20NVIDIA.pdf">Check out the Enterprise-Ready AI solution powered by Canonical and NVIDIA.&nbsp;<i class="p-icon--begin-downloading"></i></a></p>
 		</div>
 		<div class="col-6 u-align--center u-vertically-center u-hide--small u-hide--medium">
-			{{
-				image (
-				url="https://assets.ubuntu.com/v1/9d5e5884-diagram-nvidia.png",
-				alt="",
-				width="1144",
-				height="729",
-				hi_def=True,
-				loading="auto"
-				) | safe
-			}}
+			<a href="https://assets.ubuntu.com/v1/49180a1d-AI%20enterprise%20solution%20powered%20by%20Canonical%20and%20NVIDIA.pdf" target="_blank" aria-hidden="true" tabindex="-1">
+				{{
+					image (
+					url="https://assets.ubuntu.com/v1/9d5e5884-diagram-nvidia.png",
+					alt="Check out the Enterprise-Ready AI solution powered by Canonical and NVIDIA",
+					width="1144",
+					height="729",
+					hi_def=True,
+					loading="auto"
+					) | safe
+				}}
+			</a>
 		</div>
 	</div>
 </section>
@@ -204,7 +206,7 @@
 		<div class="col-6">
 			<p>End-to-end customer support is available when you need it for all Canonical software backed by NVIDIA across all NVIDIA hardware platforms. New Ubuntu releases are made available like clockwork with Canonical's periodic <a href="/about/release-cycle">release cycle</a>. Ubuntu's reliable maintenance cycle, with updates every 3-5 weeks fosters trust across the community.
 			</p>
-			<img src="https://assets.ubuntu.com/v1/5b483842-cog_trimmed.svg" class="u-no-margin-bottom" style="margin-bottom: -7px;"/>
+			<img src="https://assets.ubuntu.com/v1/5b483842-cog_trimmed.svg" alt="" class="u-no-margin-bottom" style="margin-bottom: -7px;"/>
 			<hr class="u-no-margin-top" />
 			<p><a href="/support">Learn more about enterprise open-source support</a></p>
 		</div>
@@ -262,7 +264,7 @@
 			<li class="p-list__item">Extensive catalogue of ready-to-use containers</li>
 		</ul>
 	</div>
-	
+
 	<div class="row p-strip u-no-padding--top">
 		<hr class="u-no-margin--bottom" />
 		<div class="col-6">
@@ -330,7 +332,7 @@
 			</ul>
 		</div>
 	</div>
-	
+
 	<div class="row">
 		<hr class="u-no-margin--bottom" />
 		<div class="col-6">
@@ -371,7 +373,7 @@
 					</a>
 				<li>
 			</ul>
-			
+
 		</div>
 	</div>
 </section>
@@ -417,7 +419,7 @@
           }}
 				</div>
 				<div class="p-logo-section__item">
-          
+
           {{ image (
             url="https://assets.ubuntu.com/v1/234dbea3-aws-logo.png",
             alt="",
@@ -447,14 +449,14 @@
             width="288",
             height="289",
             hi_def=True,
-            loading="auto|lazy"	
+            loading="auto|lazy"
             ) | safe
           }}
 				</div>
 			</div>
 		</div>
 	</div>
-	
+
 </section>
 
 <!-- Set default Marketo information for contact form below-->


### PR DESCRIPTION
## Done

- Added a link around the image as requested in the [copy doc](https://docs.google.com/document/d/1DJ1FuEswAojPNSX9JCLcWJwy-va5VMzuuLGwSNM0lRY/edit?disco=AAAA0iU6AU0)

## QA

- Open the demo
- Go to /nvidia
- Scroll to the "Turnkey AI solutions for the enterprise powered by Canonical and NVIDIA" and check the image is clickable as requested in the copydoc
- Check for a11y issues

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-4878
