### PR TITLE
fix automotive resources page to link blog title and image

### DIFF
--- a/templates/automotive/resources.html
+++ b/templates/automotive/resources.html
@@ -229,9 +229,7 @@
   <template style="display:none" id="automotive-resources-articles-template">
     <div class="col-3">
       <div class="u-crop--16-9">
-        <a class="article-link" aria-hidden="true" tabindex="-1">
-          <div class="article-image p-image-wrapper"></div>
-        </a>
+        <div class="article-image p-image-wrapper"></div>
       </div>
       <h3 class="p-heading--5"><a class="article-link article-title"></a></h3>
       <p class="article-excerpt"></p>
@@ -247,6 +245,7 @@
       articleTemplateSelector: "#automotive-resources-articles-template",
       excerptLength: 100,
       groupId: "4340",
+      linkImage: true,
     }
     )
 </script>


### PR DESCRIPTION
## Done

- link blog title on automotive/resources page

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- check blog title and images are linked on the automotive/resources page