### PR TITLE
WD-8006 - update link in /ai/roadshow

### DIFF
--- a/templates/ai/roadshow.html
+++ b/templates/ai/roadshow.html
@@ -21,8 +21,8 @@
         <p class="p-heading--5">How enterprises are using generative AI with open source</p>
         <p>From the USA to the Netherlands, from UAE to Mexico, Canonical experts are going on an AI roadshow across the globe. We are ready to showcase LLMs applications and predictive analytics use cases across various industries. Get answers to your most common AI/ML questions and talk to our team about big data, MLOps and generative AI use cases with open source.</p>
         <p>
-          <a href="#find-us" class="p-button--positive">Check where to find us</a>
-          <a href="https://calendly.com/andreea-munteanu-1/canonical-ai-roadshow" class="p-button">Book a meeting</a>
+          <a href="/blog/highlights-canonical-ai-roadshow-2023" class="p-button--positive">Read the roadshow highlights</a>
+          <a href="/ai#get-in-touch" class="p-button">Get in touch</a>
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Done

Update link and text in [roadshow](https://ubuntu-com-13429.demos.haus/ai/roadshow) page

## QA

- [demo link](https://ubuntu-com-13429.demos.haus/)
- [copy doc](https://docs.google.com/document/d/1CA0GUU6yRB65yfDaKi1dgN8DED2bDAFI2h-swSVtMtg/edit)
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check that links and text are correct according to copy doc

## Issue / Card
[WD-8006](https://warthogs.atlassian.net/browse/WD-8006)

Fixes #

## Screenshots


[WD-8006]: https://warthogs.atlassian.net/browse/WD-8006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ