### PR TITLE
WD-6935 - update link and text in /openstack

### DIFF
--- a/templates/openstack/index.html
+++ b/templates/openstack/index.html
@@ -788,7 +788,7 @@
     <div class="col-6">
       <h2 class="p-heading--4">From VMware to OpenStack</h2>
       <p>VMware costs increasing? Don't worry. Charmed OpenStack brings down the TCO of cloud infrastructure. Our team of cloud experts will help you to migrate from VMware to Charmed OpenStack and take control over your budget back.</p>
-      <a href="/engage/vmware-migration-to-open-source">Explore migration strategies&nbsp;&rsaquo;</a>
+      <a href="/engage/from-vmware-to-openstack">Move from VMware to OpenStack&nbsp;&rsaquo;</a>
     </div>
     <div class="col-6">
       <h2 class="p-heading--4">Install OpenStack yourself</h2>


### PR DESCRIPTION
## Done

- Update link and text in https://ubuntu-com-13281.demos.haus/openstack according to [copydoc](https://docs.google.com/document/d/1eqHK0hc9v7Mn-XV36QRyNkJenTXgBQR_-RULKm5rZ5o/edit)

## QA

- [demo link](https://ubuntu-com-13281.demos.haus)
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check whether link and text are correct

## Issue / Card
[WD-6935](https://warthogs.atlassian.net/browse/WD-6935)
Fixes #

## Screenshots


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-6935]: https://warthogs.atlassian.net/browse/WD-6935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ