### PR TITLE
Update desktop to server on tab 3 of /download/amd-xilinx

### DIFF
--- a/templates/download/amd-xilinx/tab-3.html
+++ b/templates/download/amd-xilinx/tab-3.html
@@ -1,9 +1,8 @@
 <div tabindex="0" role="tabpanel" id="versal-adaptive-evaluation-kits-tab" aria-labelledby="versal-adaptive-evaluation-kits" aria-hidden="false">
   <div class="row u-vertically-center u-no-padding">
     <div class="col-6">
-      <h2>Download Ubuntu Desktop</h2>
-      <h3 class="p-heading--4">Ubuntu Desktop 22.04 LTS</h3>
-      <p class="u-sv1">Ubuntu Desktop 22.04 (Developer Preview)</p>
+      <h2>Download Ubuntu Server</h2>
+      <p class="u-sv1">Ubuntu Server 22.04 (Developer Preview)</p>
       <p>The version of Ubuntu is meant for evaluation and development purposes only. It should not be used in production systems.</p>
       <div class="p-notification--information is-inline">
         <div class="p-notification__content">


### PR DESCRIPTION
## Done

- Update desktop to server on tab 3 of /download/amd-xilinx as per [copydoc](https://docs.google.com/document/d/1cxQnEErs8FZ3dZ_IhlfcaJ03gE_vrMJfRC-5me9IDd4/edit#heading=h.r1pnhz6oolxo)

## QA

- [See demo](https://ubuntu-com-13053.demos.haus/download/amd-xilinx)
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-5189

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
