### PR TITLE
fix: shorten form acquisition URLs - WD-6294

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -59,16 +59,17 @@ class TestViewsFunctions(TestCase):
             "&utm_campaign=7018jyr44t534e000000Lrr2AAC"
         )
 
-        # Case 1: url is less than 255 characters
+        # Case 1: url is shorten to less than 255 characters
         # and only fbclid/gclid parameters are removed
         self.assertEqual(shorten_acquisition_url(first_url), first_url_check)
         self.assertLess(len(shorten_acquisition_url(first_url)), 255)
 
-        # Case 2: url is less than 255 characters
+        # Case 2: url is shorten to less than 255 characters
         # and all parameters are removed (including UTM parameters)
         self.assertEqual(shorten_acquisition_url(second_url), second_url_check)
         self.assertLess(len(shorten_acquisition_url(second_url)), 255)
 
-        # Case 3: url already less than 255 characters are not shortened
+        # Case 3: url is already less than 255 characters
+        # and is not shortened
         self.assertEqual(shorten_acquisition_url(third_url), third_url)
         self.assertLess(len(shorten_acquisition_url(third_url)), 255)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,0 +1,74 @@
+# Packages
+from unittest import TestCase
+
+# Local
+from webapp.views import shorten_acquisition_url
+
+
+class TestViewsFunctions(TestCase):
+    def test_shorten_acquisition_url(self):
+        """
+        Test that the acquisition url is shortened to < 255 characters
+
+        fcclid and gclid parameters are removed initially
+        If the url is still too long, all parameters are removed
+        """
+
+        # this url should still have UTM parameters after shortening
+        first_url = (
+            "https://ubuntu.com/engage/secure-kubernetes-at-the-edge?"
+            "utm_source=facebook_ad&utm_medium=cpc"
+            "&utm_campaign=7018e000000Lrr2AAC"
+            "&fbclid=IwAR15h71YCzbtXmItLpTWGKvX6LGlbBNrsYAsoq-IEJiF"
+            "9SYy_aDXgpsIqn0_aem_AbSMY4GVnRtIgih_p0mTaKvNZH6T3Qy73p"
+            "lm8KSqnZJXAsol_n1J440OjNsdU2s6-a0urWDolTPSE0nv3SYoY3jU"
+            "&gclid=IwAR15h71YCzbtXmItLpTWGKvX6LGlbBNrsYAsoq-IEJiF9"
+            "SYy_aDXgpsIqn0_aem_AbSMY4GVnRtIgih_p0mTaKvNZH6T3Qy73p"
+            "lm8KSqnZJXAsol_n1J440OjNsdU2s6-a0urWDolTPSE0nv3SYoY3jU"
+        )
+
+        first_url_check = (
+            "https://ubuntu.com/engage/secure-kubernetes-at-the-edge?"
+            "utm_source=facebook_ad&utm_medium=cpc"
+            "&utm_campaign=7018e000000Lrr2AAC"
+        )
+
+        # this url should not have UTM parameters after shortening
+        second_url = (
+            "https://ubuntu.com/engage/secure-kubernetes-at-the-edge?"
+            "utm_source=facebook_ad&utm_medium=cpcrHds-f323rdf34v4t24fd"
+            "fsfrdfSAsewetv_trfsdgdfg4234rchb534z2243h_rtgrcawretthfghff"
+            "&utm_campaign=7018ihtrHdsf323rrdfSASYHe000000Lr8450oh2oEEDV"
+            "EfdfodifnjvFSF0w94ngoinsdgfw4c12r2AAC"
+            "&fbclid=IwAR15h71YCzbtXmItLpTWGKvX6LGlbBNrsYAsoq-IEJiF9SYy_aDX"
+            "gpsIqn0_aem_AbSMY4GVnRtIgih_p0mTaKvNZH6T3Qy73plm8KSqnZJXAsol_n"
+            "1J440OjNsdU2s6-a0urWDolTPSE0nv3SYoY3jU"
+            "&gclid=IwAR15h71YCzbtXmItLpTWGKvX6LGlbBNrsYAsoq-IEJiF9SYy_aDXg"
+            "psIqn0_aem_AbSMY4GVnRtIgih_p0mTaKvNZH6T3Qy73plm8KSqnZJXAsol_n1"
+            "J440OjNsdU2s6-a0urWDolTPSE0nv3SYoY3jU"
+        )
+
+        second_url_check = (
+            "https://ubuntu.com/engage/secure-kubernetes-at-the-edge"
+        )
+
+        # this url should not be shortened
+        third_url = (
+            "https://ubuntu.com/engage/secure-kubernetes-at-the-edge?"
+            "utm_source=facebook_ad&utm_medium=button"
+            "&utm_campaign=7018jyr44t534e000000Lrr2AAC"
+        )
+
+        # Case 1: url is less than 255 characters
+        # and only fbclid/gclid parameters are removed
+        self.assertEqual(shorten_acquisition_url(first_url), first_url_check)
+        self.assertLess(len(shorten_acquisition_url(first_url)), 255)
+
+        # Case 2: url is less than 255 characters
+        # and all parameters are removed (including UTM parameters)
+        self.assertEqual(shorten_acquisition_url(second_url), second_url_check)
+        self.assertLess(len(shorten_acquisition_url(second_url)), 255)
+
+        # Case 3: url already less than 255 characters are not shortened
+        self.assertEqual(shorten_acquisition_url(third_url), third_url)
+        self.assertLess(len(shorten_acquisition_url(third_url)), 255)

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -845,11 +845,15 @@ def shorten_acquisition_url(acquisition_url):
         url_without_params = acquisition_url.split("?")[0]
         url_params_string = acquisition_url.split("?")[1]
         url_params_list = url_params_string.split("&")
+        url_params_to_remove = []
 
         # Check for and remove fbclid and gclid parameters
         for param in url_params_list:
             if param.startswith("fbclid") or param.startswith("gclid"):
-                url_params_list.remove(param)
+                url_params_to_remove.append(param)
+
+        for param in url_params_to_remove:
+            url_params_list.remove(param)
 
         new_acquisition_url = (
             url_without_params + "?" + "&".join(url_params_list)
@@ -860,7 +864,6 @@ def shorten_acquisition_url(acquisition_url):
             return new_acquisition_url.split("?")[0]
 
         return new_acquisition_url
-
     return acquisition_url
 
 
@@ -924,7 +927,7 @@ def marketo_submit():
 
     if "acquisition_url" in form_fields:
         shortened_url = shorten_acquisition_url(form_fields["acquisition_url"])
-        form_fields["acquisition_url"] = shorten_acquisition_url
+        form_fields["acquisition_url"] = shortened_url
         enrichment_fields["acquisition_url"] = shortened_url
     else:
         shortened_url = shorten_acquisition_url(referrer)

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -846,7 +846,7 @@ def shorten_acquisition_url(acquisition_url):
         url_params_string = acquisition_url.split("?")[1]
         url_params_list = url_params_string.split("&")
 
-        ## Check for and remove fbclid and gclid parameters
+        # Check for and remove fbclid and gclid parameters
         for param in url_params_list:
             if param.startswith("fbclid") or param.startswith("gclid"):
                 url_params_list.remove(param)

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -836,6 +836,34 @@ def sitemap_index():
     return response
 
 
+def shorten_acquisition_url(acquisition_url):
+    """
+    Shorten the acquisition URL sent when submitting forms
+    """
+
+    if len(acquisition_url) > 255:
+        url_without_params = acquisition_url.split("?")[0]
+        url_params_string = acquisition_url.split("?")[1]
+        url_params_list = url_params_string.split("&")
+
+        ## Check for and remove fbclid and gclid parameters
+        for param in url_params_list:
+            if param.startswith("fbclid") or param.startswith("gclid"):
+                url_params_list.remove(param)
+
+        new_acquisition_url = (
+            url_without_params + "?" + "&".join(url_params_list)
+        )
+
+        # If the URL is still too long, remove all parameters
+        if len(new_acquisition_url) > 255:
+            return new_acquisition_url.split("?")[0]
+
+        return new_acquisition_url
+
+    return acquisition_url
+
+
 def marketo_submit():
     form_fields = {}
     for key in flask.request.form:
@@ -895,9 +923,12 @@ def marketo_submit():
         }
 
     if "acquisition_url" in form_fields:
-        enrichment_fields["acquisition_url"] = form_fields["acquisition_url"]
+        shortened_url = shorten_acquisition_url(form_fields["acquisition_url"])
+        form_fields["acquisition_url"] = shorten_acquisition_url
+        enrichment_fields["acquisition_url"] = shortened_url
     else:
-        enrichment_fields["acquisition_url"] = referrer
+        shortened_url = shorten_acquisition_url(referrer)
+        enrichment_fields["acquisition_url"] = shortened_url
 
     if "preferredLanguage" in form_fields:
         enrichment_fields["preferredLanguage"] = form_fields[


### PR DESCRIPTION
## Done

- Shorten acquisition URLs on submitted forms as described by the task: [WD-6294](https://warthogs.atlassian.net/browse/WD-6294)
  - The task is to ensure the acquisition URLs are not longer than 255 characters, if they are the `fbclid` and `gclid` parameters should be removed.

## QA

- Go to any page with a form and add any of these query parameters to the url: `?utm_source=facebook_ad&utm_medium=cpc&utm_campaign=7018e000000Lrr2AAC&fbclid=IwAR15h71YCzbtXmItLpTWGKvX6LGlbBNrsYAsoq-IEJiF9SYy_aDXgpsIqn0_aem_AbSMY4GVnRtIgih_p0mTaKvNZH6T3Qy73plm8KSqnZJXAsol_n1J440OjNsdU2s6-a0urWDolTPSE0nv3SYoY3jU` 
or 
`?utm_source=facebook_ad&utm_medium=cpc&utm_campaign=7018e000000Lrr2AAC&gclid=IwAR15h71YCzbtXmItLpTWGKvX6LGlbBNrsYAsoq-IEJiF9SYy_aDXgpsIqn0_aem_AbSMY4GVnRtIgih_p0mTaKvNZH6T3Qy73plm8KSqnZJXAsol_n1J440OjNsdU2s6-a0urWDolTPSE0nv3SYoY3jU`
  - For example: https://ubuntu-com-13244.demos.haus/contact-us would become https://ubuntu-com-13244.demos.haus/contact-us?utm_source=facebook_ad&utm_medium=cpc&utm_campaign=7018e000000Lrr2AAC&fbclid=IwAR15h71YCzbtXmItLpTWGKvX6LGlbBNrsYAsoq-IEJiF9SYy_aDXgpsIqn0_aem_AbSMY4GVnRtIgih_p0mTaKvNZH6T3Qy73plm8KSqnZJXAsol_n1J440OjNsdU2s6-a0urWDolTPSE0nv3SYoY3jU
- After submitting the form go to marketo and check that the aquisition url is shortened.

#### Quick link you can test
- [Engage page](https://ubuntu-com-13244.demos.haus/engage/secure-kubernetes-at-the-edge?utm_source=facebook_ad&utm_medium=cpc&utm_campaign=7018e000000Lrr2AAC&fbclid=IwAR15h71YCzbtXmItLpTWGKvX6LGlbBNrsYAsoq-IEJiF9SYy_aDXgpsIqn0_aem_AbSMY4GVnRtIgih_p0mTaKvNZH6T3Qy73plm8KSqnZJXAsol_n1J440OjNsdU2s6-a0urWDolTPSE0nv3SYoY3jU)

## Issue / Card

- [WD-6294](https://warthogs.atlassian.net/browse/WD-6294)

[WD-6294]: https://warthogs.atlassian.net/browse/WD-6294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WD-6294]: https://warthogs.atlassian.net/browse/WD-6294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ