### PR TITLE
Force HTTPS on Trueability exam iframe.

### DIFF
--- a/templates/credentials/exam.html
+++ b/templates/credentials/exam.html
@@ -7,7 +7,7 @@
 
 {% block content %}
 
-<section class="p-strip--suru-topped u-no-padding">
+<section class="p-strip u-no-padding">
   <iframe title="Exam" class="u-no-margin" id="exam-iframe" onload="setIframeHeight()" scrolling="no" width="100%" src="{{ url }}"></iframe>
 </section>
 

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -41,6 +41,7 @@ EXAM_NAMES = {
 
 RESERVATION_STATES = {
     "created": "Scheduled",
+    "notified": "Scheduled",
     "scheduled": "Scheduled",
     "processed": "Complete",
     "canceled": "Cancelled",
@@ -309,20 +310,19 @@ def cred_your_exams(ua_contracts_api, trueability_api, **kwargs):
                             "actions": actions,
                         }
                     )
-                elif state == "Scheduled" and starts_at > now + timedelta(
-                    minutes=30
-                ):
-                    actions.extend(
-                        [
-                            {
-                                "text": "Reschedule",
-                                "href": "/credentials/schedule?"
-                                f"contractItemID={contract_item_id}"
-                                f"&uuid={r['uuid']}",
-                                "button_class": "p-button",
-                            },
-                        ]
-                    )
+                elif state == "Scheduled":
+                    if now + timedelta(minutes=30) < starts_at:
+                        actions.extend(
+                            [
+                                {
+                                    "text": "Reschedule",
+                                    "href": "/credentials/schedule?"
+                                    f"contractItemID={contract_item_id}"
+                                    f"&uuid={r['uuid']}",
+                                    "button_class": "p-button",
+                                },
+                            ]
+                        )
 
                     exams_scheduled.append(
                         {

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -487,7 +487,9 @@ def cred_exam(trueability_api, **_):
     if assessment_user != sso_user:
         return flask.abort(403)
 
-    url = trueability_api.get_assessment_redirect(assessment_id)
+    url = trueability_api.get_assessment_redirect(assessment_id).replace(
+        "http://", "https://"
+    )
     return flask.render_template("credentials/exam.html", url=url)
 
 


### PR DESCRIPTION
## Done

Force HTTPS on Trueability exam iframe.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Load an exam and make sure the iframe source is an https link.
