### PR TITLE
Fix navigation for engage pages

### DIFF
--- a/templates/engage/base.html
+++ b/templates/engage/base.html
@@ -25,28 +25,28 @@
 <span id="publish_date" class="u-hide">{{metadata["publish_date"]}}</span>
 <span id="created_date" class="u-hide">{{metadata["created_at"]}}</span>
 <section class="p-strip p-engage-banner--{{metadata['banner_class']}}">
-  <div class="u-fixed-width navigation-logo-engage">
+  <div class="u-fixed-width">
     <a href="/">
       {% if metadata['banner_class'] == 'light' %}
         {{
-          image(
-            url="https://assets.ubuntu.com/v1/04115a7e-ubuntu_black-orange_hex.svg",
-            alt="Ubuntu",
-            height="32",
-            width="143",
-            hi_def=True,
-            loading="auto"
+          image (
+          url="https://assets.ubuntu.com/v1/43ef5c89-Canonical Ubuntu.svg",
+          alt="",
+          width="300",
+          height="55",
+          hi_def=True,
+          loading="auto"
           ) | safe
         }}
       {% else %}
         {{
-          image(
-            url="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg",
-            alt="Ubuntu",
-            height="32",
-            width="143",
-            hi_def=True,
-            loading="auto"
+          image (
+          url="https://assets.ubuntu.com/v1/b4f695ea-Canonical Ubuntu copy 2.svg",
+          alt="",
+          width="300",
+          height="55",
+          hi_def=True,
+          loading="auto"
           ) | safe
         }}
       {% endif %}

--- a/templates/engage/base_engage.html
+++ b/templates/engage/base_engage.html
@@ -1,6 +1,3 @@
-{% if hide_nav is not defined %}
-  {% set hide_nav = True %}
-{% endif %}
 {% extends "templates/base.html" %}
 
 {% block meta_copydoc %}https://drive.google.com/drive/folders/1FyMcu6vqGnyQMdWLRjvxJVWm8gHgslk4{% endblock meta_copydoc %}


### PR DESCRIPTION
## Done

- Fix navigation
- Quick update Ubuntu logo (we have a task later to [re-design the entire page](https://warthogs.atlassian.net/browse/WD-7146))

## QA

- Go to any engage page e.g. https://ubuntu-com-13565.demos.haus/engage/canonical-intel-telco-france-event check that the navigation shows up. You can compare with current https://ubuntu.com/engage/canonical-intel-telco-france-event
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-8808

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
