### PR TITLE
Update K8s docs homepage

### DIFF
--- a/templates/kubernetes/docs/index.md
+++ b/templates/kubernetes/docs/index.md
@@ -8,29 +8,48 @@ context:
 toc: False
 ---
 
- Charmed Kubernetes<sup>&reg;</sup> is pure Kubernetes tested across the widest range of clouds with modern metrics and monitoring, brought to you by the people who deliver Ubuntu.
+Charmed Kubernetes<sup>&reg;</sup>, is pure Kubernetes tested across the widest range of clouds with modern metrics and
+ monitoring, brought to you by the people who deliver Ubuntu.
 
-Google, Microsoft, and many other institutions run Kubernetes on Ubuntu because we focus on the latest container capabilities in modern kernels. That's why it's the top choice for enterprise Kubernetes, too.
+Google, Microsoft, and many other institutions run Kubernetes on Ubuntu because we focus on the latest container capabi
+lities in modern kernels. That’s why it’s the top choice for enterprise Kubernetes, too.
 
-[Find out more in the Charmed Kubernetes overview&nbsp;&rsaquo;](/kubernetes/docs/overview)
+[Find out more in the Charmed Kubernetes overview&nbsp;&rsaquo;](../overview)
 
-<img src="https://assets.ubuntu.com/v1/843c77b6-juju-at-a-glace.svg" width="608" alt="" style="margin-top: 1rem;">
+<img src="https://assets.ubuntu.com/v1/843c77b6-juju-at-a-glace.svg" style="float:right; margin-left: 2rem; border: 0
+" alt="">
 
-<div class="p-strip is-shallow">
-  <div class="row p-divider">
-    <div class="col-3 p-divider__block">
-      <h3>Get started</h3>
-      <p><a href="/kubernetes/docs/quickstart">Install Charmed Kubernetes&nbsp;&rsaquo;</a></p>
-    </div>
-    <div class="col-3 p-divider__block">
-      <h3>What's new</h3>
-      <p><em>Charmed Kubernetes 1.28 released!</em> Check out the <a href="/kubernetes/docs/1.28/components">latest version here</a>.</p>
-      <p>How Devs, DevOps and businesses <em>really</em> use Kubernetes: <a href="https://juju.is/cloud-native-kubernetes-usage-report-2021">Read the latest industry report</a></p>
-    </div>
-    <div class="col-3 p-divider__block">
-      <h3>Tutorials</h3>
-      <p><a href="/tutorials/how-to-install-portainer-on-canonical-kubernetes#1-overview">Install Portainer on Charmed Kubernetes</a></p>
-    </div>
-  </div>
+## In this documentation
+
+<div class="md-table">
+<table>
+<thead>
+<tr>
+<th></th>
+<th></th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><a href="/docs/tutorials">Tutorials</a><br>  Get started with this introduction to Charmed Kubernetes <br></td>
+<td><a href="/docs/how-to">How-to guides</a> <br> Step-by-step guides covering key operations and common tasks</td>
+</tr>
+<tr>
+<td><a href="/docs/explanation">Explanation</a> <br> Concepts - discussion and clarification of key topics</td>
+<td><a href="/docs/reference">Reference</a> <br> Technical information - specifications, commands, architecture</td>
+</tr>
+</tbody>
+</table>
 </div>
 
+---
+
+## Project and community
+
+Charmed Kubernetes is a member of the Ubuntu family. It's an open source project that welcomes community involvement, contributions, suggestions, fixes and constructive feedback.
+
+* [Our Code of Conduct](https://ubuntu.com/community/code-of-conduct)
+* [Visit us on Slack at #canonical-kubernetes](https://slack.k8s.io/)
+* [Join the Discourse forum](https://discuss.kubernetes.io/)
+* [Contribute to our documentation](https://github.com/charmed-kubernetes/kubernetes-docs)
+* [Source code and project management](https://github.com/charmed-kubernetes)


### PR DESCRIPTION
## Done

- Reworked the landing page to standardise on diataxis layout.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes