### PR TITLE
Fix notice prefix error

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -28,6 +28,7 @@ from webapp.security.views import (
     cve_index,
     cves_sitemap,
     notice,
+    notice_redirect,
     notices,
     notices_feed,
     notices_sitemap,
@@ -450,6 +451,11 @@ app.register_blueprint(build_blueprint(blog_views), url_prefix="/blog")
 
 # usn section
 app.add_url_rule("/security/notices", view_func=notices)
+
+app.add_url_rule(
+    "/security/notices/<prefix>",
+    view_func=notice_redirect,
+)
 
 app.add_url_rule(
     r"/security/notices/<regex('(lsn-|LSN-|usn-|USN-)\d{1,10}-\d{1,2}'):notice_id>",  # noqa: E501

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -28,7 +28,6 @@ from webapp.security.views import (
     cve_index,
     cves_sitemap,
     notice,
-    notice_redirect,
     notices,
     notices_feed,
     notices_sitemap,
@@ -453,8 +452,8 @@ app.register_blueprint(build_blueprint(blog_views), url_prefix="/blog")
 app.add_url_rule("/security/notices", view_func=notices)
 
 app.add_url_rule(
-    "/security/notices/<prefix>",
-    view_func=notice_redirect,
+    "/security/notices/<notice_id>",
+    view_func=notice,
 )
 
 app.add_url_rule(

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -36,17 +36,6 @@ def get_processed_details(notice):
     )
 
 
-def notice_redirect(prefix):
-    prefix = prefix.lower()
-
-    if prefix == "lsn":
-        return flask.redirect("/security/notices?details=lsn")
-    elif prefix == "usn":
-        return flask.redirect("/security/notices?details=usn")
-    else:
-        flask.abort(404)
-
-
 def notice(notice_id):
     notice = security_api.get_notice(notice_id)
 

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -36,6 +36,17 @@ def get_processed_details(notice):
     )
 
 
+def notice_redirect(prefix):
+    prefix = prefix.lower()
+
+    if prefix == "lsn":
+        return flask.redirect("/security/notices?details=lsn")
+    elif prefix == "usn":
+        return flask.redirect("/security/notices?details=usn")
+    else:
+        flask.abort(404)
+
+
 def notice(notice_id):
     notice = security_api.get_notice(notice_id)
 


### PR DESCRIPTION
## Done

- Fixed false 500 when user tries to visit a notice with an incomplete id which matches an existing template name

## Rationale

Notices can have one of two prefixes: usn or lsn. When you visit `/security/notices` and click on any given notice in the list, the template that gets triggered is `/notices/lsn.html` or `/notices/usn.html`, respectively. This bug came about because we had some users try to visit `/security/notices/usn` which, because we actually do have a template with that name and we did not have a rule in place for it, was causing jinja errors. This PR changes the behavior so that when a user tries to visit `/security/notices/<prefix>` it correctly shows 404. 

## QA

- View the site locally in your web browser at: https://ubuntu-com-13361.demos.haus/security/notices/lsn
  - See that you get 404
- View the site locally in your web browser at: https://ubuntu-com-13361.demos.haus/security/notices/usn
  - See that you get 404

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-6886
