### PR TITLE
Improve not renewed label logic

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.test.tsx
@@ -378,6 +378,7 @@ describe("SubscriptionDetails", () => {
       type: UserSubscriptionType.Legacy,
       statuses: userSubscriptionStatusesFactory.build({
         is_renewed: false,
+        is_renewable: true,
         is_renewal_actionable: true,
       }),
     });
@@ -563,6 +564,7 @@ describe("SubscriptionDetails", () => {
       type: UserSubscriptionType.Legacy,
       statuses: userSubscriptionStatusesFactory.build({
         is_renewed: false,
+        is_renewable: false,
         is_renewal_actionable: false,
       }),
     });

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.test.tsx
@@ -397,6 +397,30 @@ describe("SubscriptionDetails", () => {
     expect(wrapper.find(".p-chip__value").text()).toBe("Not renewed");
   });
 
+  it("it does not display the not renewed label for legacy actionable but not renewable", () => {
+    const contract = userSubscriptionFactory.build({
+      type: UserSubscriptionType.Legacy,
+      statuses: userSubscriptionStatusesFactory.build({
+        is_renewed: false,
+        is_renewable: false,
+        is_renewal_actionable: true,
+      }),
+    });
+
+    queryClient.setQueryData("userSubscriptions", [contract]);
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <SubscriptionDetails
+          onCloseModal={jest.fn()}
+          selectedId={contract.id}
+          setHasUnsavedChanges={jest.fn()}
+        />
+      </QueryClientProvider>
+    );
+
+    expect(wrapper.find(".p-chip__value").exists()).toBe(false);
+  });
+
   it("it does display the renewed label for legacy renewed", () => {
     const contract = userSubscriptionFactory.build({
       type: UserSubscriptionType.Legacy,

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/SubscriptionDetails.tsx
@@ -143,7 +143,8 @@ export const SubscriptionDetails = forwardRef<HTMLDivElement, Props>(
                         </button>
                       ) : (
                         <>
-                          {subscription.statuses.is_renewal_actionable ? (
+                          {subscription.statuses.is_renewal_actionable &&
+                          subscription.statuses.is_renewable ? (
                             <button className="p-chip--caution">
                               <span className="p-chip__value">Not renewed</span>
                             </button>


### PR DESCRIPTION
## Done

- Some renewals are added to legacy purchases earlier than expected. Display the `Not renewed` label only if the renewal is also ready to be purchased : `statuses.is_renewable == true`

## QA

- Hard to QA, you need to View As user from a local environment. 
- But look, label "Not Renewed" disappears:
Prod: 
![image](https://github.com/canonical/ubuntu.com/assets/6387619/ecb4d3b3-b48f-43a3-8b7c-d7d2f042283e)
After the change:
![image](https://github.com/canonical/ubuntu.com/assets/6387619/1a2354a7-6e40-45d6-a79d-ef898d4534bf)
 

## Issue / Card

Fixes #https://warthogs.atlassian.net/browse/WD-5368