### PR TITLE
WD-10165 - update release charts for 24.04

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -94,7 +94,8 @@ export var serverAndDesktopReleases = [
     endDate: new Date("2024-07-20T00:00:00"),
     taskName: "23.10 (Mantic Minotaur)",
     status: "INTERIM_RELEASE",
-  },{
+  },
+  {
     startDate: new Date("2024-04-25T00:00:00"),
     endDate: new Date("2034-04-25T00:00:00"),
     taskName: "24.04 LTS (Noble Numbat)",

--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -94,6 +94,23 @@ export var serverAndDesktopReleases = [
     endDate: new Date("2024-07-20T00:00:00"),
     taskName: "23.10 (Mantic Minotaur)",
     status: "INTERIM_RELEASE",
+  },{
+    startDate: new Date("2024-04-25T00:00:00"),
+    endDate: new Date("2034-04-25T00:00:00"),
+    taskName: "24.04 LTS (Noble Numbat)",
+    status: "MAIN_UNIVERSE",
+  },
+  {
+    startDate: new Date("2024-04-25T00:00:00"),
+    endDate: new Date("2029-04-25T00:00:00"),
+    taskName: "24.04 LTS (Noble Numbat)",
+    status: "HARDWARE_AND_MAINTENANCE_UPDATES",
+  },
+  {
+    startDate: new Date("2029-04-25T00:00:00"),
+    endDate: new Date("2034-04-25T00:00:00"),
+    taskName: "24.04 LTS (Noble Numbat)",
+    status: "ESM",
   },
 ];
 
@@ -1246,8 +1263,8 @@ export var microStackStatus = {
 };
 
 export var desktopServerReleaseNames = [
+  "24.04 LTS (Noble Numbat)",
   "23.10 (Mantic Minotaur)",
-  "23.04 (Lunar Lobster)",
   "22.04 LTS (Jammy Jellyfish)",
   "20.04 LTS (Focal Fossa)",
   "18.04 LTS (Bionic Beaver)",

--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -83,12 +83,6 @@ export var serverAndDesktopReleases = [
     taskName: "22.04 LTS (Jammy Jellyfish)",
     status: "ESM",
   },
-  // {
-  //   startDate: new Date("2023-04-20T00:00:00"),
-  //   endDate: new Date("2024-01-20T00:00:00"),
-  //   taskName: "23.04 (Lunar Lobster)",
-  //   status: "INTERIM_RELEASE",
-  // },
   {
     startDate: new Date("2023-10-20T00:00:00"),
     endDate: new Date("2024-07-20T00:00:00"),

--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -83,12 +83,12 @@ export var serverAndDesktopReleases = [
     taskName: "22.04 LTS (Jammy Jellyfish)",
     status: "ESM",
   },
-  {
-    startDate: new Date("2023-04-20T00:00:00"),
-    endDate: new Date("2024-01-20T00:00:00"),
-    taskName: "23.04 (Lunar Lobster)",
-    status: "INTERIM_RELEASE",
-  },
+  // {
+  //   startDate: new Date("2023-04-20T00:00:00"),
+  //   endDate: new Date("2024-01-20T00:00:00"),
+  //   taskName: "23.04 (Lunar Lobster)",
+  //   status: "INTERIM_RELEASE",
+  // },
   {
     startDate: new Date("2023-10-20T00:00:00"),
     endDate: new Date("2024-07-20T00:00:00"),

--- a/templates/about/release_cycles/releases-table.html
+++ b/templates/about/release_cycles/releases-table.html
@@ -9,15 +9,15 @@
     </thead>
     <tbody>
         <tr>
-            <td>23.10 (Mantic Minotaur)</td>
-            <td>Oct 2023</td>
-            <td>Jul 2024</td>
+            <td><strong>24.04 LTS (Noble Numbat)</strong></td>
+            <td>Apr 2024</td>
+            <td>Apr 2034</td>
             <td>&nbsp;</td>
         </tr>
         <tr>
-            <td>23.04 (Lunar Lobster)</td>
-            <td>Apr 2023</td>
-            <td>Jan 2024</td>
+            <td>23.10 (Mantic Minotaur)</td>
+            <td>Oct 2023</td>
+            <td>Jul 2024</td>
             <td>&nbsp;</td>
         </tr>
         <tr>

--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -239,7 +239,6 @@
   </div>
 </section>
 
-
 <div class="p-section">
   <div class="u-fixed-width p-section--shallow">
     <hr class="p-rule" />
@@ -359,7 +358,7 @@
     <div class="col">
       <p class="p-heading--5">From public clouds to data centres to devices</p>
       <p>Ubuntu is the most popular guest operating system on public clouds, the foundation for private cloud implementation and the platform of choice of developers according to the <a href="https://recruit-c7ff.kxcdn.com/recruit/wp-content/uploads/2020/05/he-developer-survey-2020.pdf">2020 HackerEarth Developer Survey</a>.</p>
-      <hr class="is-muted">
+      <hr class="is-muted" />
       <a href="/engage/from-vmware-to-open-source">Watch a webinar - “From VMware to Open Source”&nbsp;&rsaquo;</a>
     </div>
   </div>

--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -259,6 +259,12 @@
         </thead>
         <tbody>
           <tr>
+            <td><strong>24.04 LTS</strong></td>
+            <td>Apr 2024</td>
+            <td>Apr 2034</td>
+            <td></td>
+          </tr>
+          <tr>
             <td><strong>Ubuntu 22.04 LTS</strong></td>
             <td>April 2022</td>
             <td>April 2027</td>


### PR DESCRIPTION
## Done

Updated release charts for 24.04

## QA

- [demo link](https://ubuntu-com-13734.demos.haus/)
- View the site on the demo
- Be sure to test on mobile, tablet and desktop screen sizes
- Go to [/server](https://ubuntu-com-13734.demos.haus/server), [/about/release-cycle](https://ubuntu-com-13734.demos.haus/about/release-cycle) and [/desktop/developers](https://ubuntu-com-13734.demos.haus/desktop/developers) and check that the chart has 24.04 added and 23.04 removed

## Issue / Card
[WD-10165](https://warthogs.atlassian.net/browse/WD-10165)

[WD-10165]: https://warthogs.atlassian.net/browse/WD-10165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ