### PR TITLE
WD-7093 - change asset in /download/amd

### DIFF
--- a/templates/download/amd/tab-2.html
+++ b/templates/download/amd/tab-2.html
@@ -6,7 +6,7 @@
     <div class="col-6 amd-container u-align--center col-medium-4">
       {{
         image (
-        url="https://assets.ubuntu.com/v1/62c9deff-AMD%20KR260%20KV260.png",
+        url="https://assets.ubuntu.com/v1/0f377de2-AMD_KR260_KV260-removebg-preview.png",
         alt="AMD Kria&trade;KR260 circuit board",
         width="1200",
         height="628",


### PR DESCRIPTION
## Done

- Changed asset in the second tab in https://ubuntu-com-13330.demos.haus/download/amd

## QA

- [copydoc](https://docs.google.com/document/d/1cxQnEErs8FZ3dZ_IhlfcaJ03gE_vrMJfRC-5me9IDd4/edit#heading=h.9lw1gwsuva2l)
- [demo link](https://ubuntu-com-13330.demos.haus/)
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check whether the asset is correct

## Issue / Card
[WD-7093](https://warthogs.atlassian.net/browse/WD-7093)
Fixes #

## Screenshots


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-7093]: https://warthogs.atlassian.net/browse/WD-7093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ