### PR TITLE
Fix the logo layout on the ai/roadshow page

### DIFF
--- a/templates/ai/roadshow.html
+++ b/templates/ai/roadshow.html
@@ -33,9 +33,9 @@
       <hr class="p-rule" />
       <p class="p-heading--2">Develop artificial intelligence projects <br class="u-hide--small"/>on any environment with&nbsp;Canonical</p>
       <div class="p-logo-section">
-        <div class="p-logo-section__itemsu-no-margin--bottom">
-          <div class="p-logo-section__item--variable">
-            {{ 
+        <div class="p-logo-section__items u-no-margin--bottom">
+          <div class="p-logo-section__item">
+            {{
               image (
               url="https://assets.ubuntu.com/v1/d7829629-nvidia-logo.svg",
               alt="Nvidia",
@@ -47,8 +47,8 @@
               ) | safe
             }}
           </div>
-          <div class="p-logo-section__item--variable">
-            {{ 
+          <div class="p-logo-section__item">
+            {{
               image (
               url="https://assets.ubuntu.com/v1/a34e318a-lenovo-logo.svg",
               alt="Lenovo",
@@ -60,8 +60,8 @@
               ) | safe
             }}
           </div>
-          <div class="p-logo-section__item--variable">
-            {{ 
+          <div class="p-logo-section__item">
+            {{
               image (
               url="https://assets.ubuntu.com/v1/136e7089-hp-enterprise-logo.svg",
               alt="HP Enterprise",
@@ -73,8 +73,8 @@
               ) | safe
             }}
           </div>
-          <div class="p-logo-section__item--variable">
-            {{ 
+          <div class="p-logo-section__item">
+            {{
               image (
               url="https://assets.ubuntu.com/v1/25514caf-dell-logo.svg",
               alt="Dell",
@@ -86,8 +86,8 @@
               ) | safe
             }}
           </div>
-          <div class="p-logo-section__item--variable">
-            {{ 
+          <div class="p-logo-section__item">
+            {{
               image (
               url="https://assets.ubuntu.com/v1/3a7ece3a-microsoft-azure-new-logo.svg",
               alt="Azure",
@@ -99,8 +99,8 @@
               ) | safe
             }}
           </div>
-          <div class="p-logo-section__item--variable">
-            {{ 
+          <div class="p-logo-section__item">
+            {{
               image (
               url="https://assets.ubuntu.com/v1/4cd2ba24-aws-logo.svg",
               alt="AWS",
@@ -112,7 +112,7 @@
               ) | safe
             }}
           </div>
-          <div class="p-logo-section__item--variable">
+          <div class="p-logo-section__item">
             {{ image (
               url="https://assets.ubuntu.com/v1/7577d797-google-logo.svg",
               alt="Google",
@@ -254,7 +254,7 @@
                 <p><strong>11-12 October 2023 <br />Amsterdam, Netherlands</strong></p>
                 <p>Talk: Building LLMs: from zero to hero with <a href="https://www.linkedin.com/in/mm4zur/">Maciej Mazur</a>, Canonical</p>
                 <p>Workshop: Building your LLM Factory with <a href="https://www.linkedin.com/in/mbalint/">Michael Balint</a>, NVIDIA, <a href="https://www.linkedin.com/in/andreea-mihaela-munteanu/">Andreea Munteanu</a>, <a href="https://www.linkedin.com/in/mm4zur/">Maciej Mazur</a>, Canonical</p>
-                {{ 
+                {{
                   image (
                   url="https://assets.ubuntu.com/v1/1ac0e434-Nvidia_Logo_Horizontal.svg",
                   alt="",


### PR DESCRIPTION
## Done

- Fix the logo layout on the ai/roadshow page

## QA

- Go to /ai/roadshow and see the logo section is not vertically aligned.
