### PR TITLE
[WD-7552] make the checkbox on Thank You page mandatory to comply with GDPR

### DIFF
--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -60,7 +60,7 @@
           <li class="p-list__item u-no-margin--top">
             <label class="p-checkbox">
               <input class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn"
-                name="canonicalUpdatesOptIn" type="checkbox" />
+                name="canonicalUpdatesOptIn" type="checkbox" required="" />
               <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about
                 Canonical’s
                 products


### PR DESCRIPTION
## Done

- Make the "I agree to receive information about Canonical’s products and services." checkox under e-mail address input field required for submitting an email. This is coming from [here](https://warthogs.atlassian.net/browse/WD-6669?focusedCommentId=344652).

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Navigate to /download/desktop/thank-you page, fill in your email address and click on "Subscribe now" button. It should ask you to check the checkbox as well.

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-7552

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
