### PR TITLE
WD-6938 - add link to /openstack/consulting

### DIFF
--- a/templates/shared/pricing/_openstack-packages.html
+++ b/templates/shared/pricing/_openstack-packages.html
@@ -38,7 +38,7 @@
         <li class="p-list__item is-ticked">Secrets management</li>
       </ul>
       <p>Workshops determine the optimal architecture for your workloads and integration requirements.</p>
-      <p><a href="/openstack/consulting">Migrate from VMware&nbsp;&rsaquo;</a></p>
+      <p><a href="/engage/from-vmware-to-openstack">Migrate from VMware&nbsp;&rsaquo;</a></p>
     </div>
   </div>
   <div class="u-fixed-width">


### PR DESCRIPTION
## Done

- Added link to https://ubuntu-com-13279.demos.haus/openstack/consulting according to [copydoc](https://docs.google.com/document/d/1f83OSIHVQGMjF7b0pZUKFvoubMGqi_b-OYbSpyhveX4/edit)

## QA

- [demo link](https://ubuntu-com-13279.demos.haus)
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check whether the link is correct

## Issue / Card
[WD-6938](https://warthogs.atlassian.net/browse/WD-6938)
Fixes #

## Screenshots


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-6938]: https://warthogs.atlassian.net/browse/WD-6938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ