### PR TITLE
Hide notification for personal users

### DIFF
--- a/static/js/src/advantage/users/hooks/useRequestAccountUsers.tsx
+++ b/static/js/src/advantage/users/hooks/useRequestAccountUsers.tsx
@@ -5,13 +5,9 @@ const useRequestAccountUsers = () => {
   const { isLoading, isError, isSuccess, data, error } = useQuery(
     "accountUsers",
     async () => {
-      try {
-        const res = await requestAccountUsers();
+      const res = await requestAccountUsers();
 
-        return res;
-      } catch (error) {
-        throw error;
-      }
+      return res;
     }
   );
 

--- a/static/js/src/advantage/users/hooks/useRequestAccountUsers.tsx
+++ b/static/js/src/advantage/users/hooks/useRequestAccountUsers.tsx
@@ -10,14 +10,7 @@ const useRequestAccountUsers = () => {
 
         return res;
       } catch (error) {
-        if (
-          error instanceof Error &&
-          error.message.includes("cannot find purchase account")
-        ) {
-          return undefined;
-        } else {
-          throw error;
-        }
+        throw error;
       }
     }
   );

--- a/tests/cypress/integration/pro/checkout_spec.js
+++ b/tests/cypress/integration/pro/checkout_spec.js
@@ -194,7 +194,7 @@ context("Checkout - Your information", () => {
 });
 
 context("Checkout purchase", () => {
-  it.only("user: it should purchase", () => {
+  it("user: it should purchase", () => {
     cy.visit("/pro/subscribe");
     cy.acceptCookiePolicy();
     cy.selectProducts();


### PR DESCRIPTION
## Done

- Users with Free token only (without Purchase account) should not get the `Add account users` notification.

## QA

-  Use a fresh account. You should not see the notification.
- Use an account with a paid subscription, you should see the notification.

## Issue / Card

Fixes #https://warthogs.atlassian.net/browse/WD-6618