### PR TITLE
edit index.html: 'subscriptions expands' -> 'subscriptions expand'

### DIFF
--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -234,7 +234,7 @@
     <div class="col">
       <p class="p-heading--5">Stay up-to-date with regular updates and upgrades</p>
       <p>Long-term support (LTS) releases of Ubuntu Server receive standard security updates for around 2,500 packages in the Ubuntu Main repository for five years by default. Every six months, interim releases bring new features, while hardware enablement updates add support for the latest machines to all supported LTS releases.</p>
-      <p><a href="/pro">Ubuntu Pro</a> subscriptions expands security maintenance to over 30,000 packages for 10 years and provides optional, enterprise-grade phone and ticket support by Canonical.</p>
+      <p><a href="/pro">Ubuntu Pro</a> subscriptions expand security maintenance to over 30,000 packages for 10 years and provide optional, enterprise-grade phone and ticket support by Canonical.</p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
Replace
> Ubuntu Pro subscriptions expands security maintenance to over 30,000 packages for 10 years and provides optional, enterprise-grade phone and ticket support by Canonical.

with

> Ubuntu Pro subscriptions expand security maintenance to over 30,000 packages for 10 years and provide optional, enterprise-grade phone and ticket support by Canonical.

I propose this edit to make the [subject and verb agree](https://owl.purdue.edu/owl/general_writing/grammar/subject_verb_agreement.html).

The subject 'subscriptions' is plural so I make the verbs 'expand' and 'provide' rather than 'expands' and 'provides'.

### An alternative to the edit in the commit
The subject 'subscriptions' could be made singular to make the subject and verbs agree:
> An Ubuntu Pro subscription expands security maintenance to over 30,000 packages for 10 years and provides optional, enterprise-grade phone and ticket support by Canonical.