### PR TITLE
Update broken download links

### DIFF
--- a/templates/download/nvidia-jetson/tab-1-jetson-agx-orin.html
+++ b/templates/download/nvidia-jetson/tab-1-jetson-agx-orin.html
@@ -29,7 +29,7 @@
         </div>
       </div>
       <p>
-				<a class="p-button--positive" href="http://cdimage.ubuntu.com/releases/jammy/release/nvidia-tegra/ubuntu-22.04-preinstalled-server-arm64+tegra-igx.img.xz">
+				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/jammy/release/nvidia-tegra/ubuntu-22.04-preinstalled-server-arm64+tegra-igx.img.xz">
           Download <span class="u-off-screen">Ubuntu Server</span> 22.04
         </a>
         <a class="p-button" href="https://developer.nvidia.com/downloads/embedded/l4t/r36_release_v2.0/release/jetson_linux_r36.2.0_aarch64.tbz2">Download Jetson AGX Orin boot firmware</a>

--- a/templates/download/nvidia-jetson/tab-2-jetson-orin-nano.html
+++ b/templates/download/nvidia-jetson/tab-2-jetson-orin-nano.html
@@ -29,7 +29,7 @@
         </div>
       </div>
       <p>
-				<a class="p-button--positive" href="http://cdimage.ubuntu.com/releases/jammy/release/nvidia-tegra/ubuntu-22.04-preinstalled-server-arm64+tegra-igx.img.xz">
+				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/jammy/release/nvidia-tegra/ubuntu-22.04-preinstalled-server-arm64+tegra-igx.img.xz">
           Download <span class="u-off-screen">Ubuntu Server</span> 22.04
         </a>
         <a class="p-button" href="https://developer.nvidia.com/downloads/embedded/l4t/r36_release_v2.0/release/jetson_linux_r36.2.0_aarch64.tbz2">Download Jetson Orin Nano boot firmware</a>


### PR DESCRIPTION
## Done

- Updated broken download links

## QA

- View the site locally in your web browser at: https://ubuntu-com-13662.demos.haus/download/nvidia-jetson
- Click download links on both tabs and see that they download correctly

## Issue / Card

Originally reported on [MM](https://chat.canonical.com/canonical/pl/bcp33mcgx7n7bjygtjyon15xec)
