### PR TITLE
Fixes more 404s

### DIFF
--- a/templates/kubernetes/docs/1.16/charm-docker-registry.md
+++ b/templates/kubernetes/docs/1.16/charm-docker-registry.md
@@ -485,7 +485,7 @@ juju config docker-registry \
 
 The recommended way to delete images from the registry is to use the `rmi`
 action. If necessary, this charm can be configured to
-[allow deletion][storage-delete] of blobs and manifests by digest by setting
+allow deletion of blobs and manifests by digest by setting
 the `storage-delete` config option to `true`:
 
 ```bash

--- a/templates/kubernetes/docs/1.17/charm-docker-registry.md
+++ b/templates/kubernetes/docs/1.17/charm-docker-registry.md
@@ -485,7 +485,7 @@ juju config docker-registry \
 
 The recommended way to delete images from the registry is to use the `rmi`
 action. If necessary, this charm can be configured to
-[allow deletion][storage-delete] of blobs and manifests by digest by setting
+allow deletion of blobs and manifests by digest by setting
 the `storage-delete` config option to `true`:
 
 ```bash

--- a/templates/kubernetes/docs/1.18/charm-docker-registry.md
+++ b/templates/kubernetes/docs/1.18/charm-docker-registry.md
@@ -486,7 +486,7 @@ juju config docker-registry \
 
 The recommended way to delete images from the registry is to use the `rmi`
 action. If necessary, this charm can be configured to
-[allow deletion][storage-delete] of blobs and manifests by digest by setting
+allow deletion of blobs and manifests by digest by setting
 the `storage-delete` config option to `true`:
 
 ```bash

--- a/templates/kubernetes/docs/1.19/charm-docker-registry.md
+++ b/templates/kubernetes/docs/1.19/charm-docker-registry.md
@@ -486,7 +486,7 @@ juju config docker-registry \
 
 The recommended way to delete images from the registry is to use the `rmi`
 action. If necessary, this charm can be configured to
-[allow deletion][storage-delete] of blobs and manifests by digest by setting
+allow deletion of blobs and manifests by digest by setting
 the `storage-delete` config option to `true`:
 
 ```bash

--- a/templates/kubernetes/docs/1.19/upgrading.md
+++ b/templates/kubernetes/docs/1.19/upgrading.md
@@ -400,7 +400,7 @@ juju run-action kubernetes-worker/1 upgrade
 
 ## Upgrading the Machine's Series
 
-All of the charms support [upgrading the machine's series via Juju](https://juju.is/docs/upgrading-series).
+All of the charms support [upgrading the machine's series via Juju](https://juju.is/docs/juju/manage-machines#heading--upgrade-a-machine).
 As each machine is upgraded, the applications on that machine will be stopped and the unit will
 go into a `blocked` status until the upgrade is complete. For the worker units, pods will be drained
 from the node and onto one of the other nodes at the start of the upgrade, and the node will be removed

--- a/templates/kubernetes/docs/1.20/charm-docker-registry.md
+++ b/templates/kubernetes/docs/1.20/charm-docker-registry.md
@@ -485,7 +485,7 @@ juju config docker-registry \
 
 The recommended way to delete images from the registry is to use the `rmi`
 action. If necessary, this charm can be configured to
-[allow deletion][storage-delete] of blobs and manifests by digest by setting
+allow deletion of blobs and manifests by digest by setting
 the `storage-delete` config option to `true`:
 
 ```bash

--- a/templates/kubernetes/docs/1.20/upgrading.md
+++ b/templates/kubernetes/docs/1.20/upgrading.md
@@ -414,7 +414,7 @@ juju run-action kubernetes-worker/1 upgrade
 
 ## Upgrading the Machine's Series
 
-All of the charms support [upgrading the machine's series via Juju](https://juju.is/docs/upgrading-series).
+All of the charms support [upgrading the machine's series via Juju](https://juju.is/docs/juju/manage-machines#heading--upgrade-a-machine).
 As each machine is upgraded, the applications on that machine will be stopped and the unit will
 go into a `blocked` status until the upgrade is complete. For the worker units, pods will be drained
 from the node and onto one of the other nodes at the start of the upgrade, and the node will be removed

--- a/templates/kubernetes/docs/1.21/charm-docker-registry.md
+++ b/templates/kubernetes/docs/1.21/charm-docker-registry.md
@@ -485,7 +485,7 @@ juju config docker-registry \
 
 The recommended way to delete images from the registry is to use the `rmi`
 action. If necessary, this charm can be configured to
-[allow deletion][storage-delete] of blobs and manifests by digest by setting
+allow deletion of blobs and manifests by digest by setting
 the `storage-delete` config option to `true`:
 
 ```bash

--- a/templates/kubernetes/docs/1.22/charm-docker-registry.md
+++ b/templates/kubernetes/docs/1.22/charm-docker-registry.md
@@ -485,7 +485,7 @@ juju config docker-registry \
 
 The recommended way to delete images from the registry is to use the `rmi`
 action. If necessary, this charm can be configured to
-[allow deletion][storage-delete] of blobs and manifests by digest by setting
+allow deletion of blobs and manifests by digest by setting
 the `storage-delete` config option to `true`:
 
 ```bash


### PR DESCRIPTION
## Done

- broken links relating to Docker (in deprecated charm docs)
- broken links relating to Juju upgrades

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
