### PR TITLE
Update sitemap_index.xml to include robotics sitemap

### DIFF
--- a/templates/sitemap_index.xml
+++ b/templates/sitemap_index.xml
@@ -27,4 +27,7 @@
   <sitemap>
    <loc>https://ubuntu.com/security/livepatch/docs/sitemap.xml</loc>
   </sitemap>
+  <sitemap>
+   <loc>https://ubuntu.com/robotics/docs/sitemap.xml</loc>
+  </sitemap>
 </sitemapindex>


### PR DESCRIPTION
## Done

- Adds a link to the robotics sitemap to the sitemap_index

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-4765

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
