### PR TITLE
Playwright Test - Checkout show correct VAT

### DIFF
--- a/tests/playwright/tests/pro/checkout.spec.ts
+++ b/tests/playwright/tests/pro/checkout.spec.ts
@@ -41,4 +41,42 @@ test.describe("Checkout - Region and taxes", () => {
     expect(await page.$('[data-testid="total"]')).toBeNull();
     expect(await page.$('[data-testid="tax"]')).toBeNull();
   })
+
+  test("It should show correct VAT price", async ({page}) => {
+    await page.goto("/pro/subscribe")
+    await acceptCookiePolicy(page)
+    await selectProducts(page);
+    await page.getByRole("button", { name: "Buy now" }).click();
+
+    await login(page);
+    
+    await page.route(ENDPOINTS.customerInfo,  async (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({...customerInfoResponse, "customerInfo": {...customerInfoResponse.customerInfo, "address": {...customerInfoResponse.customerInfo.address, "country": "FR" }}})
+      });
+    });
+
+    await page.route(ENDPOINTS.preview,  async (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({...previewResponse,  "tax_amount": 4500, "total": 49500})
+      });
+    });
+   
+    await page.locator(
+      ":nth-child(1) > .p-stepped-list__content > .row > .u-align--right > .p-action-button"
+    ).click(); // Click "Edit" button
+    await page.getByLabel("Country/Region:").selectOption({ label: 'France' })
+    await page.locator(".u-align--right > :nth-child(2)").click(); // Click "Save" button
+
+    const country = await page.$('[data-testid="country"]')
+    const countryText = await country?.innerText();
+
+    expect(countryText).toBe("France")
+    expect( page.locator('[data-testid="total"]')).toBeVisible()
+    expect( page.locator('[data-testid="tax"]')).toBeVisible()
+  })
 })


### PR DESCRIPTION
## Done
- This test can be running only locally. 
- Test to show correct VAT when country changes

## QA
how to run tests locally
- Save [this credentials](https://pastebin.canonical.com/p/m3PyRkf38P/) in `.env.local`
- Go to `playwright.config.ts` and comment out `testIgnore: '**\/pro/**',`
- Command `dotrun`
- Command `yarn playwright test /tests/playwright/tests/pro/checkout.spec.ts --ui ` or `yarn playwright test /tests/playwright/tests/pro/checkout.spec.ts` (`yarn playwright test` if you want to run all the playwright tests)
- Check tests pass locally

## Issue / Card

Fixes #https://warthogs.atlassian.net/browse/WD-8053