### PR TITLE
Pass along UTMs when doing a blog redirect

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -736,10 +736,17 @@ class BlogRedirects(BlogView):
         if "article" not in context:
             return flask.abort(404)
 
-        # Redirect canonical annoucements
+        # Capture the original query string
+        original_query_string = flask.request.query_string.decode("utf-8")
+
+        # Redirect canonical announcements
         group = context["article"].get("group")
         if isinstance(group, dict) and group["id"] == 2100:
-            return flask.redirect(f"https://canonical.com/blog/{slug}")
+            redirect_url = f"https://canonical.com/blog/{slug}"
+            # Append the original query string to the redirect URL
+            if original_query_string:
+                redirect_url += f"?{original_query_string}"
+            return flask.redirect(redirect_url)
 
         # Set blog notice date
         blog_notice = {}

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -736,14 +736,12 @@ class BlogRedirects(BlogView):
         if "article" not in context:
             return flask.abort(404)
 
-        # Capture the original query string
-        original_query_string = flask.request.query_string.decode("utf-8")
-
         # Redirect canonical announcements
         group = context["article"].get("group")
         if isinstance(group, dict) and group["id"] == 2100:
             redirect_url = f"https://canonical.com/blog/{slug}"
             # Append the original query string to the redirect URL
+            original_query_string = flask.request.query_string.decode("utf-8")
             if original_query_string:
                 redirect_url += f"?{original_query_string}"
             return flask.redirect(redirect_url)


### PR DESCRIPTION
## Done

- Updated the blog redirection logic to append URL params.

## QA

- Go to https://ubuntu-com-13381.demos.haus/blog/chiselled-ubuntu-ga?utm_source=marketo&utm_medium=email&utm_campaign=newsletter-2023-48
- Ensure you are redirected to the Canonical blog
- Ensure UTMs from the original URL are still there
