### PR TITLE
WD-10249 Add Korean engage templates

### DIFF
--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -37,6 +37,7 @@
           <option value="es">Espa&ntilde;ol</option>
           <option value="fr">Fran&ccedil;ais</option>
           <option value="it">Italiano</option>
+          <option value="kr">Korean</option>
           <option value="pt">Portugu&ecirc;s</option>
           <option value="ru">Русс&#1082;&#1080;&#1081;</option>
         </select>
@@ -86,7 +87,7 @@
   {% if metadata | length > 0 %}
   <div class="row u-equal-height">
     {% for item in metadata %}
-      {% with 
+      {% with
         title=item.topic_name,
         title_link=item.path,
         description=item.subtitle,
@@ -134,14 +135,14 @@ function clearFilters() {
     el.addEventListener("change", function(e) {
       const value = e.target.value;
       const selectFields = document.querySelectorAll("select:checked")
-      
+
       if (url.searchParams.has(key)) {
         url.searchParams.delete(key);
       }
       if (value !== "all") {
         url.searchParams.append(key, value);
       }
-      
+
       window.location = url;
     });
   }

--- a/templates/engage/shared/_kr_engage_form.html
+++ b/templates/engage/shared/_kr_engage_form.html
@@ -1,0 +1,67 @@
+<!-- MARKETO FORM -->
+<form action="/marketo/submit" method="post" id="mktoForm_{{ id }}">
+  <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
+    <legend class="u-off-screen">연락처 정보</legend>
+    <ul class="p-list">
+      <li>
+        <label for="firstName">이름:</label>
+        <input required id="firstName" name="firstName" maxlength="255" type="text" value="" />
+      </li>
+      <li>
+        <label for="lastName">성:</label>
+        <input required id="lastName" name="lastName" maxlength="255" type="text" />
+      </li>
+      <li>
+        <label for="email">직장 이메일:</label>
+        <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" value="" />
+      </li>
+      <li>
+        <label for="company">회사 이름:</label>
+        <input required id="company" name="company" maxlength="255" type="text" />
+      </li>
+      <li>
+        <label for="jobTitle">직위:</label>
+        <input required id="jobTitle" name="title" maxlength="255" type="text" />
+      </li>
+      <li>
+        <label for="phone">휴대폰 번호:</label>
+        <input required id="phone" name="phone" maxlength="255" type="tel" />
+      </li>
+      <li>
+        <label class="p-checkbox">
+          <input class="p-checkbox__input" name="canonicalUpdatesOptIn" aria-labelledby="canonicalUpdatesOptIn" value="yes" type="checkbox" />
+          <span class="p-checkbox__label" id="canonicalUpdatesOptIn">Canonical의 제품 및 서비스에 대한 정보 수신에 동의합니다.</span>
+        </label>
+      </li>
+      <li>
+        <p>이 양식을 제출함으로써 나는 다음과 같은 내용에 동의함을 확인합니다: <a href="/legal/data-privacy/contact">Canonical의 개인정보 보호정책</a> 및 <a href="/legal/data-privacy">개인 정보 정책</a>.</p>
+      </li>
+      {# These are honey pot fields to catch bots #}
+      <li class="u-off-screen">
+        <label class="website" for="website">웹사이트:</label>
+        <input name="website" type="text" class="website" autocomplete="off" value="" id="website" tabindex="-1" />
+      </li>
+      <li class="u-off-screen">
+        <label class="name" for="name">이름:</label>
+        <input name="name" type="text" class="name" autocomplete="off" value="" id="name" tabindex="-1" />
+      </li>
+      {# End of honey pots #}
+      <li>
+        <input name="Consent_to_Processing__c" aria-label="Consent" value="Yes" type="hidden" />
+      </li>
+      <li>
+        <button type="submit" class="u-no-margin--bottom {% if cta_class %}{{ cta_class }}{% endif %}" >{% if cta %}{{ cta }}{% else %}백서 다운로드{% endif %}</button>
+        <input name="formid" aria-label="formid" value="{{ id }}" type="hidden" />
+        <input type="hidden" name="returnURL" aria-label="returnURL" value="{{ returnURL }}" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="{{ utm_campaign }}" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="{{ utm_medium }}" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="{{ utm_source }}" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="{{ utm_content }}" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="{{ utm_term }}" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Facebook_Click_ID__c" id="Facebook_Click_ID__c" value="" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" id="preferredLanguage" name="preferredLanguage" maxlength="255" value="" />
+      </li>
+    </ul>
+  </fieldset>
+</form>

--- a/templates/engage/shared/_kr_thank-you.html
+++ b/templates/engage/shared/_kr_thank-you.html
@@ -1,0 +1,89 @@
+{% extends "engage/base_engage.html" %}
+
+{% block title %}다운로드 {{ resource_name }} {% endblock %}
+
+{% block head_extra %}<meta name="robots" content="noindex" />{% endblock %}
+
+{% block content %}
+<style>
+  .global-nav .global-nav__header-logo-anchor {
+    padding-left: 0 !important;
+  }
+</style>
+<section class="p-strip p-engage-banner--grad">
+  <div class="u-fixed-width navigation-logo-engage">
+    <a href="/">
+      {{
+        image(
+            url="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg",
+            alt="Ubuntu",
+            width="143",
+            height="32",
+            hi_def=True,
+            loading="auto",
+        ) | safe
+      }}
+    </a>
+  </div>
+  <div class="row">
+    <div class="col-8">
+      <h1>
+        감사합니다
+      </h1>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip">
+  <div class="u-fixed-width">
+    {% if form_details and "access_to_content" in metadata and metadata.access_to_content == "true" %}
+
+      <h3>다음의 {{ resource_name }} 내용을 {{ form_details.email }}로 보내드렸습니다.</h3>
+      <p>
+        <a class="p-button--positive" href="{{ request_url }}">마지막 페이지로 돌아가기</a>
+        <a class="p-button" href="/contact-us">문의하기</a>
+      </p>
+      <p>
+        받지 못하셨나요? 스팸 폴더를 확인하고 올바른 이메일 주소를 사용했는지 확인하세요.
+      </p>
+      <p>
+        <a href="{{ request_url }}">아니면 다시 보내보세요</a>
+      </p>
+
+    {% else %}
+      {% if "thank_you_text" in metadata %}
+        <p>{{ metadata["thank_you_text"] }}</p>
+      {% else %}
+        <p>이제 {{ resources_name }}을(를) 다운로드할 준비가 되었습니다.</p>
+      {% endif %}
+      {% if "contact_form_only" not in metadata and metadata.contact_form_only != "true" or ("access_to_content" in metadata and metadata.access_to_content == "true") %}
+        {% if metadata.resource_url and metadata.resource_url != "" %}
+          <p>
+            <a class="p-button--positive" href="{{ resource_url }}">다운로드</a>
+          </p>
+        {% endif %}
+      {% endif %}
+    {% endif %}
+  </div>
+</section>
+
+{% if related | length > 0 %}
+<section class="p-strip--light">
+  <div class="row">
+    <div class="col-8">
+      <h2 class="p-heading--3">당신이 또 관심 있어야 할 주제는 다음과 같습니다.</h2>
+    </div>
+  </div>
+  <div class="row p-divider">
+    {% for page in related %}
+    <div class="col-4 p-divider__block">
+      <!-- THREE ADDITIONAL CTAs -->
+      <h4>{{ page["topic_name"] }}</h4>
+      <p>{{ page["subtitle"] }}</p>
+      <p><a href="{{ page['path'] }}">더보기&nbsp;&rsaquo;</a></p>
+    </div>
+    {% endfor %}
+  </div>
+</section>
+{% endif %}
+{% endblock content %}


### PR DESCRIPTION
## Done

- Add Korean engage templates
- Add Korean to the lang dropdown on the /engage page

## QA

- Open the demo
- Go to https://ubuntu-com-13737.demos.haus/engage/2024-automotive-trends-kr
- Check it works correctly

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-10249

## Screenshot
![image](https://github.com/canonical/ubuntu.com/assets/1413534/3500ed7e-c537-411a-a18e-379c3fe4650c)
