### PR TITLE
Remove fullName field and add first&last name field on /observibility/managed contact-us form

### DIFF
--- a/templates/shared/forms/interactive/managed-observability.html
+++ b/templates/shared/forms/interactive/managed-observability.html
@@ -99,8 +99,12 @@
             <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form" >
               <ul class="p-list">
                 <li class="p-list__item">
-                  <label for="fullName">Name:</label>
-                  <input required id="fullName" name="fullName" maxlength="255" type="text" required="required" />
+                  <label for="firstName">First name:</label>
+                  <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
+                </li>
+                <li class="p-list__item">
+                  <label for="lastName">Last name:</label>
+                  <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
                 </li>
                 <li class="p-list__item">
                   <label for="email">Work email:</label>

--- a/templates/shared/forms/interactive/managed-observability.html
+++ b/templates/shared/forms/interactive/managed-observability.html
@@ -111,6 +111,18 @@
                   <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
                 </li>
                 <li class="p-list__item">
+                  <label for="phone">Phone number:</label>
+                  <input id="phone" name="phone" maxlength="255" type="tel">
+                </li>
+                <li class="p-list__item">
+                  <label for="company">Company:</label>
+                  <input required id="company" name="company" maxlength="255" type="text" />
+                </li>
+                <li class="p-list__item">
+                  <label for="jobTitle">Job title:</label>
+                  <input required id="jobTitle" name="title" maxlength="255" type="text" />
+                </li>
+                <li class="p-list__item">
                   <label class="p-checkbox">
                     <input class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
                     <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>


### PR DESCRIPTION
## Done

Remove fullName field and ass first&last name field on /observibility/managed contact-us form
https://docs.google.com/document/d/1i8PeYVXFbSZXnFqrHTDs7kyjwDPPfD97zXnkZKdlaDk/edit?disco=AAAANZSzF60&usp_dm=true#heading=h.a2otybczuqyf

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue
https://warthogs.atlassian.net/browse/WD-6880
