### PR TITLE
[WD-8235] replace a link in /robotics/what-is-ros

### DIFF
--- a/.github/workflows/live-links.yaml
+++ b/.github/workflows/live-links.yaml
@@ -37,6 +37,7 @@ jobs:
             https://ubuntu.com/security
             http://www.brendangregg.com
             http://www.adlinktech.com/en/index
+            https://www.zoominfo.com/legal/privacy-policy
             /flags.png
             /flags@2x.png
             https?://[a-z0-9]*\.example\.com

--- a/templates/robotics/what-is-ros.html
+++ b/templates/robotics/what-is-ros.html
@@ -87,7 +87,7 @@
       }}
       <h2>What is ROS 2?</h2>
       <p>ROS 2 is a complete re-design of the framework, tackling the shortcomings of the first generation, effectively bringing it to industry needs and standards. ROS 2 contains new sets of packages that can be installed alongside ROS 1 to ease migration to a more secure platform. ROS 2 takes advantage of new technologies and newly updated APIs asked for by the community.</p>
-      <p><a class="p-button--positive" href="https://index.ros.org/doc/ros2/Tutorials/">Get started with ROS 2</a></p>
+      <p><a class="p-button--positive" href="https://docs.ros.org/en/humble/Tutorials.html">Get started with ROS 2</a></p>
   </div>
 </section>
 


### PR DESCRIPTION
## Done

- Replaced link in https://ubuntu-com-13460.demos.haus/robotics/what-is-ros according to [copy doc](https://docs.google.com/document/d/1yX2Ikcn1fgIKX3el8fKWQt7SGxSwY633TfW5V1lwUuc/edit)
- Added a link to ZoomInfo Privacy Policy page to ignore list of `check-links` GH action, because it's weirdly returning 403 when requesting through cURL (suggested by Ant [here](https://chat.canonical.com/canonical/pl/yi3ub35a138p5ba3n65fddr7eh))

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Navigate to https://ubuntu-com-13460.demos.haus/robotics/what-is-ros and click on `Get started with ROS 2` button. It should open a tutorial page for ROS 2. 

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-8235

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
