### PR TITLE
Update link name on /legal/data-privacy

### DIFF
--- a/templates/engage/shared/_de_engage_form.html
+++ b/templates/engage/shared/_de_engage_form.html
@@ -3,7 +3,7 @@
   <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
     <legend class="u-off-screen">Kontaktinformationen</legend>
     <ul class="p-list u-no-margin--bottom">
-      <li class="p-list__item">
+      <li>
         <label for="firstName">Vorname:</label>
         <input required id="firstName" name="firstName" maxlength="255" type="text" aria-label="First Name">
       </li>

--- a/templates/engage/shared/_en_engage_form.html
+++ b/templates/engage/shared/_en_engage_form.html
@@ -3,7 +3,7 @@
   <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
     <legend class="u-off-screen">Contact information</legend>
     <ul class="p-list">
-      <li class="p-list__item">
+      <li>
         <label for="firstName">First name:</label>
         <input required id="firstName" name="firstName" maxlength="255" type="text" value="">
       </li>

--- a/templates/engage/shared/_es_engage_form.html
+++ b/templates/engage/shared/_es_engage_form.html
@@ -3,7 +3,7 @@
   <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
     <legend class="u-off-screen">Información del contacto</legend>
     <ul class="p-list">
-      <li class="p-list__item">
+      <li>
         <label for="firstName">Nombre:</label>
         <input required id="firstName" name="firstName" maxlength="255" type="text"
           aria-label="Nombre">

--- a/templates/engage/shared/_it_engage_form.html
+++ b/templates/engage/shared/_it_engage_form.html
@@ -3,7 +3,7 @@
   <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
     <legend class="u-off-screen">Informazioni sui contatti</legend>
     <ul class="p-list">
-      <li class="p-list__item">
+      <li>
         <label for="firstName">Nome:</label>
         <input required id="firstName" name="firstName" maxlength="255" type="text"
           aria-label="Nome">

--- a/templates/engage/shared/_pt_engage_form.html
+++ b/templates/engage/shared/_pt_engage_form.html
@@ -3,7 +3,7 @@
   <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
     <legend class="u-off-screen">Informações de contato</legend>
     <ul class="p-list">
-      <li class="p-list__item">
+      <li>
         <label for="firstName">Primeiro Nome:</label>
         <input required id="firstName" name="firstName" maxlength="255" type="text"
           aria-label="First Name">

--- a/templates/engage/shared/_ru_engage_form.html
+++ b/templates/engage/shared/_ru_engage_form.html
@@ -3,7 +3,7 @@
     <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
         <legend class="u-off-screen">Контактная информация</legend>
         <ul class="p-list">
-        <li class="p-list__item">
+        <li>
             <label for="firstName">Имя:</label>
             <input required id="firstName" name="firstName" maxlength="255" type="text">
         </li>

--- a/templates/engage/shared/_zh-TW_engage_form.html
+++ b/templates/engage/shared/_zh-TW_engage_form.html
@@ -3,7 +3,7 @@
   <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
     <legend class="u-off-screen">Contact information</legend>
     <ul class="p-list">
-      <li class="p-list__item">
+      <li>
         <label for="firstName">First name:</label>
         <input required id="firstName" name="firstName" maxlength="255" type="text" value="">
       </li>

--- a/templates/legal/data-privacy/index.html
+++ b/templates/legal/data-privacy/index.html
@@ -41,7 +41,7 @@
         <li class="p-list__item"><a href="/legal/data-privacy/unilateral-nda">Confidentiality agreement privacy notice&nbsp;&rsaquo;</a></li>
         <li class="p-list__item"><a href="/legal/data-privacy/credentials">Canonical Credentials privacy notice&nbsp;&rsaquo;</a></li>
         <li class="p-list__item"><a href="/legal/data-privacy/recruitment">Recruitment privacy notice&nbsp;&rsaquo;</a></li>
-        <li class="p-list__item"><a href="/legal/data-privacy/community-discourse">Ubuntu Community Discourse&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a href="/legal/data-privacy/community-discourse">Ubuntu Community Discourse Privacy Notice&nbsp;&rsaquo;</a></li>
       </ul>
       <h2 id="information-we-collect-from-you">Information we collect from you</h2>
       <ul class="p-list">
@@ -254,6 +254,22 @@
             <td>
               <p>Vimeo hosts our videos. Their cookies provides more information about how many people view our videos and for how long.</p>
               <p><a href="https://vimeo.com/privacy">Vimeo's privacy policy</a></p>
+            </td>
+          </tr>
+          <tr>
+            <td>N.Rich</td>
+            <td><code>_naiuid</code></td>
+            <td>
+              <p>N.Rich tracking allows us to optimize our account-based marketing campaigns, enabling more granular, cookie-based analytics, and advertising personalization.</p>
+              <p><a href="https://privacy.nrich.ai/privacy-notice">N.Rich privacy notice</a></p>
+            </td>
+          </tr>
+          <tr>
+            <td>Salesloft</td>
+            <td><code>sliguid</code>, <code>slirequested</code>, <code>slireg</code>, <code>sli_token</code>, <code>site_identity</code></td>
+            <td>
+              <p>Salesloft website tracking lets us track activity and interactions with web pages in Salesloft's platform.</p>
+              <p><a href="https://salesloft.com/privacy-notice/">Salesloft's privacy notice</a></p>
             </td>
           </tr>
         </tbody>


### PR DESCRIPTION
## Done

- Changes the link 'Ubuntu Community Discourse' to 'Ubuntu Community Discourse Privacy Notice' on /legal/data-privacy based on [copydoc](https://docs.google.com/document/d/1AlOE2_-BqZNP4hiiuf8kZney8g1zvqAlDYl2u3X6m6I/edit). I believe this was the only change, the other changes appear to be live. As for the request from Sarah, lets see if she get's back to use quickly and if she does we can include that change also.
- Removes a class from a `<li>` on an engage form so it matches the rest of the list visually.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-5503
