### PR TITLE
Fix broken tutorials styling in Vanilla 4

### DIFF
--- a/static/sass/_layout-tutorial.scss
+++ b/static/sass/_layout-tutorial.scss
@@ -41,7 +41,7 @@
   }
 
   .l-tutorial__nav-title {
-    // recreate circle styling from Vanilla 3.0, to unlock Vanilla 4.0 migation
+    // recreate circle styling from Vanilla 3.0, to unblock Vanilla 4.0 migation
     // FIXME: Vanilla 4.0 doesn't use circled steps, so this needs to be redesigned and updated, possibly to use standard side navigation
     &::before {
       border: 1px solid $colors--light-theme--text-default;
@@ -59,8 +59,8 @@
       font-weight: 400;
 
       &::before {
-        background-color: $color-brand;
-        color: $color-x-light;
+        background-color: $colors--light-theme--text-default;
+        color: $colors--dark-theme--text-default;
         font-weight: 300;
       }
     }

--- a/static/sass/_layout-tutorial.scss
+++ b/static/sass/_layout-tutorial.scss
@@ -37,22 +37,32 @@
   }
 
   .l-tutorial__nav-item {
-    padding-bottom: $spv--small;
-
-    &.is-active {
-      @include vf-highlight-bar($colors--light-theme--text-default, left);
-
-      background-color: $colors--light-theme--background-active;
-    }
+    padding-bottom: $sp-medium;
   }
 
   .l-tutorial__nav-title {
-    margin-bottom: 0;
-
+    // recreate circle styling from Vanilla 3.0, to unlock Vanilla 4.0 migation
+    // FIXME: Vanilla 4.0 doesn't use circled steps, so this needs to be redesigned and updated, possibly to use standard side navigation
     &::before {
+      border: 1px solid $colors--light-theme--text-default;
+      border-radius: 50%;
+      content: counter(li);
       height: $sp-large;
+      // line height is calculated to vertically center the number, which is size of the circle minus the border
+      line-height: calc($sp-large - 2px);
       margin-right: $sp-medium;
+      text-align: center;
       width: $sp-large;
+    }
+
+    .is-active & {
+      font-weight: 400;
+
+      &::before {
+        background-color: $color-brand;
+        color: $color-x-light;
+        font-weight: 300;
+      }
     }
   }
 

--- a/static/sass/_layout-tutorial.scss
+++ b/static/sass/_layout-tutorial.scss
@@ -37,24 +37,22 @@
   }
 
   .l-tutorial__nav-item {
-    padding-bottom: $sp-medium;
+    padding-bottom: $spv--small;
+
+    &.is-active {
+      @include vf-highlight-bar($colors--light-theme--text-default, left);
+
+      background-color: $colors--light-theme--background-active;
+    }
   }
 
   .l-tutorial__nav-title {
+    margin-bottom: 0;
+
     &::before {
       height: $sp-large;
       margin-right: $sp-medium;
       width: $sp-large;
-    }
-
-    .is-active & {
-      font-weight: 400;
-
-      &::before {
-        background-color: $color-brand;
-        color: $color-x-light;
-        font-weight: 300;
-      }
     }
   }
 

--- a/templates/tutorials/tutorial.html
+++ b/templates/tutorials/tutorial.html
@@ -26,7 +26,7 @@
     <ol class="l-tutorial__nav p-stepped-list u-hide--small" id="menu-tutorial">
       {% for section in document.sections %}
         <li class="p-stepped-list__item l-tutorial__nav-item">
-          <p class="p-stepped-list__title l-tutorial__nav-title u-no-margin--bottom">
+          <p class="p-stepped-list__title l-tutorial__nav-title">
             <a class="l-tutorial__nav-link" href="#{{ loop.index }}-{{ section['slug'] }}">
               {{ section["title"]}}
             </a>

--- a/templates/tutorials/tutorial.html
+++ b/templates/tutorials/tutorial.html
@@ -26,7 +26,7 @@
     <ol class="l-tutorial__nav p-stepped-list u-hide--small" id="menu-tutorial">
       {% for section in document.sections %}
         <li class="p-stepped-list__item l-tutorial__nav-item">
-          <p class="p-stepped-list__title l-tutorial__nav-title">
+          <p class="p-stepped-list__title l-tutorial__nav-title u-no-margin--bottom">
             <a class="l-tutorial__nav-link" href="#{{ loop.index }}-{{ section['slug'] }}">
               {{ section["title"]}}
             </a>


### PR DESCRIPTION
## Done

In Vanilla 4 we removed circles from stepped list counters.
Tutorials had custom styles that used the stepped list counters and changed their colour for active tutorial step. This became broken in Vanilla 4.0, because there are no circles to highlight anymore.

As a workaround this PR recreates similar circle styling locally in ubuntu.com. 
But eventually this should be addressed while rebranding tutorials by changing stepped list to better component for side navigation.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to any tutorial, make sure steps navigation doesn't look broken:
  - https://ubuntu-com-13150.demos.haus/tutorials/how-to-upgrade-ubuntu-lts-to-ubuntu-pro-on-aws-using-aws-license-manager#1-overview


## Screenshots

Before, in Vanilla 3.0 (https://ubuntu.com/tutorials/how-to-upgrade-ubuntu-lts-to-ubuntu-pro-on-aws-using-aws-license-manager#1-overview)

<img width="1542" alt="image" src="https://github.com/canonical/ubuntu.com/assets/83575/61505c66-fdc8-4d28-99d1-6cc784a6f7d4">


Broken after applying Vanilla 4.0 (https://ubuntu-com-13131.demos.haus/tutorials/how-to-upgrade-ubuntu-lts-to-ubuntu-pro-on-aws-using-aws-license-manager#1-overview)
<img width="1542" alt="image" src="https://github.com/canonical/ubuntu.com/assets/83575/3e21006c-d909-46b8-9620-eb4d916ae63d">

Fixed by this PR (https://ubuntu-com-13150.demos.haus/tutorials/how-to-upgrade-ubuntu-lts-to-ubuntu-pro-on-aws-using-aws-license-manager#1-overview)

<img width="1325" alt="image" src="https://github.com/canonical/ubuntu.com/assets/83575/bf1e9061-b148-4a1d-80c8-928490d5a4ad">





## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
