### PR TITLE
Update kernel release chart colours

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -1205,25 +1205,25 @@ export var desktopServerStatus = {
 };
 
 export var kernelStatus = {
-  LTS: "chart__bar--orange",
-  ESM: "chart__bar--aubergine",
+  LTS: "chart__bar--black",
+  ESM: "chart__bar--aubergine-light",
   INTERIM_RELEASE: "chart__bar--grey",
 };
 
 export var kernelReleaseScheduleStatus = {
-  LTS: "chart__bar--orange",
+  LTS: "chart__bar--black",
   INTERIM_RELEASE: "chart__bar--grey",
 };
 
 export var kernelStatusLTS = {
-  LTS: "chart__bar--orange",
+  LTS: "chart__bar--black",
   CVE: "chart__bar--grey",
 };
 
 export var kernelStatusALL = {
-  LTS: "chart__bar--orange",
+  LTS: "chart__bar--black",
   INTERIM_RELEASE: "chart__bar--grey",
-  EARLY: "chart__bar--aubergine",
+  EARLY: "chart__bar--aubergine-light",
 };
 
 export var openStackStatus = {


### PR DESCRIPTION
## Done

- Updates bar chart colours based on [figma design](https://www.figma.com/file/koBN9oI6CGTjR7ucgB0lcJ/Kernel-release-cycle?type=whiteboard&node-id=0-1&t=u5TEhPMThSR8pHfx-0) and UX advice 

## QA

- https://ubuntu-com-13714.demos.haus/kernel/lifecycle
- https://ubuntu-com-13714.demos.haus/about/release-cycle#ubuntu-kernel-release-cycle

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-10071
