### PR TITLE
WD-8502 - add sources to nvidia page

### DIFF
--- a/templates/nvidia/index.html
+++ b/templates/nvidia/index.html
@@ -141,7 +141,8 @@
 				<li class="p-list__item"><a href="/kubernetes/charmed-k8s">Learn more for Charmed Kubernetes</a><li>
 				<li class="p-list__item"><a href="https://microk8s.io/resources?_ga=2.63950252.208025466.1654521646-1680362023.1652798743">Explore MicroK8s</a><li>
 				<li class="p-list__item"><a href="https://www.nvidia.com/en-us/data-center/dgx-ready-software/">Check out certified MLOps software for NVIDIA DGX systems</a><li>
-				<li class="p-list__item no-border"><a href="/engage/kubernetes-by-canonical-delivered-on-nvidia-dgx-systems"> Download the solution brief: Kubernetes by Canonical delivered on NVIDIA DGX systems</a><li>
+				<li class="p-list__item"><a href="/engage/kubernetes-by-canonical-delivered-on-nvidia-dgx-systems"> Download the solution brief: Kubernetes by Canonical delivered on NVIDIA DGX systems</a><li>
+				<li class="p-list__item no-border">Read the blog: <a href="/blog/canonical-kubernetes-enhances-ai-ml-development-capabilities-with-nvidia-integrations">Canonical Kubernetes enhances AI/ML development capabilities with NVIDIA integrations</a><li>
 			</ul>
 		</div>
 	</div>
@@ -375,6 +376,11 @@
 				<li class="p-list__item">
 					Whitepaper: <a href="/engage/run-ai-at-scale">
 						Run AI at Scale - Build Your Performant ML Stack with NVIDIA DGX and Kubeflow
+					</a>
+				</li>
+				<li class="p-list__item">
+					Reference architecture: <a href="https://pages.ubuntu.com/rs/066-EOV-335/images/EGX_MicroK8s_Kubeflow_Reference_Architecture.pdf">
+						Run AI at the Edge: Use MicroK8s with Charmed Kubeflow on NVIDIA EGX platform
 					</a>
 				</li>
 				<li class="p-list__item no-border">


### PR DESCRIPTION
## Done

Add 2 sources to /nvidia page

## QA

- [demo link](https://ubuntu-com-13501.demos.haus/nvidia)
- [copy doc](https://docs.google.com/document/d/1DJ1FuEswAojPNSX9JCLcWJwy-va5VMzuuLGwSNM0lRY/edit)
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check that the links and text are correct

## Issue / Card
[WD-8502](https://warthogs.atlassian.net/browse/WD-8502)

Fixes #

## Screenshots


[WD-8429]: https://warthogs.atlassian.net/browse/WD-8429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[WD-8502]: https://warthogs.atlassian.net/browse/WD-8502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ