### PR TITLE
Remove robots.txt to unblock Google crawling

### DIFF
--- a/static/files/robots.txt
+++ b/static/files/robots.txt
@@ -1,4 +1,0 @@
-User-Agent: *
-Disallow: /search
-Disallow: /search*
-Sitemap: https://ubuntu.com/static/files/sitemap.xml


### PR DESCRIPTION
## Done

- [List of work items including drive-bys - remember to add the why and what of this work.]

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
