### PR TITLE
[WD-6353] change 23.04 to 23.10 on RISC-V download page

### DIFF
--- a/templates/download/risc-v/tab-1.html
+++ b/templates/download/risc-v/tab-1.html
@@ -23,7 +23,7 @@
     </div>
     <div class="col-6">
       <p>
-				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+nezha.img.xz">Download 23.04</a>
+				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.10/release/ubuntu-23.10-preinstalled-server-riscv64+nezha.img.xz">Download 23.10</a>
 				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.3/release/ubuntu-22.04.3-preinstalled-server-riscv64+nezha.img.xz">Download 22.04.3</a>
 			</p>
 			<p><a href="https://wiki.ubuntu.com/RISC-V/Nezha%20D1">How to install Ubuntu on the Nezha</a></p>

--- a/templates/download/risc-v/tab-2.html
+++ b/templates/download/risc-v/tab-2.html
@@ -29,7 +29,7 @@
 			</ul>
       <hr class="is-fixed-width col-6">
       <p>
-				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+icicle.img.xz">Download 23.04</a>
+				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.10/release/ubuntu-23.10-preinstalled-server-riscv64+icicle.img.xz">Download 23.10</a>
 				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.3/release/ubuntu-22.04.3-preinstalled-server-riscv64+icicle.img.xz">Download 22.04.3</a>
 			</p>
       <p><a href="https://wiki.ubuntu.com/RISC-V/PolarFire%20SoC%20FPGA%20Icicle%20Kit">How to install Ubuntu on the Microchip Polarfire SoC FPGA Icicle Kit</a></p>

--- a/templates/download/risc-v/tab-3.html
+++ b/templates/download/risc-v/tab-3.html
@@ -23,7 +23,7 @@
     </div>
     <div class="col-6">
       <p class="u-sv3">
-				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+unmatched.img.xz">Download 23.04</a>
+				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.10/release/ubuntu-23.10-preinstalled-server-riscv64+unmatched.img.xz">Download 23.10</a>
 				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.3/release/ubuntu-22.04.3-preinstalled-server-riscv64+unmatched.img.xz">Download 22.04.3</a>
 			</p>
     </div>
@@ -35,7 +35,7 @@
     </div>
     <div class="col-6">
       <p>
-				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-live-server-riscv64.img.gz">Download 23.04 live installer</a>
+				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.10/release/ubuntu-23.10-live-server-riscv64.img.gz">Download 23.10 live installer</a>
 				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.3/release/ubuntu-22.04.3-live-server-riscv64.img.gz">Download 22.04.3 live installer</a>
 			</p>
       <p><a href="https://wiki.ubuntu.com/RISC-V/QEMU">How to install Ubuntu on QEMU RISC-V</a></p>

--- a/templates/download/risc-v/tab-4.html
+++ b/templates/download/risc-v/tab-4.html
@@ -24,7 +24,7 @@
     <div class="col-6">
       <p class="p-notification__message"><i class="p-icon--information"></i> If you have an NVMe drive, we advise you to use the Ubuntu Server live installer.</p>
       <p class="u-sv3">
-        <a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+unmatched.img.xz">Download 23.04</a>
+        <a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.10/release/ubuntu-23.10-preinstalled-server-riscv64+unmatched.img.xz">Download 23.10</a>
         <a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.3/release/ubuntu-22.04.3-preinstalled-server-riscv64+unmatched.img.xz">Download 22.04.3</a>
       </p>
     </div>
@@ -36,7 +36,7 @@
     </div>
     <div class="col-6">
       <p>
-				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-live-server-riscv64.img.gz">Download 23.04 live installer</a>
+				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.10/release/ubuntu-23.10-live-server-riscv64.img.gz">Download 23.10 live installer</a>
 				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.3/release/ubuntu-22.04.3-live-server-riscv64.img.gz">Download 22.04.3 live installer</a>
 			</p>
 			<p><a href="https://wiki.ubuntu.com/RISC-V/SiFive%20HiFive%20Unmatched">How to install Ubuntu on SiFive HiFive Unmatched</a></p>

--- a/templates/download/risc-v/tab-5.html
+++ b/templates/download/risc-v/tab-5.html
@@ -24,7 +24,7 @@
     </div>
     <div class="col-6">
       <p>
-				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+licheerv.img.xz">Download 23.04</a>
+				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.10/release/ubuntu-23.10-preinstalled-server-riscv64+licheerv.img.xz">Download 23.10</a>
 				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.3/release/ubuntu-22.04.3-preinstalled-server-riscv64+licheerv.img.xz">Download 22.04.3</a>
 			</p>
 			<p><a href="https://wiki.ubuntu.com/RISC-V/LicheeRV">How to install Ubuntu on the LicheeRV Dock</a></p>

--- a/templates/download/risc-v/tab-6.html
+++ b/templates/download/risc-v/tab-6.html
@@ -23,7 +23,7 @@
     </div>
     <div class="col-6">
       <p>
-        <a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+visionfive.img.xz">Download 23.04</a>
+        <a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.10/release/ubuntu-23.10-preinstalled-server-riscv64+visionfive.img.xz">Download 23.10</a>
         <a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.3/release/ubuntu-22.04.3-preinstalled-server-riscv64+visionfive.img.xz">Download 22.04.3</a>
       </p>
       <p><a href="https://wiki.ubuntu.com/RISC-V/StarFive%20VisionFive">How to install Ubuntu on the VisionFive</a></p>

--- a/templates/download/risc-v/tab-7.html
+++ b/templates/download/risc-v/tab-7.html
@@ -23,6 +23,17 @@
     </div>
     <div class="col-6">
       <p><a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.10/release/ubuntu-23.10-preinstalled-server-riscv64+visionfive2.img.xz">Download 23.10</a></p>
+    </div>
+  </div>
+  <div class="row p-strip u-no-padding--top">
+    <hr class="col-9">
+    <div class="col-3">
+      <h3 class="p-heading--5 u-no-padding--top">Ubuntu Server <br class="u-hide--small">live installer</h3>
+    </div>
+    <div class="col-6">
+      <p>
+				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.10/release/ubuntu-23.10-live-server-riscv64.img.gz">Download 23.10 live installer</a>
+			</p>
       <p><a href="https://wiki.ubuntu.com/RISC-V/StarFive%20VisionFive%202">How to install Ubuntu on the VisionFive</a></p>
     </div>
   </div>

--- a/templates/download/risc-v/tab-7.html
+++ b/templates/download/risc-v/tab-7.html
@@ -22,7 +22,7 @@
       <h3 class="p-heading--5 u-no-padding--top">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
     </div>
     <div class="col-6">
-      <p><a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.04/release/ubuntu-23.04-preinstalled-server-riscv64+visionfive2.img.xz">Download 23.04</a></p>
+      <p><a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.10/release/ubuntu-23.10-preinstalled-server-riscv64+visionfive2.img.xz">Download 23.10</a></p>
       <p><a href="https://wiki.ubuntu.com/RISC-V/StarFive%20VisionFive%202">How to install Ubuntu on the VisionFive</a></p>
     </div>
   </div>

--- a/templates/download/risc-v/tab-7.html
+++ b/templates/download/risc-v/tab-7.html
@@ -34,7 +34,7 @@
       <p>
 				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.10/release/ubuntu-23.10-live-server-riscv64.img.gz">Download 23.10 live installer</a>
 			</p>
-      <p><a href="https://wiki.ubuntu.com/RISC-V/StarFive%20VisionFive%202">How to install Ubuntu on the VisionFive</a></p>
+      <p><a href="https://wiki.ubuntu.com/RISC-V/StarFive%20VisionFive%202">How to install Ubuntu on the VisionFive 2</a></p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Done

- Updated Ubuntu images to 23.10 on RISC-V download page

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Navigate to `/download/risc-v` and check that all tabs for different boards have links to download 23.10 image instead of 23.04

## Issue / Card

Closes https://warthogs.atlassian.net/browse/WD-6353

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
