### PR TITLE
[WD-8623] remove Support sub-navigation item from /pricing bubble

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -474,8 +474,6 @@ pricing:
   children:
     - title: Overview
       path: /pricing
-    - title: Support
-      path: /pricing/infra
     - title: Consulting
       path: /pricing/consulting
     - title: Desktops


### PR DESCRIPTION
## Done

- Remove "Support" from sub-navigation item from /pricing bubble since the page it used to open before does not exist anymore (/pricing/infra)

## QA

- Navigate to https://ubuntu-com-13540.demos.haus/pricing and check if "Support" sub-navigation item does not exist

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-8623

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
