### PR TITLE
Fix acquisition URLs for jp/cn.ubuntu.com

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -892,8 +892,12 @@ def marketo_submit():
     if "email" in form_fields:
         enrichment_fields = {
             "email": form_fields["email"],
-            "acquisition_url": referrer,
         }
+
+    if "acquisition_url" in form_fields:
+        enrichment_fields["acquisition_url"] = form_fields["acquisition_url"]
+    else:
+        enrichment_fields["acquisition_url"] = referrer
 
     if "preferredLanguage" in form_fields:
         enrichment_fields["preferredLanguage"] = form_fields[


### PR DESCRIPTION
## Done

`acquisition_url` shows only hostname, Marketing requires this to be the full page URL. This is an attempt to achieve that using an alternative source.

## QA

- Go to https://jp-ubuntu-com-463.demos.haus/blog/accelerating-the-adoption-of-ai-in-banking-with-mlops-jp
- Submit the newsletter form on the right.
- Check ubuntu forms work too e.g. https://ubuntu-com-13089.demos.haus/blog/canonical-extends-commercial-openstack-offering-to-small-scale-cloud-environments-with-project-sunbeam fill up newsletter form on the right and that you don't get marketo sentry errors https://sentry.is.canonical.com/canonical/ubuntu-com/
- You should receive the acquisition URL now in Marketo.

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-5585?atlOrigin=eyJpIjoiMWZkM2Y1MWJmM2QyNDJlMDhiYjcyZDBiMjQyOWQ2ZTYiLCJwIjoiaiJ9


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
