### PR TITLE
WD-6314 - rebrand /ai/what-is-kubeflow

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1539,4 +1539,3 @@ hr.is-extra-muted {
 .u-kube-logo-height {
   height: 96px;
 }
-

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1533,3 +1533,10 @@ hr.is-extra-muted {
   background-color: rgba(0, 0, 0, 0.1);
   opacity: 0.5;
 }
+
+// Needed to adjusted logos of different sizes
+// design may need to provide logos with same height
+.u-kube-logo-height {
+  height: 96px;
+}
+

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1366,6 +1366,12 @@ $color-link-dark: #69c !default;
   }
 }
 
+// XXX: Lyubo: reduce logo section component height globally (to be moved to vanilla)
+.p-logo-section--dense .p-logo-section__logo,
+.p-logo-section--dense .p-logo-section__logo {
+  height: 6rem;
+}
+
 .p-logo-section.has-misaligned-images {
   .p-logo-section__item {
     margin-bottom: $spv--x-large;
@@ -1534,14 +1540,3 @@ hr.is-extra-muted {
   opacity: 0.5;
 }
 
-// Needed to adjusted logos of different sizes
-// design may need to provide logos with same height
-.u-kube-logo-height {
-  height: 96px;
-}
-
-// XXX: Lyubo: reduce logo section component height globally (to be moved to vanilla)
-.p-logo-section--dense .p-logo-section__logo,
-.p-logo-section--dense .p-logo-section__logo {
-  height: 6rem;
-}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1367,7 +1367,6 @@ $color-link-dark: #69c !default;
 }
 
 // XXX: Lyubo: reduce logo section component height globally (to be moved to vanilla)
-.p-logo-section--dense .p-logo-section__logo,
 .p-logo-section--dense .p-logo-section__logo {
   height: 6rem;
 }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1378,14 +1378,6 @@ $color-link-dark: #69c !default;
   }
 }
 
-.p-logo-section--dense {
-  .p-logo-section__items {
-    .p-logo-section__item > img {
-      height: 96px;
-    }
-  }
-}
-
 // XXX: pete f: vanilla issue here -
 // https://github.com/canonical/vanilla-framework/issues/4877
 .p-divider {

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1539,4 +1539,3 @@ hr.is-extra-muted {
   background-color: rgba(0, 0, 0, 0.1);
   opacity: 0.5;
 }
-

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1537,11 +1537,11 @@ hr.is-extra-muted {
 // Needed to adjusted logos of different sizes
 // design may need to provide logos with same height
 .u-kube-logo-height {
-  height: 96px!important;
+  height: 96px;
 }
 
 // XXX: Lyubo: reduce logo section component height globally (to be moved to vanilla)
-.p-logo-section .p-logo-section__logo,
+.p-logo-section--dense .p-logo-section__logo,
 .p-logo-section--dense .p-logo-section__logo {
   height: 6rem;
 }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1378,6 +1378,14 @@ $color-link-dark: #69c !default;
   }
 }
 
+.p-logo-section--dense {
+  .p-logo-section__items {
+    .p-logo-section__item > img {
+      height: 96px;
+    }
+  }
+}
+
 // XXX: pete f: vanilla issue here -
 // https://github.com/canonical/vanilla-framework/issues/4877
 .p-divider {

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1539,3 +1539,9 @@ hr.is-extra-muted {
 .u-kube-logo-height {
   height: 96px;
 }
+
+// XXX: Lyubo: reduce logo section component height globally (to be moved to vanilla)
+.p-logo-section .p-logo-section__logo,
+.p-logo-section--dense .p-logo-section__logo {
+  height: 6rem;
+}

--- a/templates/ai/what-is-kubeflow.html
+++ b/templates/ai/what-is-kubeflow.html
@@ -85,7 +85,7 @@
                 width="91",
                 height="96",
                 hi_def=True,
-                loading="auto"
+                loading="auto",
                 attr={"class": "p-logo-section__logo"}
                 ) | safe
               }}
@@ -146,42 +146,173 @@
       <div class="p-logo-section--dense p-section--shallow">
         <div class="p-logo-section__items">
           <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/f7f624aa-jupyter-logo.png" alt="Jupyter" class="p-logo-section__logo" />
+            {{
+            image (
+              url="https://assets.ubuntu.com/v1/f7f624aa-jupyter-logo.png",
+              alt="Jupyter",
+              width="48",
+              height="96",
+              hi_def=True,
+              loading="lazy",
+              attr={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
           </div>
           <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/c497f959-tensor-flow-logo.png" alt="TensorFlow" class="p-logo-section__logo" />
+            {{
+              image (
+                url="https://assets.ubuntu.com/v1/c497f959-tensor-flow-logo.png",
+                alt="TensorFlow",
+                width="92",
+                height="96",
+                hi_def=True,
+                loading="lazy",
+                attr={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
           </div>
           <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/2f4bd927-seldon-logo.png" alt="Seldon" class="p-logo-section__logo" />
+            {{
+              image (
+                url="https://assets.ubuntu.com/v1/2f4bd927-seldon-logo.png",
+                alt="Seldon",
+                width="281",
+                height="288",
+                hi_def=True,
+                loading="lazy",
+                attr={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
           </div>
           <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/6b0f7cdc-ambassador%20%20logo.png" alt="Ambassador" class="p-logo-section__logo" />
+            {{
+              image (
+                url="https://assets.ubuntu.com/v1/6b0f7cdc-ambassador  logo.png",
+                alt="Ambassador",
+                width="58",
+                height="288",
+                hi_def=True,
+                loading="lazy",
+                attr={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
           </div>
           <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/fe513e7b-pytorch-logo.png" alt="PyTorch" class="p-logo-section__logo" />
+            {{
+              image (
+                url="https://assets.ubuntu.com/v1/fe513e7b-pytorch-logo.png",
+                alt="PyTorch",
+                width="83",
+                height="96",
+                hi_def=True,
+                loading="lazy",
+                attr={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
           </div>
           <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/c112372b-istio%20logo.png" alt="Istio" class="p-logo-section__logo" />
+            {{
+              image (
+                url="https://assets.ubuntu.com/v1/c112372b-istio logo.png",
+                alt="Istio",
+                width="83",
+                height="96",
+                hi_def=True,
+                loading="lazy",
+                attr={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
           </div>
           <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/e9ce15ff-mxnet%20logo.png" alt="MXNet" class="p-logo-section__logo" />
+            {{
+              image (
+                url="https://assets.ubuntu.com/v1/e9ce15ff-mxnet logo.png",
+                alt="MXNet",
+                width="93",
+                height="96",
+                hi_def=True,
+                loading="lazy",
+                attr={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
           </div>
           <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/9c91dbfd-katib-logo.png" alt="Katib" class="p-logo-section__logo" />
+            {{
+              image(
+                url="https://assets.ubuntu.com/v1/9c91dbfd-katib-logo.png",
+                alt="Katib",
+                width="32",
+                height="96",
+                hi_def=True,
+                loading="lazy",
+                attr={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
           </div>
           <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/8d5fee47-prometheus%20logo.png" alt="Prometheus" class="p-logo-section__logo" />
+            {{
+              image (
+                url="https://assets.ubuntu.com/v1/8d5fee47-prometheus logo.png",
+                alt="Prometheus",
+                width="31",
+                height="96",
+                hi_def=True,
+                loading="lazy",
+                attr={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
           </div>
           <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/2c68ca73-onnx%20logo.png" alt="ONNX" class="p-logo-section__logo" />
+            {{
+              image(
+                url="https://assets.ubuntu.com/v1/2c68ca73-onnx logo.png",
+                alt="ONNX",
+                width="87",
+                height="96",
+                hi_def=True,
+                loading="lazy",
+                attr={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
           </div>
           <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/091fa892-xgboost%20logo.png" alt="XGBoost" class="p-logo-section__logo" />
+            {{
+              image (
+                url="https://assets.ubuntu.com/v1/091fa892-xgboost logo.png",
+                alt="XGBoost",
+                width="73",
+                height="96",
+                hi_def=True,
+                loading="lazy",
+                attr={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
           </div>
           <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/d335fd1c-scikit%20logo.png" alt="Scikit" class="p-logo-section__logo" />
+            {{
+              image(
+                url="https://assets.ubuntu.com/v1/d335fd1c-scikit logo.png",
+                alt="Scikit",
+                width="87",
+                height="96",
+                hi_def=True,
+                loading="lazy",
+                attr={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
           </div>
           <div class="p-logo-section__item">
+            {{
+              image(
+                url="https://assets.ubuntu.com/v1/c5ae87ca-pachyderm logo.png",
+                alt="Pachyderm",
+                width="32",
+                height="96",
+                hi_def=True,
+                loading="lazy",
+                attr={"class": "p-logo-section__logo"}
+                ) | safe
+            }}
             <img src="https://assets.ubuntu.com/v1/c5ae87ca-pachyderm%20logo.png" alt="Pachyderm" class="p-logo-section__logo" />
           </div>
         </div>
@@ -291,6 +422,16 @@
       <div class="col p-logo-section--dense">
         <div class="p-logo-section__items">
           <div class="p-logo-section__item">
+            {{
+              image (
+                url="https://assets.ubuntu.com/v1/ea6008a0-spotify-logo.png",
+                alt="Spotify",
+                width="272",
+                height="288",
+                hi_def=True,
+                loading="auto"
+              ) | safe
+            }}
             <img src="https://assets.ubuntu.com/v1/ea6008a0-spotify-logo.png" alt="Spotify" class="p-logo-section__logo" />
           </div>
           <div class="p-logo-section__item">

--- a/templates/ai/what-is-kubeflow.html
+++ b/templates/ai/what-is-kubeflow.html
@@ -26,9 +26,9 @@
       </div>
       <div class="col">
         <div class="row">
-        <div class="col-5 p-section--shallow">
+        <div class="col-6 p-section--shallow">
           <h1 class=u-no-margin--bottom>What is Kubeflow?</h1>
-          <h2>Kubeflow is the open source machine learning MLOps platform</h2>
+          <p class="p-heading--2">Kubeflow is the open source machine learning MLOps platform</p>
         </div>
         <div class="col-3">
           <p>Kubeflow enables you to develop and deploy machine learning models at any scale. It is a cloud-native application that runs on any cloud.</p>
@@ -49,85 +49,25 @@
     <hr class="p-rule" />
     <h2 class="p-section--shallow">Contributors to Kubeflow</h2>
     <div class="row--25-75">
-      <div class="col p-logo-section has-misaligned-images">
+      <div class="col p-logo-section">
         <div class="p-logo-section__items">
           <div class="p-logo-section__item">
-            {{
-            image(
-            url="https://assets.ubuntu.com/v1/bc4d28f8-Google_2015_logo.svg",
-            alt="Google",
-            height="42",
-            width="128",
-            hi_def=True,
-            attrs={"class": "p-logo-section__logo"},
-            loading="lazy",
-            ) | safe
-            }}
+            <img src="https://assets.ubuntu.com/v1/7577d797-google-logo.svg" alt="Gooogle" class="p-logo-section__logo" />
           </div>
           <div class="p-logo-section__item">
-            {{
-            image(
-            url="https://assets.ubuntu.com/v1/b179abab-microsoft-logo+copy.svg",
-            alt="Microsoft",
-            height="33",
-            width="145",
-            hi_def=True,
-            attrs={"class": "p-logo-section__logo"},
-            loading="lazy",
-            ) | safe
-            }}
+            <img src="https://assets.ubuntu.com/v1/6ece1a68-microsoft-logo.png" alt="Microsoft" class="p-logo-section__logo"  />
           </div>
           <div class="p-logo-section__item">
-            {{
-            image(
-            url="https://assets.ubuntu.com/v1/563c0d9b-_Canonical.svg",
-            alt="Canonical",
-            height="400",
-            width="1400",
-            hi_def=True,
-            attrs={"class": "p-logo-section__logo"},
-            loading="lazy",
-            ) | safe
-            }}
+            <img src="https://assets.ubuntu.com/v1/756d9941-canonical-logo.png" alt="Canonical" class="p-logo-section__logo"  />
           </div>
           <div class="p-logo-section__item">
-            {{
-            image(
-            url="https://assets.ubuntu.com/v1/16aec8e3-cisco-logo-transparent.png",
-            alt="Cisco",
-            height="53",
-            width="110",
-            hi_def=True,
-            attrs={"class": "p-logo-section__logo"},
-            loading="lazy",
-            ) | safe
-            }}
+            <img src="https://assets.ubuntu.com/v1/1c72e761-cisco-logo.png" alt="Cisco" class="p-logo-section__logo"  />
           </div>
           <div class="p-logo-section__item">
-            {{
-            image(
-            url="https://assets.ubuntu.com/v1/67db21e0-logo-ibm.png",
-            alt="IBM",
-            height="40",
-            width="90",
-            hi_def=True,
-            attrs={"class": "p-logo-section__logo"},
-            loading="lazy",
-            ) | safe
-            }}
+            <img src="https://assets.ubuntu.com/v1/c8792945-ibm-logo.png" alt="IBM" class="p-logo-section__logo"  />
           </div>
           <div class="p-logo-section__item">
-            {{
-            image(
-            url="https://assets.ubuntu.com/v1/e0ef0377-intel-logo-2-1.png",
-            alt="intel",
-            height="35",
-            width="90",
-            hi_def=True,
-            attrs={"class": "p-logo-section__logo"},
-            loading="lazy",
-            ) | safe
-            }}
+            <img src="https://assets.ubuntu.com/v1/834d57ab-intel-logo.png" alt="Intel" class="p-logo-section__logo"  />
           </div>
         </div>
       </div>
@@ -142,189 +82,53 @@
   </div>
   <div class="row--25-75">
     <div class="col">
-      <div class="p-logo-section has-misaligned-images">
+      <div class="p-logo-section">
         <div class="p-logo-section__items">
           <div class="p-logo-section__item">
-            {{
-            image(
-            url="https://assets.ubuntu.com/v1/8ee86883-jupyter-logo.png",
-            alt="Jupyter",
-            height="90",
-            width="80",
-            hi_def=True,
-            attrs={"class": "p-logo-section__logos"},
-            loading="lazy",
-            ) | safe
-            }}
-          </div>
-          <div class="p-logo-section__item ">
-            {{
-            image(
-            url="https://assets.ubuntu.com/v1/57dd2115-TensorFlow-logo.svg",
-            alt="TensorFlow",
-            height="90",
-            width="90",
-            hi_def=True,
-            attrs={"class": "p-logo-section__logos"},
-            loading="lazy",
-            ) | safe
-            }}
+            <img src="https://assets.ubuntu.com/v1/f7f624aa-jupyter-logo.png" alt="Jupyter" class="p-logo-section__logo" />
           </div>
           <div class="p-logo-section__item">
-            {{
-            image(
-            url="https://assets.ubuntu.com/v1/86dc5036-Seldon_logo.svg",
-            alt="Seldon",
-            height="90",
-            width="100",
-            hi_def=True,
-            attrs={"class": "p-logo-section__logos"},
-            loading="lazy",
-            ) | safe
-            }}
+            <img src="https://assets.ubuntu.com/v1/c497f959-tensor-flow-logo.png" alt="TensorFlow" class="p-logo-section__logo"  />
           </div>
           <div class="p-logo-section__item">
-            {{
-            image(
-            url="https://assets.ubuntu.com/v1/3d0a8131-ambassador-logo.png",
-            alt="Ambassador",
-            height="100",
-            width="80",
-            hi_def=True,
-            attrs={"class": "p-logo-section__logos"},
-            loading="lazy",
-            ) | safe
-            }}
+            <img src="https://assets.ubuntu.com/v1/2f4bd927-seldon-logo.png" alt="Seldon" class="p-logo-section__logo"  />
           </div>
           <div class="p-logo-section__item">
-            {{
-            image(
-            url="https://assets.ubuntu.com/v1/9b1d457f-PyTorch_logo.svg",
-            alt="PyTorch",
-            height="90",
-            width="100",
-            hi_def=True,
-            attrs={"class": "p-logo-section__logos"},
-            loading="lazy",
-            ) | safe
-            }}
+            <img src="https://assets.ubuntu.com/v1/6b0f7cdc-ambassador%20%20logo.png" alt="Ambassador" class="p-logo-section__logo"  />
           </div>
           <div class="p-logo-section__item">
-            {{
-            image(
-            url="https://assets.ubuntu.com/v1/5d796b1c-itsio-logo.png",
-            alt="Istio",
-            height="60",
-            width="100",
-            hi_def=True,
-            attrs={"class": "p-logo-section__logos"},
-            loading="lazy",
-            ) | safe
-            }}
+            <img src="https://assets.ubuntu.com/v1/fe513e7b-pytorch-logo.png" alt="PyTorch" class="p-logo-section__logo"  />
           </div>
           <div class="p-logo-section__item">
-            {{
-            image(
-            url="https://assets.ubuntu.com/v1/6b57da22-mxnet-logo.png",
-            alt="MXNet",
-            height="40",
-            width="110",
-            hi_def=True,
-            attrs={"class": "p-logo-section__logos"},
-            loading="lazy",
-            ) | safe
-            }}
+            <img src="https://assets.ubuntu.com/v1/c112372b-istio%20logo.png" alt="Istio" class="p-logo-section__logo"  />
           </div>
           <div class="p-logo-section__item">
-            {{
-            image(
-            url="https://assets.ubuntu.com/v1/41913ead-katib-logo.png",
-            alt="Katib",
-            height="90",
-            width="75",
-            hi_def=True,
-            attrs={"class": "p-logo-section__logos"},
-            loading="lazy",
-            ) | safe
-            }}
+            <img src="https://assets.ubuntu.com/v1/e9ce15ff-mxnet%20logo.png" alt="MXNet" class="p-logo-section__logo" />
           </div>
           <div class="p-logo-section__item">
-            {{
-            image(
-            url="https://assets.ubuntu.com/v1/826d5be3-1200px-Prometheus_software_logo.svg.png",
-            alt="Prometheus",
-            height="80",
-            width="80",
-            hi_def=True,
-            attrs={"class": "p-logo-section__logos"},
-            loading="lazy",
-            ) | safe
-            }}
+            <img src="https://assets.ubuntu.com/v1/9c91dbfd-katib-logo.png" alt="Katib" class="p-logo-section__logo"  />
+          </div>
+          <div class="p-logo-section__item">
+            <img src="https://assets.ubuntu.com/v1/8d5fee47-prometheus%20logo.png" alt="Prometheus" class="p-logo-section__logo"  />
+          </div>
+          <div class="p-logo-section__item">
+            <img src="https://assets.ubuntu.com/v1/2c68ca73-onnx%20logo.png" alt="ONNX" class="p-logo-section__logo"  />
+          </div>
+          <div class="p-logo-section__item">
+            <img src="https://assets.ubuntu.com/v1/a7650f84-xgboost%20logo.png" alt="XGBoost" class="p-logo-section__logo"  />
+          </div>
+          <div class="p-logo-section__item">
+            <img src="https://assets.ubuntu.com/v1/d335fd1c-scikit%20logo.png" alt="Scikit" class="p-logo-section__logo"  />
+          </div>
+          <div class="p-logo-section__item">
+            <img src="https://assets.ubuntu.com/v1/c5ae87ca-pachyderm%20logo.png" alt="Pachyderm" class="p-logo-section__logo"  />
           </div>
         </div>
       </div>
-      <hr class="p-rule" />
-      <div class="p-logo-section has-misaligned-images p-section--shallow">
-        <div class="p-logo-section__items">
-          <div class="p-logo-section__item">
-            {{
-            image(
-            url="https://assets.ubuntu.com/v1/653daa8b-onnx-logo.png",
-            alt="ONNX",
-            height="30",
-            width="110",
-            hi_def=True,
-            attrs={"class": "p-logo-section__logos"},
-            loading="lazy",
-            ) | safe
-            }}
-          </div>
-          <div class="p-logo-section__item">
-            {{
-            image(
-            url="https://assets.ubuntu.com/v1/2af7ca99-xgboost-logo.png",
-            alt="XGBoost",
-            height="37",
-            width="110",
-            hi_def=True,
-            attrs={"class": "p-logo-section__logos"},
-            loading="lazy",
-            ) | safe
-            }}
-          </div>
-          <div class="p-logo-section__item">
-            {{
-            image(
-            url="https://assets.ubuntu.com/v1/f4ffa06e-scikit-learn-logo.png",
-            alt="Scikit",
-            height="60",
-            width="110",
-            hi_def=True,
-            attrs={"class": "p-logo-section__logos"},
-            loading="lazy",
-            ) | safe
-            }}
-          </div>
-          <div class="p-logo-section__item ">
-            {{
-            image(
-            url="https://assets.ubuntu.com/v1/7c4d800a-pachyderm-logo.png",
-            alt="Pachyderm",
-            height="100",
-            width="110",
-            hi_def=True,
-            attrs={"class": "p-logo-section__logos"},
-            loading="lazy",
-            ) | safe
-            }}
-          </div>
-        </div>
-      </div>
-
+      <hr class="p-rule u-hide--small u-hide--medium" />
       <div class="row">
-        <hr class="p-rule" />
         <div class="col-3">
-          <p class="p-heading--5">Kubeflow dashboard</p>
+          <h3 class="p-heading--5">Kubeflow dashboard</h3>
           <p><a href="https://www.kubeflow.org/docs/components/central-dash/overview/">Central dashboard</a> with <a
               href="https://www.kubeflow.org/docs/components/multi-tenancy/overview/">multi-user isolation</a> provides
             a
@@ -332,14 +136,14 @@
             production.</p>
         </div>
         <div class="col-3">
-          <p class="p-heading--5">JupyterLab and VSCode</p>
+          <h3 class="p-heading--5">JupyterLab and VSCode</h3>
           <p>With Kubeflow users can <a href="https://www.kubeflow.org/docs/components/notebooks/setup/">spin-up Jupyter
               notebook servers</a> but also VSCode directly from the dashboard, allocating the right storage, CPUs and
             GPUs.
           </p>
         </div>
         <div class="col-3">
-          <p class="p-heading--5">ML libraries & frameworks</p>
+          <h3 class="p-heading--5">ML libraries & frameworks</h3>
           <p>Kubeflow is compatible with your choice of data science libraries and frameworks. <a
               href="https://www.kubeflow.org/docs/components/training/tftraining/">TensorFlow</a>, <a
               href="https://www.kubeflow.org/docs/components/training/pytorch/">PyTorch</a>, <a
@@ -349,10 +153,10 @@
         </div>
       </div>
 
+      <hr class="p-rule u-hide--small u-hide--medium" />
       <div class="row">
-        <hr class="p-rule" />
         <div class="col-3">
-          <p class="p-heading--5">Kubeflow Pipelines</p>
+          <h3 class="p-heading--5">Kubeflow Pipelines</h3>
           <p>Automate your ML workflow into pipelines by containerizing steps as pipeline components and defining
             inputs,
             outputs, parameters and generated artifacts. <a
@@ -361,7 +165,7 @@
           </p>
         </div>
         <div class="col-3">
-          <p class="p-heading--5">Experiments, Runs and Recurring Runs</p>
+          <h3 class="p-heading--5">Experiments, Runs and Recurring Runs</h3>
           <p>Experiments, groups of <a
               href="https://www.kubeflow.org/docs/pipelines/pipelines-quickstart/#run-an-ml-pipeline">Kubeflow Pipeline
               'Runs'</a> and <a
@@ -370,7 +174,7 @@
 
         </div>
         <div class="col-3">
-          <p class="p-heading--5">Hyperparameter tuning / AutoML</p>
+          <h3 class="p-heading--5">Hyperparameter tuning / AutoML</h3>
           <p>Kubeflow includes <a href="https://www.kubeflow.org/docs/components/katib/">Katib</a> for hyperparameter
             tuning.
             Katib runs pipelines with different hyperparameters (e.g. learning rate, # of hidden layers) optimising for
@@ -379,23 +183,23 @@
         </div>
       </div>
 
+      <hr class="p-rule u-hide--small u-hide--medium" />
       <div class="row">
-        <hr class="p-rule" />
         <div class="col-3">
-          <p class="p-heading--5">KServe for inference serving</p>
+          <h3 class="p-heading--5">KServe for inference serving</h3>
           <p><a href="https://www.kubeflow.org/docs/components/serving/kfserving/">KServe</a> is a multi-framework model
             deployment tool with serverless inferencing, canary roll-outs, pre & post-processing and explainability. <a
               href="/blog/what-is-kfserving">Learn more&nbsp;&rsaquo;</a></p>
         </div>
         <div class="col-3">
-          <p class="p-heading--5">The integrations you need</p>
+          <h3 class="p-heading--5">The integrations you need</h3>
           <p>Charmed Kubeflow integrates with <a href="https://github.com/mlopsworks/charms">MLFlow</a> for model
             registry,
             staging, and monitoring in production, <a href="https://github.com/SeldonIO/seldon-core">Seldon Core</a> for
             inference serving and <a href="https://spark.apache.org/">Apache Spark</a> for parallel data processing.
         </div>
         <div class="col-3">
-          <p class="p-heading--5">More...</p>
+          <h3 class="p-heading--5">More...</h3>
           <p>Save, compare and share generated artifacts - models, images, plots.</p>
         </div>
       </div>
@@ -429,7 +233,7 @@
     <div class="u-align--center u-hide--small p-image-wrapper">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/c58561f9-why-mlops-viz.png",
+          url="https://assets.ubuntu.com/v1/123b422b-why-mlops-viz.svg",
           alt="",
           width="1200",
           hi_def=True,
@@ -453,98 +257,28 @@
       <a href="https://ubuntu.com/engage/ai-ml-casestudy-tasmania/">Read our case study with
         the University of Tasmania</a>
     </div>
-    <div class="p-logo-section has-misaligned-images">
+    <div class="p-logo-section">
       <div class="p-logo-section__items">
         <div class="p-logo-section__item">
-          {{
-          image(
-          url="https://assets.ubuntu.com/v1/1688fbe0-Spotify_logo.svg",
-          alt="Spotify",
-          height="42",
-          width="128",
-          hi_def=True,
-          attrs={"class": "p-logo-section__logo"},
-          loading="lazy",
-          ) | safe
-          }}
+          <img src="https://assets.ubuntu.com/v1/ea6008a0-spotify-logo.png" alt="Spotify" class="p-logo-section__logo" />
         </div>
         <div class="p-logo-section__item">
-          {{
-          image(
-          url="https://assets.ubuntu.com/v1/6889bfcb-uber-logo.png",
-          alt="Uber",
-          height="115",
-          width="128",
-          hi_def=True,
-          attrs={"class": "p-logo-section__logo"},
-          loading="lazy",
-          ) | safe
-          }}
+          <img src="https://assets.ubuntu.com/v1/b6b0b414-uber-logo.png" alt="Uber" class="p-logo-section__logo" />
         </div>
         <div class="p-logo-section__item">
-          {{
-          image(
-          url="https://assets.ubuntu.com/v1/0c18b0ae-paypal_logo.svg",
-          alt="PayPal",
-          height="42",
-          width="128",
-          hi_def=True,
-          attrs={"class": "p-logo-section__logo"},
-          loading="lazy",
-          ) | safe
-          }}
+          <img src="https://assets.ubuntu.com/v1/63870c2f-paypal-logo.png" alt="PayPal" class="p-logo-section__logo" />
         </div>
         <div class="p-logo-section__item">
-          {{
-          image(
-          url="https://assets.ubuntu.com/v1/4a1c3691-lyft.svg",
-          alt="Lyft",
-          height="60",
-          width="128",
-          hi_def=True,
-          attrs={"class": "p-logo-section__logo"},
-          loading="lazy",
-          ) | safe
-          }}
+          <img src="https://assets.ubuntu.com/v1/6117dd11-lyft-logo.png" alt="Lyft" class="p-logo-section__logo" />
         </div>
         <div class="p-logo-section__item">
-          {{
-          image(
-          url="https://assets.ubuntu.com/v1/202457a2-CERN_logo2.svg",
-          alt="Cern",
-          height="128",
-          width="128",
-          hi_def=True,
-          attrs={"class": "p-logo-section__logo"},
-          loading="lazy",
-          ) | safe
-          }}
+          <img src="https://assets.ubuntu.com/v1/c358b12a-cern-logo.png" alt="Cern" class="p-logo-section__logo" />
         </div>
         <div class="p-logo-section__item">
-          {{
-          image(
-          url="https://assets.ubuntu.com/v1/b7693339-logo-bloomberg.svg",
-          alt="Bloomberg",
-          height="32",
-          width="138",
-          hi_def=True,
-          attrs={"class": "p-logo-section__logo"},
-          loading="lazy",
-          ) | safe
-          }}
+          <img src="https://assets.ubuntu.com/v1/b0eca934-Bloomberg-Logo.png" alt="Bloomberg" class="p-logo-section__logo" />
         </div>
         <div class="p-logo-section__item">
-          {{
-          image(
-          url="https://assets.ubuntu.com/v1/4f597a36-Shopify.svg",
-          alt="Shopify",
-          height="150",
-          width="150",
-          hi_def=True,
-          attrs={"class": "p-logo-section__logo"},
-          loading="lazy",
-          ) | safe
-          }}
+          <img src="https://assets.ubuntu.com/v1/a1996ad2-shopify-logo.png" alt="Shopify" class="p-logo-section__logo" />
         </div>
       </div>
     </div>
@@ -585,8 +319,6 @@
     </div>
   </div>
 </section>
-
-{% with first_item="_cloud_bootstack", second_item="_cloud_ubuntu_advantage", third_item="_cloud_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
 
 {% endblock content %}
   

--- a/templates/ai/what-is-kubeflow.html
+++ b/templates/ai/what-is-kubeflow.html
@@ -11,17 +11,15 @@
   <div class="p-section">
     <div class="row--25-75">
       <div class="col u-no-padding--bottom">
-        <div>
-          {{ image (
-          url="https://assets.ubuntu.com/v1/6d72759e-kubeflow-logo.png",
-          alt="Kubeflow",
-          width="182",
-          height="42",
-          hi_def=True,
-          loading="auto"
+          {{ image(
+            url="https://assets.ubuntu.com/v1/6d72759e-kubeflow-logo.png",
+            alt="Kubeflow",
+            width="182",
+            height="42",
+            hi_def=True,
+            loading="auto"
           ) | safe
           }}
-        </div>
       </div>
       <div class="col">
         <div class="row">
@@ -31,7 +29,7 @@
         </div>
         <div class="col-3">
           <p>Kubeflow enables you to develop and deploy machine learning models at any scale. It is a cloud-native application that runs on any cloud.</p>
-          <p>Charmed Kubeflow is Canonical’s distribution. It is secure and seamlessly integrated with other leading tools such as MLflow.</p>
+          <p>Charmed Kubeflow is Canonical's distribution. It is secure and seamlessly integrated with other leading tools such as MLflow.</p>
         </div>
         </div>
 
@@ -49,83 +47,83 @@
     <h2 class="p-section--shallow">Contributors to Kubeflow</h2>
     <div class="row--25-75">
       <div class="col">
-        <div class="p-logo-section--dense p-section--shallow">
+        <div class="p-logo-section">
           <div class="p-logo-section__items">
             <div class="p-logo-section__item">
               {{
-                image (
+                image(
                   url="https://assets.ubuntu.com/v1/7577d797-google-logo.svg",
                   alt="Google",
                   width="71",
                   height="96",
                   hi_def=True,
                   loading="auto",
-                  attr={"class": "p-logo-section__logo"}
+                  attrs={"class": "p-logo-section__logo"}
                 ) | safe
               }}
             </div>
             <div class="p-logo-section__item">
               {{
-                image (
+                image(
                   url="https://assets.ubuntu.com/v1/6ece1a68-microsoft-logo.png",
                   alt="Microsoft",
                   width="105",
                   height="96",
                   hi_def=True,
                   loading="auto",
-                  attr={"class": "p-logo-section__logo"}
+                  attrs={"class": "p-logo-section__logo"}
                 ) | safe
               }}
             </div>
             <div class="p-logo-section__item">
               {{
-                image (
+                image(
                 url="https://assets.ubuntu.com/v1/756d9941-canonical-logo.png",
                 alt="Canonical",
                 width="91",
                 height="96",
                 hi_def=True,
                 loading="auto",
-                attr={"class": "p-logo-section__logo"}
+                attrs={"class": "p-logo-section__logo"}
                 ) | safe
               }}
             </div>
             <div class="p-logo-section__item">
               {{
-                image (
+                image(
                   url="https://assets.ubuntu.com/v1/1c72e761-cisco-logo.png",
                   alt="Cisco",
                   width="232",
                   height="384",
                   hi_def=True,
                   loading="auto",
-                  attr={"class": "p-logo-section__logo"}
+                  attrs={"class": "p-logo-section__logo"}
                 ) | safe
               }}
             </div>
             <div class="p-logo-section__item">
               {{
-                image (
+                image(
                 url="https://assets.ubuntu.com/v1/c8792945-ibm-logo.png",
                 alt="IBM",
                 width="47",
                 height="96",
                 hi_def=True,
                 loading="auto",
-                attr={"class": "p-logo-section__logo"}
+                attrs={"class": "p-logo-section__logo"}
                 ) | safe
               }}
             </div>
             <div class="p-logo-section__item">
               {{
-                image (
+                image(
                   url="https://assets.ubuntu.com/v1/834d57ab-intel-logo.png",
                   alt="Intel",
                   width="48",
                   height="96",
                   hi_def=True,
                   loading="auto",
-                  attr={"class": "p-logo-section__logo"}
+                  attrs={"class": "p-logo-section__logo"}
                 ) | safe
               }}
             </div>
@@ -147,92 +145,92 @@
         <div class="p-logo-section__items">
           <div class="p-logo-section__item">
             {{
-            image (
-              url="https://assets.ubuntu.com/v1/f7f624aa-jupyter-logo.png",
-              alt="Jupyter",
-              width="48",
-              height="96",
-              hi_def=True,
-              loading="lazy",
-              attr={"class": "p-logo-section__logo"}
+              image(
+                url="https://assets.ubuntu.com/v1/f7f624aa-jupyter-logo.png",
+                alt="Jupyter",
+                width="48",
+                height="96",
+                hi_def=True,
+                loading="lazy",
+                attrs={"class": "p-logo-section__logo"}
               ) | safe
             }}
           </div>
           <div class="p-logo-section__item">
             {{
-              image (
+              image(
                 url="https://assets.ubuntu.com/v1/c497f959-tensor-flow-logo.png",
                 alt="TensorFlow",
                 width="92",
                 height="96",
                 hi_def=True,
                 loading="lazy",
-                attr={"class": "p-logo-section__logo"}
+                attrs={"class": "p-logo-section__logo"}
               ) | safe
             }}
           </div>
           <div class="p-logo-section__item">
             {{
-              image (
+              image(
                 url="https://assets.ubuntu.com/v1/2f4bd927-seldon-logo.png",
                 alt="Seldon",
                 width="281",
                 height="288",
                 hi_def=True,
                 loading="lazy",
-                attr={"class": "p-logo-section__logo"}
+                attrs={"class": "p-logo-section__logo"}
               ) | safe
             }}
           </div>
           <div class="p-logo-section__item">
             {{
-              image (
+              image(
                 url="https://assets.ubuntu.com/v1/6b0f7cdc-ambassador  logo.png",
                 alt="Ambassador",
                 width="58",
                 height="288",
                 hi_def=True,
                 loading="lazy",
-                attr={"class": "p-logo-section__logo"}
+                attrs={"class": "p-logo-section__logo"}
               ) | safe
             }}
           </div>
           <div class="p-logo-section__item">
             {{
-              image (
+              image(
                 url="https://assets.ubuntu.com/v1/fe513e7b-pytorch-logo.png",
                 alt="PyTorch",
                 width="83",
                 height="96",
                 hi_def=True,
                 loading="lazy",
-                attr={"class": "p-logo-section__logo"}
+                attrs={"class": "p-logo-section__logo"}
               ) | safe
             }}
           </div>
           <div class="p-logo-section__item">
             {{
-              image (
+              image(
                 url="https://assets.ubuntu.com/v1/c112372b-istio logo.png",
                 alt="Istio",
                 width="83",
                 height="96",
                 hi_def=True,
                 loading="lazy",
-                attr={"class": "p-logo-section__logo"}
+                attrs={"class": "p-logo-section__logo"}
               ) | safe
             }}
           </div>
           <div class="p-logo-section__item">
             {{
-              image (
+              image(
                 url="https://assets.ubuntu.com/v1/e9ce15ff-mxnet logo.png",
                 alt="MXNet",
                 width="93",
                 height="96",
                 hi_def=True,
                 loading="lazy",
-                attr={"class": "p-logo-section__logo"}
+                attrs={"class": "p-logo-section__logo"}
               ) | safe
             }}
           </div>
@@ -245,20 +243,20 @@
                 height="96",
                 hi_def=True,
                 loading="lazy",
-                attr={"class": "p-logo-section__logo"}
+                attrs={"class": "p-logo-section__logo"}
               ) | safe
             }}
           </div>
           <div class="p-logo-section__item">
             {{
-              image (
+              image(
                 url="https://assets.ubuntu.com/v1/8d5fee47-prometheus logo.png",
                 alt="Prometheus",
                 width="31",
                 height="96",
                 hi_def=True,
                 loading="lazy",
-                attr={"class": "p-logo-section__logo"}
+                attrs={"class": "p-logo-section__logo"}
               ) | safe
             }}
           </div>
@@ -271,20 +269,20 @@
                 height="96",
                 hi_def=True,
                 loading="lazy",
-                attr={"class": "p-logo-section__logo"}
+                attrs={"class": "p-logo-section__logo"}
               ) | safe
             }}
           </div>
           <div class="p-logo-section__item">
             {{
-              image (
+              image(
                 url="https://assets.ubuntu.com/v1/091fa892-xgboost logo.png",
                 alt="XGBoost",
                 width="73",
                 height="96",
                 hi_def=True,
                 loading="lazy",
-                attr={"class": "p-logo-section__logo"}
+                attrs={"class": "p-logo-section__logo"}
               ) | safe
             }}
           </div>
@@ -297,7 +295,7 @@
                 height="96",
                 hi_def=True,
                 loading="lazy",
-                attr={"class": "p-logo-section__logo"}
+                attrs={"class": "p-logo-section__logo"}
               ) | safe
             }}
           </div>
@@ -310,10 +308,9 @@
                 height="96",
                 hi_def=True,
                 loading="lazy",
-                attr={"class": "p-logo-section__logo"}
+                attrs={"class": "p-logo-section__logo"}
                 ) | safe
             }}
-            <img src="https://assets.ubuntu.com/v1/c5ae87ca-pachyderm%20logo.png" alt="Pachyderm" class="p-logo-section__logo" />
           </div>
         </div>
       </div>
@@ -419,38 +416,98 @@
       <a href="/engage/ai-ml-casestudy-tasmania/">Read our case study with the University of Tasmania</a>
     </div>
     <div class="row--25-75">
-      <div class="col p-logo-section--dense">
+      <div class="col p-logo-section">
         <div class="p-logo-section__items">
           <div class="p-logo-section__item">
             {{
-              image (
+              image(
                 url="https://assets.ubuntu.com/v1/ea6008a0-spotify-logo.png",
                 alt="Spotify",
-                width="272",
-                height="288",
+                width="90",
+                height="96",
                 hi_def=True,
-                loading="auto"
+                loading="auto",
+                attrs={"class": "p-logo-section__logo"}
               ) | safe
             }}
-            <img src="https://assets.ubuntu.com/v1/ea6008a0-spotify-logo.png" alt="Spotify" class="p-logo-section__logo" />
           </div>
           <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/b6b0b414-uber-logo.png" alt="Uber" class="p-logo-section__logo" />
+            {{
+              image(
+                url="https://assets.ubuntu.com/v1/b6b0b414-uber-logo.png",
+                alt="Uber",
+                width="44",
+                height="96",
+                hi_def=True,
+                loading="lazy",
+                attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
           </div>
           <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/63870c2f-paypal-logo.png" alt="PayPal" class="p-logo-section__logo" />
+            {{
+              image(
+                url="https://assets.ubuntu.com/v1/63870c2f-paypal-logo.png",
+                alt="Paypal",
+                width="86",
+                height="96",
+                hi_def=True,
+                loading="lazy",
+                attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
           </div>
           <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/6117dd11-lyft-logo.png" alt="Lyft" class="p-logo-section__logo" />
+            {{
+              image(
+                url="https://assets.ubuntu.com/v1/6117dd11-lyft-logo.png",
+                alt="Lyft",
+                width="96",
+                height="96",
+                hi_def=True,
+                loading="lazy",
+                attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
           </div>
           <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/c358b12a-cern-logo.png" alt="Cern" class="p-logo-section__logo" />
+            {{
+              image(
+                url="https://assets.ubuntu.com/v1/c358b12a-cern-logo.png",
+                alt="Cern",
+                width="73",
+                height="96",
+                hi_def=True,
+                loading="lazy",
+                attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
           </div>
           <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/b0eca934-Bloomberg-Logo.png" alt="Bloomberg" class="p-logo-section__logo" />
+            {{
+              image(
+                url="https://assets.ubuntu.com/v1/b0eca934-Bloomberg-Logo.png",
+                alt="Bloomberg",
+                width="96",
+                height="96",
+                hi_def=True,
+                loading="lazy",
+                attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
           </div>
           <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/a1996ad2-shopify-logo.png" alt="Shopify" class="p-logo-section__logo" />
+            {{
+              image(
+                url="https://assets.ubuntu.com/v1/a1996ad2-shopify-logo.png",
+                alt="Shopify",
+                width="89",
+                height="96",
+                hi_def=True,
+                loading="lazy",
+                attrs={"class": "p-logo-section__logo"}
+              ) | safe
+            }}
           </div>
         </div>
       </div>
@@ -474,7 +531,7 @@
               </p>
             </div>
             <div class="col">
-              <p>Read more about Charmed MLflow’s capabilities and follow our tutorials.</p>
+              <p>Read more about Charmed MLflow's capabilities and follow our tutorials.</p>
             </div>
           </div>
         </li>
@@ -524,4 +581,3 @@
 </section>
 
 {% endblock content %}
-  

--- a/templates/ai/what-is-kubeflow.html
+++ b/templates/ai/what-is-kubeflow.html
@@ -228,7 +228,7 @@
       <p>Bringing AI solutions to market can involve many steps: data pre-processing, training, model deployment or inference serving at scale... The list of tasks is complex and keeping them in a set of notebooks or scripts is hard to maintain, share and collaborate on, leading to inefficient processes.</p>
       <p class="p-section--shallow"><a href="https://papers.nips.cc/paper/5656-hidden-technical-debt-in-machine-learning-systems.pdf">Google describes</a> that only about 20% of the effort and code required to bring AI systems to production is the development of ML code, while the remaining is operations. Standardizing ops in your ML workflows can hence greatly decrease time-to-market and costs for your AI solutions.</p>
       <hr />
-      <a href="https://ubuntu.com/blog/what-is-mlops">Read more about MLOps.</a>
+      <a href="https://ubuntu.com/blog/what-is-mlops">Read more about MLOps</a>
     </div>
     <div class="u-align--center u-hide--small p-image-wrapper">
       {{

--- a/templates/ai/what-is-kubeflow.html
+++ b/templates/ai/what-is-kubeflow.html
@@ -15,8 +15,8 @@
           {{ image (
           url="https://assets.ubuntu.com/v1/cb6b2ca8-kubeflow-logo.png",
           alt="Kubeflow",
-          width="197",
-          height="45",
+          width="196",
+          height="40",
           hi_def=True,
           loading="auto"
           ) | safe

--- a/templates/ai/what-is-kubeflow.html
+++ b/templates/ai/what-is-kubeflow.html
@@ -268,20 +268,40 @@
     <div class="col u-no-margin--bottom">
       <h2>Kubeflow resources</h2>
     </div>
-    <ul class="col p-list--divided u-no-margin--bottom">
-      <li class="p-list__item row--50-50">
-        <a class="col" href="https://charmed-kubeflow.io/docs">Charmed Kubeflow docs</a>
-        <p class="col">Read more about Charmed MLflow’s capabilities and follow our tutorials.</p>
-      </li>
-      <li class="p-list__item row--50-50">
-        <a class="col" href="/engage/kubeflow-vs-mlflow">Kubeflow vs. MLflow</a>
-        <p class="col">Understand the differences between the most famous open source solutions.</p>
-      </li>
-      <li class="p-list__item row--50-50">
-        <a class="col" href="/engage/mlops-guide">Guide to MLOps</a>
-        <p class="col">Learn how to take models to production using open source MLOps platforms.</p>
-      </li>
-    </ul>
+    <div class="col">
+      <ul class="p-list--divided u-no-margin--bottom">
+        <li class="p-list__item">
+          <div class="row--50-50">
+            <div class="col">
+              <a href="https://charmed-kubeflow.io/docs">Charmed Kubeflow docs</a>
+            </div>
+            <div class="col">
+              <p>Read more about Charmed MLflow’s capabilities and follow our tutorials.</p>
+            </div>
+          </div>
+        </li>
+        <li class="p-list__item">
+          <div class="row--50-50">
+            <div class="col">
+              <a href="/engage/kubeflow-vs-mlflow">Kubeflow vs. MLflow</a>
+            </div>
+            <div class="col">
+              <p>Understand the differences between the most famous open source solutions.</p>
+            </div>
+          </div>
+        </li>
+        <li class="p-list__item">
+          <div class="row--50-50">
+            <div class="col">
+              <a href="/engage/mlops-guide">Guide to MLOps</a>
+            </div>
+            <div class="col">
+              <p>Learn how to take models to production using open source MLOps platforms.</p>
+            </div>
+          </div>
+        </li>
+      </ul>
+    </div>
   </div>
 </section>
 

--- a/templates/ai/what-is-kubeflow.html
+++ b/templates/ai/what-is-kubeflow.html
@@ -47,28 +47,28 @@
   <div class="u-fixed-width">
     <hr class="p-rule" />
     <h2 class="p-section--shallow">Contributors to Kubeflow</h2>
-    <div class="row--25-75">
-      <div class="col">
-        <div class="p-logo-section p-section--shallow">
-          <div class="p-logo-section__items">
-            <div class="p-logo-section__item">
-              <img src="https://assets.ubuntu.com/v1/7577d797-google-logo.svg" alt="Google" class="p-logo-section__logo u-kube-logo-height" />
-            </div>
-            <div class="p-logo-section__item">
-              <img src="https://assets.ubuntu.com/v1/6ece1a68-microsoft-logo.png" alt="Microsoft" class="p-logo-section__logo u-kube-logo-height" />
-            </div>
-            <div class="p-logo-section__item">
-              <img src="https://assets.ubuntu.com/v1/756d9941-canonical-logo.png" alt="Canonical" class="p-logo-section__logo u-kube-logo-height" />
-            </div>
-            <div class="p-logo-section__item">
-              <img src="https://assets.ubuntu.com/v1/1c72e761-cisco-logo.png" alt="Cisco" class="p-logo-section__logo u-kube-logo-height" />
-            </div>
-            <div class="p-logo-section__item">
-              <img src="https://assets.ubuntu.com/v1/c8792945-ibm-logo.png" alt="IBM" class="p-logo-section__logo u-kube-logo-height" />
-            </div>
-            <div class="p-logo-section__item">
-              <img src="https://assets.ubuntu.com/v1/834d57ab-intel-logo.png" alt="Intel" class="p-logo-section__logo u-kube-logo-height" />
-            </div>
+  </div>
+  <div class="row--25-75">
+    <div class="col">
+      <div class="p-logo-section">
+        <div class="p-logo-section__items">
+          <div class="p-logo-section__item">
+            <img src="https://assets.ubuntu.com/v1/7577d797-google-logo.svg" alt="Google" class="p-logo-section__logo u-kube-logo-height" />
+          </div>
+          <div class="p-logo-section__item">
+            <img src="https://assets.ubuntu.com/v1/6ece1a68-microsoft-logo.png" alt="Microsoft" class="p-logo-section__logo u-kube-logo-height" />
+          </div>
+          <div class="p-logo-section__item">
+            <img src="https://assets.ubuntu.com/v1/756d9941-canonical-logo.png" alt="Canonical" class="p-logo-section__logo u-kube-logo-height" />
+          </div>
+          <div class="p-logo-section__item">
+            <img src="https://assets.ubuntu.com/v1/1c72e761-cisco-logo.png" alt="Cisco" class="p-logo-section__logo u-kube-logo-height" />
+          </div>
+          <div class="p-logo-section__item">
+            <img src="https://assets.ubuntu.com/v1/c8792945-ibm-logo.png" alt="IBM" class="p-logo-section__logo u-kube-logo-height" />
+          </div>
+          <div class="p-logo-section__item">
+            <img src="https://assets.ubuntu.com/v1/834d57ab-intel-logo.png" alt="Intel" class="p-logo-section__logo u-kube-logo-height" />
           </div>
         </div>
       </div>

--- a/templates/ai/what-is-kubeflow.html
+++ b/templates/ai/what-is-kubeflow.html
@@ -256,14 +256,14 @@
 </section>
 
 <section class="p-section--shallow">
-  <div class="row--50-50">
+  <div class="row">
     <hr class="p-rule" />
-    <div class="col u-no-margin--bottom">
+    <div class="col-6 col-medium-12 u-no-margin--bottom">
       <h2>Kubeflow resources</h2>
     </div>
-    <div class="col">
+    <div class="col-6 col-medium-12">
       <ul class="p-list--divided">
-        <li class="p-list__item">
+        <li class="p-list__item u-no-padding--top">
           <div class="row--50-50">
             <div class="col">
               <p>

--- a/templates/ai/what-is-kubeflow.html
+++ b/templates/ai/what-is-kubeflow.html
@@ -10,11 +10,10 @@
 <section class="p-strip is-shallow u-no-padding--bottom">
   <div class="p-section">
     <div class="row--25-75">
-      <div class="col p-strip is-shallow u-no-padding--bottom">
-        <div
-          class="p-section">
+      <div class="col u-no-padding--bottom">
+        <div>
           {{ image (
-          url="https://assets.ubuntu.com/v1/b1f04506-Kubeflow-Logo-RGB.svg",
+          url="https://assets.ubuntu.com/v1/cb6b2ca8-kubeflow-logo.png",
           alt="Kubeflow",
           width="197",
           height="45",
@@ -82,7 +81,7 @@
   </div>
   <div class="row--25-75">
     <div class="col">
-      <div class="p-logo-section">
+      <div class="p-logo-section--dense">
         <div class="p-logo-section__items">
           <div class="p-logo-section__item">
             <img src="https://assets.ubuntu.com/v1/f7f624aa-jupyter-logo.png" alt="Jupyter" class="p-logo-section__logo" />
@@ -127,15 +126,15 @@
       </div>
       <hr class="p-rule u-hide--small u-hide--medium" />
       <div class="row">
-        <div class="col-3">
+        <div class="col-3 col-medium-2">
           <h3 class="p-heading--5">Kubeflow dashboard</h3>
           <p><a href="https://www.kubeflow.org/docs/components/central-dash/overview/">Central dashboard</a> with <a href="https://www.kubeflow.org/docs/components/multi-tenancy/overview/">multi-user isolation</a> provides a platform for data scientists and engineers to leverage K8s to develop, deploy and monitor their models in production.</p>
         </div>
-        <div class="col-3">
+        <div class="col-3 col-medium-2">
           <h3 class="p-heading--5">JupyterLab and VSCode</h3>
           <p>With Kubeflow users can <a href="https://www.kubeflow.org/docs/components/notebooks/setup/">spin-up Jupyter notebook servers</a> but also VSCode directly from the dashboard, allocating the right storage, CPUs and GPUs.</p>
         </div>
-        <div class="col-3">
+        <div class="col-3 col-medium-2">
           <h3 class="p-heading--5">ML libraries & frameworks</h3>
           <p>Kubeflow is compatible with your choice of data science libraries and frameworks. 
             <a href="https://www.kubeflow.org/docs/components/training/tftraining/">TensorFlow</a>, 
@@ -146,33 +145,33 @@
         </div>
       </div>
 
-      <hr class="p-rule u-hide--small u-hide--medium" />
+      <hr class="p-rule u-hide--small" />
       <div class="row">
-        <div class="col-3">
+        <div class="col-3 col-medium-2">
           <h3 class="p-heading--5">Kubeflow Pipelines</h3>
           <p>Automate your ML workflow into pipelines by containerizing steps as pipeline components and defining inputs, outputs, parameters and generated artifacts. <a class="/blog/data-science-workflows-on-kubernetes-with-kubeflow-pipelines-part-1">Learn more&nbsp;&rsaquo;</a>
           </p>
         </div>
-        <div class="col-3">
+        <div class="col-3 col-medium-2">
           <h3 class="p-heading--5">Experiments, Runs and Recurring Runs</h3>
           <p>Experiments, groups of <a href="https://www.kubeflow.org/docs/pipelines/pipelines-quickstart/#run-an-ml-pipeline">Kubeflow Pipeline 'Runs'</a> and <a href="https://www.kubeflow.org/docs/components/pipelines/overview/concepts/run/">Recurring Runs</a>, allow you to find the right parameters for your model, compare and replicate results.</p>
         </div>
-        <div class="col-3">
+        <div class="col-3 col-medium-2">
           <h3 class="p-heading--5">Hyperparameter tuning / AutoML</h3>
           <p>Kubeflow includes <a href="https://www.kubeflow.org/docs/components/katib/">Katib</a> for hyperparameter tuning. Katib runs pipelines with different hyperparameters (e.g. learning rate, # of hidden layers) optimising for the best ML model.</p>
         </div>
       </div>
-      <hr class="p-rule u-hide--small u-hide--medium" />
+      <hr class="p-rule u-hide--small" />
       <div class="row">
-        <div class="col-3">
+        <div class="col-3 col-medium-2">
           <h3 class="p-heading--5">KServe for inference serving</h3>
           <p><a href="https://www.kubeflow.org/docs/components/serving/kfserving/">KServe</a> is a multi-framework model deployment tool with serverless inferencing, canary roll-outs, pre & post-processing and explainability. <a href="/blog/what-is-kfserving">Learn more&nbsp;&rsaquo;</a></p>
         </div>
-        <div class="col-3">
+        <div class="col-3 col-medium-2">
           <h3 class="p-heading--5">The integrations you need</h3>
           <p>Charmed Kubeflow integrates with <a href="https://github.com/mlopsworks/charms">MLFlow</a> for model registry, staging, and monitoring in production, <a href="https://github.com/SeldonIO/seldon-core">Seldon Core</a> for inference serving and <a href="https://spark.apache.org/">Apache Spark</a> for parallel data processing.
         </div>
-        <div class="col-3">
+        <div class="col-3 col-medium-2">
           <h3 class="p-heading--5">More...</h3>
           <p>Save, compare and share generated artifacts - models, images, plots.</p>
         </div>
@@ -208,15 +207,7 @@
       <a href="/blog/what-is-mlops">Read more about MLOps</a>
     </div>
     <div class="u-align--center u-hide--small p-image-wrapper">
-      {{
-        image(
-          url="https://assets.ubuntu.com/v1/123b422b-why-mlops-viz.svg",
-          alt="",
-          width="1200",
-          hi_def=True,
-          loading="lazy",
-        ) | safe
-      }}
+      <img src="https://assets.ubuntu.com/v1/085604f2-u.c__ai__kubeflow.svg" />
     </div>
   </div>
 </section>
@@ -273,7 +264,9 @@
         <li class="p-list__item">
           <div class="row--50-50">
             <div class="col">
-              <a href="https://charmed-kubeflow.io/docs">Charmed Kubeflow docs</a>
+              <p>
+                <a href="https://charmed-kubeflow.io/docs">Charmed Kubeflow docs</a>
+              </p>
             </div>
             <div class="col">
               <p>Read more about Charmed MLflow’s capabilities and follow our tutorials.</p>
@@ -283,7 +276,9 @@
         <li class="p-list__item">
           <div class="row--50-50">
             <div class="col">
-              <a href="/engage/kubeflow-vs-mlflow">Kubeflow vs. MLflow</a>
+              <p>
+                <a href="/engage/kubeflow-vs-mlflow">Kubeflow vs. MLflow</a>
+              </p>
             </div>
             <div class="col">
               <p>Understand the differences between the most famous open source solutions.</p>
@@ -293,7 +288,9 @@
         <li class="p-list__item">
           <div class="row--50-50">
             <div class="col">
-              <a href="/engage/mlops-guide">Guide to MLOps</a>
+              <p>
+                <a href="/engage/mlops-guide">Guide to MLOps</a>
+              </p>
             </div>
             <div class="col">
               <p>Learn how to take models to production using open source MLOps platforms.</p>

--- a/templates/ai/what-is-kubeflow.html
+++ b/templates/ai/what-is-kubeflow.html
@@ -10,13 +10,13 @@
 <section class="p-strip is-shallow u-no-padding--bottom">
   <div class="p-section">
     <div class="row--25-75">
-      <div class="col u-no-padding--bottom p-section">
+      <div class="col u-no-padding--bottom">
         <div>
           {{ image (
           url="https://assets.ubuntu.com/v1/6d72759e-kubeflow-logo.png",
           alt="Kubeflow",
-          width="852",
-          height="175",
+          width="182",
+          height="42",
           hi_def=True,
           loading="auto"
           ) | safe
@@ -48,25 +48,87 @@
     <hr class="p-rule" />
     <h2 class="p-section--shallow">Contributors to Kubeflow</h2>
     <div class="row--25-75">
-      <div class="col p-logo-section">
-        <div class="p-logo-section__items">
-          <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/7577d797-google-logo.svg" alt="Google" class="p-logo-section__logo" />
-          </div>
-          <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/6ece1a68-microsoft-logo.png" alt="Microsoft" class="p-logo-section__logo" />
-          </div>
-          <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/756d9941-canonical-logo.png" alt="Canonical" class="p-logo-section__logo" />
-          </div>
-          <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/1c72e761-cisco-logo.png" alt="Cisco" class="p-logo-section__logo" />
-          </div>
-          <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/c8792945-ibm-logo.png" alt="IBM" class="p-logo-section__logo" />
-          </div>
-          <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/834d57ab-intel-logo.png" alt="Intel" class="p-logo-section__logo" />
+      <div class="col">
+        <div class="p-logo-section--dense p-section--shallow">
+          <div class="p-logo-section__items">
+            <div class="p-logo-section__item">
+              {{
+                image (
+                  url="https://assets.ubuntu.com/v1/7577d797-google-logo.svg",
+                  alt="Google",
+                  width="71",
+                  height="96",
+                  hi_def=True,
+                  loading="auto",
+                  attr={"class": "p-logo-section__logo"}
+                ) | safe
+              }}
+            </div>
+            <div class="p-logo-section__item">
+              {{
+                image (
+                  url="https://assets.ubuntu.com/v1/6ece1a68-microsoft-logo.png",
+                  alt="Microsoft",
+                  width="105",
+                  height="96",
+                  hi_def=True,
+                  loading="auto",
+                  attr={"class": "p-logo-section__logo"}
+                ) | safe
+              }}
+            </div>
+            <div class="p-logo-section__item">
+              {{
+                image (
+                url="https://assets.ubuntu.com/v1/756d9941-canonical-logo.png",
+                alt="Canonical",
+                width="91",
+                height="96",
+                hi_def=True,
+                loading="auto"
+                attr={"class": "p-logo-section__logo"}
+                ) | safe
+              }}
+            </div>
+            <div class="p-logo-section__item">
+              {{
+                image (
+                  url="https://assets.ubuntu.com/v1/1c72e761-cisco-logo.png",
+                  alt="Cisco",
+                  width="232",
+                  height="384",
+                  hi_def=True,
+                  loading="auto",
+                  attr={"class": "p-logo-section__logo"}
+                ) | safe
+              }}
+            </div>
+            <div class="p-logo-section__item">
+              {{
+                image (
+                url="https://assets.ubuntu.com/v1/c8792945-ibm-logo.png",
+                alt="IBM",
+                width="47",
+                height="96",
+                hi_def=True,
+                loading="auto",
+                attr={"class": "p-logo-section__logo"}
+                ) | safe
+              }}
+            </div>
+            <div class="p-logo-section__item">
+              {{
+                image (
+                  url="https://assets.ubuntu.com/v1/834d57ab-intel-logo.png",
+                  alt="Intel",
+                  width="48",
+                  height="96",
+                  hi_def=True,
+                  loading="auto",
+                  attr={"class": "p-logo-section__logo"}
+                ) | safe
+              }}
+            </div>
           </div>
         </div>
       </div>

--- a/templates/ai/what-is-kubeflow.html
+++ b/templates/ai/what-is-kubeflow.html
@@ -15,7 +15,8 @@
           {{ image (
           url="https://assets.ubuntu.com/v1/cb6b2ca8-kubeflow-logo.png",
           alt="Kubeflow",
-          width="284",
+          width="852",
+          height="175",
           hi_def=True,
           loading="auto"
           ) | safe

--- a/templates/ai/what-is-kubeflow.html
+++ b/templates/ai/what-is-kubeflow.html
@@ -83,7 +83,7 @@
   </div>
   <div class="row--25-75">
     <div class="col">
-      <div class="p-logo-section p-section--shallow">
+      <div class="p-logo-section--dense p-section">
         <div class="p-logo-section__items">
           <div class="p-logo-section__item">
             <img src="https://assets.ubuntu.com/v1/f7f624aa-jupyter-logo.png" alt="Jupyter" class="p-logo-section__logo u-kube-logo-height" />
@@ -229,7 +229,7 @@
     </div>
     <div class="row--25-75">
       <div class="col">
-        <div class="p-logo-section">
+        <div class="p-logo-section--dense">
           <div class="p-logo-section__items">
             <div class="p-logo-section__item">
               <img src="https://assets.ubuntu.com/v1/ea6008a0-spotify-logo.png" alt="Spotify" class="p-logo-section__logo u-kube-logo-height" />

--- a/templates/ai/what-is-kubeflow.html
+++ b/templates/ai/what-is-kubeflow.html
@@ -4,45 +4,55 @@
 {% block meta_description %}Charmed Kubeflow is an enterprise-ready, fully supported MLOps platform for any cloud. A complete, free, open source solution for sophisticated data science labs.{% endblock meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1m-96RlGkbzFa1KaGAxYFpY0ztIlsTuViCjXSAlErQlg{% endblock meta_copydoc %}
 
+{% block body_class %}is-paper{% endblock body_class %}
 {% block content %}
 
-<section class="p-strip u-no-padding--top u-no-padding--bottom">
-  <div class="p-strip--suru-topped">
-    <div class="row u-equal-height">
-      <div class="col-6">
-        <h1 class="u-sv2">What is Kubeflow?</h1>
-        <p class="p-heading--4">Kubeflow is the open source machine learning toolkit on top of Kubernetes.</p>
-        <p class="u-sv3">Kubeflow translates steps in your data science workflow into Kubernetes jobs,  providing the cloud-native interface for your ML libraries, frameworks, pipelines and notebooks.</p>
-        <p>
-          <a class="p-button--positive" href="https://charmed-kubeflow.io/docs/install">
-          Charmed Kubeflow
-          </a>
-          <a href="https://charmed-kubeflow.io/#get-in-touch">Contact&nbsp;us&nbsp;now&nbsp;&rsaquo;</a>
-        </p>
-      </div>
-      <div class="col-4 col-start-large-8 u-vertically-center u-hide--medium u-hide--small u-align--center">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/da5a7c9e-Kubeflow-Logo.svg",
-          alt="",
-          height="230",
-          width="230",
+<section class="p-strip is-shallow u-no-padding--bottom">
+  <div class="p-section">
+    <div class="row--25-75">
+      <div class="col p-strip is-shallow u-no-padding--bottom">
+        <div
+          class="p-section">
+          {{ image (
+          url="https://assets.ubuntu.com/v1/b1f04506-Kubeflow-Logo-RGB.svg",
+          alt="Kubeflow",
+          width="197",
+          height="45",
           hi_def=True,
-          loading="auto",
+          loading="auto"
           ) | safe
-        }}
+          }}
+        </div>
+      </div>
+      <div class="col">
+        <div class="row">
+        <div class="col-5 p-section--shallow">
+          <h1 class=u-no-margin--bottom>What is Kubeflow?</h1>
+          <h2>Kubeflow is the open source machine learning MLOps platform</h2>
+        </div>
+        <div class="col-3">
+          <p>Kubeflow enables you to develop and deploy machine learning models at any scale. It is a cloud-native application that runs on any cloud.</p>
+          <p> Charmed Kubeflow is  Canonical’s distribution. It is secure and seamlessly integrated with other leading tools such as MLflow.</p>
+        </div>
+        </div>
+
+        <hr />
+        <a class="p-button--positive" href="https://charmed-kubeflow.io/docs/install">Try out Charmed Kubeflow</a>
+        <a class="p-button" href="/engage/mlops-toolkit">Read our MLOps toolkit</a>
       </div>
     </div>
   </div>
 </section>
 
-<section class="p-strip--light">
+<section class="p-section--shallow">
   <div class="u-fixed-width">
-    <p class="p-muted-heading">Contributors to Kubeflow</p>
-    <div class="p-logo-section has-misaligned-images">
-      <div class="p-logo-section__items">
-        <div class="p-logo-section__item">
-          {{
+    <hr class="p-rule" />
+    <h2 class="p-section--shallow">Contributors to Kubeflow</h2>
+    <div class="row--25-75">
+      <div class="col p-logo-section has-misaligned-images">
+        <div class="p-logo-section__items">
+          <div class="p-logo-section__item">
+            {{
             image(
             url="https://assets.ubuntu.com/v1/bc4d28f8-Google_2015_logo.svg",
             alt="Google",
@@ -52,10 +62,10 @@
             attrs={"class": "p-logo-section__logo"},
             loading="lazy",
             ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{
             image(
             url="https://assets.ubuntu.com/v1/b179abab-microsoft-logo+copy.svg",
             alt="Microsoft",
@@ -65,10 +75,10 @@
             attrs={"class": "p-logo-section__logo"},
             loading="lazy",
             ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{
             image(
             url="https://assets.ubuntu.com/v1/563c0d9b-_Canonical.svg",
             alt="Canonical",
@@ -78,10 +88,10 @@
             attrs={"class": "p-logo-section__logo"},
             loading="lazy",
             ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{
             image(
             url="https://assets.ubuntu.com/v1/16aec8e3-cisco-logo-transparent.png",
             alt="Cisco",
@@ -91,10 +101,10 @@
             attrs={"class": "p-logo-section__logo"},
             loading="lazy",
             ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{
             image(
             url="https://assets.ubuntu.com/v1/67db21e0-logo-ibm.png",
             alt="IBM",
@@ -104,10 +114,10 @@
             attrs={"class": "p-logo-section__logo"},
             loading="lazy",
             ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{
             image(
             url="https://assets.ubuntu.com/v1/e0ef0377-intel-logo-2-1.png",
             alt="intel",
@@ -117,7 +127,8 @@
             attrs={"class": "p-logo-section__logo"},
             loading="lazy",
             ) | safe
-          }}
+            }}
+          </div>
         </div>
       </div>
     </div>
@@ -126,44 +137,16 @@
 
 <section class="p-strip">
   <div class="u-fixed-width">
-    <h2 class="u-sv3">What's inside Kubeflow?</h2>
+    <hr class="p-rule" />
+    <h2 class="p-section--shallow">What's inside Kubeflow?</h2>
   </div>
-  <div class="row">
-    <div class="col-7">
-      <p class="p-heading--4">Kubeflow dashboard</p>
-      <p><a href="https://www.kubeflow.org/docs/components/central-dash/overview/">Central dashboard</a> with <a href="https://www.kubeflow.org/docs/components/multi-tenancy/overview/">multi-user isolation</a> provides a platform for data scientists and engineers to leverage K8s to develop, deploy and monitor their models in production.</p>
-
-      <p class="p-heading--4">JupyterLab and VSCode</p>
-      <p>With Kubeflow users can <a href="https://www.kubeflow.org/docs/components/notebooks/setup/">spin-up Jupyter notebook servers</a> but also VSCode directly from the dashboard, allocating the right storage, CPUs and GPUs.</p>
-
-      <p class="p-heading--4">ML libraries & frameworks</p>
-      <p>Kubeflow is compatible with your choice of data science libraries and frameworks. <a href="https://www.kubeflow.org/docs/components/training/tftraining/">TensorFlow</a>, <a href="https://www.kubeflow.org/docs/components/training/pytorch/">PyTorch</a>, <a href="https://www.kubeflow.org/docs/components/training/mxnet/">MXNet</a>, <a href="https://github.com/kubeflow/xgboost-operator">XGBoost</a>, <a href="https://scikit-learn.org/stable/">scikit-learn</a> and more.</p>
-
-      <p class="p-heading--4">Kubeflow Pipelines</p>
-      <p>Automate your ML workflow into pipelines by containerizing steps as pipeline components and defining inputs, outputs, parameters and generated artifacts. <a class="/blog/data-science-workflows-on-kubernetes-with-kubeflow-pipelines-part-1">Learn more&nbsp;&rsaquo;</a></p>
-      
-      <p class="p-heading--4">Experiments, Runs and Recurring Runs</p>
-      <p>Experiments, groups of <a href="https://www.kubeflow.org/docs/pipelines/pipelines-quickstart/#run-an-ml-pipeline">Kubeflow Pipeline 'Runs'</a> and <a href="https://www.kubeflow.org/docs/components/pipelines/overview/concepts/run/">Recurring Runs</a>, allow you to find the right parameters for your model, compare and replicate results.</p>
-      
-      <p class="p-heading--4">Hyperparameter tuning / AutoML</p>
-      <p>Kubeflow includes <a href="https://www.kubeflow.org/docs/components/katib/">Katib</a> for hyperparameter tuning. Katib runs pipelines with different hyperparameters (e.g. learning rate, # of hidden layers) optimising for the best ML model.</p>
-
-      <p class="p-heading--4">KServe for inference serving</p>
-      <p><a href="https://www.kubeflow.org/docs/components/serving/kfserving/">KServe</a> is a multi-framework model deployment tool with serverless inferencing, canary roll-outs, pre & post-processing and explainability. <a href="/blog/what-is-kfserving">Learn more&nbsp;&rsaquo;</a></p>
-
-      <p class="p-heading--4">The integrations you need</p>
-      <p>Charmed Kubeflow integrates with <a href="https://github.com/mlopsworks/charms">MLFlow</a> for model registry, staging, and monitoring in production, <a href="https://github.com/SeldonIO/seldon-core">Seldon Core</a> for inference serving and <a href="https://spark.apache.org/">Apache Spark</a> for parallel data processing.
-
-      <p class="p-heading--4">More...</p>
-      <p>Save, compare and share generated artifacts - models, images, plots.</p>
-
-    </div>
-    <div class="col-5 u-hide--small u-hide--medium">
+  <div class="row--25-75">
+    <div class="col">
       <div class="p-logo-section has-misaligned-images">
-      <div class="p-logo-section__items">
-        <div class="p-logo-section__item">
-        {{
-          image(
+        <div class="p-logo-section__items">
+          <div class="p-logo-section__item">
+            {{
+            image(
             url="https://assets.ubuntu.com/v1/8ee86883-jupyter-logo.png",
             alt="Jupyter",
             height="90",
@@ -171,103 +154,38 @@
             hi_def=True,
             attrs={"class": "p-logo-section__logos"},
             loading="lazy",
-          ) | safe
-        }}
-        </div>
-        <div class="p-logo-section__item ">
-        {{
-          image(
-            url="https://assets.ubuntu.com/v1/c4da5b86-Tensor-flow-logo.png",
+            ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item ">
+            {{
+            image(
+            url="https://assets.ubuntu.com/v1/57dd2115-TensorFlow-logo.svg",
             alt="TensorFlow",
             height="90",
             width="90",
             hi_def=True,
             attrs={"class": "p-logo-section__logos"},
             loading="lazy",
-          ) | safe
-        }}
-        </div>
-        <div class="p-logo-section__item">
-        {{
-          image(
-            url="https://assets.ubuntu.com/v1/6d6b4148-seldon-logo.png",
+            ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{
+            image(
+            url="https://assets.ubuntu.com/v1/86dc5036-Seldon_logo.svg",
             alt="Seldon",
             height="90",
             width="100",
             hi_def=True,
             attrs={"class": "p-logo-section__logos"},
             loading="lazy",
-          ) | safe
-        }}
-        </div>
-        <div class="p-logo-section__item">
-        {{
-          image(
-            url="https://assets.ubuntu.com/v1/a774cbbb-py-torch-logo.png",
-            alt="PyTorch",
-            height="90",
-            width="100",
-            hi_def=True,
-            attrs={"class": "p-logo-section__logos"},
-            loading="lazy",
-          ) | safe
-        }}
-        </div>
-        <div class="p-logo-section__item">
-        {{
-          image(
-            url="https://assets.ubuntu.com/v1/5d796b1c-itsio-logo.png",
-            alt="Istio",
-            height="60",
-            width="100",
-            hi_def=True,
-            attrs={"class": "p-logo-section__logos"},
-            loading="lazy",
-          ) | safe
-        }}
-        </div>
-        <div class="p-logo-section__item">
-        {{
-          image(
-            url="https://assets.ubuntu.com/v1/6b57da22-mxnet-logo.png",
-            alt="MXNet",
-            height="40",
-            width="110",
-            hi_def=True,
-            attrs={"class": "p-logo-section__logos"},
-            loading="lazy",
-          ) | safe
-        }}
-        </div>
-        <div class="p-logo-section__item">
-        {{
-          image(
-            url="https://assets.ubuntu.com/v1/41913ead-katib-logo.png",
-            alt="Katib",
-            height="90",
-            width="75",
-            hi_def=True,
-            attrs={"class": "p-logo-section__logos"},
-            loading="lazy",
-          ) | safe
-        }}
-        </div>
-        <div class="p-logo-section__item">
-        {{
-          image(
-            url="https://assets.ubuntu.com/v1/826d5be3-1200px-Prometheus_software_logo.svg.png",
-            alt="Prometheus",
-            height="80",
-            width="80",
-            hi_def=True,
-            attrs={"class": "p-logo-section__logos"},
-            loading="lazy",
-          ) | safe
-        }}
-        </div>
-        <div class="p-logo-section__item">
-        {{
-          image(
+            ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{
+            image(
             url="https://assets.ubuntu.com/v1/3d0a8131-ambassador-logo.png",
             alt="Ambassador",
             height="100",
@@ -275,12 +193,82 @@
             hi_def=True,
             attrs={"class": "p-logo-section__logos"},
             loading="lazy",
-          ) | safe
-        }}
+            ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{
+            image(
+            url="https://assets.ubuntu.com/v1/9b1d457f-PyTorch_logo.svg",
+            alt="PyTorch",
+            height="90",
+            width="100",
+            hi_def=True,
+            attrs={"class": "p-logo-section__logos"},
+            loading="lazy",
+            ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{
+            image(
+            url="https://assets.ubuntu.com/v1/5d796b1c-itsio-logo.png",
+            alt="Istio",
+            height="60",
+            width="100",
+            hi_def=True,
+            attrs={"class": "p-logo-section__logos"},
+            loading="lazy",
+            ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{
+            image(
+            url="https://assets.ubuntu.com/v1/6b57da22-mxnet-logo.png",
+            alt="MXNet",
+            height="40",
+            width="110",
+            hi_def=True,
+            attrs={"class": "p-logo-section__logos"},
+            loading="lazy",
+            ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{
+            image(
+            url="https://assets.ubuntu.com/v1/41913ead-katib-logo.png",
+            alt="Katib",
+            height="90",
+            width="75",
+            hi_def=True,
+            attrs={"class": "p-logo-section__logos"},
+            loading="lazy",
+            ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{
+            image(
+            url="https://assets.ubuntu.com/v1/826d5be3-1200px-Prometheus_software_logo.svg.png",
+            alt="Prometheus",
+            height="80",
+            width="80",
+            hi_def=True,
+            attrs={"class": "p-logo-section__logos"},
+            loading="lazy",
+            ) | safe
+            }}
+          </div>
         </div>
-        <div class="p-logo-section__item">
-        {{
-          image(
+      </div>
+      <hr class="p-rule" />
+      <div class="p-logo-section has-misaligned-images p-section--shallow">
+        <div class="p-logo-section__items">
+          <div class="p-logo-section__item">
+            {{
+            image(
             url="https://assets.ubuntu.com/v1/653daa8b-onnx-logo.png",
             alt="ONNX",
             height="30",
@@ -288,12 +276,12 @@
             hi_def=True,
             attrs={"class": "p-logo-section__logos"},
             loading="lazy",
-          ) | safe
-        }}
-        </div>
-        <div class="p-logo-section__item">
-        {{
-          image(
+            ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{
+            image(
             url="https://assets.ubuntu.com/v1/2af7ca99-xgboost-logo.png",
             alt="XGBoost",
             height="37",
@@ -301,12 +289,12 @@
             hi_def=True,
             attrs={"class": "p-logo-section__logos"},
             loading="lazy",
-          ) | safe
-        }}
-        </div>
-        <div class="p-logo-section__item">
-        {{
-          image(
+            ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{
+            image(
             url="https://assets.ubuntu.com/v1/f4ffa06e-scikit-learn-logo.png",
             alt="Scikit",
             height="60",
@@ -314,12 +302,12 @@
             hi_def=True,
             attrs={"class": "p-logo-section__logos"},
             loading="lazy",
-          ) | safe
-        }}
-        </div>
-        <div class="p-logo-section__item ">
-        {{
-          image(
+            ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item ">
+            {{
+            image(
             url="https://assets.ubuntu.com/v1/7c4d800a-pachyderm-logo.png",
             alt="Pachyderm",
             height="100",
@@ -327,286 +315,274 @@
             hi_def=True,
             attrs={"class": "p-logo-section__logos"},
             loading="lazy",
-          ) | safe
-        }}
+            ) | safe
+            }}
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <hr class="p-rule" />
+        <div class="col-3">
+          <p class="p-heading--5">Kubeflow dashboard</p>
+          <p><a href="https://www.kubeflow.org/docs/components/central-dash/overview/">Central dashboard</a> with <a
+              href="https://www.kubeflow.org/docs/components/multi-tenancy/overview/">multi-user isolation</a> provides
+            a
+            platform for data scientists and engineers to leverage K8s to develop, deploy and monitor their models in
+            production.</p>
+        </div>
+        <div class="col-3">
+          <p class="p-heading--5">JupyterLab and VSCode</p>
+          <p>With Kubeflow users can <a href="https://www.kubeflow.org/docs/components/notebooks/setup/">spin-up Jupyter
+              notebook servers</a> but also VSCode directly from the dashboard, allocating the right storage, CPUs and
+            GPUs.
+          </p>
+        </div>
+        <div class="col-3">
+          <p class="p-heading--5">ML libraries & frameworks</p>
+          <p>Kubeflow is compatible with your choice of data science libraries and frameworks. <a
+              href="https://www.kubeflow.org/docs/components/training/tftraining/">TensorFlow</a>, <a
+              href="https://www.kubeflow.org/docs/components/training/pytorch/">PyTorch</a>, <a
+              href="https://www.kubeflow.org/docs/components/training/mxnet/">MXNet</a>, <a
+              href="https://github.com/kubeflow/xgboost-operator">XGBoost</a>, <a
+              href="https://scikit-learn.org/stable/">scikit-learn</a> and more.</p>
+        </div>
+      </div>
+
+      <div class="row">
+        <hr class="p-rule" />
+        <div class="col-3">
+          <p class="p-heading--5">Kubeflow Pipelines</p>
+          <p>Automate your ML workflow into pipelines by containerizing steps as pipeline components and defining
+            inputs,
+            outputs, parameters and generated artifacts. <a
+              class="/blog/data-science-workflows-on-kubernetes-with-kubeflow-pipelines-part-1">Learn
+              more&nbsp;&rsaquo;</a>
+          </p>
+        </div>
+        <div class="col-3">
+          <p class="p-heading--5">Experiments, Runs and Recurring Runs</p>
+          <p>Experiments, groups of <a
+              href="https://www.kubeflow.org/docs/pipelines/pipelines-quickstart/#run-an-ml-pipeline">Kubeflow Pipeline
+              'Runs'</a> and <a
+              href="https://www.kubeflow.org/docs/components/pipelines/overview/concepts/run/">Recurring
+              Runs</a>, allow you to find the right parameters for your model, compare and replicate results.</p>
+
+        </div>
+        <div class="col-3">
+          <p class="p-heading--5">Hyperparameter tuning / AutoML</p>
+          <p>Kubeflow includes <a href="https://www.kubeflow.org/docs/components/katib/">Katib</a> for hyperparameter
+            tuning.
+            Katib runs pipelines with different hyperparameters (e.g. learning rate, # of hidden layers) optimising for
+            the
+            best ML model.</p>
+        </div>
+      </div>
+
+      <div class="row">
+        <hr class="p-rule" />
+        <div class="col-3">
+          <p class="p-heading--5">KServe for inference serving</p>
+          <p><a href="https://www.kubeflow.org/docs/components/serving/kfserving/">KServe</a> is a multi-framework model
+            deployment tool with serverless inferencing, canary roll-outs, pre & post-processing and explainability. <a
+              href="/blog/what-is-kfserving">Learn more&nbsp;&rsaquo;</a></p>
+        </div>
+        <div class="col-3">
+          <p class="p-heading--5">The integrations you need</p>
+          <p>Charmed Kubeflow integrates with <a href="https://github.com/mlopsworks/charms">MLFlow</a> for model
+            registry,
+            staging, and monitoring in production, <a href="https://github.com/SeldonIO/seldon-core">Seldon Core</a> for
+            inference serving and <a href="https://spark.apache.org/">Apache Spark</a> for parallel data processing.
+        </div>
+        <div class="col-3">
+          <p class="p-heading--5">More...</p>
+          <p>Save, compare and share generated artifacts - models, images, plots.</p>
         </div>
       </div>
     </div>
+</section>
+
+<section class="p-section">
+  <div class="row--50-50">
+    <hr class="p-rule"/>
+    <h2 class="col">MLOps at any scale</h2>
+    <div class="col">
+      <p>Enterprise-ready Charmed Kubeflow, the fully supported MLOps platform for any cloud, is validate and certified on high-end AI hardware, such as NVIDIA DGX.</p>
+      <p class="p-section--shallow">A complete solution for sophisticated data science labs. Upgrades and security updates - all supported in the free, open source distribution.</p>
+
+      <hr />
+      <a class="p-button--positive" href="https://ubuntu.com/engage/run-ai-at-scale">Get the whitepaper</a>
+    </div>
   </div>
 </section>
 
-<section class="p-strip--square-darksuru is-dark">
-  <div class="row u-equal-height">
-    <div class="col-7 u-vertically-center">
-      <div>
-        <h2>Kubeflow AI and MLOps at any scale</h2>
-        <p>Enterprise-ready Charmed Kubeflow, the fully supported MLOps platform for any cloud.</p>
-        <p>A complete solution for sophisticated data science labs. Upgrades and security updates - all supported in the free, open source distribution.</p>
-        <p>
-          <a class="p-button--positive" href="https://charmed-kubeflow.io/docs/quickstart">Install now</a>
-          <a href="https://www.youtube.com/watch?v=kutDYSB-_PI&t=149s" class="p-button">Watch demo</a>
-        </p>
-      </div>
+<section class="p-section">
+  <div class="row--50-50">
+    <hr class="p-rule"/>
+    <h2 class="col">Why MLOps?</h2>
+    <div class="col p-section--shallow">
+      <p>Bringing AI solutions to market can involve many steps: data pre-processing, training, model deployment or inference serving at scale... The list of tasks is complex and keeping them in a set of notebooks or scripts is hard to maintain, share and collaborate on, leading to inefficient processes.</p>
+      <p class="p-section--shallow"><a href="https://papers.nips.cc/paper/5656-hidden-technical-debt-in-machine-learning-systems.pdf">Google describes</a> that only about 20% of the effort and code required to bring AI systems to production is the development of ML code, while the remaining is operations. Standardizing ops in your ML workflows can hence greatly decrease time-to-market and costs for your AI solutions.</p>
+      <hr />
+      <a href="https://ubuntu.com/blog/what-is-mlops">Read more about MLOps.</a>
     </div>
-    <div class="col-5 u-align--center">
+    <div class="u-align--center u-hide--small p-image-wrapper">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/20f5bfae-Kubeflow-nicely-packaged-simple-transparent.svg",
+          url="https://assets.ubuntu.com/v1/c58561f9-why-mlops-viz.png",
           alt="",
-          width="212",
-          height="201",
+          width="1200",
           hi_def=True,
+          loading="lazy",
         ) | safe
       }}
-
-  </div>
-</section>
-
-<section class="p-strip">
-  <div class="u-fixed-width u-sv1">
-    <h2>Why MLOps?</h2>
-  </div>
-  <div class="row">
-    <div class="col-8">
-      <p>Bringing AI solutions to market can involve many steps: data pre-processing, training, model deployment or inference serving at scale... The list of tasks is complex and keeping them in a set of notebooks or scripts is hard to maintain, share and collaborate on, leading to inefficient processes.</p>
-      <p>
-      In the study, <a href="https://papers.nips.cc/paper/5656-hidden-technical-debt-in-machine-learning-systems.pdf">Hidden Technical Debt in Machine Learning Systems</a>, Google describes that only about 20% of the effort and code required to bring AI systems to production is the development of ML code, while the remaining is operations. Standardizing ops in your ML workflows can hence greatly decrease time-to-market and costs for your AI solutions.
-      </p>
-      <div class="u-fixed-width u-hide--small">
-        <figure class="u-no-margin">
-          {{
-            image(
-             url="https://assets.ubuntu.com/v1/aa8145e8-what+is+kubeflow+-+outlined.svg",
-             alt="",
-             height="274",
-             width="800",
-             hi_def=True,
-             loading="lazy",
-           ) | safe
-          }}
-         <figcaption>
-         Area = effort & code
-         </figcaption>
-       </figure>
-      </div>
     </div>
   </div>
 </section>
 
-<section class="p-strip--light">
-
-  <div class="row">
-    <div class="col-6">
-      <h2 class="u-fixed-width u-sv1">Who uses Kubeflow?</h2>
+<section class="p-section">
+  <div class="row--50-50">
+    <hr class="p-rule" />
+    <h2 class="col">Who uses Kubeflow?</h2>
+    <div class="col p-section">
       <p>Thousands of companies have chosen Kubeflow for their AI/ML stack.</p>
-      <p>From research institutions like CERN, to transport and logistics companies &ndash; Uber, Lyft, GoJek &ndash; to financial and media industries with Spotify, Bloomberg, Shopify and&nbsp;PayPal.</p>
-      <p>Forward-looking enterprises are using Kubeflow to empower their data scientists.</p>
+      <p>From research institutions like CERN, to transport and logistics companies - Uber, Lyft, GoJek - to financial
+        and media industries with Spotify, Bloomberg, Shopify and PayPal.</p>
+      <p class="p-section--shallow">Forward-looking enterprises are using Kubeflow to empower their data scientists.</p>
+      <hr />
+      <a href="https://ubuntu.com/engage/ai-ml-casestudy-tasmania/">Read our case study with
+        the University of Tasmania</a>
     </div>
- <div class="col-6 u-vertically-center">
-   <div class="p-logo-section has-misaligned-images">
+    <div class="p-logo-section has-misaligned-images">
       <div class="p-logo-section__items">
         <div class="p-logo-section__item">
           {{
-            image(
-              url="https://assets.ubuntu.com/v1/0c18b0ae-paypal_logo.svg",
-              alt="PayPal",
-              height="22",
-              width="85",
-              hi_def=True,
-              attrs={"class": "p-logo-section__logo"},
-              loading="lazy",
-              ) | safe
-            }}
-          </div>
-          <div class="p-logo-section__item ">
-            {{
-              image(
-              url="https://assets.ubuntu.com/v1/c4da5b86-Tensor-flow-logo.png",
-              alt="TensorFlow",
-              height="90",
-              width="90",
-              hi_def=True,
-              attrs={"class": "p-logo-section__logo"},
-              loading="lazy",
-              ) | safe
-            }}
-          </div>
-          <div class="p-logo-section__item">
-            {{
-              image(
-              url="https://assets.ubuntu.com/v1/6d6b4148-seldon-logo.png",
-              alt="Seldon",
-              height="90",
-              width="100",
-              hi_def=True,
-              attrs={"class": "p-logo-section__logo"},
-              loading="lazy",
-              ) | safe
-            }}
-          </div>
-          <div class="p-logo-section__item">
-            {{
-              image(
-              url="https://assets.ubuntu.com/v1/a774cbbb-py-torch-logo.png",
-              alt="PyTorch",
-              height="90",
-              width="100",
-              hi_def=True,
-              attrs={"class": "p-logo-section__logo"},
-              loading="lazy",
-              ) | safe
-            }}
-          </div>
-          <div class="p-logo-section__item">
-            {{
-              image(
-              url="https://assets.ubuntu.com/v1/5d796b1c-itsio-logo.png",
-              alt="Istio",
-              height="60",
-              width="100",
-              hi_def=True,
-              attrs={"class": "p-logo-section__logo"},
-              loading="lazy",
-              ) | safe
-            }}
-          </div>
-          <div class="p-logo-section__item">
-            {{
-              image(
-              url="https://assets.ubuntu.com/v1/6b57da22-mxnet-logo.png",
-              alt="MXNet",
-              height="40",
-              width="110",
-              hi_def=True,
-              attrs={"class": "p-logo-section__logo"},
-              loading="lazy",
-              ) | safe
-            }}
-          </div>
-          <div class="p-logo-section__item">
-            {{
-              image(
-              url="https://assets.ubuntu.com/v1/41913ead-katib-logo.png",
-              alt="Katib",
-              height="90",
-              width="75",
-              hi_def=True,
-              attrs={"class": "p-logo-section__logo"},
-              loading="lazy",
-              ) | safe
-            }}
-          </div>
-          <div class="p-logo-section__item">
-            {{
-              image(
-              url="https://assets.ubuntu.com/v1/826d5be3-1200px-Prometheus_software_logo.svg.png",
-              alt="Prometheus",
-              height="80",
-              width="80",
-              hi_def=True,
-              attrs={"class": "p-logo-section__logo"},
-              loading="lazy",
-              ) | safe
-            }}
-          </div>
-          <div class="p-logo-section__item">
-            {{
-              image(
-              url="https://assets.ubuntu.com/v1/3d0a8131-ambassador-logo.png",
-              alt="Ambassador",
-              height="100",
-              width="80",
-              hi_def=True,
-              attrs={"class": "p-logo-section__logo"},
-              loading="lazy",
-              ) | safe
-            }}
-          </div>
-          <div class="p-logo-section__item">
-            {{
-              image(
-              url="https://assets.ubuntu.com/v1/653daa8b-onnx-logo.png",
-              alt="ONNX",
-              height="30",
-              width="110",
-              hi_def=True,
-              attrs={"class": "p-logo-section__logo"},
-              loading="lazy",
-              ) | safe
-            }}
-          </div>
-          <div class="p-logo-section__item">
-            {{
-              image(
-              url="https://assets.ubuntu.com/v1/2af7ca99-xgboost-logo.png",
-              alt="XGBoost",
-              height="37",
-              width="110",
-              hi_def=True,
-              attrs={"class": "p-logo-section__logo"},
-              loading="lazy",
-              ) | safe
-            }}
-          </div>
-          <div class="p-logo-section__item">
-            {{
-              image(
-              url="https://assets.ubuntu.com/v1/f4ffa06e-scikit-learn-logo.png",
-              alt="Scikit",
-              height="60",
-              width="110",
-              hi_def=True,
-              attrs={"class": "p-logo-section__logo"},
-              loading="lazy",
-              ) | safe
-            }}
-          </div>
-          <div class="p-logo-section__item ">
-            {{
-              image(
-              url="https://assets.ubuntu.com/v1/7c4d800a-pachyderm-logo.png",
-              alt="Pachyderm",
-              height="100",
-              width="110",
-              hi_def=True,
-              attrs={"class": "p-logo-section__logo"},
-              loading="lazy",
-              ) | safe
-            }}
-          </div>
+          image(
+          url="https://assets.ubuntu.com/v1/1688fbe0-Spotify_logo.svg",
+          alt="Spotify",
+          height="42",
+          width="128",
+          hi_def=True,
+          attrs={"class": "p-logo-section__logo"},
+          loading="lazy",
+          ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{
+          image(
+          url="https://assets.ubuntu.com/v1/6889bfcb-uber-logo.png",
+          alt="Uber",
+          height="115",
+          width="128",
+          hi_def=True,
+          attrs={"class": "p-logo-section__logo"},
+          loading="lazy",
+          ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{
+          image(
+          url="https://assets.ubuntu.com/v1/0c18b0ae-paypal_logo.svg",
+          alt="PayPal",
+          height="42",
+          width="128",
+          hi_def=True,
+          attrs={"class": "p-logo-section__logo"},
+          loading="lazy",
+          ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{
+          image(
+          url="https://assets.ubuntu.com/v1/4a1c3691-lyft.svg",
+          alt="Lyft",
+          height="60",
+          width="128",
+          hi_def=True,
+          attrs={"class": "p-logo-section__logo"},
+          loading="lazy",
+          ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{
+          image(
+          url="https://assets.ubuntu.com/v1/202457a2-CERN_logo2.svg",
+          alt="Cern",
+          height="128",
+          width="128",
+          hi_def=True,
+          attrs={"class": "p-logo-section__logo"},
+          loading="lazy",
+          ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{
+          image(
+          url="https://assets.ubuntu.com/v1/b7693339-logo-bloomberg.svg",
+          alt="Bloomberg",
+          height="32",
+          width="138",
+          hi_def=True,
+          attrs={"class": "p-logo-section__logo"},
+          loading="lazy",
+          ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{
+          image(
+          url="https://assets.ubuntu.com/v1/4f597a36-Shopify.svg",
+          alt="Shopify",
+          height="150",
+          width="150",
+          hi_def=True,
+          attrs={"class": "p-logo-section__logo"},
+          loading="lazy",
+          ) | safe
+          }}
         </div>
       </div>
     </div>
   </div>
 </section>
-  
-<section class="p-strip">
-  <div class="row u-equal-height">
-    <div class="col-4">
-      {{
-        image(
-        url="https://assets.ubuntu.com/v1/a1317807-Install+Kubeflow.svg",
-        alt="Uber",
-        height="175",
-        width="250",
-        hi_def=True,
-        attrs={"class": "u-hide--small"},
-        loading="lazy",
-      ) | safe
-    }}
+
+<section>
+  <div class="row--50-50">
+    <hr class="p-rule" />
+    <h2 class="col u-no-margin--bottom">Kubeflow resources</h2>
+    <ul class="col p-list--divided u-no-margin--bottom">
+      <li class="p-list__item row--50-50">
+        <a class="col" href="https://charmed-kubeflow.io/docs">Charmed Kubeflow docs</a>
+        <p class="col">Read more about Charmed MLflow’s capabilities and follow our tutorials.</p>
+      </li>
+      <li class="p-list__item row--50-50">
+        <a class="col" href="/engage/kubeflow-vs-mlflow">Kubeflow vs. MLflow</a>
+        <p class="col">Understand the differences between the most famous open source solutions.</p>
+      </li>
+      <li class="p-list__item row--50-50">
+        <a class="col" href="/engage/mlops-guide">Guide to MLOps</a>
+        <p class="col">Learn how to take models to production using open source MLOps platforms.</p>
+      </li>
+    </ul>
   </div>
-  <div class="col-8">
-    <h2 class="u-fixed-width u-sv1">Get started today</h2>
-    <p class="u-sv2 p-heading--4">Try-out Kubeflow on your Kubernetes environment. Or on MicroK8s - Zero-ops Kubernetes with high availability.</p>
-    <p>Deploy locally on your workstation, cloud VM or on-prem server.</p>
-    <p>
-      <a class="p-button--positive" href="https://charmed-kubeflow.io/docs/quickstart">
-      Try Kubeflow on MicroK8s
-      </a>
-      <a href="https://charmed-kubeflow.io/#get-in-touch">
-        Contact us now&nbsp;&rsaquo;
-      </a>
-    </p>
+</section>
+
+<section class="p-strip is-deep is-bordered">
+  <div class="row--50-50">
+    <hr class="p-rule" />
+    <h2 class="col">Get started today</h2>
+    <div class="col">
+      <p>Try-out Kubeflow on your Kubernetes environment. Or on MicroK8s - Zero-ops Kubernetes with high availability.</p>
+      <p class="p-section--shallow">Deploy locally on your workstation, cloud VM or on-prem server.</p>
+      <hr />
+      <a class="p-button--positive" href="https://charmed-kubeflow.io/docs/quickstart">Try Kubeflow on MicroK8s</a>
+      <a class="p-button" href="https://charmed-kubeflow.io/#get-in-touch">Contact us now</a>
+    </div>
   </div>
 </section>
 

--- a/templates/ai/what-is-kubeflow.html
+++ b/templates/ai/what-is-kubeflow.html
@@ -13,7 +13,7 @@
       <div class="col u-no-padding--bottom p-section">
         <div>
           {{ image (
-          url="https://assets.ubuntu.com/v1/cb6b2ca8-kubeflow-logo.png",
+          url="https://assets.ubuntu.com/v1/6d72759e-kubeflow-logo.png",
           alt="Kubeflow",
           width="852",
           height="175",

--- a/templates/ai/what-is-kubeflow.html
+++ b/templates/ai/what-is-kubeflow.html
@@ -49,7 +49,7 @@
     <h2 class="p-section--shallow">Contributors to Kubeflow</h2>
     <div class="row--25-75">
       <div class="col">
-        <div class="p-logo-section--dense p-section--shallow">
+        <div class="p-logo-section p-section--shallow">
           <div class="p-logo-section__items">
             <div class="p-logo-section__item">
               <img src="https://assets.ubuntu.com/v1/7577d797-google-logo.svg" alt="Google" class="p-logo-section__logo u-kube-logo-height" />
@@ -83,7 +83,7 @@
   </div>
   <div class="row--25-75">
     <div class="col">
-      <div class="p-logo-section--dense p-section--shallow">
+      <div class="p-logo-section p-section--shallow">
         <div class="p-logo-section__items">
           <div class="p-logo-section__item">
             <img src="https://assets.ubuntu.com/v1/f7f624aa-jupyter-logo.png" alt="Jupyter" class="p-logo-section__logo u-kube-logo-height" />

--- a/templates/ai/what-is-kubeflow.html
+++ b/templates/ai/what-is-kubeflow.html
@@ -10,13 +10,12 @@
 <section class="p-strip is-shallow u-no-padding--bottom">
   <div class="p-section">
     <div class="row--25-75">
-      <div class="col u-no-padding--bottom">
+      <div class="col u-no-padding--bottom p-section">
         <div>
           {{ image (
           url="https://assets.ubuntu.com/v1/cb6b2ca8-kubeflow-logo.png",
           alt="Kubeflow",
-          width="196",
-          height="40",
+          width="284",
           hi_def=True,
           loading="auto"
           ) | safe
@@ -81,7 +80,7 @@
   </div>
   <div class="row--25-75">
     <div class="col">
-      <div class="p-logo-section--dense">
+      <div class="p-logo-section--dense p-section--shallow">
         <div class="p-logo-section__items">
           <div class="p-logo-section__item">
             <img src="https://assets.ubuntu.com/v1/f7f624aa-jupyter-logo.png" alt="Jupyter" class="p-logo-section__logo" />
@@ -114,7 +113,7 @@
             <img src="https://assets.ubuntu.com/v1/2c68ca73-onnx%20logo.png" alt="ONNX" class="p-logo-section__logo" />
           </div>
           <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/a7650f84-xgboost%20logo.png" alt="XGBoost" class="p-logo-section__logo" />
+            <img src="https://assets.ubuntu.com/v1/091fa892-xgboost%20logo.png" alt="XGBoost" class="p-logo-section__logo" />
           </div>
           <div class="p-logo-section__item">
             <img src="https://assets.ubuntu.com/v1/d335fd1c-scikit%20logo.png" alt="Scikit" class="p-logo-section__logo" />
@@ -125,7 +124,7 @@
         </div>
       </div>
       <hr class="p-rule u-hide--small u-hide--medium" />
-      <div class="row">
+      <div class="row p-section--shallow">
         <div class="col-3 col-medium-2">
           <h3 class="p-heading--5">Kubeflow dashboard</h3>
           <p><a href="https://www.kubeflow.org/docs/components/central-dash/overview/">Central dashboard</a> with <a href="https://www.kubeflow.org/docs/components/multi-tenancy/overview/">multi-user isolation</a> provides a platform for data scientists and engineers to leverage K8s to develop, deploy and monitor their models in production.</p>
@@ -147,7 +146,7 @@
 
       <hr class="p-rule u-hide--small" />
       <div class="row">
-        <div class="col-3 col-medium-2">
+        <div class="col-3 col-medium-2 p-section--shallow">
           <h3 class="p-heading--5">Kubeflow Pipelines</h3>
           <p>Automate your ML workflow into pipelines by containerizing steps as pipeline components and defining inputs, outputs, parameters and generated artifacts. <a class="/blog/data-science-workflows-on-kubernetes-with-kubeflow-pipelines-part-1">Learn more&nbsp;&rsaquo;</a>
           </p>
@@ -225,42 +224,44 @@
       <hr />
       <a href="/engage/ai-ml-casestudy-tasmania/">Read our case study with the University of Tasmania</a>
     </div>
-    <div class="p-logo-section">
-      <div class="p-logo-section__items">
-        <div class="p-logo-section__item">
-          <img src="https://assets.ubuntu.com/v1/ea6008a0-spotify-logo.png" alt="Spotify" class="p-logo-section__logo" />
-        </div>
-        <div class="p-logo-section__item">
-          <img src="https://assets.ubuntu.com/v1/b6b0b414-uber-logo.png" alt="Uber" class="p-logo-section__logo" />
-        </div>
-        <div class="p-logo-section__item">
-          <img src="https://assets.ubuntu.com/v1/63870c2f-paypal-logo.png" alt="PayPal" class="p-logo-section__logo" />
-        </div>
-        <div class="p-logo-section__item">
-          <img src="https://assets.ubuntu.com/v1/6117dd11-lyft-logo.png" alt="Lyft" class="p-logo-section__logo" />
-        </div>
-        <div class="p-logo-section__item">
-          <img src="https://assets.ubuntu.com/v1/c358b12a-cern-logo.png" alt="Cern" class="p-logo-section__logo" />
-        </div>
-        <div class="p-logo-section__item">
-          <img src="https://assets.ubuntu.com/v1/b0eca934-Bloomberg-Logo.png" alt="Bloomberg" class="p-logo-section__logo" />
-        </div>
-        <div class="p-logo-section__item">
-          <img src="https://assets.ubuntu.com/v1/a1996ad2-shopify-logo.png" alt="Shopify" class="p-logo-section__logo" />
+    <div class="row--25-75">
+      <div class="col p-logo-section--dense">
+        <div class="p-logo-section__items">
+          <div class="p-logo-section__item">
+            <img src="https://assets.ubuntu.com/v1/ea6008a0-spotify-logo.png" alt="Spotify" class="p-logo-section__logo" />
+          </div>
+          <div class="p-logo-section__item">
+            <img src="https://assets.ubuntu.com/v1/b6b0b414-uber-logo.png" alt="Uber" class="p-logo-section__logo" />
+          </div>
+          <div class="p-logo-section__item">
+            <img src="https://assets.ubuntu.com/v1/63870c2f-paypal-logo.png" alt="PayPal" class="p-logo-section__logo" />
+          </div>
+          <div class="p-logo-section__item">
+            <img src="https://assets.ubuntu.com/v1/6117dd11-lyft-logo.png" alt="Lyft" class="p-logo-section__logo" />
+          </div>
+          <div class="p-logo-section__item">
+            <img src="https://assets.ubuntu.com/v1/c358b12a-cern-logo.png" alt="Cern" class="p-logo-section__logo" />
+          </div>
+          <div class="p-logo-section__item">
+            <img src="https://assets.ubuntu.com/v1/b0eca934-Bloomberg-Logo.png" alt="Bloomberg" class="p-logo-section__logo" />
+          </div>
+          <div class="p-logo-section__item">
+            <img src="https://assets.ubuntu.com/v1/a1996ad2-shopify-logo.png" alt="Shopify" class="p-logo-section__logo" />
+          </div>
         </div>
       </div>
     </div>
   </div>
 </section>
 
-<section>
+<section class="p-section--shallow">
   <div class="row--50-50">
     <hr class="p-rule" />
     <div class="col u-no-margin--bottom">
       <h2>Kubeflow resources</h2>
     </div>
     <div class="col">
-      <ul class="p-list--divided u-no-margin--bottom">
+      <ul class="p-list--divided">
         <li class="p-list__item">
           <div class="row--50-50">
             <div class="col">
@@ -302,7 +303,7 @@
   </div>
 </section>
 
-<section class="p-strip is-deep is-bordered">
+<section class="p-section--deep">
   <div class="row--50-50">
     <hr class="p-rule" />
     <div class="col">

--- a/templates/ai/what-is-kubeflow.html
+++ b/templates/ai/what-is-kubeflow.html
@@ -32,7 +32,7 @@
         </div>
         <div class="col-3">
           <p>Kubeflow enables you to develop and deploy machine learning models at any scale. It is a cloud-native application that runs on any cloud.</p>
-          <p> Charmed Kubeflow is  Canonical’s distribution. It is secure and seamlessly integrated with other leading tools such as MLflow.</p>
+          <p>Charmed Kubeflow is Canonical’s distribution. It is secure and seamlessly integrated with other leading tools such as MLflow.</p>
         </div>
         </div>
 
@@ -52,22 +52,22 @@
       <div class="col p-logo-section">
         <div class="p-logo-section__items">
           <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/7577d797-google-logo.svg" alt="Gooogle" class="p-logo-section__logo" />
+            <img src="https://assets.ubuntu.com/v1/7577d797-google-logo.svg" alt="Google" class="p-logo-section__logo" />
           </div>
           <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/6ece1a68-microsoft-logo.png" alt="Microsoft" class="p-logo-section__logo"  />
+            <img src="https://assets.ubuntu.com/v1/6ece1a68-microsoft-logo.png" alt="Microsoft" class="p-logo-section__logo" />
           </div>
           <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/756d9941-canonical-logo.png" alt="Canonical" class="p-logo-section__logo"  />
+            <img src="https://assets.ubuntu.com/v1/756d9941-canonical-logo.png" alt="Canonical" class="p-logo-section__logo" />
           </div>
           <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/1c72e761-cisco-logo.png" alt="Cisco" class="p-logo-section__logo"  />
+            <img src="https://assets.ubuntu.com/v1/1c72e761-cisco-logo.png" alt="Cisco" class="p-logo-section__logo" />
           </div>
           <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/c8792945-ibm-logo.png" alt="IBM" class="p-logo-section__logo"  />
+            <img src="https://assets.ubuntu.com/v1/c8792945-ibm-logo.png" alt="IBM" class="p-logo-section__logo" />
           </div>
           <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/834d57ab-intel-logo.png" alt="Intel" class="p-logo-section__logo"  />
+            <img src="https://assets.ubuntu.com/v1/834d57ab-intel-logo.png" alt="Intel" class="p-logo-section__logo" />
           </div>
         </div>
       </div>
@@ -88,40 +88,40 @@
             <img src="https://assets.ubuntu.com/v1/f7f624aa-jupyter-logo.png" alt="Jupyter" class="p-logo-section__logo" />
           </div>
           <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/c497f959-tensor-flow-logo.png" alt="TensorFlow" class="p-logo-section__logo"  />
+            <img src="https://assets.ubuntu.com/v1/c497f959-tensor-flow-logo.png" alt="TensorFlow" class="p-logo-section__logo" />
           </div>
           <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/2f4bd927-seldon-logo.png" alt="Seldon" class="p-logo-section__logo"  />
+            <img src="https://assets.ubuntu.com/v1/2f4bd927-seldon-logo.png" alt="Seldon" class="p-logo-section__logo" />
           </div>
           <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/6b0f7cdc-ambassador%20%20logo.png" alt="Ambassador" class="p-logo-section__logo"  />
+            <img src="https://assets.ubuntu.com/v1/6b0f7cdc-ambassador%20%20logo.png" alt="Ambassador" class="p-logo-section__logo" />
           </div>
           <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/fe513e7b-pytorch-logo.png" alt="PyTorch" class="p-logo-section__logo"  />
+            <img src="https://assets.ubuntu.com/v1/fe513e7b-pytorch-logo.png" alt="PyTorch" class="p-logo-section__logo" />
           </div>
           <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/c112372b-istio%20logo.png" alt="Istio" class="p-logo-section__logo"  />
+            <img src="https://assets.ubuntu.com/v1/c112372b-istio%20logo.png" alt="Istio" class="p-logo-section__logo" />
           </div>
           <div class="p-logo-section__item">
             <img src="https://assets.ubuntu.com/v1/e9ce15ff-mxnet%20logo.png" alt="MXNet" class="p-logo-section__logo" />
           </div>
           <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/9c91dbfd-katib-logo.png" alt="Katib" class="p-logo-section__logo"  />
+            <img src="https://assets.ubuntu.com/v1/9c91dbfd-katib-logo.png" alt="Katib" class="p-logo-section__logo" />
           </div>
           <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/8d5fee47-prometheus%20logo.png" alt="Prometheus" class="p-logo-section__logo"  />
+            <img src="https://assets.ubuntu.com/v1/8d5fee47-prometheus%20logo.png" alt="Prometheus" class="p-logo-section__logo" />
           </div>
           <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/2c68ca73-onnx%20logo.png" alt="ONNX" class="p-logo-section__logo"  />
+            <img src="https://assets.ubuntu.com/v1/2c68ca73-onnx%20logo.png" alt="ONNX" class="p-logo-section__logo" />
           </div>
           <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/a7650f84-xgboost%20logo.png" alt="XGBoost" class="p-logo-section__logo"  />
+            <img src="https://assets.ubuntu.com/v1/a7650f84-xgboost%20logo.png" alt="XGBoost" class="p-logo-section__logo" />
           </div>
           <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/d335fd1c-scikit%20logo.png" alt="Scikit" class="p-logo-section__logo"  />
+            <img src="https://assets.ubuntu.com/v1/d335fd1c-scikit%20logo.png" alt="Scikit" class="p-logo-section__logo" />
           </div>
           <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/c5ae87ca-pachyderm%20logo.png" alt="Pachyderm" class="p-logo-section__logo"  />
+            <img src="https://assets.ubuntu.com/v1/c5ae87ca-pachyderm%20logo.png" alt="Pachyderm" class="p-logo-section__logo" />
           </div>
         </div>
       </div>
@@ -129,27 +129,20 @@
       <div class="row">
         <div class="col-3">
           <h3 class="p-heading--5">Kubeflow dashboard</h3>
-          <p><a href="https://www.kubeflow.org/docs/components/central-dash/overview/">Central dashboard</a> with <a
-              href="https://www.kubeflow.org/docs/components/multi-tenancy/overview/">multi-user isolation</a> provides
-            a
-            platform for data scientists and engineers to leverage K8s to develop, deploy and monitor their models in
-            production.</p>
+          <p><a href="https://www.kubeflow.org/docs/components/central-dash/overview/">Central dashboard</a> with <a href="https://www.kubeflow.org/docs/components/multi-tenancy/overview/">multi-user isolation</a> provides a platform for data scientists and engineers to leverage K8s to develop, deploy and monitor their models in production.</p>
         </div>
         <div class="col-3">
           <h3 class="p-heading--5">JupyterLab and VSCode</h3>
-          <p>With Kubeflow users can <a href="https://www.kubeflow.org/docs/components/notebooks/setup/">spin-up Jupyter
-              notebook servers</a> but also VSCode directly from the dashboard, allocating the right storage, CPUs and
-            GPUs.
-          </p>
+          <p>With Kubeflow users can <a href="https://www.kubeflow.org/docs/components/notebooks/setup/">spin-up Jupyter notebook servers</a> but also VSCode directly from the dashboard, allocating the right storage, CPUs and GPUs.</p>
         </div>
         <div class="col-3">
           <h3 class="p-heading--5">ML libraries & frameworks</h3>
-          <p>Kubeflow is compatible with your choice of data science libraries and frameworks. <a
-              href="https://www.kubeflow.org/docs/components/training/tftraining/">TensorFlow</a>, <a
-              href="https://www.kubeflow.org/docs/components/training/pytorch/">PyTorch</a>, <a
-              href="https://www.kubeflow.org/docs/components/training/mxnet/">MXNet</a>, <a
-              href="https://github.com/kubeflow/xgboost-operator">XGBoost</a>, <a
-              href="https://scikit-learn.org/stable/">scikit-learn</a> and more.</p>
+          <p>Kubeflow is compatible with your choice of data science libraries and frameworks. 
+            <a href="https://www.kubeflow.org/docs/components/training/tftraining/">TensorFlow</a>, 
+            <a href="https://www.kubeflow.org/docs/components/training/pytorch/">PyTorch</a>, 
+            <a href="https://www.kubeflow.org/docs/components/training/mxnet/">MXNet</a>, 
+            <a href="https://github.com/kubeflow/xgboost-operator">XGBoost</a>, 
+            <a href="https://scikit-learn.org/stable/">scikit-learn</a> and more.</p>
         </div>
       </div>
 
@@ -157,46 +150,27 @@
       <div class="row">
         <div class="col-3">
           <h3 class="p-heading--5">Kubeflow Pipelines</h3>
-          <p>Automate your ML workflow into pipelines by containerizing steps as pipeline components and defining
-            inputs,
-            outputs, parameters and generated artifacts. <a
-              class="/blog/data-science-workflows-on-kubernetes-with-kubeflow-pipelines-part-1">Learn
-              more&nbsp;&rsaquo;</a>
+          <p>Automate your ML workflow into pipelines by containerizing steps as pipeline components and defining inputs, outputs, parameters and generated artifacts. <a class="/blog/data-science-workflows-on-kubernetes-with-kubeflow-pipelines-part-1">Learn more&nbsp;&rsaquo;</a>
           </p>
         </div>
         <div class="col-3">
           <h3 class="p-heading--5">Experiments, Runs and Recurring Runs</h3>
-          <p>Experiments, groups of <a
-              href="https://www.kubeflow.org/docs/pipelines/pipelines-quickstart/#run-an-ml-pipeline">Kubeflow Pipeline
-              'Runs'</a> and <a
-              href="https://www.kubeflow.org/docs/components/pipelines/overview/concepts/run/">Recurring
-              Runs</a>, allow you to find the right parameters for your model, compare and replicate results.</p>
-
+          <p>Experiments, groups of <a href="https://www.kubeflow.org/docs/pipelines/pipelines-quickstart/#run-an-ml-pipeline">Kubeflow Pipeline 'Runs'</a> and <a href="https://www.kubeflow.org/docs/components/pipelines/overview/concepts/run/">Recurring Runs</a>, allow you to find the right parameters for your model, compare and replicate results.</p>
         </div>
         <div class="col-3">
           <h3 class="p-heading--5">Hyperparameter tuning / AutoML</h3>
-          <p>Kubeflow includes <a href="https://www.kubeflow.org/docs/components/katib/">Katib</a> for hyperparameter
-            tuning.
-            Katib runs pipelines with different hyperparameters (e.g. learning rate, # of hidden layers) optimising for
-            the
-            best ML model.</p>
+          <p>Kubeflow includes <a href="https://www.kubeflow.org/docs/components/katib/">Katib</a> for hyperparameter tuning. Katib runs pipelines with different hyperparameters (e.g. learning rate, # of hidden layers) optimising for the best ML model.</p>
         </div>
       </div>
-
       <hr class="p-rule u-hide--small u-hide--medium" />
       <div class="row">
         <div class="col-3">
           <h3 class="p-heading--5">KServe for inference serving</h3>
-          <p><a href="https://www.kubeflow.org/docs/components/serving/kfserving/">KServe</a> is a multi-framework model
-            deployment tool with serverless inferencing, canary roll-outs, pre & post-processing and explainability. <a
-              href="/blog/what-is-kfserving">Learn more&nbsp;&rsaquo;</a></p>
+          <p><a href="https://www.kubeflow.org/docs/components/serving/kfserving/">KServe</a> is a multi-framework model deployment tool with serverless inferencing, canary roll-outs, pre & post-processing and explainability. <a href="/blog/what-is-kfserving">Learn more&nbsp;&rsaquo;</a></p>
         </div>
         <div class="col-3">
           <h3 class="p-heading--5">The integrations you need</h3>
-          <p>Charmed Kubeflow integrates with <a href="https://github.com/mlopsworks/charms">MLFlow</a> for model
-            registry,
-            staging, and monitoring in production, <a href="https://github.com/SeldonIO/seldon-core">Seldon Core</a> for
-            inference serving and <a href="https://spark.apache.org/">Apache Spark</a> for parallel data processing.
+          <p>Charmed Kubeflow integrates with <a href="https://github.com/mlopsworks/charms">MLFlow</a> for model registry, staging, and monitoring in production, <a href="https://github.com/SeldonIO/seldon-core">Seldon Core</a> for inference serving and <a href="https://spark.apache.org/">Apache Spark</a> for parallel data processing.
         </div>
         <div class="col-3">
           <h3 class="p-heading--5">More...</h3>
@@ -208,14 +182,15 @@
 
 <section class="p-section">
   <div class="row--50-50">
-    <hr class="p-rule"/>
-    <h2 class="col">MLOps at any scale</h2>
+    <hr class="p-rule" />
+    <div class="col">
+      <h2>MLOps at any scale</h2>
+    </div>
     <div class="col">
       <p>Enterprise-ready Charmed Kubeflow, the fully supported MLOps platform for any cloud, is validate and certified on high-end AI hardware, such as NVIDIA DGX.</p>
       <p class="p-section--shallow">A complete solution for sophisticated data science labs. Upgrades and security updates - all supported in the free, open source distribution.</p>
-
       <hr />
-      <a class="p-button--positive" href="https://ubuntu.com/engage/run-ai-at-scale">Get the whitepaper</a>
+      <a class="p-button--positive" href="/engage/run-ai-at-scale">Get the whitepaper</a>
     </div>
   </div>
 </section>
@@ -223,12 +198,14 @@
 <section class="p-section">
   <div class="row--50-50">
     <hr class="p-rule"/>
-    <h2 class="col">Why MLOps?</h2>
+    <div class="col">
+      <h2>Why MLOps?</h2>
+    </div>
     <div class="col p-section--shallow">
       <p>Bringing AI solutions to market can involve many steps: data pre-processing, training, model deployment or inference serving at scale... The list of tasks is complex and keeping them in a set of notebooks or scripts is hard to maintain, share and collaborate on, leading to inefficient processes.</p>
       <p class="p-section--shallow"><a href="https://papers.nips.cc/paper/5656-hidden-technical-debt-in-machine-learning-systems.pdf">Google describes</a> that only about 20% of the effort and code required to bring AI systems to production is the development of ML code, while the remaining is operations. Standardizing ops in your ML workflows can hence greatly decrease time-to-market and costs for your AI solutions.</p>
       <hr />
-      <a href="https://ubuntu.com/blog/what-is-mlops">Read more about MLOps</a>
+      <a href="/blog/what-is-mlops">Read more about MLOps</a>
     </div>
     <div class="u-align--center u-hide--small p-image-wrapper">
       {{
@@ -247,15 +224,15 @@
 <section class="p-section">
   <div class="row--50-50">
     <hr class="p-rule" />
-    <h2 class="col">Who uses Kubeflow?</h2>
+    <div class="col">
+      <h2>Who uses Kubeflow?</h2>
+    </div>
     <div class="col p-section">
       <p>Thousands of companies have chosen Kubeflow for their AI/ML stack.</p>
-      <p>From research institutions like CERN, to transport and logistics companies - Uber, Lyft, GoJek - to financial
-        and media industries with Spotify, Bloomberg, Shopify and PayPal.</p>
+      <p>From research institutions like CERN, to transport and logistics companies - Uber, Lyft, GoJek - to financial and media industries with Spotify, Bloomberg, Shopify and PayPal.</p>
       <p class="p-section--shallow">Forward-looking enterprises are using Kubeflow to empower their data scientists.</p>
       <hr />
-      <a href="https://ubuntu.com/engage/ai-ml-casestudy-tasmania/">Read our case study with
-        the University of Tasmania</a>
+      <a href="/engage/ai-ml-casestudy-tasmania/">Read our case study with the University of Tasmania</a>
     </div>
     <div class="p-logo-section">
       <div class="p-logo-section__items">
@@ -288,7 +265,9 @@
 <section>
   <div class="row--50-50">
     <hr class="p-rule" />
-    <h2 class="col u-no-margin--bottom">Kubeflow resources</h2>
+    <div class="col u-no-margin--bottom">
+      <h2>Kubeflow resources</h2>
+    </div>
     <ul class="col p-list--divided u-no-margin--bottom">
       <li class="p-list__item row--50-50">
         <a class="col" href="https://charmed-kubeflow.io/docs">Charmed Kubeflow docs</a>
@@ -309,7 +288,9 @@
 <section class="p-strip is-deep is-bordered">
   <div class="row--50-50">
     <hr class="p-rule" />
-    <h2 class="col">Get started today</h2>
+    <div class="col">
+      <h2>Get started today</h2>
+    </div>
     <div class="col">
       <p>Try-out Kubeflow on your Kubernetes environment. Or on MicroK8s - Zero-ops Kubernetes with high availability.</p>
       <p class="p-section--shallow">Deploy locally on your workstation, cloud VM or on-prem server.</p>

--- a/templates/ai/what-is-kubeflow.html
+++ b/templates/ai/what-is-kubeflow.html
@@ -10,16 +10,18 @@
 <section class="p-strip is-shallow u-no-padding--bottom">
   <div class="p-section">
     <div class="row--25-75">
-      <div class="col u-no-padding--bottom">
-          {{ image(
-            url="https://assets.ubuntu.com/v1/6d72759e-kubeflow-logo.png",
-            alt="Kubeflow",
-            width="182",
-            height="42",
-            hi_def=True,
-            loading="auto"
+      <div class="col u-no-padding--bottom p-section">
+        <div>
+          {{ image (
+          url="https://assets.ubuntu.com/v1/6d72759e-kubeflow-logo.png",
+          alt="Kubeflow",
+          width="852",
+          height="175",
+          hi_def=True,
+          loading="auto"
           ) | safe
           }}
+        </div>
       </div>
       <div class="col">
         <div class="row">
@@ -29,7 +31,7 @@
         </div>
         <div class="col-3">
           <p>Kubeflow enables you to develop and deploy machine learning models at any scale. It is a cloud-native application that runs on any cloud.</p>
-          <p>Charmed Kubeflow is Canonical's distribution. It is secure and seamlessly integrated with other leading tools such as MLflow.</p>
+          <p>Charmed Kubeflow is Canonical’s distribution. It is secure and seamlessly integrated with other leading tools such as MLflow.</p>
         </div>
         </div>
 
@@ -47,85 +49,25 @@
     <h2 class="p-section--shallow">Contributors to Kubeflow</h2>
     <div class="row--25-75">
       <div class="col">
-        <div class="p-logo-section">
+        <div class="p-logo-section--dense p-section--shallow">
           <div class="p-logo-section__items">
             <div class="p-logo-section__item">
-              {{
-                image(
-                  url="https://assets.ubuntu.com/v1/7577d797-google-logo.svg",
-                  alt="Google",
-                  width="71",
-                  height="96",
-                  hi_def=True,
-                  loading="auto",
-                  attrs={"class": "p-logo-section__logo"}
-                ) | safe
-              }}
+              <img src="https://assets.ubuntu.com/v1/7577d797-google-logo.svg" alt="Google" class="p-logo-section__logo u-kube-logo-height" />
             </div>
             <div class="p-logo-section__item">
-              {{
-                image(
-                  url="https://assets.ubuntu.com/v1/6ece1a68-microsoft-logo.png",
-                  alt="Microsoft",
-                  width="105",
-                  height="96",
-                  hi_def=True,
-                  loading="auto",
-                  attrs={"class": "p-logo-section__logo"}
-                ) | safe
-              }}
+              <img src="https://assets.ubuntu.com/v1/6ece1a68-microsoft-logo.png" alt="Microsoft" class="p-logo-section__logo u-kube-logo-height" />
             </div>
             <div class="p-logo-section__item">
-              {{
-                image(
-                url="https://assets.ubuntu.com/v1/756d9941-canonical-logo.png",
-                alt="Canonical",
-                width="91",
-                height="96",
-                hi_def=True,
-                loading="auto",
-                attrs={"class": "p-logo-section__logo"}
-                ) | safe
-              }}
+              <img src="https://assets.ubuntu.com/v1/756d9941-canonical-logo.png" alt="Canonical" class="p-logo-section__logo u-kube-logo-height" />
             </div>
             <div class="p-logo-section__item">
-              {{
-                image(
-                  url="https://assets.ubuntu.com/v1/1c72e761-cisco-logo.png",
-                  alt="Cisco",
-                  width="232",
-                  height="384",
-                  hi_def=True,
-                  loading="auto",
-                  attrs={"class": "p-logo-section__logo"}
-                ) | safe
-              }}
+              <img src="https://assets.ubuntu.com/v1/1c72e761-cisco-logo.png" alt="Cisco" class="p-logo-section__logo u-kube-logo-height" />
             </div>
             <div class="p-logo-section__item">
-              {{
-                image(
-                url="https://assets.ubuntu.com/v1/c8792945-ibm-logo.png",
-                alt="IBM",
-                width="47",
-                height="96",
-                hi_def=True,
-                loading="auto",
-                attrs={"class": "p-logo-section__logo"}
-                ) | safe
-              }}
+              <img src="https://assets.ubuntu.com/v1/c8792945-ibm-logo.png" alt="IBM" class="p-logo-section__logo u-kube-logo-height" />
             </div>
             <div class="p-logo-section__item">
-              {{
-                image(
-                  url="https://assets.ubuntu.com/v1/834d57ab-intel-logo.png",
-                  alt="Intel",
-                  width="48",
-                  height="96",
-                  hi_def=True,
-                  loading="auto",
-                  attrs={"class": "p-logo-section__logo"}
-                ) | safe
-              }}
+              <img src="https://assets.ubuntu.com/v1/834d57ab-intel-logo.png" alt="Intel" class="p-logo-section__logo u-kube-logo-height" />
             </div>
           </div>
         </div>
@@ -144,173 +86,43 @@
       <div class="p-logo-section--dense p-section--shallow">
         <div class="p-logo-section__items">
           <div class="p-logo-section__item">
-            {{
-              image(
-                url="https://assets.ubuntu.com/v1/f7f624aa-jupyter-logo.png",
-                alt="Jupyter",
-                width="48",
-                height="96",
-                hi_def=True,
-                loading="lazy",
-                attrs={"class": "p-logo-section__logo"}
-              ) | safe
-            }}
+            <img src="https://assets.ubuntu.com/v1/f7f624aa-jupyter-logo.png" alt="Jupyter" class="p-logo-section__logo u-kube-logo-height" />
           </div>
           <div class="p-logo-section__item">
-            {{
-              image(
-                url="https://assets.ubuntu.com/v1/c497f959-tensor-flow-logo.png",
-                alt="TensorFlow",
-                width="92",
-                height="96",
-                hi_def=True,
-                loading="lazy",
-                attrs={"class": "p-logo-section__logo"}
-              ) | safe
-            }}
+            <img src="https://assets.ubuntu.com/v1/c497f959-tensor-flow-logo.png" alt="TensorFlow" class="p-logo-section__logo u-kube-logo-height" />
           </div>
           <div class="p-logo-section__item">
-            {{
-              image(
-                url="https://assets.ubuntu.com/v1/2f4bd927-seldon-logo.png",
-                alt="Seldon",
-                width="281",
-                height="288",
-                hi_def=True,
-                loading="lazy",
-                attrs={"class": "p-logo-section__logo"}
-              ) | safe
-            }}
+            <img src="https://assets.ubuntu.com/v1/2f4bd927-seldon-logo.png" alt="Seldon" class="p-logo-section__logo u-kube-logo-height" />
           </div>
           <div class="p-logo-section__item">
-            {{
-              image(
-                url="https://assets.ubuntu.com/v1/6b0f7cdc-ambassador  logo.png",
-                alt="Ambassador",
-                width="58",
-                height="288",
-                hi_def=True,
-                loading="lazy",
-                attrs={"class": "p-logo-section__logo"}
-              ) | safe
-            }}
+            <img src="https://assets.ubuntu.com/v1/6b0f7cdc-ambassador%20%20logo.png" alt="Ambassador" class="p-logo-section__logo u-kube-logo-height" />
           </div>
           <div class="p-logo-section__item">
-            {{
-              image(
-                url="https://assets.ubuntu.com/v1/fe513e7b-pytorch-logo.png",
-                alt="PyTorch",
-                width="83",
-                height="96",
-                hi_def=True,
-                loading="lazy",
-                attrs={"class": "p-logo-section__logo"}
-              ) | safe
-            }}
+            <img src="https://assets.ubuntu.com/v1/fe513e7b-pytorch-logo.png" alt="PyTorch" class="p-logo-section__logo u-kube-logo-height" />
           </div>
           <div class="p-logo-section__item">
-            {{
-              image(
-                url="https://assets.ubuntu.com/v1/c112372b-istio logo.png",
-                alt="Istio",
-                width="83",
-                height="96",
-                hi_def=True,
-                loading="lazy",
-                attrs={"class": "p-logo-section__logo"}
-              ) | safe
-            }}
+            <img src="https://assets.ubuntu.com/v1/c112372b-istio%20logo.png" alt="Istio" class="p-logo-section__logo u-kube-logo-height" />
           </div>
           <div class="p-logo-section__item">
-            {{
-              image(
-                url="https://assets.ubuntu.com/v1/e9ce15ff-mxnet logo.png",
-                alt="MXNet",
-                width="93",
-                height="96",
-                hi_def=True,
-                loading="lazy",
-                attrs={"class": "p-logo-section__logo"}
-              ) | safe
-            }}
+            <img src="https://assets.ubuntu.com/v1/e9ce15ff-mxnet%20logo.png" alt="MXNet" class="p-logo-section__logo u-kube-logo-height" />
           </div>
           <div class="p-logo-section__item">
-            {{
-              image(
-                url="https://assets.ubuntu.com/v1/9c91dbfd-katib-logo.png",
-                alt="Katib",
-                width="32",
-                height="96",
-                hi_def=True,
-                loading="lazy",
-                attrs={"class": "p-logo-section__logo"}
-              ) | safe
-            }}
+            <img src="https://assets.ubuntu.com/v1/9c91dbfd-katib-logo.png" alt="Katib" class="p-logo-section__logo u-kube-logo-height" />
           </div>
           <div class="p-logo-section__item">
-            {{
-              image(
-                url="https://assets.ubuntu.com/v1/8d5fee47-prometheus logo.png",
-                alt="Prometheus",
-                width="31",
-                height="96",
-                hi_def=True,
-                loading="lazy",
-                attrs={"class": "p-logo-section__logo"}
-              ) | safe
-            }}
+            <img src="https://assets.ubuntu.com/v1/8d5fee47-prometheus%20logo.png" alt="Prometheus" class="p-logo-section__logo u-kube-logo-height" />
           </div>
           <div class="p-logo-section__item">
-            {{
-              image(
-                url="https://assets.ubuntu.com/v1/2c68ca73-onnx logo.png",
-                alt="ONNX",
-                width="87",
-                height="96",
-                hi_def=True,
-                loading="lazy",
-                attrs={"class": "p-logo-section__logo"}
-              ) | safe
-            }}
+            <img src="https://assets.ubuntu.com/v1/2c68ca73-onnx%20logo.png" alt="ONNX" class="p-logo-section__logo u-kube-logo-height" />
           </div>
           <div class="p-logo-section__item">
-            {{
-              image(
-                url="https://assets.ubuntu.com/v1/091fa892-xgboost logo.png",
-                alt="XGBoost",
-                width="73",
-                height="96",
-                hi_def=True,
-                loading="lazy",
-                attrs={"class": "p-logo-section__logo"}
-              ) | safe
-            }}
+            <img src="https://assets.ubuntu.com/v1/091fa892-xgboost%20logo.png" alt="XGBoost" class="p-logo-section__logo u-kube-logo-height" />
           </div>
           <div class="p-logo-section__item">
-            {{
-              image(
-                url="https://assets.ubuntu.com/v1/d335fd1c-scikit logo.png",
-                alt="Scikit",
-                width="87",
-                height="96",
-                hi_def=True,
-                loading="lazy",
-                attrs={"class": "p-logo-section__logo"}
-              ) | safe
-            }}
+            <img src="https://assets.ubuntu.com/v1/d335fd1c-scikit%20logo.png" alt="Scikit" class="p-logo-section__logo u-kube-logo-height" />
           </div>
           <div class="p-logo-section__item">
-            {{
-              image(
-                url="https://assets.ubuntu.com/v1/c5ae87ca-pachyderm logo.png",
-                alt="Pachyderm",
-                width="32",
-                height="96",
-                hi_def=True,
-                loading="lazy",
-                attrs={"class": "p-logo-section__logo"}
-                ) | safe
-            }}
+            <img src="https://assets.ubuntu.com/v1/c5ae87ca-pachyderm%20logo.png" alt="Pachyderm" class="p-logo-section__logo u-kube-logo-height" />
           </div>
         </div>
       </div>
@@ -416,98 +228,28 @@
       <a href="/engage/ai-ml-casestudy-tasmania/">Read our case study with the University of Tasmania</a>
     </div>
     <div class="row--25-75">
-      <div class="col p-logo-section">
+      <div class="col p-logo-section--dense">
         <div class="p-logo-section__items">
           <div class="p-logo-section__item">
-            {{
-              image(
-                url="https://assets.ubuntu.com/v1/ea6008a0-spotify-logo.png",
-                alt="Spotify",
-                width="90",
-                height="96",
-                hi_def=True,
-                loading="auto",
-                attrs={"class": "p-logo-section__logo"}
-              ) | safe
-            }}
+            <img src="https://assets.ubuntu.com/v1/ea6008a0-spotify-logo.png" alt="Spotify" class="p-logo-section__logo u-kube-logo-height" />
           </div>
           <div class="p-logo-section__item">
-            {{
-              image(
-                url="https://assets.ubuntu.com/v1/b6b0b414-uber-logo.png",
-                alt="Uber",
-                width="44",
-                height="96",
-                hi_def=True,
-                loading="lazy",
-                attrs={"class": "p-logo-section__logo"}
-              ) | safe
-            }}
+            <img src="https://assets.ubuntu.com/v1/b6b0b414-uber-logo.png" alt="Uber" class="p-logo-section__logo u-kube-logo-height" />
           </div>
           <div class="p-logo-section__item">
-            {{
-              image(
-                url="https://assets.ubuntu.com/v1/63870c2f-paypal-logo.png",
-                alt="Paypal",
-                width="86",
-                height="96",
-                hi_def=True,
-                loading="lazy",
-                attrs={"class": "p-logo-section__logo"}
-              ) | safe
-            }}
+            <img src="https://assets.ubuntu.com/v1/63870c2f-paypal-logo.png" alt="PayPal" class="p-logo-section__logo u-kube-logo-height" />
           </div>
           <div class="p-logo-section__item">
-            {{
-              image(
-                url="https://assets.ubuntu.com/v1/6117dd11-lyft-logo.png",
-                alt="Lyft",
-                width="96",
-                height="96",
-                hi_def=True,
-                loading="lazy",
-                attrs={"class": "p-logo-section__logo"}
-              ) | safe
-            }}
+            <img src="https://assets.ubuntu.com/v1/6117dd11-lyft-logo.png" alt="Lyft" class="p-logo-section__logo u-kube-logo-height" />
           </div>
           <div class="p-logo-section__item">
-            {{
-              image(
-                url="https://assets.ubuntu.com/v1/c358b12a-cern-logo.png",
-                alt="Cern",
-                width="73",
-                height="96",
-                hi_def=True,
-                loading="lazy",
-                attrs={"class": "p-logo-section__logo"}
-              ) | safe
-            }}
+            <img src="https://assets.ubuntu.com/v1/c358b12a-cern-logo.png" alt="Cern" class="p-logo-section__logo u-kube-logo-height" />
           </div>
           <div class="p-logo-section__item">
-            {{
-              image(
-                url="https://assets.ubuntu.com/v1/b0eca934-Bloomberg-Logo.png",
-                alt="Bloomberg",
-                width="96",
-                height="96",
-                hi_def=True,
-                loading="lazy",
-                attrs={"class": "p-logo-section__logo"}
-              ) | safe
-            }}
+            <img src="https://assets.ubuntu.com/v1/b0eca934-Bloomberg-Logo.png" alt="Bloomberg" class="p-logo-section__logo u-kube-logo-height" />
           </div>
           <div class="p-logo-section__item">
-            {{
-              image(
-                url="https://assets.ubuntu.com/v1/a1996ad2-shopify-logo.png",
-                alt="Shopify",
-                width="89",
-                height="96",
-                hi_def=True,
-                loading="lazy",
-                attrs={"class": "p-logo-section__logo"}
-              ) | safe
-            }}
+            <img src="https://assets.ubuntu.com/v1/a1996ad2-shopify-logo.png" alt="Shopify" class="p-logo-section__logo u-kube-logo-height" />
           </div>
         </div>
       </div>
@@ -531,7 +273,7 @@
               </p>
             </div>
             <div class="col">
-              <p>Read more about Charmed MLflow's capabilities and follow our tutorials.</p>
+              <p>Read more about Charmed MLflow’s capabilities and follow our tutorials.</p>
             </div>
           </div>
         </li>


### PR DESCRIPTION
## Done

Update /ai/what-is-kubeflow design according to figma and copy doc
Need confirmation from Andreea 

## QA

- [demo link](https://ubuntu-com-13711.demos.haus/ai/what-is-kubeflow)
- [copy doc](https://docs.google.com/document/d/1m-96RlGkbzFa1KaGAxYFpY0ztIlsTuViCjXSAlErQlg/edit)
- [figma](https://www.figma.com/file/sGeCjFvA1kV9Kmvg2S2VBn/23.10-U.com---AI-bubble?node-id=248%3A1446&mode=dev)
- View the site on demo
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check that the page is correct according to the demo and copy doc

## Issue / Card
[WD-6314](https://warthogs.atlassian.net/browse/WD-6314)

[WD-6314]: https://warthogs.atlassian.net/browse/WD-6314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ