### PR TITLE
[WD-7080] squeeze Mediatek logo a bit

### DIFF
--- a/templates/download/iot/index.html
+++ b/templates/download/iot/index.html
@@ -118,7 +118,7 @@ meta_copydoc %}
       {{ image (
       url="https://assets.ubuntu.com/v1/0ebb345c-MediaTek_logo.svg",
       alt="MediaTek Genio",
-      width="147",
+      width="110",
       height="23",
       hi_def=True,
       loading="auto",


### PR DESCRIPTION
## Done

- Squeeze Mediatek logo in "Supported platforms" section of /download/iot page

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Navigate to /download/iot, scroll down to "Supported platforms" section and check Mediatek logo if it has same dimension ratio as in the original logo [here](https://assets.ubuntu.com/v1/0ebb345c-MediaTek_logo.svg).

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-7080

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
