### PR TITLE
Add tooltip to release chart bars

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -25,6 +25,8 @@ azure:
       path: /azure/fips
     - title: SQL
       path: /azure/sql
+    - title: Docs
+      path: https://documentation.ubuntu.com/azure
 
 appliance:
   title: Appliance
@@ -60,6 +62,8 @@ aws:
       path: /aws/fips
     - title: WorkSpaces
       path: /aws/workspaces
+    - title: Docs
+      path: https://documentation.ubuntu.com/aws/en/latest/
 
 managedapps:
   title: Managed
@@ -550,6 +554,8 @@ gcp:
       path: /gcp/pro
     - title: FIPS
       path: /gcp/fips
+    - title: Docs
+      path: https://documentation.ubuntu.com/gcp/en/latest/
 
 ubuntu1604:
   title: 16-04

--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -1205,25 +1205,25 @@ export var desktopServerStatus = {
 };
 
 export var kernelStatus = {
-  LTS: "chart__bar--orange",
-  ESM: "chart__bar--aubergine",
+  LTS: "chart__bar--black",
+  ESM: "chart__bar--aubergine-light",
   INTERIM_RELEASE: "chart__bar--grey",
 };
 
 export var kernelReleaseScheduleStatus = {
-  LTS: "chart__bar--orange",
+  LTS: "chart__bar--black",
   INTERIM_RELEASE: "chart__bar--grey",
 };
 
 export var kernelStatusLTS = {
-  LTS: "chart__bar--orange",
+  LTS: "chart__bar--black",
   CVE: "chart__bar--grey",
 };
 
 export var kernelStatusALL = {
-  LTS: "chart__bar--orange",
+  LTS: "chart__bar--black",
   INTERIM_RELEASE: "chart__bar--grey",
-  EARLY: "chart__bar--aubergine",
+  EARLY: "chart__bar--aubergine-light",
 };
 
 export var openStackStatus = {

--- a/static/js/src/dynamic-forms.js
+++ b/static/js/src/dynamic-forms.js
@@ -191,6 +191,7 @@ import setupIntlTelInput from "./intlTelInput.js";
       var otherContainers = document.querySelectorAll(".js-other-container");
       var phoneInput = document.querySelector("#phone");
       var modalTrigger = document.activeElement || document.body;
+      var isMultipage = contactModal.querySelector(".js-pagination").length > 1;
 
       document.onkeydown = function (evt) {
         evt = evt || window.event;
@@ -198,6 +199,13 @@ import setupIntlTelInput from "./intlTelInput.js";
           close();
         }
       };
+
+      contactModal.addEventListener("submit", function (e) {
+        addLoadingSpinner();
+        if (!isMultipage) {
+          comment.value = createMessage();
+        }
+      });
 
       if (closeModal) {
         closeModal.addEventListener("click", function (e) {
@@ -366,7 +374,9 @@ import setupIntlTelInput from "./intlTelInput.js";
         var formFields = contactModal.querySelectorAll(".js-formfield");
         formFields.forEach(function (formField) {
           var comma = "";
-          var fieldTitle = formField.querySelector(".p-heading--5");
+          var fieldTitle =
+            formField.querySelector(".p-heading--5") ??
+            formField.querySelector(".p-modal__question-heading");
           var inputs = formField.querySelectorAll("input, textarea");
           if (fieldTitle) {
             message += fieldTitle.innerText + "\r\n";
@@ -529,21 +539,17 @@ import setupIntlTelInput from "./intlTelInput.js";
       setpreferredLanguage();
 
       // Disables submit button and adds visual queue when it is submitted
-      function setupSubmitButton() {
+      function addLoadingSpinner() {
         const modalForm = formContainer.querySelector("form");
         const spinnerIcon = document.createElement("i");
         spinnerIcon.className = "p-icon--spinner u-animation--spin is-light";
-        modalForm.addEventListener("submit", function (e) {
-          const buttonRect = submitButton.getBoundingClientRect();
-          submitButton.style.width = buttonRect.width + "px";
-          submitButton.style.height = buttonRect.height + "px";
-          submitButton.disabled = true;
-          submitButton.innerText = "";
-          submitButton.appendChild(spinnerIcon);
-        });
+        const buttonRect = submitButton.getBoundingClientRect();
+        submitButton.style.width = buttonRect.width + "px";
+        submitButton.style.height = buttonRect.height + "px";
+        submitButton.disabled = true;
+        submitButton.innerText = "";
+        submitButton.appendChild(spinnerIcon);
       }
-
-      setupSubmitButton();
 
       function fireLoadedEvent() {
         var event = new CustomEvent("contactModalLoaded");

--- a/static/js/src/release-chart-old.js
+++ b/static/js/src/release-chart-old.js
@@ -78,6 +78,59 @@ function addBarsToChart(svg, tasks, taskStatus, x, y, highlightVersion) {
 }
 
 /**
+ * @param {*} svg
+ * 
+ * Adds tooltip to bars
+ */
+function addTooltipToBars(svg) {
+  const tooltip = createTooltip();
+
+  svg.selectAll(".chart rect")
+    .on("mouseover", function(e, d) {
+      const tooltipStatus = formatTooltipStatus(d.status);
+      const dateRange = `${formatDate(d.startDate)} - ${formatDate(d.endDate)}`;
+      const tooltipContent = tooltipStatus ? `${tooltipStatus}: ${dateRange}` : dateRange;
+      tooltip.select(".p-tooltip__message").text(tooltipContent);
+      tooltip.classed("u-hide", false);
+    })
+    .on("mousemove", function(e) {
+      tooltip
+        .style("left", (e.pageX + 2) + "px")
+        .style("top", (e.pageY - 3) + "px");
+    })
+    .on("mouseout", function() {
+      tooltip.classed("u-hide", true);
+    });
+}
+
+/**
+ * Creates a tooltip and appends it to the page body
+ */
+function createTooltip() {
+  const tooltip = d3.select("body").select(".p-tooltip--top-center.is-detached");
+  if (tooltip.empty()) {
+    tooltip = d3.select("body").append("div")
+      .attr("class", "p-tooltip--top-center is-detached u-hide");
+    tooltip.append("span")
+      .attr("class", "p-tooltip__message")
+      .attr("role", "tooltip");
+  }
+  
+  return tooltip;
+}
+
+/**
+ * 
+ * @param {String} date
+ * 
+ * Parse the date to be more readable
+ */
+function formatDate(date) {
+  var formatDate = d3.timeFormat("%b %Y");
+  return formatDate(date);
+}
+
+/**
  *
  * @param {*} svg
  * @param {Int} height
@@ -129,11 +182,10 @@ function cleanUpChart(svg) {
   svg.selectAll(".domain").remove();
 }
 
-/* @param {*} svg
+/**
+ * @param {*} svg
  *
- * Embolden LTS labels on y axis**
- *
-
+ * Embolden LTS labels on y axis
  */
 function emboldenLTSLabels(svg, yScale) {
   const domain = yScale.domain();
@@ -245,10 +297,46 @@ function buildChartKey(chartSelector, taskStatus) {
 }
 
 /**
+ * 
+ * @param {String} key
+ * 
+ * Formats tooltip key into readable string
+ */
+function formatTooltipStatus(key) {
+  const standardisedKey = key.toLowerCase().trim();
+  switch (standardisedKey) {
+    case "lts":
+      return "Standard support";
+    case "esm":
+      return "Expanded Security Maintenance";
+    case "interim_release":
+      return "Interim release standard security maintenance";
+    case "early":
+      return "Early preview";
+    case "cve":
+      return "CVE/Critical fixes only";
+    case "main_universe":
+      return "LTS standard security maintenance for Ubuntu Main";
+    case "hardware_and_maintenance_updates":
+      return "LTS Expanded Security Maintenance (ESM) for Ubuntu Universe";
+    case "matching_openstack_release_support":
+      return "Matching OpenStack release support";
+    case "extended_support_for_customers":
+      return "Extended support for customers";
+    case "canonical_kubernetes_expanded_security_maintenance":
+      return "Canonical Kubernetes Expanded Security Maintenance";
+    case "canonical_kubernetes_support":
+      return "Canonical Kubernetes support";
+    default:
+      return null;
+  }
+}
+
+/**
  *
  * @param {String} key
  *
- * Formats key into readable string
+ * Formats label key into readable string
  */
 function formatKeyLabel(key) {
   var keyLowerCase = key.toLowerCase().replace(/_/g, " ");
@@ -403,6 +491,7 @@ export function createReleaseChartOld(
   addYAxisVerticalLines(svg, width);
 
   addBarsToChart(svg, tasks, taskStatus, x, y, highlightVersion);
+  addTooltipToBars(svg);
 
   if (taskVersions) {
     addVersionAxis(svg, versionAxis);

--- a/static/js/src/release-chart-old.js
+++ b/static/js/src/release-chart-old.js
@@ -79,26 +79,29 @@ function addBarsToChart(svg, tasks, taskStatus, x, y, highlightVersion) {
 
 /**
  * @param {*} svg
- * 
+ *
  * Adds tooltip to bars
  */
 function addTooltipToBars(svg) {
   const tooltip = createTooltip();
 
-  svg.selectAll(".chart rect")
-    .on("mouseover", function(e, d) {
+  svg
+    .selectAll(".chart rect")
+    .on("mouseover", function (e, d) {
       const tooltipStatus = formatTooltipStatus(d.status);
       const dateRange = `${formatDate(d.startDate)} - ${formatDate(d.endDate)}`;
-      const tooltipContent = tooltipStatus ? `${tooltipStatus}: ${dateRange}` : dateRange;
+      const tooltipContent = tooltipStatus
+        ? `${tooltipStatus}: ${dateRange}`
+        : dateRange;
       tooltip.select(".p-tooltip__message").text(tooltipContent);
       tooltip.classed("u-hide", false);
     })
-    .on("mousemove", function(e) {
+    .on("mousemove", function (e) {
       tooltip
-        .style("left", (e.pageX + 2) + "px")
-        .style("top", (e.pageY - 3) + "px");
+        .style("left", e.pageX + 2 + "px")
+        .style("top", e.pageY - 3 + "px");
     })
-    .on("mouseout", function() {
+    .on("mouseout", function () {
       tooltip.classed("u-hide", true);
     });
 }
@@ -107,22 +110,27 @@ function addTooltipToBars(svg) {
  * Creates a tooltip and appends it to the page body
  */
 function createTooltip() {
-  const tooltip = d3.select("body").select(".p-tooltip--top-center.is-detached");
+  let tooltip = d3
+    .select("body")
+    .select(".p-tooltip--top-center.is-detached");
   if (tooltip.empty()) {
-    tooltip = d3.select("body").append("div")
+    tooltip = d3
+      .select("body")
+      .append("div")
       .attr("class", "p-tooltip--top-center is-detached u-hide");
-    tooltip.append("span")
+    tooltip
+      .append("span")
       .attr("class", "p-tooltip__message")
       .attr("role", "tooltip");
   }
-  
+
   return tooltip;
 }
 
 /**
- * 
+ *
  * @param {String} date
- * 
+ *
  * Parse the date to be more readable
  */
 function formatDate(date) {
@@ -297,9 +305,9 @@ function buildChartKey(chartSelector, taskStatus) {
 }
 
 /**
- * 
+ *
  * @param {String} key
- * 
+ *
  * Formats tooltip key into readable string
  */
 function formatTooltipStatus(key) {

--- a/static/js/src/release-chart-old.js
+++ b/static/js/src/release-chart-old.js
@@ -117,7 +117,8 @@ function createTooltip() {
     tooltip = d3
       .select("body")
       .append("div")
-      .attr("class", "p-tooltip--top-center is-detached u-hide");
+      .attr("class", "p-tooltip--top-center is-detached u-hide")
+      .attr("style", "pointer-events: none;");
     tooltip
       .append("span")
       .attr("class", "p-tooltip__message")

--- a/static/js/src/release-chart-old.js
+++ b/static/js/src/release-chart-old.js
@@ -110,9 +110,7 @@ function addTooltipToBars(svg) {
  * Creates a tooltip and appends it to the page body
  */
 function createTooltip() {
-  let tooltip = d3
-    .select("body")
-    .select(".p-tooltip--top-center.is-detached");
+  let tooltip = d3.select("body").select(".p-tooltip--top-center.is-detached");
   if (tooltip.empty()) {
     tooltip = d3
       .select("body")
@@ -193,6 +191,7 @@ function cleanUpChart(svg) {
 
 /**
  * @param {*} svg
+ * @param {*} yScale
  *
  * Embolden LTS labels on y axis
  */

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1347,7 +1347,7 @@ $color-link-dark: #69c !default;
 .p-modal__dialog.is-paper {
   max-width: $grid-max-width !important;
 
-  &.is-ai-modal {
+  .row--50-50 {
     .p-modal__close {
       background-color: transparent;
       margin-top: 1.5rem;

--- a/templates/download/nvidia-jetson/index.html
+++ b/templates/download/nvidia-jetson/index.html
@@ -30,7 +30,7 @@
       <p>All images are 64-bit builds of Ubuntu.</p>
       <hr />
       <p>
-        <a href="/internet-of-things/nvidia/contact-us" class="p-button--positive">Get in touch</a>
+        <a href="/internet-of-things/nvidia/contact-us" class="p-button--positive js-invoke-modal">Get in touch</a>
       </p>
     </div>
   </div>
@@ -76,5 +76,8 @@
     </div>
   </div>
 </section>
+
+<!-- Set default Marketo information for contact form below-->
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/nvidia-jetson" data-form-id="4953" data-lp-id="" data-return-url="https://ubuntu.com/internet-of-things/thank-you?product=nvidia" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 
 {% endblock content %}

--- a/templates/hpe/index.html
+++ b/templates/hpe/index.html
@@ -396,7 +396,7 @@
           <hr class="is-fixed-width p-rule">
           {% endif %}
           <div class="p-block">
-            <h2><a href="/blog/{{ article.slug }}">{{ article.title.rendered }}</a></h2>
+            <h2><a href="/blog/{{ article.slug }}">{{ article.title.rendered | safe }}</a></h2>
             <p>
               {% if 4307 in article.tags %}
               <button class="p-chip--information" onclick="location.href='/blog/tag/hpe'">

--- a/templates/shared/forms/interactive/ai.html
+++ b/templates/shared/forms/interactive/ai.html
@@ -1,5 +1,5 @@
 <div class="p-modal" id="contact-modal">
-  <div class="p-modal__dialog is-paper is-ai-modal" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
+  <div class="p-modal__dialog is-paper" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
     <div class="js-pagination js-pagination--1">
       <div class="js-formfield">
         <div class="row--50-50 p-strip is-shallow">

--- a/templates/shared/forms/interactive/nvidia-jetson.html
+++ b/templates/shared/forms/interactive/nvidia-jetson.html
@@ -1,0 +1,119 @@
+<div class="p-modal" id="contact-modal">
+  <div class="p-modal__dialog is-paper" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
+    <div class="js-pagination js-pagination--1">
+      <div class="row--50-50 p-strip is-shallow">
+        <div class="col">
+          <h2 class="p-heading--1" id="modal-title">Interested in optimised Ubuntu on NVIDIA platforms?</h2>
+          <p>Canonical announced plans to certify Ubuntu to run on NVIDIA platforms powered by the Orin architecture. Ubuntu will run on the full range of NVIDIA IoT platforms, bringing Ubuntu to the automotive industry with the NVIDIA DRIVE&reg; platform, to industrial applications with the NVIDIA IGX Orin&trade; platform, as well as to advanced embedded systems with NVIDIA Jetson Orin&trade;  system-on-modules. The optimised kernel and images will combine software features from NVIDIA with unparalleled security, reliability, and support for regulated enterprise deployments.</p>
+          <p>With this collaboration, optimised Ubuntu and Ubuntu Core images will be available for commercial-grade IoT deployments for a wide range of popular silicon platforms across a variety of vendors, establishing a de facto standard across enterprise IoT &ndash; from software- defined vehicles and industry 4.0 to retail and robotics.</p>
+          <p>Fill out the form to receive the latest update from us!</p>
+        </div>
+        <div class="col">
+          <button class="p-modal__close" aria-label="Close active modal">Close</button>
+          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
+            <div class="p-section--shallow js-formfield">
+              <h3 class="p-text--default p-modal__question-heading">Which NVIDIA platforms are you interested in?</h3>
+              <label class="p-checkbox">
+                <input class="p-checkbox__input" type="checkbox" aria-labelledby="drive-orin">
+                <span class="p-checkbox__label" id="drive-orin">Xavier</span>
+              </label>
+              <label class="p-checkbox">
+                <input class="p-checkbox__input" type="checkbox" aria-labelledby="drive-orin">
+                <span class="p-checkbox__label" id="drive-orin">DRIVE Orin</span>
+              </label>
+              <label class="p-checkbox">
+                <input class="p-checkbox__input" type="checkbox" aria-labelledby="igx-orin">
+                <span class="p-checkbox__label" id="igx-orin">IGX Orin</span>
+              </label>
+              <label class="p-checkbox">
+                <input class="p-checkbox__input" type="checkbox" aria-labelledby="jetson-agx-orin">
+                <span class="p-checkbox__label" id="jetson-agx-orin">Jetson AGX Orin</span>
+              </label>
+              <label class="p-checkbox">
+                <input class="p-checkbox__input" type="checkbox" aria-labelledby="jetson-orin-nx">
+                <span class="p-checkbox__label" id="jetson-orin-nx">Jetson Orin NX</span>
+              </label>
+              <label class="p-checkbox">
+                <input class="p-checkbox__input" type="checkbox" aria-labelledby="jetson-orin-nano">
+                <span class="p-checkbox__label" id="jetson-orin-nano">Jetson Orin Nano</span>
+              </label>
+            </div>
+            <div class="p-section--shallow js-formfield">
+              <hr class="p-rule">
+              <h3 class="p-text--default p-modal__question-heading">Tell us more about your project</h3>
+              <textarea id="tell-us-about-your-project" rows="4" maxlength="2000"></textarea>
+            </div>
+            <div class="p-section--shallow">
+              <hr class="p-rule">
+              <h3 class="p-text--default">Please leave your contact details so that we can inform you once the optimised Ubuntu images are available to download and install on your Tegra SoCs.</h3>
+              <label class="is-required" for="firstName">First name:</label>
+              <input required id="firstName" name="firstName" maxlength="255" type="text"/>
+
+              <label class="is-required" for="lastName">Last name:</label>
+              <input required id="lastName" name="lastName" maxlength="255" type="text"/>
+
+              <label class="is-required" for="company">Company:</label>
+              <input required id="company" name="company" maxlength="255" type="text"/>
+
+              <label class="is-required" for="company">Job title:</label>
+              <input required id="title" name="title" maxlength="255" type="text"/>
+
+              <label class="is-required" for="email">Email:</label>
+              <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"/>
+
+              <label class="is-required" for="phone">Mobile/cell phone number:</label>
+              <input required id="phone" name="phone" maxlength="255" type="tel" />
+            </div>
+
+            <div class="p-section--shallow">
+              <label class="p-checkbox">
+                <input class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
+                <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
+              </label>
+
+              <p>By submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</p>
+              {# These are honey pot fields to catch bots #}
+              <ul class="p-list u-off-screen">
+                <li class="u-off-screen">
+                  <label class="website" for="website">Website:</label>
+                  <input name="website" type="text" class="website" autocomplete="off" value="" id="website" tabindex="-1" />
+                </li>
+                <li class="u-off-screen">
+                  <label class="name" for="name">Name:</label>
+                  <input name="name" type="text" class="name" autocomplete="off" value="" id="name" tabindex="-1" />
+                </li>
+              </ul>
+              {# End of honey pots #}
+            </div>
+
+            <div class="u-hide">
+              <h3>Your comments</h3>
+              <ul class="p-list">
+                <li class="p-list__item">
+                  <label for="Comments_from_lead__c">What would you like to talk to us about?</label>
+                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
+                </li>
+              </ul>
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %%" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Facebook_Click_ID__c" id="Facebook_Click_ID__c" value="" />
+              <input type="hidden" aria-hidden="true" aria-label="hidden field" id="preferredLanguage" name="preferredLanguage" maxlength="255" value="" />
+            </div>
+
+            <div class="pagination p-section--shallow">
+              <hr>
+              <button type="submit" class="pagination__link--next p-button--positive" aria-label="Submit">Submit form</button>
+            </div>
+          </form>           
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/templates/thank-you.html
+++ b/templates/thank-you.html
@@ -7,7 +7,7 @@
 <section class="p-strip is-deep is-bordered">
   <div class="row">
     <div class="col-7">
-      <h1>Thanks for getting in touch</h1>
+      <h1>Thanks for getting in touch {% if product and product != "" %} about {{ product }}{% endif %}</h1>
       <h2 class="p-heading--3">Your submission was successful.</h2>
       {% if referrer and referrer != "" %}
       <p><a href="{{ referrer }}" class="p-button">Return to learn more</a></p>
@@ -36,9 +36,9 @@
   </div>
   <div class="row p-divider">
     <div class="col-4 p-divider__block">
-      <h4 class="p-heading--3">Ubuntu Advantage</h4>
+      <h4 class="p-heading--3">Ubuntu Pro</h4>
       <p>Purchase our desktop support and access Ubuntu experts whenever you need.</p>
-      <p><a href="/support">Learn about Ubuntu Advantage&nbsp;&rsaquo;</a></p>
+      <p><a href="/support">Learn about Ubuntu Pro&nbsp;&rsaquo;</a></p>
     </div>
     <div class="col-4 p-divider__block">
       <h4 class="p-heading--3">Ubuntu OpenStack</h4>

--- a/webapp/shop/api/ua_contracts/api.py
+++ b/webapp/shop/api/ua_contracts/api.py
@@ -1,3 +1,4 @@
+import logging
 from typing import List, Optional
 
 from requests.exceptions import HTTPError
@@ -11,6 +12,7 @@ class UAContractsAPI:
         token_type="Macaroon",
         api_url="https://contracts.canonical.com",
         is_for_view=False,
+        remote_addr=None,
     ):
         """
         Expects a Talisker session in most circumstances,
@@ -22,6 +24,7 @@ class UAContractsAPI:
         self.token_type = token_type
         self.api_url = api_url.rstrip("/")
         self.is_for_view = is_for_view
+        self.remote_addr = remote_addr
 
     def set_authentication_token(self, token):
         self.authentication_token = token
@@ -44,6 +47,13 @@ class UAContractsAPI:
         headers[
             "Authorization"
         ] = f"{self.token_type} {self.authentication_token}"
+
+        if self.remote_addr:
+            headers["X-Forwarded-For"] = self.remote_addr
+            logger = logging.getLogger("talisker.requests")
+            logger.info(
+                "remote address", extra={"remote_addr": self.remote_addr}
+            )
 
         response = self.session.request(
             method=method,

--- a/webapp/shop/decorators.py
+++ b/webapp/shop/decorators.py
@@ -1,11 +1,12 @@
-from distutils.util import strtobool
 import os
+
+from distutils.util import strtobool
 from functools import wraps
 from datetime import datetime
 from dateutil.parser import parse
-import pytz
 
 import flask
+import pytz
 import talisker.requests
 
 from webapp.shop.api.ua_contracts.api import UAContractsAPI
@@ -117,7 +118,7 @@ def shop_decorator(area=None, permission=None, response="json", redirect=None):
                     return flask.redirect(f"/login?next={redirect_path}")
 
             ua_contracts_api = get_ua_contracts_api_instance(
-                user_token, response, session
+                user_token, response, session, flask.request.remote_addr
             )
             advantage_mapper = AdvantageMapper(ua_contracts_api)
             is_community_member = False
@@ -247,7 +248,7 @@ def get_trueability_api_instance(area, trueability_session) -> TrueAbilityAPI:
 
 
 def get_ua_contracts_api_instance(
-    user_token, response, session
+    user_token, response, session, remote_addr
 ) -> UAContractsAPI:
     ua_contracts_api = UAContractsAPI(
         session=session,
@@ -256,6 +257,7 @@ def get_ua_contracts_api_instance(
         api_url=os.getenv(
             "CONTRACTS_API_URL", "https://contracts.canonical.com"
         ),
+        remote_addr=remote_addr,
     )
 
     if response == "html":


### PR DESCRIPTION
## Done

- Adds tooltips as detailed in the [figma design](https://www.figma.com/file/koBN9oI6CGTjR7ucgB0lcJ/Kernel-release-cycle?type=whiteboard&node-id=38-230&t=ZtnhVUJoZCfe8TFk-0)

## QA

- Check that the tooltips match the key in the following charts:
https://ubuntu-com-13713.demos.haus/about/release-cycle (check all the tabs)
https://ubuntu-com-13713.demos.haus/kernel/lifecycle

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-9302

## Screenshots

![Screenshot from 2024-04-03 14-58-32](https://github.com/canonical/ubuntu.com/assets/58276363/eee7aece-344f-413b-9dc8-dd14caef1e4d)