### PR TITLE
WD-10056 Raspi copy update

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -11,14 +11,16 @@ latest:
   release_notes_url: "https://discourse.ubuntu.com/t/mantic-minotaur-release-notes/35534"
   iso_download_size: "4.5GB"
 lts:
-  slug: JammyJellyfish
-  name: "Jammy Jellyfish"
-  short_version: "22.04"
-  full_version: "22.04.4"
-  release_date: "April 2022"
-  eol: "April 2027"
-  release_notes_url: "https://discourse.ubuntu.com/t/jammy-jellyfish-release-notes/24668"
-  iso_download_size: "4.7GB"
+  slug: NobleNumbat
+  name: "Noble Numbat"
+  short_version: "24.04"
+  full_version: "24.04"
+  release_date: "April 2024"
+  eol: "April 2029"
+  release_notes_url: "https://discourse.ubuntu.com/t/noble-numbat-release-notes/24668"
+  iso_download_size: "3.8GB"
+  raspi_server_iso_size: "2.2GB"
+  raspi_desktop_iso_size: "986MB"
 previous_lts:
   name: "Focal Fossa"
   short_version: "20.04"

--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -11,157 +11,146 @@
 {% endblock meta_copydoc %}
 {% block body_class %}is-paper{% endblock %}
 {% block content %}
-  <section class="p-strip is-shallow u-no-margin--bottom">
-    <div class="row--50-50">
-      <div class="col">
-        <h1>
-          Install Ubuntu
-          <br class="u-hide--small">
-          on a Raspberry Pi
-        </h1>
-      </div>
-      <div class="col">
-        <p>
-          Versatile and affordable, the Raspberry Pi is one of the most popular devices available on the market, with uses that range from education to industry.
-        </p>
-        <p>
-          With full Ubuntu support, open source developers have everything they need to get up and running quickly and securely.
-        </p>
-        <div class="p-section">
-          {{ image(
-              url="https://assets.ubuntu.com/v1/016b770d-raspberry+pi+horizontal.svg",
-              alt="Raspberry Pi",
-              height="48",
-              width="36",
-              hi_def=True,
-              loading="auto"
-            ) | safe
-          }}
-        </div>
+<section class="p-strip is-shallow u-no-margin--bottom">
+  <div class="row--50-50">
+    <div class="col">
+      <h1>
+        Install Ubuntu
+        <br class="u-hide--small" />
+        on a Raspberry Pi
+      </h1>
+    </div>
+    <div class="col">
+      <p>
+        Versatile and affordable, the Raspberry Pi is one of the most popular devices available on the market, with uses that range from education to industry.
+      </p>
+      <p>
+        With full Ubuntu support, open source developers have everything they need to get up and running quickly and securely.
+      </p>
+      <div class="p-section">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/016b770d-raspberry+pi+horizontal.svg",
+            alt="Raspberry Pi",
+            height="48",
+            width="36",
+            hi_def=True,
+            loading="auto"
+          ) | safe
+        }}
       </div>
     </div>
-  </section>
-  <section class="p-section">
-    <hr class="p-rule is-fixed-width" />
-    <div class="row--50-50">
-      <div class="col">
-        <h2>First time installing Ubuntu on Raspberry Pi?</h2>
-      </div>
-      <div class="col">
-        <p>
-          The simplest way is to use the <a href="https://www.raspberrypi.com/software/">Raspberry Pi Imager</a> which enables you to select an Ubuntu image when flashing your SD card.
-        </p>
-        <p>If you are on Ubuntu, open the terminal and run:</p>
-        <pre><code>sudo snap install rpi-imager</code></pre>
-        <p>
-          And follow our <a href="/tutorials/how-to-install-ubuntu-desktop-on-raspberry-pi-4#1-overview">Desktop</a>, <a href="/tutorials/how-to-install-ubuntu-on-your-raspberry-pi#1-overview">Server</a> and <a href="/download/raspberry-pi-core">Core</a> tutorials to get started.
-        </p>
-        <div class="p-image--wrapper p-section--shallow">
-          <img src="https://assets.ubuntu.com/v1/e24d92fc-raspberry-pi-imager-2024.png"
-               alt="Screenshot of the Raspberry Pi Imager, with three buttons letting you choose the Raspberry Pi device, operating system and storage where to write the image" />
-        </div>
+  </div>
+</section>
+<section class="p-section">
+  <hr class="p-rule is-fixed-width" />
+  <div class="row--50-50">
+    <div class="col">
+      <h2>First time installing Ubuntu on Raspberry Pi?</h2>
+    </div>
+    <div class="col">
+      <p>
+        The simplest way is to use the <a href="https://www.raspberrypi.com/software/">Raspberry Pi Imager</a> which enables you to select an Ubuntu image when flashing your SD card.
+      </p>
+      <p>If you are on Ubuntu, open the terminal and run:</p>
+      <pre><code>sudo snap install rpi-imager</code></pre>
+      <p>
+        And follow our <a href="/tutorials/how-to-install-ubuntu-desktop-on-raspberry-pi-4#1-overview">Desktop</a>, <a href="/tutorials/how-to-install-ubuntu-on-your-raspberry-pi#1-overview">Server</a> and <a href="/download/raspberry-pi-core">Core</a> tutorials to get started.
+      </p>
+      <div class="p-image--wrapper p-section--shallow">
+        <img src="https://assets.ubuntu.com/v1/e24d92fc-raspberry-pi-imager-2024.png"
+              alt="Screenshot of the Raspberry Pi Imager, with three buttons letting you choose the Raspberry Pi device, operating system and storage where to write the image" />
       </div>
     </div>
-  </section>
-  <section class="p-section">
-    <hr class="p-rule is-fixed-width" />
-    <div class="row--50-50 p-section">
-      <div class="col">
-        <h2>Ubuntu {{ releases.latest.full_version }}</h2>
-      </div>
-      <div class="col">
-        <p>
-          The Raspberry Pi 5 is supported on the latest development release of Ubuntu with nine months of support, until July 2024.
-        </p>
-        <hr />
-        <p class="u-responsive-realign">
-          <a href="/download/raspberry-pi/thank-you?version={{ releases.latest.full_version }}&amp;architecture=desktop-arm64+raspi"
-             onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 64-bit - Ubuntu Desktop', 'eventLabel' : '{{ releases.latest.full_version }}', 'eventValue' : undefined });"
-             class="p-button u-no-margin--bottom">Download Ubuntu Desktop {{ releases.latest.full_version }}</a>
-          &nbsp;
-          <span class="u-text--muted">ISO image, 2.4GB</span>
-        </p>
-        <p>Minimum 4GBs of RAM required</p>
-        <hr />
-        <p class="u-responsive-realign">
-          <a href="/download/raspberry-pi/thank-you?version={{ releases.latest.full_version }}&amp;architecture=server-arm64+raspi"
-             onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 64-bit - Ubuntu Server', 'eventLabel' : '{{ releases.latest.full_version }}', 'eventValue' : undefined });"
-             class="p-button">Download Ubuntu Server {{ releases.latest.full_version }}</a>
-          &nbsp;
-          <span class="u-text--muted">ISO image, 1.1GB</span>
-        </p>
+  </div>
+</section>
+<hr class="p-rule is-fixed-width" />
+<section class="p-section">
+  <div class="row--50-50 p-section">
+    <div class="col u-image-position">
+      <h2>Ubuntu {{ releases.lts.full_version }} LTS</h2>
+      <div class="u-image-position--bottom">
+        {{
+          image(
+            url="https://assets.ubuntu.com/v1/3b5fa561-mascot-numbat@2x.png",
+            alt="Noble Numbat",
+            width="182",
+            height="135",
+            hi_def=True,
+            loading="auto"
+          ) | safe
+        }}
       </div>
     </div>
-    <hr class="p-rule is-fixed-width" />
-    <div class="row--50-50 p-section">
-      <div class="col">
-        <h2>Ubuntu {{ releases.lts.full_version }} LTS</h2>
-      </div>
-      <div class="col">
-        <p>
-          The latest Long Term Supported release of Ubuntu with five years of security patching and maintenance until April 2027, extended to ten years with <a href="/pro">Ubuntu Pro</a>.
-        </p>
-        <hr />
-        <p class="u-responsive-realign">
-          <a class="p-button--positive"
-             href="/download/raspberry-pi/thank-you?version={{ releases.lts.full_version }}&amp;architecture=desktop-arm64+raspi"
-             onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 64-bit - Ubuntu Desktop', 'eventLabel' : '{{ releases.lts.full_version }}', 'eventValue' : undefined });"
-             class="p-button u-no-margin--bottom">Download Ubuntu Desktop {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr></a>
-          <span class="u-text--muted">ISO image, 2.2GB</span>
-        </p>
-        <p>Minimum 2GBs of RAM and 16GB storage required</p>
-        <hr />
-        <p class="u-responsive-realign">
-          <a href="/download/raspberry-pi/thank-you?version={{ releases.lts.full_version }}&amp;architecture=server-arm64+raspi"
-             onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 64-bit - Ubuntu Server', 'eventLabel' : '{{ releases.lts.full_version }}', 'eventValue' : undefined });"
-             class="p-button">Download Ubuntu Server {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr></a>
-          <span class="u-text--muted">ISO image, 986MB</span>
-        </p>
-      </div>
+    <div class="col">
+      <p>
+        The latest LTS version of Ubuntu, for desktop PCs and laptops. LTS stands for long-term support — which means five years of free security and maintenance updates, extended to 10 years with <a href="/pro">Ubuntu Pro</a>.
+      </p>
+      <hr />
+      <p class="u-responsive-realign">
+        <a href="/download/raspberry-pi/thank-you?version={{ releases.lts.full_version }}&amp;architecture=desktop-arm64+raspi"
+            onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 64-bit - Ubuntu Desktop', 'eventLabel' : '{{ releases.lts.full_version }}', 'eventValue' : undefined });"
+            class="p-button--positive u-no-margin--bottom">Download Ubuntu Desktop {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr></a>
+        {% if releases.lts.raspi_desktop_iso_size %}
+          <span class="u-text--muted">ISO image, {{ releases.lts.raspi_desktop_iso_size }}</span>
+        {% endif %}
+      </p>
+      <p>Minimum 2GBs of RAM and 16GB storage required</p>
+      <hr />
+      <p class="u-responsive-realign">
+        <a href="/download/raspberry-pi/thank-you?version={{ releases.lts.full_version }}&amp;architecture=server-arm64+raspi"
+            onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 64-bit - Ubuntu Server', 'eventLabel' : '{{ releases.lts.full_version }}', 'eventValue' : undefined });"
+            class="p-button">Download Ubuntu Server {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr></a>
+        {% if releases.lts.raspi_desktop_iso_size %}
+          <span class="u-text--muted">ISO image, {{ releases.lts.raspi_server_iso_size }}</span>
+        {% endif %}
+      </p>
     </div>
-    <hr class="p-rule is-fixed-width" />
-    <div class="row--50-50">
-      <div class="col">
-        <h2>Ubuntu Core 22</h2>
-      </div>
-      <div class="col">
-        <p>
-          An immutable, strictly confined operating system designed for Internet of Things (IoT) use-cases with a focus on security and simplified maintenance, supported until 2032.
-        </p>
-        <hr />
-        <p class="u-responsive-realign">
-          <a href="/download/raspberry-pi/thank-you?version={{ releases.latest.core_version }}&amp;architecture=core-22-arm64+raspi"
-             onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 64-bit - Ubuntu Core', 'eventLabel' : '{{ releases.latest.core_version }}', 'eventValue' : undefined });"
-             class="p-button">Download Ubuntu Core {{ releases.latest.core_version }}</a>
-          <span class="u-text--muted">ISO image, 263MB</span>
-        </p>
-      </div>
+  </div>
+  <hr class="p-rule is-fixed-width" />
+  <div class="row--50-50">
+    <div class="col">
+      <h2>Ubuntu Core 22</h2>
     </div>
-  </section>
-  <section class="p-section">
-    <hr class="p-rule is-fixed-width" />
-    <div class="row--50-50">
-      <div class="col">
-        <h2>Supported devices</h2>
-      </div>
-      <div class="col">
-        <p>
-          Certified devices are tested for reliability and performance, ensuring you have the best out-of-the-box Ubuntu experience. Ubuntu <abbr title="Long-term support">LTS</abbr> releases are certified on select Raspberry Pi hardware.
-        </p>
-        <hr />
-        <ul class="p-inline-list u-responsive-realign">
-          <li class="p-inline-list__item">
-            <a href="/certified">Learn more about Ubuntu Certified&nbsp;&rsaquo;</a>
-          </li>
-          <li class="p-inline-list__item">
-            <a href="/certified/iot?q=&limit=13&vendor=Raspberry+Pi+Foundation">All certified Raspberry Pi hardware&nbsp;&rsaquo;</a>
-          </li>
-        </ul>
-      </div>
+    <div class="col">
+      <p>
+        An immutable, strictly confined operating system designed for Internet of Things (IoT) use-cases with a focus on security and simplified maintenance, supported until 2032.
+      </p>
+      <hr />
+      <p class="u-responsive-realign">
+        <a href="/download/raspberry-pi/thank-you?version={{ releases.latest.core_version }}&amp;architecture=core-22-arm64+raspi"
+            onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 64-bit - Ubuntu Core', 'eventLabel' : '{{ releases.latest.core_version }}', 'eventValue' : undefined });"
+            class="p-button">Download Ubuntu Core {{ releases.latest.core_version }}</a>
+        <span class="u-text--muted">ISO image, 263MB</span>
+      </p>
     </div>
-  </section>
-  <section class="p-section">
-    <div class="u-fixed-width u-table-horizontal-scroll">
+  </div>
+</section>
+<section class="p-section">
+  <hr class="p-rule is-fixed-width" />
+  <div class="row--50-50">
+    <div class="col">
+      <h2>Supported devices</h2>
+    </div>
+    <div class="col">
+      <p>
+        Certified devices are tested for reliability and performance, ensuring you have the best out-of-the-box Ubuntu experience. Ubuntu <abbr title="Long-term support">LTS</abbr> releases are certified on select Raspberry Pi hardware.
+      </p>
+      <hr />
+      <ul class="p-inline-list u-responsive-realign">
+        <li class="p-inline-list__item">
+          <a href="/certified">Learn more about Ubuntu Certified&nbsp;&rsaquo;</a>
+        </li>
+        <li class="p-inline-list__item">
+          <a href="/certified/iot?q=&limit=13&vendor=Raspberry+Pi+Foundation">All certified Raspberry Pi hardware&nbsp;&rsaquo;</a>
+        </li>
+      </ul>
+    </div>
+  </div>
+</section>
+<section class="p-section">
+  <div class="row">
+    <div class="col-medium-6 col-9 col-start-large-4 u-table-horizontal-scroll">
       <table class="u-table-horizontal-scroll__table" aria-label="Raspberry Pi support with Ubuntu">
         <thead>
           <tr>
@@ -171,114 +160,28 @@
               Ubuntu {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr>
             </th>
             <th style="width: 20%">Ubuntu Core {{ releases.latest.core_version }}</th>
-            <th>Ubuntu {{ releases.latest.full_version }}</th>
           </tr>
         </thead>
         <tbody>
           <tr>
             <th>
-              <p>Raspberry Pi 2</p>
+              <p>Raspberry Pi 5</p>
             </th>
             <td>
               {{
                 image (
-                url="https://assets.ubuntu.com/v1/8542c958-Raspberry+Pi+2.png",
-                alt="Raspberry Pi 2",
-                width="73",
-                height="48",
-                hi_def=True,
-                loading="lazy",
-                attrs={"class": "u-hide--small"},
-                ) | safe
+                  url="https://assets.ubuntu.com/v1/14667b44-raspberry-pi_5.png",
+                  alt="Raspberry Pi 5",
+                  width="61",
+                  height="46",
+                  hi_def=True,
+                  loading="lazy",
+                  attrs={"class": "u-hide--small"},
+              ) | safe
               }}
             </td>
-            <td>Yes, certified</td>
             <td>Yes, certified</td>
             <td>-</td>
-          </tr>
-          <tr>
-            <th>
-              <p>Raspberry Pi 3</p>
-            </th>
-            <td>
-              {{
-                image(
-                  url="https://assets.ubuntu.com/v1/c4a007b6-Raspberry+Pi+3.png",
-                  alt="Rapsberry Pi 3",
-                  height="48",
-                  width="75",
-                  hi_def=True,
-                  loading="lazy",
-                  attrs={"class": "u-hide--small"},
-                ) | safe
-              }}
-            </td>
-            <td>Yes, certified</td>
-            <td>Yes, certified</td>
-            <td>-</td>
-          </tr>
-          <tr>
-            <th>
-              <p>Raspberry Pi 4</p>
-            </th>
-            <td>
-              {{
-                image(
-                  url="https://assets.ubuntu.com/v1/a999bb5f-Raspberry+Pi+4.png",
-                  alt="Raspberry Pi 4",
-                  height="48",
-                  width="75",
-                  hi_def=True,
-                  loading="lazy",
-                  attrs={"class": "u-hide--small"},
-                ) | safe
-              }}
-            </td>
-            <td>Yes, certified</td>
-            <td>Yes, certified</td>
-            <td>Yes</td>
-          </tr>
-          <tr>
-            <th>
-              <p>Raspberry Pi 400</p>
-            </th>
-            <td>
-              {{
-                image(
-                  url="https://assets.ubuntu.com/v1/cfdcd6c7-Raspberry-Pi-400-back--1536x1097.png",
-                  alt="Raspberry Pi 400",
-                  height="48",
-                  width="93",
-                  hi_def=True,
-                  loading="lazy",
-                  attrs={"class": "u-hide--small"},
-                ) | safe
-              }}
-            </td>
-            <td>Yes, certified</td>
-            <td>Yes, certified</td>
-            <td>Yes</td>
-          </tr>
-          <tr>
-            <th>
-              <p>Raspberry Pi CM4</p>
-            </th>
-            <td>
-              {{
-                image (
-                  url="https://assets.ubuntu.com/v1/3be8f179-Raspberry-Pi-CM4.png",
-                  alt="Raspberry Pi CM4",
-                  height="48",
-                  width="68",
-                  hi_def=True,
-                  loading="lazy",
-                  attrs={"class": "u-hide--small"},
-                ) | safe
-              }}
-            </td>
-            <td>Yes, certified</td>
-            <td>Yes, certified</td>
-            <td>Yes</td>
           </tr>
           <tr>
             <th>
@@ -299,83 +202,142 @@
             </td>
             <td>Yes, certified</td>
             <td>Yes, certified</td>
-            <td>Yes</td>
           </tr>
           <tr>
             <th>
-              <p>Raspberry Pi 5</p>
+              <p>Raspberry Pi CM4</p>
             </th>
             <td>
               {{
                 image (
-                  url="https://assets.ubuntu.com/v1/14667b44-raspberry-pi_5.png",
-                  alt="Raspberry Pi 5",
-                  width="61",
-                  height="46",
+                  url="https://assets.ubuntu.com/v1/3be8f179-Raspberry-Pi-CM4.png",
+                  alt="Raspberry Pi CM4",
+                  height="48",
+                  width="68",
                   hi_def=True,
                   loading="lazy",
                   attrs={"class": "u-hide--small"},
-              ) | safe
+                ) | safe
+              }}
+            </td>
+            <td>Yes, certified</td>
+            <td>Yes, certified</td>
+          </tr>
+          <tr>
+            <th>
+              <p>Raspberry Pi 400</p>
+            </th>
+            <td>
+              {{
+                image(
+                  url="https://assets.ubuntu.com/v1/cfdcd6c7-Raspberry-Pi-400-back--1536x1097.png",
+                  alt="Raspberry Pi 400",
+                  height="48",
+                  width="93",
+                  hi_def=True,
+                  loading="lazy",
+                  attrs={"class": "u-hide--small"},
+                ) | safe
+              }}
+            </td>
+            <td>Yes, certified</td>
+            <td>Yes, certified</td>
+          </tr>
+          <tr>
+            <th>
+              <p>Raspberry Pi 4</p>
+            </th>
+            <td>
+              {{
+                image(
+                  url="https://assets.ubuntu.com/v1/a999bb5f-Raspberry+Pi+4.png",
+                  alt="Raspberry Pi 4",
+                  height="48",
+                  width="75",
+                  hi_def=True,
+                  loading="lazy",
+                  attrs={"class": "u-hide--small"},
+                ) | safe
+              }}
+            </td>
+            <td>Yes, certified</td>
+            <td>Yes, certified</td>
+          </tr>
+          <tr>
+            <th>
+              <p>Raspberry Pi 3</p>
+            </th>
+            <td>
+              {{
+                image(
+                  url="https://assets.ubuntu.com/v1/c4a007b6-Raspberry+Pi+3.png",
+                  alt="Rapsberry Pi 3",
+                  height="48",
+                  width="75",
+                  hi_def=True,
+                  loading="lazy",
+                  attrs={"class": "u-hide--small"},
+                ) | safe
               }}
             </td>
             <td>-</td>
-            <td>-</td>
-            <td>Yes</td>
+            <td>Yes, certified</td>
           </tr>
         </tbody>
       </table>
     </div>
-  </section>
-  <section class="p-section">
-    <hr class="p-rule is-fixed-width" />
-    <div class="row--50-50">
-      <div class="col">
-        <h2>Make something great today</h2>
-      </div>
-      <div class="col">
-        <ul class="p-list--divided">
-          <li class="p-list__item">
-            <a href="/blog/linux-gaming-tutorial-raspberry-pi-minecraft-server-on-ubuntu-desktop">Raspberry Pi Tutorial: Host a Minecraft server on Ubuntu Desktop</a>
-          </li>
-          <li class="p-list__item">
-            <a href="/blog/common-sense-using-the-raspberry-pi-sense-hat-on-ubuntu-impish-indri">Common Sense &mdash; using the Raspberry Pi Sense HAT on Ubuntu Impish Indri</a>
-          </li>
-          <li class="p-list__item">
-            <a href="/blog/homelab-clusters-lxd-micro-cloud-on-raspberry-pi">Homelab clusters: LXD micro cloud on Raspberry Pi</a>
-          </li>
-          <li class="p-list__item">
-            <a href="https://maas.io/tutorials/build-your-own-bare-metal-cloud-using-a-raspberry-pi-cluster-with-maas#1-overview">Build your own bare metal cloud using a Raspberry Pi cluster with MAAS</a>
-          </li>
-        </ul>
+  </div>
+</section>
+<section class="p-section">
+  <hr class="p-rule is-fixed-width" />
+  <div class="row--50-50">
+    <div class="col">
+      <h2>Make something great today</h2>
+    </div>
+    <div class="col">
+      <ul class="p-list--divided">
+        <li class="p-list__item">
+          <a href="/blog/linux-gaming-tutorial-raspberry-pi-minecraft-server-on-ubuntu-desktop">Raspberry Pi Tutorial: Host a Minecraft server on Ubuntu Desktop</a>
+        </li>
+        <li class="p-list__item">
+          <a href="/blog/common-sense-using-the-raspberry-pi-sense-hat-on-ubuntu-impish-indri">Common Sense &mdash; using the Raspberry Pi Sense HAT on Ubuntu Impish Indri</a>
+        </li>
+        <li class="p-list__item">
+          <a href="/blog/homelab-clusters-lxd-micro-cloud-on-raspberry-pi">Homelab clusters: LXD micro cloud on Raspberry Pi</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://maas.io/tutorials/build-your-own-bare-metal-cloud-using-a-raspberry-pi-cluster-with-maas#1-overview">Build your own bare metal cloud using a Raspberry Pi cluster with MAAS</a>
+        </li>
+      </ul>
+    </div>
+  </div>
+</section>
+<section class="p-section--deep">
+  <hr class="p-rule is-fixed-width" />
+  <div class="row">
+    <div class="col-3 col-medium-6">
+      <div class="p-section--shallow">
+        <h2 class="p-text--small-caps">
+          <a href="/blog/tag/raspberry-pi">Latest from&nbsp;our&nbsp;blog&nbsp;&rsaquo;</a>
+        </h2>
       </div>
     </div>
-  </section>
-  <section class="p-section--deep">
-    <hr class="p-rule is-fixed-width" />
-    <div class="row">
-      <div class="col-3 col-medium-6">
-        <div class="p-section--shallow">
-          <h2 class="p-text--small-caps">
-            <a href="/blog/tag/raspberry-pi">Latest from&nbsp;our&nbsp;blog&nbsp;&rsaquo;</a>
-          </h2>
-        </div>
-      </div>
-      <div class="col-9 col-medium-6">
-        <div class="row p-section--shallow" id="blog-latest"></div>
-      </div>
+    <div class="col-9 col-medium-6">
+      <div class="row p-section--shallow" id="blog-latest"></div>
     </div>
-    <template style="display:none" id="blog-template">
-      <div class="col-3 col-medium-2">
-        <div class="article-image u-blog-thumbnails p-image-wrapper"></div>
-         <h3 class="p-heading--5">
-          <a class="article-link article-title"></a>
-        </h3>
-        <p class="article-excerpt"></p>
-      </div>
-    </template>
-  </section>
-  <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-  <script>
+  </div>
+  <template style="display:none" id="blog-template">
+    <div class="col-3 col-medium-2">
+      <div class="article-image u-blog-thumbnails p-image-wrapper"></div>
+        <h3 class="p-heading--5">
+        <a class="article-link article-title"></a>
+      </h3>
+      <p class="article-excerpt"></p>
+    </div>
+  </template>
+</section>
+<script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
+<script>
   canonicalLatestNews.fetchLatestNews(
     {
       articlesContainerSelector: "#blog-latest",
@@ -386,5 +348,5 @@
       linkImage: true,
     }
   )
-  </script>
+</script>
 {% endblock %}


### PR DESCRIPTION
## Done

- Update Raspi download page for 24.04 release

## QA

- Go to https://ubuntu-com-13738.demos.haus/download/raspberry-pi and compare changes in the [copy doc](https://docs.google.com/document/d/1KgnSBa8mbR7qwlxxtqbE5a1wXh5GjtVums8TIB7IGVw/edit#heading=h.486pnd5pwc1e)
- Download links won't download because we still don't have the ISOs
- Check it matches the design in the screenshot below
    - Be sure to test on mobile, tablet and desktop screen sizes

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-10056

## Screenshots (Design review)

![raspberry-pi](https://github.com/canonical/ubuntu.com/assets/14939793/1004804f-b167-48dd-9176-680e21a68a03)



## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
