### PR TITLE
WD-8702 - add content to /hpe

### DIFF
--- a/templates/hpe/index.html
+++ b/templates/hpe/index.html
@@ -286,7 +286,7 @@
   <div class="row u-no-padding--top">
     <hr class="p-rule" />
     <div class="col-6 col-medium-2">
-      <h2>Reference design</h2>
+      <h2>Reference designs</h2>
     </div>
     <div class="col-6 col-medium-4">
       <div class="u-image-separation">
@@ -303,12 +303,24 @@
         }}
       </div>
       <p>Learn how these HPE and Canonical components complement each other to create an entire solution for Telecom Service Providers.</p>
-      <ul class="p-list--divided">
-        <li class="p-list__item has-bullet"><a href="/engage/hpe-telco-validated-design-with-canonical-anbox">Anbox Reference Design</a></li>
-        <li class="p-list__item has-bullet"><a href="/engage/hpe-telco-validated-design-with-canonical-kubernetes">Kubernetes Reference Design</a></li>
-        <li class="p-list__item has-bullet"><a href="/engage/hpe-telco-validated-design-with-canonical-microcloud">MicroCloud Reference Design</a></li>
-        <li class="p-list__item has-bullet"><a href="/engage/hpe-telco-validated-design-with-canonical-openstack">OpenStack Reference Design</a></li>
-      </ul>
+      <div class="row">
+        <p class="col-6 p-heading--4">For Servers</p>
+        <ul class="col-6 p-list--divided">
+          <li class="p-list__item has-bullet"><a href="/engage/hpe-telco-validated-design-with-canonical-anbox">Anbox Reference Design</a></li>
+          <li class="p-list__item has-bullet"><a href="/engage/hpe-telco-validated-design-with-canonical-kubernetes">Kubernetes Reference Design</a></li>
+          <li class="p-list__item has-bullet"><a href="/engage/hpe-telco-validated-design-with-canonical-microcloud">MicroCloud Reference Design</a></li>
+          <li class="p-list__item has-bullet"><a href="/engage/hpe-telco-validated-design-with-canonical-openstack">OpenStack Reference Design</a></li>
+        </ul>
+      </div>
+      <div class="row">
+        <p class="col-6 p-heading--4">For Storage</p>
+        <ul class="col-6 p-list--divided">
+          <li class="p-list__item has-bullet"><a href="/engage/hpe-alletra-6000-validated-design-openstack">OpenStack for HPE Alletra Storage 6000</a></li>
+          <li class="p-list__item has-bullet"><a href="/engage/hpe-alletra-9000-validated-design-openstack">OpenStack for HPE Alletra Storage 9000</a></li>
+          <li class="p-list__item has-bullet"><a href="/engage/hpe-alletra-6000-validated-design-kubernetes">Kubernetes for HPE Alletra Storage 6000</a></li>
+          <li class="p-list__item has-bullet"><a href="/engage/hpe-alletra-9000-validated-design-kubernetes">Kubernetes for HPE Alletra Storage 9000</a></li>
+        </ul>
+      </div>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

Add content to Reference designs section on /hpe

## QA
- [demo link](https://ubuntu-com-13545.demos.haus/blog)
- [copy doc](https://docs.google.com/document/d/1A2__NxIU6jFKprs5thPNtIPfOc7E9VhZEoPFu01lT_8/edit)
- [figma](https://www.figma.com/file/WIizcxJW1PcpPpvjUX433B/23.10-U.com---HPE-partner-page?node-id=1%3A754&mode=dev)
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check that the page is correctly updated according to copy doc

## Issue / Card
[WD-8702](https://warthogs.atlassian.net/browse/WD-8702)

Fixes #

## Screenshots
