### PR TITLE
WD-9428 - remove roadshow from ai navigation

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -216,8 +216,6 @@ ai:
       path: /ai/mlflow
     - title: Consulting
       path: /ai/consulting
-    - title: Roadshow
-      path: /ai/roadshow
 
 kubernetes:
   title: Canonical Kubernetes


### PR DESCRIPTION
## Done

Remove Roadshow from u.com/ai navigation

## QA

- [demo link](https://ubuntu-com-13653.demos.haus/ai)
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check that the item is removed

## Issue / Card
[WD-9428](https://warthogs.atlassian.net/browse/WD-9428)
Fixes #

## Screenshots

[WD-9428]: https://warthogs.atlassian.net/browse/WD-9428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ