### PR TITLE
Replaced Last updated text to fix potential ambiguity.

### DIFF
--- a/templates/templates/docs/shared/_docs.html
+++ b/templates/templates/docs/shared/_docs.html
@@ -155,7 +155,7 @@
 			<div class="p-strip is-shallow">
 				<div class="p-notification--information">
 					<div class="p-notification__content">
-            <p class="p-notification__message">Last updated {{ document.updated }}. <a href="{{ forum_url }}{{ document.topic_path }}">Help improve this document in the forum</a>.</p>
+            <p class="p-notification__message">This page was last modified {{ document.updated }}. <a href="{{ forum_url }}{{ document.topic_path }}">Help improve this document in the forum</a>.</p>
           </div>
 				</div>
 			</div>


### PR DESCRIPTION
## Done

For documentation generated from Discourse
- updated the _Last updated_ footer to now read _This page was last modified_.

## Issue 

Fixes an issue where visitors to a documentation landing page might assume none of the documentation pages have been updated since the _Last updated_ text (when this is only referencing the index page).

cc @petesfrench 

