### PR TITLE
[WD-8000] add Jira integration config file

### DIFF
--- a/.github/.jira_sync_config.yaml
+++ b/.github/.jira_sync_config.yaml
@@ -1,0 +1,25 @@
+settings:
+  # Jira project key to create the issue in
+  jira_project_key: "WD"
+
+  # Dictionary mapping GitHub issue status to Jira issue status
+  status_mapping:
+    opened: Untriaged
+    closed: done
+
+  # (Optional) Jira project components that should be attached to the created issue
+  # Component names are case-sensitive
+  components:
+    - Sites Tribe
+
+  # (Optional) (Default: false) Add a new comment in GitHub with a link to Jira created issue
+  add_gh_comment: false
+
+  # (Optional) (Default: true) Synchronize issue description from GitHub to Jira
+  sync_description: true
+
+  # (Optional) (Default: true) Synchronize comments from GitHub to Jira
+  sync_comments: true
+
+  # (Optional) (Default: None) Parent Epic key to link the issue to
+  epic_key: "WD-6777"


### PR DESCRIPTION
## Done

- Added a config file that will integrate GH with Jira so that new GH issues will automatically create tasks in Jira. This is done in a similar way as it is done in canonical.com: https://github.com/canonical/canonical.com/blob/main/.github/.jira_sync_config.yaml

## QA

Can be QA-ed only after merging since to test it you need a new GH issue or you need to close and re-open an existing one. 

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-8000

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
