### PR TITLE
inclusive identities

### DIFF
--- a/templates/security/disclosure-policy.html
+++ b/templates/security/disclosure-policy.html
@@ -15,6 +15,7 @@
       </h1>
       <p>
         <i>Valid since: October 2020</i>
+        <i>Last updated: October 2023</i>
       </p>
       <p>
         Canonical and the Ubuntu Security Team participate in responsible disclosure and collaborate with the wider community on security issues. This describes how to contact the Ubuntu Security Team, what you can expect when you contact us, and what we expect from you.
@@ -99,7 +100,7 @@
         We are not affiliated with any bug bounty programs. We do not ourselves pay for bug reports, in either our software or our infrastructure.
       </p>
       <p>
-        We are happy to give credit to reporters in our CVE assignments and in our Ubuntu Security Notices. We will use real names of discoverers, with no affiliations, in our USNs.
+        We are happy to give credit to reporters in our CVE assignments and in our Ubuntu Security Notices. We will use known identities of discoverers, with no affiliations, in our USNs.
       </p>
       <h2>
         Disclosure timelines


### PR DESCRIPTION
Please update Ubuntu's Disclosure Policy to be more inclusive.

Currently, the policy states that only "real names" will be credited for the discovery of vulnerabilities.

The term "real name" is ambiguous. It can be interpreted as meaning someones legal name. Requiring legal name can be used for discrimination. For this reason, [the Kernel recently changed their DCO requirements with](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=d4563201f33a022fc0353033d9dfeb1606a88330): 
```
-using your real name (sorry, no pseudonyms or anonymous contributions.)
+using a known identity (sorry, no anonymous contributions.)
```

People around the world use Romanized identities on the internet. Individuals may associate *real name* to a *dead name*. There are many reasons to use another identity, including personal safety. We should be inclusive of a discoverer's requested identity.

As a recent example, the Security team participated as judges at ZDI's Pwn2Own 2023 event. When a vulnerability was discovered in Ubuntu we attributed the CVE to the discoverer's requested common name out of respect.

Please [join LXD](https://github.com/canonical/lxd/commit/4dd79c063e6b0d719b6acfa8a3ee08aea55c50a9) to make our policies more inclusive, by giving security research credit to a person's requested identity.