### PR TITLE
Remove unused GA events from dynamic-form.js

### DIFF
--- a/static/js/src/dynamic-forms.js
+++ b/static/js/src/dynamic-forms.js
@@ -200,18 +200,6 @@ import setupIntlTelInput from "./intlTelInput.js";
         }
       };
 
-      if (submitButton) {
-        submitButton.addEventListener("click", function () {
-          ga(
-            "send",
-            "event",
-            "interactive-forms",
-            "submitted",
-            window.location.pathname
-          );
-        });
-      }
-
       if (closeModal) {
         closeModal.addEventListener("click", function (e) {
           e.preventDefault();

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -380,10 +380,9 @@ def cred_assessments(trueability_api, **_):
 @shop_decorator(area="cred", permission="user", response="html")
 def cred_exam(trueability_api, **_):
     email = flask.session["openid"]["email"].lower()
-    if (
-        os.getenv("CREDENTIALS_CONFIDENTIALITY_ENABLED")
-        and not has_filed_confidentiality_agreement(email)
-    ):
+    if os.getenv(
+        "CREDENTIALS_CONFIDENTIALITY_ENABLED"
+    ) and not has_filed_confidentiality_agreement(email):
         return flask.render_template("credentials/exam-no-agreement.html"), 403
 
     assessment_id = flask.request.args.get("id")


### PR DESCRIPTION
## Done

- Remove unused GA events from dynamic-form.js as it is not registering in google analytics

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
