### PR TITLE
Pro - Hide cost for legacy subscriptions

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/DetailsContent.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/DetailsContent.tsx
@@ -115,10 +115,17 @@ const DetailsContent = ({ selectedId, setHasUnsavedChanges }: Props) => {
     <div>
       <Row className="u-sv4">
         {generateFeatures([
-          {
-            title: "Cost",
-            value: currencyFormatter.format((subscription.price ?? 0) / 100),
-          },
+          ...(subscription.type === UserSubscriptionType.Legacy
+            ? // Don't show the cost for legacy subscriptions.
+              []
+            : [
+                {
+                  title: "Cost",
+                  value: currencyFormatter.format(
+                    (subscription.price ?? 0) / 100
+                  ),
+                },
+              ]),
           ...(subscription.type === UserSubscriptionType.Legacy
             ? // Don't show the billing column for legacy subscriptions.
               []


### PR DESCRIPTION
## Done

-  Hide cost of legacy subscriptions in the dashboard, as the values are wrong and are confusing customers.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to /pro/dashboard
    - Check if price for legacy subscriptions are not showing
    - Check if the cost for all the other subscriptions are there

## Issue / Card

Fixes [#WD-10260](https://warthogs.atlassian.net/browse/WD-10260)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
