### PR TITLE
WD-7158 - update link on /consulting

### DIFF
--- a/templates/pricing/consulting.html
+++ b/templates/pricing/consulting.html
@@ -23,7 +23,7 @@
 
   <div class="u-fixed-width">
     <p>
-      <a href="https://assets.ubuntu.com/v1/d4766546-Private-Cloud-Build_Datasheet.pdf" class="p-button">
+      <a href="https://assets.ubuntu.com/v1/1c82430f-Private%20Cloud%20Build_DS_25.07.23%20v2.pdf" class="p-button">
         Download the datasheet
       </a>
       <a href="/support/contact-us?product=openstack" data-form-location="/shared/forms/interactive/support-openstack" data-form-id="1240" data-lp-id="2065" data-return-url="/pricing/consulting#success" data-lp-url="https://pages.ubuntu.com/things-contact-us.html" class="js-invoke-modal p-button--positive"> Get in touch</a>


### PR DESCRIPTION
## Done

- Updated the download link in https://ubuntu-com-13337.demos.haus/consulting

## QA

- [copy doc](https://docs.google.com/document/d/1sXeOQ9eLq53NcfbrorYstHkZYTdut33jbN5LyHoDdYY/edit#heading=h.xv4ec899rw2v)
- [demo link](https://ubuntu-com-13337.demos.haus/)
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
-  Check download link to be correct

## Issue / Card
[WD-7158](https://warthogs.atlassian.net/browse/WD-7158)
Fixes #

## Screenshots


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-7158]: https://warthogs.atlassian.net/browse/WD-7158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ