### PR TITLE
Fix unclosed link in table of contents

### DIFF
--- a/templates/legal/ubuntu-pro-description/ja/_toc_ja.html
+++ b/templates/legal/ubuntu-pro-description/ja/_toc_ja.html
@@ -2,7 +2,7 @@
   <h4 class="p-table-of-contents__header">目次</h4>
   <nav class="p-table-of-contents__nav">
     <ul class="p-list u-no-margin--bottom">
-      <li><a href="#uprosd-security-and-compliance">Security and compliance/a></li>
+      <li><a href="#uprosd-security-and-compliance">Security and compliance</a></li>
       <li>
         <ul>
           <li><a href="#uprosd-esm">拡張セキュリティメンテナンス（ESM）</a></li>


### PR DESCRIPTION
## Done

- Fixes broken HTML markup in a link in table of contents on JA version of the site



## QA

- Check out this feature branch
- Check demo at https://ubuntu-com-13194.demos.haus/legal/ubuntu-pro-description/ja
- Make sure there is no leaking markup in the table of contents


## Screenshots

Before (https://ubuntu.com/legal/ubuntu-pro-description/ja):

<img width="396" alt="image" src="https://github.com/canonical/ubuntu.com/assets/83575/2c6be513-81de-4d9c-bb0d-cd8d4e0a783d">

After:

<img width="365" alt="image" src="https://github.com/canonical/ubuntu.com/assets/83575/01753044-f93c-43ea-8a25-67457d27c2a1">


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
