### PR TITLE
[copy update] WD-5374 remove ceph install link

### DIFF
--- a/templates/ceph/index.html
+++ b/templates/ceph/index.html
@@ -285,7 +285,6 @@
         <li class="p-list__item is-ticked">Get access to the storage experts 24/7 or during business hours</li>
         <li class="p-list__item is-ticked">Alternatively, get extended security maintenance if all you need is peace of mind by consuming security patches from the world's leading security team</li>
       </ul>
-      <p><a href="/ceph/install">Install Charmed Ceph&nbsp;&rsaquo;</a></p>
       <p><a href="/pricing/infra">Find out more&nbsp;&rsaquo;</a></p>
     </div>
     


### PR DESCRIPTION
## Done

- Remove wrongfully placed Ceph install link

## QA

- Check out [the demo here](url) and make sure the link shown in [the task](https://warthogs.atlassian.net/browse/WD-5374) is removed from the page.

## Issue / Card

- [WD-5374](https://warthogs.atlassian.net/browse/WD-5374)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-5374]: https://warthogs.atlassian.net/browse/WD-5374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ