### PR TITLE
WD-6598 - update release link and asset

### DIFF
--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -65,7 +65,7 @@
       <div class="u-align--center u-sv4">
         {{
           image (
-          url="https://assets.ubuntu.com/v1/3a32d136-Lobster_circular.png",
+          url="https://assets.ubuntu.com/v1/d708a347-mantic-minotaur-logo.png",
           alt="",
           width="200",
           height="200",
@@ -79,7 +79,7 @@
         <script>performance.mark("Download (Desktop) button rendered")</script>
       </p>
       <p>
-        <a href="https://cdimage.ubuntu.com/releases/lunar/release/ubuntu-23.04-desktop-legacy-amd64.iso" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{ releases.latest.short_version }} legacy installer', 'eventValue' : undefined });">Download {{ releases.latest.short_version }} (Legacy Desktop Installer)</a>
+        <a href="https://cdimage.ubuntu.com/releases/lunar/release/ubuntu-{{ releases.latest.short_version }}-desktop-legacy-amd64.iso" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{ releases.latest.short_version }} legacy installer', 'eventValue' : undefined });">Download {{ releases.latest.short_version }} (Legacy Desktop Installer)</a>
       </p>
       <p><small>For other versions of Ubuntu Desktop including torrents, the network installer, a list of local mirrors and past releases <a href="/download/alternative-downloads">see our alternative downloads</a>.</small></p>
     </div>


### PR DESCRIPTION
## Done

- Updated link and asset for /download/desktop 23.10 release

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
