### PR TITLE
Add Pro network requirements documentation link to dashboard

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.test.tsx
@@ -91,7 +91,7 @@ describe("DetailsTabs", () => {
     // Switch to the docs tab:
     wrapper.find("[data-test='docs-tab']").simulate("click");
     const docsLinks = wrapper.find("[data-test='doc-link']");
-    expect(docsLinks.length).toBe(1);
+    expect(docsLinks.length).toBe(2);
     expect(docsLinks.at(0).text()).toBe("Livepatch");
   });
 
@@ -117,7 +117,7 @@ describe("DetailsTabs", () => {
     // Switch to the docs tab:
     wrapper.find("[data-test='docs-tab']").simulate("click");
     const docsLinks = wrapper.find("[data-test='doc-link']");
-    expect(docsLinks.length).toBe(1);
+    expect(docsLinks.length).toBe(2);
     expect(docsLinks.at(0).text()).toBe("Ubuntu Pro (esm-apps) tutorial");
   });
 

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.tsx
@@ -181,6 +181,13 @@ const DetailsTabs = ({
             </a>
           ),
         }))
+        .concat({
+          label: (
+            <a data-test="doc-link" href="https://canonical-ubuntu-pro-client.readthedocs-hosted.com/en/latest/references/network_requirements.html">
+              Ubuntu Pro network requirements
+            </a>
+          ),
+        })
         .concat(
           token
             ? [

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.tsx
@@ -183,7 +183,10 @@ const DetailsTabs = ({
         }))
         .concat({
           label: (
-            <a data-test="doc-link" href="https://canonical-ubuntu-pro-client.readthedocs-hosted.com/en/latest/references/network_requirements.html">
+            <a
+              data-test="doc-link"
+              href="https://canonical-ubuntu-pro-client.readthedocs-hosted.com/en/latest/references/network_requirements.html"
+            >
               Ubuntu Pro network requirements
             </a>
           ),


### PR DESCRIPTION
## Done

- Added [Ubuntu Pro network requirements](https://canonical-ubuntu-pro-client.readthedocs-hosted.com/en/latest/references/network_requirements.html) to Documentation & tutorials on Pro Dashboard

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/pro/dashboard
- Check the new link shows in the documentation.

## Issue / Card

Fixes [#WD-6469](https://warthogs.atlassian.net/browse/WD-6469)

## Screenshots
![Screenshot 2023-10-03 at 6 29 57 PM](https://github.com/canonical/ubuntu.com/assets/62298176/d6fb2cc9-e0dd-4e57-b37a-aeb9cbaf9563)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
