### PR TITLE
Update aws pro links

### DIFF
--- a/templates/aws/shared/_get_pro.html
+++ b/templates/aws/shared/_get_pro.html
@@ -5,17 +5,14 @@
     </div>
   </div>
   <div class="row p-divider">
-    <div class="col-3 p-divider__block">
-      <h3 class="p-heading--4"><a href="https://aws.amazon.com/marketplace/pp/B087L1R4G4">20.04 LTS</a></h3>
+    <div class="col-4 p-divider__block">
+      <h3 class="p-heading--4"><a href="https://aws.amazon.com/marketplace/pp/prodview-ngmnrama2krsg">20.04 LTS</a></h3>
     </div>
-    <div class="col-3 p-divider__block">
-      <h3 class="p-heading--4"><a href="https://aws.amazon.com/marketplace/pp/B0821T9RL2">18.04 LTS</a></h3>
+    <div class="col-4 p-divider__block">
+      <h3 class="p-heading--4"><a href="https://aws.amazon.com/marketplace/pp/prodview-322njmk4u5jam">18.04 LTS</a></h3>
     </div>
-    <div class="col-3 p-divider__block">
-      <h3 class="p-heading--4"><a href="https://aws.amazon.com/marketplace/pp/B0821WW873">16.04 LTS</a></h3>
-    </div>
-    <div class="col-3 p-divider__block">
-      <h3 class="p-heading--4"><a href="https://aws.amazon.com/marketplace/pp/B0821V7QJP">14.04 LTS</a></h3>
+    <div class="col-4 p-divider__block">
+      <h3 class="p-heading--4"><a href="https://aws.amazon.com/marketplace/pp/prodview-vmuff4yhmwfna">16.04 LTS</a></h3>
     </div>
   </div>
   <div class="row">


### PR DESCRIPTION
## Done

- Updated links as per [doc](https://docs.google.com/document/d/1lkH-MSPmgjCMP4gI0FW29YIKVDvBuddxA63iQhmsYIU/edit)

## QA

- View the site locally in your web browser at: https://ubuntu-com-13322.demos.haus/aws
- Check against doc

## Issue / Card

Fixes  https://warthogs.atlassian.net/browse/WD-7091

## Screenshots
![image](https://github.com/canonical/ubuntu.com/assets/17607612/ae739d2c-fe78-4f32-88c1-c06eb003134a)

