### PR TITLE
[WD-7913] support portal legal pages

### DIFF
--- a/templates/legal/data-privacy/index.html
+++ b/templates/legal/data-privacy/index.html
@@ -64,7 +64,7 @@
       <p>Canonical may collect non-personally-identifying information of the sort that web browsers and servers typically make available, such as the browser type, referring site, and the date and time of each visitor request. Our purpose in collecting non-personally identifying information is to better understand how visitors use our websites and services. For further information about how we use cookies, see the "cookie" section below.</p>
       <p>Please note that Canonical may also collect system information during installation of Ubuntu and on first login to Ubuntu. This system information is subject to a <a href="/legal/online-account-terms">Legal Notice</a>.</p>
       <h3>Error reports</h3>
-      <p>When you chose to send an error report, it includes a unique identifier for your computer. This identifier does not identify you, unless you (or someone acting on your behalf) discloses it separately. An error report may include personal information such as the state of programs that were running at the time. You can block future error reports from the privacy panel of System Settings or by deselecting the "Enable Google Analytics in MAAS UI to shape improvements in user experience" box where applicable.</p>
+      <p>When you chose to send an error report, it includes a unique identifier for your computer. This identifier does not identify you, unless you (or someone acting on your behalf) discloses it separately. An error report may include personal information such as the state of programs that were running at the time. You can block future error reports from the privacy panel of System Settings.</p>
       <h3>Ubuntu online accounts</h3>
       <p>When you use Ubuntu online accounts, your personal information is stored on your PC and it can be accessed by some applications. Further information can be found in a <a href="/legal/online-account-terms">Legal Notice</a>.</p>
       <h3>Contacting us</h3>
@@ -145,7 +145,7 @@
         </tbody>
       </table>
       <h2 id="cookies">Cookies</h2>
-      <p>Our website uses cookies to distinguish you from other users of our website. This helps us to provide you with a good experience when you browse our website and also allows us to improve our site.</p>
+      <p>Our website and services use cookies to distinguish you from other users of our website and services. This helps us to provide you with a good experience when you browse our website or use our services and also allows us to improve our site and services.</p>
       <h3>What is a cookie?</h3>
       <p>A cookie is a small file of letters and numbers that we store on your browser or the hard drive of your computer if you agree. Cookies contain information that is transferred to your computer's hard drive.</p>
       <p>We use the following cookies:</p>

--- a/templates/legal/data-privacy/index.html
+++ b/templates/legal/data-privacy/index.html
@@ -42,6 +42,7 @@
         <li class="p-list__item"><a href="/legal/data-privacy/credentials">Canonical Credentials privacy notice&nbsp;&rsaquo;</a></li>
         <li class="p-list__item"><a href="/legal/data-privacy/recruitment">Recruitment privacy notice&nbsp;&rsaquo;</a></li>
         <li class="p-list__item"><a href="/legal/data-privacy/community-discourse">Ubuntu Community Discourse Privacy Notice&nbsp;&rsaquo;</a></li>
+        <li class="p-list__item"><a href="/legal/data-privacy/support-portal">Canonical Support Portal&nbsp;&rsaquo;</a></li>
       </ul>
       <h2 id="information-we-collect-from-you">Information we collect from you</h2>
       <ul class="p-list">

--- a/templates/legal/data-privacy/support-portal.md
+++ b/templates/legal/data-privacy/support-portal.md
@@ -3,11 +3,9 @@ wrapper_template: "legal/_base_legal_markdown.html"
 context:
   title: "Privacy notice – Canonical Support Portal"
   description: This privacy notice tells you about the information collected from you when you access the Canonical Support Portal. In collecting this information, we are acting as a data controller and, by law, we are required to provide you with information about us, about why and how we use your data, and about the rights you have over your data.
+  update_date: "Version - December 2023"
   copydoc: https://docs.google.com/document/d/1x8vH0dabSF7en7KenZKKDlugFHjbKwtdonuKPbQUDiM/edit
 ---
-
-<h4 class="p-muted-heading">Version - January 2024</h4>
-<hr style="margin-bottom: 2rem;" />
 
 # Privacy notice – Canonical Support Portal
 
@@ -66,7 +64,7 @@ If you would like to unsubscribe from any email, you can also click the “unsub
 
 ## Keeping your personal information secure
 
-We have appropriate security measures in place to prevent personal information from being accidentally lost, or used or accessed in an unauthorized way. We limit access to your personal information to those who have a genuine business need to know it. Those processing your information will do so only in an authorized manner and are subject to a duty of confidentiality.
+We have appropriate security measures in place to prevent personal information from being accidentally lost, or used or accessed in an unauthorised way. We limit access to your personal information to those who have a genuine business need to know it. Those processing your information will do so only in an authorised manner and are subject to a duty of confidentiality.
 
 We also have procedures in place to deal with any suspected data security breach. We will notify you and any applicable regulator of a suspected data breach where we are legally required to do so.
 

--- a/templates/legal/data-privacy/support-portal.md
+++ b/templates/legal/data-privacy/support-portal.md
@@ -1,0 +1,101 @@
+---
+wrapper_template: "legal/_base_legal_markdown.html"
+context:
+  title: "Privacy notice – Canonical Support Portal"
+  description: This privacy notice tells you about the information collected from you when you access the Canonical Support Portal. In collecting this information, we are acting as a data controller and, by law, we are required to provide you with information about us, about why and how we use your data, and about the rights you have over your data.
+  copydoc: https://docs.google.com/document/d/1x8vH0dabSF7en7KenZKKDlugFHjbKwtdonuKPbQUDiM/edit
+---
+
+<h4 class="p-muted-heading">Version - January 2024</h4>
+<hr style="margin-bottom: 2rem;" />
+
+# Privacy notice – Canonical Support Portal
+
+This privacy notice tells you about the information collected from you when you access the Canonical Support Portal. In collecting this information, we are acting as a data controller and, by law, we are required to provide you with information about us, about why and how we use your data, and about the rights you have over your data. For more information, please see our <a href="/legal/data-privacy">privacy policy</a>.
+
+## Who are we?
+
+We are Canonical Group Limited. Our address is 5 New Street Square, London, EC4A 3TW, United Kingdom. You can contact us by post at the above address or by email to <a href="mailto:dataprotection@canonical.com">dataprotection@canonical.com</a> for the attention of “Legal”.
+
+We are not required to have a data protection officer, so any enquiries about our use of your personal data should be addressed to the contact details above.
+
+## What personal data do we collect?
+
+When you register to access the Canonical Support Portal we may ask you for your name and email address, timezone, country, IP address and related information.
+
+## Why do we collect this information?
+
+We will use your information for making the Canonical Support Portal available to you, as well as for user and product research purposes. We ask for your consent to do this and will only contact you for this purpose for as long as you continue to consent.
+
+We may also use your information to send you other news and product updates from Canonical. This may involve us calling you, where we have your phone number in order to do so.
+
+## What do we do with your information?
+
+Your information is stored in our database and may be processed outside of the European Economic Area. It is shared with the third parties only as reasonably required for Canonical to process and store your data in accordance with this notice.
+
+Such countries do not have the same data protection laws as the United Kingdom and EEA. Where the European Commission has not given a formal decision that such countries provide an adequate level of data protection similar to those which currently apply to the United Kingdom and EEA, any transfer of your personal information will be subject to approved contract terms designed to help safeguard your privacy rights and give you remedies in the unlikely event of misuse of you personal information. If you would like further information, please contact us (see "Your right to complain" below).
+
+## How long do we keep your information for?
+
+Your information is kept for as long as you continue to consent and for so long as reasonably required thereafter in accordance with our record retention policy.
+
+## Your rights over your information
+
+You have a number of important rights under data protection laws. In summary, those include rights to:
+
+- Fair processing of information and transparency over how we use your personal information.
+- Access to your personal information and to certain other supplementary information that this Privacy Notice is already designed to address.
+- Require us to correct any mistakes in your information which we hold.
+- Require the erasure of personal information concerning you in certain situations.
+- Receive the personal information concerning you which you have provided to us, in a structured, commonly used and machine-readable format and have the right to transmit that data to a third party in certain situations.
+- Object at any time to processing of personal information concerning you for direct marketing.
+- Object to decisions being taken by automated means which produce legal effects concerning you or similarly significantly affect you.
+- Object in certain other situations to our continued processing of your personal information.
+- Otherwise restrict our processing of your personal information in certain circumstances.
+- Claim compensation for damages caused by our breach of any data protection laws.
+
+For further information on each of those rights, including the circumstances in which they apply, see the Guidance from the UK Information Commissioner’s Office (ICO) on individuals rights under the General Data Protection Regulation.
+
+If you would like to exercise any of those rights, please:
+
+1. Email or write to us (see “Your right to complain” below).
+2. Provide us enough information to identify you.
+3. Let us know the information to which your request relates.
+
+If you would like to unsubscribe from any email, you can also click the “unsubscribe” button at the bottom of the email. Please note that unsubscribing is not automatic, but will be implemented once confirmed by our personnel.
+
+## Keeping your personal information secure
+
+We have appropriate security measures in place to prevent personal information from being accidentally lost, or used or accessed in an unauthorized way. We limit access to your personal information to those who have a genuine business need to know it. Those processing your information will do so only in an authorized manner and are subject to a duty of confidentiality.
+
+We also have procedures in place to deal with any suspected data security breach. We will notify you and any applicable regulator of a suspected data breach where we are legally required to do so.
+
+## Your right to complain
+
+We hope that we can resolve any query or concern you raise about our use of your information. You can contact us at any time. Any questions, comments and requests regarding this Privacy notice or any other related matter are welcomed and should be addressed to <a href="mailto:dataprotection@canonical.com">dataprotection@canonical.com</a> or to the address below:
+
+<div style="margin: 2rem;">
+  <p>
+    Legal, Canonical<br />
+    St Dunstans House<br />
+    4th floor, 201 Borough High St<br />
+    London SE1 1JA<br />
+    United Kingdom<br />
+  </p>
+</div>
+
+Alternatively, you can use the relevant contact us form.
+
+If you have a complaint about our use of your information, you can contact the Information Commissioner’s Office via their website at <a href="https://ico.org.uk/concerns/">ico.org.uk/concerns/</a> or write to them at:
+
+<div style="margin: 2rem;">
+  <p>
+    Information Commissioner's Office<br />
+    Wycliffe House<br />
+    Water Lane<br />
+    Wilmslow<br />
+    Cheshire<br />
+    SK9 5AF<br />
+    United Kingdom
+  </p>
+</div>

--- a/templates/legal/terms-and-policies/index.html
+++ b/templates/legal/terms-and-policies/index.html
@@ -150,6 +150,12 @@
       <p>The terms governing use of Canonical's Ubuntu Community Discourse Forum.</p>
       <p><a href="/legal/terms-and-policies/discourse-terms">View Canonical Ubuntu Community Discourse Forum terms&nbsp;&rsaquo;</a></p>
     </div>
+
+    <div class="col-6 p-card">
+      <h3>Canonical Support Portal Terms of Service</h3>
+      <p>The terms governing  use of Canonical’s support portal.</p>
+      <p><a href="/legal/terms-and-policies/support-portal">Access Canonical Support Portal terms&nbsp;&rsaquo;</a></p>
+    </div>
   </div>
 </div>
 

--- a/templates/legal/terms-and-policies/support-portal.md
+++ b/templates/legal/terms-and-policies/support-portal.md
@@ -1,0 +1,112 @@
+---
+wrapper_template: "legal/_base_legal_markdown.html"
+context:
+  title: "Canonical Support Portal - Terms of Service"
+  description: "Ubuntu and Canonical Legal - Canonical Support Portal Terms of Service"
+  update_date: "Version - December 2023"
+  copydoc: https://docs.google.com/document/d/1ugZ-7R6qSYSKjofiPicy444c5zXho81J3Z_f-hpCcZc/edit
+---
+
+# Canonical Support Portal - Terms of Service
+
+These Terms of Service cover your ("**you**" or "**your**") use of the Canonical Support Portal (the “**Portal**”) provided by Canonical Group Limited ("**Canonical**", "**us**", "**our**" or "**we**") subject to and in accordance with these Terms of Service.
+
+Please read these Terms of Service carefully before you use the Portal. By using the Portal, you agree to become bound by these Terms of Service. You may not use the Portal for illegal or unauthorised purposes or otherwise not in accordance with these Terms of Service.
+
+If you are entering into these Terms of Service on behalf of a company or legal entity, you represent that you have authority to bind such company or legal entity, its officers, employees and agents and all users who access the Portal, to these Terms of Service. “you” and “your” shall refer to the company or legal entity and such users. If you do not have such authority do not accept these Terms of Service.
+
+Any change or update to the Portal or Terms of Service will be made in accordance with section 4 below.
+
+## 1. Canonical Support Portal
+
+The Portal is a self-serve, web-based customer service tool. It enables you, as a Canonical customer representative, to find information, request support and resolve issues autonomously. Canonical customers with active assets can:
+
+- manage their support requests;
+- read knowledge base articles;
+- find phone numbers for sales and support; and
+- view their assets.
+
+## 2. Account
+
+You will need to register for an Ubuntu One account and subsequently use Single Sign On (SSO) to access and use the Portal. SSO is an identity provider service that creates, maintains and manages user identity information, providing authentication services for Canonical and other third party applications. An Ubuntu One account is the single account you use to log in to certain services and sites related to <a href="https://www.ubuntu.com">www.ubuntu.com</a>. We reserve the right to reject your request for an SSO and Ubuntu One account or to immediately cancel or suspend your SSO and Ubuntu One account and your use of the Portal at any time if you do not comply with the following requirements. You must not attempt to create an SSO and Ubuntu One account or use the Portal if doing so would violate these Terms of Service. You must:
+
+- have an Ubuntu One account and log in through SSO;
+- not use the Portal for illegal or unauthorised purposes (or which encourage or permit illegal or authorised purposes), in infringement of a third party's’ rights or otherwise in accordance with these Terms of Service;
+- not take any action or use the Portal in any way that might bring Canonical into disrepute or affect the ability of Canonical to provide the Portal;
+- not use the Portal in any manner that might be libellous or defamatory, that contains threats or incites violence towards individuals or entities, or that violates the privacy rights of any third party.
+
+If you do not have an Ubuntu One account you will need to create this. You are responsible for choosing an appropriate password for your account and for keeping such password secure. Canonical will not ask you for your password and you should not reveal it to anyone. You are responsible for keeping your account details up to date.
+
+You may request deletion of any data held in the Portal at any time by emailing <a href="mailto:support@canonical.com">support@canonical.com</a>. Note that this does not delete your Ubuntu One account, since you might be using it for other Canonical services. To delete your Ubuntu One account, visit <a href="https://login.ubuntu.com/">https://login.ubuntu.com/</a> and click **Permanently delete account**.
+
+## 3. Changes and termination
+
+We continually aim to improve the delivery and content of the Portal and accordingly may make changes to the Portal from time to time.
+
+New features may be added, but we may also modify or discontinue (temporarily or permanently) part of the Portal, in part or in whole.
+
+In the event of a material change to the Portal, we will notify you via the email you have provided to us. What constitutes a material change in this circumstance will be determined by Canonical, in good faith and using common sense and reasonable judgment.
+
+Similarly, we may occasionally make changes to these Terms of Service. If Canonical does make changes to these Terms of Service, all changes will go into effect at the time we post the updated Terms of Service or as otherwise notified at that time.
+
+## 4. Intellectual property and content
+
+### Intellectual property
+
+You have a non-exclusive, non-transferable (to the extent permitted by law) right to view, access and use the Portal for such time as it is made available by us strictly in accordance with these Terms of Service.
+
+You will not acquire any rights to the Portal (or the intellectual property rights contained therein) from your use of the Portal, other than as set out in these Terms of Service.
+
+### Canonical materials
+
+All materials contained within the Portal are copyright of Canonical. All content provided by you or a third party are accessed at your sole discretion and risk.
+
+### Third party content
+
+You may use and access content provided by third parties in your use of the Portal.
+
+Canonical is not responsible for any content provided by any third party. Should you reasonably believe that any third party content you access through the Service is in breach of any law, regulation or third party's rights, you should notify Canonical in writing at the address below. In doing so, please: (a) identify the material which you believe to be infringing; (b) identify what you believe this material infringes and why; (c) Provide your name, email address, address and telephone number; (d) confirm that you believe in good faith that this material is infringing a law or third party's rights and that, to the best of your knowledge, the information you are providing is correct; (e) identify if you are acting on behalf of the third party whose rights may have been infringed; and (f) provide your physical or electronic signature.
+
+### Licence
+
+To the extent that the Portal is not provided to you under an open source licence, Canonical grants to you a world-wide, non-exclusive, non-transferable licence for so long as we provide access to the Portal, to use Canonical’s intellectual property rights in the Portal (“**Licensed IP**”) in accordance with these Terms of Service. You may not use, copy, modify, disassemble, decompile, reverse engineer, or distribute the Licensed IP except as expressly permitted in these Terms of Service, or permit access to the Licensed IP to any third party other than those acting on your behalf except as expressly permitted in these Terms of Service.
+
+## 5. Personal data
+
+In order to access and use the Portal, you will be required to provide information about yourself such as your name and email address, as well as optional information such, timezone, country, IP address and related information. Any such information you provide to Canonical must always be accurate, correct and up to date. We may also ask you to participate in Portal related surveys, for feedback purposes. Participating in surveys is optional.
+
+Our <a href="/legal/data-privacy">Privacy Policy</a> and <a href="/legal/data-privacy/support-portal">Support Portal Privacy Notice</a> explain how we treat your personal data and protect your privacy when using our services. Canonical may need to provide limited personal data, such as your name and email address, to third parties for the purposes of providing you with access to the Portal. By accessing and using the Portal you are agreeing to the use of your personal data in this way.
+
+We may also collect certain non-personally-identifiable information, which is located on your computer. The information collected may include statistics relating to how often data is transferred, and performance metrics in relation to software and configuration. You agree this information may be retained and used by Canonical.
+
+Canonical may disclose any or all personal data and contents you have sent, posted or published if required to comply with applicable law or the order or requirement of a court, administrative agency or other governmental body. All other use of your personal data is subject to the Privacy Policy and applicable Privacy Notice.
+
+## 6. Liability
+
+Your use of the Portal is at your sole risk. The Portal is provided on an “as is” and “as available” basis without warranty of any kind, other than as expressly set out in these Terms of Service. All warranties (whether express, implied, statutory or otherwise) in respect of the Portal are expressly excluded to the maximum extent permitted by law.
+
+Canonical will provide the Portal with reasonable care and skill, and Canonical will use reasonable efforts to ensure the availability of the Portal, but makes no guarantee that the Portal will be available without interruption or will be error-free.
+
+In the case of third party content, you acknowledge that such content is provided to you by the relevant third party pursuant to the relevant terms and conditions and Canonical will have no liability whatsoever in contract, tort or otherwise to you in respect of such content.
+
+Canonical will not be liable in contract, tort or otherwise for any: indirect or consequential loss; loss of profits; loss of revenue; loss of anticipated savings; loss of business or business opportunity; loss of goodwill; or loss of or corruption to data. Otherwise, Canonical’s total liability in contract, tort or otherwise for any claims is limited to £100.
+
+Nothing in these Terms of Service will exclude or limit Canonical’s liability for: death or personal injury caused by the negligence of Canonical; fraud or fraudulent misrepresentation; or any other liability that cannot be excluded or limited by law.
+
+## 7. General
+
+These Terms of Service are governed by the laws of England and any dispute will be heard by the courts in England.
+
+Failure by Canonical to enforce any right or provision of these Terms of Service shall not constitute a waiver of such right or provision. If any part of these Terms of Service is held invalid or unenforceable, that part will be construed to reflect the parties original intent, and the remaining portions will remain in full force and effect. The terms of these Terms of Service do not affect your statutory rights.
+
+Any notices should be sent by registered post to:
+
+<div style="margin: 2rem;">
+  <p>
+    Canonical Group Limited,<br />
+    St Dunstans House<br />
+    4th floor, 201 Borough High St<br />
+    London SE1 1JA<br />
+    United Kingdom<br />
+  </p>
+</div>


### PR DESCRIPTION
## Done

- Add a Data Privacy and a Terms and Policies pages for Support Portal according to the following copy docs:
   - https://docs.google.com/document/d/1x8vH0dabSF7en7KenZKKDlugFHjbKwtdonuKPbQUDiM/edit
   - https://docs.google.com/document/d/1AlOE2_-BqZNP4hiiuf8kZney8g1zvqAlDYl2u3X6m6I/edit
   - https://docs.google.com/document/d/1ugZ-7R6qSYSKjofiPicy444c5zXho81J3Z_f-hpCcZc/edit
   - https://docs.google.com/document/d/1p3ZWroZ3nkw8XJJdPvPxSlWGYcLZLT8UbUVuppBcyHk/edit

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Navigate to https://ubuntu-com-13426.demos.haus/legal/data-privacy and check if it has a new link that takes to Support Portal Data Privacy page.
    - Check the content of a new page at https://ubuntu-com-13426.demos.haus/legal/data-privacy/support-portal
- Navigate to https://ubuntu-com-13426.demos.haus/legal/terms-and-policies and check if it has a new link that takes to Support Portal Terms and Policies page.
    - Check the content of a new page at https://ubuntu-com-13426.demos.haus/legal/terms-and-policies/support-portal

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-7913

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
