### PR TITLE
[WD-7240] redirect EdgeX tutorial page to the IoT landing page

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -967,6 +967,7 @@ tutorial/(?P<path>.*)/?: /tutorials/{path}
 tutorials/microstack-get-started? : /openstack/tutorials
 tutorials/install-openstack-with-conjure-up? : /openstack/tutorials
 tutorials/electron-kiosk/?: https://mir-server.io/docs/make-a-secure-ubuntu-web-kiosk
+tutorials/get-started-with-edgex-as-snaps?: /internet-of-things
 
 # Image builder
 build: /core/build


### PR DESCRIPTION
## Done

- Redirect EdgeX tutorial at `/tutorials/get-started-with-edgex-as-snaps` to IoT landing page at `/internet-of-things`

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Navigate to `/tutorials/get-started-with-edgex-as-snaps` and check that it redirects to `/internet-of-things`

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-7240

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
