### PR TITLE
WD-9396 - update engage pages form resubmit

### DIFF
--- a/templates/engage/thank-you.html
+++ b/templates/engage/thank-you.html
@@ -39,10 +39,7 @@
         <a class="p-button" href="/contact-us">Contact us</a>
       </p>
       <p>
-        Not received it? Check your spam folder and that you've used the right email address.
-      </p>
-      <p>
-        <a href="{{ request_url }}">Or try resending it</a>
+        Did not get it? Check your spam folder and that you've used the right email address.
       </p>
 
     {% else %}


### PR DESCRIPTION
## Done

As a quick fix it was chosen to remove 'resend it' link. Separate maintenance ticket will be created to investigate other solutions.

## QA

- [demo link](https://ubuntu-com-13691.demos.haus/engage/run-ai-at-scale)
- [copy doc](https://docs.google.com/document/d/1T5AdArzT5nZfur3wDTNPlb74bNCIW_leFhdmoaQ72DE/edit#heading=h.hkikdgm7ujct)
- View the site on demo
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check that the page is correct according to copy doc

## Issue / Card
[WD-9396](https://warthogs.atlassian.net/browse/WD-9396)


[WD-9396]: https://warthogs.atlassian.net/browse/WD-9396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ