### PR TITLE
Remove description under product type physical on pro subscribe form.

### DIFF
--- a/static/js/src/advantage/subscribe/react/components/Form/ProductType/ProductType.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/ProductType/ProductType.tsx
@@ -356,19 +356,6 @@ const ProductType = () => {
             checked={productType === ProductTypes.physical}
           />
         </Col>
-        {productType === ProductTypes.physical && (
-          <Col size={12} style={{ marginLeft: "35px" }}>
-            <p>
-              <strong>Unlimited VMs on selected hypervisors</strong>
-            </p>
-            <p>
-              Any of: KVM | Qemu | Boch, VMWare ESXi, LXD | LXC, Xen, Hyper-V
-              (WSL, Multipass), VirtualBox, z/VM, Docker. All Nodes in the
-              cluster have to be subscribed to the service in order to benefit
-              from the unlimited VM support
-            </p>
-          </Col>
-        )}
         <Col size={12}>
           <RadioInput
             label="Public cloud instances"


### PR DESCRIPTION
## Done
Remove description under product type physical on pro subscribe form.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/pro/subscribe
- When you select "Physical servers with unlimited VMs" there is no help text under the option.
