### PR TITLE
Update FIPS title and webinar link

### DIFF
--- a/templates/security/fips.html
+++ b/templates/security/fips.html
@@ -75,14 +75,14 @@
 <section class="p-strip">
   <div class="row">
     <div class="col-6">
-      <h2>How does Ubuntu enable your compliance with FIPS and DISA-STIG?</h2>
+      <h2>How Ubuntu enables your compliance with FedRAMP, FISMA, FIPS and DISA-STIG</h2>
       <p>Learn about the US government security standards and the common challenges faced by organizations in their implementation. See how the Ubuntu Security Guide can transform systems compliance in a few minutes. Get to know how Ubuntu is a secure platform for government agencies and complying organizations to build, operate and innovate with open source applications and technologies.</p>
       <a class="p-button--positive js-invoke-modal" href="/security/contact-us">Contact us</a>
     </div>
     <div class="col-6 u-hide--medium u-hide--small u-align--center">
       <div class="jsBrightTALKEmbedWrapper u-vertically-center" style="width:100%; height:100%; position:relative;background: #ffffff;">
         <script class="jsBrightTALKEmbedConfig" type="application/json">
-          { "channelId" : 6793, "language": "en-US", "commId" : 524647, "displayMode" : "standalone", "height" : "280" }
+          { "channelId" : 6793, "language": "en-US", "commId" : 591276, "displayMode" : "standalone", "height" : "280" }
         </script>
         <script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script>
         <script>


### PR DESCRIPTION
## Done

- Updated the title and webinar link for the FIPS section based on [copydoc](https://docs.google.com/document/d/1moTJCAtFXKD7ZXrxB-EB7GPVyZRTSIdkP-0BhPZl69M/edit)

## QA

- Check that the demo is running at https://ubuntu-com-13323.demos.haus/security/fips
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-7071

