### PR TITLE
edit index.html: maintanance -> maintenance

### DIFF
--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -445,7 +445,7 @@
       <h2>Ubuntu Pro</h2>
     </div>
     <div class="col">
-      <p>Ubuntu Pro offers a single, per-node packaging of the most comprehensive software, hardening and security in the industry. With the Base OS, OpenStack, Kubernetes and Applications security maintanance included, Ubuntu Pro delivers everything you need to future-proof your data centre.</p>
+      <p>Ubuntu Pro offers a single, per-node packaging of the most comprehensive software, hardening and security in the industry. With the Base OS, OpenStack, Kubernetes and Applications security maintenance included, Ubuntu Pro delivers everything you need to future-proof your data centre.</p>
       <p>Furthermore, you can add support for the Base OS, Infrastructure and Applications.</p>
       <hr />
       <a href="/pricing/infra">Learn more about Canonical support&nbsp;&rsaquo;</a>


### PR DESCRIPTION
Replace 'maintanance' with 'maintenance'. 

Reasons for edit:

1. 
Other uses of the word on this page spell it 'maintenance':
 - 'expands security maintenance'
 - 'Expanded security maintenance'


2. 
Google Ngram 1800-2019 shows 'maintenance' occurred >1000 times as frequently as 'maintanance':
 - [maintenance](https://books.google.com/ngrams/graph?content=maintenance&year_start=1800&year_end=2019&corpus=en-2019&smoothing=3)
 - [maintanance](https://books.google.com/ngrams/graph?content=maintanance&year_start=1800&year_end=2019&corpus=en-2019&smoothing=3
)


3.
[OED](https://www.oed.com/search/dictionary/?scope=Entries&q=maintanance) shows 'maintanance' as a spelling variant of 'maintenance'. 

But other online dictionaries do not have an entry for 'maintanance': 
 - [merriam-webster](https://www.merriam-webster.com/dictionary/maintanance)
 - [dictionary.cambridge.org](https://dictionary.cambridge.org/spellcheck/english/?q=maintanance)
 - [oxford learners dictionaries](https://www.oxfordlearnersdictionaries.com/spellcheck/english/?q=maintanance)