### PR TITLE
Ubuntu Pro service terms typo

### DIFF
--- a/templates/legal/ubuntu-pro-service-terms/index.md
+++ b/templates/legal/ubuntu-pro-service-terms/index.md
@@ -34,7 +34,7 @@ When used in this Agreement, the following terms mean:
 
 **Licensed IP**: Canonical’s Intellectual Property Rights in the Software and Services.
 
-**Order**: If Customer is buying Services directly from Canonical: Customer's order for Services which incorporates this Agreement and identifies Customer's name, contact information, Services, fees. An Order may be in the form of a statement of work. If Customer is buying Services through Canonical's reseller: Customer's agreement to purchase the Services and pay applicable fees.
+**Order**: If Customer is buying Services directly from Canonical: Customer's order for Services which incorporates this Agreement and identifies Customer's name, contact information, Services, and fees. An Order may be in the form of a statement of work. If Customer is buying Services through Canonical's reseller: Customer's agreement to purchase the Services and pay applicable fees.
 
 **Registration Process**: The process under which a Customer registers with Canonical to receive Services purchased through Canonical's reseller.
 


### PR DESCRIPTION
## Done

- Updated copy as per [comment](https://docs.google.com/document/d/1aeqs6k-jgTf8xu3bOcloYpRgvIy7DuGjwyk7TLeTcqw/edit?disco=AAABGaTPkZI), follow-up of https://github.com/canonical/ubuntu.com/pull/13579

## QA

- View the site locally in your web browser at: https://ubuntu-com-13589.demos.haus/legal/ubuntu-pro-service-terms
- See that the typo has been fixed

## Issue / Card

Fixes #