### PR TITLE
add an instruction to robots.txt to exclude docs search page

### DIFF
--- a/static/files/robots.txt
+++ b/static/files/robots.txt
@@ -1,4 +1,5 @@
 User-Agent: *
 Disallow: /search
 Disallow: /search*
+Disallow: /server/docs/search*
 Sitemap: https://ubuntu.com/sitemap.xml


### PR DESCRIPTION
## Done

- Added an instruction to robots.txt to exclude /server/docs/search* page since it's dynamic and doesn't need to be indexed by Google.

## QA

- Can be QA-ed after deployment by checking logs in Google Search Console. Currently there are a lot of 5xx and 403 errors coming from the page as Google is trying to index all the different search queries.

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
