### PR TITLE
Remove Support from navigation

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -318,8 +318,6 @@ support:
       path: /pro/dashboard
     - title: Account users
       path: /pro/users
-    - title: Support
-      path: /support
     - title: Pricing
       path: /pricing/pro
     - title: Discourse
@@ -335,8 +333,6 @@ pro:
       path: /pro/dashboard
     - title: Account users
       path: /pro/users
-    - title: Support
-      path: /support
     - title: Pricing
       path: /pricing/pro
     - title: Tutorial


### PR DESCRIPTION
## Done

- Remove support from sub-nav.

## QA

- Is the support button there on the subnav on /pro and /pro/dashboard? I don't think so!

## Issue / Card

Fixes #https://warthogs.atlassian.net/browse/WD-4639