### PR TITLE
WD-6948 - add security section to /contact-us

### DIFF
--- a/templates/contact-us/index.html
+++ b/templates/contact-us/index.html
@@ -40,6 +40,11 @@
         Please note that we cannot provide you with legal advice. For any other queries, please contact us on <a href="mailto:legal@canonical.com">legal@canonical.com</a>.
       </p>
 
+      <h2>Security enquiries</h2>
+      <p>
+        If you have any security questions about Canonical products please email <a href="mailto:security@canonical.com">security@canonical.com</a>.
+      </p>
+
       <h2>Trademark enquiries</h2>
       <p>
         To request an Ubuntu trademark licence, or to make any other trademark enquiry, please <a href="/legal/terms-and-policies/contact-us">submit an enquiry</a>. A member of our trademarks team will be in touch with you shortly.
@@ -47,7 +52,7 @@
 
       <h2>Data Privacy enquiries</h2>
       <p>
-        For information about about data privacy, please read our <a href="/legal/data-privacy">Privacy Policy</a> or <a href="/legal/data-privacy/enquiry">submit an enquiry</a>. A member of our data privacy team will be in touch with you shortly.
+        For information about data privacy, please read our <a href="/legal/data-privacy">Privacy Policy</a> or <a href="/legal/data-privacy/enquiry">submit an enquiry</a>. A member of our data privacy team will be in touch with you shortly.
       </p>
     </div>
   </div>


### PR DESCRIPTION
## Done

- Added security enquiries section to https://ubuntu-com-13285.demos.haus/contact-us
- [copydoc](https://docs.google.com/document/d/1LK7lJlhke8hKesVSglHxNSfUCDw0bfddzM4vezeXvBQ/edit)

## QA

- Check out this feature branch [demo link](https://ubuntu-com-13285.demos.haus/)
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check security enquiries section according to copydoc

## Issue / Card
[WD-6948](https://warthogs.atlassian.net/browse/WD-6948)
Fixes #

## Screenshots


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

[WD-6948]: https://warthogs.atlassian.net/browse/WD-6948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ