### PR TITLE
Fix typo in MLOps datasheet link

### DIFF
--- a/templates/ai/index.html
+++ b/templates/ai/index.html
@@ -511,7 +511,7 @@
           </div>
           <hr class="p-rule">
           <p>
-            <a href="https://pages.ubuntu.com/rs/066-EOV-335/images/Charmed Kubeflow - Digital.pdf">Get the Managed MLOpsdatasheet&nbsp;&rsaquo;</a>
+            <a href="https://pages.ubuntu.com/rs/066-EOV-335/images/Charmed Kubeflow%20-%20Digital.pdf">Get the Managed MLOps datasheet&nbsp;&rsaquo;</a>
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Done

- Add a space to the link text
- Encoded the spaces in the URL

## QA

- Check this change fixes this request: https://docs.google.com/document/d/1HP9YdHF11yVQ9SLl0VXhLezDZREsr1GHIKNi9wT1Gv0/edit?usp=drivesdk&disco=AAABDo70EZw