### PR TITLE
Add link to CUE Activation Keys shop

### DIFF
--- a/static/js/src/advantage/credentials/api/keys.js
+++ b/static/js/src/advantage/credentials/api/keys.js
@@ -40,3 +40,15 @@ export async function activateKey(activationKey) {
   const data = await response.json();
   return data;
 }
+
+export async function getKeyProducts() {
+  let response = await fetch("/credentials/keys/products", {
+    method: "GET",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+  });
+  const data = await response.json();
+  return data;
+}

--- a/static/js/src/advantage/credentials/api/keys.js
+++ b/static/js/src/advantage/credentials/api/keys.js
@@ -52,3 +52,15 @@ export async function getKeyProducts() {
   const data = await response.json();
   return data;
 }
+
+export async function getExamProducts() {
+  let response = await fetch("/credentials/exam/products", {
+    method: "GET",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+  });
+  const data = await response.json();
+  return data;
+}

--- a/static/js/src/advantage/credentials/components/CredExamShop/CredExamShop.tsx
+++ b/static/js/src/advantage/credentials/components/CredExamShop/CredExamShop.tsx
@@ -86,7 +86,6 @@ const CredExamShop = () => {
       }
     }
     setExamProducts(ExamProductDescriptions);
-    console.log(ExamProductDescriptions);
   }, [ExamData]);
   if (isLoading) {
     return <Spinner />;

--- a/static/js/src/advantage/credentials/components/CredExamShop/CredExamShop.tsx
+++ b/static/js/src/advantage/credentials/components/CredExamShop/CredExamShop.tsx
@@ -1,29 +1,22 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import {
   Button,
   Col,
   RadioInput,
   Row,
   Strip,
+  Spinner,
 } from "@canonical/react-components";
 import classNames from "classnames";
 import { currencyFormatter } from "advantage/react/utils";
+import { Product } from "advantage/subscribe/blender/utils/utils";
+import { useQuery } from "react-query";
+import { getExamProducts } from "advantage/credentials/api/keys";
 
 const CredExamShop = () => {
-  const ExamProducts = [
+  const ExamProductDescriptions = [
     {
       id: "cue-linux-essentials",
-      longId: "lAK5jL8zvMjZOwaysIMQyGRAdOLgTQQH0xpezu2oYp74",
-      name: "CUE Linux Essentials",
-      period: "none",
-      price: {
-        currency: "USD",
-        value: 4900,
-      },
-      productID: "cue-linux-essentials",
-      status: "active",
-      private: false,
-      marketplace: "canonical-cube",
       metadata: [
         {
           key: "description",
@@ -34,13 +27,6 @@ const CredExamShop = () => {
     },
     {
       id: "cue-02-desktop",
-      longId: "lAMGrt4buzUR0-faJqg-Ot6dgNLn7ubIpWiyDgOrsDCg",
-      name: "CUE.02 Desktop QuickCert",
-      price: { value: 4900, currency: "USD" },
-      productID: "cue-02-desktop",
-      canBeTrialled: false,
-      private: true,
-      marketplace: "canonical-cube",
       metadata: [
         {
           key: "description",
@@ -51,13 +37,6 @@ const CredExamShop = () => {
     },
     {
       id: "cue-03-server",
-      longId: "lAMGrt4buzUR0-faJqg-Ot6dgNLn7ubIpWiyDgOrsDCg",
-      name: "CUE.03 Server QuickCert",
-      price: { value: 4900, currency: "USD" },
-      productID: "cue-03-server",
-      canBeTrialled: false,
-      private: true,
-      marketplace: "canonical-cube",
       metadata: [
         {
           key: "description",
@@ -67,6 +46,10 @@ const CredExamShop = () => {
       ],
     },
   ];
+  const { isLoading, data: ExamData } = useQuery(["ExamProducts"], async () => {
+    return getExamProducts();
+  });
+  const [ExamProducts, setExamProducts] = useState<Product[]>([]);
   const [exam, setExam] = useState(0);
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setExam(parseInt(event.target.value));
@@ -88,6 +71,28 @@ const CredExamShop = () => {
     );
     location.href = "/account/checkout";
   };
+  useEffect(() => {
+    const tempExamProducts = [];
+    console.log(ExamData);
+    if(ExamData === undefined) {
+      return;
+    }
+    for (const exam of ExamData) {
+      for (const examDescription of ExamProductDescriptions) {
+        if (exam.id === examDescription.id) {
+          exam.metadata = examDescription.metadata;
+          tempExamProducts.push(exam);
+        }
+      }
+    }
+    setExamProducts(tempExamProducts);
+    console.log(ExamData);
+    console.log(tempExamProducts);
+  }, [ExamData]);
+  if (isLoading) {
+    return <Spinner />;
+  }
+
   return (
     <>
       <Strip className="product-selector">
@@ -118,7 +123,7 @@ const CredExamShop = () => {
                     <span className="p-radio__label">
                       <RadioInput
                         labelClassName="inner-label"
-                        label={examElement.name}
+                        label={examElement?.name}
                         checked={exam == examIndex}
                         value={examIndex}
                         onChange={handleChange}
@@ -162,7 +167,7 @@ const CredExamShop = () => {
               >
                 <RadioInput
                   inline
-                  label={examElement.name}
+                  label={examElement?.name}
                   checked={exam == examIndex}
                   value={examIndex}
                   onChange={handleChange}
@@ -198,7 +203,7 @@ const CredExamShop = () => {
         <Row>
           <Col size={6} style={{ display: "flex" }}>
             <p className="p-heading--2" style={{ marginBlock: "auto" }}>
-              {ExamProducts[exam].name}
+              {ExamProducts[exam]?.name}
             </p>
           </Col>
           <Col size={3} small={2} style={{ display: "flex" }}>

--- a/static/js/src/advantage/credentials/components/CredExamShop/CredExamShop.tsx
+++ b/static/js/src/advantage/credentials/components/CredExamShop/CredExamShop.tsx
@@ -9,14 +9,15 @@ import {
 } from "@canonical/react-components";
 import classNames from "classnames";
 import { currencyFormatter } from "advantage/react/utils";
-import { Product } from "advantage/subscribe/blender/utils/utils";
+import { Product } from "advantage/credentials/utils/utils";
 import { useQuery } from "react-query";
 import { getExamProducts } from "advantage/credentials/api/keys";
 
 const CredExamShop = () => {
-  const ExamProductDescriptions = [
+  const ExamProductDescriptions: Product[] = [
     {
       id: "cue-linux-essentials",
+      name: "CUE Linux Essentials",
       metadata: [
         {
           key: "description",
@@ -27,6 +28,7 @@ const CredExamShop = () => {
     },
     {
       id: "cue-02-desktop",
+      name: "CUE Desktop",
       metadata: [
         {
           key: "description",
@@ -37,6 +39,7 @@ const CredExamShop = () => {
     },
     {
       id: "cue-03-server",
+      name: "CUE Server",
       metadata: [
         {
           key: "description",
@@ -72,22 +75,18 @@ const CredExamShop = () => {
     location.href = "/account/checkout";
   };
   useEffect(() => {
-    const tempExamProducts = [];
-    console.log(ExamData);
-    if(ExamData === undefined) {
+    if (ExamData === undefined) {
       return;
     }
-    for (const exam of ExamData) {
-      for (const examDescription of ExamProductDescriptions) {
+    for (const examDescription of ExamProductDescriptions) {
+      for (const exam of ExamData) {
         if (exam.id === examDescription.id) {
-          exam.metadata = examDescription.metadata;
-          tempExamProducts.push(exam);
+          Object.assign(examDescription, exam);
         }
       }
     }
-    setExamProducts(tempExamProducts);
-    console.log(ExamData);
-    console.log(tempExamProducts);
+    setExamProducts(ExamProductDescriptions);
+    console.log(ExamProductDescriptions);
   }, [ExamData]);
   if (isLoading) {
     return <Spinner />;
@@ -118,7 +117,7 @@ const CredExamShop = () => {
                       value={examIndex}
                       checked={exam == examIndex}
                       onChange={handleChange}
-                      disabled={examElement.private}
+                      disabled={examElement.price === undefined}
                     />
                     <span className="p-radio__label">
                       <RadioInput
@@ -127,7 +126,7 @@ const CredExamShop = () => {
                         checked={exam == examIndex}
                         value={examIndex}
                         onChange={handleChange}
-                        disabled={examElement.private}
+                        disabled={examElement.price === undefined}
                       />
                       <hr />
                       <p style={{ paddingLeft: "1rem", paddingRight: "1rem" }}>
@@ -138,7 +137,7 @@ const CredExamShop = () => {
                         className="u-align--right"
                         style={{ paddingRight: "1rem" }}
                       >
-                        {examElement.private
+                        {examElement.price === undefined
                           ? "Coming Soon!"
                           : "Price: " +
                             currencyFormatter.format(
@@ -171,7 +170,7 @@ const CredExamShop = () => {
                   checked={exam == examIndex}
                   value={examIndex}
                   onChange={handleChange}
-                  disabled={examElement.private}
+                  disabled={examElement.price === undefined}
                 />
                 <span>
                   <p style={{ paddingLeft: "1rem", paddingRight: "1rem" }}>
@@ -183,7 +182,7 @@ const CredExamShop = () => {
                     className="u-align--right"
                     style={{ paddingRight: "1rem" }}
                   >
-                    {examElement.private
+                    {examElement.price === undefined
                       ? "Coming Soon!"
                       : "Price: " +
                         currencyFormatter.format(examElement.price.value / 100)}
@@ -209,7 +208,7 @@ const CredExamShop = () => {
           <Col size={3} small={2} style={{ display: "flex" }}>
             <p className="p-heading--2" style={{ marginBlock: "auto" }}>
               {currencyFormatter.format(
-                (ExamProducts[exam]?.price.value ?? 0) / 100 ?? 0
+                (ExamProducts[exam]?.price?.value ?? 0) / 100 ?? 0
               )}
             </p>
           </Col>

--- a/static/js/src/advantage/credentials/components/CredKeyShop/CredKeyShop.tsx
+++ b/static/js/src/advantage/credentials/components/CredKeyShop/CredKeyShop.tsx
@@ -48,7 +48,11 @@ const CredKeyShop = () => {
     location.href = "/account/checkout";
   };
   useEffect(() => {
-    setCUEExamKey(keyProducts?.find((product: Product) => product.id === "cue-activation-key"));
+    setCUEExamKey(
+      keyProducts?.find(
+        (product: Product) => product.id === "cue-activation-key"
+      )
+    );
   }, [keyProducts]);
   return (
     <>
@@ -95,9 +99,19 @@ const CredKeyShop = () => {
             )}
           </Col>
           <Col size={3}>
-            {isLoading?<Button appearance="positive"><Spinner></Spinner></Button>:<Button appearance="positive" type="submit" onClick={handleSubmit}>
-              Buy Now
-            </Button>}
+            {isLoading ? (
+              <Button appearance="positive">
+                <Spinner></Spinner>
+              </Button>
+            ) : (
+              <Button
+                appearance="positive"
+                type="submit"
+                onClick={handleSubmit}
+              >
+                Buy Now
+              </Button>
+            )}
           </Col>
         </Row>
       </section>

--- a/static/js/src/advantage/credentials/components/CredKeyShop/CredKeyShop.tsx
+++ b/static/js/src/advantage/credentials/components/CredKeyShop/CredKeyShop.tsx
@@ -12,7 +12,7 @@ import { currencyFormatter } from "advantage/react/utils";
 const CredKeyShop = () => {
   const CUEExamKey = {
     id: "cue-activation-key",
-    longId: "lAMGrt4buzUR0-faJqg-Ot6dgNLn7ubIpWiyDgOrsDCg",
+    longId: "lAEPoNKYCFgZGmddQXplCtcnf5wMpYUXloGygjPK3y0E",
     name: "CUE Activation Key",
     price: { value: 4900, currency: "USD" },
     productID: "cue-activation-key",

--- a/static/js/src/advantage/credentials/components/CredKeyShop/CredKeyShop.tsx
+++ b/static/js/src/advantage/credentials/components/CredKeyShop/CredKeyShop.tsx
@@ -1,25 +1,26 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import {
   Button,
   Col,
   Form,
   Input,
   Row,
+  Spinner,
   Strip,
 } from "@canonical/react-components";
 import { currencyFormatter } from "advantage/react/utils";
+import { getKeyProducts } from "advantage/credentials/api/keys";
+import { Product } from "advantage/subscribe/checkout/utils/types";
+import { useQuery } from "react-query";
 
 const CredKeyShop = () => {
-  const CUEExamKey = {
-    id: "cue-activation-key",
-    longId: "lAEPoNKYCFgZGmddQXplCtcnf5wMpYUXloGygjPK3y0E",
-    name: "CUE Activation Key",
-    price: { value: 4900, currency: "USD" },
-    productID: "cue-activation-key",
-    canBeTrialled: false,
-    private: false,
-    marketplace: "canonical-cube",
-  };
+  const { isLoading, data: keyProducts } = useQuery(
+    ["KeyProducts"],
+    async () => {
+      return getKeyProducts();
+    }
+  );
+  const [CUEExamKey, setCUEExamKey] = useState<Product | null>(null);
   const checkoutData = localStorage.getItem("shop-checkout-data") || "{}";
   const parsedCheckoutData = JSON.parse(checkoutData);
   const initQuantity: number = parsedCheckoutData?.quantity;
@@ -46,6 +47,9 @@ const CredKeyShop = () => {
     );
     location.href = "/account/checkout";
   };
+  useEffect(() => {
+    setCUEExamKey(keyProducts?.find((product: Product) => product.id === "cue-activation-key"));
+  }, [keyProducts]);
   return (
     <>
       <Strip>
@@ -91,9 +95,9 @@ const CredKeyShop = () => {
             )}
           </Col>
           <Col size={3}>
-            <Button appearance="positive" type="submit" onClick={handleSubmit}>
+            {isLoading?<Button appearance="positive"><Spinner></Spinner></Button>:<Button appearance="positive" type="submit" onClick={handleSubmit}>
               Buy Now
-            </Button>
+            </Button>}
           </Col>
         </Row>
       </section>

--- a/static/js/src/advantage/credentials/components/CredWebhookResponses/CredWebhookResponses.tsx
+++ b/static/js/src/advantage/credentials/components/CredWebhookResponses/CredWebhookResponses.tsx
@@ -20,7 +20,6 @@ type WebhookResponse = {
 const CredWebhookResponses = () => {
   const [searchParams] = useSearchParams();
   const page = parseInt(searchParams.get("page") || "1");
-  console.log(page);
   const { data } = useQuery(["WebhookResponses"], async () => {
     return getFilteredWebhookResponses("4190", page);
   });
@@ -30,7 +29,6 @@ const CredWebhookResponses = () => {
     if (data && data["webhook_responses"]) {
       changeTableData(data["webhook_responses"]);
     }
-    console.log(data);
   }, [data]);
 
   return (

--- a/static/js/src/advantage/credentials/utils/utils.ts
+++ b/static/js/src/advantage/credentials/utils/utils.ts
@@ -1,0 +1,13 @@
+import { UserSubscriptionMarketplace } from "advantage/api/enum";
+
+export type Product = {
+  longId?: string;
+  name: string;
+  price?: {
+    value: number;
+    currency: string;
+  };
+  id: string;
+  marketplace?: UserSubscriptionMarketplace;
+  metadata: Array<{ key: string; value: string }>;
+};

--- a/static/js/src/advantage/subscribe/blender/utils/utils.ts
+++ b/static/js/src/advantage/subscribe/blender/utils/utils.ts
@@ -29,6 +29,7 @@ export type Product = {
   id: ProductIDs;
   productID: string;
   marketplace: UserSubscriptionMarketplace;
+  metadata?: Array<{ key: string; value: string }>;
 };
 
 export type ProductListings = {

--- a/static/js/src/advantage/subscribe/blender/utils/utils.ts
+++ b/static/js/src/advantage/subscribe/blender/utils/utils.ts
@@ -29,7 +29,6 @@ export type Product = {
   id: ProductIDs;
   productID: string;
   marketplace: UserSubscriptionMarketplace;
-  metadata?: Array<{ key: string; value: string }>;
 };
 
 export type ProductListings = {

--- a/templates/credentials/index.html
+++ b/templates/credentials/index.html
@@ -23,12 +23,10 @@ endblock meta_copydoc %} {% block content %}
       </p>
       <p>
         {% if user_purchasing %}
-        <a href="/credentials/shop">
-          <button class="p-button--positive">Get your exam now!</button>
+        <a href="/credentials/shop" class="p-button--positive">Get started on your exam journey!
         </a>
         {% endif %} {% if enterprise_purchasing %}
-        <a href="/credentials/shop/keys">
-          <button class="p-button is-dark">Buy exam attempts</button>
+        <a href="/credentials/shop/keys" class="p-button">Buy exams in bulk
         </a>
         {% endif %} {% if not user_purchasing and not enterprise_purchasing %}
         <i>

--- a/templates/credentials/index.html
+++ b/templates/credentials/index.html
@@ -21,20 +21,22 @@ endblock meta_copydoc %} {% block content %}
         Find the shortest path to your passion. Develop and certify your skills
         on the world's most popular Linux OS.
       </p>
-      {% if can_purchase %}
       <p>
-        <a href="/credentials/shop"
-          ><button class="p-button--positive">Get your exam now!</button></a
-        >
-      </p>
-      {% else %}
-      <p>
+        {% if user_purchasing %}
+        <a href="/credentials/shop">
+          <button class="p-button--positive">Get your exam now!</button>
+        </a>
+        {% endif %} {% if enterprise_purchasing %}
+        <a href="/credentials/shop/keys">
+          <button class="p-button is-dark">Buy exam attempts</button>
+        </a>
+        {% endif %} {% if not user_purchasing and not enterprise_purchasing %}
         <i>
           Sign-ups for the CUE.01: Linux beta are now closed. Please check back
           for future announcements and beta opportunities.
         </i>
+        {% endif %}
       </p>
-      {% endif %}
     </div>
   </div>
 </section>
@@ -136,9 +138,13 @@ endblock meta_copydoc %} {% block content %}
               >Syllabus&nbsp;›</a
             >
           </div>
-          {% if can_purchase %}
+          {% if user_purchasing %}
           <div class="col-2">
             <a href="/credentials/shop">Take now&nbsp;›</a>
+          </div>
+          {% endif %} {% if enterprise_purchasing %}
+          <div class="col-2">
+            <a href="/credentials/shop/keys">Buy exam attempts&nbsp;›</a>
           </div>
           {% endif %}
         </div>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -81,10 +81,9 @@ from webapp.shop.cred.views import (
     cred_syllabus_data,
     cred_your_exams,
     get_activation_keys,
-    get_exam_products,
+    get_cue_products,
     get_filtered_webhook_responses,
     get_issued_badges,
-    get_key_products,
     get_my_issued_badges,
     get_webhook_response,
     issue_badges,
@@ -1133,7 +1132,9 @@ app.add_url_rule("/credentials/cancel-exam", view_func=cred_cancel_exam)
 app.add_url_rule("/credentials/assessments", view_func=cred_assessments)
 app.add_url_rule("/credentials/exam", view_func=cred_exam)
 app.add_url_rule(
-    "/credentials/exam/products", view_func=get_exam_products, methods=["GET"]
+    "/credentials/<string:type>/products",
+    view_func=get_cue_products,
+    methods=["GET"],
 )
 app.add_url_rule(
     "/credentials/exit-survey",
@@ -1164,9 +1165,6 @@ app.add_url_rule(
     "/credentials/keys/activate",
     view_func=activate_activation_key,
     methods=["POST"],
-)
-app.add_url_rule(
-    "/credentials/keys/products", view_func=get_key_products, methods=["GET"]
 )
 app.add_url_rule(
     "/credentials/beta/activation",

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -81,6 +81,7 @@ from webapp.shop.cred.views import (
     cred_syllabus_data,
     cred_your_exams,
     get_activation_keys,
+    get_exam_products,
     get_filtered_webhook_responses,
     get_issued_badges,
     get_key_products,
@@ -1131,6 +1132,9 @@ app.add_url_rule("/credentials/your-exams", view_func=cred_your_exams)
 app.add_url_rule("/credentials/cancel-exam", view_func=cred_cancel_exam)
 app.add_url_rule("/credentials/assessments", view_func=cred_assessments)
 app.add_url_rule("/credentials/exam", view_func=cred_exam)
+app.add_url_rule(
+    "/credentials/exam/products", view_func=get_exam_products, methods=["GET"]
+)
 app.add_url_rule(
     "/credentials/exit-survey",
     view_func=cred_submit_form,

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -83,6 +83,7 @@ from webapp.shop.cred.views import (
     get_activation_keys,
     get_filtered_webhook_responses,
     get_issued_badges,
+    get_key_products,
     get_my_issued_badges,
     get_webhook_response,
     issue_badges,
@@ -1159,6 +1160,9 @@ app.add_url_rule(
     "/credentials/keys/activate",
     view_func=activate_activation_key,
     methods=["POST"],
+)
+app.add_url_rule(
+    "/credentials/keys/products", view_func=get_key_products, methods=["GET"]
 )
 app.add_url_rule(
     "/credentials/beta/activation",

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -734,3 +734,22 @@ def get_key_products(ua_contracts_api, **kwargs):
         if listing["productID"].endswith("key")
     ]
     return flask.jsonify(key_products)
+
+
+@shop_decorator(area="cred", permission="user", response="json")
+def get_exam_products(ua_contracts_api, **kwargs):
+    listings = ua_contracts_api.get_product_listings("canonical-cube").get(
+        "productListings"
+    )
+    exam_products = [
+        {
+            "id": listing["productID"],
+            "longId": listing["id"],
+            "period": listing["period"],
+            "marketplace": listing["marketplace"],
+            "name": listing["name"],
+            "price": listing["price"],
+        }
+        for listing in listings
+    ]
+    return flask.jsonify(exam_products)

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -714,3 +714,23 @@ def issue_badges(trueability_api, credly_api, **kwargs):
             return (flask.jsonify(new_badge), 500)
     # 403 Forbidden. Request was valid but the server is refusing action
     return flask.jsonify({"status": "badge_not_issued"}), 403
+
+
+@shop_decorator(area="cred", permission="user", response="json")
+def get_key_products(ua_contracts_api, **kwargs):
+    listings = ua_contracts_api.get_product_listings("canonical-cube").get(
+        "productListings"
+    )
+    key_products = [
+        {
+            "id": listing["productID"],
+            "longId": listing["id"],
+            "period": listing["period"],
+            "marketplace": listing["marketplace"],
+            "name": listing["name"],
+            "price": listing["price"],
+        }
+        for listing in listings
+        if listing["productID"].endswith("key")
+    ]
+    return flask.jsonify(key_products)

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -46,12 +46,18 @@ def cred_home(ua_contracts_api, **_):
     available_products = ua_contracts_api.get_product_listings(
         "canonical-cube"
     ).get("productListings")
+    user_purchasing = False
+    enterprise_purchasing = False
     for product in available_products:
         if product.get("name") == "CUE Linux Essentials":
-            return flask.render_template(
-                "credentials/index.html", can_purchase=True
-            )
-    return flask.render_template("credentials/index.html", can_purchase=False)
+            user_purchasing = True
+        if product.get("name") == "CUE Activation Key":
+            enterprise_purchasing = True
+    return flask.render_template(
+        "credentials/index.html",
+        user_purchasing=user_purchasing,
+        enterprise_purchasing=enterprise_purchasing,
+    )
 
 
 @shop_decorator(area="cred", permission="user_or_guest", response="html")

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -717,11 +717,11 @@ def issue_badges(trueability_api, credly_api, **kwargs):
 
 
 @shop_decorator(area="cred", permission="user", response="json")
-def get_key_products(ua_contracts_api, **kwargs):
+def get_cue_products(ua_contracts_api, type, **kwargs):
     listings = ua_contracts_api.get_product_listings("canonical-cube").get(
         "productListings"
     )
-    key_products = [
+    filtered_products = [
         {
             "id": listing["productID"],
             "longId": listing["id"],
@@ -731,25 +731,7 @@ def get_key_products(ua_contracts_api, **kwargs):
             "price": listing["price"],
         }
         for listing in listings
-        if listing["productID"].endswith("key")
+        if (listing["productID"].endswith("key") and type == "keys")
+        or (type == "exam")
     ]
-    return flask.jsonify(key_products)
-
-
-@shop_decorator(area="cred", permission="user", response="json")
-def get_exam_products(ua_contracts_api, **kwargs):
-    listings = ua_contracts_api.get_product_listings("canonical-cube").get(
-        "productListings"
-    )
-    exam_products = [
-        {
-            "id": listing["productID"],
-            "longId": listing["id"],
-            "period": listing["period"],
-            "marketplace": listing["marketplace"],
-            "name": listing["name"],
-            "price": listing["price"],
-        }
-        for listing in listings
-    ]
-    return flask.jsonify(exam_products)
+    return flask.jsonify(filtered_products)


### PR DESCRIPTION
## Done

- Reopening the keys shop when the CUE Activation Keys go live in production.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to /credentials
    - There will be two buttons for individual exams and keys
- Change the CONTRACTS_API_URL to production in `.env.local`
    - Restart dotrun
    - Go to /credentials again
    - There should be a text in italics as things are not in production yet 

## Issue / Card

Fixes [#WD-5840](https://warthogs.atlassian.net/browse/WD-5840)

## Screenshots

### In Staging

![image](https://github.com/canonical/ubuntu.com/assets/30973042/832abaab-5eef-4a8c-b58f-0d063c7bcf06)
![image](https://github.com/canonical/ubuntu.com/assets/30973042/7315fdf4-eec6-4e4a-9a3a-524cb2f6c033)

### In Produciton
![image](https://github.com/canonical/ubuntu.com/assets/30973042/d43a0b6c-f88c-461c-98f1-0feb65a9ccb5)
![image](https://github.com/canonical/ubuntu.com/assets/30973042/0feac766-ed3f-4a08-88bf-f2d2bbb996b4)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
