### PR TITLE
Match Pro Desktop infra with uai-essential-desktop

### DIFF
--- a/static/js/src/advantage/subscribe/react/components/ProductSummary/ProductSummary.test.tsx
+++ b/static/js/src/advantage/subscribe/react/components/ProductSummary/ProductSummary.test.tsx
@@ -7,6 +7,7 @@ import {
   ProductListings,
   ProductTypes,
   ProductUsers,
+  LTSVersions,
 } from "advantage/subscribe/react/utils/utils";
 import { productListFixture } from "advantage/subscribe/react/utils/test/Mocks";
 
@@ -16,24 +17,52 @@ beforeAll(() => {
 
 test("Should show Buy now button and full service description link when 'organisation' is selected ", async () => {
   render(
-    <FormProvider initialUser={ProductUsers.organisation}>
+    <FormProvider
+      initialType={ProductTypes.physical}
+      initialUser={ProductUsers.organisation}
+    >
       <ProductSummary />
     </FormProvider>
   );
-
+  expect(screen.getByTestId("summary-product-name")).toHaveTextContent(
+    "Ubuntu Pro"
+  );
+  expect(screen.getByTestId("summary-product-name")?.textContent).not.toContain(
+    "Desktop"
+  );
   expect(
     screen.getAllByText("See full service description")[0]
   ).toHaveAttribute("href", "/legal/ubuntu-pro-description");
   expect(screen.getAllByText("Buy now")[0]).toBeInTheDocument();
 });
 
+test("Should show Ubuntu Pro Desktop when 'Desktops' is selected ", async () => {
+  render(
+    <FormProvider
+      initialType={ProductTypes.desktop}
+      initialUser={ProductUsers.organisation}
+      initialVersion={LTSVersions.trusty}
+    >
+      <ProductSummary />
+    </FormProvider>
+  );
+  expect(screen.getByTestId("summary-product-name")?.textContent).toContain(
+    "Desktop"
+  );
+  expect(
+    screen.getAllByText("See full service description")[0]
+  ).toHaveAttribute("href", "/legal/ubuntu-pro-description");
+  expect(screen.getAllByText("Buy now")[0]).toBeInTheDocument();
+});
 test("Should show register button and person subscription terms of service when 'myself' is selected ", async () => {
   render(
     <FormProvider initialUser={ProductUsers.myself}>
       <ProductSummary />
     </FormProvider>
   );
-
+  expect(screen.getByTestId("summary-product-name")).toHaveTextContent(
+    /^Ubuntu Pro$/
+  );
   expect(screen.getByTestId("personal-subscription")).toHaveAttribute(
     "href",
     "/legal/ubuntu-pro/personal"

--- a/static/js/src/advantage/subscribe/react/components/ProductSummary/ProductSummary.tsx
+++ b/static/js/src/advantage/subscribe/react/components/ProductSummary/ProductSummary.tsx
@@ -61,7 +61,7 @@ const ProductSummary = () => {
           </Col>
           <hr />
           <Col size={6}>
-            <p className="p-heading--2">
+            <p className="p-heading--2" data-testid="summary-product-name">
               {productUser === ProductUsers.myself
                 ? "Ubuntu Pro"
                 : product?.name}

--- a/static/js/src/advantage/subscribe/react/utils/utils.ts
+++ b/static/js/src/advantage/subscribe/react/utils/utils.ts
@@ -249,6 +249,8 @@ export const getProduct = (
       return "uaia-standard-physical-yearly";
     case `${ProductTypes.physical}-${Features.pro}-${Support.full}-${SLA.everyday}-${Periods.yearly}`:
       return "uaia-advanced-physical-yearly";
+    case `${ProductTypes.desktop}-${Features.infra}-${Support.none}-${SLA.none}-${Periods.yearly}`:
+      return "uai-essential-desktop-yearly";
     case `${ProductTypes.desktop}-${Features.pro}-${Support.none}-${SLA.none}-${Periods.yearly}`:
       return "uai-essential-desktop-yearly";
     case `${ProductTypes.desktop}-${Features.pro}-${Support.none}-${SLA.none}-${Periods.monthly}`:


### PR DESCRIPTION
## Done
- Match Pro Desktop infra with `uai-essential-desktop`
- Write some test code for product summary

## QA

- Go to /pro/subscribe 
- Select organisation - desktops - 14.04 LTS
- Check only Ubuntu Pro (Infra-only) is available
- Check product name is Ubuntu Pro desktop and price is $25 per machine in the product summary 
<img width="1160" alt="image" src="https://github.com/canonical/ubuntu.com/assets/57550290/13f03ef4-ca4d-46e1-bc6d-471a288916a6">

## Issue / Card

Fixes #
