### PR TITLE
Redirect for Ubuntu fan package doc URL

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -868,6 +868,7 @@ usn/rss\.xml: "/security/notices/rss.xml"
 (?P<page>.+)/: "/{page}"
 telecommunications/?: "/telco"
 telcos/?: "/telco"
+fan/?: "https://wiki.ubuntu.com/FanNetworking"
 
 # Community
 community/canonical/?: "/community/governance/canonical"


### PR DESCRIPTION
## QA

- Go to https://ubuntu-com-13097.demos.haus/fan should redirect to https://github.com/canonical/ubuntu.com/issues/12927


## Issue / Card

Fixes https://github.com/canonical/ubuntu.com/issues/12927

