### PR TITLE
Add docs links to subnavs 

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -25,6 +25,8 @@ azure:
       path: /azure/fips
     - title: SQL
       path: /azure/sql
+    - title: Docs
+      path: https://documentation.ubuntu.com/azure
 
 appliance:
   title: Appliance
@@ -60,6 +62,8 @@ aws:
       path: /aws/fips
     - title: WorkSpaces
       path: /aws/workspaces
+    - title: Docs
+      path: https://documentation.ubuntu.com/aws/en/latest/
 
 managedapps:
   title: Managed
@@ -550,6 +554,8 @@ gcp:
       path: /gcp/pro
     - title: FIPS
       path: /gcp/fips
+    - title: Docs
+      path: https://documentation.ubuntu.com/gcp/en/latest/
 
 ubuntu1604:
   title: 16-04


### PR DESCRIPTION
## Done

- Added docs links to /aws, /azure, and /gcp subnavs as per ticket 

## QA

- View the site locally in your web browser at: 
  - https://ubuntu-com-13717.demos.haus/aws
  - https://ubuntu-com-13717.demos.haus/azure
  - https://ubuntu-com-13717.demos.haus/gcp
- See that all have available "Docs" links in the subnav and that they route to the urls specified in the ticket

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-10049
