### PR TITLE
[WD-7314] add a redirect from a blog post to another page

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -945,6 +945,7 @@ blog/kubernetes-1-19-available-from-canonical..*: /blog/kubernetes-1-19-availabl
 blog/kubernetes-1-21-available-from-canonical..*: /blog/kubernetes-1-21-available-from-canonical
 blog/what-is-elasticsearch-and-how-are-enterprises-using-it: /blog/what-is-elasticsearch
 blog/managed-postgresql: /blog/what-is-postgresql
+blog/howto-host-your-own-snap-store: /internet-of-things/appstore
 
 # Move snappy topic to snapcraft
 blog/topics/snappy/?: /blog/topics/snapcraft


### PR DESCRIPTION
## Done

- Add redirect from /blog/howto-host-your-own-snap-store to /internet-of-things/appstore

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Navigate to /blog/howto-host-your-own-snap-store and check if it redirects to /internet-of-things/appstore

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-7314

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
