### PR TITLE
Update copy docs for pro pricing

### DIFF
--- a/templates/pricing/pro.html
+++ b/templates/pricing/pro.html
@@ -51,7 +51,7 @@
             <td>$300</td>
           </tr>
           <tr>
-            <td>Server with unlimited VMs*<br><span class="u-text--muted">(machine/year)</span></td>
+            <td>Server with unlimited VMs<br><span class="u-text--muted">(machine/year)</span></td>
             <td>$500</td>
             <td>$1,775</td>
             <td>$3,400</td>
@@ -113,7 +113,7 @@
             <td>yes</td>
           </tr>
           <tr>
-            <td>USG harderning with CIS and DISA-STIG profiles<br><span class="u-text--muted">(DISA-STIG tooling & automation for Ubuntu 20.04 LTS and 22.04 LTS)</span></td>
+            <td>USG hardening with CIS and DISA-STIG profiles<br><span class="u-text--muted">(DISA-STIG tooling & automation for Ubuntu 20.04 LTS and 22.04 LTS)</span></td>
             <td>yes</td>
             <td>yes</td>
             <td>yes</td>
@@ -220,8 +220,6 @@
       <h5>Notes</h5>
     </div>
     <div class="col-10 col-medium-6">
-      <p>* Any of: KVM | Qemu | Boch, VMWare ESXi, LXD | LXC, Xen, Hyper-V (WSL, Multipass), VirtualBox, z/VM, Docker. All Nodes in the cluster have to be subscribed to the service in order to benefit from the unlimited VM support</p>
-      <hr class="u-no-margin--bottom">
       <p>N.B.: Weekday support is half the price of 24/7 support</p>
       <hr class="u-no-margin--bottom">
       <p>N.B.: Subscriptions are not just for enterprise customers. Anyone can get <a href="/pro">a personal subscription</a> for free on up to 5 machines</p>


### PR DESCRIPTION
## Done

- Update copy docs for pro pricing page

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to `/pricing/pro`

## Issue / Card

Fixes [WD-7929](https://warthogs.atlassian.net/browse/WD-7929)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-7929]: https://warthogs.atlassian.net/browse/WD-7929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ