### PR TITLE
Rebrand /download/server pages

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -9,6 +9,7 @@ latest:
   eol: "July 2024"
   past_eol_date: false
   release_notes_url: "https://discourse.ubuntu.com/t/mantic-minotaur-release-notes/35534"
+  iso_download_size: "4.5GB"
 lts:
   slug: JammyJellyfish
   name: "Jammy Jellyfish"

--- a/templates/download/server/choose.html
+++ b/templates/download/server/choose.html
@@ -1,58 +1,27 @@
-{% extends "download/_base_download.html" %}
 
-{% block title %}Get Ubuntu Server | Download{% endblock %}
-{% block meta_description %}Get Ubuntu Server one of three ways; by using Multipass on your desktop, using MAAS to provision machines in your data centre or installing it directly on a server.{% endblock meta_description %}
-{% block meta_copydoc %}https://docs.google.com/document/d/1Qob4Ni_y1ffIdSWqaw2xH0dxiHZQmkRGP5nuoBhIfyM/edit{% endblock meta_copydoc %}
-
-{% block content %}
-<section class="p-strip--suru-topped">
-  <div class="row u-equal-height">
-    <div class="col-7">
-      <h1>Get Ubuntu Server</h1>
-      <h2 class="js-download-option">Option 3: Automated server provisioning</h2>
-      <p>Provision machines with Ubuntu Server in a fully automated way with MAAS</p>
-      <ul class="p-list">
+<section class="p-tabs__content p-section" id="automated-provisioning" role="tabpanel" aria-labelledby="automated-provisioning-tab">
+  <div class="row--50-50">
+    <div class="col">
+      <h2>Provisioning machines with Ubuntu Server in a fully automated way with MAAS</h2>
+    </div>
+    <div class="col">
+      <ul class="p-list--divided u-no-margin--bottom">
         <li class="p-list__item is-ticked">Bare metal cloud experience</li>
         <li class="p-list__item is-ticked">Ubuntu Server, CentOS and Windows machines</li>
         <li class="p-list__item is-ticked">Infrastructure discovery and automation</li>
       </ul>
-      <p><a href="https://maas.io" class="p-button--positive u-no-margin--top" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Server download', 'eventAction' : 'Select option', 'eventLabel' : 'MAAS', 'eventValue' : undefined });">Get MAAS</a></p>
-    </div>
-    <div class="col-5 u-hide--medium u-hide--small u-align--center u-vertically-center" style="min-height: 328px">
-      {{
-        image(
-          url="https://assets.ubuntu.com/v1/1be3ba70-maas-images.png?w=504",
-          alt="",
-          height="310",
-          width="504",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class": "p-image--bordered"}
+      <hr />
+      <a href="https://maas.io" class="p-button--positive">Get MAAS</a>
+      {{ 
+        image (
+        url="https://assets.ubuntu.com/v1/56548950-image 1.png",
+        alt="",
+        width="601",
+        height="370",
+        hi_def=True,
+        loading="auto"
         ) | safe
       }}
     </div>
   </div>
-  <div class="row">
-    <div class="col-12">
-      <form action="/download/server" method="post" style="display: inline">
-        <input type="hidden" name="next-step" value="server">
-        <button type="submit" class="p-button" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Server download', 'eventAction' : 'Previous option', 'eventLabel' : 'Option 1', 'eventValue' : undefined });">
-          Option 1 - Manual server installation
-        </button>
-      </form>
-      <form action="/download/server" method="post" style="display: inline">
-        <input type="hidden" name="next-step" value="multipass">
-        <button type="submit" class="p-button is-inline" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Server download', 'eventAction' : 'Next option', 'eventLabel' : 'Option 2', 'eventValue' : undefined });">
-          Option 2 - Instant Ubuntu VMs
-        </button>
-      </form>
-      <button disabled class="p-button u-no-margin--top is-inline">
-        Option 3 - Automated server provisioning
-      </button>
-    </div>
-  </div>
 </section>
-
-{% with first_item="_download_server_installation", second_item="_download_server_guide", third_item="_download_helping_hands" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
-
-{% endblock content %}

--- a/templates/download/server/choose.html
+++ b/templates/download/server/choose.html
@@ -14,12 +14,12 @@
       <a href="https://maas.io" class="p-button--positive">Get MAAS</a>
       {{ 
         image (
-        url="https://assets.ubuntu.com/v1/56548950-image 1.png",
+        url="https://assets.ubuntu.com/v1/a89f3311-maas-2024.png",
         alt="",
-        width="601",
-        height="370",
+        width="1280",
+        height="720",
         hi_def=True,
-        loading="auto"
+        loading="lazy"
         ) | safe
       }}
     </div>

--- a/templates/download/server/choose.html
+++ b/templates/download/server/choose.html
@@ -2,7 +2,7 @@
 <section class="p-tabs__content p-section" id="automated-provisioning" role="tabpanel" aria-labelledby="automated-provisioning-tab">
   <div class="row--50-50">
     <div class="col">
-      <h2>Provisioning machines with Ubuntu Server in a fully automated way with MAAS</h2>
+      <h2>Provision machines with Ubuntu Server in a fully automated way with MAAS</h2>
     </div>
     <div class="col">
       <ul class="p-list--divided u-no-margin--bottom">

--- a/templates/download/server/download.html
+++ b/templates/download/server/download.html
@@ -84,7 +84,7 @@
       </div>
       <div class="col-3 col-medium-2">
         <h3 class="p-heading--5"><a href="https://discourse.ubuntu.com/">Community Discourse</a></h3>
-        <p>Discuss with Ubuntu developers and make your voice heard.</p>
+        <p>Join the Ubuntu developers community and make your voice heard.</p>
       </div>  
      </div> 
     </div>

--- a/templates/download/server/download.html
+++ b/templates/download/server/download.html
@@ -1,0 +1,261 @@
+{% extends "download/_base_download.html" %}
+
+{% block title %}Thank you for downloading Ubuntu Server{% endblock %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1S5zY7HN_Q8eQWch0mCEfLICfj8pW1bct9_wGArCNIqc/edit{% endblock meta_copydoc %}
+
+{% block body_class %}is-paper{% endblock body_class %}
+
+{% block head_extra %}
+  <meta name="robots" content="noindex" />
+{% endblock %}
+
+{% block content %}
+<noscript>
+  <meta
+    http-equiv="refresh"
+    content="3;url=https://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-live-server-amd64.iso"
+  />
+</noscript>
+
+<section class="p-strip is-shallow u-no-padding--bottom">
+  <div class="row--50-50">
+    <div class="col">
+      <h1 class="js-download-option">Thank you for downloading Ubuntu Server {{ version }}</h1>
+      <p>Your download should start in the background. If it doesn't,
+        <a href="https://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-live-server-amd64.iso">download&nbsp;now</a>.<br />
+        {% with version=version, system="live-server", architecture="amd64" %}
+          {% include "download/shared/_verify-checksums.html" %}
+        {% endwith %}
+      </p>
+    </div>
+    <div class="col">
+      {% include 'shared/_server-download-newsletter.html' %}
+    </div>
+  </div>
+</section>
+
+{% include 'download/shared/_server_weekly_news.html' %}
+
+<section class="p-section">
+  <hr class="p-rule is-fixed-width" />
+  <div class="row--50-50">
+    <div class="col">
+      <h2>Ubuntu CLI cheatsheet</h2>
+      <div class="p-section--shallow">
+        <p>Learn how to use the command line efficiently and get started with DevOps &mdash; from basic file management to LXD virtualisation and Ubuntu Pro.</p>
+      </div>
+      <button class="p-button--positive" onclick="toggleModal()">Download the CLI cheat sheet</button>
+    </div>
+    <div class="col">
+      <div class="p-section--shallow p-image-wrapper">
+        {{
+          image (
+          url="https://assets.ubuntu.com/v1/639c1f12-server-cli-cheatsheet.png",
+          alt="CLI cheat sheet",
+          width="1200",
+          height="849",
+          hi_def=True,
+          loading="auto"
+          ) | safe
+        }}
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="p-section">
+  <hr class="p-rule is-fixed-width" />
+  <div class="row">
+    <div class="col-3 col-medium-2">
+      <div class="p-section">
+        <h2 class="p-muted-heading">Resources</h2>
+      </div>
+    </div>
+    <div class="col-9">
+     <div class="row">
+      <div class="col-3 col-medium-2">
+        <h3 class="p-heading--5"><a href="/server/docs">Ubuntu Server documentation</a></h3>
+        <p>The Ubuntu Server documentation, curated by community and Ubuntu developers.</p>
+      </div>
+      <div class="col-3 col-medium-2">
+        <h3 class="p-heading--5"><a href="https://askubuntu.com/">Ask Ubuntu</a></h3>
+        <p>Stuck somewhere? Get your Ubuntu questions answered by power users.</p>
+      </div>
+      <div class="col-3 col-medium-2">
+        <h3 class="p-heading--5"><a href="https://discourse.ubuntu.com/">Community Discourse</a></h3>
+        <p>Discuss with Ubuntu developers and make your voice heard.</p>
+      </div>  
+     </div> 
+    </div>
+  </div>
+</section>
+
+{% include 'shared/_download-ubuntu-thank-you-pro-section.html' %}
+
+<section class="p-section">
+  <div class="p-section--shallow u-fixed-width">
+    <hr class="p-rule" />
+    <h2 class="p-muted-heading">More from Canonical</h2>
+  </div>
+  <div class="row">
+    <div class="col-3 col-medium-6">
+      <div class="row">
+        <div class="col-6 col-medium-2">
+          <h3>
+            <a href="https://maas.io/?_gl=1*1y3394w*_gcl_au*Mzg2MjE3ODk3LjE3MDI0NjY1NDY.&_ga=2.256850242.873815666.1709630805-805571671.1709630804">
+              {{
+                image (
+                url="https://assets.ubuntu.com/v1/d3039f38-MAAS-logo.svg",
+                alt="MAAS",
+                width="104",
+                height="42",
+                hi_def=True,
+                loading="auto"
+                ) | safe
+              }}
+            </a>
+          </h3>
+        </div>
+        <div class="col-6 col-medium-4">
+          <p>Build a bare metal cloud with super fast server provisioning.</p>
+          <hr class="p-rule" />
+          <p>
+            <a href="https://maas.io/">Learn more about MAAS&nbsp;&rsaquo;</a>
+          </p>
+        </div>
+      </div>
+    </div>
+    <div class="col-3 col-medium-6">
+      <div class="row">
+        <div class="col-6 col-medium-2">
+          <h3>
+            <a href="https://canonical.com/lxd">
+              {{
+                image (
+                  url="https://assets.ubuntu.com/v1/84ed7eb1-LXD-logo.svg",
+                  alt="LXD",
+                  width="80",
+                  height="42",
+                  hi_def=True,
+                  loading="auto"
+                ) | safe
+              }}
+            </a>
+          </h3>
+        </div>
+        <div class="col-6 col-medium-4">
+          <p>Fast, dense, and secure container and VM management at any scale.</p>
+          <hr class="p-rule" />
+          <p>
+            <a href="https://canonical.com/lxd">Learn more about LXD&nbsp;&rsaquo;</a>
+          </p>
+        </div>
+      </div>
+    </div>
+    <div class="col-3 col-medium-6">
+      <div class="row">
+        <div class="col-6 col-medium-2">
+          <h3>
+            <a href="https://juju.is/">
+            {{
+              image (
+                url="https://assets.ubuntu.com/v1/35f593dd-Juju-logo.svg",
+                alt="Juju",
+                width="79",
+                height="42",
+                hi_def=True,
+                loading="auto"
+              ) | safe
+            }}
+            </a>
+          </h3>
+        </div>
+        <div class="col-6 col-medium-4">
+          <p>Design and deploy entire workloads in just a few clicks.</p>
+          <hr class="p-rule" />
+          <p>
+            <a href="https://juju.is/">Learn more about Juju&nbsp;&rsaquo;</a>
+          </p>
+        </div>
+      </div>
+    </div>
+    <div class="col-3 col-medium-6">
+      <div class="row">
+        <div class="col-6 col-medium-2">
+          <h3>
+            <a href="https://multipass.run/">
+            {{
+              image (
+                url="https://assets.ubuntu.com/v1/ede1a596-Multipass-logo.svg",
+                alt="Multipass",
+                width="141",
+                height="42",
+                hi_def=True,
+                loading="auto"
+              ) | safe
+            }}
+            </a>
+          </h3>
+        </div>
+        <div class="col-6 col-medium-4">
+          <p>Spin up Ubuntu VMs on Windows, Mac and Linux.</p>
+          <hr class="p-rule" />
+          <p>
+            <a href="https://multipass.run/">Learn more about Multipass&nbsp;&rsaquo;</a>
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="p-section--deep">
+  <div class="row">
+    <hr class="p-rule"/>
+    <div class="col-3 col-medium-6">
+      <div class="p-section--shallow">
+        <h2 class="p-text--small-caps"><a href="/blog/tag/ubuntu-server">Latest from&nbsp;our&nbsp;blog&nbsp;&rsaquo;</a></h2>
+      </div>
+    </div>
+    <div class="col-9 col-medium-6">
+      <div class="row p-section--shallow" id="ubuntu-server-latest">
+      </div>
+    </div>
+  </div>
+
+  <template style="display:none" id="ubuntu-server-template">
+    <div class="col-3 col-medium-2">
+      <h3 class="p-heading--5"><a class="article-link article-title"></a></h3>
+      <p class="article-excerpt"></p>
+    </div>
+  </template>
+</section>
+
+<script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
+<script>
+  canonicalLatestNews.fetchLatestNews(
+    {
+      articlesContainerSelector: "#ubuntu-server-latest",
+      articleTemplateSelector: "#ubuntu-server-template",
+      excerptLength: 200,
+      tagId: 1610,
+      limit: 3
+    }
+  )
+</script>
+
+{% endblock content %}
+
+{% block footer_extra %}
+<script src="{{ versioned_static('js/dist/image-download.js') }}"></script>
+
+<script defer>
+  var version = '{{ version }}';
+
+  var GAlabel = version + '-server-amd64';
+  var imagePath = version + '/ubuntu-' + version + '-live-server-amd64.iso';
+
+  window.initImageDownload(imagePath, GAlabel);
+</script>
+{% endblock footer_extra %}

--- a/templates/download/server/manual.html
+++ b/templates/download/server/manual.html
@@ -20,7 +20,7 @@
     <nav class="p-tabs">
       <ul class="p-tabs__list js-tabbed-content u-no-margin--bottom" role="tablist" data-maintain-hash="true">
         <li class="p-tabs__item">
-          <a class="p-tabs__link" role="tab" aria-selected="true" id="manual-install-tab" href="#manual-install" aria-controls="manual-install">Manual install</a>
+          <a class="p-tabs__link" role="tab" aria-selected="true" id="manual-install-tab" href="#manual-install" aria-controls="manual-install">Manual installation</a>
         </li>
         <li class="p-tabs__item">
           <a class="p-tabs__link" role="tab" aria-selected="false" id="instant-vms-tab" href="#instant-vms" aria-controls="instant-vms" tabindex="-1">Instant VMs</a>
@@ -55,14 +55,12 @@
       <div class="p-section--shallow">
         <p>The latest <abbr title="Long-term support">LTS</abbr> version of Ubuntu Server. LTS stands for long-term support &mdash; which means five years of free security and maintenance updates, extended to 10 years with <a href="/pro">Ubuntu Pro</a>.</p>
         <hr />
-        <form action="/download/server" method="post" style="display: inline">
-          <input type="hidden" name="version" value="{{ releases.lts.full_version }}">
-          <input type="hidden" name="architecture" value="amd64">
-          <input type="hidden" name="next-step" value="download">
-          <button style="margin-right: 1rem;" type="submit" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Server download', 'eventAction' : 'Select option', 'eventLabel' : '{{ releases.lts.full_version }}', 'eventValue' : undefined });">Download {{ releases.lts.full_version }} LTS</button>
-        </form>
+        <a class="p-button--positive"
+          href="/download/server/thank-you?version={{ releases.lts.full_version }}&amp;architecture=amd64"
+          onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Server download', 'eventAction' : 'Select option', 'eventLabel' : '{{ releases.lts.full_version }}', 'eventValue' : undefined });">Download {{ releases.lts.full_version }} LTS
+        </a>
         <span class="u-text--muted">ISO image{% if releases.lts.iso_download_size %}, {{ releases.lts.iso_download_size }}{% endif %}</span>
-        <p><a href="#downloads">Alternative downloads&nbsp;&rsaquo;</a></p>
+        <p><a href="/download/alternative-downloads">Alternative downloads&nbsp;&rsaquo;</a></p>
         <p><a href="#architectures">Alternative architectures&nbsp;&rsaquo;</a></p>
       </div>
 
@@ -70,7 +68,7 @@
         <nav class="p-tabs">
           <ul class="p-tabs__list js-tabbed-content u-no-margin--bottom" role="tablist" data-maintain-hash="true">
             <li class="p-tabs__item">
-              <a class="p-tabs__link" role="tab" aria-selected="true" id="release-notes-tab" href="#release-notes" aria-controls="release-notes">Release notes</a>
+              <a class="p-tabs__link" role="tab" aria-selected="true" id="release-notes-tab" href="#release-notes" aria-controls="release-notes">What's new</a>
             </li>
             <li class="p-tabs__item">
               <a class="p-tabs__link" role="tab" aria-selected="false" id="system-requirements-tab" href="#system-requirements" aria-controls="system-requirements" tabindex="-1">System requirements</a>
@@ -93,7 +91,7 @@
         </ul>
         <hr class="p-rule" />
         <p>
-          <a href="https://discourse.ubuntu.com/t/jammy-jellyfish-release-notes/24668">Full {{ releases.lts.full_version }} release notes&nbsp;&rsaquo;</a>
+          <a href="https://discourse.ubuntu.com/t/jammy-jellyfish-release-notes/24668">Full {{ releases.lts.short_version }} release notes&nbsp;&rsaquo;</a>
         </p>
       </div>
 
@@ -129,30 +127,28 @@
       <div class="col">
         <p>The latest version of Ubuntu Server, including nine months of security and maintenance updates, until July 2024.</p>
         <hr />
-        <form action="/download/server" method="post" style="display: inline">
-          <input type="hidden" name="version" value="{{ releases.latest.full_version }}">
-          <input type="hidden" name="architecture" value="amd64">
-          <input type="hidden" name="next-step" value="download">
-          <button style="margin-right: 1rem;" type="submit" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Server download', 'eventAction' : 'Select option', 'eventLabel' : '{{ releases.latest.full_version }}', 'eventValue' : undefined });">Download {{ releases.latest.full_version }}</button>
-        </form>
-        <span class="u-text--muted">ISO image, {{ releases.lts.iso_download_size }}</span>
+        <a class="p-button--positive"
+        href="/download/server/thank-you?version={{ releases.latest.full_version }}&amp;architecture=amd64"
+        onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Server download', 'eventAction' : 'Select option', 'eventLabel' : '{{ releases.latest.full_version }}', 'eventValue' : undefined });">Download {{ releases.latest.full_version }}
+        </a>
+        <span class="u-text--muted">ISO image{% if releases.latest.iso_download_size %}, {{ releases.latest.iso_download_size }} {% endif %}</span>
         <p><a href="https://discourse.ubuntu.com/t/mantic-minotaur-release-notes/35534">Read the 23.10 release notes&nbsp;&rsaquo;</a></p>
       </div>
     </div>
   </section>
   
   <section class="p-section">
-    <div class="row--25-75">
+    <div class="row">
       <hr class="p-rule" />
-      <div class="col">
+      <div class="col-3 p-section--shallow">
         <h3 class="p-text--small-caps">Alternative downloads</h3>
       </div>
-      <div class="col">
+      <div class="col-9 col-medium-6">
         <div class="row p-section--shallow">
-          <div class="col-3">
+          <div class="col-3 col-medium-3">
             <h4 class="p-heading--5">BitTorrent</h4>
           </div>
-          <div class="col-6">
+          <div class="col-6 col-medium-3">
             <p>BitTorrent sometimes enables higher download speeds and more reliable downloads of large files.</p>
             <hr />
             <a class="p-button" href="https://releases.ubuntu.com/{{ releases.lts.short_version }}/ubuntu-{{ releases.lts.full_version }}-live-server-amd64.iso.torrent">Torrent for {{ releases.lts.full_version }} LTS</a>
@@ -161,10 +157,10 @@
         </div>
         <hr />
         <div class="row p-section--shallow">
-          <div class="col-3">
+          <div class="col-3 col-medium-3">
             <h4 class="p-heading--5">Ubuntu Server {{ releases.previous_lts.short_version }} LTS</h4>
           </div>
-          <div class="col-6">
+          <div class="col-6 col-medium-3">
             <p>The previous long-term support version of Ubuntu Server, including support guaranteed until April 2025.</p>
             <hr />
             <form action="/download/server" method="post" style="display: inline">
@@ -177,13 +173,67 @@
         </div>
         <hr />
         <div class="row p-section--shallow">
-          <div class="col-3">
+          <div class="col-3 col-medium-3">
             <h4 class="p-heading--5">
               <a href="/download/alternative-downloads">Other versions&nbsp;&rsaquo;</a>
             </h4>
           </div>
-          <div class="col-6">
+          <div class="col-6 col-medium-3">
             <p>Other versions of Ubuntu Server including torrents, the network installer, a list of local mirrors and past releases.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section" id="architectures" style="scroll-margin-top: 3.4rem;">
+    <div class="row">
+      <hr class="p-rule" />
+      <div class="col-3 p-section--shallow">
+        <h3 class="p-text--small-caps">Alternative architectures</h3>
+      </div>
+      <div class="col-9 col-medium-6">
+        <div class="row p-section--shallow">
+          <div class="col-3 col-medium-3">
+            <h4 class="p-heading--5">
+              <a href="/download/server/arm">ARM&nbsp;&rsaquo;</a>
+            </h4>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>Optimised for hyperscale deployments and certified on ARM chipsets &mdash; Ubuntu Server for ARM includes the 64-bit ARMv7 and ARMv8 platforms.</p>
+          </div>
+        </div>
+        <hr />
+        <div class="row p-section--shallow">
+          <div class="col-3 col-medium-3">
+            <h4 class="p-heading--5">
+              <a href="/download/server/power">IBM POWER&nbsp;&rsaquo;</a>
+            </h4>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>Ubuntu is available on the IBM POWER platform, bringing the entire Ubuntu ecosystem to IBM POWER.</p>
+          </div>
+        </div>
+        <hr />
+        <div class="row p-section--shallow">
+          <div class="col-3 col-medium-3">
+            <h4 class="p-heading--5">
+              <a href="/download/server/s390x">IBM Z (s390x)&nbsp;&rsaquo;</a>
+            </h4>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>IBM Z and LinuxONE leverage open technology solutions to meet the demands of the new application economy. Ubuntu is now available on those platforms with Multipass, MicroK8s and more.</p>
+          </div>
+        </div>
+        <hr />
+        <div class="row p-section--shallow">
+          <div class="col-3 col-medium-3">
+            <h4 class="p-heading--5">
+              <a href="/download/server/s390x">RISC-V&nbsp;&rsaquo;</a>
+            </h4>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>Ubuntu &mdash; now available for multiple RISC-V platforms to accelerate innovation.</p>
           </div>
         </div>
       </div>

--- a/templates/download/server/manual.html
+++ b/templates/download/server/manual.html
@@ -61,7 +61,7 @@
           <input type="hidden" name="next-step" value="download">
           <button style="margin-right: 1rem;" type="submit" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Server download', 'eventAction' : 'Select option', 'eventLabel' : '{{ releases.lts.full_version }}', 'eventValue' : undefined });">Download {{ releases.lts.full_version }} LTS</button>
         </form>
-        <span class="u-text--muted">ISO image, {% if releases.lts.iso_download_size %}{{ releases.lts.iso_download_size }}{% endif %}</span>
+        <span class="u-text--muted">ISO image{% if releases.lts.iso_download_size %}, {{ releases.lts.iso_download_size }}{% endif %}</span>
         <p><a href="#downloads">Alternative downloads&nbsp;&rsaquo;</a></p>
         <p><a href="#architectures">Alternative architectures&nbsp;&rsaquo;</a></p>
       </div>

--- a/templates/download/server/manual.html
+++ b/templates/download/server/manual.html
@@ -59,7 +59,7 @@
           href="/download/server/thank-you?version={{ releases.lts.full_version }}&amp;architecture=amd64"
           onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Server download', 'eventAction' : 'Select option', 'eventLabel' : '{{ releases.lts.full_version }}', 'eventValue' : undefined });">Download {{ releases.lts.full_version }} LTS
         </a>
-        <span class="u-text--muted">ISO image{% if releases.lts.iso_download_size %}, {{ releases.lts.iso_download_size }}{% endif %}</span>
+        <span class="u-text--muted">ISO image, 2GB</span>
         <p><a href="/download/alternative-downloads">Alternative downloads&nbsp;&rsaquo;</a></p>
         <p><a href="#architectures">Alternative architectures&nbsp;&rsaquo;</a></p>
       </div>
@@ -131,7 +131,7 @@
         href="/download/server/thank-you?version={{ releases.latest.full_version }}&amp;architecture=amd64"
         onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Server download', 'eventAction' : 'Select option', 'eventLabel' : '{{ releases.latest.full_version }}', 'eventValue' : undefined });">Download {{ releases.latest.full_version }}
         </a>
-        <span class="u-text--muted">ISO image{% if releases.latest.iso_download_size %}, {{ releases.latest.iso_download_size }} {% endif %}</span>
+        <span class="u-text--muted">ISO image, 2.5GB</span>
         <p><a href="https://discourse.ubuntu.com/t/mantic-minotaur-release-notes/35534">Read the 23.10 release notes&nbsp;&rsaquo;</a></p>
       </div>
     </div>
@@ -436,15 +436,37 @@
         ".p-tabs__link[href='" + currentHash + "']"
       );
     const targetIds = ["release-notes", "system-requirements", "how-to-install"];
-    const targetControl = activeTab.getAttribute("aria-controls")
 
-    if (targetIds.includes(targetControl)) {
-      indexTab = document.getElementById("manual-install")
-      indexTab.classList.remove("u-hide")
+    if (activeTab) {
+      const targetControl = activeTab.getAttribute("aria-controls")
+  
+      if (targetIds.includes(targetControl)) {
+        indexTab = document.getElementById("manual-install")
+        indexTab.classList.remove("u-hide")
+      }
+    }
+  }
+
+  // Prevents non-tab hash links from hiding the tab content
+  function handleNonTabHashClick () {
+    const currentHash = window.location.hash;
+    const activeTab = document.querySelector(
+        ".p-tabs__link[href='#release-notes']"
+      );
+    const targetControl = activeTab.getAttribute("aria-controls")
+    const tabContentContainers = document.querySelectorAll(".p-tabs__content");
+
+    if (currentHash && currentHash == "#architectures") {
+      tabContentContainers.forEach(container => {
+        if (container.id !== targetControl && container.id !== "manual-install") {
+          container.classList.add("u-hide")
+        }
+      })
     }
   }
 
   addEventListener("DOMContentLoaded", () => {
+    handleNonTabHashClick()
     showParentTab()
   });
   

--- a/templates/download/server/manual.html
+++ b/templates/download/server/manual.html
@@ -1,204 +1,382 @@
 {% extends "download/_base_download.html" %}
 
-{% block title %}Get Ubuntu Server | Download{% endblock %}
+{% block title %}Get Ubuntu Server{% endblock %}
+
 {% block meta_description %}Get Ubuntu Server one of three ways; by using Multipass on your desktop, using MAAS to provision machines in your data centre or installing it directly on a server.{% endblock meta_description %}
+
 {% block meta_copydoc %}https://docs.google.com/document/d/1Qob4Ni_y1ffIdSWqaw2xH0dxiHZQmkRGP5nuoBhIfyM/edit{% endblock meta_copydoc %}
+
+{% block body_class %}is-paper{% endblock body_class %}
 
 {% block content %}
 
-<section class="p-strip--suru-topped">
-  <div class="row u-equal-height">
-    <div class="col-7">
-      <h1>Get Ubuntu Server</h1>
-      <h2 class="js-download-option">
-        Option 1: Manual server installation
-      </h2>
-      <p>
-        USB or DVD image based physical install
-      </p>
-      <ul class="p-list">
-        <li class="p-list__item is-ticked">OS security guaranteed until April 2027</li>
-        <li class="p-list__item is-ticked">Expanded security maintenance until April 2032</li>
-        <li class="p-list__item is-ticked">Commercial support for enterprise customers</li>
-      </ul>
-    </div>
-    <div class="col-4 col-start-large-8 u-hide--medium u-hide--small u-align--center u-vertically-center">
-      {{ image (
-        url="https://assets.ubuntu.com/v1/b743f1ee-jj-in-circle.png",
-        alt="",
-        width="250",
-        height="250",
-        hi_def=True,
-        loading="auto"
-        ) | safe
-      }}
-    </div>
+<section class="p-strip is-shallow u-no-margin--bottom">
+  <div class=" p-section u-fixed-width">
+    <h1>Get Ubuntu Server</h1>
   </div>
-  <div class="row">
-    <div class="col-12">
-      <ul class="p-inline-list u-no-margin--bottom">
-        <li class="p-inline-list__item">
-          <a class="p-button--positive"
-          href="/download/server/thank-you?version={{ releases.lts.full_version }}&amp;architecture=amd64"
-          onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Server download', 'eventAction' : 'Select option', 'eventLabel' : '{{ releases.lts.full_version }}', 'eventValue' : undefined });">Download Ubuntu Server {{ releases.lts.full_version }} LTS</a>
-        </li>
-        <li class="p-inline-list__item"><a href="#downloads">Alternative downloads&nbsp;&rsaquo;</a></li>
-        <li class="p-inline-list__item"><a href="#architectures">Alternative architectures&nbsp;&rsaquo;</a></li>
-      </ul>
-      <p class="u-sv3">
-        <a href="{{ releases.lts.release_notes_url }}">
-          Read the Ubuntu Server {{ releases.lts.short_version }} LTS release notes&nbsp;&rsaquo;
-        </a>
-      </p>
-    </div>
-
-  </div>
-  <div class="row">
-    <div class="col-12" style="display:flex; flex-wrap: wrap;">
-      <button disabled class="p-button">
-        Option 1 - Manual server installation
-      </button>
-      <form action="/download/server" method="post">
-        <input type="hidden" name="next-step" value="multipass">
-        <button type="submit" class="p-button" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Server download', 'eventAction' : 'Next option', 'eventLabel' : 'Option 2', 'eventValue' : undefined });" style="margin-right: 1rem">
-          Option 2 - Instant Ubuntu VMs
-        </button>
-      </form>
-      <form action="/download/server" method="post">
-        <input type="hidden" name="next-step" value="choose">
-        <button type="submit" class="p-button" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Server download', 'eventAction' : 'Next option', 'eventLabel' : 'Option 3', 'eventValue' : undefined });">
-          Option 3 - Automated server provisioning
-        </button>
-      </form>
-    </div>
-  </div>
-  {% if releases.latest.short_version > releases.lts.short_version %}
-  <div class="p-strip is-shallow">
-    <div class="u-fixed-width">
-      <hr>
-    </div>
-  </div>
-  <div class="row u-equal-height" id="releases">
-    <div class="col-6">
-      <h2>Alternative releases</h2>
-      <h3>
-        Ubuntu Server {{ releases.latest.full_version }}
-      </h3>
-      <p>
-        The latest version of Ubuntu Server, including nine months of security and maintenance updates, until {{ releases.latest.eol }}.
-      </p>
-      <a class="p-button--positive"
-        href="/download/server/thank-you?version={{ releases.latest.full_version }}&amp;architecture=amd64"
-        onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Server download', 'eventAction' : 'Select option', 'eventLabel' : '{{ releases.latest.full_version }}', 'eventValue' : undefined });">Download Ubuntu Server {{ releases.latest.full_version }}</a>
-      <p>
-        <a href="{{ releases.latest.release_notes_url }}">
-          Read the Ubuntu Server {{ releases.latest.short_version }} release notes&nbsp;&rsaquo;
-        </a>
-      </p>
-    </div>
-    <div class="col-4 col-start-large-8 u-hide--medium u-hide--small u-align--center u-vertically-center">
-      {{ image (
-        url="https://assets.ubuntu.com/v1/57a36cad-Minotaur_circular.png",
-        alt="",
-        width="260",
-        height="260",
-        hi_def=True,
-        loading="lazy"
-        ) | safe
-      }}
-    </div>
-  </div>
-  {% endif %}
 </section>
-
-<section class="p-strip--light u-no-padding--bottom" id="downloads">
-  <div class="row">
-    <div class="col-10">
-      <h2>Alternative downloads</h2>
-    </div>
-  </div>
-  <div class="row u-equal-height">
-    <div class="col-4 p-card">
-      <h3 class="p-card__title">BitTorrents</h3>
-      <p>BitTorrent sometimes enables higher download speeds and more reliable downloads of large files.</p>
-      <ul class="p-list u-no-margin--bottom">
-        <li class="p-list__item">
-          <a class="download-torrent p-button u-no-margin--bottom" href="https://releases.ubuntu.com/{{ releases.lts.short_version }}/ubuntu-{{ releases.lts.full_version }}-live-server-amd64.iso.torrent">
-            Ubuntu Server {{ releases.lts.full_version }} LTS
-          </a>
+<section class="p-section--shallow">
+  <div class="js-tab-container u-fixed-width">
+    <nav class="p-tabs">
+      <ul class="p-tabs__list js-tabbed-content u-no-margin--bottom" role="tablist" data-maintain-hash="true">
+        <li class="p-tabs__item">
+          <a class="p-tabs__link" role="tab" aria-selected="true" id="manual-install-tab" href="#manual-install" aria-controls="manual-install">Manual Install</a>
         </li>
-        <li class="p-list__item">
-          <a class="download-torrent p-button u-no-margin--bottom" href="https://releases.ubuntu.com/{{ releases.latest.short_version }}/ubuntu-{{ releases.latest.full_version }}-live-server-amd64.iso.torrent">
-            Ubuntu Server {{ releases.latest.full_version }}
-          </a>
+        <li class="p-tabs__item">
+          <a class="p-tabs__link" role="tab" aria-selected="false" id="instant-vms-tab" href="#instant-vms" aria-controls="instant-vms" tabindex="-1">Instant VMs</a>
+        </li>
+        <li class="p-tabs__item">
+          <a class="p-tabs__link" role="tab" aria-selected="false" id="automated-provisioning-tab" href="#automated-provisioning" aria-controls="automated-provisioning" tabindex="-1">Automated provisioning</a>
         </li>
       </ul>
-    </div>
-    <div class="col-4 p-card">
-      <h3 class="p-card__title">
-        Ubuntu Server {{ releases.previous_lts.short_version }} LTS
-      </h3>
-      <p>
-        The previous long-term support version of Ubuntu Server, including support guaranteed until {{ releases.previous_lts.eol }}.
-      </p>
-      <a class="p-button"
-        href="/download/server/thank-you?version={{ releases.previous_lts.full_version }}&amp;architecture=amd64"
-        onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Server download', 'eventAction' : 'Select option', 'eventLabel' : '{{ releases.previous_lts.full_version }}', 'eventValue' : undefined });">Get Ubuntu Server {{ releases.previous_lts.full_version }} LTS</a>
-    </div>
-    <div class="col-4 p-card">
-      <h3 class="p-card__title">Other versions</h3>
-      <p>Other versions of Ubuntu Server including torrents, the network installer, a list of local mirrors and past releases.</p>
-      <p><a href="/download/alternative-downloads">See alternative downloads&nbsp;&rsaquo;</a></p>
-    </div>
+    </nav>
   </div>
 </section>
 
-<section class="p-strip--light" id="architectures">
-  <div class="row">
-    <div class="col-10">
-      <h2>Alternative architectures</h2>
+<section class="p-tabs__content p-section" id="manual-install" role="tabpanel" aria-labelledby="manual-install-tab">
+  <div class="row--50-50">
+    <div class="col">
+      <h2>Ubuntu {{ releases.lts.full_version }} LTS</h2>
+      <div class="p-image-wrapper">
+        {{ image (
+          url="https://assets.ubuntu.com/v1/b743f1ee-jj-in-circle.png",
+          alt="",
+          width="200",
+          height="200",
+          hi_def=True,
+          loading="auto"
+          ) | safe
+        }}
+      </div>
+    </div>
+    <div class="col">
+      <div class="p-section--shallow">
+        <p>The latest <abbr title="Long-term support">LTS</abbr> version of Ubuntu Server. LTS stands for long-term support &mdash; which means five years of free security and maintenance updates, extended to 10 years with <a href="/pro">Ubuntu Pro</a>.</p>
+        <hr />
+        <form action="/download/server" method="post" style="display: inline">
+          <input type="hidden" name="version" value="{{ releases.lts.full_version }}">
+          <input type="hidden" name="architecture" value="amd64">
+          <input type="hidden" name="next-step" value="download">
+          <button style="margin-right: 1rem;" type="submit" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Server download', 'eventAction' : 'Select option', 'eventLabel' : '{{ releases.lts.full_version }}', 'eventValue' : undefined });">Download {{ releases.lts.full_version }} LTS</button>
+        </form>
+        <span class="u-text--muted">ISO image, {{ releases.lts.iso_download_size }}</span>
+        <p><a href="#downloads">Alternative downloads&nbsp;&rsaquo;</a></p>
+        <p><a href="#architectures">Alternative architectures&nbsp;&rsaquo;</a></p>
+      </div>
+
+      <div class="js-tab-container">
+        <nav class="p-tabs">
+          <ul class="p-tabs__list js-tabbed-content u-no-margin--bottom" role="tablist" data-maintain-hash="true">
+            <li class="p-tabs__item">
+              <a class="p-tabs__link" role="tab" aria-selected="true" id="release-notes-tab" href="#release-notes" aria-controls="release-notes">Release notes</a>
+            </li>
+            <li class="p-tabs__item">
+              <a class="p-tabs__link" role="tab" aria-selected="false" id="system-requirements-tab" href="#system-requirements" aria-controls="system-requirements" tabindex="-1">System requirements</a>
+            </li>
+            <li class="p-tabs__item">
+              <a class="p-tabs__link" role="tab" aria-selected="false" id="how-to-install-tab" href="#how-to-install" aria-controls="how-to-install" tabindex="-1">How to install</a>
+            </li>
+          </ul>
+        </nav>
+      </div>
+
+      <div class="p-tabs__content" id="release-notes" role="tabpanel" aria-labelledby="release-notes-tab">
+        <ul class="p-list--divided">
+          <li class="p-list__item is-ticked">OpenSSL 3.0 for modern, general-purpose cryptography and secure communication</li>
+          <li class="p-list__item is-ticked">Native host and guest drivers for NVIDIA virtual GPU (vGPU) software 14</li>
+          <li class="p-list__item is-ticked">Network acceleration improvements with SmartNIC support in Netplan</li>
+          <li class="p-list__item is-ticked">General support for GlusterFS, FRRouting and realmd/adcli under the Ubuntu main component</li>
+          <li class="p-list__item is-ticked">Linux 5.15 kernel for the recent hardware and security updates</li>
+          <li class="p-list__item is-ticked">Updates to QEMU, libvirt, PHP, Ruby, GCC, Python, MySQL, OpenLDAP, Samba</li>
+        </ul>
+        <hr class="p-rule" />
+        <p>
+          <a href="https://discourse.ubuntu.com/t/jammy-jellyfish-release-notes/24668">Full {{ releases.lts.full_version }} release notes </a>
+        </p>
+      </div>
+
+      <div class="p-tabs__content" id="system-requirements" role="tabpanel" aria-labelledby="system-requirements-tab">
+        <ul class="p-list--divided">
+          <li class="p-list__item is-ticked">1 GHz processor or better</li>
+          <li class="p-list__item is-ticked">1 GB system memory</li>
+          <li class="p-list__item is-ticked">2.5 GB of free hard drive space</li>
+          <li class="p-list__item is-ticked">Either a USB port or a DVD drive for the installer media</li>
+        </ul>
+      </div>
+
+      <div class="p-tabs__content" id="how-to-install" role="tabpanel" aria-labelledby="how-to-install-tab">
+        <p>To install Ubuntu Server:</p>
+        <ol class="p-list--divided">
+          <li class="p-list__item">Download the ISO image</li>
+          <li class="p-list__item">Create a bootable USB flash drive with <a href="https://etcher.balena.io/">balenaEtcher</a> or similar</li>
+          <li class="p-list__item">Boot from the USB flash drive</li>
+        </ol>
+        <hr class="p-rule" />
+        <p>
+          <a href="/tutorials/install-ubuntu-server">Follow the step-by-step tutorial&nbsp;&rsaquo;</a>
+        </p>
+      </div>
     </div>
   </div>
-  <div class="row u-equal-height">
-    <div class="col-3 p-card">
-      <h3 class="p-card__title">Ubuntu Server for ARM</h3>
-      <p>
-        Optimised for hyperscale deployments and certified on ARM chipsets &mdash; Ubuntu Server for ARM includes the 64-bit ARMv7 and ARMv8 platforms.
-      </p>
-      <p>
-        <a href="/download/server/arm">Get Ubuntu Server for ARM&nbsp;&rsaquo;</a>
-      </p>
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr />
+      <div class="col">
+        <h2>Ubuntu {{ releases.latest.full_version }}</h2>
+      </div>
+      <div class="col">
+        <p>The latest version of Ubuntu Server, including nine months of security and maintenance updates, until July 2024.</p>
+        <hr />
+        <form action="/download/server" method="post" style="display: inline">
+          <input type="hidden" name="version" value="{{ releases.latest.full_version }}">
+          <input type="hidden" name="architecture" value="amd64">
+          <input type="hidden" name="next-step" value="download">
+          <button style="margin-right: 1rem;" type="submit" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Server download', 'eventAction' : 'Select option', 'eventLabel' : '{{ releases.latest.full_version }}', 'eventValue' : undefined });">Download {{ releases.latest.full_version }}</button>
+        </form>
+        <span class="u-text--muted">ISO image, {{ releases.lts.iso_download_size }}</span>
+        <p><a href="/download/alternative-download">Read the 23.10 release notes&nbsp;&rsaquo;</a></p>
+      </div>
     </div>
-    <div class="col-3 p-card">
-      <h3 class="p-card__title">Ubuntu for POWER</h3>
-      <p>
-        Ubuntu is available on the IBM POWER platform, bringing the entire Ubuntu ecosystem to IBM POWER.
-      </p>
-      <p>
-        <a href="/download/server/power">Get Ubuntu Server for POWER&nbsp;&rsaquo;</a>
-      </p>
+  </section>
+  
+  <section class="p-section">
+    <div class="row--25-75">
+      <hr class="p-rule" />
+      <div class="col">
+        <h3 class="p-text--small-caps">Alternative downloads</h3>
+      </div>
+      <div class="col">
+        <div class="row p-section--shallow">
+          <div class="col-3">
+            <h4 class="p-heading--5">BitTorrent</h4>
+          </div>
+          <div class="col-6">
+            <p>BitTorrent sometimes enables higher download speeds and more reliable downloads of large files.</p>
+            <hr />
+            <a class="p-button" href="https://releases.ubuntu.com/{{ releases.lts.short_version }}/ubuntu-{{ releases.lts.full_version }}-live-server-amd64.iso.torrent">Torrent for {{ releases.lts.full_version }} LTS</a>
+            <a class="p-button" href="https://releases.ubuntu.com/{{ releases.latest.short_version }}/ubuntu-{{ releases.latest.full_version }}-live-server-amd64.iso.torrent">Torrent for {{ releases.latest.full_version }}</a>
+          </div>
+        </div>
+        <hr />
+        <div class="row p-section--shallow">
+          <div class="col-3">
+            <h4 class="p-heading--5">Ubuntu Server {{ releases.previous_lts.short_version }} LTS</h4>
+          </div>
+          <div class="col-6">
+            <p>The previous long-term support version of Ubuntu Server, including support guaranteed until April 2025.</p>
+            <hr />
+            <form action="/download/server" method="post" style="display: inline">
+              <input type="hidden" name="version" value="{{ releases.previous_lts.full_version }}">
+              <input type="hidden" name="architecture" value="amd64">
+              <input type="hidden" name="next-step" value="download">
+              <button type="submit" class="p-button" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Server download', 'eventAction' : 'Select option', 'eventLabel' : '{{ releases.previous_lts.full_version }}', 'eventValue' : undefined });">Download {{ releases.previous_lts.full_version }} LTS</button>
+            </form>
+          </div>
+        </div>
+        <hr />
+        <div class="row p-section--shallow">
+          <div class="col-3">
+            <h4 class="p-heading--5">
+              <a href="/download/alternative-downloads">Other versions&nbsp;&rsaquo;</a>
+            </h4>
+          </div>
+          <div class="col-6">
+            <p>Other versions of Ubuntu Server including torrents, the network installer, a list of local mirrors and past releases.</p>
+          </div>
+        </div>
+      </div>
     </div>
-    <div class="col-3 p-card">
-      <h3 class="p-card__title">Ubuntu for IBM Z (s390x)</h3>
-      <p>
-        IBM Z and LinuxONE leverage open technology solutions to meet the demands of the new application economy. Ubuntu is now available on those platforms with Multipass, MicroK8s and more.
-      </p>
-      <p>
-        <a href="/download/server/s390x">Get Ubuntu Server for IBM Z&nbsp;&rsaquo;</a>
-      </p>
+  </section>
+  
+  {% include 'shared/_download-ubuntu-thank-you-pro-section.html' %}
+  
+  <section class="p-section">
+    <div class="p-section--shallow u-fixed-width">
+      <hr class="p-rule" />
+      <h2 class="p-muted-heading">More from Canonical</h2>
     </div>
-    <div class="col-3 p-card">
-      <h3 class="p-card__title">Ubuntu for RISC-V</h3>
-      <p>
-        Ubuntu - now available for multiple RISC-V platforms to accelerate innovation.
-      </p>
-      <p>
-        <a href="/download/risc-v">Get Ubuntu Server for SiFive Unmatched, StarFive VisionFive and Allwinner Nezha&nbsp;&rsaquo;</a>
-      </p>
+    <div class="row">
+      <div class="col-3 col-medium-6">
+        <div class="row">
+          <div class="col-6 col-medium-2">
+            <h3>
+              <a href="https://maas.io/?_gl=1*1y3394w*_gcl_au*Mzg2MjE3ODk3LjE3MDI0NjY1NDY.&_ga=2.256850242.873815666.1709630805-805571671.1709630804">
+                {{
+                  image (
+                  url="https://assets.ubuntu.com/v1/d3039f38-MAAS-logo.svg",
+                  alt="MAAS",
+                  width="104",
+                  height="42",
+                  hi_def=True,
+                  loading="auto"
+                  ) | safe
+                }}
+              </a>
+            </h3>
+          </div>
+          <div class="col-6 col-medium-4">
+            <p>Build a bare metal cloud with super fast server provisioning.</p>
+            <hr class="p-rule" />
+            <p>
+              <a href="https://maas.io/">Learn more about MAAS&nbsp;&rsaquo;</a>
+            </p>
+          </div>
+        </div>
+      </div>
+      <div class="col-3 col-medium-6">
+        <div class="row">
+          <div class="col-6 col-medium-2">
+            <h3>
+              <a href="https://canonical.com/lxd">
+                {{
+                  image (
+                    url="https://assets.ubuntu.com/v1/84ed7eb1-LXD-logo.svg",
+                    alt="LXD",
+                    width="80",
+                    height="42",
+                    hi_def=True,
+                    loading="auto"
+                  ) | safe
+                }}
+              </a>
+            </h3>
+          </div>
+          <div class="col-6 col-medium-4">
+            <p>Fast, dense, and secure container and VM management at any scale.</p>
+            <hr class="p-rule" />
+            <p>
+              <a href="https://canonical.com/lxd">Learn more about LXD&nbsp;&rsaquo;</a>
+            </p>
+          </div>
+        </div>
+      </div>
+      <div class="col-3 col-medium-6">
+        <div class="row">
+          <div class="col-6 col-medium-2">
+            <h3>
+              <a href="https://juju.is/">
+              {{
+                image (
+                  url="https://assets.ubuntu.com/v1/35f593dd-Juju-logo.svg",
+                  alt="Juju",
+                  width="79",
+                  height="42",
+                  hi_def=True,
+                  loading="auto"
+                ) | safe
+              }}
+              </a>
+            </h3>
+          </div>
+          <div class="col-6 col-medium-4">
+            <p>Design and deploy entire workloads in just a few clicks.</p>
+            <hr class="p-rule" />
+            <p>
+              <a href="https://juju.is/">Learn more about Juju&nbsp;&rsaquo;</a>
+            </p>
+          </div>
+        </div>
+      </div>
+      <div class="col-3 col-medium-6">
+        <div class="row">
+          <div class="col-6 col-medium-2">
+            <h3>
+              <a href="https://multipass.run/">
+              {{
+                image (
+                  url="https://assets.ubuntu.com/v1/ede1a596-Multipass-logo.svg",
+                  alt="Multipass",
+                  width="141",
+                  height="42",
+                  hi_def=True,
+                  loading="auto"
+                ) | safe
+              }}
+              </a>
+            </h3>
+          </div>
+          <div class="col-6 col-medium-4">
+            <p>Spin up Ubuntu VMs on Windows, Mac and Linux.</p>
+            <hr class="p-rule" />
+            <p>
+              <a href="https://multipass.run/">Learn more about Multipass&nbsp;&rsaquo;</a>
+            </p>
+          </div>
+        </div>
+      </div>
     </div>
-  </div>
+  </section>
+
+  <section class="p-section">
+    <hr class="p-rule is-fixed-width" />
+    <div class="row">
+      <div class="col-3 col-medium-2">
+        <div class="p-section">
+          <h2 class="p-muted-heading">Resources</h2>
+        </div>
+      </div>
+      <div class="col-9">
+       <div class="row">
+        <div class="col-3 col-medium-2">
+          <h3 class="p-heading--5"><a href="/server/docs">Ubuntu Server documentation</a></h3>
+          <p>The Ubuntu Server documentation, curated by community and Ubuntu developers.</p>
+        </div>
+        <div class="col-3 col-medium-2">
+          <h3 class="p-heading--5"><a href="https://askubuntu.com/">Ask Ubuntu</a></h3>
+          <p>Stuck somewhere? Get your Ubuntu questions answered by power users.</p>
+        </div>
+        <div class="col-3 col-medium-2">
+          <h3 class="p-heading--5"><a href="https://discourse.ubuntu.com/">Community Discourse</a></h3>
+          <p>Discuss with Ubuntu developers and make your voice heard.</p>
+        </div>  
+       </div> 
+      </div>
+    </div>
+  </section>
 </section>
 
-{% with first_item="_download_server_installation", second_item="_download_server_guide", third_item="_download_helping_hands" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
+{% include 'download/server/multipass.html' %}
 
-{% endblock content %}
+{% include 'download/server/choose.html' %}
+
+<section class="p-section--deep">
+  <div class="row">
+    <hr class="p-rule"/>
+    <div class="col-3 col-medium-6">
+      <div class="p-section--shallow">
+        <h2 class="p-text--small-caps"><a href="/blog/tag/ubuntu-server">Latest from&nbsp;our&nbsp;blog&nbsp;&rsaquo;</a></h2>
+      </div>
+    </div>
+    <div class="col-9 col-medium-6">
+      <div class="row p-section--shallow" id="ubuntu-server-latest">
+      </div>
+    </div>
+  </div>
+
+  <template style="display:none" id="ubuntu-server-template">
+    <div class="col-3 col-medium-2">
+      <div class="u-crop--16-9">
+        <div class="article-image p-image-wrapper"></div>
+      </div>
+      <h3 class="p-heading--5"><a class="article-link article-title"></a></h3>
+      <p class="article-excerpt"></p>
+    </div>
+  </template>
+</section>
+
+<script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
+<script>
+  canonicalLatestNews.fetchLatestNews(
+    {
+      articlesContainerSelector: "#ubuntu-server-latest",
+      articleTemplateSelector: "#ubuntu-server-template",
+      excerptLength: 200,
+      tagId: 1610,
+      limit: 3
+    }
+  )
+</script>
+
+{% endblock %}
+
+

--- a/templates/download/server/manual.html
+++ b/templates/download/server/manual.html
@@ -1,6 +1,6 @@
 {% extends "download/_base_download.html" %}
 
-{% block title %}Get Ubuntu Server{% endblock %}
+{% block title %}Get Ubuntu Server | Download{% endblock %}
 
 {% block meta_description %}Get Ubuntu Server one of three ways; by using Multipass on your desktop, using MAAS to provision machines in your data centre or installing it directly on a server.{% endblock meta_description %}
 
@@ -10,7 +10,7 @@
 
 {% block content %}
 
-<section class="p-strip is-shallow u-no-margin--bottom">
+<section class="p-strip is-shallow u-no-padding--bottom">
   <div class=" p-section u-fixed-width">
     <h1>Get Ubuntu Server</h1>
   </div>
@@ -20,7 +20,7 @@
     <nav class="p-tabs">
       <ul class="p-tabs__list js-tabbed-content u-no-margin--bottom" role="tablist" data-maintain-hash="true">
         <li class="p-tabs__item">
-          <a class="p-tabs__link" role="tab" aria-selected="true" id="manual-install-tab" href="#manual-install" aria-controls="manual-install">Manual Install</a>
+          <a class="p-tabs__link" role="tab" aria-selected="true" id="manual-install-tab" href="#manual-install" aria-controls="manual-install">Manual install</a>
         </li>
         <li class="p-tabs__item">
           <a class="p-tabs__link" role="tab" aria-selected="false" id="instant-vms-tab" href="#instant-vms" aria-controls="instant-vms" tabindex="-1">Instant VMs</a>
@@ -36,7 +36,9 @@
 <section class="p-tabs__content p-section" id="manual-install" role="tabpanel" aria-labelledby="manual-install-tab">
   <div class="row--50-50">
     <div class="col">
-      <h2>Ubuntu {{ releases.lts.full_version }} LTS</h2>
+      <div class="p-section">
+        <h2>Ubuntu {{ releases.lts.full_version }} LTS</h2>
+      </div>
       <div class="p-image-wrapper">
         {{ image (
           url="https://assets.ubuntu.com/v1/b743f1ee-jj-in-circle.png",
@@ -59,7 +61,7 @@
           <input type="hidden" name="next-step" value="download">
           <button style="margin-right: 1rem;" type="submit" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Server download', 'eventAction' : 'Select option', 'eventLabel' : '{{ releases.lts.full_version }}', 'eventValue' : undefined });">Download {{ releases.lts.full_version }} LTS</button>
         </form>
-        <span class="u-text--muted">ISO image, {{ releases.lts.iso_download_size }}</span>
+        <span class="u-text--muted">ISO image, {% if releases.lts.iso_download_size %}{{ releases.lts.iso_download_size }}{% endif %}</span>
         <p><a href="#downloads">Alternative downloads&nbsp;&rsaquo;</a></p>
         <p><a href="#architectures">Alternative architectures&nbsp;&rsaquo;</a></p>
       </div>
@@ -80,7 +82,7 @@
         </nav>
       </div>
 
-      <div class="p-tabs__content" id="release-notes" role="tabpanel" aria-labelledby="release-notes-tab">
+      <div class="p-tabs__content p-section" id="release-notes" role="tabpanel" aria-labelledby="release-notes-tab">
         <ul class="p-list--divided">
           <li class="p-list__item is-ticked">OpenSSL 3.0 for modern, general-purpose cryptography and secure communication</li>
           <li class="p-list__item is-ticked">Native host and guest drivers for NVIDIA virtual GPU (vGPU) software 14</li>
@@ -91,11 +93,11 @@
         </ul>
         <hr class="p-rule" />
         <p>
-          <a href="https://discourse.ubuntu.com/t/jammy-jellyfish-release-notes/24668">Full {{ releases.lts.full_version }} release notes </a>
+          <a href="https://discourse.ubuntu.com/t/jammy-jellyfish-release-notes/24668">Full {{ releases.lts.full_version }} release notes&nbsp;&rsaquo;</a>
         </p>
       </div>
 
-      <div class="p-tabs__content" id="system-requirements" role="tabpanel" aria-labelledby="system-requirements-tab">
+      <div class="p-tabs__content p-section" id="system-requirements" role="tabpanel" aria-labelledby="system-requirements-tab">
         <ul class="p-list--divided">
           <li class="p-list__item is-ticked">1 GHz processor or better</li>
           <li class="p-list__item is-ticked">1 GB system memory</li>
@@ -104,7 +106,7 @@
         </ul>
       </div>
 
-      <div class="p-tabs__content" id="how-to-install" role="tabpanel" aria-labelledby="how-to-install-tab">
+      <div class="p-tabs__content p-section" id="how-to-install" role="tabpanel" aria-labelledby="how-to-install-tab">
         <p>To install Ubuntu Server:</p>
         <ol class="p-list--divided">
           <li class="p-list__item">Download the ISO image</li>
@@ -134,7 +136,7 @@
           <button style="margin-right: 1rem;" type="submit" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Server download', 'eventAction' : 'Select option', 'eventLabel' : '{{ releases.latest.full_version }}', 'eventValue' : undefined });">Download {{ releases.latest.full_version }}</button>
         </form>
         <span class="u-text--muted">ISO image, {{ releases.lts.iso_download_size }}</span>
-        <p><a href="/download/alternative-download">Read the 23.10 release notes&nbsp;&rsaquo;</a></p>
+        <p><a href="https://discourse.ubuntu.com/t/mantic-minotaur-release-notes/35534">Read the 23.10 release notes&nbsp;&rsaquo;</a></p>
       </div>
     </div>
   </section>
@@ -375,6 +377,27 @@
       limit: 3
     }
   )
+
+  // This page has a nested tab section, this script will show 
+  // the default parent tab when the page is loaded if the hash is a child tab
+  function showParentTab() {
+    const currentHash = window.location.hash;
+    const activeTab = document.querySelector(
+        ".p-tabs__link[href='" + currentHash + "']"
+      );
+    const targetIds = ["release-notes", "system-requirements", "how-to-install"];
+    const targetControl = activeTab.getAttribute("aria-controls")
+
+    if (targetIds.includes(targetControl)) {
+      indexTab = document.getElementById("manual-install")
+      indexTab.classList.remove("u-hide")
+    }
+  }
+
+  addEventListener("DOMContentLoaded", () => {
+    showParentTab()
+  });
+  
 </script>
 
 {% endblock %}

--- a/templates/download/server/multipass.html
+++ b/templates/download/server/multipass.html
@@ -1,61 +1,16 @@
-{% extends "download/_base_download.html" %}
-
-{% block title %}Get Ubuntu Server  | Download{% endblock %}
-{% block meta_description %}Get Ubuntu Server one of three ways; by using Multipass on your desktop, using MAAS to provision machines in your data centre or installing it directly on a server.{% endblock meta_description %}
-{% block meta_copydoc %}https://docs.google.com/document/d/1Qob4Ni_y1ffIdSWqaw2xH0dxiHZQmkRGP5nuoBhIfyM/edit{% endblock meta_copydoc %}
-
-{% block content %}
-<section class="p-strip--suru-topped">
-  <div class="row u-equal-height">
-    <div class="col-6">
-      <h1>Get Ubuntu Server</h1>
-      <h2 class="js-download-option">Option 2: Instant Ubuntu VMs</h2>
-      <p>Try Multipass, a mini cloud on Mac, Windows and Linux</p>
-      <ul class="p-list">
+<section class="p-tabs__content p-section" id="instant-vms" role="tabpanel" aria-labelledby="instant-vms-tab">
+  <div class="row--50-50">
+    <div class="col">
+      <h2>Ubuntu VMs on demand for Windows, Mac and Linux with Multipass</h2>
+    </div>
+    <div class="col">
+      <ul class="p-list--divided u-no-margin--bottom">
         <li class="p-list__item is-ticked">Always up-to-date with security fixes</li>
         <li class="p-list__item is-ticked"><a href="https://cloud-init.io/">Cloud-init</a> metadata for cloud dev and test</li>
         <li class="p-list__item is-ticked">Virtualbox, Hyper-V, HyperKit or KVM</li>
       </ul>
-      <p>
-        <a href="https://multipass.run" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Server download', 'eventAction' : 'Select option', 'eventLabel' : 'Multipass', 'eventValue' : undefined });">Get Multipass</a>
-      </p>
-    </div>
-    <div class="col-4 col-start-large-8 u-hide--medium u-hide--small u-align--center u-vertically-center" style="min-height: 328px">
-      <div class=" u-hide--medium u-hide--small u-align--center">
-        {{
-          image(
-            url="https://assets.ubuntu.com/v1/0698ab2d-muiltipass-promo-header.png",
-            alt="",
-            height="392",
-            width="716",
-            hi_def=True,
-            loading="lazy"
-          ) | safe
-        }}
-      </div>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-12">
-      <form action="/download/server" method="post" style="display: inline">
-        <input type="hidden" name="next-step" value="server">
-        <button type="submit" class="p-button" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Server download', 'eventAction' : 'Previous option', 'eventLabel' : 'Option 1', 'eventValue' : undefined });">
-          Option 1 - Manual server installation
-        </button>
-      </form>
-      <button disabled class="p-button u-no-margin--top is-inline">
-        Option 2 - Instant Ubuntu VMs
-      </button>
-      <form action="/download/server" method="post" style="display: inline">
-        <input type="hidden" name="next-step" value="choose">
-        <button type="submit" class="p-button is-inline" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Server download', 'eventAction' : 'Previous option', 'eventLabel' : 'Option 2', 'eventValue' : undefined });">
-          Option 3 - Automated server provisioning
-        </button>
-      </form>
+      <hr />
+      <a href="https://multipass.run/" class="p-button--positive">Get Multipass</a>
     </div>
   </div>
 </section>
-
-{% with first_item="_download_server_installation", second_item="_download_server_guide", third_item="_download_helping_hands" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
-
-{% endblock content %}

--- a/templates/shared/_download-ubuntu-thank-you-pro-section.html
+++ b/templates/shared/_download-ubuntu-thank-you-pro-section.html
@@ -19,7 +19,7 @@
       <h2>Get enterprise support<br class="u-hide--medium u-hide--small"/> for Ubuntu Server</h2>
     </div>
     <div class="col">
-      <p>Ubuntu Pro is a comprehensive subscription delivering enterprise-grade security, management tooling, and extended support for developers and organisations. Ubuntu Pro is free for personal use on up to five machines</p>
+      <p>Ubuntu Pro is a comprehensive subscription delivering enterprise-grade security, management tooling, and extended support for developers and organisations. Ubuntu Pro is free for personal use on up to five machines.</p>
       <hr class="p-rule" />
       <ul class="p-list--divided u-no-padding--bottom">
         <li class="p-list__item is-ticked">Security updates for the <a href="/esm">full open source stack</a></li>

--- a/templates/shared/_server-download-newsletter.html
+++ b/templates/shared/_server-download-newsletter.html
@@ -1,0 +1,35 @@
+<div>
+	<h2>Sign up for our newsletter</h2>
+	<p>Get the latest Ubuntu news and updates in your inbox.</p>
+</div>
+
+<form action="/marketo/submit" method="post" id="mktoForm_4960" onsubmit="ga('send', 'Newsletter', 'Signup', 'Ubuntu Server download newsletter signup');">
+	<label for="email" class="is-required">Email:</label>
+	<input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
+
+	<div class="p-section--shallow">
+		<label class="p-checkbox">
+			<input required class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
+			<span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
+		</label>
+		<p>By submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</p>
+		<hr />
+		<button type="submit" class="p-button--positive">Subscribe now</button>
+	</div>
+
+	<div class="p-section--shallow">
+		<input value="4960" name="formid" type="hidden">
+		<input type="hidden" name="Consent_to_Processing__c" value="yes" />
+		<input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="/download/server#newsletter-signup" />
+		<input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign"
+			value="" />
+		<input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+		<input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+		<input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+		<input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+		<input type="hidden" aria-hidden="true" aria-label="hidden field" id="preferredLanguage" name="preferredLanguage"
+			maxlength="255" value="" />
+		<input type="hidden" name="thankyoumessage"
+			value="Thank you for signing up for our newsletter!<br/>In these regular emails you will find the latest updates from Ubuntu and upcoming events where you can meet our team.">
+	</div>
+</form>


### PR DESCRIPTION
## Done

- Applied rebrand as per [doc](https://docs.google.com/document/d/1Qob4Ni_y1ffIdSWqaw2xH0dxiHZQmkRGP5nuoBhIfyM/edit) and [mock-up](https://www.figma.com/file/cVGimTPHky4h3BPXfrT6GB/24.04-U.com---download-(rebranding)?node-id=906%3A7906&mode=dev)

## QA

- View the site locally in your web browser at: https://ubuntu-com-13704.demos.haus/download/server
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check against doc and design
- Please make sure each download still works as expected

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-8497