### PR TITLE
Update link in iot pro banner

### DIFF
--- a/templates/shared/_pro-for-devices-banner.html
+++ b/templates/shared/_pro-for-devices-banner.html
@@ -1,7 +1,7 @@
 <div class="u-fixed-width">
-  <div class="p-notification--information">
+  <div class="p-notification--information is-light">
     <div class="p-notification__content">
-      <h5 class="p-notification__title">New: Ubuntu Pro for Devices</h5>
+      <h5 class="p-notification__title">New: <a href="https://canonical.com/blog/ubuntu-pro-for-devices">Ubuntu Pro for Devices</a></h5>
       <p class="p-notification__message">Ubuntu Pro for Devices offers IoT enterprise customers product security, compliance and longevity. <a href="https://canonical.com/blog/ubuntu-pro-for-devices">Read the press release to learn more</a>.</p>
     </div>
   </div>


### PR DESCRIPTION
## Done

- pdm requested the link also appear in the heading ('Ubuntu Pro for Devices') of the notification
- also fixed an issue with the banner appearing dark on /embedded

## QA

- Go to https://ubuntu-com-13736.demos.haus/internet-of-things and https://ubuntu-com-13736.demos.haus/embedded and see there is a clickable link under [Ubuntu Pro for Devices](https://canonical.com/blog/ubuntu-pro-for-devices), this is the same link as under [Read the press release to learn more](https://canonical.com/blog/ubuntu-pro-for-devices).
- See how on [ubuntu.com/embedded](https://ubuntu.com/embedded) the notification is dark background and on [the demo](https://ubuntu-com-13736.demos.haus/embedded) its not


