### PR TITLE
adjust release-cycle dates for k8s 1.28

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -1514,38 +1514,50 @@ export var kubernetesReleases = [
   },
   {
     startDate: new Date("2022-09-01T00:00:00"),
-    endDate: new Date("2023-08-23T00:00:00"),
+    endDate: new Date("2023-08-28T00:00:00"),
     taskName: "Kubernetes 1.25",
     status: "CANONICAL_KUBERNETES_SUPPORT",
   },
   {
-    startDate: new Date("2023-08-23T00:00:00"),
-    endDate: new Date("2024-05-03T00:00:00"),
+    startDate: new Date("2023-08-28T00:00:00"),
+    endDate: new Date("2024-04-28T00:00:00"),
     taskName: "Kubernetes 1.25",
     status: "CANONICAL_KUBERNETES_EXPANDED_SECURITY_MAINTENANCE",
   },
   {
     startDate: new Date("2022-12-15T00:00:00"),
-    endDate: new Date("2023-12-15T00:00:00"),
+    endDate: new Date("2023-12-28T00:00:00"),
     taskName: "Kubernetes 1.26",
     status: "CANONICAL_KUBERNETES_SUPPORT",
   },
   {
-    startDate: new Date("2023-12-15T00:00:00"),
-    endDate: new Date("2024-08-23T00:00:00"),
+    startDate: new Date("2023-12-28T00:00:00"),
+    endDate: new Date("2024-08-28T00:00:00"),
     taskName: "Kubernetes 1.26",
     status: "CANONICAL_KUBERNETES_EXPANDED_SECURITY_MAINTENANCE",
   },
   {
     startDate: new Date("2023-04-21T00:00:00"),
-    endDate: new Date("2024-04-21T00:00:00"),
+    endDate: new Date("2024-04-28T00:00:00"),
     taskName: "Kubernetes 1.27",
     status: "CANONICAL_KUBERNETES_SUPPORT",
   },
   {
-    startDate: new Date("2024-04-21T00:00:00"),
-    endDate: new Date("2024-12-06T00:00:00"),
+    startDate: new Date("2024-04-28T00:00:00"),
+    endDate: new Date("2024-12-28T00:00:00"),
     taskName: "Kubernetes 1.27",
+    status: "CANONICAL_KUBERNETES_EXPANDED_SECURITY_MAINTENANCE",
+  },
+  {
+    startDate: new Date("2023-08-18T00:00:00"),
+    endDate: new Date("2024-08-28T00:00:00"),
+    taskName: "Kubernetes 1.28",
+    status: "CANONICAL_KUBERNETES_SUPPORT",
+  },
+  {
+    startDate: new Date("2024-08-28T00:00:00"),
+    endDate: new Date("2025-04-28T00:00:00"),
+    taskName: "Kubernetes 1.28",
     status: "CANONICAL_KUBERNETES_EXPANDED_SECURITY_MAINTENANCE",
   },
 ];
@@ -1898,6 +1910,7 @@ export var microStackReleaseNames = [
 ];
 
 export var kubernetesReleaseNames = [
+  "Kubernetes 1.28",
   "Kubernetes 1.27",
   "Kubernetes 1.26",
   "Kubernetes 1.25",

--- a/templates/about/release_cycles/k8s-eol.html
+++ b/templates/about/release_cycles/k8s-eol.html
@@ -12,9 +12,15 @@
         </thead>
         <tbody>
           <tr>
+            <td><strong>1.28.x</strong></td>
+            <td align='right'>Aug 2023</td>
+            <td align='right'>Aug 2024</td>
+            <td align='right'>Apr 2025</td>
+          </tr>
+          <tr>
             <td><strong>1.27.x</strong></td>
-            <td align='right'>April 2023</td>
-            <td align='right'>April 2024</td>
+            <td align='right'>Apr 2023</td>
+            <td align='right'>Apr 2024</td>
             <td align='right'>Dec 2024</td>
           </tr>
           <tr>
@@ -27,7 +33,7 @@
             <td><strong>1.25.x</strong></td>
             <td align='right'>Sep 2022</td>
             <td align='right'>Aug 2023</td>
-            <td align='right'>May 2024</td>
+            <td align='right'>Apr 2024</td>
           </tr>
           <tr>
             <td><strong>1.24.x</strong></td>


### PR DESCRIPTION
Our support dates were a bit off.  Upstream k8s releases enter maintenance mode every 12(ish) months and always on the 28th:

https://kubernetes.io/releases/patch-releases

This PR aligns our `n-2` releases with the 12mo upstream dates and our `n-4` esm window with the respective 8mo period that follows.

## Done

- align current release support with upstream dates
- add 1.28 dates

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes https://github.com/charmed-kubernetes/kubernetes-docs/issues/808

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
