### PR TITLE
K8s link fixes

### DIFF
--- a/templates/kubernetes/docs/1.21/upgrading.md
+++ b/templates/kubernetes/docs/1.21/upgrading.md
@@ -411,7 +411,7 @@ juju run-action kubernetes-worker/1 upgrade
 
 ## Upgrading the Machine's Series
 
-All of the charms support [upgrading the machine's series via Juju](https://juju.is/docs/upgrading-series).
+All of the charms support [upgrading the machine's series via Juju](https://juju.is/docs/juju/manage-machines#heading--upgrade-a-workload-machine).
 As each machine is upgraded, the applications on that machine will be stopped and the unit will
 go into a `blocked` status until the upgrade is complete. For the worker units, pods will be drained
 from the node and onto one of the other nodes at the start of the upgrade, and the node will be removed

--- a/templates/kubernetes/docs/index.md
+++ b/templates/kubernetes/docs/index.md
@@ -11,8 +11,8 @@ toc: False
 Charmed Kubernetes<sup>&reg;</sup>, is pure Kubernetes tested across the widest range of clouds with modern metrics and
  monitoring, brought to you by the people who deliver Ubuntu.
 
-Google, Microsoft, and many other institutions run Kubernetes on Ubuntu because we focus on the latest container capabi
-lities in modern kernels. That’s why it’s the top choice for enterprise Kubernetes, too.
+Google, Microsoft, and many other institutions run Kubernetes on Ubuntu because we focus on the latest container 
+capabilities in modern kernels. That’s why it’s the top choice for enterprise Kubernetes, too.
 
 [Find out more in the Charmed Kubernetes overview&nbsp;&rsaquo;](/kubernetes/docs/overview)
 

--- a/templates/kubernetes/docs/index.md
+++ b/templates/kubernetes/docs/index.md
@@ -14,7 +14,7 @@ Charmed Kubernetes<sup>&reg;</sup>, is pure Kubernetes tested across the widest 
 Google, Microsoft, and many other institutions run Kubernetes on Ubuntu because we focus on the latest container capabi
 lities in modern kernels. That’s why it’s the top choice for enterprise Kubernetes, too.
 
-[Find out more in the Charmed Kubernetes overview&nbsp;&rsaquo;](../overview)
+[Find out more in the Charmed Kubernetes overview&nbsp;&rsaquo;](/kubernetes/docs/overview)
 
 <img src="https://assets.ubuntu.com/v1/843c77b6-juju-at-a-glace.svg" style="float:right; margin-left: 2rem; border: 0
 " alt="">


### PR DESCRIPTION
## Done

- fixes two broken links and a typo
- 
## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
