### PR TITLE
WD-7205 - enrich /real-time page with images

### DIFF
--- a/templates/real-time/index.html
+++ b/templates/real-time/index.html
@@ -64,8 +64,6 @@
     <div class="col-12 col-medium-3 p-section--shallow">
       <h2>Real-time Ubuntu use cases</h2>
     </div>
-  </div>
-  <div class="row u-hide--medium u-equal-height">
     <div class="col-3 col-medium-3">
       <h3 class="p-heading--5">Industrial settings</h3>
       <p class="p-cases">PLCs in assembly lines must deliver and process data in real-time to ensure system
@@ -135,8 +133,6 @@
         }}
       </div>
     </div>
-  </div>
-  <div class="row u-hide--medium">
     <p>Not sure real-time is for you? <br /><a href="/kernel/real-time/contact-us">Get in touch</a> to talk over
       your
       use case with our sales team</p>
@@ -154,7 +150,8 @@
             <h3 class="p-heading--5">Industrial settings</h3>
           </div>
           <div class="col-6">
-            <p>PLCs in assembly lines must deliver and process data in real-time to ensure system integrity and continuous production.</p>
+            <p>PLCs in assembly lines must deliver and process data in real-time to ensure system integrity and
+              continuous production.</p>
           </div>
         </div>
       </div>
@@ -165,7 +162,8 @@
             <h3 class="p-heading--5">Telco</h3>
           </div>
           <div class="col-6">
-            <p>Real-time Ubuntu brings ultra-low latency and enhanced security capabilities to telco workloads and the critical infrastructure they run on.</p>
+            <p>Real-time Ubuntu brings ultra-low latency and enhanced security capabilities to telco workloads and the
+              critical infrastructure they run on.</p>
           </div>
         </div>
       </div>
@@ -176,7 +174,8 @@
             <h3 class="p-heading--5">Healthcare robotics</h3>
           </div>
           <div class="col-6">
-            <p>From autonomous mobile robots to life-support medical equipment, healthcare systems must complete tasks within specified deadlines.</p>
+            <p>From autonomous mobile robots to life-support medical equipment, healthcare systems must complete tasks
+              within specified deadlines.</p>
           </div>
         </div>
       </div>
@@ -187,7 +186,8 @@
             <h3 class="p-heading--5">Automotive</h3>
           </div>
           <div class="col-6">
-            <p>Automotive manufacturers are increasingly reliant on real-time Linux for infotainment systems, HMIs and latency-sensitive scenarios.</p>
+            <p>Automotive manufacturers are increasingly reliant on real-time Linux for infotainment systems, HMIs and
+              latency-sensitive scenarios.</p>
           </div>
         </div>
       </div>
@@ -195,7 +195,8 @@
         <hr class="p-rule">
         <div class="row">
           <div class="col-6 col-start-large-4">
-            <p>Not sure real-time is for you? <br/><a href="/kernel/real-time/contact-us">Get in touch</a> to talk over your use case with our sales team</p>
+            <p>Not sure real-time is for you? <br /><a href="/kernel/real-time/contact-us">Get in touch</a> to talk over
+              your use case with our sales team</p>
           </div>
         </div>
       </div>

--- a/templates/real-time/index.html
+++ b/templates/real-time/index.html
@@ -130,6 +130,9 @@
       ) | safe
       }}</div>
   </div>
+  <div class="row">
+    <p>Not sure real-time is for you? <br /><a href="/kernel/real-time/contact-us">Get in touch</a> to talk over your use case with our sales team</p>
+  </div>
 </section>
 
 <section class="p-section">

--- a/templates/real-time/index.html
+++ b/templates/real-time/index.html
@@ -75,7 +75,7 @@
         {{
         image(
         url="https://assets.ubuntu.com/v1/007d3fe1-Industrial@3x.png",
-        alt="Industrial image",
+        alt="",
         width="284",
         hi_def=True,
         loading="lazy",
@@ -93,7 +93,7 @@
         {{
         image(
         url="https://assets.ubuntu.com/v1/04c896e6-Telco@3x.png",
-        alt="Telco image",
+        alt="",
         width="284",
         hi_def=True,
         loading="lazy",
@@ -110,7 +110,7 @@
         {{
         image(
         url="https://assets.ubuntu.com/v1/9969e00e-Healthcare@3x.png",
-        alt="Healthcare image",
+        alt="",
         width="284",
         hi_def=True,
         loading="lazy",
@@ -127,7 +127,7 @@
         {{
         image(
         url="https://assets.ubuntu.com/v1/4ffd9127-Automotive@3x.png",
-        alt="Automotive image",
+        alt="",
         width="284",
         hi_def=True,
         loading="lazy",

--- a/templates/real-time/index.html
+++ b/templates/real-time/index.html
@@ -59,13 +59,13 @@
 </section>
 
 <section class="p-section">
-  <div class="row">
+  <div class="row u-hide--medium">
     <hr class="p-rule">
     <div class="col-12 col-medium-3 p-section--shallow">
       <h2>Real-time Ubuntu use cases</h2>
     </div>
   </div>
-  <div class="row u-equal-height">
+  <div class="row u-hide--medium u-equal-height">
     <div class="col-3 col-medium-3">
       <h3 class="p-heading--5">Industrial settings</h3>
       <p class="p-cases">PLCs in assembly lines must deliver and process data in real-time to ensure system
@@ -136,10 +136,70 @@
       </div>
     </div>
   </div>
-  <div class="row">
+  <div class="row u-hide--medium">
     <p>Not sure real-time is for you? <br /><a href="/kernel/real-time/contact-us">Get in touch</a> to talk over
       your
       use case with our sales team</p>
+  </div>
+  <div class="row u-hide--small u-hide--large">
+    <hr class="p-rule">
+    <div class="col-12 col-medium-3 p-section--shallow">
+      <h2>Real-time Ubuntu use cases</h2>
+    </div>
+    <div class="col-9 col-start-large-4 col-medium-3">
+      <div class="p-section--shallow">
+        <hr class="p-rule u-hide--medium">
+        <div class="row">
+          <div class="col-3">
+            <h3 class="p-heading--5">Industrial settings</h3>
+          </div>
+          <div class="col-6">
+            <p>PLCs in assembly lines must deliver and process data in real-time to ensure system integrity and continuous production.</p>
+          </div>
+        </div>
+      </div>
+      <div class="p-section--shallow">
+        <hr class="p-rule">
+        <div class="row">
+          <div class="col-3">
+            <h3 class="p-heading--5">Telco</h3>
+          </div>
+          <div class="col-6">
+            <p>Real-time Ubuntu brings ultra-low latency and enhanced security capabilities to telco workloads and the critical infrastructure they run on.</p>
+          </div>
+        </div>
+      </div>
+      <div class="p-section--shallow">
+        <hr class="p-rule">
+        <div class="row">
+          <div class="col-3">
+            <h3 class="p-heading--5">Healthcare robotics</h3>
+          </div>
+          <div class="col-6">
+            <p>From autonomous mobile robots to life-support medical equipment, healthcare systems must complete tasks within specified deadlines.</p>
+          </div>
+        </div>
+      </div>
+      <div class="p-section--shallow">
+        <hr class="p-rule">
+        <div class="row">
+          <div class="col-3">
+            <h3 class="p-heading--5">Automotive</h3>
+          </div>
+          <div class="col-6">
+            <p>Automotive manufacturers are increasingly reliant on real-time Linux for infotainment systems, HMIs and latency-sensitive scenarios.</p>
+          </div>
+        </div>
+      </div>
+      <div class="p-section--shallow">
+        <hr class="p-rule">
+        <div class="row">
+          <div class="col-6 col-start-large-4">
+            <p>Not sure real-time is for you? <br/><a href="/kernel/real-time/contact-us">Get in touch</a> to talk over your use case with our sales team</p>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 </section>
 

--- a/templates/real-time/index.html
+++ b/templates/real-time/index.html
@@ -68,7 +68,8 @@
   <div class="row u-equal-height">
     <div class="col-3 col-medium-3">
       <h3 class="p-heading--5">Industrial settings</h3>
-      <p style="min-height: 130px;">PLCs in assembly lines must deliver and process data in real-time to ensure system integrity and continuous
+      <p class="p-cases">PLCs in assembly lines must deliver and process data in real-time to ensure system
+        integrity and continuous
         production.</p>
       <div class="u-hide--small" style="background-color: rgba(0, 0, 0, 0.03);">
         {{
@@ -84,7 +85,8 @@
     </div>
     <div class="col-3 col-medium-3">
       <h3 class="p-heading--5">Telco</h3>
-      <p style="min-height: 130px;">Real-time Ubuntu brings ultra-low latency and enhanced security capabilities to telco workloads and the
+      <p class="p-cases">Real-time Ubuntu brings ultra-low latency and enhanced security capabilities to
+        telco workloads and the
         critical
         infrastructure they run on.</p>
       <div class="u-hide--small" style="background-color: rgba(0, 0, 0, 0.03);">
@@ -101,7 +103,8 @@
     </div>
     <div class="col-3 col-medium-3">
       <h3 class="p-heading--5">Healthcare robotics</h3>
-      <p style="min-height: 130px;">From autonomous mobile robots to life-support medical equipment, healthcare systems must complete tasks within
+      <p class="p-cases">From autonomous mobile robots to life-support medical equipment, healthcare systems
+        must complete tasks within
         specified deadlines.</p>
       <div class="u-hide--small" style="background-color: rgba(0, 0, 0, 0.03);">
         {{
@@ -117,7 +120,8 @@
     </div>
     <div class="col-3 col-medium-3">
       <h3 class="p-heading--5">Automotive</h3>
-      <p style="min-height: 130px;">Automotive manufacturers are increasingly reliant on real-time Linux for infotainment systems, HMIs and
+      <p class="p-cases">Automotive manufacturers are increasingly reliant on real-time Linux for
+        infotainment systems, HMIs and
         latency-sensitive scenarios.</p>
       <div class="u-hide--small" style="background-color: rgba(0, 0, 0, 0.03);">
         {{
@@ -131,11 +135,12 @@
         }}
       </div>
     </div>
-    <div class="row">
-      <p>Not sure real-time is for you? <br /><a href="/kernel/real-time/contact-us">Get in touch</a> to talk over
-        your
-        use case with our sales team</p>
-    </div>
+  </div>
+  <div class="row">
+    <p>Not sure real-time is for you? <br /><a href="/kernel/real-time/contact-us">Get in touch</a> to talk over
+      your
+      use case with our sales team</p>
+  </div>
 </section>
 
 <section class="p-section">
@@ -237,5 +242,17 @@ pro enable realtime-kernel --variant intel-iotg</code></pre>
 <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/real-time" data-form-id="4914" data-lp-id="" data-return-url="/real-time#success" data-lp-url="https://ubuntu.com/kernel/real-time/contact-us">
 </div>
 <script src="/static/js/src/static-forms.js"></script>
+<style>
+  @media (min-width: 1032px) {
+    .p-cases {
+      min-height: 130px;
+    }
+  }
 
+  @media (min-width: 620px) and (max-width: 1032px) {
+    .p-cases {
+      min-height: 105px;
+    }
+  }
+</style>
 {% endblock content %}

--- a/templates/real-time/index.html
+++ b/templates/real-time/index.html
@@ -64,60 +64,71 @@
     <div class="col-12 col-medium-3 p-section--shallow">
       <h2>Real-time Ubuntu use cases</h2>
     </div>
-    <div class="col-9 col-start-large-4 col-medium-3">
-      <div class="p-section--shallow">
-        <hr class="p-rule u-hide--medium">
-        <div class="row">
-          <div class="col-3">
-            <h3 class="p-heading--5">Industrial settings</h3>
-          </div>
-          <div class="col-6">
-            <p>PLCs in assembly lines must deliver and process data in real-time to ensure system integrity and continuous production.</p>
-          </div>
-        </div>
-      </div>
-      <div class="p-section--shallow">
-        <hr class="p-rule">
-        <div class="row">
-          <div class="col-3">
-            <h3 class="p-heading--5">Telco</h3>
-          </div>
-          <div class="col-6">
-            <p>Real-time Ubuntu brings ultra-low latency and enhanced security capabilities to telco workloads and the critical infrastructure they run on.</p>
-          </div>
-        </div>
-      </div>
-      <div class="p-section--shallow">
-        <hr class="p-rule">
-        <div class="row">
-          <div class="col-3">
-            <h3 class="p-heading--5">Healthcare robotics</h3>
-          </div>
-          <div class="col-6">
-            <p>From autonomous mobile robots to life-support medical equipment, healthcare systems must complete tasks within specified deadlines.</p>
-          </div>
-        </div>
-      </div>
-      <div class="p-section--shallow">
-        <hr class="p-rule">
-        <div class="row">
-          <div class="col-3">
-            <h3 class="p-heading--5">Automotive</h3>
-          </div>
-          <div class="col-6">
-            <p>Automotive manufacturers are increasingly reliant on real-time Linux for infotainment systems, HMIs and latency-sensitive scenarios.</p>
-          </div>
-        </div>
-      </div>
-      <div class="p-section--shallow">
-        <hr class="p-rule">
-        <div class="row">
-          <div class="col-6 col-start-large-4">
-            <p>Not sure real-time is for you? <br/><a href="/kernel/real-time/contact-us">Get in touch</a> to talk over your use case with our sales team</p>
-          </div>
-        </div>
-      </div>
+  </div>
+  <div class="row u-equal-height">
+    <div class="col-3 col-medium-3">
+      <h3 class="p-heading--5">Industrial settings</h3>
+      <p>PLCs in assembly lines must deliver and process data in real-time to ensure system integrity and continuous
+        production.</p>
     </div>
+    <div class="col-3 col-medium-3">
+      <h3 class="p-heading--5">Telco</h3>
+      <p>Real-time Ubuntu brings ultra-low latency and enhanced security capabilities to telco workloads and the
+        critical
+        infrastructure they run on.</p>
+    </div>
+    <div class="col-3 col-medium-3">
+      <h3 class="p-heading--5">Healthcare robotics</h3>
+      <p>From autonomous mobile robots to life-support medical equipment, healthcare systems must complete tasks within
+        specified deadlines.</p>
+    </div>
+    <div class="col-3 col-medium-3">
+      <h3 class="p-heading--5">Automotive</h3>
+      <p>Automotive manufacturers are increasingly reliant on real-time Linux for infotainment systems, HMIs and
+        latency-sensitive scenarios.</p>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-3">
+      {{
+      image(
+      url="https://assets.ubuntu.com/v1/9c01921f-Industrial.png",
+      alt="Industrial image",
+      width="284",
+      hi_def=True,
+      loading="lazy",
+      ) | safe
+      }}
+    </div>
+    <div class="col-3">
+      {{
+      image(
+      url="https://assets.ubuntu.com/v1/e2c4ed69-Telco.png",
+      alt="Telco image",
+      width="284",
+      hi_def=True,
+      loading="lazy",
+      ) | safe
+      }}
+    </div>
+    <div class="col-3">{{
+      image(
+      url="https://assets.ubuntu.com/v1/bdf43d88-Healthcare.png",
+      alt="Healthcare image",
+      width="284",
+      hi_def=True,
+      loading="lazy",
+      ) | safe
+      }}</div>
+    <div class="col-3">{{
+      image(
+      url="https://assets.ubuntu.com/v1/b8561c6a-Automotive.png",
+      alt="Automotive image",
+      width="284",
+      hi_def=True,
+      loading="lazy",
+      ) | safe
+      }}</div>
   </div>
 </section>
 

--- a/templates/real-time/index.html
+++ b/templates/real-time/index.html
@@ -68,66 +68,74 @@
   <div class="row u-equal-height">
     <div class="col-3 col-medium-3">
       <h3 class="p-heading--5">Industrial settings</h3>
-      <p>PLCs in assembly lines must deliver and process data in real-time to ensure system integrity and continuous
+      <p style="min-height: 130px;">PLCs in assembly lines must deliver and process data in real-time to ensure system integrity and continuous
         production.</p>
-      {{
-      image(
-      url="https://assets.ubuntu.com/v1/9c01921f-Industrial.png",
-      alt="Industrial image",
-      width="284",
-      hi_def=True,
-      loading="lazy",
-      ) | safe
-      }}
+      <div class="u-hide--small" style="background-color: rgba(0, 0, 0, 0.03);">
+        {{
+        image(
+        url="https://assets.ubuntu.com/v1/007d3fe1-Industrial@3x.png",
+        alt="Industrial image",
+        width="284",
+        hi_def=True,
+        loading="lazy",
+        ) | safe
+        }}
+      </div>
     </div>
     <div class="col-3 col-medium-3">
       <h3 class="p-heading--5">Telco</h3>
-      <p>Real-time Ubuntu brings ultra-low latency and enhanced security capabilities to telco workloads and the
+      <p style="min-height: 130px;">Real-time Ubuntu brings ultra-low latency and enhanced security capabilities to telco workloads and the
         critical
         infrastructure they run on.</p>
-      {{
-      image(
-      url="https://assets.ubuntu.com/v1/e2c4ed69-Telco.png",
-      alt="Telco image",
-      width="284",
-      hi_def=True,
-      loading="lazy",
-      ) | safe
-      }}
+      <div class="u-hide--small" style="background-color: rgba(0, 0, 0, 0.03);">
+        {{
+        image(
+        url="https://assets.ubuntu.com/v1/04c896e6-Telco@3x.png",
+        alt="Telco image",
+        width="284",
+        hi_def=True,
+        loading="lazy",
+        ) | safe
+        }}
+      </div>
     </div>
     <div class="col-3 col-medium-3">
       <h3 class="p-heading--5">Healthcare robotics</h3>
-      <p>From autonomous mobile robots to life-support medical equipment, healthcare systems must complete tasks within
+      <p style="min-height: 130px;">From autonomous mobile robots to life-support medical equipment, healthcare systems must complete tasks within
         specified deadlines.</p>
-      {{
-      image(
-      url="https://assets.ubuntu.com/v1/bdf43d88-Healthcare.png",
-      alt="Healthcare image",
-      width="284",
-      hi_def=True,
-      loading="lazy",
-      ) | safe
-      }}
+      <div class="u-hide--small" style="background-color: rgba(0, 0, 0, 0.03);">
+        {{
+        image(
+        url="https://assets.ubuntu.com/v1/9969e00e-Healthcare@3x.png",
+        alt="Healthcare image",
+        width="284",
+        hi_def=True,
+        loading="lazy",
+        ) | safe
+        }}
+      </div>
     </div>
     <div class="col-3 col-medium-3">
       <h3 class="p-heading--5">Automotive</h3>
-      <p>Automotive manufacturers are increasingly reliant on real-time Linux for infotainment systems, HMIs and
+      <p style="min-height: 130px;">Automotive manufacturers are increasingly reliant on real-time Linux for infotainment systems, HMIs and
         latency-sensitive scenarios.</p>
-      {{
-      image(
-      url="https://assets.ubuntu.com/v1/b8561c6a-Automotive.png",
-      alt="Automotive image",
-      width="284",
-      hi_def=True,
-      loading="lazy",
-      ) | safe
-      }}
+      <div class="u-hide--small" style="background-color: rgba(0, 0, 0, 0.03);">
+        {{
+        image(
+        url="https://assets.ubuntu.com/v1/4ffd9127-Automotive@3x.png",
+        alt="Automotive image",
+        width="284",
+        hi_def=True,
+        loading="lazy",
+        ) | safe
+        }}
+      </div>
     </div>
-  </div>
-  <div class="row">
-    <p>Not sure real-time is for you? <br /><a href="/kernel/real-time/contact-us">Get in touch</a> to talk over your
-      use case with our sales team</p>
-  </div>
+    <div class="row">
+      <p>Not sure real-time is for you? <br /><a href="/kernel/real-time/contact-us">Get in touch</a> to talk over
+        your
+        use case with our sales team</p>
+    </div>
 </section>
 
 <section class="p-section">

--- a/templates/real-time/index.html
+++ b/templates/real-time/index.html
@@ -70,26 +70,6 @@
       <h3 class="p-heading--5">Industrial settings</h3>
       <p>PLCs in assembly lines must deliver and process data in real-time to ensure system integrity and continuous
         production.</p>
-    </div>
-    <div class="col-3 col-medium-3">
-      <h3 class="p-heading--5">Telco</h3>
-      <p>Real-time Ubuntu brings ultra-low latency and enhanced security capabilities to telco workloads and the
-        critical
-        infrastructure they run on.</p>
-    </div>
-    <div class="col-3 col-medium-3">
-      <h3 class="p-heading--5">Healthcare robotics</h3>
-      <p>From autonomous mobile robots to life-support medical equipment, healthcare systems must complete tasks within
-        specified deadlines.</p>
-    </div>
-    <div class="col-3 col-medium-3">
-      <h3 class="p-heading--5">Automotive</h3>
-      <p>Automotive manufacturers are increasingly reliant on real-time Linux for infotainment systems, HMIs and
-        latency-sensitive scenarios.</p>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-3">
       {{
       image(
       url="https://assets.ubuntu.com/v1/9c01921f-Industrial.png",
@@ -100,7 +80,11 @@
       ) | safe
       }}
     </div>
-    <div class="col-3">
+    <div class="col-3 col-medium-3">
+      <h3 class="p-heading--5">Telco</h3>
+      <p>Real-time Ubuntu brings ultra-low latency and enhanced security capabilities to telco workloads and the
+        critical
+        infrastructure they run on.</p>
       {{
       image(
       url="https://assets.ubuntu.com/v1/e2c4ed69-Telco.png",
@@ -111,7 +95,11 @@
       ) | safe
       }}
     </div>
-    <div class="col-3">{{
+    <div class="col-3 col-medium-3">
+      <h3 class="p-heading--5">Healthcare robotics</h3>
+      <p>From autonomous mobile robots to life-support medical equipment, healthcare systems must complete tasks within
+        specified deadlines.</p>
+      {{
       image(
       url="https://assets.ubuntu.com/v1/bdf43d88-Healthcare.png",
       alt="Healthcare image",
@@ -119,8 +107,13 @@
       hi_def=True,
       loading="lazy",
       ) | safe
-      }}</div>
-    <div class="col-3">{{
+      }}
+    </div>
+    <div class="col-3 col-medium-3">
+      <h3 class="p-heading--5">Automotive</h3>
+      <p>Automotive manufacturers are increasingly reliant on real-time Linux for infotainment systems, HMIs and
+        latency-sensitive scenarios.</p>
+      {{
       image(
       url="https://assets.ubuntu.com/v1/b8561c6a-Automotive.png",
       alt="Automotive image",
@@ -128,10 +121,12 @@
       hi_def=True,
       loading="lazy",
       ) | safe
-      }}</div>
+      }}
+    </div>
   </div>
   <div class="row">
-    <p>Not sure real-time is for you? <br /><a href="/kernel/real-time/contact-us">Get in touch</a> to talk over your use case with our sales team</p>
+    <p>Not sure real-time is for you? <br /><a href="/kernel/real-time/contact-us">Get in touch</a> to talk over your
+      use case with our sales team</p>
   </div>
 </section>
 


### PR DESCRIPTION
## Done

- Added images in https://ubuntu-com-13359.demos.haus/real-time

## QA

- [figma design](https://www.figma.com/file/Cr1S07Ivk632jniBAG89S8/23.10-U.com---Real-time-Ubuntu?type=design&node-id=0-1&mode=design&t=QcxshpHOoI7PE0oV-0)
- [demo link](https://ubuntu-com-13359.demos.haus/)
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
-  Check that images and text are correct

## Issue / Card
[WD-7205](https://warthogs.atlassian.net/browse/WD-7205)
Fixes #

## Screenshots


## Help

[WD-7205]: https://warthogs.atlassian.net/browse/WD-7205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ