### PR TITLE
Update /kernel/lifecycle with most recent changes

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -456,7 +456,7 @@ export var kernelReleases2204 = [
   {
     startDate: new Date("2023-08-16T00:00:00"),
     endDate: new Date("2024-02-18T00:00:00"),
-    taskName: "Ubuntu 20.04.3 LTS (v6.2)",
+    taskName: "Ubuntu 22.04.3 LTS (v6.2)",
     status: "LTS",
   },
 ];
@@ -1769,7 +1769,7 @@ export var kernelReleaseNames2204 = [
   "Ubuntu 22.04.0 LTS (v5.15)",
   "Ubuntu 22.04.1 LTS (v5.15)",
   "Ubuntu 22.04.2 LTS (v5.19)",
-  "Ubuntu 20.04.3 LTS (v6.2)",
+  "Ubuntu 22.04.3 LTS (v6.2)",
 ];
 
 export var kernelReleaseNames2004 = [

--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -451,13 +451,13 @@ export var kernelReleases2204 = [
     startDate: new Date("2023-02-17T00:00:00"),
     endDate: new Date("2023-07-22T00:00:00"),
     taskName: "Ubuntu 22.04.2 LTS (v5.19)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2023-08-16T00:00:00"),
     endDate: new Date("2024-02-18T00:00:00"),
     taskName: "Ubuntu 20.04.3 LTS (v6.2)",
-    status: "LTS"
+    status: "LTS",
   },
 ];
 
@@ -928,13 +928,13 @@ export var kernelReleasesALL = [
     startDate: new Date("2023-02-01T00:00:00"),
     endDate: new Date("2023-07-01T00:00:00"),
     taskName: "Ubuntu 22.04.2 LTS (v5.19)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2023-08-01T00:00:00"),
     endDate: new Date("2024-01-01T00:00:00"),
     taskName: "Ubuntu 22.04.3 LTS (v6.2)",
-    status: "LTS"
+    status: "LTS",
   },
 ];
 
@@ -1189,13 +1189,13 @@ export var kernelReleasesLTS = [
     startDate: new Date("2023-02-01T00:00:00"),
     endDate: new Date("2023-07-01T00:00:00"),
     taskName: "Ubuntu 22.04.2 LTS (v5.19)",
-    status: "LTS"
+    status: "LTS",
   },
   {
     startDate: new Date("2023-08-01T00:00:00"),
     endDate: new Date("2024-01-01T00:00:00"),
     taskName: "Ubuntu 22.04.3 LTS (v6.2)",
-    status: "LTS"
+    status: "LTS",
   },
 ];
 

--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -450,8 +450,14 @@ export var kernelReleases2204 = [
   {
     startDate: new Date("2023-02-17T00:00:00"),
     endDate: new Date("2023-07-22T00:00:00"),
-    taskName: "Ubuntu 22.04.3 LTS (v5.19)",
-    status: "LTS",
+    taskName: "Ubuntu 22.04.2 LTS (v5.19)",
+    status: "LTS"
+  },
+  {
+    startDate: new Date("2023-08-16T00:00:00"),
+    endDate: new Date("2024-02-18T00:00:00"),
+    taskName: "Ubuntu 20.04.3 LTS (v6.2)",
+    status: "LTS"
   },
 ];
 
@@ -921,8 +927,14 @@ export var kernelReleasesALL = [
   {
     startDate: new Date("2023-02-01T00:00:00"),
     endDate: new Date("2023-07-01T00:00:00"),
-    taskName: "Ubuntu 22.04.3 LTS (v5.19)",
-    status: "LTS",
+    taskName: "Ubuntu 22.04.2 LTS (v5.19)",
+    status: "LTS"
+  },
+  {
+    startDate: new Date("2023-08-01T00:00:00"),
+    endDate: new Date("2024-01-01T00:00:00"),
+    taskName: "Ubuntu 22.04.3 LTS (v6.2)",
+    status: "LTS"
   },
 ];
 
@@ -1176,8 +1188,14 @@ export var kernelReleasesLTS = [
   {
     startDate: new Date("2023-02-01T00:00:00"),
     endDate: new Date("2023-07-01T00:00:00"),
-    taskName: "Ubuntu 22.04.3 LTS (v5.19)",
-    status: "LTS",
+    taskName: "Ubuntu 22.04.2 LTS (v5.19)",
+    status: "LTS"
+  },
+  {
+    startDate: new Date("2023-08-01T00:00:00"),
+    endDate: new Date("2024-01-01T00:00:00"),
+    taskName: "Ubuntu 22.04.3 LTS (v6.2)",
+    status: "LTS"
   },
 ];
 
@@ -1750,7 +1768,8 @@ export var kernelVersionNames = [
 export var kernelReleaseNames2204 = [
   "Ubuntu 22.04.0 LTS (v5.15)",
   "Ubuntu 22.04.1 LTS (v5.15)",
-  "Ubuntu 22.04.3 LTS (v5.19)",
+  "Ubuntu 22.04.2 LTS (v5.19)",
+  "Ubuntu 20.04.3 LTS (v6.2)",
 ];
 
 export var kernelReleaseNames2004 = [
@@ -1816,7 +1835,8 @@ export var kernelReleaseNamesALL = [
   "Ubuntu 22.04.0 LTS (v5.15)",
   "Ubuntu 20.04.5 LTS (v5.15)",
   "Ubuntu 22.04.1 LTS (v5.15)",
-  "Ubuntu 22.04.3 LTS (v5.19)",
+  "Ubuntu 22.04.2 LTS (v5.19)",
+  "Ubuntu 22.04.3 LTS (v6.2)",
 ];
 
 export var kernelReleaseNamesLTS = [
@@ -1846,7 +1866,8 @@ export var kernelReleaseNamesLTS = [
   "Ubuntu 22.04.0 LTS (v5.15)",
   "Ubuntu 20.04.5 LTS (v5.15)",
   "Ubuntu 22.04.1 LTS (v5.15)",
-  "Ubuntu 22.04.3 LTS (v5.19)",
+  "Ubuntu 22.04.2 LTS (v5.19)",
+  "Ubuntu 22.04.3 LTS (v6.2)",
 ];
 
 export var openStackReleaseNames = [


### PR DESCRIPTION
## Done

**I have shared the demo link with Brett and will wait for his approval before merging.**

- Updates the graphs `All releases`, `All LTS releases` and `22.04 LTS` with latest data from [the spreadsheet](https://docs.google.com/spreadsheets/d/1KIuOAa620yseE0uhIl67u2SlS0bWlPI_d98bvYM2Yl8/edit#gid=1844838308)

## QA

- Check that the data displayed in [the demo](https://ubuntu-com-13147.demos.haus/kernel/lifecycle) matches that in the spreadsheets and addresses the issues described in the original issue

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-5048