### PR TITLE
WD-6860 - update real-time link

### DIFF
--- a/templates/core/features/index.html
+++ b/templates/core/features/index.html
@@ -80,7 +80,7 @@
         <li class="p-list__item is-ticked">Bounded response times for stringent latency requirements</li>
       </ul>
       <p>
-        <a href="/blog/real-time-ubuntu-is-now-generally-available">Learn more about the real-time kernel&nbsp;&rsaquo;</a>
+        <a href="/real-time">Learn more about the real-time kernel&nbsp;&rsaquo;</a>
       </p>
     </div>
     <div class="col-4 u-align--center u-vertically-center u-hide--medium u-hide--small">

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -357,7 +357,7 @@
         <img src="https://assets.ubuntu.com/v1/4f70dabc-Kernel.svg" class="p-media-object__image" alt="">
         <div class="p-media-object__details">
           <h3 class="p-media-object__title">
-            <a href="/blog/real-time-ubuntu-is-now-generally-available">Real-time kernel</a>
+            <a href="/real-time">Real-time kernel</a>
           </h3>
           <p class="p-media-object__content p-heading--5" style="margin-bottom: 0;">Time-bound for mission-critical latency requirements</p>
           <p class="p-media-object__content">The real-time kernel integrates the PREEMPT_RT patchset to reduce the kernel latencies as required by the most demanding workloads, guaranteeing a time-predictable task execution.</p>

--- a/templates/download/iot/intel-iot.html
+++ b/templates/download/iot/intel-iot.html
@@ -97,7 +97,7 @@
   <div class="row">
     <div class="col-8">
       <h2>Real-time Ubuntu optimised for Intel SoCs</h2>
-      <p>Optimised <a href="/blog/real-time-ubuntu-is-now-generally-available">real-time Ubuntu</a> is now production-ready on 12th Gen Intel&reg; Core&trade; processors (code name Alder Lake S). More platforms will be announced shortly.</p>
+      <p>Optimised <a href="/real-time">Real-time Ubuntu</a> is now production-ready on 12th Gen Intel&reg; Core&trade; processors (code name Alder Lake S). More platforms will be announced shortly.</p>
       <p>Coupled with Intel&reg; Time Coordinated Computing (Intel&reg; TCC) and Time Sensitive Networking (IEEE TSN), the real-time Ubuntu kernel delivers industrial-grade performance to the time-bound workloads of industrial enterprises.</p>
       <p><a href="/engage/realtime-webinar-ga">Watch the joint webinar by Canonical and Intel on how real-time Ubuntu on Intel accelerates industrial transformation</a></p>
       <p>Real-time Ubuntu on Intel SoCs is available via <a href="/pro">Ubuntu Pro</a>, Canonical's enterprise security and compliance subscription, covering all aspects of open infrastructure. With an <a href="/pro/dashboard">Ubuntu Pro subscription</a>, launching the kernel is as easy as:</p>

--- a/templates/industrial/index.html
+++ b/templates/industrial/index.html
@@ -197,7 +197,7 @@
       <p class="p-heading--4">Harness data to supercharge shop floor productivity</p>
       <ul>
         <li>Build smart industrial gateways with open source</li>
-        <li>Real-time Linux support</li>
+        <li><a href="/real-time">Real-time</a> Linux support</li>
         <li>Connect your factory to the public clouds</li>
         <li>Deploy industrial apps on your machines</li>
         <li>Implement bespoke device fleet management</li>


### PR DESCRIPTION
## Done

- Updated real-time links on /core, /download/iot, /core/features and /industrial
- https://ubuntu-com-13272.demos.haus/core -> [copy doc](https://docs.google.com/document/d/1UFpefDRSAcndNBnWp0hDyzqk74aciqhBWJEi05htWmU/edit#heading=h.ljeurx6cb36j), https://ubuntu-com-13272.demos.haus/download/iot -> [copydoc](https://docs.google.com/document/d/1hxKzPs6e6JQaa9tBqfZ55GAXrVnEryEWBja8HlXy-lc/edit), https://ubuntu-com-13272.demos.haus/core/features -> [copydoc](https://docs.google.com/document/d/10S6FGVRA1R1qi9v859CnFrl8rS25Za2SjEmSpPVQkzY/edit#heading=h.gfn96hvf16o), https://ubuntu-com-13272.demos.haus/industrial -> [copydoc](https://docs.google.com/document/d/1QiU75g49lRKebt82oyLSxR3-PU96Sk87nqauAZ4vvIY/edit)

## QA

- Check out this feature branch [demo link](https://ubuntu-com-13272.demos.haus)
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check real-time hyperlinks according to copydocs

## Issue / Card
[WD-6860](https://warthogs.atlassian.net/browse/WD-6860)
Fixes #

## Screenshots


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-6860]: https://warthogs.atlassian.net/browse/WD-6860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ