### PR TITLE
WD-8565 - update image on /about/release-cycle

### DIFF
--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -117,10 +117,10 @@
       <div class="u-fixed-width u-hide--small">
         {{
           image (
-          url="https://assets.ubuntu.com/v1/55599a4c-Ubuntu+LTS+Base+OS_3.svg",
+          url="https://assets.ubuntu.com/v1/f6aa32ab-Ubuntu+LTS+Base+OS_2024.svg",
           alt="",
           width="656",
-          height="331",
+          height="347",
           hi_def=True,
           loading="lazy"
           ) | safe


### PR DESCRIPTION
## Done

Update image on /release-cycle according to copy doc

## QA

- [demo link](https://ubuntu-com-13516.demos.haus/about/release-cycle#ubuntu)
- [copy doc](https://docs.google.com/document/d/1-l3B7AoyDoETaL80UhlfEWCVKmMWPdy3zoF5LpsGcYQ/edit)
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check that the image is correct

## Issue / Card
[WD-8565](https://warthogs.atlassian.net/browse/WD-8565)

Fixes #

## Screenshots

[WD-8565]: https://warthogs.atlassian.net/browse/WD-8565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ