### PR TITLE
WD-5114 - Update the legal addresses across the site

### DIFF
--- a/templates/contact-us/index.html
+++ b/templates/contact-us/index.html
@@ -63,10 +63,10 @@
       <div itemprop="address" itemscope itemtype="https://schema.org/PostalAddress">
         <ul class="p-list">
           <li itemprop="name"><strong>Canonical Group Limited</strong></li>
-          <li itemprop="streetAddress">2nd Floor, Clarendon House</li>
-          <li itemprop="streetAddress">Victoria Street</li>
-          <li itemprop="postalCode">Douglas IM1 2LN</li>
-          <li itemprop="addressLocality">Isle of Man</li>
+          <li itemprop="streetAddress">The Office Group, St Dunstans House,</li>
+          <li itemprop="streetAddress">4th floor, 201 Borough High St,</li>
+          <li itemprop="postalCode">SE1 1JA</li>
+          <li itemprop="addressLocality">London, United Kingdom</li>
         </ul>
       </div>
       <ul class="p-list">

--- a/templates/legal/anbox-cloud-privacy-notice.html
+++ b/templates/legal/anbox-cloud-privacy-notice.html
@@ -14,7 +14,7 @@
       </section>
       <section>
         <h2 id="who-are-we">Who are we?</h2>
-        <p>We are Canonical Group Limited. Our address is 2nd Floor, Clarendon House, Victoria Street, Douglas IM1 2LN, Isle of Man. You can contact us by post at the above address or by email to <a href="mailto:dataprotection@canonical.com">dataprotection@canonical.com</a> for the attention of "Legal".</p>
+        <p>We are Canonical Group Limited. Our address is 5 New Street Square, London, EC4A 3TW, United Kingdom. You can contact us by post at the address  set out in the “right to complain” section, below or by email to <a href="mailto:dataprotection@canonical.com">dataprotection@canonical.com</a> for the attention of "Legal".</p>
         <p>We are not required to have a data protection officer, so any enquiries about our use of your personal data should be addressed to the contact details above.</p>
       </section>
       <section>

--- a/templates/legal/anbox-cloud-privacy-notice.html
+++ b/templates/legal/anbox-cloud-privacy-notice.html
@@ -68,8 +68,12 @@
       <section>
         <h2 id="your-right-to-complain">Your right to complain</h2>
         <p>We hope that we can resolve any query or concern you raise about our use of your information. You can contact us at any time. Any questions, comments and requests regarding this Privacy notice or any other related matter are welcomed and should be addressed to <a href="mailto:dataprotection@canonical.com">dataprotection@canonical.com</a> or to the address below:</p>
-        <p>Legal, Canonical<br>
-          2nd Floor, Clarendon House,<br /> Victoria Street,<br /> Douglas IM1 2LN,<br /> Isle of Man</p>
+        <div style="margin:2rem;">
+Legal, Canonical<br />
+4th floor, 201 Borough High St.<br />
+London SE1 1JA<br />
+United Kingdom<br />
+</div>
         <p>Alternatively, you can use the relevant contact us form.</p>
         <p>If you have a complaint about our use of your information, you can contact the Information Commissioner's Office via their website at <a href="https://ico.org.uk/make-a-complaint">ico.org.uk/make-a-complaint</a> or write to them at:</p>
         <p>Information Commissioner's Office<br>

--- a/templates/legal/data-privacy/contact.md
+++ b/templates/legal/data-privacy/contact.md
@@ -6,7 +6,7 @@ context:
   copydoc: https://docs.google.com/document/d/1MSwPrKMFgcKKjnBfcudlnca0wa4I58vQdM8VroKSno0/edit#
 ---
 
-<h4 class="p-muted-heading">Version - April 2018</h4>
+<h4 class="p-muted-heading">Version - July 2023</h4>
 <hr style="margin-bottom: 2rem;" />
 
 # Privacy notice - Contact us and enquiries
@@ -15,7 +15,7 @@ This privacy notice tells you about the information we collect from you when you
 
 ## Who are we?
 
-We are Canonical Group Limited. Our address is 2nd Floor, Clarendon House, Victoria Street, Douglas IM1 2LN, Isle of Man. You can contact us by post at the above address or by email to [dataprotection@canonical.com](mailto:dataprotection@canonical.com) for the attention of "Legal".
+We are Canonical Group Limited. Our address is 5 New Street Square, London, EC4A 3TW, United Kingdom. You can contact us by post at the address  set out in the “right to complain” section, below or by email to [dataprotection@canonical.com](mailto:dataprotection@canonical.com) for the attention of "Legal".
 
 We are not required to have a data protection officer, so any enquiries about our use of your personal data should be addressed to the contact details above.
 

--- a/templates/legal/data-privacy/esxi.md
+++ b/templates/legal/data-privacy/esxi.md
@@ -15,7 +15,7 @@ This privacy notice tells you about the information collected from you when you 
 
 ## Who are we?
 
-We are Canonical Group Limited. Our address is 2nd Floor, Clarendon House, Victoria Street, Douglas IM1 2LN, Isle of Man. You can contact us by post at the above address or by email to [dataprotection@canonical.com](mailto:dataprotection@canonical.com) for the attention of "Legal".
+We are Canonical Group Limited. Our address is 5 New Street Square, London, EC4A 3TW, United Kingdom. You can contact us by post at the address set out in the “right to complain” section, below or by email to [dataprotection@canonical.com](mailto:dataprotection@canonical.com) for the attention of "Legal".
 
 We are not required to have a data protection officer, so any enquiries about our use of your personal data should be addressed to the contact details above.
 
@@ -83,7 +83,7 @@ We hope that we can resolve any query or concern you raise about our use of your
 Legal, Canonical<br />
     2nd Floor, Clarendon House, <br/>
     Victoria Street, <br/>
-    Douglas IM1 2LN, <br/> 
+    Douglas IM1 2LN, <br/>
     Isle of Man
 </div>
 

--- a/templates/legal/data-privacy/esxi.md
+++ b/templates/legal/data-privacy/esxi.md
@@ -6,7 +6,7 @@ context:
   copydoc: https://docs.google.com/document/d/1I1PtxFqV1KNsnnxJlo-Q9V7JDvkbmsAxAvVk4Nf9aLQ
 ---
 
-<h4 class="p-muted-heading">Version - May 2019</h4>
+<h4 class="p-muted-heading">Version - July 2023</h4>
 <hr style="margin-bottom: 2rem;" />
 
 # Privacy notice – ESXi
@@ -80,11 +80,10 @@ This Privacy Notice will be reviewed from time to time. If we decide to change t
 We hope that we can resolve any query or concern you raise about our use of your information. You can contact us at any time. Any questions, comments and requests regarding this Privacy notice or any other related matter are welcomed and should be addressed to [dataprotection@canonical.com](mailto:dataprotection@canonical.com) or to the address below:
 
 <div style="margin:2rem;">
-Legal, Canonical<br />
-    2nd Floor, Clarendon House, <br/>
-    Victoria Street, <br/>
-    Douglas IM1 2LN, <br/>
-    Isle of Man
+  Legal, Canonical<br />
+  4th floor, 201 Borough High St.<br />
+  London SE1 1JA<br />
+  United Kingdom<br />
 </div>
 
 Alternatively, you can use the relevant contact us form.

--- a/templates/legal/data-privacy/events.md
+++ b/templates/legal/data-privacy/events.md
@@ -6,7 +6,7 @@ context:
   copydoc: https://docs.google.com/document/d/1-2bcVP8SVKnfe-qdCrqWM0rCRk8A0JKo_dcKR8jJ2wY
 ---
 
-<h4 class="p-muted-heading">Version - December 2019</h4>
+<h4 class="p-muted-heading">Version - July 2023</h4>
 <hr style="margin-bottom: 2rem;" />
 
 # Privacy Notice – Events
@@ -15,7 +15,7 @@ This Privacy Notice tells you about the information collected from you when you 
 
 ## Who are we?
 
-We are Canonical Group Limited. Our address is 2nd Floor, Clarendon House, Victoria Street, Douglas IM1 2LN, Isle of Man. You can contact us by post at the above address or by email to [dataprotection@canonical.com](mailto:dataprotection@canonical.com) for the attention of "Legal".
+We are Canonical Group Limited. Our registered address is 5 New Street Square, London, EC4A 3TW, United Kingdom. You can contact us by post at the address set out in the “right to complain” section, below or by email to [dataprotection@canonical.com](mailto:dataprotection@canonical.com) for the attention of "Legal".
 
 We are not required to have a data protection officer, so any enquiries about our use of your personal data should be addressed to the contact details above.
 
@@ -106,8 +106,10 @@ This Privacy Notice will be reviewed from time to time. If we decide to change t
 We hope that we can resolve any query or concern you raise about our use of your information. You can contact us at any time. Any questions, comments and requests regarding this Privacy Notice or any other related matter are welcomed and should be addressed to [dataprotection@canonical.com](mailto:dataprotection@canonical.com) or to the address below:
 
 <div style="margin:2rem;">
-Legal, Canonical<br />
-2nd Floor, Clarendon House,<br/>Victoria Street,<br/>Douglas IM1 2LN,<br/>Isle of Man
+4th Floor<br />
+201 Borough High Street<br />
+London SE1 1JA<br />
+United Kingdom<br />
 </div>
 
 Alternatively, you can use the relevant contact us form.

--- a/templates/legal/data-privacy/index.html
+++ b/templates/legal/data-privacy/index.html
@@ -293,7 +293,10 @@
       <div style="margin: 2rem;">
         <p>
           Legal, Canonical<br />
-          2nd Floor, Clarendon House,<br/>Victoria Street,<br/>Douglas IM1 2LN,<br/>Isle of Man
+          4th Floor, <br />
+          201 Borough High Street<br />
+          London SE1 1JA<br />
+          United Kingdom<br />
         </p>
       </div>
       <p>Alternatively you can use the relevant <a href="/contact-us">contact us</a> form.</p>

--- a/templates/legal/data-privacy/newsletter.md
+++ b/templates/legal/data-privacy/newsletter.md
@@ -16,7 +16,7 @@ This privacy notice tells you about the information we collect from you when you
 
 ## Who are we?
 
-We are Canonical Group Limited. Our address is 2nd Floor, Clarendon House, Victoria Street, Douglas IM1 2LN, Isle of Man. You can contact us by post at the above address or by email to [dataprotection@canonical.com](mailto:dataprotection@canonical.com) for the attention of "Legal".
+We are Canonical Group Limited. Our address is 5 New Street Square, London, EC4A 3TW, United Kingdom. You can contact us by post at the address set out in the “right to complain” section, below or by email to [dataprotection@canonical.com](mailto:dataprotection@canonical.com) for the attention of "Legal".
 
 We are not required to have a data protection officer, so any enquiries about our use of your personal data should be addressed to the contact details above.
 

--- a/templates/legal/data-privacy/newsletter.md
+++ b/templates/legal/data-privacy/newsletter.md
@@ -6,7 +6,7 @@ context:
   copydoc: https://docs.google.com/document/d/1Et7uuP82vYgk-sXTOeLLlKi0NzwCdDHkSlfLS7IClzo/edit
 ---
 
-<h4 class="p-muted-heading">Version - April 2018</h4>
+<h4 class="p-muted-heading">Version - July 2023</h4>
 
 <hr style="margin-bottom: 2rem;" />
 

--- a/templates/legal/data-privacy/online-competitions.md
+++ b/templates/legal/data-privacy/online-competitions.md
@@ -15,7 +15,7 @@ This Privacy Notice tells you about the information collected from you when you 
 
 ## Who are we?
 
-We are Canonical Group Limited. Our address is 2nd Floor, Clarendon House, Victoria Street, Douglas IM1 2LN, Isle of Man. You can contact us by post at the above address or by email to <a href="mailto:dataprotection@canonical.com">dataprotection@canonical.com</a> for the attention of "Legal".
+We are Canonical Group Limited. Our address is 5 New Street Square, London, EC4A 3TW, United Kingdom. You can contact us by post at the address set out in the “right to complain” section, below or by email to <a href="mailto:dataprotection@canonical.com">dataprotection@canonical.com</a> for the attention of "Legal".
 
 We are not required to have a data protection officer, so any enquiries about our use of your personal data should be addressed to the contact details above.
 

--- a/templates/legal/data-privacy/online-purchase.md
+++ b/templates/legal/data-privacy/online-purchase.md
@@ -117,7 +117,9 @@ We hope that we can resolve any query or concern you raise about our use of your
 
 <div style="margin:2rem;">
 Legal, Canonical<br />
-2nd Floor, Clarendon House,<br/>Victoria Street,<br/>Douglas IM1 2LN,<br/>Isle of Man
+4th floor, 201 Borough High St.<br />
+London SE1 1JA<br />
+United Kingdom<br />
 </div>
 
 Alternatively, you can use the relevant contact us form.

--- a/templates/legal/data-privacy/online-purchase.md
+++ b/templates/legal/data-privacy/online-purchase.md
@@ -6,7 +6,7 @@ context:
   copydoc: https://docs.google.com/document/d/1ZSNnMiLJl6SGSV0D_cr6MJAwpkf6xzbKYJdTL9MxLHc/edit
 ---
 
-<h4 class="p-muted-heading">Version - September 2020</h4>
+<h4 class="p-muted-heading">Version - July 2023</h4>
 <hr style="margin-bottom: 2rem;" />
 
 # Privacy notice - Online purchase
@@ -15,7 +15,7 @@ This privacy notice tells you about the information we collect from you when you
 
 ## Who are we?
 
-We are Canonical Group Limited. Our address is 2nd Floor, Clarendon House, Victoria Street, Douglas IM1 2LN, Isle of Man. You can contact us by post at the above address or by email to [dataprotection@canonical.com](mailto:dataprotection@canonical.com) for the attention of "Legal".
+We are Canonical Group Limited. Our address is 5 New Street Square, London, EC4A 3TW, United Kingdom. You can contact us by post at the address set out in the "right to complain" section, below or by email to [dataprotection@canonical.com](mailto:dataprotection@canonical.com) for the attention of "Legal".
 
 We are not required to have a data protection officer, so any enquiries about our use of your personal data should be addressed to the contact details above.
 

--- a/templates/legal/data-privacy/partner-portal.md
+++ b/templates/legal/data-privacy/partner-portal.md
@@ -6,7 +6,7 @@ context:
   copydoc: https://docs.google.com/document/d/1yuh7dL3jjkj21sKJCUhm_z00PKzH4vssY339wbp4U-s/edit
 ---
 
-<h4 class="p-muted-heading">Version - February 2019</h4>
+<h4 class="p-muted-heading">Version - July 2023</h4>
 <hr style="margin-bottom: 2rem;" />
 
 # Privacy notice - Partner Portal
@@ -15,7 +15,7 @@ This privacy notice tells you about the information we collect from you when you
 
 ## Who are we ?
 
-We are Canonical Group Limited. Our address is 2nd Floor, Clarendon House, Victoria Street, Douglas IM1 2LN, Isle of Man. You can contact us by post at the above address or by email to [dataprotection@canonical.com](mailto:dataprotection@canonical.com) for the attention of "Legal".
+We are Canonical Group Limited. Our address is 5 New Street Square, London, EC4A 3TW, United Kingdom. You can contact us by post at the address set out in the “right to complain” section, below or by email to [dataprotection@canonical.com](mailto:dataprotection@canonical.com) for the attention of "Legal".
 
 We are not required to have a data protection officer, so any enquiries about our use of your personal data should be addressed to the contact details above.
 

--- a/templates/legal/data-privacy/partner-portal.md
+++ b/templates/legal/data-privacy/partner-portal.md
@@ -96,7 +96,7 @@ To submit a request by email, post or telephone, please use the contact informat
 
 Canonical offers a free email newsletter subscription service to keep you informed of our products and services. You may receive these marketing communications from us. We incorporate a tracking system in our email marketing communications which allows us to monitor whether the email has been opened and which links are the most popular. This allows us to tailor and refine our service. to ensure that the emails you receive are relevant to your interests.
 
-Where you have consented to receiving email marketing material from us or are currently receiving material relating to similar products or services, you may at any time ask us to cease sending you such material by clicking the unsubscribe button at the end of the email or by sending an email to [dataprotection@canonical.com](mailto:dataprotection@canonical.com) with the heading "unsubscribe" or you can go to your subscription centre page (you will need to login if you have not already done so) and click the 'unsubscribe' link at the foot of the page as appropriate. Unsubscribe instructions are also clearly outlined at the bottom of every direct marketing email that we send you.
+Where you have consented to receiving email marketing material from us or are currently receiving material relating to similar products or services, you may at any time ask us to cease sending you such material by clicking the unsubscribe button at the end of the email or by sending an email to [dataprotection@canonical.com](mailto:dataprotection@canonical.com) with the heading "unsubscribe" or you can go to your subscription centre page (you will be asked to insert the email address you receive the marketing communications on) and click the 'unsubscribe' link at the foot of the page as appropriate. Unsubscribe instructions are also clearly outlined at the bottom of every direct marketing email that we send you.
 
 ## Links to other websites
 
@@ -125,7 +125,9 @@ We hope that we can resolve any query or concern you raise about our use of your
 
 <div style="margin:2rem;">
 Legal, Canonical<br />
-2nd Floor, Clarendon House,<br/>Victoria Street,<br/>Douglas IM1 2LN,<br/>Isle of Man
+4th floor, 201 Borough High St.<br />
+London SE1 1JA<br />
+United Kingdom<br />
 </div>
 
 Alternatively, you can use the relevant [contact us](/legal/data-privacy/enquiry) form.

--- a/templates/legal/data-privacy/recruitment.html
+++ b/templates/legal/data-privacy/recruitment.html
@@ -7,7 +7,7 @@
 <div class="p-strip is-deep" style="overflow-x: visible;">
   <div class="row">
     <div class="col-8">
-      <h4 class="p-muted-heading">Last Updated: 18/02/2022</h4>
+      <h4 class="p-muted-heading">Last Updated: July 2023</h4>
       <hr style="margin-bottom: 2rem;" />
 
       <h1>Recruitment Privacy Notice</h1>
@@ -123,7 +123,6 @@
         <li><b>Rights to Objection, Restriction and Erasure:</b> You have the right to restrict how your personal information is being used, and the right to request us to delete your information.</li>
         <li><b>Right to Withdraw Consent:</b> Although we do not generally process your personal information based on your consent, in circumstances which this is the case, you may withdraw your consent at any time.</li>
         <li><b>Right to be Informed:</b> You have the right to be informed about how we collect, use and retain your personal information, which is why we have set these out within this policy. If you have further queries on how we use your personal information, you may contact us at any time.</li>
-        <li><b>Rights Against Automated Decision-Making and Profiling:</b> We do not use automated decision-making or profiling for recruitment purposes.</li>
       </ul>
 
       <h2 id="exercising-your-rights">10. Exercising your rights</h2>

--- a/templates/legal/data-privacy/recruitment.html
+++ b/templates/legal/data-privacy/recruitment.html
@@ -113,11 +113,7 @@
 
       <p>If you do not want us to keep your information after the recruitment process has ended, please contact us at <a href="mailto:dataprotection@canonical.com">dataprotection@canonical.com</a>.</p>
 
-      <h2 id="automated-decision-making">9. Automated decision-making</h2>
-
-      <p>We do not use automated decision-making for recruitment purposes. All applications are reviewed by Canonical employees, who assess your suitability for the role you have applied for.</p>
-
-      <h2 id="your-rights">10. Your rights</h2>
+      <h2 id="your-rights">9. Your rights</h2>
 
       <p>You have a number of rights which you may be able to exercise with regards to your personal information. These rights have been listed below:</p>
 
@@ -130,21 +126,21 @@
         <li><b>Rights Against Automated Decision-Making and Profiling:</b> We do not use automated decision-making or profiling for recruitment purposes.</li>
       </ul>
 
-      <h2 id="exercising-your-rights">11. Exercising your rights</h2>
+      <h2 id="exercising-your-rights">10. Exercising your rights</h2>
 
       <p>To exercise any of these rights above, please contact us at <a href="mailto:dataprotection@canonical.com">dataprotection@canonical.com</a>, providing your name and contact details. Depending on your request, we may ask for further verification of your identity, or additional information in order to fulfil your request.</p>
 
-      <h2 id="right-to-complain">12. Right to complain</h2>
+      <h2 id="right-to-complain">11. Right to complain</h2>
 
       <p>If you wish to make a complaint to us about how we use or retain your personal information, please contact us at <a href="mailto:dataprotection@canonical.com">dataprotection@canonical.com</a>.</p>
 
       <p>You also have the right to submit a complaint with the UK data protection authority, which is the Information Commissioner's Office (ICO). If you wish to file a complaint with the ICO, you may find the following information helpful: <a href="https://ico.org.uk/make-a-complaint/">https://ico.org.uk/make-a-complaint/</a></p>
 
-      <h2 id="contact-information">13. Contact information</h2>
+      <h2 id="contact-information">12. Contact information</h2>
 
       <p>If you have any questions about this notice, or about how we use or retain your personal information, please contact us at <a href="mailto:dataprotection@canonical.com">dataprotection@canonical.com</a>.</p>
 
-      <h2 id="policy-changes">14. Policy changes</h2>
+      <h2 id="policy-changes">13. Policy changes</h2>
 
       <p>This is the latest version of our Recruitment Privacy Notice and is in effect as of the “Last Updated” date which may be found at the top of the notice. As we may change this notice from time to time, you should check here regularly for the most up-to-date version.</p>
     </div>
@@ -163,12 +159,11 @@
               <li><a href="#international-data-transfers">6. International data transfers</a></li>
               <li><a href="#how-we-protect-your-information">7. How we protect your information</a></li>
               <li><a href="#how-long-we-keep-your-information">8. How long we keep your information</a></li>
-              <li><a href="#automated-decision-making">9. Automated decision-making</a></li>
-              <li><a href="#your-rights">10. Your rights</a></li>
-              <li><a href="#exercising-your-rights">11. Exercising your rights</a></li>
-              <li><a href="#right-to-complain">12. Right to complain</a></li>
-              <li><a href="#contact-information">13. Contact information</a></li>
-              <li><a href="#policy-changes">14. Policy changes</a></li>
+              <li><a href="#your-rights">9. Your rights</a></li>
+              <li><a href="#exercising-your-rights">10. Exercising your rights</a></li>
+              <li><a href="#right-to-complain">11. Right to complain</a></li>
+              <li><a href="#contact-information">12. Contact information</a></li>
+              <li><a href="#policy-changes">13. Policy changes</a></li>
             </ul>
           </nav>
         </div>

--- a/templates/legal/data-privacy/snap-store.md
+++ b/templates/legal/data-privacy/snap-store.md
@@ -6,7 +6,7 @@ context:
   copydoc: https://docs.google.com/document/d/1rEyCOZWoKKJRPIg5jhANfWVibZJ9QVfqj4MkeNIJp4M/edit#
 ---
 
-<h4 class="p-muted-heading">VERSION - OCTOBER 2020</h4>
+<h4 class="p-muted-heading">Version - July 2023</h4>
 <hr style="margin-bottom: 2rem;" />
 
 # Privacy notice - Snaps and Snap store
@@ -15,7 +15,7 @@ This privacy notice tells you about the information we collect from you when you
 
 ## Who are we?
 
-We are Canonical Group Limited. Our address is 2nd Floor, Clarendon House, Victoria Street, Douglas IM1 2LN, Isle of Man. You can contact us by post at the above address or by email to [dataprotection@canonical.com](mailto:dataprotection@canonical.com) for the attention of "Legal".
+We are Canonical Group Limited. Our address is 5 New Street Square, London, EC4A 3TW, United Kingdom. You can contact us by post at the address set out in the “right to complain” section, below or by email to [dataprotection@canonical.com](mailto:dataprotection@canonical.com) for the attention of "Legal".
 
 We are not required to have a data protection officer, so any enquiries about our use of your personal data should be addressed to the contact details above.
 

--- a/templates/legal/data-privacy/snap-store.md
+++ b/templates/legal/data-privacy/snap-store.md
@@ -115,7 +115,9 @@ We hope that we can resolve any query or concern you raise about our use of your
 
 <div style="margin:2rem;">
 Legal, Canonical<br />
-2nd Floor, Clarendon House,<br/>Victoria Street,<br/>Douglas IM1 2LN,<br/>Isle of Man
+4th floor, 201 Borough High St.<br />
+London SE1 1JA<br />
+United Kingdom<br />
 </div>
 
 Alternatively, you can use the relevant contact us form.

--- a/templates/legal/data-privacy/snapcraft-nps.md
+++ b/templates/legal/data-privacy/snapcraft-nps.md
@@ -78,7 +78,9 @@ We hope that we can resolve any query or concern you raise about our use of your
 
 <div style="margin:2rem;">
 Legal, Canonical<br />
-2nd Floor, Clarendon House,<br/>Victoria Street,<br/>Douglas IM1 2LN,<br/>Isle of Man
+4th floor, 201 Borough High St.<br />
+London SE1 1JA<br />
+United Kingdom<br />
 </div>
 
 Alternatively, you can use the relevant contact us form.

--- a/templates/legal/data-privacy/snapcraft-nps.md
+++ b/templates/legal/data-privacy/snapcraft-nps.md
@@ -6,7 +6,7 @@ context:
   copydoc: https://docs.google.com/document/d/1JODNGJQ0G-aSrycKTv4XOGmJVWw98Fqk2gLfHmQqgB4/edit
 ---
 
-<h4 class="p-muted-heading">Version - December 2018</h4>
+<h4 class="p-muted-heading">Version - July 2023</h4>
 <hr style="margin-bottom: 2rem;" />
 
 # Privacy notice – Snapcraft NPS Survey
@@ -15,7 +15,7 @@ This Privacy notice tells you about the information collected from you when you 
 
 ## Who are we?
 
-We are Canonical Group Limited. Our address is 2nd Floor, Clarendon House, Victoria Street, Douglas IM1 2LN, Isle of Man. You can contact us by post at the above address or by email to [dataprotection@canonical.com](mailto:dataprotection@canonical.com) for the attention of "Legal".
+We are Canonical Group Limited. Our address is 5 New Street Square, London, EC4A 3TW, United Kingdom. You can contact us by post at the address set out in the "right to complain" section, below or by email to [dataprotection@canonical.com](mailto:dataprotection@canonical.com) for the attention of "Legal".
 
 We are not required to have a data protection officer, so any enquiries about our use of your personal data should be addressed to the contact details above.
 

--- a/templates/legal/data-privacy/sso.md
+++ b/templates/legal/data-privacy/sso.md
@@ -2,16 +2,16 @@
 wrapper_template: "legal/_base_legal_markdown.html"
 context:
   title: "Privacy notice – Single Sign On (SSO) and Ubuntu One"
-  description: "This privacy notice tells you about the information collected from you when you register for a Single Sign On (SSO) and/or Ubuntu One account."
+  description: "This privacy notice tells you about the information collected from you when you register for a Single Sign On (SSO) and/or Ubuntu One account"
   copydoc: https://docs.google.com/document/d/1nOk02AAjdOi2sW4rc1FOIO1n1BNzfU-iX88EKayXw-k/edit#
 ---
 
 <h4 class="p-muted-heading">Version - August 2022</h4>
 <hr style="margin-bottom: 2rem;" />
 
-# Privacy notice - Single Sign On (SSO)
+# Privacy notice - Single Sign On (SSO) and Ubuntu One
 
-This privacy notice tells you about the information collected from you when you register for a Single Sign On (SSO) account and/or Ubuntu One account. SSO is an identity provider service that creates, maintains and manages user identity information, providing authentication services for Canonical and other third party applications. Ubuntu One the single account you use to log in to all services and sites related to www.ubuntu.com. In collecting this information, we are acting as a data controller and, by law, we are required to provide you with information about us, about why and how we use your data, and about the rights you have over your data. For more information, please see our [privacy policy](/legal/data-privacy).
+This privacy notice tells you about the information collected from you when you register for a Single Sign On (SSO) account and/or Ubuntu One account. SSO is an identity provider service that creates, maintains and manages user identity information, providing authentication services for Canonical and other third party applications. Ubuntu One the single account you use to log in to all services and sites related to www.ubuntu.com. In collecting this information, we are acting as a data controller and, by law, we are required to provide you with information about us, about why and how we use your data, and about the rights you have over your data. For more information, please see our[privacy policy](/legal/data-privacy).
 
 ## Who are we?
 
@@ -31,7 +31,7 @@ Your information will be used by us for the provision of services in the creatio
 
 Your information is stored in our database and may be processed outside of the European Economic Area. It is shared with the third parties only as reasonably required for Canonical to process and store your data in accordance with this notice.
 
-Such countries do not have the same data protection laws as the United Kingdom and EEA. Where the European Commission has not given a formal decision that such countries provide an adequate level of data protection similar to those which currently apply to the United Kingdom and EEA, any transfer of your personal information will be subject to approved contract terms designed to help safeguard your privacy rights and give you remedies in the unlikely event of misuse of you personal information. If you would like further information, please contact us (see "Your right to complain" below).
+Such countries do not have the same data protection laws as the United Kingdom and EEA. Where the European Commission has not given a formal decision that such countries provide an adequate level of data protection similar to those which currently apply to the United Kingdom and EEA, any transfer of your personal information will be subject to approved contract terms designed to help safeguard your privacy rights and give you remedies in the unlikely event of misuse of you personal information. If you would like further information, please contact us (see “Your right to complain” below).
 
 ## How long do we keep your information for?
 
@@ -61,7 +61,7 @@ If you would like to exercise any of those rights, please:
 - Provide us proof of your identity.
 - Let us know the information to which your request relates.
 
-Please note that if you ask us to remove your SSO and/or Ubuntu One account you will no longer be able to access certain Canonical and third party services.
+Let us know the information to which your request relates. Please note that if you ask us to remove your SSO and/or Ubuntu One account you will no longer be able to access certain Canonical and third party services.
 
 ## Your right to complain
 

--- a/templates/legal/data-privacy/sso.md
+++ b/templates/legal/data-privacy/sso.md
@@ -15,7 +15,7 @@ This privacy notice tells you about the information collected from you when you 
 
 ## Who are we?
 
-We are Canonical Group Limited. Our address is 2nd Floor, Clarendon House, Victoria Street, Douglas IM1 2LN, Isle of Man. You can contact us by post at the above address or by email to [dataprotection@canonical.com](mailto:dataprotection@canonical.com) for the attention of "Legal".
+We are Canonical Group Limited. Our address is 5 New Street Square, London, EC4A 3TW, United Kingdom. You can contact us by post at the address set out in the “right to complain” section, below or by email to [dataprotection@canonical.com](mailto:dataprotection@canonical.com) for the attention of "Legal".
 
 We are not required to have a data protection officer, so any enquiries about our use of your personal data should be addressed to the contact details above.
 

--- a/templates/legal/data-privacy/survey.md
+++ b/templates/legal/data-privacy/survey.md
@@ -6,7 +6,7 @@ context:
   copydoc: https://docs.google.com/document/d/164IVIF3f8Prh7MTl8gTDal0jaPJt15PxdhMKToFhMu8
 ---
 
-<h4 class="p-muted-heading">Version - December 2019</h4>
+<h4 class="p-muted-heading">Version - July 2023</h4>
 <hr style="margin-bottom: 2rem;" />
 
 # Privacy Notice – Survey
@@ -17,7 +17,7 @@ We will use your survey responses to assess Canonical's offerings and to improve
 
 ## Who are we?
 
-We are Canonical Group Limited. Our address is 5th, Floor Blue Fin Building, 110 Southwark Street, London, SE1 0SU. You can contact us by post at the above address or by email to [dataprotection@canonical.com](mailto:dataprotection@canonical.com) for the attention of "Legal".
+We are Canonical Group Limited. Our address is 5 New Street Square, London, EC4A 3TW, United Kingdom. You can contact us by post at the address set out in the “right to complain” section, below or by email to [dataprotection@canonical.com](mailto:dataprotection@canonical.com) for the attention of "Legal".
 
 We are not required to have a data protection officer, so any enquiries about our use of your personal data should be addressed to the contact details above.
 

--- a/templates/legal/data-privacy/survey.md
+++ b/templates/legal/data-privacy/survey.md
@@ -81,7 +81,10 @@ We hope that we can resolve any query or concern you raise about our use of your
 
 <div style="margin:2rem;">
 Legal, Canonical<br />
-2nd Floor, Clarendon House,<br/>Victoria Street,<br/>Douglas IM1 2LN,<br/>Isle of Man
+The Office Group<br />
+4th floor, 201 Borough High St,<br />
+London SE1 1JA,<br />
+United Kingdom<br />
 </div>
 
 Alternatively, you can use the relevant contact us form.

--- a/templates/legal/data-privacy/unilateral-nda.md
+++ b/templates/legal/data-privacy/unilateral-nda.md
@@ -15,7 +15,7 @@ This privacy notice tells you about the information we collect from you when you
 
 ## Who are we?
 
-We are Canonical Group Limited. Our address is 5th Floor Blue Fin Building, 110 Southwark Street, London, SE1 0SU. You can contact us by post at the above address or by email to <a href="mailto:dataprotection@canonical.com">dataprotection@canonical.com</a> for the attention of "Legal".
+We are Canonical Group Limited. Our address is 5 New Street Square, London, EC4A 3TW, United Kingdom. You can contact us by post at the address set out in the “right to complain” section, below or by email to <a href="mailto:dataprotection@canonical.com">dataprotection@canonical.com</a> for the attention of "Legal".
 
 We are not required to have a data protection officer, so any enquiries about our use of your personal data should be addressed to the contact details above.
 

--- a/templates/legal/data-privacy/unilateral-nda.md
+++ b/templates/legal/data-privacy/unilateral-nda.md
@@ -6,7 +6,7 @@ context:
   copydoc: https://docs.google.com/document/d/1MzxiuSwLvT440Ew5-3aPsFHo2zy2QVt1ZEJJpVEaZho/edit?ts=5f33e3f5#
 ---
 
-<h4 class="p-muted-heading">Version - August 2020</h4>
+<h4 class="p-muted-heading">Version - July 2023</h4>
 <hr style="margin-bottom: 2rem;" />
 
 # Privacy Notice – Confidentiality agreement

--- a/templates/legal/data-privacy/user-survey.md
+++ b/templates/legal/data-privacy/user-survey.md
@@ -79,7 +79,9 @@ We hope that we can resolve any query or concern you raise about our use of your
 
 <div style="margin:2rem;">
 Legal, Canonical<br />
-2nd Floor, Clarendon House,<br/>Victoria Street,<br/>Douglas IM1 2LN,<br/>Isle of Man
+4th floor, 201 Borough High St.<br />
+London SE1 1JA<br />
+United Kingdom<br />
 </div>
 
 Alternatively, you can use the relevant contact us form.

--- a/templates/legal/data-privacy/user-survey.md
+++ b/templates/legal/data-privacy/user-survey.md
@@ -6,7 +6,7 @@ context:
   copydoc: https://docs.google.com/document/d/1XKWK3VvJe0Z_soJqO3F0BrrXwlP9ZObYYKxA1hym7QU/edit
 ---
 
-<h4 class="p-muted-heading">Version - February 2019</h4>
+<h4 class="p-muted-heading">Version - July 2023</h4>
 <hr style="margin-bottom: 2rem;" />
 
 # Privacy notice – User Survey
@@ -15,7 +15,7 @@ This privacy notice tells you about the information collected from you when you 
 
 ## Who are we?
 
-We are Canonical Group Limited. Our address is 2nd Floor, Clarendon House, Victoria Street, Douglas IM1 2LN, Isle of Man. You can contact us by post at the above address or by email to [dataprotection@canonical.com](mailto:dataprotection@canonical.com) for the attention of "Legal".
+We are Canonical Group Limited. Our address is 5 New street Square, London, EC4A 3TW, United Kingdom. You can contact us by post at the address set out in the "right to complain" section, below or by email to [dataprotection@canonical.com](mailto:dataprotection@canonical.com) for the attention of "Legal".
 
 We are not required to have a data protection officer, so any enquiries about our use of your personal data should be addressed to the contact details above.
 

--- a/templates/legal/data-privacy/webinar.md
+++ b/templates/legal/data-privacy/webinar.md
@@ -49,7 +49,18 @@ You can also ask us to stop using your information for news or product updates â
 
 ## Your right to complain
 
-If you have a complaint about our use of your information, you can contact the Information Commissioner's Office via their website at [ico.org.uk/make-a-complaint/](https://ico.org.uk/make-a-complaint/) or write to them at:
+We hope that we can resolve any query or concern you raise about our use of your information. You can contact us at any time. Any questions, comments and requests regarding this Privacy Notice or any other related matter are welcomed and should be addressed to [dataprotection@canonical.com](mailto:dataprotection@canonical.com) or to the address below:
+
+<div style="margin:2rem;">
+Legal, Canonical<br />
+4th floor, 201 Borough High St.<br />
+London SE1 1JA<br />
+United Kingdom<br />
+</div>
+
+Alternatively, you can use the relevant contact us form.
+
+If you have a complaint about our use of your information, you can contact the Information Commissionerâ€™s Office via their website at [ico.org.uk/make-a-complaintor](https://ico.org.uk/make-a-complaint/) write to them at:
 
 <div style="margin:2rem;">
 Information Commissioner's Office<br />

--- a/templates/legal/data-privacy/webinar.md
+++ b/templates/legal/data-privacy/webinar.md
@@ -6,7 +6,7 @@ context:
   copydoc: https://docs.google.com/document/d/1wMKqustrdcGK-yzGGe9we6nyHDvLUPukQaPpMA5T6wk/edit
 ---
 
-<h4 class="p-muted-heading">Version - May 2018</h4>
+<h4 class="p-muted-heading">Version - July 2023</h4>
 <hr style="margin-bottom: 2rem;" />
 
 # Privacy notice – Webinars via BrightTALK
@@ -15,7 +15,7 @@ This privacy notice tells you about the information collected from you when you 
 
 ## Who are we?
 
-We are Canonical Group Limited. Our address is 2nd Floor, Clarendon House, Victoria Street, Douglas IM1 2LN, Isle of Man. You can contact us by post at the above address or by email to [dataprotection@canonical.com](mailto:dataprotection@canonical.com) for the attention of "Legal".
+We are Canonical Group Limited. Our address is 5 New Street Square, London, EC4A 3TW, United Kingdom. You can contact us by post at the address set out in the "right to complain" section, below or by email to [dataprotection@canonical.com](mailto:dataprotection@canonical.com) for the attention of "Legal".
 
 We are not required to have a data protection officer, so any enquiries about our use of your personal data should be addressed to the contact details above.
 

--- a/templates/legal/livepatch-terms-of-service.html
+++ b/templates/legal/livepatch-terms-of-service.html
@@ -66,8 +66,6 @@
         <h2 id="general">8. General</h2>
         <p>These Terms of Service are governed by the laws of England and any dispute will be heard by the courts in England.</p>
         <p>Failure by Canonical to enforce any right or provision of these Terms of Service shall not constitute a waiver of such right or provision. If any part of these Terms of Service is held invalid or unenforceable, that part will be construed to reflect the parties original intent, and the remaining portions will remain in full force and effect. The terms of these Terms of Service do not affect your statutory rights.</p>
-        <p>Any notices should be sent by registered post to:</p>
-        <p>Canonical Group Limited,<br>2nd Floor, Clarendon House,<br/> Victoria Street,<br/> Douglas IM1 2LN,<br/> Isle of Man</p>
         <p>Version: 21 November 2016</p>
       </section>
     </div>

--- a/templates/legal/motd.html
+++ b/templates/legal/motd.html
@@ -12,7 +12,7 @@
       <p><strong>Version &mdash; June 2020</strong></p>
       <p>This legal notice tells you about the information we collect using MOTD &mdash; Message of the Day. "motd-news" is a package that makes a call periodically to Canonical servers to get updated news for support and informational purposes. An example of an MOTD is shown at the end of this notice. As part of sending the message information is also collected by Canonical as set out below.</p>
       <h2 id="who-are-we">Who are we?</h2>
-      <p>We are Canonical Group Limited. Our address is 2nd Floor, Clarendon House, Victoria Street, Douglas IM1 2LN, Isle of Man. You can contact us by post at the above address or by email to <a href="mailto:legal@canonical.com">legal@canonical.com</a> for the attention of "Legal".</p>
+      <p>We are Canonical Group Limited. Our address is 5 New Street Square, London, EC4A 3TW, United Kingdom. You can contact us by post at the address  set out in the “right to complain” section, below or by email to <a href="mailto:legal@canonical.com">legal@canonical.com</a> for the attention of "Legal".</p>
       <h2 id="what-information-do-we-collect">What information do we collect?</h2>
       <p>The following data is being collected by Canonical</p>
       <table>

--- a/templates/legal/systems-information-notice.html
+++ b/templates/legal/systems-information-notice.html
@@ -12,7 +12,7 @@
       <p>Version - May 2018</p>
       <p>This legal notice tells you about the information we collect during installation of Ubuntu, and on first login to Ubuntu, which you can choose to share with Canonical.</p>
       <h2 id="who-are-we">Who are we?</h2>
-      <p>We are Canonical Group Limited. Our address is 2nd Floor, Clarendon House, Victoria Street, Douglas IM1 2LN, Isle of Man. You can contact us by post at the above address or by email to <a href="mailto:legal@canonical.com">legal@canonical.com</a> for the attention of "Legal".</p>
+      <p>We are Canonical Group Limited. Our address is 5 New Street Square, London, EC4A 3TW, United Kingdom. You can contact us by post at the address  set out in the “right to complain” section, below or by email to <a href="mailto:legal@canonical.com">legal@canonical.com</a> for the attention of "Legal".</p>
       <h2 id="what-system-information-do-we-collect">What system information do we collect?</h2>
       <p>During installation of Ubuntu, non-personally-identifiable system information may be shared with Canonical, including the following:</p>
       <ul>

--- a/templates/legal/systems-information-notice.html
+++ b/templates/legal/systems-information-notice.html
@@ -52,13 +52,10 @@
       <p>If you do share the system information with Canonical we are unable to identify you against your system information, so we are unable to provide you with a copy of the system information or to delete the system information on request.</p>
       <h2 id="contact">Contact</h2>
       <p>Questions, comments and requests regarding this legal notice are welcomed and should be addressed to <a href="mailto:legal@canonical.com">legal@canonical.com</a> or to the address below:</p>
-      <ul class="p-list">
-        <li class="p-list__item">Legal, Canonical</li>
-        <li class="p-list__item">2nd Floor, Clarendon House,</li>
-        <li class="p-list__item">Victoria Street,</li>
-        <li class="p-list__item">Douglas IM1 2LN,</li>
-        <li class="p-list__item">Isle of Man</li>
-      </ul>
+      <p>
+        Legal, Canonical<br>
+        2nd Floor, Clarendon House,<br/> Victoria Street,<br/> Douglas IM1 2LN,<br/> Isle of Man</p>
+      </p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Done

- Update the legal addresses across the site

## QA

- Check that the addresses are correctly now pointing to Canonical Group Limited. Our address is 5 New street Square, London, EC4A 3TW, United Kingdom
- And 4th floor, 201 Borough High St. London SE1 1JA, United Kingdom for correspondence 
- Check the odd copy doc matches

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-5114
