### PR TITLE
Update OpenStack 2023.2 EOL to 9 months

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -1235,7 +1235,7 @@ export var openStackReleases = [
   },
   {
     startDate: new Date("2023-10-01T00:00:00"),
-    endDate: new Date("2025-04-01T00:00:00"),
+    endDate: new Date("2024-07-01T00:00:00"),
     taskName: "OpenStack 2023.2",
     status: "MATCHING_OPENSTACK_RELEASE_SUPPORT",
   },

--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -190,7 +190,7 @@
     <div class="u-fixed-width">
       <h3>Charmed OpenStack</h3>
       
-      <p>OpenStack clouds deployed through <a href="/openstack/consulting">Private Cloud Build</a> or validated through <a href="/openstack/consulting">Cloud Validation</a> consulting engagement (aka Charmed OpenStack clouds) can also benefit from <a href="/legal/ubuntu-pro-description#uprosd-full-openstack-support">Full OpenStack support</a> under <a href="/support">Ubuntu Pro &plus; Support and Ubuntu Pro (Infra-only) &plus; Support</a>. Full OpenStack support is provided for all OpenStack versions available in the Ubuntu Archive and Ubuntu Cloud Archive during their lifespan under standard security maintenance (18, 36 or 60 months depending on the version).</p>
+      <p>OpenStack clouds deployed through <a href="/openstack/consulting">Private Cloud Build</a> or validated through <a href="/openstack/consulting">Cloud Validation</a> consulting engagement (aka Charmed OpenStack clouds) can also benefit from <a href="/legal/ubuntu-pro-description#uprosd-full-openstack-support">Full OpenStack support</a> under <a href="/support">Ubuntu Pro &plus; Support and Ubuntu Pro (Infra-only) &plus; Support</a>. Full OpenStack support is provided for all OpenStack versions available in the Ubuntu Archive and Ubuntu Cloud Archive during their lifespan under standard security maintenance (9, 18, 36 or 60 months depending on the version).</p>
     
       <p>Charmed OpenStack support lifecycle on Ubuntu can be represented in this way:</p>
 

--- a/templates/about/release_cycles/openstack-eol.html
+++ b/templates/about/release_cycles/openstack-eol.html
@@ -24,7 +24,7 @@
           <td>OpenStack 2023.2</td>
           <td>&nbsp;</td>
           <td>Oct 2023</td>
-          <td>Apr 2025</td>
+          <td>Jul 2024</td>
           <td>&nbsp;</td>
         </tr>
         <tr>


### PR DESCRIPTION
OpenStack 2023.2 is a non-SLURP which means users can upgrade from 2023.1 to 2023.3 without going through 2023.2. Therefore, 2023.2 will only be supported for 9 months.

Fixes #13239