### PR TITLE
[WD-9841] point to correct JS to render the chart on /server

### DIFF
--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -247,7 +247,7 @@
   </div>
   <div class="row">
     <div class="col-10" style="overflow: auto;">
-      <div class="u-hide--small" id="server-desktop-eol"></div>
+      <div class="u-hide--small" id="server-desktop-eol-old"></div>
       <table class="u-hide--medium u-hide--large" style="width: auto;">
         <thead>
           <tr>
@@ -342,7 +342,7 @@
   </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.8.2/d3.min.js"></script>
-<script src="{{ versioned_static('js/dist/release-chart.js') }}"></script>
+<script src="{{ versioned_static('js/dist/release-chart-manager.js') }}"></script>
 
 <div class="p-section">
   <div class="row--50-50">


### PR DESCRIPTION
## Done

- point to correct JS to render the chart on /server

## QA

- Navigate to [/server](https://ubuntu-com-13683.demos.haus/server)
- Scroll down to "Security support for Ubuntu releases" section
- Check that the chart renders on bigger screens

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-9841

## Screenshots

![Screenshot 2024-03-20 at 13 58 52](https://github.com/canonical/ubuntu.com/assets/15943863/0889fab5-bf8a-4a8b-843e-7687060af199)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
