### PR TITLE
[WD-6779] enable 23.10 desktop download button/link

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -3,6 +3,7 @@ latest:
   name: "Mantic Minotaur"
   short_version: "23.10"
   full_version: "23.10"
+  desktop_version: "23.10.1"
   core_version: "23"
   release_date: "October 2023"
   eol: "July 2024"
@@ -31,7 +32,7 @@ openstack_lts:
 
 checksums:
   desktop:
-    "23.10": "444c8a7b993cb6f103d7df1144954064889cbf7491b2415518d5dd0875e3a96f *ubuntu-23.10-desktop-amd64.iso"
+    "23.10.1": "3b6c5275366d02160554fa5703add462da3b8ce9be1749f8806e8dbbffaa2b5a *ubuntu-23.10.1-desktop-amd64.iso"
     "22.04.3": "a435f6f393dda581172490eda9f683c32e495158a780b5a1de422ee77d98e909 *ubuntu-22.04.3-desktop-amd64.iso"
     "21.10": "f8d3ab0faeaecb5d26628ae1aa21c9a13e0a242c381aa08157db8624d574b830 *ubuntu-21.10-desktop-amd64.iso"
     "20.04.6": "510ce77afcb9537f198bc7daa0e5b503b6e67aaed68146943c231baeaab94df1 *ubuntu-20.04.6-desktop-amd64.iso"

--- a/releases.yaml
+++ b/releases.yaml
@@ -3,7 +3,7 @@ latest:
   name: "Mantic Minotaur"
   short_version: "23.10"
   full_version: "23.10"
-  desktop_version: "23.10.1"
+  desktop_version: "23.10.1" # for 23.10 release only, because Desktop image for 23.10 release has version 23.10.1, while as all other images have version 23.10
   core_version: "23"
   release_date: "October 2023"
   eol: "July 2024"

--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -55,14 +55,9 @@ meta_copydoc %}
       <h3 class="p-heading--4"><span>Ubuntu {{ releases.latest.full_version }}</span></h3>
       <ul class="p-list--divided">
         <li class="p-list__item">
-          {# <a class="download-torrent"
-            href="https://releases.ubuntu.com/{{ releases.latest.short_version }}/ubuntu-{{ releases.latest.full_version }}-desktop-amd64.iso.torrent">Ubuntu
-            {{ releases.latest.full_version }} Desktop (64-bit)</a> #}
-          <p class="p-form-help-text u-no-margin--bottom">Ubuntu 23.10 Desktop cannot be
-            downloaded right now. We apologize while we work on <a
-              href="https://discourse.ubuntu.com/t/announcement-ubuntu-desktop-23-10-release-image-is-being-updated-to-resolve-a-malicious-translation-incident/39365">correcting
-              the issue.</a>
-          </p>
+          <a class="download-torrent"
+            href="https://releases.ubuntu.com/{{ releases.latest.desktop_version }}/ubuntu-{{ releases.latest.desktop_version }}-desktop-amd64.iso.torrent">Ubuntu
+            {{ releases.latest.full_version }} Desktop (64-bit)</a>
         </li>
         <li class="p-list__item">
           <a class="download-torrent"

--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -87,18 +87,12 @@ meta_copydoc %}
         }}
       </div>
       <p>
-        <a class="p-button--positive is-wide is-disabled u-no-margin--bottom"
-          aria-describedby="downloadButtonHelpMessage" style="pointer-events: none"
-          href="/download/desktop/thank-you?version={{ releases.latest.full_version }}&amp;architecture=amd64"
+        <a class="p-button--positive is-wide"
+          href="/download/desktop/thank-you?version={{ releases.latest.desktop_version }}&amp;architecture=amd64"
           onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">
           Download {{ releases.latest.full_version }}
         </a>
         <script>performance.mark("Download (Desktop) button rendered")</script>
-      <p class="p-form-help-text" id="downloadButtonHelpMessage">Ubuntu 23.10 cannot be downloaded right now. We
-        apologize while we work on <a
-          href="https://discourse.ubuntu.com/t/announcement-ubuntu-desktop-23-10-release-image-is-being-updated-to-resolve-a-malicious-translation-incident/39365">correcting
-          the issue.</a>
-      </p>
       </p>
       <p>
         <a href="https://cdimage.ubuntu.com/releases/mantic/release/ubuntu-{{ releases.latest.short_version }}-desktop-legacy-amd64.iso"


### PR DESCRIPTION

## Done

- Enabled (returned) 23.10 desktop image download button/link on two pages:
      - /download/desktop
      - /download/alternative-downloads
- Added new property called `desktop_version` in `releases.yml` since the latest Desktop image has a different version than all other 23.10 release images
- Updated the checksum for the latest desktop image

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Navigage to /download/desktop and check that the Download 23.10 button is enabled and the desktop image can be downloaded.
- Navigate to /download/alternative-downloads and check that Download 23.10 Desktop (64-bit) link exists and clicking on it downloads the desktop image.

## Issue / Card

Closes https://warthogs.atlassian.net/browse/WD-6779

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
