### PR TITLE
[copy update] WD-6607 - Fix typo on `/ai/mlflow`

### DIFF
--- a/templates/ai/mlflow.html
+++ b/templates/ai/mlflow.html
@@ -224,7 +224,7 @@
     <div class="col">
       <div class="row">
         <div class="col-3">
-          <h3 class="p-heading--5">Manged services</h3>
+          <h3 class="p-heading--5">Managed services</h3>
         </div>
         <div class="col-6">
           <div class="p-section--shallow">


### PR DESCRIPTION
## Done

- Fix typo on `/ai/mlflow`

## QA

- Check out [the demo here](url) and see the typo [described in the task](https://warthogs.atlassian.net/browse/WD-6607) is fixed.

## Issue / Card

- [WD-6607](https://warthogs.atlassian.net/browse/WD-6607)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
