### PR TITLE
[copy update] WD-5923 - Quick Fix (Remove image underneath header)

### DIFF
--- a/templates/ai/roadshow.html
+++ b/templates/ai/roadshow.html
@@ -25,17 +25,6 @@
           <a href="https://calendly.com/andreea-munteanu-1/canonical-ai-roadshow" class="p-button">Book a meeting</a>
         </p>
       </div>
-      <div class="col-12 is-paper__image--container u-align--center u-hide--small">
-        {{ image (
-          url="https://assets.ubuntu.com/v1/62b68b29-Canonical%20AI%20ML%20Illustrations%20v5-01.svg",
-          alt="",
-          width="625",
-          height="351",
-          hi_def=True,
-          loading="auto"
-          ) | safe
-        }}
-      </div>
     </div>
   </section>
 


### PR DESCRIPTION
## Done

- Remove the image underneath the header on `/ai/roadshow`.

## QA

- Check out [the demo here](url) and confirm that the image has been removed, as requested in [this comment](https://warthogs.atlassian.net/browse/WD-5923?focusedCommentId=307558).

## Issue / Card

- [WD-5923](https://warthogs.atlassian.net/browse/WD-5923)
- Quick fix for changes previously merged for in #13117

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
