### PR TITLE
[WD-8072] change EOL date for Openstack 2023.2 to July 2024

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -1172,7 +1172,7 @@ export var openStackReleases = [
   },
   {
     startDate: new Date("2023-10-01T00:00:00"),
-    endDate: new Date("2025-04-01T00:00:00"),
+    endDate: new Date("2024-07-01T00:00:00"),
     taskName: "OpenStack 2023.2",
     status: "MATCHING_OPENSTACK_RELEASE_SUPPORT",
   },

--- a/templates/about/release_cycles/openstack-eol.html
+++ b/templates/about/release_cycles/openstack-eol.html
@@ -24,7 +24,7 @@
           <td>OpenStack 2023.2</td>
           <td>&nbsp;</td>
           <td>Oct 2023</td>
-          <td>Apr 2025</td>
+          <td>Jul 2024</td>
           <td>&nbsp;</td>
         </tr>
         <tr>


### PR DESCRIPTION
## Done

- Changed EOL date for Openstack 2023.2 from April 2025 to July 2024

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check that End of Life date for Openstack 2023.2 is changed to July 2024 both in the chart and in the table (on small screens). The page URL is https://ubuntu-com-13437.demos.haus/about/release-cycle#openstack-release-cycle

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-8072

## Screenshots

![Screenshot 2024-01-05 at 12 31 36](https://github.com/canonical/ubuntu.com/assets/15943863/adec0e07-5b5f-4fff-ab16-9607990d29c6)
![Screenshot 2024-01-05 at 12 31 47](https://github.com/canonical/ubuntu.com/assets/15943863/a9784e96-6c77-4557-821e-614f16a69110)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
