### PR TITLE
use REBASE_TOKEN that has workflow permission for automatic rebase

### DIFF
--- a/.github/workflows/rebase.yaml
+++ b/.github/workflows/rebase.yaml
@@ -16,11 +16,11 @@ jobs:
       - name: Checkout the latest code
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.REBASE_TOKEN }}
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
       - name: Automatic Rebase
         uses: cirrus-actions/rebase@1.8
         with:
           autosquash: ${{ contains(github.event.comment.body, '/autosquash') || contains(github.event.comment.body, '/rebase-autosquash') }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.REBASE_TOKEN }}


### PR DESCRIPTION
## Done

- Apparently in order to be able to automatically re-run GH actions after a rebase command using a `/rebase` comment in PRs, we need to use a PAT that has `workflow` permission. The default GITHUB_TOKEN token doesn't have that permission and therefore GH actions fail.
- Created a PAT called `REBASE_TOKEN` with `workflow` permission in my settings. Whoever wants to use this command will need to add that PAT as well.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Add `/rebase` comment to your PR and check GH actions that are triggered after that. They should succeed.

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
