### PR TITLE
adjust release-cycle dates for k8s 1.29

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -922,138 +922,6 @@ export var openStackReleases = [
 
 export var kubernetesReleases = [
   {
-    startDate: new Date("2019-03-27T00:00:00"),
-    endDate: new Date("2019-12-17T00:00:00"),
-    taskName: "Kubernetes 1.14",
-    status: "CANONICAL_KUBERNETES_SUPPORT",
-  },
-  {
-    startDate: new Date("2019-12-17T00:00:00"),
-    endDate: new Date("2020-09-30T00:00:00"),
-    taskName: "Kubernetes 1.14",
-    status: "CANONICAL_KUBERNETES_EXPANDED_SECURITY_MAINTENANCE",
-  },
-  {
-    startDate: new Date("2019-06-28T00:00:00"),
-    endDate: new Date("2020-04-13T00:00:00"),
-    taskName: "Kubernetes 1.15",
-    status: "CANONICAL_KUBERNETES_SUPPORT",
-  },
-  {
-    startDate: new Date("2020-04-13T00:00:00"),
-    endDate: new Date("2020-12-16T00:00:00"),
-    taskName: "Kubernetes 1.15",
-    status: "CANONICAL_KUBERNETES_EXPANDED_SECURITY_MAINTENANCE",
-  },
-  {
-    startDate: new Date("2019-09-27T00:00:00"),
-    endDate: new Date("2020-09-30T00:00:00"),
-    taskName: "Kubernetes 1.16",
-    status: "CANONICAL_KUBERNETES_SUPPORT",
-  },
-  {
-    startDate: new Date("2020-09-30T00:00:00"),
-    endDate: new Date("2021-04-15T00:00:00"),
-    taskName: "Kubernetes 1.16",
-    status: "CANONICAL_KUBERNETES_EXPANDED_SECURITY_MAINTENANCE",
-  },
-  {
-    startDate: new Date("2019-12-17T00:00:00"),
-    endDate: new Date("2020-12-16T00:00:00"),
-    taskName: "Kubernetes 1.17",
-    status: "CANONICAL_KUBERNETES_SUPPORT",
-  },
-  {
-    startDate: new Date("2020-12-16T00:00:00"),
-    endDate: new Date("2021-09-01T00:00:00"),
-    taskName: "Kubernetes 1.17",
-    status: "CANONICAL_KUBERNETES_EXPANDED_SECURITY_MAINTENANCE",
-  },
-  {
-    startDate: new Date("2020-04-13T00:00:00"),
-    endDate: new Date("2021-04-15T00:00:00"),
-    taskName: "Kubernetes 1.18",
-    status: "CANONICAL_KUBERNETES_SUPPORT",
-  },
-  {
-    startDate: new Date("2021-04-15T00:00:00"),
-    endDate: new Date("2021-12-15T00:00:00"),
-    taskName: "Kubernetes 1.18",
-    status: "CANONICAL_KUBERNETES_EXPANDED_SECURITY_MAINTENANCE",
-  },
-  {
-    startDate: new Date("2020-09-30T00:00:00"),
-    endDate: new Date("2021-09-01T00:00:00"),
-    taskName: "Kubernetes 1.19",
-    status: "CANONICAL_KUBERNETES_SUPPORT",
-  },
-  {
-    startDate: new Date("2021-09-01T00:00:00"),
-    endDate: new Date("2022-05-06T00:00:00"),
-    taskName: "Kubernetes 1.19",
-    status: "CANONICAL_KUBERNETES_EXPANDED_SECURITY_MAINTENANCE",
-  },
-  {
-    startDate: new Date("2020-12-16T00:00:00"),
-    endDate: new Date("2021-12-15T00:00:00"),
-    taskName: "Kubernetes 1.20",
-    status: "CANONICAL_KUBERNETES_SUPPORT",
-  },
-  {
-    startDate: new Date("2021-12-15T00:00:00"),
-    endDate: new Date("2022-09-01T00:00:00"),
-    taskName: "Kubernetes 1.20",
-    status: "CANONICAL_KUBERNETES_EXPANDED_SECURITY_MAINTENANCE",
-  },
-  {
-    startDate: new Date("2021-04-15T00:00:00"),
-    endDate: new Date("2022-05-06T00:00:00"),
-    taskName: "Kubernetes 1.21",
-    status: "CANONICAL_KUBERNETES_SUPPORT",
-  },
-  {
-    startDate: new Date("2022-05-06T00:00:00"),
-    endDate: new Date("2022-12-15T00:00:00"),
-    taskName: "Kubernetes 1.21",
-    status: "CANONICAL_KUBERNETES_EXPANDED_SECURITY_MAINTENANCE",
-  },
-  {
-    startDate: new Date("2021-09-01T00:00:00"),
-    endDate: new Date("2022-09-01T00:00:00"),
-    taskName: "Kubernetes 1.22",
-    status: "CANONICAL_KUBERNETES_SUPPORT",
-  },
-  {
-    startDate: new Date("2022-08-23T00:00:00"),
-    endDate: new Date("2023-05-03T00:00:00"),
-    taskName: "Kubernetes 1.22",
-    status: "CANONICAL_KUBERNETES_EXPANDED_SECURITY_MAINTENANCE",
-  },
-  {
-    startDate: new Date("2021-12-15T00:00:00"),
-    endDate: new Date("2022-12-15T00:00:00"),
-    taskName: "Kubernetes 1.23",
-    status: "CANONICAL_KUBERNETES_SUPPORT",
-  },
-  {
-    startDate: new Date("2022-12-15T00:00:00"),
-    endDate: new Date("2023-08-23T00:00:00"),
-    taskName: "Kubernetes 1.23",
-    status: "CANONICAL_KUBERNETES_EXPANDED_SECURITY_MAINTENANCE",
-  },
-  {
-    startDate: new Date("2022-05-06T00:00:00"),
-    endDate: new Date("2023-05-03T00:00:00"),
-    taskName: "Kubernetes 1.24",
-    status: "CANONICAL_KUBERNETES_SUPPORT",
-  },
-  {
-    startDate: new Date("2023-05-03T00:00:00"),
-    endDate: new Date("2023-12-06T00:00:00"),
-    taskName: "Kubernetes 1.24",
-    status: "CANONICAL_KUBERNETES_EXPANDED_SECURITY_MAINTENANCE",
-  },
-  {
     startDate: new Date("2022-09-01T00:00:00"),
     endDate: new Date("2023-08-28T00:00:00"),
     taskName: "Kubernetes 1.25",
@@ -1099,6 +967,18 @@ export var kubernetesReleases = [
     startDate: new Date("2024-08-28T00:00:00"),
     endDate: new Date("2025-04-28T00:00:00"),
     taskName: "Kubernetes 1.28",
+    status: "CANONICAL_KUBERNETES_EXPANDED_SECURITY_MAINTENANCE",
+  },
+  {
+    startDate: new Date("2023-12-15T00:00:00"),
+    endDate: new Date("2024-12-28T00:00:00"),
+    taskName: "Kubernetes 1.29",
+    status: "CANONICAL_KUBERNETES_SUPPORT",
+  },
+  {
+    startDate: new Date("2024-12-28T00:00:00"),
+    endDate: new Date("2025-08-28T00:00:00"),
+    taskName: "Kubernetes 1.29",
     status: "CANONICAL_KUBERNETES_EXPANDED_SECURITY_MAINTENANCE",
   },
 ];
@@ -1376,21 +1256,11 @@ export var microStackReleaseNames = [
 ];
 
 export var kubernetesReleaseNames = [
+  "Kubernetes 1.29",
   "Kubernetes 1.28",
   "Kubernetes 1.27",
   "Kubernetes 1.26",
   "Kubernetes 1.25",
-  "Kubernetes 1.24",
-  "Kubernetes 1.23",
-  "Kubernetes 1.22",
-  "Kubernetes 1.21",
-  "Kubernetes 1.20",
-  "Kubernetes 1.19",
-  "Kubernetes 1.18",
-  "Kubernetes 1.17",
-  "Kubernetes 1.16",
-  "Kubernetes 1.15",
-  "Kubernetes 1.14",
 ];
 
 export var kernelReleaseScheduleNames = [

--- a/templates/about/release_cycles/k8s-eol.html
+++ b/templates/about/release_cycles/k8s-eol.html
@@ -12,6 +12,12 @@
       </thead>
       <tbody>
         <tr>
+          <td><strong>1.29.x</strong></td>
+          <td>Dec 2023</td>
+          <td>Dec 2024</td>
+          <td>Aug 2025</td>
+        </tr>
+        <tr>
           <td><strong>1.28.x</strong></td>
           <td>Aug 2023</td>
           <td>Aug 2024</td>
@@ -34,72 +40,6 @@
           <td>Sep 2022</td>
           <td>Aug 2023</td>
           <td>Apr 2024</td>
-        </tr>
-        <tr>
-          <td><strong>1.24.x</strong></td>
-          <td>May 2022</td>
-          <td>May 2023</td>
-          <td>Dec 2023</td>
-        </tr>
-        <tr>
-          <td><strong>1.23.x</strong></td>
-          <td>Dec 2021</td>
-          <td>Dec 2022</td>
-          <td>Aug 2023</td>
-        </tr>
-        <tr>
-          <td><strong>1.22.x</strong></td>
-          <td>Sep 2021</td>
-          <td>Sep 2022</td>
-          <td>May 2023</td>
-        </tr>
-        <tr>
-          <td><strong>1.21.x</strong></td>
-          <td>Apr 2021</td>
-          <td>May 2022</td>
-          <td>Dec 2022</td>
-        </tr>
-        <tr>
-          <td><strong>1.20.x</strong></td>
-          <td>Dec 2020</td>
-          <td>Dec 2021</td>
-          <td>Sep 2022</td>
-        </tr>
-        <tr>
-          <td><strong>1.19.x</strong></td>
-          <td>Sep 2020</td>
-          <td>Sep 2021</td>
-          <td>May 2022</td>
-        </tr>
-        <tr>
-          <td><strong>1.18.x</strong></td>
-          <td>Apr 2020</td>
-          <td>Apr 2021</td>
-          <td>Dec 2021</td>
-        </tr>
-        <tr>
-          <td><strong>1.17.x</strong></td>
-          <td>Dec 2019</td>
-          <td>Dec 2020</td>
-          <td>Sep 2021</td>
-        </tr>
-        <tr>
-          <td><strong>1.16.x</strong></td>
-          <td>Sep 2019</td>
-          <td>Sep 2020</td>
-          <td>Apr 2021</td>
-        </tr>
-        <tr>
-          <td><strong>1.15.x</strong></td>
-          <td>Jun 2019</td>
-          <td>Apr 2020</td>
-          <td>Dec 2020</td>
-        </tr>
-        <tr>
-          <td><strong>1.14.x</strong></td>
-          <td>Mar 2019</td>
-          <td>Dec 2019</td>
-          <td>Sep 2020</td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
## Done

- remove EOL k8s releases (only 1.25+ is currently supported)
- add 1.29 dates

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes

## Issue / Card

Fixes https://github.com/charmed-kubernetes/kubernetes-docs/issues/837

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
