### PR TITLE
WD-8849 - add new section to kubernetes/resources

### DIFF
--- a/templates/kubernetes/resources.html
+++ b/templates/kubernetes/resources.html
@@ -44,7 +44,7 @@
   <div class="row">
     <div class="col-6">
       <h2 class="p-section--shallow">Try our newest Canonical Kubernetes distribution</h2>
-      <p><a href="/kubernetes/ck8s">Try Canonical Kubernetes today&nbsp;&rsaquo;</a></p>
+      <p><a href="http://documentation.ubuntu.com/canonical-kubernetes">Try Canonical Kubernetes today&nbsp;&rsaquo;</a></p>
       <p><a href="/kubernetes">Read the announcement&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-6 ">

--- a/templates/kubernetes/resources.html
+++ b/templates/kubernetes/resources.html
@@ -41,6 +41,19 @@
   </article>
 </section>
 <section class="p-strip--light">
+  <div class="row">
+    <div class="col-6">
+      <h2 class="p-section--shallow">Try our newest Canonical Kubernetes distribution</h2>
+      <p><a href="/kubernetes/ck8s">Try Canonical Kubernetes today&nbsp;&rsaquo;</a></p>
+      <p><a href="/kubernetes">Read the announcement&nbsp;&rsaquo;</a></p>
+    </div>
+    <div class="col-6 ">
+      <p>Canonical Kubernetes is our newest K8s distribution, currently in beta. When it reaches general availability, it will come with 12 years of Long Term Support (LTS) and built-in features like networking, local storage, dns or ingress.</p>
+      <p>For small scale clusters It can be deployed with a single command and join new nodes with two more. It can also be combined with <a href="http://juju.is">Juju</a> to provide maintenance automation for large scale clusters.</p>
+    </div>
+  </div>
+</section>
+<section class="p-strip">
   <div class="u-fixed-width">
     <h2>Videos and webinars</h2>
   </div>
@@ -196,7 +209,7 @@
     </div>
   </article>
 </section>
-<section class="p-strip">
+<section class="p-strip--light">
   <div class="u-fixed-width">
     <h2>Case studies/Whitepapers/Industry reports</h2>
   </div>
@@ -314,7 +327,7 @@
     </div>
   </article>
 </section>
-<section class="p-strip--light">
+<section class="p-strip">
   <div class="u-fixed-width">
     <h2>Blogs</h2>
     <p>All Canonical blogs related to Kubernetes can be found here. This rich set of content covers everything from high-level product announcements to hands-on technical guides that dig into more complicated topics.</p>
@@ -470,7 +483,7 @@
     </div>
   </article>
 </section>
-<section class="p-strip">
+<section class="p-strip--light">
   <div class="u-fixed-width">
     <h2>Reference architectures/Solution briefs</h2>
   </div>


### PR DESCRIPTION
## Done

Add a new section to "Try our newest Canonical Kubernetes distribution" /kubernetes/resources

Note: links at the bottom of the section will be released on March 6th together with k8s-bubble-refresh feature

## QA
- [demo link](https://ubuntu-com-13617.demos.haus/kubernetes/resources)
- [copy doc](https://docs.google.com/document/d/1enaCJ4Vt9a_2_l6xYccnZ-fBVUejPSmfMi8LP2aDA9c/edit#heading=h.wlkvcxbum9h0)
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check that the section is correct according to copy doc

## Issue / Card
[WD-8849](https://warthogs.atlassian.net/browse/WD-8849)

Fixes #

## Screenshots


[WD-8849]: https://warthogs.atlassian.net/browse/WD-8849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ