### PR TITLE
Rename all instances of AMD-xilinx to AMD

### DIFF
--- a/templates/certified/model-details.html
+++ b/templates/certified/model-details.html
@@ -85,7 +85,7 @@
               <p class="u-no-margin--bottom">Pre-installed in some regions with a custom Ubuntu image that takes advantage of the system's hardware features and may include additional software. Standard images of Ubuntu may not work well, or at all.</p>
               {% if vendor == "Xilinx" %}
                 <p class="u-no-margin--bottom" style="padding-top:1.4rem;">
-                  <a href="/download/amd-xilinx" class="p-button">Download</a>
+                  <a href="/download/amd" class="p-button">Download</a>
                 </p>
               {% endif %}
             {% elif release.level == "Certified" %}

--- a/templates/download/amd/tab-3.html
+++ b/templates/download/amd/tab-3.html
@@ -43,7 +43,7 @@
       <h3 class="p-heading--5 u-no-padding--top"><strong>Are you working on a commercial project?</strong></h3>
     </div>
     <div class="col-6">
-      <p>Canonical partners with silicon vendors, board manufacturers and leading enterprises to shorten time-to-market. If you are deploying Ubuntu on AMD platforms at-scale, <a class="js-invoke-modal" href="/download/amd-xilinx#get-in-touch">please reach out to Canonical</a> to get access to ongoing bug fixes, critical security patching, long-term support; or to learn more about our solutions for custom board enablement, and application development services.</p>
+      <p>Canonical partners with silicon vendors, board manufacturers and leading enterprises to shorten time-to-market. If you are deploying Ubuntu on AMD platforms at-scale, <a class="js-invoke-modal" href="/download/amd#get-in-touch">please reach out to Canonical</a> to get access to ongoing bug fixes, critical security patching, long-term support; or to learn more about our solutions for custom board enablement, and application development services.</p>
       <p>For information about using Canonical's Ubuntu images on a commercial project, <a href="/legal/intellectual-property-policy">read Canonical's IP policy</a>.</p>
     </div>
   </div>

--- a/templates/download/iot/index.html
+++ b/templates/download/iot/index.html
@@ -86,16 +86,16 @@
       </div>
       <div class="col-2 col-medium-3">
         {{ image (
-          url="https://assets.ubuntu.com/v1/f8ef46d3-AMD_Xilinx_logo.svg",
+          url="https://assets.ubuntu.com/v1/327b8104-AMD_E_Blk_RGB.png",
           alt="AMD XILINX",
-          width="72",
+          width="187",
           height="45",
           hi_def=True,
           loading="auto"
           ) | safe
         }}
         <p>
-          <a href="/download/amd-xilinx">Install Ubuntu Desktop&nbsp;&rsaquo;</a>
+          <a href="/download/amd">Install Ubuntu Desktop&nbsp;&rsaquo;</a>
         </p>
       </div>
       <div class="col-2 col-medium-3">
@@ -236,16 +236,17 @@
           <p><a href="/download/qualcomm-dragonboard-410c">Install Ubuntu Core 18&nbsp;&rsaquo;</a></p>
         </div>
         <div class="col-4">
-          {{ image (
-            url="https://assets.ubuntu.com/v1/f8ef46d3-AMD_Xilinx_logo.svg",
-            alt="AMD Xilinx logo",
-            width="72",
+          {{
+            image (
+            url="https://assets.ubuntu.com/v1/327b8104-AMD_E_Blk_RGB.png",
+            alt="",
+            width="187",
             height="45",
             hi_def=True,
-            loading="auto"
+            loading="lazy"
             ) | safe
           }}
-          <p><a href="/download/amd-xilinx">Install Ubuntu Desktop&nbsp;&rsaquo;</a></p>
+          <p><a href="/download/amd">Install Ubuntu Desktop&nbsp;&rsaquo;</a></p>
         </div>
         <div class="col-4">
           {{ image (
@@ -254,7 +255,7 @@
             width="75",
             height="42",
             hi_def=True,
-            loading="auto"
+            loading="lazy"
             ) | safe
           }}
           <p>

--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -468,13 +468,14 @@
     </div>
     <div class="col-6 p-card">
       <header class="no-border u-align--center u-vertically-center u-hide--medium u-hide--small" style="min-height: 7rem;">
-        {{ image (
-          url="https://assets.ubuntu.com/v1/f8ef46d3-AMD_Xilinx_logo.svg",
+        {{
+          image (
+          url="https://assets.ubuntu.com/v1/327b8104-AMD_E_Blk_RGB.png",
           alt="",
-          width="121",
-          height="75",
+          width="271",
+          height="65",
           hi_def=True,
-          loading="lazy"
+          loading="auto|lazy"
           ) | safe
         }}
       </header>

--- a/templates/templates/navigation-download-h.html
+++ b/templates/templates/navigation-download-h.html
@@ -48,8 +48,8 @@
             <li class='p-list__item'><a class='p-link' href='/download/intel-iei-tank-870'>
               Intel IEI TANK 870
             </a></li>
-            <li class='p-list__item'><a class='p-link' href='/download/amd-xilinx'>
-              AMD-Xilinx Evaluation kits & SOMs
+            <li class='p-list__item'><a class='p-link' href='/download/amd'>
+              AMD Evaluation kits & SOMs
             </a></li>
             <li class='p-list__item'><a class='p-link' href='/download/risc-v'>
               RISC-V platforms

--- a/tests/cypress/integration/navigation_spec.js
+++ b/tests/cypress/integration/navigation_spec.js
@@ -9,7 +9,7 @@ context("Navigation", () => {
   it("should display the navigation sections when clicked", () => {
     cy.get('nav')
     .findByRole('link', {name: /Download/i}).click();
-    cy.findByRole('link', { name: /AMD-Xilinx Evaluation kits & SOMs/ })
+    cy.findByRole('link', { name: /AMD Evaluation kits & SOMs/ })
       .should("be.visible");
     cy.get('nav')
     .findByRole('link', {name: /Community/i}).click();

--- a/webapp/certified/helpers.py
+++ b/webapp/certified/helpers.py
@@ -18,7 +18,7 @@ def get_download_url(model_details):
 
     if "core" in platform_category:
         if make == "xilinx":
-            return "https://ubuntu.com/download/amd-xilinx"
+            return "https://ubuntu.com/download/amd"
 
         return "https://ubuntu.com/download/iot/"
 


### PR DESCRIPTION
## Done

Rename AMD-xilinx to AMD

## QA

- Check all instances of AMD-xilinx have been updated to amd. E.g. https://ubuntu-com-13170.demos.haus/certified/202202-29985
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
