### PR TITLE
WD-7467 - update aws link for cloud download

### DIFF
--- a/templates/shared/_ubuntu_pro_on_public_cloud.html
+++ b/templates/shared/_ubuntu_pro_on_public_cloud.html
@@ -30,7 +30,7 @@
         <li class="p-list__item is-ticked">Proven for enterprise-scale workloads on all leading public clouds</li>
         <li class="p-list__item is-ticked">Free from licence fees, regardless of how many images you run</li>
       </ul>
-      <a class="p-button" href="https://aws.amazon.com/marketplace/pp/B087QQNGF1?qid=1591613411512&sr=0-2&ref_=srh_res_product_title">Ubuntu Server on AWS</a>
+      <a class="p-button" href="/aws">Ubuntu Server on AWS</a>
       <a class="p-button" href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-server-jammy?tab=Overview">Ubuntu Server on Azure</a>
       <a class="p-button" href="https://console.cloud.google.com/marketplace/browse?q=ubuntu%20canonical">Ubuntu Server on GCP</a>
     </div>


### PR DESCRIPTION
## Done

- Updated AWS link in https://ubuntu-com-13363.demos.haus/download/cloud

## QA

- [copy doc](https://docs.google.com/document/d/1kp7QQXst1EbCjZjzWZP3YZwfmG0EIXLfQoRUVaMEZng/edit)
- [demo link](https://ubuntu-com-13363.demos.haus/)
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
-  Check that the link is correct

## Issue / Card
[WD-7467](https://warthogs.atlassian.net/browse/WD-7467)
Fixes #

## Screenshots


## Help


[WD-7467]: https://warthogs.atlassian.net/browse/WD-7467?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ