### PR TITLE
chore: change HOSTNAME variable name to HOST_NAME

### DIFF
--- a/templates/landscape/install.html
+++ b/templates/landscape/install.html
@@ -179,7 +179,7 @@
                   <p class="u-no-padding--top">Set your hostname using variables</p>
                   <p>Replace <strong>landscape.yourdomain.com</strong> with the FQDN pointing to your server, and set the HOSTNAME and DOMAIN variables based on the FQDN.</p>
                   <div class="p-code-snippet">
-                    <pre class="p-code-snippet__block is-wrapped"><code>HOSTNAME=landscape
+                    <pre class="p-code-snippet__block is-wrapped"><code>HOST_NAME=landscape
 DOMAIN=yourdomain.com
 FQDN=$HOST_NAME.$DOMAIN
 sudo hostnamectl set-hostname "$FQDN"</code></pre>


### PR DESCRIPTION
## Done

- Changed HOSTNAME variable name to HOST_NAME.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #13444 

## Screenshots

![Screenshot from 2024-02-08 14-34-25](https://github.com/canonical/ubuntu.com/assets/48877319/44e0f8c7-bfe6-4194-a516-bc0dd68d5e04)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
