### PR TITLE
WD-9834 - add section to /download/amd

### DIFF
--- a/templates/download/amd/_working_commercial_section.html
+++ b/templates/download/amd/_working_commercial_section.html
@@ -1,0 +1,14 @@
+{% block outer_content %}
+    {% block content %}
+    <div class="row p-strip u-no-padding--top">
+		<hr class="col-9">
+		<div class="col-3">
+		  <h3 class="p-heading--5 u-no-padding--top"><strong>Are you working on a commercial project?</strong></h3>
+		</div>
+		<div class="col-6">
+		  <p>Canonical partners with silicon vendors, board manufacturers and leading enterprises to shorten time-to-market. If you are deploying Ubuntu on AMD platforms at-scale, <a class="js-invoke-modal" href="/download/amd#get-in-touch">please reach out to Canonical</a> to get access to ongoing bug fixes, critical security patching, long-term support; or to learn more about our solutions for custom board enablement, and application development services.</p>
+		  <p>For information about using Canonical's Ubuntu images on a commercial project, <a href="">read Canonical's IP policy</a>.</p>
+		</div>
+	</div>
+    {% endblock %}
+{% endblock %}

--- a/templates/download/amd/tab-1.html
+++ b/templates/download/amd/tab-1.html
@@ -39,16 +39,7 @@
 		</div>
 	</div>
 
-	<div class="row p-strip u-no-padding--top">
-		<hr class="col-9">
-		<div class="col-3">
-		  <h3 class="p-heading--5 u-no-padding--top"><strong>Are you working on a commercial project?</strong></h3>
-		</div>
-		<div class="col-6">
-		  <p>Canonical partners with silicon vendors, board manufacturers and leading enterprises to shorten time-to-market. If you are deploying Ubuntu on AMD platforms at-scale, <a class="js-invoke-modal" href="/download/amd#get-in-touch">please reach out to Canonical</a> to get access to ongoing bug fixes, critical security patching, long-term support; or to learn more about our solutions for custom board enablement, and application development services.</p>
-		  <p>For information about using Canonical's Ubuntu images on a commercial project, <a href="">read Canonical's IP policy</a>.</p>
-		</div>
-	</div>
+	{% include "download/amd/_working_commercial_section.html" %}
 
 	<div class="row p-strip u-no-padding--top">
 		<hr class="col-9">

--- a/templates/download/amd/tab-1.html
+++ b/templates/download/amd/tab-1.html
@@ -42,6 +42,17 @@
 	<div class="row p-strip u-no-padding--top">
 		<hr class="col-9">
 		<div class="col-3">
+		  <h3 class="p-heading--5 u-no-padding--top"><strong>Are you working on a commercial project?</strong></h3>
+		</div>
+		<div class="col-6">
+		  <p>Canonical partners with silicon vendors, board manufacturers and leading enterprises to shorten time-to-market. If you are deploying Ubuntu on AMD platforms at-scale, <a class="js-invoke-modal" href="/download/amd#get-in-touch">please reach out to Canonical</a> to get access to ongoing bug fixes, critical security patching, long-term support; or to learn more about our solutions for custom board enablement, and application development services.</p>
+		  <p>For information about using Canonical's Ubuntu images on a commercial project, <a href="">read Canonical's IP policy</a>.</p>
+		</div>
+	</div>
+
+	<div class="row p-strip u-no-padding--top">
+		<hr class="col-9">
+		<div class="col-3">
 			<h3 class="p-heading--5 u-no-padding--top"><strong>AMD Ubuntu Software Development Kit</strong></h3>
 		</div>
 		<div class="col-6">

--- a/templates/download/amd/tab-2.html
+++ b/templates/download/amd/tab-2.html
@@ -46,16 +46,7 @@
     </div>
   </div>
 
-  <div class="row p-strip u-no-padding--top">
-    <hr class="col-9">
-    <div class="col-3">
-      <h3 class="p-heading--5 u-no-padding--top"><strong>Are you working on a commercial project?</strong></h3>
-    </div>
-    <div class="col-6">
-      <p>Canonical partners with silicon vendors, board manufacturers and leading enterprises to shorten time-to-market. If you are deploying Ubuntu on AMD platforms at-scale, <a class="js-invoke-modal" href="/download/amd#get-in-touch">please reach out to Canonical</a> to get access to ongoing bug fixes, critical security patching, long-term support; or to learn more about our solutions for custom board enablement, and application development services.</p>
-      <p>For information about using Canonical's Ubuntu images on a commercial project, <a href="">read Canonical's IP policy</a>.</p>
-    </div>
-  </div>
+	{% include "download/amd/_working_commercial_section.html" %}
 
   <div class="row p-strip u-no-padding--top">
     <hr class="col-9">

--- a/templates/download/amd/tab-3.html
+++ b/templates/download/amd/tab-3.html
@@ -43,16 +43,7 @@
     </div>
   </div>
 
-  <div class="row p-strip u-no-padding--top">
-    <hr class="col-9">
-    <div class="col-3">
-      <h3 class="p-heading--5 u-no-padding--top"><strong>Are you working on a commercial project?</strong></h3>
-    </div>
-    <div class="col-6">
-      <p>Canonical partners with silicon vendors, board manufacturers and leading enterprises to shorten time-to-market. If you are deploying Ubuntu on AMD platforms at-scale, <a class="js-invoke-modal" href="/download/amd#get-in-touch">please reach out to Canonical</a> to get access to ongoing bug fixes, critical security patching, long-term support; or to learn more about our solutions for custom board enablement, and application development services.</p>
-      <p>For information about using Canonical's Ubuntu images on a commercial project, <a href="/legal/intellectual-property-policy">read Canonical's IP policy</a>.</p>
-    </div>
-  </div>
+	{% include "download/amd/_working_commercial_section.html" %}
 
   <div class="row p-strip u-no-padding--top">
     <hr class="col-9">


### PR DESCRIPTION
## Done

Add 'Are you working on a commercial project?' section to /download/amd

## QA

- [demo link](https://ubuntu-com-13684.demos.haus/download/amd)
- [copy doc](https://docs.google.com/document/d/1cxQnEErs8FZ3dZ_IhlfcaJ03gE_vrMJfRC-5me9IDd4/edit)
- View the site on demo
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check that the section is added correctly

## Issue / Card
[WD-9834](https://warthogs.atlassian.net/browse/WD-9834)

[WD-9834]: https://warthogs.atlassian.net/browse/WD-9834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ