### PR TITLE
WD-9049 - fix contact form field not being sent

### DIFF
--- a/static/js/src/static-forms.js
+++ b/static/js/src/static-forms.js
@@ -129,7 +129,9 @@ function setUpStaticForms(form, formId) {
         });
       });
 
-      commentsFromLead.value = message;
+      if (formFields.length) {
+        commentsFromLead.value = message;
+      }
       return message;
     });
   }


### PR DESCRIPTION
## Done

The form was not sending the Comments_from_lead__c field. This happened because other forms were building this field dynamically from multiple question and removing text for the forms that have only one question for Comments_from_lead__c. This issue is fixed in this PR.

## QA
- [demo link](https://ubuntu-com-13641.demos.haus/support/contact-us)
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check that the form sends correct fields to market

## Issue / Card
[WD-9049](https://warthogs.atlassian.net/browse/WD-9049)

Fixes #

## Screenshots

[WD-9049]: https://warthogs.atlassian.net/browse/WD-9049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ