### PR TITLE
[WD-9029] replace TNM logo with a smaller one to align with other logos in /hpe

### DIFF
--- a/templates/hpe/index.html
+++ b/templates/hpe/index.html
@@ -163,7 +163,7 @@
       <div class="p-logo-section__items">
         <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/6cd78b57-at%26t-logo.png" alt=""></div>
         <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/a3bb7ca4-mercedes-benz-group-logo.png" alt=""></div>
-        <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/1459d379-tmn_logo.png" alt=""></div>
+        <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/d6df40cd-tmn_logo.png" alt=""></div>
         <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/1dc7af1e-panasonic-logo.png" alt=""></div>
         <div class="p-logo-section__item"><img class="p-logo-section__logo" src="https://assets.ubuntu.com/v1/4af3ad39-barclays-logo.png" alt=""></div>
       </div>


### PR DESCRIPTION
## Done

- Replaced TNM logo with a smaller one to align with other logos in https://ubuntu-com-13595.demos.haus/hpe page

## QA

- Navigate to https://ubuntu-com-13595.demos.haus/hpe and check if TNM logo is aligned in size with other logos at "Proven results from collaborative solutions" section

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-9029

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
