### PR TITLE
Fix logo misalignment

### DIFF
--- a/static/js/src/support-chart.js
+++ b/static/js/src/support-chart.js
@@ -403,14 +403,11 @@ function buildChartKey(chartSelector, taskStatus) {
  * a list of texts, based on a given container width
  */
 function getMaxNumberOfLines(textList, width) {
-  var tempSvg = (svg = document.createElementNS(
-    "http://www.w3.org/2000/svg",
-    "svg"
-  ));
-  svg.style.position = "absolute";
-  svg.style.visibility = "hidden";
-  svg.width = width;
-  document.body.appendChild(svg);
+  var tempSvg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  tempSvg.style.position = "absolute";
+  tempSvg.style.visibility = "hidden";
+  tempSvg.width = width;
+  document.body.appendChild(tempSvg);
 
   var maxNumberOfLines = 1;
 
@@ -420,14 +417,14 @@ function getMaxNumberOfLines(textList, width) {
       "text"
     );
     textNode.textContent = formatKeyLabel(key);
-    svg.appendChild(textNode);
+    tempSvg.appendChild(textNode);
     var numberOfLines = Math.ceil(textNode.getComputedTextLength() / width);
     if (numberOfLines > maxNumberOfLines) {
       maxNumberOfLines = numberOfLines;
     }
-    svg.removeChild(textNode);
+    tempSvg.removeChild(textNode);
   });
-  document.body.removeChild(svg);
+  document.body.removeChild(tempSvg);
   return maxNumberOfLines;
 }
 
@@ -451,7 +448,7 @@ function wrapText(text, width) {
       x = text.attr("x"),
       y = text.attr("y"),
       dy = 0;
-    tspan = text
+    var tspan = text
       .text(null)
       .append("tspan")
       .attr("x", x)

--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -380,7 +380,7 @@
             height="256",
             hi_def=True,
             loading="auto|lazy",
-            attrs={"class": "p-icon-section__icon"}
+            attrs={"class": "p-logo-section__logo"}
             ) | safe
           }}
         </div>
@@ -392,7 +392,7 @@
             height="144",
             hi_def=True,
             loading="lazy",
-            attrs={"class": "p-icon-section__icon"}
+            attrs={"class": "p-logo-section__logo"}
             ) | safe
           }}
         </div>
@@ -404,7 +404,7 @@
             height="144",
             hi_def=True,
             loading="auto|lazy",
-            attrs={"class": "p-icon-section__icon"}
+            attrs={"class": "p-logo-section__logo"}
             ) | safe
           }}
         </div>
@@ -416,7 +416,7 @@
             height="257",
             hi_def=True,
             loading="lazy",
-            attrs={"class": "p-icon-section__icon"}
+            attrs={"class": "p-logo-section__logo"}
             ) | safe
           }}
         </div>
@@ -428,7 +428,7 @@
             height="288",
             hi_def=True,
             loading="lazy",
-            attrs={"class": "p-icon-section__icon"}
+            attrs={"class": "p-logo-section__logo"}
             ) | safe
           }}
         </div>
@@ -440,7 +440,7 @@
             height="372",
             hi_def=True,
             loading="lazy",
-            attrs={"class": "p-icon-section__icon"}
+            attrs={"class": "p-logo-section__logo"}
             ) | safe
           }}
         </div>
@@ -452,7 +452,7 @@
             height="257",
             hi_def=True,
             loading="lazy",
-            attrs={"class": "p-icon-section__icon"}
+            attrs={"class": "p-logo-section__logo"}
             ) | safe
           }}
         </div>

--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -113,7 +113,7 @@
           height="288",
           hi_def=True,
           loading="lazy",
-          attrs={"class": "p-icon-section__icon"}
+          attrs={"class": "p-logo-section__logo"}
           ) | safe
           }}
         </div>
@@ -129,7 +129,7 @@
             ) | safe
           }}
         </div>
-        <div class="p-icon-section__item ">
+        <div class="p-logo-section__item ">
           {{ image (
             url="https://assets.ubuntu.com/v1/1652445f-keras-logo.png",
             alt="keras logo",


### PR DESCRIPTION
## Done

- Fixes an incorrect class name that caused a misalignment

## QA

BEFORE:
![image](https://github.com/canonical/ubuntu.com/assets/58276363/5e0dd7b0-cea1-4b7e-a6b6-41542df1b345)
AFTER:
![image](https://github.com/canonical/ubuntu.com/assets/58276363/66f9ecff-3141-4ec1-8b3c-3cc9c3f2ef05)


## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
