### PR TITLE
Re-introduce margin to h1 on /download/desktop

### DIFF
--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -8,7 +8,7 @@ meta_copydoc %}
 
 <section class="p-strip--suru-shape-light is-deep">
   <div class="u-fixed-width">
-    <h1 class="p-heading--2 u-no-margin--bottom"><strong>Download Ubuntu Desktop</strong></h1>
+    <h1 class="p-heading--2"><strong>Download Ubuntu Desktop</strong></h1>
     <p>The open-source desktop operating system that powers millions of PCs and laptops around the world. Find out more
       about Ubuntu's features and how we support developers and organisations below.</p>
     <p>


### PR DESCRIPTION
## Done

Before:
![image](https://github.com/canonical/ubuntu.com/assets/58276363/7e6ccaab-1a96-4e17-b987-535251e8a8d3)
After:
![image](https://github.com/canonical/ubuntu.com/assets/58276363/5987ccd6-48c2-4c83-b7a4-f9e39a0efedc)
