### PR TITLE
WD-5743 - Replace 22.04.2 with 22.04.3

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -22,7 +22,7 @@ Merging a pull request (PR) into the `main` branch will automatically trigger a 
 - [`./redirects.yaml`](rerdirects.yaml): A file defining URL paths for 302 redirects
 - [`./deleted.yaml`](deleted.yaml): A file defining URL paths for 310 deleted responses
 - [`./entrypoint`](entrypoint): The commands for running the application with Gunicorn. This is used within `Dockerfile` for running the production site.
--  [`./Dockerfile`](Dockerfile): Used by the [production Jenkins job](https://jenkins.canonical.com/webteam/job/ubuntu.com) for building the production docker image. See [our standard deployment flow](https://discourse.canonical.com/t/how-the-standard-website-deployment-flow-is-set-up-in-github-jenkins-and-kubernetes/2112).
+- [`./Dockerfile`](Dockerfile): Used by the [production Jenkins job](https://jenkins.canonical.com/webteam/job/ubuntu.com) for building the production docker image. See [our standard deployment flow](https://discourse.canonical.com/t/how-the-standard-website-deployment-flow-is-set-up-in-github-jenkins-and-kubernetes/2112).
 - [`./releases.yaml`](releases.yaml): For defining releases of Ubuntu, which get displayed on ubuntu.com/download etc.
 - [`./navigation.yaml`](navigation.yaml): Navigation sections within ubuntu.com.
 - [`./appliances.yaml`](appliances.yaml): Appliance metadata for displaying on ubuntu.com/appliance
@@ -42,7 +42,7 @@ Merging a pull request (PR) into the `main` branch will automatically trigger a 
 
 The homepage ([url rule](webapp/app.py#L637)) has no server-side dynamic functionality, so is instead served directly by the template finder view from `templates/index.html`.
 
-Since ubuntu.com is a high-traffic site, and the homepage its most popular page, it is important that the initial response for this page remains as fast as possible, so it should *not* be making server-side database or API calls directly if it can be avoided.
+Since ubuntu.com is a high-traffic site, and the homepage its most popular page, it is important that the initial response for this page remains as fast as possible, so it should _not_ be making server-side database or API calls directly if it can be avoided.
 
 #### Homepage takeovers and engage pages
 
@@ -88,7 +88,7 @@ We have had trouble with search spam in the past which has led to us hitting API
 
 The download pages, e.g. https://ubuntu.com/download/desktop, include links for people to download Ubuntu. These pages get extremely busy on our six-monthly release days.
 
-When people click the "Download" button they are sent to the thank-you page, e.g. `https://ubuntu.com/download/desktop/thank-you?version=22.04.2&architecture=amd64` ([url rule](webapp/app.py#L396-L403), [view function](webapp/views.py#L170-L184)). Similar to the homepage, it's important that this page is served as straightforwardly as possible with no back-end API/database calls so the page can remain responsive.
+When people click the "Download" button they are sent to the thank-you page, e.g. `https://ubuntu.com/download/desktop/thank-you?version=22.04.3&architecture=amd64` ([url rule](webapp/app.py#L396-L403), [view function](webapp/views.py#L170-L184)). Similar to the homepage, it's important that this page is served as straightforwardly as possible with no back-end API/database calls so the page can remain responsive.
 
 After the page has loaded, JavaScript will download the list of download mirrors from https://ubuntu.com/mirrors.json and choose one to trigger the download with. If JavaScript isn't available, the download will instead be triggered from our own download server, releases.ubuntu.com.
 

--- a/releases.yaml
+++ b/releases.yaml
@@ -12,7 +12,7 @@ lts:
   slug: JammyJellyfish
   name: "Jammy Jellyfish"
   short_version: "22.04"
-  full_version: "22.04.2"
+  full_version: "22.04.3"
   release_date: "April 2022"
   eol: "April 2027"
   release_notes_url: "https://discourse.ubuntu.com/t/jammy-jellyfish-release-notes/24668"
@@ -32,33 +32,33 @@ openstack_lts:
 checksums:
   desktop:
     "23.04": "a8cd6ccff865e17dd136658f6388480c9a5bc57274b29f7d5bd0ed855a9281a5 *ubuntu-23.04-desktop-amd64.iso"
-    "22.04.2": "b98dac940a82b110e6265ca78d1320f1f7103861e922aa1a54e4202686e9bbd3 *ubuntu-22.04.2-desktop-amd64.iso"
+    "22.04.3": "a435f6f393dda581172490eda9f683c32e495158a780b5a1de422ee77d98e909 *ubuntu-22.04.3-desktop-amd64.iso"
     "21.10": "f8d3ab0faeaecb5d26628ae1aa21c9a13e0a242c381aa08157db8624d574b830 *ubuntu-21.10-desktop-amd64.iso"
     "20.04.6": "510ce77afcb9537f198bc7daa0e5b503b6e67aaed68146943c231baeaab94df1 *ubuntu-20.04.6-desktop-amd64.iso"
   live-server:
     "23.04": "c7cda48494a6d7d9665964388a3fc9c824b3bef0c9ea3818a1be982bc80d346b *ubuntu-23.04-live-server-amd64.iso"
-    "22.04.2": "5e38b55d57d94ff029719342357325ed3bda38fa80054f9330dc789cd2d43931 *ubuntu-22.04.2-live-server-amd64.iso"
+    "22.04.3": "a4acfda10b18da50e2ec50ccaf860d7f20b389df8765611142305c0e911d16fd *ubuntu-22.04.3-live-server-amd64.iso"
     "21.10": "e84f546dfc6743f24e8b1e15db9cc2d2c698ec57d9adfb852971772d1ce692d4 *ubuntu-21.10-live-server-amd64.iso"
     "20.04.6": "b8f31413336b9393ad5d8ef0282717b2ab19f007df2e9ed5196c13d8f9153c8b *ubuntu-20.04.6-live-server-amd64.iso"
     "18.04.6": "6c647b1ab4318e8c560d5748f908e108be654bad1e165f7cf4f3c1fc43995934 *ubuntu-18.04.6-live-server-amd64.iso"
   desktop-arm64+raspi:
     "23.04": "c851edd5d05362b7a9fe9a6e44824d89114de2c07b6f08d97ad790f0bafdc9f1 *ubuntu-23.04-preinstalled-desktop-arm64+raspi.img.xz"
-    "22.04.2": "c7d39e37455c2ff3def2b125abb046245a9e6fbf8519f711aa22485eabd3bc52 *ubuntu-22.04.2-preinstalled-desktop-arm64+raspi.img.xz"
+    "22.04.3": "d187127752ebf16201102d32c1e7fa7a17532c6b5ccf7b3b08507d0ab0e3416c *ubuntu-22.04.3-preinstalled-desktop-arm64+raspi.img.xz"
     "21.10": "5187d507099f26bc4d8218085109af498fae5ff93b40c668f83bab5c7574d954 *ubuntu-21.10-preinstalled-desktop-arm64+raspi.img.xz"
     "21.04": "d89ee327a00b98d7166b1a8cc95d17762aaacd3b4d0fc756c5b6b65df1708f48 *ubuntu-21.04-preinstalled-desktop-arm64+raspi.img.xz"
   server-arm64+raspi:
     "23.04": "cd2a99b065b98078ad2bfec428d5bb876be19c9f5aa8abb8e5dd14125bf611b8 *ubuntu-23.04-preinstalled-server-arm64+raspi.img.xz"
-    "22.04.2": "22705473ab9c1ca19012fe2d42f917218b823d1a815dabb8a240681c51d143a5 *ubuntu-22.04.2-preinstalled-server-arm64+raspi.img.xz"
+    "22.04.3": "f3842efb3be1be4243c24203bd16e335f155fdbe104b1ed8c5efc548ea478ab0 *ubuntu-22.04.3-preinstalled-server-arm64+raspi.img.xz"
     "21.10": "126f940d3b270a6c1fc5a183ac8a3d193805fead4f517296a7df9d3e7d691a03 *ubuntu-21.10-preinstalled-server-arm64+raspi.img.xz"
     "20.04.5": "44b98acd3fd4379c6b194696520b6aecb2f596b601e43e9b6934c83f0aa61026 *ubuntu-20.04.5-preinstalled-server-arm64+raspi.img.xz"
   server-armhf+raspi:
     "23.04": "4d6e43707260c3653bdbc30eecd4148b6b314612b8c522de4a60d74fd3df128f *ubuntu-23.04-preinstalled-server-armhf+raspi.img.xz"
-    "22.04.2": "45b2fb10f63fa2e820d0bd34693d86a507499f6efae1f4848af6601ebfaf8745 *ubuntu-22.04.2-preinstalled-server-armhf+raspi.img.xz"
+    "22.04.3": "dbab406bfa473ebf95aa2e34e87ebf64467067ffa0478daa85c48e213b925ed6 *ubuntu-22.04.3-preinstalled-server-armhf+raspi.img.xz"
     "21.10": "341593c9607ed20744cd86941d94d73e3ba4f74e8ef2633eec63ce9b0cfac5a1 *ubuntu-21.10-preinstalled-server-armhf+raspi.img.xz"
     "20.04.5": "065c41846ddf7a1c636a1aac5a7d49ebcee819b141f9d57fd586c5f84b9b7942 *ubuntu-20.04.5-preinstalled-server-armhf+raspi.img.xz"
   server-riscv64:
     "23.04": "774a679251c496426727fcab1355f41f2523845dac405bfe9814a5c4c588df14 *ubuntu-23.04-preinstalled-server-riscv64+unmatched.img.xz"
-    "22.04.2": "7a31a92f6a17e497bc8d5e72b2862ed0eb6cc68ca3a4efb1893ddcbfda13e9bd *ubuntu-22.04.2-preinstalled-server-riscv64+unmatched.img.xz"
+    "22.04.3": "b739d17a3a7f0494b2d804c5f54fd2f303ba665acf353ee3bef78825bfc7b39c *ubuntu-22.04.3-preinstalled-server-riscv64+unmatched.img.xz"
     "21.10": "8067892fa627eb219b31dc629f31f3bda6b015dfeabf2fdc9b0ed150bf7984b8 *ubuntu-21.10-preinstalled-server-riscv64+unmatched.img.xz"
   core-22-arm64+raspi:
     "22": "374697bd7324f10ff3c00007b75ca42885aff161cbddb63b1d14bc1551e69ce2 *ubuntu-core-22-arm64+raspi.img.xz"

--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -164,7 +164,7 @@ export var kernelReleases = [
   {
     startDate: new Date("2023-02-01T00:00:00"),
     endDate: new Date("2027-04-01T00:00:00"),
-    taskName: "Ubuntu 22.04.2 LTS",
+    taskName: "Ubuntu 22.04.3 LTS",
     taskVersion: "Kernel version",
     status: "LTS",
   },
@@ -436,7 +436,7 @@ export var kernelReleases2204 = [
   {
     startDate: new Date("2023-02-17T00:00:00"),
     endDate: new Date("2023-07-22T00:00:00"),
-    taskName: "Ubuntu 22.04.2 LTS (v5.19)",
+    taskName: "Ubuntu 22.04.3 LTS (v5.19)",
     status: "LTS",
   },
 ];
@@ -907,7 +907,7 @@ export var kernelReleasesALL = [
   {
     startDate: new Date("2023-02-01T00:00:00"),
     endDate: new Date("2023-07-01T00:00:00"),
-    taskName: "Ubuntu 22.04.2 LTS (v5.19)",
+    taskName: "Ubuntu 22.04.3 LTS (v5.19)",
     status: "LTS",
   },
 ];
@@ -1162,7 +1162,7 @@ export var kernelReleasesLTS = [
   {
     startDate: new Date("2023-02-01T00:00:00"),
     endDate: new Date("2023-07-01T00:00:00"),
-    taskName: "Ubuntu 22.04.2 LTS (v5.19)",
+    taskName: "Ubuntu 22.04.3 LTS (v5.19)",
     status: "LTS",
   },
 ];
@@ -1680,7 +1680,7 @@ export var desktopServerReleaseNames = [
 ];
 
 export var kernelReleaseNames = [
-  "Ubuntu 22.04.2 LTS",
+  "Ubuntu 22.04.3 LTS",
   "Ubuntu 22.10",
   "Ubuntu 22.04.1 LTS",
   "Ubuntu 20.04.5 LTS",
@@ -1732,7 +1732,7 @@ export var kernelVersionNames = [
 export var kernelReleaseNames2204 = [
   "Ubuntu 22.04.0 LTS (v5.15)",
   "Ubuntu 22.04.1 LTS (v5.15)",
-  "Ubuntu 22.04.2 LTS (v5.19)",
+  "Ubuntu 22.04.3 LTS (v5.19)",
 ];
 
 export var kernelReleaseNames2004 = [
@@ -1798,7 +1798,7 @@ export var kernelReleaseNamesALL = [
   "Ubuntu 22.04.0 LTS (v5.15)",
   "Ubuntu 20.04.5 LTS (v5.15)",
   "Ubuntu 22.04.1 LTS (v5.15)",
-  "Ubuntu 22.04.2 LTS (v5.19)",
+  "Ubuntu 22.04.3 LTS (v5.19)",
 ];
 
 export var kernelReleaseNamesLTS = [
@@ -1828,7 +1828,7 @@ export var kernelReleaseNamesLTS = [
   "Ubuntu 22.04.0 LTS (v5.15)",
   "Ubuntu 20.04.5 LTS (v5.15)",
   "Ubuntu 22.04.1 LTS (v5.15)",
-  "Ubuntu 22.04.2 LTS (v5.19)",
+  "Ubuntu 22.04.3 LTS (v5.19)",
 ];
 
 export var openStackReleaseNames = [

--- a/templates/download/risc-v/tab-1.html
+++ b/templates/download/risc-v/tab-1.html
@@ -24,7 +24,7 @@
     <div class="col-6">
       <p>
 				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+nezha.img.xz">Download 23.04</a>
-				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+nezha.img.xz">Download 22.04.2</a>
+				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.3/release/ubuntu-22.04.3-preinstalled-server-riscv64+nezha.img.xz">Download 22.04.3</a>
 			</p>
 			<p><a href="https://wiki.ubuntu.com/RISC-V/Nezha%20D1">How to install Ubuntu on the Nezha</a></p>
     </div>

--- a/templates/download/risc-v/tab-2.html
+++ b/templates/download/risc-v/tab-2.html
@@ -4,7 +4,7 @@
       <h2 class="u-hide--small">Microchip Polarfire SoC <br>FPGA Icicle Kit</h2>
     </div>
     <div class="col-6 risc-v-container u-vertically-center u-align--center">
-      {{ 
+      {{
         image (
         url="https://assets.ubuntu.com/v1/0f48dfd1-Microchip+PolarFire.png",
         alt="",
@@ -30,7 +30,7 @@
       <hr class="is-fixed-width col-6">
       <p>
 				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+icicle.img.xz">Download 23.04</a>
-				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+icicle.img.xz">Download 22.04.2</a>
+				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.3/release/ubuntu-22.04.3-preinstalled-server-riscv64+icicle.img.xz">Download 22.04.3</a>
 			</p>
       <p><a href="https://wiki.ubuntu.com/RISC-V/PolarFire%20SoC%20FPGA%20Icicle%20Kit">How to install Ubuntu on the Microchip Polarfire SoC FPGA Icicle Kit</a></p>
     </div>

--- a/templates/download/risc-v/tab-3.html
+++ b/templates/download/risc-v/tab-3.html
@@ -24,7 +24,7 @@
     <div class="col-6">
       <p class="u-sv3">
 				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+unmatched.img.xz">Download 23.04</a>
-				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+unmatched.img.xz">Download 22.04.2</a>
+				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.3/release/ubuntu-22.04.3-preinstalled-server-riscv64+unmatched.img.xz">Download 22.04.3</a>
 			</p>
     </div>
   </div>
@@ -36,7 +36,7 @@
     <div class="col-6">
       <p>
 				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-live-server-riscv64.img.gz">Download 23.04 live installer</a>
-				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-live-server-riscv64.img.gz">Download 22.04.2 live installer</a>
+				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.3/release/ubuntu-22.04.3-live-server-riscv64.img.gz">Download 22.04.3 live installer</a>
 			</p>
       <p><a href="https://wiki.ubuntu.com/RISC-V/QEMU">How to install Ubuntu on QEMU RISC-V</a></p>
     </div>

--- a/templates/download/risc-v/tab-4.html
+++ b/templates/download/risc-v/tab-4.html
@@ -25,7 +25,7 @@
       <p class="p-notification__message"><i class="p-icon--information"></i> If you have an NVMe drive, we advise you to use the Ubuntu Server live installer.</p>
       <p class="u-sv3">
         <a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+unmatched.img.xz">Download 23.04</a>
-        <a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+unmatched.img.xz">Download 22.04.2</a>
+        <a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.3/release/ubuntu-22.04.3-preinstalled-server-riscv64+unmatched.img.xz">Download 22.04.3</a>
       </p>
     </div>
   </div>
@@ -37,7 +37,7 @@
     <div class="col-6">
       <p>
 				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-live-server-riscv64.img.gz">Download 23.04 live installer</a>
-				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-live-server-riscv64.img.gz">Download 22.04.2 live installer</a>
+				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.3/release/ubuntu-22.04.3-live-server-riscv64.img.gz">Download 22.04.3 live installer</a>
 			</p>
 			<p><a href="https://wiki.ubuntu.com/RISC-V/SiFive%20HiFive%20Unmatched">How to install Ubuntu on SiFive HiFive Unmatched</a></p>
     </div>

--- a/templates/download/risc-v/tab-5.html
+++ b/templates/download/risc-v/tab-5.html
@@ -4,7 +4,7 @@
       <h2 class="u-hide--small">Sipeed LicheeRV Dock</h2>
     </div>
     <div class="col-6 risc-v-container u-vertically-center u-align--center">
-      {{ 
+      {{
         image (
         url="https://assets.ubuntu.com/v1/4c609299-Sipeed+LicheeRV+-+Edited.png",
         alt="",
@@ -25,7 +25,7 @@
     <div class="col-6">
       <p>
 				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+licheerv.img.xz">Download 23.04</a>
-				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+licheerv.img.xz">Download 22.04.2</a>
+				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.3/release/ubuntu-22.04.3-preinstalled-server-riscv64+licheerv.img.xz">Download 22.04.3</a>
 			</p>
 			<p><a href="https://wiki.ubuntu.com/RISC-V/LicheeRV">How to install Ubuntu on the LicheeRV Dock</a></p>
     </div>

--- a/templates/download/risc-v/tab-6.html
+++ b/templates/download/risc-v/tab-6.html
@@ -24,7 +24,7 @@
     <div class="col-6">
       <p>
         <a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+visionfive.img.xz">Download 23.04</a>
-        <a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.2/release/ubuntu-22.04.2-preinstalled-server-riscv64+visionfive.img.xz">Download 22.04.2</a>
+        <a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.3/release/ubuntu-22.04.3-preinstalled-server-riscv64+visionfive.img.xz">Download 22.04.3</a>
       </p>
       <p><a href="https://wiki.ubuntu.com/RISC-V/StarFive%20VisionFive">How to install Ubuntu on the VisionFive</a></p>
     </div>

--- a/templates/shared/_kernel-support-schedule.html
+++ b/templates/shared/_kernel-support-schedule.html
@@ -39,7 +39,7 @@
             <td>Apr 2032</td>
           </tr>
           <tr>
-            <td><strong>Ubuntu 22.04.2 LTS (v5.19)</strong></td>
+            <td><strong>Ubuntu 22.04.3 LTS (v5.19)</strong></td>
             <td>Feb 2023</td>
             <td>Jul 2023</td>
             <td>&nbsp;</td>
@@ -425,7 +425,7 @@
             <td>Apr 2027</td>
           </tr>
           <tr>
-            <td><strong>Ubuntu 22.04.2 LTS (v5.19)</strong></td>
+            <td><strong>Ubuntu 22.04.3 LTS (v5.19)</strong></td>
             <td>Feb 2023</td>
             <td>&nbsp;</td>
             <td>Jul 2023</td>
@@ -615,7 +615,7 @@
             <td>Apr 2027</td>
           </tr>
           <tr>
-            <td><strong>Ubuntu 22.04.2 LTS (v5.19)</strong></td>
+            <td><strong>Ubuntu 22.04.3 LTS (v5.19)</strong></td>
             <td>&nbsp;</td>
             <td>Feb 2023</td>
             <td>Jul 2023</td>


### PR DESCRIPTION
## Done

- Replace 22.04.2 with 22.04.3

## QA

- Open the demo
- Go through the different download platforms desktop/server/iot etc
- See that all say 22.04.3 and the links contain the new point

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-5743
