### PR TITLE
DES-823 - update contact us link on iot smart displays

### DIFF
--- a/templates/internet-of-things/smart-displays.html
+++ b/templates/internet-of-things/smart-displays.html
@@ -17,7 +17,7 @@
           Digital signage and kiosk <br class="u-hide--large">with Ubuntu
         </h1>
         <p class="p-heading--4">The easy, secure, and reliable way of building open source digital signage software for your business.</p>
-        <p><a href="/core/services" class="p-button--positive">Contact us to learn more</a></p>
+        <p><a href="/internet-of-things/smart-displays#get-in-touch" class="p-button--positive">Contact us to learn more</a></p>
         <p><a href="/engage/Embedding_IoT_GUI_with_Ubuntu_Frame" class="p-link--inverted">Develop GUIs for IoT with our guide&nbsp;&rsaquo;</a></p>
       </div>
     </div>


### PR DESCRIPTION
## Done

- Fixed contact us link in https://ubuntu-com-13360.demos.haus/internet-of-things/smart-displays

## QA

- [copy doc](https://docs.google.com/document/d/1fFvBl-ZZvKDFV6OMv7O4kudQKtyxfvSU60rfVdKluAQ/edit#heading=h.odnh1uuyfmr1)
- [demo link](https://ubuntu-com-13360.demos.haus/)
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
-  Check that the link is correct

## Issue / Card
[DES-823](https://warthogs.atlassian.net/browse/DES-823)
Fixes #

## Screenshots


## Help

[DES-823]: https://warthogs.atlassian.net/browse/DES-823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ