### PR TITLE
Update Favicon to Logo 2022

### DIFF
--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -21,7 +21,7 @@
 
   <link rel="canonical" href="{% block canonical_url %}{{ request.url }}{% endblock %}">
 
-  <link rel="shortcut icon" href="https://assets.ubuntu.com/v1/49a1a858-favicon-32x32.png" type="image/x-icon">
+  <link rel="shortcut icon" href="https://assets.ubuntu.com/v1/f16c40d0-Favicon+-+CoF.svg" type="image/x-icon">
   <link rel="apple-touch-icon" href="https://assets.ubuntu.com/v1/17b68252-apple-touch-icon-180x180-precomposed-ubuntu.png">
 
   {% block head_extra %}{% endblock %}


### PR DESCRIPTION
## Done

- [List of work items including drive-bys - remember to add the why and what of this work.]
- Fixed issue #13245 

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
