### PR TITLE
WD-9157 - add CTA button to /aws/pro

### DIFF
--- a/templates/aws/pro.html
+++ b/templates/aws/pro.html
@@ -12,6 +12,11 @@
       <p class="p-heading--3">For production. For professionals.</p>
       <p>Ubuntu Pro for AWS is a premium image delivering the most comprehensive open source security and AWS compliance. Ubuntu Pro is suitable for small to large-scale Linux enterprise operations offering pay-as-you-go billing on your existing AWS invoice.</p>
       <p>Available on AMD64 and Graviton architectures</p>
+      <h3 class="p-heading--4">Ubuntu Pro 22.04 LTS
+        <span class="p-status-label--rounded">Latest</span>
+      </h3>
+      <p>Delivers additional layer of security and compliance services and security patches covering a wider range of packages, until 2032.</p>
+      <p><a href="https://aws.amazon.com/marketplace/pp/prodview-dxdx74ozlxsl2" class="p-button--positive">Launch now</a></p>
       <p class="p-heading--4">
         <a href="/blog/upgrade-your-existing-ubuntu-lts-instances-to-ubuntu-pro-in-aws">Upgrade Ubuntu LTS to Ubuntu Pro</a>
       </p>


### PR DESCRIPTION
## Done

Added CTA button to /aws/pro

## QA
- [demo link](https://ubuntu-com-13642.demos.haus/aws/pro)
- [copy doc](https://docs.google.com/document/d/1pLRWJZSpE04nYt-yHBtCjxGI7VZsigcP2UJIBmR8i-0/edit)
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check that the page is correctly updated according to copy doc

## Issue / Card
[WD-9157](https://warthogs.atlassian.net/browse/WD-9157)

Fixes #

## Screenshots

[WD-9157]: https://warthogs.atlassian.net/browse/WD-9157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ