### PR TITLE
Update Wintermute logo

### DIFF
--- a/templates/supermicro/index.html
+++ b/templates/supermicro/index.html
@@ -137,18 +137,17 @@ open-source solutions that are both validated and fully supported{% endblock %}
             }}
           </div>
           <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/a968be32-wintermute-logo.svg" class="p-logo-section__logo" alt="WinterMute" width="120" height="100" />
-            <!-- {{
+            {{
             image (
-            url="https://assets.ubuntu.com/v1/a968be32-wintermute-logo.svg",
+            url="https://assets.ubuntu.com/v1/8cc11190-wintermute-logo.svg",
             alt="WinterMute",
-            width="90",
-            height="120",
-            hi_def=True,
+            width="174",
+            height="144",
+            hi_def=False,
             loading="lazy",
             attrs={"class": "p-logo-section__logo"}
             ) | safe
-            }} -->
+            }}
           </div>
           <div class="p-logo-section__item">
             {{

--- a/templates/supermicro/index.html
+++ b/templates/supermicro/index.html
@@ -137,9 +137,10 @@ open-source solutions that are both validated and fully supported{% endblock %}
             }}
           </div>
           <div class="p-logo-section__item">
-            {{
+            <img src="https://assets.ubuntu.com/v1/a968be32-wintermute-logo.svg" class="p-logo-section__logo" alt="WinterMute" width="120" height="100" />
+            <!-- {{
             image (
-            url="https://assets.ubuntu.com/v1/9d00e2d9-wintermute-logo.png",
+            url="https://assets.ubuntu.com/v1/a968be32-wintermute-logo.svg",
             alt="WinterMute",
             width="90",
             height="120",
@@ -147,7 +148,7 @@ open-source solutions that are both validated and fully supported{% endblock %}
             loading="lazy",
             attrs={"class": "p-logo-section__logo"}
             ) | safe
-            }}
+            }} -->
           </div>
           <div class="p-logo-section__item">
             {{

--- a/templates/supermicro/index.html
+++ b/templates/supermicro/index.html
@@ -143,7 +143,7 @@ open-source solutions that are both validated and fully supported{% endblock %}
             alt="WinterMute",
             width="174",
             height="144",
-            hi_def=False,
+            hi_def=True,
             loading="lazy",
             attrs={"class": "p-logo-section__logo"}
             ) | safe


### PR DESCRIPTION
## Done

- Updated Wintermute logo as per [doc](https://docs.google.com/document/d/192QGE7qzo8nQ-XkyhWIDckBkKHo8kf9rhAFgFVukTic/edit)

## QA

- View the site locally in your web browser at: http://0.0.0.0:8001/supermicro
- See that the change has been made

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-9048
