### PR TITLE
Check notice id string before calling api

### DIFF
--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -37,7 +37,11 @@ def get_processed_details(notice):
 
 
 def notice(notice_id):
-    notice = security_api.get_notice(notice_id)
+    # Check if notice_id is a valid USN or LSN
+    if re.fullmatch(r"(USN|LSN|SSN)-\d{1,5}-\d{1,2}", notice_id):
+        notice = security_api.get_notice(notice_id)
+    else:
+        flask.abort(404)
 
     if not notice:
         flask.abort(404)


### PR DESCRIPTION
## Done

- Added a validity check for the notice_id

## Rationale

- We keep getting [strange requests](https://sentry.is.canonical.com/canonical/ubuntu-security/issues/32551/events/4182935/) that should throw 404s but are instead throwing 503s I believe because of the special characters. If we validate the provided notice_id before we make a call to the api it 404s correctly. 

## QA

- View the site locally in your web browser at: https://ubuntu-com-13650.demos.haus/security/notices/vbdb%0A.json.json
  - See that you get 404
- Now visit https://ubuntu-com-13650.demos.haus/security/notices/USN-6679-8 
  - This is a valid `notice_id` string, but the notice actually does not exist. Confirm that the previous behavior for this case is unaffected and also returns 404 

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-9449
