### PR TITLE
[WD-7973] add small chages to content of legal pages for partner portal

### DIFF
--- a/templates/legal/data-privacy/partner-portal.md
+++ b/templates/legal/data-privacy/partner-portal.md
@@ -3,11 +3,9 @@ wrapper_template: "legal/_base_legal_markdown.html"
 context:
   title: "Privacy notice – Partner Portal"
   description: This privacy notice tells you about the information we collect from you when you access the Canonical Partner Portal.
+  update_date: "Version - January 2024"
   copydoc: https://docs.google.com/document/d/1yuh7dL3jjkj21sKJCUhm_z00PKzH4vssY339wbp4U-s/edit
 ---
-
-<h4 class="p-muted-heading">Version - July 2023</h4>
-<hr style="margin-bottom: 2rem;" />
 
 # Privacy notice - Partner Portal
 
@@ -21,7 +19,7 @@ We are not required to have a data protection officer, so any enquiries about ou
 
 ## What personal data do we collect?
 
-When you access the Canonical Partner Portal, we ask you to submit your USERID and password. You will ask be asked for further information through the deal registration system, including name, address, contact telephone number, email address and information about the deal you are registering.
+When you access the Canonical Partner Portal, we ask you to submit your USERID and password. You will be asked for further information through the deal registration system, including name, address, contact telephone number, email address and information about the deal you are registering.
 
 ## Why do we collect this information?
 
@@ -42,7 +40,7 @@ We may:
 
 Your information is stored in our order processing system and may be processed outside of the European Economic Area. It is shared with the third parties set out below and as reasonably required for Canonical to process and store your data.
 
-The Canonical Partner Platform is hosted by a third party supplier, Gorilla Toolz, Inc. and the deal registration system (part of the Canonical Partner Platform) is hosted by a third party supplier, Vartopia LLC. In order for the Canonical Partner Platform to operate we share your information with these third party suppliers and they may share information about you with us.
+The Canonical Partner Platform is hosted by a third party supplier, Zift Solutions. In order for the Canonical Partner Platform to operate we share your information with this third party supplier and they may share information about you with us.
 
 ## Our legal basis to use your Personal information
 

--- a/templates/legal/partner-portal-terms.md
+++ b/templates/legal/partner-portal-terms.md
@@ -3,7 +3,7 @@ wrapper_template: "legal/_base_legal_markdown.html"
 context:
   title: "Partner Portal terms and conditions"
   description: "This privacy notice tells you about the information we collect from you when you submit your information to us via an enquiry or contact us form on our website."
-  update_date: "Version - February 2019"
+  update_date: "Version - January 2024"
   copydoc: https://docs.google.com/document/d/1CqJbwC3KpEJeJaCUVjAIN0y6ZLmoc7gVlFyc-BeFMYw/edit#
 ---
 
@@ -15,13 +15,13 @@ context:
 
 ## Copyright
 
-The website HTML, text, images audio, video, software or other content that is made available on Canonical's Partner Platform or otherwise hosted by Canonical are the property of someone - the author in the case of content produced elsewhere and reproduced here with permission of Canonical, the platform provider or content suppliers (e.g. Gorilla Toolz, Inc. and Vartopia, LLC.). Before you use this content in some way please take care to ensure that you have the relevant rights and permissions from the copyright holder.
+The website HTML, text, images audio, video, software or other content that is made available on Canonical's Partner Platform or otherwise hosted by Canonical are the property of someone - the author in the case of content produced elsewhere and reproduced here with permission of Canonical, the platform provider or content suppliers (e.g. Zift Solutions). Before you use this content in some way please take care to ensure that you have the relevant rights and permissions from the copyright holder.
 
 You are welcome to display on your computer, download and print pages from Canonical's Partner Platform for internal use only. You must retain copyright, trademark and other notices unaltered on any copies or printouts you make. Certain materials available on this site are "open source" materials subject to the GNU General Public Licence ("GPL") or other open-source licence and are so marked. Use of those materials is governed by the individual applicable licence.
 
 ## Trademarks
 
-Any trademarks, logos and service marks displayed on Canonical's Partner Platform are the property of their owners, whether Canonical or third parties. For example, the Gorilla Toolz logo is a registered trademark of Gorilla Toolz, Inc.
+Any trademarks, logos and service marks displayed on Canonical's Partner Platform are the property of their owners, whether Canonical or third parties. For example, the ZiftONE logo is a registered trademark of Zift Solutions.
 
 ## Privacy policy
 


### PR DESCRIPTION
## Done

- Add changes to content in /legal/partner-portal-terms according to [copy doc](https://docs.google.com/document/d/1CqJbwC3KpEJeJaCUVjAIN0y6ZLmoc7gVlFyc-BeFMYw/edit)
- Add changes to content in /legal/data-privacy/partner-portal according to [copy doc](https://docs.google.com/document/d/1yuh7dL3jjkj21sKJCUhm_z00PKzH4vssY339wbp4U-s/edit#heading=h.2dlolyb)

Demo links to pages:
https://ubuntu-com-13413.demos.haus/legal/partner-portal-terms
https://ubuntu-com-13413.demos.haus/legal/data-privacy/partner-portal 

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Navigate to above mentioned pages and check the changes

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-7973

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
