### PR TITLE
WD-6916 - add cells to the cookie table

### DIFF
--- a/templates/legal/data-privacy/index.html
+++ b/templates/legal/data-privacy/index.html
@@ -286,7 +286,7 @@
               <code>_cc_dc_</code>, <code>rla3</code>, <code>pxrc</code>,
               <code>IDE</code>, <code>i</code>, <code>CookieConsent</code>, <code>__cf_bm</code>, 
               <code>lrsync</code>, <code>_ga</code>, <code>chs</code>, <code>visitorid</code>, <code>insent-user-id</code>,
-              <code>_zitok</code>, <code> _px3</code>, <code>__cf_bm</code>
+              <code>_zitok</code>, <code>_px3</code>, <code>__cf_bm</code>
             </td>
             <td>
               <p>Using ZoomInfo’s WebSights service, we can get a better idea of user behavior on our websites based on firmographic data.</p>

--- a/templates/legal/data-privacy/index.html
+++ b/templates/legal/data-privacy/index.html
@@ -272,6 +272,35 @@
               <p><a href="https://salesloft.com/privacy-notice/">Salesloft's privacy notice</a></p>
             </td>
           </tr>
+          <tr>
+            <td>Reddit</td>
+            <td><code>_rdt_uuid</code>, <code>reddaid</code></td>
+            <td>
+              <p>Using the Reddit Pixel, we can build a retargeting audience. This helps us reconnect with people who’ve shown interest.</p>
+              <p><a href="https://www.reddit.com/policies/privacy-policy">Reddit's privacy policy</a></p>
+            </td>
+          </tr>
+          <tr>
+            <td>ZoomInfo</td>
+            <td><code>ab</code>, <code>u</code>, <code>ssi</code>, <code>demdex</code>, <code>dpm</code>, <code>_cc_id</code>,
+              <code>_cc_dc_</code>, <code>rla3</code>, <code>pxrc</code>,
+              <code>IDE</code>, <code>i</code>, <code>CookieConsent</code>, <code>__cf_bm</code>, 
+              <code>lrsync</code>, <code>_ga</code>, <code>chs</code>, <code>visitorid</code>, <code>insent-user-id</code>,
+              <code>_zitok</code>, <code> _px3</code>, <code>__cf_bm</code>
+            </td>
+            <td>
+              <p>Using ZoomInfo’s WebSights service, we can get a better idea of user behavior on our websites based on firmographic data.</p>
+              <p><a href="https://www.zoominfo.com/legal/privacy-policy">ZoomInfo's privacy policy</a></p>
+            </td>
+          </tr>
+          <tr>
+            <td>Visual Website Optimizer</td>
+            <td> <p><a href="https://help.vwo.com/hc/en-us/articles/360033990873-Cookies-Stored-by-VWO">As set out by Visual Website Optimizer</a></p></td>
+            <td>
+              <p>Using Visual Website Optimizer, we can track visitor journeys to analyze, test our websites and provide the best experience.</p>
+              <p><a href="https://vwo.com/privacy-policy/">Visual Website Optimizer’s privacy policy</a></p>
+            </td>
+          </tr>
         </tbody>
       </table>
 


### PR DESCRIPTION
## Done

- Update cookie table at https://ubuntu-com-13277.demos.haus/legal/data-privacy according to [copydoc](https://docs.google.com/document/d/1AlOE2_-BqZNP4hiiuf8kZney8g1zvqAlDYl2u3X6m6I/edit)

## QA

- [demo link](https://ubuntu-com-13277.demos.haus)
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check the cookie table to be correct

## Issue / Card
[WD-6916](https://warthogs.atlassian.net/browse/WD-6916)
Fixes #

## Screenshots


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-6916]: https://warthogs.atlassian.net/browse/WD-6916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ