### PR TITLE
Update survery link on /openstack/install

### DIFF
--- a/templates/openstack/install.html
+++ b/templates/openstack/install.html
@@ -136,7 +136,7 @@
       <div class="col-6 p-card">
         <img class="p-card__thumbnail--large" src="https://assets.ubuntu.com/v1/67d90042-compliance-icon-no-padding.svg" alt="">
         <hr class="u-sv1">
-        <p><a href="https://www.openstack.org/user-survey/survey-2022/landing">Fill in the survey&nbsp;&rsaquo;</a></p>
+        <p><a href="https://www.openstack.org/user-survey/survey-2024/landing">Fill in the survey&nbsp;&rsaquo;</a></p>
         <p class="p-card__content">The OpenStack User Survey provides users an opportunity to influence the community and software direction. By sharing information about your configuration and requirements, the Open Infrastructure Foundation User Committee will be able to advocate on your behalf.</p>
       </div>
       <div class="col-6 p-card">


### PR DESCRIPTION
## Done

- Update survery link on /openstack/tutorials based on [copydoc](https://docs.google.com/document/d/1eQ16jzv6YRGzG_k_C-tUnhM06k6_Ic6fZM-x_ARMzuc/edit#heading=h.4t7jro4ogj)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-6016