### PR TITLE
Pro page: fix typos

### DIFF
--- a/templates/pro/index.html
+++ b/templates/pro/index.html
@@ -384,7 +384,7 @@
                 <strong>1,800+</strong>
               </div>
               <div class="col-4">
-                <p>additional high and critical patches<br/> only availiable with Ubuntu&nbsp;Pro</p>
+                <p>additional high and critical patches<br/> only available with Ubuntu&nbsp;Pro</p>
               </div>
             </div>
             <hr class="p-rule is-muted"/>
@@ -408,7 +408,7 @@
           </div>
           <hr class="p-rule is-muted"/>
           <p><a href="/pro/why-pro">Learn why security professionals choose Ubuntu&nbsp;Pro&nbsp;&rsaquo;</a></p>
-          <p>* <a href="https://go.snyk.io/state-of-open-source-security-report-2022-dwn-typ.html">According to Snyk</a> organisation need on average 97.8 days to fix a vulnerability. With Ubuntu&nbsp;Pro currently measured average time to fix for Critical CVE vulnerability fixes is less than 24h.</p>
+          <p>* <a href="https://go.snyk.io/state-of-open-source-security-report-2022-dwn-typ.html">According to Snyk</a> organisations need 97.8 days on average to fix a vulnerability. With Ubuntu&nbsp;Pro, the currently measured average time to fix for Critical CVE vulnerabilities is less than 24h.</p>
         </div>
       </div>
     </div>
@@ -473,7 +473,7 @@
       </div>
       <div class="col">
         <p>Reduce your operational risk with certified automation tools for hardening and compliance profiles, including CIS, DISA-STIG, FIPS 140, and Common Criteria.</p>
-        <p>Ubuntu&nbsp;Pro offers tooling to achieve and maintain compliance on-remise and on public clouds: <a href="/aws/pro">AWS</a>, <a href="/azure/pro">Azure</a> and <a href="/gcp/pro">GCP</a>.</p>
+        <p>Ubuntu&nbsp;Pro offers tooling to achieve and maintain compliance on-premise and on public clouds: <a href="/aws/pro">AWS</a>, <a href="/azure/pro">Azure</a> and <a href="/gcp/pro">GCP</a>.</p>
         <hr class="p-rule is-muted"/>
         <p>
           <a href="/security/certifications">Learn more about compliance and hardening</a>


### PR DESCRIPTION
## Done

- Fix typos on pro page.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site in web browser at: https://ubuntu-com-13243.demos.haus/pro
- Review for typos
