### PR TITLE
[WD-8132] bring back accidentally removed /legal/ubuntu-pro page

### DIFF
--- a/templates/legal/ubuntu-pro/index.html
+++ b/templates/legal/ubuntu-pro/index.html
@@ -1,0 +1,69 @@
+{% extends "legal/_base_legal.html" %}
+
+{% block title %}Ubuntu Pro service description{% endblock %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1p-xlkejIG5ZZhOfGrYnq6rmIpTpaX46yW4HArDtPX1s/edit
+{% endblock meta_copydoc %}
+
+{% block content %}
+<section class="p-strip">
+  <div class="row">
+    <div class="col-8">
+      <h1>Ubuntu Pro</h1>
+      <p><a href="/pro">Ubuntu Pro</a> is Canonical's service package for Ubuntu. It offers tiered levels of support for
+        desktop, server and cloud deployments. In this section, you can see our service description, but don't forget
+        that there will still be some details in your customer agreement that are specific to your deployment.</p>
+      <p>If you're interested in support for an Ubuntu deployment or you're a reseller and you want to offer it to your
+        customers, you can <a href="/pro">learn more about Ubuntu Pro here</a>.</p>
+    </div>
+    <div class="col-4">
+      <div class="u-align--center">
+        {{
+        image(
+        url="https://assets.ubuntu.com/v1/4e72de34-image-document-ubuntuassurance.svg",
+        alt="Ubuntu Pro",
+        width="166",
+        height="200",
+        hi_def=True,
+        loading="auto",
+        attrs={"class": "u-hide--small"},
+        ) | safe
+        }}
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="row u-equal-height">
+    <div class="col-6 p-card">
+      <h3>Ubuntu Pro service description</h3>
+      <p>This describes the services we provide to our Ubuntu Pro customers. It mentions several Canonical products, but
+        please note that we can only provide services for the products listed in your customer agreement.</p>
+      <p><a href="https://assets.ubuntu.com/v1/c7468163-Ubuntu%20Pro%20description%2014.12.23.pdf">View the Ubuntu Pro
+          service description&nbsp;&rsaquo;</a></p>
+    </div>
+    <div class="col-6 p-card">
+      <h3>Ubuntu Assurance</h3>
+      <p>The Ubuntu Pro Assurance Programme provides indemnification from Canonical against claims of intellectual
+        property infringement support customers might face as a result of using Ubuntu. This agreement is part of all
+        Canonical support contracts.
+      </p>
+      <p><a href="/legal/ubuntu-pro-assurance">View Ubuntu Pro Assurance&nbsp;&rsaquo;</a></p>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-6 p-card">
+      <h3>Ubuntu Pro terms</h3>
+      <p>This agreement sets out Canonical's standard service terms for Ubuntu Pro customers.</p>
+      <p><a href="/legal/ubuntu-pro-service-terms">View the Ubuntu Pro service terms&nbsp;&rsaquo;</a></p>
+    </div>
+    <div class="col-6 p-card">
+      <h3>Ubuntu Pro Personal terms</h3>
+      <p>The terms of service of the free personal use of Ubuntu Pro on up to 5 machines</p>
+      <p><a href="/legal/ubuntu-pro/personal">View the Ubuntu Pro Personal service terms&nbsp;&rsaquo;</a></p>
+    </div>
+  </div>
+</section>
+
+{% endblock content %}


### PR DESCRIPTION
## Done

- Bring back accidentally removed /legal/ubuntu-pro page

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check if a page at /legal/ubuntu-pro exists and opens fine

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-8132

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
