### PR TITLE
Update ubuntu lts security support graph with new design

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -1593,10 +1593,10 @@ export var microStackReleases = [
 ];
 
 export var desktopServerStatus = {
-  HARDWARE_AND_MAINTENANCE_UPDATES: "chart__bar--orange",
+  HARDWARE_AND_MAINTENANCE_UPDATES: "chart__bar--black",
   MAINTENANCE_UPDATES: "chart__bar--orange-light",
-  ESM: "chart__bar--aubergine",
-  MAIN_UNIVERSE: "chart__bar--charcoal",
+  ESM: "chart__bar--aubergine-light",
+  MAIN_UNIVERSE: "chart__bar--aubergine-mid-light",
   INTERIM_RELEASE: "chart__bar--grey",
 };
 

--- a/static/js/src/release-chart.js
+++ b/static/js/src/release-chart.js
@@ -40,6 +40,15 @@ import {
 } from "./chart-data";
 
 function buildCharts() {
+  if (document.querySelector("#server-desktop-eol-old")) {
+    delete desktopServerStatus.MAINTENANCE_UPDATES;
+    createChart(
+      "#server-desktop-eol-old",
+      desktopServerReleaseNames,
+      desktopServerStatus,
+      serverAndDesktopReleases
+    );
+  }
   if (document.querySelector("#server-desktop-eol")) {
     delete desktopServerStatus.MAINTENANCE_UPDATES;
     createSupportChart(
@@ -164,6 +173,10 @@ function buildCharts() {
 }
 
 function clearCharts() {
+  const serverDesktopEolOld = document.querySelector("#server-desktop-eol-old");
+  if (serverDesktopEolOld) {
+    serverDesktopEolOld.innerHTML = "";
+  }
   const serverDesktopEol = document.querySelector("#server-desktop-eol");
   if (serverDesktopEol) {
     serverDesktopEol.innerHTML = "";

--- a/static/js/src/release-chart.js
+++ b/static/js/src/release-chart.js
@@ -1,4 +1,5 @@
 import { createChart } from "./chart";
+import { createSupportChart } from "./support-chart";
 import { debounce } from "./utils/debounce.js";
 import {
   serverAndDesktopReleases,
@@ -41,8 +42,9 @@ import {
 function buildCharts() {
   if (document.querySelector("#server-desktop-eol")) {
     delete desktopServerStatus.MAINTENANCE_UPDATES;
-    createChart(
+    createSupportChart(
       "#server-desktop-eol",
+      "#server-desktop-eol-key",
       desktopServerReleaseNames,
       desktopServerStatus,
       serverAndDesktopReleases
@@ -165,6 +167,10 @@ function clearCharts() {
   const serverDesktopEol = document.querySelector("#server-desktop-eol");
   if (serverDesktopEol) {
     serverDesktopEol.innerHTML = "";
+  }
+  const serverDesktopEolKey = document.querySelector("#server-desktop-eol-key");
+  if (serverDesktopEolKey) {
+    serverDesktopEolKey.innerHTML = "";
   }
   const eol1604 = document.querySelector("#eol-1604");
   if (eol1604) {

--- a/static/js/src/support-chart.js
+++ b/static/js/src/support-chart.js
@@ -135,7 +135,8 @@ function formatLabel(textElement) {
     .append("tspan")
     .attr("x", textXValue)
     .attr("dy", "-0.5em")
-    .text(words[0]);
+    .text(words[0])
+    .call(emboldenLTSLabels);
 
   if (words.length > 1) {
     textElement
@@ -143,6 +144,20 @@ function formatLabel(textElement) {
       .attr("x", textXValue)
       .attr("dy", "1.6em")
       .text(words.slice(1).join(" "));
+  }
+}
+
+/**
+ *
+ * @param {*} textNode
+ *
+ * Embolden text if it contains LTS
+ *
+ */
+function emboldenLTSLabels(textNode) {
+  const textContent = textNode.text();
+  if (textContent?.includes("LTS")) {
+    textNode.classed("chart__label--bold", true);
   }
 }
 
@@ -269,39 +284,29 @@ function cleanUpChart(svg) {
 /**
  *
  * @param {*} svg
- *
- * Embolden LTS labels on y axis**
- *
- */
-function emboldenLTSLabels(svg) {
-  svg.selectAll(".tick text tspan").select(function () {
-    var text = this.textContent;
-    if (text.includes("LTS")) {
-      this.classList.add("chart__label--bold");
-    }
-  });
-}
-
-/**
- *
- * @param {*} svg
  * @param {String} highlightVersion
  *
  * Set version axis labels
  */
-function highlightChartRow(svg, highlightVersion) {
-  svg.selectAll(".tick text").select(function () {
-    var text = this.textContent;
+function highlightChartRow(svg, scale, highlightVersion) {
+  const domain = scale.domain();
+  const tickValues = domain.map((value) => value.toString());
+
+  svg.selectAll(".y.axis .tick text").each(function (d, i) {
+    const tickText = d3.select(this);
+    const textContent = tickValues[i].toString();
+
     var isNotHighlightedVersion =
-      highlightVersion && !text.includes(highlightVersion);
-    var isYearLabel = text.includes("20") && !text.includes("Ubuntu ");
+      highlightVersion && !textContent.includes(highlightVersion);
+    var isYearLabel =
+      textContent.includes("20") && !textContent.includes("Ubuntu ");
 
     if (isNotHighlightedVersion) {
-      this.classList.add("chart__label--transparent");
+      tickText.classed("chart__label--transparent", true);
     }
 
     if (isYearLabel) {
-      this.classList.remove("chart__label--transparent");
+      tickText.classed("chart__label--transparent", false);
     }
   });
 }
@@ -647,6 +652,5 @@ export function createSupportChart(
   cleanUpChart(svg);
   buildChartKey(keyAttachmentSelector, taskStatus);
 
-  emboldenLTSLabels(svg);
   highlightChartRow(svg, highlightVersion);
 }

--- a/static/js/src/support-chart.js
+++ b/static/js/src/support-chart.js
@@ -1,0 +1,550 @@
+/**
+ *
+ * @param {Array} tasks
+ *
+ * Sorts tasks by date
+ */
+function sortTasks(tasks) {
+  tasks.sort(function (a, b) {
+    return a.endDate - b.endDate;
+  });
+
+  tasks.sort(function (a, b) {
+    return a.startDate - b.startDate;
+  });
+
+  return tasks;
+}
+
+/**
+ *
+ * @param {*} svg
+ * @param {Array} tasks
+ * @param {Object} taskStatus
+ * @param {*} x
+ * @param {*} y
+ *
+ * Add bars to chart using supplied data
+ */
+function addBarsToChart(svg, tasks, taskStatus, x, y, highlightVersion) {
+  svg
+    .selectAll(".chart")
+    .data(tasks, function (d) {
+      return d.startDate + d.taskName + d.endDate;
+    })
+    .enter()
+    .append("rect")
+    .attr("class", function (d) {
+      var className = "";
+
+      if (taskStatus[d.status] === null) {
+        return "bar";
+      }
+
+      if (highlightVersion && !d.taskName.includes(highlightVersion)) {
+        className += " chart__bar--transparent";
+      }
+
+      className += " " + taskStatus[d.status];
+
+      return className;
+    })
+    .attr("y", 0)
+    .attr("transform", function (d) {
+      if (d.status === "MAIN_UNIVERSE" || d.status === "PRO_SUPPORT") {
+        return (
+          "translate(" +
+          x(d.startDate) +
+          "," +
+          (y(d.taskName) - y.bandwidth()) +
+          ")"
+        );
+      }
+      return "translate(" + x(d.startDate) + "," + y(d.taskName) + ")";
+    })
+    .attr("height", function () {
+      return y.bandwidth();
+    })
+    .attr("width", function (d) {
+      return x(d.endDate) - x(d.startDate);
+    });
+}
+
+/**
+ *
+ * @param {*} svg
+ * @param {Int} height
+ * @param {Object} margin
+ * @param {*} xAxis
+ *
+ * Add x-axis group to SVG
+ */
+function addXAxis(svg, height, margin, xAxis) {
+  svg
+    .append("g")
+    .attr("class", "x axis")
+    .attr("transform", "translate(0, " + (margin.top - 32) + ")")
+    .call(xAxis);
+}
+
+/**
+ *
+ * @param {*} svg
+ * @param {*} yAxis
+ *
+ * Append y-axis group to SVG
+ */
+function appendYAxisGroup(svg, yAxis) {
+  return svg
+    .append("g")
+    .attr("class", "y axis")
+    .call(yAxis);
+}
+
+/**
+ *
+ * @param {*} yAxisGroup
+ * @param {*} y
+ *
+ * Centers labels in line with bars
+ */
+function transformTickText(yAxisGroup, y) {
+  yAxisGroup.selectAll(".tick text")
+    .attr("transform", function (d) {
+      var centerOffset = y.bandwidth() / 2;
+      return "translate(0, " + -centerOffset + ")";
+    });
+}
+
+/**
+ *
+ * @param {*} textElement
+ *
+ * Splits the label into version number (inc. LTS if it exists)
+ * and release name and puts them over two lines
+ */
+function formatLabel(textElement) {
+  var textXValue = textElement.attr("x");
+  var words = textElement.text().split("(");
+
+  if (words[1]) {
+    words[1] = "(" + words[1];
+  }
+
+  textElement.text(""); 
+
+  textElement
+    .append("tspan")
+    .attr("x", textXValue)
+    .attr("dy", "-0.5em")
+    .text(words[0]);
+
+  if (words.length > 1) {
+    textElement
+      .append("tspan")
+      .attr("x", textXValue)
+      .attr("dy", "1.6em")
+      .text(words.slice(1).join(" "));
+  }
+}
+
+/**
+ *
+ * @param {*} yAxisGroup
+ *
+ * Loops through the axis labels and calls the formatLabel
+ * function on them
+ */
+function formatAxisLabels(yAxisGroup) {
+  yAxisGroup.selectAll(".tick text")
+    .call(function (t) {
+      t.each(function (d) {
+        formatLabel(d3.select(this));
+      });
+    });
+}
+
+/**
+ *
+ * @param {*} svg
+ * @param {*} yAxis
+ * @param {*} y
+ *
+ * Builds and appends the y-axis
+ */
+function addYAxis(svg, yAxis, y) {
+  var yAxisGroup = appendYAxisGroup(svg, yAxis);
+  transformTickText(yAxisGroup, y);
+  formatAxisLabels(yAxisGroup);
+}
+
+
+/**
+ *
+ * @param {*} yAxis
+ *
+ * Gets the tick positions of the y-axis
+ */
+function getTickPositions(yAxis) {
+  const yAxisScale = yAxis.scale();
+  const ticks = yAxisScale.ticks ? yAxisScale.ticks() : yAxisScale.domain();
+  return ticks.map(tick => yAxisScale(tick));
+}
+
+/**
+ *
+ * @param {*} svg
+ * @param {Int} x1
+ * @param {Int} x2
+ * @param {*} y
+ * @param {String} strokeColor
+ * @param {Int} strokeColor
+ *
+ * Appends a horiontal line to the SVG based on custom parameters
+ */
+function addHorizontalLine(svg, x1, x2, y, strokeColor, strokeWidth) {
+  svg.append("line")
+    .attr("x1", x1)
+    .attr("x2", x2)
+    .attr("y1", y)
+    .attr("y2", y)
+    .attr("stroke", strokeColor)
+    .attr("stroke-width", strokeWidth);
+}
+
+/**
+ *
+ * @param {*} svg
+ * @param {*} yAxis
+ * @param {Int} width
+ * @param {Obj} margin
+ *
+ * Find the postion of the Y-axis ticks and adds a horizontal
+ * line above each label and one that spans the chart area
+ */
+function addYAxisHorizontalLines(svg, yAxis, width, margin) {
+  const tickPositions = getTickPositions(yAxis);
+
+  const lineAdjustment = 27;
+
+  tickPositions.forEach((posY, index) => {
+    addHorizontalLine(svg, -margin.left, 0, posY - lineAdjustment, "#D9D9D9", 2);
+
+    addHorizontalLine(svg, 0, width + margin.right, posY - lineAdjustment, "#D9D9D9", index === 0 ? 2 : 1);
+  });
+}
+
+/**
+ *
+ * @param {*} svg
+ * @param {*} versionAxis
+ *
+ * Add version axis to chart
+ */
+function addVersionAxis(svg, versionAxis) {
+  svg.append("g").attr("class", "version axis").call(versionAxis);
+}
+
+/**
+ *
+ * @param {*} svg
+ *
+ * Clean up unwanted elements on chart put in by d3.js
+ */
+function cleanUpChart(svg) {
+  svg.selectAll(".domain").remove();
+}
+
+/**
+ *
+ * @param {*} svg
+ *
+ * Embolden LTS labels on y axis**
+ *
+ */
+function emboldenLTSLabels(svg) {
+  svg.selectAll(".tick text tspan").select(function () {
+    var text = this.textContent;
+    console.log("test", text);
+    if (text.includes("LTS")) {
+      this.classList.add("chart__label--bold");
+    }
+  });
+}
+
+/**
+ *
+ * @param {*} svg
+ * @param {String} highlightVersion
+ * 
+ * Set version axis labels
+ */
+function highlightChartRow(svg, highlightVersion) {
+  svg.selectAll(".tick text").select(function () {
+    var text = this.textContent;
+    var isNotHighlightedVersion =
+      highlightVersion && !text.includes(highlightVersion);
+    var isYearLabel = text.includes("20") && !text.includes("Ubuntu ");
+
+    if (isNotHighlightedVersion) {
+      this.classList.add("chart__label--transparent");
+    }
+
+    if (isYearLabel) {
+      this.classList.remove("chart__label--transparent");
+    }
+  });
+}
+
+/**
+ *
+ * @param {*} svg
+ * 
+ * Set version axis labels
+ */
+function setVersionAxisLabels(svg, taskVersions) {
+  svg.selectAll(".version .tick text").select(function (tickLabel, index) {
+    this.textContent = taskVersions[index];
+  });
+}
+
+/**
+ *
+ * @param {*} svg
+ * @param {Int} height
+ *
+ * Adds vertical lines to the x axis
+ */
+function addXAxisVerticalLines(svg, height, margin) {
+  svg
+    .selectAll(".x.axis .tick line")
+    .attr("y1", height - margin.bottom - margin.top)
+    .attr("y2", 26);
+}
+
+/**
+ *
+ * @param {String} chartSelector
+ * @param {Object} taskStatus
+ *
+ * Builds key for supplied chart based on task status
+ */
+function buildChartKey(chartSelector, taskStatus) {
+  var taskStatusKeys = Object.keys(taskStatus);
+  var rectDimensions = 25;
+  var rowHeight = rectDimensions + 5;
+  var gapBetweenRectAndText = 10;
+  var verticalTextAlignmentOffset = 16;
+
+  var chartKey = d3
+    .select(chartSelector)
+    .append("svg")
+    .attr("class", "chart-key")
+    .attr("width", "550")
+    .attr("height", rowHeight * taskStatusKeys.length);
+
+  taskStatusKeys.forEach(function (key, i) {
+    var keyRow = chartKey
+      .append("g")
+      .attr("class", "chart-key__row")
+      .attr("transform", "translate(0, " + rowHeight * i + ")")
+      .attr("height", rectDimensions);
+
+    keyRow
+      .append("rect")
+      .attr("class", taskStatus[key])
+      .attr("width", rectDimensions)
+      .attr("height", rectDimensions)
+      .attr("y", 0);
+
+    keyRow
+      .append("text")
+      .text(formatKeyLabel(key))
+      .attr("class", "chart-key__label")
+      .attr("x", rectDimensions + gapBetweenRectAndText)
+      .attr("y", verticalTextAlignmentOffset);
+  });
+}
+
+/**
+ *
+ * @param {String} key
+ *
+ * Formats key into readable string
+ */
+function formatKeyLabel(key) {
+  var keyLowerCase = key.toLowerCase().replace(/_/g, " ");
+  var formattedKey =
+    keyLowerCase.charAt(0).toUpperCase() + keyLowerCase.substr(1);
+  formattedKey = formattedKey.replace(
+    "Lts",
+    "Ubuntu LTS release Standard Support"
+  );
+  formattedKey = formattedKey.replace(" openstack ", " OpenStack ");
+  formattedKey = formattedKey.replace("kub", "Kub");
+  formattedKey = formattedKey.replace(
+    "Interim release",
+    "Interim release standard security maintenance (9 months)"
+  );
+  formattedKey = formattedKey.replace(
+    "Esm",
+    "LTS Expanded Security Maintenance (ESM) for Ubuntu Main (additional 5 years)"
+  );
+  formattedKey = formattedKey.replace("Cve", "CVE/Critical fixes only");
+  formattedKey = formattedKey.replace("Early", "Early preview");
+  formattedKey = formattedKey.replace(
+    "Hardware and maintenance updates",
+    "LTS standard security maintenance for Ubuntu Main (initial 5 years)"
+  );
+  formattedKey = formattedKey.replace(
+    "Main universe",
+    "LTS Expanded Security Maintenance (ESM) for Ubuntu Universe (10 years)"
+  );
+  formattedKey = formattedKey.replace(
+    "Microstack esm",
+    "Expanded Security Maintenance (ESM)"
+  );
+  formattedKey = formattedKey.replace(
+    "Pro support",
+    "Ubuntu Pro + Support coverage"
+  );
+  return formattedKey;
+}
+
+/**
+ *
+ * @param {Array} taskTypes
+ *
+ * Calculate the longest Y-Axis label
+ */
+function calculateYAxisWidth(YAxisLabels) {
+  var YAxisLabelsCopy = YAxisLabels.slice();
+  var longestLabel = YAxisLabelsCopy.sort(function (a, b) {
+    return b.length - a.length;
+  })[0];
+  return longestLabel.length * 7;
+}
+
+/**
+ *
+ * @param {String} chartSelector
+ * @param {Array} taskTypes
+ * @param {Object} taskStatus
+ * @param {Array} tasks
+ *
+ * Builds chart using supplied selector and data
+ */
+export function createSupportChart(
+  chartSelector,
+  keySelector,
+  taskTypes,
+  taskStatus,
+  tasks,
+  taskVersions,
+  removePadding,
+  highlightVersion
+) {
+  var margin = {
+    top: 12,
+    right: 40,
+    bottom: 20,
+  };
+  margin.left = calculateYAxisWidth(taskTypes);
+  var rowHeight = 64;
+  var timeDomainStart;
+  var timeDomainEnd;
+  var earliestStartDate = d3.min(tasks, (d) => d.startDate);
+  var latestEndDate = d3.max(tasks, (d) => d.endDate);
+  if (removePadding) {
+    timeDomainStart = earliestStartDate;
+    timeDomainEnd = latestEndDate;
+  } else {
+    timeDomainStart = d3.timeYear.offset(earliestStartDate, -1);
+    timeDomainEnd = d3.timeYear.offset(latestEndDate, +1);
+  }
+  var keyAttachmentSelector = keySelector || chartSelector;
+  var height = taskTypes.length * rowHeight;
+  var containerWidth = document.querySelector(chartSelector).clientWidth;
+  if (containerWidth <= 0) {
+    var closestCol = document
+      .querySelector(chartSelector)
+      .closest('[class*="col-"]');
+
+    if (closestCol.clientWidth <= 0) {
+      return;
+    }
+
+    containerWidth = closestCol.clientWidth - margin.left;
+  }
+  var width = containerWidth - margin.right - margin.left;
+
+  var x = d3
+    .scaleTime()
+    .domain([timeDomainStart, timeDomainEnd])
+    .range([0, width + margin.right])
+    .clamp(true);
+
+  var y = d3
+    .scaleBand()
+    .domain(taskTypes)
+    .rangeRound([0, height - margin.top - margin.bottom])
+    .padding(0.58);
+
+  var version = d3
+    .scaleBand()
+    .domain(taskTypes)
+    .rangeRound([0, height - margin.top - margin.bottom])
+    .padding(0.4);
+
+  var xAxis = d3.axisBottom(x);
+
+  var yAxis = d3.axisRight(y).tickPadding(-margin.left).tickSize(0);
+
+  var chartTranslateX = margin.left;
+
+  if (taskVersions) {
+    var versionAxis = d3
+      .axisRight(version)
+      .tickPadding(-margin.left * 1.6)
+      .tickSize(0);
+
+    chartTranslateX = margin.left * 1.6;
+  }
+
+  sortTasks(tasks);
+
+  // Build initial chart body
+  var svg = d3
+    .select(chartSelector)
+    .append("svg")
+    .attr("class", "chart")
+    .attr("width", width + margin.left + margin.right)
+    .attr("height", height - margin.top - margin.bottom)
+    .append("g")
+    .attr("class", "gantt-chart")
+    .attr("width", width + margin.left + margin.right)
+    .attr("height", height)
+    .attr(
+      "transform",
+      "translate(" + chartTranslateX + ", " + margin.top + ")"
+    );
+
+  addBarsToChart(svg, tasks, taskStatus, x, y, highlightVersion);
+  addXAxis(svg, height, margin, xAxis);
+  addYAxis(svg, yAxis, y);
+
+  if (taskVersions) {
+    addVersionAxis(svg, versionAxis);
+    setVersionAxisLabels(svg, taskVersions);
+  }
+
+  addXAxisVerticalLines(svg, height, margin);
+  addYAxisHorizontalLines(svg, yAxis, width, margin);
+  cleanUpChart(svg);
+  buildChartKey(keyAttachmentSelector, taskStatus);
+
+  setTimeout(function () {
+    emboldenLTSLabels(svg);
+    highlightChartRow(svg, highlightVersion);
+  }, 0);
+}

--- a/static/js/src/support-chart.js
+++ b/static/js/src/support-chart.js
@@ -652,5 +652,5 @@ export function createSupportChart(
   cleanUpChart(svg);
   buildChartKey(keyAttachmentSelector, taskStatus);
 
-  highlightChartRow(svg, highlightVersion);
+  highlightChartRow(svg, y, highlightVersion);
 }

--- a/static/sass/_pattern_chart.scss
+++ b/static/sass/_pattern_chart.scss
@@ -90,8 +90,8 @@
   }
 
   .x.axis text {
+    color: #666;
     font-size: 16px;
-    color: #666666;
     text-anchor: start !important;
   }
 

--- a/static/sass/_pattern_chart.scss
+++ b/static/sass/_pattern_chart.scss
@@ -26,6 +26,18 @@
   stroke-width: 1px;
 }
 
+.chart__bar--aubergine-mid-light {
+  fill: #923a66;
+  stroke: #923a66;
+  stroke-width: 1px;
+}
+
+.chart__bar--aubergine-light {
+  fill: #cba7b8;
+  stroke: #cba7b8;
+  stroke-width: 1px;
+}
+
 .chart__bar--green {
   fill: green;
   stroke: green;
@@ -35,6 +47,12 @@
 .chart__bar--charcoal {
   fill: #333;
   stroke: #333;
+  stroke-width: 1px;
+}
+
+.chart__bar--black {
+  fill: #111;
+  stroke: #111;
   stroke-width: 1px;
 }
 
@@ -64,6 +82,22 @@
 .x.axis text {
   font-size: 12px;
   text-anchor: start !important;
+}
+
+#server-desktop-eol {
+  .tick text {
+    font-size: 16px;
+  }
+
+  .x.axis text {
+    font-size: 16px;
+    color: #666666;
+    text-anchor: start !important;
+  }
+
+  .chart__label--bold {
+    font-weight: 600;
+  }
 }
 
 .chart-key {

--- a/templates/about/release_cycles/ubuntu-eol.html
+++ b/templates/about/release_cycles/ubuntu-eol.html
@@ -3,6 +3,7 @@
     <h3 class="u-no-margin--bottom">Ubuntu releases</h3>
 
     <div class="u-hide--small" id="server-desktop-eol"></div>
+    <div class="u-hide--small" id="server-desktop-eol-key"></div>
 
     {% include "about/release_cycles/releases-table.html" %}
   </div>

--- a/templates/about/release_cycles/ubuntu-eol.html
+++ b/templates/about/release_cycles/ubuntu-eol.html
@@ -2,8 +2,7 @@
   <div class="col-10" style="overflow: auto;">
     <h3 class="u-no-margin--bottom">Ubuntu releases</h3>
 
-    <div class="u-hide--small" id="server-desktop-eol"></div>
-    <div class="u-hide--small" id="server-desktop-eol-key"></div>
+    <div class="u-hide--small" id="server-desktop-eol-old"></div>
 
     {% include "about/release_cycles/releases-table.html" %}
   </div>

--- a/templates/about/release_cycles/ubuntu-small-eol.html
+++ b/templates/about/release_cycles/ubuntu-small-eol.html
@@ -1,6 +1,7 @@
 <div class="row">
     <div class="col-8">
       <div class="u-hide--small" id="server-desktop-eol"></div>
+      <div class="u-hide--small" id="server-desktop-eol-key"></div>
       {% include "about/release_cycles/releases-table.html" %}
     </div>
   </div>

--- a/templates/about/release_cycles/ubuntu-small-eol.html
+++ b/templates/about/release_cycles/ubuntu-small-eol.html
@@ -1,7 +1,6 @@
 <div class="row">
     <div class="col-8">
-      <div class="u-hide--small" id="server-desktop-eol"></div>
-      <div class="u-hide--small" id="server-desktop-eol-key"></div>
+      <div class="u-hide--small" id="server-desktop-eol-old"></div>
       {% include "about/release_cycles/releases-table.html" %}
     </div>
   </div>

--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -545,7 +545,7 @@
         </div>
         <div class="col-6 col-medium-3">
           <p>Download Ubuntu Desktop and replace your current operating system. It's easy to install on Windows or macOS, or run Ubuntu alongside it.</p>
-          <hr class="is-extra-muted" />
+          <hr class="is-extra-muted" / />
           <a class="p-button--positive u-no-margin--bottom" href="/download/desktop">Download now</a>
         </div>
       </div>
@@ -556,7 +556,7 @@
         </div>
         <div class="col-6 col-medium-3">
           <p>Ubuntu is available on a huge range of devices from the world's largest hardware manufacturers, including Dell, HP, and Lenovo.</p>
-          <hr class="is-extra-muted" />
+          <hr class="is-extra-muted" / />
           <a href="https://canonical.com/partners/desktop">Find out more about our retail partners&nbsp;&rsaquo;</a>
         </div>
       </div>
@@ -567,7 +567,7 @@
         </div>
         <div class="col-6 col-medium-3">
           <p>Share ideas, write code, and get advice and help from our large, active community of IT professionals.</p>
-          <hr class="is-extra-muted" />
+          <hr class="is-extra-muted" / />
           <ul class="p-inline-list--middot">
             <li class="p-inline-list__item">
               <a href="https://discourse.ubuntu.com/">Ubuntu Discourse</a>

--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -77,6 +77,8 @@
     <div class="col">
       <h2>Security support <br aria-hidden/>for Ubuntu releases</h2>
     </div>
+    <div class="col" id="server-desktop-eol-key" style="padding-top:1rem;">
+    </div>
   </div>
   <div class="u-fixed-width">
     <div class="u-hide--small" id="server-desktop-eol"></div>

--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -17,7 +17,6 @@
     <div class="row--50-50">
       <div class="col">
         <h1>Ubuntu Desktop <br aria-hidden/>for developers</h1>
- 
       </div>
       <div class="col">
         <p>Whether you're an app or web developer, engineering manager, data scientist, or AI/ML researcher &mdash; Ubuntu is your ideal workstation.</p>
@@ -116,7 +115,7 @@
           ) | safe
           }}
         </div>
-        <div class="p-logo-section__item ">
+        <div class="p-logo-section__item">
           {{ image (
             url="https://assets.ubuntu.com/v1/e332a639-jupyter-logo.png",
             alt="juptyer logo",
@@ -546,7 +545,7 @@
         </div>
         <div class="col-6 col-medium-3">
           <p>Download Ubuntu Desktop and replace your current operating system. It's easy to install on Windows or macOS, or run Ubuntu alongside it.</p>
-          <hr class="is-extra-muted" / />
+          <hr class="is-extra-muted" />
           <a class="p-button--positive u-no-margin--bottom" href="/download/desktop">Download now</a>
         </div>
       </div>
@@ -557,7 +556,7 @@
         </div>
         <div class="col-6 col-medium-3">
           <p>Ubuntu is available on a huge range of devices from the world's largest hardware manufacturers, including Dell, HP, and Lenovo.</p>
-          <hr class="is-extra-muted" / />
+          <hr class="is-extra-muted" />
           <a href="https://canonical.com/partners/desktop">Find out more about our retail partners&nbsp;&rsaquo;</a>
         </div>
       </div>
@@ -568,7 +567,7 @@
         </div>
         <div class="col-6 col-medium-3">
           <p>Share ideas, write code, and get advice and help from our large, active community of IT professionals.</p>
-          <hr class="is-extra-muted" / />
+          <hr class="is-extra-muted" />
           <ul class="p-inline-list--middot">
             <li class="p-inline-list__item">
               <a href="https://discourse.ubuntu.com/">Ubuntu Discourse</a>

--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -111,7 +111,7 @@
           height="288",
           hi_def=True,
           loading="lazy",
-          attrs={"class": "p-logo-section__logo"}
+          attrs={"class": "p-icon-section__icon"}
           ) | safe
           }}
         </div>
@@ -127,7 +127,7 @@
             ) | safe
           }}
         </div>
-        <div class="p-logo-section__item ">
+        <div class="p-icon-section__item ">
           {{ image (
             url="https://assets.ubuntu.com/v1/1652445f-keras-logo.png",
             alt="keras logo",
@@ -545,7 +545,7 @@
         </div>
         <div class="col-6 col-medium-3">
           <p>Download Ubuntu Desktop and replace your current operating system. It's easy to install on Windows or macOS, or run Ubuntu alongside it.</p>
-          <hr class="is-extra-muted" / />
+          <hr class="is-extra-muted" />
           <a class="p-button--positive u-no-margin--bottom" href="/download/desktop">Download now</a>
         </div>
       </div>
@@ -556,7 +556,7 @@
         </div>
         <div class="col-6 col-medium-3">
           <p>Ubuntu is available on a huge range of devices from the world's largest hardware manufacturers, including Dell, HP, and Lenovo.</p>
-          <hr class="is-extra-muted" / />
+          <hr class="is-extra-muted" />
           <a href="https://canonical.com/partners/desktop">Find out more about our retail partners&nbsp;&rsaquo;</a>
         </div>
       </div>
@@ -567,7 +567,7 @@
         </div>
         <div class="col-6 col-medium-3">
           <p>Share ideas, write code, and get advice and help from our large, active community of IT professionals.</p>
-          <hr class="is-extra-muted" / />
+          <hr class="is-extra-muted" />
           <ul class="p-inline-list--middot">
             <li class="p-inline-list__item">
               <a href="https://discourse.ubuntu.com/">Ubuntu Discourse</a>
@@ -628,7 +628,6 @@
     }
     )
 </script>
-
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.8.2/d3.min.js" defer></script>
 <script src="{{ versioned_static('js/dist/release-chart.js') }}" defer></script>

--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -454,66 +454,6 @@
             ) | safe
           }}
         </div>
-        <div class="p-logo-section__item">
-          {{ image (
-            url="https://assets.ubuntu.com/v1/fe17c507-dell-logo.svg",
-            alt="dell logo",
-            width="71",
-            height="144",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-logo-section__logo"}
-            ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{ image (
-            url="https://assets.ubuntu.com/v1/dac5c9d7-amd-logo.png",
-            alt="amd logo",
-            width="186",
-            height="257",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-logo-section__logo"}
-            ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{ image (
-            url="https://assets.ubuntu.com/v1/834d57ab-intel-logo.png",
-            alt="intel logo",
-            width="149",
-            height="288",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-logo-section__logo"}
-            ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{ image (
-            url="https://assets.ubuntu.com/v1/d9d05f49-arm-logo.png",
-            alt="arm logo",
-            width="183",
-            height="372",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-logo-section__logo"}
-            ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{ image (
-            url="https://assets.ubuntu.com/v1/49c503f5-nvidia-logo.png",
-            alt="nvidia logo",
-            width="254",
-            height="257",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-logo-section__logo"}
-            ) | safe
-          }}
-        </div>
       </div>
     </div>
   </div>

--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -454,6 +454,66 @@
             ) | safe
           }}
         </div>
+        <div class="p-icon-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/fe17c507-dell-logo.svg",
+            alt="dell logo",
+            width="71",
+            height="144",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-icon-section__icon"}
+            ) | safe
+          }}
+        </div>
+        <div class="p-icon-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/dac5c9d7-amd-logo.png",
+            alt="amd logo",
+            width="186",
+            height="257",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-icon-section__icon"}
+            ) | safe
+          }}
+        </div>
+        <div class="p-icon-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/834d57ab-intel-logo.png",
+            alt="intel logo",
+            width="149",
+            height="288",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-icon-section__icon"}
+            ) | safe
+          }}
+        </div>
+        <div class="p-icon-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/d9d05f49-arm-logo.png",
+            alt="arm logo",
+            width="183",
+            height="372",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-icon-section__icon"}
+            ) | safe
+          }}
+        </div>
+        <div class="p-icon-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/49c503f5-nvidia-logo.png",
+            alt="nvidia logo",
+            width="254",
+            height="257",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-icon-section__icon"}
+            ) | safe
+          }}
+        </div>
       </div>
     </div>
   </div>

--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -454,7 +454,7 @@
             ) | safe
           }}
         </div>
-        <div class="p-icon-section__item">
+        <div class="p-logo-section__item">
           {{ image (
             url="https://assets.ubuntu.com/v1/fe17c507-dell-logo.svg",
             alt="dell logo",
@@ -462,11 +462,11 @@
             height="144",
             hi_def=True,
             loading="lazy",
-            attrs={"class": "p-icon-section__icon"}
+            attrs={"class": "p-logo-section__logo"}
             ) | safe
           }}
         </div>
-        <div class="p-icon-section__item">
+        <div class="p-logo-section__item">
           {{ image (
             url="https://assets.ubuntu.com/v1/dac5c9d7-amd-logo.png",
             alt="amd logo",
@@ -474,11 +474,11 @@
             height="257",
             hi_def=True,
             loading="lazy",
-            attrs={"class": "p-icon-section__icon"}
+            attrs={"class": "p-logo-section__logo"}
             ) | safe
           }}
         </div>
-        <div class="p-icon-section__item">
+        <div class="p-logo-section__item">
           {{ image (
             url="https://assets.ubuntu.com/v1/834d57ab-intel-logo.png",
             alt="intel logo",
@@ -486,11 +486,11 @@
             height="288",
             hi_def=True,
             loading="lazy",
-            attrs={"class": "p-icon-section__icon"}
+            attrs={"class": "p-logo-section__logo"}
             ) | safe
           }}
         </div>
-        <div class="p-icon-section__item">
+        <div class="p-logo-section__item">
           {{ image (
             url="https://assets.ubuntu.com/v1/d9d05f49-arm-logo.png",
             alt="arm logo",
@@ -498,11 +498,11 @@
             height="372",
             hi_def=True,
             loading="lazy",
-            attrs={"class": "p-icon-section__icon"}
+            attrs={"class": "p-logo-section__logo"}
             ) | safe
           }}
         </div>
-        <div class="p-icon-section__item">
+        <div class="p-logo-section__item">
           {{ image (
             url="https://assets.ubuntu.com/v1/49c503f5-nvidia-logo.png",
             alt="nvidia logo",
@@ -510,7 +510,7 @@
             height="257",
             hi_def=True,
             loading="lazy",
-            attrs={"class": "p-icon-section__icon"}
+            attrs={"class": "p-logo-section__logo"}
             ) | safe
           }}
         </div>

--- a/templates/shared/_release_schedule.html
+++ b/templates/shared/_release_schedule.html
@@ -15,8 +15,7 @@
   </div>
   <div class="row">
     <div class="col-10" style="overflow: auto;">
-      <div class="u-hide--small" id="server-desktop-eol"></div>
-      <div class="u-hide--small" id="server-desktop-eol-key"></div>
+      <div class="u-hide--small" id="server-desktop-eol-old"></div>
       <table class="u-hide--medium u-hide--large" style="width: auto;">
         <thead>
           <tr>

--- a/templates/shared/_release_schedule.html
+++ b/templates/shared/_release_schedule.html
@@ -16,6 +16,7 @@
   <div class="row">
     <div class="col-10" style="overflow: auto;">
       <div class="u-hide--small" id="server-desktop-eol"></div>
+      <div class="u-hide--small" id="server-desktop-eol-key"></div>
       <table class="u-hide--medium u-hide--large" style="width: auto;">
         <thead>
           <tr>


### PR DESCRIPTION
## Done

- Creates a new function `createSupportChart` that creates a graph based on the design [found in this figma file](https://www.figma.com/file/wLOtPeQhAiExhQCwKYhi3H/24.04-U.com---desktop-(rebranding)?type=design&node-id=871-2991&mode=design&t=6JDKoP4OfQHU60Eo-0). A screenshot comparison can be found below.
- Updates where this graph was used previously to work with the new graph (this means adding a place for the key to attach)

## QA

- Go to /desktop/developers and see that the graph matches the design
- Check that it works on medium and large screens and becomes a table on small screens
- Check the other pages where it is used and see that it doesn't break or anything (ie. /about/releases)

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-8270

## Screenshots

Desgin:
![image](https://github.com/canonical/ubuntu.com/assets/58276363/e2fe392d-65ed-4e96-a698-dc7216829223)

D3 reproduction:
![image](https://github.com/canonical/ubuntu.com/assets/58276363/29eb352d-0472-4b37-a84c-868225e6f536)
