### PR TITLE
Update GA tracking and a location hash in the URL

### DIFF
--- a/static/js/src/navigation.js
+++ b/static/js/src/navigation.js
@@ -117,9 +117,17 @@ function handleDropdownClick(clickedDropdown) {
 
 function updateUrlHash(id, open) {
   if (id !== null && id !== undefined && open) {
-    window.history.pushState(null, document.title, window.location.pathname + window.location.search + `#${id}`);
+    window.history.pushState(
+      null,
+      document.title,
+      window.location.pathname + window.location.search + `#${id}`
+    );
   } else {
-    window.history.pushState(null, document.title, window.location.pathname + window.location.search);
+    window.history.pushState(
+      null,
+      document.title,
+      window.location.pathname + window.location.search
+    );
   }
 }
 
@@ -174,7 +182,7 @@ function updateNavMenu(dropdown, show) {
   }
 
   // This is needed as the onhover/onfocus effect does not work with touch screens,
-  // but will trigger calling the navigation contents. We then need to manually 
+  // but will trigger calling the navigation contents. We then need to manually
   // open the dropdown.
   function handleMutation(mutationsList, observer) {
     mutationsList.forEach((mutation) => {

--- a/static/js/src/navigation.js
+++ b/static/js/src/navigation.js
@@ -116,7 +116,7 @@ function handleDropdownClick(clickedDropdown) {
 }
 
 function updateUrlHash(id, open) {
-  if (id !== null && id !== undefined && open) {
+  if (id  && open) {
     window.history.pushState(
       null,
       document.title,

--- a/static/js/src/navigation.js
+++ b/static/js/src/navigation.js
@@ -115,6 +115,14 @@ function handleDropdownClick(clickedDropdown) {
   setTabindex(clickedDropdown.querySelector("ul.p-navigation__dropdown"));
 }
 
+function updateUrlHash(id, open) {
+  if (id !== null && id !== undefined && open) {
+    window.history.pushState(null, document.title, window.location.pathname + window.location.search + `#${id}`);
+  } else {
+    window.history.pushState(null, document.title, window.location.pathname + window.location.search);
+  }
+}
+
 function goBackOneLevel(e, backButton) {
   e.preventDefault();
   const target = backButton.parentNode.parentNode;
@@ -161,6 +169,13 @@ function updateNavMenu(dropdown, show) {
   );
   let isAccountDropdown = dropdown.classList.contains("js-account");
 
+  if (dropdownContent) {
+    updateUrlHash(dropdown.id, show);
+  }
+
+  // This is needed as the onhover/onfocus effect does not work with touch screens,
+  // but will trigger calling the navigation contents. We then need to manually 
+  // open the dropdown.
   function handleMutation(mutationsList, observer) {
     mutationsList.forEach((mutation) => {
       if (mutation.type === "childList") {
@@ -350,7 +365,6 @@ function closeNav() {
   });
   closeMobileDropdown();
   closeDesktopDropdown();
-
   document.removeEventListener("keyup", keyPressHandler);
 }
 
@@ -388,6 +402,7 @@ function closeMobileDropdown() {
 function closeAll() {
   closeSearch();
   closeNav();
+  updateUrlHash();
   setTabindex(mainList);
 }
 
@@ -544,13 +559,13 @@ if (accountContainer) {
 
 var origin = window.location.href;
 
-addGANavEvents("#canonical-global-nav", "www.ubuntu.com-nav-global");
+addGANavEvents("#all-canonical-link", "www.ubuntu.com-nav-global");
 addGANavEvents("#canonical-login", "www.ubuntu.com-nav-0-login");
-addGANavEvents("#enterprise-content", "www.ubuntu.com-nav-1-enterprise");
-addGANavEvents("#developer-content", "www.ubuntu.com-nav-1-developer");
-addGANavEvents("#community-content", "www.ubuntu.com-nav-1-community");
-addGANavEvents("#get-ubuntun-content", "www.ubuntu.com-nav-1-get-ubuntu");
-addGANavEvents(".p-navigation--secondary", "www.ubuntu.com-nav-2");
+addGANavEvents("#use-case", "www.ubuntu.com-nav-1-use-case");
+addGANavEvents("#support", "www.ubuntu.com-nav-1-support");
+addGANavEvents("#community", "www.ubuntu.com-nav-1-community");
+addGANavEvents("#get-ubuntu", "www.ubuntu.com-nav-1-get-ubuntu");
+addGANavEvents(".p-navigation.is-secondary", "www.ubuntu.com-nav-2");
 addGANavEvents(".p-contextual-footer", "www.ubuntu.com-footer-contextual");
 addGANavEvents(".p-footer__nav", "www.ubuntu.com-nav-footer-0");
 addGANavEvents(".p-footer--secondary", "www.ubuntu.com-nav-footer-1");

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -140,7 +140,6 @@ from webapp.views import (
     subscription_centre,
     thank_you,
     unlisted_engage_page,
-    build_engage_pages_sitemap,
     navigation_nojs,
 )
 


### PR DESCRIPTION
## Done

- Updates the ids the GA events attach to
- Add a hash in the url (ubuntu.com/#products) depending on where in the navigation you are. This only applies to top level items.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-7400