### PR TITLE
WD-7757 - add missing images to /internet-of-things

### DIFF
--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -273,6 +273,7 @@
           url="https://assets.ubuntu.com/v1/0532297f-Developer.svg",
           alt="",
           width="200",
+          height="125"
           hi_def=True,
           loading="lazy",
           ) | safe
@@ -290,6 +291,7 @@
           url="https://assets.ubuntu.com/v1/5da98122-Chip.svg",
           alt="",
           width="160",
+          height="125"
           hi_def=True,
           loading="lazy",
           ) | safe

--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -272,7 +272,7 @@
         {{ image (
           url="https://assets.ubuntu.com/v1/0532297f-Developer.svg",
           alt="",
-          width="200",
+          width="250",
           height="156",
           hi_def=True,
           loading="lazy",

--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -270,7 +270,7 @@
       <h3>Ubuntu</h3>
       <div class="u-hide--small" style="margin-bottom: 1rem;">
         {{ image (
-          url="https://assets.ubuntu.com/v1/a87c9844-Developer.svg",
+          url="https://assets.ubuntu.com/v1/0532297f-Developer.svg",
           alt="",
           width="200",
           height="156",

--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -268,6 +268,17 @@
     <div class="col-6">
       <hr>
       <h3>Ubuntu</h3>
+      <div class=" u-align--center u-hide--small">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/f78ed474-Developer_w_logo.svg",
+          alt="",
+          width="400",
+          height="385",
+          hi_def=True,
+          loading="lazy",
+          ) | safe
+        }}
+      </div>
       <p><a href="/desktop">Ubuntu</a> is a solid foundation for all software development and the OS of choice for developers.</p>
       <p>Ubuntu Pro is a comprehensive subscription on top of Ubuntu that gives you confidence in your full open source stack. Benefit from 10 years of security maintenance with automated security patches at scale, access real time capabilities optimised for embedded devices, and ensure uptime and minimal time to remediation.</p>
       <a href="/pro" class="p-button">Learn more about Ubuntu Pro</a>
@@ -275,6 +286,17 @@
     <div class="col-6">
       <hr>
       <h3>Ubuntu Core</h3>
+      <div class=" u-align--center u-hide--small">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/fcb92825-Chip_w_logo.svg",
+          alt="",
+          width="450",
+          height="385",
+          hi_def=True,
+          loading="lazy",
+          ) | safe
+        }}
+      </div>
       <p>Ubuntu Core is our open source operating system designed for IoT and edge, with the strong security model you've come to expect from Ubuntu. Core is used by IoT start-ups and large enterprises, with huge fleets of devices in the field today.</p>
       <p>Ubuntu Core uses the same kernel, libraries, and system software as classic Ubuntu, resulting in a smooth transition to production, and includes Ubuntu Pro as the standard.</p>
       <p><a href="/core" class="p-button">Learn more about Ubuntu Core</a></p>

--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -272,8 +272,7 @@
         {{ image (
           url="https://assets.ubuntu.com/v1/0532297f-Developer.svg",
           alt="",
-          width="250",
-          height="156",
+          width="200",
           hi_def=True,
           loading="lazy",
           ) | safe
@@ -290,8 +289,7 @@
         {{ image (
           url="https://assets.ubuntu.com/v1/5da98122-Chip.svg",
           alt="",
-          width="200",
-          height="156",
+          width="160",
           hi_def=True,
           loading="lazy",
           ) | safe

--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -273,7 +273,7 @@
           url="https://assets.ubuntu.com/v1/0532297f-Developer.svg",
           alt="",
           width="200",
-          height="125"
+          height="125",
           hi_def=True,
           loading="lazy",
           ) | safe
@@ -291,7 +291,7 @@
           url="https://assets.ubuntu.com/v1/5da98122-Chip.svg",
           alt="",
           width="160",
-          height="125"
+          height="125",
           hi_def=True,
           loading="lazy",
           ) | safe

--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -268,12 +268,12 @@
     <div class="col-6">
       <hr>
       <h3>Ubuntu</h3>
-      <div class=" u-align--center u-hide--small">
+      <div class="u-hide--small" style="margin-bottom: 1rem;">
         {{ image (
-          url="https://assets.ubuntu.com/v1/f78ed474-Developer_w_logo.svg",
+          url="https://assets.ubuntu.com/v1/a87c9844-Developer.svg",
           alt="",
-          width="400",
-          height="385",
+          width="200",
+          height="156",
           hi_def=True,
           loading="lazy",
           ) | safe
@@ -286,12 +286,12 @@
     <div class="col-6">
       <hr>
       <h3>Ubuntu Core</h3>
-      <div class=" u-align--center u-hide--small">
+      <div class="u-hide--small" style="margin-bottom: 1rem;">
         {{ image (
-          url="https://assets.ubuntu.com/v1/fcb92825-Chip_w_logo.svg",
+          url="https://assets.ubuntu.com/v1/5da98122-Chip.svg",
           alt="",
-          width="450",
-          height="385",
+          width="200",
+          height="156",
           hi_def=True,
           loading="lazy",
           ) | safe


### PR DESCRIPTION
## Done

Added missing images to /internet-of-things page

## QA

- [demo link](https://ubuntu-com-13392.demos.haus/internet-of-things)
- [copy doc](https://docs.google.com/document/d/1nBx1SP3Y10gXX0rZPDaz1Gudy-hWP4XRMUcETyPBldI/edit#heading=h.arqqr1uv66j6)
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check that images on /internet-of-things page are correct
## Issue / Card
[WD-7757](https://warthogs.atlassian.net/browse/WD-7757)

Fixes #

## Screenshots


[WD-7757]: https://warthogs.atlassian.net/browse/WD-7757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ