### PR TITLE
[WD-9102] fix Kernel charts and tables for 22.04.4 release

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -99,8 +99,8 @@ export var serverAndDesktopReleases = [
 
 export var kernelReleases = [
   {
-    startDate: null,
-    endDate: null,
+    startDate: new Date("2024-02-01T00:00:00"),
+    endDate: new Date("2024-08-01T00:00:00"),
     taskName: "22.04.4 LTS",
     taskVersion: "6.5 kernel",
     status: "LTS",
@@ -115,7 +115,7 @@ export var kernelReleases = [
   {
     startDate: new Date("2023-08-01T00:00:00"),
     endDate: new Date("2024-01-01T00:00:00"),
-    taskName: "22.04.4 LTS",
+    taskName: "22.04.3 LTS",
     taskVersion: "6.2 kernel",
     status: "LTS",
   },
@@ -317,7 +317,13 @@ export var kernelReleases2204 = [
   {
     startDate: new Date("2023-08-16T00:00:00"),
     endDate: new Date("2024-01-18T00:00:00"),
-    taskName: "Ubuntu 22.04.4 LTS (v6.2)",
+    taskName: "Ubuntu 22.04.3 LTS (v6.2)",
+    status: "LTS",
+  },
+  {
+    startDate: new Date("2024-02-01T00:00:00"),
+    endDate: new Date("2024-08-01T00:00:00"),
+    taskName: "Ubuntu 22.04.4 LTS (v6.5)",
     status: "LTS",
   },
 ];
@@ -602,7 +608,7 @@ export var kernelReleasesALL = [
   {
     startDate: new Date("2023-08-01T00:00:00"),
     endDate: new Date("2024-01-01T00:00:00"),
-    taskName: "Ubuntu 22.04.4 LTS (v6.2)",
+    taskName: "Ubuntu 22.04.3 LTS (v6.2)",
     status: "LTS",
   },
   {
@@ -610,6 +616,12 @@ export var kernelReleasesALL = [
     endDate: new Date("2024-07-01T00:00:00"),
     taskName: "Ubuntu 23.10 (v6.5)",
     status: "INTERIM_RELEASE",
+  },
+  {
+    startDate: new Date("2024-02-01T00:00:00"),
+    endDate: new Date("2024-08-01T00:00:00"),
+    taskName: "Ubuntu 22.04.4 LTS (v6.5)",
+    status: "LTS",
   },
 ];
 
@@ -767,7 +779,13 @@ export var kernelReleasesLTS = [
   {
     startDate: new Date("2023-08-01T00:00:00"),
     endDate: new Date("2024-01-01T00:00:00"),
-    taskName: "Ubuntu 22.04.4 LTS (v6.2)",
+    taskName: "Ubuntu 22.04.3 LTS (v6.2)",
+    status: "LTS",
+  },
+  {
+    startDate: new Date("2024-02-01T00:00:00"),
+    endDate: new Date("2024-08-01T00:00:00"),
+    taskName: "Ubuntu 22.04.4 LTS (v6.5)",
     status: "LTS",
   },
 ];
@@ -1288,7 +1306,7 @@ export var desktopServerReleaseNames = [
 ];
 
 export var kernelReleaseNames = [
-  "22.04.4 LTS (soon)",
+  "22.04.4 LTS",
   "23.10",
   "22.04.3 LTS",
   "22.04.2 LTS",
@@ -1329,7 +1347,8 @@ export var kernelReleaseNames2204 = [
   "Ubuntu 22.04.0 LTS (v5.15)",
   "Ubuntu 22.04.1 LTS (v5.15)",
   "Ubuntu 22.04.2 LTS (v5.19)",
-  "Ubuntu 22.04.4 LTS (v6.2)",
+  "Ubuntu 22.04.3 LTS (v6.2)",
+  "Ubuntu 22.04.4 LTS (v6.5)",
 ];
 
 export var kernelReleaseNames2004 = [
@@ -1366,8 +1385,9 @@ export var kernelReleaseNamesALL = [
   "Ubuntu 20.04.5 LTS (v5.15)",
   "Ubuntu 22.04.1 LTS (v5.15)",
   "Ubuntu 22.04.2 LTS (v5.19)",
-  "Ubuntu 22.04.4 LTS (v6.2)",
+  "Ubuntu 22.04.3 LTS (v6.2)",
   "Ubuntu 23.10 (v6.5)",
+  "Ubuntu 22.04.4 LTS (v6.5)",
 ];
 
 export var kernelReleaseNamesLTS = [
@@ -1384,7 +1404,8 @@ export var kernelReleaseNamesLTS = [
   "Ubuntu 20.04.5 LTS (v5.15)",
   "Ubuntu 22.04.1 LTS (v5.15)",
   "Ubuntu 22.04.2 LTS (v5.19)",
-  "Ubuntu 22.04.4 LTS (v6.2)",
+  "Ubuntu 22.04.3 LTS (v6.2)",
+  "Ubuntu 22.04.4 LTS (v6.5)",
 ];
 
 export var openStackReleaseNames = [

--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -113,20 +113,6 @@ export var kernelReleases = [
     status: "INTERIM_RELEASE",
   },
   {
-    startDate: new Date("2023-08-01T00:00:00"),
-    endDate: new Date("2024-01-01T00:00:00"),
-    taskName: "22.04.3 LTS",
-    taskVersion: "6.2 kernel",
-    status: "LTS",
-  },
-  {
-    startDate: new Date("2023-02-01T00:00:00"),
-    endDate: new Date("2023-07-01T00:00:00"),
-    taskName: "22.04.2 LTS",
-    taskVersion: "5.19 kernel",
-    status: "LTS",
-  },
-  {
     startDate: new Date("2022-08-01T00:00:00"),
     endDate: new Date("2027-04-01T00:00:00"),
     taskName: "22.04.1 LTS",
@@ -306,18 +292,6 @@ export var kernelReleases2204 = [
     startDate: new Date("2022-08-21T00:00:00"),
     endDate: new Date("2027-04-22T00:00:00"),
     taskName: "Ubuntu 22.04.1 LTS (v5.15)",
-    status: "LTS",
-  },
-  {
-    startDate: new Date("2023-02-17T00:00:00"),
-    endDate: new Date("2023-07-22T00:00:00"),
-    taskName: "Ubuntu 22.04.2 LTS (v5.19)",
-    status: "LTS",
-  },
-  {
-    startDate: new Date("2023-08-16T00:00:00"),
-    endDate: new Date("2024-01-18T00:00:00"),
-    taskName: "Ubuntu 22.04.3 LTS (v6.2)",
     status: "LTS",
   },
   {
@@ -600,18 +574,6 @@ export var kernelReleasesALL = [
     status: "LTS",
   },
   {
-    startDate: new Date("2023-02-01T00:00:00"),
-    endDate: new Date("2023-07-01T00:00:00"),
-    taskName: "Ubuntu 22.04.2 LTS (v5.19)",
-    status: "LTS",
-  },
-  {
-    startDate: new Date("2023-08-01T00:00:00"),
-    endDate: new Date("2024-01-01T00:00:00"),
-    taskName: "Ubuntu 22.04.3 LTS (v6.2)",
-    status: "LTS",
-  },
-  {
     startDate: new Date("2023-10-01T00:00:00"),
     endDate: new Date("2024-07-01T00:00:00"),
     taskName: "Ubuntu 23.10 (v6.5)",
@@ -769,18 +731,6 @@ export var kernelReleasesLTS = [
     endDate: new Date("2027-04-01T00:00:00"),
     taskName: "Ubuntu 22.04.1 LTS (v5.15)",
     status: "CVE",
-  },
-  {
-    startDate: new Date("2023-02-01T00:00:00"),
-    endDate: new Date("2023-07-01T00:00:00"),
-    taskName: "Ubuntu 22.04.2 LTS (v5.19)",
-    status: "LTS",
-  },
-  {
-    startDate: new Date("2023-08-01T00:00:00"),
-    endDate: new Date("2024-01-01T00:00:00"),
-    taskName: "Ubuntu 22.04.3 LTS (v6.2)",
-    status: "LTS",
   },
   {
     startDate: new Date("2024-02-01T00:00:00"),
@@ -1308,8 +1258,6 @@ export var desktopServerReleaseNames = [
 export var kernelReleaseNames = [
   "22.04.4 LTS",
   "23.10",
-  "22.04.3 LTS",
-  "22.04.2 LTS",
   "22.04.1 LTS",
   "20.04.5 LTS",
   "22.04.0 LTS",
@@ -1327,8 +1275,6 @@ export var kernelReleaseNames = [
 export var kernelVersionNames = [
   "6.5",
   "",
-  "6.2",
-  "5.19",
   "5.15",
   "",
   "",
@@ -1346,8 +1292,6 @@ export var kernelVersionNames = [
 export var kernelReleaseNames2204 = [
   "Ubuntu 22.04.0 LTS (v5.15)",
   "Ubuntu 22.04.1 LTS (v5.15)",
-  "Ubuntu 22.04.2 LTS (v5.19)",
-  "Ubuntu 22.04.3 LTS (v6.2)",
   "Ubuntu 22.04.4 LTS (v6.5)",
 ];
 
@@ -1384,8 +1328,6 @@ export var kernelReleaseNamesALL = [
   "Ubuntu 22.04.0 LTS (v5.15)",
   "Ubuntu 20.04.5 LTS (v5.15)",
   "Ubuntu 22.04.1 LTS (v5.15)",
-  "Ubuntu 22.04.2 LTS (v5.19)",
-  "Ubuntu 22.04.3 LTS (v6.2)",
   "Ubuntu 23.10 (v6.5)",
   "Ubuntu 22.04.4 LTS (v6.5)",
 ];
@@ -1403,8 +1345,6 @@ export var kernelReleaseNamesLTS = [
   "Ubuntu 22.04.0 LTS (v5.15)",
   "Ubuntu 20.04.5 LTS (v5.15)",
   "Ubuntu 22.04.1 LTS (v5.15)",
-  "Ubuntu 22.04.2 LTS (v5.19)",
-  "Ubuntu 22.04.3 LTS (v6.2)",
   "Ubuntu 22.04.4 LTS (v6.5)",
 ];
 

--- a/templates/about/release_cycles/kernel-eol.html
+++ b/templates/about/release_cycles/kernel-eol.html
@@ -23,21 +23,7 @@
         <tr>
           <td><strong>23.10</strong></td>
           <td>Oct 2023</td>
-          <td>Jan 2024</td>
-          <td>&nbsp;</td>
-        </tr>
-        <tr>
-          <td><strong>6.2</strong></td>
-          <td><strong>22.04.3 LTS</strong></td>
-          <td>Aug 2023</td>
-          <td>Jan 2024</td>
-          <td>&nbsp;</td>
-        </tr>
-        <tr>
-          <td><strong>5.19</strong></td>
-          <td><strong>22.04.2 LTS</strong></td>
-          <td>Feb 2023</td>
-          <td>Jul 2023</td>
+          <td>Jul 2024</td>
           <td>&nbsp;</td>
         </tr>
         <tr>

--- a/templates/about/release_cycles/kernel-eol.html
+++ b/templates/about/release_cycles/kernel-eol.html
@@ -15,9 +15,9 @@
       <tbody>
         <tr>
           <td rowspan="2"><strong>6.5</strong></td>
-          <td><strong>22.04.4</strong></td>
-          <td>&nbsp;</td>
-          <td>&nbsp;</td>
+          <td><strong>22.04.4 LTS</strong></td>
+          <td>Feb 2024</td>
+          <td>Aug 2024</td>
           <td>&nbsp;</td>
         </tr>
         <tr>

--- a/templates/shared/_kernel-support-schedule.html
+++ b/templates/shared/_kernel-support-schedule.html
@@ -51,9 +51,14 @@
             <td>Jul 2023</td>
           </tr>
           <tr>
-            <td><strong>Ubuntu 22.04.4 LTS (v6.2)</strong></td>
+            <td><strong>Ubuntu 22.04.3 LTS (v6.2)</strong></td>
             <td>Aug 2023</td>
             <td>Jan 2024</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 22.04.4 LTS (v6.5)</strong></td>
+            <td>Feb 2024</td>
+            <td>Aug 2024</td>
           </tr>
         </tbody>
       </table>
@@ -274,10 +279,16 @@
             <td>Jul 2023</td>
           </tr>
           <tr>
-            <td><strong>Ubuntu 22.04.4 LTS (v6.2)</strong></td>
+            <td><strong>Ubuntu 22.04.3 LTS (v6.2)</strong></td>
             <td>Aug 2023</td>
             <td>&nbsp;</td>
             <td>Jan 2024</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 22.04.4 LTS (v6.5)</strong></td>
+            <td>Feb 2024</td>
+            <td>&nbsp;</td>
+            <td>Aug 2024</td>
           </tr>
         </tbody>
       </table>
@@ -374,7 +385,7 @@
             <td>Jul 2023</td>
           </tr>
           <tr>
-            <td><strong>Ubuntu 22.04.4 LTS (v6.2)</strong></td>
+            <td><strong>Ubuntu 22.04.3 LTS (v6.2)</strong></td>
             <td>&nbsp;</td>
             <td>Aug 2023</td>
             <td>Jan 2023</td>
@@ -384,6 +395,12 @@
             <td>&nbsp;</td>
             <td>Oct 2023</td>
             <td>Jul 2023</td>
+          </tr>
+          <tr>
+            <td><strong>Ubuntu 22.04.4 LTS (v6.5)</strong></td>
+            <td>&nbsp;</td>
+            <td>Feb 2024</td>
+            <td>Aug 2024</td>
           </tr>
         </tbody>
       </table>

--- a/templates/shared/_kernel-support-schedule.html
+++ b/templates/shared/_kernel-support-schedule.html
@@ -46,16 +46,6 @@
             <td>Apr 2027</td>
           </tr>
           <tr>
-            <td><strong>Ubuntu 22.04.2 LTS (v5.19)</strong></td>
-            <td>Feb 2023</td>
-            <td>Jul 2023</td>
-          </tr>
-          <tr>
-            <td><strong>Ubuntu 22.04.3 LTS (v6.2)</strong></td>
-            <td>Aug 2023</td>
-            <td>Jan 2024</td>
-          </tr>
-          <tr>
             <td><strong>Ubuntu 22.04.4 LTS (v6.5)</strong></td>
             <td>Feb 2024</td>
             <td>Aug 2024</td>
@@ -273,18 +263,6 @@
             <td>Apr 2027</td>
           </tr>
           <tr>
-            <td><strong>Ubuntu 22.04.2 LTS (v5.19)</strong></td>
-            <td>Feb 2023</td>
-            <td>&nbsp;</td>
-            <td>Jul 2023</td>
-          </tr>
-          <tr>
-            <td><strong>Ubuntu 22.04.3 LTS (v6.2)</strong></td>
-            <td>Aug 2023</td>
-            <td>&nbsp;</td>
-            <td>Jan 2024</td>
-          </tr>
-          <tr>
             <td><strong>Ubuntu 22.04.4 LTS (v6.5)</strong></td>
             <td>Feb 2024</td>
             <td>&nbsp;</td>
@@ -377,18 +355,6 @@
             <td>&nbsp;</td>
             <td>Aug 2022</td>
             <td>Apr 2027</td>
-          </tr>
-          <tr>
-            <td><strong>Ubuntu 22.04.2 LTS (v5.19)</strong></td>
-            <td>&nbsp;</td>
-            <td>Feb 2023</td>
-            <td>Jul 2023</td>
-          </tr>
-          <tr>
-            <td><strong>Ubuntu 22.04.3 LTS (v6.2)</strong></td>
-            <td>&nbsp;</td>
-            <td>Aug 2023</td>
-            <td>Jan 2023</td>
           </tr>
           <tr>
             <td>Ubuntu 23.10 (v6.5)</td>


### PR DESCRIPTION
## Done

- After yesterday's release of 22.04.4 version of Ubuntu there were changes made in several places, including Kernel charts at /about/release-cycle#ubuntu-kernel-release-cycle and /kernel/lifecycle. But it was not done correctly, as in 22.04.3 should not be replaced by 22.04.4, it needs to be added as a separate release instead. And this is what was fixed by this PR.
- Removed kernel versions 6.2 and 5.19 from all kernel charts and tables because their lifecycle has finished.

## QA

- Navigate to https://ubuntu-com-13615.demos.haus/about/release-cycle#ubuntu-kernel-release-cycle and check if the chart and the table have 22.04.4 release that corresponds to 6.5 kernel version. Also check that 6.2 and 5.19 versions of kernel do not show.
- Navigate to https://ubuntu-com-13615.demos.haus/kernel/lifecycle and check the chart on bigger screens and the table on smaller screens in the following tabs:
   - All releases
   - All LTS releases
   - 22.04 LTS
   , and check that 22.04.4 release is there and that it has 6.5 kernel version. Also check that 6.2 and 5.19 versions of kernel do not show.

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-9102

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
