### PR TITLE
Update /certified paths to favor pretty links

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -124,15 +124,15 @@ category/product/(server|ubuntu-server-edition)/?: /server
 category/product/ubuntu-advantage/?: /support
 category/product/ubuntu-light/?: http://lubuntu.net/
 # old certification.ubuntu.com redirects
-certified/desktop/?: "/certified?category=Desktop&category=Laptop"
-certified/server/?: "/certified?category=Server"
-certified/soc/?: "/certified?category=SoC"
+certified/desktop/?: "/certified/desktops"
+certified/server/?: "/certified/servers"
+certified/soc/?: "/certified/socs"
 certified/hardware/(?P<canonical_id>.*): "/certified/{canonical_id}"
 certified/catalog/search/?: "/certified"
-certified/desktop/models/?: "/certified?category=Desktop&category=Laptop"
-certified/server/models/?: "/certified?category=Server"
+certified/desktop/models/?: "/certified/desktops"
+certified/server/models/?: "/certified/servers"
 certified/iot/models/?: "/certified/iot"
-certified/soc/models/?: "/certified?category=SoC"
+certified/soc/models/?: "/certified/socs"
 certified/why-certified/?: "/certified/why-certify"
 certified/devices/?: "/certified/iot"
 certification/?: "/certified"

--- a/tests/cassettes/TestCertification.test_search_results.yaml
+++ b/tests/cassettes/TestCertification.test_search_results.yaml
@@ -9,38 +9,40 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.28.2
     method: GET
     uri: https://certification.canonical.com/api/v1/certifiedreleases/?format=json&limit=0
   response:
     body:
       string: '{"meta": {"limit": 1000, "next": null, "offset": 0, "previous": null,
-        "total_count": 7}, "objects": [{"desktops": 97, "laptops": 161, "release":
+        "total_count": 8}, "objects": [{"desktops": 199, "laptops": 443, "release":
         "20.04 LTS", "resource_uri": "/api/v1/certifiedreleases/20.04%20LTS/", "servers":
-        278, "smart_core": 14, "soc": 3, "total": 554}, {"desktops": 0, "laptops":
+        395, "smart_core": 46, "soc": 5, "total": 1094}, {"desktops": 0, "laptops":
         0, "release": "Core 20", "resource_uri": "/api/v1/certifiedreleases/Core%2020/",
-        "servers": 0, "smart_core": 7, "soc": 0, "total": 7}, {"desktops": 1, "laptops":
+        "servers": 0, "smart_core": 26, "soc": 0, "total": 26}, {"desktops": 0, "laptops":
         0, "release": "Core 18", "resource_uri": "/api/v1/certifiedreleases/Core%2018/",
-        "servers": 0, "smart_core": 13, "soc": 0, "total": 14}, {"desktops": 116,
+        "servers": 0, "smart_core": 16, "soc": 0, "total": 16}, {"desktops": 115,
         "laptops": 258, "release": "18.04 LTS", "resource_uri": "/api/v1/certifiedreleases/18.04%20LTS/",
-        "servers": 380, "smart_core": 6, "soc": 8, "total": 770}, {"desktops": 0,
-        "laptops": 0, "release": "16.04 LTS", "resource_uri": "/api/v1/certifiedreleases/16.04%20LTS/",
-        "servers": 430, "smart_core": 2, "soc": 6, "total": 438}, {"desktops": 0,
+        "servers": 399, "smart_core": 10, "soc": 10, "total": 794}, {"desktops": 0,
+        "laptops": 0, "release": "18.04", "resource_uri": "/api/v1/certifiedreleases/18.04/",
+        "servers": 2, "smart_core": 0, "soc": 0, "total": 2}, {"desktops": 2, "laptops":
+        0, "release": "16.04 LTS", "resource_uri": "/api/v1/certifiedreleases/16.04%20LTS/",
+        "servers": 419, "smart_core": 0, "soc": 0, "total": 421}, {"desktops": 0,
         "laptops": 0, "release": "Core 16", "resource_uri": "/api/v1/certifiedreleases/Core%2016/",
-        "servers": 0, "smart_core": 10, "soc": 0, "total": 10}, {"desktops": 0, "laptops":
-        0, "release": "14.04 LTS", "resource_uri": "/api/v1/certifiedreleases/14.04%20LTS/",
-        "servers": 326, "smart_core": 0, "soc": 3, "total": 329}]}'
+        "servers": 0, "smart_core": 5, "soc": 0, "total": 5}, {"desktops": 91, "laptops":
+        137, "release": "22.04 LTS", "resource_uri": "/api/v1/certifiedreleases/22.04%20LTS/",
+        "servers": 344, "smart_core": 13, "soc": 0, "total": 595}]}'
     headers:
       Cache-Control:
       - no-cache
       Connection:
       - Keep-Alive
       Content-Length:
-      - '1279'
+      - '1443'
       Content-Type:
       - application/json
       Date:
-      - Thu, 29 Jul 2021 11:15:12 GMT
+      - Tue, 25 Jul 2023 11:25:08 GMT
       Keep-Alive:
       - timeout=5, max=100
       Server:
@@ -49,6 +51,14 @@ interactions:
       - max-age=2592000
       Vary:
       - Accept,Cookie
+      X-QueryInspect-Duplicate-SQL-Queries:
+      - '0'
+      X-QueryInspect-Num-SQL-Queries:
+      - '2'
+      X-QueryInspect-Total-Request-Time:
+      - 95 ms
+      X-QueryInspect-Total-SQL-Time:
+      - 88 ms
     status:
       code: 200
       message: OK
@@ -62,95 +72,117 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.28.2
     method: GET
     uri: https://certification.canonical.com/api/v1/certifiedmakes/?format=json&limit=0
   response:
     body:
       string: '{"meta": {"limit": 1000, "next": null, "offset": 0, "previous": null,
-        "total_count": 35}, "objects": [{"desktops": 75, "laptops": 272, "make": "Dell",
-        "resource_uri": "/api/v1/certifiedmakes/Dell/", "servers": 0, "smart_core":
-        4, "soc": 0, "total": 352}, {"desktops": 64, "laptops": 87, "make": "Lenovo",
-        "resource_uri": "/api/v1/certifiedmakes/Lenovo/", "servers": 97, "smart_core":
-        0, "soc": 0, "total": 248}, {"desktops": 0, "laptops": 0, "make": "Supermicro",
-        "resource_uri": "/api/v1/certifiedmakes/Supermicro/", "servers": 151, "smart_core":
-        0, "soc": 0, "total": 151}, {"desktops": 0, "laptops": 0, "make": "Dell EMC",
-        "resource_uri": "/api/v1/certifiedmakes/Dell%20EMC/", "servers": 128, "smart_core":
-        0, "soc": 0, "total": 128}, {"desktops": 62, "laptops": 42, "make": "HP",
+        "total_count": 46}, "objects": [{"desktops": 139, "laptops": 465, "make":
+        "Dell", "resource_uri": "/api/v1/certifiedmakes/Dell/", "servers": 2, "smart_core":
+        8, "soc": 0, "total": 621}, {"desktops": 115, "laptops": 198, "make": "Lenovo",
+        "resource_uri": "/api/v1/certifiedmakes/Lenovo/", "servers": 96, "smart_core":
+        3, "soc": 0, "total": 412}, {"desktops": 113, "laptops": 140, "make": "HP",
         "resource_uri": "/api/v1/certifiedmakes/HP/", "servers": 0, "smart_core":
-        0, "soc": 0, "total": 104}, {"desktops": 0, "laptops": 0, "make": "IBM", "resource_uri":
-        "/api/v1/certifiedmakes/IBM/", "servers": 80, "smart_core": 0, "soc": 0, "total":
-        80}, {"desktops": 0, "laptops": 0, "make": "Huawei Technologies Co., Ltd.",
-        "resource_uri": "/api/v1/certifiedmakes/Huawei%20Technologies%20Co.,%20Ltd./",
-        "servers": 66, "smart_core": 0, "soc": 6, "total": 72}, {"desktops": 0, "laptops":
-        0, "make": "QUANTA Computer Inc", "resource_uri": "/api/v1/certifiedmakes/QUANTA%20Computer%20Inc/",
-        "servers": 66, "smart_core": 0, "soc": 0, "total": 66}, {"desktops": 0, "laptops":
+        0, "soc": 0, "total": 256}, {"desktops": 0, "laptops": 0, "make": "Supermicro",
+        "resource_uri": "/api/v1/certifiedmakes/Supermicro/", "servers": 152, "smart_core":
+        0, "soc": 0, "total": 152}, {"desktops": 0, "laptops": 0, "make": "Dell Technologies",
+        "resource_uri": "/api/v1/certifiedmakes/Dell%20Technologies/", "servers":
+        121, "smart_core": 0, "soc": 0, "total": 121}, {"desktops": 0, "laptops":
         0, "make": "HPE", "resource_uri": "/api/v1/certifiedmakes/HPE/", "servers":
-        58, "smart_core": 0, "soc": 0, "total": 58}, {"desktops": 0, "laptops": 0,
-        "make": "Fujitsu Limited.", "resource_uri": "/api/v1/certifiedmakes/Fujitsu%20Limited./",
+        85, "smart_core": 0, "soc": 0, "total": 85}, {"desktops": 0, "laptops": 0,
+        "make": "IBM", "resource_uri": "/api/v1/certifiedmakes/IBM/", "servers": 79,
+        "smart_core": 0, "soc": 0, "total": 79}, {"desktops": 0, "laptops": 0, "make":
+        "ASUSTeK Computer Inc.", "resource_uri": "/api/v1/certifiedmakes/ASUSTeK%20Computer%20Inc./",
+        "servers": 64, "smart_core": 1, "soc": 0, "total": 65}, {"desktops": 0, "laptops":
+        0, "make": "Huawei Technologies Co., Ltd.", "resource_uri": "/api/v1/certifiedmakes/Huawei%20Technologies%20Co.,%20Ltd./",
+        "servers": 53, "smart_core": 0, "soc": 6, "total": 59}, {"desktops": 0, "laptops":
+        0, "make": "Fujitsu Limited.", "resource_uri": "/api/v1/certifiedmakes/Fujitsu%20Limited./",
+        "servers": 56, "smart_core": 0, "soc": 0, "total": 56}, {"desktops": 0, "laptops":
+        0, "make": "QUANTA Computer Inc", "resource_uri": "/api/v1/certifiedmakes/QUANTA%20Computer%20Inc/",
         "servers": 53, "smart_core": 0, "soc": 0, "total": 53}, {"desktops": 0, "laptops":
         0, "make": "Cisco UCS", "resource_uri": "/api/v1/certifiedmakes/Cisco%20UCS/",
-        "servers": 51, "smart_core": 0, "soc": 0, "total": 51}, {"desktops": 0, "laptops":
-        0, "make": "NEC Corporation", "resource_uri": "/api/v1/certifiedmakes/NEC%20Corporation/",
-        "servers": 42, "smart_core": 0, "soc": 0, "total": 42}, {"desktops": 0, "laptops":
+        "servers": 49, "smart_core": 0, "soc": 0, "total": 49}, {"desktops": 0, "laptops":
         0, "make": "New H3C Technologies Co., Ltd", "resource_uri": "/api/v1/certifiedmakes/New%20H3C%20Technologies%20Co.,%20Ltd/",
-        "servers": 28, "smart_core": 0, "soc": 0, "total": 28}, {"desktops": 0, "laptops":
-        0, "make": "ASUSTeK Computer Inc.", "resource_uri": "/api/v1/certifiedmakes/ASUSTeK%20Computer%20Inc./",
-        "servers": 22, "smart_core": 0, "soc": 0, "total": 22}, {"desktops": 0, "laptops":
+        "servers": 43, "smart_core": 0, "soc": 0, "total": 43}, {"desktops": 0, "laptops":
+        0, "make": "NEC Corporation", "resource_uri": "/api/v1/certifiedmakes/NEC%20Corporation/",
+        "servers": 34, "smart_core": 0, "soc": 0, "total": 34}, {"desktops": 0, "laptops":
         0, "make": "Inspur Electronic Information Industry Co., Ltd.", "resource_uri":
         "/api/v1/certifiedmakes/Inspur%20Electronic%20Information%20Industry%20Co.,%20Ltd./",
-        "servers": 14, "smart_core": 0, "soc": 0, "total": 14}, {"desktops": 0, "laptops":
+        "servers": 29, "smart_core": 0, "soc": 0, "total": 29}, {"desktops": 0, "laptops":
+        0, "make": "xFusion Digital Technologies Co., Ltd.", "resource_uri": "/api/v1/certifiedmakes/xFusion%20Digital%20Technologies%20Co.,%20Ltd./",
+        "servers": 17, "smart_core": 0, "soc": 0, "total": 17}, {"desktops": 0, "laptops":
+        0, "make": "Giga Computing", "resource_uri": "/api/v1/certifiedmakes/Giga%20Computing/",
+        "servers": 17, "smart_core": 0, "soc": 0, "total": 17}, {"desktops": 0, "laptops":
+        0, "make": "ADVANTECH", "resource_uri": "/api/v1/certifiedmakes/ADVANTECH/",
+        "servers": 0, "smart_core": 17, "soc": 0, "total": 17}, {"desktops": 5, "laptops":
         0, "make": "Raspberry Pi Foundation", "resource_uri": "/api/v1/certifiedmakes/Raspberry%20Pi%20Foundation/",
-        "servers": 0, "smart_core": 13, "soc": 0, "total": 13}, {"desktops": 0, "laptops":
+        "servers": 0, "smart_core": 12, "soc": 0, "total": 17}, {"desktops": 0, "laptops":
         0, "make": "Ericsson, Inc.", "resource_uri": "/api/v1/certifiedmakes/Ericsson,%20Inc./",
-        "servers": 11, "smart_core": 0, "soc": 0, "total": 11}, {"desktops": 1, "laptops":
-        0, "make": "Intel Corp.", "resource_uri": "/api/v1/certifiedmakes/Intel%20Corp./",
-        "servers": 0, "smart_core": 6, "soc": 0, "total": 7}, {"desktops": 0, "laptops":
+        "servers": 11, "smart_core": 0, "soc": 0, "total": 11}, {"desktops": 0, "laptops":
         0, "make": "Kontron", "resource_uri": "/api/v1/certifiedmakes/Kontron/", "servers":
         7, "smart_core": 0, "soc": 0, "total": 7}, {"desktops": 0, "laptops": 0, "make":
+        "Intel Corp.", "resource_uri": "/api/v1/certifiedmakes/Intel%20Corp./", "servers":
+        0, "smart_core": 6, "soc": 0, "total": 6}, {"desktops": 0, "laptops": 0, "make":
         "Cavium, Inc.", "resource_uri": "/api/v1/certifiedmakes/Cavium,%20Inc./",
         "servers": 3, "smart_core": 0, "soc": 2, "total": 5}, {"desktops": 0, "laptops":
-        0, "make": "Open Compute Project", "resource_uri": "/api/v1/certifiedmakes/Open%20Compute%20Project/",
-        "servers": 5, "smart_core": 0, "soc": 0, "total": 5}, {"desktops": 0, "laptops":
-        0, "make": "Applied Micro Circuits Corp.", "resource_uri": "/api/v1/certifiedmakes/Applied%20Micro%20Circuits%20Corp./",
-        "servers": 1, "smart_core": 0, "soc": 3, "total": 4}, {"desktops": 0, "laptops":
-        0, "make": "nVidia", "resource_uri": "/api/v1/certifiedmakes/nVidia/", "servers":
-        3, "smart_core": 0, "soc": 0, "total": 4}, {"desktops": 0, "laptops": 0, "make":
+        0, "make": "Xilinx", "resource_uri": "/api/v1/certifiedmakes/Xilinx/", "servers":
+        0, "smart_core": 5, "soc": 0, "total": 5}, {"desktops": 0, "laptops": 0, "make":
+        "OnLogic", "resource_uri": "/api/v1/certifiedmakes/OnLogic/", "servers": 0,
+        "smart_core": 4, "soc": 0, "total": 4}, {"desktops": 0, "laptops": 0, "make":
         "DFI", "resource_uri": "/api/v1/certifiedmakes/DFI/", "servers": 0, "smart_core":
-        3, "soc": 0, "total": 3}, {"desktops": 0, "laptops": 0, "make": "Qualcomm
-        Inc", "resource_uri": "/api/v1/certifiedmakes/Qualcomm%20Inc/", "servers":
-        1, "smart_core": 1, "soc": 1, "total": 3}, {"desktops": 0, "laptops": 0, "make":
-        "Advantech", "resource_uri": "/api/v1/certifiedmakes/Advantech/", "servers":
-        0, "smart_core": 3, "soc": 0, "total": 3}, {"desktops": 0, "laptops": 0, "make":
-        "Penguin Computing", "resource_uri": "/api/v1/certifiedmakes/Penguin%20Computing/",
+        4, "soc": 0, "total": 4}, {"desktops": 0, "laptops": 0, "make": "nVidia",
+        "resource_uri": "/api/v1/certifiedmakes/nVidia/", "servers": 3, "smart_core":
+        0, "soc": 0, "total": 4}, {"desktops": 0, "laptops": 0, "make": "AAEON Technology
+        Inc.", "resource_uri": "/api/v1/certifiedmakes/AAEON%20Technology%20Inc./",
+        "servers": 0, "smart_core": 4, "soc": 0, "total": 4}, {"desktops": 0, "laptops":
+        0, "make": "Honeywell, Inc.", "resource_uri": "/api/v1/certifiedmakes/Honeywell,%20Inc./",
+        "servers": 0, "smart_core": 3, "soc": 0, "total": 3}, {"desktops": 0, "laptops":
+        0, "make": "Mellanox Technologies", "resource_uri": "/api/v1/certifiedmakes/Mellanox%20Technologies/",
+        "servers": 0, "smart_core": 1, "soc": 0, "total": 3}, {"desktops": 0, "laptops":
+        0, "make": "ASRock Industrial", "resource_uri": "/api/v1/certifiedmakes/ASRock%20Industrial/",
+        "servers": 0, "smart_core": 2, "soc": 0, "total": 2}, {"desktops": 0, "laptops":
+        0, "make": "Penguin Computing", "resource_uri": "/api/v1/certifiedmakes/Penguin%20Computing/",
         "servers": 2, "smart_core": 0, "soc": 0, "total": 2}, {"desktops": 0, "laptops":
+        0, "make": "Ampere Computing, LLC", "resource_uri": "/api/v1/certifiedmakes/Ampere%20Computing,%20LLC/",
+        "servers": 0, "smart_core": 0, "soc": 2, "total": 2}, {"desktops": 0, "laptops":
+        0, "make": "Eurotech", "resource_uri": "/api/v1/certifiedmakes/Eurotech/",
+        "servers": 0, "smart_core": 2, "soc": 0, "total": 2}, {"desktops": 0, "laptops":
         0, "make": "Wiwynn", "resource_uri": "/api/v1/certifiedmakes/Wiwynn/", "servers":
         2, "smart_core": 0, "soc": 0, "total": 2}, {"desktops": 0, "laptops": 0, "make":
-        "Gigabyte", "resource_uri": "/api/v1/certifiedmakes/Gigabyte/", "servers":
+        "GIGA-BYTE TECHNOLOGY CO., LTD.", "resource_uri": "/api/v1/certifiedmakes/GIGA-BYTE%20TECHNOLOGY%20CO.,%20LTD./",
+        "servers": 2, "smart_core": 0, "soc": 0, "total": 2}, {"desktops": 0, "laptops":
+        0, "make": "ADLink Technology, Inc.", "resource_uri": "/api/v1/certifiedmakes/ADLink%20Technology,%20Inc./",
+        "servers": 0, "smart_core": 2, "soc": 0, "total": 2}, {"desktops": 0, "laptops":
+        0, "make": "Fujitsu", "resource_uri": "/api/v1/certifiedmakes/Fujitsu/", "servers":
         2, "smart_core": 0, "soc": 0, "total": 2}, {"desktops": 0, "laptops": 0, "make":
-        "HITACHI", "resource_uri": "/api/v1/certifiedmakes/HITACHI/", "servers": 1,
-        "smart_core": 0, "soc": 0, "total": 1}, {"desktops": 0, "laptops": 0, "make":
-        "Mellanox Technologies", "resource_uri": "/api/v1/certifiedmakes/Mellanox%20Technologies/",
+        "Interactive Strength Inc", "resource_uri": "/api/v1/certifiedmakes/Interactive%20Strength%20Inc/",
         "servers": 0, "smart_core": 1, "soc": 0, "total": 1}, {"desktops": 0, "laptops":
-        0, "make": "Rigado", "resource_uri": "/api/v1/certifiedmakes/Rigado/", "servers":
+        0, "make": "Avnet IoT Gateway", "resource_uri": "/api/v1/certifiedmakes/Avnet%20IoT%20Gateway/",
+        "servers": 0, "smart_core": 1, "soc": 0, "total": 1}, {"desktops": 0, "laptops":
+        0, "make": "ZTE", "resource_uri": "/api/v1/certifiedmakes/ZTE/", "servers":
+        1, "smart_core": 0, "soc": 0, "total": 1}, {"desktops": 0, "laptops": 0, "make":
+        "Element Biosciences", "resource_uri": "/api/v1/certifiedmakes/Element%20Biosciences/",
+        "servers": 0, "smart_core": 1, "soc": 0, "total": 1}, {"desktops": 0, "laptops":
+        0, "make": "FETCi", "resource_uri": "/api/v1/certifiedmakes/FETCi/", "servers":
+        1, "smart_core": 0, "soc": 0, "total": 1}, {"desktops": 0, "laptops": 0, "make":
+        "Rigado", "resource_uri": "/api/v1/certifiedmakes/Rigado/", "servers": 0,
+        "smart_core": 1, "soc": 0, "total": 1}, {"desktops": 0, "laptops": 0, "make":
+        "Axiomtek", "resource_uri": "/api/v1/certifiedmakes/Axiomtek/", "servers":
         0, "smart_core": 1, "soc": 0, "total": 1}, {"desktops": 0, "laptops": 0, "make":
-        "Eurotech", "resource_uri": "/api/v1/certifiedmakes/Eurotech/", "servers":
-        0, "smart_core": 1, "soc": 0, "total": 1}, {"desktops": 0, "laptops": 0, "make":
-        "ASUS Computers, Inc.", "resource_uri": "/api/v1/certifiedmakes/ASUS%20Computers,%20Inc./",
-        "servers": 1, "smart_core": 0, "soc": 0, "total": 1}, {"desktops": 0, "laptops":
-        0, "make": "Interactive Strength Inc", "resource_uri": "/api/v1/certifiedmakes/Interactive%20Strength%20Inc/",
-        "servers": 0, "smart_core": 1, "soc": 0, "total": 1}]}'
+        "Open Compute Project", "resource_uri": "/api/v1/certifiedmakes/Open%20Compute%20Project/",
+        "servers": 1, "smart_core": 0, "soc": 0, "total": 1}]}'
     headers:
       Cache-Control:
       - no-cache
       Connection:
       - Keep-Alive
       Content-Length:
-      - '6090'
+      - '8037'
       Content-Type:
       - application/json
       Date:
-      - Thu, 29 Jul 2021 11:15:12 GMT
+      - Tue, 25 Jul 2023 11:25:08 GMT
       Keep-Alive:
       - timeout=5, max=99
       Server:
@@ -159,6 +191,14 @@ interactions:
       - max-age=2592000
       Vary:
       - Accept,Cookie
+      X-QueryInspect-Duplicate-SQL-Queries:
+      - '0'
+      X-QueryInspect-Num-SQL-Queries:
+      - '2'
+      X-QueryInspect-Total-Request-Time:
+      - 103 ms
+      X-QueryInspect-Total-SQL-Time:
+      - 82 ms
     status:
       code: 200
       message: OK
@@ -172,68 +212,85 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.28.2
     method: GET
-    uri: https://certification.canonical.com/api/v1/vendorsummaries/server/?format=json
+    uri: https://certification.canonical.com/api/v1/certifiedmodels/?format=json&limit=20&offset=0&vendor=Dell&query=xps&category__in=Laptop%2CDesktop
   response:
     body:
-      string: '{"vendors": [{"14.04 LTS": 31, "16.04 LTS": 68, "18.04 LTS": 93, "20.04
-        LTS": 29, "releases": ["20.04 LTS", "18.04 LTS", "16.04 LTS", "14.04 LTS"],
-        "total": 221, "vendor": "Supermicro"}, {"14.04 LTS": 64, "16.04 LTS": 48,
-        "18.04 LTS": 47, "20.04 LTS": 46, "releases": ["20.04 LTS", "18.04 LTS", "16.04
-        LTS", "14.04 LTS"], "total": 205, "vendor": "Dell EMC"}, {"14.04 LTS": 35,
-        "16.04 LTS": 41, "18.04 LTS": 46, "20.04 LTS": 50, "releases": ["20.04 LTS",
-        "18.04 LTS", "16.04 LTS", "14.04 LTS"], "total": 172, "vendor": "Lenovo"},
-        {"14.04 LTS": 20, "16.04 LTS": 38, "18.04 LTS": 33, "20.04 LTS": 20, "releases":
-        ["20.04 LTS", "18.04 LTS", "16.04 LTS", "14.04 LTS"], "total": 111, "vendor":
-        "Huawei Technologies Co., Ltd."}, {"14.04 LTS": 25, "16.04 LTS": 37, "18.04
-        LTS": 25, "20.04 LTS": 8, "releases": ["20.04 LTS", "18.04 LTS", "16.04 LTS",
-        "14.04 LTS"], "total": 95, "vendor": "Fujitsu Limited."}, {"14.04 LTS": 28,
-        "16.04 LTS": 25, "18.04 LTS": 20, "20.04 LTS": 22, "releases": ["20.04 LTS",
-        "18.04 LTS", "16.04 LTS", "14.04 LTS"], "total": 95, "vendor": "Cisco UCS"},
-        {"14.04 LTS": 23, "16.04 LTS": 32, "18.04 LTS": 16, "20.04 LTS": 9, "releases":
-        ["20.04 LTS", "18.04 LTS", "16.04 LTS", "14.04 LTS"], "total": 80, "vendor":
-        "QUANTA Computer Inc"}, {"14.04 LTS": 24, "16.04 LTS": 14, "18.04 LTS": 20,
-        "20.04 LTS": 22, "releases": ["20.04 LTS", "18.04 LTS", "16.04 LTS", "14.04
-        LTS"], "total": 80, "vendor": "HPE"}, {"14.04 LTS": 31, "16.04 LTS": 33, "18.04
-        LTS": 11, "releases": ["18.04 LTS", "16.04 LTS", "14.04 LTS"], "total": 75,
-        "vendor": "NEC Corporation"}, {"14.04 LTS": 20, "16.04 LTS": 21, "18.04 LTS":
-        10, "20.04 LTS": 8, "releases": ["20.04 LTS", "18.04 LTS", "16.04 LTS", "14.04
-        LTS"], "total": 59, "vendor": "IBM"}, {"16.04 LTS": 3, "18.04 LTS": 16, "20.04
-        LTS": 21, "releases": ["20.04 LTS", "18.04 LTS", "16.04 LTS"], "total": 40,
-        "vendor": "New H3C Technologies Co., Ltd"}, {"14.04 LTS": 6, "16.04 LTS":
-        13, "18.04 LTS": 9, "releases": ["18.04 LTS", "16.04 LTS", "14.04 LTS"], "total":
-        28, "vendor": "Ericsson, Inc."}, {"14.04 LTS": 5, "16.04 LTS": 13, "18.04
-        LTS": 6, "20.04 LTS": 3, "releases": ["20.04 LTS", "18.04 LTS", "16.04 LTS",
-        "14.04 LTS"], "total": 27, "vendor": "Inspur Electronic Information Industry
-        Co., Ltd."}, {"18.04 LTS": 3, "20.04 LTS": 22, "releases": ["20.04 LTS", "18.04
-        LTS"], "total": 25, "vendor": "ASUSTeK Computer Inc."}, {"14.04 LTS": 1, "16.04
-        LTS": 7, "18.04 LTS": 5, "releases": ["18.04 LTS", "16.04 LTS", "14.04 LTS"],
-        "total": 13, "vendor": "Kontron"}, {"16.04 LTS": 1, "18.04 LTS": 3, "20.04
-        LTS": 3, "releases": ["20.04 LTS", "18.04 LTS", "16.04 LTS"], "total": 7,
-        "vendor": "nVidia"}, {"16.04 LTS": 3, "18.04 LTS": 3, "releases": ["18.04
-        LTS", "16.04 LTS"], "total": 6, "vendor": "Cavium, Inc."}, {"14.04 LTS": 4,
-        "16.04 LTS": 1, "releases": ["16.04 LTS", "14.04 LTS"], "total": 5, "vendor":
-        "Open Compute Project"}, {"18.04 LTS": 2, "releases": ["18.04 LTS"], "total":
-        2, "vendor": "Wiwynn"}, {"16.04 LTS": 1, "18.04 LTS": 1, "releases": ["18.04
-        LTS", "16.04 LTS"], "total": 2, "vendor": "Gigabyte"}, {"16.04 LTS": 2, "releases":
-        ["16.04 LTS"], "total": 2, "vendor": "Penguin Computing"}, {"14.04 LTS": 1,
-        "releases": ["14.04 LTS"], "total": 1, "vendor": "Applied Micro Circuits Corp."},
-        {"20.04 LTS": 1, "releases": ["20.04 LTS"], "total": 1, "vendor": "ASUS Computers,
-        Inc."}, {"16.04 LTS": 1, "releases": ["16.04 LTS"], "total": 1, "vendor":
-        "Qualcomm Inc"}, {"14.04 LTS": 1, "releases": ["14.04 LTS"], "total": 1, "vendor":
-        "HITACHI"}]}'
+      string: '{"meta": {"limit": 20, "next": "/api/v1/certifiedmodels/?format=json&vendor=Dell&query=xps&category__in=Laptop%2CDesktop&limit=20&offset=20",
+        "offset": 0, "previous": null, "total_count": 31}, "objects": [{"canonical_id":
+        "201906-27119", "category": "Laptop", "completed": "2019-09-27T21:22:33.103146",
+        "level": "Certified Pre-Install", "major_release": "18.04 LTS", "make": "Dell",
+        "model": "XPS 13 7390", "release": "18.04 LTS", "resource_uri": "/api/v1/certifiedmodels/201906-27119/"},
+        {"canonical_id": "201906-27131", "category": "Laptop", "completed": "2019-09-27T21:20:13.682473",
+        "level": "Certified Pre-Install", "major_release": "18.04 LTS", "make": "Dell",
+        "model": "XPS 13 7390", "release": "18.04 LTS", "resource_uri": "/api/v1/certifiedmodels/201906-27131/"},
+        {"canonical_id": "201906-27151", "category": "Laptop", "completed": "2019-09-27T21:23:47.568870",
+        "level": "Certified Pre-Install", "major_release": "18.04 LTS", "make": "Dell",
+        "model": "XPS 13 7390", "release": "18.04 LTS", "resource_uri": "/api/v1/certifiedmodels/201906-27151/"},
+        {"canonical_id": "201910-27449", "category": "Laptop", "completed": "2020-05-14T00:56:30.180711",
+        "level": "Certified Pre-Install", "major_release": "20.04 LTS", "make": "Dell",
+        "model": "XPS 13 9300", "release": "20.04 LTS", "resource_uri": "/api/v1/certifiedmodels/201910-27449/"},
+        {"canonical_id": "201910-27450", "category": "Laptop", "completed": "2020-02-18T21:21:10.977054",
+        "level": "Certified Pre-Install", "major_release": "18.04 LTS", "make": "Dell",
+        "model": "XPS 13 9300", "release": "18.04 LTS", "resource_uri": "/api/v1/certifiedmodels/201910-27450/"},
+        {"canonical_id": "201911-27454", "category": "Laptop", "completed": "2020-05-14T00:57:11.782255",
+        "level": "Certified Pre-Install", "major_release": "20.04 LTS", "make": "Dell",
+        "model": "XPS 13 9300", "release": "20.04 LTS", "resource_uri": "/api/v1/certifiedmodels/201911-27454/"},
+        {"canonical_id": "201911-27457", "category": "Laptop", "completed": "2020-02-18T21:26:25.078396",
+        "level": "Certified Pre-Install", "major_release": "18.04 LTS", "make": "Dell",
+        "model": "XPS 13 9300", "release": "18.04 LTS", "resource_uri": "/api/v1/certifiedmodels/201911-27457/"},
+        {"canonical_id": "201911-27469", "category": "Laptop", "completed": "2020-02-18T21:29:09.773765",
+        "level": "Certified Pre-Install", "major_release": "18.04 LTS", "make": "Dell",
+        "model": "XPS 13 9300", "release": "18.04 LTS", "resource_uri": "/api/v1/certifiedmodels/201911-27469/"},
+        {"canonical_id": "202007-28040", "category": "Laptop", "completed": "2020-10-02T18:40:33.552657",
+        "level": "Certified Pre-Install", "major_release": "20.04 LTS", "make": "Dell",
+        "model": "XPS 13 9310", "release": "20.04 LTS", "resource_uri": "/api/v1/certifiedmodels/202007-28040/"},
+        {"canonical_id": "202007-28045", "category": "Laptop", "completed": "2020-10-02T18:39:43.223649",
+        "level": "Certified Pre-Install", "major_release": "20.04 LTS", "make": "Dell",
+        "model": "XPS 13 9310", "release": "20.04 LTS", "resource_uri": "/api/v1/certifiedmodels/202007-28045/"},
+        {"canonical_id": "202007-28046", "category": "Laptop", "completed": "2020-10-02T18:38:09.374209",
+        "level": "Certified Pre-Install", "major_release": "20.04 LTS", "make": "Dell",
+        "model": "XPS 13 9310", "release": "20.04 LTS", "resource_uri": "/api/v1/certifiedmodels/202007-28046/"},
+        {"canonical_id": "202007-28063", "category": "Laptop", "completed": "2020-10-02T18:38:51.561750",
+        "level": "Certified Pre-Install", "major_release": "20.04 LTS", "make": "Dell",
+        "model": "XPS 13 9310", "release": "20.04 LTS", "resource_uri": "/api/v1/certifiedmodels/202007-28063/"},
+        {"canonical_id": "201708-25695", "category": "Laptop", "completed": "2018-07-26T16:58:21.731947",
+        "level": "Certified Pre-Install", "major_release": "18.04 LTS", "make": "Dell",
+        "model": "XPS 13 9370", "release": "18.04 LTS", "resource_uri": "/api/v1/certifiedmodels/201708-25695/"},
+        {"canonical_id": "201712-26015", "category": "Laptop", "completed": "2018-07-26T16:57:05.823353",
+        "level": "Certified Pre-Install", "major_release": "18.04 LTS", "make": "Dell",
+        "model": "XPS 13 9370", "release": "18.04 LTS", "resource_uri": "/api/v1/certifiedmodels/201712-26015/"},
+        {"canonical_id": "201712-26038", "category": "Laptop", "completed": "2018-07-26T16:56:05.088761",
+        "level": "Certified Pre-Install", "major_release": "18.04 LTS", "make": "Dell",
+        "model": "XPS 13 9370", "release": "18.04 LTS", "resource_uri": "/api/v1/certifiedmodels/201712-26038/"},
+        {"canonical_id": "201810-26510", "category": "Laptop", "completed": "2019-01-11T21:53:46.964184",
+        "level": "Certified Pre-Install", "major_release": "18.04 LTS", "make": "Dell",
+        "model": "XPS 13 9380", "release": "18.04 LTS", "resource_uri": "/api/v1/certifiedmodels/201810-26510/"},
+        {"canonical_id": "201810-26512", "category": "Laptop", "completed": "2019-01-11T21:54:44.236586",
+        "level": "Certified Pre-Install", "major_release": "18.04 LTS", "make": "Dell",
+        "model": "XPS 13 9380", "release": "18.04 LTS", "resource_uri": "/api/v1/certifiedmodels/201810-26512/"},
+        {"canonical_id": "201810-26515", "category": "Laptop", "completed": "2019-01-11T21:52:46.041281",
+        "level": "Certified Pre-Install", "major_release": "18.04 LTS", "make": "Dell",
+        "model": "XPS 13 9380", "release": "18.04 LTS", "resource_uri": "/api/v1/certifiedmodels/201810-26515/"},
+        {"canonical_id": "201810-26535", "category": "Laptop", "completed": "2019-01-11T21:55:47.382570",
+        "level": "Certified Pre-Install", "major_release": "18.04 LTS", "make": "Dell",
+        "model": "XPS 13 9380", "release": "18.04 LTS", "resource_uri": "/api/v1/certifiedmodels/201810-26535/"},
+        {"canonical_id": "202112-29801", "category": "Laptop", "completed": "2022-07-18T14:15:12.019364",
+        "level": "Certified Pre-Install", "major_release": "22.04 LTS", "make": "Dell",
+        "model": "XPS 13 Plus (Core i5-1240P)", "release": "22.04 LTS", "resource_uri":
+        "/api/v1/certifiedmodels/202112-29801/"}]}'
     headers:
       Cache-Control:
       - no-cache
       Connection:
       - Keep-Alive
       Content-Length:
-      - '3497'
+      - '5901'
       Content-Type:
       - application/json
       Date:
-      - Thu, 29 Jul 2021 11:15:14 GMT
+      - Tue, 25 Jul 2023 11:25:08 GMT
       Keep-Alive:
       - timeout=5, max=98
       Server:
@@ -242,102 +299,14 @@ interactions:
       - max-age=2592000
       Vary:
       - Accept,Cookie
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.25.1
-    method: GET
-    uri: https://certification.canonical.com/api/v1/certifiedmodels/?format=json&limit=20&offset=0&vendor=Dell&query=xps&category__in=Laptop
-  response:
-    body:
-      string: '{"meta": {"limit": 20, "next": null, "offset": 0, "previous": null,
-        "total_count": 19}, "objects": [{"canonical_id": "201906-27119", "category":
-        "Laptop", "completed": "2019-09-27T21:22:33.103146", "level": "Enabled", "major_release":
-        "18.04 LTS", "make": "Dell", "model": "XPS 13 7390", "release": "18.04 LTS",
-        "resource_uri": "/api/v1/certifiedmodels/201906-27119/"}, {"canonical_id":
-        "201906-27131", "category": "Laptop", "completed": "2019-09-27T21:20:13.682473",
-        "level": "Enabled", "major_release": "18.04 LTS", "make": "Dell", "model":
-        "XPS 13 7390", "release": "18.04 LTS", "resource_uri": "/api/v1/certifiedmodels/201906-27131/"},
-        {"canonical_id": "201906-27151", "category": "Laptop", "completed": "2019-09-27T21:23:47.568870",
-        "level": "Enabled", "major_release": "18.04 LTS", "make": "Dell", "model":
-        "XPS 13 7390", "release": "18.04 LTS", "resource_uri": "/api/v1/certifiedmodels/201906-27151/"},
-        {"canonical_id": "201910-27449", "category": "Laptop", "completed": "2020-02-18T21:24:14.702611",
-        "level": "Enabled", "major_release": "18.04 LTS", "make": "Dell", "model":
-        "XPS 13 9300", "release": "18.04 LTS", "resource_uri": "/api/v1/certifiedmodels/201910-27449/"},
-        {"canonical_id": "201910-27450", "category": "Laptop", "completed": "2020-05-14T00:55:14.224520",
-        "level": "Enabled", "major_release": "20.04 LTS", "make": "Dell", "model":
-        "XPS 13 9300", "release": "20.04 LTS", "resource_uri": "/api/v1/certifiedmodels/201910-27450/"},
-        {"canonical_id": "201911-27454", "category": "Laptop", "completed": "2020-05-14T00:57:11.782255",
-        "level": "Enabled", "major_release": "20.04 LTS", "make": "Dell", "model":
-        "XPS 13 9300", "release": "20.04 LTS", "resource_uri": "/api/v1/certifiedmodels/201911-27454/"},
-        {"canonical_id": "201911-27457", "category": "Laptop", "completed": "2020-05-14T00:57:50.195277",
-        "level": "Enabled", "major_release": "20.04 LTS", "make": "Dell", "model":
-        "XPS 13 9300", "release": "20.04 LTS", "resource_uri": "/api/v1/certifiedmodels/201911-27457/"},
-        {"canonical_id": "201911-27469", "category": "Laptop", "completed": "2020-02-18T21:29:09.773765",
-        "level": "Enabled", "major_release": "18.04 LTS", "make": "Dell", "model":
-        "XPS 13 9300", "release": "18.04 LTS", "resource_uri": "/api/v1/certifiedmodels/201911-27469/"},
-        {"canonical_id": "202007-28040", "category": "Laptop", "completed": "2020-10-02T18:40:33.552657",
-        "level": "Enabled", "major_release": "20.04 LTS", "make": "Dell", "model":
-        "XPS 13 9310", "release": "20.04 LTS", "resource_uri": "/api/v1/certifiedmodels/202007-28040/"},
-        {"canonical_id": "202007-28045", "category": "Laptop", "completed": "2020-10-02T18:39:43.223649",
-        "level": "Enabled", "major_release": "20.04 LTS", "make": "Dell", "model":
-        "XPS 13 9310", "release": "20.04 LTS", "resource_uri": "/api/v1/certifiedmodels/202007-28045/"},
-        {"canonical_id": "202007-28046", "category": "Laptop", "completed": "2020-10-02T18:38:09.374209",
-        "level": "Enabled", "major_release": "20.04 LTS", "make": "Dell", "model":
-        "XPS 13 9310", "release": "20.04 LTS", "resource_uri": "/api/v1/certifiedmodels/202007-28046/"},
-        {"canonical_id": "202007-28063", "category": "Laptop", "completed": "2020-10-02T18:38:51.561750",
-        "level": "Enabled", "major_release": "20.04 LTS", "make": "Dell", "model":
-        "XPS 13 9310", "release": "20.04 LTS", "resource_uri": "/api/v1/certifiedmodels/202007-28063/"},
-        {"canonical_id": "201708-25695", "category": "Laptop", "completed": "2018-07-26T16:58:21.731947",
-        "level": "Enabled", "major_release": "18.04 LTS", "make": "Dell", "model":
-        "XPS 13 9370", "release": "18.04 LTS", "resource_uri": "/api/v1/certifiedmodels/201708-25695/"},
-        {"canonical_id": "201712-26015", "category": "Laptop", "completed": "2018-07-26T16:57:05.823353",
-        "level": "Enabled", "major_release": "18.04 LTS", "make": "Dell", "model":
-        "XPS 13 9370", "release": "18.04 LTS", "resource_uri": "/api/v1/certifiedmodels/201712-26015/"},
-        {"canonical_id": "201712-26038", "category": "Laptop", "completed": "2018-07-26T16:56:05.088761",
-        "level": "Enabled", "major_release": "18.04 LTS", "make": "Dell", "model":
-        "XPS 13 9370", "release": "18.04 LTS", "resource_uri": "/api/v1/certifiedmodels/201712-26038/"},
-        {"canonical_id": "201810-26510", "category": "Laptop", "completed": "2019-01-11T21:53:46.964184",
-        "level": "Enabled", "major_release": "18.04 LTS", "make": "Dell", "model":
-        "XPS 13 9380", "release": "18.04 LTS", "resource_uri": "/api/v1/certifiedmodels/201810-26510/"},
-        {"canonical_id": "201810-26512", "category": "Laptop", "completed": "2019-01-11T21:54:44.236586",
-        "level": "Enabled", "major_release": "18.04 LTS", "make": "Dell", "model":
-        "XPS 13 9380", "release": "18.04 LTS", "resource_uri": "/api/v1/certifiedmodels/201810-26512/"},
-        {"canonical_id": "201810-26515", "category": "Laptop", "completed": "2019-01-11T21:52:46.041281",
-        "level": "Enabled", "major_release": "18.04 LTS", "make": "Dell", "model":
-        "XPS 13 9380", "release": "18.04 LTS", "resource_uri": "/api/v1/certifiedmodels/201810-26515/"},
-        {"canonical_id": "201810-26535", "category": "Laptop", "completed": "2019-01-11T21:55:47.382570",
-        "level": "Enabled", "major_release": "18.04 LTS", "make": "Dell", "model":
-        "XPS 13 9380", "release": "18.04 LTS", "resource_uri": "/api/v1/certifiedmodels/201810-26535/"}]}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Connection:
-      - Keep-Alive
-      Content-Length:
-      - '5230'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 29 Jul 2021 11:15:14 GMT
-      Keep-Alive:
-      - timeout=5, max=97
-      Server:
-      - gunicorn/19.9.0
-      Strict-Transport-Security:
-      - max-age=2592000
-      Vary:
-      - Accept,Cookie
+      X-QueryInspect-Duplicate-SQL-Queries:
+      - '0'
+      X-QueryInspect-Num-SQL-Queries:
+      - '2'
+      X-QueryInspect-Total-Request-Time:
+      - 79 ms
+      X-QueryInspect-Total-SQL-Time:
+      - 65 ms
     status:
       code: 200
       message: OK

--- a/tests/test_certification.py
+++ b/tests/test_certification.py
@@ -27,7 +27,7 @@ class TestCertification(VCRTestCase):
 
     def test_search_results(self):
         response = self.client.get(
-            "/certified?q=xps&category=Laptop&vendor=Dell"
+            "/certified?q=xps&category=Laptop&category=Desktop&vendor=Dell"
         )
         self.assertEqual(response.status_code, 200)
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -20,19 +20,7 @@ from canonicalwebteam.flask_base.app import FlaskBase
 from canonicalwebteam.search import build_search_view
 from canonicalwebteam.templatefinder import TemplateFinder
 
-from webapp.certified.views import (
-    certified_component_details,
-    certified_desktops,
-    certified_devices,
-    certified_hardware_details,
-    certified_home,
-    certified_laptops,
-    certified_model_details,
-    certified_servers,
-    certified_socs,
-    certified_vendors,
-    certified_why,
-)
+from webapp.certified.views import certified_routes
 from webapp.handlers import init_handlers
 from webapp.login import login_handler, logout
 from webapp.security.views import (
@@ -1331,47 +1319,7 @@ app.add_url_rule(
 
 robotics_docs.init_app(app)
 
-app.add_url_rule("/certified", view_func=certified_home)
-app.add_url_rule(
-    "/certified/<canonical_id>",
-    view_func=certified_model_details,
-)
-app.add_url_rule(
-    "/certified/<canonical_id>/<release>",
-    view_func=certified_hardware_details,
-)
-app.add_url_rule(
-    "/certified/component/<component_id>",
-    view_func=certified_component_details,
-)
-app.add_url_rule(
-    "/certified/vendors/<vendor>",
-    view_func=certified_vendors,
-)
-app.add_url_rule(
-    "/certified/desktops",
-    view_func=certified_desktops,
-)
-app.add_url_rule(
-    "/certified/laptops",
-    view_func=certified_laptops,
-)
-app.add_url_rule(
-    "/certified/servers",
-    view_func=certified_servers,
-)
-app.add_url_rule(
-    "/certified/iot",
-    view_func=certified_devices,
-)
-app.add_url_rule(
-    "/certified/socs",
-    view_func=certified_socs,
-)
-app.add_url_rule(
-    "/certified/why-certify",
-    view_func=certified_why,
-)
+certified_routes(app)
 
 # Override openstack/install
 app.add_url_rule(


### PR DESCRIPTION
## Done

At the moment[ https://ubuntu.com/certified?q=&category=Desktop](https://ubuntu.com/certified?q=&category=Desktop) and [Certified desktops | Ubuntu](https://ubuntu.com/certified/desktops)  look different. They shouldn’t. The former (the regular search page) should redirect to the latter (the category page).

Pretty URLs should take precedence, so queries like[ https://ubuntu.com/certified?q=Nvidia&category=Desktop](https://ubuntu.com/certified?q=&category=Desktop) should be redirected to[ https://ubuntu.com/certified/desktops?q=Nvidia](https://ubuntu.com/certified/desktops?q=Nvidia) (URL should remain unchanged when more than one category is selected)

When there is more than one category selected, URL structure should remain unchanged: https://ubuntu.com/certified?q=Nvidia&category=Desktop&category=Laptops

## QA

- Check https://ubuntu-com-13051.demos.haus/certified?q=g5&category=Desktop redirects to https://ubuntu-com-13051.demos.haus/certified?q=g5&category=Desktop
- Check https://ubuntu-com-13051.demos.haus/certified?q=Nvidia&category=Desktop redirects to https://ubuntu-com-13051.demos.haus/certified/desktops?q=Nvidia
- Check https://ubuntu-com-13051.demos.haus/certified?q=Nvidia&category=Desktop&category=Laptop remains unchanged

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-4665?atlOrigin=eyJpIjoiMDhiYTUyZDkwYWI0NGQxZWJkOTA1MWRlMWVjYTk3YTMiLCJwIjoiaiJ9

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
