### PR TITLE
Make resource_url optional for contact_form_only engage pages

### DIFF
--- a/templates/engage/base.html
+++ b/templates/engage/base.html
@@ -30,10 +30,10 @@
       {% if metadata['banner_class'] == 'light' %}
         {{
           image(
-            url="https://assets.ubuntu.com/v1/04115a7e-ubuntu_black-orange_hex.svg",
+            url="https://assets.ubuntu.com/v1/43ef5c89-Canonical Ubuntu.svg",
             alt="Ubuntu",
-            height="32",
-            width="143",
+            width="300",
+            height="55",
             hi_def=True,
             loading="auto"
           ) | safe
@@ -41,16 +41,15 @@
       {% else %}
         {{
           image(
-            url="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg",
+            url="https://assets.ubuntu.com/v1/b4f695ea-Canonical Ubuntu copy 2.svg",
             alt="Ubuntu",
-            height="32",
-            width="143",
+            width="300",
+            height="55",
             hi_def=True,
             loading="auto"
           ) | safe
         }}
       {% endif %}
-
     </a>
   </div>
   <div class="row">

--- a/templates/engage/shared/_de_thank-you.html
+++ b/templates/engage/shared/_de_thank-you.html
@@ -32,37 +32,33 @@
 <section class="p-strip">
   <div class="row">
     <div class="col-8">
-      {% if 'pages.ubuntu.com' or 'assets.ubuntu.com' in resource_url %}
-        {% if form_details and "access_to_content" in metadata and metadata.access_to_content == "true" %}
+      {% if form_details and "access_to_content" in metadata and metadata.access_to_content == "true" %}
 
-          <h3>Wir haben eine Kopie des Whitepapers per e-mail {{ resource_name }} an {{ form_details.email }}</h3>
-          <p>
-            <a class="p-button--positive" href="{{ request_url }}">Zurück zur letzten Seite</a>
-            <a class="p-button" href="/contact-us">Kontaktiere uns</a>
-          </p>          
-          <p>
-            Nicht erhalten? Überprüfen Sie Ihren Spam-Ordner und ob Sie die richtige E-Mail-Adresse verwendet haben.
-          </p>
-          <p>
-            <a href="{{ request_url }}">Oder versuchen Sie es erneut</a>
-          </p>
+        <h3>Wir haben eine Kopie des Whitepapers per e-mail {{ resource_name }} an {{ form_details.email }}</h3>
+        <p>
+          <a class="p-button--positive" href="{{ request_url }}">Zurück zur letzten Seite</a>
+          <a class="p-button" href="/contact-us">Kontaktiere uns</a>
+        </p>          
+        <p>
+          Nicht erhalten? Überprüfen Sie Ihren Spam-Ordner und ob Sie die richtige E-Mail-Adresse verwendet haben.
+        </p>
+        <p>
+          <a href="{{ request_url }}">Oder versuchen Sie es erneut</a>
+        </p>
 
+      {% else %}
+        {% if "thank_you_text" in metadata %}
+          <p>{{ metadata["thank_you_text"] }}</p>
         {% else %}
-          {% if "thank_you_text" in metadata %}
-            <p>{{ metadata["thank_you_text"] }}</p>
-          {% else %}
-            <p>{{ resource_name }} ist jetzt zum Download bereit.</p>
-          {% endif %}
-          {% if "contact_form_only" not in metadata and metadata.contact_form_only != "true" or ("access_to_content" in metadata and metadata.access_to_content == "true") %}
-            <p>
-              <a class="p-button--positive" href="{{ resource_url }}">Herunterladen</a>
-            </p>
+          <p>{{ resource_name }} ist jetzt zum Download bereit.</p>
+        {% endif %}
+        {% if "contact_form_only" not in metadata and metadata.contact_form_only != "true" or ("access_to_content" in metadata and metadata.access_to_content == "true") %}
+          {% if metadata.resource_url and metadata.resource_url != "" %}
+          <p>
+            <a class="p-button--positive" href="{{ resource_url }}">Herunterladen</a>
+          </p>
           {% endif %}
         {% endif %}
-      {% else %}
-        <p>
-          Diese Downloadanfrage wird leider nicht erkannt. Bitte teilen Sie uns dies unter <a href="https://github.com/canonical-websites/www.ubuntu.com/issues/new?body=Bad+resource+download+link+from {{ request.url | urlencode }}">Einreichung und Ausgabe auf GitHub </a>. Und lassen Sie uns wissen, was Sie zum Herunterladen ausgenommen haben.
-        </p>
       {% endif %}
     </div>
   </div>

--- a/templates/engage/shared/_es_thank-you.html
+++ b/templates/engage/shared/_es_thank-you.html
@@ -31,39 +31,35 @@
 
 <section class="p-strip">
   <div class="u-fixed-width">
-    {% if 'pages.ubuntu.com' or 'assets.ubuntu.com' in resource_url %}
-      {% if form_details and "access_to_content" in metadata and metadata.access_to_content == "true" %}
+    {% if form_details and "access_to_content" in metadata and metadata.access_to_content == "true" %}
 
-        <h3>Le hemos enviado una copia de {{ resource_name }} a {{ form_details.email }}</h3>
-        <p>
-          <a class="p-button--positive" href="{{ request_url }}">A la p&aacute;gina anterior</a>
-          <a class="p-button" href="/contact-us">Cont&aacute;ctanos</a>
-        </p>          
-        <p>
-          ¿No lo ha recibido? Revise la carpeta de spam y aseg&uacute;rese de haber introducido el e-mail correcto.
-        </p>
-        <p>
-          <a href="{{ request_url }}">O pruebe enviarlo de nuevo.</a>
-        </p>
+      <h3>Le hemos enviado una copia de {{ resource_name }} a {{ form_details.email }}</h3>
+      <p>
+        <a class="p-button--positive" href="{{ request_url }}">A la p&aacute;gina anterior</a>
+        <a class="p-button" href="/contact-us">Cont&aacute;ctanos</a>
+      </p>          
+      <p>
+        ¿No lo ha recibido? Revise la carpeta de spam y aseg&uacute;rese de haber introducido el e-mail correcto.
+      </p>
+      <p>
+        <a href="{{ request_url }}">O pruebe enviarlo de nuevo.</a>
+      </p>
 
+    {% else %}
+      {% if "thank_you_text" in metadata %}
+        <p>{{ metadata["thank_you_text"] }}</p>
       {% else %}
-        {% if "thank_you_text" in metadata %}
-          <p>{{ metadata["thank_you_text"] }}</p>
-        {% else %}
-          <p>
-            El {{ resource_name }} est&aacute; listo para descargar.
-          </p>
-        {% endif %}
-        {% if "contact_form_only" not in metadata and metadata.contact_form_only != "true" or ("access_to_content" in metadata and metadata.access_to_content == "true") %}
-          <p>
-            <a class="p-button--positive" href="{{ resource_url }}">Descargar</a>
-          </p>
+        <p>
+          El {{ resource_name }} est&aacute; listo para descargar.
+        </p>
+      {% endif %}
+      {% if "contact_form_only" not in metadata and metadata.contact_form_only != "true" or ("access_to_content" in metadata and metadata.access_to_content == "true") %}
+        {% if metadata.resource_url and metadata.resource_url != "" %}
+        <p>
+          <a class="p-button--positive" href="{{ resource_url }}">Descargar</a>
+        </p>
         {% endif %}
       {% endif %}
-    {% else %}
-      <p>
-        Disculpa, no hemos entendido la petici&oacute; de descarga.  Por favor, inf&oacute;rmanos rellenando <a href="https://github.com/canonical-websites/www.ubuntu.com/issues/new?body=Bad+resource+download+link+from {{ request.url | urlencode }}">este formulario en GitHub</a>. Y dinos qu&eacute; esperabas descargarte.
-      </p>
     {% endif %}
   </div>
 </section>

--- a/templates/engage/shared/_fr_thank-you.html
+++ b/templates/engage/shared/_fr_thank-you.html
@@ -32,40 +32,36 @@
 <section class="p-strip">
   <div class="row">
     <div class="col-8">
-      {% if 'pages.ubuntu.com' or 'assets.ubuntu.com' in resource_url %}
-        {% if form_details and "access_to_content" in metadata and metadata.access_to_content == "true" %}
-  
+      {% if form_details and "access_to_content" in metadata and metadata.access_to_content == "true" %}
 
-        <h3>Nous avons envoyé une copie de {{ resource_name }} à {{ form_details.email }}</h3>
-        <p>
-          <a class="p-button--positive" href="{{ request_url }}">Retour à la dernière page</a>
-          <a class="p-button" href="/contact-us">Contactez-nous</a>
-        </p>          
-        <p>
-          Pas reçu? Vérifiez votre dossier spam et vérifiez que vous avez utilisé la bonne adresse e-mail.
-        </p>
-        <p>
-          <a href="{{ request_url }}">Ou essayez de le renvoyer</a>
-        </p>
 
+      <h3>Nous avons envoyé une copie de {{ resource_name }} à {{ form_details.email }}</h3>
+      <p>
+        <a class="p-button--positive" href="{{ request_url }}">Retour à la dernière page</a>
+        <a class="p-button" href="/contact-us">Contactez-nous</a>
+      </p>          
+      <p>
+        Pas reçu? Vérifiez votre dossier spam et vérifiez que vous avez utilisé la bonne adresse e-mail.
+      </p>
+      <p>
+        <a href="{{ request_url }}">Ou essayez de le renvoyer</a>
+      </p>
+
+      {% else %}
+        {% if "thank_you_text" in metadata %}
+          <p>{{ metadata["thank_you_text"] }}</p>
         {% else %}
-          {% if "thank_you_text" in metadata %}
-            <p>{{ metadata["thank_you_text"] }}</p>
-          {% else %}
+        <p>
+          La {{ resource_name }} est prête à être téléchargée.
+        </p>
+        {% endif %}
+        {% if "contact_form_only" not in metadata and metadata.contact_form_only != "true" or ("access_to_content" in metadata and metadata.access_to_content == "true") %}
+          {% if metadata.resource_url and metadata.resource_url != "" %}
           <p>
-            La {{ resource_name }} est prête à être téléchargée.
+            <a class="p-button--positive" href="{{ resource_url }}">Téléchargée</a>
           </p>
           {% endif %}
-          {% if "contact_form_only" not in metadata and metadata.contact_form_only != "true" or ("access_to_content" in metadata and metadata.access_to_content == "true") %}
-            <p>
-              <a class="p-button--positive" href="{{ resource_url }}">Téléchargée</a>
-            </p>
-          {% endif %}
         {% endif %}
-      {% else %}
-        <p>
-            Désolé, nous ne reconnaissons pas cette demande de téléchargement. Veuillez nous le <a href="https://github.com/canonical-websites/www.ubuntu.com/issues/new?body=Bad+resource+download+link+from {{ request.url | urlencode }}">faire savoir en déposant et en émettant un problème sur GitHub</a>. Et dites-nous ce que vous attendiez de télécharger.
-        </p>
       {% endif %}
     </div>
   </div>

--- a/templates/engage/shared/_it_thank-you.html
+++ b/templates/engage/shared/_it_thank-you.html
@@ -32,39 +32,35 @@
 <section class="p-strip">
   <div class="row">
     <div class="col-8">
-      {% if 'pages.ubuntu.com' or 'assets.ubuntu.com' in resource_url %}
-        {% if form_details and "access_to_content" in metadata and metadata.access_to_content == "true" %}
+      {% if form_details and "access_to_content" in metadata and metadata.access_to_content == "true" %}
 
-        <h3>Abbiamo inviato una copia di {{ resource_name }} a {{ form_details.email }}</h3>
-        <p>
-          <a class="p-button--positive" href="{{ request_url }}">Torna all'ultima pagina</a>
-          <a class="p-button" href="/contact-us">Contattaci</a>
-        </p>          
-        <p>
-          Non l'hai ricevuto? Controlla la tua cartella spam e di aver utilizzato l'indirizzo email corretto.
-        </p>
-        <p>
-          <a href="{{ request_url }}">Oppure prova a inviarlo di nuovo</a>
-        </p>
+      <h3>Abbiamo inviato una copia di {{ resource_name }} a {{ form_details.email }}</h3>
+      <p>
+        <a class="p-button--positive" href="{{ request_url }}">Torna all'ultima pagina</a>
+        <a class="p-button" href="/contact-us">Contattaci</a>
+      </p>          
+      <p>
+        Non l'hai ricevuto? Controlla la tua cartella spam e di aver utilizzato l'indirizzo email corretto.
+      </p>
+      <p>
+        <a href="{{ request_url }}">Oppure prova a inviarlo di nuovo</a>
+      </p>
 
+      {% else %}
+        {% if "thank_you_text" in metadata %}
+          <p>{{ metadata["thank_you_text"] }}</p>
         {% else %}
-          {% if "thank_you_text" in metadata %}
-            <p>{{ metadata["thank_you_text"] }}</p>
-          {% else %}
-            <p>
-              La {{ resource_name }} risorsa è ora pronta per il scarica.
-            </p>
-          {% endif %}
-          {% if "contact_form_only" not in metadata and metadata.contact_form_only != "true" or ("access_to_content" in metadata and metadata.access_to_content == "true") %}
+          <p>
+            La {{ resource_name }} risorsa è ora pronta per il scarica.
+          </p>
+        {% endif %}
+        {% if "contact_form_only" not in metadata and metadata.contact_form_only != "true" or ("access_to_content" in metadata and metadata.access_to_content == "true") %}
+          {% if metadata.resource_url and metadata.resource_url != "" %}
           <p>
             <a class="p-button--positive" href="{{ resource_url }}">Scarica</a>
           </p>
           {% endif %}
         {% endif %}
-      {% else %}
-        <p>
-            Spiacenti, non riconosciamo questa richiesta di scarica. Fatecelo sapere tramite <a href="https://github.com/canonical-websites/www.ubuntu.com/issues/new?body=Bad+resource+download+link+from {{ request.url | urlencode }}"> archiviazione ed emissione su GitHub </a>. E facci sapere cosa hai escluso per il download.
-        </p>
       {% endif %}
     </div>
   </div>

--- a/templates/engage/shared/_pt_thank-you.html
+++ b/templates/engage/shared/_pt_thank-you.html
@@ -32,38 +32,34 @@
 <section class="p-strip">
   <div class="row">
     <div class="col-8">
-      {% if 'pages.ubuntu.com' or 'assets.ubuntu.com' in resource_url %}
-        {% if form_details and "access_to_content" in metadata and metadata.access_to_content == "true" %}
-          <h3>Enviamos uma cópia do e-mail {{ resource_name }} para {{ form_details.email }}</h3>
-          <p>
-            <a class="p-button--positive" href="{{ request_url }}">Voltar para a última página</a>
-            <a class="p-button" href="/contact-us">Contate-Nos</a>
-          </p>          
-          <p>
-            Não recebeu? Verifique sua pasta de spam e se você usou o endereço de e-mail correto.
-          </p>
-          <p>
-            <a href="{{ request_url }}">Ou tente reenviar</a>
-          </p>
+      {% if form_details and "access_to_content" in metadata and metadata.access_to_content == "true" %}
+        <h3>Enviamos uma cópia do e-mail {{ resource_name }} para {{ form_details.email }}</h3>
+        <p>
+          <a class="p-button--positive" href="{{ request_url }}">Voltar para a última página</a>
+          <a class="p-button" href="/contact-us">Contate-Nos</a>
+        </p>          
+        <p>
+          Não recebeu? Verifique sua pasta de spam e se você usou o endereço de e-mail correto.
+        </p>
+        <p>
+          <a href="{{ request_url }}">Ou tente reenviar</a>
+        </p>
 
+      {% else %}
+        {% if "thank_you_text" in metadata %}
+          <p>{{ metadata["thank_you_text"] }}</p>
         {% else %}
-          {% if "thank_you_text" in metadata %}
-            <p>{{ metadata["thank_you_text"] }}</p>
-          {% else %}
-          <p>
-            {{ resource_name | capitalize }} est&aacute; pronto para download.
-          </p>
-          {% endif %}
-          {% if "contact_form_only" not in metadata and metadata.contact_form_only != "true" or ("access_to_content" in metadata and metadata.access_to_content == "true") %}
+        <p>
+          {{ resource_name | capitalize }} est&aacute; pronto para download.
+        </p>
+        {% endif %}
+        {% if "contact_form_only" not in metadata and metadata.contact_form_only != "true" or ("access_to_content" in metadata and metadata.access_to_content == "true") %}
+          {% if metadata.resource_url and metadata.resource_url != "" %}
           <p>
             <a class="p-button--positive" href="{{ resource_url }}">Download</a>
           </p>
           {% endif %}
         {% endif %}
-      {% else %}
-        <p>
-          Desculpe, não reconhecemos esta solicitação de download. Informe-nos por <a href="https://github.com/canonical-websites/www.ubuntu.com/issues/new?body=Bad+resource+download+link+from {{ request.url | urlencode }}">arquivamento e problema no GitHub </a>. E diga-nos o que você deseja baixar.
-        </p>
       {% endif %}
     </div>
   </div>

--- a/templates/engage/shared/_ru_thank-you.html
+++ b/templates/engage/shared/_ru_thank-you.html
@@ -32,38 +32,34 @@
 <section class="p-strip">
   <div class="row">
     <div class="col-8">
-      {% if 'pages.ubuntu.com' or 'assets.ubuntu.com' in resource_url %}
-        {% if form_details and "access_to_content" in metadata and metadata.access_to_content == "true" %}
-          <h3>Мы отправили вам копию {{ resource_name }} по {{ form_details.email }}</h3>
-          <p>
-            <a class="p-button--positive" href="{{ request_url }}">Вернуться к последней странице</a>
-            <a class="p-button" href="/contact-us">Свяжитесь с нами</a>
-          </p>          
-          <p>
-            Не получил? Проверьте папку со спамом и убедитесь, что вы использовали правильный адрес электронной почты.
-          </p>
-          <p>
-            <a href="{{ request_url }}">Или попробуйте отправить повторно</a>
-          </p>
+      {% if form_details and "access_to_content" in metadata and metadata.access_to_content == "true" %}
+        <h3>Мы отправили вам копию {{ resource_name }} по {{ form_details.email }}</h3>
+        <p>
+          <a class="p-button--positive" href="{{ request_url }}">Вернуться к последней странице</a>
+          <a class="p-button" href="/contact-us">Свяжитесь с нами</a>
+        </p>          
+        <p>
+          Не получил? Проверьте папку со спамом и убедитесь, что вы использовали правильный адрес электронной почты.
+        </p>
+        <p>
+          <a href="{{ request_url }}">Или попробуйте отправить повторно</a>
+        </p>
 
+      {% else %}
+        {% if "thank_you_text" in metadata %}
+          <p>{{ metadata["thank_you_text"] }}</p>
         {% else %}
-          {% if "thank_you_text" in metadata %}
-            <p>{{ metadata["thank_you_text"] }}</p>
-          {% else %}
-          <p>
-            {{ resource_name }} готов к загрузке.
-          </p>
-          {% endif %}
-          {% if "contact_form_only" not in metadata and metadata.contact_form_only != "true" or ("access_to_content" in metadata and metadata.access_to_content == "true") %}
-          <p>
-            <a class="p-button--positive" href="{{ resource_url }}">Загрузить</a>
-          </p>
+        <p>
+          {{ resource_name }} готов к загрузке.
+        </p>
+        {% endif %}
+        {% if "contact_form_only" not in metadata and metadata.contact_form_only != "true" or ("access_to_content" in metadata and metadata.access_to_content == "true") %}
+          {% if metadata.resource_url and metadata.resource_url != "" %}
+            <p>
+              <a class="p-button--positive" href="{{ resource_url }}">Загрузить</a>
+            </p>
           {% endif %}
         {% endif %}
-      {% else %}
-        <p>
-          К сожалению, мы не распознаем этот запрос на загрузку. Пожалуйста, дайте нам знать <a href="https://github.com/canonical-websites/www.ubuntu.com/issues/new?body=Bad+resource+download+link+from {{ request.url | urlencode }}">заполнив вопрос на GitHub</a>, дайте нам знать, что вы ожидали загрузить.
-        </p>
       {% endif %}
     </div>
   </div>

--- a/templates/engage/shared/_zh-TW_thank-you.html
+++ b/templates/engage/shared/_zh-TW_thank-you.html
@@ -36,7 +36,6 @@
 
 <section class="p-strip">
   <div class="u-fixed-width">
-  {% if 'pages.ubuntu.com' or 'assets.ubuntu.com' in resource_url %}
     {% if form_details and "access_to_content" in metadata and metadata.access_to_content == "true" %}
     
       <h3>We've emailed a copy of {{ resource_name }} to {{ form_details.email }}</h3>
@@ -58,17 +57,13 @@
         <p>The {{ resource_name }} is now ready to download.</p>
       {% endif %}
       {% if "contact_form_only" not in metadata and metadata.contact_form_only != "true" or ("access_to_content" in metadata and metadata.access_to_content == "true") %}
-        <p>
-          <a class="p-button--positive" href="{{ resource_url }}">Download</a>
-        </p>
+        {% if metadata.resource_url and metadata.resource_url != "" %}
+          <p>
+            <a class="p-button--positive" href="{{ resource_url }}">Download</a>
+          </p>
+        {% endif %}
       {% endif %}
     {% endif %}
-      
-  {% else %}
-    <p>
-      Sorry, we do not recognise this download request.  Please let us know by <a href="https://github.com/canonical-websites/www.ubuntu.com/issues/new?body=Bad+resource+download+link+from {{ request.url | urlencode }}">filing and issue on GitHub</a>. And let us know what you excepted to download.
-    </p>
-  {% endif %}
   </div>
 </section>
 

--- a/templates/engage/thank-you.html
+++ b/templates/engage/thank-you.html
@@ -31,7 +31,6 @@
 
 <section class="p-strip">
   <div class="u-fixed-width">
-  {% if 'pages.ubuntu.com' or 'assets.ubuntu.com' in resource_url %}
     {% if form_details and "access_to_content" in metadata and metadata.access_to_content == "true" %}
     
       <h3>We've emailed a copy of the {{ resource_name }} to {{ form_details.email }}</h3>
@@ -53,17 +52,13 @@
         <p>The {{ resource_name }} is now ready to download.</p>
       {% endif %}
       {% if "contact_form_only" not in metadata and metadata.contact_form_only != "true" or ("access_to_content" in metadata and metadata.access_to_content == "true") %}
+        {% if metadata.resource_url and metadata.resource_url != "" %}
         <p>
           <a class="p-button--positive" href="{{ resource_url }}">Download</a>
         </p>
+        {% endif %}
       {% endif %}
     {% endif %}
-      
-  {% else %}
-    <p>
-      Sorry, we do not recognise this download request.  Please let us know by <a href="https://github.com/canonical-websites/www.ubuntu.com/issues/new?body=Bad+resource+download+link+from {{ request.url | urlencode }}">filing and issue on GitHub</a>. And let us know what you excepted to download.
-    </p>
-  {% endif %}
   </div>
 </section>
 

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -518,7 +518,7 @@ def engage_thank_you(engage_pages):
             "resource_url" not in metadata or metadata["resource_url"] == ""
         ) and (
             "contact_form_only" not in metadata
-            or metadata["contact_form_only"] == "true"
+            or metadata["contact_form_only"] != "true"
         ):
             return flask.abort(404)
 


### PR DESCRIPTION
## Done

Because of a bug, engage pages authors added `resource_url` even when there was no need for one, which is the case of engage pages when used as `contact_form_only`. This is the fix of `views.py`.

The rest of the templates changes are to remove redundant stuff, with the fix they are not needed anymore. Also to ensure the correct text shows.

## QA

- Go to https://discourse.ubuntu.com/t/campaign-ubuntu-pro-for-redis/36455 and remove the value https://ubuntu.com of the `resource_url` metadata.
- Now go to https://ubuntu-com-13624.demos.haus/engage/redis-ubuntu-pro-1-month-trial, fill out the form with test data, the page should work. This doesn't work in prod if the discourse topic `resource_url` is not empty.

Check everything else works fine:
- Check that any other non- `contact_form_only` works, e.g. https://ubuntu-com-13624.demos.haus/engage/accelerate-banking-transformation-with-secure-open-source_tw , fill out the form with data and make sure the thank-you page works and you can download the whitepaper

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-6283

