### PR TITLE
Update CTA roadshow.html

### DIFF
--- a/templates/ai/roadshow.html
+++ b/templates/ai/roadshow.html
@@ -22,7 +22,7 @@
         <p>From the USA to the Netherlands, from UAE to Mexico, Canonical experts are going on an AI roadshow across the globe. We are ready to showcase LLMs applications and predictive analytics use cases across various industries. Get answers to your most common AI/ML questions and talk to our team about big data, MLOps and generative AI use cases with open source.</p>
         <p>
           <a href="#find-us" class="p-button--positive">Check where to find us</a>
-          <a href="https://calendly.com/andreea-munteanu-1/canonical-ai-roadshow" class="p-button">Book a meeting</a>
+          <a href="https://ubuntu.com/ai/contact-us?product=ai-index" class="p-button">Get in touch</a>
         </p>
       </div>
       <div class="col-12 is-paper__image--container u-align--center u-hide--small">
@@ -424,7 +424,7 @@
       <div class="col-12">
         <div class="p-block">
           <p class="p-heading--2 u-no-margin--bottom">
-            To join us at an event, <a href="https://calendly.com/andreea-munteanu-1/canonical-ai-roadshow">book a meeting</a><br />
+            To join us at an event, <a href="https://ubuntu.com/ai/contact-us?product=ai-index">contact us now.</a><br />
             For future AI events, contact <a href="mailto:pr@canonical.com">pr@canonical.com</a>
           </p>
         </div>

--- a/templates/ai/roadshow.html
+++ b/templates/ai/roadshow.html
@@ -22,7 +22,7 @@
         <p>From the USA to the Netherlands, from UAE to Mexico, Canonical experts are going on an AI roadshow across the globe. We are ready to showcase LLMs applications and predictive analytics use cases across various industries. Get answers to your most common AI/ML questions and talk to our team about big data, MLOps and generative AI use cases with open source.</p>
         <p>
           <a href="#find-us" class="p-button--positive">Check where to find us</a>
-          <a href="https://ubuntu.com/ai/contact-us?product=ai-index" class="p-button">Get in touch</a>
+          <a href="https://calendly.com/andreea-munteanu-1/canonical-ai-roadshow" class="p-button">Book a meeting</a>
         </p>
       </div>
       <div class="col-12 is-paper__image--container u-align--center u-hide--small">


### PR DESCRIPTION
I updated the calendly link to a contact form https://ubuntu.com/ai/contact-us?product=ai-index

## Done

- Update in the copy the https://ubuntu.com/ai/contact-us?product=ai-index (from the Calendly one) and copy from _Book a meeting_ to _Get in touch_
 
## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

Deployed and checked locally
