### PR TITLE
Update lxd install page copy

### DIFF
--- a/templates/lxd/install.html
+++ b/templates/lxd/install.html
@@ -23,7 +23,7 @@
 
 <section class="p-strip--light">
   <div class="u-fixed-width">
-    <h2>Install LXD in 4 easy steps</h2>
+    <h2>Get started with LXD in 4 easy steps</h2>
     <ol class="p-stepped-list--detailed">
       <li class="p-stepped-list__item">
         <h3 class="p-stepped-list__title">Install LXD as a snap</h3>


### PR DESCRIPTION
## Done

- Update heading on lxd install page

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- check the heading on /lxd/install second heading changed

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
