### PR TITLE
Copy updates on /telco

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -598,8 +598,6 @@ telco:
       path: /telco/cnf
     - title: OpenRAN
       path: /telco/openran
-    - title: Magma
-      path: /telco/magma
 
 certification:
   title: Ubuntu Certified
@@ -648,4 +646,3 @@ landscape:
       path: /landscape/docs
     - title: Log in to Landscape
       path: https://landscape.canonical.com/login/authenticate
-

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -882,6 +882,7 @@ usn/rss\.xml: "/security/notices/rss.xml"
 (?P<page>.+)/: "/{page}"
 telecommunications/?: "/telco"
 telcos/?: "/telco"
+telco/magma/?: "/telco"
 fan/?: "https://wiki.ubuntu.com/FanNetworking"
 
 # Community

--- a/templates/telco/index.html
+++ b/templates/telco/index.html
@@ -20,14 +20,14 @@
       </p>
     </div>
     <div class="col-5 u-align--center u-vertically-center u-hide--medium u-hide--small">
-      {{ 
-        image (
-        url="https://assets.ubuntu.com/v1/d2387483-telecommunications-grey.svg",
+
+      {{ image (
+        url="https://assets.ubuntu.com/v1/95248a92-Canonical Telco Illustrations 06.png",
         alt="",
-        width="300",
-        height="300",
+        width="5000",
+        height="3334",
         hi_def=True,
-        loading="auto",
+        loading="auto"
         ) | safe
       }}
     </div>
@@ -111,12 +111,11 @@
       </p>
     </div>
     <div class="col-6 u-align--center u-vertically-center">
-      {{ 
-        image (
-        url="https://assets.ubuntu.com/v1/cb2bad68-Security-with-Ubuntu-Pro.png",
+      {{ image (
+        url="https://assets.ubuntu.com/v1/f451efae-Canonical Telco Illustrations 05.png",
         alt="",
-        width="406",
-        height="377",
+        width="5000",
+        height="3334",
         hi_def=True,
         loading="lazy"
         ) | safe
@@ -126,12 +125,11 @@
   </div>
   <div class="row">
     <div class="col-6 u-align--center u-vertically-center">
-      {{ 
-        image (
-        url="https://assets.ubuntu.com/v1/b261f3cb-telco-edge-cloud.png",
+      {{ image (
+        url="https://assets.ubuntu.com/v1/95248a92-Canonical Telco Illustrations 06.png",
         alt="",
-        width="538",
-        height="284",
+        width="5000",
+        height="3334",
         hi_def=True,
         loading="lazy"
         ) | safe
@@ -141,7 +139,7 @@
       <h2>Performant and efficient telco edge clouds</h2>
       <p>Modern edge clouds delivered with carrier-grade open source solutions, tailored for the needs of telecom operators.</p>
       <ul class="p-list">
-        <li class="p-list__item is-ticked">Minimal footprint with optimally sizes</li>
+        <li class="p-list__item is-ticked">Minimal footprint with optimal sizes</li>
         <li class="p-list__item is-ticked">Scalable, modular and highly-available</li>
         <li class="p-list__item is-ticked">Cloud-native for Open RAN, 5G and MEC</li>
         <li class="p-list__item is-ticked">Unattended operations with full automation</li>
@@ -157,9 +155,10 @@
         Learn more about our modern telco edge solutions:
       </p>
       <ul class="p-list">
-        <li class="p-list__item has-bullet"><a href="/blog/bringing-automation-to-telco-edge-clouds-at-scale">Cloud Native Execution Platform (CNEP)</a></li>
+        <li class="p-list__item has-bullet"><a href="/blog/bringing-automation-to-telco-edge-clouds-at-scale">A composable cloud-native telco cloud solution</a></li>
         <li class="p-list__item has-bullet"><a href="https://canonical.com/microcloud">Scalable private clouds and edge computing with MicroCloud</a></li>
         <li class="p-list__item has-bullet"><a href="/kubernetes">Highly-available and pure upstream Canonical Kubernetes</a></li>
+      </ul>
     </div>
   </div>
 </section>
@@ -171,12 +170,11 @@
       </h2>
     </div>
     <div class="col-5 u-vertically-center u-align--center u-align--left-medium u-hide--small">
-      {{ 
-        image (
-        url="https://assets.ubuntu.com/v1/be72de6b-Vodafone-Logo.png",
-        alt="Vodafone",
-        width="3840",
-        height="2160",
+      {{ image (
+        url="https://assets.ubuntu.com/v1/1f96a3a1-Canonical Telco Illustrations 03.png",
+        alt="",
+        width="5000",
+        height="3334",
         hi_def=True,
         loading="lazy"
         ) | safe
@@ -251,42 +249,11 @@
         <div class="p-card__content">
           <ul class="p-list">
             <li class="p-list__item has-bullet">Economical in every way.</li>
-            <li class="p-list__item has-bullet">Smart operations, optimal architecture, better pricing.</li>
+            <li class="p-list__item has-bullet">Smart operations, optimal architecture and better pricing.</li>
             <li class="p-list__item has-bullet">TCO reduction of your cloud, while expanding your budget for innovation with <a href="/openstack">Canonical OpenStack</a> and <a href="https://canonical.com/microcloud">Canonical MicroCloud</a></li>
           </ul>
         </div>
       </div>
-    </div>
-  </div>
-</section>
-
-<section class="p-section">
-  <div class="row">
-    <div class="col-6 u-align--center u-vertically-center">
-      {{ 
-        image (
-        url="https://assets.ubuntu.com/v1/d82d9e4b-Canonical-Kubernetes-logo-2022.png",
-        alt="",
-        width="353",
-        height="103",
-        hi_def=True,
-        loading="lazy"
-        ) | safe
-      }}
-    </div>
-    <div class="col-6">
-      <h2>Infrastructure for cloud native telco</h2>
-      <ul class="p-list">
-        <li class="p-list__item is-ticked">Modular and scalable edge clouds with Canonical Kubernetes on MicroCloud or bare metal.</li>
-        <li class="p-list__item is-ticked">Reliable and stable core clouds with Canonical Kubernetes on OpenStack or bare metal.</li>
-        <li class="p-list__item is-ticked">Repeatable and trusted deployment and operations for CNFs.</li>
-        <li class="p-list__item is-ticked">Optimal and minimally-sized containers with chiselled Ubuntu images.</li>
-      </ul>
-      <p>Learn how we support cloud-native telco with:</p>
-      <ul class="p-list">
-        <li class="p-list__item has-bullet"><a href="/blog/combining-distroless-and-ubuntu-chiselled-containers">Chiselled Ubuntu</a></li>
-        <li class="p-list__item has-bullet"><a href="/kubernetes">Canonical Kubernetes</a></li>
-      </ul>
     </div>
   </div>
 </section>
@@ -308,6 +275,7 @@
     </div>
     <div class="col-8">
       <p class="p-heading--3">Thanks to Canonical's OpenStack distribution, BT can bring 5G to more people in the UK, with cost-effectiveness and reliability. This was delivered with Canonical's automation solutions, which made it possible for BT to better scale and manage large-scale infrastructure.</p>
+      <p><a href="/blog/bt-turns-to-canonical-ubuntu-to-enable-next-generation-5g-cloud-core">Read the case study&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </section>
@@ -335,7 +303,6 @@
   </div>
 </section>
 
-
 <section class="p-strip">
   <div class="row">
     <div class="col-6">
@@ -343,18 +310,17 @@
       <p>Streamline the efficiency and productivity of your business applications with the performance and cost-efficiency benefits brought to you by private mobile networks with our secure open source solutions.</p>
       <p>Focus on your business applications and processes while our software runs and maintains your telco infrastructure with automation.</p>
       <p>We provide a full software stack with repeatable deployment steps that easily scale across your enterprise sites.</p>
-      <p>Our private mobile telco stack is powered by carrier-grade software infrastructure products  that come with built-in high-availability, security, and interoperability.</p>
+      <p>Our private mobile telco stack is powered by carrier-grade software infrastructure products  that come with built-in high-availability, security and interoperability.</p>
       <p>
         <a href="/blog/introduction-to-open-source-private-lte-and-5g-networks">Intro to open source private LTE and 5G&nbsp;&rsaquo;</a>
       </p>
     </div>
     <div class="col-6 u-vertically-center u-align--center u-align--left-medium u-hide--small">
-      {{ 
-        image (
-        url="https://assets.ubuntu.com/v1/1e013f0c-private-mobile-network-city-display.png",
+      {{ image (
+        url="https://assets.ubuntu.com/v1/f5b4d69b-Canonical Telco Illustrations 02.png",
         alt="",
-        width="420",
-        height="307",
+        width="5000",
+        height="3334",
         hi_def=True,
         loading="lazy"
         ) | safe
@@ -499,10 +465,10 @@
         </div>
         <div class="p-logo-section__item">
           {{ image (
-            url="https://assets.ubuntu.com/v1/f253ee6e-telecom-infra-project-vector-logo.svg",
-            alt="Telecom Infra",
-            width="150",
-            height="150",
+            url="https://assets.ubuntu.com/v1/eeae998a-telecominfraproject-logo.svg",
+            alt="Telecom Infra Project",
+            width="300",
+            height="49",
             hi_def=True,
             attrs={"class": "p-logo-section__logo"},
             loading="lazy"


### PR DESCRIPTION
## Done
*TODO: remove pages /magma, /osm (and its children, if needed) - ongoing convo in do*

- Copy updates based on [copydoc](https://docs.google.com/document/d/1a3otoXCbXtddJG2HCnYIIHJiDxvG-pzFPtLobVB4-vw/edit)
- Removes 'magma' from the navigation and adds a redirect to /telco

## QA

- Go to /telco and check that the changes match the [copydoc](https://docs.google.com/document/d/1a3otoXCbXtddJG2HCnYIIHJiDxvG-pzFPtLobVB4-vw/edit) *excluding* the two sections photo'd below:
![image](https://github.com/canonical/ubuntu.com/assets/58276363/05a27930-fe71-4b1f-ab0e-ec075751ea46)
![image](https://github.com/canonical/ubuntu.com/assets/58276363/7b20f2a1-ec7c-4391-85c2-adc3631c13d8)


## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-10370

