### PR TITLE
Is expiring closed/done Renewal bug fix

### DIFF
--- a/webapp/shop/api/ua_contracts/helpers.py
+++ b/webapp/shop/api/ua_contracts/helpers.py
@@ -228,7 +228,9 @@ def get_user_subscription_statuses(
     if type == "free":
         return statuses
 
-    if renewal is None or (renewal and renewal.status != "closed"):
+    if renewal is None or (
+        renewal and renewal.status not in ["done", "closed"]
+    ):
         date_statuses = get_date_statuses(type, end_date)
         statuses["is_expiring"] = date_statuses["is_expiring"]
         statuses["is_in_grace_period"] = date_statuses["is_in_grace_period"]


### PR DESCRIPTION
## Done

- There are two Renewal statuses that mean that a Legacy subscription was renewed: done, closed.
- Before we only considered "closed".
- The logic we had was making it that Renewed (with status closed) Legacy subscriptions would no longer have the `will expire soon` notifications. As it was renewed.
- But Renewed (with the status done) Legacy subscriptions would still show `will expire soon` notifications. Now they behave as closed renewals.

## QA

- Hard to QA due to having to hard-code yourself expiring subscriptions. But here is a screenshot:
![image](https://github.com/canonical/ubuntu.com/assets/6387619/df851333-567e-4bee-bdd2-810688abd59d)
Bottom subscription no longer shows the expiring soon notification. 

## Issue / Card

Fixes #https://warthogs.atlassian.net/browse/WD-5535
