### PR TITLE
Update Enterprise nav link

### DIFF
--- a/templates/templates/navigation-enterprise-h.html
+++ b/templates/templates/navigation-enterprise-h.html
@@ -55,7 +55,7 @@
             <li class="p-list__item"><a href="/kubernetes/features">Multicloud K8s on bare metal, VMware, and all public clouds</a></li>
             <li class="p-list__item"><a href="/kubernetes/managed">Fully managed K8s</a></li>
             <li class="p-list__item"><a href="https://microk8s.io" title="Visit the MicroK8s website - external site" >Get K8s for your workstation and edge / IoT</a></li>
-            <li class="p-list__item"><a href="/ai/what-is-kubeflow">AI and ML on Kubernetes</a></li>
+            <li class="p-list__item"><a href="/ai/">AI and ML on Kubernetes</a></li>
             <li class="p-list__item"><a href="http://charmed-kubeflow.io">Easy Kubeflow operations</a></li>
             <li class="p-list__item"><a href="https://cloud.google.com/kubernetes-engine/docs/concepts/node-images#ubuntu">GKE with Ubuntu on Google Cloud</a></li>
             <li class="p-list__item"><a href="/openstack/tco-calculator">TCO calculator</a></li>

--- a/templates/templates/navigation-enterprise-h.html
+++ b/templates/templates/navigation-enterprise-h.html
@@ -55,7 +55,7 @@
             <li class="p-list__item"><a href="/kubernetes/features">Multicloud K8s on bare metal, VMware, and all public clouds</a></li>
             <li class="p-list__item"><a href="/kubernetes/managed">Fully managed K8s</a></li>
             <li class="p-list__item"><a href="https://microk8s.io" title="Visit the MicroK8s website - external site" >Get K8s for your workstation and edge / IoT</a></li>
-            <li class="p-list__item"><a href="/ai/">AI and ML on Kubernetes</a></li>
+            <li class="p-list__item"><a href="/ai">AI and ML on Kubernetes</a></li>
             <li class="p-list__item"><a href="http://charmed-kubeflow.io">Easy Kubeflow operations</a></li>
             <li class="p-list__item"><a href="https://cloud.google.com/kubernetes-engine/docs/concepts/node-images#ubuntu">GKE with Ubuntu on Google Cloud</a></li>
             <li class="p-list__item"><a href="/openstack/tco-calculator">TCO calculator</a></li>


### PR DESCRIPTION
## Done

- Updated link in Enterprise nav as per [doc](https://docs.google.com/document/d/1YBdQvLuqEpEQr_QqyycxMhZr4OaLapMlNJyYKCmPJsQ/edit)

## QA

- View the site locally in your web browser at: https://ubuntu-com-13251.demos.haus/#enterprise
- See that the change has been made

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-6783