### PR TITLE
Create modal form for nvidia-jetson

### DIFF
--- a/static/js/src/dynamic-forms.js
+++ b/static/js/src/dynamic-forms.js
@@ -191,6 +191,7 @@ import setupIntlTelInput from "./intlTelInput.js";
       var otherContainers = document.querySelectorAll(".js-other-container");
       var phoneInput = document.querySelector("#phone");
       var modalTrigger = document.activeElement || document.body;
+      var isMutlipage = contactModal.querySelector(".js-pagination").length > 1;
 
       document.onkeydown = function (evt) {
         evt = evt || window.event;
@@ -198,6 +199,13 @@ import setupIntlTelInput from "./intlTelInput.js";
           close();
         }
       };
+
+      contactModal.addEventListener("submit", function (e) {
+        addLoadingSpinner();
+        if (!isMutlipage) {
+          comment.value = createMessage();
+        }
+      });
 
       if (closeModal) {
         closeModal.addEventListener("click", function (e) {
@@ -366,7 +374,7 @@ import setupIntlTelInput from "./intlTelInput.js";
         var formFields = contactModal.querySelectorAll(".js-formfield");
         formFields.forEach(function (formField) {
           var comma = "";
-          var fieldTitle = formField.querySelector(".p-heading--5");
+          var fieldTitle = formField.querySelector(".p-heading--5") ?? formField.querySelector(".p-modal__question-heading");
           var inputs = formField.querySelectorAll("input, textarea");
           if (fieldTitle) {
             message += fieldTitle.innerText + "\r\n";
@@ -529,21 +537,17 @@ import setupIntlTelInput from "./intlTelInput.js";
       setpreferredLanguage();
 
       // Disables submit button and adds visual queue when it is submitted
-      function setupSubmitButton() {
+      function addLoadingSpinner() {
         const modalForm = formContainer.querySelector("form");
         const spinnerIcon = document.createElement("i");
         spinnerIcon.className = "p-icon--spinner u-animation--spin is-light";
-        modalForm.addEventListener("submit", function (e) {
-          const buttonRect = submitButton.getBoundingClientRect();
-          submitButton.style.width = buttonRect.width + "px";
-          submitButton.style.height = buttonRect.height + "px";
-          submitButton.disabled = true;
-          submitButton.innerText = "";
-          submitButton.appendChild(spinnerIcon);
-        });
+        const buttonRect = submitButton.getBoundingClientRect();
+        submitButton.style.width = buttonRect.width + "px";
+        submitButton.style.height = buttonRect.height + "px";
+        submitButton.disabled = true;
+        submitButton.innerText = "";
+        submitButton.appendChild(spinnerIcon);
       }
-
-      setupSubmitButton();
 
       function fireLoadedEvent() {
         var event = new CustomEvent("contactModalLoaded");

--- a/static/js/src/dynamic-forms.js
+++ b/static/js/src/dynamic-forms.js
@@ -374,7 +374,9 @@ import setupIntlTelInput from "./intlTelInput.js";
         var formFields = contactModal.querySelectorAll(".js-formfield");
         formFields.forEach(function (formField) {
           var comma = "";
-          var fieldTitle = formField.querySelector(".p-heading--5") ?? formField.querySelector(".p-modal__question-heading");
+          var fieldTitle =
+            formField.querySelector(".p-heading--5") ??
+            formField.querySelector(".p-modal__question-heading");
           var inputs = formField.querySelectorAll("input, textarea");
           if (fieldTitle) {
             message += fieldTitle.innerText + "\r\n";

--- a/static/js/src/dynamic-forms.js
+++ b/static/js/src/dynamic-forms.js
@@ -191,7 +191,7 @@ import setupIntlTelInput from "./intlTelInput.js";
       var otherContainers = document.querySelectorAll(".js-other-container");
       var phoneInput = document.querySelector("#phone");
       var modalTrigger = document.activeElement || document.body;
-      var isMutlipage = contactModal.querySelector(".js-pagination").length > 1;
+      var isMultipage = contactModal.querySelector(".js-pagination").length > 1;
 
       document.onkeydown = function (evt) {
         evt = evt || window.event;
@@ -202,7 +202,7 @@ import setupIntlTelInput from "./intlTelInput.js";
 
       contactModal.addEventListener("submit", function (e) {
         addLoadingSpinner();
-        if (!isMutlipage) {
+        if (!isMultipage) {
           comment.value = createMessage();
         }
       });

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1347,7 +1347,7 @@ $color-link-dark: #69c !default;
 .p-modal__dialog.is-paper {
   max-width: $grid-max-width !important;
 
-  &.is-ai-modal {
+  .row--50-50 {
     .p-modal__close {
       background-color: transparent;
       margin-top: 1.5rem;

--- a/templates/download/nvidia-jetson/index.html
+++ b/templates/download/nvidia-jetson/index.html
@@ -30,7 +30,7 @@
       <p>All images are 64-bit builds of Ubuntu.</p>
       <hr />
       <p>
-        <a href="/internet-of-things/nvidia/contact-us" class="p-button--positive">Get in touch</a>
+        <a href="/internet-of-things/nvidia/contact-us" class="p-button--positive js-invoke-modal">Get in touch</a>
       </p>
     </div>
   </div>
@@ -76,5 +76,8 @@
     </div>
   </div>
 </section>
+
+<!-- Set default Marketo information for contact form below-->
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/nvidia-jetson" data-form-id="4953" data-lp-id="" data-return-url="https://ubuntu.com/internet-of-things/thank-you?product=nvidia" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 
 {% endblock content %}

--- a/templates/shared/forms/interactive/kernel-beta-signup.html
+++ b/templates/shared/forms/interactive/kernel-beta-signup.html
@@ -167,8 +167,6 @@
             <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
             <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
             <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
-            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
-            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Facebook_Click_ID__c" id="Facebook_Click_ID__c" value="" />
             <input type="hidden" aria-hidden="true" aria-label="hidden field" id="preferredLanguage" name="preferredLanguage" maxlength="255" value="" />
             <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
 

--- a/templates/shared/forms/interactive/kernel-beta-signup.html
+++ b/templates/shared/forms/interactive/kernel-beta-signup.html
@@ -167,6 +167,8 @@
             <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
             <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
             <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Facebook_Click_ID__c" id="Facebook_Click_ID__c" value="" />
             <input type="hidden" aria-hidden="true" aria-label="hidden field" id="preferredLanguage" name="preferredLanguage" maxlength="255" value="" />
             <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
 

--- a/templates/shared/forms/interactive/nvidia-jetson.html
+++ b/templates/shared/forms/interactive/nvidia-jetson.html
@@ -1,119 +1,117 @@
 <div class="p-modal" id="contact-modal">
   <div class="p-modal__dialog is-paper" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
     <div class="js-pagination js-pagination--1">
-      <div class="js-formfield">
-        <div class="row--50-50 p-strip is-shallow">
-          <div class="col">
-            <h2 class="p-heading--1" id="modal-title">Interested in optimised Ubuntu on NVIDIA platforms?</h2>
-            <p>Canonical announced plans to certify Ubuntu to run on NVIDIA platforms powered by the Orin architecture. Ubuntu will run on the full range of NVIDIA IoT platforms, bringing Ubuntu to the automotive industry with the NVIDIA DRIVE&reg; platform, to industrial applications with the NVIDIA IGX Orin&trade; platform, as well as to advanced embedded systems with NVIDIA Jetson Orin&trade;  system-on-modules. The optimised kernel and images will combine software features from NVIDIA with unparalleled security, reliability, and support for regulated enterprise deployments.</p>
-            <p>With this collaboration, optimised Ubuntu and Ubuntu Core images will be available for commercial-grade IoT deployments for a wide range of popular silicon platforms across a variety of vendors, establishing a de facto standard across enterprise IoT &ndash; from software- defined vehicles and industry 4.0 to retail and robotics.</p>
-            <p>Fill out the form to receive the latest update from us!</p>
-          </div>
-          <div class="col">
-            <button class="p-modal__close" aria-label="Close active modal">Close</button>
-            <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
-              <div class="p-section--shallow">
-                <h3 class="p-text--default">Which NVIDIA platforms are you interested in?</h3>
-                <label class="p-checkbox">
-                  <input class="p-checkbox__input" type="checkbox" aria-labelledby="drive-orin" name="which-nvidia-orin-platforms" value="DRIVE Orin">
-                  <span class="p-checkbox__label" id="drive-orin">Xavier</span>
-                </label>
-                <label class="p-checkbox">
-                  <input class="p-checkbox__input" type="checkbox" aria-labelledby="drive-orin" name="which-nvidia-orin-platforms" value="DRIVE Orin">
-                  <span class="p-checkbox__label" id="drive-orin">DRIVE Orin</span>
-                </label>
-                <label class="p-checkbox">
-                  <input class="p-checkbox__input" type="checkbox" aria-labelledby="igx-orin" name="which-nvidia-orin-platforms" value="IGX Orin">
-                  <span class="p-checkbox__label" id="igx-orin">IGX Orin</span>
-                </label>
-                <label class="p-checkbox">
-                  <input class="p-checkbox__input" type="checkbox" aria-labelledby="jetson-agx-orin" name="which-nvidia-orin-platforms" value="Jetson AGX Orin">
-                  <span class="p-checkbox__label" id="jetson-agx-orin">Jetson AGX Orin</span>
-                </label>
-                <label class="p-checkbox">
-                  <input class="p-checkbox__input" type="checkbox" aria-labelledby="jetson-orin-nx" name="which-nvidia-orin-platforms" value="Jetson Orin NX">
-                  <span class="p-checkbox__label" id="jetson-orin-nx">Jetson Orin NX</span>
-                </label>
-                <label class="p-checkbox">
-                  <input class="p-checkbox__input" type="checkbox" aria-labelledby="jetson-orin-nano" name="which-nvidia-orin-platforms" value="Jetson Orin Nano">
-                  <span class="p-checkbox__label" id="jetson-orin-nano">Jetson Orin Nano</span>
-                </label>
-              </div>
-              <div class="p-section--shallow">
-                <hr class="p-rule">
-                <h3 class="p-text--default">Tell us more about your project</h3>
-                <textarea id="tell-us-about-your-project" name="tell-us-about-your-project" rows="4" maxlength="2000"></textarea>
-              </div>
-              <div class="p-section--shallow">
-                <hr class="p-rule">
-                <h3 class="p-text--default">Please leave your contact details so that we can inform you once the optimised Ubuntu images are available to download and install on your Tegra SoCs.</h3>
-                <label for="firstName">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text"/>
+      <div class="row--50-50 p-strip is-shallow">
+        <div class="col">
+          <h2 class="p-heading--1" id="modal-title">Interested in optimised Ubuntu on NVIDIA platforms?</h2>
+          <p>Canonical announced plans to certify Ubuntu to run on NVIDIA platforms powered by the Orin architecture. Ubuntu will run on the full range of NVIDIA IoT platforms, bringing Ubuntu to the automotive industry with the NVIDIA DRIVE&reg; platform, to industrial applications with the NVIDIA IGX Orin&trade; platform, as well as to advanced embedded systems with NVIDIA Jetson Orin&trade;  system-on-modules. The optimised kernel and images will combine software features from NVIDIA with unparalleled security, reliability, and support for regulated enterprise deployments.</p>
+          <p>With this collaboration, optimised Ubuntu and Ubuntu Core images will be available for commercial-grade IoT deployments for a wide range of popular silicon platforms across a variety of vendors, establishing a de facto standard across enterprise IoT &ndash; from software- defined vehicles and industry 4.0 to retail and robotics.</p>
+          <p>Fill out the form to receive the latest update from us!</p>
+        </div>
+        <div class="col">
+          <button class="p-modal__close" aria-label="Close active modal">Close</button>
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
+            <div class="p-section--shallow js-formfield">
+              <h3 class="p-text--default p-modal__question-heading">Which NVIDIA platforms are you interested in?</h3>
+              <label class="p-checkbox">
+                <input class="p-checkbox__input" type="checkbox" aria-labelledby="drive-orin">
+                <span class="p-checkbox__label" id="drive-orin">Xavier</span>
+              </label>
+              <label class="p-checkbox">
+                <input class="p-checkbox__input" type="checkbox" aria-labelledby="drive-orin">
+                <span class="p-checkbox__label" id="drive-orin">DRIVE Orin</span>
+              </label>
+              <label class="p-checkbox">
+                <input class="p-checkbox__input" type="checkbox" aria-labelledby="igx-orin">
+                <span class="p-checkbox__label" id="igx-orin">IGX Orin</span>
+              </label>
+              <label class="p-checkbox">
+                <input class="p-checkbox__input" type="checkbox" aria-labelledby="jetson-agx-orin">
+                <span class="p-checkbox__label" id="jetson-agx-orin">Jetson AGX Orin</span>
+              </label>
+              <label class="p-checkbox">
+                <input class="p-checkbox__input" type="checkbox" aria-labelledby="jetson-orin-nx">
+                <span class="p-checkbox__label" id="jetson-orin-nx">Jetson Orin NX</span>
+              </label>
+              <label class="p-checkbox">
+                <input class="p-checkbox__input" type="checkbox" aria-labelledby="jetson-orin-nano">
+                <span class="p-checkbox__label" id="jetson-orin-nano">Jetson Orin Nano</span>
+              </label>
+            </div>
+            <div class="p-section--shallow js-formfield">
+              <hr class="p-rule">
+              <h3 class="p-text--default p-modal__question-heading">Tell us more about your project</h3>
+              <textarea id="tell-us-about-your-project" rows="4" maxlength="2000"></textarea>
+            </div>
+            <div class="p-section--shallow">
+              <hr class="p-rule">
+              <h3 class="p-text--default">Please leave your contact details so that we can inform you once the optimised Ubuntu images are available to download and install on your Tegra SoCs.</h3>
+              <label for="firstName">First name:</label>
+              <input required id="firstName" name="firstName" maxlength="255" type="text"/>
 
-                <label for="lastName">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text"/>
+              <label for="lastName">Last name:</label>
+              <input required id="lastName" name="lastName" maxlength="255" type="text"/>
 
-                <label for="company">Company:</label>
-                <input required id="company" name="company" maxlength="255" type="text"/>
+              <label for="company">Company:</label>
+              <input required id="company" name="company" maxlength="255" type="text"/>
 
-                <label for="company">Job title:</label>
-                <input required id="title" name="title" maxlength="255" type="text"/>
+              <label for="company">Job title:</label>
+              <input required id="title" name="title" maxlength="255" type="text"/>
 
-                <label for="email">Email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"/>
+              <label for="email">Email:</label>
+              <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"/>
 
-                <label for="phone">Mobile/cell phone number:</label>
-                <input required id="phone" name="phone" maxlength="255" type="tel" />
-              </div>
+              <label for="phone">Mobile/cell phone number:</label>
+              <input required id="phone" name="phone" maxlength="255" type="tel" />
+            </div>
 
-              <div class="p-section--shallow">
-                <label class="p-checkbox">
-                  <input class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
-                  <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
-                </label>
+            <div class="p-section--shallow">
+              <label class="p-checkbox">
+                <input class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
+                <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
+              </label>
 
-                <p>By submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</p>
-                {# These are honey pot fields to catch bots #}
-                <ul class="p-list u-off-screen">
-                  <li class="u-off-screen">
-                    <label class="website" for="website">Website:</label>
-                    <input name="website" type="text" class="website" autocomplete="off" value="" id="website" tabindex="-1" />
-                  </li>
-                  <li class="u-off-screen">
-                    <label class="name" for="name">Name:</label>
-                    <input name="name" type="text" class="name" autocomplete="off" value="" id="name" tabindex="-1" />
-                  </li>
-                </ul>
-                {# End of honey pots #}
-              </div>
+              <p>By submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</p>
+              {# These are honey pot fields to catch bots #}
+              <ul class="p-list u-off-screen">
+                <li class="u-off-screen">
+                  <label class="website" for="website">Website:</label>
+                  <input name="website" type="text" class="website" autocomplete="off" value="" id="website" tabindex="-1" />
+                </li>
+                <li class="u-off-screen">
+                  <label class="name" for="name">Name:</label>
+                  <input name="name" type="text" class="name" autocomplete="off" value="" id="name" tabindex="-1" />
+                </li>
+              </ul>
+              {# End of honey pots #}
+            </div>
 
-              <div class="u-hide">
-                <h3>Your comments</h3>
-                <ul class="p-list">
-                  <li class="p-list__item">
-                    <label for="Comments_from_lead__c">What would you like to talk to us about?</label>
-                    <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
-                  </li>
-                </ul>
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %%" />
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Facebook_Click_ID__c" id="Facebook_Click_ID__c" value="" />
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" id="preferredLanguage" name="preferredLanguage" maxlength="255" value="" />
-              </div>
+            <div class="u-hide">
+              <h3>Your comments</h3>
+              <ul class="p-list">
+                <li class="p-list__item">
+                  <label for="Comments_from_lead__c">What would you like to talk to us about?</label>
+                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
+                </li>
+              </ul>
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Facebook_Click_ID__c" id="Facebook_Click_ID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" id="preferredLanguage" name="preferredLanguage" maxlength="255" value="" />
+            </div>
 
-              <div class="pagination p-section--shallow">
-                <hr>
-                <button type="submit" class="pagination__link--next p-button--positive" aria-label="Submit">Submit form</button>
-              </div>
-            </form>           
-          </div>
+            <div class="pagination p-section--shallow">
+              <hr>
+              <button type="submit" class="pagination__link--next p-button--positive" aria-label="Submit">Submit form</button>
+            </div>
+          </form>           
         </div>
       </div>
     </div>

--- a/templates/shared/forms/interactive/nvidia-jetson.html
+++ b/templates/shared/forms/interactive/nvidia-jetson.html
@@ -4,49 +4,49 @@
       <div class="js-formfield">
         <div class="row--50-50 p-strip is-shallow">
           <div class="col">
-            <h2 class="p-heading--1" id="modal-title">Open source AI: a scalable path to production</h2>
-            <p>Looking to scale your MLOPs infrastructure or need consulting services to kick start your AI journey? Our experts are here to help you.</p>
+            <h2 class="p-heading--1" id="modal-title">Interested in optimised Ubuntu on NVIDIA platforms?</h2>
+            <p>Canonical announced plans to certify Ubuntu to run on NVIDIA platforms powered by the Orin architecture. Ubuntu will run on the full range of NVIDIA IoT platforms, bringing Ubuntu to the automotive industry with the NVIDIA DRIVE&reg; platform, to industrial applications with the NVIDIA IGX Orin&trade; platform, as well as to advanced embedded systems with NVIDIA Jetson Orin&trade;  system-on-modules. The optimised kernel and images will combine software features from NVIDIA with unparalleled security, reliability, and support for regulated enterprise deployments.</p>
+            <p>With this collaboration, optimised Ubuntu and Ubuntu Core images will be available for commercial-grade IoT deployments for a wide range of popular silicon platforms across a variety of vendors, establishing a de facto standard across enterprise IoT &ndash; from software- defined vehicles and industry 4.0 to retail and robotics.</p>
+            <p>Fill out the form to receive the latest update from us!</p>
           </div>
           <div class="col">
             <button class="p-modal__close" aria-label="Close active modal">Close</button>
-            <form action="/marketo/submit" onsubmit="stringifyCustomFields()" method="post" id="mktoForm_%% formid %%" class="modal-form">
+            <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
               <div class="p-section--shallow">
-                <p>Do you already have any AI projects rolled out in your enterprise?</p>
-                <label class="p-radio">
-                  <input type="radio" value="Yes" class="p-radio__input" id="aiProjectsYes" name="aiProjects" aria-labelledby="aiProjectsYes" required>
-                  <span class="p-radio__label" id="aiProjectsYes">Yes</span>
+                <h3 class="p-text--default">Which NVIDIA platforms are you interested in?</h3>
+                <label class="p-checkbox">
+                  <input class="p-checkbox__input" type="checkbox" aria-labelledby="drive-orin" name="which-nvidia-orin-platforms" value="DRIVE Orin">
+                  <span class="p-checkbox__label" id="drive-orin">Xavier</span>
                 </label>
-                <label class="p-radio">
-                  <input type="radio" value="No" class="p-radio__input" id="aiProjectsNo" name="aiProjects" aria-labelledby="aiProjectsNo" required>
-                  <span class="p-radio__label" id="aiProjectsNo">No</span>
+                <label class="p-checkbox">
+                  <input class="p-checkbox__input" type="checkbox" aria-labelledby="drive-orin" name="which-nvidia-orin-platforms" value="DRIVE Orin">
+                  <span class="p-checkbox__label" id="drive-orin">DRIVE Orin</span>
+                </label>
+                <label class="p-checkbox">
+                  <input class="p-checkbox__input" type="checkbox" aria-labelledby="igx-orin" name="which-nvidia-orin-platforms" value="IGX Orin">
+                  <span class="p-checkbox__label" id="igx-orin">IGX Orin</span>
+                </label>
+                <label class="p-checkbox">
+                  <input class="p-checkbox__input" type="checkbox" aria-labelledby="jetson-agx-orin" name="which-nvidia-orin-platforms" value="Jetson AGX Orin">
+                  <span class="p-checkbox__label" id="jetson-agx-orin">Jetson AGX Orin</span>
+                </label>
+                <label class="p-checkbox">
+                  <input class="p-checkbox__input" type="checkbox" aria-labelledby="jetson-orin-nx" name="which-nvidia-orin-platforms" value="Jetson Orin NX">
+                  <span class="p-checkbox__label" id="jetson-orin-nx">Jetson Orin NX</span>
+                </label>
+                <label class="p-checkbox">
+                  <input class="p-checkbox__input" type="checkbox" aria-labelledby="jetson-orin-nano" name="which-nvidia-orin-platforms" value="Jetson Orin Nano">
+                  <span class="p-checkbox__label" id="jetson-orin-nano">Jetson Orin Nano</span>
                 </label>
               </div>
               <div class="p-section--shallow">
                 <hr class="p-rule">
-                <p>What are you interested in from our AI offering?</p>
-                <label class="p-checkbox js-checkbox">
-                  <input type="checkbox" aria-labelledby="canonicalMlopsSolution" class="p-checkbox__input">
-                  <span class="p-checkbox__label" id="canonicalMlopsSolution">Canonical MLOps solution</span>
-                </label>
-                <label class="p-checkbox js-checkbox">
-                  <input type="checkbox" aria-labelledby="aiConsultingServices" class="p-checkbox__input">
-                  <span class="p-checkbox__label" id="aiConsultingServices">AI consultancy services</span>
-                </label>
-                <label class="p-checkbox js-checkbox">
-                  <input type="checkbox" aria-labelledby="mlopsWorkshop" class="p-checkbox__input">
-                  <span class="p-checkbox__label" id="mlopsWorkshop">MLOps Workshop</span>
-                </label>
-                <label class="p-checkbox js-checkbox">
-                  <input type="checkbox" aria-labelledby="notSure" class="p-checkbox__input">
-                  <span class="p-checkbox__label" id="notSure">Not sure</span>
-                </label>
+                <h3 class="p-text--default">Tell us more about your project</h3>
+                <textarea id="tell-us-about-your-project" name="tell-us-about-your-project" rows="4" maxlength="2000"></textarea>
               </div>
               <div class="p-section--shallow">
                 <hr class="p-rule">
-                <label for="mlopsRequirements">Add details about your AI or MLOps requirements</label>
-                <textarea id="mlopsRequirements"></textarea>
-                <hr class="p-rule">
-                <p>Add your information</p>
+                <h3 class="p-text--default">Please leave your contact details so that we can inform you once the optimised Ubuntu images are available to download and install on your Tegra SoCs.</h3>
                 <label for="firstName">First name:</label>
                 <input required id="firstName" name="firstName" maxlength="255" type="text"/>
 
@@ -56,13 +56,13 @@
                 <label for="company">Company:</label>
                 <input required id="company" name="company" maxlength="255" type="text"/>
 
-                <label for="company">Title:</label>
+                <label for="company">Job title:</label>
                 <input required id="title" name="title" maxlength="255" type="text"/>
 
                 <label for="email">Email:</label>
                 <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"/>
 
-                <label for="phone">Phone number:</label>
+                <label for="phone">Mobile/cell phone number:</label>
                 <input required id="phone" name="phone" maxlength="255" type="tel" />
               </div>
 

--- a/templates/shared/forms/interactive/nvidia-jetson.html
+++ b/templates/shared/forms/interactive/nvidia-jetson.html
@@ -46,22 +46,22 @@
             <div class="p-section--shallow">
               <hr class="p-rule">
               <h3 class="p-text--default">Please leave your contact details so that we can inform you once the optimised Ubuntu images are available to download and install on your Tegra SoCs.</h3>
-              <label for="firstName">First name:</label>
+              <label for="firstName">First name: <span>*</span></label>
               <input required id="firstName" name="firstName" maxlength="255" type="text"/>
 
-              <label for="lastName">Last name:</label>
+              <label for="lastName">Last name: <span>*</span></label>
               <input required id="lastName" name="lastName" maxlength="255" type="text"/>
 
-              <label for="company">Company:</label>
+              <label for="company">Company: <span>*</span></label>
               <input required id="company" name="company" maxlength="255" type="text"/>
 
-              <label for="company">Job title:</label>
+              <label for="company">Job title: <span>*</span></label>
               <input required id="title" name="title" maxlength="255" type="text"/>
 
-              <label for="email">Email:</label>
+              <label for="email">Email: <span>*</span></label>
               <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"/>
 
-              <label for="phone">Mobile/cell phone number:</label>
+              <label for="phone">Mobile/cell phone number: <span>*</span></label>
               <input required id="phone" name="phone" maxlength="255" type="tel" />
             </div>
 

--- a/templates/shared/forms/interactive/nvidia-jetson.html
+++ b/templates/shared/forms/interactive/nvidia-jetson.html
@@ -46,22 +46,22 @@
             <div class="p-section--shallow">
               <hr class="p-rule">
               <h3 class="p-text--default">Please leave your contact details so that we can inform you once the optimised Ubuntu images are available to download and install on your Tegra SoCs.</h3>
-              <label for="firstName">First name: <span>*</span></label>
+              <label class="is-required" for="firstName">First name:</label>
               <input required id="firstName" name="firstName" maxlength="255" type="text"/>
 
-              <label for="lastName">Last name: <span>*</span></label>
+              <label class="is-required" for="lastName">Last name:</label>
               <input required id="lastName" name="lastName" maxlength="255" type="text"/>
 
-              <label for="company">Company: <span>*</span></label>
+              <label class="is-required" for="company">Company:</label>
               <input required id="company" name="company" maxlength="255" type="text"/>
 
-              <label for="company">Job title: <span>*</span></label>
+              <label class="is-required" for="company">Job title:</label>
               <input required id="title" name="title" maxlength="255" type="text"/>
 
-              <label for="email">Email: <span>*</span></label>
+              <label class="is-required" for="email">Email:</label>
               <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"/>
 
-              <label for="phone">Mobile/cell phone number: <span>*</span></label>
+              <label class="is-required" for="phone">Mobile/cell phone number:</label>
               <input required id="phone" name="phone" maxlength="255" type="tel" />
             </div>
 

--- a/templates/thank-you.html
+++ b/templates/thank-you.html
@@ -7,7 +7,7 @@
 <section class="p-strip is-deep is-bordered">
   <div class="row">
     <div class="col-7">
-      <h1>Thanks for getting in touch</h1>
+      <h1>Thanks for getting in touch {% if product and product != "" %} about {{ product }}{% endif %}</h1>
       <h2 class="p-heading--3">Your submission was successful.</h2>
       {% if referrer and referrer != "" %}
       <p><a href="{{ referrer }}" class="p-button">Return to learn more</a></p>
@@ -36,9 +36,9 @@
   </div>
   <div class="row p-divider">
     <div class="col-4 p-divider__block">
-      <h4 class="p-heading--3">Ubuntu Advantage</h4>
+      <h4 class="p-heading--3">Ubuntu Pro</h4>
       <p>Purchase our desktop support and access Ubuntu experts whenever you need.</p>
-      <p><a href="/support">Learn about Ubuntu Advantage&nbsp;&rsaquo;</a></p>
+      <p><a href="/support">Learn about Ubuntu Pro&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-4 p-divider__block">
       <h4 class="p-heading--3">Ubuntu OpenStack</h4>


### PR DESCRIPTION
## Done

- Creates modal form based on the design of https://ubuntu.com/ai#get-in-touch (see [figma](https://www.figma.com/file/sGeCjFvA1kV9Kmvg2S2VBn/23.10-U.com---AI-bubble?type=design&node-id=248-1446&mode=design&t=SMx52yK27AMAlSAb-0)) and the content of https://ubuntu.com/internet-of-things/nvidia/contact-us (see [copydoc](https://docs.google.com/document/d/1znVFFLSyTmDwCplvloGAlEI3p_dpGH8v82hbYzVfz0o/edit#heading=h.dxn10eelvkoc))
- A little change to how dynamic forms works, it now check if it is a single page modal and updates the comments from lead on submit instead of 'next page' as it does usually.
- updates some specific styling to be generic across 50-50 modals
- updates a thank-you page to accept 'product' param (it isn't used here though)

## QA

- Go to https://ubuntu-com-13702.demos.haus/download/nvidia-jetson
- Click the 'contact us' button and see the modal opens
- fill in in and submit the form, compare this to the static form, they should submit the same payload
- check [marketo](https://engage-sj.marketo.com/?munchkinId=066-EOV-335#/classic/SL100936298B2LA1)

- Check the updated styling still works on the AI modal

- Check other dynamic forms works

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-9817

## Screenshots
Based on:
![image](https://github.com/canonical/ubuntu.com/assets/58276363/d74d6276-e518-4b42-a4c8-a8b92e22ee4e)

New form:
![image](https://github.com/canonical/ubuntu.com/assets/58276363/6809a8b7-76dc-4a2f-81f1-332234936e1a)

