### PR TITLE
Update pro contact form

### DIFF
--- a/templates/shared/_pro-contact-us-form.html
+++ b/templates/shared/_pro-contact-us-form.html
@@ -29,13 +29,13 @@
                 <input type="checkbox" aria-labelledby="20-04" class="p-checkbox__input" value="20.04 LTS">
                 <span class="p-checkbox__label" id="20-04">20.04 LTS</span>
               </label>
+            </div>
+            <div class="col-4 u-sv3">
+              <strong>LTS out of standard support</strong>
               <label class="p-checkbox">
                 <input type="checkbox" aria-labelledby="18-04" class="p-checkbox__input" value="18.04 LTS">
                 <span class="p-checkbox__label" id="18-04">18.04 LTS</span>
               </label>
-            </div>
-            <div class="col-4 u-sv3">
-              <strong>LTS during extended support</strong>
               <label class="p-checkbox">
                 <input type="checkbox" aria-labelledby="16-04" class="p-checkbox__input" value="16.04 LTS">
                 <span class="p-checkbox__label" id="16-04">16.04 LTS</span>


### PR DESCRIPTION
## Done
- Updated contact us form for Pro

## QA
- Go to `/contact-us/form?product=pro`
- Renamed "LTS during extended support" to "LTS out of standard support"
- 18.04 is moved to “LTS during extended support”


## Issue / Card
[WD-6901](https://warthogs.atlassian.net/browse/WD-6901)

## Screenshots
![Screenshot 2023-10-25 at 9 45 01 AM](https://github.com/canonical/ubuntu.com/assets/62298176/920baa89-c76e-4888-9997-1fc82490ca54)



## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-6901]: https://warthogs.atlassian.net/browse/WD-6901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ