### PR TITLE
Adds keyboard trapping for mobile

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,5 @@ django-openid-auth==0.17
 time-machine==2.9.0
 filelock==3.12.0
 bleach==6.0.0
+numpy==1.24.4
+python-slugify==8.0.1

--- a/static/js/src/core.js
+++ b/static/js/src/core.js
@@ -1,13 +1,6 @@
 import { cookiePolicy } from "@canonical/cookie-policy";
 import { createNav } from "@canonical/global-nav";
 
-// Initalise the global navigation.
-createNav({
-  showLogins: false,
-  hiring: "https://canonical.com/careers/start",
-  maxWidth: "80rem",
-});
-
 // Initalise the cookie policy notification.
 cookiePolicy();
 

--- a/static/js/src/navigation.js
+++ b/static/js/src/navigation.js
@@ -443,17 +443,13 @@ function handleTabKey(e) {
   // Find which dropdown container we are in
   const dropdownPanel = getContainingDropdown(e.target);
   const mobileDropdownPanel = getMobileContainingDropdown(e.target);
-  console.log("in handle tab key", "dropdown panel", dropdownPanel)
-console.log("is last link", isLastLinkFocused(e, dropdownPanel))
   if (mobileDropdownPanel && isLastMobileLinkFocused(e, mobileDropdownPanel)) {
-    console.log("is last mobile link")
     e.preventDefault();
     const canonicalLogo = navigation.querySelector(
       ".p-navigation__tagged-logo > a"
     );
     canonicalLogo.focus();
   } else if (dropdownPanel && isLastLinkFocused(e, dropdownPanel)) {
-    console.log("lsat link etc etc")
     const currDropdownToggle = mainList.querySelector(
       ":scope > .p-navigation__item--dropdown-toggle.is-active"
     );
@@ -485,7 +481,6 @@ function handleShiftTabKey(e) {
 
 function isLastLinkFocused(e, dropdownPanel) {
   const listOfLinks = dropdownPanel?.querySelectorAll("a");
-  console.log("list of links", listOfLinks)
   if (listOfLinks?.length > 0) {
     const lastLink = Array.from(listOfLinks).pop();
     return e.target === lastLink;

--- a/static/js/src/navigation.js
+++ b/static/js/src/navigation.js
@@ -443,14 +443,17 @@ function handleTabKey(e) {
   // Find which dropdown container we are in
   const dropdownPanel = getContainingDropdown(e.target);
   const mobileDropdownPanel = getMobileContainingDropdown(e.target);
-
+  console.log("in handle tab key", "dropdown panel", dropdownPanel)
+console.log("is last link", isLastLinkFocused(e, dropdownPanel))
   if (mobileDropdownPanel && isLastMobileLinkFocused(e, mobileDropdownPanel)) {
+    console.log("is last mobile link")
     e.preventDefault();
     const canonicalLogo = navigation.querySelector(
       ".p-navigation__tagged-logo > a"
     );
     canonicalLogo.focus();
   } else if (dropdownPanel && isLastLinkFocused(e, dropdownPanel)) {
+    console.log("lsat link etc etc")
     const currDropdownToggle = mainList.querySelector(
       ":scope > .p-navigation__item--dropdown-toggle.is-active"
     );
@@ -482,6 +485,7 @@ function handleShiftTabKey(e) {
 
 function isLastLinkFocused(e, dropdownPanel) {
   const listOfLinks = dropdownPanel?.querySelectorAll("a");
+  console.log("list of links", listOfLinks)
   if (listOfLinks?.length > 0) {
     const lastLink = Array.from(listOfLinks).pop();
     return e.target === lastLink;
@@ -517,7 +521,7 @@ function isFirstLinkFocused(e, dropdownPanel) {
 
 function getContainingDropdown(target) {
   return (
-    target.closest(".dropdown-window__sidenav-content.is-active") ||
+    target.closest(".dropdown-window__sidenav-content") ||
     target.closest(".dropdown-window__content") ||
     target.closest(".global-nav-dropdown__content")
   );

--- a/static/js/src/navigation.js
+++ b/static/js/src/navigation.js
@@ -144,7 +144,7 @@ function goBackOneLevel(e, backButton) {
   }
 }
 
-function keyPressHandler(e) {
+function escKeyPressHandler(e) {
   if (e.key === "Escape") {
     closeAll();
   }
@@ -365,8 +365,12 @@ function setTabIndex(target) {
     });
   });
 
-  target.querySelectorAll("li").forEach((element) => {
-    if (element.parentNode === target || element.parentNode.parentNode === target) {
+  const targetLiItems = target.querySelectorAll("li");
+  targetLiItems.forEach((element, index) => {
+    if (
+      element.parentNode === target ||
+      element.parentNode.parentNode === target
+    ) {
       element.children[0].setAttribute("tabindex", "0");
     }
   });
@@ -388,6 +392,9 @@ function setTabIndex(target) {
   }
 }
 
+/** 
+  Setup functions for keyboard navigation and trapping
+*/
 function addKeyboardEvents() {
   document.addEventListener("keydown", keyboardNavigationHandler);
 }
@@ -433,8 +440,17 @@ function handleEscapeKey(e) {
 }
 
 function handleTabKey(e) {
+  // Find which dropdown container we are in
   const dropdownPanel = getContainingDropdown(e.target);
-  if (dropdownPanel && isLastLinkFocused(e, dropdownPanel)) {
+  const mobileDropdownPanel = getMobileContainingDropdown(e.target);
+
+  if (mobileDropdownPanel && isLastMobileLinkFocused(e, mobileDropdownPanel)) {
+    e.preventDefault();
+    const canonicalLogo = navigation.querySelector(
+      ".p-navigation__tagged-logo > a"
+    );
+    canonicalLogo.focus();
+  } else if (dropdownPanel && isLastLinkFocused(e, dropdownPanel)) {
     const currDropdownToggle = mainList.querySelector(
       ":scope > .p-navigation__item--dropdown-toggle.is-active"
     );
@@ -466,15 +482,34 @@ function handleShiftTabKey(e) {
 
 function isLastLinkFocused(e, dropdownPanel) {
   const listOfLinks = dropdownPanel?.querySelectorAll("a");
-  if (listOfLinks) {
+  if (listOfLinks?.length > 0) {
     const lastLink = Array.from(listOfLinks).pop();
     return e.target === lastLink;
   }
 }
 
+function isLastMobileLinkFocused(e, dropdownPanel) {
+  // Find what level of the navigation we are in, 'menuItems' being the top level
+  const listOfMenuItems = dropdownPanel?.querySelectorAll(
+    "li[role='menuitem']"
+  );
+  const listOfLinks = Array.from(
+    dropdownPanel?.querySelectorAll(":scope > li")
+  );
+  if (listOfMenuItems?.length > 0) {
+    const lastLink = Array.from(listOfMenuItems).pop();
+    return e.target === lastLink.firstElementChild;
+  } else if (listOfLinks?.length > 0) {
+    // Sometimes there is a secondary list of links, so we need to add those to the list
+    appendSecondaryListItems(dropdownPanel, listOfLinks);
+    const lastLink = Array.from(listOfLinks).pop();
+    return e.target === lastLink.firstElementChild;
+  }
+}
+
 function isFirstLinkFocused(e, dropdownPanel) {
   const listOfLinks = dropdownPanel?.querySelectorAll("a");
-  if (listOfLinks) {
+  if (listOfLinks?.length > 0) {
     const firstLink = Array.from(listOfLinks).shift();
     return e.target === firstLink;
   }
@@ -488,6 +523,13 @@ function getContainingDropdown(target) {
   );
 }
 
+function getMobileContainingDropdown(target) {
+  return (
+    target.closest(".p-navigation__dropdown") ||
+    target.closest(".p-navigation__nav >  .p-navigation__items")
+  );
+}
+
 function isInTabPanel(target) {
   return target.closest(".dropdown-window__tab-panel") ? true : false;
 }
@@ -497,6 +539,19 @@ function tabPanelExists(target) {
   return parentContainer?.querySelector(".dropdown-window__tab-panel")
     ? true
     : false;
+}
+
+function appendSecondaryListItems(dropdownPanel, listOfLinks) {
+  const secondaryList = [
+    ...(dropdownPanel
+      .querySelector(":scope > .p-navigation__secondary-links")
+      ?.querySelectorAll("li") || []),
+  ];
+  if (secondaryList?.length > 0) {
+    secondaryList.forEach((listItem) => {
+      listOfLinks.push(listItem);
+    });
+  }
 }
 
 function toggleMenu(e) {
@@ -516,7 +571,8 @@ function closeNav() {
   });
   closeMobileDropdown();
   closeDesktopDropdown();
-  document.removeEventListener("keyup", keyPressHandler);
+  removeKeyboardEvents();
+  document.removeEventListener("keyup", escKeyPressHandler);
 }
 
 function closeDesktopDropdown() {
@@ -527,7 +583,6 @@ function closeDesktopDropdown() {
       dropdownContent.classList.add("u-hide");
     }
   });
-  removeKeyboardEvents();
 }
 
 function closeMobileDropdown() {
@@ -566,8 +621,9 @@ function openMenu(e) {
   });
 
   navigation.classList.add("has-menu-open");
-  document.addEventListener("keyup", keyPressHandler);
+  document.addEventListener("keyup", escKeyPressHandler);
   setTabIndex(mainList);
+  addKeyboardEvents();
 }
 
 // Setup and functions for navigation search
@@ -607,7 +663,7 @@ function openSearch(e) {
     addClassesToElements([secondaryNav], ["u-hide"]);
   }
   searchInput.focus();
-  document.addEventListener("keyup", keyPressHandler);
+  document.addEventListener("keyup", escKeyPressHandler);
 }
 
 function closeSearch() {
@@ -621,7 +677,7 @@ function closeSearch() {
     secondaryNav.classList.remove("u-hide");
   }
 
-  document.removeEventListener("keyup", keyPressHandler);
+  document.removeEventListener("keyup", escKeyPressHandler);
 }
 
 const searchButtons = document.querySelectorAll(".js-search-button");

--- a/static/js/src/navigation.js
+++ b/static/js/src/navigation.js
@@ -1,5 +1,5 @@
 const ANIMATION_DELAY = 200;
-const MOBILE_VIEW_BREAKPOINT = 1250;
+const MOBILE_VIEW_BREAKPOINT = 1281;
 const dropdownWindow = document.querySelector(".dropdown-window");
 const dropdownWindowOverlay = document.querySelector(
   ".dropdown-window-overlay"
@@ -112,7 +112,7 @@ function toggleSecondaryMobileNavDropdown(e) {
 function handleDropdownClick(clickedDropdown) {
   const isActive = clickedDropdown.classList.contains("is-active");
   updateNavMenu(clickedDropdown, !isActive);
-  setTabindex(clickedDropdown.querySelector("ul.p-navigation__dropdown"));
+  setTabIndex(clickedDropdown.querySelector("ul.p-navigation__dropdown"));
 }
 
 function updateUrlHash(id, open) {
@@ -137,7 +137,7 @@ function goBackOneLevel(e, backButton) {
   target.setAttribute("aria-hidden", true);
   toggleIsActiveState(backButton.closest(".is-active"), false);
   toggleIsActiveState(backButton.closest(".is-active"), false);
-  setTabindex(target.parentNode.parentNode);
+  setTabIndex(target.parentNode.parentNode);
 
   if (target.parentNode.getAttribute("role") == "menuitem") {
     updateNavMenu(target.parentNode, false);
@@ -356,7 +356,7 @@ function fetchDropdown(url, id) {
   @param {HTMLNode} target <ul class="p-navigation__items">
   or <ul class="p-navigation__dropdown">
 */
-function setTabindex(target) {
+function setTabIndex(target) {
   const lists = [...dropdowns, mainList];
   lists.forEach((list) => {
     const elements = list.querySelectorAll("ul > li > a, ul > li > button");
@@ -366,7 +366,7 @@ function setTabindex(target) {
   });
 
   target.querySelectorAll("li").forEach((element) => {
-    if (element.parentNode === target) {
+    if (element.parentNode === target || element.parentNode.parentNode === target) {
       element.children[0].setAttribute("tabindex", "0");
     }
   });
@@ -555,7 +555,7 @@ function closeAll() {
   closeSearch();
   closeNav();
   updateUrlHash();
-  setTabindex(mainList);
+  setTabIndex(mainList);
 }
 
 function openMenu(e) {
@@ -567,7 +567,7 @@ function openMenu(e) {
 
   navigation.classList.add("has-menu-open");
   document.addEventListener("keyup", keyPressHandler);
-  setTabindex(mainList);
+  setTabIndex(mainList);
 }
 
 // Setup and functions for navigation search

--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -97,7 +97,7 @@ $meganav-height: 3rem;
           }
 
           .p-muted-heading {
-            padding-left: calc(1.5rem + $row-margin-medium);
+            padding-left: 0 !important;
           }
         }
 
@@ -131,7 +131,7 @@ $meganav-height: 3rem;
           }
 
           .p-muted-heading {
-            padding-left: calc(1.5rem + $row-margin-small);
+            padding-left: 0 !important;
           }
         }
 
@@ -316,10 +316,14 @@ $meganav-height: 3rem;
         @extend .dropdown-window__side-panel;
 
         margin-top: 1.5rem;
-        padding-left: calc(1rem + $row-margin-medium) !important;
+        padding-left: calc(1.5rem + $row-margin-medium) !important;
 
         @media (max-width: $breakpoint-medium) {
           padding-left: calc(1rem + $row-margin-small) !important;
+        }
+        
+        a {
+          color: #69c;
         }
       }
     }

--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -11,7 +11,7 @@ $meganav-height: 3rem;
   }
 
   #all-canonical-content-mobile {
-    @media (min-width: $breakpoint-navigation-threshold - 1) {
+    @media (min-width: $breakpoint-navigation-threshold) {
       display: none;
     }
   }
@@ -81,6 +81,7 @@ $meganav-height: 3rem;
               content: none;
             }
           }
+
           .p-navigation__item--dropdown-toggle:first-of-type,
           .p-navigation__item--dropdown-close:first-of-type {
             > .p-navigation__link::before {
@@ -204,6 +205,21 @@ $meganav-height: 3rem;
         }
       }
 
+      .p-navigation__secondary-links {
+        @extend .dropdown-window__side-panel;
+
+        margin-top: 1.5rem;
+        padding-left: calc(1.5rem + $row-margin-medium) !important;
+
+        @media (max-width: $breakpoint-medium) {
+          padding-left: calc(1rem + $row-margin-small) !important;
+        }
+
+        a {
+          color: #69c;
+        }
+      }
+
       ul.p-navigation__dropdown {
         li.p-navigation__dropdown-item {
           line-height: 1.5rem;
@@ -309,21 +325,6 @@ $meganav-height: 3rem;
         @media (max-width: $breakpoint-navigation-threshold) {
           right: 1.5rem;
           top: 1rem;
-        }
-      }
-
-      .p-navigation__secondary-links {
-        @extend .dropdown-window__side-panel;
-
-        margin-top: 1.5rem;
-        padding-left: calc(1.5rem + $row-margin-medium) !important;
-
-        @media (max-width: $breakpoint-medium) {
-          padding-left: calc(1rem + $row-margin-small) !important;
-        }
-        
-        a {
-          color: #69c;
         }
       }
     }

--- a/templates/templates/meganav/base.html
+++ b/templates/templates/meganav/base.html
@@ -239,10 +239,9 @@
           {% endfor %}
         {% endfor %}
         {% if side_nav_section.secondary_links %}
-        <div class="p-navigation__secondary-links">
           {% for links_section in side_nav_section.secondary_links %}
-            <p class="p-muted-heading is-muted">{{ links_section.title }}</p>
-            <ul class="p-list">
+          <ul class="p-list p-navigation__secondary-links">
+              <p class="p-muted-heading is-muted">{{ links_section.title }}</p>
               {% for link in links_section.links %}
                 <li class="p-list__item">
                   <a class="dropdown-window__side-panel-link" href="{{ link.url }}">{{ link.title }}</a>
@@ -250,7 +249,6 @@
               {% endfor %}
             </ul>
           {% endfor %}
-        </div>
         {% endif %}
       </ul>
     </li>

--- a/templates/templates/meganav/base.html
+++ b/templates/templates/meganav/base.html
@@ -244,7 +244,7 @@
               <p class="p-muted-heading is-muted">{{ links_section.title }}</p>
               {% for link in links_section.links %}
                 <li class="p-list__item">
-                  <a class="dropdown-window__side-panel-link" href="{{ link.url }}">{{ link.title }}</a>
+                  <a class="dropdown-window__side-panel-link" href="{{ link.url }}" tabindex="-1">{{ link.title }}</a>
                 </li>
               {% endfor %}
             </ul>


### PR DESCRIPTION
## Done
This work addressed the following comments:

Keyboard navigation: focus after last link in dropdown
When we open, e.g., "Products", and then select a tab on the left sidebar, e.g. "Ubuntu OS", and then tab through all the links until the end, hitting tab after the last link on the right closes the dropdown and moves the focus to the next item on the top navigation (in this case "Use cases"). This is correct and the [intended behaviour](https://warthogs.atlassian.net/browse/WD-7516?focusedCommentId=349710).

However, when we open, e.g., "Products" and then tab through all the links without selecting a tab on the left sidebar, hitting tab after the last link on the right moves the focus past the whole navigation into the content, with the navigation remains open. The behaviour here should be exactly the same as above: it should close the dropdown and move focus to the next top level item, "Use cases" in this case.

Keyboard navigation on mobile
Also on keyboard navigation, Pete mentioned there was up a bug when tabbing on secondary links on mobile. I see indeed that focus seems to move to out of screen elements when tabbing through quick links there. E.g., under Products > Ubuntu OS, focus seems lost once you move past the Multipass link, instead of jumping to the first quick link (Upgrade Ubuntu).

## QA

- Check that the keyboard navigation works as described above

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-8037
