### PR TITLE
Change active footer accordion colour - small screens

### DIFF
--- a/static/sass/_pattern_footer.scss
+++ b/static/sass/_pattern_footer.scss
@@ -216,7 +216,7 @@
   .p-footer__title.active {
     background-color: $colors--light-theme--background-hover;
 
-    a, 
+    a,
     span {
       &::before {
         transform: none;

--- a/static/sass/_pattern_footer.scss
+++ b/static/sass/_pattern_footer.scss
@@ -257,7 +257,7 @@
     display: block;
 
     @media only screen and (max-width: $breakpoint-small) {
-      background-color: #e5e5e5;
+      background-color: $color-mid-x-light;
     }    
   }
 

--- a/static/sass/_pattern_footer.scss
+++ b/static/sass/_pattern_footer.scss
@@ -245,7 +245,7 @@
 
   .p-footer__title.active {
     background-image: url("#{$assets-path}43e2b367-arrow_up_9fa097.png");
-    font-weight: 800;
+    background-color: $colors--light-theme--background-hover;
     
 
     @media only screen and (min-width: $breakpoint-small) {
@@ -254,12 +254,7 @@
   }
 
   .p-footer__title.active + .second-level-nav {
-    display: block;
-    background-color: $color-mid-x-light;
-
-    @media only screen and (min-width: $breakpoint-small) {
-      background-color: initial;
-    }    
+    display: block;    
   }
 
   .p-footer__title-text {

--- a/static/sass/_pattern_footer.scss
+++ b/static/sass/_pattern_footer.scss
@@ -95,7 +95,6 @@
   .p-footer__title {
     @include footer-title;
 
-    // background-image: url("#{$assets-path}7bd1bd7b-arrow_down_9fa097.svg");
     background-position: calc(100% - 10px) 50%;
     background-repeat: no-repeat;
     background-size: 13px 13px;
@@ -150,6 +149,7 @@
         @extend %icon;
         @include vf-icon-chevron($color-mid-dark);
         @include vf-transition($property: transform, $duration: fast);
+        transform: rotate(-90deg);
 
         content: '';
         margin-right: $sph--large;
@@ -266,8 +266,13 @@
   }
 
   .p-footer__title.active {
-    // background-image: url("#{$assets-path}43e2b367-arrow_up_9fa097.png");
     background-color: $colors--light-theme--background-hover;
+
+    a {
+      &::before {
+        transform: none;
+      }
+    }
 
     @media only screen and (min-width: $breakpoint-small) {
       background: none;

--- a/static/sass/_pattern_footer.scss
+++ b/static/sass/_pattern_footer.scss
@@ -245,6 +245,8 @@
 
   .p-footer__title.active {
     background-image: url("#{$assets-path}43e2b367-arrow_up_9fa097.png");
+    font-weight: 800;
+    
 
     @media only screen and (min-width: $breakpoint-small) {
       background: none;
@@ -253,6 +255,7 @@
 
   .p-footer__title.active + .second-level-nav {
     display: block;
+    background-color: #e5e5e5;
   }
 
   .p-footer__title-text {

--- a/static/sass/_pattern_footer.scss
+++ b/static/sass/_pattern_footer.scss
@@ -255,7 +255,10 @@
 
   .p-footer__title.active + .second-level-nav {
     display: block;
-    background-color: #e5e5e5;
+
+    @media only screen and (max-width: $breakpoint-small) {
+      background-color: #e5e5e5;
+    }    
   }
 
   .p-footer__title-text {

--- a/static/sass/_pattern_footer.scss
+++ b/static/sass/_pattern_footer.scss
@@ -216,7 +216,8 @@
   .p-footer__title.active {
     background-color: $colors--light-theme--background-hover;
 
-    a {
+    a, 
+    span {
       &::before {
         transform: none;
       }

--- a/static/sass/_pattern_footer.scss
+++ b/static/sass/_pattern_footer.scss
@@ -95,7 +95,7 @@
   .p-footer__title {
     @include footer-title;
 
-    background-image: url("#{$assets-path}7bd1bd7b-arrow_down_9fa097.svg");
+    // background-image: url("#{$assets-path}7bd1bd7b-arrow_down_9fa097.svg");
     background-position: calc(100% - 10px) 50%;
     background-repeat: no-repeat;
     background-size: 13px 13px;
@@ -127,7 +127,8 @@
       }
     }
 
-    a {
+    a,
+    span {
       &:hover {
         text-decoration: none;
 
@@ -143,6 +144,15 @@
         @media only screen and (min-width: $breakpoint-small) {
           font-weight: normal;
         }
+      }
+
+      &::before {
+        @extend %icon;
+        @include vf-icon-chevron($color-mid-dark);
+        @include vf-transition($property: transform, $duration: fast);
+
+        content: '';
+        margin-right: $sph--large;
       }
 
       &::after {
@@ -233,6 +243,11 @@
         line-height: 1.25;
         padding: $sp-medium;
 
+        &::before {
+          content: "";
+          margin-left: 2rem;
+        }
+
         @media only screen and (min-width: $breakpoint-small) {
           border: 0;
           font-size: 0.8125rem;
@@ -244,9 +259,8 @@
   }
 
   .p-footer__title.active {
-    background-image: url("#{$assets-path}43e2b367-arrow_up_9fa097.png");
+    // background-image: url("#{$assets-path}43e2b367-arrow_up_9fa097.png");
     background-color: $colors--light-theme--background-hover;
-    
 
     @media only screen and (min-width: $breakpoint-small) {
       background: none;

--- a/static/sass/_pattern_footer.scss
+++ b/static/sass/_pattern_footer.scss
@@ -255,9 +255,10 @@
 
   .p-footer__title.active + .second-level-nav {
     display: block;
+    background-color: $color-mid-x-light;
 
-    @media only screen and (max-width: $breakpoint-small) {
-      background-color: $color-mid-x-light;
+    @media only screen and (min-width: $breakpoint-small) {
+      background-color: initial;
     }    
   }
 

--- a/static/sass/_pattern_footer.scss
+++ b/static/sass/_pattern_footer.scss
@@ -341,6 +341,7 @@
 
   .p-footer-list-single-child {
     @media only screen and (max-width: $breakpoint-small) {
+      border-top: 1px solid $color-mid-light;
       margin-left: $sp-small;
     }
   }

--- a/static/sass/_pattern_footer.scss
+++ b/static/sass/_pattern_footer.scss
@@ -149,14 +149,14 @@
         @extend %icon;
         @include vf-icon-chevron($color-mid-dark);
         @include vf-transition($property: transform, $duration: fast);
-        transform: rotate(-90deg);
 
-        content: '';
+        content: "";
         margin-right: $sph--large;
+        transform: rotate(-90deg);
 
         @media only screen and (min-width: $breakpoint-small) {
           display: none;
-        } 
+        }
       }
 
       &::after {

--- a/static/sass/_pattern_footer.scss
+++ b/static/sass/_pattern_footer.scss
@@ -236,7 +236,6 @@
       }
 
       a {
-        border-top: 1px solid $color-mid-light;
         color: $color-dark;
         display: block;
         font-size: 1rem;

--- a/static/sass/_pattern_footer.scss
+++ b/static/sass/_pattern_footer.scss
@@ -153,6 +153,10 @@
 
         content: '';
         margin-right: $sph--large;
+
+        @media only screen and (min-width: $breakpoint-small) {
+          display: none;
+        } 
       }
 
       &::after {
@@ -245,6 +249,10 @@
         &::before {
           content: "";
           margin-left: 2rem;
+          
+          @media only screen and (min-width: $breakpoint-small) {
+            display: none;
+          }
         }
 
         @media only screen and (min-width: $breakpoint-small) {

--- a/static/sass/_pattern_footer.scss
+++ b/static/sass/_pattern_footer.scss
@@ -124,10 +124,7 @@
       @media only screen and (min-width: $breakpoint-small) {
         padding: 0 0 $sp-x-small;
       }
-    }
 
-    a,
-    span {
       &:hover {
         text-decoration: none;
 
@@ -216,6 +213,20 @@
     }
   }
 
+  .p-footer__title.active {
+    background-color: $colors--light-theme--background-hover;
+
+    a {
+      &::before {
+        transform: none;
+      }
+    }
+
+    @media only screen and (min-width: $breakpoint-small) {
+      background: none;
+    }
+  }
+
   .p-footer .second-level-nav {
     margin: 0;
     padding: 0;
@@ -249,7 +260,7 @@
         &::before {
           content: "";
           margin-left: 2rem;
-          
+
           @media only screen and (min-width: $breakpoint-small) {
             display: none;
           }
@@ -265,22 +276,8 @@
     }
   }
 
-  .p-footer__title.active {
-    background-color: $colors--light-theme--background-hover;
-
-    a {
-      &::before {
-        transform: none;
-      }
-    }
-
-    @media only screen and (min-width: $breakpoint-small) {
-      background: none;
-    }
-  }
-
   .p-footer__title.active + .second-level-nav {
-    display: block;    
+    display: block;
   }
 
   .p-footer__title-text {

--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -5,6 +5,34 @@
 <footer class="p-footer p-strip u-clearfix">
   <div class="u-fixed-width p-footer__container">
     <p class="u-hide--medium u-hide--large link-to-top"><a href="#"><small>Back to top</small></a></p>
+    <aside class="p-accordion">
+      <ul class="p-accordion__list">
+        <li class="p-accordion__group">
+          <div role="heading" aria-level="3" class="p-accordion__heading">
+            <button type="button" class="p-accordion__tab" id="tab1" aria-controls="tab1-section" aria-expanded="true">What is MAAS?</button>
+          </div>
+          <section class="p-accordion__panel" id="tab1-section" aria-hidden="false" aria-labelledby="tab1">
+            <p>MAAS expands to “Metal As A Service” – it converts bare-metal servers into cloud instances of virtual machines. There is no need to manage individual units. You can quickly provision or destroy machines, as if they were instances hosted in a public cloud like Amazon AWS, Google GCE, or Microsoft Azure.</p>
+          </section>
+        </li>
+        <li class="p-accordion__group">
+          <div role="heading" aria-level="3" class="p-accordion__heading">
+            <button type="button" class="p-accordion__tab" id="tab2" aria-controls="tab2-section" aria-expanded="false">What MAAS offers</button>
+          </div>
+          <section class="p-accordion__panel" id="tab2-section" aria-hidden="true" aria-labelledby="tab2">
+            <p>MAAS can manage a large number of physical machines by merging them into user-defined resource pools. MAAS automatically provisions participating machines and makes them available for use. You can return unused machines to the assigned pool at any time.</p>
+          </section>
+        </li>
+        <li class="p-accordion__group">
+          <div role="heading" aria-level="3" class="p-accordion__heading">
+            <button type="button" class="p-accordion__tab" id="tab3" aria-controls="tab3-section" aria-expanded="false">How MAAS works</button>
+          </div>
+          <section class="p-accordion__panel" id="tab3-section" aria-hidden="true" aria-labelledby="tab3">
+            <p>When you add a new machine to MAAS, or elect to add a machine that MAAS has enlisted, MAAS commissions it for service and adds it to the pool. At that point, the machine is ready for use. MAAS keeps things simple, marking machines as “New,” “Commissioning,” “Ready,” and so on.</p>
+          </section>
+        </li>
+      </ul>
+    </aside>
     <nav aria-label="Footer navigation" id="main-navigation" class="p-footer__nav u-clearfix row u-no-padding--left u-no-padding--right">
       <div class="p-footer__nav-col col-2 col-medium-2 u-no-margin--bottom">
         <ul class="p-footer__links">

--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -5,34 +5,6 @@
 <footer class="p-footer p-strip u-clearfix">
   <div class="u-fixed-width p-footer__container">
     <p class="u-hide--medium u-hide--large link-to-top"><a href="#"><small>Back to top</small></a></p>
-    <aside class="p-accordion">
-      <ul class="p-accordion__list">
-        <li class="p-accordion__group">
-          <div role="heading" aria-level="3" class="p-accordion__heading">
-            <button type="button" class="p-accordion__tab" id="tab1" aria-controls="tab1-section" aria-expanded="true">What is MAAS?</button>
-          </div>
-          <section class="p-accordion__panel" id="tab1-section" aria-hidden="false" aria-labelledby="tab1">
-            <p>MAAS expands to “Metal As A Service” – it converts bare-metal servers into cloud instances of virtual machines. There is no need to manage individual units. You can quickly provision or destroy machines, as if they were instances hosted in a public cloud like Amazon AWS, Google GCE, or Microsoft Azure.</p>
-          </section>
-        </li>
-        <li class="p-accordion__group">
-          <div role="heading" aria-level="3" class="p-accordion__heading">
-            <button type="button" class="p-accordion__tab" id="tab2" aria-controls="tab2-section" aria-expanded="false">What MAAS offers</button>
-          </div>
-          <section class="p-accordion__panel" id="tab2-section" aria-hidden="true" aria-labelledby="tab2">
-            <p>MAAS can manage a large number of physical machines by merging them into user-defined resource pools. MAAS automatically provisions participating machines and makes them available for use. You can return unused machines to the assigned pool at any time.</p>
-          </section>
-        </li>
-        <li class="p-accordion__group">
-          <div role="heading" aria-level="3" class="p-accordion__heading">
-            <button type="button" class="p-accordion__tab" id="tab3" aria-controls="tab3-section" aria-expanded="false">How MAAS works</button>
-          </div>
-          <section class="p-accordion__panel" id="tab3-section" aria-hidden="true" aria-labelledby="tab3">
-            <p>When you add a new machine to MAAS, or elect to add a machine that MAAS has enlisted, MAAS commissions it for service and adds it to the pool. At that point, the machine is ready for use. MAAS keeps things simple, marking machines as “New,” “Commissioning,” “Ready,” and so on.</p>
-          </section>
-        </li>
-      </ul>
-    </aside>
     <nav aria-label="Footer navigation" id="main-navigation" class="p-footer__nav u-clearfix row u-no-padding--left u-no-padding--right">
       <div class="p-footer__nav-col col-2 col-medium-2 u-no-margin--bottom">
         <ul class="p-footer__links">


### PR DESCRIPTION
## Done

Currently when a footer accordion header is clicked, it's a little tricky to distinguish between the accordion header, its second-level dropdown contents and the rest of the footer. I've suggested some separate improvements to the footer in [another PR](https://github.com/canonical/ubuntu.com/pull/13006) which could outdate my below screenshot, but those still have this same issue. 

Proposing an improvement for the footer on small screens:

- When a footer accordion header is clicked (active), its nested items change background colour (`$color-mid-x-light`). This grey is light enough for you to make out the divider between each item.
- When the header is clicked, it also increases font-weight to distinguish it from the other unclicked headers above it.

## QA

- Open demo and view Ubuntu.com footer on small screen (620px>). Open separate tab of live website for comparison. 
- In demo, open accordions to see changes made. Drag screen-size to see they're only made to small-screens.

## Screenshots

Before:
<img width="511" alt="Screenshot 2023-07-11 at 10 20 56" src="https://github.com/canonical/ubuntu.com/assets/95416961/26d53cbf-02f3-46d8-9697-c70b03155e58">

After:
<img width="506" alt="Screenshot 2023-07-11 at 10 21 11" src="https://github.com/canonical/ubuntu.com/assets/95416961/eb464cea-65ba-48a0-ae7e-3fd65f362225">



Please feel free to provide any tweaks or feedback on this! Thanks :)  
