### PR TITLE
Remove robotics topic from blog subnav

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -254,8 +254,6 @@ blog:
       path: /blog/cloud-and-server
     - title: Web and Design
       path: /blog/topics/design
-    - title: Robotics
-      path: /blog/topics/robotics
     - title: People and culture
       path: /blog/people-and-culture
     - title: Archives


### PR DESCRIPTION
## Done

- Removed robotics topic from blog subnav as per linked ticket

## QA

- View the site locally in your web browser at: http://0.0.0.0:8001/blog
- See that the requested change has been made

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-9040