### PR TITLE
WD-9175 - fix broken link on u.com

### DIFF
--- a/build.js
+++ b/build.js
@@ -32,7 +32,8 @@ let entries = {
   "random-partner-logos": "./static/js/src/random-partner-logos.js",
   "credEnterprisePurchasing": "./static/js/src/advantage/credentials/app.tsx",
   activate: "./static/js/src/activate.js",
-  "chiselled-chart": "./static/js/src/charts/chiselled-chart.js"
+  "chiselled-chart": "./static/js/src/charts/chiselled-chart.js",
+  tabbedContent: "./static/js/src/tabbed-content.js",
 };
 
 const isDev = process && process.env && process.env.NODE_ENV === "development";


### PR DESCRIPTION
## Done

Fixed broken links in the [Links on live](https://github.com/canonical/ubuntu.com/actions/runs/8168377162)

## QA
- [demo link](https://ubuntu-com-13648.demos.haus/ceph/install)
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check that the error about missing file does not happen

## Issue / Card
[WD-9175](https://warthogs.atlassian.net/browse/WD-9175)

Fixes #

## Screenshots

[WD-9175]: https://warthogs.atlassian.net/browse/WD-9175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ