### PR TITLE
Add K8s docs index pages

### DIFF
--- a/templates/kubernetes/docs/explanation-index.md
+++ b/templates/kubernetes/docs/explanation-index.md
@@ -1,0 +1,39 @@
+---
+wrapper_template: "templates/docs/markdown.html"
+markdown_includes:
+  nav: "kubernetes/docs/shared/_side-navigation.md"
+context:
+  title: "Explanation topics"
+  description: an index of topics in this category
+keywords: Cloud, cluster, storage
+tags: [operating]
+sidebar: k8smain-sidebar
+permalink: explanation-index.html
+layout: [base, ubuntu-com]
+toc: False
+---
+Our explanatory and conceptual guides are written to provide a better understanding of topics related to Charmed Kubernetes and Kubernetes in general. They help you to expand your knowledge and become better at understanding and operating **Charmed Kubernetes**.
+
+| **Explanation guides** | Notes |
+|--|--|
+| [Charmed Kubernetes overview](/kubernetes/docs/overview) | |
+| [Cloud integration](/kubernetes/docs/explain-cloud)| Storage, loadbalancers...|
+| [Networking](/kubernetes/docs/cni-overview)| CNIs and networking topics|
+| [High Availability](/kubernetes/docs/high-availability)| HA strategies|
+| [Security](/kubernetes/docs/security)| Security overview |
+
+For a quick start to your Kubernetes journey, our tutorials section contains a step-by-step tutorial to help you through your first time experience.
+
+If you have a specific goal, but are already familiar with Kubernetes, our _How-to_ guides have more practical application. They'll help you achieve an end-result but may require you to understand and adapt the steps to fit your specific requirements.
+
+Take a look at our  _Reference section_ when  you need to know more about versions, releases and other reference material.
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <div class="p-notification__content">
+    <p class="p-notification__message">We appreciate your feedback on the documentation. You can
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/main/pages/k8s/explanation-index.md" >edit this page</a>
+    or
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.</p>
+  </div>
+</div>

--- a/templates/kubernetes/docs/how-to-index.md
+++ b/templates/kubernetes/docs/how-to-index.md
@@ -1,0 +1,130 @@
+---
+wrapper_template: "templates/docs/markdown.html"
+markdown_includes:
+  nav: "kubernetes/docs/shared/_side-navigation.md"
+context:
+  title: "How-to topics"
+  description: an index of topics in this category
+keywords: Cloud, cluster, storage
+tags: [operating]
+sidebar: k8smain-sidebar
+permalink: how-to-index.html
+layout: [base, ubuntu-com]
+toc: False
+---
+
+If you have a specific goal, but are already familiar with Kubernetes, our How-to guides are more specific and contain less background information. They’ll help you achieve an end result but may require you to understand and adapt the steps to fit your specific requirements.
+
+There are a large number of guides, so we list them here by the same categories used in the navigation.
+
+
+## Installation
+
+- [Install on a cloud](/kubernetes/docs/install-manual) 
+- [Install locally with LXD](/kubernetes/docs/install-local)  
+- [Install on Equinix](/kubernetes/docs/equinix)  
+
+
+There are also two 'special case' scenarios we provide guidance for:
+
+- [Installing offline, or in a restricted environment](/kubernetes/docs/install-offline)
+- [Installing for NVIDIA DGX](/kubernetes/docs/nvidia-dgx)
+
+## Cloud integration
+
+- [AWS](/kubernetes/docs/aws-integration)
+- [Azure](/kubernetes/docs/azure-integration)
+- [GCP](/kubernetes/docs/gcp-integration)
+- [OpenStack](/kubernetes/docs/openstack-integration)
+- [vSphere](/kubernetes/docs/vsphere-integration)
+- [LXD (Local install)](/kubernetes/docs/install-local)
+- [Equinix Metal](/kubernetes/docs/equinix)
+
+## CNI and networking
+
+Charmed Kubernetes supports a wide variety of network options for your cluster, provided by additional charms. 
+
+- [Flannel](/kubernetes/docs/cni-flannel)
+- [Calico](/kubernetes/docs/cni-calico)
+- [Canal](/kubernetes/docs/cni-canal)
+- [Cilium](/kubernetes/docs/cni-cilium)
+- [Kube OVN](/kubernetes/docs/cni-kube-ovn)
+- [Tigera Secure EE](/kubernetes/docs/tigera-secure-ee)
+- [Multus](/kubernetes/docs/cni-multus)
+- [SR-IOV](/kubernetes/docs/cni-sriov)
+- [Using multiple networks](/kubernetes/docs/multiple-networks)
+- [IPv6](/kubernetes/docs/ipv6)
+- [Ingress](/kubernetes/docs/ingress)
+
+## Container runtimes
+In addition to the standard runtime, Charmed Kubernetes supports a variety of container runtime options.
+- [Containerd](/kubernetes/docs/container-runtime)
+- [Kata](/kubernetes/docs/kata)
+- [VM workloads (KubeVirt)](/kubernetes/docs/kubevirt)
+- [GPU workers](/kubernetes/docs/gpu-workers)
+
+
+## Operating Kubernetes
+
+These guides demonstrate the common tasks any user is likely to need:
+
+- [Basic operations](/kubernetes/docs/operations)
+- [Configure ingress](/kubernetes/docs/ingress)
+- [Add storage](/kubernetes/docs/storage)
+- [Scale your cluster](/kubernetes/docs/scaling)
+- [Make an etcd backup](/kubernetes/docs/backups)
+- [Upgrade to a new version](/kubernetes/docs/upgrading)
+- [Decommission a cluster](/kubernetes/docs/decommissioning)
+- [Logging](/kubernetes/docs/logging)
+- [Perform audit Logging](/kubernetes/docs/audit-logging)
+
+There are additional services supported by the Charmed Kubernetes team, which
+can be added to your cluster, or further configuration made to the default
+setup which are covered in these guides:
+
+- [Configure and use CDK addons](/kubernetes/docs/cdk-addons)
+- [Monitor with Grafana/Prometheus](/kubernetes/docs/monitoring)
+- [Use K8s Operator Charms](/kubernetes/docs/operator-charms)
+- [Schedule containers with Volcano](/kubernetes/docs/volcano)
+- [Use the cluster autoscaler](/kubernetes/docs/autoscaler)
+- [Validate your cluster with e2e](/kubernetes/docs/validation)
+- [Use a private Docker Registry](/kubernetes/docs/docker-registry)
+- [Configuring proxies](/kubernetes/docs/proxies)
+
+
+If you run into trouble, please see the troubleshooting guide:
+
+- [Troubleshooting](/kubernetes/docs/troubleshooting)
+
+## High availability
+Charmed Kubernetes supports enhancement for High Availability through a variety of approaches. Follow the links below for more information:
+
+- [Using keepalived](/kubernetes/docs/keepalived)
+- [Using HAcluster](/kubernetes/docs/hacluster)
+- [Using MetalLB](/kubernetes/docs/metallb)
+- [Adding a custom load balancer](/kubernetes/docs/custom-loadbalancer)
+
+## Securing your cluster
+The term 'security' covers a great many subtopics related to running a Kubernetes cluster, ranging from aspects of the workloads to the underlying OS. Please see the [overview of security](/kubernetes/docs/security) page for a better understanding of the approach to securing your cluster.
+
+The guides in this section contain How tos for pursuing specific security goals: 
+
+- [Authorisation and authentication](/kubernetes/docs/auth)
+- [Use Vault as a CA](/kubernetes/docs/using-vault)
+- [Authenticate with LDAP](/kubernetes/docs/ldap)
+- [Use the OPA Gatekeeper](/kubernetes/docs/gatekeeper)
+- [Use encryption-at-rest](/kubernetes/docs/encryption-at-rest)
+
+
+
+
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <div class="p-notification__content">
+    <p class="p-notification__message">We appreciate your feedback on the documentation. You can
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/main/pages/k8s/how-to-index.md" >edit this page</a>
+    or
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.</p>
+  </div>
+</div>

--- a/templates/kubernetes/docs/index.md
+++ b/templates/kubernetes/docs/index.md
@@ -31,12 +31,12 @@ lities in modern kernels. That’s why it’s the top choice for enterprise Kube
 </thead>
 <tbody>
 <tr>
-<td><a href="/docs/tutorials">Tutorials</a><br>  Get started with this introduction to Charmed Kubernetes <br></td>
-<td><a href="/docs/how-to">How-to guides</a> <br> Step-by-step guides covering key operations and common tasks</td>
+<td><a href="/kubernetes/docs/tutorials-index">Tutorials</a><br>  Get started with this introduction to Charmed Kubernetes <br></td>
+<td><a href="/kubernetes/docs/how-to-index">How-to guides</a> <br> Step-by-step guides covering key operations and common tasks</td>
 </tr>
 <tr>
-<td><a href="/docs/explanation">Explanation</a> <br> Concepts - discussion and clarification of key topics</td>
-<td><a href="/docs/reference">Reference</a> <br> Technical information - specifications, commands, architecture</td>
+<td><a href="/kubernetes/docs/explanation-index">Explanation</a> <br> Concepts - discussion and clarification of key topics</td>
+<td><a href="/kubernetes/docs/reference-index">Reference</a> <br> Technical information - specifications, commands, architecture</td>
 </tr>
 </tbody>
 </table>

--- a/templates/kubernetes/docs/reference-index.md
+++ b/templates/kubernetes/docs/reference-index.md
@@ -1,0 +1,41 @@
+---
+wrapper_template: "templates/docs/markdown.html"
+markdown_includes:
+  nav: "kubernetes/docs/shared/_side-navigation.md"
+context:
+  title: "Reference topics"
+  description: an index of topics in this category
+keywords: Cloud, cluster, storage
+tags: [operating]
+sidebar: k8smain-sidebar
+permalink: reference-index.html
+layout: [base, ubuntu-com]
+toc: False
+---
+Our reference pages contain more specific details about **Charmed Kubernetes** you may need to look up from time to time.
+
+| **Reference pages** | Notes |
+|--|--|
+| [Version info](/kubernetes/docs/supported-versions) | Supported versions and components |
+| [Release notes](/kubernetes/docs/release-notes) | |
+| [Snap refresh settings](/kubernetes/docs/snap-refresh) | Determining update frequency|
+| [Kubernetes Packages](/kubernetes/docs/packages) | Package specifics |
+| [Inclusive naming](/kubernetes/docs/inclusive-naming) | Our policy on inclusive language|
+| [CIS compliance](/kubernetes/docs/cis-compliance) | CIS test details|
+| [Get in touch](/kubernetes/docs/get-in-touch) | |
+
+For a quick start to your Kubernetes journey, our _Tutorials_ section contains a step-by-step tutorial to help you through your first time experience.
+
+If you have a specific goal, but are already familiar with Kubernetes, our _How-to_ guides have more practical application. They'll help you achieve an end-result but may require you to understand and adapt the steps to fit your specific requirements.
+
+For a better understanding of how Charmed Kubernetes works, and how it can be used and configured, our _Explanation_ section helps you to expand your knowledge.
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <div class="p-notification__content">
+    <p class="p-notification__message">We appreciate your feedback on the documentation. You can
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/main/pages/k8s/reference-index.md" >edit this page</a>
+    or
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.</p>
+  </div>
+</div>

--- a/templates/kubernetes/docs/tutorials-index.md
+++ b/templates/kubernetes/docs/tutorials-index.md
@@ -1,0 +1,37 @@
+---
+wrapper_template: "templates/docs/markdown.html"
+markdown_includes:
+  nav: "kubernetes/docs/shared/_side-navigation.md"
+context:
+  title: "Tutorial topics"
+  description: an index of topics in this category
+keywords: Cloud, cluster, storage
+tags: [operating]
+sidebar: k8smain-sidebar
+permalink: tutorials-index.html
+layout: [base, ubuntu-com]
+toc: False
+---
+
+This section of our documentation contains step-by-step tutorials to guide you through installing and using **Charmed Kubernetes**
+Our tutorials have been written to make as few assumptions as possible, and to be accessible to everyone. They're an ideal place to start learning.
+
+| Tutorial |  |
+|--|--|
+| [Quickstart](/kubernetes/docs/quickstart/) | Installation instructions and a quickstart guide |
+
+If you have a specific goal, but are already familiar with Kubernetes, our _How-to_ guides have more practical application. They'll help you achieve an end-result but may require you to understand and adapt the steps to fit your specific requirements.
+
+For a better understanding of how Charmed Kubernetes works, and how it can be used and configured, our _Explanation_ section helps you to expand your knowledge.
+
+Take a look at our _Reference section_ when  you need to know more about versions, releases and other reference material.
+
+<!-- FEEDBACK -->
+<div class="p-notification--information">
+  <div class="p-notification__content">
+    <p class="p-notification__message">We appreciate your feedback on the documentation. You can
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/edit/main/pages/k8s/tutorials-index.md" >edit this page</a>
+    or
+    <a href="https://github.com/charmed-kubernetes/kubernetes-docs/issues/new" >file a bug here</a>.</p>
+  </div>
+</div>


### PR DESCRIPTION
## Done

- Adds four pages to serve as the indexes for the diataxis sections
- corrects the index page to point at these
- 
## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
