### PR TITLE
Typo in desktop/features.html

### DIFF
--- a/templates/desktop/features.html
+++ b/templates/desktop/features.html
@@ -220,7 +220,7 @@
     <div class="col-5 col-start-large-8">
       <div class="p-card--overlay">
         <h2>Web browsing</h2>
-        <p>Renowned for speed and security, Ubuntu and Firefox make browsing the web a pleasure again.  Ubuntu also support Chrome and other browsers that can be installed from the Ubuntu Software centre.</p>
+        <p>Renowned for speed and security, Ubuntu and Firefox make browsing the web a pleasure again.  Ubuntu also supports Chrome and other browsers that can be installed from the Ubuntu Software centre.</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Fixed typo in desktop/features.html

## Done

- [List of work items including drive-bys - remember to add the why and what of this work.]

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
