### PR TITLE
[WD-7202] remove support phone numbers

### DIFF
--- a/templates/contact-us/index.html
+++ b/templates/contact-us/index.html
@@ -13,9 +13,6 @@
   </div>
   <div class="row">
     <div class="col-5">
-      <h2>Sales enquiries</h2>
-      {% include "shared/_call-sales-long.html" %}
-
       <h2>Online</h2>
       <p>
         <a href="/contact-us/form?product=generic-contact-us">Ask us</a> about our products, support, training or consulting and we will get in touch with you within one working day.

--- a/templates/shared/_cloud-contact-us-form.html
+++ b/templates/shared/_cloud-contact-us-form.html
@@ -102,17 +102,14 @@
 
     <div class="col-4">
       <div class="p-card">
-        <h3 class="p-card__title">Any questions? Call us</h3>
-        {% include "shared/_call-sales-long.html" %}
+        <h3 class="p-card__title">Need help with Ubuntu?</h3>
+        <p>If you are just looking for some free support for yourself, you can try:</p>
+        <ul class="p-list--divided">
+          <li class="p-list__item"><a href="https://askubuntu.com/">Ask Ubuntu</a></li>
+          <li class="p-list__item"><a href="https://ubuntuforums.org/">The Ubuntu forum</a></li>
+          <li class="p-list__item"><a href="https://help.ubuntu.com/">Help docs</a></li>
+        </ul>
       </div>
-      <div class="p-card">
-      <h3 class="p-card__title">Need help with Ubuntu?</h3>
-      <p>If you are just looking for some free support for yourself, you can try:</p>
-      <ul class="p-list--divided">
-        <li class="p-list__item"><a href="https://askubuntu.com/">Ask Ubuntu</a></li>
-        <li class="p-list__item"><a href="https://ubuntuforums.org/">The Ubuntu forum</a></li>
-        <li class="p-list__item"><a href="https://help.ubuntu.com/">Help docs</a></li>
-      </ul>
     </div>
   </div>
 </section>

--- a/templates/shared/_pro-contact-us-form.html
+++ b/templates/shared/_pro-contact-us-form.html
@@ -314,10 +314,6 @@
 
     <div class="col-4">
       <div class="p-card">
-        <h2 class="p-heading--3 p-card__title">Any questions? Call us</h2>
-        {% include "shared/_call-sales-long.html" %}
-      </div>
-      <div class="p-card">
         <h2 class="p-heading--3 p-card__title">Need help with Ubuntu?</h2>
         <p>If you are just looking for some free support for yourself, you can try:</p>
         <ul class="p-list--divided">


### PR DESCRIPTION
## Done

- Removed phone numbers from the following pages:
   - /contact-us
   - /contact-us/form
   - /<product>/contact-us, where <product> is one of:
      - openstack
      - support
      - kubernetes
      - security
      - wsl
      - managed
      - containers
      - download

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check all the pages listed above ("Done" section) if the phone numbers do now show there anymore

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-7202

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
