### PR TITLE
Remove dead link to jaas.ai/experts

### DIFF
--- a/templates/templates/navigation-enterprise-h.html
+++ b/templates/templates/navigation-enterprise-h.html
@@ -239,7 +239,6 @@
         <ul class="p-inline-list--middot is-x-dense">
           <li class="p-inline-list__item"><a href="/openstack/consulting">OpenStack</a></li>
           <li class="p-inline-list__item"><a href="/kubernetes">Kubernetes</a></li>
-          <li class="p-inline-list__item"><a href="https://jaas.ai/experts" title="Visit our Juju experts - external site">Juju experts</a></li>
           <li class="p-inline-list__item"><a href="/ai/services">MLOps</a></li>
         </ul>
       </div>

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -380,10 +380,9 @@ def cred_assessments(trueability_api, **_):
 @shop_decorator(area="cred", permission="user", response="html")
 def cred_exam(trueability_api, **_):
     email = flask.session["openid"]["email"].lower()
-    if (
-        os.getenv("CREDENTIALS_CONFIDENTIALITY_ENABLED")
-        and not has_filed_confidentiality_agreement(email)
-    ):
+    if os.getenv(
+        "CREDENTIALS_CONFIDENTIALITY_ENABLED"
+    ) and not has_filed_confidentiality_agreement(email):
         return flask.render_template("credentials/exam-no-agreement.html"), 403
 
     assessment_id = flask.request.args.get("id")


### PR DESCRIPTION
## Done
Removed a link to a non-existent page

## QA
- Go to https://ubuntu-com-13335.demos.haus/#enterprise
- Check that there is no "Juju experts" link in the "Consulting" row at the bottom of the menu