### PR TITLE
Reinstate infer language script

### DIFF
--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -13,7 +13,8 @@
   <script src="https://assets.ubuntu.com/v1/703e23c9-lazysizes+noscript+native-loading.5.1.2.min.js" defer></script>
 
   <script src="{{ versioned_static('js/dist/main.js') }}" defer></script>
-
+  <script src="{{ versioned_static('js/src/infer-preferred-language.js')}}"></script>
+  
   <link rel="stylesheet" type="text/css" media="screen" href="{{ versioned_static('css/styles.css') }}">
   <link rel="stylesheet" type="text/css" media="print" href="{{ versioned_static('css/print.css') }}">
   <script>performance.mark("Stylesheets finished")</script>


### PR DESCRIPTION
## Done

- Reinstated script accidentally deleted in https://github.com/canonical/ubuntu.com/pull/13466/

## QA

- View the site locally in your web browser at: https://ubuntu-com-13510.demos.haus/
- Inspect the page and see that you no longer get `ReferenceError: getPrimaryParentLanguage is not defined` as compared to prod and that takeovers load as expected 

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-8551
