### PR TITLE
[WD-6707] Minor changes on download pages

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -147,12 +147,6 @@ export var serverAndDesktopReleases = [
     status: "ESM",
   },
   {
-    startDate: new Date("2022-10-20T00:00:00"),
-    endDate: new Date("2023-07-20T00:00:00"),
-    taskName: "22.10 (Kinetic Kudu)",
-    status: "INTERIM_RELEASE",
-  },
-  {
     startDate: new Date("2023-04-20T00:00:00"),
     endDate: new Date("2024-01-20T00:00:00"),
     taskName: "23.04 (Lunar Lobster)",
@@ -1710,7 +1704,6 @@ export var smallReleaseNames = [
 export var desktopServerReleaseNames = [
   "23.10 (Mantic Minotaur)",
   "23.04 (Lunar Lobster)",
-  "22.10 (Kinetic Kudu)",
   "22.04 LTS (Jammy Jellyfish)",
   "20.04 LTS (Focal Fossa)",
   "18.04 LTS (Bionic Beaver)",

--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -118,11 +118,6 @@ meta_copydoc %}
             <td>Apr 2032</td>
           </tr>
           <tr>
-            <td>22.10 (Kinetic Kudu)</td>
-            <td>Oct 2022</td>
-            <td>Jul 2023</td>
-          </tr>
-          <tr>
             <td>23.04 (Lunar Lobster)</td>
             <td>Apr 2023</td>
             <td>Jan 2024</td>

--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -2,9 +2,12 @@
 
 {% block title %}Get Ubuntu | Download{% endblock %}
 
-{% block meta_description %}Download Ubuntu desktop, Ubuntu Server, Ubuntu for Raspberry Pi and IoT devices, Ubuntu Core and all the Ubuntu flavours.  Ubuntu is an open-source software platform that runs everywhere from the PC to the server and the cloud.{% endblock %}
+{% block meta_description %}Download Ubuntu desktop, Ubuntu Server, Ubuntu for Raspberry Pi and IoT devices, Ubuntu Core
+and all the Ubuntu flavours. Ubuntu is an open-source software platform that runs everywhere from the PC to the server
+and the cloud.{% endblock %}
 
-{% block meta_copydoc %}https://docs.google.com/document/d/1egsCcmFiz8czeHsvwoB9Jz815Ij5Urtf7Ngrru6Zd4o/edit{% endblock meta_copydoc %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1egsCcmFiz8czeHsvwoB9Jz815Ij5Urtf7Ngrru6Zd4o/edit{% endblock
+meta_copydoc %}
 
 {% block meta_image %}https://assets.ubuntu.com/v1/28e0ebb7-Focal-Fossa-gradient-outline.svg{% endblock %}
 
@@ -15,7 +18,8 @@
       <h1 class="p-heading--2 u-no-margin--bottom"><strong>Ubuntu downloads</strong></h1>
       <h2 class="u-no-padding--top u-text--muted">Ubuntu Desktop</h2>
       <p>
-        Fast, free and full of new features. The latest release of Ubuntu Desktop delivers new tools and enhancements for developers,
+        Fast, free and full of new features. The latest release of Ubuntu Desktop delivers new tools and enhancements
+        for developers,
         creators, gamers and administrators.
       </p>
       <p>
@@ -23,18 +27,19 @@
       </p>
       <p><a href="/download/desktop" class="p-button--positive">Download Ubuntu Desktop</a></p>
       <p>
-        <strong>Do you want to upgrade?</strong> <a href="/tutorials/tutorial-upgrading-ubuntu-desktop">Follow our simple guide</a>
+        <strong>Do you want to upgrade?</strong> <a href="/tutorials/tutorial-upgrading-ubuntu-desktop">Follow our
+          simple guide</a>
       </p>
     </div>
     <div class="col-6 u-hide--medium u-hide--small u-align--center">
       {{ image (
-        url="https://assets.ubuntu.com/v1/95ef22cd-mascots-lobster+jj.png",
-        alt="",
-        width="540",
-        height="230",
-        hi_def=True,
-        loading="auto"
-        ) | safe
+      url="https://assets.ubuntu.com/v1/e55bf8b8-mascots-minotaur+jj.png",
+      alt="",
+      width="540",
+      height="230",
+      hi_def=True,
+      loading="auto"
+      ) | safe
       }}
     </div>
   </div>
@@ -44,14 +49,14 @@
   <div class="row u-equal-height">
     <div class="col-1 u-hide--small u-vertically-center u-align--center">
       {{
-        image(
-        url="https://assets.ubuntu.com/v1/ea34f006-Multipass+logomark_rgb.svg",
-        alt="Ubuntu",
-        width="40",
-        height="40",
-        hi_def=True,
-        loading="auto",
-        ) | safe
+      image(
+      url="https://assets.ubuntu.com/v1/ea34f006-Multipass+logomark_rgb.svg",
+      alt="Ubuntu",
+      width="40",
+      height="40",
+      hi_def=True,
+      loading="auto",
+      ) | safe
       }}
     </div>
     <div class="col-5 u-vertically-center">
@@ -62,14 +67,14 @@
     </div>
     <div class="col-1 u-hide--small u-vertically-center u-align--center">
       {{
-        image(
-        url="https://assets.ubuntu.com/v1/08563efa-picto-windows.svg",
-        alt="Windows",
-        width="40",
-        height="40",
-        hi_def=True,
-        loading="auto",
-        ) | safe
+      image(
+      url="https://assets.ubuntu.com/v1/08563efa-picto-windows.svg",
+      alt="Windows",
+      width="40",
+      height="40",
+      hi_def=True,
+      loading="auto",
+      ) | safe
       }}
     </div>
     <div class="col-5 u-vertically-center">
@@ -90,7 +95,8 @@
         </a>
       </h3>
       <p>
-        Whether you want to configure a simple file server or build a fifty thousand-node cloud, you can rely on Ubuntu Server and its five years of free updates.
+        Whether you want to configure a simple file server or build a fifty thousand-node cloud, you can rely on Ubuntu
+        Server and its five years of free updates.
       </p>
     </div>
     <div class="col-6 u-sv3">
@@ -100,7 +106,8 @@
         </a>
       </h3>
       <p>
-        Ubuntu is the reference OS for OpenStack. Try <a href="/openstack/install">Canonical OpenStack</a> on a single machine or start building a production cloud on a cluster &mdash; just add servers.
+        Ubuntu is the reference OS for OpenStack. Try <a href="/openstack/install">Canonical OpenStack</a> on a single
+        machine or start building a production cloud on a cluster &mdash; just add servers.
       </p>
     </div>
   </div>
@@ -112,7 +119,8 @@
         </a>
       </h3>
       <p>
-        Ubuntu flavours offer a unique way to experience Ubuntu with different choices of default applications and settings, backed by the full Ubuntu archive for packages and updates.
+        Ubuntu flavours offer a unique way to experience Ubuntu with different choices of default applications and
+        settings, backed by the full Ubuntu archive for packages and updates.
       </p>
     </div>
     <div class="col-6 u-sv3">
@@ -122,7 +130,8 @@
         </a>
       </h3>
       <p>
-        Are you a developer who wants to try snappy Ubuntu Core? The new, transactionally updated Ubuntu for clouds and devices.
+        Are you a developer who wants to try snappy Ubuntu Core? The new, transactionally updated Ubuntu for clouds and
+        devices.
       </p>
     </div>
   </div>
@@ -131,13 +140,16 @@
 <section class="p-strip--light">
   <div class="u-fixed-width">
     <h2>Alternative downloads</h2>
-    <p>There are several other ways to get Ubuntu including torrents, which can potentially mean a quicker download, our network installer for older systems and special configurations and links to our regional mirrors for our older (and newer) releases.</p>
+    <p>There are several other ways to get Ubuntu including torrents, which can potentially mean a quicker download, our
+      network installer for older systems and special configurations and links to our regional mirrors for our older
+      (and newer) releases.</p>
     <p>
       <a href="/download/alternative-downloads" class="p-button">Alternative downloads</a>
     </p>
   </div>
 </section>
 
-{% with first_item="_download_enterprise_support", second_item="_download_documentation", third_item="_download_helping_hands" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
+{% with first_item="_download_enterprise_support", second_item="_download_documentation",
+third_item="_download_helping_hands" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 {% endblock content %}

--- a/templates/download/iot/index.html
+++ b/templates/download/iot/index.html
@@ -1,7 +1,8 @@
 {% extends "download/iot/_base_iot.html" %}
 
 {% block title %}Download Ubuntu for IoT boards | Download{% endblock %}
-{% block meta_copydoc %}https://docs.google.com/document/d/1Sxdl5cGGe1wbHmKB2eL2zQLfVW3KBea02a2FIGx3VdQ/edit{% endblock meta_copydoc %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1Sxdl5cGGe1wbHmKB2eL2zQLfVW3KBea02a2FIGx3VdQ/edit{% endblock
+meta_copydoc %}
 
 {% block content %}
 
@@ -16,287 +17,297 @@
       <div class="p-heading-icon">
         <div class="p-heading-icon__header">
           {{
-            image(
-              url="https://assets.ubuntu.com/v1/a8a6238c-RGB+RPi.svg",
-              alt="Raspberry Pi",
-              width="40",
-              height="40",
-              hi_def=True,
-              loading="auto",
-              attrs={"class": "p-heading-icon__img"},
-            ) | safe
+          image(
+          url="https://assets.ubuntu.com/v1/a8a6238c-RGB+RPi.svg",
+          alt="Raspberry Pi",
+          width="40",
+          height="40",
+          hi_def=True,
+          loading="auto",
+          attrs={"class": "p-heading-icon__img"},
+          ) | safe
           }}
           <h2 class="p-heading-icon__title p-heading--3">Ubuntu for Raspberry Pi</h2>
         </div>
       </div>
       <p>
-        Get the power, ease and flexibility of Ubuntu for Raspberry Pi 2, 3 or 4.<br />
+        Get the power, ease and flexibility of Ubuntu for Raspberry Pi 2, 3, 4 or 5.<br />
         Get started with an Ubuntu Server or Desktop image for a familiar development environment.
       </p>
-      <p><a class="p-button--positive" href="/download/raspberry-pi">Install on Raspberry Pi 2, 3 or 4</a></p>
+      <p><a class="p-button--positive" href="/download/raspberry-pi">Install on Raspberry Pi</a></p>
     </div>
     <div class="col-5 col-start-large-8 u-hide--medium u-hide--small u-align--center">
       {{
-        image(
-          url="https://assets.ubuntu.com/v1/a999bb5f-Raspberry+Pi+4.png",
-          alt="",
-          height="268",
-          width="420",
-          hi_def=True,
-        ) | safe
+      image(
+      url="https://assets.ubuntu.com/v1/a999bb5f-Raspberry+Pi+4.png",
+      alt="",
+      height="268",
+      width="420",
+      hi_def=True,
+      ) | safe
       }}
     </div>
-  </section>
+</section>
 
 
-  <section class="p-strip is-deep">
-    <div class="row">
-      <div class="col-2 col-medium-4">
-        <h3>Supported platforms</h3>
-      </div>
-      <div class="col-2 col-medium-3">
-        {{
-          image(
-            url="https://assets.ubuntu.com/v1/a69b2863-intel+nuc.svg",
-            alt="Intel NUC",
-            width="120",
-            height="45",
-            hi_def=True,
-            loading="auto",
-          ) | safe
-        }}
-        <p>
-          <a href="/download/intel-nuc-desktop">Install Ubuntu Desktop&nbsp;&rsaquo;</a>
-        </p>
-      </div>
-      <div class="col-2 col-medium-3">
-        {{
-          image(
-            url="https://assets.ubuntu.com/v1/88444b11-logo-up2.svg",
-            alt="Up2",
-            width="63",
-            height="45",
-            hi_def=True,
-            loading="auto",
-          ) | safe
-        }}
-        <p>
-          <a href="/download/up-squared-iot-grove-server">Install Ubuntu Server&nbsp;&rsaquo;</a>
-        </p>
-      </div>
-      <div class="col-2 col-medium-3">
-        {{ image (
-          url="https://assets.ubuntu.com/v1/327b8104-AMD_E_Blk_RGB.png",
-          alt="AMD XILINX",
-          width="187",
-          height="45",
-          hi_def=True,
-          loading="auto"
-          ) | safe
-        }}
-        <p>
-          <a href="/download/amd">Install Ubuntu Desktop&nbsp;&rsaquo;</a>
-        </p>
-      </div>
-      <div class="col-2 col-medium-3">
-        {{ image (
-          url="https://assets.ubuntu.com/v1/26cbe599-intel-logo.jpg",
-          alt="Intel",
-          width="75",
-          height="42",
-          hi_def=True,
-          loading="auto"
-          ) | safe
-        }}
-        <p>
-          <a href="/download/iot/intel-iotg">Install Ubuntu Desktop&nbsp;&rsaquo;</a>
-        </p>
-      </div>
-      <div class="col-2 col-medium-3">
-        {{ image (
-          url="https://assets.ubuntu.com/v1/4d5b8d51-riscv-color.svg",
-          alt="RISC-V",
-          width="147",
-          height="23",
-          hi_def=True,
-          loading="auto",
-          attrs={"style": "margin: 0.5rem 0 0.75rem; max-width: 147px;"}
-          ) | safe
-        }}
-        <p>
-          <a href="/download/risc-v">Install Ubuntu Server&nbsp;&rsaquo;</a>
-        </p>
-      </div>
-    </div>
-    <br />
-    <div class="row">
-      <div class="col-8">
-        <h3>The ultimate Ubuntu Experience</h3>
-      </div>
-      </div>
-    <div class="row">
-      <div class="col-8">
-        <p>Ubuntu works along with silicon vendors and manufacturers to enable and certify Ubuntu on a wide range of hardware. The certified hardware passes our extensive testing and review process in our labs, ensuring that Ubuntu runs well out of the box, and regression tests are performed before every system update is delivered.</p>
-
-        <a class="p-button--positive" href="/certified">Get Certified Hardware</a>
-      </div>
-      <div class="col-4 u-align--center u-hide--medium u-hide--small">
-        {{ image (
-          url="https://assets.ubuntu.com/v1/d9c2c5bf-ubuntu_certified.png",
-          alt="",
-          width="106",
-          height="150",
-          hi_def=True,
-          loading="lazy"
-          ) | safe
-        }}
-      </div>
-    </div>
-  </section>
-
-  <section id="core" class="p-strip--light">
-    <div class="row u-equal-height p-divider">
-      <div class="col-7">
-        <h3 class="p-heading--2">Ubuntu Core</h3>
-        <p>
-          Ubuntu Core is a lean, strictly confined and fully transactional operating system. We designed it from the ground up, to focus on security and simplified maintenance, for appliances and large device networks. Ubuntu Core is powered by snaps - the universal Linux packaging format.
-        </p>
-        <p>
-          <a class="p-button is-inline" style="margin-left: 0;" href="/core">Learn more about Ubuntu Core</a><br class="u-hide--large u-hide--medium" /><a href="/download/kvm">Install on your workstation in a KVM&nbsp;&rsaquo;</a>
-        </p>
-      </div>
-      <div class="col-5 p-divider__block u-vertically-center u-hide--medium u-hide--small u-align--center">
-        {{
-          image(
-            url="https://assets.ubuntu.com/v1/0bdfaf89-ubuntu-core-logo-45.svg",
-            alt="Canonical Ubuntu Core logo",
-            width="315",
-            height="45",
-            hi_def=True,
-            loading="lazy"
-          ) | safe
-        }}
-      </div>
-    </div>
-  </section>
-
-  <section class="p-strip">
-    <div class="u-fixed-width u-sv3">
+<section class="p-strip is-deep">
+  <div class="row">
+    <div class="col-2 col-medium-4">
       <h3>Supported platforms</h3>
     </div>
-    <div class="row u-sv3">
-      <div class="col-4">
-          {{ image (
-            url="https://assets.ubuntu.com/v1/977f2b7a-raspberry+pi+horizontal.svg",
-            alt="Raspberry Pi logo",
-            width="168",
-            height="45",
-            hi_def=True,
-            loading="lazy"
-            ) | safe
-          }}
-        <p><a href="/download/iot/raspberry-pi">Install Ubuntu Core 22&nbsp;&rsaquo;</a></p>
-        </div>
-        <div class="col-4">
-          {{ image (
-            url="https://assets.ubuntu.com/v1/a69b2863-intel+nuc.svg",
-            alt="Intel NUC logo",
-            width="120",
-            height="45",
-            hi_def=True,
-            loading="lazy"
-            ) | safe
-          }}
-          <p><a href="/download/iot/intel-nuc">Install Ubuntu Core 22&nbsp;&rsaquo;</a></p>
-        </div>
-        <div class="col-4">
-          {{ image (
-            url="https://assets.ubuntu.com/v1/db577ec7-tank-logo.svg",
-            alt="Intel Tank logo",
-            width="163",
-            height="45",
-            hi_def=True,
-            loading="lazy"
-            ) | safe
-          }}
-          <p><a href="/download/intel-iei-tank-870">Install Ubuntu Core 18&nbsp;&rsaquo;</a></p>
-        </div>
-      </div>
-      <div class="row u-sv3">
-        <div class="col-4">
-          {{ image (
-            url="https://assets.ubuntu.com/v1/2a6d29c9-snapdragon.svg",
-            alt="Qualcomm Snapdragon logo",
-            width="139",
-            height="45",
-            hi_def=True,
-            loading="lazy"
-            ) | safe
-          }}
-          <p><a href="/download/qualcomm-dragonboard-410c">Install Ubuntu Core 18&nbsp;&rsaquo;</a></p>
-        </div>
-        <div class="col-4">
-          {{
-            image (
-            url="https://assets.ubuntu.com/v1/327b8104-AMD_E_Blk_RGB.png",
-            alt="",
-            width="187",
-            height="45",
-            hi_def=True,
-            loading="lazy"
-            ) | safe
-          }}
-          <p><a href="/download/amd">Install Ubuntu Desktop&nbsp;&rsaquo;</a></p>
-        </div>
-        <div class="col-4">
-          {{ image (
-            url="https://assets.ubuntu.com/v1/26cbe599-intel-logo.jpg",
-            alt="Intel logo",
-            width="75",
-            height="42",
-            hi_def=True,
-            loading="lazy"
-            ) | safe
-          }}
-          <p>
-            <a href="/download/iot/intel-iotg">Install Ubuntu Core 20&nbsp;&rsaquo;</a>
-          </p>
-        </div>
-      </div>
-      <div class="u-fixed-width">
-        <p>
-          <a class="p-button" href="https://cdimage.ubuntu.com/ubuntu-core/20/stable/current/">
-            Browse all supported images
-          </a>
-        </p>
-      </div>
-    </section>
-
-    <div class="u-fixed-width">
-      <hr />
+    <div class="col-2 col-medium-3">
+      {{
+      image(
+      url="https://assets.ubuntu.com/v1/a69b2863-intel+nuc.svg",
+      alt="Intel NUC",
+      width="120",
+      height="45",
+      hi_def=True,
+      loading="auto",
+      ) | safe
+      }}
+      <p>
+        <a href="/download/intel-nuc-desktop">Install Ubuntu Desktop&nbsp;&rsaquo;</a>
+      </p>
     </div>
-
-    <section class="p-strip">
-      <div class="u-fixed-width">
-        <h3 class="u-sv3 p-heading--2">Can't find your board of choice?</h3>
-        <p>
-          <a class="p-button--positive js-invoke-modal" href="/download/contact-us">Get in touch</a>
-        </p>
-      </div>
-    </section>
-
-    <section class="p-strip--light is-deep">
-      {% with head="Make something great today", subhead="Download appliance images for your PC, Raspberry Pi or a virtual machine" %}{% include "/appliance/shared/_appliance-advert-strip.html" %}{% endwith %}
-    </section>
-
-    <!-- Set default Marketo information for contact form below-->
-    <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/general" data-form-id="1266" data-lp-id="" data-return-url="https://www.ubuntu.com/download/thank-you?product=supported-platforms" data-lp-url="https://ubuntu.com/download/contact-us?product=supported-platforms">
+    <div class="col-2 col-medium-3">
+      {{
+      image(
+      url="https://assets.ubuntu.com/v1/88444b11-logo-up2.svg",
+      alt="Up2",
+      width="63",
+      height="45",
+      hi_def=True,
+      loading="auto",
+      ) | safe
+      }}
+      <p>
+        <a href="/download/up-squared-iot-grove-server">Install Ubuntu Server&nbsp;&rsaquo;</a>
+      </p>
     </div>
+    <div class="col-2 col-medium-3">
+      {{ image (
+      url="https://assets.ubuntu.com/v1/327b8104-AMD_E_Blk_RGB.png",
+      alt="AMD XILINX",
+      width="187",
+      height="45",
+      hi_def=True,
+      loading="auto"
+      ) | safe
+      }}
+      <p>
+        <a href="/download/amd">Install Ubuntu Desktop&nbsp;&rsaquo;</a>
+      </p>
+    </div>
+    <div class="col-2 col-medium-3">
+      {{ image (
+      url="https://assets.ubuntu.com/v1/26cbe599-intel-logo.jpg",
+      alt="Intel",
+      width="75",
+      height="42",
+      hi_def=True,
+      loading="auto"
+      ) | safe
+      }}
+      <p>
+        <a href="/download/iot/intel-iotg">Install Ubuntu Desktop&nbsp;&rsaquo;</a>
+      </p>
+    </div>
+    <div class="col-2 col-medium-3">
+      {{ image (
+      url="https://assets.ubuntu.com/v1/4d5b8d51-riscv-color.svg",
+      alt="RISC-V",
+      width="147",
+      height="23",
+      hi_def=True,
+      loading="auto",
+      attrs={"style": "margin: 0.5rem 0 0.75rem; max-width: 147px;"}
+      ) | safe
+      }}
+      <p>
+        <a href="/download/risc-v">Install Ubuntu Server&nbsp;&rsaquo;</a>
+      </p>
+    </div>
+  </div>
+  <br />
+  <div class="row">
+    <div class="col-8">
+      <h3>The ultimate Ubuntu Experience</h3>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-8">
+      <p>Ubuntu works along with silicon vendors and manufacturers to enable and certify Ubuntu on a wide range of
+        hardware. The certified hardware passes our extensive testing and review process in our labs, ensuring that
+        Ubuntu runs well out of the box, and regression tests are performed before every system update is delivered.</p>
+
+      <a class="p-button--positive" href="/certified">Get Certified Hardware</a>
+    </div>
+    <div class="col-4 u-align--center u-hide--medium u-hide--small">
+      {{ image (
+      url="https://assets.ubuntu.com/v1/d9c2c5bf-ubuntu_certified.png",
+      alt="",
+      width="106",
+      height="150",
+      hi_def=True,
+      loading="lazy"
+      ) | safe
+      }}
+    </div>
+  </div>
+</section>
+
+<section id="core" class="p-strip--light">
+  <div class="row u-equal-height p-divider">
+    <div class="col-7">
+      <h3 class="p-heading--2">Ubuntu Core</h3>
+      <p>
+        Ubuntu Core is a lean, strictly confined and fully transactional operating system. We designed it from the
+        ground up, to focus on security and simplified maintenance, for appliances and large device networks. Ubuntu
+        Core is powered by snaps - the universal Linux packaging format.
+      </p>
+      <p>
+        <a class="p-button is-inline" style="margin-left: 0;" href="/core">Learn more about Ubuntu Core</a><br
+          class="u-hide--large u-hide--medium" /><a href="/download/kvm">Install on your workstation in a
+          KVM&nbsp;&rsaquo;</a>
+      </p>
+    </div>
+    <div class="col-5 p-divider__block u-vertically-center u-hide--medium u-hide--small u-align--center">
+      {{
+      image(
+      url="https://assets.ubuntu.com/v1/0bdfaf89-ubuntu-core-logo-45.svg",
+      alt="Canonical Ubuntu Core logo",
+      width="315",
+      height="45",
+      hi_def=True,
+      loading="lazy"
+      ) | safe
+      }}
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="u-fixed-width u-sv3">
+    <h3>Supported platforms</h3>
+  </div>
+  <div class="row u-sv3">
+    <div class="col-4">
+      {{ image (
+      url="https://assets.ubuntu.com/v1/977f2b7a-raspberry+pi+horizontal.svg",
+      alt="Raspberry Pi logo",
+      width="168",
+      height="45",
+      hi_def=True,
+      loading="lazy"
+      ) | safe
+      }}
+      <p><a href="/download/iot/raspberry-pi">Install Ubuntu Core 22&nbsp;&rsaquo;</a></p>
+    </div>
+    <div class="col-4">
+      {{ image (
+      url="https://assets.ubuntu.com/v1/a69b2863-intel+nuc.svg",
+      alt="Intel NUC logo",
+      width="120",
+      height="45",
+      hi_def=True,
+      loading="lazy"
+      ) | safe
+      }}
+      <p><a href="/download/iot/intel-nuc">Install Ubuntu Core 22&nbsp;&rsaquo;</a></p>
+    </div>
+    <div class="col-4">
+      {{ image (
+      url="https://assets.ubuntu.com/v1/db577ec7-tank-logo.svg",
+      alt="Intel Tank logo",
+      width="163",
+      height="45",
+      hi_def=True,
+      loading="lazy"
+      ) | safe
+      }}
+      <p><a href="/download/intel-iei-tank-870">Install Ubuntu Core 18&nbsp;&rsaquo;</a></p>
+    </div>
+  </div>
+  <div class="row u-sv3">
+    <div class="col-4">
+      {{ image (
+      url="https://assets.ubuntu.com/v1/2a6d29c9-snapdragon.svg",
+      alt="Qualcomm Snapdragon logo",
+      width="139",
+      height="45",
+      hi_def=True,
+      loading="lazy"
+      ) | safe
+      }}
+      <p><a href="/download/qualcomm-dragonboard-410c">Install Ubuntu Core 18&nbsp;&rsaquo;</a></p>
+    </div>
+    <div class="col-4">
+      {{
+      image (
+      url="https://assets.ubuntu.com/v1/327b8104-AMD_E_Blk_RGB.png",
+      alt="",
+      width="187",
+      height="45",
+      hi_def=True,
+      loading="lazy"
+      ) | safe
+      }}
+      <p><a href="/download/amd">Install Ubuntu Desktop&nbsp;&rsaquo;</a></p>
+    </div>
+    <div class="col-4">
+      {{ image (
+      url="https://assets.ubuntu.com/v1/26cbe599-intel-logo.jpg",
+      alt="Intel logo",
+      width="75",
+      height="42",
+      hi_def=True,
+      loading="lazy"
+      ) | safe
+      }}
+      <p>
+        <a href="/download/iot/intel-iotg">Install Ubuntu Core 20&nbsp;&rsaquo;</a>
+      </p>
+    </div>
+  </div>
+  <div class="u-fixed-width">
+    <p>
+      <a class="p-button" href="https://cdimage.ubuntu.com/ubuntu-core/20/stable/current/">
+        Browse all supported images
+      </a>
+    </p>
+  </div>
+</section>
+
+<div class="u-fixed-width">
+  <hr />
+</div>
+
+<section class="p-strip">
+  <div class="u-fixed-width">
+    <h3 class="u-sv3 p-heading--2">Can't find your board of choice?</h3>
+    <p>
+      <a class="p-button--positive js-invoke-modal" href="/download/contact-us">Get in touch</a>
+    </p>
+  </div>
+</section>
+
+<section class="p-strip--light is-deep">
+  {% with head="Make something great today", subhead="Download appliance images for your PC, Raspberry Pi or a virtual
+  machine" %}{% include "/appliance/shared/_appliance-advert-strip.html" %}{% endwith %}
+</section>
+
+<!-- Set default Marketo information for contact form below-->
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/general"
+  data-form-id="1266" data-lp-id=""
+  data-return-url="https://www.ubuntu.com/download/thank-you?product=supported-platforms"
+  data-lp-url="https://ubuntu.com/download/contact-us?product=supported-platforms">
+</div>
 
 
-    {% with heading="Not finding the board you want? " %}{% include "/pricing/shared/_enablement-strip.html" %}{% endwith %}
+{% with heading="Not finding the board you want? " %}{% include "/pricing/shared/_enablement-strip.html" %}{% endwith %}
 
-    {% with first_item="_core_learn_more", second_item="_core_contribute", third_item="_iot_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
+{% with first_item="_core_learn_more", second_item="_core_contribute", third_item="_iot_further_reading" %}{% include
+"shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
-    {% endblock content %}
-
+{% endblock content %}


### PR DESCRIPTION
## Done

- Remove 22.10 release from charts on `/desktop/developers`, `/16-04` and `/16-04/azure`, since it's not supported anymore
- Replace Lobster mascot with Minotaur mascot on `/download` page
- Fix Raspberry Pi related text on `/download/iot` page

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Naviage to all above mentioned (in Done section) routes and check changes

## Issue / Card

Closes https://warthogs.atlassian.net/browse/WD-6707

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
