### PR TITLE
WD-6593 - Update Livepatch column to be architecture specific, closes…

### DIFF
--- a/templates/security/esm.html
+++ b/templates/security/esm.html
@@ -515,35 +515,35 @@
             <td>Ubuntu 14.04 LTS (Trusty Tahr)</td>
             <td>Until 2024</td>
             <td>n/a</td>
-            <td>yes</td>
+            <td>amd64</td>
             <td>amd64</td>
           </tr>
           <tr>
             <td><a href="/16-04">Ubuntu 16.04 LTS (Xenial Xerus)</a></td>
             <td>Until 2026</td>
             <td>Until 2026</td>
-            <td>yes</td>
+            <td>amd64</td>
             <td>amd64, s390x</td>
           </tr>
           <tr>
             <td>Ubuntu 18.04 LTS (Bionic Beaver)</td>
             <td>Until 2028</td>
             <td>Until 2028</td>
-            <td>yes</td>
+            <td>amd64</td>
             <td>amd64, arm64, s390x, ppc64el</td>
           </tr>
           <tr>
             <td>Ubuntu 20.04 LTS (Focal Fossa)</td>
             <td>Until 2030</td>
             <td>Until 2030</td>
-            <td>yes</td>
+            <td>amd64</td>
             <td>amd64, arm64, s390x, ppc64el, RISC-V</td>
           </tr>
           <tr>
             <td>Ubuntu 22.04 LTS (Jammy Jellyfish)</td>
             <td>Until 2032</td>
             <td>Until 2032</td>
-            <td>yes</td>
+            <td>amd64, <br/> s390x</td>
             <td>amd64, arm64, s390x, ppc64el, RISC-V</td>
           </tr>
         </tbody>


### PR DESCRIPTION
… #13196

## Done

- Update Livepatch column at /security/esm according to issue #13196 

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check the table to be correct

## Issue / Card
[WD-6593](https://warthogs.atlassian.net/browse/WD-6593)

Fixes #13196 

## Screenshots

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-6593]: https://warthogs.atlassian.net/browse/WD-6593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ