### PR TITLE
fix for checkout error

### DIFF
--- a/static/js/src/advantage/subscribe/checkout/components/Checkout/Checkout.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Checkout/Checkout.tsx
@@ -67,7 +67,12 @@ const Checkout = ({ product, quantity, action }: Props) => {
             <Formik
               onSubmit={() => {}}
               initialValues={initialValues}
-              enableReinitialize={!!userInfo?.customerInfo?.address?.country}
+              enableReinitialize={
+                (!!userInfo?.customerInfo?.address?.country &&
+                  action === "renewal") ||
+                (!!userInfo?.customerInfo?.defaultPaymentMethod &&
+                  action === "purchase")
+              }
             >
               <>
                 <Col emptyLarge={7} size={6}>


### PR DESCRIPTION
## Done

- Fixes card checkout error for new users
## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Make a new account on checkout
    - add vat number with something wrong and save
    - and do everything right
    - click buy button
    - then you get error message with VAT number
    - and then remove the wrong vat number and save
    - and then click buy button
    - Should not get any errors

## Issue / Card

Fixes #[WD-6481](https://warthogs.atlassian.net/browse/WD-6481)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-6481]: https://warthogs.atlassian.net/browse/WD-6481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ