### PR TITLE
Open target meganav dropdown based on url hash on load

### DIFF
--- a/static/js/src/navigation.js
+++ b/static/js/src/navigation.js
@@ -149,10 +149,9 @@ function handleUrlHash() {
   const targetDropdown = targetId ? navigation.querySelector(targetId) : null;
   if (targetDropdown) {
     const currViewportWidth = window.innerWidth;
-    const isMobile = currViewportWidth < MOBILE_VIEW_BREAKPOINT
+    const isMobile = currViewportWidth < MOBILE_VIEW_BREAKPOINT;
     if (isMobile) {
       const menuToggle = navigation.querySelector(".js-menu-button");
-      console.log("menuToggle", menuToggle);
       menuToggle?.click();
     }
     fetchDropdown("/templates/meganav/" + targetDropdown.id, targetDropdown.id);
@@ -242,8 +241,8 @@ function updateNavMenu(dropdown, show) {
     else updateDropdownStates(dropdown, show);
     showDesktopDropdown(show);
   } else if (dropdownContentMobile) {
-    updateMobileDropdownState(dropdown, show);
     updateWindowHeight();
+    updateMobileDropdownState(dropdown, show);
   } else {
     const observer = new MutationObserver(handleMutation);
     const observerConfig = { childList: true, subtree: true };
@@ -263,9 +262,9 @@ function updateDropdownStates(dropdown, show, delay) {
         updateMobileDropdownState(filteredDropdown, !show);
       });
   }
+  updateWindowHeight();
   updateDesktopDropdownStates(dropdown, show, delay);
   updateMobileDropdownState(dropdown, show, isNested);
-  updateWindowHeight();
 }
 
 function updateDesktopDropdownStates(dropdown, show, delay) {

--- a/static/js/src/navigation.js
+++ b/static/js/src/navigation.js
@@ -145,7 +145,7 @@ function updateUrlHash(id, open) {
 }
 
 function handleUrlHash() {
-  const targetId = window.location.hash
+  const targetId = window.location.hash;
   const targetDropdown = targetId ? navigation.querySelector(targetId) : null;
   if (targetDropdown) {
     fetchDropdown("/templates/meganav/" + targetDropdown.id, targetDropdown.id);

--- a/static/js/src/navigation.js
+++ b/static/js/src/navigation.js
@@ -146,8 +146,8 @@ function updateUrlHash(id, open) {
 
 function handleUrlHash() {
   const targetId = window.location.hash
-  if(targetId !== "") {
-    const targetDropdown = navigation.querySelector(targetId);
+  const targetDropdown = targetId ? navigation.querySelector(targetId) : null;
+  if (targetDropdown) {
     fetchDropdown("/templates/meganav/" + targetDropdown.id, targetDropdown.id);
     targetDropdown?.querySelector("a").click();
   }

--- a/static/js/src/navigation.js
+++ b/static/js/src/navigation.js
@@ -148,8 +148,15 @@ function handleUrlHash() {
   const targetId = window.location.hash;
   const targetDropdown = targetId ? navigation.querySelector(targetId) : null;
   if (targetDropdown) {
+    const currViewportWidth = window.innerWidth;
+    const isMobile = currViewportWidth < MOBILE_VIEW_BREAKPOINT
+    if (isMobile) {
+      const menuToggle = navigation.querySelector(".js-menu-button");
+      console.log("menuToggle", menuToggle);
+      menuToggle?.click();
+    }
     fetchDropdown("/templates/meganav/" + targetDropdown.id, targetDropdown.id);
-    targetDropdown?.querySelector("a").click();
+    handleDropdownClick(targetDropdown);
   }
 }
 

--- a/static/js/src/navigation.js
+++ b/static/js/src/navigation.js
@@ -18,6 +18,9 @@ let dropdowns = [];
 const mainList = document.querySelector(
   "nav.p-navigation__nav > .p-navigation__items"
 );
+// Get the navigations initial height for use in 'updateWindowHeight'
+const navEle = document.querySelector(".p-navigation__nav");
+const originalMaxHeight = navEle.style.maxHeight;
 
 navigation.classList.add("js-enabled");
 nav.classList.remove("u-hide");
@@ -241,8 +244,8 @@ function updateNavMenu(dropdown, show) {
     else updateDropdownStates(dropdown, show);
     showDesktopDropdown(show);
   } else if (dropdownContentMobile) {
-    updateWindowHeight();
     updateMobileDropdownState(dropdown, show);
+    updateWindowHeight();
   } else {
     const observer = new MutationObserver(handleMutation);
     const observerConfig = { childList: true, subtree: true };
@@ -262,9 +265,9 @@ function updateDropdownStates(dropdown, show, delay) {
         updateMobileDropdownState(filteredDropdown, !show);
       });
   }
-  updateWindowHeight();
   updateDesktopDropdownStates(dropdown, show, delay);
   updateMobileDropdownState(dropdown, show, isNested);
+  updateWindowHeight();
 }
 
 function updateDesktopDropdownStates(dropdown, show, delay) {
@@ -334,8 +337,6 @@ function getUrlBarHeight(element) {
 }
 
 // Handles mobile navigation height taking up veiwport space
-const navEle = document.querySelector(".p-navigation__nav");
-const originalMaxHeight = navEle.style.maxHeight;
 function updateWindowHeight() {
   navEle.style.maxHeight = originalMaxHeight;
   const isInDropdownList = mainList.classList.contains("is-active");

--- a/static/js/src/navigation.js
+++ b/static/js/src/navigation.js
@@ -21,6 +21,12 @@ const mainList = document.querySelector(
 
 navigation.classList.add("js-enabled");
 nav.classList.remove("u-hide");
+document.addEventListener("DOMContentLoaded", () => {
+  setUpGlobalNav();
+});
+window.addEventListener("load", () => {
+  handleUrlHash();
+});
 
 //Helper functions
 
@@ -69,7 +75,6 @@ mainList.addEventListener("click", function (e) {
   }
 });
 
-window.addEventListener("load", closeAll);
 let wasBelowSpecificWidth = window.innerWidth < MOBILE_VIEW_BREAKPOINT;
 window.addEventListener("resize", function () {
   // Only closeAll if the resize event crosses the MOBILE_VIEW_BREAKPOINT threshold
@@ -136,6 +141,15 @@ function updateUrlHash(id, open) {
       document.title,
       window.location.pathname + window.location.search
     );
+  }
+}
+
+function handleUrlHash() {
+  const targetId = window.location.hash
+  if(targetId !== "") {
+    const targetDropdown = navigation.querySelector(targetId);
+    fetchDropdown("/templates/meganav/" + targetDropdown.id, targetDropdown.id);
+    targetDropdown?.querySelector("a").click();
   }
 }
 
@@ -754,9 +768,6 @@ function setUpGlobalNav() {
       dropdown.prepend(backButton);
     });
 }
-document.addEventListener("DOMContentLoaded", () => {
-  setUpGlobalNav();
-});
 
 // Initiate login
 var accountContainer = document.querySelector(".js-account");


### PR DESCRIPTION
## Done

- Adds a function 'handleUrlHash', that on load, will check if the url has a hash (ex. #products) and open the corresponding dropdown

## QA

- Go to  and see that nothing opens
- Go to https://ubuntu-com-13546.demos.haus/#products and see that the 'products' dropdown opens
- Go to https://ubuntu-com-13546.demos.haus/download/desktop#use-case and see that the 'use-case' dropdown opens
- Go to https://ubuntu-com-13546.demos.haus/#made-up-hash and see that nothing opens
- check normal functionality is retained

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-8727


