### PR TITLE
add djlint formatter support to u.com

### DIFF
--- a/.djlintrc
+++ b/.djlintrc
@@ -1,0 +1,18 @@
+{
+  "blank_line_after_tag": "load,extends",
+  "blank_line_before_tag": "load,extends,block, macro",
+  "close_void_tags": true,
+  "ignore": "J018,H006,H021,H023,H029,T002,T003,T028",
+  "include": "H017",
+  "max_blank_lines": 1,
+  "max_line_length": "120",
+  "profile": "jinja",
+  "format_css": true,
+  "format_js": true,
+  "css": {
+    "indent_size": 2
+  },
+  "js": {
+    "indent_size": 2
+  }
+}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -87,6 +87,34 @@ jobs:
       - name: Lint python
         run: dotrun lint-python
 
+  lint-jinja:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install node dependencies
+        run: yarn install --immutable
+
+      - name: Install python dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          sudo pip3 install djlint
+
+      - name: Get changed HTML files in the templates folder
+        id: changed-files
+        uses: tj-actions/changed-files@v43
+        with:
+          files: templates/**
+
+      - name: Lint jinja
+        if: steps.changed-files.outputs.any_changed == 'true'
+        env:
+          CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+        run: |
+          echo "The following files have changed: $CHANGED_FILES"
+          djlint $CHANGED_FILES --lint
+
   validate-deploy:
     runs-on: ubuntu-latest
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,3 +31,4 @@ filelock==3.12.0
 bleach==6.0.0
 numpy==1.24.4
 python-slugify==8.0.1
+djlint==1.34.1


### PR DESCRIPTION
## Done

- Added djLint support to ubuntu.com similarly to canonical.com

## QA

- Set up djLint in your codebase as described in Discourse topic here: https://discourse.canonical.com/t/configuring-editors-for-formatting-and-linting/188
- Open any Jinja template and format it
- Check that the formatting was performed by running `git diff` on that file
- Check for red marks in the file if there are any that require manual fix
- If there were red marks check that they disappear after fixing and saving changes

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
