### PR TITLE
WD-6807 - update /thank-you page, banner issue

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -800,6 +800,16 @@ td.p-accordion {
   z-index: 10;
 }
 
+#newsletter-signup {
+  display: none;
+  position: absolute;
+}
+
+#newsletter-signup:target {
+  display: block;
+  z-index: 10;
+}
+
 #updated {
   display: none;
 }

--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -78,7 +78,7 @@
           </span>
           <input value="1212" name="formid" type="hidden">
           <input type="hidden" name="Consent_to_Processing__c" value="yes" />
-          <input type="hidden" name="returnURL" value="http://{{ http_host }}/download/desktop/thank-you?newsletter=true" />
+          <input type="hidden" name="returnURL" value="http://{{ http_host }}/download/desktop/thank-you#success" />
           <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
           <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
           <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
@@ -87,7 +87,7 @@
           <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
           <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Facebook_Click_ID__c" id="Facebook_Click_ID__c" value="" />
           <input type="hidden" aria-hidden="true" aria-label="hidden field" id="preferredLanguage" name="preferredLanguage" maxlength="255" value="" />
-          <input type="hidden" name="thankyoumessage" value="Thank you for subscribing!<br />You will begin receiving emails as new content is posted. You may unsubscribe any time by clicking the link in the email.">
+          <input type="hidden" name="thankyoumessage" value="Thank you for signing up for our newsletter!">
         </div>
       </form>
     </div>

--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -41,10 +41,8 @@
           {% endif %}
         </p>
       </div>
-      <div class="u-hide" id="contact-form-container" data-form-id="4960" data-lp-id=""
-        data-return-url="/download/desktop/thank-you#newsletter-signup"
-        data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
-      </div>
+
+
       <form class="col-6" action="/marketo/submit" method="post" id="mktoForm_4960"
         onsubmit="ga('send', 'Newsletter', 'Signup', 'New homepage newsletter signup');">
         <h1 style="font-weight: 100;">Sign up for our newsletter</h1>

--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -46,10 +46,8 @@
         <p>It will help further the open source development of Ubuntu.</p>
         {% endif %}
       </div>
-      <div class="u-hide" id="contact-form-container" data-form-id="4960" data-lp-id=""
-        data-return-url="/download/desktop/thank-you#newsletter-signup"
-        data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
-      </div>
+
+
       <form class="col-6" action="/marketo/submit" method="post" id="mktoForm_4960"
         onsubmit="ga('send', 'Newsletter', 'Signup', 'New homepage newsletter signup');">
         <h1 style="font-weight: 100;">Sign up for our newsletter</h1>

--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -47,7 +47,9 @@
         <p>It will help further the open source development of Ubuntu.</p>
         {% endif %}
       </div>
-      <form class="col-6">
+      <div class="u-hide" id="contact-form-container" data-form-id="1212" data-lp-id="" data-return-url="/download/desktop/thank-you#success" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+      </div>
+      <form class="col-6" action="/marketo/submit" method="post" id="mktoForm_1212" onsubmit="ga('send', 'Newsletter', 'Signup', 'New homepage newsletter signup');">
         <h1 style="font-weight: 100;">Sign up for our newsletter</h1>
         <p>Get the latest Ubuntu news and updates in your inbox.</p>
         <ul class="p-list">
@@ -69,14 +71,23 @@
                 href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a
                 href="/legal/data-privacy">Privacy Policy</a>.</p>
           </li>
-          <li class="p-list__item">
-            <button type="submit" class="p-button--positive">Subscribe now</button>
-          </li>
         </ul>
         <div>
-          <!-- <input type="hidden" aria-hidden="true" name="Consent_to_Processing__c" value="Yes">
-          <input type="hidden" aria-hidden="true" name="formid" value="3415"> -->
-          <input type="hidden" aria-hidden="true" name="returnURL" value="/download/desktop/thank-you#success" />
+          <span class="p-card--content">
+            <button type="submit" class="p-button--positive">Subscribe now</button>
+          </span>
+          <input value="1212" name="formid" type="hidden">
+          <input type="hidden" name="Consent_to_Processing__c" value="yes" />
+          <input type="hidden" name="returnURL" value="http://{{ http_host }}/download/desktop/thank-you?newsletter=true" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Facebook_Click_ID__c" id="Facebook_Click_ID__c" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" id="preferredLanguage" name="preferredLanguage" maxlength="255" value="" />
+          <input type="hidden" name="thankyoumessage" value="Thank you for subscribing!<br />You will begin receiving emails as new content is posted. You may unsubscribe any time by clicking the link in the email.">
         </div>
       </form>
     </div>

--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -29,18 +29,27 @@
   <div class="p-strip--suru-topped">
     <div class="row">
       <div class="col-6">
+        {% if version %}
         <h1 style="font-weight: 100;">Thank you for downloading Ubuntu Desktop</h1>
         <p>Your download should start automatically. If it doesn't,
           {% if architecture == 'amd64+mac' %}
-          <a href="https://cdimage.ubuntu.com/releases/{{ version }}/release/ubuntu-{{ version }}-desktop-amd64+mac.iso">download now</a>.
+          <a
+            href="https://cdimage.ubuntu.com/releases/{{ version }}/release/ubuntu-{{ version }}-desktop-amd64+mac.iso">download
+            now</a>.
           {% else %}
           <a href="https://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-desktop-{{ architecture }}.iso">download
             now</a>.
           {% endif %}
         </p>
+        {% else %}
+        <h1>Thank you for your contribution</h1>
+        <p>It will help further the open source development of Ubuntu.</p>
+        {% endif %}
       </div>
-
-
+      <div class="u-hide" id="contact-form-container" data-form-id="4960" data-lp-id=""
+        data-return-url="/download/desktop/thank-you#newsletter-signup"
+        data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+      </div>
       <form class="col-6" action="/marketo/submit" method="post" id="mktoForm_4960"
         onsubmit="ga('send', 'Newsletter', 'Signup', 'New homepage newsletter signup');">
         <h1 style="font-weight: 100;">Sign up for our newsletter</h1>

--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -28,25 +28,59 @@
 <section class="p-strip is-bordered u-no-padding--top u-no-padding--bottom" style="overflow: visible;">
   <div class="p-strip--suru-topped">
     <div class="row">
-      <div class="col-8">
+      <div class="col-6">
         {% if version %}
         <h1 style="font-weight: 100;">Thank you for downloading Ubuntu Desktop</h1>
         <p>Your download should start automatically. If it doesn't,
           {% if architecture == 'amd64+mac' %}
-          <a href="https://cdimage.ubuntu.com/releases/{{ version }}/release/ubuntu-{{ version }}-desktop-amd64+mac.iso">download now</a>.
+          <a href="https://cdimage.ubuntu.com/releases/{{ version }}/release/ubuntu-{{ version }}-desktop-amd64+mac.iso">download
+            now</a>.
           {% else %}
-          <a href="https://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-desktop-{{ architecture }}.iso">download now</a>.
+          <a href="https://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-desktop-{{ architecture }}.iso">download
+            now</a>.
           {% endif %}
         </p>
-        {% with version=version, system="desktop", architecture=architecture %}{% include "download/shared/_verify-checksums.html" %}{% endwith %}
+        {% with version=version, system="desktop", architecture=architecture %}{% include
+        "download/shared/_verify-checksums.html" %}{% endwith %}
         {% else %}
         <h1>Thank you for your contribution</h1>
         <p>It will help further the open source development of Ubuntu.</p>
         {% endif %}
       </div>
+      <form class="col-6">
+        <h1 style="font-weight: 100;">Sign up for our newsletter</h1>
+        <p>Get the latest Ubuntu news and updates in your inbox.</p>
+        <ul class="p-list">
+          <li class="p-list__item">
+            <label for="email">Email:</label>
+            <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
+          </li>
+          <li class="p-list__item u-no-margin--top">
+            <label class="p-checkbox">
+              <input class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn"
+                type="checkbox" />
+              <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical’s
+                products
+                and services.</span>
+            </label>
+          </li>
+          <li class="p-list__item u-no-margin--top">
+            <p>By submitting this form, I confirm that I have read and agree to <a
+                href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a
+                href="/legal/data-privacy">Privacy Policy</a>.</p>
+          </li>
+          <li class="p-list__item">
+            <button type="submit" class="p-button--positive">Subscribe now</button>
+          </li>
+        </ul>
+        <div>
+          <!-- <input type="hidden" aria-hidden="true" name="Consent_to_Processing__c" value="Yes">
+          <input type="hidden" aria-hidden="true" name="formid" value="3415"> -->
+          <input type="hidden" aria-hidden="true" name="returnURL" value="/download/desktop/thank-you#success" />
+        </div>
+      </form>
     </div>
-  </div>
-</section>
+    </section>
 
 <section class="p-strip--light">
   <div class="u-fixed-width">

--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -33,7 +33,8 @@
         <h1 style="font-weight: 100;">Thank you for downloading Ubuntu Desktop</h1>
         <p>Your download should start automatically. If it doesn't,
           {% if architecture == 'amd64+mac' %}
-          <a href="https://cdimage.ubuntu.com/releases/{{ version }}/release/ubuntu-{{ version }}-desktop-amd64+mac.iso">download
+          <a
+            href="https://cdimage.ubuntu.com/releases/{{ version }}/release/ubuntu-{{ version }}-desktop-amd64+mac.iso">download
             now</a>.
           {% else %}
           <a href="https://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-desktop-{{ architecture }}.iso">download
@@ -47,9 +48,12 @@
         <p>It will help further the open source development of Ubuntu.</p>
         {% endif %}
       </div>
-      <div class="u-hide" id="contact-form-container" data-form-id="1212" data-lp-id="" data-return-url="/download/desktop/thank-you#success" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+      <div class="u-hide" id="contact-form-container" data-form-id="4960" data-lp-id=""
+        data-return-url="/download/desktop/thank-you#newsletter-signup"
+        data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
       </div>
-      <form class="col-6" action="/marketo/submit" method="post" id="mktoForm_1212" onsubmit="ga('send', 'Newsletter', 'Signup', 'New homepage newsletter signup');">
+      <form class="col-6" action="/marketo/submit" method="post" id="mktoForm_4960"
+        onsubmit="ga('send', 'Newsletter', 'Signup', 'New homepage newsletter signup');">
         <h1 style="font-weight: 100;">Sign up for our newsletter</h1>
         <p>Get the latest Ubuntu news and updates in your inbox.</p>
         <ul class="p-list">
@@ -59,9 +63,10 @@
           </li>
           <li class="p-list__item u-no-margin--top">
             <label class="p-checkbox">
-              <input class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn"
-                type="checkbox" />
-              <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical’s
+              <input class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn"
+                name="canonicalUpdatesOptIn" type="checkbox" />
+              <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about
+                Canonical’s
                 products
                 and services.</span>
             </label>
@@ -76,22 +81,28 @@
           <span class="p-card--content">
             <button type="submit" class="p-button--positive">Subscribe now</button>
           </span>
-          <input value="1212" name="formid" type="hidden">
+          <input value="4960" name="formid" type="hidden">
           <input type="hidden" name="Consent_to_Processing__c" value="yes" />
-          <input type="hidden" name="returnURL" value="http://{{ http_host }}/download/desktop/thank-you#success" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+          <input type="hidden" name="returnURL"
+            value="http://{{ http_host }}/download/desktop/thank-you#newsletter-signup" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign"
+            value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium"
+            value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source"
+            value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content"
+            value="" />
           <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
           <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Facebook_Click_ID__c" id="Facebook_Click_ID__c" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" id="preferredLanguage" name="preferredLanguage" maxlength="255" value="" />
-          <input type="hidden" name="thankyoumessage" value="Thank you for signing up for our newsletter!">
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Facebook_Click_ID__c"
+            id="Facebook_Click_ID__c" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" id="preferredLanguage"
+            name="preferredLanguage" maxlength="255" value="" />
         </div>
       </form>
     </div>
-    </section>
+</section>
 
 <section class="p-strip--light">
   <div class="u-fixed-width">
@@ -269,98 +280,6 @@
           </div>
         </div>
       </form>
-    </div>
-    <div class="col-4 col-start-large-9" style="position: sticky; top: 2rem;">
-      <div class="p-card">
-        <h4 class="p-muted-heading">Newsletter signup</h4>
-        <hr class="u-sv1" />
-        <h3 class="p-card--title">Select topics you're interested in</h3>
-        <form action="/marketo/submit" method="post" id="mktoForm_1212" onsubmit="ga('send', 'Newsletter', 'Signup', 'New homepage newsletter signup');">
-          <div class="p-card--content">
-            <ul class="p-list">
-              <li class="p-list__item u-clearfix">
-                <label class="p-checkbox">
-                  <input type="checkbox" aria-labelledby="insightscloudserver" class="p-checkbox__input" name="insightscloudserver" value="true" />
-                  <span class="p-checkbox__label" id="insightscloudserver">Cloud and Server</span>
-                </label>
-
-              </li>
-              <li class="p-list__item u-clearfix">
-                <label class="p-checkbox">
-                  <input type="checkbox" aria-labelledby="insightsdesktop" class="p-checkbox__input" name="insightsdesktop" value="true" />
-                  <span class="p-checkbox__label" id="insightsdesktop">Desktop</span>
-                </label>
-
-              </li>
-              <li class="p-list__item u-clearfix">
-                <label class="p-checkbox">
-                  <input type="checkbox" aria-labelledby="insightsiot" class="p-checkbox__input" name="insightsiot" value="true" />
-                  <span class="p-checkbox__label" id="insightsiot">Internet of Things</span>
-                </label>
-
-              </li>
-              <li class="p-list__item u-clearfix">
-                <label class="p-checkbox">
-                  <input class="p-checkbox__input" aria-labelledby="insightsrobotics" name="insightsrobotics" value="true" type="checkbox">
-                  <span class="p-checkbox__label" id="insightsrobotics">Robotics</span>
-                </label>
-              </li>
-              <li class="p-list__item u-clearfix">
-                <label class="p-checkbox">
-                  <input class="p-checkbox__input" aria-labelledby="insightstutorials" name="insightstutorials" value="true" type="checkbox">
-                  <span class="p-checkbox__label" id="insightstutorials">Tutorials</span>
-                </label>
-              </li>
-              {# These are honey pot fields to catch bots #}
-              <li class="u-off-screen">
-                <label class="website" for="website">Website:</label>
-                <input name="website" type="text" class="website" autocomplete="off" value="" id="website" tabindex="-1" />
-              </li>
-              <li class="u-off-screen">
-                <label class="name" for="name">Name:</label>
-                <input name="name" type="text" class="name" autocomplete="off" value="" id="name" tabindex="-1" />
-              </li>
-              {# End of honey pots #}
-            </ul>
-            <div>
-              <label>
-                <span class="u-no-margin--top">Work email: <span>*</span></span>
-                <input required  id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
-              </label>
-            </div>
-            <div>
-              <label class="p-checkbox">
-                <input class="p-checkbox__input" name="canonicalUpdatesOptIn" aria-labelledby="CanonicalUpdatesOptIn" value="yes" type="checkbox" />
-                <span class="p-checkbox__label" id="CanonicalUpdatesOptIn">
-                  <small>I agree to receive information about Canonical's products and services.</small>
-                </span>
-              </label>
-            </div>
-            <p>
-              <small>In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/newsletter">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</small>
-            </p>
-
-
-            <div>
-              <span class="p-card--content">
-                <button type="submit" class="u-no-margin--bottom">Subscribe now</button>
-              </span>
-              <input value="1212" name="formid" type="hidden">
-              <input type="hidden" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" name="returnURL" value="http://{{ http_host }}/download/desktop/thank-you?newsletter=true" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Facebook_Click_ID__c" id="Facebook_Click_ID__c" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" id="preferredLanguage" name="preferredLanguage" maxlength="255" value="" />
-              <input type="hidden" name="thankyoumessage" value="Thank you for subscribing!<br />You will begin receiving emails as new content is posted. You may unsubscribe any time by clicking the link in the email.">
-            </div>
-          </div>
-        </form>
-      </div>
     </div>
   </div>
 </section>

--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -32,9 +32,7 @@
         <h1 style="font-weight: 100;">Thank you for downloading Ubuntu Desktop</h1>
         <p>Your download should start automatically. If it doesn't,
           {% if architecture == 'amd64+mac' %}
-          <a
-            href="https://cdimage.ubuntu.com/releases/{{ version }}/release/ubuntu-{{ version }}-desktop-amd64+mac.iso">download
-            now</a>.
+          <a href="https://cdimage.ubuntu.com/releases/{{ version }}/release/ubuntu-{{ version }}-desktop-amd64+mac.iso">download now</a>.
           {% else %}
           <a href="https://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-desktop-{{ architecture }}.iso">download
             now</a>.

--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -29,7 +29,6 @@
   <div class="p-strip--suru-topped">
     <div class="row">
       <div class="col-6">
-        {% if version %}
         <h1 style="font-weight: 100;">Thank you for downloading Ubuntu Desktop</h1>
         <p>Your download should start automatically. If it doesn't,
           {% if architecture == 'amd64+mac' %}
@@ -41,12 +40,6 @@
             now</a>.
           {% endif %}
         </p>
-        {% with version=version, system="desktop", architecture=architecture %}{% include
-        "download/shared/_verify-checksums.html" %}{% endwith %}
-        {% else %}
-        <h1>Thank you for your contribution</h1>
-        <p>It will help further the open source development of Ubuntu.</p>
-        {% endif %}
       </div>
       <div class="u-hide" id="contact-form-container" data-form-id="4960" data-lp-id=""
         data-return-url="/download/desktop/thank-you#newsletter-signup"
@@ -58,7 +51,7 @@
         <p>Get the latest Ubuntu news and updates in your inbox.</p>
         <ul class="p-list">
           <li class="p-list__item">
-            <label for="email">Email:</label>
+            <label for="email">* Email:</label>
             <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
           </li>
           <li class="p-list__item u-no-margin--top">

--- a/templates/templates/_tag_manager.html
+++ b/templates/templates/_tag_manager.html
@@ -20,3 +20,5 @@
         '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
         })(window,document,'script','dataLayer','GTM-K92JCQ');</script>
         <!-- End Google Tag Manager -->
+
+        <style>#rememberMe {display: none;}</style>

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -98,7 +98,7 @@
       <div class="u-fixed-width">
         <div class="p-notification--positive u-no-margin--bottom">
           <div class="p-notification__content">
-            <p class="p-notification__message">Thank you for signing up for our newsletter!</p>
+            <p class="p-notification__message">Thank you for signing up for our newsletter!<a href="#" onclick="location.href = document.referrer; return false;"><i class="p-notification__close">Close</i></a></p>
           </div>
         </div>
       </div>

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -94,6 +94,15 @@
         </div>
       </div>
     </div>
+    <div id="newsletter-signup" class="p-strip u-no-padding--top">
+      <div class="u-fixed-width">
+        <div class="p-notification--positive u-no-margin--bottom">
+          <div class="p-notification__content">
+            <p class="p-notification__message">Thank you for signing up for our newsletter!</p>
+          </div>
+        </div>
+      </div>
+    </div>
     <main id="main-content" class="inner-wrapper">
       {% block content_head %}{% endblock %}
       {% block content_container %}


### PR DESCRIPTION
## Done

- Updated the first section in https://ubuntu-com-13353.demos.haus/download/desktop/thank-you

## QA

- [copy doc](https://docs.google.com/document/d/187Vg9I0Jjlp1_yAjYtHdoEwFCJeVOaz9Kzeb6kptMpA/edit)
- [demo link](https://ubuntu-com-13353.demos.haus/)
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
-  Check the first section on page

## Issue / Card
[WD-6807](https://warthogs.atlassian.net/browse/WD-6807)
Fixes #

## Screenshots


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

[WD-6807]: https://warthogs.atlassian.net/browse/WD-6807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ