### PR TITLE
Revert core version

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -4,7 +4,7 @@ latest:
   short_version: "23.10"
   full_version: "23.10"
   desktop_version: "23.10.1" # for 23.10 release only, because Desktop image for 23.10 release has version 23.10.1, while as all other images have version 23.10
-  core_version: "23"
+  core_version: "22"
   release_date: "October 2023"
   eol: "July 2024"
   past_eol_date: false


### PR DESCRIPTION
## Done

- Reverted Core version as there is no Core 23

## QA

- View the site locally in your web browser at: https://ubuntu-com-13262.demos.haus/rapsberry-pi
- See that the version in the download link for the Ubuntu Core 22 has been updated

## Issue / Card

Fixes https://github.com/canonical/ubuntu.com/issues/13242
