### PR TITLE
Remove support portal seats column

### DIFF
--- a/static/js/src/advantage/users/components/ExplainingTable.tsx
+++ b/static/js/src/advantage/users/components/ExplainingTable.tsx
@@ -25,10 +25,6 @@ const ExplainingTable = () => (
           content: "Payment & Invoices",
           className: "u-align--center",
         },
-        {
-          content: "Support Portal seat",
-          className: "u-align--center",
-        },
       ]}
       rows={[
         {
@@ -36,10 +32,6 @@ const ExplainingTable = () => (
             {
               content: "Admin",
               role: "rowheader",
-            },
-            {
-              content: <Icon name={ICONS.success} />,
-              className: "u-align--center",
             },
             {
               content: <Icon name={ICONS.success} />,
@@ -81,10 +73,6 @@ const ExplainingTable = () => (
               content: <Icon name={ICONS.error} />,
               className: "u-align--center",
             },
-            {
-              content: <Icon name={ICONS.success} />,
-              className: "u-align--center",
-            },
           ],
         },
         {
@@ -107,10 +95,6 @@ const ExplainingTable = () => (
             },
             {
               content: <Icon name={ICONS.success} />,
-              className: "u-align--center",
-            },
-            {
-              content: <Icon name={ICONS.error} />,
               className: "u-align--center",
             },
           ],


### PR DESCRIPTION
## Done

- Remove support portal seats column on pro account management page

## QA

- Check out this feature branch
- Go to `/pro/users`
- Check that support portal seats column is removed

## Issue / Card

Fixes [WD-9527](https://warthogs.atlassian.net/browse/WD-9527?focusedCommentId=434989&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-434989)

## Screenshots
<img width="1154" alt="Screenshot 2024-03-20 at 11 34 07 AM" src="https://github.com/canonical/ubuntu.com/assets/62298176/781c9df3-fdcf-4f0e-9138-fd19ad59d716">



## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-9527]: https://warthogs.atlassian.net/browse/WD-9527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ