### PR TITLE
Fix p-muted-heading alignment

### DIFF
--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -205,7 +205,7 @@ $meganav-height: 3rem;
 
         .p-muted-heading {
           padding-left: 3rem;
-          
+
           @media (max-width: $breakpoint-medium) {
             padding-left: 2.5rem;
           }
@@ -231,7 +231,6 @@ $meganav-height: 3rem;
       }
 
       .p-navigation__secondary-links {
-
         margin-top: 1.5rem;
         padding-left: calc(1.5rem + $row-margin-medium);
 

--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -98,7 +98,7 @@ $meganav-height: 3rem;
           }
 
           .p-muted-heading {
-            padding-left: 0 !important;
+            padding-left: 0;
           }
         }
 
@@ -132,7 +132,7 @@ $meganav-height: 3rem;
           }
 
           .p-muted-heading {
-            padding-left: 0 !important;
+            padding-left: 0;
           }
         }
 
@@ -201,6 +201,10 @@ $meganav-height: 3rem;
 
         &::before {
           box-shadow: none;
+        }
+
+        .p-muted-heading {
+          padding-left: 3rem;
         }
       }
 

--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -205,6 +205,14 @@ $meganav-height: 3rem;
 
         .p-muted-heading {
           padding-left: 3rem;
+          
+          @media (max-width: $breakpoint-medium) {
+            padding-left: 2.5rem;
+          }
+        }
+
+        .p-navigation__secondary-links .p-muted-heading {
+          padding-left: 0;
         }
       }
 
@@ -223,13 +231,12 @@ $meganav-height: 3rem;
       }
 
       .p-navigation__secondary-links {
-        @extend .dropdown-window__side-panel;
 
         margin-top: 1.5rem;
-        padding-left: calc(1.5rem + $row-margin-medium) !important;
+        padding-left: calc(1.5rem + $row-margin-medium);
 
         @media (max-width: $breakpoint-medium) {
-          padding-left: calc(1rem + $row-margin-small) !important;
+          padding-left: calc(1.5rem + $row-margin-small);
         }
 
         a {

--- a/templates/templates/meganav/base.html
+++ b/templates/templates/meganav/base.html
@@ -271,5 +271,24 @@
         {% endwith %}
       {% endfor %}
     {% endfor %}
+    {% if "highlighted_secondary_links" in sections %}
+      {% for links_section in sections.highlighted_secondary_links %}
+        {% if links_section.title %}
+        <p class="p-muted-heading is-muted u-no-padding--top">{{ links_section.title }}</p>
+        {% endif %}
+        {% for link in links_section.links %}
+          {% with 
+            url = link.url, 
+            title = link.title, 
+            description = link.description,
+            secondary_cta_url = link.secondary_cta_url,
+            secondary_cta_title = link.secondary_cta_title,
+            tabindex = "-1"
+          %}
+            {% include "templates/meganav/_list-item.html" %}
+          {% endwith %}
+        {% endfor %}
+      {% endfor %}
+    {% endif%}
   {% endif %}
 </ul>

--- a/templates/templates/meganav/base.html
+++ b/templates/templates/meganav/base.html
@@ -274,7 +274,7 @@
     {% if "highlighted_secondary_links" in sections %}
       {% for links_section in sections.highlighted_secondary_links %}
         {% if links_section.title %}
-        <p class="p-muted-heading is-muted">{{ links_section.title }}</p>
+        <p class="p-muted-heading is-muted" style="padding-top: 1rem;">{{ links_section.title }}</p>
         {% endif %}
         {% for link in links_section.links %}
           {% with 

--- a/templates/templates/meganav/base.html
+++ b/templates/templates/meganav/base.html
@@ -274,7 +274,7 @@
     {% if "highlighted_secondary_links" in sections %}
       {% for links_section in sections.highlighted_secondary_links %}
         {% if links_section.title %}
-        <p class="p-muted-heading is-muted u-no-padding--top">{{ links_section.title }}</p>
+        <p class="p-muted-heading is-muted">{{ links_section.title }}</p>
         {% endif %}
         {% for link in links_section.links %}
           {% with 


### PR DESCRIPTION
## Done

- Fixes the align of headings for secondary links in mobile view. ex. products > ubuntu OS > scroll down
- Add in the 'by industry' that was missing under 'use cases' on mobile
![image](https://github.com/canonical/ubuntu.com/assets/58276363/b1e2c123-3e13-4ad3-a0c4-7864dfc06a3b)


## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
