### PR TITLE
Fix incorrect data on /about/release-cycle

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -161,12 +161,26 @@ export var serverAndDesktopReleases = [
 ];
 
 export var kernelReleases = [
+	{
+    startDate: new Date("2023-08-01T00:00:00"),
+    endDate: new Date("2024-01-01T00:00:00"),
+    taskName: "Ubuntu 22.04.3 LTS",
+    taskVersion: "6.2 kernel",
+    status: "INTERIM_RELEASE"
+  },
+  {
+    startDate: new Date("2023-04-01T00:00:00"),
+    endDate: new Date("2024-01-01T00:00:00"),
+    taskName: "Ubuntu 23.04",
+    taskVersion: "",
+    status: "INTERIM_RELEASE"
+  },
   {
     startDate: new Date("2023-02-01T00:00:00"),
-    endDate: new Date("2027-04-01T00:00:00"),
-    taskName: "Ubuntu 22.04.3 LTS",
+    endDate: new Date("2023-07-01T00:00:00"),
+    taskName: "Ubuntu 22.04.2 LTS",
     taskVersion: "Kernel version",
-    status: "LTS",
+    status: "LTS"
   },
   {
     startDate: new Date("2022-10-01T00:00:00"),
@@ -1681,6 +1695,8 @@ export var desktopServerReleaseNames = [
 
 export var kernelReleaseNames = [
   "Ubuntu 22.04.3 LTS",
+  "Ubuntu 23.04",
+  "Ubuntu 22.04.2 LTS",
   "Ubuntu 22.10",
   "Ubuntu 22.04.1 LTS",
   "Ubuntu 20.04.5 LTS",
@@ -1705,6 +1721,8 @@ export var kernelReleaseNames = [
 ];
 
 export var kernelVersionNames = [
+  "6.2 kernel",
+  "",
   "5.19 kernel",
   "",
   "5.15 kernel",

--- a/templates/about/release_cycles/kernel-eol.html
+++ b/templates/about/release_cycles/kernel-eol.html
@@ -13,7 +13,39 @@
         </thead>
         <tbody>
           <tr>
-            <td rowspan="2"><strong>22.04 kernel</strong></td>
+            <td rowspan="2"><strong>6.2 kernel</strong></td>
+            <td><strong>Ubuntu 22.04.3 LTS</strong></td>
+            <td>Aug 2023</td>
+            <td>Jan 2024</td>
+            <td>&nbsp;</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 23.04</strong></td>
+            <td>Apr 2023</td>
+            <td>Jan 2024</td>
+            <td>&nbsp;</td>
+          </tr>
+          <tr>
+            <td rowspan="2"><strong>5.19 kernel</strong></td>
+            <td><strong>Ubuntu 22.04.2 LTS</strong></td>
+            <td>Feb 2023</td>
+            <td>Jul 2023</td>
+            <td>&nbsp;</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 22.10</strong></td>
+            <td>Oct 2022</td>
+            <td>Jul 2023</td>
+            <td>&nbsp;</td>
+          </tr>
+          <tr>
+            <td rowspan="3"><strong>5.15 kernel</strong></td>
+            <td><strong>Ubuntu 22.04.1 LTS</strong></td>
+            <td>Aug 2022</td>
+            <td>Apr 2027</td>
+            <td>&nbsp;</td>
+          </tr>
+          <tr>
             <td><strong>Ubuntu 20.04.5 LTS</strong></td>
             <td>Aug 2022</td>
             <td>Apr 2025</td>
@@ -65,6 +97,7 @@
             <td>&nbsp;</td>
           </tr>
           <tr>
+            <td rowspan="3"><strong>5.4 kernel</strong></td>
             <td><strong>Ubuntu 18.04.5 LTS</strong></td>
             <td>Aug 2020</td>
             <td>Apr 2023</td>


### PR DESCRIPTION
## Done

- See issue here: https://github.com/canonical/ubuntu.com/issues/13030
- Updated based on data from [the spreadsheet](https://docs.google.com/spreadsheets/d/1KIuOAa620yseE0uhIl67u2SlS0bWlPI_d98bvYM2Yl8/edit#gid=550510389), tab 'kernel all'

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes https://github.com/canonical/ubuntu.com/issues/13030

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
