### PR TITLE
Final fixes for /ai bubble refresh

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -206,7 +206,7 @@ ai:
       path: /ai
     - title: MLOps
       path: /ai/mlops
-    - title: What is Kubeflow
+    - title: Kubeflow
       path: /ai/what-is-kubeflow
     - title: MLflow
       path: /ai/mlflow

--- a/static/sass/_pattern_ai.scss
+++ b/static/sass/_pattern_ai.scss
@@ -28,26 +28,4 @@
       }
     }
   }
-
-  .ai-logos {
-    .p-logo-section__items {
-      justify-content: space-between;
-    }
-
-    .p-logo-section__item {
-      max-width: fit-content;
-    }
-
-    .p-logo-section__logo {
-      height: 8rem;
-
-      @media screen and (min-width: $breakpoint-small) and (max-width: $breakpoint-large - 1) {
-        height: 4rem;
-      }
-
-      @media screen and (max-width: $breakpoint-small - 1) {
-        height: auto;
-      }
-    }
-  }
 }

--- a/templates/ai/index.html
+++ b/templates/ai/index.html
@@ -57,7 +57,7 @@
     <h2>Develop artificial intelligence projects on any environment</h2>
   </div>
   <div class="u-fixed-width">
-    <div class="p-logo-section ai-logos">
+    <div class="p-logo-section">
       <div class="p-logo-section__items">
         <div class="p-logo-section__item">
           {{ image (

--- a/templates/ai/mlflow.html
+++ b/templates/ai/mlflow.html
@@ -188,7 +188,7 @@
     </div>
     <div class="col">
       <div class="p-strip is-shallow">
-        <img src="https://assets.ubuntu.com/v1/b21b2f8a-ai-mlflow.svg">
+        <img src="https://assets.ubuntu.com/v1/b21b2f8a-ai-mlflow.svg" alt="MLflow">
       </div>
       <p>Run Charmed MLflow on any environment. The machine learning platform is made for everyone &ndash; from enthusiasts who are just getting started to enterprises running workloads at scale.</p>
       <div class="p-section--shallow">
@@ -320,7 +320,7 @@
 </section>
 <!-- Set default Marketo information for contact form below-->
 <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/ai" data-form-id="3231" data-lp-id="6279" data-return-url="https://ubuntu.com/ai/thank-you?product=ai-managed" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
-
+</div>
 <script src="/static/js/src/ai-form.js"></script>
 {% endblock content %}
     

--- a/templates/ai/mlflow.html
+++ b/templates/ai/mlflow.html
@@ -43,7 +43,7 @@
     <hr class="p-rule">
     <div class="col">
       <div class="p-section--shallow">
-        <h2>Get the features <br class="u-hide--small">upstream MLflow</h2>
+        <h2>Get the features of<br class="u-hide--small">upstream MLflow</h2>
       </div>
     </div>
     <div class="col">
@@ -74,7 +74,7 @@
       </div>
     </div>
     <div class="col">
-      <p>In addition to upstream features, Charmed MLflow also includes:</p>
+      <p>In addition to upstream features, Charmed MLflow includes:</p>
       <div class="p-section--shallow">
         <hr class="p-rule is-muted">
         <ul class="p-list--divided">
@@ -107,28 +107,32 @@
           }}
         </div>
         <div class="p-logo-section__item">
-          {{ image (
-            url="https://assets.ubuntu.com/v1/4f123dc2-apache-spark-logo.png",
-            alt="Apache Spark",
-            width="150",
-            height="256",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-logo-section__logo"},
-            ) | safe
-          }}
+          <a href="/data/spark">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/4f123dc2-apache-spark-logo.png",
+              alt="Apache Spark",
+              width="150",
+              height="256",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-logo-section__logo"},
+              ) | safe
+            }}
+          </a>
         </div>
         <div class="p-logo-section__item">
-          {{ image (
-            url="https://assets.ubuntu.com/v1/35962db5-kubeflow-logo.png",
-            alt="Kubeflow",
-            width="89",
-            height="256",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-logo-section__logo"},
-            ) | safe
-          }}
+          <a href="/ai/what-is-kubeflow">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/35962db5-kubeflow-logo.png",
+              alt="Kubeflow",
+              width="89",
+              height="256",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-logo-section__logo"},
+              ) | safe
+            }}
+          </a>
         </div>
         <div class="p-logo-section__item">
           {{ image (
@@ -155,16 +159,18 @@
           }}
         </div>
         <div class="p-logo-section__item">
-          {{ image (
-            url="https://assets.ubuntu.com/v1/8875229f-Juju-logo.png",
-            alt="Juju",
-            width="133",
-            height="256",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-logo-section__logo"},
-            ) | safe
-          }}
+          <a href="https://juju.is/">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/8875229f-Juju-logo.png",
+              alt="Juju",
+              width="133",
+              height="256",
+              hi_def=True,
+              loading="lazy",
+              attrs={"class": "p-logo-section__logo"},
+              ) | safe
+            }}
+          </a>
         </div>
       </div>
     </div>

--- a/templates/ai/what-is-kubeflow.html
+++ b/templates/ai/what-is-kubeflow.html
@@ -402,7 +402,7 @@
     <div class="col-6">
       <h2 class="u-fixed-width u-sv1">Who uses Kubeflow?</h2>
       <p>Thousands of companies have chosen Kubeflow for their AI/ML stack.</p>
-      <p>From research institutions like CERN, to transport and logistics companies - Uber, Lyft, GoJek - to financial and media industries with Spotify, Bloomberg, Shopify and PayPal.</p>
+      <p>From research institutions like CERN, to transport and logistics companies &ndash; Uber, Lyft, GoJek &ndash; to financial and media industries with Spotify, Bloomberg, Shopify and&nbsp;PayPal.</p>
       <p>Forward-looking enterprises are using Kubeflow to empower their data scientists.</p>
     </div>
  <div class="col-6 u-vertically-center">


### PR DESCRIPTION
## Done

- Addressed stakeholder feedback:
  - Fix typos, update Kubeflow title in subnav, update logos on landing to use base Vanilla, added missing links to MLflow logos (not all have links)

## QA

- View the site locally in your web browser at: https://ubuntu-com-13158.demos.haus/ai
    - Be sure to test on mobile, tablet and desktop screen sizes
- Click through the affected pages and make sure everything looks as expected
