### PR TITLE
WD-6769 - fix dowload link

### DIFF
--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -79,7 +79,7 @@
         <script>performance.mark("Download (Desktop) button rendered")</script>
       </p>
       <p>
-        <a href="https://cdimage.ubuntu.com/releases/lunar/release/ubuntu-{{ releases.latest.short_version }}-desktop-legacy-amd64.iso" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{ releases.latest.short_version }} legacy installer', 'eventValue' : undefined });">Download {{ releases.latest.short_version }} (Legacy Desktop Installer)</a>
+        <a href="https://cdimage.ubuntu.com/releases/mantic/release/ubuntu-{{ releases.latest.short_version }}-desktop-legacy-amd64.iso" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{ releases.latest.short_version }} legacy installer', 'eventValue' : undefined });">Download {{ releases.latest.short_version }} (Legacy Desktop Installer)</a>
       </p>
       <p><small>For other versions of Ubuntu Desktop including torrents, the network installer, a list of local mirrors and past releases <a href="/download/alternative-downloads">see our alternative downloads</a>.</small></p>
     </div>


### PR DESCRIPTION
## Done

- Fixed ubuntu download link

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
