### PR TITLE
Bump canonicalwebteam.blog to 6.4.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 canonicalwebteam.flask-base==1.1.0
 canonicalwebteam.http==1.0.3
-canonicalwebteam.blog==6.4.0
+canonicalwebteam.blog==6.4.1
 canonicalwebteam.search==1.3.0
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.3.1


### PR DESCRIPTION
## Done

Bump canonicalwebteam.blog to 6.4.1

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Go to `/blog/people-and-culture` and check the page renders
- Navigate the blog in general and check there are no errors
