### PR TITLE
Update checksums for UC22 raspi images.

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -62,6 +62,6 @@ checksums:
     "22.04.3": "b739d17a3a7f0494b2d804c5f54fd2f303ba665acf353ee3bef78825bfc7b39c *ubuntu-22.04.3-preinstalled-server-riscv64+unmatched.img.xz"
     "21.10": "8067892fa627eb219b31dc629f31f3bda6b015dfeabf2fdc9b0ed150bf7984b8 *ubuntu-21.10-preinstalled-server-riscv64+unmatched.img.xz"
   core-22-arm64+raspi:
-    "22": "374697bd7324f10ff3c00007b75ca42885aff161cbddb63b1d14bc1551e69ce2 *ubuntu-core-22-arm64+raspi.img.xz"
+    "22": "7639f5ff8bb5c0d4cf0e86041b56dd0daa27a3d05b475a9a85c5d085b561fb8e *ubuntu-core-22-arm64+raspi.img.xz"
   core-22-armhf+raspi:
-    "22": "e495c578f6279d0bbb13437cf04574142013ec77d61855e8bc7f51919dc88739 *ubuntu-core-22-armhf+raspi.img.xz"
+    "22": "4c4b3958626611aff85bfa5873c45ad22fdf7642be868b5722900fa88e6fca86 *ubuntu-core-22-armhf+raspi.img.xz"


### PR DESCRIPTION
## Done

- The UC22 raspi image checksums were out-of-date, so updated those.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #13336

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
