### PR TITLE
Add functionality to account for height differences on mobile caused by the url navigation

### DIFF
--- a/static/js/src/navigation.js
+++ b/static/js/src/navigation.js
@@ -63,7 +63,7 @@ mainList.addEventListener("click", function (e) {
     target.classList.contains("p-navigation__secondary-link") ||
     target.classList.contains("p-button--positive")
   ) {
-    if (target.tagName == "A" || target.firstChild.tagName == "A") {
+    if (target.tagName === "A" || target.firstChild.tagName === "A") {
       window.location.href = target.href;
     }
   }

--- a/static/js/src/navigation.js
+++ b/static/js/src/navigation.js
@@ -308,7 +308,7 @@ function toggleGlobalNavVisibility(dropdown, show, delay) {
 
 function getUrlBarHeight(element) {
   const visibleHeight = window.innerHeight;
-  const fullHeight = document.querySelector('#control-height').clientHeight;
+  const fullHeight = document.querySelector("#control-height").clientHeight;
   const barHeight = fullHeight - visibleHeight;
   return barHeight;
 }
@@ -320,7 +320,7 @@ function updateWindowHeight() {
   navEle.style.maxHeight = originalMaxHeight;
   const isInDropdownList = mainList.classList.contains("is-active");
   if (isInDropdownList) {
-    const newHeight = (navEle.clientHeight - getUrlBarHeight() - 20) + 'px';
+    const newHeight = navEle.clientHeight - getUrlBarHeight() - 20 + "px";
     navEle.style.maxHeight = newHeight;
   } else {
     navEle.style.maxHeight = originalMaxHeight;

--- a/static/js/src/navigation.js
+++ b/static/js/src/navigation.js
@@ -60,10 +60,12 @@ mainList.addEventListener("click", function (e) {
     }
   } else if (
     target.classList.contains("p-navigation__dropdown-item") ||
-    (target.classList.contains("p-navigation__secondary-link") &&
-      target.tagName == "A")
+    target.classList.contains("p-navigation__secondary-link") ||
+    target.classList.contains("p-button--positive")
   ) {
-    window.location.href = target.href;
+    if (target.tagName == "A" || target.firstChild.tagName == "A") {
+      window.location.href = target.href;
+    }
   }
 });
 
@@ -148,6 +150,7 @@ function goBackOneLevel(e, backButton) {
   if (target.parentNode.getAttribute("role") == "menuitem") {
     updateNavMenu(target.parentNode, false);
   }
+  updateWindowHeight();
 }
 
 function escKeyPressHandler(e) {
@@ -219,6 +222,7 @@ function updateNavMenu(dropdown, show) {
     showDesktopDropdown(show);
   } else if (dropdownContentMobile) {
     updateMobileDropdownState(dropdown, show);
+    updateWindowHeight();
   } else {
     const observer = new MutationObserver(handleMutation);
     const observerConfig = { childList: true, subtree: true };
@@ -240,6 +244,7 @@ function updateDropdownStates(dropdown, show, delay) {
   }
   updateDesktopDropdownStates(dropdown, show, delay);
   updateMobileDropdownState(dropdown, show, isNested);
+  updateWindowHeight();
 }
 
 function updateDesktopDropdownStates(dropdown, show, delay) {
@@ -298,6 +303,27 @@ function toggleGlobalNavVisibility(dropdown, show, delay) {
     setTimeout(() => {
       globalNavInnerContent.classList.add("u-hide");
     }, delay);
+  }
+}
+
+function getUrlBarHeight(element) {
+  const visibleHeight = window.innerHeight;
+  const fullHeight = document.querySelector('#control-height').clientHeight;
+  const barHeight = fullHeight - visibleHeight;
+  return barHeight;
+}
+
+// Handles mobile navigation height taking up veiwport space
+const navEle = document.querySelector(".p-navigation__nav");
+const originalMaxHeight = navEle.style.maxHeight;
+function updateWindowHeight() {
+  navEle.style.maxHeight = originalMaxHeight;
+  const isInDropdownList = mainList.classList.contains("is-active");
+  if (isInDropdownList) {
+    const newHeight = (navEle.clientHeight - getUrlBarHeight() - 20) + 'px';
+    navEle.style.maxHeight = newHeight;
+  } else {
+    navEle.style.maxHeight = originalMaxHeight;
   }
 }
 
@@ -420,8 +446,8 @@ function keyboardNavigationHandler(e) {
 }
 
 function handleEscapeKey(e) {
-  // If '.dropdown-window__sidenav-content' exists we are in the dropdown window
-  // so we want to move up to the side-tabs
+  // If '.dropdown-window__sidenav-content' exists we are in the
+  // dropdown window so we want to move up to the side-tabs
   const targetTabId = e.target.closest(
     ".dropdown-window__sidenav-content.is-active"
   )?.id;
@@ -616,6 +642,7 @@ function closeAll() {
   closeNav();
   updateUrlHash();
   setTabIndex(mainList);
+  updateWindowHeight();
 }
 
 function openMenu(e) {

--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -5,8 +5,8 @@ $meganav-height: 3rem;
 @mixin ubuntu-p-navigation {
   #control-height {
     height: 100vh;
-    width: 0;
     position: absolute;
+    width: 0;
   }
 
   #all-canonical-mobile .global-nav__header-link-anchor::after {

--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -3,6 +3,12 @@ $row-margin-small: 1rem;
 $meganav-height: 3rem;
 
 @mixin ubuntu-p-navigation {
+  #control-height {
+    height: 100vh;
+    width: 0;
+    position: absolute;
+  }
+
   #all-canonical-mobile .global-nav__header-link-anchor::after {
     @media (max-width: $breakpoint-small) {
       right: 1rem !important;

--- a/templates/templates/_navigation.html
+++ b/templates/templates/_navigation.html
@@ -61,6 +61,7 @@
   </div>
   {% endblock header_banner %}
   <div class="p-navigation__search-overlay"></div>
+  <div id="control-height"></div>
 </header>
 <div class="dropdown-window-overlay fade-animation"></div>
 <div class="dropdown-window slide-animation {% if breadcrumbs and breadcrumbs.children or breadcrumbs.grandchildren %}is-reduced {% elif breadcrumbs == 'tutorials' %}is-reduced{% endif %}">


### PR DESCRIPTION
## Done

- adds functionality that calculate the view port size taking into account the size of the url bar
- fly by fix on links that also contained buttons not working

## QA

- Test that all links are visible on mobile view, these are the places it was reported:

-- on iOS it stops on Industrial, so that Robotics and Telco are left invisible below. You can hold and scroll down to expose both Robotics and Telco, but as soon as you release your finger they will hide again.
-- on Android it stops on Robotics and there is no way to see Telco that is hidden below. Holding and scrolling down doesn't do anything.
This is a bug that doesn't allow to click on items that are overflown.

- go to get ubuntu > desktop and check the top link works it clicked as does the download button

## Issue / Card

Fixes  [the comment here](https://github.com/canonical/ubuntu.com/pull/12939)