### PR TITLE
[WD-8852] replace lint text in charmed-k8s page

### DIFF
--- a/templates/kubernetes/charmed-k8s.html
+++ b/templates/kubernetes/charmed-k8s.html
@@ -119,7 +119,7 @@
   </div>
   <div class="row">
     <div class="col-12">
-      <p><a href="https://juju.is/">Learn more about the Charmed Operator Framework&nbsp;&rsaquo;</a></p>
+      <p><a href="https://juju.is/">Learn more about Juju, an orchestration engine for software operators&nbsp;&rsaquo;</a></p>
       <p>Need help to tackle the K8s complexity? <a href="/kubernetes/managed">Let us manage Kubernetes for you&nbsp;&rsaquo;</a></p>
     </div>
   </div>


### PR DESCRIPTION
## Done

- Changed text in one of the links at /kubernetes/charmed-k8s according to [copy doc](https://docs.google.com/document/d/1mEOBW4pfsWJqTLm9Pn9myKtaslD-QB2RvUKcNQ52bXU/edit)

## QA

- Open https://ubuntu-com-13587.demos.haus/kubernetes/charmed-k8s, scroll down to "Model driven Kubernetes" section and check the text of the link

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-8852

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
