### PR TITLE
[WD-9067] add Ubuntu Server for 64k page size image download to /download/server/arm

### DIFF
--- a/templates/download/server/arm.html
+++ b/templates/download/server/arm.html
@@ -35,21 +35,39 @@
       <h3 class="p-card__title">Ubuntu Server</h3>
       <div class="p-card__content">
         <p>
-          This is the iso image of the Ubuntu Server installer.
+          This is the default iso image of the Ubuntu Server installer.
         </p>
         <p>
           <a href="https://cdimage.ubuntu.com/releases/{{ releases.lts.short_version }}/release/ubuntu-{{ releases.lts.full_version }}-live-server-arm64.iso" class="p-button--positive is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'ARM server download', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });">
-            Download Ubuntu {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr>
+            Download {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr>
           </a>
         </p>
         {% if releases.latest.short_version > releases.lts.short_version %}
         <p>
           <a href="https://cdimage.ubuntu.com/releases/{{ releases.latest.short_version }}/release/ubuntu-{{ releases.latest.full_version }}-live-server-arm64.iso" class="p-button is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'ARM server download', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">
-            Download Ubuntu {{ releases.latest.full_version }}
+            Download {{ releases.latest.full_version }}
           </a>
         </p>
         {% endif %}
-        <p><a href="/download/alternative-downloads">Alternative and previous releases&nbsp;&rsaquo;</a></p>
+        <p>
+          <a href="/download/alternative-downloads">Alternative and previous releases&nbsp;&rsaquo;</a>
+          &nbsp;&nbsp;
+          <a href="https://wiki.ubuntu.com/ARM/Server/Install">How to install&nbsp;&rsaquo;</a>
+        </p>
+      </div>
+    </div>
+    <div class="col-6 p-card is-divided">
+      <h3 class="p-card__title">Ubuntu Server (64k page size)</h3>
+      <div class="p-card__content">
+        <p>
+          This iso is suited for servers with ample memory running memory-intensive applications.
+        </p>
+        <p>
+          <a href="https://cdimage.ubuntu.com/releases/{{ releases.lts.short_version }}/release/ubuntu-{{ releases.lts.full_version }}-live-server-arm64+largemem.iso" class="p-button--positive is-wide" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'ARM server download', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });">
+            Download {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr> (64k page size)
+          </a>
+        </p>
+        <p><a href="/server/docs/choosing-between-the-arm64-and-arm64-largemem-installer-options">Find out if 64k page size is for you&nbsp;&rsaquo;</a></p>
       </div>
     </div>
   </div>
@@ -63,8 +81,8 @@
       <ul class="p-list">
         <li class="p-list__item is-ticked">The LXD container hypervisor, giving you instant access to isolated, secured environments running with bare metal performance</li>
         <li class="p-list__item is-ticked">Application container technology based on Docker and Kubernetes, including FAN-based networking</li>
-        <li class="p-list__item is-ticked">SQL and NoSQL databases including CouchDB, MySQL, PostgreSQL, Redis and sqlite</li>
-        <li class="p-list__item is-ticked">A wide collection of Web technologies, from HTTP servers to frameworks including Apache, Django, memcached, nginx, Wordpress and varnish</li>
+        <li class="p-list__item is-ticked">SQL and NoSQL databases including CouchDB, MySQL, PostgreSQL, Redis and SQLite</li>
+        <li class="p-list__item is-ticked">A wide collection of web technologies, from HTTP servers to frameworks including Apache, Django, memcached, Nginx, WordPress and Varnish</li>
       </ul>
     </div>
     <div class="col-4 u-align--center u-vertically-center u-hide--medium u-hide--small">
@@ -98,7 +116,7 @@
     </div>
     <div class="col-8">
       <h3>Commercially supported and ready to deploy today</h3>
-      <p>Pair your ARM server deployment with enterprise-grade 24x7 support with Ubuntu Advantage to get the SLA-backed  assurance that you are fully covered by our system and architecture experts &mdash; no matter what comes up.</p>
+      <p>Pair your ARM server deployment with enterprise-grade 24x7 support with <a href="/pro">Ubuntu Pro</a> to get the SLA-backed  assurance that you are fully covered by our system and architecture experts &mdash; no matter what comes up.</p>
       <p>Built for cutting-edge hardware, from the HP Moonshot range to standard form-factor certified systems, Ubuntu and ARM Server provide truly compelling economics for cloud-scale deployment.</p>
       <p><a href="/server/contact-us?product=server-arm">Contact us about your ARM server plans&nbsp;&rsaquo;</a></p>
     </div>

--- a/templates/download/server/arm.html
+++ b/templates/download/server/arm.html
@@ -52,7 +52,7 @@
         <p>
           <a href="/download/alternative-downloads">Alternative and previous releases&nbsp;&rsaquo;</a>
           &nbsp;&nbsp;
-          <a href="https://wiki.ubuntu.com/ARM/Server/Install">How to install&nbsp;&rsaquo;</a>
+          <a href="https://wiki.ubuntu.com/ARM/Server/Install" style="white-space: nowrap">How to install&nbsp;&rsaquo;</a>
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Done

- Added Ubuntu Server for 64k page size image download to https://ubuntu-com-13614.demos.haus/download/server/arm and made a few copy update changes according to the [copy doc](https://docs.google.com/document/d/1whVU3DvB9j5k6Ed3UvLZCEN6BU-lZcow4ZefqKQqokg/edit).

## QA

- Navigate to https://ubuntu-com-13614.demos.haus/download/server/arm and check if the changes correspond to the above mentioned copy doc and if the images download correctly.

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-9067

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
