### PR TITLE
Add discourse url to engage page

### DIFF
--- a/templates/engage/base.html
+++ b/templates/engage/base.html
@@ -16,6 +16,9 @@
   {% if metadata['path'] == "/engage/ShellOnboarding" %}
     <meta name="robots" content="noindex, nofollow" />
   {% endif %}
+
+  <meta name="discourse-url" value="{{ metadata['topic_path'] }}" />
+
 {% endblock %}
 
 {% block meta_copydoc %}{{ metadata["meta_copydoc"] }}{% endblock meta_copydoc %}


### PR DESCRIPTION
## Done

- Add discourse topic url to meta to make it easier to find. [Here is some more context](https://chat.canonical.com/canonical/pl/mdkat5rry7d6bcgsbowj698ebc)

## QA

- Go to https://ubuntu-com-13298.demos.haus/engage/guide-to-micro-clouds right click and view source code
- Check there is new meta tag called `discourse-url` 

## Issue / Card
Fixes [WD-11357](https://warthogs.atlassian.net/browse/WD-11357)



[WD-11357]: https://warthogs.atlassian.net/browse/WD-11357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ