### PR TITLE
[WD-7975] replace image with a typo in /confidential-computing

### DIFF
--- a/templates/confidential-computing/index.html
+++ b/templates/confidential-computing/index.html
@@ -59,7 +59,7 @@ privacy-enhancing technology strategy with Ubuntu confidential VMs on both publi
         </p>
         <div class="u-align--center u-vertically-center u-hide--small">
           {{ image (
-          url="https://assets.ubuntu.com/v1/48765e85-Intel%20%20TDX%20and%20Ubuntu%20Figure.png",
+          url="https://assets.ubuntu.com/v1/eb3679e5-Intel%20%20TDX%20and%20Ubuntu%20Figure.png",
           alt="Diagram showing that Ubuntu builds cater to both the host and guest sides, empowering users to launch a
           confidential TDX virtual machine seamlessly",
           width="410",


### PR DESCRIPTION
## Done

- Replaced an image on /confidential-computing page according to [copy doc](https://docs.google.com/document/d/1QGwS5CYlwXkaPibSFvcag6zLcUH5lNDUbM18hCqbOJM/edit)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check if the new image is shown on the page, specifically if the typo "Ubuntu Kernal" is replaced with "Ubuntu Kernel".

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-7975

## Screenshots

![Screenshot 2023-12-15 at 12 06 45](https://github.com/canonical/ubuntu.com/assets/15943863/6dbcf813-09da-41b7-990b-1cb6e75b47b4)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
