### PR TITLE
Bump canonicalwebteam.discourse to 5.4.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ canonicalwebteam.blog==6.4.1
 canonicalwebteam.search==1.3.0
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.3.1
-canonicalwebteam.discourse==5.4.4
+canonicalwebteam.discourse==5.4.5
 python-dateutil==2.8.2
 pytz==2022.7.1
 maxminddb-geolite2==2018.703


### PR DESCRIPTION
## Done

Bump canonicalwebteam.discourse to 5.4.5

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Go to `/tutorials/install-ubuntu-desktop-1804#1-overview` and check the tutorial renders.
