### PR TITLE
WD-6939 - update text and link in /openstack/compare

### DIFF
--- a/templates/openstack/compare.html
+++ b/templates/openstack/compare.html
@@ -11,7 +11,7 @@
       <h1>OpenStack distributions: <br class="u-hide--small">a comparison</h1>
       <p>Looking for a detailed OpenStack distributions comparison? Have a look at the table below and see how Canonical's Charmed OpenStack differs from other distributions. Discover more by clicking on each Charmed OpenStack cell.</p>
       <p><a href="/openstack/contact-us" class="p-button--positive js-invoke-modal">Move to Charmed OpenStack</a></p>
-      <p><a href="/engage/vmware-to-charmed-openstack">Read the whitepaper &mdash; "From VMware to Charmed OpenStack"&nbsp;&rsaquo;</a></p>
+      <p><a href="/engage/from-vmware-to-openstack">Read the whitepaper &mdash; "From VMware to OpenStack"&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-4 u-hide--medium u-hide--small">
       {{


### PR DESCRIPTION
## Done

- Update text and link in https://ubuntu-com-13280.demos.haus/openstack/compare according to [copydoc](https://docs.google.com/document/d/1ibpATi-e0rKP3GaLgvzwO_XyFU9ZTsUaCHMwrg96MZM/edit)

## QA

- [demo link](https://ubuntu-com-13280.demos.haus)
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check whether text and link are correct

## Issue / Card
[WD-6939](https://warthogs.atlassian.net/browse/WD-6939)

Fixes #

## Screenshots


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-6939]: https://warthogs.atlassian.net/browse/WD-6939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ