### PR TITLE
[WD-10110] add 'safe' instruction to blog post's title on /hpe

### DIFF
--- a/templates/hpe/index.html
+++ b/templates/hpe/index.html
@@ -396,7 +396,7 @@
           <hr class="is-fixed-width p-rule">
           {% endif %}
           <div class="p-block">
-            <h2><a href="/blog/{{ article.slug }}">{{ article.title.rendered }}</a></h2>
+            <h2><a href="/blog/{{ article.slug }}">{{ article.title.rendered | safe }}</a></h2>
             <p>
               {% if 4307 in article.tags %}
               <button class="p-chip--information" onclick="location.href='/blog/tag/hpe'">


### PR DESCRIPTION
## Done

- Fix the way blog post's title is rendered at /hpe page's last section for blog posts

## QA

- Navigate to https://ubuntu-com-13716.demos.haus/hpe
- Scroll all the way down
- Check if the blog posts' titles show correctly, without any code like on the screenshot below

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-10110

## Screenshots

![Screenshot 2024-04-04 at 11 48 15](https://github.com/canonical/ubuntu.com/assets/15943863/ac048ce8-710e-41af-8e06-5656ce27edb5)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
