### PR TITLE
Refresh /download/alternative-downloads

### DIFF
--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -26,7 +26,7 @@ meta_copydoc %}
     <div class="col-3">
       <div class="p-side-navigation--raw-html is-sticky" id="drawer" style="top: 80px;">
         <button class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">
-          Toggle side navigation
+          Toggle table of contents
         </button>
         <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="drawer"></div>
         <nav class="p-side-navigation__drawer" aria-label="documentation side navigation">

--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -6,137 +6,316 @@ text-based alternate installer or find previous versions of Ubuntu?{% endblock %
 {% block meta_copydoc %}https://docs.google.com/document/d/1VhmFVE3dK81mE3zcC9FVA6f5SGJ-DHan7WWlrlfRcvo/edit{% endblock
 meta_copydoc %}
 
+{% block body_class %}is-paper{% endblock body_class %}
+
 {% block content %}
-<div class="p-strip--suru-topped is-bordered">
+<div class="p-strip--suru-shape-light is-shallow">
+  <div class="p-section">
+    <div class="row">
+      <div class="col-9 col-start-large-4">
+        <h1>Alternative downloads</h1>
+        <p>There are several other ways to get Ubuntu including torrents, which can potentially mean a quicker download, our network installer for older systems and special configurations and links to our regional mirrors for our older (and newer) releases.</p> 
+        <p>If you don't specifically require any of these installers, we recommend using our <a href="/download">standard downloads</a>.</p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="p-section">
   <div class="row">
-    <div class="col-8">
-      <h1>Alternative downloads</h1>
-      <p>There are several other ways to get Ubuntu including torrents, which can potentially mean a quicker download,
-        our network installer for older systems and special configurations and links to our regional mirrors for our
-        older (and newer) releases. If you don't specifically require any of these installers, we recommend using our <a
-          href="/download">standard downloads</a>.</p>
+    <div class="col-3">
+      <div class="p-side-navigation--raw-html is-sticky" id="drawer" style="top: 80px;">
+        <button class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">
+          Toggle side navigation
+        </button>
+        <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="drawer"></div>
+        <nav class="p-side-navigation__drawer" aria-label="documentation side navigation">
+          <div class="p-side-navigation__drawer-header">
+            <button class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="drawer">
+              Toggle table of contents
+            </button>
+          </div>
+          <ul>
+            <li class="p-side-navigation__item">
+              <a class="highlight-link" href="#bit-torrent">BitTorrent</a>
+            </li>
+            <li class="p-side-navigation__item">
+              <a class="highlight-link" href="#other-images-and-mirrors">Other images and mirrors</a>
+            </li>
+            <li class="p-side-navigation__item">
+              <a class="highlight-link" href="#past-releases-and-other-flavours">Past releases and other flavours</a>
+            </li>
+            <li class="p-side-navigation__item">
+              <a class="highlight-link" href="#network-installer">Network installer</a>
+            </li>
+          </ul>
+        </nav>
+      </div>
     </div>
-  </div>
-</div>
-
-<div class="p-strip--light is-bordered">
-  <div class="row" id="network-installer">
-    <div class="col-8">
-      <h2>Network installer</h2>
-      <p>The network installer lets you install Ubuntu over a network. It includes the minimal set of packages needed to
-        start and the rest of the packages are downloaded over the network. Since only current packages are downloaded,
-        there is no need to upgrade packages immediately after installation.</p>
-      <p>The network installer is ideal if you have a computer that cannot run the graphical installer, for example,
-        because it does not meet the minimum requirements for the live CD/DVD, or because the computer requires extra
-        configuration before a graphical desktop can be used. The network installer is also useful if you want to
-        install Ubuntu on a large number of computers at once.</p>
-      <p>For 22.04 LTS, users can use the new Ubuntu Live installer to setup and configure a network install.</p>
-      <ul class="p-list">
-        <li class="p-list__item is-ticked"><a
-            href="https://discourse.ubuntu.com/t/netbooting-the-live-server-installer">Instructions for the {{
-            releases.lts.short_version }} LTS Ubuntu Live installer</a></li>
-      </ul>
-    </div>
-  </div>
-</div>
-
-<div class="p-strip is-bordered">
-  <div class="row" id="bittorrents">
-    <div class="col-8">
-      <h2 id="bittorrent">BitTorrent</h2>
-      <p>BitTorrent is a peer-to-peer download network that sometimes enables higher download speeds and more reliable
-        downloads of large files. You need a BitTorrent client on your computer to enable this download method.</p>
-    </div>
-  </div>
-
-  <div class="row">
-    {% if releases.latest.short_version > releases.lts.short_version %}
-    <div class="col-4">
-      <h3 class="p-heading--4"><span>Ubuntu {{ releases.latest.full_version }}</span></h3>
-      <ul class="p-list--divided">
-        <li class="p-list__item">
-          <a class="download-torrent"
-            href="https://releases.ubuntu.com/{{ releases.latest.desktop_version }}/ubuntu-{{ releases.latest.desktop_version }}-desktop-amd64.iso.torrent">Ubuntu
-            {{ releases.latest.full_version }} Desktop (64-bit)</a>
-        </li>
-        <li class="p-list__item">
-          <a class="download-torrent"
-            href="https://releases.ubuntu.com/{{ releases.latest.short_version }}/ubuntu-{{ releases.latest.full_version }}-live-server-amd64.iso.torrent">Ubuntu
-            Server {{ releases.latest.full_version }}</a>
-        </li>
-      </ul>
-    </div>
-    {% endif %}
-    <div class="col-4">
-      <h3 class="p-heading--4">
-        <span>Ubuntu {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr></span>
-      </h3>
-      <ul class="p-list--divided">
-        <li class="p-list__item">
-          <a class="download-torrent"
-            href="https://releases.ubuntu.com/{{ releases.lts.short_version }}/ubuntu-{{ releases.lts.full_version }}-desktop-amd64.iso.torrent">Ubuntu
-            {{ releases.lts.full_version }} Desktop (64-bit)</a>
-        </li>
-        <li class="p-list__item">
-          <a class="download-torrent"
-            href="https://releases.ubuntu.com/{{ releases.lts.short_version }}/ubuntu-{{ releases.lts.full_version }}-live-server-amd64.iso.torrent">Ubuntu
-            Server {{ releases.lts.full_version }} LTS</a>
-        </li>
-      </ul>
-    </div>
-    <div class="col-4">
-      <h3 class="p-heading--4">
-        <span>Ubuntu {{ releases.previous_lts.full_version }} <abbr title="Long-term support">LTS</abbr></span>
-      </h3>
-      <ul class="p-list--divided">
-        <li class="p-list__item">
-          <a class="download-lts"
-            href="https://releases.ubuntu.com/{{ releases.previous_lts.short_version }}/ubuntu-{{ releases.previous_lts.full_version }}-desktop-amd64.iso.torrent">Ubuntu
-            {{ releases.previous_lts.full_version }} Desktop (64-bit)</a>
-        </li>
-        <li class="p-list__item">
-          <a class="download-lts"
-            href="https://releases.ubuntu.com/{{ releases.previous_lts.short_version }}/ubuntu-{{ releases.previous_lts.full_version }}-live-server-amd64.iso.torrent">Ubuntu
-            Server {{ releases.previous_lts.full_version }} LTS</a>
-        </li>
-      </ul>
-    </div>
-  </div>
-</div>
-
-<div class="p-strip--light">
-  <div class="row p-divider">
-    <div class="col-6 p-divider__block">
-      <h2 id="other-images-and-mirrors">Other images and mirrors</h2>
-      <p>For the full list of available Ubuntu images, we recommend you select a mirror local to you.</p>
-      <p><a href="https://launchpad.net/ubuntu/+cdmirrors">See all Ubuntu mirrors</a></p>
-    </div>
-    <div class="col-6 p-divider__block">
-      <h2 id="past-releases-and-other-flavours">Past releases and other flavours</h2>
-      <p>Looking for an older release of Ubuntu? Whether you need a POWER, IBMz (s390x), ARM, an obsolete release or a
-        previous LTS point release with its original stack, you can find them in past releases.</p>
-      <ul class="p-list">
-        <li class="p-list__item is-ticked">
-          <a href="https://releases.ubuntu.com/{{ releases.previous_lts.full_version }}/">Ubuntu {{
-            releases.previous_lts.short_version }} LTS ({{ releases.previous_lts.name }})</a>
-        </li>
-        {% if releases.latest.past_eol_date != true and releases.latest.short_version < releases.lts.short_version %}
-          <li class="p-list__item is-ticked">
-          <a href="https://releases.ubuntu.com/{{ releases.latest.full_version }}/">Ubuntu {{
-            releases.latest.short_version }} ({{ releases.latest.name }})</a>
-          </li>
+    <div class="col-9">
+      <div class="p-section">
+        <hr class="p-rule"/>
+        <div class="p-section--shallow">
+          <h2 id="bit-torrent" class="question-heading" style="scroll-margin-top: 3.4rem;">BitTorrent</h2>
+        </div>
+        <div class="p-section--shallow">
+          <p>BitTorrent is a peer-to-peer download network that sometimes enables higher download speeds and more reliable downloads of large files. You need a BitTorrent client on your computer to enable this download method.</p>
+        </div>
+        <hr class="p-rule"/>
+        <div class="row">
+          {% if releases.latest.short_version > releases.lts.short_version %}
+          <div class="col-3 col-medium-2">
+            <h3 class="p-heading--5">Ubuntu {{ releases.latest.full_version }}</h3>
+            <p>
+              <a class="download-torrent"
+                href="https://releases.ubuntu.com/{{ releases.latest.desktop_version }}/ubuntu-{{ releases.latest.desktop_version }}-desktop-amd64.iso.torrent">Ubuntu
+                {{ releases.latest.full_version }} Desktop (64-bit)</a>
+            </p>
+            <p>
+              <a class="download-torrent"
+                href="https://releases.ubuntu.com/{{ releases.latest.short_version }}/ubuntu-{{ releases.latest.full_version }}-live-server-amd64.iso.torrent">Ubuntu
+                Server {{ releases.latest.full_version }}</a>
+            </p>
+          </div>
           {% endif %}
-          <li class="p-list__item is-ticked">
-            <a href="https://releases.ubuntu.com/{{ releases.previous_previous_lts.full_version }}/">Ubuntu {{
-              releases.previous_previous_lts.short_version }} LTS ({{ releases.previous_previous_lts.name }})</a>
-          </li>
-      </ul>
-      <p><a href="https://releases.ubuntu.com/">Past releases</a></p>
+          <div class="col-3 col-medium-2">
+            <h3 class="p-heading--5">
+              Ubuntu {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr>
+            </h3>
+            <p>
+              <a class="download-torrent"
+                href="https://releases.ubuntu.com/{{ releases.lts.short_version }}/ubuntu-{{ releases.lts.full_version }}-desktop-amd64.iso.torrent">Ubuntu
+                {{ releases.lts.full_version }} Desktop (64-bit)</a>
+            </p>
+            <p>
+              <a class="download-torrent"
+                href="https://releases.ubuntu.com/{{ releases.lts.short_version }}/ubuntu-{{ releases.lts.full_version }}-live-server-amd64.iso.torrent">Ubuntu
+                Server {{ releases.lts.full_version }} LTS</a>
+            </p>
+          </div>
+          <div class="col-3 col-medium-2">
+            <h3 class="p-heading--5">
+              Ubuntu {{ releases.previous_lts.full_version }} <abbr title="Long-term support">LTS</abbr>
+            </h3>
+            <p>
+              <a class="download-lts"
+                href="https://releases.ubuntu.com/{{ releases.previous_lts.short_version }}/ubuntu-{{ releases.previous_lts.full_version }}-desktop-amd64.iso.torrent">Ubuntu
+                {{ releases.previous_lts.full_version }} Desktop (64-bit)</a>
+            </p>
+            <p>
+              <a class="download-lts"
+                href="https://releases.ubuntu.com/{{ releases.previous_lts.short_version }}/ubuntu-{{ releases.previous_lts.full_version }}-live-server-amd64.iso.torrent">Ubuntu
+                Server {{ releases.previous_lts.full_version }} LTS</a>
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div class="p-section">
+        <div class="row">
+          <hr class="p-rule">
+          <div class="col-7">
+            <div class="p-section--shallow">
+              <h2 id="other-images-and-mirrors" class="question-heading" style="scroll-margin-top: 3.4rem;">Other images and mirrors</h2>
+            </div>
+            <p>For the full list of available Ubuntu images, we recommend you select a mirror local to you.</p>
+            <hr class="is-muted"/>
+            <p>
+              <a href="https://launchpad.net/ubuntu/+cdmirrors">All Ubuntu mirrors&nbsp;&rsaquo;</a>
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div class="p-section">
+        <div class="row">
+          <hr class="p-rule">
+          <div class="col-7">
+            <div class="p-section--shallow">
+              <h2 id="past-releases-and-other-flavours" class="question-heading" style="scroll-margin-top: 3.4rem;">Past releases and other flavours</h2>
+            </div>
+            <p>Looking for an older release of Ubuntu? Whether you need a POWER, IBMz (s390x), ARM, an obsolete release or a previous LTS point release with its original stack, you can find them in past releases.</p>
+            <hr class="p-rule is-muted"/>
+            <p>
+              <a href="https://releases.ubuntu.com/20.04.6/?_gl=1*19ip6hm*_gcl_au*MTE4NTIyOTI0MS4xNzA3MTMxMDQx&_ga=2.149898549.2084151835.1707729318-1126754318.1683186906">Ubuntu 20.04 LTS (Focal Fossa)</a>
+            </p>
+            <hr class="p-rule is-muted"/>
+            <p>
+              <a href="https://releases.ubuntu.com/18.04.6/?_gl=1*19ip6hm*_gcl_au*MTE4NTIyOTI0MS4xNzA3MTMxMDQx&_ga=2.149898549.2084151835.1707729318-1126754318.1683186906">Ubuntu 18.04 LTS (Bionic Beaver)</a>
+            </p>
+            <hr class="p-rule is-muted"/>
+            <p>
+              <a href="https://releases.ubuntu.com/?_gl=1*19ip6hm*_gcl_au*MTE4NTIyOTI0MS4xNzA3MTMxMDQx&_ga=2.149898549.2084151835.1707729318-1126754318.1683186906">All past releases&nbsp;&rsaquo;</a>
+            </p>
+            </ul>
+          </div>
+        </div>
+      </div>
+
+      <div class="p-section">
+        <div class="row">
+          <hr class="p-rule">
+          <div class="col-7">
+            <div class="p-section--shallow">
+              <h2 id="network-installer" class="question-heading" style="scroll-margin-top: 3.4rem;">Network installer</h2>
+            </div>
+            <p>The network installer lets you install Ubuntu over a network. It includes the minimal set of packages needed to start and the rest of the packages are downloaded over the network. Since only current packages are downloaded, there is no need to upgrade packages immediately after installation.</p>
+            <p>The network installer is ideal if you have a computer that cannot run the graphical installer. It is also useful if you want to install Ubuntu on a large number of computers at once.</p>
+            <hr class="p-rule is-muted">
+            <p><a href="https://discourse.ubuntu.com/t/netbooting-the-live-server-installer?_gl=1*1t2mr3n*_gcl_au*MTE4NTIyOTI0MS4xNzA3MTMxMDQx&_ga=2.204825875.2084151835.1707729318-1126754318.1683186906">Instructions for the 22.04 LTS Ubuntu Live installer&nbsp;&rsaquo;</a></p>
+            <hr class="p-rule is-muted">
+            <p><a href="https://discourse.ubuntu.com/t/netbooting-the-live-server-installer">Instructions for the 20.04 Ubuntu Live installer&nbsp;&rsaquo;</a></p>
+            <hr class="p-rule is-muted">
+            <p><a href="http://cdimage.ubuntu.com/netboot/18.04/">Download the network installer for 18.04 LTS&nbsp;&rsaquo;</a></p>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </div>
 
-{% with first_item="_download_more_info_enterprise", second_item="_download_all_installation",
-third_item="_download_helping_hands" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
+{% include "download/shared/_footer.html" %}
+
+<script type="text/javascript">
+  function setUpTogglableSideNav() {
+    var navigationDrawer = document.querySelector("#drawer");
+    var navigationDrawerToggles = Array.prototype.slice.call(
+      document.querySelectorAll(".js-drawer-toggle")
+    );
+
+    if (navigationDrawer) {
+      var navigationLinks = Array.prototype.slice.call(
+        navigationDrawer.querySelectorAll("a")
+      );
+
+      navigationDrawerToggles.forEach(function(toggle) {
+        toggle.addEventListener("click", function() {
+          navigationDrawer.classList.toggle("is-expanded");
+        });
+      });
+
+      navigationLinks.forEach(function(link) {
+        link.addEventListener("click", function() {
+          navigationDrawer.classList.remove("is-expanded");
+        });
+      });
+    }
+  };
+
+  function setUpDynamicSideNav() {
+    const questions = Array.prototype.slice.call(
+      document.querySelectorAll(".question-heading")
+    );
+
+    const navigationLinks = Array.prototype.slice.call(
+      document.querySelectorAll(".highlight-link")
+    );
+
+    questions.forEach(function(question) {
+      const observer = new IntersectionObserver(function(entry) {
+        if (entry[0].isIntersecting) {
+          const questionId = entry[0].target.id;
+          navigationLinks.forEach(function(link) {
+            if (link.getAttribute("href") === `#${questionId}`) {
+              console.log("adding")
+              link.classList.add("is-active");
+            } else {
+              console.log("removing")
+              link.classList.remove("is-active");
+            }
+          });
+        }
+      }, {
+        rootMargin: "0px 0px -800px",
+        threshold: 1,
+      });
+
+      observer.observe(question);
+    });
+  };
+
+
+  /**
+   Toggles the expanded/collapsed classed on side navigation element.
+
+  @param {HTMLElement} sideNavigation The side navigation element.
+  @param {Boolean} show Whether to show or hide the drawer.
+  @param {Boolean} ignoreTogglerFocus when we click on menu there is no redirect, the focus should jump into selected section
+  */
+  function toggleDrawer(sideNavigation, show, ignoreTogglerFocus = false) {
+    const toggleButtonOutsideDrawer = sideNavigation.querySelector(
+      ".p-side-navigation__toggle"
+    );
+    const toggleButtonInsideDrawer = sideNavigation.querySelector(
+      ".p-side-navigation__toggle--in-drawer"
+    );
+
+    if (sideNavigation) {
+      if (show) {
+        sideNavigation.classList.remove("is-collapsed");
+        sideNavigation.classList.add("is-expanded");
+
+        if (!ignoreTogglerFocus) {
+          toggleButtonInsideDrawer.focus();
+        }
+        toggleButtonOutsideDrawer.setAttribute("aria-expanded", "true");
+        toggleButtonInsideDrawer.setAttribute("aria-expanded", "true");
+      } else {
+        sideNavigation.classList.remove("is-expanded");
+        sideNavigation.classList.add("is-collapsed");
+
+        if (!ignoreTogglerFocus) {
+          toggleButtonOutsideDrawer.focus();
+        }
+        toggleButtonOutsideDrawer.setAttribute("aria-expanded", "false");
+        toggleButtonInsideDrawer.setAttribute("aria-expanded", "false");
+      }
+    }
+  }
+
+  /**
+   Setup default values of aria-expanded for the toggle button, list title and list itself
+
+  @param {HTMLButtonElement} toggleMenu
+  */
+  const setupToggleMenu = (toggleMenu) => {
+    const isExpanded = toggleMenu.getAttribute("aria-expanded") === "true";
+    if (!isExpanded) {
+      toggleMenu.setAttribute("aria-expanded", isExpanded);
+    }
+    const item = toggleMenu.closest(".p-side-navigation__item");
+    const link = item.querySelector(".p-side-navigation__link");
+    const nestedList = item.querySelector(".p-side-navigation__list");
+    if (!link?.hasAttribute("aria-expanded")) {
+      link.setAttribute("aria-expanded", isExpanded);
+    }
+    if (!nestedList?.hasAttribute("aria-expanded")) {
+      nestedList.setAttribute("aria-expanded", isExpanded);
+    }
+  };
+
+  /**
+   Handle toggle button to show/hide submenu
+
+  @param {Event} e
+  */
+  const handleToggleMenu = (e) => {
+    const item = e.currentTarget.closest(".p-side-navigation__item");
+    const button = item.querySelector(".p-side-navigation__expand");
+    const link = item.querySelector(".p-side-navigation__link");
+    const nestedList = item.querySelector(".p-side-navigation__list");
+    [button, link, nestedList].forEach((el) =>
+      el.setAttribute(
+        "aria-expanded",
+        el.getAttribute("aria-expanded") === "true" ? "false" : "true"
+      )
+    );
+  };
+
+  (function() {
+    setUpTogglableSideNav();
+    setUpDynamicSideNav();
+  })();
+</script>
 
 {% endblock content %}

--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -37,7 +37,7 @@ meta_copydoc %}
           </div>
           <ul>
             <li class="p-side-navigation__item">
-              <a class="highlight-link" href="#bit-torrent">BitTorrent</a>
+              <a class="highlight-link is-active" href="#bit-torrent">BitTorrent</a>
             </li>
             <li class="p-side-navigation__item">
               <a class="highlight-link" href="#other-images-and-mirrors">Other images and mirrors</a>
@@ -217,10 +217,8 @@ meta_copydoc %}
           const questionId = entry[0].target.id;
           navigationLinks.forEach(function(link) {
             if (link.getAttribute("href") === `#${questionId}`) {
-              console.log("adding")
               link.classList.add("is-active");
             } else {
-              console.log("removing")
               link.classList.remove("is-active");
             }
           });
@@ -232,84 +230,6 @@ meta_copydoc %}
 
       observer.observe(question);
     });
-  };
-
-
-  /**
-   Toggles the expanded/collapsed classed on side navigation element.
-
-  @param {HTMLElement} sideNavigation The side navigation element.
-  @param {Boolean} show Whether to show or hide the drawer.
-  @param {Boolean} ignoreTogglerFocus when we click on menu there is no redirect, the focus should jump into selected section
-  */
-  function toggleDrawer(sideNavigation, show, ignoreTogglerFocus = false) {
-    const toggleButtonOutsideDrawer = sideNavigation.querySelector(
-      ".p-side-navigation__toggle"
-    );
-    const toggleButtonInsideDrawer = sideNavigation.querySelector(
-      ".p-side-navigation__toggle--in-drawer"
-    );
-
-    if (sideNavigation) {
-      if (show) {
-        sideNavigation.classList.remove("is-collapsed");
-        sideNavigation.classList.add("is-expanded");
-
-        if (!ignoreTogglerFocus) {
-          toggleButtonInsideDrawer.focus();
-        }
-        toggleButtonOutsideDrawer.setAttribute("aria-expanded", "true");
-        toggleButtonInsideDrawer.setAttribute("aria-expanded", "true");
-      } else {
-        sideNavigation.classList.remove("is-expanded");
-        sideNavigation.classList.add("is-collapsed");
-
-        if (!ignoreTogglerFocus) {
-          toggleButtonOutsideDrawer.focus();
-        }
-        toggleButtonOutsideDrawer.setAttribute("aria-expanded", "false");
-        toggleButtonInsideDrawer.setAttribute("aria-expanded", "false");
-      }
-    }
-  }
-
-  /**
-   Setup default values of aria-expanded for the toggle button, list title and list itself
-
-  @param {HTMLButtonElement} toggleMenu
-  */
-  const setupToggleMenu = (toggleMenu) => {
-    const isExpanded = toggleMenu.getAttribute("aria-expanded") === "true";
-    if (!isExpanded) {
-      toggleMenu.setAttribute("aria-expanded", isExpanded);
-    }
-    const item = toggleMenu.closest(".p-side-navigation__item");
-    const link = item.querySelector(".p-side-navigation__link");
-    const nestedList = item.querySelector(".p-side-navigation__list");
-    if (!link?.hasAttribute("aria-expanded")) {
-      link.setAttribute("aria-expanded", isExpanded);
-    }
-    if (!nestedList?.hasAttribute("aria-expanded")) {
-      nestedList.setAttribute("aria-expanded", isExpanded);
-    }
-  };
-
-  /**
-   Handle toggle button to show/hide submenu
-
-  @param {Event} e
-  */
-  const handleToggleMenu = (e) => {
-    const item = e.currentTarget.closest(".p-side-navigation__item");
-    const button = item.querySelector(".p-side-navigation__expand");
-    const link = item.querySelector(".p-side-navigation__link");
-    const nestedList = item.querySelector(".p-side-navigation__list");
-    [button, link, nestedList].forEach((el) =>
-      el.setAttribute(
-        "aria-expanded",
-        el.getAttribute("aria-expanded") === "true" ? "false" : "true"
-      )
-    );
   };
 
   (function() {

--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -203,7 +203,7 @@ meta_copydoc %}
     }
   };
 
-  function setUpDynamicSideNav() {
+  function setUpDynamicSideNav(viewPortHeight) {
     const questions = Array.prototype.slice.call(
       document.querySelectorAll(".question-heading")
     );
@@ -225,8 +225,8 @@ meta_copydoc %}
           });
         }
       }, {
-        rootMargin: "0px 0px -800px",
-        threshold: 1,
+        rootMargin: `0px 0px -80%`,
+        threshold: 0.5,
       });
 
       observer.observe(question);
@@ -237,6 +237,10 @@ meta_copydoc %}
     setUpTogglableSideNav();
     setUpDynamicSideNav();
   })();
+
+
+// start observing a DOM node
+
 </script>
 
 {% endblock content %}

--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -161,6 +161,7 @@ meta_copydoc %}
             </div>
             <p>The network installer lets you install Ubuntu over a network. It includes the minimal set of packages needed to start and the rest of the packages are downloaded over the network. Since only current packages are downloaded, there is no need to upgrade packages immediately after installation.</p>
             <p>The network installer is ideal if you have a computer that cannot run the graphical installer. It is also useful if you want to install Ubuntu on a large number of computers at once.</p>
+            <p>For 22.04 LTS, users can use the new Ubuntu Live installer to setup and configure a network install.</p>
             <hr class="p-rule is-muted">
             <p><a href="https://discourse.ubuntu.com/t/netbooting-the-live-server-installer?_gl=1*1t2mr3n*_gcl_au*MTE4NTIyOTI0MS4xNzA3MTMxMDQx&_ga=2.204825875.2084151835.1707729318-1126754318.1683186906">Instructions for the 22.04 LTS Ubuntu Live installer&nbsp;&rsaquo;</a></p>
             <hr class="p-rule is-muted">

--- a/templates/download/shared/_footer.html
+++ b/templates/download/shared/_footer.html
@@ -1,18 +1,18 @@
 <div class="p-section">
   <div class="p-section--shallow u-fixed-width">
-    <hr class="p-rule">
+    <hr class="p-rule" />
     <h2>Get started with Ubuntu today</h2>
   </div>
   <div class="row">
     <div class="col-9 col-start-large-4">
-      <hr class="p-rule">
+      <hr class="p-rule" />
       <div class="row">
         <div class="col-3 col-medium-2">
           <h3 class="p-heading--5">Professional support for Ubuntu</h3>
           <p>Get enterprise-grade support for Ubuntu from Canonical. We help organisations around the world to manage their Ubuntu cloud, server and desktop deployments.</p>
-          <hr class="is-muted">
+          <hr class="is-muted" />
           <p>
-            <a href="/pro">Get Ubuntu Pro</a>
+            <a href="/pro">Get Ubuntu Pro&nbsp;&rsaquo;</a>
           </p>
         </div>
         <div class="col-3 col-medium-2">

--- a/templates/download/shared/_footer.html
+++ b/templates/download/shared/_footer.html
@@ -1,0 +1,54 @@
+<div class="p-section">
+  <div class="p-section--shallow u-fixed-width">
+    <hr class="p-rule">
+    <h2>Get started with Ubuntu today</h2>
+  </div>
+  <div class="row">
+    <div class="col-9 col-start-large-4">
+      <hr class="p-rule">
+      <div class="row">
+        <div class="col-3 col-medium-2">
+          <h3 class="p-heading--5">Professional support for Ubuntu</h3>
+          <p>Get enterprise-grade support for Ubuntu from Canonical. We help organisations around the world to manage their Ubuntu cloud, server and desktop deployments.</p>
+          <hr class="is-muted">
+          <p>
+            <a href="/pro">Get Ubuntu Pro</a>
+          </p>
+        </div>
+        <div class="col-3 col-medium-2">
+          <h3 class="p-heading--5">Detailed documentation</h3>
+          <p>
+            <a href="https://tutorials.ubuntu.com/tutorial/tutorial-install-ubuntu-desktop">Installing Ubuntu Desktop</a>
+          </p>
+          <p>
+            <a href="/download/server/install-ubuntu-server">Installing Ubuntu Server</a>
+          </p>
+          <p>
+            <a href="https://help.ubuntu.com/">Ubuntu Desktop docs</a>
+          </p>
+          <p>
+            <a href="/server/docs">Ubuntu Server docs</a>
+          </p>
+          <p>
+            <a href="/tutorials/how-to-verify-ubuntu">Verify your download</a>
+          </p>
+        </div>
+        <div class="col-3 col-medium-2">
+          <h3 class="p-heading--5">Get help</h3>
+          <p>
+            <a href="https://discourse.ubuntu.com/">Ubuntu Discourse</a>
+          </p>
+          <p>
+            <a href="https://askubuntu.com/">Ask Ubuntu</a>
+          </p>
+          <p>
+            <a href="https://answers.launchpad.net/ubuntu">Launchpad Answers</a>
+          </p>
+          <p>
+            <a href="https://wiki.ubuntu.com/IRC/ChannelList">IRC-based support</a>
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Done

- Refreshes https://ubuntu-com-13573.demos.haus/download/alternative-downloads based mostly on the current [live site](https://ubuntu.com/download/alternative-downloads) but with some changes applied from the [copy doc](https://docs.google.com/document/d/1VhmFVE3dK81mE3zcC9FVA6f5SGJ-DHan7WWlrlfRcvo/edit) and applying the [new design](https://www.figma.com/file/cVGimTPHky4h3BPXfrT6GB/24.04-U.com---download-(rebranding)?node-id=1%3A4&mode=dev)
- implements a side navigation 

## QA

- Go to https://ubuntu-com-13573.demos.haus/download/alternative-downloads heck the content matches the [live site](https://ubuntu.com/download/alternative-downloads) and the changes in [copy doc](https://docs.google.com/document/d/1VhmFVE3dK81mE3zcC9FVA6f5SGJ-DHan7WWlrlfRcvo/edit)
- Check the side navigation works. It should track your position in the page and also take you to a given section when clicked, like the one on https://canonical.com/documentation 
- Check on different screen sizes

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-8494
