### PR TITLE
Show agreement notification in your-exams

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -241,7 +241,7 @@ production:
             name: ubuntu-google-datastore
 
         - name: CREDENTIALS_CONFIDENTIALITY_ENABLED
-          value: false
+          value: true
 
         - name: CONFIDENTIALITY_AGREEMENT_WEBHOOK_USERNAME
           secretKeyRef:
@@ -716,7 +716,7 @@ staging:
             name: ubuntu-google-datastore
 
         - name: CREDENTIALS_CONFIDENTIALITY_ENABLED
-          value: false
+          value: true
 
         - name: CONFIDENTIALITY_AGREEMENT_WEBHOOK_USERNAME
           secretKeyRef:
@@ -932,6 +932,9 @@ staging:
 
 demo:
   env:
+    - name: CREDENTIALS_CONFIDENTIALITY_ENABLED
+      value: false
+
     - name: GOOGLE_CLOUD_DISABLE_GRPC
       value: true
 

--- a/templates/credentials/your-exams.html
+++ b/templates/credentials/your-exams.html
@@ -21,6 +21,16 @@ meta_copydoc %}
   </div>
 </section>
 <section class="p-strip u-no-padding--top">
+  {% if agreement_notification %}
+  <div class="row">
+    <div class="p-notification--caution is-inline" id="notification">
+      <div class="p-notification__content">
+        <h5 class="p-notification__title">Attention:</h5>
+        <p class="p-notification__message">Before start your exam you need to sign our <a href="/legal/confidentiality-agreement">confidentiality agreement.</a></p>
+      </div>
+    </div>
+  </div>
+  {% endif %}
   <div class="row">
     <table aria-label="Scheduled exams">
       <thead>


### PR DESCRIPTION
## Done

- Add notification in your-exams page if you haven't signed the agreement.
- Enable agreement in staging, production and disable in demos.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Go to your exams page and check the notifications shows up before you sign the agreement.