### PR TITLE
Forbidden checkout on technical account

### DIFF
--- a/templates/account/forbidden.html
+++ b/templates/account/forbidden.html
@@ -12,7 +12,11 @@
     <div class="row">
       <div class="col-12">
         <h1>Access Forbidden</h1>
-        <p>You cannot perform that action. Contact your account administrator for more information.</p>
+        {% if is_technical %}	
+          <p>You are currently signed in with a Technical account. "Technical" users are denied access to purchase account. Try again with a different account.</p>
+        {% else %}
+          <p>You cannot perform that action. Contact your account administrator for more information.</p>
+        {% endif %}
       </div>
     </div>
   </section>

--- a/templates/account/forbidden.html
+++ b/templates/account/forbidden.html
@@ -12,10 +12,12 @@
     <div class="row">
       <div class="col-12">
         <h1>Access Forbidden</h1>
-        {% if is_technical %}	
-          <p>You are currently signed in with a Technical account. "Technical" users are denied access to purchase account. Try again with a different account.</p>
-        {% else %}
-          <p>You cannot perform that action. Contact your account administrator for more information.</p>
+        {% if reason=="is_not_admin" %}	
+          <p>You need administrator rights to the account to access this feature.</p>
+        {% elif reason=="is_technical" %}
+          <p>You have "Technical" user access to this account. "Technical" users are denied access to some features. Contact your account administrator for more information.</p>
+        {% elif reason=="is_only_personal" %}
+          <p>This feature is accessible only by users with enterprise subscriptions for commercial use.</p>
         {% endif %}
       </div>
     </div>

--- a/webapp/shop/advantage/views.py
+++ b/webapp/shop/advantage/views.py
@@ -202,7 +202,9 @@ def advantage_shop_view(advantage_mapper, **kwargs):
             # One will need to be created later; expected condition.
             pass
         except AccessForbiddenError:
-            return flask.render_template("account/forbidden.html")
+            return flask.render_template(
+                "account/forbidden.html", reason="is_technical"
+            )
 
     all_subscriptions = []
     if account:
@@ -240,12 +242,18 @@ def advantage_account_users_view(advantage_mapper, **kwargs):
     try:
         account = advantage_mapper.get_purchase_account("canonical-ua")
     except UAContractsUserHasNoAccount:
-        pass
+        return flask.render_template(
+            "account/forbidden.html", reason="is_only_personal"
+        )
     except AccessForbiddenError:
-        return flask.render_template("account/forbidden.html")
+        return flask.render_template(
+            "account/forbidden.html", reason="is_technical"
+        )
 
-    if account is None or account.role != "admin":
-        return flask.render_template("account/forbidden.html")
+    if account.role != "admin":
+        return flask.render_template(
+            "account/forbidden.html", reason="is_not_admin"
+        )
 
     return flask.render_template("advantage/users/index.html")
 
@@ -589,7 +597,9 @@ def blender_shop_view(advantage_mapper, **kwargs):
             # One will need to be created later; expected condition.
             pass
         except AccessForbiddenError:
-            return flask.render_template("account/forbidden.html")
+            return flask.render_template(
+                "account/forbidden.html", reason="is_technical"
+            )
 
     all_subscriptions = []
     if account:
@@ -661,7 +671,9 @@ def get_activate_view(advantage_mapper: AdvantageMapper, **kwargs):
     except UAContractsUserHasNoAccount:
         pass
     except AccessForbiddenError:
-        return flask.render_template("account/forbidden.html")
+        return flask.render_template(
+            "account/forbidden.html", reason="is_technical"
+        )
 
     return flask.render_template(
         "pro/activate.html",

--- a/webapp/shop/views.py
+++ b/webapp/shop/views.py
@@ -93,7 +93,9 @@ def invoices_view(advantage_mapper: AdvantageMapper, **kwargs):
     except UAContractsUserHasNoAccount:
         account = None
     except AccessForbiddenError:
-        return flask.render_template("account/forbidden.html")
+        return flask.render_template(
+            "account/forbidden.html", reason="is_technical"
+        )
 
     payments = []
     if account:
@@ -135,7 +137,9 @@ def payment_methods_view(advantage_mapper, ua_contracts_api, **kwargs):
     except UAContractsUserHasNoAccount:
         pass
     except AccessForbiddenError:
-        return flask.render_template("account/forbidden.html")
+        return flask.render_template(
+            "account/forbidden.html", reason="is_technical"
+        )
 
     if account:
         account_id = account.id
@@ -333,15 +337,13 @@ def support(**kwargs):
 
 @shop_decorator(area="account", permission="user", response="html")
 def checkout(advantage_mapper, **kwargs):
-    is_technical = False
     try:
         advantage_mapper.get_purchase_account("canonical-ua")
     except UAContractsUserHasNoAccount:
         pass
     except AccessForbiddenError:
-        is_technical = True
         return flask.render_template(
-            "account/forbidden.html", is_technical=is_technical
+            "account/forbidden.html", reason="is_technical"
         )
     return flask.render_template(
         "account/checkout.html",

--- a/webapp/shop/views.py
+++ b/webapp/shop/views.py
@@ -332,7 +332,17 @@ def support(**kwargs):
 
 
 @shop_decorator(area="account", permission="user", response="html")
-def checkout(**kwargs):
+def checkout(advantage_mapper, **kwargs):
+    is_technical = False
+    try:
+        advantage_mapper.get_purchase_account("canonical-ua")
+    except UAContractsUserHasNoAccount:
+        pass
+    except AccessForbiddenError:
+        is_technical = True
+        return flask.render_template(
+            "account/forbidden.html", is_technical=is_technical
+        )
     return flask.render_template(
         "account/checkout.html",
     )


### PR DESCRIPTION
## Done

- Show access forbidden page on /account/checkout when signed in with a technical account 

## QA
Check these...

Forbidden pages tests:
- As `personal` (Free token only):
- [x]  Go to /pro/users -> Check right message shows up
- As `technical`:  
- [x] Go to /pro/users -> Check right message shows up
- [x] Go to /pro/subscribe -> Check right message shows up
- [x] Go to /pro/activate -> Check right message shows up
- [x] Go to /pro/subscribe/blender -> Check right message shows up
- [x] Go to /account/checkout -> Check right message shows up
- [x]  Go to /account/invoices -> Check right message shows up
- [x] Go to /account/payment-methods -> Check right message shows up
- As `billing`:
- [x] Go to /pro/users -> Check right message shows up for non-admin

## Issue / Card

Fixes #https://warthogs.atlassian.net/browse/WD-6480

## Screenshots

<img width="741" alt="image" src="https://github.com/canonical/ubuntu.com/assets/57550290/cd2ddc7d-21ee-42db-bf7e-80323762c48d">
