### PR TITLE
[WD-7080] add Mediatek to supported platforms on IoT page

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,6 @@ google-api-python-client==2.78.0
 google-auth-httplib2==0.1.0
 google-auth-oauthlib==1.0.0
 google-cloud-datastore==2.16.1
-black
 django-openid-auth==0.17
 time-machine==2.9.0
 filelock==3.12.0

--- a/templates/download/iot/index.html
+++ b/templates/download/iot/index.html
@@ -52,9 +52,10 @@ meta_copydoc %}
 
 <section class="p-strip is-deep">
   <div class="row">
-    <div class="col-2 col-medium-4">
-      <h3>Supported platforms</h3>
-    </div>
+    <h3>Supported platforms</h3>
+    <div class="u-sv2 u-hide--medium u-hide--small"></div>
+  </div>
+  <div class="row">
     <div class="col-2 col-medium-3">
       {{
       image(
@@ -111,6 +112,21 @@ meta_copydoc %}
       }}
       <p>
         <a href="/download/iot/intel-iotg">Install Ubuntu Desktop&nbsp;&rsaquo;</a>
+      </p>
+    </div>
+    <div class="col-2 col-medium-3">
+      {{ image (
+      url="https://assets.ubuntu.com/v1/0ebb345c-MediaTek_logo.svg",
+      alt="MediaTek Genio",
+      width="147",
+      height="23",
+      hi_def=True,
+      loading="auto",
+      attrs={"style": "margin: 0.5rem 0 0.75rem; max-width: 147px;"}
+      ) | safe
+      }}
+      <p>
+        <a href="/download/mediatek-genio">Install Ubuntu Desktop and Server&nbsp;&rsaquo;</a>
       </p>
     </div>
     <div class="col-2 col-medium-3">

--- a/templates/download/iot/index.html
+++ b/templates/download/iot/index.html
@@ -88,9 +88,9 @@ meta_copydoc %}
     </div>
     <div class="col-2 col-medium-3">
       {{ image (
-      url="https://assets.ubuntu.com/v1/327b8104-AMD_E_Blk_RGB.png",
+      url="https://assets.ubuntu.com/v1/d19b919d-logo-amd-160.png",
       alt="AMD XILINX",
-      width="187",
+      width="90",
       height="45",
       hi_def=True,
       loading="auto"
@@ -105,7 +105,7 @@ meta_copydoc %}
       url="https://assets.ubuntu.com/v1/26cbe599-intel-logo.jpg",
       alt="Intel",
       width="75",
-      height="42",
+      height="45",
       hi_def=True,
       loading="auto"
       ) | safe

--- a/templates/download/iot/index.html
+++ b/templates/download/iot/index.html
@@ -234,9 +234,9 @@ meta_copydoc %}
     </div>
     <div class="col-4">
       {{ image (
-      url="https://assets.ubuntu.com/v1/db577ec7-tank-logo.svg",
+      url="https://assets.ubuntu.com/v1/0721e5aa-tank-logo.svg",
       alt="Intel Tank logo",
-      width="163",
+      width="80",
       height="45",
       hi_def=True,
       loading="lazy"
@@ -261,9 +261,9 @@ meta_copydoc %}
     <div class="col-4">
       {{
       image (
-      url="https://assets.ubuntu.com/v1/327b8104-AMD_E_Blk_RGB.png",
+      url="https://assets.ubuntu.com/v1/d19b919d-logo-amd-160.png",
       alt="",
-      width="187",
+      width="90",
       height="45",
       hi_def=True,
       loading="lazy"


### PR DESCRIPTION
## Done

Added Mediatek logo and link to "Supported Platforms" section according to [copy doc](https://docs.google.com/document/d/1Sxdl5cGGe1wbHmKB2eL2zQLfVW3KBea02a2FIGx3VdQ/edit#heading=h.kqw4j3f3aj61)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Navigate to /download/iot and check the "Supported platforms" section if it has Mediatek
    - Check the layout of the section on different screen widths 

## Issue / Card

Closes https://warthogs.atlassian.net/browse/WD-7080

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
