### PR TITLE
[WD-9663] remove OSM from the list in /managed/apps

### DIFF
--- a/templates/managed/apps/index.html
+++ b/templates/managed/apps/index.html
@@ -73,26 +73,6 @@ coverage.{% endblock meta_description %}
         <div style="min-width: 50%">
         {{
           image(
-          url="https://assets.ubuntu.com/v1/176a11dd-opensource-MANO.svg",
-          alt="Open Source MANO",
-          width="144",
-          height="52",
-          hi_def=True,
-          loading="lazy",
-          attrs={"style": "height: 50px; width: auto; margin-bottom: 2rem; margin-top:.8rem;"},
-          ) | safe
-        }}
-        </div>
-        <div class="p-matrix__content u-align--center">
-          <div class="p-matrix__desc">
-            <p class="p-muted-heading" style="margin-left: 1rem"><a href="/blog/managed-apps-charmed-osm">Simplified NFV adoption</a></p>
-          </div>
-        </div>
-      </li>
-      <li class="p-matrix__item u-align--center">
-        <div style="min-width: 50%">
-        {{
-          image(
           url="https://assets.ubuntu.com/v1/b1f04506-Kubeflow-Logo-RGB.svg",
           alt="Kubeflow",
           width="398",


### PR DESCRIPTION
## Done

- Remove OSM logo from /managed/apps page according to the [copy doc](https://docs.google.com/document/d/1fLRWW-Gtslaia2ypSrLJVBxZVHo5FY5Q84o97Gs2-w4/edit).

## QA

- Navigate to [managed/apps](https://ubuntu-com-13676.demos.haus/managed/apps) and check that Mano logo is removed

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-9663

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
