### PR TITLE
fix: adds automatic redirect to exam survey

### DIFF
--- a/templates/credentials/exam.html
+++ b/templates/credentials/exam.html
@@ -37,6 +37,24 @@
 
   document.addEventListener('click', refocusIframe);
   document.addEventListener('keydown', refocusIframe);
+
+  // ping TruCredential every 1 minute to check if exam is over
+  async function checkExamStatus(){
+    fetch("/credentials/exam/{{assessment_id}}/status", {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        "Accept": "application/json"
+      }
+    })
+    .then((r)=>r.json())
+    .then((data)=>{
+      if(data.assessment.ended === true){
+        window.location.href = "/credentials/exit-survey";
+      }
+    });
+  }
+  setInterval(checkExamStatus, 1000);
 </script>
 
 {% endblock content%}

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -69,6 +69,7 @@ from webapp.shop.cred.views import (
     cred_beta_activation,
     cred_cancel_exam,
     cred_exam,
+    cred_exam_status,
     cred_home,
     cred_redeem_code,
     cred_schedule,
@@ -866,6 +867,7 @@ app.add_url_rule("/credentials/your-exams", view_func=cred_your_exams)
 app.add_url_rule("/credentials/cancel-exam", view_func=cred_cancel_exam)
 app.add_url_rule("/credentials/assessments", view_func=cred_assessments)
 app.add_url_rule("/credentials/exam", view_func=cred_exam)
+app.add_url_rule("/credentials/exam/<exam_id>/status", view_func=cred_exam_status)
 app.add_url_rule(
     "/credentials/<string:type>/products",
     view_func=get_cue_products,

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -398,8 +398,13 @@ def cred_exam(trueability_api, **_):
         return flask.abort(403)
 
     url = trueability_api.get_assessment_redirect(assessment_id)
-    return flask.render_template("credentials/exam.html", url=url)
+    return flask.render_template("credentials/exam.html", url=url, assessment_id=assessment_id)
 
+@shop_decorator(area="cred", permission="user", response="json")
+def cred_exam_status(trueability_api, **kwargs):
+    assessment_id = kwargs.get("exam_id")
+    assessment = trueability_api.get_assessment(assessment_id)
+    return flask.jsonify(assessment)
 
 @shop_decorator(area="cred", permission="user", response="html")
 def cred_syllabus_data(**_):


### PR DESCRIPTION
## Done

- After an exam, it should redirect to the survey page

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Schedule an exam
- Take the exam
- Once the exam ends, it should redirect to the survey page

## Issue / Card

Fixes [#WD-7899](https://warthogs.atlassian.net/browse/WD-7899)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
