### PR TITLE
Fix alignment on bubble and remove black box on mobile

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,5 @@ django-openid-auth==0.17
 time-machine==2.9.0
 filelock==3.12.0
 bleach==6.0.0
+numpy==1.24.4
+python-slugify==8.0.1

--- a/static/js/src/core.js
+++ b/static/js/src/core.js
@@ -1,13 +1,6 @@
 import { cookiePolicy } from "@canonical/cookie-policy";
 import { createNav } from "@canonical/global-nav";
 
-// Initalise the global navigation.
-createNav({
-  showLogins: false,
-  hiring: "https://canonical.com/careers/start",
-  maxWidth: "80rem",
-});
-
 // Initalise the cookie policy notification.
 cookiePolicy();
 

--- a/static/sass/_pattern_navigation-dropdown.scss
+++ b/static/sass/_pattern_navigation-dropdown.scss
@@ -114,7 +114,7 @@
 
   .dropdown-window__main-panel,
   .dropdown-window__side-panel {
-    margin: 2.5rem 0;
+    margin: 2.5rem 0 2.5rem -.25rem;
 
     .p-muted-heading {
       color: rgba(255, 255, 255, 0.6);

--- a/static/sass/_pattern_navigation-dropdown.scss
+++ b/static/sass/_pattern_navigation-dropdown.scss
@@ -114,7 +114,7 @@
 
   .dropdown-window__main-panel,
   .dropdown-window__side-panel {
-    margin: 2.5rem 0 2.5rem -0.25rem;
+    margin: 2.5rem 0 2.5rem -0.5rem;
 
     .p-muted-heading {
       color: rgba(255, 255, 255, 0.6);

--- a/static/sass/_pattern_navigation-dropdown.scss
+++ b/static/sass/_pattern_navigation-dropdown.scss
@@ -114,7 +114,7 @@
 
   .dropdown-window__main-panel,
   .dropdown-window__side-panel {
-    margin: 2.5rem 0 2.5rem -.25rem;
+    margin: 2.5rem 0 2.5rem -0.25rem;
 
     .p-muted-heading {
       color: rgba(255, 255, 255, 0.6);

--- a/static/sass/_pattern_navigation-dropdown.scss
+++ b/static/sass/_pattern_navigation-dropdown.scss
@@ -86,8 +86,8 @@
           display: none;
         }
 
-        &.js-tab.is-active {
-          background-color: #2d2d2d;
+        &.is-active {
+          background: #2d2d2d;
         }
       }
 

--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -29,7 +29,7 @@ $meganav-height: 3rem;
     }
 
     .global-nav__link {
-      color: 69;
+      color: #69c
     }
   }
 
@@ -639,7 +639,7 @@ $meganav-height: 3rem;
     overflow-x: unset !important;
 
     h2 {
-      color: #f7f7f7;
+      color: $color-light;
       padding-left: 1.5rem;
     }
 

--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -29,7 +29,7 @@ $meganav-height: 3rem;
     }
 
     .global-nav__link {
-      color: #69c
+      color: #69c;
     }
   }
 

--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -43,7 +43,6 @@ $meganav-height: 3rem;
     }
 
     .p-navigation__nav {
-      margin-left: -2rem;
       margin-right: 0;
       max-height: calc(100vh - 3rem);
       width: auto;
@@ -187,6 +186,10 @@ $meganav-height: 3rem;
 
         &[aria-hidden="false"] {
           overflow: unset;
+        }
+
+        &::before {
+          box-shadow: none;
         }
       }
 
@@ -417,15 +420,15 @@ $meganav-height: 3rem;
       }
     }
 
-    button.p-navigation__link.js-menu-button {
-      padding-left: 1rem;
-      padding-right: 1rem;
-    }
-
     .p-navigation__item {
       .p-navigation__link {
         color: $color-mid-light;
       }
+
+      .js-menu-button.p-navigation__link {
+        padding-left: 1rem;
+        padding-right: 1rem;
+      }  
     }
 
     .p-navigation__link--search-toggle {
@@ -555,10 +558,6 @@ $meganav-height: 3rem;
     position: sticky;
     top: 0;
     z-index: 10;
-
-    .p-navigation__nav {
-      margin-left: -2rem;
-    }
 
     .p-navigation__nav.is-open {
       display: flex;

--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -44,6 +44,7 @@ $meganav-height: 3rem;
 
     .p-navigation__nav {
       margin-right: 0;
+      margin-left: -.75rem;
       max-height: calc(100vh - 3rem);
       width: auto;
 
@@ -568,22 +569,26 @@ $meganav-height: 3rem;
     top: 0;
     z-index: 10;
 
-    .p-navigation__nav.is-open {
-      display: flex;
+    .p-navigation__nav {
+      margin-left: -.75rem;
 
-      .p-navigation__items {
-        display: block;
-      }
+      &.is-open {
+        display: flex;
 
-      .p-navigation__link {
-        padding-left: calc(1rem + $row-margin-medium);
-
-        @media (max-width: $breakpoint-medium) {
-          padding-left: calc(1rem + $row-margin-small);
+        .p-navigation__items {
+          display: block;
         }
 
-        &::before {
-          left: $row-margin-small;
+        .p-navigation__link {
+          padding-left: calc(1rem + $row-margin-medium);
+
+          @media (max-width: $breakpoint-medium) {
+            padding-left: calc(1rem + $row-margin-small);
+          }
+
+          &::before {
+            left: $row-margin-small;
+          }
         }
       }
     }

--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -43,8 +43,8 @@ $meganav-height: 3rem;
     }
 
     .p-navigation__nav {
+      margin-left: -0.75rem;
       margin-right: 0;
-      margin-left: -.75rem;
       max-height: calc(100vh - 3rem);
       width: auto;
 
@@ -433,7 +433,7 @@ $meganav-height: 3rem;
       .js-menu-button.p-navigation__link {
         padding-left: 1rem;
         padding-right: 1rem;
-      }  
+      }
     }
 
     .p-navigation__link--search-toggle {
@@ -446,8 +446,8 @@ $meganav-height: 3rem;
 
       &::after {
         color: $color-mid-light;
-        top: 1rem;
         right: 1rem;
+        top: 1rem;
       }
     }
 
@@ -570,7 +570,7 @@ $meganav-height: 3rem;
     z-index: 10;
 
     .p-navigation__nav {
-      margin-left: -.75rem;
+      margin-left: -0.75rem;
 
       &.is-open {
         display: flex;

--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -400,6 +400,10 @@ $meganav-height: 3rem;
       .p-navigation__link {
         padding-left: 0;
         padding-top: 0.5rem;
+
+        @media (max-width: $breakpoint-navigation-threshold) {
+          padding-top: 0.75rem;
+        }
       }
     }
 
@@ -435,9 +439,14 @@ $meganav-height: 3rem;
       padding-bottom: 0.5rem;
       padding-top: 0.5rem;
 
+      @media (max-width: $breakpoint-large) {
+        padding-right: 3rem;
+      }
+
       &::after {
         color: $color-mid-light;
-        top: 0.75rem;
+        top: 1rem;
+        right: 1rem;
       }
     }
 

--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -43,7 +43,7 @@ $meganav-height: 3rem;
     }
 
     .p-navigation__nav {
-      margin-left: -0.75rem;
+      margin-left: -1rem;
       margin-right: 0;
       max-height: calc(100vh - 3rem);
       width: auto;
@@ -570,7 +570,7 @@ $meganav-height: 3rem;
     z-index: 10;
 
     .p-navigation__nav {
-      margin-left: -0.75rem;
+      margin-left: -1rem;
 
       &.is-open {
         display: flex;


### PR DESCRIPTION
## Done

These are the issues that have been fixed:

Two other visual bugs:

The padding of the menu button needs to be adjusted in bubbles on mobile, should match that of "Canonical Ubuntu" next to it. (Please check that whatever you do here doesn't affect the button on the home, which has different padding)
![image](https://github.com/canonical/ubuntu.com/assets/58276363/854d153b-2e19-4c02-992c-9442a34361be)


There's an alignment issue between navigation and the third column in rebranded pages. This looks OK in the [/data bubble](https://canonical.com/data) and [microk8s.io](https://microk8s.io/). In the example below, "Products" and "Your subscriptions" should align with "Ubuntu Pro" in the hero; see how it does in the Data bubble below that.
![image](https://github.com/canonical/ubuntu.com/assets/58276363/7711d5aa-04e3-4cca-b59c-7d7e50aa1123)


Little visual bug on mobile
I noticed a visual bug persists on mobile: see the darker rectangle.

![image](https://github.com/canonical/ubuntu.com/assets/58276363/3077757b-d1b7-493f-8041-18ba724b0186)


## QA

- Check out this feature branch and see that the above issues are fixed
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-8038
