### PR TITLE
Single CVE page

### DIFF
--- a/static/sass/_pattern_cve.scss
+++ b/static/sass/_pattern_cve.scss
@@ -380,8 +380,8 @@
 
   .u-cve-gap {
     display: grid;
-    grid-template-columns: repeat(3, 1fr);
     gap: 30px 20px;
+    grid-template-columns: repeat(3, 1fr);
   }
 
   .u-cve-base-score {

--- a/static/sass/_pattern_cve.scss
+++ b/static/sass/_pattern_cve.scss
@@ -377,4 +377,10 @@
     bottom: 0;
     position: sticky;
   }
+
+  .u-cve-gap {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 30px 20px;
+  }
 }

--- a/static/sass/_pattern_cve.scss
+++ b/static/sass/_pattern_cve.scss
@@ -19,21 +19,16 @@
   .cve-table {
     @extend %small-text;
     @media only screen and (max-width: $breakpoint-small) {
+      display: block;
       overflow-x: auto;
+      white-space: nowrap;
     }
   }
 
   .cve-table thead th {
     word-wrap: break-word;
-    @media only screen and (max-width: $breakpoint-small) {
-      &:nth-child(1) {
-        background-color: #fff;
-        left: 0;
-        position: sticky;
-        z-index: 1;
-      }
-    }
   }
+
   .cve-table thead tr {
     border-bottom: 0;
   }
@@ -397,4 +392,23 @@
       margin-top: 0.2rem;
     }
   }
+
+  .cve-hero-scores {
+    display: flex;
+
+    @media screen and (min-width: $breakpoint-large) {
+      gap: 9%;
+    }
+
+    @media screen and (max-width: $breakpoint-small) {
+      flex-direction: column;
+    }
+  }
+
+  .u-adjust-table-heading {
+    width: 19rem;
+    @media screen and (max-width: $breakpoint-small) {
+      width: fit-content;
+    }
+  } 
 }

--- a/static/sass/_pattern_cve.scss
+++ b/static/sass/_pattern_cve.scss
@@ -410,5 +410,5 @@
     @media screen and (max-width: $breakpoint-small) {
       width: fit-content;
     }
-  } 
+  }
 }

--- a/static/sass/_pattern_cve.scss
+++ b/static/sass/_pattern_cve.scss
@@ -383,4 +383,18 @@
     grid-template-columns: repeat(3, 1fr);
     gap: 30px 20px;
   }
+
+  .u-cve-base-score {
+    display: flex;
+
+    .p-heading-icon__img {
+      height: 1.5rem;
+      margin-left: -0.5rem;
+      margin-right: 0;
+    }
+
+    span {
+      margin-top: 0.2rem;
+    }
+  }
 }

--- a/templates/security/cve/cve.html
+++ b/templates/security/cve/cve.html
@@ -14,6 +14,7 @@
   <div class="row p-section">
     <div class="col-start-large-4 col-9">
       <h1>{{ cve.id }}</h1>
+      
       {% if cve.codename %}
       <p class="u-cve-gap">
         <span>Name</span><span>{{ cve.codename }}</span>
@@ -73,17 +74,33 @@
               <h2 class="p-text--small-caps">Cvss 3 Severity Score</h2>
               <div class="p-heading-icon--small">
                 <div class="p-heading-icon__header p-section--shallow">
-                  <img src="https://assets.ubuntu.com/v1/8010f9e0-CVE-Priority-icon-Medium.svg" alt="" class="p-heading-icon__img">
-                  
-                  <p class="p-heading-icon__title u-no-margin--bottom p-heading--4">
-                    <strong>{{ cvssV3.baseScore | capitalize }}</strong>
-                  </p>
-
+                  {% set baseScore = cvssV3.baseScore  %}
+                  {% if baseScore <= 3.9 %}
+                    <img src="https://assets.ubuntu.com/v1/03ac6f86-CVE-Priority-icon-Low.svg" alt="" class="p-heading-icon__img">
+                    <p class="p-heading-icon__title u-no-margin--bottom p-heading--4">
+                      <strong>{{ cvssV3.baseScore | capitalize }} &middot; Low</strong>
+                    </p>
+                  {% elif baseScore <= 6.9 %}
+                    <img src="https://assets.ubuntu.com/v1/8010f9e0-CVE-Priority-icon-Medium.svg" alt="" class="p-heading-icon__img">
+                    <p class="p-heading-icon__title u-no-margin--bottom p-heading--4">
+                      <strong>{{ cvssV3.baseScore | capitalize }} &middot; Medium</strong>
+                    </p>
+                  {% elif baseScore <= 8.9 %}
+                    <img src="https://assets.ubuntu.com/v1/3887354e-CVE-Priority-icon-High.svg" alt="" class="p-heading-icon__img">
+                    <p class="p-heading-icon__title u-no-margin--bottom p-heading--4">
+                      <strong>{{ cvssV3.baseScore | capitalize }} &middot; High</strong>
+                    </p>
+                  {% elif baseScore <= 10 %}
+                    <img src="https://assets.ubuntu.com/v1/c96f27b9-CVE-Priority-icon-Critical.svg" alt="" class="p-heading-icon__img">
+                    <p class="p-heading-icon__title u-no-margin--bottom p-heading--4">
+                      <strong>{{ cvssV3.baseScore | capitalize }} &middot; Critical</strong>
+                    </p>
+                  {% endif %}
                 </div>
               </div>
-              <p class="p-heading--5 u-no-margin--bottom"><a href="#impact-score">Score breakdown</a></p>
-            {% elif cve.cvss3 %}
-                <p>CVSS 3 base score: {{ cve.cvss3 }} Medium</p>
+              <p><a href="#impact-score">Score breakdown</a></p>
+              {% elif cve.cvss3 %}
+                <p>CVSS 3 base score: {{ cve.cvss3 }}</p>
             </div>
           {% endif %}
         </div>
@@ -95,7 +112,7 @@
 <section class="p-section">
   <div class="row">
     <aside class="col-3">
-      <div class="p-side-navigation--raw-html is-sticky" id="drawer">
+      <div class="p-side-navigation--raw-html" id="drawer" style="position: sticky; top: 4rem;">
         <button class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">
           Toggle side navigation
         </button>
@@ -107,28 +124,43 @@
             </button>
           </div>
           <ul>
+            {% if cve.description %}
             <li class="p-side-navigation__item">
               <a class="highlight-link is-active" href="#description">Description</a>
             </li>
+            {% endif %}
+            {% if cve.mitigation %}
             <li class="p-side-navigation__item">
               <a class="highlight-link" href="#mitigation">Mitigation</a>
             </li>
+            {% endif %}
+            {% if cve.status %}
             <li class="p-side-navigation__item">
               <a class="highlight-link" href="#status">Status</a>
             </li>
+            {% endif %}
+            {% if cve.notes and not cve.priority_reason %}
+            <li class="p-side-navigation__item">
+              <a class="highlight-link" href="#notes">Notes</a>
+            </li>
+            {% endif %}
+            {% if cve.impact %}
             <li class="p-side-navigation__item">
               <a class="highlight-link" href="#impact-score">Severity score breakdown</a>
             </li>
+            {% endif %}
+            {% if cve.references %}
             <li class="p-side-navigation__item">
               <a class="highlight-link" href="#references">References</a>
             </li>
+            {% endif %}
           </ul>
         </nav>
       </div>
     </aside>
     
     <main class="col-9">
-      <div class="p-section section-heading" id="description">
+      <div class="p-section section-heading" id="description" style="scroll-margin-top: 3.5rem;">
         {% if cve.description %}
           <p class=" u-no-padding--top">{{ cve.description }}</p>
         {% endif %}
@@ -138,19 +170,21 @@
           <p>{{ cve.ubuntu_description }}</p>
           <a href="#notes">Read the notes from the security team</a>
         {% endif %}
-  
-        <h3>Why is this CVE high priority?</h3>
-        <p>By using unprivileged user namespaces, this can be exploited to achieve local privilege escalation.</p>  
+        
+        {% if cve.priority_reason %}
+          <h3>Why is this CVE {{ cve.priority }} priority?</h3>
+          <p>{{ cve.priority_reason }}</p>
+        {% endif %}
       </div>
 
       {% if cve.mitigation %}
-        <div class="p-section section-heading" id="mitigation">
+        <div class="p-section section-heading" id="mitigation" style="scroll-margin-top: 3.5rem;">
           <h2>Mitigation</h2>
           <p>{{ cve.mitigation }}</p>
         </div>
       {% endif %}
       
-      <div class="p-section section-heading" id="status">
+      <div class="p-section section-heading" id="status" style="scroll-margin-top: 3.5rem;">
         <h2>Status</h2>
         <div class="u-fixed-width p-section">
           <label class="p-switch" style="float: right;">
@@ -166,16 +200,16 @@
             <table class="cve-table">
               <thead>
                 <tr>
-                  <th style="width: 15rem;">Package</th>
-                  <th>Ubuntu Release</th>
-                  <th style="padding-left: 1.5rem;">Status</th>
+                  <th style="width: 12rem;">Package</th>
+                  <th style="width: 18rem;">Ubuntu Release</th>
+                  <th style="padding-left: 1.5rem; width:25rem">Status</th>
                 </tr>
               </thead>
               <tbody>
                 {% for package in cve.packages %}
                   {% for status in package.statuses %}
                     <tr>
-                      {% if status.release_codename %}
+                      {% if status.release_codename and status.release_codename != "upstream" %}
                         {% if loop.index == 1 %}
                           <td rowspan="{{ package.statuses | length }}">
                             {{ package["name"] }}
@@ -186,29 +220,28 @@
                         </td>
                         
                         {% if status.status == "DNE" %}
-                          <td class="u-text--muted" style="padding-left: 1.5rem;">  
+                          <td class="u-text--muted">  
                             Not in release
                         {% elif status.status == "not-affected" %}
-                          <td class="u-text--muted" style="padding-left: 1.5rem;">  
-                            Not affected
+                          <td class="u-text--muted">  
+                            <i class="p-icon--success"></i> <span>Not affected</span>
                         {% elif status.status == "needs-triage" %}
                           <td>
-                          Needs triage
+                          Needs evaluation
                         {% elif status.status == "needed" %}
                           <td>
-                          Needed
+                            <i class="p-icon--error"></i> <span>Vulnerable</span>
                         {% elif status.status == "deferred" %}
                           <td>
-                          Deferred
+                            <i class="p-icon--error"></i> <span>Vulnerable, fix deferred</span>
                         {% elif status.status == "ignored" %}
-                          <td style="padding-left: 1.5rem;">
-                          Ignored
+                          <td>
+                            <i class="p-icon--hide"></i> <span>Ignored</span>
                         {% elif status.status == "pending" %}
                           <td>
-                          Pending
+                            <i class="p-icon--error"></i> <span>Vulnerable, work in progress</span>
                         {% elif status.status == "released" %}
                         <td>
-
                         <i class="p-icon--success"></i> <span>Fixed</span>
                           {% if status.description %}
                             <span class="u-text--muted">{{ status.description }}</span>
@@ -242,10 +275,32 @@
         </p>
       </div>
 
-      <div class="p-section question-heading" id="#notes">
+      {% if cve.expanded_coverage %}
+      <div class="p-section">
+        <h3>Get expanded security coverage with Ubuntu Pro</h3>
+        <p>Reduce your average CVE exposure time from 98 days to 1 day with expanded CVE patching, ten-years security maintenance and optional support for the full stack of open-source applications. Free for personal use.</p>
+        <a class="p-button--positive" href="/pro">Get Ubuntu Pro</a>
       </div>
+      {% endif %}
 
-      <div class="p-section" id="#patch-details">
+      {% if cve.notes and not cve.priority_reason %}
+      <div class="p-section section-heading" id="notes" style="scroll-margin-top: 3.5rem;">
+        <h2>Notes</h2>
+        <div class="row">
+          <div class="col-6">
+            {% for note in cve.notes %}
+            <hr />
+            {% if note.author %}
+              <h3 class="p-heading--5"><a href="https://launchpad.net/~{{ note.author }}">{{ note.author }}</a></h3>
+            {% endif %}
+            <p>{{ note.note }}</p>
+            {% endfor %}
+          </div>
+        </div>
+      </div>
+      {% endif %}
+
+      <div class="p-section" id="#patch-details" style="scroll-margin-top: 3.5rem;">
         <h3>Patch details</h3>
         <div class="p-notification--information">
           <div class="p-notification__content">
@@ -275,15 +330,15 @@
                         {% elif patch.type == "break-fix" %}
                           <li class="p-list__item has-bullet">
                             Introduced by
-                            <a href="https://git.kernel.org/linus/{{ patch.content.introduced }}">{{ patch.content.introduced }}</a>,
+                            <a href="https://git.kernel.org/linus/{{ patch.content.introduced }}">{{ patch.content.introduced[:7] }}</a>,
                             fixed by
-                            <a href="https://git.kernel.org/linus/{{ patch.content.fixed }}">{{ patch.content.fixed }}</a>
+                            <a href="https://git.kernel.org/linus/{{ patch.content.fixed }}">{{ patch.content.fixed[:7] }}</a>
                           </li>
                         {% elif patch.type == "link" %}
                           <li class="p-list__item has-bullet">
                             {{ patch.content.prefix | capitalize }}:
                             {% if patch.content.suffix %}
-                            <a href="{{ patch.content.suffix }}">{{ patch.content.suffix }}</a>
+                            <a href="{{ patch.content.suffix }}">{{ patch.content.suffix_text[:7] }}</a>
                           </li>
                         {% else %}
                         <li class="p-list__item has-bullet">
@@ -303,7 +358,7 @@
       </div>
 
       {% if cvssV3 %}
-      <div class="p-section question-heading" id="impact-score">
+      <div class="p-section section-heading" id="impact-score">
         <div class="">
           <h2>Severity score breakdown</h2>
           <table>
@@ -316,7 +371,22 @@
             <tbody>
               <tr>
                 <th>Base score</th>
-                <td>{{cvssV3.baseScore}}</td>
+                <td  class="u-cve-base-score">
+                  {% set baseScore = cvssV3.baseScore  %}
+                  {% if baseScore <= 3.9 %}
+                    <img src="https://assets.ubuntu.com/v1/03ac6f86-CVE-Priority-icon-Low.svg" alt="" class="p-heading-icon__img">
+                      <span>{{ cvssV3.baseScore | capitalize }} &middot; Low</span>
+                  {% elif baseScore <= 6.9 %}
+                    <img src="https://assets.ubuntu.com/v1/8010f9e0-CVE-Priority-icon-Medium.svg" alt="" class="p-heading-icon__img">
+                      <span>{{ cvssV3.baseScore | capitalize }} &middot; Medium</span>
+                  {% elif baseScore <= 8.9 %}
+                    <img src="https://assets.ubuntu.com/v1/3887354e-CVE-Priority-icon-High.svg" alt="" class="p-heading-icon__img">
+                      <span>{{ cvssV3.baseScore | capitalize }} &middot; High</span>
+                  {% elif baseScore <= 10 %}
+                    <img src="https://assets.ubuntu.com/v1/c96f27b9-CVE-Priority-icon-Critical.svg" alt="" class="p-heading-icon__img">
+                      <span>{{ cvssV3.baseScore | capitalize }} &middot; Critical</span>
+                  {% endif %}
+                </td>
               </tr>
               <tr>
                 <th>Attack vector</th>
@@ -360,64 +430,56 @@
       </div>
       {% endif %}
 
-      <div class="p-section section-heading" id="references">
-        <h2>References</h2>
-        <ul class="p-inline-list p-section--shallow">
-          <li class="p-inline-list__item">
-            <a href="https://cve.mitre.org/cgi-bin/cvename.cgi?name={{ cve.id }}">
-              MITRE
-            </a>
-          </li>
-          <li class="p-inline-list__item">
-            <a href="https://nvd.nist.gov/vuln/detail/{{ cve.id }}">
-              NVD
-            </a>
-          </li>
-          <li class="p-inline-list__item">
-            <a href="https://launchpad.net/bugs/cve/{{ cve.id }}">
-              Launchpad
-            </a>
-          </li>
-          <li class="p-inline-list__item">
-            <a href="https://security-tracker.debian.org/tracker/{{ cve.id }}">Debian</a>
-          </li>
-        </ul>
-
-        <h3>Related Ubuntu Security Notices (USN)</h3>
-        <ul class="p-list">
-          {% for notice in cve.notices %}
+      <div class="p-section section-heading" id="references" style="scroll-margin-top: 3.5rem;">
+        <div class="p-section">
+          <h2>References</h2>
           <ul class="p-inline-list p-section--shallow">
             <li class="p-inline-list__item">
-              <a href="https://usn.ubuntu.com/{{ notice.id }}">
-                {{ notice.id }}
+              <a href="https://cve.mitre.org/cgi-bin/cvename.cgi?name={{ cve.id }}">
+                MITRE
               </a>
             </li>
             <li class="p-inline-list__item">
-              {{ notice.title }}
+              <a href="https://nvd.nist.gov/vuln/detail/{{ cve.id }}">
+                NVD
+              </a>
             </li>
-            <li class="p-inline-list__item u-text--muted">
-              {{ notice.published }}
+            <li class="p-inline-list__item">
+              <a href="https://launchpad.net/bugs/cve/{{ cve.id }}">
+                Launchpad
+              </a>
+            </li>
+            <li class="p-inline-list__item">
+              <a href="https://security-tracker.debian.org/tracker/{{ cve.id }}">Debian</a>
             </li>
           </ul>
-          {% endfor %}
-        </ul>
+        </div>
+
+        <div class="p-section">
+          <h3>Related Ubuntu Security Notices (USN)</h3>
+          <ul class="p-list">
+            {% for notice in cve.notices %}
+            <ul class="p-inline-list">
+              <li class="p-inline-list__item">
+                <a href="https://usn.ubuntu.com/{{ notice.id }}">
+                  {{ notice.id }}
+                </a>
+              </li>
+              <li class="p-inline-list__item">
+                {{ notice.title }}
+              </li>
+              <li class="p-inline-list__item u-text--muted">
+                {{ notice.published }}
+              </li>
+            </ul>
+            {% endfor %}
+          </ul>
+        </div>
+
       </div>
     </main>
   </div>
 </section>
-
-      {% if cve.status == 'active' and cve.notes %}
-        <h2>Notes</h2>
-        <table>
-          <tr><th style="width: 10em;">Author</th><th>Note</th></tr>
-          {% for note in cve.notes %}
-          <tr>
-            <td><a href="https://launchpad.net/~{{ note.author }}">{{ note.author }}</a></td>
-            <td><pre>{{ note.note }}</pre></td>
-          </tr>
-          {% endfor %}
-        </table>
-      {% endif %}
 
 <script>
    function setUpDynamicSideNav() {

--- a/templates/security/cve/cve.html
+++ b/templates/security/cve/cve.html
@@ -31,12 +31,12 @@
 
       <hr class="p-rule" />
       {% if cve.priority or cvssV3 %}
-        <div class="row" style="display: flex; gap: 9%;">
+        <div class="row cve-hero-scores">
           {% if cve.priority %}
             <div class="">
-              <p class="p-text--small-caps">Ubuntu priority</p>
+              <p class="p-text--small-caps" style="margin-bottom: 1.1rem;">Ubuntu priority</p>
               <div class="p-heading-icon--small">
-                <div class="p-heading-icon__header p-section--shallow">
+                <div class="p-heading-icon__header">
                   {% if cve.priority == 'unknown' %}
                     <img src="https://assets.ubuntu.com/v1/2dff197f-CVE-Priority-icon-Unknown.svg" alt="" class="p-heading-icon__img">
                   {% endif %}
@@ -60,7 +60,7 @@
                   {% if cve.priority == 'critical' %}
                     <img src="https://assets.ubuntu.com/v1/c96f27b9-CVE-Priority-icon-Critical.svg" alt="" class="p-heading-icon__img">
                   {% endif %}
-                  <p class="p-heading-icon__title u-no-margin--bottom p-heading--4">
+                  <p class="p-heading-icon__title p-heading--4">
                     <strong>{{ cve.priority | capitalize }}</strong>
                   </p>
                 </div>
@@ -71,9 +71,9 @@
           
           {% if cvssV3 %}
             <div class="">
-              <h2 class="p-text--small-caps">Cvss 3 Severity Score</h2>
+              <h2 class="p-text--small-caps"  style="margin-bottom: 1.1rem;">Cvss 3 Severity Score</h2>
               <div class="p-heading-icon--small">
-                <div class="p-heading-icon__header p-section--shallow">
+                <div class="p-heading-icon__header">
                   {% set baseScore = cvssV3.baseScore  %}
                   {% if baseScore <= 3.9 %}
                     <img src="https://assets.ubuntu.com/v1/03ac6f86-CVE-Priority-icon-Low.svg" alt="" class="p-heading-icon__img">
@@ -87,12 +87,12 @@
                     </p>
                   {% elif baseScore <= 8.9 %}
                     <img src="https://assets.ubuntu.com/v1/3887354e-CVE-Priority-icon-High.svg" alt="" class="p-heading-icon__img">
-                    <p class="p-heading-icon__title u-no-margin--bottom p-heading--4">
+                    <p class="p-heading-icon__title p-heading--4">
                       <strong>{{ cvssV3.baseScore | capitalize }} &middot; High</strong>
                     </p>
                   {% elif baseScore <= 10 %}
                     <img src="https://assets.ubuntu.com/v1/c96f27b9-CVE-Priority-icon-Critical.svg" alt="" class="p-heading-icon__img">
-                    <p class="p-heading-icon__title u-no-margin--bottom p-heading--4">
+                    <p class="p-heading-icon__title p-heading--4">
                       <strong>{{ cvssV3.baseScore | capitalize }} &middot; Critical</strong>
                     </p>
                   {% endif %}
@@ -112,7 +112,7 @@
 <section class="p-section">
   <div class="row">
     <aside class="col-3">
-      <div class="p-side-navigation--raw-html" id="drawer" style="position: sticky; top: 4rem;">
+      <div class="p-side-navigation--raw-html u-hide--small u-hide--medium" id="drawer" style="position: sticky; top: 4rem;">
         <button class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">
           Toggle side navigation
         </button>
@@ -185,8 +185,8 @@
       {% endif %}
       
       <div class="p-section section-heading" id="status" style="scroll-margin-top: 3.5rem;">
-        <h2>Status</h2>
-        <div class="u-fixed-width p-section">
+        <div class="u-fixed-width p-section" style="display: flex; justify-content: space-between;">
+          <h2>Status</h2>
           <label class="p-switch" style="float: right;">
             <input type="checkbox" class="p-switch__input" role="switch">
             <span class="p-switch__slider"></span>
@@ -224,7 +224,7 @@
                             Not in release
                         {% elif status.status == "not-affected" %}
                           <td class="u-text--muted">  
-                            <i class="p-icon--success"></i> <span>Not affected</span>
+                            Not affected
                         {% elif status.status == "needs-triage" %}
                           <td>
                           Needs evaluation
@@ -236,7 +236,7 @@
                             <i class="p-icon--error"></i> <span>Vulnerable, fix deferred</span>
                         {% elif status.status == "ignored" %}
                           <td>
-                            <i class="p-icon--hide"></i> <span>Ignored</span>
+                            Ignored
                         {% elif status.status == "pending" %}
                           <td>
                             <i class="p-icon--error"></i> <span>Vulnerable, work in progress</span>
@@ -300,7 +300,7 @@
       </div>
       {% endif %}
 
-      <div class="p-section" id="#patch-details" style="scroll-margin-top: 3.5rem;">
+      <div class="p-section" id="patch-details" style="scroll-margin-top: 3.5rem;">
         <h3>Patch details</h3>
         <div class="p-notification--information">
           <div class="p-notification__content">
@@ -310,7 +310,7 @@
         <table>
           <thead>
             <tr>
-              <th style="width: 19rem;">Package</th>
+              <th class="u-adjust-table-heading">Package</th>
               <th>Patch details</th>
             </tr>
           </thead>
@@ -358,7 +358,7 @@
       </div>
 
       {% if cvssV3 %}
-      <div class="p-section section-heading" id="impact-score">
+      <div class="p-section section-heading" id="impact-score" style="scroll-margin-top: 3.5rem;">
         <div class="">
           <h2>Severity score breakdown</h2>
           <table>
@@ -431,51 +431,43 @@
       {% endif %}
 
       <div class="p-section section-heading" id="references" style="scroll-margin-top: 3.5rem;">
-        <div class="p-section">
-          <h2>References</h2>
-          <ul class="p-inline-list p-section--shallow">
-            <li class="p-inline-list__item">
-              <a href="https://cve.mitre.org/cgi-bin/cvename.cgi?name={{ cve.id }}">
-                MITRE
-              </a>
-            </li>
-            <li class="p-inline-list__item">
-              <a href="https://nvd.nist.gov/vuln/detail/{{ cve.id }}">
-                NVD
-              </a>
-            </li>
-            <li class="p-inline-list__item">
-              <a href="https://launchpad.net/bugs/cve/{{ cve.id }}">
-                Launchpad
-              </a>
-            </li>
-            <li class="p-inline-list__item">
-              <a href="https://security-tracker.debian.org/tracker/{{ cve.id }}">Debian</a>
-            </li>
-          </ul>
-        </div>
+        <h2>References</h2>
+        <ul class="p-inline-list p-section--shallow">
+          <li class="p-inline-list__item">
+            <a href="https://cve.mitre.org/cgi-bin/cvename.cgi?name={{ cve.id }}">MITRE</a>
+          </li>
+          <li class="p-inline-list__item">
+            <a href="https://nvd.nist.gov/vuln/detail/{{ cve.id }}">NVD</a>
+          </li>
+          <li class="p-inline-list__item">
+            <a href="https://launchpad.net/bugs/cve/{{ cve.id }}">Launchpad</a>
+          </li>
+          <li class="p-inline-list__item">
+            <a href="https://security-tracker.debian.org/tracker/{{ cve.id }}">Debian</a>
+          </li>
+        </ul>
 
-        <div class="p-section">
-          <h3>Related Ubuntu Security Notices (USN)</h3>
-          <ul class="p-list">
-            {% for notice in cve.notices %}
-            <ul class="p-inline-list">
-              <li class="p-inline-list__item">
-                <a href="https://usn.ubuntu.com/{{ notice.id }}">
-                  {{ notice.id }}
-                </a>
-              </li>
-              <li class="p-inline-list__item">
-                {{ notice.title }}
-              </li>
-              <li class="p-inline-list__item u-text--muted">
-                {{ notice.published }}
-              </li>
-            </ul>
-            {% endfor %}
+        {% if cve.notices %}
+        <h3>Related Ubuntu Security Notices (USN)</h3>
+        <ul class="p-list">
+          {% for notice in cve.notices %}
+          <ul class="p-inline-list">
+            <li class="p-inline-list__item"><a href="https://usn.ubuntu.com/{{ notice.id }}">{{ notice.id }}</a></li>
+            <li class="p-inline-list__item">{{ notice.title }}</li>
+            <li class="p-inline-list__item u-text--muted">{{ notice.published }}</li>
           </ul>
-        </div>
+          {% endfor %}
+        </ul>
+        {% endif %}
 
+        {% if other_references %}
+        <h3>Other references</h3>
+        <ul class="p-list">
+          {% for reference in other_references %}
+            <li class="p-list__item"><a href="{{ reference }}">{{ reference }}</a></li>
+          {% endfor %}
+        </ul>
+        {% endif %}
       </div>
     </main>
   </div>

--- a/templates/security/cve/cve.html
+++ b/templates/security/cve/cve.html
@@ -77,12 +77,12 @@
                   {% set baseScore = cvssV3.baseScore  %}
                   {% if baseScore <= 3.9 %}
                     <img src="https://assets.ubuntu.com/v1/03ac6f86-CVE-Priority-icon-Low.svg" alt="" class="p-heading-icon__img">
-                    <p class="p-heading-icon__title u-no-margin--bottom p-heading--4">
+                    <p class="p-heading-icon__title p-heading--4">
                       <strong>{{ cvssV3.baseScore | capitalize }} &middot; Low</strong>
                     </p>
                   {% elif baseScore <= 6.9 %}
                     <img src="https://assets.ubuntu.com/v1/8010f9e0-CVE-Priority-icon-Medium.svg" alt="" class="p-heading-icon__img">
-                    <p class="p-heading-icon__title u-no-margin--bottom p-heading--4">
+                    <p class="p-heading-icon__title p-heading--4">
                       <strong>{{ cvssV3.baseScore | capitalize }} &middot; Medium</strong>
                     </p>
                   {% elif baseScore <= 8.9 %}
@@ -432,7 +432,7 @@
 
       <div class="p-section section-heading" id="references" style="scroll-margin-top: 3.5rem;">
         <h2>References</h2>
-        <ul class="p-inline-list p-section--shallow">
+        <ul class="p-inline-list">
           <li class="p-inline-list__item">
             <a href="https://cve.mitre.org/cgi-bin/cvename.cgi?name={{ cve.id }}">MITRE</a>
           </li>

--- a/templates/security/cve/cve.html
+++ b/templates/security/cve/cve.html
@@ -1,10 +1,78 @@
 {% extends "security/cve/base_cve.html" %}
+
 {% block title %}{{ cve.id }}{% endblock %}
 
+{% block body_class %}is-paper{% endblock body_class %}
+
 {% block content %}
+
 {% if cve.impact %}
  {% set cvssV3 = cve.impact.baseMetricV3.cvssV3 %}
 {% endif %}
+
+<section class="p-strip is-shallow u-no-padding--bottom">
+  <div class="row p-section">
+    <div class="col-start-large-4 col-9">
+      <h1>{{ cve.id }}</h1>
+      <span>Name</span><span>Test</span>
+      {% if cve.published %}
+      <p>Publication date <span>{{ cve.published }}</span></p>
+      {% endif %}
+      {% if cve.updated_at %}
+      <p>Last updated <span>{{ cve.updated_at }}</span></p>
+      {% endif %}
+      <hr class="p-rule" />
+    </div>
+  </div>
+</section>
+
+<section class="p-section">
+  <div class="row">
+    <aside class="col-3">
+      <div class="p-side-navigation--raw-html is-sticky" id="drawer">
+        <button class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">
+          Toggle side navigation
+        </button>
+        <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="drawer"></div>
+        <nav class="p-side-navigation__drawer" aria-label="documentation side navigation">
+          <div class="p-side-navigation__drawer-header">
+            <button class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="drawer">
+              Toggle table of contents
+            </button>
+          </div>
+          <ul>
+            <li class="p-side-navigation__item">
+              <a class="highlight-link" href="#description">Description</a>
+            </li>
+            <li class="p-side-navigation__item">
+              <a class="highlight-link" href="#mitigation">Mitigation</a>
+            </li>
+            <li class="p-side-navigation__item">
+              <a class="highlight-link" href="#status">Status</a>
+            </li>
+            <li class="p-side-navigation__item">
+              <a class="highlight-link" href="#severity-breakdown">Severity score breakdown</a>
+            </li>
+            <li class="p-side-navigation__item">
+              <a class="highlight-link" href="#refrences">Refrences</a>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </aside>
+    <main class="col-9">
+      {% if cve.description %}
+      <p>{{ cve.description }}</p>
+      {% endif %}
+
+      {% if cve.ubuntu_description %}
+      <h2 class="p-heading--3">From the Ubuntu Security Team</h2>
+      <p>{{ cve.ubuntu_description }}</p>
+      {% endif %}
+    </main>
+  </div>
+</section>
+
 
 {% if cve.status == 'rejected' or cve.status == 'not-in-ubuntu' %}
   <section class="p-strip--light is-bordered--top">
@@ -15,9 +83,6 @@
     <div class="col-9">
       <h1>{{ cve.id }}</h1>
 
-      {% if cve.published %}
-      <p>Published: <strong>{{ cve.published }}</strong></p>
-      {% endif %}
 
       {% if cve.status == 'not-in-ubuntu' %}
         <p>This CVE does not apply to software in Ubuntu archives.</p>

--- a/templates/security/cve/cve.html
+++ b/templates/security/cve/cve.html
@@ -14,14 +14,80 @@
   <div class="row p-section">
     <div class="col-start-large-4 col-9">
       <h1>{{ cve.id }}</h1>
-      <span>Name</span><span>Test</span>
+      {% if cve.codename %}
+      <p class="u-cve-gap">
+        <span>Name</span><span>{{ cve.codename }}</span>
+      </p>
+      {% endif %}
+
       {% if cve.published %}
-      <p>Publication date <span>{{ cve.published }}</span></p>
+        <p class="u-cve-gap">Publication date <span>{{ cve.published }}</span></p>
       {% endif %}
+
       {% if cve.updated_at %}
-      <p>Last updated <span>{{ cve.updated_at }}</span></p>
+        <p class="u-cve-gap">Last updated <span>{{ cve.updated_at }}</span></p>
       {% endif %}
+
       <hr class="p-rule" />
+      {% if cve.priority or cvssV3 %}
+        <div class="row" style="display: flex; gap: 9%;">
+          {% if cve.priority %}
+            <div class="">
+              <p class="p-text--small-caps">Ubuntu priority</p>
+              <div class="p-heading-icon--small">
+                <div class="p-heading-icon__header p-section--shallow">
+                  {% if cve.priority == 'unknown' %}
+                    <img src="https://assets.ubuntu.com/v1/2dff197f-CVE-Priority-icon-Unknown.svg" alt="" class="p-heading-icon__img">
+                  {% endif %}
+      
+                  {% if cve.priority == 'negligible' %}
+                    <img src="https://assets.ubuntu.com/v1/ef6c75b8-CVE-Priority-icon-Negligible.svg" alt="" class="p-heading-icon__img">
+                  {% endif %}
+      
+                  {% if cve.priority == 'low' %}
+                    <img src="https://assets.ubuntu.com/v1/03ac6f86-CVE-Priority-icon-Low.svg" alt="" class="p-heading-icon__img">
+                  {% endif %}
+      
+                  {% if cve.priority == 'medium' %}
+                    <img src="https://assets.ubuntu.com/v1/8010f9e0-CVE-Priority-icon-Medium.svg" alt="" class="p-heading-icon__img">
+                  {% endif %}
+      
+                  {% if cve.priority == 'high' %}
+                    <img src="https://assets.ubuntu.com/v1/3887354e-CVE-Priority-icon-High.svg" alt="" class="p-heading-icon__img">
+                  {% endif %}
+      
+                  {% if cve.priority == 'critical' %}
+                    <img src="https://assets.ubuntu.com/v1/c96f27b9-CVE-Priority-icon-Critical.svg" alt="" class="p-heading-icon__img">
+                  {% endif %}
+                  <p class="p-heading-icon__title u-no-margin--bottom p-heading--4">
+                    <strong>{{ cve.priority | capitalize }}</strong>
+                  </p>
+                </div>
+                <p><a>Why this priority?</a></p>
+              </div>
+            </div>
+          {% endif %}
+          
+          {% if cvssV3 %}
+            <div class="">
+              <h2 class="p-text--small-caps">Cvss 3 Severity Score</h2>
+              <div class="p-heading-icon--small">
+                <div class="p-heading-icon__header p-section--shallow">
+                  <img src="https://assets.ubuntu.com/v1/8010f9e0-CVE-Priority-icon-Medium.svg" alt="" class="p-heading-icon__img">
+                  
+                  <p class="p-heading-icon__title u-no-margin--bottom p-heading--4">
+                    <strong>{{ cvssV3.baseScore | capitalize }}</strong>
+                  </p>
+
+                </div>
+              </div>
+              <p class="p-heading--5 u-no-margin--bottom"><a href="#impact-score">Score breakdown</a></p>
+            {% elif cve.cvss3 %}
+                <p>CVSS 3 base score: {{ cve.cvss3 }} Medium</p>
+            </div>
+          {% endif %}
+        </div>
+      {% endif %}
     </div>
   </div>
 </section>
@@ -42,7 +108,7 @@
           </div>
           <ul>
             <li class="p-side-navigation__item">
-              <a class="highlight-link" href="#description">Description</a>
+              <a class="highlight-link is-active" href="#description">Description</a>
             </li>
             <li class="p-side-navigation__item">
               <a class="highlight-link" href="#mitigation">Mitigation</a>
@@ -51,51 +117,294 @@
               <a class="highlight-link" href="#status">Status</a>
             </li>
             <li class="p-side-navigation__item">
-              <a class="highlight-link" href="#severity-breakdown">Severity score breakdown</a>
+              <a class="highlight-link" href="#impact-score">Severity score breakdown</a>
             </li>
             <li class="p-side-navigation__item">
-              <a class="highlight-link" href="#refrences">Refrences</a>
+              <a class="highlight-link" href="#references">References</a>
             </li>
           </ul>
         </nav>
       </div>
     </aside>
+    
     <main class="col-9">
-      {% if cve.description %}
-      <p>{{ cve.description }}</p>
+      <div class="p-section section-heading" id="description">
+        {% if cve.description %}
+          <p class=" u-no-padding--top">{{ cve.description }}</p>
+        {% endif %}
+  
+        {% if cve.ubuntu_description %}
+          <h2 class="p-heading--3">From the Ubuntu Security Team</h2>
+          <p>{{ cve.ubuntu_description }}</p>
+          <a href="#notes">Read the notes from the security team</a>
+        {% endif %}
+  
+        <h3>Why is this CVE high priority?</h3>
+        <p>By using unprivileged user namespaces, this can be exploited to achieve local privilege escalation.</p>  
+      </div>
+
+      {% if cve.mitigation %}
+        <div class="p-section section-heading" id="mitigation">
+          <h2>Mitigation</h2>
+          <p>{{ cve.mitigation }}</p>
+        </div>
+      {% endif %}
+      
+      <div class="p-section section-heading" id="status">
+        <h2>Status</h2>
+        <div class="u-fixed-width p-section">
+          <label class="p-switch" style="float: right;">
+            <input type="checkbox" class="p-switch__input" role="switch">
+            <span class="p-switch__slider"></span>
+            <span class="p-switch__label">Show also unmaintained releases</span>
+          </label>
+        </div>
+
+        {% if cve.status == 'active' %}
+        <div class="row p-section--shallow">
+          <div>
+            <table class="cve-table">
+              <thead>
+                <tr>
+                  <th style="width: 15rem;">Package</th>
+                  <th>Ubuntu Release</th>
+                  <th style="padding-left: 1.5rem;">Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for package in cve.packages %}
+                  {% for status in package.statuses %}
+                    <tr>
+                      {% if status.release_codename %}
+                        {% if loop.index == 1 %}
+                          <td rowspan="{{ package.statuses | length }}">
+                            {{ package["name"] }}
+                          </td>
+                        {% endif %}
+                        <td>
+                          {{ status.release_codename }}
+                        </td>
+                        
+                        {% if status.status == "DNE" %}
+                          <td class="u-text--muted" style="padding-left: 1.5rem;">  
+                            Not in release
+                        {% elif status.status == "not-affected" %}
+                          <td class="u-text--muted" style="padding-left: 1.5rem;">  
+                            Not affected
+                        {% elif status.status == "needs-triage" %}
+                          <td>
+                          Needs triage
+                        {% elif status.status == "needed" %}
+                          <td>
+                          Needed
+                        {% elif status.status == "deferred" %}
+                          <td>
+                          Deferred
+                        {% elif status.status == "ignored" %}
+                          <td style="padding-left: 1.5rem;">
+                          Ignored
+                        {% elif status.status == "pending" %}
+                          <td>
+                          Pending
+                        {% elif status.status == "released" %}
+                        <td>
+
+                        <i class="p-icon--success"></i> <span>Fixed</span>
+                          {% if status.description %}
+                            <span class="u-text--muted">{{ status.description }}</span>
+                          {% endif %}
+                        {% endif %}
+
+                          {% if status.pocket == "esm-infra" %}
+                            <a class="p-chip" href="/pro">
+                              <span class="p-chip__value">Ubuntu pro</span>
+                            </a>
+                          {% endif %}
+                          {% if status.pocket == "esm-apps" %}
+                            <a class="p-chip" href="/pro">
+                              <span class="p-chip__value"><small>Ubuntu pro</small></span>
+                            </a>
+                          {% endif %}
+                        </td>
+                      {% endif %}
+                    </tr>
+                  {% endfor %}
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+        </div>
+        {% endif %}
+        <hr class="is-muted"/>
+        <p>
+          <a style="margin-right: 1rem;">How can I get the fixes?</a>
+          <a href="#patch-details">Patch details</a>
+        </p>
+      </div>
+
+      <div class="p-section question-heading" id="#notes">
+      </div>
+
+      <div class="p-section" id="#patch-details">
+        <h3>Patch details</h3>
+        <div class="p-notification--information">
+          <div class="p-notification__content">
+            <p class="p-notification__message">For informational purposes only. We recommend not to cherry-pick updates. <a href="">How can I get the fixes?</a></p>
+          </div>
+        </div>
+        <table>
+          <thead>
+            <tr>
+              <th style="width: 19rem;">Package</th>
+              <th>Patch details</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for package in cve.packages %}
+              {% if package["name"] in patches|map(attribute="name")%}
+                <tr>
+                  <td> {{ package["name"] }} </td>
+                  <td>
+                    <ul class="p-list">
+                    {% for patch in patches %}
+                      {% if patch.name == package["name"]%}
+                        {% if patch.type == "text" %}
+                          <li class="p-list__item has-bullet">
+                            {{ patch.content }}
+                          </li>
+                        {% elif patch.type == "break-fix" %}
+                          <li class="p-list__item has-bullet">
+                            Introduced by
+                            <a href="https://git.kernel.org/linus/{{ patch.content.introduced }}">{{ patch.content.introduced }}</a>,
+                            fixed by
+                            <a href="https://git.kernel.org/linus/{{ patch.content.fixed }}">{{ patch.content.fixed }}</a>
+                          </li>
+                        {% elif patch.type == "link" %}
+                          <li class="p-list__item has-bullet">
+                            {{ patch.content.prefix | capitalize }}:
+                            {% if patch.content.suffix %}
+                            <a href="{{ patch.content.suffix }}">{{ patch.content.suffix }}</a>
+                          </li>
+                        {% else %}
+                        <li class="p-list__item has-bullet">
+                            {{ patch.content.suffix }}
+                        </li>
+                        {% endif %}
+                      {% endif %}
+                        {% endif %}                    
+                      {% endfor %}
+                    </ul>
+                  </td>
+                </tr>
+              {% endif%}
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+
+      {% if cvssV3 %}
+      <div class="p-section question-heading" id="impact-score">
+        <div class="">
+          <h2>Severity score breakdown</h2>
+          <table>
+            <thead>
+              <tr>
+                <th style="width: 17rem;">Parameter</th>
+                <th class="u-align--left">Value</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th>Base score</th>
+                <td>{{cvssV3.baseScore}}</td>
+              </tr>
+              <tr>
+                <th>Attack vector</th>
+                <td>{{cvssV3.attackVector | capitalize}}</td>
+              </tr>
+              <tr>
+                <th>Attack complexity</th>
+                <td>{{cvssV3.attackComplexity | capitalize}}</td>
+              </tr>
+              <tr>
+                <th>Privileges required</th>
+                <td>{{cvssV3.privilegesRequired | capitalize}}</td>
+              </tr>
+              <tr>
+                <th>User interaction</th>
+                <td>{{cvssV3.userInteraction | capitalize}}</td>
+              </tr>
+              <tr>
+                <th>Scope</th>
+                <td>{{cvssV3.scope | capitalize}}</td>
+              </tr>
+              <tr>
+                <th>Confidentiality</th>
+                <td>{{cvssV3.confidentialityImpact | capitalize}}</td>
+              </tr>
+              <tr>
+                <th>Integrity impact</th>
+                <td>{{cvssV3.integrityImpact | capitalize}}</td>
+              </tr>
+              <tr>
+                <th>Availability impact</th>
+                <td>{{cvssV3.availabilityImpact | capitalize}}</td>
+              </tr>
+              <tr>
+                <th>Vector</th>
+                <td>{{cvssV3.vectorString}}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
       {% endif %}
 
-      {% if cve.ubuntu_description %}
-      <h2 class="p-heading--3">From the Ubuntu Security Team</h2>
-      <p>{{ cve.ubuntu_description }}</p>
-      {% endif %}
+      <div class="p-section section-heading" id="references">
+        <h2>References</h2>
+        <ul class="p-inline-list p-section--shallow">
+          <li class="p-inline-list__item">
+            <a href="https://cve.mitre.org/cgi-bin/cvename.cgi?name={{ cve.id }}">
+              MITRE
+            </a>
+          </li>
+          <li class="p-inline-list__item">
+            <a href="https://nvd.nist.gov/vuln/detail/{{ cve.id }}">
+              NVD
+            </a>
+          </li>
+          <li class="p-inline-list__item">
+            <a href="https://launchpad.net/bugs/cve/{{ cve.id }}">
+              Launchpad
+            </a>
+          </li>
+          <li class="p-inline-list__item">
+            <a href="https://security-tracker.debian.org/tracker/{{ cve.id }}">Debian</a>
+          </li>
+        </ul>
+
+        <h3>Related Ubuntu Security Notices (USN)</h3>
+        <ul class="p-list">
+          {% for notice in cve.notices %}
+          <ul class="p-inline-list p-section--shallow">
+            <li class="p-inline-list__item">
+              <a href="https://usn.ubuntu.com/{{ notice.id }}">
+                {{ notice.id }}
+              </a>
+            </li>
+            <li class="p-inline-list__item">
+              {{ notice.title }}
+            </li>
+            <li class="p-inline-list__item u-text--muted">
+              {{ notice.published }}
+            </li>
+          </ul>
+          {% endfor %}
+        </ul>
+      </div>
     </main>
   </div>
 </section>
-
-
-{% if cve.status == 'rejected' or cve.status == 'not-in-ubuntu' %}
-  <section class="p-strip--light is-bordered--top">
-{% else %}
-  <section class="p-strip">
-{% endif %}
-  <div class="row">
-    <div class="col-9">
-      <h1>{{ cve.id }}</h1>
-
-
-      {% if cve.status == 'not-in-ubuntu' %}
-        <p>This CVE does not apply to software in Ubuntu archives.</p>
-      {% endif %}
-
-      {% if cve.description %}
-      <p>{{ cve.description }}</p>
-      {% endif %}
-
-      {% if cve.ubuntu_description %}
-      <h2>From the Ubuntu Security Team</h2>
-      <p>{{ cve.ubuntu_description }}</p>
-      {% endif %}
 
       {% if cve.status == 'active' and cve.notes %}
         <h2>Notes</h2>
@@ -110,334 +419,36 @@
         </table>
       {% endif %}
 
-      {%if cve.mitigation %}
-      <h2>Mitigation</h2>
-      <pre>{{ cve.mitigation }}</pre>
-      {% endif %}
-    </div>
+<script>
+   function setUpDynamicSideNav() {
+    const sections = Array.prototype.slice.call(
+      document.querySelectorAll(".section-heading")
+    );
 
-    <div class="col-3">
-      {% if cve.status == 'active' and cve.priority %}
-      <div class="cve-status-box">
-        <h2 class="p-muted-heading">Priority</h2>
-        <div class="p-heading-icon--small">
-          <div class="p-heading-icon__header">
-            {% if cve.priority == 'unknown' %}
-              <img src="https://assets.ubuntu.com/v1/2dff197f-CVE-Priority-icon-Unknown.svg" alt="" class="p-heading-icon__img">
-            {% endif %}
+    const navigationLinks = Array.prototype.slice.call(
+      document.querySelectorAll(".highlight-link")
+    );
 
-            {% if cve.priority == 'negligible' %}
-              <img src="https://assets.ubuntu.com/v1/ef6c75b8-CVE-Priority-icon-Negligible.svg" alt="" class="p-heading-icon__img">
-            {% endif %}
+    sections.forEach(function(section) {
+      const observer = new IntersectionObserver(function(entry) {
+        if (entry[0].isIntersecting) {
+          const sectionId = entry[0].target.id;
+          navigationLinks.forEach(function(link) {
+            if (link.getAttribute("href") === `#${sectionId}`) {
+              link.classList.add("is-active");
+            } else {
+              link.classList.remove("is-active");
+            }
+          });
+        }
+      }, {
+        rootMargin: "-200px 0px -400px",
+        threshold: 0.5,
+      });
 
-            {% if cve.priority == 'low' %}
-              <img src="https://assets.ubuntu.com/v1/03ac6f86-CVE-Priority-icon-Low.svg" alt="" class="p-heading-icon__img">
-            {% endif %}
-
-            {% if cve.priority == 'medium' %}
-              <img src="https://assets.ubuntu.com/v1/8010f9e0-CVE-Priority-icon-Medium.svg" alt="" class="p-heading-icon__img">
-            {% endif %}
-
-            {% if cve.priority == 'high' %}
-              <img src="https://assets.ubuntu.com/v1/3887354e-CVE-Priority-icon-High.svg" alt="" class="p-heading-icon__img">
-            {% endif %}
-
-            {% if cve.priority == 'critical' %}
-              <img src="https://assets.ubuntu.com/v1/c96f27b9-CVE-Priority-icon-Critical.svg" alt="" class="p-heading-icon__img">
-            {% endif %}
-            <p class="p-heading-icon__title u-no-margin--bottom p-heading--4">
-              {{ cve.priority | capitalize }}
-            </p>
-          </div>
-        </div>
-      </div>
-        {% if cvssV3 %}
-        <div class="cve-status-box u-no-margin--bottom">
-          <h2 class="p-muted-heading">Cvss 3 Severity Score</h2>
-          <p class="u-no-margin--bottom p-heading--4">{{cvssV3.baseScore}}</p>
-          <p class="p-heading--5 u-no-margin--bottom"><a href="#impact-score">Score breakdown</a></p>
-        </div>
-        {% elif cve.cvss3 %}
-          <p>CVSS 3 base score: {{ cve.cvss3 }}</p>
-        {% endif %}
-
-      {% endif %}
-
-      {% if cve.status == 'rejected' %}
-      <div class="cve-status-box--highlight">
-        <div class="p-heading--4 u-no-margin--bottom">
-          Rejected
-        </div>
-      </div>
-      {% endif %}
-
-      {% if cve.status == 'not-in-ubuntu' %}
-      <div class="cve-status-box--highlight">
-        <div class="p-heading--4 u-no-margin--bottom">
-          Not in Ubuntu
-        </div>
-      </div>
-      {% endif %}
-    </div>
-
-  </div>
-
-    {% if cve.status == 'active' %}
-    <div class="row">
-      <div class="col-9">
-        <h2>Status</h2>
-        <table class="cve-table">
-          <thead>
-            <tr>
-              <th>Package</th>
-              <th>Release</th>
-              <th>Status</th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for package in cve.packages %}
-              {% for status in package.statuses %}
-                <tr>
-                  {% if status.release_codename %}
-                    {% if loop.index == 1 %}
-                      <td rowspan="{{ package.statuses | length }}">
-                        <a href="/security/cves?q=&package={{ package["name"] }}">{{ package["name"] }}</a><br>
-                        <small>
-                        {% if package["name"] in kenetic_packages or package["name"] in melodic_packages  %}
-                          <a href="/robotics/ros-esm">ROS ESM</a>
-                        {% else %}
-                          <a href="https://launchpad.net/ubuntu/+source/{{ package["name"] }}">Launchpad</a>,
-                          <a href="https://packages.ubuntu.com/search?suite=all&section=all&arch=any&searchon=sourcenames&keywords={{ package["name"] }}">Ubuntu</a>,
-                          <a href="https://tracker.debian.org/{{ package["name"] }}">Debian</a>
-                        {% endif %}
-                        </small>
-                      </td>
-                    {% endif %}
-                    <td>
-                      {{ status.release_codename }}
-                    </td>
-                    {% if status.status == "DNE" or status.status == "not-affected" %}
-                      <td class="cve-table-cell--muted">
-                    {% else %}
-                      <td class="cve-table-cell">
-                    {% endif %}
-                    {% if status.status == "DNE" %}
-                      Does not exist
-                      <div class="cve-color-strip--dne"></div>
-                    {% elif status.status == "needs-triage" %}
-                      Needs triage
-                      <div class="cve-color-strip--needs-triage"></div>
-                    {% elif status.status == "not-affected" %}
-                      Not vulnerable
-                      <div class="cve-color-strip--not-affected"></div>
-                    {% elif status.status == "needed" %}
-                      Needed
-                      <div class="cve-color-strip--needed"></div>
-                    {% elif status.status == "deferred" %}
-                      Deferred
-                      <div class="cve-color-strip--deferred"></div>
-                    {% elif status.status == "ignored" %}
-                      Ignored
-                      <div class="cve-color-strip--ignored"></div>
-                    {% elif status.status == "pending" %}
-                      Pending
-                      <div class="cve-color-strip--pending"></div>
-                    {% elif status.status == "released" %}
-                      <div class="cve-color-strip--released"></div>
-                      Released
-                    {% endif %}
-                    {% if status.description %}
-                      ({{ status.description }})
-                    {% endif %}
-                    <br>
-                    <small>
-                      {% if status.pocket == "esm-infra" %}
-                        <a href="/pro">Available with Ubuntu Pro or Ubuntu Pro (Infra-only)</a>
-                      {% endif %}
-                      {% if status.pocket == "esm-apps" %}
-                        <a href="/pro">Available with Ubuntu Pro</a>
-                      {% endif %}
-                    </small>
-                    </td>
-                  {% endif %}
-                </tr>
-              {% endfor %}
-              {% if package["name"] in patches|map(attribute="name")%}
-                <tr>
-                  <td style="border-top: 0px"></td>
-                  <td colspan="2">
-                    Patches: <br>
-                    <small>
-                      {% for patch in patches %}
-                        {% if patch.name == package["name"]%}
-                          {% if patch.type == "text" %}
-                            {{ patch.content }}
-                          {% elif patch.type == "break-fix" %}
-                            Introduced by
-                            <p><a href="https://git.kernel.org/linus/{{ patch.content.introduced }}">{{ patch.content.introduced }}</a><br>
-                            </p>
-                              Fixed by
-                            <a href="https://git.kernel.org/linus/{{ patch.content.fixed }}">{{ patch.content.fixed }}</a>
-                          {% elif patch.type == "link" %}
-                            {{ patch.content.prefix }}:
-                            {% if patch.content.suffix %}
-                              <a href="{{ patch.content.suffix }}">{{ patch.content.suffix }}</a>
-                            {% else %}
-                              {{ patch.content.suffix }}
-                            {% endif %}
-                          {% endif %}
-                        {% endif %}
-                        <br>
-                      {% endfor %}
-                    </small>
-                  </td>
-                </tr>
-              {% endif%}
-              {% if package["name"] in tags|map(attribute="name") %}
-                <tr>
-                  <td style="border-top: 0px"></td>
-                  <td colspan="2" style="border-top: 5px double #cdcdcd">
-                    <small>
-                        {% for tag in tags %}
-                          {% if tag.name == package["name"] %}
-                            {% if tag.text == "not-ue" %}
-                              This package is not directly supported by the Ubuntu Security Team
-                            {% elif tag.text == "universe-binary" %}
-                              Binaries built from this source package are in <a href="https://wiki.ubuntu.com/SecurityTeam/FAQ#Official_Support">Universe</a> and so are supported by the community.
-                            {% elif tag.text == "apparmor" %}
-                              This vulnerability is mitigated in part by an <a href="https://wiki.ubuntu.com/Security/Features#apparmor">AppArmor</a> profile.
-                            {% elif tag.text == "stack-protector" %}
-                              This vulnerability is mitigated in part by the use of gcc's <a href="https://wiki.ubuntu.com/Security/Features#stack-protector">stack protector</a> in Ubuntu.
-                            {% elif tag.text == "fortify-source" %}
-                              This vulnerability is mitigated in part by the use of <a href="https://wiki.ubuntu.com/Security/Features#fortify-source">-D_FORTIFY_SOURCE=2</a> in Ubuntu.
-                            {% elif tag.text == "symlink-restriction" %}
-                              This vulnerability is mitigated in part by the use of <a href="https://wiki.ubuntu.com/Security/Features#symlink">symlink</a> restrictions in Ubuntu.
-                            {% elif tag.text == "hardlink-restriction" %}
-                              This vulnerability is mitigated in part by the use of <a href="https://wiki.ubuntu.com/Security/Features#hardlink">hardlink</a> restrictions in Ubuntu.
-                            {% elif tag.text == "heap-protector" %}
-                              This vulnerability is mitigated in part by the use of GNU C Library <a href="https://wiki.ubuntu.com/Security/Features#heap-protector">heap protector</a> in Ubuntu.
-                            {% elif tag.text == "pie" %}
-                              This vulnerability is mitigated in part by the use of <a href="https://wiki.ubuntu.com/Security/Features#pie">Position Independent Executables</a> in Ubuntu.
-                            {% else %}
-                              {{ tag.text }}
-                            {% endif %}
-                          {% endif %}
-                        {% endfor %}
-                    </small>
-                  </td>
-                </tr>
-              {% endif %}
-              {% endfor %}
-          </tbody>
-        </table>
-      </div>
-    </div>
-    {% endif %}
-
-    {% if cvssV3 %}
-    <div class="row" id="impact-score">
-      <div class="col-9">
-        <h2>Severity score breakdown</h2>
-        <table>
-          <thead>
-            <tr>
-              <th style="width: 17rem;">Parameter</th>
-              <th class="u-align--left">Value</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <th>Base score</th>
-              <td>{{cvssV3.baseScore}}</td>
-            </tr>
-            <tr>
-              <th>Attack vector</th>
-              <td>{{cvssV3.attackVector | capitalize}}</td>
-            </tr>
-            <tr>
-              <th>Attack complexity</th>
-              <td>{{cvssV3.attackComplexity | capitalize}}</td>
-            </tr>
-            <tr>
-              <th>Privileges required</th>
-              <td>{{cvssV3.privilegesRequired | capitalize}}</td>
-            </tr>
-            <tr>
-              <th>User interaction</th>
-              <td>{{cvssV3.userInteraction | capitalize}}</td>
-            </tr>
-            <tr>
-              <th>Scope</th>
-              <td>{{cvssV3.scope | capitalize}}</td>
-            </tr>
-            <tr>
-              <th>Confidentiality</th>
-              <td>{{cvssV3.confidentialityImpact | capitalize}}</td>
-            </tr>
-            <tr>
-              <th>Integrity impact</th>
-              <td>{{cvssV3.integrityImpact | capitalize}}</td>
-            </tr>
-            <tr>
-              <th>Availability impact</th>
-              <td>{{cvssV3.availabilityImpact | capitalize}}</td>
-            </tr>
-            <tr>
-              <th>Vector</th>
-              <td>{{cvssV3.vectorString}}</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </div>
-    {% endif %}
-
-    <div class="row">
-      <div class="col-9">
-        <h2>References</h2>
-        <ul>
-          {% if cve.references %}
-            {% for reference in cve.references %}
-              
-                <li><a href="{{ reference }}">{{ reference }}</a></li>
-    
-            {% endfor %}
-          {% else %}
-            <li>
-              <a href="https://cve.mitre.org/cgi-bin/cvename.cgi?name={{ cve.id }}">
-                MITRE
-              </a>
-            </li>
-          {% endif %}
-          <li>
-            <a href="https://nvd.nist.gov/vuln/detail/{{ cve.id }}">
-              NVD
-            </a>
-          </li>
-          <li>
-            <a href="https://launchpad.net/bugs/cve/{{ cve.id }}">
-              Launchpad
-            </a>
-          </li>
-          <li>
-            <a href="https://security-tracker.debian.org/tracker/{{ cve.id }}">Debian</a>
-          </li>
-        </ul>
-
-        {% if cve.bugs and "" not in cve.bugs %}
-          <h2>Bugs</h2>
-          <ul>
-            {% for bug in cve.bugs %}
-              {% if 'http' in bug %}
-                <li><a href="{{ bug }}">{{ bug }}</a></li>
-              {% endif %}
-            {% endfor %}
-          </ul>
-        {% endif %}
-      </div>
-    </div>
-  </section>
-
-  {% with first_item="_security_discussion", second_item="_security_esm",
-third_item="_security_further_reading" %}{% include
-"shared/contextual_footers/_contextual_footer.html" %}{% endwith %} {% endblock %}
+      observer.observe(section);
+    });
+  };
+  setUpDynamicSideNav();
+</script>
+{% endblock %}

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -478,13 +478,14 @@ def cve_index():
         order=order,
     )
 
+
 def does_not_include_base_url(link):
     default_reference_urls = [
         "https://cve.mitre.org/",
         "https://nvd.nist.gov",
         "https://launchpad.net/",
         "https://security-tracker.debian.org",
-        "https://ubuntu.com/security/notices"
+        "https://ubuntu.com/security/notices",
     ]
     for base_url in default_reference_urls:
         if base_url in link:
@@ -539,15 +540,15 @@ def cve(cve_id):
 
     # Format remaining references
     other_references = []
-   
+
     if cve.get("references"):
         for reference in cve["references"]:
             if does_not_include_base_url(reference):
                 other_references.append(reference)
-    
+
     # format patches
     formatted_patches = []
-    
+
     if cve["patches"]:
         for package_name, patches in cve["patches"].items():
             for patch in patches:

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -494,6 +494,17 @@ def cve(cve_id):
         cve["published"] = dateutil.parser.parse(cve["published"]).strftime(
             "%-d %B %Y"
         )
+    
+    if cve.get("updated_at"):
+        cve["updated_at"] = dateutil.parser.parse(cve["updated_at"]).strftime(
+            "%-d %B %Y"
+        )
+
+    if cve.get("notices"):
+        for notice in cve["notices"]:
+            notice["published"] = dateutil.parser.parse(
+                notice["published"]
+            ).strftime("%-d %B %Y")
 
     # format patches
     formatted_patches = []

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -13,7 +13,6 @@ from feedgen.entry import FeedEntry
 from feedgen.feed import FeedGenerator
 from mistune import Markdown
 from sortedcontainers import SortedDict
-from operator import itemgetter
 
 # Local
 from webapp.context import api_session
@@ -529,12 +528,12 @@ def cve(cve_id):
     formatted_patches = []
 
     # TODO: Format references
-    default_reference_urls = [
-        "https://cve.mitre.org/",
-        "https://nvd.nist.gov",
-        "https://launchpad.net/",
-        "https://security-tracker.debian.org",
-    ]
+    # default_reference_urls = [
+    #     "https://cve.mitre.org/",
+    #     "https://nvd.nist.gov",
+    #     "https://launchpad.net/",
+    #     "https://security-tracker.debian.org",
+    # ]
 
     if cve["patches"]:
         for package_name, patches in cve["patches"].items():

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -568,6 +568,8 @@ def cve(cve_id):
                     match = re.search(pattern, suffix)
                     if match:
                         suffix_text = match.group(1)
+                    else:
+                        suffix_text = ""
 
                     formatted_patches.append(
                         {

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -478,6 +478,19 @@ def cve_index():
         order=order,
     )
 
+def does_not_include_base_url(link):
+    default_reference_urls = [
+        "https://cve.mitre.org/",
+        "https://nvd.nist.gov",
+        "https://launchpad.net/",
+        "https://security-tracker.debian.org",
+        "https://ubuntu.com/security/notices"
+    ]
+    for base_url in default_reference_urls:
+        if base_url in link:
+            return False
+    return True
+
 
 def cve(cve_id):
     """
@@ -524,17 +537,17 @@ def cve(cve_id):
                     cve["expanded_coverage"] = True
                     break
 
+    # Format remaining references
+    other_references = []
+   
+    if cve.get("references"):
+        for reference in cve["references"]:
+            if does_not_include_base_url(reference):
+                other_references.append(reference)
+    
     # format patches
     formatted_patches = []
-
-    # TODO: Format references
-    # default_reference_urls = [
-    #     "https://cve.mitre.org/",
-    #     "https://nvd.nist.gov",
-    #     "https://launchpad.net/",
-    #     "https://security-tracker.debian.org",
-    # ]
-
+    
     if cve["patches"]:
         for package_name, patches in cve["patches"].items():
             for patch in patches:
@@ -611,6 +624,7 @@ def cve(cve_id):
         tags=formatted_tags,
         kenetic_packages=kenetic_packages,
         melodic_packages=melodic_packages,
+        other_references=other_references,
     )
 
 


### PR DESCRIPTION
## Done

- Applied redesign as per [mock-up](https://www.figma.com/file/nUJEBpOPTW74RqDRuMQXxB/23.04-U.com---CVEs?node-id=949%3A23161&mode=dev)

## Future work

The JS functionality to toggle unmantained releases will be handled in a separate pr, as will further styling updates to the status table. "Other references" will also be handled separately as this field needs additional refactoring to satisfy the design.

## QA

- View the site locally in your web browser at: 
    - https://ubuntu-com-13679.demos.haus/security/CVE-2022-28737
    - https://ubuntu-com-13679.demos.haus/security/CVE-2023-5678
    - https://ubuntu-com-13679.demos.haus/security/CVE-2011-1497
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check against design, noting known discrepancies listed in future work above 

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-5648
