### PR TITLE
[WD-9573] change quick links for Ubuntu for IoT navigation

### DIFF
--- a/meganav.yaml
+++ b/meganav.yaml
@@ -914,22 +914,18 @@ get_ubuntu:
       secondary_links:
         - title: Quick links
           links:
-            - title: Ubuntu for Raspberry Pi
-              url: /raspberry-pi
+            - title: AMD Evaluation kits & SOMs
+              url: /download/xilinx
             - title: Intel IoT platforms
               url: /download/iot/intel-iotg
-            - title: Intel NUC
-              url: /download/intel-nuc
-            - title: Qualcomm Dragonboard 410c
-              url: /download/qualcomm-dragonboard-410c
-            - title: Intel IEI TANK 870
-              url: /download/intel-iei-tank-870
-            - title: AMD-Xilinx Evaluation kits & SOMs
-              url: /download/xilinx
             - title: Mediatek Genio
               url: /download/mediatek-genio
             - title: NVIDIA Jetson
               url: /download/nvidia-jetson
+            - title: Raspberry Pi
+              url: /raspberry-pi
+            - title: RISC-V platforms
+              url: /download/risc-v
       section_footer:
         cta_title: Get Ubuntu for IoT
         cta_url: /download/iot


### PR DESCRIPTION
## Done

- Changed Quick Links section of the "Ubuntu for IoT" part of the navigation according to the [copy doc](https://docs.google.com/document/d/1DCNvYHfC7AbOcqflTBaVd571iKAP_PaTfnqTENVEDVw/edit).

## QA

- Click on "Get Ubuntu" in the top navigation
- Select "Ubuntu for IoT" from the left side of the navigation
- Check the "Quick Links" section on the right if it's the same as suggested in the [copy doc](https://docs.google.com/document/d/1DCNvYHfC7AbOcqflTBaVd571iKAP_PaTfnqTENVEDVw/edit).

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-9573

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
