### PR TITLE
Show beta message on credentials homepage

### DIFF
--- a/templates/credentials/index.html
+++ b/templates/credentials/index.html
@@ -13,8 +13,10 @@
       <h1>Canonical Credentials</h1>
       <p class="p-heading--4">Learn, excel, certify!</p>
       <p>Find the shortest path to your passion. Develop and certify your skills on the world's most popular Linux OS.</p>
-      {% if can_purchase %}
+      {% if not can_purchase %}
       <p><a href="/credentials/shop"><button class="p-button--positive">Get your exam now!</button></a></p>
+      {% else %}
+      <p><i>Sign-ups for the CUE.01: Linux beta are now closed. Please check back for future announcements and beta opportunities.</i></p>
       {% endif %}
     </div>
   </div>


### PR DESCRIPTION
## Done

Show beta message on credentials homepage when there are no product listings available.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/credentials
- Check that when there is no listing to purchase you see the message regarding the beta.
