### PR TITLE
[WD-5943] Added beta message to credentials index page

### DIFF
--- a/templates/credentials/index.html
+++ b/templates/credentials/index.html
@@ -1,20 +1,39 @@
-{% extends "credentials/base_cred.html" %}
+{% extends "credentials/base_cred.html" %} {% block title %}Canonical
+Credentials{% endblock %} {% block meta_description %}The Canonical Ubuntu
+Essentials exams certify knowledge and verify skills in general Linux, Ubuntu
+Desktop, and Ubuntu Server topics.{% endblock meta_description %} {% block
+meta_copydoc
+%}https://docs.google.com/document/d/1QuhO-9FEOGLrYp8bErS_9snqdljl7d6tFAUoNQxoVDQ/edit{%
+endblock meta_copydoc %} {% block content %}
 
-{% block title %}Canonical Credentials{% endblock %}
-
-{% block meta_description %}The Canonical Ubuntu Essentials exams certify knowledge and verify skills in general Linux, Ubuntu Desktop, and Ubuntu Server topics.{% endblock meta_description %}
-{% block meta_copydoc %}https://docs.google.com/document/d/1QuhO-9FEOGLrYp8bErS_9snqdljl7d6tFAUoNQxoVDQ/edit{% endblock meta_copydoc %}
-
-{% block content %}
-
-<section class="p-strip--image is-dark is-deep" style="background-image: url(https://assets.ubuntu.com/v1/4a1f9f33-suru-cut.png); background-position: 100% 60%">
+<section
+  class="p-strip--image is-dark is-deep"
+  style="
+    background-image: url(https://assets.ubuntu.com/v1/4a1f9f33-suru-cut.png);
+    background-position: 100% 60%;
+  "
+>
   <div class="row u-equal-height">
     <div class="col-6">
       <h1>Canonical Credentials</h1>
       <p class="p-heading--4">Learn, excel, certify!</p>
-      <p>Find the shortest path to your passion. Develop and certify your skills on the world's most popular Linux OS.</p>
+      <p>
+        Find the shortest path to your passion. Develop and certify your skills
+        on the world's most popular Linux OS.
+      </p>
       {% if can_purchase %}
-      <p><a href="/credentials/shop"><button class="p-button--positive">Get your exam now!</button></a></p>
+      <p>
+        <a href="/credentials/shop"
+          ><button class="p-button--positive">Get your exam now!</button></a
+        >
+      </p>
+      {% else %}
+      <p>
+        <i>
+          Sign-ups for the CUE.01: Linux beta are now closed. Please check back
+          for future announcements and beta opportunities.
+        </i>
+      </p>
       {% endif %}
     </div>
   </div>
@@ -23,20 +42,25 @@
   <div class="row">
     <div class="col-6">
       <h2 class="u-sv2">Why certify?</h2>
-      <p>Ubuntu is the world's most popular open source OS for both development and deployment, from the data centre to the cloud to the Internet of things. So whether you are trying to pave your way into the tech field, or looking to upgrade your career or prove your skills, Canonical Credentials is here for you!</p>
-      <p>This program is designed to help you demonstrate your expertise to countless enterprise organisations who are more likely than not using Ubuntu software today.</p>
+      <p>
+        Ubuntu is the world's most popular open source OS for both development
+        and deployment, from the data centre to the cloud to the Internet of
+        things. So whether you are trying to pave your way into the tech field,
+        or looking to upgrade your career or prove your skills, Canonical
+        Credentials is here for you!
+      </p>
+      <p>
+        This program is designed to help you demonstrate your expertise to
+        countless enterprise organisations who are more likely than not using
+        Ubuntu software today.
+      </p>
     </div>
-    <div class="col-6 col-start-large-9 u-hide--small u-hide--medium u-vertically-center">
-      {{
-        image (
-        url="https://assets.ubuntu.com/v1/92959538-Rosette.svg",
-        alt="Canonical Ubuntu Essentials badge",
-        width="141",
-        height="320",
-        hi_def=True,
-        loading="auto"
-        ) | safe
-      }}
+    <div
+      class="col-6 col-start-large-9 u-hide--small u-hide--medium u-vertically-center"
+    >
+      {{ image ( url="https://assets.ubuntu.com/v1/92959538-Rosette.svg",
+      alt="Canonical Ubuntu Essentials badge", width="141", height="320",
+      hi_def=True, loading="auto" ) | safe }}
     </div>
   </div>
 </section>
@@ -47,13 +71,32 @@
     </div>
     <div class="col-6">
       <h3 class="p-heading--5 u-no-margin--bottom">Validate your knowledge</h3>
-      <p class="u-sv2">Challenge yourself, expand your skill set, and test your knowledge. The official Canonical Ubuntu badges will certify your knowledge and recognise you as an industry expert.</p>
-      <hr class="is-fixed-width u-no-margin--bottom">
-      <h3 class="p-heading--5 u-no-margin--bottom">Real-life hands-on testing</h3>
-      <p class="u-sv2">Exam questions simulate a real life problem or task that can be part of the day to day of a professional working in an Ubuntu environment. Real-world environments provide a familiar setting to showcase your problem-solving skills.</p>
-      <hr class="is-fixed-width u-no-margin--bottom">
-      <h3 class="p-heading--5 u-no-margin--bottom">Intelligently designed to suit your schedule</h3>
-      <p>Your career path: now with stepping stones! Our modular program features simple, laser-focused building blocks, or QuickCerts (QC) to help you take the exams most relevant to you while simultaneously earning badges toward more advanced credential tracks. Earn the badges you need without spending time and energy you don’t have.</p>
+      <p class="u-sv2">
+        Challenge yourself, expand your skill set, and test your knowledge. The
+        official Canonical Ubuntu badges will certify your knowledge and
+        recognise you as an industry expert.
+      </p>
+      <hr class="is-fixed-width u-no-margin--bottom" />
+      <h3 class="p-heading--5 u-no-margin--bottom">
+        Real-life hands-on testing
+      </h3>
+      <p class="u-sv2">
+        Exam questions simulate a real life problem or task that can be part of
+        the day to day of a professional working in an Ubuntu environment.
+        Real-world environments provide a familiar setting to showcase your
+        problem-solving skills.
+      </p>
+      <hr class="is-fixed-width u-no-margin--bottom" />
+      <h3 class="p-heading--5 u-no-margin--bottom">
+        Intelligently designed to suit your schedule
+      </h3>
+      <p>
+        Your career path: now with stepping stones! Our modular program features
+        simple, laser-focused building blocks, or QuickCerts (QC) to help you
+        take the exams most relevant to you while simultaneously earning badges
+        toward more advanced credential tracks. Earn the badges you need without
+        spending time and energy you don’t have.
+      </p>
     </div>
   </div>
 </section>
@@ -63,7 +106,11 @@
       <h2>The future is almost here...</h2>
     </div>
     <div class="col-6">
-      <p>Help establish the certification programme today and be at the forefront of the programme of tomorrow. Be the first to hear about upcoming exams and new credentials in the upcoming year!</p>
+      <p>
+        Help establish the certification programme today and be at the forefront
+        of the programme of tomorrow. Be the first to hear about upcoming exams
+        and new credentials in the upcoming year!
+      </p>
     </div>
   </div>
 </section>
@@ -74,11 +121,20 @@
     </div>
     <div class="col-6">
       <div class="u-sv4">
-        <h3 class="p-heading--5 u-no-margin--bottom">CUE.01: Linux QuickCert</h3>
-        <p>Prove your basic operational knowledge of Linux by demonstrating your ability to secure, operate and maintain basic system resources. Topics include user and group management, file and filesystem navigation, and logs and installation tasks related to system maintenance.</p>
+        <h3 class="p-heading--5 u-no-margin--bottom">
+          CUE.01: Linux QuickCert
+        </h3>
+        <p>
+          Prove your basic operational knowledge of Linux by demonstrating your
+          ability to secure, operate and maintain basic system resources. Topics
+          include user and group management, file and filesystem navigation, and
+          logs and installation tasks related to system maintenance.
+        </p>
         <div class="row">
           <div class="col-2">
-            <a href="/credentials/syllabus?exam=CUE.01%3A%20Linux">Syllabus&nbsp;›</a>
+            <a href="/credentials/syllabus?exam=CUE.01%3A%20Linux"
+              >Syllabus&nbsp;›</a
+            >
           </div>
           {% if can_purchase %}
           <div class="col-2">
@@ -88,16 +144,32 @@
         </div>
       </div>
       <div class="u-sv4">
-        <hr class="is-fixed-width u-no-margin--bottom">
-        <h3 class="p-heading--5 u-no-margin--bottom">CUE.02: Desktop QuickCert</h3>
-        <p>Demonstrate your knowledge of Ubuntu Desktop administrative essentials. Topics include package management, system installation, data gathering, and managing printing and displays.</p>
-        <a href="/credentials/syllabus?exam=CUE.02%3A%20Desktop">Syllabus&nbsp;›</a>
+        <hr class="is-fixed-width u-no-margin--bottom" />
+        <h3 class="p-heading--5 u-no-margin--bottom">
+          CUE.02: Desktop QuickCert
+        </h3>
+        <p>
+          Demonstrate your knowledge of Ubuntu Desktop administrative
+          essentials. Topics include package management, system installation,
+          data gathering, and managing printing and displays.
+        </p>
+        <a href="/credentials/syllabus?exam=CUE.02%3A%20Desktop"
+          >Syllabus&nbsp;›</a
+        >
       </div>
       <div class="u-sv4">
-        <hr class="is-fixed-width u-no-margin--bottom">
-        <h3 class="p-heading--5 u-no-margin--bottom">CUE.03: Server QuickCert</h3>
-        <p>Illustrate your knowledge of common Ubuntu Server administrative tasks and troubleshooting. Topics include job control, performance tuning, services management, and Bash scripting.</p>
-        <a href="/credentials/syllabus?exam=CUE.03%3A%20Server">Syllabus&nbsp;›</a>
+        <hr class="is-fixed-width u-no-margin--bottom" />
+        <h3 class="p-heading--5 u-no-margin--bottom">
+          CUE.03: Server QuickCert
+        </h3>
+        <p>
+          Illustrate your knowledge of common Ubuntu Server administrative tasks
+          and troubleshooting. Topics include job control, performance tuning,
+          services management, and Bash scripting.
+        </p>
+        <a href="/credentials/syllabus?exam=CUE.03%3A%20Server"
+          >Syllabus&nbsp;›</a
+        >
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Done

- Added back information about the beta signups being closed for now on the index page of credentials 

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- Change the `CONTRACTS_API_URL` in `.env.local` to production url
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- visit [/credentials](http://0.0.0.0:8001/credentials)
- Verify that there is a line on the landing about the beta signups being closed.

## Issue / Card

Fixes [#WD-5943](https://warthogs.atlassian.net/browse/WD-5943)

## Screenshots
![image](https://github.com/canonical/ubuntu.com/assets/30973042/77d4cb1c-7a1b-4fbc-bf8b-d2fb6d2dd499)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
