### PR TITLE
Wd 7967 expired contracts still show the schedule button

### DIFF
--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -191,6 +191,7 @@ def cred_your_exams(ua_contracts_api, trueability_api, **kwargs):
     exams_not_taken = []
     exams_complete = []
     exams_cancelled = []
+    exams_expired = []
 
     if exam_contracts:
         for exam_contract in exam_contracts:
@@ -199,6 +200,12 @@ def cred_your_exams(ua_contracts_api, trueability_api, **kwargs):
             contract_item_id = (
                 exam_contract.get("id") or exam_contract["contractItem"]["id"]
             )
+            if "effectivenessContext" in exam_contract and "status" in exam_contract["effectivenessContext"] and exam_contract["effectivenessContext"]["status"] == "expired":
+                    exams_expired.append(
+                        {"name": name, "state": "Expired", "actions": []}
+                    )
+                    continue
+
             if "reservation" in exam_contract["cueContext"]:
                 response = trueability_api.get_assessment_reservation(
                     exam_contract["cueContext"]["reservation"]["IDs"][-1]
@@ -311,6 +318,7 @@ def cred_your_exams(ua_contracts_api, trueability_api, **kwargs):
         + exams_not_taken
         + exams_complete
         + exams_cancelled
+        + exams_expired
     )
 
     response = flask.make_response(

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -200,7 +200,7 @@ def cred_your_exams(ua_contracts_api, trueability_api, **kwargs):
             contract_item_id = (
                 exam_contract.get("id") or exam_contract["contractItem"]["id"]
             )
-            
+
             if (
                 "effectivenessContext" in exam_contract
                 and "status" in exam_contract["effectivenessContext"]

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -200,11 +200,17 @@ def cred_your_exams(ua_contracts_api, trueability_api, **kwargs):
             contract_item_id = (
                 exam_contract.get("id") or exam_contract["contractItem"]["id"]
             )
-            if "effectivenessContext" in exam_contract and "status" in exam_contract["effectivenessContext"] and exam_contract["effectivenessContext"]["status"] == "expired":
-                    exams_expired.append(
-                        {"name": name, "state": "Expired", "actions": []}
-                    )
-                    continue
+            
+            if (
+                "effectivenessContext" in exam_contract
+                and "status" in exam_contract["effectivenessContext"]
+                and exam_contract["effectivenessContext"]["status"]
+                == "expired"
+            ):
+                exams_expired.append(
+                    {"name": name, "state": "Expired", "actions": []}
+                )
+                continue
 
             if "reservation" in exam_contract["cueContext"]:
                 response = trueability_api.get_assessment_reservation(


### PR DESCRIPTION
## Done

- Expired contracts no longer show schedule button 

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Buy any exam
- Wait for a month for it to expire
- Should see an expired status and no schedule button

## Issue / Card

Fixes [#WD-7967](https://warthogs.atlassian.net/browse/WD-7967)

## Screenshots

![image](https://github.com/canonical/ubuntu.com/assets/30973042/6224a028-8336-45f6-b5a1-70f13732411c)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
