### PR TITLE
[WD-5855] new page for confidential computing

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -322,7 +322,7 @@ support:
       path: /pricing/pro
     - title: Discourse
       path: https://discourse.ubuntu.com/c/ubuntu-pro
-      
+
 pro:
   title: Pro
   path: /pro

--- a/templates/confidential-computing/index.html
+++ b/templates/confidential-computing/index.html
@@ -18,7 +18,7 @@ privacy-enhancing technology strategy with Ubuntu confidential VMs on both publi
           </p>
         </div>
         <hr />
-        <a class="js-invoke-modal p-button--positive" href="/contact-us">Contact us</a>
+        <a class="js-invoke-modal p-button--positive" href="/contact-us">Contact us to learn more</a>
       </div>
     </div>
 
@@ -145,14 +145,14 @@ privacy-enhancing technology strategy with Ubuntu confidential VMs on both publi
                 url="https://assets.ubuntu.com/v1/2c479064-cloud-logo%201.svg",
                 alt="Google Cloud logo",
                 height="22",
-                width="129",
+                width="120",
                 hi_def=True,
                 loading="lazy" ) | safe
               }}
             </p>
           </div>
           <div class="col-4 col-medium-3 col-small-2">
-            <p><a href="https://ubuntu.com/blog/start-your-snp-vms-on-google-cloud">AMD SEV SNP with Ubuntu 22.04 LTS on Google Cloud</a></p>
+            <p><a href="/blog/start-your-snp-vms-on-google-cloud">AMD SEV SNP with Ubuntu 22.04 LTS on Google Cloud</a></p>
           </div>
         </div>
         <hr />
@@ -163,7 +163,7 @@ privacy-enhancing technology strategy with Ubuntu confidential VMs on both publi
                 url="https://assets.ubuntu.com/v1/8e5cc412-AWS.svg",
                 alt="AWS logo",
                 height="22",
-                width="40",
+                width="36",
                 hi_def=True,
                 loading="lazy" ) | safe
               }}
@@ -183,7 +183,7 @@ privacy-enhancing technology strategy with Ubuntu confidential VMs on both publi
     <div class="row">
       <div class="col-12">
         <p class="p-heading--2">
-          <a href="https://ubuntu.com/engage/introduction-confidential-computing">Download our guide to confidential computing ›</a>
+          <a href="/engage/introduction-confidential-computing">Download our guide to confidential computing ›</a>
         </p>
       </div>
     </div>
@@ -204,7 +204,7 @@ privacy-enhancing technology strategy with Ubuntu confidential VMs on both publi
           any platform with your data.
         </p>
         <p>
-          <a href="https://ubuntu.com/blog/build-foundation-zero-trust-strategy-ubuntu-confidential-computing">Learn
+          <a href="/blog/build-foundation-zero-trust-strategy-ubuntu-confidential-computing">Learn
             more about zero trust and confidential computing ›</a>
         </p>
       </div>
@@ -244,17 +244,17 @@ privacy-enhancing technology strategy with Ubuntu confidential VMs on both publi
       <div class="col">
         <ul class="p-list--divided u-no-margin--bottom">
           <li class="p-list__item">
-            <a href="https://ubuntu.com/blog/what-is-confidential-computing-a-high-level-explanation-for-cisos">What is
+            <a href="/blog/what-is-confidential-computing-a-high-level-explanation-for-cisos">What is
               confidential computing? A high-level explanation for CISOs</a>
           </li>
           <li class="p-list__item">
             <a
-              href="https://ubuntu.com/blog/confidential-computing-in-public-clouds-isolation-and-remote-attestation-explained">Confidential
+              href="/blog/confidential-computing-in-public-clouds-isolation-and-remote-attestation-explained">Confidential
               computing in public clouds: isolation and remote
               attestation explained</a>
           </li>
           <li class="p-list__item">
-            <a href="https://ubuntu.com/blog/cloud-cyber-security-with-ubuntu-pro-confidential-vms">Strengthen your cloud
+            <a href="/blog/cloud-cyber-security-with-ubuntu-pro-confidential-vms">Strengthen your cloud
               cyber security with Ubuntu Pro and confidential VMs</a>
           </li>
         </ul>
@@ -267,7 +267,7 @@ privacy-enhancing technology strategy with Ubuntu confidential VMs on both publi
   <div class="row">
     <div class="col-12">
       <p class="p-heading--2">
-        <a class="js-invoke-modal" href="">Contact us to discuss your use case ›</a>
+        <a class="js-invoke-modal" href="/contact-us">Contact us to discuss your use case ›</a>
       </p>
     </div>
   </div>

--- a/templates/confidential-computing/index.html
+++ b/templates/confidential-computing/index.html
@@ -7,10 +7,10 @@ privacy-enhancing technology strategy with Ubuntu confidential VMs on both publi
 
 {% block outer_content %}
 <div class="is-paper">
-  <section class="p-strip is-bordered">
+  <section class="p-strip is-shallow u-no-padding--bottom">
     <div class="row">
-      <div class="col-9 col-medium-4 col-start-large-4 col-start-medium-3">
-        <div class="p-section">
+      <div class="col-9 col-start-large-4">
+        <div class="p-section--shallow">
           <h1 class="u-no-margin--bottom">Ubuntu for confidential computing</h1>
           <p class="p-heading--2">
             Protect your data in use,
@@ -22,173 +22,167 @@ privacy-enhancing technology strategy with Ubuntu confidential VMs on both publi
       </div>
     </div>
 
-    <div class="u-fixed-width u-no-padding u-hide--medium u-hide--small">
+    <div class="u-fixed-width u-no-padding">
       <img src="https://assets.ubuntu.com/v1/7f34ade9-website_suru_25.jpg" alt=""
         style="aspect-ratio: 5.177570093457944; width: 100%" />
     </div>
+  </section>
 
+  <section class="p-section">
     <hr class="is-fixed-width" />
-
-    <div class="p-strip u-no-padding--top">
-      <div class="row--50-50">
-        <div class="col">
-          <h2>How confidential VMs work</h2>
-        </div>
-        <div class="col">
-          <p>
-            Confidential VMs introduce a new trust boundary which only includes
-            the software running within, and the platform’s hardware. All other
-            software outside is no longer part of your trusted computing base.
-          </p>
-          <div class="p-image__background--3-2 u-align--center u-vertically-center">
-            {{ image (
-              url="https://assets.ubuntu.com/v1/abd7bccf-Hypervisor%20diagram%203.png",
-              alt="Hypervisor diagram",
-              width="195",
-              height="282",
-              hi_def=True,
-              loading="lazy" ) | safe
-            }}
-          </div>
-          <p>
-            To provide such strong security guarantees, confidential computing
-            relies on two main primitives:
-          </p>
-        </div>
+    <div class="row--50-50">
+      <div class="col">
+        <h2>How confidential VMs work</h2>
       </div>
-      <div class="row">
-        <div class="col-9 col-start-large-4 col-medium-3 col-start-medium-4">
-          <hr class="p-rule" />
-          <div class="row">
-            <div class="col-3 col-medium-3">
-              <h3 class="p-heading-icon__title p-heading--5">1. Isolation</h3>
-            </div>
-            <div class="col-6 col-medium-3">
-              <p>
-                Confidential computing capable CPUs are equipped with an AES
-                hardware memory encryption engine, which encrypts data when it is
-                written to system memory, and decrypts it when read. The
-                encryption key itself is stored in the hardware root of trust and
-                is never exposed to the platform’s system software.
-              </p>
-            </div>
-          </div>
+      <div class="col">
+        <p>
+          Confidential VMs introduce a new trust boundary which only includes
+          the software running within, and the platform’s hardware. All other
+          software outside is no longer part of your trusted computing base.
+        </p>
+        <div class="p-image__background--3-2 u-align--center u-vertically-center">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/abd7bccf-Hypervisor%20diagram%203.png",
+            alt="Hypervisor diagram",
+            width="195",
+            height="282",
+            hi_def=True,
+            loading="lazy" ) | safe
+          }}
         </div>
-        <div class="col-9 col-start-large-4 col-medium-3 col-start-medium-4">
-          <hr class="p-rule" />
-          <div class="row">
-            <div class="col-3 col-medium-3">
-              <h3 class="p-heading-icon__title p-heading--5">
-                2. Remote attestation
-              </h3>
-            </div>
-            <div class="col-6 col-medium-3">
-              <p>
-                When a confidential VM is launched, its integrity is verified and
-                its initial code and data are measured by a hardware root of
-                trust. This ensures they have not been tampered with. The
-                measurement is cryptographically signed and can be attested to a
-                remote verifier.
-              </p>
-            </div>
-          </div>
-        </div>
+        <p>
+          To provide such strong security guarantees, confidential computing
+          relies on two main primitives:
+        </p>
       </div>
     </div>
-
-    <hr class="is-fixed-width" />
-
     <div class="row">
-      <div class="col-6 col-medium-12">
-        <h2>Enterprise-grade confidential VMs on all major public clouds</h2>
+      <div class="col-9 col-start-large-4 col-medium-3 col-start-medium-4">
+        <hr class="p-rule" />
+        <div class="row">
+          <div class="col-3 col-medium-3">
+            <h3 class="p-heading-icon__title p-heading--5">1. Isolation</h3>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              Confidential computing capable CPUs are equipped with an AES
+              hardware memory encryption engine, which encrypts data when it is
+              written to system memory, and decrypts it when read. The
+              encryption key itself is stored in the hardware root of trust and
+              is never exposed to the platform’s system software.
+            </p>
+          </div>
+        </div>
       </div>
-      <div class="col-6 col-medium-12">
-        <table aria-label="">
-          <tbody>
-            <tr>
-              <td class="u-table-cell-padding-overlap" style="width: 158px">
-                <p class="u-no-margin--bottom">
-                  {{ image (
-                    url="https://assets.ubuntu.com/v1/dbab00f7-Microsoft_Azure.svg",
-                    alt="Azure logo",
-                    height="22",
-                    width="22",
-                    hi_def=True,
-                    loading="lazy" ) | safe
-                  }}
-                </p>
-              </td>
-              <td class="u-hide--small" style="width: 32px"></td>
-              <td class="u-table-cell-padding-overlap">
-                <p>
-                  <a
-                    href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-confidential-vm-focal?tab=Overview">AMD
-                    SEV SNP with Ubuntu 20.04 LTS on Azure</a>
-                </p>
-                <hr />
-                <p>
-                  <a
-                    href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-confidential-vm-jammy">AMD
-                    SEV SNP with Ubuntu 22.04 LTS on Azure</a>
-                </p>
-                <hr />
-                <p>
-                  <a
-                    href="https://forms.office.com/pages/responsepage.aspx?id=v4j5cvGGr0GRqy180BHbR9_qJVF-zyZCqvwR_iaG2EFUME1BT1hJN0I1VjhGWE9QNUJGREQ5QUlMNS4u">Intel
-                    TDX in private preview with 22.04 LTS on Azure</a>
-                </p>
-              </td>
-            </tr>
-            <tr>
-              <td class="u-table-cell-padding-overlap">
-                <p class="u-no-margin--bottom">
-                  {{ image (
-                    url="https://assets.ubuntu.com/v1/2c479064-cloud-logo%201.svg",
-                    alt="Google Cloud logo",
-                    height="22",
-                    width="129",
-                    hi_def=True,
-                    loading="lazy" ) | safe
-                  }}
-                </p>
-              </td>
-              <td></td>
-              <td class="u-table-cell-padding-overlap">
-                <p>
-                  <a href="https://ubuntu.com/blog/start-your-snp-vms-on-google-cloud">AMD SEV SNP with Ubuntu 22.04 LTS on Google Cloud</a>
-                </p>
-              </td>
-            </tr>
-            <tr>
-              <td class="u-table-cell-padding-overlap">
-                <p class="u-no-margin--bottom">
-                  {{ image (
-                    url="https://assets.ubuntu.com/v1/8e5cc412-AWS.svg",
-                    alt="AWS logo",
-                    height="22",
-                    width="40",
-                    hi_def=True,
-                    loading="lazy" ) | safe
-                  }}
-                </p>
-              </td>
-              <td></td>
-              <td class="u-table-cell-padding-overlap">
-                <p>
-                  <a href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/snp-requirements.html">AMD SEV SNP with Ubuntu 23.10 on AWS</a>
-                </p>
-              </td>
-            </tr>
-          </tbody>
-        </table>
+      <div class="col-9 col-start-large-4 col-medium-3 col-start-medium-4">
+        <hr class="p-rule" />
+        <div class="row">
+          <div class="col-3 col-medium-3">
+            <h3 class="p-heading-icon__title p-heading--5">
+              2. Remote attestation
+            </h3>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              When a confidential VM is launched, its integrity is verified and
+              its initial code and data are measured by a hardware root of
+              trust. This ensures they have not been tampered with. The
+              measurement is cryptographically signed and can be attested to a
+              remote verifier.
+            </p>
+          </div>
+        </div>
       </div>
     </div>
   </section>
 
+  <hr class="is-fixed-width" />
+
+  <section class="p-strip u-no-padding--top">
+    <div class="row">
+      <div class="col-6 col-medium-6">
+        <h2>Enterprise-grade confidential VMs on all major public clouds</h2>
+      </div>
+      <div class="col-6 col-medium-6">
+        <div class="row">
+          <div class="col-2 col-medium-3 col-small-2 u-pad-logo">
+            <p class="u-no-margin--bottom">
+              {{ image (
+                url="https://assets.ubuntu.com/v1/dbab00f7-Microsoft_Azure.svg",
+                alt="Azure logo",
+                height="22",
+                width="22",
+                hi_def=True,
+                loading="lazy" ) | safe
+              }}
+            </p>
+          </div>
+          <div class="col-4 col-medium-3 col-small-2">
+            <ul class="p-list--divided u-no-margin--bottom">
+              <li class="p-list__item">
+                <a
+                  href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-confidential-vm-focal?tab=Overview">AMD
+                  SEV SNP with Ubuntu 20.04 LTS on Azure</a>
+              </li>
+              <li class="p-list__item">
+                <a
+                  href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-confidential-vm-jammy">AMD
+                  SEV SNP with Ubuntu 22.04 LTS on Azure</a>
+              </li>
+              <li class="p-list__item">
+                <a
+                  href="https://forms.office.com/pages/responsepage.aspx?id=v4j5cvGGr0GRqy180BHbR9_qJVF-zyZCqvwR_iaG2EFUME1BT1hJN0I1VjhGWE9QNUJGREQ5QUlMNS4u">Intel
+                  TDX in private preview with 22.04 LTS on Azure</a>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <hr />
+        <div class="row">
+          <div class="col-2 col-medium-3 col-small-2 u-pad-logo">
+            <p class="u-no-margin--bottom">
+              {{ image (
+                url="https://assets.ubuntu.com/v1/2c479064-cloud-logo%201.svg",
+                alt="Google Cloud logo",
+                height="22",
+                width="129",
+                hi_def=True,
+                loading="lazy" ) | safe
+              }}
+            </p>
+          </div>
+          <div class="col-4 col-medium-3 col-small-2">
+            <p><a href="https://ubuntu.com/blog/start-your-snp-vms-on-google-cloud">AMD SEV SNP with Ubuntu 22.04 LTS on Google Cloud</a></p>
+          </div>
+        </div>
+        <hr />
+        <div class="row">
+          <div class="col-2 col-medium-3 col-small-2 u-pad-logo">
+            <p class="u-no-margin--bottom">
+              {{ image (
+                url="https://assets.ubuntu.com/v1/8e5cc412-AWS.svg",
+                alt="AWS logo",
+                height="22",
+                width="40",
+                hi_def=True,
+                loading="lazy" ) | safe
+              }}
+            </p>
+          </div>
+          <div class="col-4 col-medium-3 col-small-2">
+            <p><a href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/snp-requirements.html">AMD SEV SNP with Ubuntu 23.10 on AWS</a></p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <hr class="is-fixed-width" />
+
   <section class="p-strip is-deep">
     <div class="row">
       <div class="col-12">
-        <p class="p-heading--2 u-no-margin--bottom">
+        <p class="p-heading--2">
           <a href="https://ubuntu.com/engage/introduction-confidential-computing">Download our guide to confidential computing ›</a>
         </p>
       </div>
@@ -242,28 +236,28 @@ privacy-enhancing technology strategy with Ubuntu confidential VMs on both publi
 
   <hr class="is-fixed-width" />
 
-  <section class="p-strip u-no-padding--top">
+  <section class="p-strip is-deep u-no-padding--top">
     <div class="row--50-50">
       <div class="col">
         <h2>Learn more about confidential computing</h2>
       </div>
       <div class="col">
-        <p>
-          <a href="https://ubuntu.com/blog/what-is-confidential-computing-a-high-level-explanation-for-cisos">What is
-            confidential computing? A high-level explanation for CISOs</a>
-        </p>
-        <hr class="p-rule" />
-        <p>
-          <a
-            href="https://ubuntu.com/blog/confidential-computing-in-public-clouds-isolation-and-remote-attestation-explained">Confidential
-            computing in public clouds: isolation and remote
-            attestation explained</a>
-        </p>
-        <hr class="p-rule" />
-        <p>
-          <a href="https://ubuntu.com/blog/cloud-cyber-security-with-ubuntu-pro-confidential-vms">Strengthen your cloud
-            cyber security with Ubuntu Pro and confidential VMs</a>
-        </p>
+        <ul class="p-list--divided u-no-margin--bottom">
+          <li class="p-list__item">
+            <a href="https://ubuntu.com/blog/what-is-confidential-computing-a-high-level-explanation-for-cisos">What is
+              confidential computing? A high-level explanation for CISOs</a>
+          </li>
+          <li class="p-list__item">
+            <a
+              href="https://ubuntu.com/blog/confidential-computing-in-public-clouds-isolation-and-remote-attestation-explained">Confidential
+              computing in public clouds: isolation and remote
+              attestation explained</a>
+          </li>
+          <li class="p-list__item">
+            <a href="https://ubuntu.com/blog/cloud-cyber-security-with-ubuntu-pro-confidential-vms">Strengthen your cloud
+              cyber security with Ubuntu Pro and confidential VMs</a>
+          </li>
+        </ul>
       </div>
     </div>
   </section>
@@ -272,7 +266,7 @@ privacy-enhancing technology strategy with Ubuntu confidential VMs on both publi
 <section class="p-strip--white is-deep">
   <div class="row">
     <div class="col-12">
-      <p class="p-heading--2 u-no-margin--bottom">
+      <p class="p-heading--2">
         <a class="js-invoke-modal" href="">Contact us to discuss your use case ›</a>
       </p>
     </div>

--- a/templates/confidential-computing/index.html
+++ b/templates/confidential-computing/index.html
@@ -1,0 +1,282 @@
+{% extends "templates/base.html" %}
+
+{% block title %}Confidential Computing{% endblock %}
+{% block meta_description %}Protect data in use with confidential computing. Build the foundation of your
+privacy-enhancing technology strategy with Ubuntu confidential VMs on both public and private clouds.{% endblock %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1QGwS5CYlwXkaPibSFvcag6zLcUH5lNDUbM18hCqbOJM/edit{% endblock %}
+
+{% block outer_content %}
+<div class="is-paper">
+  <section class="p-strip is-bordered">
+    <div class="row">
+      <div class="col-9 col-medium-4 col-start-large-4 col-start-medium-3">
+        <div class="p-section">
+          <h1 class="u-no-margin--bottom">Ubuntu for confidential computing</h1>
+          <p class="p-heading--2">
+            Protect your data is use,
+            <br class="u-hide--small u-hide--medium" />across public and private
+            clouds.
+          </p>
+        </div>
+        <hr />
+        <button class="p-button--positive">Contact us</button>
+      </div>
+    </div>
+
+    <div class="u-fixed-width u-no-padding u-hide--medium u-hide--small">
+      <img src="https://assets.ubuntu.com/v1/7f34ade9-website_suru_25.jpg" alt=""
+        style="aspect-ratio: 5.177570093457944; width: 100%" />
+    </div>
+
+    <hr class="is-fixed-width" />
+
+    <div class="p-strip u-no-padding--top">
+      <div class="row--50-50">
+        <div class="col">
+          <h2>How confidential VMs work</h2>
+        </div>
+        <div class="col">
+          <p>
+            Confidential VMs introduce a new trust boundary which only includes
+            the software running within, and the platform’s hardware. All other
+            software outside is no longer part of your trusted computing base.
+          </p>
+          <div class="p-image__background--3-2 u-align--center u-vertically-center">
+            {{ image (
+              url="https://assets.ubuntu.com/v1/abd7bccf-Hypervisor%20diagram%203.png",
+              alt="Hypervisor diagram",
+              width="195",
+              height="282",
+              hi_def=True,
+              loading="lazy" ) | safe
+            }}
+          </div>
+          <p>
+            To provide such strong security guarantees, confidential computing
+            relies on two main primitives:
+          </p>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-9 col-start-large-4 col-medium-3 col-start-medium-4">
+          <hr class="p-rule" />
+          <div class="row">
+            <div class="col-3 col-medium-3">
+              <h3 class="p-heading-icon__title p-heading--5">1. Isolation</h3>
+            </div>
+            <div class="col-6 col-medium-3">
+              <p>
+                Confidential computing capable CPUs are equipped with an AES
+                hardware memory encryption engine, which encrypts data when it is
+                written to system memory, and decrypts it when read. The
+                encryption key itself is stored in the hardware root of trust and
+                is never exposed to the platform’s system software.
+              </p>
+            </div>
+          </div>
+        </div>
+        <div class="col-9 col-start-large-4 col-medium-3 col-start-medium-4">
+          <hr class="p-rule" />
+          <div class="row">
+            <div class="col-3 col-medium-3">
+              <h3 class="p-heading-icon__title p-heading--5">
+                2. Remote attestation
+              </h3>
+            </div>
+            <div class="col-6 col-medium-3">
+              <p>
+                When a confidential VM is launched, its integrity is verified and
+                its initial code and data are measured by a hardware root of
+                trust. This ensures they have not been tampered with. The
+                measurement is cryptographically signed and can be attested to a
+                remote verifier.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <hr class="is-fixed-width" />
+
+    <div class="row">
+      <div class="col-6 col-medium-12">
+        <h2>Enterprise-grade confidential VMs on all major public clouds</h2>
+      </div>
+      <div class="col-6 col-medium-12">
+        <table aria-label="">
+          <tbody>
+            <tr>
+              <td class="u-table-cell-padding-overlap" style="width: 158px">
+                <p class="u-no-margin--bottom">
+                  {{ image (
+                    url="https://assets.ubuntu.com/v1/dbab00f7-Microsoft_Azure.svg",
+                    alt="Azure logo",
+                    height="22",
+                    width="22",
+                    hi_def=True,
+                    loading="lazy" ) | safe
+                  }}
+                </p>
+              </td>
+              <td class="u-hide--small" style="width: 32px"></td>
+              <td class="u-table-cell-padding-overlap">
+                <p>
+                  <a
+                    href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-confidential-vm-focal?tab=Overview">AMD
+                    SEV SNP with Ubuntu 20.04 LTS on Azure</a>
+                </p>
+                <hr />
+                <p>
+                  <a
+                    href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-confidential-vm-jammy">AMD
+                    SEV SNP with Ubuntu 22.04 LTS on Azure</a>
+                </p>
+                <hr />
+                <p>
+                  <a
+                    href="https://forms.office.com/pages/responsepage.aspx?id=v4j5cvGGr0GRqy180BHbR9_qJVF-zyZCqvwR_iaG2EFUME1BT1hJN0I1VjhGWE9QNUJGREQ5QUlMNS4u">Intel
+                    TDX in private preview with 22.04 LTS on Azure</a>
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td class="u-table-cell-padding-overlap">
+                <p class="u-no-margin--bottom">
+                  {{ image (
+                    url="https://assets.ubuntu.com/v1/2c479064-cloud-logo%201.svg",
+                    alt="Google Cloud logo",
+                    height="22",
+                    width="129",
+                    hi_def=True,
+                    loading="lazy" ) | safe
+                  }}
+                </p>
+              </td>
+              <td></td>
+              <td class="u-table-cell-padding-overlap">
+                <p>
+                  <a href="https://ubuntu.com/blog/start-your-snp-vms-on-google-cloud">AMD SEV SNP with Ubuntu 22.04 LTS on Google Cloud</a>
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td class="u-table-cell-padding-overlap">
+                <p class="u-no-margin--bottom">
+                  {{ image (
+                    url="https://assets.ubuntu.com/v1/8e5cc412-AWS.svg",
+                    alt="AWS logo",
+                    height="22",
+                    width="40",
+                    hi_def=True,
+                    loading="lazy" ) | safe
+                  }}
+                </p>
+              </td>
+              <td></td>
+              <td class="u-table-cell-padding-overlap">
+                <p>
+                  <a href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/snp-requirements.html">AMD SEV SNP with Ubuntu 23.10 on AWS</a>
+                </p>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-strip is-deep">
+    <div class="row">
+      <div class="col-12">
+        <p class="p-heading--2 u-no-margin--bottom">
+          <a href="https://ubuntu.com/engage/introduction-confidential-computing">Download our guide to confidential computing ›</a>
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <hr class="is-fixed-width" />
+
+  <section class="p-strip u-no-padding--top">
+    <div class="row--50-50">
+      <div class="col">
+        <h2>A solid foundation of your zero trust strategy</h2>
+      </div>
+      <div class="col">
+        <p>
+          With confidential computing, you can remove the privileged systems
+          software from your trusted computing base, reduce your attack surface,
+          and get a remotely verifiable cryptographic guarantee before trusting
+          any platform with your data.
+        </p>
+        <p>
+          <a href="https://ubuntu.com/blog/build-foundation-zero-trust-strategy-ubuntu-confidential-computing">Learn
+            more about zero trust and confidential computing ›</a>
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <hr class="is-fixed-width" />
+
+  <section class="p-strip u-no-padding--top">
+    <div class="row--50-50">
+      <div class="col">
+        <h2>Confidential computing in your private data centre</h2>
+      </div>
+      <div class="col">
+        <p>
+          Combine good data governance practices with the latest advances in
+          privacy-enhancing computation. Use confidential computing to protect
+          the confidentiality and integrity of the sensitive data hosted on your
+          on-premises servers, using hardware-rooted primitives beyond
+          traditional measures.
+        </p>
+        <p>
+          <a href="https://canonical.com/blog/why-do-you-also-need-confidential-computing-for-your-private-datacenter">Why
+            use confidential VMs in your private datacenter? ›</a>
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <hr class="is-fixed-width" />
+
+  <section class="p-strip u-no-padding--top">
+    <div class="row--50-50">
+      <div class="col">
+        <h2>Learn more about confidential computing</h2>
+      </div>
+      <div class="col">
+        <p>
+          <a href="https://ubuntu.com/blog/what-is-confidential-computing-a-high-level-explanation-for-cisos">What is
+            confidential computing? A high-level explanation for CISOs</a>
+        </p>
+        <hr class="p-rule" />
+        <p>
+          <a
+            href="https://ubuntu.com/blog/confidential-computing-in-public-clouds-isolation-and-remote-attestation-explained">Confidential
+            computing in public clouds: isolation and remote
+            attestation explained</a>
+        </p>
+        <hr class="p-rule" />
+        <p>
+          <a href="https://ubuntu.com/blog/cloud-cyber-security-with-ubuntu-pro-confidential-vms">Strengthen your cloud
+            cyber security with Ubuntu Pro and confidential VMs</a>
+        </p>
+      </div>
+    </div>
+  </section>
+</div>
+
+<section class="p-strip--white is-deep">
+  <div class="row">
+    <div class="col-12">
+      <p class="p-heading--2 u-no-margin--bottom">
+        <a href="">Contact us to discuss your use case ›</a>
+      </p>
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/templates/confidential-computing/index.html
+++ b/templates/confidential-computing/index.html
@@ -13,13 +13,12 @@ privacy-enhancing technology strategy with Ubuntu confidential VMs on both publi
         <div class="p-section">
           <h1 class="u-no-margin--bottom">Ubuntu for confidential computing</h1>
           <p class="p-heading--2">
-            Protect your data is use,
-            <br class="u-hide--small u-hide--medium" />across public and private
-            clouds.
+            Protect your data in use,
+            <br class="u-hide--small u-hide--medium" />across public and private clouds.
           </p>
         </div>
         <hr />
-        <button class="p-button--positive">Contact us</button>
+        <a class="js-invoke-modal p-button--positive" href="/contact-us">Contact us</a>
       </div>
     </div>
 
@@ -274,9 +273,21 @@ privacy-enhancing technology strategy with Ubuntu confidential VMs on both publi
   <div class="row">
     <div class="col-12">
       <p class="p-heading--2 u-no-margin--bottom">
-        <a href="">Contact us to discuss your use case ›</a>
+        <a class="js-invoke-modal" href="">Contact us to discuss your use case ›</a>
       </p>
     </div>
   </div>
 </section>
+
+<!-- Set default Marketo information for contact form below-->
+<div 
+  class="u-hide"
+  id="contact-form-container"
+  data-form-location="/shared/forms/interactive/confidential-computing"
+  data-form-id="5352"
+  data-lp-id=""
+  data-return-url="https://ubuntu.com/contact-us/form/thank-you"
+  data-lp-url="">
+</div>
+
 {% endblock %}

--- a/templates/shared/forms/interactive/confidential-computing.html
+++ b/templates/shared/forms/interactive/confidential-computing.html
@@ -1,0 +1,77 @@
+<div class="p-modal" id="contact-modal">
+  <div class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
+    <header class="p-modal__header" style="display: block; border-bottom: 0;">
+      <button class="p-modal__close" aria-label="Close active modal" style="margin-left: -1rem">Close</button>
+      <h2 class="p-modal__title u-sv1" id="modal-title">Contact us</h2>
+    </header>
+
+    <div class="js-pagination js-pagination--1">
+      <p id="modal-description" class="u-no-max-width u-no-margin--bottom">Discuss your confidential computing use case with our experts</p>
+      <div class="row u-no-padding">
+        <div class="col-6">
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
+            <ul class="p-list">
+              <li class="p-list__item">
+                <label for="customerName">Name:</label>
+                <input required id="customerName" name="name" maxlength="255" type="text" required="required" />
+              </li>
+              <li class="p-list__item">
+                <label for="email">Email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
+              </li>
+              <li class="p-list__item">
+                <label for="phone">Phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
+              </li>
+              <li class="p-list__item">
+                <label for="Company">Company:</label>
+                <input id="Company" name="Company" maxlength="255" type="text" required="required"/>
+              </li>
+              <li>
+                <label for="title">Job title:</label>
+                <input required id="title" name="title" maxlength="255" type="text" required="required">
+              </li>              
+
+              {% include "shared/forms/_country.html" %}
+              
+              <li class="p-list__item">In submitting this form, I confirm that I have read and agree to 
+                <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and 
+                <a href="/legal/data-privacy">Privacy Policy</a>.
+              </li>
+              {# These are honey pot fields to catch bots #}
+              <li class="u-off-screen">
+                <label class="website" for="website">Website:</label>
+                <input name="website" type="text" class="website" autocomplete="off" value="" id="website" tabindex="-1" />
+              </li>
+              <li class="u-off-screen">
+                <label class="name" for="name">Name:</label>
+                <input name="name" type="text" class="name" autocomplete="off" value="" id="name" tabindex="-1" />
+              </li>
+              {# End of honey pots #}
+            </ul>
+
+            <div class="u-hide">
+              <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Facebook_Click_ID__c" id="Facebook_Click_ID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" id="preferredLanguage" name="preferredLanguage" maxlength="255" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
+            </div>
+
+            <div class="pagination">
+              <button type="submit" class="p-button--positive" aria-label="Submit">Let's discuss</button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Done

- Add a new page called "Confidential Computing" according to [copy doc](https://docs.google.com/document/d/1QGwS5CYlwXkaPibSFvcag6zLcUH5lNDUbM18hCqbOJM/edit#heading=h.n4yj7d5ptzm9) and [design](https://www.figma.com/file/zyG3Iyys2GlxxfqfQQT7bT/23.10-U.com---Confidential-computing?type=design&node-id=0%3A1&mode=dev)
- Add a new modal contact form for "Confidential Computing" according to [copy doc](https://docs.google.com/document/d/1F4QYakPaIAL5fcttOnegkldTiWQ_tRon9apfbradX08/edit#heading=h.6d3m0dei0nxs)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Navigate to [https://ubuntu-com-13161.demos.haus/confidential-computing](https://ubuntu-com-13161.demos.haus/confidential-computing)

## Issue / Card

https://warthogs.atlassian.net/browse/WD-5855
https://warthogs.atlassian.net/browse/WD-6009


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
