### PR TITLE
Fix typo in ceph/install

### DIFF
--- a/templates/ceph/install.html
+++ b/templates/ceph/install.html
@@ -33,7 +33,7 @@
   </div>
 </section>
 
-<seciton class="p-strip">
+<section class="p-strip">
   <div class="u-fixed-width js-tabbed-content">
     <div class="p-tabs">
       <div class="p-tabs__list" role="tablist" aria-label="Ceph installation instructions">
@@ -245,7 +245,7 @@
       </div>
     </div>
   </div>
-</seciton>
+</section>
 
 <section class="p-strip--light is-deep">
   <div class="row u-equal-height">


### PR DESCRIPTION
## Done

- Fix `<section>` typo

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
