### PR TITLE
WD-9913 Update dropdown selections & branding on /schedule, /redeem, /your-exams, /shop for consistency

### DIFF
--- a/static/js/src/advantage/credentials/components/CredExamShop/CredExamShop.tsx
+++ b/static/js/src/advantage/credentials/components/CredExamShop/CredExamShop.tsx
@@ -17,7 +17,7 @@ const CredExamShop = () => {
   const ExamProductDescriptions: Product[] = [
     {
       id: "cue-linux-essentials",
-      name: "CUE Linux Essentials",
+      name: "CUE.01 Linux",
       metadata: [
         {
           key: "description",
@@ -28,7 +28,7 @@ const CredExamShop = () => {
     },
     {
       id: "cue-02-desktop",
-      name: "CUE Desktop",
+      name: "CUE.02 Desktop",
       metadata: [
         {
           key: "description",
@@ -39,7 +39,7 @@ const CredExamShop = () => {
     },
     {
       id: "cue-03-server",
-      name: "CUE Server",
+      name: "CUE.03 Server",
       metadata: [
         {
           key: "description",

--- a/templates/credentials/redeem_with_form.html
+++ b/templates/credentials/redeem_with_form.html
@@ -27,7 +27,7 @@ Ubuntu Desktop, and Ubuntu Server topics.{% endblock meta_description %}
           </div>
           <div class="col-3">
           <select id="exam" name="exam" required>
-            <option value="cue-linux-essentials">CUE.01: Linux</option>
+            <option value="cue-linux-essentials">CUE.01 Linux</option>
           </select>
           </div>
         </div>

--- a/templates/credentials/schedule.html
+++ b/templates/credentials/schedule.html
@@ -30,7 +30,7 @@ meta_copydoc %}
         <input type="number" name="contractItemID" value="{{contract_item_id}}" hidden />
         <label class="p-heading--5" for="exam-name">Select your exam</label>
         <select class="spaced-bottom--smaller is-paper--input" id="exam-name" name="name" required>
-          <option value="linux-essentials">CUE: Linux</option>
+          <option value="linux-essentials">CUE.01 Linux</option>
         </select>
         <label class="p-heading--5" for="exam-timezone">Select your timezone</label>
         <select class="spaced-bottom--smaller is-paper--input" id="exam-timezone" name="timezone" required>

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -40,8 +40,8 @@ TIMEZONE_COUNTRIES = {
 TIMEZONE_COUNTRIES["Asia/Calcutta"] = "IN"
 
 EXAM_NAMES = {
-    "cue-test": "CUE: Linux Beta",
-    "cue-linux-essentials": "CUE.01: Linux",
+    "cue-test": "CUE Linux Beta",
+    "cue-linux-essentials": "CUE.01 Linux",
 }
 
 RESERVATION_STATES = {
@@ -245,7 +245,7 @@ def cred_your_exams(ua_contracts_api, trueability_api, **kwargs):
                 response = trueability_api.get_assessment_reservation(
                     exam_contract["cueContext"]["reservation"]["IDs"][-1]
                 )
-                r = response["assessment_reservation"]
+                r = response.get("assessment_reservation")
                 timezone = r["user"]["time_zone"]
                 tz_info = pytz.timezone(timezone)
                 starts_at = (


### PR DESCRIPTION
## Done

- Remove colons from exam names

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes [#WD-9913](https://warthogs.atlassian.net/browse/WD-9913)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
