### PR TITLE
Update example.com wildcard in livelinks check

### DIFF
--- a/.github/workflows/live-links.yaml
+++ b/.github/workflows/live-links.yaml
@@ -39,7 +39,7 @@ jobs:
             http://www.adlinktech.com/en/index
             /flags.png
             /flags@2x.png
-            http://*.example.com
+            http:\/\/[a-z0-9]*\.example\.com
 
           [output]
           status=0


### PR DESCRIPTION
## Done

- Update the regex wildcard in livelink workflow to work with all forms of example.com links 

## QA

- Go to https://regex101.com/
- Enter `http://sunbeam01.example.com` into the test string
- Use `http://*.example.com` as the regular expression and see that it does not match and in fact fails
- Enter `http:\/\/[a-z0-9]*\.example\.com` as the regex and see it matches the sunbeam URL
