### PR TITLE
WD-6442 - Update checksums for 23.10

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -31,33 +31,33 @@ openstack_lts:
 
 checksums:
   desktop:
-    "23.04": "a8cd6ccff865e17dd136658f6388480c9a5bc57274b29f7d5bd0ed855a9281a5 *ubuntu-23.04-desktop-amd64.iso"
+    "23.10": "444c8a7b993cb6f103d7df1144954064889cbf7491b2415518d5dd0875e3a96f *ubuntu-23.10-desktop-amd64.iso"
     "22.04.3": "a435f6f393dda581172490eda9f683c32e495158a780b5a1de422ee77d98e909 *ubuntu-22.04.3-desktop-amd64.iso"
     "21.10": "f8d3ab0faeaecb5d26628ae1aa21c9a13e0a242c381aa08157db8624d574b830 *ubuntu-21.10-desktop-amd64.iso"
     "20.04.6": "510ce77afcb9537f198bc7daa0e5b503b6e67aaed68146943c231baeaab94df1 *ubuntu-20.04.6-desktop-amd64.iso"
   live-server:
-    "23.04": "c7cda48494a6d7d9665964388a3fc9c824b3bef0c9ea3818a1be982bc80d346b *ubuntu-23.04-live-server-amd64.iso"
+    "23.10": "d2fb80d9ce77511ed500bcc1f813e6f676d4a3577009dfebce24269ca23346a5 *ubuntu-23.10-live-server-amd64.iso"
     "22.04.3": "a4acfda10b18da50e2ec50ccaf860d7f20b389df8765611142305c0e911d16fd *ubuntu-22.04.3-live-server-amd64.iso"
     "21.10": "e84f546dfc6743f24e8b1e15db9cc2d2c698ec57d9adfb852971772d1ce692d4 *ubuntu-21.10-live-server-amd64.iso"
     "20.04.6": "b8f31413336b9393ad5d8ef0282717b2ab19f007df2e9ed5196c13d8f9153c8b *ubuntu-20.04.6-live-server-amd64.iso"
     "18.04.6": "6c647b1ab4318e8c560d5748f908e108be654bad1e165f7cf4f3c1fc43995934 *ubuntu-18.04.6-live-server-amd64.iso"
   desktop-arm64+raspi:
-    "23.04": "c851edd5d05362b7a9fe9a6e44824d89114de2c07b6f08d97ad790f0bafdc9f1 *ubuntu-23.04-preinstalled-desktop-arm64+raspi.img.xz"
+    "23.10": "92cbd905c36114effcec6943d3438845dfac07e3bb238cde4c510b41a71f694b *ubuntu-23.10-preinstalled-desktop-arm64+raspi.img.xz"
     "22.04.3": "d187127752ebf16201102d32c1e7fa7a17532c6b5ccf7b3b08507d0ab0e3416c *ubuntu-22.04.3-preinstalled-desktop-arm64+raspi.img.xz"
     "21.10": "5187d507099f26bc4d8218085109af498fae5ff93b40c668f83bab5c7574d954 *ubuntu-21.10-preinstalled-desktop-arm64+raspi.img.xz"
     "21.04": "d89ee327a00b98d7166b1a8cc95d17762aaacd3b4d0fc756c5b6b65df1708f48 *ubuntu-21.04-preinstalled-desktop-arm64+raspi.img.xz"
   server-arm64+raspi:
-    "23.04": "cd2a99b065b98078ad2bfec428d5bb876be19c9f5aa8abb8e5dd14125bf611b8 *ubuntu-23.04-preinstalled-server-arm64+raspi.img.xz"
+    "23.10": "81886cefc6b7abe5baf26dbc353bc69924dfc76416c15c3c3d03cf5ba30c90e8 *ubuntu-23.10-preinstalled-server-arm64+raspi.img.xz"
     "22.04.3": "f3842efb3be1be4243c24203bd16e335f155fdbe104b1ed8c5efc548ea478ab0 *ubuntu-22.04.3-preinstalled-server-arm64+raspi.img.xz"
     "21.10": "126f940d3b270a6c1fc5a183ac8a3d193805fead4f517296a7df9d3e7d691a03 *ubuntu-21.10-preinstalled-server-arm64+raspi.img.xz"
     "20.04.5": "44b98acd3fd4379c6b194696520b6aecb2f596b601e43e9b6934c83f0aa61026 *ubuntu-20.04.5-preinstalled-server-arm64+raspi.img.xz"
   server-armhf+raspi:
-    "23.04": "4d6e43707260c3653bdbc30eecd4148b6b314612b8c522de4a60d74fd3df128f *ubuntu-23.04-preinstalled-server-armhf+raspi.img.xz"
+    "23.10": "bab926a3f86837888940db1bbae64b6f7e03b03d044c1669167b6a42fd20cac2 *ubuntu-23.10-preinstalled-server-armhf+raspi.img.xz"
     "22.04.3": "dbab406bfa473ebf95aa2e34e87ebf64467067ffa0478daa85c48e213b925ed6 *ubuntu-22.04.3-preinstalled-server-armhf+raspi.img.xz"
     "21.10": "341593c9607ed20744cd86941d94d73e3ba4f74e8ef2633eec63ce9b0cfac5a1 *ubuntu-21.10-preinstalled-server-armhf+raspi.img.xz"
     "20.04.5": "065c41846ddf7a1c636a1aac5a7d49ebcee819b141f9d57fd586c5f84b9b7942 *ubuntu-20.04.5-preinstalled-server-armhf+raspi.img.xz"
   server-riscv64:
-    "23.04": "774a679251c496426727fcab1355f41f2523845dac405bfe9814a5c4c588df14 *ubuntu-23.04-preinstalled-server-riscv64+unmatched.img.xz"
+    "23.10": "5c300b9fff78f5d86fec06787e833573220165aeb310a8f1b5c56ca888bc91c2 *ubuntu-23.10-preinstalled-server-riscv64+unmatched.img.xz"
     "22.04.3": "b739d17a3a7f0494b2d804c5f54fd2f303ba665acf353ee3bef78825bfc7b39c *ubuntu-22.04.3-preinstalled-server-riscv64+unmatched.img.xz"
     "21.10": "8067892fa627eb219b31dc629f31f3bda6b015dfeabf2fdc9b0ed150bf7984b8 *ubuntu-21.10-preinstalled-server-riscv64+unmatched.img.xz"
   core-22-arm64+raspi:


### PR DESCRIPTION
## Done

- Updated the checksums for 23.10 release

## QA

- Check the downloads work and match the checksums

```
444c8a7b993cb6f103d7df1144954064889cbf7491b2415518d5dd0875e3a96f *ubuntu-23.10-desktop-amd64.iso
d2fb80d9ce77511ed500bcc1f813e6f676d4a3577009dfebce24269ca23346a5 *ubuntu-23.10-live-server-amd64.iso
228dc794edcbbdce0f60fa7e3aa0490d4524fe054644b6e81eee0be7ca924656 *ubuntu-23.10-desktop-legacy-amd64.iso
5ea4c792a0cc5462a975d2f253182e9678cc70172ebd444d730f2c4fd7678e43 *ubuntu-23.10-live-server-arm64.iso
cfe96609cc7bbc92495772d6676f2a066d16b058a61f4502161c3302dad6cabb *ubuntu-23.10-live-server-ppc64el.iso
c610dc499e3837d81befe6f47bee27f3b952a794c3eec3c026fa7cd5b25151b6 *ubuntu-23.10-live-server-riscv64.img.gz
7ac8166432f5d4ef3e3e3dbdb4b47323ab4816ad85db7cab0ffa62c1690fc15b *ubuntu-23.10-live-server-s390x.iso
92cbd905c36114effcec6943d3438845dfac07e3bb238cde4c510b41a71f694b *ubuntu-23.10-preinstalled-desktop-arm64+raspi.img.xz
81886cefc6b7abe5baf26dbc353bc69924dfc76416c15c3c3d03cf5ba30c90e8 *ubuntu-23.10-preinstalled-server-arm64+raspi.img.xz
bab926a3f86837888940db1bbae64b6f7e03b03d044c1669167b6a42fd20cac2 *ubuntu-23.10-preinstalled-server-armhf+raspi.img.xz
b227af13a505a1c87198f6590ba4acecbc5d649b4f0951ac0f2985ed857a63b3 *ubuntu-23.10-preinstalled-server-riscv64+icicle.img.xz
8cf210d58088eaeb00ae005100510eddbc701d2770ab1264d0e491e4910793c9 *ubuntu-23.10-preinstalled-server-riscv64+licheerv.img.xz
ac50daec22125b549a4c081b9330a979627569c31df44236cd9c68b80b98e12f *ubuntu-23.10-preinstalled-server-riscv64+nezha.img.xz
5c300b9fff78f5d86fec06787e833573220165aeb310a8f1b5c56ca888bc91c2 *ubuntu-23.10-preinstalled-server-riscv64+unmatched.img.xz
10e879fdd449bdeb235e2ae5c33e813eb59e61af004dcf93d804e186619773cb *ubuntu-23.10-preinstalled-server-riscv64+visionfive.img.xz
f9610971e6ca1548c46525100c1a17e882fe1c5d0f95c423736101bbd174f8e0 *ubuntu-23.10-preinstalled-server-riscv64+visionfive2.img.xz
cf6662e1646ae140bdb0d4231bb688c2a04c245d70518de812d3c98463184147 *ubuntu-23.10-preinstalled-server-riscv64.img.xz
```

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-6442
