### PR TITLE
[WD-9255] replace URL for datasheet in /download/server/thank-you

### DIFF
--- a/templates/download/shared/_server_weekly_news.html
+++ b/templates/download/shared/_server_weekly_news.html
@@ -49,7 +49,7 @@
       <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
       <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Facebook_Click_ID__c" id="Facebook_Click_ID__c" value="" />
       <input type="hidden" aria-hidden="true" aria-label="hidden field" id="preferredLanguage" name="preferredLanguage" maxlength="255" value="" />
-      <input type="hidden" name="returnURL" value="https://assets.ubuntu.com/v1/60e44ad3-Ubuntu.Server.CLI.pro.tips.19.04.22.pdf" />
+      <input type="hidden" name="returnURL" value="https://assets.ubuntu.com/v1/3bd0daaf-Ubuntu%20Server%20CLI%20cheat%20sheet%202024%20v6.pdf" />
     </form>
   </div>
 </div>


### PR DESCRIPTION
## Done

- Replaced URL to PDF datasheet in /download/server Thank You page according to [copy doc](https://docs.google.com/document/d/1S5zY7HN_Q8eQWch0mCEfLICfj8pW1bct9_wGArCNIqc/edit).

## QA

- Navigate to /download/server
- Download an image of Ubuntu
- On the opened Thank You page click on "Download the pro tips" button
- In a modal fill in the form and click on "Download the pro tips" button
- Check if the downloaded PDF corresponds to the one specified in the [copy doc](https://docs.google.com/document/d/1S5zY7HN_Q8eQWch0mCEfLICfj8pW1bct9_wGArCNIqc/edit).

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-9255

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
