### PR TITLE
Ignore 301 redirection loop from linkchecker

### DIFF
--- a/.github/workflows/live-links.yaml
+++ b/.github/workflows/live-links.yaml
@@ -42,6 +42,7 @@ jobs:
             /flags.png
             /flags@2x.png
             https?://[a-z0-9]*\.example\.com
+            https://lenovopress.lenovo.com/*
 
           [output]
           status=0


### PR DESCRIPTION
## Done

Added an ignore rule to the link links checker to ignore the Lenovo permanent redirect to the same page.

## QA

Check that this will resolve the remaining error in the latest live links action.