### PR TITLE
Fix secondary links bug

### DIFF
--- a/static/js/src/navigation.js
+++ b/static/js/src/navigation.js
@@ -60,8 +60,8 @@ mainList.addEventListener("click", function (e) {
     }
   } else if (
     target.classList.contains("p-navigation__dropdown-item") ||
-    target.classList.contains("p-navigation__secondary-link") &&
-    target.tagName == "A"
+    (target.classList.contains("p-navigation__secondary-link") &&
+      target.tagName == "A")
   ) {
     window.location.href = target.href;
   }

--- a/static/js/src/navigation.js
+++ b/static/js/src/navigation.js
@@ -59,10 +59,10 @@ mainList.addEventListener("click", function (e) {
       handleDropdownClick(e.target.parentNode);
     }
   } else if (
-    target.classList.contains("p-navigation__dropdown") &&
+    target.classList.contains("p-navigation__dropdown-item") ||
+    target.classList.contains("p-navigation__secondary-link") &&
     target.tagName == "A"
   ) {
-    // This handles the globa-nav using a slightly different class naming convention
     window.location.href = target.href;
   }
 });

--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -38,6 +38,10 @@ $meganav-height: 3rem;
     top: 0;
     z-index: 40;
 
+    .p-navigation__secondary-link {
+      @extend .dropdown-window__side-panel-link;
+    }
+
     .p-link--inverted {
       font-weight: 400;
     }

--- a/templates/templates/meganav/base.html
+++ b/templates/templates/meganav/base.html
@@ -244,7 +244,7 @@
               <p class="p-muted-heading is-muted">{{ links_section.title }}</p>
               {% for link in links_section.links %}
                 <li class="p-list__item">
-                  <a class="dropdown-window__side-panel-link" href="{{ link.url }}" tabindex="-1">{{ link.title }}</a>
+                  <a class="p-navigation__secondary-link" href="{{ link.url }}" tabindex="-1">{{ link.title }}</a>
                 </li>
               {% endfor %}
             </ul>


### PR DESCRIPTION
## Done

- There was a bug where secondary links in mobile view and all links in global nav weren't working weren't working due to changes in class name. This PR addresses those.

## QA

- Open the demo on a mobile screen
- Go to 'Products' > 'Ubuntu OS' and check that the secondary links at the bottom work:
![image](https://github.com/canonical/ubuntu.com/assets/58276363/f5c4999d-3d32-4dfe-b77f-107009550dcd)
- Go to 'All Canonical' > 'About' and check that any of the links there work:
![image](https://github.com/canonical/ubuntu.com/assets/58276363/7ee1036f-69f2-4fe0-8dd3-800b85827e14)
- Check the same links work on desktop view.

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-8530
