### PR TITLE
Wd 8076 add magic attach code as query param in pro attach

### DIFF
--- a/templates/pro/attach/index.html
+++ b/templates/pro/attach/index.html
@@ -23,7 +23,7 @@
                         <div class="col-8">
                             <div class="p-form__control u-clearfix">
                                 <input class="p-form-validation__input" type="text" aria-invalid="false"
-                                    id="magic-attach-code" name="userCode" maxlength="6"
+                                    id="magic-attach-code" name="userCode" maxlength="6" value="{{ magic_attach_code }}"
                                     label="Enter the code displayed in your installation">
                             </div>
                         </div>

--- a/webapp/shop/advantage/views.py
+++ b/webapp/shop/advantage/views.py
@@ -647,10 +647,11 @@ def activate_magic_attach(advantage_mapper, **kwargs):
 
 
 @shop_decorator(area="advantage", permission="user", response="html")
-@use_kwargs({"email": String(), "subscription": String()}, location="query")
+@use_kwargs({"email": String(), "subscription": String(), "magic-attach-code": String()}, location="query")
 def magic_attach_view(advantage_mapper: AdvantageMapper, **kwargs):
     email = kwargs.get("email")
     selected_id = kwargs.get("subscription")
+    magic_attach_code = kwargs.get("magic-attach-code")
 
     user_subscriptions = advantage_mapper.get_user_subscriptions(
         email=email, marketplaces=["canonical-ua"]
@@ -660,6 +661,7 @@ def magic_attach_view(advantage_mapper: AdvantageMapper, **kwargs):
         "pro/attach/index.html",
         subscriptions=user_subscriptions,
         selected_id=selected_id,
+        magic_attach_code = magic_attach_code,
     )
 
 

--- a/webapp/shop/advantage/views.py
+++ b/webapp/shop/advantage/views.py
@@ -647,11 +647,18 @@ def activate_magic_attach(advantage_mapper, **kwargs):
 
 
 @shop_decorator(area="advantage", permission="user", response="html")
-@use_kwargs({"email": String(), "subscription": String(), "magic-attach-code": String()}, location="query")
+@use_kwargs(
+    {
+        "email": String(),
+        "subscription": String(),
+        "magic-attach-code": String(),
+    },
+    location="query",
+)
 def magic_attach_view(advantage_mapper: AdvantageMapper, **kwargs):
     email = kwargs.get("email")
     selected_id = kwargs.get("subscription")
-    magic_attach_code = kwargs.get("magic-attach-code")
+    magic_attach_code = kwargs.get("magic-attach-code", "")
 
     user_subscriptions = advantage_mapper.get_user_subscriptions(
         email=email, marketplaces=["canonical-ua"]
@@ -661,7 +668,7 @@ def magic_attach_view(advantage_mapper: AdvantageMapper, **kwargs):
         "pro/attach/index.html",
         subscriptions=user_subscriptions,
         selected_id=selected_id,
-        magic_attach_code = magic_attach_code,
+        magic_attach_code=magic_attach_code,
     )
 
 


### PR DESCRIPTION
## Done

- Added magic-attach-code as query param for /pro/attach

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Visit /pro/attach?magic-attach-code=<some code>
- Also ensure it works with default subscription selected

## Issue / Card

Fixes [#WD-8076](https://warthogs.atlassian.net/browse/WD-8076)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
