### PR TITLE
WD-10215 - add contact button to /support

### DIFF
--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -510,6 +510,7 @@
       <h5>Add phone and ticket support on top of Ubuntu Pro</h5>
       <p>Build with confidence with 24/7/365 phone and ticket support. Get prompt help when something breaks on more than 25,000 packages in the Ubuntu Main and Universe repositories, including the most widely used open source applications and toolchains.</p>
       <p>Benefit from the collective knowledge of our team, based on our 20 years of experience building and sustaining open source software.</p>
+      <a class="p-button--positive" href="/support/contact-us?product=support-overview">Contact us</a>
     </div>
   </div>
 </section>

--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -582,7 +582,7 @@
           <h3 class="p-heading--5">ROCKs</h3>
         </div>
         <div class="col-6 col-medium-3">
-          <p>In addition to the <a href="https://opencontainers.org/">OCI</a>-compliant container images listed in the Canonical <a href="https://github.com/orgs/canonical/packages?ecosystem=container&tab=packages&ecosystem=container&q=charmed-">GitHub</a>, <a href="http://hub.docker.com/u/ubuntu/">Docker hub</a> and <a href="https://gallery.ecr.aws/ubuntu">Amazon ECR</a>, get full support for:</p>
+          <p>In addition to the <a href="https://opencontainers.org/">OCI</a>-compliant container images listed in the Canonical <a href="https://github.com/orgs/canonical/packages?ecosystem=container&tab=packages&ecosystem=container&q=charmed-">GitHub</a>, <a href="https://hub.docker.com/u/ubuntu/">Docker hub</a> and <a href="https://gallery.ecr.aws/ubuntu">Amazon ECR</a>, get full support for:</p>
           <ul class="p-list--divided">
             <li class="p-list__item has-bullet"><a href="https://canonical-rockcraft.readthedocs-hosted.com/en/latest/explanation/rocks/">ROCKs</a>, Canonical's new generation of OCI-compliant, container images, built on top of Ubuntu LTS and optimised to run applications</li>
             <li class="p-list__item has-bullet"><a href="https://ubuntu.com/engage/chiselled-ubuntu-images-for-containers">Chiselled Ubuntu</a>, Canonical's distroless container images that only fit the strictly required dependencies</li>


### PR DESCRIPTION
## Done

Add button to /support

## QA

- [demo link](https://ubuntu-com-13735.demos.haus/support)
- [copy doc](https://docs.google.com/document/d/1AU2dwTXpQk2UuEvSuAqRKrbPWYb-LR0ZGvWu6xw95I8/edit)
- View the site on demo
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check that the page is correct according to copy doc

## Issue / Card
[WD-10215](https://warthogs.atlassian.net/browse/WD-10215)

[WD-10215]: https://warthogs.atlassian.net/browse/WD-10215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ