### PR TITLE
WD-8891 - add new section to kubernetes/what-is-kubernetes

### DIFF
--- a/templates/kubernetes/what-is-kubernetes.html
+++ b/templates/kubernetes/what-is-kubernetes.html
@@ -855,7 +855,7 @@
     <div class="row">
       <div class="col-6">
         <h2 class="p-section--shallow">Try our newest Canonical Kubernetes distribution</h2>
-        <p><a href="/kubernetes/ck8s">Try Canonical Kubernetes today&nbsp;&rsaquo;</a></p>
+        <p><a href="http://documentation.ubuntu.com/canonical-kubernetes">Try Canonical Kubernetes today&nbsp;&rsaquo;</a></p>
         <p><a href="/kubernetes">Read the announcement&nbsp;&rsaquo;</a></p>
       </div>
       <div class="col-6 ">

--- a/templates/kubernetes/what-is-kubernetes.html
+++ b/templates/kubernetes/what-is-kubernetes.html
@@ -852,6 +852,20 @@
   </section>
 
   <section class="p-strip--light">
+    <div class="row">
+      <div class="col-6">
+        <h2 class="p-section--shallow">Try our newest Canonical Kubernetes distribution</h2>
+        <p><a href="/kubernetes/ck8s">Try Canonical Kubernetes today&nbsp;&rsaquo;</a></p>
+        <p><a href="/kubernetes">Read the announcement&nbsp;&rsaquo;</a></p>
+      </div>
+      <div class="col-6 ">
+        <p>Canonical Kubernetes is our newest K8s distribution, currently in beta. When it reaches general availability, it will come with 12 years of Long Term Support (LTS) and built-in features like networking, local storage, dns or ingress.</p>
+        <p>For small scale clusters It can be deployed with a single command and join new nodes with two more. It can also be combined with <a href="http://juju.is">Juju</a> to provide maintenance automation for large scale clusters.</p>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-strip">
     <div class="row u-vertically-center">
       <div class="col-8">
         <h2 class="p-heading--3">Get your K8s questions answered today</h2>


### PR DESCRIPTION
## Done

Add a new section to "Try our newest Canonical Kubernetes distribution" /kubernetes/what-is-kubernetes

Note: links at the bottom of the section will be released on March 6th together with k8s-bubble-refresh feature

## QA
- [demo link](https://ubuntu-com-13618.demos.haus/kubernetes/what-is-kubernetes)
- [copy doc](https://docs.google.com/document/d/19ZAsyujRHjOBIKP15F-4Z9L24KpfoYrx0YpL-0gO6sE/edit)
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check that the section is correct according to copy doc

## Issue / Card
[WD-8891](https://warthogs.atlassian.net/browse/WD-8891)

Fixes #

## Screenshots

[WD-8891]: https://warthogs.atlassian.net/browse/WD-8891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ