### PR TITLE
Hide free token if active subscriptions exist

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.test.tsx
@@ -98,7 +98,7 @@ describe("SubscriptionList", () => {
     );
   });
 
-  it("displays a free subscription", () => {
+  it("displays a free subscription when no subscriptions exist", () => {
     const wrapper = mount(
       <QueryClientProvider client={queryClient}>
         <SubscriptionList onSetActive={jest.fn()} />
@@ -121,6 +121,57 @@ describe("SubscriptionList", () => {
     expect(
       wrapper.find("[data-test='free-subscription']").prop("isSelected")
     ).toBe(true);
+  });
+
+  it("hide free subscription if an active paid subscription exists", () => {
+    const subscriptions = [
+      userSubscriptionFactory.build({
+        statuses: userSubscriptionStatusesFactory.build({
+          is_subscription_active: true,
+        }),
+      }),
+      userSubscriptionFactory.build({
+        statuses: userSubscriptionStatusesFactory.build({
+          is_expired: true,
+          is_subscription_active: false,
+        }),
+      }),
+      freeSubscription,
+    ];
+    queryClient.setQueryData("userSubscriptions", subscriptions);
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <SubscriptionList onSetActive={jest.fn()} />
+      </QueryClientProvider>
+    );
+    const token = wrapper.find("[data-test='free-subscription']");
+    expect(token.exists()).toBe(false);
+  });
+
+  it("display free subscription if there is no active paid subscription", () => {
+    queryClient.setQueryData("userSubscriptions", [
+      userSubscriptionFactory.build({
+        statuses: userSubscriptionStatusesFactory.build({
+          is_cancelled: true,
+          is_subscription_active: false,
+        }),
+      }),
+      userSubscriptionFactory.build({
+        statuses: userSubscriptionStatusesFactory.build({
+          is_expired: true,
+          is_subscription_active: false,
+        }),
+      }),
+      freeSubscription,
+    ]);
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <SubscriptionList onSetActive={jest.fn()} />
+      </QueryClientProvider>
+    );
+    const token = wrapper.find("[data-test='free-subscription']");
+    expect(token.exists()).toBe(true);
+    expect(token.prop("subscription")).toStrictEqual(freeSubscription);
   });
 
   it("shows the renewal settings if there subscriptions for which we should present the auto-renewal option", () => {

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.test.tsx
@@ -123,18 +123,15 @@ describe("SubscriptionList", () => {
     ).toBe(true);
   });
 
-  it("hide free subscription if an active paid subscription exists", () => {
+  it("hide free subscription if a valid paid subscription exists", () => {
     const subscriptions = [
       userSubscriptionFactory.build({
-        statuses: userSubscriptionStatusesFactory.build({
-          is_subscription_active: true,
-        }),
+        start_date: new Date("2023-12-31T02:56:54Z"),
+        end_date: new Date("2024-12-31T02:56:54Z"),
       }),
       userSubscriptionFactory.build({
-        statuses: userSubscriptionStatusesFactory.build({
-          is_expired: true,
-          is_subscription_active: false,
-        }),
+        start_date: new Date("2020-08-11T02:56:54Z"),
+        end_date: new Date("2021-08-11T02:56:54Z"),
       }),
       freeSubscription,
     ];
@@ -148,19 +145,11 @@ describe("SubscriptionList", () => {
     expect(token.exists()).toBe(false);
   });
 
-  it("display free subscription if there is no active paid subscription", () => {
+  it("display free subscription if there is no valid paid subscription", () => {
     queryClient.setQueryData("userSubscriptions", [
       userSubscriptionFactory.build({
-        statuses: userSubscriptionStatusesFactory.build({
-          is_cancelled: true,
-          is_subscription_active: false,
-        }),
-      }),
-      userSubscriptionFactory.build({
-        statuses: userSubscriptionStatusesFactory.build({
-          is_expired: true,
-          is_subscription_active: false,
-        }),
+        start_date: new Date("2020-08-11T02:56:54Z"),
+        end_date: new Date("2021-08-11T02:56:54Z"),
       }),
       freeSubscription,
     ]);

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.tsx
@@ -87,7 +87,7 @@ const SubscriptionList = ({ selectedId, onSetActive }: Props) => {
     )
   );
 
-  const checkValidSubscription = (subscriptions: UserSubscription[]) => {
+  const hasActiveSubscription = (subscriptions: UserSubscription[]) => {
     const now = Date.now();
     return subscriptions.some(({ start_date, end_date }) => {
       if (start_date && end_date) {
@@ -99,9 +99,7 @@ const SubscriptionList = ({ selectedId, onSetActive }: Props) => {
     });
   };
 
-  const showFreeSubscription =
-    !checkValidSubscription(sortedUASubscriptions) &&
-    !checkValidSubscription(sortedBlenderSubscriptions);
+  const showFreeSubscription = !hasActiveSubscription(sortedUASubscriptions);
 
   return (
     <div className="p-subscriptions__list p-card" style={{ overflow: "unset" }}>

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.tsx
@@ -88,14 +88,9 @@ const SubscriptionList = ({ selectedId, onSetActive }: Props) => {
   );
 
   const checkActiveSubscription = (subscriptions: UserSubscription[]) => {
-    let activeSubscription = false;
-    subscriptions?.length > 0 &&
-      subscriptions?.forEach((subscription) => {
-        if (subscription?.statuses?.is_subscription_active == true) {
-          activeSubscription = true;
-        }
-      });
-    return activeSubscription;
+    return subscriptions?.some(
+      (subscription) => subscription?.statuses?.is_subscription_active === true
+    );
   };
 
   const showFreeSubscription =

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.tsx
@@ -87,15 +87,21 @@ const SubscriptionList = ({ selectedId, onSetActive }: Props) => {
     )
   );
 
-  const checkActiveSubscription = (subscriptions: UserSubscription[]) => {
-    return subscriptions?.some(
-      (subscription) => subscription?.statuses?.is_subscription_active === true
-    );
+  const checkValidSubscription = (subscriptions: UserSubscription[]) => {
+    const now = Date.now();
+    return subscriptions.some(({ start_date, end_date }) => {
+      if (start_date && end_date) {
+        const startDate = new Date(start_date).getTime();
+        const endDate = new Date(end_date).getTime();
+        return startDate <= now && endDate >= now;
+      }
+      return false;
+    });
   };
 
   const showFreeSubscription =
-    !checkActiveSubscription(sortedUASubscriptions) &&
-    !checkActiveSubscription(sortedBlenderSubscriptions);
+    !checkValidSubscription(sortedUASubscriptions) &&
+    !checkValidSubscription(sortedBlenderSubscriptions);
 
   return (
     <div className="p-subscriptions__list p-card" style={{ overflow: "unset" }}>

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionList/SubscriptionList.tsx
@@ -13,6 +13,7 @@ import { SelectedId } from "../Content/types";
 
 import ListCard from "./ListCard";
 import ListGroup from "./ListGroup";
+import { UserSubscription } from "advantage/api/types";
 
 type Props = {
   selectedId?: SelectedId;
@@ -86,6 +87,21 @@ const SubscriptionList = ({ selectedId, onSetActive }: Props) => {
     )
   );
 
+  const checkActiveSubscription = (subscriptions: UserSubscription[]) => {
+    let activeSubscription = false;
+    subscriptions?.length > 0 &&
+      subscriptions?.forEach((subscription) => {
+        if (subscription?.statuses?.is_subscription_active == true) {
+          activeSubscription = true;
+        }
+      });
+    return activeSubscription;
+  };
+
+  const showFreeSubscription =
+    !checkActiveSubscription(sortedUASubscriptions) &&
+    !checkActiveSubscription(sortedBlenderSubscriptions);
+
   return (
     <div className="p-subscriptions__list p-card" style={{ overflow: "unset" }}>
       {sortedUASubscriptions.length ? (
@@ -108,7 +124,7 @@ const SubscriptionList = ({ selectedId, onSetActive }: Props) => {
         </ListGroup>
       ) : null}
 
-      {freeSubscription ? (
+      {freeSubscription && showFreeSubscription ? (
         <ListGroup
           title="Free personal token"
           marketplace={UserSubscriptionMarketplace.Free}

--- a/static/js/src/tabbed-content.js
+++ b/static/js/src/tabbed-content.js
@@ -213,7 +213,7 @@
   const boards = document.querySelectorAll(`[role=tabpanel]`);
   const dropdownSelect = document.getElementById("boardSelect");
 
-  dropdownSelect.addEventListener("change", (event) => {
+  dropdownSelect?.addEventListener("change", (event) => {
     selectBoard();
   });
 


### PR DESCRIPTION
## Done

- Hide free personal token if active paid subscriptions exist on `/pro/dashboard`

## QA

- Go to `/pro/dashboard`
- Check free personal token displays when no subscription exists
- Check free personal token is hidden when valid paid subscriptions exist (start date <= now and end date >= now) 
- Check free personal token displays again when valid paid subscriptions doesn't exist. 

## Issue / Card

Fixes #https://warthogs.atlassian.net/jira/software/c/projects/WD/boards/801?selectedIssue=WD-9026
