### PR TITLE
When multiple forms are present in a page, update the UTMs based on which form is opened

### DIFF
--- a/static/js/src/dynamic-forms.js
+++ b/static/js/src/dynamic-forms.js
@@ -58,7 +58,7 @@ import setupIntlTelInput from "./intlTelInput.js";
             title.innerHTML = formData.title;
           }
           setProductContext(contactButton);
-          setUTMs();
+          setUTMs(formData.formId);
           setGclid();
           setFBclid();
           loadCaptchaScript();
@@ -130,27 +130,26 @@ import setupIntlTelInput from "./intlTelInput.js";
       }
     }
 
-    function setUTMs() {
+    function setUTMs(formId) {
       var params = new URLSearchParams(window.location.search);
-      var utm_campaign = document.getElementById("utm_campaign");
+      var targetForm = document.getElementById(`mktoForm_${formId}`);
+      var utm_campaign = targetForm.querySelector("#utm_campaign");
       if (utm_campaign) {
         utm_campaign.value = params.get("utm_campaign");
       }
-      var utm_source = document.getElementById("utm_source");
+      var utm_source = targetForm.querySelector("#utm_source");
       if (utm_source) {
         utm_source.value = params.get("utm_source");
       }
-      var utm_medium = document.getElementById("utm_medium");
+      var utm_medium = targetForm.querySelector("#utm_medium");
       if (utm_medium) {
         utm_medium.value = params.get("utm_medium");
       }
-
-      var utm_content = document.getElementById("utm_content");
+      var utm_content = targetForm.querySelector("#utm_content");
       if (utm_content) {
         utm_content.value = params.get("utm_content");
       }
-
-      var utm_term = document.getElementById("utm_term");
+      var utm_term = targetForm.querySelector("#utm_term");
       if (utm_term) {
         utm_term.value = params.get("utm_term");
       }

--- a/templates/shared/contextual_footers/_download_iot_iotg_newsletter.html
+++ b/templates/shared/contextual_footers/_download_iot_iotg_newsletter.html
@@ -5,7 +5,7 @@
     <ul class="p-list u-clearfix">
       <li class="p-list__item">
         <label for="email">Your email:</label>
-        <input id="email" name="email" maxlength="255" type="email"  aria-required="true" >
+        <input id="email" name="email" maxlength="255" type="email"  aria-required="true" required>
       </li>
       <li class="p-list__item">
         <label class="p-checkbox">

--- a/templates/shared/contextual_footers/_download_iot_iotg_newsletter.html
+++ b/templates/shared/contextual_footers/_download_iot_iotg_newsletter.html
@@ -5,7 +5,7 @@
     <ul class="p-list u-clearfix">
       <li class="p-list__item">
         <label for="email">Your email:</label>
-        <input id="email" name="email" maxlength="255" type="email"  aria-required="true" required>
+        <input id="email" name="email" maxlength="255" type="email"  aria-required="true" required />
       </li>
       <li class="p-list__item">
         <label class="p-checkbox">


### PR DESCRIPTION
## Done

- When multiple forms are present in a page, update the UTMs based on which form is opened by using the form id to grab the target form first
- Flyby change: Make the email field in newsletter signup required

## QA

- Check out https://ubuntu-com-13370.demos.haus/download/contact-us?utm_source=google&utm_medium=cpc&utm_campaign=701N1000004GoRgIAK&utm_term=CustomIIOT&utm_content=YTvideo
- make sure the UTMs passed in the URL are present in the forms payload

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-7550
