### PR TITLE
[WD-8151] fix broken links

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1028,3 +1028,6 @@ security/notices/(usn/)?(?P<usn_id>[\d]{4}-[\d]{1,2})/?: /security/notices/USN-{
 
 # Fix search results https://github.com/canonical/ubuntu.com/issues/12510
 pricing/desktops: "/pricing/desktop"
+
+# Documentation pages (coming from discourse)
+server/docs/virtualization-introduction: /server/docs/introduction-to-virtualization

--- a/templates/robotics/community.html
+++ b/templates/robotics/community.html
@@ -249,7 +249,7 @@
         <a class="p-button--positive" href="https://ubuntu.com/blog/topics/robotics">Learn more</a>
       </p>
       <p>
-        <a href="https://index.ros.org/doc/ros2/Governance/">More info about the TSC</a>
+        <a href="https://docs.ros.org/en/rolling/The-ROS2-Project/Governance.html">More info about the TSC</a>
       </p>
     </div>
     <div class="col-5 u-vertically-center u-hide--medium u-hide--small u-align--center">

--- a/webapp/context.py
+++ b/webapp/context.py
@@ -159,5 +159,6 @@ def date_has_passed(date_str):
 
 def sort_by_key_and_ordered_list(list_to_sort, obj_key, ordered_list):
     return sorted(
-        list_to_sort, key=lambda item: ordered_list.index(item[obj_key])
+        list_to_sort, key=lambda item: ordered_list.index(
+            item[obj_key]) if item[obj_key] in ordered_list else len(ordered_list)
     )

--- a/webapp/context.py
+++ b/webapp/context.py
@@ -159,6 +159,8 @@ def date_has_passed(date_str):
 
 def sort_by_key_and_ordered_list(list_to_sort, obj_key, ordered_list):
     return sorted(
-        list_to_sort, key=lambda item: ordered_list.index(
-            item[obj_key]) if item[obj_key] in ordered_list else len(ordered_list)
+        list_to_sort,
+        key=lambda item: ordered_list.index(item[obj_key])
+        if item[obj_key] in ordered_list
+        else len(ordered_list),
     )


### PR DESCRIPTION
## Done

- Replaced links in places where it was outputting 404 or 500. Used a [daily automated job](https://github.com/canonical/ubuntu.com/actions/workflows/live-links.yaml)'s output as a source of truth.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Check that https://ubuntu-com-13451.demos.haus/server/docs/virtualization-introduction doesn't output 404
- Check that `More info about the TSC` link on https://ubuntu-com-13451.demos.haus/robotics/community opens a ROC2 page and doesn't output 404.
- Check that https://ubuntu-com-13451.demos.haus/iot/gateways doesn't output 500 and opens a page.

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-8151

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
