### PR TITLE
Update release links

### DIFF
--- a/static/js/src/cve/cve.js
+++ b/static/js/src/cve/cve.js
@@ -153,11 +153,11 @@ tooltipIconList.forEach(function (tooltipIcon) {
   );
 });
 
-function toggleCVEList() {
+function showCVEList() {
   if (urlParams.has("status")) {
     recentCves.classList.add("u-hide");
     cveList.classList.remove("u-hide");
   }
 }
 
-toggleCVEList();
+showCVEList();

--- a/static/js/src/cve/cve.js
+++ b/static/js/src/cve/cve.js
@@ -157,7 +157,7 @@ function toggleCVEList() {
   if (urlParams.has("status")) {
     recentCves.classList.add("u-hide");
     cveList.classList.remove("u-hide");
-  } 
+  }
 }
 
 toggleCVEList();

--- a/static/js/src/cve/cve.js
+++ b/static/js/src/cve/cve.js
@@ -9,6 +9,10 @@ import {
 
 const searchInput = document.querySelector("#q");
 const searchForm = document.querySelector("#searchForm");
+const cveList = document.querySelector("#cve-list");
+const recentCves = document.querySelector("#recent-cves");
+const url = new URL(window.location.href);
+const urlParams = new URLSearchParams(url.search);
 
 function handleCveIdInput(value) {
   const packageInput = document.querySelector("#package");
@@ -148,3 +152,12 @@ tooltipIconList.forEach(function (tooltipIcon) {
     false
   );
 });
+
+function toggleCVEList() {
+  if (urlParams.has("status")) {
+    recentCves.classList.add("u-hide");
+    cveList.classList.remove("u-hide");
+  } 
+}
+
+toggleCVEList();

--- a/templates/security/cve/index.html
+++ b/templates/security/cve/index.html
@@ -68,13 +68,14 @@
         </div>
         <div class="col-7">
           <ul class="p-inline-list" style="margin-top: .3rem;">
-            <li class="p-inline-list__item"><a>All maintained releases</a></li>
-            <li class="p-inline-list__item"><a>All LTS</a></li>
-            <li class="p-inline-list__item"><a>22.04 LTS</a></li>
-            <li class="p-inline-list__item"><a>20.04 LTS</a></li>
-            <li class="p-inline-list__item"><a>18.04 LTS</a></li>
-            <li class="p-inline-list__item"><a>23.10</a></li>
-            <li class="p-inline-list__item"><a>Other releases</a></li>
+            <!-- Once the search results page is finished and the cve list is not tied to the current table cols, selected releases, maintained releases, and lts releases will be accounted for separately -->
+            <li class="p-inline-list__item"><a href="/security/cves?{% for release in selected_releases %}version={{release.codename}}&status=&{% endfor %}">All maintained releases</a></li>
+            <li class="p-inline-list__item"><a href="/security/cves?version=jammy&status=&version=focal&status=&version=bionic&status=&version=xenial&status=&version=trusty&status=">All LTS</a></li>
+            <li class="p-inline-list__item"><a href="/security/cves?version=jammy&status=">22.04 LTS</a></li>
+            <li class="p-inline-list__item"><a href="/security/cves?version=focal&status=">20.04 LTS</a></li>
+            <li class="p-inline-list__item"><a href="/security/cves?version=bionic&status=">18.04 LTS</a></li>
+            <li class="p-inline-list__item"><a href="/security/cves?version=mantic&status=">23.10</a></li>
+            <li class="p-inline-list__item"><a href="/security/cves?status=">Other releases</a></li>
           </ul>
         </div>
       </div>
@@ -82,7 +83,7 @@
   </div>
 </section>
 
-<section class="p-section">
+<section class="p-section" id="recent-cves">
   <div class="row">
     <hr class="p-rule"/>
     <div class="col-3 p-section--shallow">
@@ -160,7 +161,7 @@
   </div>
 </section>
 
-<section class="p-strip is-shallow u-overflow-inherit u-hide">
+<section class="p-strip is-shallow u-overflow-inherit u-hide" id="cve-list">
   <div class="u-fixed-width">
     {% if query or package or priority %}
     <h2>

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -368,6 +368,8 @@ def cve_index():
             all_releases.append(release)
 
     selected_releases = []
+    lts_releases = []
+    maintained_releases = []
 
     for release in all_releases:
         # format dates
@@ -377,13 +379,18 @@ def cve_index():
         esm_date = datetime.strptime(
             release["esm_expires"], "%Y-%m-%dT%H:%M:%S"
         )
+        release_date = datetime.strptime(
+            release["release_date"], "%Y-%m-%dT%H:%M:%S"
+        )
 
         # filter releases
         if versions and versions != [""]:
             for version in versions:
                 if version == release["codename"]:
                     selected_releases.append(release)
-        elif support_date > datetime.now() or esm_date > datetime.now():
+        elif (
+            support_date > datetime.now() or esm_date > datetime.now()
+        ) and release_date < datetime.now():
             selected_releases.append(release)
 
     selected_releases = sorted(selected_releases, key=lambda d: d["version"])
@@ -425,6 +432,8 @@ def cve_index():
         versions=versions,
         statuses=statuses,
         selected_releases=selected_releases,
+        lts_releases=lts_releases,
+        maintained_releases=maintained_releases,
         high_priority_cves=high_priority_cves,
     )
 

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -392,6 +392,9 @@ def cve_index():
             support_date > datetime.now() or esm_date > datetime.now()
         ) and release_date < datetime.now():
             selected_releases.append(release)
+            maintained_releases.append(release)
+        elif release["lts"] and release_date < datetime.now():
+            lts_releases.append(release)
 
     selected_releases = sorted(selected_releases, key=lambda d: d["version"])
 


### PR DESCRIPTION
## Done

- Added links to filtered releases

## QA

- View the site locally in your web browser at: https://ubuntu-com-13425.demos.haus/security/cves
- Click each "By Ubuntu release" link and see that each shows the expected filtered table (styling updates to this list to come in a later PR)
 Note: "Other releases" should just be the unfiltered CVE list, the table should match the current version with exception of 24.04

## Issue / Card

Fixes #https://warthogs.atlassian.net/browse/WD-7802