### PR TITLE
Kubernetes 1.28+ck2 updates

### DIFF
--- a/templates/kubernetes/docs/1.28/release-notes.md
+++ b/templates/kubernetes/docs/1.28/release-notes.md
@@ -13,6 +13,39 @@ layout: [base, ubuntu-com]
 toc: False
 ---
 
+## 1.28+ck2 Bugfix release
+
+### November 7, 2023 - `charmed-kubernetes --channel 1.28/stable`
+
+The release bundle can also be [downloaded here](https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/releases/1.28/bundle.yaml).
+
+## What's new
+
+### Containerd
+* [LP#2034080](https://bugs.launchpad.net/bugs/2034080)
+  Updated source repository for nvidia debs.
+
+### Calico
+* [LP#2037236](https://bugs.launchpad.net/bugs/2037236)
+  1.28 charm release no longer ignores `cni` networking binding.
+
+### Kubernetes-Control-Plane and Kubernetes Worker
+* [LP#2038970](https://bugs.launchpad.net/bugs/2038970)
+  Check the kubernetes cluster version before applying DevicePlugin feature gates.
+
+### Openstack Cloud Controller and CDK Addons
+* [LP#2039886](https://bugs.launchpad.net/bugs/2039886)
+  Correctly update the kubernetes cluster-name when starting the cloud-controller-manager.
+
+### Updated Images
+* [LP#2035139](https://bugs.launchpad.net/bugs/2035139)
+  Updated of various container images which address numerous CVEs in the following operators
+  - coredns charm
+  - ceph-csi charm
+  - openstack-cloud-controller charm
+  - cdk-addons
+
+
 ## 1.28+ck1 Bugfix release
 
 ### September 25, 2023 - `charmed-kubernetes --channel 1.28/stable`

--- a/templates/kubernetes/docs/release-notes.md
+++ b/templates/kubernetes/docs/release-notes.md
@@ -15,6 +15,39 @@ toc: False
 
 <!-- AUTOGENERATE RELEASE NOTES HERE -->
 
+
+## 1.28+ck2 Bugfix release
+
+### November 7, 2023 - `charmed-kubernetes --channel 1.28/stable`
+
+The release bundle can also be [downloaded here](https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/releases/1.28/bundle.yaml).
+
+## What's new
+
+### Containerd
+* [LP#2034080](https://bugs.launchpad.net/bugs/2034080)
+  Updated source repository for nvidia debs.
+
+### Calico
+* [LP#2037236](https://bugs.launchpad.net/bugs/2037236)
+  1.28 charm release no longer ignores `cni` networking binding.
+
+### Kubernetes-Control-Plane and Kubernetes Worker
+* [LP#2038970](https://bugs.launchpad.net/bugs/2038970)
+  Check the kubernetes cluster version before applying DevicePlugin feature gates.
+
+### Openstack Cloud Controller and CDK Addons
+* [LP#2039886](https://bugs.launchpad.net/bugs/2039886)
+  Correctly update the kubernetes cluster-name when starting the cloud-controller-manager.
+
+### Updated Images
+* [LP#2035139](https://bugs.launchpad.net/bugs/2035139)
+  Updated of various container images which address numerous CVEs in the following operators
+  - coredns charm
+  - ceph-csi charm
+  - openstack-cloud-controller charm
+  - cdk-addons
+
 ## 1.28+ck1 Bugfix release
 
 ### September 25, 2023 - `charmed-kubernetes --channel 1.28/stable`


### PR DESCRIPTION
## Done

- Update release notes for 1.28+ck2

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes