### PR TITLE
WD-7769 - fix typo in gcp fips

### DIFF
--- a/templates/gcp/fips.html
+++ b/templates/gcp/fips.html
@@ -126,7 +126,7 @@
     </div>
     <div class="col-6 p-divider__block">
       <h4>Ubuntu Pro FIPS 20.04 LTS</h4>
-      <p>Ubuntu 16.04 LTS includes FIPS-certified 5.4  kernel and other FIPS certified modules pre-enabled out of the box. Ubuntu Pro FIPS provides expanded security maintenance through April 2030.</p>
+      <p>Ubuntu 20.04 LTS includes FIPS-certified 5.4  kernel and other FIPS certified modules pre-enabled out of the box. Ubuntu Pro FIPS provides expanded security maintenance through April 2030.</p>
       <p><a href="https://console.cloud.google.com/compute/" class="p-button--positive"><span>Launch now</span></a></p>
     </div>
   </div>


### PR DESCRIPTION
## Done

- Fix typo in https://ubuntu-com-13387.demos.haus/gcp/fips

## QA

- [copy doc](https://docs.google.com/document/d/17Rr6Fdrr7xSPi1g2h7GMTztQUGYqz2hdbNUqK0uQihw/edit#heading=h.c6wjbvvp8mcm)
- [demo link](https://ubuntu-com-13387.demos.haus/)
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
-  Check the ubuntu version is correct

## Issue / Card

Fixes # [WD-7769](https://warthogs.atlassian.net/browse/WD-7769)


[WD-7769]: https://warthogs.atlassian.net/browse/WD-7769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ