### PR TITLE
WD-9163 Rebrand ubuntu server thank-you

### DIFF
--- a/templates/download/server/download.html
+++ b/templates/download/server/download.html
@@ -1,130 +1,261 @@
 {% extends "download/_base_download.html" %}
 
-{% block title %}Thanks for downloading Ubuntu Server{% endblock %}
+{% block title %}Thank you for downloading Ubuntu Server{% endblock %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1S5zY7HN_Q8eQWch0mCEfLICfj8pW1bct9_wGArCNIqc/edit{% endblock meta_copydoc %}
+
+{% block body_class %}is-paper{% endblock body_class %}
 
 {% block head_extra %}
   <meta name="robots" content="noindex" />
 {% endblock %}
 
 {% block content %}
-  <noscript>
-    <meta
-      http-equiv="refresh"
-      content="3;url=https://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-live-server-amd64.iso"
-    />
-  </noscript>
+<noscript>
+  <meta
+    http-equiv="refresh"
+    content="3;url=https://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-live-server-amd64.iso"
+  />
+</noscript>
 
-  <section class="p-strip u-no-padding--top u-no-padding--bottom" style="overflow: visible;">
-    <div class="p-strip--suru-topped">
-      <div class="row">
-        <div class="col-6">
-          <h1 class="js-download-option">Thank you!</h1>
-          <p>Your download of Ubuntu Server {{ version }} should start in the background.</p>
-          <p>
-            If your download doesn't start automatically,
-            <a href="https://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-live-server-amd64.iso">download&nbsp;now</a>.
-          </p>
-          {% with version=version, system="live-server", architecture="amd64" %}
-            {% include "download/shared/_verify-checksums.html" %}
-          {% endwith %}
-          <h4 class="p-muted-heading">Explore:</h4>
-          <ul class="p-inline-list">
-            <li class="p-inline-list__item">
-              <a href="https://multipass.run" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Server download', 'eventAction' : 'Select option', 'eventLabel' : 'Multipass', 'eventValue' : undefined });">
-                <img src="https://assets.ubuntu.com/v1/4e0ff71e-Multipass+logo_thin_rgb.svg" alt="" width="543" height="104" style="height: 26px; width: auto;" />
-            </li>
-            <li class="p-inline-list__item">
-              <a href="https://maas.io" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Server download', 'eventAction' : 'Select option', 'eventLabel' : 'MAAS', 'eventValue' : undefined });">
-                <img src="https://assets.ubuntu.com/v1/038514e8-MAAS_black-orange_rgb.svg" alt="" width="543" height="104" style="height: 26px; width: auto;" />
-              </a>
-            </li>
-          </ul>
-        </div>
-        <div class="col-6">
-          <div class="p-card">
-            <div class="row">
-              <div class="col-3">
-                {{
-                  image(
-                      url="https://assets.ubuntu.com/v1/39a8dac8-Ubuntu_Server_CLI_pro_tips_2020-04.jpg",
-                      alt="",
-                      width="440",
-                      height="331",
-                      hi_def=True,
-                      loading="eager",
-                  ) | safe
-                }}
-              </div>
-            </div>
-            <h2 class="p-heading--3">Get Ubuntu Server pro tips</h2>
-            <p>Get the "Ubuntu Server CLI pro tips 2020" and learn how to use the command line efficiently and get started with DevOps &mdash; from basic file management to deploying Kubernetes and OpenStack.</p>
-            <p><a href="#" class="p-button--positive" aria-controls="modal">Download the pro tips</a></p>
-          </div>
-        </div>
-      </div>
+<section class="p-strip is-shallow u-no-padding--bottom">
+  <div class="row--50-50">
+    <div class="col">
+      <h1 class="js-download-option">Thank you for downloading Ubuntu Server {{ version }}</h1>
+      <p>Your download should start in the background. If it doesn't,
+        <a href="https://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-live-server-amd64.iso">download&nbsp;now</a>.<br />
+        {% with version=version, system="live-server", architecture="amd64" %}
+          {% include "download/shared/_verify-checksums.html" %}
+        {% endwith %}
+      </p>
     </div>
-  </section>
+    <div class="col">
+      {% include 'shared/_server-download-newsletter.html' %}
+    </div>
+  </div>
+</section>
 
-  {% include "download/shared/_server_weekly_news.html" %}
+{% include 'download/shared/_server_weekly_news.html' %}
 
-  <div class="p-strip--light">
-    <div class="row u-equal-height">
-      <div class="col-6">
-        <h3>Enterprise Support for Ubuntu Server</h3>
-        <p>Looking for commercial support for Ubuntu Server? Ubuntu Advantage for Infrastructure (UA-I) provides production-grade SLAs, phone and ticket support, Expanded Security Maintenance (ESM) and more.</p>
-        <p>
-          <a href="/pro" class="p-button">Purchase a subscription</a>
-          <a href="/support">Learn more about UA-I&nbsp;&rsaquo;</a>
-        </p>
+<section class="p-section">
+  <hr class="p-rule is-fixed-width" />
+  <div class="row--50-50">
+    <div class="col">
+      <h2>Ubuntu CLI cheatsheet</h2>
+      <div class="p-section--shallow">
+        <p>Learn how to use the command line efficiently and get started with DevOps &mdash; from basic file management to LXD virtualisation and Ubuntu Pro.</p>
       </div>
-      <div class="col-6 u-hide--medium u-hide--small u-align--center u-vertically-center">
+      <button class="p-button--positive" onclick="toggleModal()">Download the CLI cheat sheet</button>
+    </div>
+    <div class="col">
+      <div class="p-section--shallow p-image-wrapper">
         {{
-          image(
-              url="https://assets.ubuntu.com/v1/e9d3cf66-We+support+your+operations.svg",
-              alt="",
-              width="180",
-              height="180",
-              hi_def=True,
-              loading="lazy",
+          image (
+          url="https://assets.ubuntu.com/v1/639c1f12-server-cli-cheatsheet.png",
+          alt="CLI cheat sheet",
+          width="1200",
+          height="849",
+          hi_def=True,
+          loading="auto"
           ) | safe
         }}
       </div>
     </div>
   </div>
+</section>
 
-  <div class="p-strip">
-    <div class="row">
-      <h3 class="u-sv3">More documentation and resources</h3>
+<section class="p-section">
+  <hr class="p-rule is-fixed-width" />
+  <div class="row">
+    <div class="col-3 col-medium-2">
+      <div class="p-section">
+        <h2 class="p-muted-heading">Resources</h2>
+      </div>
     </div>
-    <div class="row u-equal-height p-divider">
-      <div class="col-4 p-divider__block">
-        <h4><a href="/server/docs">Ubuntu Server Guide&nbsp;&rsaquo;</a></h4>
+    <div class="col-9">
+     <div class="row">
+      <div class="col-3 col-medium-2">
+        <h3 class="p-heading--5"><a href="/server/docs">Ubuntu Server documentation</a></h3>
         <p>The Ubuntu Server documentation, curated by community and Ubuntu developers.</p>
       </div>
-      <div class="col-4 p-divider__block">
-        <h4><a href="https://askubuntu.com/">Ask Ubuntu</a></h4>
+      <div class="col-3 col-medium-2">
+        <h3 class="p-heading--5"><a href="https://askubuntu.com/">Ask Ubuntu</a></h3>
         <p>Stuck somewhere? Get your Ubuntu questions answered by power users.</p>
       </div>
-      <div class="col-4 p-divider__block">
-        <h4><a href="https://discourse.ubuntu.com/">Community Hub</a></h4>
+      <div class="col-3 col-medium-2">
+        <h3 class="p-heading--5"><a href="https://discourse.ubuntu.com/">Community Discourse</a></h3>
         <p>Discuss with Ubuntu developers and make your voice heard.</p>
+      </div>  
+     </div> 
+    </div>
+  </div>
+</section>
+
+{% include 'shared/_download-ubuntu-thank-you-pro-section.html' %}
+
+<section class="p-section">
+  <div class="p-section--shallow u-fixed-width">
+    <hr class="p-rule" />
+    <h2 class="p-muted-heading">More from Canonical</h2>
+  </div>
+  <div class="row">
+    <div class="col-3 col-medium-6">
+      <div class="row">
+        <div class="col-6 col-medium-2">
+          <h3>
+            <a href="https://maas.io/?_gl=1*1y3394w*_gcl_au*Mzg2MjE3ODk3LjE3MDI0NjY1NDY.&_ga=2.256850242.873815666.1709630805-805571671.1709630804">
+              {{
+                image (
+                url="https://assets.ubuntu.com/v1/d3039f38-MAAS-logo.svg",
+                alt="MAAS",
+                width="104",
+                height="42",
+                hi_def=True,
+                loading="auto"
+                ) | safe
+              }}
+            </a>
+          </h3>
+        </div>
+        <div class="col-6 col-medium-4">
+          <p>Build a bare metal cloud with super fast server provisioning.</p>
+          <hr class="p-rule" />
+          <p>
+            <a href="https://maas.io/">Learn more about MAAS&nbsp;&rsaquo;</a>
+          </p>
+        </div>
+      </div>
+    </div>
+    <div class="col-3 col-medium-6">
+      <div class="row">
+        <div class="col-6 col-medium-2">
+          <h3>
+            <a href="https://canonical.com/lxd">
+              {{
+                image (
+                  url="https://assets.ubuntu.com/v1/84ed7eb1-LXD-logo.svg",
+                  alt="LXD",
+                  width="80",
+                  height="42",
+                  hi_def=True,
+                  loading="auto"
+                ) | safe
+              }}
+            </a>
+          </h3>
+        </div>
+        <div class="col-6 col-medium-4">
+          <p>Fast, dense, and secure container and VM management at any scale.</p>
+          <hr class="p-rule" />
+          <p>
+            <a href="https://canonical.com/lxd">Learn more about LXD&nbsp;&rsaquo;</a>
+          </p>
+        </div>
+      </div>
+    </div>
+    <div class="col-3 col-medium-6">
+      <div class="row">
+        <div class="col-6 col-medium-2">
+          <h3>
+            <a href="https://juju.is/">
+            {{
+              image (
+                url="https://assets.ubuntu.com/v1/35f593dd-Juju-logo.svg",
+                alt="Juju",
+                width="79",
+                height="42",
+                hi_def=True,
+                loading="auto"
+              ) | safe
+            }}
+            </a>
+          </h3>
+        </div>
+        <div class="col-6 col-medium-4">
+          <p>Design and deploy entire workloads in just a few clicks.</p>
+          <hr class="p-rule" />
+          <p>
+            <a href="https://juju.is/">Learn more about Juju&nbsp;&rsaquo;</a>
+          </p>
+        </div>
+      </div>
+    </div>
+    <div class="col-3 col-medium-6">
+      <div class="row">
+        <div class="col-6 col-medium-2">
+          <h3>
+            <a href="https://multipass.run/">
+            {{
+              image (
+                url="https://assets.ubuntu.com/v1/ede1a596-Multipass-logo.svg",
+                alt="Multipass",
+                width="141",
+                height="42",
+                hi_def=True,
+                loading="auto"
+              ) | safe
+            }}
+            </a>
+          </h3>
+        </div>
+        <div class="col-6 col-medium-4">
+          <p>Spin up Ubuntu VMs on Windows, Mac and Linux.</p>
+          <hr class="p-rule" />
+          <p>
+            <a href="https://multipass.run/">Learn more about Multipass&nbsp;&rsaquo;</a>
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="p-section--deep">
+  <div class="row">
+    <hr class="p-rule"/>
+    <div class="col-3 col-medium-6">
+      <div class="p-section--shallow">
+        <h2 class="p-text--small-caps"><a href="/blog/tag/ubuntu-server">Latest from&nbsp;our&nbsp;blog&nbsp;&rsaquo;</a></h2>
+      </div>
+    </div>
+    <div class="col-9 col-medium-6">
+      <div class="row p-section--shallow" id="ubuntu-server-latest">
       </div>
     </div>
   </div>
 
+  <template style="display:none" id="ubuntu-server-template">
+    <div class="col-3 col-medium-2">
+      <h3 class="p-heading--5"><a class="article-link article-title"></a></h3>
+      <p class="article-excerpt"></p>
+    </div>
+  </template>
+</section>
+
+<script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
+<script>
+  canonicalLatestNews.fetchLatestNews(
+    {
+      articlesContainerSelector: "#ubuntu-server-latest",
+      articleTemplateSelector: "#ubuntu-server-template",
+      excerptLength: 200,
+      tagId: 1610,
+      limit: 3
+    }
+  )
+</script>
+
 {% endblock content %}
 
 {% block footer_extra %}
-  <script src="{{ versioned_static('js/dist/image-download.js') }}"></script>
+<script src="{{ versioned_static('js/dist/image-download.js') }}"></script>
 
-  <script defer>
-    var version = '{{ version }}';
+<script defer>
+  var version = '{{ version }}';
 
-    var GAlabel = version + '-server-amd64';
-    var imagePath = version + '/ubuntu-' + version + '-live-server-amd64.iso';
+  var GAlabel = version + '-server-amd64';
+  var imagePath = version + '/ubuntu-' + version + '-live-server-amd64.iso';
 
-    window.initImageDownload(imagePath, GAlabel);
-  </script>
+  window.initImageDownload(imagePath, GAlabel);
+</script>
 {% endblock footer_extra %}

--- a/templates/download/shared/_server_weekly_news.html
+++ b/templates/download/shared/_server_weekly_news.html
@@ -1,75 +1,71 @@
-<div class="p-modal u-hide" id="modal">
+<div id="download-cheatsheet" class="p-modal u-hide" id="modal">
   <div class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
-    <header class="p-modal__header">
-      <h2 class="p-modal__title" id="modal-title">Get Ubuntu Server pro tips</h2>
-      <button class="p-modal__close" aria-label="Close active modal" aria-controls="modal">Close</button>
-    </header>
-    <form action="/marketo/submit" method="post" id="mktoForm_3485">
-      <div class="row u-no-padding">
-        <div class="col-6">
-          <label for="firstName">First name:</label>
-          <input required  id="firstName" name="firstName" maxlength="255" type="text">
-          <label for="lastName">Last name:</label>
-          <input required  id="lastName" name="lastName" maxlength="255" type="text">
-          <label for="company">Company name:</label>
-          <input required  id="company" name="company" maxlength="255" type="text">
-        </div>
-        <div class="col-6">
-          <label for="title">Job title:</label>
-          <input required  id="title" name="title" maxlength="255" type="text">
-          <label for="email">Work email:</label>
-          <input required  id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$">
-          <label for="phone">Mobile/cell phone number:</label>
-          <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
-          <div class="u-off-screen">
-            {# These are honey pot fields to catch bots #}
-            <label class="website" for="website">Website:</label>
-            <input name="website" type="text" class="website" autocomplete="off" value="" id="website" tabindex="-1" />
-            <label class="name" for="name">Name:</label>
-            <input name="name" type="text" class="name" autocomplete="off" value="" id="name" tabindex="-1" />
-            {# End of honey pots #}
-          </div>
-        </div>
+    <div class="row--50-50 p-strip is-shallow">
+      <div class="col">
+        <h2 class="p-modal__title" id="modal-title">Get Ubuntu Server pro tips</h2>
+        <hr>
       </div>
+      <div class="col">
+        <button class="p-modal__close" aria-label="Close active modal" onclick="toggleModal()">Close</button>
+        <form action="/marketo/submit" method="post" id="mktoForm_3485">
+          <div class="p-section--shallow">
+            <label for="firstName">First name:</label>
+            <input required  id="firstName" name="firstName" maxlength="255" type="text" />
+            <label for="lastName">Last name:</label>
+            <input required  id="lastName" name="lastName" maxlength="255" type="text" />
+            <label for="company">Company name:</label>
+            <input required  id="company" name="company" maxlength="255" type="text" />
+            <label for="title">Job title:</label>
+            <input required  id="title" name="title" maxlength="255" type="text" />
+            <label for="email">Work email:</label>
+            <input required  id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
+            <label for="phone">Mobile/cell phone number:</label>
+            <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
+            <div class="u-off-screen">
+              {# These are honey pot fields to catch bots #}
+              <label class="website" for="website">Website:</label>
+              <input name="website" type="text" class="website" autocomplete="off" value="" id="website" tabindex="-1" />
+              <label class="name" for="name">Name:</label>
+              <input name="name" type="text" class="name" autocomplete="off" value="" id="name" tabindex="-1" />
+              {# End of honey pots #}
+            </div>
+          </div>
 
-      <label class="p-checkbox">
-        <input class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
-        <span class="p-checkbox__label" id="canonicalUpdatesOptIn"><small>I would like to receive occasional news from Canonical by email.</small></span>
-      </label>
+          <label class="p-checkbox">
+            <input class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+            <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I would like to receive news from Canonical by email.</span>
+          </label>
+    
+          <p>All information provided will be handled in accordance with the Canonical <a href="/legal">privacy policy</a>.</p>
+          <hr />
+          <button type="submit" class="p-button--positive">Download the CLI cheat sheet</button>
+          <input type="hidden" name="formid" value="3485">
+          <input type="hidden" name="Consent_to_Processing__c" value="yes" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Facebook_Click_ID__c" id="Facebook_Click_ID__c" value="" />
+          <input type="hidden" aria-hidden="true" aria-label="hidden field" id="preferredLanguage" name="preferredLanguage" maxlength="255" value="" />
+          <input type="hidden" name="returnURL" value="https://assets.ubuntu.com/v1/3bd0daaf-Ubuntu%20Server%20CLI%20cheat%20sheet%202024%20v6.pdf" />
+        </form>
 
-      <p><small>All information provided will be handled in accordance with the Canonical <a href="/legal">privacy policy</a>.</small></p>
-      <button type="submit" class="p-button--positive">Download the pro tips</button>
-      <input type="hidden" name="formid" value="3485">
-      <input type="hidden" name="Consent_to_Processing__c" value="yes" />
-      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
-      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
-      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
-      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
-      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
-      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
-      <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Facebook_Click_ID__c" id="Facebook_Click_ID__c" value="" />
-      <input type="hidden" aria-hidden="true" aria-label="hidden field" id="preferredLanguage" name="preferredLanguage" maxlength="255" value="" />
-      <input type="hidden" name="returnURL" value="https://assets.ubuntu.com/v1/3bd0daaf-Ubuntu%20Server%20CLI%20cheat%20sheet%202024%20v6.pdf" />
-    </form>
+      </div>
+    </div>
   </div>
 </div>
 
 <script>
   /**
-    Toggles visibility of modal dialog.
-    @param {HTMLElement} modal Modal dialog to show or hide.
+    Toggles modal dialog.
+    @param {HTMLElement} event modal Modal dialog to show or hide.
   */
-  function toggleModal(modal) {
-    if (modal && modal.classList.contains('p-modal')) {
-      modal.classList.toggle('u-hide');
+  function toggleModal(event) {
+    var targetControls = document.getElementById("download-cheatsheet");
+    if (targetControls && targetControls.classList.contains('p-modal')) {
+      targetControls.classList.toggle('u-hide');
     }
   }
-
-  // Add click handler for clicks on elements with aria-controls
-  document.addEventListener('click', function (event) {
-    var targetControls = event.target.getAttribute('aria-controls');
-    if (targetControls) {
-      toggleModal(document.getElementById(targetControls));
-    }
-  });
 </script>

--- a/templates/download/shared/_verify-checksums.html
+++ b/templates/download/shared/_verify-checksums.html
@@ -1,19 +1,24 @@
-<p>
-  You can
-  <span class="p-contextual-menu--left">
-    <a href="#" class="p-contextual-menu__toggle" data-trigger="click" aria-controls="menu-4" aria-expanded="false" aria-haspopup="true">verify your download</a>
-    <span class="p-contextual-menu__dropdown" id="menu-4" aria-hidden="true" aria-label="Verification instructions:" style="width: 600px; max-width: 70vw; padding: 1rem;">
-      {% if releases.checksums[system] and releases.checksums[system][version] %}
-      <span class="p-contextual-menu__group">
-        <small>Run this command in your terminal in the directory the iso was downloaded to verify the SHA256 checksum:</small><br />
-        <code style="display: block; margin-top: 1rem;">echo "{{ releases.checksums[system][version] }}" | shasum -a 256 --check</code><br />
-        <small>You should get the following output:</small><br />
-        <code style="display: block; margin-top: 1rem;">ubuntu-{{ version }}-{% if system != architecture %}{{ system }}-{% else %}preinstalled-server-{% endif %}{{ architecture }}.iso: OK</code><br />
-        <small>Or follow this tutorial to learn <a href="/tutorials/tutorial-how-to-verify-ubuntu">how to verify downloads</a></small>
-      </span>
-      {% else %}
-        <small>Please check the <a href="https://cdimage.ubuntu.com/releases/{{ version }}/release/SHA256SUMS">SHA256SUMS page</a> for the checksum numbers.</small>
-      {% endif %}
-    </span>
-  </span>{% if not 'raspi' in system %}, or get <a href="/tutorials/tutorial-install-ubuntu-{% if system == 'live-server'%}server{% else %}{{ system }}{% endif %}?backURL=https://ubuntu.com/download/{% if system == 'live-server'%}server{% else %}{{ system }}{% endif %}/thank-you">help on installing</a>{% endif %}.
-</p>
+You can <button class="p-button--link" onclick="verifyDownloadContent()">verify your download</button>{% if not 'raspi' in system %}, or get <a href="/tutorials/tutorial-install-ubuntu-{% if system == 'live-server'%}server{% else %}{{ system }}{% endif %}?backURL=https://ubuntu.com/download/{% if system == 'live-server'%}server{% else %}{{ system }}{% endif %}/thank-you">help on installing</a>{% endif %}.
+
+
+<div class="u-hide" id="menu-4" aria-hidden="true" aria-label="Verification instructions:">
+  {% if releases.checksums[system] and releases.checksums[system][version] %}
+    <p>Run this command in your terminal in the directory the iso was downloaded to verify the SHA256 checksum:</p>
+    <pre>echo "{{ releases.checksums[system][version] }}" | shasum -a 256 --check</pre>
+    <p>You should get the following output:</p>
+    <pre>ubuntu-{{ version }}-{% if system != architecture %}{{ system }}-{% else %}preinstalled-server-{% endif %}{{ architecture }}.iso: OK</pre>
+    <p>Or follow this tutorial to learn <a href="/tutorials/tutorial-how-to-verify-ubuntu">how to verify downloads</a>.</p>
+  {% else %}
+    <p>Please check the <a href="https://cdimage.ubuntu.com/releases/{{ version }}/release/SHA256SUMS">SHA256SUMS page</a> for the checksum numbers.</p>
+  {% endif %}
+</div>
+
+
+<script type="text/javascript">
+  function verifyDownloadContent() {
+    var targetControls = document.getElementById("menu-4");
+    if (targetControls) {
+      targetControls.classList.toggle('u-hide');
+    }
+  }
+</script>

--- a/templates/shared/_download-ubuntu-thank-you-pro-section.html
+++ b/templates/shared/_download-ubuntu-thank-you-pro-section.html
@@ -1,0 +1,36 @@
+<section class="p-section">
+  <div class="u-fixed-width">
+    <a href="/pro">
+    {{
+      image (
+      url="https://assets.ubuntu.com/v1/2f32b5f5-Ubuntu-Pro-logo.svg",
+      alt="Ubuntu Pro",
+      width="170",
+      height="42",
+      hi_def=True,
+      loading="lazy"
+      ) | safe
+    }}
+    </a>
+    <hr class="p-rule" />
+  </div>
+  <div class="row--50-50">
+    <div class="col">
+      <h2>Get enterprise support<br class="u-hide--medium u-hide--small"/> for Ubuntu Server</h2>
+    </div>
+    <div class="col">
+      <p>Ubuntu Pro is a comprehensive subscription delivering enterprise-grade security, management tooling, and extended support for developers and organisations. Ubuntu Pro is free for personal use on up to five machines</p>
+      <hr class="p-rule" />
+      <ul class="p-list--divided u-no-padding--bottom">
+        <li class="p-list__item is-ticked">Security updates for the <a href="/esm">full open source stack</a></li>
+        <li class="p-list__item is-ticked">Estate <a href="/landscape/features">monitoring and management</a></li>
+        <li class="p-list__item is-ticked"><a href="/security/certifications">FIPS 140-2 certified modules and CIS hardening</a></li>
+        <li class="p-list__item is-ticked">Minimise rolling reboots with <a href="/livepatch">Kernel Livepatch</a></li>
+        <li class="p-list__item is-ticked">Optional weekday or 24/7 support tiers</li>
+      </ul>
+      <hr />
+      <a href="/pro" class="p-button--positive">Get Ubuntu Pro</a>
+      <a href="/engage/vulnerability-management" class="p-button">Download our whitepaper</a>
+    </div>
+  </div>
+</section>

--- a/templates/shared/_server-download-newsletter.html
+++ b/templates/shared/_server-download-newsletter.html
@@ -1,0 +1,35 @@
+<div>
+	<h2>Sign up for our newsletter</h2>
+	<p>Get the latest Ubuntu news and updates in your inbox.</p>
+</div>
+
+<form action="/marketo/submit" method="post" id="mktoForm_4960" onsubmit="ga('send', 'Newsletter', 'Signup', 'Ubuntu Server download newsletter signup');">
+	<label for="email">Email*:</label>
+	<input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
+
+	<div class="p-section--shallow">
+		<label class="p-checkbox">
+			<input required class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
+			<span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
+		</label>
+		<p>By submitting this form, I confirm that I have read and agree to <a href="https://www.ubuntu.com/legal/dataprivacy" target="_blank">Canonical's Privacy Policy</a>.</p>
+		<hr />
+		<button type="submit" class="p-button--positive">Subscribe now</button>
+	</div>
+
+	<div class="p-section--shallow">
+		<input value="4960" name="formid" type="hidden">
+		<input type="hidden" name="Consent_to_Processing__c" value="yes" />
+		<input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="/download/server#newsletter-signup" />
+		<input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign"
+			value="" />
+		<input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+		<input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+		<input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+		<input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+		<input type="hidden" aria-hidden="true" aria-label="hidden field" id="preferredLanguage" name="preferredLanguage"
+			maxlength="255" value="" />
+		<input type="hidden" name="thankyoumessage"
+			value="Thank you for signing up for our newsletter!<br/>In these regular emails you will find the latest updates from Ubuntu and upcoming events where you can meet our team.">
+	</div>
+</form>


### PR DESCRIPTION
## Done

- Rebrand content and design of /download/server

## QA

- Go to https://ubuntu-com-13629.demos.haus/download/server and choose to download Ubuntu server directly.
- Check the thank you page (click on the Download Ubuntu Server 22.04.4 LTS) with[ copy docs](https://docs.google.com/document/d/1S5zY7HN_Q8eQWch0mCEfLICfj8pW1bct9_wGArCNIqc/edit) and design below
    - Be sure to test on mobile, tablet and desktop screen sizes
 - Test the 2 forms, the newsletter signup and the CLI cheatsheet.

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-9163

## Screenshots

![thank-you](https://github.com/canonical/ubuntu.com/assets/14939793/14bccdbf-cca2-46f7-bdb0-1ad6953821a5)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
