### PR TITLE
Fix broken network requirements link

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.tsx
@@ -139,7 +139,7 @@ const DetailsTabs = ({
                 <tr>
                   <td data-test="doc-link">Ubuntu Pro network requirements</td>
                   <td>
-                    <a href="https://canonical-ubuntu-pro-client.readthedocs-hosted.com/en/latest/references/network_requirements.html">
+                    <a href="https://canonical-ubuntu-pro-client.readthedocs-hosted.com/en/latest/references/network_requirements">
                       Ubuntu Pro network requirements
                     </a>
                   </td>


### PR DESCRIPTION
## Done

- Fix the broken `Ubuntu Pro network requirements` link

## QA

- Go to `/pro/dashboard`
- Click on `Ubuntu Pro network requirements` and it should redirect to the correct page

## Issue / Card

Fixes [WD-6499](https://warthogs.atlassian.net/browse/WD-6469)

## Screenshots
![Screenshot 2023-12-01 at 3 51 15 PM](https://github.com/canonical/ubuntu.com/assets/62298176/33e21e90-9b32-4b89-830b-b5c6ed74362d)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-6499]: https://warthogs.atlassian.net/browse/WD-6499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ