### PR TITLE
Update meta for AMD download page

### DIFF
--- a/templates/download/amd/index.html
+++ b/templates/download/amd/index.html
@@ -4,7 +4,7 @@
 
 {% block meta_description %}Use Ubuntu on AMD for the familiar developer experience and an accelerated path to production.{% endblock meta_description %}
 
-{% block meta_image %}https://assets.ubuntu.com/v1/2b571c08-xilinx_metaimage.jpeg{% endblock meta_image %}
+{% block meta_image %}https://assets.ubuntu.com/v1/2fe9d465-AMD%20download%20page%20meta%20image.png{% endblock meta_image %}
 
 {% block meta_copydoc%} https://docs.google.com/document/d/1cxQnEErs8FZ3dZ_IhlfcaJ03gE_vrMJfRC-5me9IDd4 {% endblock meta_copydoc %}
 


### PR DESCRIPTION
## Done

Update meta image

## QA

- Check https://ubuntu-com-13167.demos.haus/download/xilinx has the new meta image according to [copy docs](https://docs.google.com/document/d/1cxQnEErs8FZ3dZ_IhlfcaJ03gE_vrMJfRC-5me9IDd4/edit)
- Go to https://www.opengraph.xyz/ and insert the URL into the bar, and you should see the new meta image. To compare, you can do the same with https://ubuntu.com/download/amd

    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-6078 (follow-up)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
