### PR TITLE
[copy update] WD-5338 Fix OpenStack release naming convention

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -1198,25 +1198,25 @@ export var openStackReleases = [
   {
     startDate: new Date("2024-04-01T00:00:00"),
     endDate: new Date("2027-04-01T00:00:00"),
-    taskName: "OpenStack C",
+    taskName: "OpenStack 2024.1",
     status: "MATCHING_OPENSTACK_RELEASE_SUPPORT",
   },
   {
     startDate: new Date("2023-10-01T00:00:00"),
     endDate: new Date("2025-04-01T00:00:00"),
-    taskName: "OpenStack Bobcat",
+    taskName: "OpenStack 2023.2",
     status: "MATCHING_OPENSTACK_RELEASE_SUPPORT",
   },
   {
     startDate: new Date("2023-04-01T00:00:00"),
     endDate: new Date("2024-10-01T00:00:00"),
-    taskName: "OpenStack Antelope",
+    taskName: "OpenStack 2023.1",
     status: "MATCHING_OPENSTACK_RELEASE_SUPPORT",
   },
   {
     startDate: new Date("2024-10-01T00:00:00"),
     endDate: new Date("2026-04-01T00:00:00"),
-    taskName: "OpenStack Antelope",
+    taskName: "OpenStack 2023.1",
     status: "EXTENDED_SUPPORT_FOR_CUSTOMERS",
   },
   {
@@ -1522,91 +1522,91 @@ export var microStackReleases = [
   {
     startDate: new Date("2026-04-01T00:00:00"),
     endDate: new Date("2031-04-01T00:00:00"),
-    taskName: "OpenStack G LTS",
+    taskName: "OpenStack 2026.1 LTS",
     status: "STANDARD_SECURITY_MAINTENANCE",
   },
   {
     startDate: new Date("2031-04-01T00:00:00"),
     endDate: new Date("2036-04-01T00:00:00"),
-    taskName: "OpenStack G LTS",
+    taskName: "OpenStack 2026.1 LTS",
     status: "MICROSTACK_ESM",
   },
   {
     startDate: new Date("2026-04-01T00:00:00"),
     endDate: new Date("2036-04-01T00:00:00"),
-    taskName: "OpenStack G LTS",
+    taskName: "OpenStack 2026.1 LTS",
     status: "PRO_SUPPORT",
   },
   {
     startDate: new Date("2025-10-01T00:00:00"),
     endDate: new Date("2026-07-01T00:00:00"),
-    taskName: "OpenStack F",
+    taskName: "OpenStack 2025.2",
     status: "STANDARD_SECURITY_MAINTENANCE",
   },
   {
     startDate: new Date("2025-04-01T00:00:00"),
     endDate: new Date("2026-01-01T00:00:00"),
-    taskName: "OpenStack E",
+    taskName: "OpenStack 2025.1",
     status: "STANDARD_SECURITY_MAINTENANCE",
   },
   {
     startDate: new Date("2026-01-01T00:00:00"),
     endDate: new Date("2028-04-01T00:00:00"),
-    taskName: "OpenStack E",
+    taskName: "OpenStack 2025.1",
     status: "MICROSTACK_ESM",
   },
   {
     startDate: new Date("2025-04-01T00:00:00"),
     endDate: new Date("2028-04-01T00:00:00"),
-    taskName: "OpenStack E",
+    taskName: "OpenStack 2025.1",
     status: "PRO_SUPPORT",
   },
   {
     startDate: new Date("2024-10-01T00:00:00"),
     endDate: new Date("2025-07-01T00:00:00"),
-    taskName: "OpenStack D",
+    taskName: "OpenStack 2024.2",
     status: "STANDARD_SECURITY_MAINTENANCE",
   },
   {
     startDate: new Date("2024-04-01T00:00:00"),
     endDate: new Date("2029-04-01T00:00:00"),
-    taskName: "OpenStack C LTS",
+    taskName: "OpenStack 2024.1 LTS",
     status: "STANDARD_SECURITY_MAINTENANCE",
   },
   {
     startDate: new Date("2029-04-01T00:00:00"),
     endDate: new Date("2034-04-01T00:00:00"),
-    taskName: "OpenStack C LTS",
+    taskName: "OpenStack 2024.1 LTS",
     status: "MICROSTACK_ESM",
   },
   {
     startDate: new Date("2024-04-01T00:00:00"),
     endDate: new Date("2034-04-01T00:00:00"),
-    taskName: "OpenStack C LTS",
+    taskName: "OpenStack 2024.1 LTS",
     status: "PRO_SUPPORT",
   },
   {
     startDate: new Date("2023-10-01T00:00:00"),
     endDate: new Date("2024-07-01T00:00:00"),
-    taskName: "OpenStack B",
+    taskName: "OpenStack 2023.2",
     status: "STANDARD_SECURITY_MAINTENANCE",
   },
   {
     startDate: new Date("2023-06-01T00:00:00"),
     endDate: new Date("2024-01-01T00:00:00"),
-    taskName: "OpenStack Antelope",
+    taskName: "OpenStack 2023.1",
     status: "STANDARD_SECURITY_MAINTENANCE",
   },
   {
     startDate: new Date("2024-01-01T00:00:00"),
     endDate: new Date("2026-04-01T00:00:00"),
-    taskName: "OpenStack Antelope",
+    taskName: "OpenStack 2023.1",
     status: "MICROSTACK_ESM",
   },
   {
     startDate: new Date("2023-06-01T00:00:00"),
     endDate: new Date("2026-04-01T00:00:00"),
-    taskName: "OpenStack Antelope",
+    taskName: "OpenStack 2023.1",
     status: "PRO_SUPPORT",
   },
 ];
@@ -1832,9 +1832,9 @@ export var kernelReleaseNamesLTS = [
 ];
 
 export var openStackReleaseNames = [
-  "OpenStack C",
-  "OpenStack Bobcat",
-  "OpenStack Antelope",
+  "OpenStack 2024.1",
+  "OpenStack 2023.2",
+  "OpenStack 2023.1",
   "OpenStack Zed",
   "OpenStack Yoga LTS",
   "Ubuntu 22.04 LTS",
@@ -1849,13 +1849,13 @@ export var openStackReleaseNames = [
 ];
 
 export var microStackReleaseNames = [
-  "OpenStack G LTS",
-  "OpenStack F",
-  "OpenStack E",
-  "OpenStack D",
-  "OpenStack C LTS",
-  "OpenStack B",
-  "OpenStack Antelope",
+  "OpenStack 2026.1 LTS",
+  "OpenStack 2025.2",
+  "OpenStack 2025.1",
+  "OpenStack 2024.2",
+  "OpenStack 2024.1 LTS",
+  "OpenStack 2023.2",
+  "OpenStack 2023.1",
 ];
 
 export var kubernetesReleaseNames = [

--- a/templates/about/openstack-release-cycle.html
+++ b/templates/about/openstack-release-cycle.html
@@ -14,21 +14,21 @@
       </thead>
       <tbody>
         <tr>
-          <td>OpenStack C</td>
+          <td>OpenStack 2024.1</td>
           <td>&nbsp;</td>
           <td>Apr 2024</td>
           <td>Apr 2027</td>
           <td>&nbsp;</td>
         </tr>
         <tr>
-          <td>OpenStack Bobcat</td>
+          <td>OpenStack 2023.2</td>
           <td>&nbsp;</td>
           <td>Oct 2023</td>
           <td>Apr 2025</td>
           <td>&nbsp;</td>
         </tr>
         <tr>
-          <td>OpenStack Antelope</td>
+          <td>OpenStack 2023.1</td>
           <td>&nbsp;</td>
           <td>Apr 2023</td>
           <td>Oct 2024</td>

--- a/templates/about/release_cycles/microstack-eol.html
+++ b/templates/about/release_cycles/microstack-eol.html
@@ -13,49 +13,49 @@
         </thead>
         <tbody>
           <tr>
-            <td>OpenStack G LTS</td>
+            <td>OpenStack 2026.1 LTS</td>
             <td>Apr 2026</td>
             <td>Apr 2031</td>
             <td>Apr 2036</td>
             <td>Yes</td>
           </tr>
           <tr>
-            <td>OpenStack F</td>
+            <td>OpenStack 2025.2</td>
             <td>Oct 2025</td>
             <td>Jul 2026</td>
             <td>&nbsp;</td>
             <td>No</td>
           </tr>
           <tr>
-            <td>OpenStack E</td>
+            <td>OpenStack 2025.1</td>
             <td>Apr 2025</td>
             <td>Jan 2026</td>
             <td>Apr 2028</td>
             <td>Yes</td>
           </tr>
           <tr>
-            <td>OpenStack D</td>
+            <td>OpenStack 2024.2</td>
             <td>Oct 2024</td>
             <td>Jul 2025</td>
             <td>&nbsp;</td>
             <td>No</td>
           </tr>
           <tr>
-            <td>OpenStack C LTS</td>
+            <td>OpenStack 2024.1 LTS</td>
             <td>Apr 2024</td>
             <td>Apr 2029</td>
             <td>Apr 2034</td>
             <td>Yes</td>
           </tr>
           <tr>
-            <td>OpenStack Bobcat</td>
+            <td>OpenStack 2023.2</td>
             <td>Oct 2023</td>
             <td>Jul 2024</td>
             <td>&nbsp;</td>
             <td>No</td>
           </tr>
           <tr>
-            <td>OpenStack Antelope</td>
+            <td>OpenStack 2023.1</td>
             <td>Jun 2023</td>
             <td>Jan 2024</td>
             <td>Apr 2026</td>

--- a/templates/about/release_cycles/openstack-eol.html
+++ b/templates/about/release_cycles/openstack-eol.html
@@ -14,21 +14,21 @@
       </thead>
       <tbody>
         <tr>
-          <td>OpenStack C</td>
+          <td>OpenStack 2024.1</td>
           <td>&nbsp;</td>
           <td>Apr 2024</td>
           <td>Apr 2027</td>
           <td>&nbsp;</td>
         </tr>
         <tr>
-          <td>OpenStack Bobcat</td>
+          <td>OpenStack 2023.2</td>
           <td>&nbsp;</td>
           <td>Oct 2023</td>
           <td>Apr 2025</td>
           <td>&nbsp;</td>
         </tr>
         <tr>
-          <td>OpenStack Antelope</td>
+          <td>OpenStack 2023.1</td>
           <td>&nbsp;</td>
           <td>Apr 2023</td>
           <td>Oct 2024</td>


### PR DESCRIPTION
## Done

- Fix the OpenStack release name convention for recent years (2023 - present)

## QA

- Check out [the demo here](url) and compare it with the requested change in this issue: #13000
- Make sure the new mappings are correct:
  - OpenStack Antelope -> OpenStack 2023.1
  - OpenStack Bobcat/B -> OpenStack 2023.2
  - OpenStack C -> OpenStack 2024.1
  - OpenStack D -> OpenStack 2024.2
  - OpenStack E -> OpenStack 2025.1
  - OpenStack F -> OpenStack 2025.2
  - OpenStack G -> OpenStack 2026.1
- Ensure to check both the MicroStack and Charmed OpenStack chart
  - Test on mobile screens as well

## Issue / Card

- #13000 
- [WD-5338](https://warthogs.atlassian.net/browse/WD-5338)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-5338]: https://warthogs.atlassian.net/browse/WD-5338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ