### PR TITLE
Wd 8751 update the pro subscribe page visuals

### DIFF
--- a/static/js/src/advantage/subscribe/react/components/Form/Feature/Feature.test.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Feature/Feature.test.tsx
@@ -22,8 +22,8 @@ test("Feature section renders correctly", () => {
     </FormProvider>
   );
 
-  screen.getAllByText("Ubuntu Pro");
-  screen.getAllByText("Ubuntu Pro (Infra-only)");
+  screen.getAllByText("Pro - all repositories");
+  screen.getAllByText("Infra only - limited subset");
 });
 
 test("Feature sections disables Infra + Apps if destkop is selected", () => {

--- a/static/js/src/advantage/subscribe/react/components/Form/Feature/Feature.test.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Feature/Feature.test.tsx
@@ -23,7 +23,7 @@ test("Feature section renders correctly", () => {
   );
 
   screen.getAllByText("Pro - all repositories");
-  screen.getAllByText("Infra only - limited subset");
+  screen.getAllByText("Infra - only limited subset");
 });
 
 test("Feature sections disables Infra + Apps if destkop is selected", () => {

--- a/static/js/src/advantage/subscribe/react/components/Form/Feature/Feature.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Feature/Feature.tsx
@@ -26,131 +26,290 @@ const Feature = () => {
 
   return (
     <>
-    <Row className="u-hide--small">
-      <Col size={6}><h2>What security coverage do you need?</h2></Col>
-      <Col size={6}>
-        <div
-          className={classNames({
-            row: true,
-            "p-divider": true,
-          })}
-          data-testid="wrapper">
-          <p>Not sure? Run [command] to find out which packages and repositories you are currently using.</p>
-          <RadioInput 
-            label="Pro - all repositories" 
-            checked={feature === Features.pro}
-            value={Features.pro}
-            onChange={handleChange}
-            disabled={proDisabled}
-          />
-          <hr/>
-          <RadioInput label="Infra only - limited subset"
-            checked={feature === Features.infra}
-            value={Features.infra}
-            onChange={handleChange}
-            disabled={infraOnlyDisabled}
-          />
-        </div>
-      </Col>
-      <hr className="is-fixed-width"/>
-    </Row>
-    <Row  className="u-hide--small">
-      <Col size={3}>
-        <h1>{ feature === Features.pro ? "25000" : "2300" }</h1>
-      </Col>
-      <Col size={3}>
-        <p>Covers { feature === Features.pro ? "25000" : "2300" } packages in Ubuntu Main { feature === Features.pro ? "and Universe":""}</p>
-      </Col>
-      <Col size={6}>
-        <div className="p-graphic-main"/>
-        <div className={classNames({
-          "p-graphic-universe": feature === Features.pro,
-          "p-graphic-universe--empty": feature === Features.infra
-        })}/>
-        <p className="p-text--small graphic-legend-main">LTS standard security maintenance for Ubuntu Main (initial 5 years)</p>
-        { feature===Features.pro && <p className="p-text--small graphic-legend-universe">LTS Expanded Security Maintenance (ESM) for Ubuntu Main (additional 5 years)</p> }
-      </Col>
-    </Row>
-    <Row>
-      <div className={classNames({"logos-wrapper": true, "col-6": feature===Features.infra})}>
-        <img
-          src="https://assets.ubuntu.com/v1/3ad7e0a9-systemd-logo.png"
-          alt="Systemd"
-        />
-        <img
-          src="https://assets.ubuntu.com/v1/3cf0ba5d-rabbitmq-logo.png"
-          alt="RabbitMQ"
-        />
-        <img
-          src="https://assets.ubuntu.com/v1/9259b689-openssl-logo.png"
-          alt="OpenSSL"
-        />
-        <img
-          src="https://assets.ubuntu.com/v1/a0dac4a0-ruby-logo.png"
-          alt="Ruby"
-        />
-        <img
-          src="https://assets.ubuntu.com/v1/9cdee338-php-logo.png"
-          alt="PHP"
-        />
-        <img
-          src="https://assets.ubuntu.com/v1/8b409e96-nginex+logo.png"
-          alt="NGINX"
-        />
-        <img
-          src="https://assets.ubuntu.com/v1/24058ec5-mysql+logo.png"
-          alt="MySQL"
-        />
-        { feature===Features.pro && <>
-          <img
-            src="https://assets.ubuntu.com/v1/6b709d7b-apache+tomcat+logo.png"
-            alt="Apache Tomcat"
+      <Row>
+        <Col size={6}><h2>What security coverage do you need?</h2></Col>
+        <Col size={6}>
+          <div
+            className={classNames({
+              row: true,
+              "p-divider": true,
+            })}
+            data-testid="wrapper">
+            <p>Not sure? Run <code> pro security-status</code> to find out which packages and repositories you are currently using.</p>
+            <RadioInput
+              label="Pro - all repositories"
+              checked={feature === Features.pro}
+              value={Features.pro}
+              onChange={handleChange}
+              disabled={proDisabled}
             />
-          <img
-            src="https://assets.ubuntu.com/v1/bb10115e-nagios+logo.png"
-            alt="Agios"
+            <hr />
+            <RadioInput label="Infra only - limited subset"
+              checked={feature === Features.infra}
+              value={Features.infra}
+              onChange={handleChange}
+              disabled={infraOnlyDisabled}
             />
-          <img
-            src="https://assets.ubuntu.com/v1/0d264437-nagios+logo-1.png"
-            alt="NodeJS"
-            />
-          <img
-            src="https://assets.ubuntu.com/v1/60a15fa2-puppet-logo.png"
-            alt="Puppet"
-            />
-          <img
-            src="https://assets.ubuntu.com/v1/38530c4f-redis-logo.png"
-            alt="Redis"
-            />
-          <img
-            src="https://assets.ubuntu.com/v1/e60387dd-rust-logo.png"
-            alt="Rust"
-            />
-          <img
-            src="https://assets.ubuntu.com/v1/842e6353-wordpress-logo.png"
-            alt="Wordpress"
-            />
-        </>}
-      </div>
-    </Row>
+          </div>
+        </Col>
+        <Col size={11} emptyMedium={2} emptyLarge={2}>
+          <hr className="is-fixed-width" />
+        </Col>
+      </Row>
+      <Row >
+        <Col size={2} emptyMedium={2} emptyLarge={2}>
+          <h1>{feature === Features.pro ? "25000" : "2300"}</h1>
+        </Col>
+        <Col size={3}>
+          <p>Covers {feature === Features.pro ? "25000" : "2300"} packages in Ubuntu Main {feature === Features.pro ? "and Universe" : ""}</p>
+        </Col>
+        <Col size={6}>
+          <div className="p-graphic-main" />
+          <div className={classNames({
+            "p-graphic-universe": feature === Features.pro,
+            "p-graphic-universe--empty": feature === Features.infra
+          })} />
+          <p className="p-text--small graphic-legend-main">LTS standard security maintenance for Ubuntu Main (initial 5 years)</p>
+          {feature === Features.pro && <p className="p-text--small graphic-legend-universe">LTS Expanded Security Maintenance (ESM) for Ubuntu Main (additional 5 years)</p>}
+        </Col>
+      </Row>
+      <Row>
+        <Col size={11} emptySmall={2} emptyLarge={2}>
+          <div className="p-logo-section--dense">
+            <div className="p-logo-section__items u-sv3">
+              <div className="p-logo-section__item u-sv1">
+                <img
+                  src="https://assets.ubuntu.com/v1/3ad7e0a9-systemd-logo.png"
+                  alt="Systemd"
+                  width="67"
+                  height="64"
+                  className="p-logo-section__logo"
+                  />
+              </div>
+              <div className="p-logo-section__item u-sv1">
+                <img
+                  src="https://assets.ubuntu.com/v1/3b69f369-ruby-logo.png"
+                  alt=""
+                  width="104"
+                  height="252"
+                  className="p-logo-section__logo"
+                />
+              </div>
+              <div className="p-logo-section__item u-sv1">
+                <img
+                  src="https://assets.ubuntu.com/v1/bedc5d63-rabbitmq-logo.png"
+                  alt=""
+                  width="248"
+                  height="257"
+                  className="p-logo-section__logo"
+                />
+              </div>
+              <div className="p-logo-section__item u-sv1">
+                <img
+                  src="https://assets.ubuntu.com/v1/c2cd0bc4-php-logo.png"
+                  alt=""
+                  width="160"
+                  height="252"
+                  className="p-logo-section__logo"
+                />
+              </div>
+              <div className="p-logo-section__item u-sv1">
+                <img
+                  src="https://assets.ubuntu.com/v1/86fdc1d7-openssl-logo.png"
+                  alt=""
+                  width="172"
+                  height="252"
+                  className="p-logo-section__logo"
+                />
+              </div>
+              <div className="p-logo-section__item u-sv1">
+                <img
+                  src="https://assets.ubuntu.com/v1/a92957da-nginex logo.png"
+                  alt=""
+                  width="184"
+                  height="258"
+                  className="p-logo-section__logo"
+                />
+              </div>
+              <div className="p-logo-section__item u-sv1">
+                <img
+                  src="https://assets.ubuntu.com/v1/0e5bcec1-mysql logo.png"
+                  alt=""
+                  width="180"
+                  height="252"
+                  className="p-logo-section__logo"
+                />
+              </div>
+              { feature===Features.pro &&
+              <>
+              <div className="p-logo-section__item u-sv1">
+                <img
+                  src="https://assets.ubuntu.com/v1/6cdc1a69-ansible logo.png"
+                  alt=""
+                  width="124"
+                  height="253"
+                  className="p-logo-section__logo"
+                />
+              </div>
+              <div className="p-logo-section__item u-sv1">
+                <img
+                  src="https://assets.ubuntu.com/v1/605af026-apache tomcat logo.png"
+                  alt=""
+                  width="204"
+                  height="253"
+                  className="p-logo-section__logo"
+                />
+              </div>
+              <div className="p-logo-section__item u-sv1">
+                <img
+                  src="https://assets.ubuntu.com/v1/5dbf023e-docker logo.png"
+                  alt=""
+                  width="244"
+                  height="245"
+                  className="p-logo-section__logo"
+                />
+              </div>
+              <div className="p-logo-section__item u-sv1">
+                <img
+                  src="https://assets.ubuntu.com/v1/933cc587-etcd logo.png"
+                  alt=""
+                  width="196"
+                  height="253"
+                  className="p-logo-section__logo"
+                />
+              </div>
+              <div className="p-logo-section__item u-sv1">
+                <img
+                  src="https://assets.ubuntu.com/v1/1f55452f-glusterfs logo.png"
+                  alt=""
+                  width="196"
+                  height="253"
+                  className="p-logo-section__logo"
+                />
+              </div>
+              <div className="p-logo-section__item u-sv1">
+                <img
+                  src="https://assets.ubuntu.com/v1/973c8e10-Frame 19.png"
+                  alt=""
+                  width="232"
+                  height="253"
+                  className="p-logo-section__logo"
+                />
+              </div>
+              <div className="p-logo-section__item u-sv1">
+                <img
+                  src="https://assets.ubuntu.com/v1/3ec28413-powerdns logo.png"
+                  alt=""
+                  width="252"
+                  height="253"
+                  className="p-logo-section__logo"
+                />
+              </div>
+              <div className="p-logo-section__item u-sv1">
+                <img
+                  src="https://assets.ubuntu.com/v1/7e68a46f-perl logo.png"
+                  alt=""
+                  width="252"
+                  height="253"
+                  className="p-logo-section__logo"
+                />
+              </div>
+              <div className="p-logo-section__item u-sv1">
+                <img
+                  src="https://assets.ubuntu.com/v1/35e5c439-puppet logo.png"
+                  alt=""
+                  width="236"
+                  height="253"
+                  className="p-logo-section__logo"
+                />
+              </div>
+              <div className="p-logo-section__item u-sv1">
+                <img
+                  src="https://assets.ubuntu.com/v1/2ad3b2ba-python logo.png"
+                  alt=""
+                  width="252"
+                  height="253"
+                  className="p-logo-section__logo"
+                />
+              </div>
+              <div className="p-logo-section__item u-sv1">
+                <img
+                  src="https://assets.ubuntu.com/v1/8279fc01-go logo.png"
+                  alt=""
+                  width="168"
+                  height="253"
+                  className="p-logo-section__logo"
+                />
+              </div>
+              <div className="p-logo-section__item u-sv1">
+                <img
+                  src="https://assets.ubuntu.com/v1/94f1e342-nagios logo.png"
+                  alt=""
+                  width="252"
+                  height="253"
+                  className="p-logo-section__logo"
+                />
+              </div>
+              <div className="p-logo-section__item u-sv1">
+                <img
+                  src="https://assets.ubuntu.com/v1/5b13a988-nginex logo-1.png"
+                  alt=""
+                  width="252"
+                  height="253"
+                  className="p-logo-section__logo"
+                />
+              </div>
+              <div className="p-logo-section__item u-sv1">
+                <img
+                  src="https://assets.ubuntu.com/v1/56d8741e-node-logo.png"
+                  alt=""
+                  width="196"
+                  height="253"
+                  className="p-logo-section__logo"
+                />
+              </div>
+              <div className="p-logo-section__item u-sv1">
+                <img
+                  src="https://assets.ubuntu.com/v1/fa78f5b4-openjdk logo.png"
+                  alt=""
+                  width="240"
+                  height="253"
+                  className="p-logo-section__logo"
+                />
+              </div>
+              <div className="p-logo-section__item u-sv1">
+                <img
+                  src="https://assets.ubuntu.com/v1/05c01589-redis logo.png"
+                  alt=""
+                  width="252"
+                  height="253"
+                  className="p-logo-section__logo"
+                />
+              </div>
+              <div className="p-logo-section__item u-sv1">
+                <img
+                  src="https://assets.ubuntu.com/v1/850af73c-ruby-rails logo.png"
+                  alt=""
+                  width="240"
+                  height="253"
+                  className="p-logo-section__logo"
+                />
+              </div>
+              <div className="p-logo-section__item u-sv1">
+                <img
+                  src="https://assets.ubuntu.com/v1/93af6c88-rust logo.png"
+                  alt=""
+                  width="120"
+                  height="252"
+                  className="p-logo-section__logo"
+                />
+              </div>
+              </>}
+            </div>
+          </div>
+        </Col>
+      </Row>
 
-  
-      <Col className="u-hide u-show--small" size={12} small={4}>
-        <RadioInput
-          label="Ubuntu Pro"
-          value={Features.pro}
-          checked={feature === Features.pro}
-          onChange={handleChange}
-          disabled={proDisabled}
-        />
-        <RadioInput
-          label="Ubuntu Pro (Infra-only)"
-          value={Features.infra}
-          checked={feature === Features.infra}
-          onChange={handleChange}
-          disabled={infraOnlyDisabled}
-        />
-      </Col>
       <Col
         className="p-divider__block u-align--center u-hide u-show--small"
         size={6}
@@ -175,161 +334,3 @@ const Feature = () => {
 };
 
 export default Feature;
-
-{/* <Row style={{ gap: "0" }} className="u-hide--small">
-            <Col size={6} className="description-column">
-              <div className="heading">
-                <strong>
-                  Security coverage for critical, high and selected medium CVEs for:
-                </strong>
-              </div>
-              <div className="main">
-                <p>
-                  Over 2,300 open source deb packages in Ubuntu Main repository for
-                  10 years, including:
-                </p>
-                <div className="logos-wrapper">
-                  <img
-                    src="https://assets.ubuntu.com/v1/3ad7e0a9-systemd-logo.png"
-                    alt="Systemd"
-                  />
-                  <img
-                    src="https://assets.ubuntu.com/v1/3cf0ba5d-rabbitmq-logo.png"
-                    alt="RabbitMQ"
-                  />
-                  <img
-                    src="https://assets.ubuntu.com/v1/9259b689-openssl-logo.png"
-                    alt="OpenSSL"
-                  />
-                  <img
-                    src="https://assets.ubuntu.com/v1/a0dac4a0-ruby-logo.png"
-                    alt="Ruby"
-                  />
-                  <img
-                    src="https://assets.ubuntu.com/v1/9cdee338-php-logo.png"
-                    alt="PHP"
-                  />
-                  <img
-                    src="https://assets.ubuntu.com/v1/8b409e96-nginex+logo.png"
-                    alt="NGINX"
-                  />
-                  <img
-                    src="https://assets.ubuntu.com/v1/24058ec5-mysql+logo.png"
-                    alt="MySQL"
-                  />
-                </div>
-              </div>
-              <div className="universe">
-                <p>
-                  Over 23,000 open source deb packages in Ubuntu Universe repository
-                  for 10 years, including:
-                </p>
-                <div className="logos-wrapper">
-                  <img
-                    src="https://assets.ubuntu.com/v1/6b709d7b-apache+tomcat+logo.png"
-                    alt="Apache Tomcat"
-                  />
-                  <img
-                    src="https://assets.ubuntu.com/v1/bb10115e-nagios+logo.png"
-                    alt="Agios"
-                  />
-                  <img
-                    src="https://assets.ubuntu.com/v1/0d264437-nagios+logo-1.png"
-                    alt="NodeJS"
-                  />
-                  <img
-                    src="https://assets.ubuntu.com/v1/60a15fa2-puppet-logo.png"
-                    alt="Puppet"
-                  />
-                  <img
-                    src="https://assets.ubuntu.com/v1/38530c4f-redis-logo.png"
-                    alt="Redis"
-                  />
-                  <img
-                    src="https://assets.ubuntu.com/v1/e60387dd-rust-logo.png"
-                    alt="Rust"
-                  />
-                  <img
-                    src="https://assets.ubuntu.com/v1/842e6353-wordpress-logo.png"
-                    alt="Wordpress"
-                  />
-                </div>
-              </div>
-            </Col>
-            <Col size={3}>
-              <div
-                className={classNames({
-                  "p-card--radio--column": true,
-                  "is-selected": feature === Features.pro,
-                })}
-              >
-                <label className="p-radio u-align-text--center">
-                  <input
-                    data-testid="pro"
-                    className="p-radio__input"
-                    autoComplete="off"
-                    type="radio"
-                    aria-labelledby={`pro-label`}
-                    value={Features.pro}
-                    checked={feature === Features.pro}
-                    onChange={handleChange}
-                    disabled={proDisabled}
-                  />
-                  <span className="p-radio__label" id={`pro-label`}>
-                    <RadioInput
-                      labelClassName="inner-label"
-                      label={"Ubuntu Pro"}
-                      checked={feature === Features.pro}
-                      value={Features.pro}
-                      onChange={handleChange}
-                      disabled={proDisabled}
-                    />
-                    <div className="included">
-                      <i className="p-icon--success"></i>Included
-                    </div>
-                    <div className="included">
-                      <i className="p-icon--success"></i> Included
-                    </div>
-                  </span>
-                </label>
-              </div>
-            </Col>
-            <Col size={3}>
-              <div
-                className={classNames({
-                  "p-card--radio--column": true,
-                  "is-selected": feature === Features.infra,
-                })}
-              >
-                <label className="p-radio u-align-text--center">
-                  <input
-                    data-testid="infra-only"
-                    className="p-radio__input"
-                    autoComplete="off"
-                    type="radio"
-                    aria-labelledby={`infra-label`}
-                    value={Features.infra}
-                    checked={feature === Features.infra}
-                    onChange={handleChange}
-                    disabled={infraOnlyDisabled}
-                  />
-                  <span className="p-radio__label" id={`infra-label`}>
-                    <RadioInput
-                      labelClassName="inner-label"
-                      label={"Ubuntu Pro (Infra-only)"}
-                      checked={feature === Features.infra}
-                      value={Features.infra}
-                      onChange={handleChange}
-                      disabled={infraOnlyDisabled}
-                    />
-                    <div className="included">
-                      <i className="p-icon--success"></i>Included
-                    </div>
-                    <div className="included">
-                      <i className="p-icon--error"></i> Not included
-                    </div>
-                  </span>
-                </label>
-              </div>
-            </Col>
-          </Row> */}

--- a/static/js/src/advantage/subscribe/react/components/Form/Feature/Feature.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Feature/Feature.tsx
@@ -48,6 +48,7 @@ const Feature = () => {
               value={Features.pro}
               onChange={handleChange}
               disabled={proDisabled}
+              data-testid="pro"
             />
             <hr />
             <RadioInput
@@ -56,6 +57,7 @@ const Feature = () => {
               value={Features.infra}
               onChange={handleChange}
               disabled={infraOnlyDisabled}
+              data-testid="infra-only"
             />
           </div>
         </Col>

--- a/static/js/src/advantage/subscribe/react/components/Form/Feature/Feature.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Feature/Feature.tsx
@@ -84,11 +84,13 @@ const Feature = () => {
             })}
           />
           <p className="p-text--small graphic-legend-main">
-            10 years of security maintenance for packages in Ubuntu Main repository
+            10 years of security maintenance for packages in Ubuntu Main
+            repository
           </p>
           {feature === Features.pro && (
             <p className="p-text--small graphic-legend-universe">
-              10 years of security maintenance for packages in Ubuntu Universe repository
+              10 years of security maintenance for packages in Ubuntu Universe
+              repository
             </p>
           )}
         </Col>

--- a/static/js/src/advantage/subscribe/react/components/Form/Feature/Feature.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Feature/Feature.tsx
@@ -52,7 +52,7 @@ const Feature = () => {
             />
             <hr />
             <RadioInput
-              label="Infra only - limited subset"
+              label="Infra - only limited subset"
               checked={feature === Features.infra}
               value={Features.infra}
               onChange={handleChange}
@@ -67,11 +67,11 @@ const Feature = () => {
       </Row>
       <Row>
         <Col size={2} emptyMedium={2} emptyLarge={2}>
-          <h1>{feature === Features.pro ? "25000" : "2300"}</h1>
+          <h1>{feature === Features.pro ? "25,000" : "2,300"}</h1>
         </Col>
         <Col size={3}>
           <p>
-            Covers {feature === Features.pro ? "25000" : "2300"} packages in
+            Covers {feature === Features.pro ? "25,000" : "2,300"} packages in
             Ubuntu Main {feature === Features.pro ? "and Universe" : ""}
           </p>
         </Col>
@@ -84,18 +84,17 @@ const Feature = () => {
             })}
           />
           <p className="p-text--small graphic-legend-main">
-            LTS standard security maintenance for Ubuntu Main (initial 5 years)
+            10 years of security maintenance for packages in Ubuntu Main repository
           </p>
           {feature === Features.pro && (
             <p className="p-text--small graphic-legend-universe">
-              LTS Expanded Security Maintenance (ESM) for Ubuntu Main
-              (additional 5 years)
+              10 years of security maintenance for packages in Ubuntu Universe repository
             </p>
           )}
         </Col>
       </Row>
       <Row>
-        <Col size={11} emptySmall={2} emptyLarge={2}>
+        <Col size={11} emptyLarge={2}>
           <div className="p-logo-section--dense">
             <div className="p-logo-section__items u-sv3">
               <div className="p-logo-section__item u-sv1">
@@ -331,26 +330,6 @@ const Feature = () => {
           </div>
         </Col>
       </Row>
-
-      <Col
-        className="p-divider__block u-align--center u-hide u-show--small"
-        size={6}
-        small={2}
-      >
-        <h4>2,300+</h4>
-        <p>packages in Ubuntu main, including:</p>
-      </Col>
-      <Col
-        className={classNames({
-          "p-divider__block u-align--center u-hide u-show--small": true,
-          "u-disable": Features.infra === feature,
-        })}
-        size={6}
-        small={2}
-      >
-        <h4>23,000+</h4>
-        <p>packages in Ubuntu universe, including:</p>
-      </Col>
     </>
   );
 };

--- a/static/js/src/advantage/subscribe/react/components/Form/Feature/Feature.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Feature/Feature.tsx
@@ -71,7 +71,7 @@ const Feature = () => {
         </Col>
         <Col size={3}>
           <p>
-            Covers {feature === Features.pro ? "25,000" : "2,300"} packages in
+            {feature === Features.pro ? "25,000" : "2,300"} packages in
             Ubuntu Main {feature === Features.pro ? "and Universe" : ""}
           </p>
         </Col>

--- a/static/js/src/advantage/subscribe/react/components/Form/Feature/Feature.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Feature/Feature.tsx
@@ -25,170 +25,116 @@ const Feature = () => {
   const proDisabled = version === LTSVersions.trusty;
 
   return (
-    <div
-      className={classNames({
-        row: true,
-        "p-divider": true,
-      })}
-      data-testid="wrapper"
-    >
-      <Row style={{ gap: "0" }} className="u-hide--small">
-        <Col size={6} className="description-column">
-          <div className="heading">
-            <strong>
-              Security coverage for critical, high and selected medium CVEs for:
-            </strong>
-          </div>
-          <div className="main">
-            <p>
-              Over 2,300 open source deb packages in Ubuntu Main repository for
-              10 years, including:
-            </p>
-            <div className="logos-wrapper">
-              <img
-                src="https://assets.ubuntu.com/v1/3ad7e0a9-systemd-logo.png"
-                alt="Systemd"
-              />
-              <img
-                src="https://assets.ubuntu.com/v1/3cf0ba5d-rabbitmq-logo.png"
-                alt="RabbitMQ"
-              />
-              <img
-                src="https://assets.ubuntu.com/v1/9259b689-openssl-logo.png"
-                alt="OpenSSL"
-              />
-              <img
-                src="https://assets.ubuntu.com/v1/a0dac4a0-ruby-logo.png"
-                alt="Ruby"
-              />
-              <img
-                src="https://assets.ubuntu.com/v1/9cdee338-php-logo.png"
-                alt="PHP"
-              />
-              <img
-                src="https://assets.ubuntu.com/v1/8b409e96-nginex+logo.png"
-                alt="NGINX"
-              />
-              <img
-                src="https://assets.ubuntu.com/v1/24058ec5-mysql+logo.png"
-                alt="MySQL"
-              />
-            </div>
-          </div>
-          <div className="universe">
-            <p>
-              Over 23,000 open source deb packages in Ubuntu Universe repository
-              for 10 years, including:
-            </p>
-            <div className="logos-wrapper">
-              <img
-                src="https://assets.ubuntu.com/v1/6b709d7b-apache+tomcat+logo.png"
-                alt="Apache Tomcat"
-              />
-              <img
-                src="https://assets.ubuntu.com/v1/bb10115e-nagios+logo.png"
-                alt="Agios"
-              />
-              <img
-                src="https://assets.ubuntu.com/v1/0d264437-nagios+logo-1.png"
-                alt="NodeJS"
-              />
-              <img
-                src="https://assets.ubuntu.com/v1/60a15fa2-puppet-logo.png"
-                alt="Puppet"
-              />
-              <img
-                src="https://assets.ubuntu.com/v1/38530c4f-redis-logo.png"
-                alt="Redis"
-              />
-              <img
-                src="https://assets.ubuntu.com/v1/e60387dd-rust-logo.png"
-                alt="Rust"
-              />
-              <img
-                src="https://assets.ubuntu.com/v1/842e6353-wordpress-logo.png"
-                alt="Wordpress"
-              />
-            </div>
-          </div>
-        </Col>
-        <Col size={3}>
-          <div
-            className={classNames({
-              "p-card--radio--column": true,
-              "is-selected": feature === Features.pro,
-            })}
-          >
-            <label className="p-radio u-align-text--center">
-              <input
-                data-testid="pro"
-                className="p-radio__input"
-                autoComplete="off"
-                type="radio"
-                aria-labelledby={`pro-label`}
-                value={Features.pro}
-                checked={feature === Features.pro}
-                onChange={handleChange}
-                disabled={proDisabled}
-              />
-              <span className="p-radio__label" id={`pro-label`}>
-                <RadioInput
-                  labelClassName="inner-label"
-                  label={"Ubuntu Pro"}
-                  checked={feature === Features.pro}
-                  value={Features.pro}
-                  onChange={handleChange}
-                  disabled={proDisabled}
-                />
-                <div className="included">
-                  <i className="p-icon--success"></i>Included
-                </div>
-                <div className="included">
-                  <i className="p-icon--success"></i> Included
-                </div>
-              </span>
-            </label>
-          </div>
-        </Col>
-        <Col size={3}>
-          <div
-            className={classNames({
-              "p-card--radio--column": true,
-              "is-selected": feature === Features.infra,
-            })}
-          >
-            <label className="p-radio u-align-text--center">
-              <input
-                data-testid="infra-only"
-                className="p-radio__input"
-                autoComplete="off"
-                type="radio"
-                aria-labelledby={`infra-label`}
-                value={Features.infra}
-                checked={feature === Features.infra}
-                onChange={handleChange}
-                disabled={infraOnlyDisabled}
-              />
-              <span className="p-radio__label" id={`infra-label`}>
-                <RadioInput
-                  labelClassName="inner-label"
-                  label={"Ubuntu Pro (Infra-only)"}
-                  checked={feature === Features.infra}
-                  value={Features.infra}
-                  onChange={handleChange}
-                  disabled={infraOnlyDisabled}
-                />
-                <div className="included">
-                  <i className="p-icon--success"></i>Included
-                </div>
-                <div className="included">
-                  <i className="p-icon--error"></i> Not included
-                </div>
-              </span>
-            </label>
-          </div>
-        </Col>
-      </Row>
+    <>
+    <Row className="u-hide--small">
+      <Col size={6}><h2>What security coverage do you need?</h2></Col>
+      <Col size={6}>
+        <div
+          className={classNames({
+            row: true,
+            "p-divider": true,
+          })}
+          data-testid="wrapper">
+          <p>Not sure? Run [command] to find out which packages and repositories you are currently using.</p>
+          <RadioInput 
+            label="Pro - all repositories" 
+            checked={feature === Features.pro}
+            value={Features.pro}
+            onChange={handleChange}
+            disabled={proDisabled}
+          />
+          <hr/>
+          <RadioInput label="Infra only - limited subset"
+            checked={feature === Features.infra}
+            value={Features.infra}
+            onChange={handleChange}
+            disabled={infraOnlyDisabled}
+          />
+        </div>
+      </Col>
+      <hr className="is-fixed-width"/>
+    </Row>
+    <Row  className="u-hide--small">
+      <Col size={3}>
+        <h1>{ feature === Features.pro ? "25000" : "2300" }</h1>
+      </Col>
+      <Col size={3}>
+        <p>Covers { feature === Features.pro ? "25000" : "2300" } packages in Ubuntu Main { feature === Features.pro ? "and Universe":""}</p>
+      </Col>
+      <Col size={6}>
+        <div className="p-graphic-main"/>
+        <div className={classNames({
+          "p-graphic-universe": feature === Features.pro,
+          "p-graphic-universe--empty": feature === Features.infra
+        })}/>
+        <p className="p-text--small graphic-legend-main">LTS standard security maintenance for Ubuntu Main (initial 5 years)</p>
+        { feature===Features.pro && <p className="p-text--small graphic-legend-universe">LTS Expanded Security Maintenance (ESM) for Ubuntu Main (additional 5 years)</p> }
+      </Col>
+    </Row>
+    <Row>
+      <div className={classNames({"logos-wrapper": true, "col-6": feature===Features.infra})}>
+        <img
+          src="https://assets.ubuntu.com/v1/3ad7e0a9-systemd-logo.png"
+          alt="Systemd"
+        />
+        <img
+          src="https://assets.ubuntu.com/v1/3cf0ba5d-rabbitmq-logo.png"
+          alt="RabbitMQ"
+        />
+        <img
+          src="https://assets.ubuntu.com/v1/9259b689-openssl-logo.png"
+          alt="OpenSSL"
+        />
+        <img
+          src="https://assets.ubuntu.com/v1/a0dac4a0-ruby-logo.png"
+          alt="Ruby"
+        />
+        <img
+          src="https://assets.ubuntu.com/v1/9cdee338-php-logo.png"
+          alt="PHP"
+        />
+        <img
+          src="https://assets.ubuntu.com/v1/8b409e96-nginex+logo.png"
+          alt="NGINX"
+        />
+        <img
+          src="https://assets.ubuntu.com/v1/24058ec5-mysql+logo.png"
+          alt="MySQL"
+        />
+        { feature===Features.pro && <>
+          <img
+            src="https://assets.ubuntu.com/v1/6b709d7b-apache+tomcat+logo.png"
+            alt="Apache Tomcat"
+            />
+          <img
+            src="https://assets.ubuntu.com/v1/bb10115e-nagios+logo.png"
+            alt="Agios"
+            />
+          <img
+            src="https://assets.ubuntu.com/v1/0d264437-nagios+logo-1.png"
+            alt="NodeJS"
+            />
+          <img
+            src="https://assets.ubuntu.com/v1/60a15fa2-puppet-logo.png"
+            alt="Puppet"
+            />
+          <img
+            src="https://assets.ubuntu.com/v1/38530c4f-redis-logo.png"
+            alt="Redis"
+            />
+          <img
+            src="https://assets.ubuntu.com/v1/e60387dd-rust-logo.png"
+            alt="Rust"
+            />
+          <img
+            src="https://assets.ubuntu.com/v1/842e6353-wordpress-logo.png"
+            alt="Wordpress"
+            />
+        </>}
+      </div>
+    </Row>
+
+  
       <Col className="u-hide u-show--small" size={12} small={4}>
         <RadioInput
           label="Ubuntu Pro"
@@ -224,8 +170,166 @@ const Feature = () => {
         <h4>23,000+</h4>
         <p>packages in Ubuntu universe, including:</p>
       </Col>
-    </div>
+    </>
   );
 };
 
 export default Feature;
+
+{/* <Row style={{ gap: "0" }} className="u-hide--small">
+            <Col size={6} className="description-column">
+              <div className="heading">
+                <strong>
+                  Security coverage for critical, high and selected medium CVEs for:
+                </strong>
+              </div>
+              <div className="main">
+                <p>
+                  Over 2,300 open source deb packages in Ubuntu Main repository for
+                  10 years, including:
+                </p>
+                <div className="logos-wrapper">
+                  <img
+                    src="https://assets.ubuntu.com/v1/3ad7e0a9-systemd-logo.png"
+                    alt="Systemd"
+                  />
+                  <img
+                    src="https://assets.ubuntu.com/v1/3cf0ba5d-rabbitmq-logo.png"
+                    alt="RabbitMQ"
+                  />
+                  <img
+                    src="https://assets.ubuntu.com/v1/9259b689-openssl-logo.png"
+                    alt="OpenSSL"
+                  />
+                  <img
+                    src="https://assets.ubuntu.com/v1/a0dac4a0-ruby-logo.png"
+                    alt="Ruby"
+                  />
+                  <img
+                    src="https://assets.ubuntu.com/v1/9cdee338-php-logo.png"
+                    alt="PHP"
+                  />
+                  <img
+                    src="https://assets.ubuntu.com/v1/8b409e96-nginex+logo.png"
+                    alt="NGINX"
+                  />
+                  <img
+                    src="https://assets.ubuntu.com/v1/24058ec5-mysql+logo.png"
+                    alt="MySQL"
+                  />
+                </div>
+              </div>
+              <div className="universe">
+                <p>
+                  Over 23,000 open source deb packages in Ubuntu Universe repository
+                  for 10 years, including:
+                </p>
+                <div className="logos-wrapper">
+                  <img
+                    src="https://assets.ubuntu.com/v1/6b709d7b-apache+tomcat+logo.png"
+                    alt="Apache Tomcat"
+                  />
+                  <img
+                    src="https://assets.ubuntu.com/v1/bb10115e-nagios+logo.png"
+                    alt="Agios"
+                  />
+                  <img
+                    src="https://assets.ubuntu.com/v1/0d264437-nagios+logo-1.png"
+                    alt="NodeJS"
+                  />
+                  <img
+                    src="https://assets.ubuntu.com/v1/60a15fa2-puppet-logo.png"
+                    alt="Puppet"
+                  />
+                  <img
+                    src="https://assets.ubuntu.com/v1/38530c4f-redis-logo.png"
+                    alt="Redis"
+                  />
+                  <img
+                    src="https://assets.ubuntu.com/v1/e60387dd-rust-logo.png"
+                    alt="Rust"
+                  />
+                  <img
+                    src="https://assets.ubuntu.com/v1/842e6353-wordpress-logo.png"
+                    alt="Wordpress"
+                  />
+                </div>
+              </div>
+            </Col>
+            <Col size={3}>
+              <div
+                className={classNames({
+                  "p-card--radio--column": true,
+                  "is-selected": feature === Features.pro,
+                })}
+              >
+                <label className="p-radio u-align-text--center">
+                  <input
+                    data-testid="pro"
+                    className="p-radio__input"
+                    autoComplete="off"
+                    type="radio"
+                    aria-labelledby={`pro-label`}
+                    value={Features.pro}
+                    checked={feature === Features.pro}
+                    onChange={handleChange}
+                    disabled={proDisabled}
+                  />
+                  <span className="p-radio__label" id={`pro-label`}>
+                    <RadioInput
+                      labelClassName="inner-label"
+                      label={"Ubuntu Pro"}
+                      checked={feature === Features.pro}
+                      value={Features.pro}
+                      onChange={handleChange}
+                      disabled={proDisabled}
+                    />
+                    <div className="included">
+                      <i className="p-icon--success"></i>Included
+                    </div>
+                    <div className="included">
+                      <i className="p-icon--success"></i> Included
+                    </div>
+                  </span>
+                </label>
+              </div>
+            </Col>
+            <Col size={3}>
+              <div
+                className={classNames({
+                  "p-card--radio--column": true,
+                  "is-selected": feature === Features.infra,
+                })}
+              >
+                <label className="p-radio u-align-text--center">
+                  <input
+                    data-testid="infra-only"
+                    className="p-radio__input"
+                    autoComplete="off"
+                    type="radio"
+                    aria-labelledby={`infra-label`}
+                    value={Features.infra}
+                    checked={feature === Features.infra}
+                    onChange={handleChange}
+                    disabled={infraOnlyDisabled}
+                  />
+                  <span className="p-radio__label" id={`infra-label`}>
+                    <RadioInput
+                      labelClassName="inner-label"
+                      label={"Ubuntu Pro (Infra-only)"}
+                      checked={feature === Features.infra}
+                      value={Features.infra}
+                      onChange={handleChange}
+                      disabled={infraOnlyDisabled}
+                    />
+                    <div className="included">
+                      <i className="p-icon--success"></i>Included
+                    </div>
+                    <div className="included">
+                      <i className="p-icon--error"></i> Not included
+                    </div>
+                  </span>
+                </label>
+              </div>
+            </Col>
+          </Row> */}

--- a/static/js/src/advantage/subscribe/react/components/Form/Feature/Feature.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Feature/Feature.tsx
@@ -71,8 +71,8 @@ const Feature = () => {
         </Col>
         <Col size={3}>
           <p>
-            {feature === Features.pro ? "25,000" : "2,300"} packages in
-            Ubuntu Main {feature === Features.pro ? "and Universe" : ""}
+            packages in Ubuntu Main{" "}
+            {feature === Features.pro ? "and Universe" : ""}
           </p>
         </Col>
         <Col size={6}>

--- a/static/js/src/advantage/subscribe/react/components/Form/Feature/Feature.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Feature/Feature.tsx
@@ -27,15 +27,21 @@ const Feature = () => {
   return (
     <>
       <Row>
-        <Col size={6}><h2>What security coverage do you need?</h2></Col>
+        <Col size={6}>
+          <h2>What security coverage do you need?</h2>
+        </Col>
         <Col size={6}>
           <div
             className={classNames({
               row: true,
               "p-divider": true,
             })}
-            data-testid="wrapper">
-            <p>Not sure? Run <code> pro security-status</code> to find out which packages and repositories you are currently using.</p>
+            data-testid="wrapper"
+          >
+            <p>
+              Not sure? Run <code> pro security-status</code> to find out which
+              packages and repositories you are currently using.
+            </p>
             <RadioInput
               label="Pro - all repositories"
               checked={feature === Features.pro}
@@ -44,7 +50,8 @@ const Feature = () => {
               disabled={proDisabled}
             />
             <hr />
-            <RadioInput label="Infra only - limited subset"
+            <RadioInput
+              label="Infra only - limited subset"
               checked={feature === Features.infra}
               value={Features.infra}
               onChange={handleChange}
@@ -56,21 +63,33 @@ const Feature = () => {
           <hr className="is-fixed-width" />
         </Col>
       </Row>
-      <Row >
+      <Row>
         <Col size={2} emptyMedium={2} emptyLarge={2}>
           <h1>{feature === Features.pro ? "25000" : "2300"}</h1>
         </Col>
         <Col size={3}>
-          <p>Covers {feature === Features.pro ? "25000" : "2300"} packages in Ubuntu Main {feature === Features.pro ? "and Universe" : ""}</p>
+          <p>
+            Covers {feature === Features.pro ? "25000" : "2300"} packages in
+            Ubuntu Main {feature === Features.pro ? "and Universe" : ""}
+          </p>
         </Col>
         <Col size={6}>
           <div className="p-graphic-main" />
-          <div className={classNames({
-            "p-graphic-universe": feature === Features.pro,
-            "p-graphic-universe--empty": feature === Features.infra
-          })} />
-          <p className="p-text--small graphic-legend-main">LTS standard security maintenance for Ubuntu Main (initial 5 years)</p>
-          {feature === Features.pro && <p className="p-text--small graphic-legend-universe">LTS Expanded Security Maintenance (ESM) for Ubuntu Main (additional 5 years)</p>}
+          <div
+            className={classNames({
+              "p-graphic-universe": feature === Features.pro,
+              "p-graphic-universe--empty": feature === Features.infra,
+            })}
+          />
+          <p className="p-text--small graphic-legend-main">
+            LTS standard security maintenance for Ubuntu Main (initial 5 years)
+          </p>
+          {feature === Features.pro && (
+            <p className="p-text--small graphic-legend-universe">
+              LTS Expanded Security Maintenance (ESM) for Ubuntu Main
+              (additional 5 years)
+            </p>
+          )}
         </Col>
       </Row>
       <Row>
@@ -84,7 +103,7 @@ const Feature = () => {
                   width="67"
                   height="64"
                   className="p-logo-section__logo"
-                  />
+                />
               </div>
               <div className="p-logo-section__item u-sv1">
                 <img
@@ -140,171 +159,172 @@ const Feature = () => {
                   className="p-logo-section__logo"
                 />
               </div>
-              { feature===Features.pro &&
-              <>
-              <div className="p-logo-section__item u-sv1">
-                <img
-                  src="https://assets.ubuntu.com/v1/6cdc1a69-ansible logo.png"
-                  alt=""
-                  width="124"
-                  height="253"
-                  className="p-logo-section__logo"
-                />
-              </div>
-              <div className="p-logo-section__item u-sv1">
-                <img
-                  src="https://assets.ubuntu.com/v1/605af026-apache tomcat logo.png"
-                  alt=""
-                  width="204"
-                  height="253"
-                  className="p-logo-section__logo"
-                />
-              </div>
-              <div className="p-logo-section__item u-sv1">
-                <img
-                  src="https://assets.ubuntu.com/v1/5dbf023e-docker logo.png"
-                  alt=""
-                  width="244"
-                  height="245"
-                  className="p-logo-section__logo"
-                />
-              </div>
-              <div className="p-logo-section__item u-sv1">
-                <img
-                  src="https://assets.ubuntu.com/v1/933cc587-etcd logo.png"
-                  alt=""
-                  width="196"
-                  height="253"
-                  className="p-logo-section__logo"
-                />
-              </div>
-              <div className="p-logo-section__item u-sv1">
-                <img
-                  src="https://assets.ubuntu.com/v1/1f55452f-glusterfs logo.png"
-                  alt=""
-                  width="196"
-                  height="253"
-                  className="p-logo-section__logo"
-                />
-              </div>
-              <div className="p-logo-section__item u-sv1">
-                <img
-                  src="https://assets.ubuntu.com/v1/973c8e10-Frame 19.png"
-                  alt=""
-                  width="232"
-                  height="253"
-                  className="p-logo-section__logo"
-                />
-              </div>
-              <div className="p-logo-section__item u-sv1">
-                <img
-                  src="https://assets.ubuntu.com/v1/3ec28413-powerdns logo.png"
-                  alt=""
-                  width="252"
-                  height="253"
-                  className="p-logo-section__logo"
-                />
-              </div>
-              <div className="p-logo-section__item u-sv1">
-                <img
-                  src="https://assets.ubuntu.com/v1/7e68a46f-perl logo.png"
-                  alt=""
-                  width="252"
-                  height="253"
-                  className="p-logo-section__logo"
-                />
-              </div>
-              <div className="p-logo-section__item u-sv1">
-                <img
-                  src="https://assets.ubuntu.com/v1/35e5c439-puppet logo.png"
-                  alt=""
-                  width="236"
-                  height="253"
-                  className="p-logo-section__logo"
-                />
-              </div>
-              <div className="p-logo-section__item u-sv1">
-                <img
-                  src="https://assets.ubuntu.com/v1/2ad3b2ba-python logo.png"
-                  alt=""
-                  width="252"
-                  height="253"
-                  className="p-logo-section__logo"
-                />
-              </div>
-              <div className="p-logo-section__item u-sv1">
-                <img
-                  src="https://assets.ubuntu.com/v1/8279fc01-go logo.png"
-                  alt=""
-                  width="168"
-                  height="253"
-                  className="p-logo-section__logo"
-                />
-              </div>
-              <div className="p-logo-section__item u-sv1">
-                <img
-                  src="https://assets.ubuntu.com/v1/94f1e342-nagios logo.png"
-                  alt=""
-                  width="252"
-                  height="253"
-                  className="p-logo-section__logo"
-                />
-              </div>
-              <div className="p-logo-section__item u-sv1">
-                <img
-                  src="https://assets.ubuntu.com/v1/5b13a988-nginex logo-1.png"
-                  alt=""
-                  width="252"
-                  height="253"
-                  className="p-logo-section__logo"
-                />
-              </div>
-              <div className="p-logo-section__item u-sv1">
-                <img
-                  src="https://assets.ubuntu.com/v1/56d8741e-node-logo.png"
-                  alt=""
-                  width="196"
-                  height="253"
-                  className="p-logo-section__logo"
-                />
-              </div>
-              <div className="p-logo-section__item u-sv1">
-                <img
-                  src="https://assets.ubuntu.com/v1/fa78f5b4-openjdk logo.png"
-                  alt=""
-                  width="240"
-                  height="253"
-                  className="p-logo-section__logo"
-                />
-              </div>
-              <div className="p-logo-section__item u-sv1">
-                <img
-                  src="https://assets.ubuntu.com/v1/05c01589-redis logo.png"
-                  alt=""
-                  width="252"
-                  height="253"
-                  className="p-logo-section__logo"
-                />
-              </div>
-              <div className="p-logo-section__item u-sv1">
-                <img
-                  src="https://assets.ubuntu.com/v1/850af73c-ruby-rails logo.png"
-                  alt=""
-                  width="240"
-                  height="253"
-                  className="p-logo-section__logo"
-                />
-              </div>
-              <div className="p-logo-section__item u-sv1">
-                <img
-                  src="https://assets.ubuntu.com/v1/93af6c88-rust logo.png"
-                  alt=""
-                  width="120"
-                  height="252"
-                  className="p-logo-section__logo"
-                />
-              </div>
-              </>}
+              {feature === Features.pro && (
+                <>
+                  <div className="p-logo-section__item u-sv1">
+                    <img
+                      src="https://assets.ubuntu.com/v1/6cdc1a69-ansible logo.png"
+                      alt=""
+                      width="124"
+                      height="253"
+                      className="p-logo-section__logo"
+                    />
+                  </div>
+                  <div className="p-logo-section__item u-sv1">
+                    <img
+                      src="https://assets.ubuntu.com/v1/605af026-apache tomcat logo.png"
+                      alt=""
+                      width="204"
+                      height="253"
+                      className="p-logo-section__logo"
+                    />
+                  </div>
+                  <div className="p-logo-section__item u-sv1">
+                    <img
+                      src="https://assets.ubuntu.com/v1/5dbf023e-docker logo.png"
+                      alt=""
+                      width="244"
+                      height="245"
+                      className="p-logo-section__logo"
+                    />
+                  </div>
+                  <div className="p-logo-section__item u-sv1">
+                    <img
+                      src="https://assets.ubuntu.com/v1/933cc587-etcd logo.png"
+                      alt=""
+                      width="196"
+                      height="253"
+                      className="p-logo-section__logo"
+                    />
+                  </div>
+                  <div className="p-logo-section__item u-sv1">
+                    <img
+                      src="https://assets.ubuntu.com/v1/1f55452f-glusterfs logo.png"
+                      alt=""
+                      width="196"
+                      height="253"
+                      className="p-logo-section__logo"
+                    />
+                  </div>
+                  <div className="p-logo-section__item u-sv1">
+                    <img
+                      src="https://assets.ubuntu.com/v1/973c8e10-Frame 19.png"
+                      alt=""
+                      width="232"
+                      height="253"
+                      className="p-logo-section__logo"
+                    />
+                  </div>
+                  <div className="p-logo-section__item u-sv1">
+                    <img
+                      src="https://assets.ubuntu.com/v1/3ec28413-powerdns logo.png"
+                      alt=""
+                      width="252"
+                      height="253"
+                      className="p-logo-section__logo"
+                    />
+                  </div>
+                  <div className="p-logo-section__item u-sv1">
+                    <img
+                      src="https://assets.ubuntu.com/v1/7e68a46f-perl logo.png"
+                      alt=""
+                      width="252"
+                      height="253"
+                      className="p-logo-section__logo"
+                    />
+                  </div>
+                  <div className="p-logo-section__item u-sv1">
+                    <img
+                      src="https://assets.ubuntu.com/v1/35e5c439-puppet logo.png"
+                      alt=""
+                      width="236"
+                      height="253"
+                      className="p-logo-section__logo"
+                    />
+                  </div>
+                  <div className="p-logo-section__item u-sv1">
+                    <img
+                      src="https://assets.ubuntu.com/v1/2ad3b2ba-python logo.png"
+                      alt=""
+                      width="252"
+                      height="253"
+                      className="p-logo-section__logo"
+                    />
+                  </div>
+                  <div className="p-logo-section__item u-sv1">
+                    <img
+                      src="https://assets.ubuntu.com/v1/8279fc01-go logo.png"
+                      alt=""
+                      width="168"
+                      height="253"
+                      className="p-logo-section__logo"
+                    />
+                  </div>
+                  <div className="p-logo-section__item u-sv1">
+                    <img
+                      src="https://assets.ubuntu.com/v1/94f1e342-nagios logo.png"
+                      alt=""
+                      width="252"
+                      height="253"
+                      className="p-logo-section__logo"
+                    />
+                  </div>
+                  <div className="p-logo-section__item u-sv1">
+                    <img
+                      src="https://assets.ubuntu.com/v1/5b13a988-nginex logo-1.png"
+                      alt=""
+                      width="252"
+                      height="253"
+                      className="p-logo-section__logo"
+                    />
+                  </div>
+                  <div className="p-logo-section__item u-sv1">
+                    <img
+                      src="https://assets.ubuntu.com/v1/56d8741e-node-logo.png"
+                      alt=""
+                      width="196"
+                      height="253"
+                      className="p-logo-section__logo"
+                    />
+                  </div>
+                  <div className="p-logo-section__item u-sv1">
+                    <img
+                      src="https://assets.ubuntu.com/v1/fa78f5b4-openjdk logo.png"
+                      alt=""
+                      width="240"
+                      height="253"
+                      className="p-logo-section__logo"
+                    />
+                  </div>
+                  <div className="p-logo-section__item u-sv1">
+                    <img
+                      src="https://assets.ubuntu.com/v1/05c01589-redis logo.png"
+                      alt=""
+                      width="252"
+                      height="253"
+                      className="p-logo-section__logo"
+                    />
+                  </div>
+                  <div className="p-logo-section__item u-sv1">
+                    <img
+                      src="https://assets.ubuntu.com/v1/850af73c-ruby-rails logo.png"
+                      alt=""
+                      width="240"
+                      height="253"
+                      className="p-logo-section__logo"
+                    />
+                  </div>
+                  <div className="p-logo-section__item u-sv1">
+                    <img
+                      src="https://assets.ubuntu.com/v1/93af6c88-rust logo.png"
+                      alt=""
+                      width="120"
+                      height="252"
+                      className="p-logo-section__logo"
+                    />
+                  </div>
+                </>
+              )}
             </div>
           </div>
         </Col>

--- a/static/js/src/advantage/subscribe/react/components/Form/Form.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Form.tsx
@@ -76,12 +76,7 @@ const Form = () => {
                 <hr />
               </Row>
               <Strip includeCol={false}>
-                <Col size={12}>
-                  <h2>What security coverage do you need?</h2>
-                </Col>
-                <Col size={12}>
-                  <Feature />
-                </Col>
+                <Feature />
               </Strip>
               <Row>
                 <hr />

--- a/static/js/src/advantage/subscribe/react/components/ProductSummary/ProductSummary.tsx
+++ b/static/js/src/advantage/subscribe/react/components/ProductSummary/ProductSummary.tsx
@@ -37,7 +37,7 @@ const ProductSummary = () => {
   return (
     <>
       <section
-        className={`p-strip--light is-shallow p-shop-cart u-hide--small ${
+        className={`p-strip--light is-shallow p-shop-cart u-hide--small u-hide--medium ${
           isHidden ? "p-shop-cart--hidden" : ""
         }`}
         id="summary-section"
@@ -134,7 +134,7 @@ const ProductSummary = () => {
         </Row>
       </section>
       <section
-        className={`p-strip--light is-shallow p-shop-cart--small u-hide u-show--small ${
+        className={`p-strip--light is-shallow p-shop-cart--small u-hide u-show--medium ${
           isHidden ? "p-shop-cart--hidden" : ""
         }`}
         id="summary-section"

--- a/static/sass/_pattern_subscribe.scss
+++ b/static/sass/_pattern_subscribe.scss
@@ -27,11 +27,9 @@
     margin-bottom: 2rem;
 
     &::before {
-      @extend .p-heading--3;
+      @extend .p-heading--2;
 
       align-items: center;
-      border: 1px solid;
-      border-radius: 100%;
       content: counter(headings);
       display: inline-flex;
       flex-shrink: 0;

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1467,38 +1467,38 @@ $color-link-dark: #69c !default;
 }
 
 .p-graphic-main {
-  width: 10%;
   background: #923a66;
-  height: 48px;
   display: inline-block;
+  height: 48px;
+  width: 10%;
 }
 
 .p-graphic-universe {
-  width: 90%;
-  background: #000000;
-  height: 48px;
+  background: #000;
   display: inline-block;
+  height: 48px;
+  width: 90%;
 }
 .p-graphic-universe--empty {
-  border-width: 1px;
   border-color: #757575;
   border-style: dashed;
-  width: 90%;
-  height: 48px;
+  border-width: 1px;
   display: inline-block;
+  height: 48px;
+  width: 90%;
 }
 
 .graphic-legend-main,
 .graphic-legend-universe {
-  gap: 1.2rem;
   display: flex;
   flex-direction: row;
+  gap: 1.2rem;
   &::before {
+    content: "";
     display: inline-flex;
+    flex-shrink: 0;
     height: 25px;
     width: 25px;
-    content: "";
-    flex-shrink: 0;
   }
 }
 .graphic-legend-main::before {

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1466,20 +1466,20 @@ $color-link-dark: #69c !default;
   }
 }
 
-.p-graphic-main{
+.p-graphic-main {
   width: 10%;
-  background: #923A66;
+  background: #923a66;
   height: 48px;
   display: inline-block;
 }
 
-.p-graphic-universe{
+.p-graphic-universe {
   width: 90%;
   background: #000000;
   height: 48px;
   display: inline-block;
 }
-.p-graphic-universe--empty{
+.p-graphic-universe--empty {
   border-width: 1px;
   border-color: #757575;
   border-style: dashed;
@@ -1488,22 +1488,23 @@ $color-link-dark: #69c !default;
   display: inline-block;
 }
 
-.graphic-legend-main, .graphic-legend-universe{
-  gap:1.2rem;
+.graphic-legend-main,
+.graphic-legend-universe {
+  gap: 1.2rem;
   display: flex;
   flex-direction: row;
-  &::before{
+  &::before {
     display: inline-flex;
     height: 25px;
     width: 25px;
-    content:"";
+    content: "";
     flex-shrink: 0;
   }
 }
-.graphic-legend-main::before{
+.graphic-legend-main::before {
   background: #923a66;
 }
-.graphic-legend-universe::before{
+.graphic-legend-universe::before {
   background: #000;
 }
 
@@ -1534,5 +1535,3 @@ hr.is-extra-muted {
   background-color: rgba(0, 0, 0, 0.1);
   opacity: 0.5;
 }
-
-

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1466,6 +1466,47 @@ $color-link-dark: #69c !default;
   }
 }
 
+.p-graphic-main{
+  width: 10%;
+  background: #923A66;
+  height: 48px;
+  display: inline-block;
+}
+
+.p-graphic-universe{
+  width: 90%;
+  background: #000000;
+  height: 48px;
+  display: inline-block;
+}
+.p-graphic-universe--empty{
+  border-width: 1px;
+  border-color: #757575;
+  border-style: dashed;
+  width: 90%;
+  height: 48px;
+  display: inline-block;
+}
+
+.graphic-legend-main, .graphic-legend-universe{
+  gap:1.2rem;
+  display: flex;
+  flex-direction: row;
+  &::before{
+    display: inline-flex;
+    height: 25px;
+    width: 25px;
+    content:"";
+    flex-shrink: 0;
+  }
+}
+.graphic-legend-main::before{
+  background: #923a66;
+}
+.graphic-legend-universe::before{
+  background: #000;
+}
+
 // XXX: MPT: Can be removed once this is fixed in Vanilla
 // https://github.com/canonical/vanilla-framework/pull/4950
 .desktop-footer {
@@ -1493,3 +1534,5 @@ hr.is-extra-muted {
   background-color: rgba(0, 0, 0, 0.1);
   opacity: 0.5;
 }
+
+

--- a/templates/advantage/subscribe/index.html
+++ b/templates/advantage/subscribe/index.html
@@ -6,7 +6,7 @@ meta_copydoc
 %}https://docs.google.com/document/d/1UqL8YJH9ywvOXnrt3syY0U8fiOakfAGWmLS9uerwAWk/edit{%
 endblock meta_copydoc %} {% block content %}
 
-<div id="react-root">
+<div id="react-root" class="is-paper">
   <section class="p-strip u-no-padding--top">
     <div class="row">
       <div class="col-12 u-no-margin--bottom p-card">


### PR DESCRIPTION
## Done

- updated /pro/subscribe page

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- checkout /pro/subscribe
- Should match the visuals [here](https://www.figma.com/file/ZAihKxF2wmj9wvoPSnPKmY/Commercial%3A-Ubuntu-Pro?type=design&node-id=558%3A5908&mode=design&t=Ix81wAC44BDZwiMr-1)

## Issue / Card

Fixes #[WD-8751](https://warthogs.atlassian.net/browse/WD-8751)

## Screenshots

![image](https://github.com/canonical/ubuntu.com/assets/30973042/b609c714-cb59-4a57-bb19-5ef1690fb864)



## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-8751]: https://warthogs.atlassian.net/browse/WD-8751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ