### PR TITLE
Hide error message when value changes

### DIFF
--- a/static/js/src/advantage/subscribe/checkout/components/Checkout/Checkout.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Checkout/Checkout.tsx
@@ -31,33 +31,11 @@ const Checkout = ({ product, quantity, action }: Props) => {
   const productCanBeTrialled = product?.canBeTrialled;
   const canTrial = canBeTrialled(productCanBeTrialled, userCanTrial);
   const initialValues = getInitialFormValues(product, canTrial, userInfo);
+  const [formChanged, setFormChanged] = useState({});
 
   useEffect(() => {
-    const handleInputChange = () => {
-      error ? setError(null) : null;
-    };
-
-    const inputElements = document.querySelectorAll("input");
-    const selectElements = document.querySelectorAll("select");
-
-    inputElements.forEach((input) => {
-      input.addEventListener("change", handleInputChange);
-    });
-
-    selectElements.forEach((select) => {
-      select.addEventListener("change", handleInputChange);
-    });
-
-    return () => {
-      inputElements.forEach((input) => {
-        input.removeEventListener("change", handleInputChange);
-      });
-
-      selectElements.forEach((select) => {
-        select.removeEventListener("change", handleInputChange);
-      });
-    };
-  }, [error]);
+    error ? setError(null) : null;
+  }, [formChanged]);
 
   if (!localStorage.getItem("gaEventTriggered")) {
     localStorage.setItem("gaEventTriggered", "true");
@@ -92,6 +70,11 @@ const Checkout = ({ product, quantity, action }: Props) => {
             </>
           ) : (
             <Formik
+              innerRef={(formikActions) =>
+                formikActions && formikActions.errors
+                  ? setFormChanged(formikActions.values)
+                  : setFormChanged({})
+              }
               onSubmit={() => {}}
               initialValues={initialValues}
               enableReinitialize={

--- a/static/js/src/advantage/subscribe/checkout/components/Checkout/Checkout.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Checkout/Checkout.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { Formik } from "formik";
 import {
   Col,
@@ -31,6 +31,33 @@ const Checkout = ({ product, quantity, action }: Props) => {
   const productCanBeTrialled = product?.canBeTrialled;
   const canTrial = canBeTrialled(productCanBeTrialled, userCanTrial);
   const initialValues = getInitialFormValues(product, canTrial, userInfo);
+
+  useEffect(() => {
+    const handleInputChange = () => {
+      error ? setError(null) : null;
+    };
+
+    const inputElements = document.querySelectorAll("input");
+    const selectElements = document.querySelectorAll("select");
+
+    inputElements.forEach((input) => {
+      input.addEventListener("change", handleInputChange);
+    });
+
+    selectElements.forEach((select) => {
+      select.addEventListener("change", handleInputChange);
+    });
+
+    return () => {
+      inputElements.forEach((input) => {
+        input.removeEventListener("change", handleInputChange);
+      });
+
+      selectElements.forEach((select) => {
+        select.removeEventListener("change", handleInputChange);
+      });
+    };
+  }, [error]);
 
   if (!localStorage.getItem("gaEventTriggered")) {
     localStorage.setItem("gaEventTriggered", "true");

--- a/static/js/src/advantage/subscribe/checkout/components/UserInfoForm/UserInfoForm.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/UserInfoForm/UserInfoForm.tsx
@@ -90,6 +90,7 @@ const UserInfoForm = ({ setError }: Props) => {
           queryClient.invalidateQueries("preview");
           setIsButtonDisabled(false);
           setIsEditing(false);
+          setError(null);
         },
         onError: (error) => {
           setFieldValue("Description", false);

--- a/templates/account/checkout.html
+++ b/templates/account/checkout.html
@@ -7,25 +7,25 @@ meta_copydoc
 endblock meta_copydoc %} {% block content %}
 
 <div id="shop-checkout-app">
-    <div class="p-strip">
-        <div class="u-fixed-width">
-            <h1 class="p-heading--2">
-                Checkout
-            </h1>
-        </div>
+  <div class="p-strip">
+    <div class="u-fixed-width">
+      <h1 class="p-heading--2">
+        Checkout
+      </h1>
     </div>
-    <div class="p-strip u-no-padding--top">
-        <div class="row">
-            <div class="u-no-margin--bottom p-card">
-                <div class="p-card__content">
-                    <span class="p-text--default">
-                        <i class="p-icon--spinner u-animation--spin"></i>
-                    </span>
-                    Loading…
-                </div>
-            </div>
+  </div>
+  <div class="p-strip u-no-padding--top">
+    <div class="row">
+      <div class="u-no-margin--bottom p-card">
+        <div class="p-card__content">
+          <span class="p-text--default">
+            <i class="p-icon--spinner u-animation--spin"></i>
+          </span>
+          Loading…
         </div>
+      </div>
     </div>
+  </div>
 </div>
 
 <script>


### PR DESCRIPTION
## Done

- Hide global error message when any field is updated
- Applied suggestions from https://github.com/canonical/ubuntu.com/pull/12759

## QA

- Go to /pro/subscribe
- Click "Buy now" button
- Type invalid VAT number and check global error message displays properly
- Update VAT field with new number, error message should disappear when the field is updated
- Type invalid card number and check global error message displays properly
- Update card number with valid number, save and check that the global error message disappears

- QA with other error cases as well

## Issue / Card

Fixes [WD-2941](https://warthogs.atlassian.net/jira/software/c/projects/WD/boards/801?selectedIssue=WD-2941)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-2941]: https://warthogs.atlassian.net/browse/WD-2941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ