### PR TITLE
add to README steps to fix Chromium related error on Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ Once it's installed, run the project with:
 dotrun
 ```
 
+For Mac users, in case running `dotrun` returns an error related to Chromium, add the following line to your local `.env.local` file (create one if you don't have it):
+
+```
+PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+```
+
 Once the server has started, you can visit <http://127.0.0.1:8001> in your browser.
 
 # Deploy


### PR DESCRIPTION
## Done

- For some Mac machines (with silicon chips) when you run `dotrun` to spin up local instance you get an error related to not being able to download/install Chromium. I added a step how to fix this issue that worked for me.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/

## Issue / Card

There is not issue for this, it's just a small addition to README

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
