### PR TITLE
WD-8974 - update screenly logo on /smart-displays

### DIFF
--- a/templates/internet-of-things/smart-displays.html
+++ b/templates/internet-of-things/smart-displays.html
@@ -196,10 +196,10 @@
         <a href="https://www.screenly.io/">
           {{
             image(
-              url="https://assets.ubuntu.com/v1/3eb6002c-screenly+box-logo-horizontal+purple+%281%29.png",
+              url="https://assets.ubuntu.com/v1/be292257-Dark%20Logo.svg",
               alt="Screenly",
-              width="166",
-              height="80",
+              width="200",
+              height="46",
               hi_def=True,
               loading="lazy"
             ) | safe
@@ -209,7 +209,7 @@
       <hr class="u-sv1 u-hide--small" />
       <h3 class="p-card__title">Screenly</h3>
       <p class="p-card__content">Screenly provides the hardware and software you need to manage digital signs at scale. Update and schedule content, monitor screen health, and show content from your existing tech stack.</p>
-      <a href="https://www.screenly.io/"">Learn more about Screenly&nbsp;&rsaquo;</a>
+      <a href="https://www.screenly.io/">Learn more about Screenly&nbsp;&rsaquo;</a>
     </div>
     <div class="col-4 p-card">
       <header class="no-border u-align--center u-vertically-center u-hide--small" style="min-height: 7rem;">


### PR DESCRIPTION
## Done

Update screenplay logo on /smart-displays

## QA
- [demo link](https://ubuntu-com-13591.demos.haus/internet-of-things/smart-displays)
- [copy doc](https://docs.google.com/document/d/1fFvBl-ZZvKDFV6OMv7O4kudQKtyxfvSU60rfVdKluAQ/edit)
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check that the logo is correctly updated according to copy doc

## Issue / Card
[WD-8974](https://warthogs.atlassian.net/browse/WD-8974)

Fixes #

## Screenshots


[WD-8974]: https://warthogs.atlassian.net/browse/WD-8974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ