### PR TITLE
WD-5961 - Fix the engage sitemap date format

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -571,7 +571,9 @@ def build_engage_pages_sitemap(engage_pages):
             links.append(
                 {
                     "url": f'https://ubuntu.com{page["path"]}',
-                    "last_updated": page["updated"].strftime("%-d %B %Y"),
+                    "last_updated": page["updated"].strftime(
+                        "%Y-%m-%dT%H:%M:%SZ"
+                    ),
                 }
             )
 


### PR DESCRIPTION
## Done

- Updated the engage page sitemap date format to match other passing sitemaps like the https://ubuntu.com/ceph/docs/sitemap.xml

## QA

- Check the code
- Open the demo and go to /engage/sitemap.xml
- See the date format is ISO 8601 (for example, `2023-08-22T21:22:53Z`)

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-5961