### PR TITLE
Change mention of advantage to pro in contextual footer template

### DIFF
--- a/templates/shared/contextual_footers/_ua_got_questions.html
+++ b/templates/shared/contextual_footers/_ua_got_questions.html
@@ -1,5 +1,5 @@
 <div class="col-4 p-divider__block">
   <h3 class="p-heading--4">Got questions?</h3>
-  <p>Let our experts help you in the right direction with Ubuntu Advantage.</p>
+  <p>Let our experts help you in the right direction with Ubuntu Pro.</p>
   <p><a href="/support/contact-us?product=contextual-footer-ua" class="p-button" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'UA questions', 'eventLabel' : 'Contact us', 'eventValue' : undefined });">Contact us</a></p>
 </div>


### PR DESCRIPTION
## Done

- Updated a reference to 'advantage' to reference 'pro', as specified in the [copydoc](https://docs.google.com/document/d/1So3n5HEpBX39xxEkkChnve09gKSr9TgYUcbfdOTCevk/edit#heading=h.u0ba418n7g4n)

## QA

- Check change in code

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-10021

