### PR TITLE
Generate sitemaps and fix robots.txt path for analytics

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -726,7 +726,6 @@ release-notes/precise-pangolin/?: "https://wiki.ubuntu.com/PrecisePangolin/Relea
 releases/?: "https://releases.ubuntu.com"
 releaseendoflife/?: "/about/release-cycle"
 risc-v/?: "https://wiki.ubuntu.com/RISC-V"
-robots.txt?: "/static/files/robots.txt"
 robotics/esm/?: "/robotics/ros-esm"
 rss\.xml/?: "/blog/feed"
 rss\.xmlsubscribe=feed/?: "/blog/feed"

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-Agent: *
+Disallow: /search
+Disallow: /search*
+Sitemap: https://ubuntu.com/sitemap.xml

--- a/static/files/robots.txt
+++ b/static/files/robots.txt
@@ -1,4 +1,0 @@
-User-Agent: *
-Disallow: /search
-Disallow: /search*
-Sitemap: https://ubuntu.com/static/files/sitemap.xml

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -152,6 +152,7 @@ from webapp.views import (
     subscription_centre,
     thank_you,
     unlisted_engage_page,
+    build_engage_pages_sitemap,
 )
 
 DISCOURSE_API_KEY = os.getenv("DISCOURSE_API_KEY")
@@ -536,6 +537,13 @@ engage_pages = EngagePages(
     page_type="engage-pages",
     exclude_topics=[17229, 18033, 17250],
 )
+
+
+app.add_url_rule(
+    "/engage/sitemap.xml",
+    view_func=build_engage_pages_sitemap(engage_pages),
+)
+
 
 app.add_url_rule(
     "/openstack/resources", view_func=openstack_engage(engage_pages)

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -556,6 +556,36 @@ def unlisted_engage_page(slug):
         return flask.abort(404)
 
 
+def build_engage_pages_sitemap(engage_pages):
+    """
+    Create sitemaps for each engage page
+    """
+
+    def ep_sitemap():
+        links = []
+        metadata = engage_pages.get_index()
+        if len(metadata) == 0:
+            flask.abort(404)
+
+        for page in metadata:
+            links.append(
+                {
+                    "url": f'https://ubuntu.com/{page["path"]}',
+                    "last_updated": page["updated"].strftime("%-d %B %Y"),
+                }
+            )
+
+        xml_sitemap = flask.render_template("sitemap.xml", links=links)
+
+        response = flask.make_response(xml_sitemap)
+        response.headers["Content-Type"] = "application/xml"
+        response.headers["Cache-Control"] = "public, max-age=43200"
+
+        return response
+
+    return ep_sitemap
+
+
 def openstack_install():
     """
     OpenStack install docs


### PR DESCRIPTION
## Done

- Moved robots.txt to root folder
- Generate sitemaps for engage pages.

## QA

- https://ubuntu-com-13043.demos.haus/robots.txt Should 200 if you `curl` it (previously it was redirecting, you can check in prod)
- https://ubuntu-com-13043.demos.haus/engage/sitemap.xml should return now all links for engage pages


## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-5037?atlOrigin=eyJpIjoiOWVjYjBiZjcyYzlhNDRjODkzZGVjOGU1ZTZlYzg5ZTQiLCJwIjoiaiJ9
