### PR TITLE
Limit width of list items

### DIFF
--- a/templates/engage/base.html
+++ b/templates/engage/base.html
@@ -86,7 +86,7 @@
   {% endif %}
 {% endif %}
 
-<section class="p-strip is-shallow is-bordered">
+<section class="p-strip is-shallow is-bordered u-text-max-width">
   <div class="row">
     <div class="{% if 'form_id' in metadata and metadata['form_id'] != '' %}col-7{% else %}col-12{% endif %}">
       {{ metadata["body_html"] | safe }}


### PR DESCRIPTION
## Done

TL:DR;
Make paragraphs full width. Following [this discussion](https://chat.canonical.com/canonical/pl/77oyc3561ff5um3gjuiksgyash)

## Reasoning/Argument behind this task
We already have the option to take [full width in Vanilla](https://vanillaframework.io/docs/base/typography#line-length) so design-wise this is ok to do, also the lists already take the full width, so there is no point keeping the 40em default width for paragraphs only, both stakeholders and I agree that it looks like a lot of useless space on the right, when there is no form. But in the case of engage pages, because the paragraphs are generated in Discourse, I can't add the classname to every single `p`. So I extended the same classname for wide use in engage pages. I'm all ears if you can think of a better option.

## QA

- Check an engage page that doesn't have a form on the right side e.g. https://ubuntu-com-13439.demos.haus/engage/simplifying-mongodb-operations
- The text should expand full width.
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-7419

## Screenshots

<img width="1508" alt="Screenshot 2024-01-05 at 16 58 03" src="https://github.com/canonical/ubuntu.com/assets/14939793/f719cf89-6154-4c18-bd83-b947abb9dbc5">



## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
