### PR TITLE
[WD-6427] remove OSM from the list of supported apps

### DIFF
--- a/templates/shared/_security-patching-logo-cloud.html
+++ b/templates/shared/_security-patching-logo-cloud.html
@@ -507,27 +507,6 @@
     <span class="p-media-object__image">
       {{
         image(
-        url="https://assets.ubuntu.com/v1/7deea43e-OSM_Logo.png",
-        alt="",
-        width="40",
-        height="40",
-        hi_def=True,
-        loading="lazy",
-        attrs={"class": "p-media-object__image"},
-        ) | safe
-      }}
-    </span>
-    <span class="p-media-object__details">
-      <p class="p-media-object__title p-heading--5 u-no-margin--bottom">Open Source Mano (OSM)</p>
-    </span>
-  </div>
-</div>
-
-<div class="row">
-  <div class="col-3 col-medium-3 p-media-object">
-    <span class="p-media-object__image">
-      {{
-        image(
         url="https://assets.ubuntu.com/v1/8c0d8057-Anbox-logomark.svg",
         alt="",
         width="48",


### PR DESCRIPTION
## Done

- Removed "Open Source Mano (OSM)" from the list of supported apps

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Navigate to the following URLs to check if "Open Source Mano (OSM)" is not in the list of supported apps:
    - /support
    - /engage/unlisted/at&t-onboarding

## Issue / Card

Closes https://warthogs.atlassian.net/browse/WD-6427

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
