### PR TITLE
[WD-6656] change link for QEMU preinstalled image on RISC-V download page

### DIFF
--- a/templates/download/risc-v/tab-3.html
+++ b/templates/download/risc-v/tab-3.html
@@ -23,7 +23,7 @@
     </div>
     <div class="col-6">
       <p class="u-sv3">
-				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.10/release/ubuntu-23.10-preinstalled-server-riscv64+unmatched.img.xz">Download 23.10</a>
+				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/23.10/release/ubuntu-23.10-preinstalled-server-riscv64.img.xz">Download 23.10</a>
 				<a class="p-button" href="https://cdimage.ubuntu.com/releases/22.04.3/release/ubuntu-22.04.3-preinstalled-server-riscv64+unmatched.img.xz">Download 22.04.3</a>
 			</p>
     </div>


### PR DESCRIPTION
## Done

- Change link for downloading QEMU preinstalled image on RISC-V download page

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Navigate to `/download/risc-v` page and check the link of the button `Download 23.10` in `Ubuntu Server preinstalled image` section of `QEMU emulator` tab

## Issue / Card

Closes https://warthogs.atlassian.net/browse/WD-6656

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
