### PR TITLE
Re-order kernel-lifecycle chart data

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -1258,8 +1258,8 @@ export var desktopServerReleaseNames = [
 export var kernelReleaseNames = [
   "22.04.4 LTS",
   "23.10",
-  "22.04.1 LTS",
   "20.04.5 LTS",
+  "22.04.1 LTS",
   "22.04.0 LTS",
   "18.04.5 LTS",
   "20.04.1 LTS",
@@ -1326,16 +1326,16 @@ export var kernelReleaseNamesALL = [
   "Ubuntu 20.04.1 LTS (v5.4)",
   "Ubuntu 18.04.5 LTS (v5.4)",
   "Ubuntu 22.04.0 LTS (v5.15)",
-  "Ubuntu 20.04.5 LTS (v5.15)",
   "Ubuntu 22.04.1 LTS (v5.15)",
+  "Ubuntu 20.04.5 LTS (v5.15)",
   "Ubuntu 23.10 (v6.5)",
   "Ubuntu 22.04.4 LTS (v6.5)",
 ];
 
 export var kernelReleaseNamesLTS = [
   "Ubuntu 16.04.0 LTS (v4.4)",
-  "Ubuntu 14.04.5 LTS (v4.4)",
   "Ubuntu 16.04.1 LTS (v4.4)",
+  "Ubuntu 14.04.5 LTS (v4.4)",
   "Ubuntu 18.04.0 LTS (v4.15)",
   "Ubuntu 18.04.1 LTS (v4.15)",
   "Ubuntu 16.04.5 LTS (v4.15)",
@@ -1343,8 +1343,8 @@ export var kernelReleaseNamesLTS = [
   "Ubuntu 20.04.1 LTS (v5.4)",
   "Ubuntu 18.04.5 LTS (v5.4)",
   "Ubuntu 22.04.0 LTS (v5.15)",
-  "Ubuntu 20.04.5 LTS (v5.15)",
   "Ubuntu 22.04.1 LTS (v5.15)",
+  "Ubuntu 20.04.5 LTS (v5.15)",
   "Ubuntu 22.04.4 LTS (v6.5)",
 ];
 


### PR DESCRIPTION
## Done

- makes the changes to the graphs outlined in [the issue](https://warthogs.atlassian.net/browse/LANDPM-753)
![image](https://github.com/canonical/ubuntu.com/assets/58276363/5792e3fd-d9a6-4831-8b81-323719911e45)
![image](https://github.com/canonical/ubuntu.com/assets/58276363/382c45f1-6bff-4bda-8b7e-6e8af9804a0f)


## QA

- Check in [the demo](https://ubuntu-com-13688.demos.haus/kernel/lifecycle) that the appropriate graph changes (above) have been made
- Check it doesn't mess up other graphs ie. openstack, ubutnu releases etc

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-9799
