### PR TITLE
#12840 Issue - Correct href value

### DIFF
--- a/templates/templates/_footer-copyright-and-legal.html
+++ b/templates/templates/_footer-copyright-and-legal.html
@@ -12,7 +12,7 @@
       <a href="" class="p-link--soft js-revoke-cookie-manager"><small>Manage your tracker settings</small></a>
     </li>
     <li class="p-inline-list__item">
-      <a class="p-link--soft" href="https://github.com/canonical-websites/www.ubuntu.com/issues/new" id="report-a-bug">
+      <a class="p-link--soft" href="https://github.com/canonical/ubuntu.com/issues/new" id="report-a-bug">
         <small>Report a bug on this site</small>
       </a>
     </li>


### PR DESCRIPTION
## Issue / Card
https://github.com/canonical/ubuntu.com/issues/12840

## Done
Href value adjusted to: 
`https://github.com/canonical/ubuntu.com/issues/new`

## QA
How to test:
1. Navigate to any Ubuntu.com/* page that contains _Report a bug on this site_ link in footer
2. Scroll down to footer and hover over the _"Report a bug on this site"_ link
3. Click on link
4. Observe if you were sent to _Ubuntu GitHub repository - create new issue_ view 
5. Observe if issue footer displays the `ubuntu.com/<page>` link of source from which you've arrived from - page where you clicked on _Report a bug on this site_ link

## Screenshots
![2023-10-04 23_37_30-LeaDevelop](https://github.com/canonical/ubuntu.com/assets/104503492/e4892736-db09-49da-8d9a-187cb2de99be)
![2023-10-04 23_37_37-LeaDevelop](https://github.com/canonical/ubuntu.com/assets/104503492/cc44d0d3-19c8-4189-8206-ad78cd6dbea2)