### PR TITLE
#12841 Issue - Correct href value to https://charmhub.io/?q=OpenStack

### DIFF
--- a/templates/shared/contextual_footers/_openstack_documentation.html
+++ b/templates/shared/contextual_footers/_openstack_documentation.html
@@ -13,7 +13,7 @@
         onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'openstack documentation', 'eventLabel' : 'OpenStack Charms documentation', 'eventValue' : undefined });">OpenStack Charms documentation</a>
     </li>
     <li class="p-list__item"><a
-        href="https://jaas.ai/openstack"
+        href="https://charmhub.io/?q=OpenStack"
        
         onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'openstack documentation', 'eventLabel' : 'Charmed OpenStack', 'eventValue' : undefined });">Charmed OpenStack</a>
     </li>


### PR DESCRIPTION
## Issue / Card
https://github.com/canonical/ubuntu.com/issues/12841

## Work done
Href value was corrected to https://charmhub.io/?q=OpenStack

## QA
How to test: 

1. https://ubuntu.com/openstack
2. Scroll to section: Open Detailed documentation
3. Hoover over Charmed OpenStack link - Does browser display following url https://charmhub.io/?q=OpenStack
4. Click on the Charmed OpenStack link - Did it send to https://charmhub.io page and OpenStack filter is active
