### PR TITLE
Fix subscription status chips

### DIFF
--- a/static/sass/_pattern_subscriptions.scss
+++ b/static/sass/_pattern_subscriptions.scss
@@ -157,6 +157,7 @@
 
         .p-modal__header {
           margin-bottom: 0;
+          padding-right: 0;
 
           &::after {
             // Remove the bottom border from the title.
@@ -190,6 +191,12 @@
   // notification.
   .p-subscriptions__details-header + .p-subscriptions__details-action {
     margin-top: $spv--small;
+  }
+
+  .p-subscriptions__details-header {
+    [class*="p-chip--"] {
+      max-height: 1.8rem;
+    }
   }
 
   .p-subscriptions__details-small-title {


### PR DESCRIPTION
## Done

- Fix subscription status chips broken on small screens

## QA

- Go to /pro/subscribe
- Buy pro desktop with full support 
- Go to dashboard 
- Check the `auto-renewal on` label has fixed height on small screens

## Issue / Card

Fixes #https://warthogs.atlassian.net/jira/software/c/projects/WD/boards/801?selectedIssue=WD-6295

## Screenshots

<img width="412" alt="image" src="https://github.com/canonical/ubuntu.com/assets/57550290/f8dc6c50-d762-47e5-8c56-a865edd02608">


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
