### PR TITLE
[WD-6717] remove one link and replace another one according to copy doc

### DIFF
--- a/templates/cloud/public-cloud.html
+++ b/templates/cloud/public-cloud.html
@@ -32,7 +32,6 @@
 <section class="p-strip is-deep is-bordered">
   <div class="u-fixed-width">
     {% with title="A selection of our certified public cloud partners", json_feed_url="https://partners.ubuntu.com/partners.json?programme__name=Public%20Cloud&featured=true", feed_item_limit=10 %}{% include "shared/_partner-logos.html" %}{% endwith %}
-    <p class="u-align--center"><a href="https://partners.ubuntu.com/find-a-partner?programme=certified-public-cloud">View all certified public cloud partners&nbsp;&rsaquo;</a></p>
   </div>
 </section>
 
@@ -106,7 +105,7 @@
         <a href="https://aws.amazon.com/marketplace/pp/B087L1R4G4">Launch Ubuntu Pro 20.04 LTS for AWS&nbsp;&rsaquo;</a>
       </p>
       <p>
-        <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-focal">Launch Ubuntu Pro 20.04 LTS for Azure&nbsp;&rsaquo;</a>
+        <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-jammy?tab=Overview">Launch Ubuntu Pro 22.04 LTS for Azure&nbsp;&rsaquo;</a>
       </p>
       <p>
         <a href="https://console.cloud.google.com/marketplace/browse?q=ubuntu%20pro%20canonical">Launch Ubuntu Pro 20.04 LTS for GCP&nbsp;&rsaquo;</a>


### PR DESCRIPTION
## Done

Few content changes from the [copy doc](https://docs.google.com/document/d/1ZzUIh9Tfz5SvkrHyo4-izzmUjRka1Tn0UQisKcXGEPA/edit):
- Removed "View all certified public cloud partners" link
- Replaced link and text for Launch Ubuntu for Azure in "Ready to get started?" section

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Navigate to /cloud/public-cloud page and check if the above mentioned changed have been applied

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-6717

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
