### PR TITLE
Update 'Upgrade Ubuntu LTS' title and blog link

### DIFF
--- a/templates/azure/pro.html
+++ b/templates/azure/pro.html
@@ -16,6 +16,8 @@
       </h3>
       <p>Delivers additional layer of security and compliance services and security patches covering a wider range of packages, until 2032.</p>
       <p><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-jammy" class="p-button--positive">Launch now</a></p>
+      <h3 class="p-heading--4"><a href="/blog/announcing-in-place-upgrade-from-ubuntu-server-to-ubuntu-pro-on-azure">Upgrade Ubuntu LTS to Ubuntu Pro</a></h3>
+      <p>Upgrade to Ubuntu Pro, with no disruption to your services or VM redeployment.</p>
     </div>
     <div class="col-5 u-align--center u-vertically-center u-hide--medium u-hide--small">
       {{


### PR DESCRIPTION
## QA
- Go to https://ubuntu-com-13096.demos.haus/azure/pro
- Updated only the new "Upgrade Ubuntu LTS to Ubuntu Pro" with its blog link. The other comments look like discussion.

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-5828?atlOrigin=eyJpIjoiZjUzNWFjMGNjNzkwNGY2Yjg3OTViYmQ4ZTk3NGQ1Y2IiLCJwIjoiaiJ9


