### PR TITLE
[WD-7905] update image on /confidential-computing page

### DIFF
--- a/templates/confidential-computing/index.html
+++ b/templates/confidential-computing/index.html
@@ -59,7 +59,7 @@ privacy-enhancing technology strategy with Ubuntu confidential VMs on both publi
         </p>
         <div class="u-align--center u-vertically-center u-hide--small">
           {{ image (
-          url="https://assets.ubuntu.com/v1/4143661e-Ubuntu%20VM%20on%20Intel%20TDX.png",
+          url="https://assets.ubuntu.com/v1/48765e85-Intel%20%20TDX%20and%20Ubuntu%20Figure.png",
           alt="Diagram showing that Ubuntu builds cater to both the host and guest sides, empowering users to launch a
           confidential TDX virtual machine seamlessly",
           width="410",


### PR DESCRIPTION
## Done

- Update image in "Intel TDX is available on Ubuntu for both the host and guest" section according to [copy doc](https://docs.google.com/document/d/1QGwS5CYlwXkaPibSFvcag6zLcUH5lNDUbM18hCqbOJM/edit).

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Navigate to /confidential-computing and check if the image has been updated and corresponds to the one specified in the copy doc.

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-7905

## Screenshots

![Screenshot 2023-12-12 at 10 23 58](https://github.com/canonical/ubuntu.com/assets/15943863/7cf64f19-64c4-420a-8aa6-fbd5072e9cce)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
