### PR TITLE
WD-8429 - update aws pro coverage table

### DIFF
--- a/templates/aws/pro.html
+++ b/templates/aws/pro.html
@@ -172,12 +172,17 @@
           <tr>
             <td>FIPS</td>
             <td>16.04, 18.04 and 20.04</td>
-            <td></td>
+            <td>Coming soon</td>
           </tr>
           <tr>
             <td>FIPS-Updates</td>
             <td>16.04, 18.04 and 20.04</td>
-            <td></td>
+            <td>Coming soon</td>
+          </tr>
+          <tr>
+            <td>FIPS-Preview</td>
+            <td>22.04</td>
+            <td>22.04</td>
           </tr>
         </tbody>
       </table>


### PR DESCRIPTION
## Done

Update feature coverage table on /was/pro

## QA

- [demo link](https://ubuntu-com-13500.demos.haus/aws/pro)
- [copy doc](https://docs.google.com/document/d/1pLRWJZSpE04nYt-yHBtCjxGI7VZsigcP2UJIBmR8i-0/edit)
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check that the table is correct according to the copy doc

## Issue / Card
[WD-8429](https://warthogs.atlassian.net/browse/WD-8429)

Fixes #

## Screenshots


[WD-8429]: https://warthogs.atlassian.net/browse/WD-8429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ