### PR TITLE
Use dotrun pip instead of snap

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -29,12 +29,12 @@ jobs:
     - name: Install dotrun
       uses: canonical/install-dotrun@main
     - name: Install dependencies
-      run: /snap/bin/dotrun install
+      run: dotrun install
     - name: Build assets
-      run: /snap/bin/dotrun build
+      run: dotrun build
     - name: Run dotrun
       run: |
-        /snap/bin/dotrun &
+        dotrun &
         curl --head --fail --retry-delay 1 --retry 30 --retry-connrefused http://localhost:8001
     - name: Install Playwright Browsers
       run: yarn playwright install --with-deps

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -10,7 +10,7 @@ jobs:
 
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Build image
         run: DOCKER_BUILDKIT=1 docker build --tag ubuntu-com .
@@ -25,27 +25,29 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install dotrun
         uses: canonical/install-dotrun@main
 
       - name: Install dependencies
-        run: /snap/bin/dotrun install
+        run: |
+          sudo chmod -R 777 .
+          dotrun install
 
       - name: Build assets
-        run: /snap/bin/dotrun build
+        run: dotrun build
 
       - name: Run dotrun
         run: |
-          /snap/bin/dotrun &
+          dotrun &
           curl --head --fail --retry-delay 1 --retry 30 --retry-connrefused http://localhost:8001
 
   lint-scss:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install dependencies
         run: yarn install --immutable
@@ -57,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install dependencies
         run: yarn install --immutable
@@ -69,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install node dependencies
         run: yarn install --immutable
@@ -86,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install konf
         run: |
@@ -108,7 +110,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # fetch all history for codecov
 
@@ -121,16 +123,16 @@ jobs:
         uses: canonical/install-dotrun@main
 
       - name: Install node dependencies
-        run: /snap/bin/dotrun install
+        run: dotrun install
 
       - name: Install dependencies
-        run: /snap/bin/dotrun exec pip3 install coverage
+        run: dotrun exec pip3 install coverage
 
       - name: Build resources
-        run: /snap/bin/dotrun build
+        run: dotrun build
 
       - name: Run tests with coverage
-        run: /snap/bin/dotrun --env SEARCH_API_KEY=fake-key exec coverage run --source=. -m unittest discover tests
+        run: dotrun --env SEARCH_API_KEY=fake-key exec coverage run --source=. -m unittest discover tests
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
@@ -141,7 +143,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # fetch all history for codecov
 
@@ -165,7 +167,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install dependencies
         run: yarn install --immutable
@@ -178,7 +180,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install dependencies
         run: yarn install --immutable
@@ -192,7 +194,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: woke
         uses: canonical-web-and-design/inclusive-naming@main

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -134,7 +134,7 @@ jobs:
         run: dotrun build
 
       - name: Run tests with coverage
-        run: dotrun --env SEARCH_API_KEY=fake-key exec coverage run --source=. -m unittest discover tests
+        run: dotrun --env SEARCH_API_KEY=fake-key exec coverage run --source=. --module unittest discover tests
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -123,7 +123,9 @@ jobs:
         uses: canonical/install-dotrun@main
 
       - name: Install node dependencies
-        run: dotrun install
+        run: |
+          sudo chmod -R 777 .
+          dotrun install
 
       - name: Install dependencies
         run: dotrun exec pip3 install coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN --mount=type=cache,target=/root/.cache/pip pip3 install --user --requirement
 
 # Build stage: Install yarn dependencies
 # ===
-FROM node:18 AS yarn-dependencies
+FROM node:20 AS yarn-dependencies
 WORKDIR /srv
 ADD package.json yarn.lock .
 RUN --mount=type=cache,target=/usr/local/share/.cache/yarn yarn install --production


### PR DESCRIPTION
## Done

- Switched dotrun to pip version rather than snap for CI
- Updated the checkout GHA

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]