### PR TITLE
[WD-6300] /get-ubuntu-server copy update

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -1,13 +1,13 @@
 latest:
-  slug: LunarLobster
-  name: "Lunar Lobster"
-  short_version: "23.04"
-  full_version: "23.04"
-  core_version: "22"
-  release_date: "April 2023"
-  eol: "January 2024"
+  slug: ManticMinotaur
+  name: "Mantic Minotaur"
+  short_version: "23.10"
+  full_version: "23.10"
+  core_version: "23"
+  release_date: "October 2023"
+  eol: "July 2024"
   past_eol_date: false
-  release_notes_url: "https://discourse.ubuntu.com/t/lunar-lobster-release-notes/31910"
+  release_notes_url: "https://discourse.ubuntu.com/t/mantic-minotaur-release-notes/35534"
 lts:
   slug: JammyJellyfish
   name: "Jammy Jellyfish"

--- a/templates/download/server/manual.html
+++ b/templates/download/server/manual.html
@@ -104,7 +104,7 @@
     </div>
     <div class="col-4 col-start-large-8 u-hide--medium u-hide--small u-align--center u-vertically-center">
       {{ image (
-        url="https://assets.ubuntu.com/v1/3a32d136-Lobster_circular.png",
+        url="https://assets.ubuntu.com/v1/57a36cad-Minotaur_circular.png",
         alt="",
         width="260",
         height="260",


### PR DESCRIPTION
## Done

- Updated latest release to Mantic Minotaur in `releases.yaml`
- Updated a mascot of the latest release in `/download/server`
- [Copy doc](https://docs.google.com/document/d/1Qob4Ni_y1ffIdSWqaw2xH0dxiHZQmkRGP5nuoBhIfyM/edit)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Navigate to `/download/server` and check that the `Alternative releases` section shows information about Mantic Minotaur 23.10 release.

## Issue / Card

Closes https://warthogs.atlassian.net/browse/WD-6300

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
