### PR TITLE
WD-9003 - remove image from /developers

### DIFF
--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -47,19 +47,6 @@
       <p class="p-heading--2">The developers' choice</p>
     </div>
     <div class="col">
-      <div class="u-align--center">
-        {{ 
-          image (
-          url="https://assets.ubuntu.com/v1/7f76ac3a-hp-laptop-studio-jammy.png",
-          alt="",
-          width="1659",
-          height="1246",
-          hi_def=True,
-          loading="lazy"
-          ) | safe
-        }}
-      </div>
-      <hr class="is-extra-muted" />
       <ul class="p-list--divided u-no-margin--bottom">
         <li class="p-list__item is-ticked">Using Ubuntu Desktop provides a common platform for development, test, and production environments.</li>
         <li class="p-list__item is-ticked">Tools, such as <a href="https://juju.is/">Juju</a>, <a href="https://microk8s.io/">Microk8s</a>, and <a href="https://multipass.run/">Multipass</a> make developing, testing, and cross-building easy and affordable.</li>


### PR DESCRIPTION
## Done

Remove image from /developers

## QA
- [demo link](https://ubuntu-com-13593.demos.haus/desktop/developers)
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check that the image after "the developer's choice" is removed

## Issue / Card
[WD-9003](https://warthogs.atlassian.net/browse/WD-9003)

Fixes #

## Screenshots


[WD-9003]: https://warthogs.atlassian.net/browse/WD-9003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ