### PR TITLE
Update lxd link in meganav

### DIFF
--- a/static/js/src/navigation.js
+++ b/static/js/src/navigation.js
@@ -300,6 +300,20 @@ if (accountContainer && accountContainerSmall) {
     });
 }
 
+// TEMP FIX - DE 06.07.23
+// UPDATES LXD LINK TARGET IN THE MEGANAV UNTIL
+// WE MERGE THE NEW MEGANAV
+function replaceLxdLink() {
+  const globalNav = document.querySelector("#canonical-global-nav");
+  const lxdNavLinks = globalNav.querySelectorAll(
+    '[href="https://linuxcontainers.org/"]'
+  );
+  lxdNavLinks.forEach(function (element) {
+    element.href = "/lxd";
+  });
+}
+replaceLxdLink();
+
 // TEMP FIX - PETE F 15.05.23
 // UPDATES 'UBUNTU ADVANTAGE' TO 'UBUNTU PRO' IN THE MEGANAV UNTIL
 // WE MERGE THE NEW MEGANAV


### PR DESCRIPTION
## Done

- update link for lxd in meganav

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- check meganav (product link on the top) for the lxd link, it should point to /lxd and not to the external linuxcontainers.org page