### PR TITLE
WD-7771 - update buttons in /robotics

### DIFF
--- a/templates/robotics/index.html
+++ b/templates/robotics/index.html
@@ -218,7 +218,7 @@
       <div class="js-robotics-content" id="robotics-content-1">
         <h3 class="p-heading--2">Deploying a robotics solution?</h3>
         <p>For more than a decade, Ubuntu has provided the best development environment for robotics developers. Your team can easily build and securely deploy their devices with  <a href="/core">Ubuntu Core</a>, an operating system optimised for IoT and edge devices, and <a href="https://snapcraft.io/docs/robotics">Snaps</a>, fully-confined embedded containers. For low-tech device management, the <a href="/internet-of-things/appstore">IoT Snap Store</a> enables developers to unlock a reliable and widely-used update infrastructure that's ideal for robotics applications.</p>
-        <a class="p-button--positive js-invoke-modal" href="/robotics/docs"> Explore documentation</a>
+        <a class="p-button--positive" href="/robotics/docs"> Explore documentation</a>
       </div>
 
       <div class="u-hide--large js-robotics-content" id="robotics-content-2">

--- a/templates/robotics/index.html
+++ b/templates/robotics/index.html
@@ -260,7 +260,7 @@
         <p>Ubuntu Core uses the same kernel, libraries, and system software as classic Ubuntu, resulting in a smooth transition to production.</p>
 
         <p>
-          <a class="p-button--positive js-invoke-modal" href="/robotics/docs/how-to-guides#heading--ubuntu-core">Explore documentation</a>
+          <a class="p-button--positive" href="/robotics/docs/how-to-guides#heading--ubuntu-core">Explore documentation</a>
           <a href="/core">Learn more about Ubuntu Core&nbsp;&rsaquo;</a>
         </p>
       </div>

--- a/templates/robotics/index.html
+++ b/templates/robotics/index.html
@@ -218,6 +218,7 @@
       <div class="js-robotics-content" id="robotics-content-1">
         <h3 class="p-heading--2">Deploying a robotics solution?</h3>
         <p>For more than a decade, Ubuntu has provided the best development environment for robotics developers. Your team can easily build and securely deploy their devices with  <a href="/core">Ubuntu Core</a>, an operating system optimised for IoT and edge devices, and <a href="https://snapcraft.io/docs/robotics">Snaps</a>, fully-confined embedded containers. For low-tech device management, the <a href="/internet-of-things/appstore">IoT Snap Store</a> enables developers to unlock a reliable and widely-used update infrastructure that's ideal for robotics applications.</p>
+        <a class="p-button--positive js-invoke-modal" href="/robotics/docs"> Explore documentation</a>
       </div>
 
       <div class="u-hide--large js-robotics-content" id="robotics-content-2">
@@ -226,7 +227,8 @@
         <p>Every aspect of the development process benefits from Ubuntu's responsiveness, ease of use, regular software updates, lightweight nature, and a high degree of security.</p>
 
         <p>
-          <a href="/desktop" class="p-button--positive">Learn more about Ubuntu</a>
+          <a class="p-button--positive js-invoke-modal" href="/robotics/docs"> Explore documentation</a>
+          <a href="/desktop">Learn more about Ubuntu&nbsp;&rsaquo;</a>
         </p>
       </div>
 
@@ -235,7 +237,8 @@
         <p>Snapcraft is the command-line tool for packaging your software as a Snap. Snaps are containerised software packages designed for embedded applications, with increased performance compared to <a href="/engage/dockerandros">other technologies</a>. Snaps give you all the interfaces you need to bundle your dependencies in one package, while providing secure interfaces to access the host disc and privileged resources.</p>
 
         <p>
-          <a href="https://snapcraft.io/docs/robotics" class="p-button--positive">Learn more about Snapcraft</a>
+          <a class="p-button--positive js-invoke-modal" href="/robotics/docs"> Explore documentation</a>
+          <a href="https://snapcraft.io/docs/robotics">Learn more about Snapcraft&nbsp;&rsaquo;</a>
         </p>
       </div>
 
@@ -245,7 +248,8 @@
         <p>Companies can create either a public or private marketplace, where applications can be managed by developers and contributors.</p>
 
         <p>
-          <a href="/internet-of-things/appstore" class="p-button--positive">Learn more about IoT App Stores</a>
+          <a class="p-button--positive js-invoke-modal" href="/robotics/docs">Explore documentation</a>
+          <a href="/internet-of-things/appstore">Learn more about IoT App Stores&nbsp;&rsaquo;</a>
         </p>
       </div>
 
@@ -256,7 +260,8 @@
         <p>Ubuntu Core uses the same kernel, libraries, and system software as classic Ubuntu, resulting in a smooth transition to production.</p>
 
         <p>
-          <a href="/core" class="p-button--positive">Learn more about Ubuntu Core</a>
+          <a class="p-button--positive js-invoke-modal" href="/robotics/docs">Explore documentation</a>
+          <a href="/core">Learn more about Ubuntu Core&nbsp;&rsaquo;</a>
         </p>
       </div>
     </div>

--- a/templates/robotics/index.html
+++ b/templates/robotics/index.html
@@ -260,7 +260,7 @@
         <p>Ubuntu Core uses the same kernel, libraries, and system software as classic Ubuntu, resulting in a smooth transition to production.</p>
 
         <p>
-          <a class="p-button--positive js-invoke-modal" href="/robotics/docs">Explore documentation</a>
+          <a class="p-button--positive js-invoke-modal" href="/robotics/docs/how-to-guides#heading--ubuntu-core">Explore documentation</a>
           <a href="/core">Learn more about Ubuntu Core&nbsp;&rsaquo;</a>
         </p>
       </div>

--- a/templates/robotics/index.html
+++ b/templates/robotics/index.html
@@ -248,7 +248,7 @@
         <p>Companies can create either a public or private marketplace, where applications can be managed by developers and contributors.</p>
 
         <p>
-          <a class="p-button--positive js-invoke-modal" href="/robotics/docs">Explore documentation</a>
+          <a class="p-button--positive" href="/robotics/docs/explanation#heading--iot-app-store">Explore documentation</a>
           <a href="/internet-of-things/appstore">Learn more about IoT App Stores&nbsp;&rsaquo;</a>
         </p>
       </div>

--- a/templates/robotics/index.html
+++ b/templates/robotics/index.html
@@ -237,7 +237,7 @@
         <p>Snapcraft is the command-line tool for packaging your software as a Snap. Snaps are containerised software packages designed for embedded applications, with increased performance compared to <a href="/engage/dockerandros">other technologies</a>. Snaps give you all the interfaces you need to bundle your dependencies in one package, while providing secure interfaces to access the host disc and privileged resources.</p>
 
         <p>
-          <a class="p-button--positive js-invoke-modal" href="/robotics/docs"> Explore documentation</a>
+          <a class="p-button--positive" href="/robotics/docs/how-to-guides#heading--snapcraft"> Explore documentation</a>
           <a href="https://snapcraft.io/docs/robotics">Learn more about Snapcraft&nbsp;&rsaquo;</a>
         </p>
       </div>

--- a/templates/robotics/index.html
+++ b/templates/robotics/index.html
@@ -227,7 +227,7 @@
         <p>Every aspect of the development process benefits from Ubuntu's responsiveness, ease of use, regular software updates, lightweight nature, and a high degree of security.</p>
 
         <p>
-          <a class="p-button--positive js-invoke-modal" href="/robotics/docs"> Explore documentation</a>
+          <a class="p-button--positive" href="/robotics/docs"> Explore documentation</a>
           <a href="/desktop">Learn more about Ubuntu&nbsp;&rsaquo;</a>
         </p>
       </div>


### PR DESCRIPTION
## Done

Updated buttons in "Bringing Ubuntu’s worldwide infrastructure to your robot" section in https://ubuntu-com-13390.demos.haus/robotics

## QA

- [demo link](https://ubuntu-com-13390.demos.haus/)
- [copy doc](https://docs.google.com/document/d/1JNFk2C0shH3DapKuJM8X0QfAiD1RzHvXoydn8P9mEMg/edit#heading=h.fdlzz3sruhkt)
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check that the buttons and links on them are correct

## Issue / Card
[WD-7771](https://warthogs.atlassian.net/browse/WD-7771)

Fixes #

## Screenshots


[WD-7771]: https://warthogs.atlassian.net/browse/WD-7771?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ