### PR TITLE
WD-9618 - update core home page

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -288,7 +288,7 @@ core:
   children:
     - title: Overview
       path: /core
-    - title: Consulting
+    - title: Services
       path: /core/services
     - title: Success stories
       path: /core/stories

--- a/navigation.yaml
+++ b/navigation.yaml
@@ -286,16 +286,14 @@ core:
   path: /core
 
   children:
-    - title: Overview
-      path: /core
     - title: Services
       path: /core/services
+    - title: Overview
+      path: /core
     - title: Success stories
       path: /core/stories
     - title: Features
       path: /core/features
-    - title: Tutorials
-      path: /tutorials?q=core
     - title: Docs
       path: /core/docs
 

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "typescript": "4.5.4",
     "url-polyfill": "1.1.12",
     "url-search-params-polyfill": "8.1.1",
-    "vanilla-framework": "4.9.1",
+    "vanilla-framework": "4.10.0",
     "yup": "0.32.11"
   },
   "resolutions": {

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1558,6 +1558,7 @@ ol.p-list--divided .p-list__item::before {
 .p-hero-video-link {
   .p-hero-video__play {
     @include vf-transition(background-size, fast, out);
+
     display: block;
   }
 
@@ -1565,7 +1566,7 @@ ol.p-list--divided .p-list__item::before {
     opacity: 0.9;
   }
 
-  &.p-equal-height-row__col:before {
+  &.p-equal-height-row__col::before {
     content: none !important;
   }
 }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1554,6 +1554,22 @@ ol.p-list--divided .p-list__item::before {
   content: counter(list-item) ". ";
 }
 
+//XXX: styles from Liza's js snippet, taken here because the scss is not parsed inside js and the include doesn't work there. This should be refactored.
+.p-hero-video-link {
+  .p-hero-video__play {
+    @include vf-transition(background-size, fast, out);
+    display: block;
+  }
+
+  &:hover img {
+    opacity: 0.9;
+  }
+
+  &.p-equal-height-row__col:before {
+    content: none !important;
+  }
+}
+
 // Fix stepped list title grid bug
 // To be removed once is bug is fixed: https://github.com/canonical/vanilla-framework/issues/5002
 @media screen and (max-width: $breakpoint-small - 1) {

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -364,13 +364,13 @@ meta_copydoc %}
             ) | safe
           }}
         </div>
-        <div class="col">
+        <div class="col u-no-margin--top">
           <div class="row">
             <div class="col-6">
               <h3 class="p-heading--2">Bosch Rexroth reinvents automation</h3>
             </div>
-            <div class="col-3 p-section--shallow">
-              <div class="p-section--shallow">
+            <div class="col-3">
+              <div>
                 <p>Bosch adopts Ubuntu Core and snaps for app-based ctrl-X industry 4.0 platform.</p>
               </div>
               <hr class="p-rule is-muted" />
@@ -406,13 +406,13 @@ meta_copydoc %}
             ) | safe
           }}
         </div>
-        <div class="col">
+        <div class="col u-no-margin--top">
           <div class="row">
             <div class="col-6">
               <h3 class="p-heading--2">Pudo deploys fleet for robust last-mile logistics</h3>
             </div>
-            <div class="col-3 p-section--shallow">
-              <div class="p-section--shallow">
+            <div class="col-3">
+              <div>
                 <p>Pudo chooses Ubuntu Core as the foundation for its IoT-based APMs to maximise security and uptime.</p>
               </div>
               <hr class="is-muted p-rule" />
@@ -448,13 +448,13 @@ meta_copydoc %}
             ) | safe
           }}
         </div>
-        <div class="col">
+        <div class="col u-no-margin--top">
           <div class="row">
             <div class="col-6">
               <h3 class="p-heading--2">Rigado cuts customers’ time to market</h3>
             </div>
-            <div class="col-3 p-section--shallow">
-              <div class="p-section--shallow">
+            <div class="col-3">
+              <div>
                 <p>Ubuntu Core enables Rigado to manage end-to-end security for commercial IoT gateways.</p>
               </div>
               <hr class="is-muted p-rule" />
@@ -490,13 +490,13 @@ meta_copydoc %}
             ) | safe
           }}
         </div>
-        <div class="col">
+        <div class="col u-no-margin--top">
           <div class="row">
             <div class="col-6">
               <h3 class="p-heading--2">IBM Cloud provides highly isolated and performant bare metal servers</h3>
             </div>
-            <div class="col-3 p-section--shallow">
-              <div class="p-section--shallow">
+            <div class="col-3">
+              <div>
                 <p>IBM Cloud's bare metal servers offer highly isolated and high-performing tenant-cloud isolation through the use of Ubuntu Core.</p>
               </div>
               <hr class="is-muted p-rule" />

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -50,6 +50,9 @@ meta_copydoc %}
                               .p-hero-video-link:hover img {
                                 transform: scale(1.3);
                               }
+                              .p-equal-height-row__col:before {
+                                content: none !important;
+                              }
                             `;
         const video = document.querySelector('.p-hero-video');
         const videoContainer = document.querySelector('.p-hero-video-container');
@@ -98,8 +101,8 @@ meta_copydoc %}
       </div>
     </div>
     <div class="p-equal-height-row__col">
-      <div class="p-equal-height-row__item">
-        <div class="p-media-container u-hide--small">
+      <div class="p-equal-height-row__item u-hide--small">
+        <div class="p-media-container">
           <img width="320" src="https://assets.ubuntu.com/v1/d1d161a9-fleet-management.jpg" alt="" />
         </div>
       </div>
@@ -118,8 +121,8 @@ meta_copydoc %}
       </div>
     </div>
     <div class="p-equal-height-row__col">
-      <div class="p-equal-height-row__item">
-        <div class="p-media-container u-hide--small">
+      <div class="p-equal-height-row__item u-hide--small">
+        <div class="p-media-container">
           <img width="320" src="https://assets.ubuntu.com/v1/373f7039-agile-containerisation.png" alt="" />
         </div>
       </div>
@@ -138,8 +141,8 @@ meta_copydoc %}
       </div>
     </div>
     <div class="p-equal-height-row__col">
-      <div class="p-equal-height-row__item">
-        <div class="p-media-container u-hide--small">
+      <div class="p-equal-height-row__item u-hide--small">
+        <div class="p-media-container">
           <img width="320" src="https://assets.ubuntu.com/v1/166ec7c6-hardware-ecosystem.jpg" alt="" />
         </div>
       </div>

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -87,7 +87,7 @@ meta_copydoc %}
         </div>
       </div>
       <div class="p-equal-height-row__item">
-        <hr class="p-rule--highlight u-hide--medium u-hide--small is-muted">
+        <hr class="p-rule--highlight u-hide--medium u-hide--small is-muted" />
         <h5 class="p-heading--5">Continuous security</h5>
       </div>
       <p class="p-equal-height-row__item">
@@ -107,8 +107,8 @@ meta_copydoc %}
         </div>
       </div>
       <div class="p-equal-height-row__item">
-        <hr class="p-rule--highlight u-hide--medium u-hide--small is-muted">
-        <h5 class="p-heading--5">Fleet management</h5>
+        <hr class="p-rule--highlight u-hide--medium u-hide--small is-muted" />
+        <h5 class="p-heading--5">Device management</h5>
       </div>
       <p class="p-equal-height-row__item">
         Enjoy reliable, remotely accessible and recoverable devices which are always up-to-date with mission-critical
@@ -116,7 +116,7 @@ meta_copydoc %}
       </p>
       <div class="p-equal-height-row__item">
         <p>
-          <a href="/internet-of-things/management">Learn more about fleet management&nbsp;&rsaquo;</p></a>
+          <a href="/internet-of-things/management">Learn more about fleet management&nbsp;&rsaquo;</a>
         </p>
       </div>
     </div>
@@ -127,7 +127,7 @@ meta_copydoc %}
         </div>
       </div>
       <div class="p-equal-height-row__item">
-        <hr class="p-rule--highlight u-hide--medium u-hide--small is-muted">
+        <hr class="p-rule--highlight u-hide--medium u-hide--small is-muted" />
         <h5 class="p-heading--5">Agile containerisation</h5>
       </div>
       <p class="p-equal-height-row__item">
@@ -147,7 +147,7 @@ meta_copydoc %}
         </div>
       </div>
       <div class="p-equal-height-row__item">
-        <hr class="p-rule--highlight u-hide--medium u-hide--small is-muted">
+        <hr class="p-rule--highlight u-hide--medium u-hide--small is-muted" />
         <h5 class="p-heading--5">A strong hardware ecosystem</h5>
       </div>
       <p class="p-equal-height-row__item">

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -1,8 +1,7 @@
 {% extends "core/base_core.html" %}
 
 {% block title %}Ubuntu Core{% endblock %}
-{% block meta_description %}Ubuntu Core is Ubuntu for IoT and embedded environments, optimised for security and reliable
-ota updates. Run snaps in a high-security confined sandbox with bulletproof upgrades and a private app store.{% endblock
+{% block meta_description %}Ubuntu Core is Ubuntu for IoT and embedded devices, optimised for security and reliable over-the-air (OTA) updates. Run your applications in a high-security, immutable and reliable embedded Linux OS. {% endblock
 meta_description %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1UFpefDRSAcndNBnWp0hDyzqk74aciqhBWJEi05htWmU/edit{% endblock
 meta_copydoc %}

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -131,7 +131,9 @@ meta_copydoc %}
       </div>
     </div>
   </div>
+<div class="u-fixed-width">
   <hr class="p-rule is-muted" />
+</div>
   <div class="row">
     <div class="col-3 col-start-large-7">
       <p>

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -1,732 +1,775 @@
 {% extends "core/base_core.html" %}
 
 {% block title %}Ubuntu Core{% endblock %}
-{% block meta_description %}Ubuntu Core is Ubuntu for IoT and embedded devices, optimised for security and reliable over-the-air (OTA) updates. Run your applications in a high-security, immutable and reliable embedded Linux OS. {% endblock
+
+{% block meta_description %}
+    Ubuntu Core is Ubuntu for IoT and embedded devices, optimised for security and reliable over-the-air (OTA) updates. Run your applications in a high-security, immutable and reliable embedded Linux OS.
+{% endblock
 meta_description %}
-{% block meta_copydoc %}https://docs.google.com/document/d/1UFpefDRSAcndNBnWp0hDyzqk74aciqhBWJEi05htWmU/edit{% endblock
+
+{% block meta_copydoc %}
+    https://docs.google.com/document/d/1UFpefDRSAcndNBnWp0hDyzqk74aciqhBWJEi05htWmU/edit
+{% endblock
 meta_copydoc %}
 
-{% block body_class %}is-paper{% endblock body_class %}
+{% block body_class %}
+    is-paper
+{% endblock body_class %}
+
 {% block content %}
 
-<section class="p-strip is-shallow u-no-padding--bottom">
-  <div class="p-section row--50-50">
-    <div class="col">
-      <h1 class="u-no-margin--bottom">Ubuntu Core</h1>
-      <div class="p-section--shallow">
-        <p class="p-heading--2">The embedded Linux OS<br />for devices</p>
-      </div>
-      <div class="p-section--shallow">
-        <p class="p-heading--4">Ubuntu Core is a minimal, secure and strictly confined operating system powering devices around the world. Build your Ubuntu Core image today.</p>
-      </div>
-      <hr class="is-muted" />
-      <p>
-        <a class="p-button--positive" href="/core/docs/getting-started">Try Ubuntu Core</a>
-        <a href="https://assets.ubuntu.com/v1/1870ea66-Ubuntu_Core22_DS.06.06.22.pdf">Read&nbsp;the&nbsp;Ubuntu&nbsp;Core&nbsp;datasheet</a>
-      </p>
-    </div>
-    <div class="col u-hide--small">
-      <a href="#" aria-label="What is Ubuntu Core" class="p-hero-video-link">
-        <img src="https://assets.ubuntu.com/v1/3a0f24b8-video-thumbnail-suru-bg.png" alt="" class="p-hero-video__play" />
-      </a>
-      <div class="p-hero-video-container u-embedded-media u-hide">
-        <iframe class="p-hero-video u-embedded-media__element" src="https://www.youtube.com/embed/6NDWqH1SrGs" allow="autoplay;" frameborder="0" allowfullscreen=""></iframe>
-      </div>
-    </div>
-  </div>
-</section>
-
-<section class="p-section">
-  <div class="row--50-50 p-section--shallow">
-    <hr class="p-rule" />
-    <div class="col">
-      <h2>An OS with all the infrastructure</h2>
-    </div>
-    <div class="col">
-      <p>Ubuntu Core is more than just your embedded Linux OS, it's your whole deployment infrastructure. Build targeted
-        production-ready images, unlock over-the air (OTA) updates, deploy in air gap environments, manage your fleet of
-        devices, achieve real-time operations, and more.</p>
-      <p>Ubuntu Core will transform the way you deploy devices with the longest support window in the industry.</p>
-    </div>
-  </div>
-  <div class="p-equal-height-row has-3rd-divider">
-    <div class="p-equal-height-row__col">
-      <div class="p-equal-height-row__item u-hide--small u-hide--medium">
-        <div class="p-media-container">
-          <img width="320" src="https://assets.ubuntu.com/v1/834e417a-continuous-security.jpg" alt="" />
-        </div>
-      </div>
-      <div class="p-equal-height-row__item">
-        <hr class="p-rule--highlight u-hide--medium u-hide--small is-muted" />
-        <h3 class="p-heading--5">Continuous security</h3>
-      </div>
-      <p class="p-equal-height-row__item">
-        Imagine a world where every device is trustworthy. We designed every aspect of Ubuntu Core to create the most
-        secure embedded Linux ever, with a 10 year LTS commitment.
-      </p>
-      <div class="p-equal-height-row__item">
-        <p>
-          <a href="/security">Learn more about Ubuntu security&nbsp;&rsaquo;</a>
-        </p>
-      </div>
-    </div>
-    <div class="p-equal-height-row__col">
-      <div class="p-equal-height-row__item u-hide--small u-hide--medium">
-        <div class="p-media-container">
-          <img width="320" src="https://assets.ubuntu.com/v1/d1d161a9-fleet-management.jpg" alt="" />
-        </div>
-      </div>
-      <div class="p-equal-height-row__item">
-        <hr class="p-rule--highlight u-hide--medium u-hide--small is-muted" />
-        <h3 class="p-heading--5">Device management</h3>
-      </div>
-      <p class="p-equal-height-row__item">
-        Enjoy reliable, remotely accessible and recoverable devices which are always up-to-date with mission-critical
-        OTA updates. In connected or air-gap environments.
-      </p>
-      <div class="p-equal-height-row__item">
-        <p>
-          <a href="/internet-of-things/management">Learn more about fleet management&nbsp;&rsaquo;</a>
-        </p>
-      </div>
-    </div>
-    <div class="p-equal-height-row__col">
-      <div class="p-equal-height-row__item u-hide--small u-hide--medium">
-        <div class="p-media-container">
-          <img width="320" src="https://assets.ubuntu.com/v1/373f7039-agile-containerisation.png" alt="" />
-        </div>
-      </div>
-      <div class="p-equal-height-row__item">
-        <hr class="p-rule--highlight u-hide--medium u-hide--small is-muted" />
-        <h3 class="p-heading--5">Agile containerisation</h3>
-      </div>
-      <p class="p-equal-height-row__item">
-        Ubuntu Core is immutable and strictly confined. There is a clean separation between the kernel, OS image and
-        applications, each updated independently and protected against corruption.
-      </p>
-      <div class="p-equal-height-row__item">
-        <p>
-          <a href="/core/docs/components#heading--confinement">Learn more about confinement&nbsp;&rsaquo;</a>
-        </p>
-      </div>
-    </div>
-    <div class="p-equal-height-row__col">
-      <div class="p-equal-height-row__item u-hide--small u-hide--medium">
-        <div class="p-media-container">
-          <img width="320" src="https://assets.ubuntu.com/v1/166ec7c6-hardware-ecosystem.jpg" alt="" />
-        </div>
-      </div>
-      <div class="p-equal-height-row__item">
-        <hr class="p-rule--highlight u-hide--medium u-hide--small is-muted" />
-        <h3 class="p-heading--5">A strong hardware ecosystem</h3>
-      </div>
-      <p class="p-equal-height-row__item">
-        We enable Ubuntu Core with the best ODMs and silicon vendors in the world. We continuously test it on leading
-        IoT and edge devices and hardware.
-      </p>
-      <div class="p-equal-height-row__item">
-        <p>
-          <a href="/certified">Browse all certified hardware&nbsp;&rsaquo;</a> 
-        </p>
-      </div>
-    </div>
-  </div>
-<div class="u-fixed-width">
-  <hr class="p-rule is-muted" />
-</div>
-  <div class="row">
-    <div class="col-3 col-start-large-7">
-      <p>
-        <a href="/core/features">Discover the full feature list&nbsp;&rsaquo;</a>
-      </p>
-    </div>
-  </div>
-</section>
-
-<section class="p-section">
-  <div class="row--50-50 p-section--shallow">
-    <hr class="p-rule" />
-    <div class="col">
-      <h2>From development to deployment</h2>
-    </div>
-    <div class="col">
-      <p>Use the same kernel, the same libraries, and the same system software for a smooth transition from development
-        to production. Once you have created your application in Ubuntu Desktop or Server, build your immutable Ubuntu
-        Core image based on your developed applications and targeted hardware.</p>
-    </div>
-  </div>
-  <div class="row">
-    <hr class="is-muted col-9 col-start-large-4 col-medium-6 col-start-medium-2" />
-    <div class="col-3 col-medium-2 col-start-large-4 col-start-medium-2">
-      <ul class="js-tabbed-content p-tabs--vertical is-black u-hide--small" role="tablist" aria-label="Dev to deployment">
-        <li>
-          <button class="p-tabs__item" id="overview" role="tab" aria-selected="true"
-            aria-controls="overview-tab">Overview</button>
-        </li>
-        <li>
-          <button class="p-tabs__item" id="ubuntu-vision" role="tab" aria-selected="false"
-            aria-controls="ubuntu-vision-tab">Ubuntu</button>
-        </li>
-        <li>
-          <button class="p-tabs__item" id="snapcraft" role="tab" aria-selected="false"
-            aria-controls="snapcraft-tab">Snapcraft</button>
-        </li>
-        <li>
-          <button class="p-tabs__item" id="ubuntu-core" role="tab" aria-selected="false"
-            aria-controls="ubuntu-core-tab">Ubuntu Core</button>
-        </li>
-        <li>
-          <button class="p-tabs__item" id="snap-store" role="tab" aria-selected="false"
-            aria-controls="snap-store-tab">Snap Store</button>
-        </li>
-      </ul>
-      <form class="u-hide--large u-hide--medium">
-        <select name="boardSelect" id="boardSelect">
-          <option value="overview-tab" selected="">Overview</option>
-          <option value="ubuntu-vision-tab">Ubuntu</option>
-          <option value="snapcraft-tab">Snapcraft</option>
-          <option value="ubuntu-core-tab">Ubuntu Core</option>
-          <option value="snap-store-tab">Snap Store</option>
-        </select>
-      </form>
-    </div>
-    <div class="col-6 col-medium-3">
-      {% include "core/tabs.html" %}
-    </div>
-  </div>
-  <div class="row">
-    <hr class="is-muted col-9 col-start-large-4 col-medium-6 col-start-medium-2" />
-    <div class="col-6 col-start-large-7 col-medium-4 col-start-medium-4">
-      <p>
-        <a href="/core/docs">Get started with Ubuntu Core&nbsp;&rsaquo;</a>
-      </p>
-    </div>
-  </div>
-</section>
-
-<section class="p-section">
-  <div class="u-fixed-width p-section--shallow">
-    <hr class="p-rule" />
-    <h2>For smart use cases. Get Core. Get snaps. Get going.</h2>
-  </div>
-  <div class="row--25-75 p-section--shallow">
-    <div class="col">
-      <hr class="u-hide--small is-muted p-rule" />
-      <div class="row">
-        <div class="col-3 col-medium-2">
-          <a href="/automotive">
-            <h3 class="p-heading--5">Automotive</h3>
-            {{ image(
-                url="https://assets.ubuntu.com/v1/f867c883-For-smart-use-cases__Automotivew.png",
-                alt="",
-                width="285",
-                height="160",
-                hi_def=True,
-                loading="auto",
-                ) | safe
-            }}
-          </a>
-        </div>
-        <div class="col-3 col-medium-2">
-          <a href="/industrial">
-            <h3 class="p-heading--5">Industrial</h3>
-            {{ image(
-                url="https://assets.ubuntu.com/v1/0162bc71-For-smart-use-cases__Industrial.png",
-                alt="",
-                width="285",
-                height="160",
-                hi_def=True,
-                loading="auto",
-                ) | safe
-            }}
-          </a>
-        </div>
-        <div class="col-3 col-medium-2">
-          <a href="/robotics">
-            <h3 class="p-heading--5">Robotics</h3>
-            {{ image(
-                url="https://assets.ubuntu.com/v1/aeeeb32d-For-smart-use-cases__Robotics.png",
-                alt="",
-                width="285",
-                height="160",
-                hi_def=True,
-                loading="auto",
-                ) | safe
-            }}
-          </a>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div class="row--25-75">
-    <div class="col">
-      <hr class="u-hide--small is-muted p-rule" />
-      <div class="row">
-        <div class="col-3 col-medium-2">
-          <a href="/internet-of-things/digital-signage">
-            <h3 class="p-heading--5">Signage</h3>
-            {{ image(
-                url="https://assets.ubuntu.com/v1/9db3f004-For-smart-use-cases__Signage.png",
-                alt="",
-                width="285",
-                height="160",
-                hi_def=True,
-                loading="auto",
-                ) | safe
-            }}
-          </a>
-        </div>
-        <div class="col-3 col-medium-2">
-          <a href="/internet-of-things/smart-city">
-            <h3 class="p-heading--5">Smart cities</h3>
-            {{ image(
-                url="https://assets.ubuntu.com/v1/8dd2f04d-For-smart-use-cases__Smart-cities.png",
-                alt="",
-                width="285",
-                height="160",
-                hi_def=True,
-                loading="auto",
-                ) | safe
-            }}
-          </a>
-        </div>
-      </div>
-    </div>
-  </div>
-</section>
-
-<section class="p-section">
-  <div class="row">
-    <hr class="p-rule--highlight" />
-    <div class="col-9 col-medium-4">
-      <h2 class="p-text--small-caps p-heading--5">Ubuntu core customer stories</h2>
-    </div>
-    <div class="col-3 col-medium-2 p-section--shallow">
-      <p>
-        <a href="/core/stories">All the success stories&nbsp;&rsaquo;</a>
-      </p>
-    </div>
-  </div>
-  <div class="p-tabs">
-    <div class="row--25-75">
-      <div class="col">
-        <hr class="p-rule is-muted" />
-        <div class="p-tabs__list js-tabbed-content" role="tablist" aria-label="Customer stories">
-          <div class="p-tabs__item">
-            <button class="p-tabs__link" role="tab" aria-selected="true" aria-controls="industrial-tab"
-              id="industrial">Industrial</button>
-          </div>
-          <div class="p-tabs__item">
-            <button class="p-tabs__link" role="tab" aria-selected="false" aria-controls="smart-kiosk-tab"
-              id="smart-kiosk" tabindex="-1">Smart Kiosk</button>
-          </div>
-          <div class="p-tabs__item">
-            <button class="p-tabs__link" role="tab" aria-selected="false" aria-controls="network-tab" id="network"
-              tabindex="-1">Network</button>
-          </div>
-          <div class="p-tabs__item">
-            <button class="p-tabs__link" role="tab" aria-selected="false" aria-controls="cloud-tab" id="cloud"
-              tabindex="-1">Cloud</button>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div tabindex="0" role="tabpanel" id="industrial-tab" aria-labelledby="industrial">
-      <div class="row--25-75 u-no-margin--bottom">
-        <div class="col">
-          {{ image(
-            url="https://assets.ubuntu.com/v1/ffd88101-rexroth-for-testimonial.png",
-            alt="Rexroth",
-            width="284",
-            height="70",
-            hi_def=True,
-            loading="auto",
-            ) | safe
-          }}
-        </div>
-        <div class="col u-no-margin--top">
-          <div class="row">
-            <div class="col-6">
-              <h3 class="p-heading--2">Bosch Rexroth reinvents automation</h3>
+    <section class="p-strip is-shallow u-no-padding--bottom">
+        <div class="p-section row--50-50">
+            <div class="col">
+                <h1 class="u-no-margin--bottom">Ubuntu Core</h1>
+                <div class="p-section--shallow">
+                    <p class="p-heading--2">
+                        The embedded Linux OS
+                        <br />
+                        for devices
+                    </p>
+                </div>
+                <div class="p-section--shallow">
+                    <p class="p-heading--4">
+                        Ubuntu Core is a minimal, secure and strictly confined operating system powering devices around the world. Build your Ubuntu Core image today.
+                    </p>
+                </div>
+                <hr class="is-muted" />
+                <p>
+                    <a class="p-button--positive" href="/core/docs/getting-started">Try Ubuntu Core</a>
+                    <a href="https://assets.ubuntu.com/v1/1870ea66-Ubuntu_Core22_DS.06.06.22.pdf">Read&nbsp;the&nbsp;Ubuntu&nbsp;Core&nbsp;datasheet</a>
+                </p>
             </div>
-            <div class="col-3">
-              <p>Bosch adopts Ubuntu Core and snaps for app-based ctrl-X industry 4.0 platform.</p>
-              <hr class="p-rule is-muted" />
-              <p>
-                <a href="/blog/bosch-rexroth-adopts-ubuntu-core-and-snaps-for-app-based-ctrlx-automation-platform">Read the press release&nbsp;&rsaquo;</a>
-              </p>
+            <div class="col u-hide--small">
+                <a href="#" aria-label="What is Ubuntu Core" class="p-hero-video-link">
+                    <img src="https://assets.ubuntu.com/v1/3a0f24b8-video-thumbnail-suru-bg.png"
+                         alt=""
+                         class="p-hero-video__play" />
+                </a>
+                <div class="p-hero-video-container u-embedded-media u-hide">
+                    <iframe class="p-hero-video u-embedded-media__element"
+                            src="https://www.youtube.com/embed/6NDWqH1SrGs"
+                            allow="autoplay;"
+                            frameborder="0"
+                            allowfullscreen=""></iframe>
+                </div>
             </div>
-          </div>
-          <div>
-            {{ image(
-              url="https://assets.ubuntu.com/v1/2d152c25-rexroth-testimonial-image.jpg",
-              alt="Rexroth",
-              width="917",
-              height="392",
-              hi_def=True,
-              loading="auto",
-              ) | safe
-            }}
-          </div>
         </div>
-      </div>
-    </div>
-    <div tabindex="0" role="tabpanel" id="smart-kiosk-tab" aria-labelledby="smart-kiosk" aria-hidden="hidden">
-      <div class="row--25-75 u-no-margin--bottom">
-        <div class="col">
-          {{ image(
-            url="https://assets.ubuntu.com/v1/ea8fc1a8-pudo-testimonial-logo.png",
-            alt="Pudo",
-            width="180",
-            height="89",
-            hi_def=True,
-            loading="auto",
-            ) | safe
-          }}
-        </div>
-        <div class="col u-no-margin--top">
-          <div class="row">
-            <div class="col-6">
-              <h3 class="p-heading--2">Pudo deploys fleet for robust last-mile logistics</h3>
-            </div>
-            <div class="col-3">
-              <p>Pudo chooses Ubuntu Core as the foundation for its IoT-based APMs to maximise security and uptime.</p>
-              <hr class="is-muted p-rule" />
-              <p>
-                <a href="/engage/pudo-case-study">Read the case study&nbsp;&rsaquo;</a>
-              </p>
-            </div>
-          </div>
-          <div>
-            {{ image(
-              url="https://assets.ubuntu.com/v1/576c8402-pudo-testimonial-image.jpg",
-              alt="Pudo",
-              width="917",
-              height="392",
-              hi_def=True,
-              loading="auto",
-              ) | safe
-            }}
-          </div>
-        </div>
-      </div>
-    </div>
-    <div tabindex="0" role="tabpanel" id="network-tab" aria-labelledby="network" aria-hidden="hidden">
-      <div class="row--25-75 u-no-margin--bottom">
-        <div class="col">
-          {{ image(
-            url="https://assets.ubuntu.com/v1/80f5af45-rigado-testimonial-logo.png",
-            alt="Rigado",
-            width="200",
-            height="46",
-            hi_def=True,
-            loading="auto",
-            ) | safe
-          }}
-        </div>
-        <div class="col u-no-margin--top">
-          <div class="row">
-            <div class="col-6">
-              <h3 class="p-heading--2">Rigado cuts customers’ time to market</h3>
-            </div>
-            <div class="col-3">
-              <p>Ubuntu Core enables Rigado to manage end-to-end security for commercial IoT gateways.</p>
-              <hr class="is-muted p-rule" />
-              <p>
-                <a href="/engage/case-study-rigado">Read the case study&nbsp;&rsaquo;</a>
-              </p>
-            </div>
-          </div>
-          <div>
-            {{ image(
-              url="https://assets.ubuntu.com/v1/297369c0-rigado--testimonial-image.jpg",
-              alt="Rigado",
-              width="917",
-              height="392",
-              hi_def=True,
-              loading="auto",
-              ) | safe
-            }}
-          </div>
-        </div>
-      </div>
-    </div>
-    <div tabindex="0" role="tabpanel" id="cloud-tab" aria-labelledby="cloud" aria-hidden="hidden">
-      <div class="row--25-75 u-no-margin--bottom">
-        <div class="col">
-          {{ image(
-            url="https://assets.ubuntu.com/v1/e110996e-ibm-cloud-testimonial-logo.png",
-            alt="IBM",
-            width="200",
-            height="60",
-            hi_def=True,
-            loading="auto",
-            ) | safe
-          }}
-        </div>
-        <div class="col u-no-margin--top">
-          <div class="row">
-            <div class="col-6">
-              <h3 class="p-heading--2">IBM Cloud provides highly isolated and performant bare metal servers</h3>
-            </div>
-            <div class="col-3">
-              <p>IBM Cloud's bare metal servers offer highly isolated and high-performing tenant-cloud isolation through the use of Ubuntu Core.</p>
-              <hr class="is-muted p-rule" />
-              <p>
-                <a href="https://canonical.com/blog/cloud-isolation-ibm-bare-metal-ubuntu-core">Read the press release&nbsp;&rsaquo;</a>
-              </p>
-            </div>
-          </div>
-          <div>
-            {{ image(
-              url="https://assets.ubuntu.com/v1/534be2a2-ibm-leadspace.jpg",
-              alt="IBM",
-              width="917",
-              height="392",
-              hi_def=True,
-              loading="auto",
-              ) | safe
-            }}
-          </div>
-        </div>
-      </div>
-    </div>
+    </section>
 
-  </div>
-</section>
+    <section class="p-section">
+        <div class="row--50-50 p-section--shallow">
+            <hr class="p-rule" />
+            <div class="col">
+                <h2>An OS with all the infrastructure</h2>
+            </div>
+            <div class="col">
+                <p>
+                    Ubuntu Core is more than just your embedded Linux OS, it's your whole deployment infrastructure. Build targeted
+                    production-ready images, unlock over-the air (OTA) updates, deploy in air gap environments, manage your fleet of
+                    devices, achieve real-time operations, and more.
+                </p>
+                <p>Ubuntu Core will transform the way you deploy devices with the longest support window in the industry.</p>
+            </div>
+        </div>
+        <div class="p-equal-height-row has-3rd-divider">
+            <div class="p-equal-height-row__col">
+                <div class="p-equal-height-row__item u-hide--small u-hide--medium">
+                    <div class="p-media-container">
+                        <img width="320"
+                             src="https://assets.ubuntu.com/v1/834e417a-continuous-security.jpg"
+                             alt="" />
+                    </div>
+                </div>
+                <div class="p-equal-height-row__item">
+                    <hr class="p-rule--highlight u-hide--medium u-hide--small is-muted" />
+                    <h3 class="p-heading--5">Continuous security</h3>
+                </div>
+                <p class="p-equal-height-row__item">
+                    Imagine a world where every device is trustworthy. We designed every aspect of Ubuntu Core to create the most
+                    secure embedded Linux ever, with a 10 year LTS commitment.
+                </p>
+                <div class="p-equal-height-row__item">
+                    <p>
+                        <a href="/security">Learn more about Ubuntu security&nbsp;&rsaquo;</a>
+                    </p>
+                </div>
+            </div>
+            <div class="p-equal-height-row__col">
+                <div class="p-equal-height-row__item u-hide--small u-hide--medium">
+                    <div class="p-media-container">
+                        <img width="320"
+                             src="https://assets.ubuntu.com/v1/d1d161a9-fleet-management.jpg"
+                             alt="" />
+                    </div>
+                </div>
+                <div class="p-equal-height-row__item">
+                    <hr class="p-rule--highlight u-hide--medium u-hide--small is-muted" />
+                    <h3 class="p-heading--5">Device management</h3>
+                </div>
+                <p class="p-equal-height-row__item">
+                    Enjoy reliable, remotely accessible and recoverable devices which are always up-to-date with mission-critical
+                    OTA updates. In connected or air-gap environments.
+                </p>
+                <div class="p-equal-height-row__item">
+                    <p>
+                        <a href="/internet-of-things/management">Learn more about fleet management&nbsp;&rsaquo;</a>
+                    </p>
+                </div>
+            </div>
+            <div class="p-equal-height-row__col">
+                <div class="p-equal-height-row__item u-hide--small u-hide--medium">
+                    <div class="p-media-container">
+                        <img width="320"
+                             src="https://assets.ubuntu.com/v1/373f7039-agile-containerisation.png"
+                             alt="" />
+                    </div>
+                </div>
+                <div class="p-equal-height-row__item">
+                    <hr class="p-rule--highlight u-hide--medium u-hide--small is-muted" />
+                    <h3 class="p-heading--5">Agile containerisation</h3>
+                </div>
+                <p class="p-equal-height-row__item">
+                    Ubuntu Core is immutable and strictly confined. There is a clean separation between the kernel, OS image and
+                    applications, each updated independently and protected against corruption.
+                </p>
+                <div class="p-equal-height-row__item">
+                    <p>
+                        <a href="/core/docs/components#heading--confinement">Learn more about confinement&nbsp;&rsaquo;</a>
+                    </p>
+                </div>
+            </div>
+            <div class="p-equal-height-row__col">
+                <div class="p-equal-height-row__item u-hide--small u-hide--medium">
+                    <div class="p-media-container">
+                        <img width="320"
+                             src="https://assets.ubuntu.com/v1/166ec7c6-hardware-ecosystem.jpg"
+                             alt="" />
+                    </div>
+                </div>
+                <div class="p-equal-height-row__item">
+                    <hr class="p-rule--highlight u-hide--medium u-hide--small is-muted" />
+                    <h3 class="p-heading--5">A strong hardware ecosystem</h3>
+                </div>
+                <p class="p-equal-height-row__item">
+                    We enable Ubuntu Core with the best ODMs and silicon vendors in the world. We continuously test it on leading
+                    IoT and edge devices and hardware.
+                </p>
+                <div class="p-equal-height-row__item">
+                    <p>
+                        <a href="/certified">Browse all certified hardware&nbsp;&rsaquo;</a>
+                    </p>
+                </div>
+            </div>
+        </div>
+        <div class="u-fixed-width">
+            <hr class="p-rule is-muted" />
+        </div>
+        <div class="row">
+            <div class="col-3 col-start-large-7">
+                <p>
+                    <a href="/core/features">Discover the full feature list&nbsp;&rsaquo;</a>
+                </p>
+            </div>
+        </div>
+    </section>
 
-<section class="p-section">
-  <div class="u-fixed-width p-section--shallow">
-    <hr class="p-rule" />
-    <div class="p-section--shallow">
-      <h2>Get to market fast with our hardware ecosystem</h2>
-    </div>
-    <div class="p-logo-section--dense">
-      <div class="p-logo-section__items">
-        <div class="p-logo-section__item">
-          {{ image(
-              url="https://assets.ubuntu.com/v1/59996fad-intel-new-logo.png",
-              alt="Intel",
-              width="50",
-              height="96",
-              hi_def=True,
-              attrs={"class": "p-logo-section__logo"},
-              loading="auto",
-              ) | safe
-          }}
+    <section class="p-section">
+        <div class="row--50-50 p-section--shallow">
+            <hr class="p-rule" />
+            <div class="col">
+                <h2>From development to deployment</h2>
+            </div>
+            <div class="col">
+                <p>
+                    Use the same kernel, the same libraries, and the same system software for a smooth transition from development
+                    to production. Once you have created your application in Ubuntu Desktop or Server, build your immutable Ubuntu
+                    Core image based on your developed applications and targeted hardware.
+                </p>
+            </div>
         </div>
-        <div class="p-logo-section__item">
-          {{ image(
-              url="https://assets.ubuntu.com/v1/4bf8a9bc-amd-logo.png",
-              alt="AMD",
-              width="69",
-              height="96",
-              hi_def=True,
-              attrs={"class": "p-logo-section__logo"},
-              loading="auto",
-              ) | safe
-          }}
+        <div class="row">
+            <hr class="is-muted col-9 col-start-large-4 col-medium-6 col-start-medium-2" />
+            <div class="col-3 col-medium-2 col-start-large-4 col-start-medium-2">
+                <ul class="js-tabbed-content p-tabs--vertical is-black u-hide--small"
+                    role="tablist"
+                    aria-label="Dev to deployment">
+                    <li>
+                        <button class="p-tabs__item"
+                                id="overview"
+                                role="tab"
+                                aria-selected="true"
+                                aria-controls="overview-tab">Overview</button>
+                    </li>
+                    <li>
+                        <button class="p-tabs__item"
+                                id="ubuntu-vision"
+                                role="tab"
+                                aria-selected="false"
+                                aria-controls="ubuntu-vision-tab">Ubuntu</button>
+                    </li>
+                    <li>
+                        <button class="p-tabs__item"
+                                id="snapcraft"
+                                role="tab"
+                                aria-selected="false"
+                                aria-controls="snapcraft-tab">Snapcraft</button>
+                    </li>
+                    <li>
+                        <button class="p-tabs__item"
+                                id="ubuntu-core"
+                                role="tab"
+                                aria-selected="false"
+                                aria-controls="ubuntu-core-tab">Ubuntu Core</button>
+                    </li>
+                    <li>
+                        <button class="p-tabs__item"
+                                id="snap-store"
+                                role="tab"
+                                aria-selected="false"
+                                aria-controls="snap-store-tab">Snap Store</button>
+                    </li>
+                </ul>
+                <form class="u-hide--large u-hide--medium">
+                    <select name="boardSelect" id="boardSelect">
+                        <option value="overview-tab" selected="">Overview</option>
+                        <option value="ubuntu-vision-tab">Ubuntu</option>
+                        <option value="snapcraft-tab">Snapcraft</option>
+                        <option value="ubuntu-core-tab">Ubuntu Core</option>
+                        <option value="snap-store-tab">Snap Store</option>
+                    </select>
+                </form>
+            </div>
+            <div class="col-6 col-medium-3">{% include "core/tabs.html" %}</div>
         </div>
-        <div class="p-logo-section__item">
-          {{ image(
-            url="https://assets.ubuntu.com/v1/e7b81879-nvidia-logo.png",
-            alt="Nvidia",
-            width="94",
-            height="96",
-            hi_def=True,
-            attrs={"class": "p-logo-section__logo"},
-            loading="auto",
-            ) | safe
-          }}
+        <div class="row">
+            <hr class="is-muted col-9 col-start-large-4 col-medium-6 col-start-medium-2" />
+            <div class="col-6 col-start-large-7 col-medium-4 col-start-medium-4">
+                <p>
+                    <a href="/core/docs">Get started with Ubuntu Core&nbsp;&rsaquo;</a>
+                </p>
+            </div>
         </div>
-        <div class="p-logo-section__item">
-          {{ image(
-            url="https://assets.ubuntu.com/v1/9a25ec68-arm-logo.png",
-            alt="ARM",
-            width="47",
-            height="96",
-            hi_def=True,
-            attrs={"class": "p-logo-section__logo"},
-            loading="auto",
-            ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{ image(
-            url="https://assets.ubuntu.com/v1/31b259ec-qualcom-logo.png",
-            alt="Qualcom",
-            width="96",
-            height="96",
-            hi_def=True,
-            attrs={"class": "p-logo-section__logo"},
-            loading="auto",
-            ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{ image(
-            url="https://assets.ubuntu.com/v1/d65da7f3-advantech-logo.png",
-            alt="Advantech",
-            width="95",
-            height="96",
-            hi_def=True,
-            attrs={"class": "p-logo-section__logo"},
-            loading="auto",
-            ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{ image(
-            url="https://assets.ubuntu.com/v1/6eff0263-adlink-logo.png",
-            alt="Adlink",
-            width="101",
-            height="96",
-            hi_def=True,
-            attrs={"class": "p-logo-section__logo"},
-            loading="auto",
-            ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{ image(
-            url="https://assets.ubuntu.com/v1/be8db080-nxp-logo.png",
-            alt="NXP",
-            width="41",
-            height="96",
-            hi_def=True,
-            attrs={"class": "p-logo-section__logo"},
-            loading="auto",
-            ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{ image(
-            url="https://assets.ubuntu.com/v1/96d65ee2-mediatek-logo.png",
-            alt="MediaTeK",
-            width="77",
-            height="96",
-            hi_def=True,
-            attrs={"class": "p-logo-section__logo"},
-            loading="auto",
-            ) | safe
-          }}
-        </div>
-      </div>
-    </div>
-  </div>
-  <div class="row">
-    <hr class="p-rule is-muted" />
-    <div class="col-start-large-7 col-3 col-medium-2 col-start-medium-3">
-      <p>
-        <a href="/certified">Browse all certified hardware&nbsp;&rsaquo;</a>
-      </p>
-    </div>
-    <div class="col-3 col-medium-2">
-      <p>
-        <a href="/core/contact-us">Contact us&nbsp;&rsaquo;</a>
-      </p>
-    </div>
-  </div>
-</section>
+    </section>
 
-<section class="p-section">
-  <div class="row--50-50">
-    <hr class="p-rule" />
-    <div class="col">
-      <h2>Learn more about&nbsp;Ubuntu&nbsp;Core</h2>
-    </div>
-    <div class="col">
-      <div class="row--50-50">
-        <div class="col">
-          <h5 class="p-heading--5">Docs</h5>
+    <section class="p-section">
+        <div class="u-fixed-width p-section--shallow">
+            <hr class="p-rule" />
+            <h2>For smart use cases. Get Core. Get snaps. Get going.</h2>
         </div>
-        <div class="col">
-          <p>
-            <a href="/core/docs/getting-started">Start your Core journey today</a>
-          </p>
+        <div class="row--25-75 p-section--shallow">
+            <div class="col">
+                <hr class="u-hide--small is-muted p-rule" />
+                <div class="row">
+                    <div class="col-3 col-medium-2">
+                        <a href="/automotive">
+                            <h3 class="p-heading--5">Automotive</h3>
+                            {{ image(url="https://assets.ubuntu.com/v1/f867c883-For-smart-use-cases__Automotivew.png",
+                                                        alt="",
+                                                        width="285",
+                                                        height="160",
+                                                        hi_def=True,
+                                                        loading="auto",) | safe
+                            }}
+                        </a>
+                    </div>
+                    <div class="col-3 col-medium-2">
+                        <a href="/industrial">
+                            <h3 class="p-heading--5">Industrial</h3>
+                            {{ image(url="https://assets.ubuntu.com/v1/0162bc71-For-smart-use-cases__Industrial.png",
+                                                        alt="",
+                                                        width="285",
+                                                        height="160",
+                                                        hi_def=True,
+                                                        loading="auto",) | safe
+                            }}
+                        </a>
+                    </div>
+                    <div class="col-3 col-medium-2">
+                        <a href="/robotics">
+                            <h3 class="p-heading--5">Robotics</h3>
+                            {{ image(url="https://assets.ubuntu.com/v1/aeeeb32d-For-smart-use-cases__Robotics.png",
+                                                        alt="",
+                                                        width="285",
+                                                        height="160",
+                                                        hi_def=True,
+                                                        loading="auto",) | safe
+                            }}
+                        </a>
+                    </div>
+                </div>
+            </div>
         </div>
-      </div>
-      <hr class="is-muted p-rule" />
-      <div class="row--50-50">
-        <div class="col">
-          <h5 class="p-heading--5">Features</h5>
+        <div class="row--25-75">
+            <div class="col">
+                <hr class="u-hide--small is-muted p-rule" />
+                <div class="row">
+                    <div class="col-3 col-medium-2">
+                        <a href="/internet-of-things/digital-signage">
+                            <h3 class="p-heading--5">Signage</h3>
+                            {{ image(url="https://assets.ubuntu.com/v1/9db3f004-For-smart-use-cases__Signage.png",
+                                                        alt="",
+                                                        width="285",
+                                                        height="160",
+                                                        hi_def=True,
+                                                        loading="auto",) | safe
+                            }}
+                        </a>
+                    </div>
+                    <div class="col-3 col-medium-2">
+                        <a href="/internet-of-things/smart-city">
+                            <h3 class="p-heading--5">Smart cities</h3>
+                            {{ image(url="https://assets.ubuntu.com/v1/8dd2f04d-For-smart-use-cases__Smart-cities.png",
+                                                        alt="",
+                                                        width="285",
+                                                        height="160",
+                                                        hi_def=True,
+                                                        loading="auto",) | safe
+                            }}
+                        </a>
+                    </div>
+                </div>
+            </div>
         </div>
-        <div class="col">
-          <p>
-            <a href="/core/features">Discover everything that Core offers you</a>
-          </p>
-        </div>
-      </div>
-      <hr class="is-muted p-rule" />
-      <div class="row--50-50">
-        <div class="col">
-          <h5 class="p-heading--5">Customer stories</h5>
-        </div>
-        <div class="col">
-          <p>
-            <a href="/core/stories">Find out how our users are finding success with Core</a>
-          </p>
-        </div>
-      </div>
-      <hr class="is-muted p-rule" />
-      <div class="row--50-50">
-        <div class="col">
-          <h5 class="p-heading--5">White papers</h5>
-        </div>
-        <div class="col">
-          <p>
-            <a href="/engage/ubuntu-core-security-audit">An independent security audit of Ubuntu Core</a>
-          </p>
-          <hr class="is-muted" />
-          <p>
-            <a href="/engage/embedded-linux-make-or-buy/">Embedded Linux: make or buy?</a>
-          </p>
-        </div>
-      </div>
-      <hr class="is-muted p-rule" />
-      <div class="row--50-50">
-        <div class="col">
-          <h5 class="p-heading--5">Webinar</h5>
-        </div>
-        <div class="col">
-          <p>
-            <a href="/engage/intro-to-ubuntu-core22-webinar#:~:text=With%204%20releases%20behind%2C%20Ubuntu,edge%20devices%20makers%20must%20face.">Introduction to Ubuntu Core 22</a>
-          </p>
-        </div>
-      </div>
-    </div>
-  </div>
-</section>
+    </section>
 
-<section class="p-strip is-deep u-no-padding--top">
-  <div class="row--50-50">
-    <hr class="p-rule" />
-    <div class="col">
-      <h2>Ready to innovate?</h2>
-    </div>
-    <div class="col">
-      <div class="-section--shallow">
-        <p>Whether you are a startup bringing your concept to market or already have large fleets of devices deployed in the field, we have the expertise and infrastructure to launch and support you.</p>
-      </div>
-      <hr class="is-muted" />
-      <p>
-        <a class="p-button--positive" href="/core/contact-us">Get in touch</a>
-      </p>
-    </div>
-  </div>
-</section>
+    <section class="p-section">
+        <div class="row">
+            <hr class="p-rule--highlight" />
+            <div class="col-9 col-medium-4">
+                <h2 class="p-text--small-caps p-heading--5">Ubuntu core customer stories</h2>
+            </div>
+            <div class="col-3 col-medium-2 p-section--shallow">
+                <p>
+                    <a href="/core/stories">All the success stories&nbsp;&rsaquo;</a>
+                </p>
+            </div>
+        </div>
+        <div class="p-tabs">
+            <div class="row--25-75">
+                <div class="col">
+                    <hr class="p-rule is-muted" />
+                    <div class="p-tabs__list js-tabbed-content"
+                         role="tablist"
+                         aria-label="Customer stories">
+                        <div class="p-tabs__item">
+                            <button class="p-tabs__link"
+                                    role="tab"
+                                    aria-selected="true"
+                                    aria-controls="industrial-tab"
+                                    id="industrial">Industrial</button>
+                        </div>
+                        <div class="p-tabs__item">
+                            <button class="p-tabs__link"
+                                    role="tab"
+                                    aria-selected="false"
+                                    aria-controls="smart-kiosk-tab"
+                                    id="smart-kiosk"
+                                    tabindex="-1">Smart Kiosk</button>
+                        </div>
+                        <div class="p-tabs__item">
+                            <button class="p-tabs__link"
+                                    role="tab"
+                                    aria-selected="false"
+                                    aria-controls="network-tab"
+                                    id="network"
+                                    tabindex="-1">Network</button>
+                        </div>
+                        <div class="p-tabs__item">
+                            <button class="p-tabs__link"
+                                    role="tab"
+                                    aria-selected="false"
+                                    aria-controls="cloud-tab"
+                                    id="cloud"
+                                    tabindex="-1">Cloud</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div tabindex="0"
+                 role="tabpanel"
+                 id="industrial-tab"
+                 aria-labelledby="industrial">
+                <div class="row--25-75 u-no-margin--bottom">
+                    <div class="col">
+                        {{ image(url="https://assets.ubuntu.com/v1/ffd88101-rexroth-for-testimonial.png",
+                                                alt="Rexroth",
+                                                width="284",
+                                                height="70",
+                                                hi_def=True,
+                                                loading="auto",) | safe
+                        }}
+                    </div>
+                    <div class="col u-no-margin--top">
+                        <div class="row">
+                            <div class="col-6">
+                                <h3 class="p-heading--2">Bosch Rexroth reinvents automation</h3>
+                            </div>
+                            <div class="col-3">
+                                <p>Bosch adopts Ubuntu Core and snaps for app-based ctrl-X industry 4.0 platform.</p>
+                                <hr class="p-rule is-muted" />
+                                <p>
+                                    <a href="/blog/bosch-rexroth-adopts-ubuntu-core-and-snaps-for-app-based-ctrlx-automation-platform">Read the press release&nbsp;&rsaquo;</a>
+                                </p>
+                            </div>
+                        </div>
+                        <div>
+                            {{ image(url="https://assets.ubuntu.com/v1/2d152c25-rexroth-testimonial-image.jpg",
+                                                        alt="Rexroth",
+                                                        width="917",
+                                                        height="392",
+                                                        hi_def=True,
+                                                        loading="auto",) | safe
+                            }}
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div tabindex="0"
+                 role="tabpanel"
+                 id="smart-kiosk-tab"
+                 aria-labelledby="smart-kiosk"
+                 aria-hidden="hidden">
+                <div class="row--25-75 u-no-margin--bottom">
+                    <div class="col">
+                        {{ image(url="https://assets.ubuntu.com/v1/ea8fc1a8-pudo-testimonial-logo.png",
+                                                alt="Pudo",
+                                                width="180",
+                                                height="89",
+                                                hi_def=True,
+                                                loading="auto",) | safe
+                        }}
+                    </div>
+                    <div class="col u-no-margin--top">
+                        <div class="row">
+                            <div class="col-6">
+                                <h3 class="p-heading--2">Pudo deploys fleet for robust last-mile logistics</h3>
+                            </div>
+                            <div class="col-3">
+                                <p>Pudo chooses Ubuntu Core as the foundation for its IoT-based APMs to maximise security and uptime.</p>
+                                <hr class="is-muted p-rule" />
+                                <p>
+                                    <a href="/engage/pudo-case-study">Read the case study&nbsp;&rsaquo;</a>
+                                </p>
+                            </div>
+                        </div>
+                        <div>
+                            {{ image(url="https://assets.ubuntu.com/v1/576c8402-pudo-testimonial-image.jpg",
+                                                        alt="Pudo",
+                                                        width="917",
+                                                        height="392",
+                                                        hi_def=True,
+                                                        loading="auto",) | safe
+                            }}
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div tabindex="0"
+                 role="tabpanel"
+                 id="network-tab"
+                 aria-labelledby="network"
+                 aria-hidden="hidden">
+                <div class="row--25-75 u-no-margin--bottom">
+                    <div class="col">
+                        {{ image(url="https://assets.ubuntu.com/v1/80f5af45-rigado-testimonial-logo.png",
+                                                alt="Rigado",
+                                                width="200",
+                                                height="46",
+                                                hi_def=True,
+                                                loading="auto",) | safe
+                        }}
+                    </div>
+                    <div class="col u-no-margin--top">
+                        <div class="row">
+                            <div class="col-6">
+                                <h3 class="p-heading--2">Rigado cuts customers’ time to market</h3>
+                            </div>
+                            <div class="col-3">
+                                <p>Ubuntu Core enables Rigado to manage end-to-end security for commercial IoT gateways.</p>
+                                <hr class="is-muted p-rule" />
+                                <p>
+                                    <a href="/engage/case-study-rigado">Read the case study&nbsp;&rsaquo;</a>
+                                </p>
+                            </div>
+                        </div>
+                        <div>
+                            {{ image(url="https://assets.ubuntu.com/v1/297369c0-rigado--testimonial-image.jpg",
+                                                        alt="Rigado",
+                                                        width="917",
+                                                        height="392",
+                                                        hi_def=True,
+                                                        loading="auto",) | safe
+                            }}
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div tabindex="0"
+                 role="tabpanel"
+                 id="cloud-tab"
+                 aria-labelledby="cloud"
+                 aria-hidden="hidden">
+                <div class="row--25-75 u-no-margin--bottom">
+                    <div class="col">
+                        {{ image(url="https://assets.ubuntu.com/v1/e110996e-ibm-cloud-testimonial-logo.png",
+                                                alt="IBM",
+                                                width="200",
+                                                height="60",
+                                                hi_def=True,
+                                                loading="auto",) | safe
+                        }}
+                    </div>
+                    <div class="col u-no-margin--top">
+                        <div class="row">
+                            <div class="col-6">
+                                <h3 class="p-heading--2">IBM Cloud provides highly isolated and performant bare metal servers</h3>
+                            </div>
+                            <div class="col-3">
+                                <p>
+                                    IBM Cloud's bare metal servers offer highly isolated and high-performing tenant-cloud isolation through the use of Ubuntu Core.
+                                </p>
+                                <hr class="is-muted p-rule" />
+                                <p>
+                                    <a href="https://canonical.com/blog/cloud-isolation-ibm-bare-metal-ubuntu-core">Read the press release&nbsp;&rsaquo;</a>
+                                </p>
+                            </div>
+                        </div>
+                        <div>
+                            {{ image(url="https://assets.ubuntu.com/v1/534be2a2-ibm-leadspace.jpg",
+                                                        alt="IBM",
+                                                        width="917",
+                                                        height="392",
+                                                        hi_def=True,
+                                                        loading="auto",) | safe
+                            }}
+                        </div>
+                    </div>
+                </div>
+            </div>
 
-<!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/internet-of-things"
-  data-form-id="1266" data-lp-id="2166" data-return-url="https://ubuntu.com/core/thank-you"
-  data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
-</div>
+        </div>
+    </section>
 
-<script>
-  document.addEventListener('DOMContentLoaded', function () {
-    const videoLink = document.querySelector('.p-hero-video-link');
-    const style = document.querySelector("style");
-    style.textContent += `
+    <section class="p-section">
+        <div class="u-fixed-width p-section--shallow">
+            <hr class="p-rule" />
+            <div class="p-section--shallow">
+                <h2>Get to market fast with our hardware ecosystem</h2>
+            </div>
+            <div class="p-logo-section--dense">
+                <div class="p-logo-section__items">
+                    <div class="p-logo-section__item">
+                        {{ image(url="https://assets.ubuntu.com/v1/59996fad-intel-new-logo.png",
+                                                alt="Intel",
+                                                width="50",
+                                                height="96",
+                                                hi_def=True,
+                                                attrs={"class": "p-logo-section__logo"},
+                                                loading="auto",) | safe
+                        }}
+                    </div>
+                    <div class="p-logo-section__item">
+                        {{ image(url="https://assets.ubuntu.com/v1/4bf8a9bc-amd-logo.png",
+                                                alt="AMD",
+                                                width="69",
+                                                height="96",
+                                                hi_def=True,
+                                                attrs={"class": "p-logo-section__logo"},
+                                                loading="auto",) | safe
+                        }}
+                    </div>
+                    <div class="p-logo-section__item">
+                        {{ image(url="https://assets.ubuntu.com/v1/e7b81879-nvidia-logo.png",
+                                                alt="Nvidia",
+                                                width="94",
+                                                height="96",
+                                                hi_def=True,
+                                                attrs={"class": "p-logo-section__logo"},
+                                                loading="auto",) | safe
+                        }}
+                    </div>
+                    <div class="p-logo-section__item">
+                        {{ image(url="https://assets.ubuntu.com/v1/9a25ec68-arm-logo.png",
+                                                alt="ARM",
+                                                width="47",
+                                                height="96",
+                                                hi_def=True,
+                                                attrs={"class": "p-logo-section__logo"},
+                                                loading="auto",) | safe
+                        }}
+                    </div>
+                    <div class="p-logo-section__item">
+                        {{ image(url="https://assets.ubuntu.com/v1/31b259ec-qualcom-logo.png",
+                                                alt="Qualcom",
+                                                width="96",
+                                                height="96",
+                                                hi_def=True,
+                                                attrs={"class": "p-logo-section__logo"},
+                                                loading="auto",) | safe
+                        }}
+                    </div>
+                    <div class="p-logo-section__item">
+                        {{ image(url="https://assets.ubuntu.com/v1/d65da7f3-advantech-logo.png",
+                                                alt="Advantech",
+                                                width="95",
+                                                height="96",
+                                                hi_def=True,
+                                                attrs={"class": "p-logo-section__logo"},
+                                                loading="auto",) | safe
+                        }}
+                    </div>
+                    <div class="p-logo-section__item">
+                        {{ image(url="https://assets.ubuntu.com/v1/6eff0263-adlink-logo.png",
+                                                alt="Adlink",
+                                                width="101",
+                                                height="96",
+                                                hi_def=True,
+                                                attrs={"class": "p-logo-section__logo"},
+                                                loading="auto",) | safe
+                        }}
+                    </div>
+                    <div class="p-logo-section__item">
+                        {{ image(url="https://assets.ubuntu.com/v1/be8db080-nxp-logo.png",
+                                                alt="NXP",
+                                                width="41",
+                                                height="96",
+                                                hi_def=True,
+                                                attrs={"class": "p-logo-section__logo"},
+                                                loading="auto",) | safe
+                        }}
+                    </div>
+                    <div class="p-logo-section__item">
+                        {{ image(url="https://assets.ubuntu.com/v1/96d65ee2-mediatek-logo.png",
+                                                alt="MediaTeK",
+                                                width="77",
+                                                height="96",
+                                                hi_def=True,
+                                                attrs={"class": "p-logo-section__logo"},
+                                                loading="auto",) | safe
+                        }}
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="row">
+            <hr class="p-rule is-muted" />
+            <div class="col-start-large-7 col-3 col-medium-2 col-start-medium-3">
+                <p>
+                    <a href="/certified">Browse all certified hardware&nbsp;&rsaquo;</a>
+                </p>
+            </div>
+            <div class="col-3 col-medium-2">
+                <p>
+                    <a href="/core/contact-us">Contact us&nbsp;&rsaquo;</a>
+                </p>
+            </div>
+        </div>
+    </section>
+
+    <section class="p-section">
+        <div class="row--50-50">
+            <hr class="p-rule" />
+            <div class="col">
+                <h2>Learn more about&nbsp;Ubuntu&nbsp;Core</h2>
+            </div>
+            <div class="col">
+                <div class="row--50-50">
+                    <div class="col">
+                        <h5 class="p-heading--5">Docs</h5>
+                    </div>
+                    <div class="col">
+                        <p>
+                            <a href="/core/docs/getting-started">Start your Core journey today</a>
+                        </p>
+                    </div>
+                </div>
+                <hr class="is-muted p-rule" />
+                <div class="row--50-50">
+                    <div class="col">
+                        <h5 class="p-heading--5">Features</h5>
+                    </div>
+                    <div class="col">
+                        <p>
+                            <a href="/core/features">Discover everything that Core offers you</a>
+                        </p>
+                    </div>
+                </div>
+                <hr class="is-muted p-rule" />
+                <div class="row--50-50">
+                    <div class="col">
+                        <h5 class="p-heading--5">Customer stories</h5>
+                    </div>
+                    <div class="col">
+                        <p>
+                            <a href="/core/stories">Find out how our users are finding success with Core</a>
+                        </p>
+                    </div>
+                </div>
+                <hr class="is-muted p-rule" />
+                <div class="row--50-50">
+                    <div class="col">
+                        <h5 class="p-heading--5">White papers</h5>
+                    </div>
+                    <div class="col">
+                        <p>
+                            <a href="/engage/ubuntu-core-security-audit">An independent security audit of Ubuntu Core</a>
+                        </p>
+                        <hr class="is-muted" />
+                        <p>
+                            <a href="/engage/embedded-linux-make-or-buy/">Embedded Linux: make or buy?</a>
+                        </p>
+                    </div>
+                </div>
+                <hr class="is-muted p-rule" />
+                <div class="row--50-50">
+                    <div class="col">
+                        <h5 class="p-heading--5">Webinar</h5>
+                    </div>
+                    <div class="col">
+                        <p>
+                            <a href="/engage/intro-to-ubuntu-core22-webinar#:~:text=With%204%20releases%20behind%2C%20Ubuntu,edge%20devices%20makers%20must%20face.">Introduction to Ubuntu Core 22</a>
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section class="p-strip is-deep u-no-padding--top">
+        <div class="row--50-50">
+            <hr class="p-rule" />
+            <div class="col">
+                <h2>Ready to innovate?</h2>
+            </div>
+            <div class="col">
+                <div class="-section--shallow">
+                    <p>
+                        Whether you are a startup bringing your concept to market or already have large fleets of devices deployed in the field, we have the expertise and infrastructure to launch and support you.
+                    </p>
+                </div>
+                <hr class="is-muted" />
+                <p>
+                    <a class="p-button--positive" href="/core/contact-us">Get in touch</a>
+                </p>
+            </div>
+        </div>
+    </section>
+
+    <!-- Set default Marketo information for contact form below-->
+    <div class="u-hide"
+         id="contact-form-container"
+         data-form-location="/shared/forms/interactive/internet-of-things"
+         data-form-id="1266"
+         data-lp-id="2166"
+         data-return-url="https://ubuntu.com/core/thank-you"
+         data-lp-url="https://pages.ubuntu.com/things-contact-us.html"></div>
+
+    <script>
+      document.addEventListener('DOMContentLoaded', function() {
+        const videoLink = document.querySelector('.p-hero-video-link');
+        const style = document.querySelector("style");
+        style.textContent += `
                           .p-hero-video-link {
                             display: inline-block;
                             overflow: hidden;
@@ -742,14 +785,14 @@ meta_copydoc %}
                             content: none !important;
                           }
                         `;
-    const video = document.querySelector('.p-hero-video');
-    const videoContainer = document.querySelector('.p-hero-video-container');
-    videoLink.addEventListener('click', function(e) {
-      e.preventDefault();
-      videoContainer.classList.remove('u-hide');
-      videoLink.classList.add('u-hide');
-    });
-  });
-</script>
+        const video = document.querySelector('.p-hero-video');
+        const videoContainer = document.querySelector('.p-hero-video-container');
+        videoLink.addEventListener('click', function(e) {
+          e.preventDefault();
+          videoContainer.classList.remove('u-hide');
+          videoLink.classList.add('u-hide');
+        });
+      });
+    </script>
 
 {% endblock content %}

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -20,7 +20,7 @@ meta_copydoc %}
       <div class="p-section--shallow">
         <p class="p-heading--4">Ubuntu Core is a minimal, secure and strictly confined operating system powering devices around the world. Build your Ubuntu Core image today.</p>
       </div>
-      <hr />
+      <hr class="is-muted" />
       <p>
         <a class="p-button--positive" href="/core/docs/getting-started">Try Ubuntu Core</a>
         <a href="https://assets.ubuntu.com/v1/1870ea66-Ubuntu_Core22_DS.06.06.22.pdf">Read&nbsp;the&nbsp;Ubuntu&nbsp;Core&nbsp;datasheet</a>
@@ -28,20 +28,33 @@ meta_copydoc %}
     </div>
     <div class="col u-hide--small">
       <a href="#" aria-label="What is Ubuntu Core" class="p-hero-video-link">
-        <img src="https://assets.ubuntu.com/v1/3a0f24b8-video-thumbnail-suru-bg.png" alt="" class="p-hero-video__play">
+        <img src="https://assets.ubuntu.com/v1/3a0f24b8-video-thumbnail-suru-bg.png" alt="" class="p-hero-video__play" />
       </a>
       <div class="p-hero-video-container u-embedded-media u-hide">
         <iframe class="p-hero-video u-embedded-media__element" src="https://www.youtube.com/embed/6NDWqH1SrGs" allow="autoplay;" frameborder="0" allowfullscreen=""></iframe>
       </div>
     </div>
     <script>
-      document.addEventListener('DOMContentLoaded', function() {
+      document.addEventListener('DOMContentLoaded', function () {
         const videoLink = document.querySelector('.p-hero-video-link');
+        const style = document.querySelector("style");
+        style.textContent += `
+                              .p-hero-video-link {
+                                display: inline-block;
+                                overflow: hidden;
+                              }
+                              .p-hero-video-link img {
+                                display: block;
+                                transition: .3s ease-in-out;
+                              }
+                              .p-hero-video-link:hover img {
+                                transform: scale(1.3);
+                              }
+                            `;
         const video = document.querySelector('.p-hero-video');
         const videoContainer = document.querySelector('.p-hero-video-container');
         videoLink.addEventListener('click', function(e) {
           e.preventDefault();
-          video.src += "?autoplay=1";
           videoContainer.classList.remove('u-hide');
           videoLink.classList.add('u-hide');
         });
@@ -65,13 +78,13 @@ meta_copydoc %}
   </div>
   <div class="p-equal-height-row has-3rd-divider">
     <div class="p-equal-height-row__col">
-      <div class="p-equal-height-row__item">
+      <div class="p-equal-height-row__item u-hide--small">
         <div class="p-media-container">
-          <img width="320" src="https://assets.ubuntu.com/v1/524633ee-image-1.png" alt="">
+          <img width="320" src="https://assets.ubuntu.com/v1/834e417a-continuous-security.jpg" alt="" />
         </div>
       </div>
       <div class="p-equal-height-row__item">
-        <hr class="p-rule--highlight u-hide--medium u-hide--small">
+        <hr class="p-rule--highlight u-hide--medium u-hide--small is-muted">
         <h5 class="p-heading--5">Continuous security</h5>
       </div>
       <p class="p-equal-height-row__item">
@@ -79,19 +92,19 @@ meta_copydoc %}
         secure embedded Linux ever, with a 10 year LTS commitment.
       </p>
       <div class="p-equal-height-row__item">
-        <a href="/security">
-          <p>Learn more about Ubuntu security&nbsp;›</p>
-        </a>
+        <p>
+          <a href="/security">Learn more about Ubuntu security&nbsp;&rsaquo;</a>
+        </p>
       </div>
     </div>
     <div class="p-equal-height-row__col">
       <div class="p-equal-height-row__item">
-        <div class="p-media-container">
-          <img width="320" src="https://assets.ubuntu.com/v1/eefd5f4f-image-2.png" alt="">
+        <div class="p-media-container u-hide--small">
+          <img width="320" src="https://assets.ubuntu.com/v1/d1d161a9-fleet-management.jpg" alt="" />
         </div>
       </div>
       <div class="p-equal-height-row__item">
-        <hr class="p-rule--highlight u-hide--medium u-hide--small">
+        <hr class="p-rule--highlight u-hide--medium u-hide--small is-muted">
         <h5 class="p-heading--5">Fleet management</h5>
       </div>
       <p class="p-equal-height-row__item">
@@ -99,19 +112,19 @@ meta_copydoc %}
         OTA updates. In connected or air-gap environments.
       </p>
       <div class="p-equal-height-row__item">
-        <a href="/internet-of-things/management">
-          <p>Learn more about fleet management&nbsp;›</p>
-        </a>
+        <p>
+          <a href="/internet-of-things/management">Learn more about fleet management&nbsp;&rsaquo;</p></a>
+        </p>
       </div>
     </div>
     <div class="p-equal-height-row__col">
       <div class="p-equal-height-row__item">
-        <div class="p-media-container">
-          <img width="320" src="https://assets.ubuntu.com/v1/80fc3dd3-image-3.png" alt="">
+        <div class="p-media-container u-hide--small">
+          <img width="320" src="https://assets.ubuntu.com/v1/373f7039-agile-containerisation.png" alt="" />
         </div>
       </div>
       <div class="p-equal-height-row__item">
-        <hr class="p-rule--highlight u-hide--medium u-hide--small">
+        <hr class="p-rule--highlight u-hide--medium u-hide--small is-muted">
         <h5 class="p-heading--5">Agile containerisation</h5>
       </div>
       <p class="p-equal-height-row__item">
@@ -119,19 +132,19 @@ meta_copydoc %}
         applications, each updated independently and protected against corruption.
       </p>
       <div class="p-equal-height-row__item">
-        <a href="/core/docs/components#heading--confinement">
-          <p>Learn more about confinement&nbsp;›</p>
-        </a>
+        <p>
+          <a href="/core/docs/components#heading--confinement">Learn more about confinement&nbsp;&rsaquo;</a>
+        </p>
       </div>
     </div>
     <div class="p-equal-height-row__col">
       <div class="p-equal-height-row__item">
-        <div class="p-media-container">
-          <img width="320" src="https://assets.ubuntu.com/v1/bc53406d-image-4.png" alt="">
+        <div class="p-media-container u-hide--small">
+          <img width="320" src="https://assets.ubuntu.com/v1/166ec7c6-hardware-ecosystem.jpg" alt="" />
         </div>
       </div>
       <div class="p-equal-height-row__item">
-        <hr class="p-rule--highlight u-hide--medium u-hide--small">
+        <hr class="p-rule--highlight u-hide--medium u-hide--small is-muted">
         <h5 class="p-heading--5">A strong hardware ecosystem</h5>
       </div>
       <p class="p-equal-height-row__item">
@@ -139,9 +152,9 @@ meta_copydoc %}
         IoT and edge devices and hardware.
       </p>
       <div class="p-equal-height-row__item">
-        <a href="/certified">
-          <p>Browse all certified hardware&nbsp;›</p>
-        </a>
+        <p>
+          <a href="/certified">Browse all certified hardware&nbsp;&rsaquo;</a> 
+        </p>
       </div>
     </div>
   </div>
@@ -159,49 +172,51 @@ meta_copydoc %}
         Core image based on your developed applications and targeted hardware.</p>
     </div>
   </div>
-  <div class="row--25-75">
-    <div class="col">
-      <hr />
-      <div class="row">
-        <div class="col-3 col-medium-2">
-          <ul class="js-tabbed-content p-tabs--vertical is-black u-hide--small" role="tablist"
-            aria-label="Dev to deployment">
-            <li>
-              <button class="p-tabs__item" id="overview" role="tab" aria-selected="true" aria-controls="overview-tab">Overview</button>
-            </li>
-            <li>
-              <button class="p-tabs__item" id="ubuntu-vision" role="tab" aria-selected="false" aria-controls="ubuntu-vision-tab">Ubuntu</button>
-            </li>
-            <li>
-              <button class="p-tabs__item" id="snapcraft" role="tab" aria-selected="false" aria-controls="snapcraft-tab">Snapcraft</button>
-            </li>
-            <li>
-              <button class="p-tabs__item" id="snap-store" role="tab" aria-selected="false" aria-controls="snap-store-tab">Snap Store</button>
-            </li>
-            <li>
-              <button class="p-tabs__item" id="ubuntu-core" role="tab" aria-selected="false" aria-controls="ubuntu-core-tab">Ubuntu Core</button>
-            </li>
-          </ul>
-          <form class="u-hide--large u-hide--medium">
-            <select name="boardSelect" id="boardSelect">
-              <option value="overview-tab" selected="">Overview</option>
-              <option value="ubuntu-vision-tab">Ubuntu</option>
-              <option value="snapcraft-tab">Snapcraft</option>
-              <option value="snap-store-tab">Snap Store</option>
-              <option value="ubuntu-core-tab">Ubuntu Core</option>
-            </select>
-          </form>
-        </div>
-        <div class="col-6 col-medium-4">
-          {% include "core/tabs.html" %}
-        </div>
-      </div>
-      <hr />
-      <div class="row">
-        <div class="col-6 col-start-large-4 col-medium-4 col-start-medium-3">
-          <a href="/core/docs">Get started with Ubuntu Core&nbsp;&rsaquo;</a>
-        </div>
-      </div>
+  <div class="row">
+    <hr class="is-muted col-9 col-start-large-4 col-medium-6 col-start-medium-2" />
+    <div class="col-3 col-medium-2 col-start-large-4 col-start-medium-2">
+      <ul class="js-tabbed-content p-tabs--vertical is-black u-hide--small" role="tablist" aria-label="Dev to deployment">
+        <li>
+          <button class="p-tabs__item" id="overview" role="tab" aria-selected="true"
+            aria-controls="overview-tab">Overview</button>
+        </li>
+        <li>
+          <button class="p-tabs__item" id="ubuntu-vision" role="tab" aria-selected="false"
+            aria-controls="ubuntu-vision-tab">Ubuntu</button>
+        </li>
+        <li>
+          <button class="p-tabs__item" id="snapcraft" role="tab" aria-selected="false"
+            aria-controls="snapcraft-tab">Snapcraft</button>
+        </li>
+        <li>
+          <button class="p-tabs__item" id="ubuntu-core" role="tab" aria-selected="false"
+            aria-controls="ubuntu-core-tab">Ubuntu Core</button>
+        </li>
+        <li>
+          <button class="p-tabs__item" id="snap-store" role="tab" aria-selected="false"
+            aria-controls="snap-store-tab">Snap Store</button>
+        </li>
+      </ul>
+      <form class="u-hide--large u-hide--medium">
+        <select name="boardSelect" id="boardSelect">
+          <option value="overview-tab" selected="">Overview</option>
+          <option value="ubuntu-vision-tab">Ubuntu</option>
+          <option value="snapcraft-tab">Snapcraft</option>
+          <option value="ubuntu-core-tab">Ubuntu Core</option>
+          <option value="snap-store-tab">Snap Store</option>
+        </select>
+      </form>
+    </div>
+    <div class="col-6 col-medium-3">
+      {% include "core/tabs.html" %}
+    </div>
+  </div>
+  <div class="row">
+    <hr class="is-muted col-9 col-start-large-4 col-medium-6 col-start-medium-2" />
+    <div class="col-6 col-start-large-4 col-medium-4 col-start-medium-3">
+      <p>
+        <a href="/core/docs">Get started with Ubuntu Core&nbsp;&rsaquo;</a>
+      </p>
     </div>
   </div>
 </section>
@@ -213,7 +228,7 @@ meta_copydoc %}
   </div>
   <div class="row--25-75 p-section--shallow">
     <div class="col">
-      <hr class="u-hide--small" />
+      <hr class="u-hide--small is-muted p-rule" />
       <div class="row">
         <div class="col-3 col-medium-2">
           <a href="/automotive">
@@ -262,7 +277,7 @@ meta_copydoc %}
   </div>
   <div class="row--25-75">
     <div class="col">
-      <hr class="u-hide--small" />
+      <hr class="u-hide--small is-muted p-rule" />
       <div class="row">
         <div class="col-3 col-medium-2">
           <a href="/internet-of-things/digital-signage">
@@ -312,7 +327,7 @@ meta_copydoc %}
   <div class="p-tabs">
     <div class="row--25-75">
       <div class="col">
-        <hr class="p-rule" />
+        <hr class="p-rule is-muted" />
         <div class="p-tabs__list js-tabbed-content" role="tablist" aria-label="Customer stories">
           <div class="p-tabs__item">
             <button class="p-tabs__link" role="tab" aria-selected="true" aria-controls="industrial-tab"
@@ -355,8 +370,10 @@ meta_copydoc %}
               <div class="p-section--shallow">
                 <p>Bosch adopts Ubuntu Core and snaps for app-based ctrl-X industry 4.0 platform.</p>
               </div>
-              <hr />
-              <a href="/blog/bosch-rexroth-adopts-ubuntu-core-and-snaps-for-app-based-ctrlx-automation-platform">Read the press release&nbsp;&rsaquo;</a>
+              <hr class="p-rule is-muted" />
+              <p>
+                <a href="/blog/bosch-rexroth-adopts-ubuntu-core-and-snaps-for-app-based-ctrlx-automation-platform">Read the press release&nbsp;&rsaquo;</a>
+              </p>
             </div>
           </div>
           <div>
@@ -395,8 +412,10 @@ meta_copydoc %}
               <div class="p-section--shallow">
                 <p>Pudo chooses Ubuntu Core as the foundation for its IoT-based APMs to maximise security and uptime.</p>
               </div>
-              <hr />
-              <a href="/engage/pudo-case-study">Read the case study&nbsp;&rsaquo;</a>
+              <hr class="is-muted p-rule" />
+              <p>
+                <a href="/engage/pudo-case-study">Read the case study&nbsp;&rsaquo;</a>
+              </p>
             </div>
           </div>
           <div>
@@ -435,8 +454,10 @@ meta_copydoc %}
               <div class="p-section--shallow">
                 <p>Ubuntu Core enables Rigado to manage end-to-end security for commercial IoT gateways.</p>
               </div>
-              <hr />
-              <a href="/engage/case-study-rigado">Read the case study&nbsp;&rsaquo;</a>
+              <hr class="is-muted p-rule" />
+              <p>
+                <a href="/engage/case-study-rigado">Read the case study&nbsp;&rsaquo;</a>
+              </p>
             </div>
           </div>
           <div>
@@ -475,8 +496,10 @@ meta_copydoc %}
               <div class="p-section--shallow">
                 <p>IBM Cloud's bare metal servers offer highly isolated and high-performing tenant-cloud isolation through the use of Ubuntu Core.</p>
               </div>
-              <hr />
-              <a href="/engage/case-study-rigado">Read the press release&nbsp;&rsaquo;</a>
+              <hr class="is-muted p-rule" />
+              <p>
+                <a href="/engage/case-study-rigado">Read the press release&nbsp;&rsaquo;</a>
+              </p>
             </div>
           </div>
           <div>
@@ -617,7 +640,7 @@ meta_copydoc %}
     </div>
   </div>
   <div class="row">
-    <hr class="p-rule" />
+    <hr class="p-rule is-muted" />
     <div class="col-start-large-7 col-3 col-medium-2 col-start-medium-3">
       <p>
         <a href="/certified">Browse all certified hardware&nbsp;&rsaquo;</a>
@@ -638,72 +661,64 @@ meta_copydoc %}
       <h2>Learn more about Ubuntu Core</h2>
     </div>
     <div class="col">
-      <ul class="p-list--divided">
-        <li class="p-list__item">
-          <div class="row--50-50">
-            <div class="col">
-              <p class="p-heading--5">Docs</p>
-            </div>
-            <div class="col">
-              <p>
-                <a href="/core/docs/getting-started">Start your Core journey today</a>
-              </p>
-            </div>
-          </div>
-        </li>
-        <li class="p-list__item">
-          <div class="row--50-50">
-            <div class="col">
-              <p class="p-heading--5">Features</p>
-            </div>
-            <div class="col">
-              <p>
-                <a href="/core/features">Discover everything that Core offers you</a>
-              </p>
-            </div>
-          </div>
-        </li>
-        <li class="p-list__item">
-          <div class="row--50-50">
-            <div class="col">
-              <p class="p-heading--5">Customer stories</p>
-            </div>
-            <div class="col">
-              <p>
-                <a href="/core/stories">Find out how our users are finding success with Core</a>
-              </p>
-            </div>
-          </div>
-        </li>
-        <li class="p-list__item">
-          <div class="row--50-50">
-            <div class="col">
-              <p class="p-heading--5">White papers</p>
-            </div>
-            <div class="col">
-              <p>
-                <a href="/engage/ubuntu-core-security-audit">An independent security audit of Ubuntu Core</a>
-              </p>
-              <hr />
-              <p>
-                <a href="/engage/embedded-linux-make-or-buy/">Embedded Linux: make or buy?</a>
-              </p>
-            </div>
-          </div>
-        </li>
-        <li class="p-list__item">
-          <div class="row--50-50">
-            <div class="col">
-              <p class="p-heading--5">Webinar</p>
-            </div>
-            <div class="col">
-              <p>
-                <a href="/engage/intro-to-ubuntu-core22-webinar#:~:text=With%204%20releases%20behind%2C%20Ubuntu,edge%20devices%20makers%20must%20face.">Introduction to Ubuntu Core 22</a>
-              </p>
-            </div>
-          </div>
-        </li>
-      </ul>
+      <div class="row--50-50">
+        <div class="col">
+          <h5 class="p-heading--5">Docs</h5>
+        </div>
+        <div class="col">
+          <p>
+            <a href="/core/docs/getting-started">Start your Core journey today</a>
+          </p>
+        </div>
+      </div>
+      <hr class="is-muted p-rule" />
+      <div class="row--50-50">
+        <div class="col">
+          <h5 class="p-heading--5">Features</h5>
+        </div>
+        <div class="col">
+          <p>
+            <a href="/core/features">Discover everything that Core offers you</a>
+          </p>
+        </div>
+      </div>
+      <hr class="is-muted p-rule" />
+      <div class="row--50-50">
+        <div class="col">
+          <h5 class="p-heading--5">Customer stories</h5>
+        </div>
+        <div class="col">
+          <p>
+            <a href="/core/stories">Find out how our users are finding success with Core</a>
+          </p>
+        </div>
+      </div>
+      <hr class="is-muted p-rule" />
+      <div class="row--50-50">
+        <div class="col">
+          <h5 class="p-heading--5">White papers</h5>
+        </div>
+        <div class="col">
+          <p>
+            <a href="/engage/ubuntu-core-security-audit">An independent security audit of Ubuntu Core</a>
+          </p>
+          <hr class="is-muted" />
+          <p>
+            <a href="/engage/embedded-linux-make-or-buy/">Embedded Linux: make or buy?</a>
+          </p>
+        </div>
+      </div>
+      <hr class="is-muted p-rule" />
+      <div class="row--50-50">
+        <div class="col">
+          <h5 class="p-heading--5">Webinar</h5>
+        </div>
+        <div class="col">
+          <p>
+            <a href="/engage/intro-to-ubuntu-core22-webinar#:~:text=With%204%20releases%20behind%2C%20Ubuntu,edge%20devices%20makers%20must%20face.">Introduction to Ubuntu Core 22</a>
+          </p>
+        </div>
+      </div>
     </div>
   </div>
 </section>
@@ -718,7 +733,7 @@ meta_copydoc %}
       <div class="-section--shallow">
         <p>Whether you are a startup bringing your concept to market or already have large fleets of devices deployed in the field, we have the expertise and infrastructure to launch and support you.</p>
       </div>
-      <hr />
+      <hr class="is-muted" />
       <a class="p-button--positive" href="/core/contact-us">Get in touch</a>
     </div>
   </div>

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -67,7 +67,7 @@ meta_copydoc %}
     <div class="p-equal-height-row__col">
       <div class="p-equal-height-row__item">
         <div class="p-media-container">
-          <img width="320" src="https://assets.ubuntu.com/v1/c4176cd9-Kernelt%20industries-80%201.jpg" alt="">
+          <img width="320" src="https://assets.ubuntu.com/v1/524633ee-image-1.png" alt="">
         </div>
       </div>
       <div class="p-equal-height-row__item">
@@ -87,7 +87,7 @@ meta_copydoc %}
     <div class="p-equal-height-row__col">
       <div class="p-equal-height-row__item">
         <div class="p-media-container">
-          <img width="320" src="https://assets.ubuntu.com/v1/1624c652-Kernelt%20industries-80%201-1.jpg" alt="">
+          <img width="320" src="https://assets.ubuntu.com/v1/eefd5f4f-image-2.png" alt="">
         </div>
       </div>
       <div class="p-equal-height-row__item">
@@ -107,7 +107,7 @@ meta_copydoc %}
     <div class="p-equal-height-row__col">
       <div class="p-equal-height-row__item">
         <div class="p-media-container">
-          <img width="320" src="https://assets.ubuntu.com/v1/eb9824bf-Kernelt%20industries-80%201-2.jpg" alt="">
+          <img width="320" src="https://assets.ubuntu.com/v1/80fc3dd3-image-3.png" alt="">
         </div>
       </div>
       <div class="p-equal-height-row__item">
@@ -127,7 +127,7 @@ meta_copydoc %}
     <div class="p-equal-height-row__col">
       <div class="p-equal-height-row__item">
         <div class="p-media-container">
-          <img width="320" src="https://assets.ubuntu.com/v1/000a7695-Kernelt%20industries-80%201-3.jpg" alt="">
+          <img width="320" src="https://assets.ubuntu.com/v1/bc53406d-image-4.png" alt="">
         </div>
       </div>
       <div class="p-equal-height-row__item">

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -733,8 +733,10 @@ meta_copydoc %}
       <div class="-section--shallow">
         <p>Whether you are a startup bringing your concept to market or already have large fleets of devices deployed in the field, we have the expertise and infrastructure to launch and support you.</p>
       </div>
-      <hr class="is-muted" />
-      <a class="p-button--positive" href="/core/contact-us">Get in touch</a>
+      <hr class="is-muted p-rule" />
+      <p>
+        <a class="p-button--positive" href="/core/contact-us">Get in touch</a>
+      </p>
     </div>
   </div>
 </section>

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -196,9 +196,9 @@ meta_copydoc %}
           {% include "core/tabs.html" %}
         </div>
       </div>
+      <hr />
       <div class="row">
-        <hr />
-        <div class="col-start-large-5 col-start-medium-3 col-8 col-medium-4">
+        <div class="col-6 col-start-large-4 col-medium-4 col-start-medium-3">
           <a href="/core/docs">Get started with Ubuntu Core&nbsp;&rsaquo;</a>
         </div>
       </div>

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -14,20 +14,38 @@ meta_copydoc %}
   <div class="p-section row--50-50">
     <div class="col">
       <h1 class="u-no-margin--bottom">Ubuntu Core</h1>
-      <h2 class="p-section--shallow">The embedded Linux OS for devices</h1>
-        <p class="p-heading--4 p-section--shallow">Ubuntu Core is a minimal, secure and strictly confined operating
-          system powering devices around the world. Build your Ubuntu Core image today.</p>
-        <hr />
-        <p>
-          <a class="p-button--positive" href="/core/docs/getting-started">Try Ubuntu Core</a>
-          <a href="https://assets.ubuntu.com/v1/1870ea66-Ubuntu_Core22_DS.06.06.22.pdf">Read the Ubuntu Core
-            datasheet</a>
-        </p>
+      <div class="p-section--shallow">
+        <h2>The embedded Linux OS for devices</h2>
+      </div>
+      <div class="p-section--shallow">
+        <p class="p-heading--4">Ubuntu Core is a minimal, secure and strictly confined operating system powering devices around the world. Build your Ubuntu Core image today.</p>
+      </div>
+      <hr />
+      <p>
+        <a class="p-button--positive" href="/core/docs/getting-started">Try Ubuntu Core</a>
+        <a href="https://assets.ubuntu.com/v1/1870ea66-Ubuntu_Core22_DS.06.06.22.pdf">Read&nbsp;the&nbsp;Ubuntu&nbsp;Core&nbsp;datasheet</a>
+      </p>
     </div>
-    <div class="col u-embedded-media">
-      <iframe title="UC22 video" class="u-embedded-media__element" src="https://www.youtube.com/embed/6NDWqH1SrGs"
-        allowfullscreen=""></iframe>
+    <div class="col u-hide--small">
+      <a href="#" aria-label="What is Ubuntu Core" class="p-hero-video-link">
+        <img src="https://assets.ubuntu.com/v1/3a0f24b8-video-thumbnail-suru-bg.png" alt="" class="p-hero-video__play">
+      </a>
+      <div class="p-hero-video-container u-embedded-media u-hide">
+        <iframe class="p-hero-video u-embedded-media__element" src="https://www.youtube.com/embed/6NDWqH1SrGs?autoplay=1" allow="autoplay;" frameborder="0" allowfullscreen=""></iframe>
+      </div>
     </div>
+    <script>
+      document.addEventListener('DOMContentLoaded', function() {
+        const videoLink = document.querySelector('.p-hero-video-link');
+        const video = document.querySelector('.p-hero-video');
+        const videoContainer = document.querySelector('.p-hero-video-container');
+        videoLink.addEventListener('click', function(e) {
+          e.preventDefault();
+          videoContainer.classList.remove('u-hide');
+          videoLink.classList.add('u-hide');
+        });
+      });
+    </script>
   </div>
 </section>
 
@@ -283,7 +301,7 @@ meta_copydoc %}
   <div class="p-tabs">
     <div class="row--25-75">
       <div class="col">
-        <hr />
+        <hr class="p-rule" />
         <div class="p-tabs__list js-tabbed-content" role="tablist" aria-label="Customer stories">
           <div class="p-tabs__item">
             <button class="p-tabs__link" role="tab" aria-selected="true" aria-controls="industrial-tab"
@@ -305,7 +323,7 @@ meta_copydoc %}
       </div>
     </div>
     <div tabindex="0" role="tabpanel" id="industrial-tab" aria-labelledby="industrial">
-      <div class="row--25-75">
+      <div class="row--25-75 u-no-margin--bottom">
         <div class="col">
           {{ image (
             url="https://assets.ubuntu.com/v1/ffd88101-rexroth-for-testimonial.png",
@@ -323,33 +341,35 @@ meta_copydoc %}
               <h3 class="p-heading--2">Bosch Rexroth reinvents automation</h3>
             </div>
             <div class="col-3 p-section--shallow">
-              <p class="p-section--shallow">Bosch adopts Ubuntu Core and snaps for app-based ctrl-X industry 4.0 platform.</p>
+              <div class="p-section--shallow">
+                <p>Bosch adopts Ubuntu Core and snaps for app-based ctrl-X industry 4.0 platform.</p>
+              </div>
               <hr />
               <a href="/blog/bosch-rexroth-adopts-ubuntu-core-and-snaps-for-app-based-ctrlx-automation-platform">Read the press release&nbsp;&rsaquo;</a>
             </div>
-            <div>
-              {{ image (
-                url="https://assets.ubuntu.com/v1/2d152c25-rexroth-testimonial-image.jpg",
-                alt="Rexroth",
-                width="917",
-                height="392",
-                hi_def=True,
-                loading="auto",
-                ) | safe
-              }}
-            </div>
+          </div>
+          <div>
+            {{ image (
+              url="https://assets.ubuntu.com/v1/2d152c25-rexroth-testimonial-image.jpg",
+              alt="Rexroth",
+              width="917",
+              height="392",
+              hi_def=True,
+              loading="auto",
+              ) | safe
+            }}
           </div>
         </div>
       </div>
     </div>
     <div tabindex="0" role="tabpanel" id="smart-kiosk-tab" aria-labelledby="smart-kiosk" aria-hidden="hidden">
-      <div class="row--25-75">
+      <div class="row--25-75 u-no-margin--bottom">
         <div class="col">
           {{ image (
             url="https://assets.ubuntu.com/v1/ea8fc1a8-pudo-testimonial-logo.png",
             alt="Pudo",
             width="180",
-            height="70",
+            height="89",
             hi_def=True,
             loading="auto",
             ) | safe
@@ -361,27 +381,29 @@ meta_copydoc %}
               <h3 class="p-heading--2">Pudo deploys fleet for robust last-mile logistics</h3>
             </div>
             <div class="col-3 p-section--shallow">
-              <p class="p-section--shallow">Pudo chooses Ubuntu Core as the foundation for its IoT-based APMs to maximise security and uptime.</p>
+              <div class="p-section--shallow">
+                <p>Pudo chooses Ubuntu Core as the foundation for its IoT-based APMs to maximise security and uptime.</p>
+              </div>
               <hr />
               <a href="/engage/pudo-case-study">Read the case study&nbsp;&rsaquo;</a>
             </div>
-            <div>
-              {{ image (
-                url="https://assets.ubuntu.com/v1/576c8402-pudo-testimonial-image.jpg",
-                alt="Pudo",
-                width="917",
-                height="392",
-                hi_def=True,
-                loading="auto",
-                ) | safe
-              }}
-            </div>
+          </div>
+          <div>
+            {{ image (
+              url="https://assets.ubuntu.com/v1/576c8402-pudo-testimonial-image.jpg",
+              alt="Pudo",
+              width="917",
+              height="392",
+              hi_def=True,
+              loading="auto",
+              ) | safe
+            }}
           </div>
         </div>
       </div>
     </div>
     <div tabindex="0" role="tabpanel" id="network-tab" aria-labelledby="network" aria-hidden="hidden">
-      <div class="row--25-75">
+      <div class="row--25-75 u-no-margin--bottom">
         <div class="col">
           {{ image (
             url="https://assets.ubuntu.com/v1/80f5af45-rigado-testimonial-logo.png",
@@ -399,27 +421,29 @@ meta_copydoc %}
               <h3 class="p-heading--2">Rigado cuts customers’ time to market</h3>
             </div>
             <div class="col-3 p-section--shallow">
-              <p class="p-section--shallow">Ubuntu Core enables Rigado to manage end-to-end security for commercial IoT gateways.</p>
+              <div class="p-section--shallow">
+                <p>Ubuntu Core enables Rigado to manage end-to-end security for commercial IoT gateways.</p>
+              </div>
               <hr />
               <a href="/engage/case-study-rigado">Read the case study&nbsp;&rsaquo;</a>
             </div>
-            <div>
-              {{ image (
-                url="https://assets.ubuntu.com/v1/297369c0-rigado--testimonial-image.jpg",
-                alt="Rigado",
-                width="917",
-                height="392",
-                hi_def=True,
-                loading="auto",
-                ) | safe
-              }}
-            </div>
+          </div>
+          <div>
+            {{ image (
+              url="https://assets.ubuntu.com/v1/297369c0-rigado--testimonial-image.jpg",
+              alt="Rigado",
+              width="917",
+              height="392",
+              hi_def=True,
+              loading="auto",
+              ) | safe
+            }}
           </div>
         </div>
       </div>
     </div>
     <div tabindex="0" role="tabpanel" id="cloud-tab" aria-labelledby="cloud" aria-hidden="hidden">
-      <div class="row--25-75">
+      <div class="row--25-75 u-no-margin--bottom">
         <div class="col">
           {{ image (
             url="https://assets.ubuntu.com/v1/e110996e-ibm-cloud-testimonial-logo.png",
@@ -437,21 +461,23 @@ meta_copydoc %}
               <h3 class="p-heading--2">IBM Cloud provides highly isolated and performant bare metal servers</h3>
             </div>
             <div class="col-3 p-section--shallow">
-              <p class="p-section--shallow">IBM Cloud's bare metal servers offer highly isolated and high-performing tenant-cloud isolation through the use of Ubuntu Core.</p>
+              <div class="p-section--shallow">
+                <p>IBM Cloud's bare metal servers offer highly isolated and high-performing tenant-cloud isolation through the use of Ubuntu Core.</p>
+              </div>
               <hr />
               <a href="/engage/case-study-rigado">Read the press release&nbsp;&rsaquo;</a>
             </div>
-            <div>
-              {{ image (
-                url="https://assets.ubuntu.com/v1/534be2a2-ibm-leadspace.jpg",
-                alt="IBM",
-                width="917",
-                height="392",
-                hi_def=True,
-                loading="auto",
-                ) | safe
-              }}
-            </div>
+          </div>
+          <div>
+            {{ image (
+              url="https://assets.ubuntu.com/v1/534be2a2-ibm-leadspace.jpg",
+              alt="IBM",
+              width="917",
+              height="392",
+              hi_def=True,
+              loading="auto",
+              ) | safe
+            }}
           </div>
         </div>
       </div>
@@ -463,7 +489,9 @@ meta_copydoc %}
 <section class="p-section">
   <div class="u-fixed-width p-section--shallow">
     <hr class="p-rule" />
-    <h2 class="p-section--shallow">Get to market fast with our hardware ecosystem</h2>
+    <div class="p-section--shallow">
+      <h2>Get to market fast with our hardware ecosystem</h2>
+    </div>
     <div class="p-logo-section--dense">
       <div class="p-logo-section__items">
         <div class="p-logo-section__item">
@@ -676,7 +704,9 @@ meta_copydoc %}
       <h2>Ready to innovate?</h2>
     </div>
     <div class="col">
-      <p class="p-section--shallow">Whether you are a startup bringing your concept to market or already have large fleets of devices deployed in the field, we have the expertise and infrastructure to launch and support you.</p>
+      <div class="-section--shallow">
+        <p>Whether you are a startup bringing your concept to market or already have large fleets of devices deployed in the field, we have the expertise and infrastructure to launch and support you.</p>
+      </div>
       <hr />
       <a class="p-button--positive" href="/core/contact-us">Get in touch</a>
     </div>

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -25,7 +25,7 @@ meta_copydoc %}
                 <div class="p-section--shallow">
                     <p class="p-heading--2">
                         The embedded Linux OS
-                        <br class="u-hide--small u-hide--medium"/>
+                        <br class="u-hide--small u-hide--medium" />
                         for devices
                     </p>
                 </div>
@@ -90,7 +90,7 @@ meta_copydoc %}
                     secure embedded Linux ever, with a 10 year LTS commitment.
                 </p>
                 <div class="p-equal-height-row__item">
-                    <hr class="p-rule is-muted u-hide--small">
+                    <hr class="p-rule is-muted u-hide--small" />
                     <p>
                         <a href="/security">Learn more about Ubuntu security&nbsp;&rsaquo;</a>
                     </p>
@@ -113,7 +113,7 @@ meta_copydoc %}
                     OTA updates. In connected or air-gap environments.
                 </p>
                 <div class="p-equal-height-row__item">
-                    <hr class="p-rule is-muted u-hide--small">
+                    <hr class="p-rule is-muted u-hide--small" />
                     <p>
                         <a href="/internet-of-things/management">Learn more about fleet management&nbsp;&rsaquo;</a>
                     </p>
@@ -136,7 +136,7 @@ meta_copydoc %}
                     applications, each updated independently and protected against corruption.
                 </p>
                 <div class="p-equal-height-row__item">
-                    <hr class="p-rule is-muted u-hide--small">
+                    <hr class="p-rule is-muted u-hide--small" />
                     <p>
                         <a href="/core/docs/components#heading--confinement">Learn more about confinement&nbsp;&rsaquo;</a>
                     </p>
@@ -159,7 +159,7 @@ meta_copydoc %}
                     IoT and edge devices and hardware.
                 </p>
                 <div class="p-equal-height-row__item">
-                    <hr class="p-rule is-muted u-hide--small">
+                    <hr class="p-rule is-muted u-hide--small" />
                     <p>
                         <a href="/certified">Browse all certified hardware&nbsp;&rsaquo;</a>
                     </p>
@@ -269,11 +269,11 @@ meta_copydoc %}
                         <a href="/automotive">
                             <h3 class="p-heading--5">Automotive</h3>
                             {{ image(url="https://assets.ubuntu.com/v1/f867c883-For-smart-use-cases__Automotivew.png",
-                                alt="",
-                                width="285",
-                                height="160",
-                                hi_def=True,
-                                loading="auto",) | safe
+                                                        alt="",
+                                                        width="285",
+                                                        height="160",
+                                                        hi_def=True,
+                                                        loading="auto",) | safe
                             }}
                         </a>
                     </div>
@@ -281,11 +281,11 @@ meta_copydoc %}
                         <a href="/industrial">
                             <h3 class="p-heading--5">Industrial</h3>
                             {{ image(url="https://assets.ubuntu.com/v1/0162bc71-For-smart-use-cases__Industrial.png",
-                                alt="",
-                                width="285",
-                                height="160",
-                                hi_def=True,
-                                loading="auto",) | safe
+                                                        alt="",
+                                                        width="285",
+                                                        height="160",
+                                                        hi_def=True,
+                                                        loading="auto",) | safe
                             }}
                         </a>
                     </div>
@@ -293,11 +293,11 @@ meta_copydoc %}
                         <a href="/robotics">
                             <h3 class="p-heading--5">Robotics</h3>
                             {{ image(url="https://assets.ubuntu.com/v1/aeeeb32d-For-smart-use-cases__Robotics.png",
-                                alt="",
-                                width="285",
-                                height="160",
-                                hi_def=True,
-                                loading="auto",) | safe
+                                                        alt="",
+                                                        width="285",
+                                                        height="160",
+                                                        hi_def=True,
+                                                        loading="auto",) | safe
                             }}
                         </a>
                     </div>
@@ -397,11 +397,11 @@ meta_copydoc %}
                 <div class="row u-no-margin--bottom">
                     <div class="col-3 col-medium-2">
                         {{ image(url="https://assets.ubuntu.com/v1/ffd88101-rexroth-for-testimonial.png",
-                            alt="Rexroth",
-                            width="284",
-                            height="70",
-                            hi_def=True,
-                            loading="auto",) | safe
+                                                alt="Rexroth",
+                                                width="284",
+                                                height="70",
+                                                hi_def=True,
+                                                loading="auto",) | safe
                         }}
                     </div>
                     <div class="col-9 col-medium-4 u-no-margin--top">
@@ -419,11 +419,11 @@ meta_copydoc %}
                         </div>
                         <div>
                             {{ image(url="https://assets.ubuntu.com/v1/2d152c25-rexroth-testimonial-image.jpg",
-                                alt="Rexroth",
-                                width="917",
-                                height="392",
-                                hi_def=True,
-                                loading="auto",) | safe
+                                                        alt="Rexroth",
+                                                        width="917",
+                                                        height="392",
+                                                        hi_def=True,
+                                                        loading="auto",) | safe
                             }}
                         </div>
                     </div>
@@ -437,11 +437,11 @@ meta_copydoc %}
                 <div class="row u-no-margin--bottom">
                     <div class="col-3 col-medium-2">
                         {{ image(url="https://assets.ubuntu.com/v1/36c27b25-pudo-testimonial-logo-new.png",
-                            alt="Pudo",
-                            width="125",
-                            height="56",
-                            hi_def=True,
-                            loading="auto",) | safe
+                                                alt="Pudo",
+                                                width="125",
+                                                height="56",
+                                                hi_def=True,
+                                                loading="auto",) | safe
                         }}
                     </div>
                     <div class="col-9 col-medium-4 u-no-margin--top">
@@ -459,11 +459,11 @@ meta_copydoc %}
                         </div>
                         <div>
                             {{ image(url="https://assets.ubuntu.com/v1/576c8402-pudo-testimonial-image.jpg",
-                                alt="Pudo",
-                                width="917",
-                                height="392",
-                                hi_def=True,
-                                loading="auto",) | safe
+                                                        alt="Pudo",
+                                                        width="917",
+                                                        height="392",
+                                                        hi_def=True,
+                                                        loading="auto",) | safe
                             }}
                         </div>
                     </div>
@@ -477,11 +477,11 @@ meta_copydoc %}
                 <div class="row u-no-margin--bottom">
                     <div class="col-3 col-medium-2">
                         {{ image(url="https://assets.ubuntu.com/v1/80f5af45-rigado-testimonial-logo.png",
-                            alt="Rigado",
-                            width="217",
-                            height="51",
-                            hi_def=True,
-                            loading="auto",) | safe
+                                                alt="Rigado",
+                                                width="217",
+                                                height="51",
+                                                hi_def=True,
+                                                loading="auto",) | safe
                         }}
                     </div>
                     <div class="col-9 col-medium-4 u-no-margin--top">
@@ -499,11 +499,11 @@ meta_copydoc %}
                         </div>
                         <div>
                             {{ image(url="https://assets.ubuntu.com/v1/297369c0-rigado--testimonial-image.jpg",
-                                alt="Rigado",
-                                width="917",
-                                height="392",
-                                hi_def=True,
-                                loading="auto",) | safe
+                                                        alt="Rigado",
+                                                        width="917",
+                                                        height="392",
+                                                        hi_def=True,
+                                                        loading="auto",) | safe
                             }}
                         </div>
                     </div>
@@ -517,11 +517,11 @@ meta_copydoc %}
                 <div class="row u-no-margin--bottom">
                     <div class="col-3 col-medium-2">
                         {{ image(url="https://assets.ubuntu.com/v1/134756c3-ibm-cloud-testimonial-logo.png",
-                            alt="IBM",
-                            width="190",
-                            height="58",
-                            hi_def=True,
-                            loading="auto",) | safe
+                                                alt="IBM",
+                                                width="190",
+                                                height="58",
+                                                hi_def=True,
+                                                loading="auto",) | safe
                         }}
                     </div>
                     <div class="col-9 col-medium-4 u-no-margin--top">
@@ -541,11 +541,11 @@ meta_copydoc %}
                         </div>
                         <div>
                             {{ image(url="https://assets.ubuntu.com/v1/534be2a2-ibm-leadspace.jpg",
-                                alt="IBM",
-                                width="917",
-                                height="392",
-                                hi_def=True,
-                                loading="auto",) | safe
+                                                        alt="IBM",
+                                                        width="917",
+                                                        height="392",
+                                                        hi_def=True,
+                                                        loading="auto",) | safe
                             }}
                         </div>
                     </div>
@@ -564,92 +564,92 @@ meta_copydoc %}
                 <div class="p-logo-section__items">
                     <div class="p-logo-section__item">
                         {{ image(url="https://assets.ubuntu.com/v1/59996fad-intel-new-logo.png",
-                            alt="Intel",
-                            width="50",
-                            height="96",
-                            hi_def=True,
-                            attrs={"class": "p-logo-section__logo"},
-                            loading="auto",) | safe
+                                                alt="Intel",
+                                                width="50",
+                                                height="96",
+                                                hi_def=True,
+                                                attrs={"class": "p-logo-section__logo"},
+                                                loading="auto",) | safe
                         }}
                     </div>
                     <div class="p-logo-section__item">
                         {{ image(url="https://assets.ubuntu.com/v1/4bf8a9bc-amd-logo.png",
-                            alt="AMD",
-                            width="69",
-                            height="96",
-                            hi_def=True,
-                            attrs={"class": "p-logo-section__logo"},
-                            loading="auto",) | safe
+                                                alt="AMD",
+                                                width="69",
+                                                height="96",
+                                                hi_def=True,
+                                                attrs={"class": "p-logo-section__logo"},
+                                                loading="auto",) | safe
                         }}
                     </div>
                     <div class="p-logo-section__item">
                         {{ image(url="https://assets.ubuntu.com/v1/e7b81879-nvidia-logo.png",
-                            alt="Nvidia",
-                            width="94",
-                            height="96",
-                            hi_def=True,
-                            attrs={"class": "p-logo-section__logo"},
-                            loading="auto",) | safe
+                                                alt="Nvidia",
+                                                width="94",
+                                                height="96",
+                                                hi_def=True,
+                                                attrs={"class": "p-logo-section__logo"},
+                                                loading="auto",) | safe
                         }}
                     </div>
                     <div class="p-logo-section__item">
                         {{ image(url="https://assets.ubuntu.com/v1/9a25ec68-arm-logo.png",
-                            alt="ARM",
-                            width="47",
-                            height="96",
-                            hi_def=True,
-                            attrs={"class": "p-logo-section__logo"},
-                            loading="auto",) | safe
+                                                alt="ARM",
+                                                width="47",
+                                                height="96",
+                                                hi_def=True,
+                                                attrs={"class": "p-logo-section__logo"},
+                                                loading="auto",) | safe
                         }}
                     </div>
                     <div class="p-logo-section__item">
                         {{ image(url="https://assets.ubuntu.com/v1/31b259ec-qualcom-logo.png",
-                            alt="Qualcom",
-                            width="96",
-                            height="96",
-                            hi_def=True,
-                            attrs={"class": "p-logo-section__logo"},
-                            loading="auto",) | safe
+                                                alt="Qualcom",
+                                                width="96",
+                                                height="96",
+                                                hi_def=True,
+                                                attrs={"class": "p-logo-section__logo"},
+                                                loading="auto",) | safe
                         }}
                     </div>
                     <div class="p-logo-section__item">
                         {{ image(url="https://assets.ubuntu.com/v1/d65da7f3-advantech-logo.png",
-                            alt="Advantech",
-                            width="95",
-                            height="96",
-                            hi_def=True,
-                            attrs={"class": "p-logo-section__logo"},
-                            loading="auto",) | safe
+                                                alt="Advantech",
+                                                width="95",
+                                                height="96",
+                                                hi_def=True,
+                                                attrs={"class": "p-logo-section__logo"},
+                                                loading="auto",) | safe
                         }}
                     </div>
                     <div class="p-logo-section__item">
                         {{ image(url="https://assets.ubuntu.com/v1/6eff0263-adlink-logo.png",
-                            alt="Adlink",
-                            width="101",
-                            height="96",
-                            hi_def=True,
-                            attrs={"class": "p-logo-section__logo"},
-                            loading="auto",) | safe
+                                                alt="Adlink",
+                                                width="101",
+                                                height="96",
+                                                hi_def=True,
+                                                attrs={"class": "p-logo-section__logo"},
+                                                loading="auto",) | safe
                         }}
                     </div>
                     <div class="p-logo-section__item">
                         {{ image(url="https://assets.ubuntu.com/v1/be8db080-nxp-logo.png",
-                            alt="NXP",
-                            width="41",
-                            height="96",
-                            hi_def=True,
-                            attrs={"class": "p-logo-section__logo"},
-                            loading="auto",) | safe
+                                                alt="NXP",
+                                                width="41",
+                                                height="96",
+                                                hi_def=True,
+                                                attrs={"class": "p-logo-section__logo"},
+                                                loading="auto",) | safe
                         }}
                     </div>
                     <div class="p-logo-section__item">
                         {{ image(url="https://assets.ubuntu.com/v1/96d65ee2-mediatek-logo.png",
-                            alt="MediaTeK",
-                            width="77",
-                            height="96",
-                            hi_def=True,
-                            attrs={"class": "p-logo-section__logo"},
-                            loading="auto",) | safe
+                                                alt="MediaTeK",
+                                                width="77",
+                                                height="96",
+                                                hi_def=True,
+                                                attrs={"class": "p-logo-section__logo"},
+                                                loading="auto",) | safe
                         }}
                     </div>
                 </div>

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -31,7 +31,7 @@ meta_copydoc %}
         <img src="https://assets.ubuntu.com/v1/3a0f24b8-video-thumbnail-suru-bg.png" alt="" class="p-hero-video__play">
       </a>
       <div class="p-hero-video-container u-embedded-media u-hide">
-        <iframe class="p-hero-video u-embedded-media__element" src="https://www.youtube.com/embed/6NDWqH1SrGs?autoplay=1" allow="autoplay;" frameborder="0" allowfullscreen=""></iframe>
+        <iframe class="p-hero-video u-embedded-media__element" src="https://www.youtube.com/embed/6NDWqH1SrGs" allow="autoplay;" frameborder="0" allowfullscreen=""></iframe>
       </div>
     </div>
     <script>
@@ -41,6 +41,7 @@ meta_copydoc %}
         const videoContainer = document.querySelector('.p-hero-video-container');
         videoLink.addEventListener('click', function(e) {
           e.preventDefault();
+          video.src += "?autoplay=1";
           videoContainer.classList.remove('u-hide');
           videoLink.classList.add('u-hide');
         });

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -1,817 +1,692 @@
 {% extends "core/base_core.html" %}
 
 {% block title %}Ubuntu Core{% endblock %}
-{% block meta_description %}Ubuntu Core is Ubuntu for IoT and embedded environments, optimised for security and reliable ota updates. Run snaps in a high-security confined sandbox with bulletproof upgrades and a private app store.{% endblock meta_description %}
-{% block meta_copydoc %}https://docs.google.com/document/d/1UFpefDRSAcndNBnWp0hDyzqk74aciqhBWJEi05htWmU/edit{% endblock meta_copydoc %}
+{% block meta_description %}Ubuntu Core is Ubuntu for IoT and embedded environments, optimised for security and reliable
+ota updates. Run snaps in a high-security confined sandbox with bulletproof upgrades and a private app store.{% endblock
+meta_description %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1UFpefDRSAcndNBnWp0hDyzqk74aciqhBWJEi05htWmU/edit{% endblock
+meta_copydoc %}
 
+{% block body_class %}is-paper{% endblock body_class %}
 {% block content %}
 
-<section class="p-strip--suru">
-  {% include "shared/_rt-kernel-ga-banner.html" %}
-  <div class="row u-equal-height u-vertically-center">
-    <div class="col-7">
-      <h1>The operating system optimised for IoT and Edge</h1>
-      <p class="p-heading--4 u-sv3">Ubuntu Core is a secure, application-centric IoT OS for embedded devices</p>
-      <p>
-        <a class="p-button" href="/download/iot">Try Ubuntu Core now</a>
-        <a class="p-button--positive" href="/engage/intro-to-ubuntu-core22-webinar">Watch the webinar</a>
-      </p>
+<section class="p-strip is-shallow u-no-padding--bottom">
+  <div class="p-section row--50-50">
+    <div class="col">
+      <h1 class="u-no-margin--bottom">Ubuntu Core</h1>
+      <h2 class="p-section--shallow">The embedded Linux OS for devices</h1>
+        <p class="p-heading--4 p-section--shallow">Ubuntu Core is a minimal, secure and strictly confined operating
+          system powering devices around the world. Build your Ubuntu Core image today.</p>
+        <hr />
+        <p>
+          <a class="p-button--positive" href="/core/docs/getting-started">Try Ubuntu Core</a>
+          <a href="https://assets.ubuntu.com/v1/1870ea66-Ubuntu_Core22_DS.06.06.22.pdf">Read the Ubuntu Core
+            datasheet</a>
+        </p>
     </div>
-    <div class="col-5 u-align--center u-embedded-media">
-      <iframe title="UC22 video" class="u-embedded-media__element" src="https://www.youtube.com/embed/6NDWqH1SrGs" allowfullscreen=""></iframe>
-    </div>
-  </div>
-</section>
-<section class="p-strip">
-  <div class="u-fixed-width">
-    <h2>Why choose Ubuntu Core?</h2>
-  </div>
-  <div class="row" style="padding-top: 60px; padding-bottom: 60px;">
-    <div class="col-3">
-      <h3>Security First</h3>
-    </div>
-    <div class="col-9">
-      <p class="p-heading--5">Imagine a world where every device is trustworthy. We designed every aspect of Ubuntu Core to create the most secure embedded Linux ever, with a 10y LTS commitment.</p>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-3">
-      <div class="p-heading-icon">
-        <div class="p-heading-icon__header is-stacked">
-          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/a0f23d1b-Savings.svg" alt="">
-          <h4 class="p-heading-icon__title p-heading--5">Reduce the cost of Linux</h4>
-        </div>
-        <p>Low-level devices development is complex and resource-intensive. With Ubuntu Core and Canonical services, you can accelerate the time-to-market and reduce your costs.</p>
-      </div>
-    </div>
-    <div class="col-3">
-      <div class="p-heading-icon">
-        <div class="p-heading-icon__header is-stacked">
-          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/da8d1235-ubuntu-cof.svg" alt="">
-          <h4 class="p-heading-icon__title p-heading--5">Loved by developers</h4>
-        </div>
-        <p>Core is Ubuntu; open source, binary-compatible and backed by a strong developer community.
-          Improve productivity with a unified and application-centric developer experience.</p>
-      </div>
-    </div>
-    <div class="col-3">
-      <div class="p-heading-icon">
-        <div class="p-heading-icon__header is-stacked">
-          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/d127abd7-safety+reliability.svg" alt="">
-          <h4 class="p-heading-icon__title p-heading--5">Low-touch</h4>
-        </div>
-        <p>Reliable, self-healing, remotely accessible and recoverable devices which are always up-to-date with mission-critical over-the-air (OTA) updates.</p>
-      </div>
-    </div>
-    <div class="col-3">
-      <div class="p-heading-icon">
-        <div class="p-heading-icon__header is-stacked">
-          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/aec863e2-Off+the+shelf.svg" alt="">
-          <h4 class="p-heading-icon__title p-heading--5">A strong ecosystem of certified hardware</h4>
-        </div>
-        <p>Ubuntu Core has been enabled and is continuously tested on leading IoT and edge devices and hardware.</p>
-        <p><a href="/certified">Read more&nbsp;&rsaquo;</a></p>
-      </div>
+    <div class="col u-embedded-media">
+      <iframe title="UC22 video" class="u-embedded-media__element" src="https://www.youtube.com/embed/6NDWqH1SrGs"
+        allowfullscreen=""></iframe>
     </div>
   </div>
 </section>
-<section class="p-strip--light">
-  <div class="row u-vertically-center">
-    <div class="col-6">
-      <h2 class="u-sv3">Get to market fast with our strong ecosystem</h2>
-      <p>
-        <a class="p-button" href="/certified">Certified hardware</a>
-        <a class="p-button--positive" href="/core/contact-us">Contact us</a>
-      </p>
+
+<section class="p-section">
+  <div class="row--50-50 p-section--shallow">
+    <hr class="p-rule" />
+    <div class="col">
+      <h2>An OS with all the infrastructure</h2>
     </div>
-    <div class="col-6">
-      <div class="p-logo-section has-misaligned-images">
-        <div class="p-logo-section__items">
-          <div class="p-logo-section__item">
+    <div class="col">
+      <p>Ubuntu Core is more than just your embedded Linux OS, it's your whole deployment infrastructure. Build targeted
+        production-ready images, unlock over-the air (OTA) updates, deploy in air gap environments, manage your fleet of
+        devices, achieve real-time operations, and more.</p>
+      <p>Ubuntu Core will transform the way you deploy devices with the longest support window in the industry.</p>
+    </div>
+  </div>
+  <div class="p-equal-height-row has-3rd-divider">
+    <div class="p-equal-height-row__col">
+      <div class="p-equal-height-row__item">
+        <div class="p-media-container">
+          <img width="320" src="https://assets.ubuntu.com/v1/c4176cd9-Kernelt%20industries-80%201.jpg" alt="">
+        </div>
+      </div>
+      <div class="p-equal-height-row__item">
+        <hr class="p-rule--highlight u-hide--medium u-hide--small">
+        <h5 class="p-heading--5">Continuous security</h5>
+      </div>
+      <p class="p-equal-height-row__item">
+        Imagine a world where every device is trustworthy. We designed every aspect of Ubuntu Core to create the most
+        secure embedded Linux ever, with a 10 year LTS commitment.
+      </p>
+      <div class="p-equal-height-row__item">
+        <a href="/security">
+          <p>Learn more about Ubuntu security&nbsp;›</p>
+        </a>
+      </div>
+    </div>
+    <div class="p-equal-height-row__col">
+      <div class="p-equal-height-row__item">
+        <div class="p-media-container">
+          <img width="320" src="https://assets.ubuntu.com/v1/1624c652-Kernelt%20industries-80%201-1.jpg" alt="">
+        </div>
+      </div>
+      <div class="p-equal-height-row__item">
+        <hr class="p-rule--highlight u-hide--medium u-hide--small">
+        <h5 class="p-heading--5">Fleet management</h5>
+      </div>
+      <p class="p-equal-height-row__item">
+        Enjoy reliable, remotely accessible and recoverable devices which are always up-to-date with mission-critical
+        OTA updates. In connected or air-gap environments.
+      </p>
+      <div class="p-equal-height-row__item">
+        <a href="/internet-of-things/management">
+          <p>Learn more about fleet Management&nbsp;›</p>
+        </a>
+      </div>
+    </div>
+    <div class="p-equal-height-row__col">
+      <div class="p-equal-height-row__item">
+        <div class="p-media-container">
+          <img width="320" src="https://assets.ubuntu.com/v1/eb9824bf-Kernelt%20industries-80%201-2.jpg" alt="">
+        </div>
+      </div>
+      <div class="p-equal-height-row__item">
+        <hr class="p-rule--highlight u-hide--medium u-hide--small">
+        <h5 class="p-heading--5">Agile containerisation</h5>
+      </div>
+      <p class="p-equal-height-row__item">
+        Ubuntu Core is immutable and strictly confined. There is a clean separation between the kernel, OS image and
+        applications, each updated independently and protected against corruption.
+      </p>
+      <div class="p-equal-height-row__item">
+        <a href="/core/docs/components#heading--confinement">
+          <p>Learn more about confinement&nbsp;›</p>
+        </a>
+      </div>
+    </div>
+    <div class="p-equal-height-row__col">
+      <div class="p-equal-height-row__item">
+        <div class="p-media-container">
+          <img width="320" src="https://assets.ubuntu.com/v1/000a7695-Kernelt%20industries-80%201-3.jpg" alt="">
+        </div>
+      </div>
+      <div class="p-equal-height-row__item">
+        <hr class="p-rule--highlight u-hide--medium u-hide--small">
+        <h5 class="p-heading--5">A strong hardware ecosystem</h5>
+      </div>
+      <p class="p-equal-height-row__item">
+        We enable Ubuntu Core with the best ODMs and silicon vendors in the world. We continuously test it on leading
+        IoT and edge devices and hardware.
+      </p>
+      <div class="p-equal-height-row__item">
+        <a href="/certified">
+          <p>Browse all certified hardware&nbsp;›</p>
+        </a>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="p-section">
+  <div class="row--50-50 p-section--shallow">
+    <hr class="p-rule" />
+    <div class="col">
+      <h2>From development to deployment</h2>
+    </div>
+    <div class="col">
+      <p>Use the same kernel, the same libraries, and the same system software for a smooth transition from development
+        to production. Once you have created your application in Ubuntu Desktop or Server, build your immutable Ubuntu
+        Core image based on your developed applications and targeted hardware.</p>
+    </div>
+  </div>
+  <div class="row--25-75">
+    <div class="col">
+      <div class="row">
+        <hr />
+        <div class="col-4 col-medium-2">
+          <ul class="js-tabbed-content p-tabs--vertical is-black u-hide--small" role="tablist"
+            aria-label="Dev to deployment">
+            <li>
+              <button class="p-tabs__item" id="overview" role="tab" aria-selected="true" aria-controls="overview-tab">Overview</button>
+            </li>
+            <li>
+              <button class="p-tabs__item" id="ubuntu-vision" role="tab" aria-selected="false" aria-controls="ubuntu-vision-tab">Ubuntu</button>
+            </li>
+            <li>
+              <button class="p-tabs__item" id="snapcraft" role="tab" aria-selected="false" aria-controls="snapcraft-tab">Snapcraft</button>
+            </li>
+            <li>
+              <button class="p-tabs__item" id="snap-store" role="tab" aria-selected="false" aria-controls="snap-store-tab">Snap Store</button>
+            </li>
+            <li>
+              <button class="p-tabs__item" id="ubuntu-core" role="tab" aria-selected="false" aria-controls="ubuntu-core-tab">Ubuntu Core</button>
+            </li>
+          </ul>
+          <form class="u-hide--large u-hide--medium">
+            <select name="boardSelect" id="boardSelect">
+              <option value="overview-tab" selected="">Overview</option>
+              <option value="ubuntu-vision-tab">Ubuntu</option>
+              <option value="snapcraft-tab">Snapcraft</option>
+              <option value="snap-store-tab">Snap Store</option>
+              <option value="ubuntu-core-tab">Ubuntu Core</option>
+            </select>
+          </form>
+        </div>
+        <div class="col-8 col-medium-4">
+          {% include "core/tabs.html" %}
+        </div>
+      </div>
+      <div class="row">
+        <hr />
+        <div class="col-start-large-5 col-start-medium-3 col-8 col-medium-4">
+          <a href="/core/docs">Get started with Ubuntu Core&nbsp;&rsaquo;</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="p-section">
+  <div class="u-fixed-width p-section--shallow">
+    <hr class="p-rule" />
+    <h2>For smart use cases. Get Core. Get snaps. Get going.</h2>
+  </div>
+  <div class="row--25-75 p-section--shallow">
+    <div class="col">
+      <hr class="u-hide--small" />
+      <div class="row">
+        <div class="col-3 col-medium-2">
+          <h3 class="p-heading--5"><a href="/automotive">Automotive</a></h3>
+          {{ image (
+              url="https://assets.ubuntu.com/v1/f867c883-For-smart-use-cases__Automotivew.png",
+              alt="Automotive",
+              width="285",
+              height="160",
+              hi_def=True,
+              loading="auto",
+              ) | safe
+            }}
+        </div>
+        <div class="col-3 col-medium-2">
+          <h3 class="p-heading--5"><a href="/industrial">Industrial</a></h3>
+          {{ image (
+              url="https://assets.ubuntu.com/v1/0162bc71-For-smart-use-cases__Industrial.png",
+              alt="Industrial",
+              width="285",
+              height="160",
+              hi_def=True,
+              loading="auto",
+              ) | safe
+            }}
+        </div>
+        <div class="col-3 col-medium-2">
+          <h3 class="p-heading--5"><a href="/robotics">Robotics</a></h3>
+          {{ image (
+              url="https://assets.ubuntu.com/v1/aeeeb32d-For-smart-use-cases__Robotics.png",
+              alt="Robotics",
+              width="285",
+              height="160",
+              hi_def=True,
+              loading="auto",
+              ) | safe
+            }}
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="row--25-75">
+    <div class="col">
+      <hr class="u-hide--small" />
+      <div class="row">
+        <div class="col-3 col-medium-2">
+          <h3 class="p-heading--5"><a href="/internet-of-things/digital-signage">Signage</a></h3>
+          {{ image (
+              url="https://assets.ubuntu.com/v1/9db3f004-For-smart-use-cases__Signage.png",
+              alt="Signage",
+              width="285",
+              height="160",
+              hi_def=True,
+              loading="auto",
+              ) | safe
+            }}
+        </div>
+        <div class="col-3 col-medium-2">
+          <h3 class="p-heading--5"><a href="/internet-of-things/smart-city">Smart Cities</a></h3>
             {{ image (
-              url="https://assets.ubuntu.com/v1/67f81bfe-intel-new-logo.png",
+              url="https://assets.ubuntu.com/v1/8dd2f04d-For-smart-use-cases__Smart-cities.png",
+              alt="Smart cities",
+              width="285",
+              height="160",
+              hi_def=True,
+              loading="auto",
+              ) | safe
+            }}
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="p-section">
+  <div class="row">
+    <hr class="p-rule--highlight" />
+    <div class="col-9 col-medium-4">
+      <h2 class="p-text--small-caps p-heading--5">Ubuntu core customer stories</h2>
+    </div>
+    <div class="col-3 col-medium-2 p-section--shallow">
+      <p>
+        <a href="/core/stories">All the success stories&nbsp;&rsaquo;</a>
+      </p>
+    </div>
+  </div>
+  <div class="p-tabs">
+    <div class="row--25-75">
+      <div class="col">
+        <hr />
+        <div class="p-tabs__list js-tabbed-content" role="tablist" aria-label="Customer stories">
+          <div class="p-tabs__item">
+            <button class="p-tabs__link" role="tab" aria-selected="true" aria-controls="industrial-tab"
+              id="industrial">Industrial</button>
+          </div>
+          <div class="p-tabs__item">
+            <button class="p-tabs__link" role="tab" aria-selected="false" aria-controls="smart-kiosk-tab"
+              id="smart-kiosk" tabindex="-1">Smart Kiosk</button>
+          </div>
+          <div class="p-tabs__item">
+            <button class="p-tabs__link" role="tab" aria-selected="false" aria-controls="network-tab" id="network"
+              tabindex="-1">Network</button>
+          </div>
+          <div class="p-tabs__item">
+            <button class="p-tabs__link" role="tab" aria-selected="false" aria-controls="cloud-tab" id="cloud"
+              tabindex="-1">Cloud</button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div tabindex="0" role="tabpanel" id="industrial-tab" aria-labelledby="industrial">
+      <div class="row--25-75">
+        <div class="col">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/ffd88101-rexroth-for-testimonial.png",
+            alt="Rexroth",
+            width="284",
+            height="70",
+            hi_def=True,
+            loading="auto",
+            ) | safe
+          }}
+        </div>
+        <div class="col">
+          <div class="row">
+            <div class="col-6">
+              <h3 class="p-heading--2">Bosch Rexroth reinvents automation</h3>
+            </div>
+            <div class="col-3 p-section--shallow">
+              <p class="p-section--shallow">Bosch adopts Ubuntu Core and snaps for app-based ctrl-X industry 4.0 platform.</p>
+              <hr />
+              <a href="/blog/bosch-rexroth-adopts-ubuntu-core-and-snaps-for-app-based-ctrlx-automation-platform">Read the press release&nbsp;&rsaquo;</a>
+            </div>
+            <div>
+              {{ image (
+                url="https://assets.ubuntu.com/v1/2d152c25-rexroth-testimonial-image.jpg",
+                alt="Rexroth",
+                width="917",
+                height="392",
+                hi_def=True,
+                loading="auto",
+                ) | safe
+              }}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div tabindex="0" role="tabpanel" id="smart-kiosk-tab" aria-labelledby="smart-kiosk" aria-hidden="hidden">
+      <div class="row--25-75">
+        <div class="col">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/ea8fc1a8-pudo-testimonial-logo.png",
+            alt="Pudo",
+            width="180",
+            height="70",
+            hi_def=True,
+            loading="auto",
+            ) | safe
+          }}
+        </div>
+        <div class="col">
+          <div class="row">
+            <div class="col-6">
+              <h3 class="p-heading--2">Pudo deploys fleet for robust last-mile logistics</h3>
+            </div>
+            <div class="col-3 p-section--shallow">
+              <p class="p-section--shallow">Pudo chooses Ubuntu Core as the foundation for its IoT-based APMs to maximise security and uptime.</p>
+              <hr />
+              <a href="/engage/pudo-case-study">Read the case study&nbsp;&rsaquo;</a>
+            </div>
+            <div>
+              {{ image (
+                url="https://assets.ubuntu.com/v1/576c8402-pudo-testimonial-image.jpg",
+                alt="Pudo",
+                width="917",
+                height="392",
+                hi_def=True,
+                loading="auto",
+                ) | safe
+              }}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div tabindex="0" role="tabpanel" id="network-tab" aria-labelledby="network" aria-hidden="hidden">
+      <div class="row--25-75">
+        <div class="col">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/80f5af45-rigado-testimonial-logo.png",
+            alt="Rigado",
+            width="200",
+            height="46",
+            hi_def=True,
+            loading="auto",
+            ) | safe
+          }}
+        </div>
+        <div class="col">
+          <div class="row">
+            <div class="col-6">
+              <h3 class="p-heading--2">Rigado cuts customers’ time to market</h3>
+            </div>
+            <div class="col-3 p-section--shallow">
+              <p class="p-section--shallow">Ubuntu Core enables Rigado to manage end-to-end security for commercial IoT gateways.</p>
+              <hr />
+              <a href="/engage/case-study-rigado">Read the case study&nbsp;&rsaquo;</a>
+            </div>
+            <div>
+              {{ image (
+                url="https://assets.ubuntu.com/v1/297369c0-rigado--testimonial-image.jpg",
+                alt="Rigado",
+                width="917",
+                height="392",
+                hi_def=True,
+                loading="auto",
+                ) | safe
+              }}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div tabindex="0" role="tabpanel" id="cloud-tab" aria-labelledby="cloud" aria-hidden="hidden">
+      <div class="row--25-75">
+        <div class="col">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/e110996e-ibm-cloud-testimonial-logo.png",
+            alt="IBM",
+            width="200",
+            height="60",
+            hi_def=True,
+            loading="auto",
+            ) | safe
+          }}
+        </div>
+        <div class="col">
+          <div class="row">
+            <div class="col-6">
+              <h3 class="p-heading--2">IBM Cloud provides highly isolated and performant bare metal servers</h3>
+            </div>
+            <div class="col-3 p-section--shallow">
+              <p class="p-section--shallow">IBM Cloud's bare metal servers offer highly isolated and high-performing tenant-cloud isolation through the use of Ubuntu Core.</p>
+              <hr />
+              <a href="/engage/case-study-rigado">Read the press release&nbsp;&rsaquo;</a>
+            </div>
+            <div>
+              {{ image (
+                url="https://assets.ubuntu.com/v1/534be2a2-ibm-leadspace.jpg",
+                alt="IBM",
+                width="917",
+                height="392",
+                hi_def=True,
+                loading="auto",
+                ) | safe
+              }}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</section>
+
+<section class="p-section">
+  <div class="u-fixed-width p-section--shallow">
+    <hr class="p-rule" />
+    <h2 class="p-section--shallow">Get to market fast with our hardware ecosystem</h2>
+    <div class="p-logo-section--dense">
+      <div class="p-logo-section__items">
+        <div class="p-logo-section__item">
+          {{ image (
+              url="https://assets.ubuntu.com/v1/59996fad-intel-new-logo.png",
               alt="Intel",
-              width="288",
-              height="288",
+              width="50",
+              height="96",
               hi_def=True,
               attrs={"class": "p-logo-section__logo"},
               loading="auto",
               ) | safe
-            }}
-          </div>
-          <div class="p-logo-section__item">
-            {{ image (
-              url="https://assets.ubuntu.com/v1/8fdc3ebf-raspberry-pi-logo.png",
-              alt="Raspberry Pi",
-              width="288",
-              height="288",
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+              url="https://assets.ubuntu.com/v1/4bf8a9bc-amd-logo.png",
+              alt="AMD",
+              width="69",
+              height="96",
               hi_def=True,
               attrs={"class": "p-logo-section__logo"},
               loading="auto",
               ) | safe
-            }}
-          </div>
-          <div class="p-logo-section__item">
-            {{ image (
-              url="https://assets.ubuntu.com/v1/2b253402-advantech-logo.png",
-              alt="Advantech",
-              width="288",
-              height="288",
-              hi_def=True,
-              attrs={"class": "p-logo-section__logo"},
-              loading="lazy"
-              ) | safe
-            }}
-          </div>
-          <div class="p-logo-section__item">
-            {{ image (
-              url="https://assets.ubuntu.com/v1/75502e5c-NXP-Logo.svg",
-              alt="NXP",
-              width="128",
-              height="50",
-              hi_def=True,
-              attrs={"class": "p-logo-section__logo"},
-              loading="lazy",
-              ) | safe
-            }}
-          </div>
-        </div>
-    </div>
-  </div>
-</section>
-
-<section class="p-strip">
-  <div class="u-fixed-width">
-    <h2>For smart use cases</h2>
-    <h3 class="u-sv3">Get Core. Get snaps. Get going.</h3>
-  </div>
-  <div class="row u-equal-height u-align--center u-vertically-center u-hide--medium u-hide--small">
-    <div class="col-3">
-      <div class="u-sv2">
-      {{ image (
-        url="https://assets.ubuntu.com/v1/03aa6ccc-automotive_car-network.png",
-        alt="Automotive",
-        width="184",
-        height="107",
-        hi_def=True,
-        loading="lazy"
-        ) | safe
-        }}
-      </div>
-    </div>
-    <div class="col-3">
-      <div class="u-sv2">
-        {{ image (
-          url="https://assets.ubuntu.com/v1/5e32acc5-Factory.svg",
-          alt="",
-          width="71",
-          height="60",
-          hi_def=True,
-          loading="lazy"
-          ) | safe
-        }}
-      </div>
-    </div>
-    <div class="col-3">
-      <div class="u-sv2">
-        {{ image (
-          url="https://assets.ubuntu.com/v1/e39199bc-Internet+of+Things_digital-gateways.svg",
-          alt="Digital gateways",
-          width="80",
-          height="70",
-          hi_def=True,
-          loading="lazy"
-          ) | safe
           }}
-      </div>
-    </div>
-    <div class="col-3">
-      <div class="u-sv2">
-        {{ image (
-          url="https://assets.ubuntu.com/v1/38efd13b-solution-robot.svg",
-          alt="",
-          width="51",
-          height="81",
-          hi_def=True,
-          loading="lazy"
-          ) | safe
-        }}
-      </div>
-    </div>
-  </div>
-  <div class="row u-align--center">
-    <div class="col-3">
-      <p class="p-heading--4 u-sv2"><a href="/automotive">Automotive&nbsp;&rsaquo;</a></p>
-    </div>
-    <div class="col-3">
-      <p class="p-heading--4 u-sv2"><a href="/industrial">Industrial&nbsp;&rsaquo;</a></p>
-    </div>
-    <div class="col-3">
-      <p class="p-heading--4 u-sv2"><a href="/internet-of-things">IoT Gateways&nbsp;&rsaquo;</a></p>
-    </div>
-    <div class="col-3">
-      <p class="p-heading--4 u-sv2"><a href="robotics">Robotics&nbsp;&rsaquo;</a></p>
-    </div>
-  </div>
-  <div class="row u-equal-height u-align--center u-vertically-center u-hide--medium u-hide--small">
-    <div class="col-3">
-      <div class="u-sv2">
-        {{ image (
-          url="https://assets.ubuntu.com/v1/ec2d60d0-IoT_Digital_Signage.svg",
-          alt="Linux",
-          width="50",
-          height="75",
-          hi_def=True,
-          loading="lazy",
-          ) | safe
-          }}
-      </div>
-    </div>
-    <div class="col-3">
-      <div class="u-sv2">
-        {{ image (
-          url="https://assets.ubuntu.com/v1/e395cad3-Kubernetes_Financial_Overview.svg",
-          alt="",
-          width="110",
-          height="80",
-          hi_def=True,
-          loading="lazy",
-          ) | safe
-        }}
-      </div>
-    </div>
-    <div class="col-3">
-      <div class="u-sv2">
-        {{ image (
-          url="https://assets.ubuntu.com/v1/32675035-smart-home.png",
-          alt="",
-          width="110",
-          height="80",
-          hi_def=True,
-          loading="lazy",
-          ) | safe
-        }}
-      </div>
-    </div>
-  </div>
-  <div class="row u-align--center">
-    <div class="col-3">
-      <p class="p-heading--4 u-sv2"><a href="/internet-of-things/smart-displays">Signage&nbsp;&rsaquo;</a></p>
-    </div>
-    <div class="col-3">
-      <p class="p-heading--4 u-sv2"><a href="/internet-of-things/smart-city">Smart cities&nbsp;&rsaquo;</a></p>
-    </div>
-    <div class="col-3">
-      <p class="p-heading--4 u-sv2"><a href="/internet-of-things/smart-home">Smart home&nbsp;&rsaquo;</a></p>
-    </div>
-  </div>
-  <div class="u-fixed-width">
-    <p>Check the full list of <a href="/internet-of-things">industries</a> and <a href="/core/stories">success cases&nbsp;&rsaquo;</a></p>
-  </div>
-</section>
-
-<section class="p-strip--light" id="security-first">
-  <div class="u-fixed-width">
-    <h2>Key Features</h2>
-    <h3 class="u-sv2">Security first</h3>
-  </div>
-  <div class="row">
-    <div class="col-4">
-      <div class="p-media-object">
-        <img src="https://assets.ubuntu.com/v1/439b2228-Confinement-small.svg" class="p-media-object__image" alt="">
-        <div class="p-media-object__details">
-          <h3 class="p-media-object__title">
-            <a href="https://snapcraft.io/docs/snap-confinement">Strict confinement </a>
-          </h3>
-          <p class="p-media-object__content p-heading--5" style="margin-bottom: 0;">Keep a bad app in its box</p>
-          <p class="p-media-object__content">You trust your developers, but anybody can make a mistake. We created and integrated a whole new armoury of Linux security capabilities to ensure applications stay confined to their own data.</p>
         </div>
-      </div>
-    </div>
-    <div class="col-4">
-      <div class="p-media-object">
-        <img src="https://assets.ubuntu.com/v1/0091c970-1C-10+year.svg" class="p-media-object__image" alt="">
-        <div class="p-media-object__details">
-          <h3 class="p-media-object__title">
-            10 year security update commitment
-          </h3>
-          <p class="p-media-object__content p-heading--5" style="margin-bottom: 0;">That's a decade of sleeping soundly</p>
-          <p class="p-media-object__content">Ubuntu Core gets 10 years of Canonical maintenance. Your smallest devices are now as secure as your servers. No other embedded Linux comes close.</p>
-        </div>
-      </div>
-    </div>
-    <div class="col-4">
-      <div class="p-media-object">
-        <img src="https://assets.ubuntu.com/v1/da8d1235-ubuntu-cof.svg" class="p-media-object__image" alt="">
-        <div class="p-media-object__details">
-          <h3 class="p-media-object__title">
-           Minimal core, minimal risk, minimal bugs
-          </h3>
-          <p class="p-media-object__content p-heading--5" style="margin-bottom: 0;">We stripped Ubuntu Core down to bare essentials</p>
-          <p class="p-media-object__content">Fewer packages to attack, fewer bugs to fix, fewer forced changes. We reduced the OS to reduce the attack surface. That leaves more disk for your applications and data.</p>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-4">
-      <div class="p-media-object">
-        <img src="https://assets.ubuntu.com/v1/7e5a3ee1-scan.svg" class="p-media-object__image" alt="">
-        <div class="p-media-object__details">
-          <h3 class="p-media-object__title">
-            Vulnerability scanning
-          </h3>
-          <p class="p-media-object__content p-heading--5" style="margin-bottom: 0;">We check for known weaknesses or risks</p>
-          <p class="p-media-object__content">Automatic scanning of all snaps for vulnerable libraries and problematic code keeps the Ubuntu Core ecosystem clean and healthy.</p>
-        </div>
-      </div>
-    </div>
-    <div class="col-4">
-      <div class="p-media-object">
-        <img src="https://assets.ubuntu.com/v1/1fbe51df-UC20_Full-disc-encryption.svg" class="p-media-object__image" alt="">
-        <div class="p-media-object__details">
-          <h3 class="p-media-object__title">
-            <a href="/core/features/full-disk-encryption">Full disk encryption</a>
-          </h3>
-          <p class="p-media-object__content p-heading--5" style="margin-bottom: 0;">Protect sensitive customer data</p>
-          <p class="p-media-object__content">Lock data to devices with hardware keys in TPM or TEE, and unlock disks for your system software only, to block a physical attack on sensitive information.</p>
-        </div>
-      </div>
-    </div>
-    <div class="col-4">
-      <div class="p-media-object">
-        <img src="https://assets.ubuntu.com/v1/6ed19d21-UC20_Secure_boot.svg" class="p-media-object__image" alt="">
-        <div class="p-media-object__details">
-          <h3 class="p-media-object__title">
-            <a href="/core/features/secure-boot">Secure boot</a>
-          </h3>
-          <p class="p-media-object__content p-heading--5" style="margin-bottom: 0;">System integrity with hardware trust</p>
-          <p class="p-media-object__content">Guarantee your entire fleet of devices runs the system software you select and resist low-level boot attacks on X86 and ARM.</p>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-4">
-      <div class="p-media-object">
-        <img src="https://assets.ubuntu.com/v1/4f70dabc-Kernel.svg" class="p-media-object__image" alt="">
-        <div class="p-media-object__details">
-          <h3 class="p-media-object__title">
-            <a href="/real-time">Real-time kernel</a>
-          </h3>
-          <p class="p-media-object__content p-heading--5" style="margin-bottom: 0;">Time-bound for mission-critical latency requirements</p>
-          <p class="p-media-object__content">The real-time kernel integrates the PREEMPT_RT patchset to reduce the kernel latencies as required by the most demanding workloads, guaranteeing a time-predictable task execution.</p>
-        </div>
-      </div>
-    </div>
-    <div class="col-4">
-      <div class="p-media-object">
-        <img src="https://assets.ubuntu.com/v1/a43d61ae-update+control.svg" class="p-media-object__image" alt="">
-        <div class="p-media-object__details">
-          <h3 class="p-media-object__title">
-            <a href="/core/features/ota-updates">OTA update control</a>
-          </h3>
-          <p class="p-media-object__content p-heading--5" style="margin-bottom: 0;">Decide which updates go to your devices</p>
-          <p class="p-media-object__content">Over the air updates guarantee secure software in any location. As a device manufacturer or a snap publisher, you decide which updates are signed, certified and delivered to your devices.</p>
-        </div>
-      </div>
-    </div>
-    <div class="col-4">
-      <div class="p-media-object">
-        <img src="https://assets.ubuntu.com/v1/1e7ead79-2B-app-store.svg" class="p-media-object__image" alt="">
-        <div class="p-media-object__details">
-          <h3 class="p-media-object__title">
-            <a href="/internet-of-things/appstore">IoT app store</a>
-          </h3>
-          <p class="p-media-object__content p-heading--5" style="margin-bottom: 0;">Software curation made easy</p>
-          <p class="p-media-object__content">Every device built with Ubuntu Core has a secure app store. Use the <a href="http://snapcraft.io">global store</a> for access to thousands of free applications. Curate your own software collection with a private, enterprise app store. </p>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-4">
-      <div class="p-media-object">
-        <img src="https://assets.ubuntu.com/v1/7e5a3ee1-scan.svg" class="p-media-object__image" alt="">
-        <div class="p-media-object__details">
-          <h3 class="p-media-object__title">
-            <a href="/core/features/recovery">Low-touch device recovery</a>
-          </h3>
-          <p class="p-media-object__content p-heading--5" style="margin-bottom: 0;">Remote device recovery in the field.</p>
-          <p class="p-media-object__content">Dramatically reduce the cost of field maintenance.</p>
-        </div>
-      </div>
-    </div>
-    <div class="col-4">
-      <div class="p-media-object">
-        <img src="https://assets.ubuntu.com/v1/7de21966-snapshot.svg" class="p-media-object__image" alt="">
-        <div class="p-media-object__details">
-          <h3 class="p-media-object__title">Snapshots for application data</h3>
-          <p class="p-media-object__content p-heading--5" style="margin-bottom: 0;">Standard mechanisms for application data management.</p>
-          <p class="p-media-object__content">Every device has apps which keep track of critical data. We make sure you can manage the data which matters to you, consistently, across all your Ubuntu Core devices. Backup and restore anything, anywhere.</p>
-        </div>
-      </div>
-    </div>
-    <div class="col-4">
-      <div class="p-media-object">
-        <img src="https://assets.ubuntu.com/v1/fc3ca86d-bullet+proof.svg" class="p-media-object__image" alt="">
-        <div class="p-media-object__details">
-          <h3 class="p-media-object__title">
-            <a href="/engage/snap-deltas">Transactional updates</a>
-          </h3>
-          <p class="p-media-object__content p-heading--5" style="margin-bottom: 0;">Preserve data, and rollback on error automatically</p>
-          <p class="p-media-object__content">Your power supply may not be reliable. Your devices will be. Resilience to adversity saves money and reputations. Rely on Ubuntu Core to deliver your software updates safely.</p>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-4">
-      <div class="p-media-object">
-        <img src="https://assets.ubuntu.com/v1/d82d3860-backup+boot+paths.svg" class="p-media-object__image" alt="">
-        <div class="p-media-object__details">
-          <h3 class="p-media-object__title">Backup boot paths</h3>
-          <p class="p-media-object__content p-heading--5" style="margin-bottom: 0;">Low-level updates preserve the prior boot path.</p>
-          <p class="p-media-object__content">When you have to update the kernel or the operating system you want to know you can go back if needed. Ubuntu Core keeps the last working boot so you always have a safety net.</p>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div class="u-fixed-width">
-    <p>Check the full list of <a href="/core/features">features&nbsp;&rsaquo;</a></p>
-    <p><a href="https://assets.ubuntu.com/v1/1870ea66-Ubuntu_Core22_DS.06.06.22.pdf" class="p-button">Read the Ubuntu Core datasheet</a></p>
-  </div>
-</section>
-<section class="p-strip is-deep is-bordered">
-  <div class="u-fixed-width">
-    <h2 class="u-sv3">Learn more about Ubuntu Core</h2>
-  </div>
-  <div class="row p-divider">
-    <div class="col-4 p-divider__block">
-      <div class="p-heading-icon--small">
-        <div class="p-heading-icon__header">
-          {{
-          image(
-          url="https://assets.ubuntu.com/v1/b061c401-White+paper.svg",
-          alt="",
-          height="28",
-          width="32",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class": "p-heading-icon__img"}
-          ) | safe
-          }}
-          <p class="p-heading-icon__title">Whitepaper</h4>
-        </div>
-      </div>
-      <h3 class="p-heading--4"><a href="/engage/embedded-linux-yocto-ubuntu-core-whitepaper" onclick="dataLayer.push({' event' : 'GAEvent' , 'eventCategory' : 'product page' , 'eventAction' : 'core - left' , 'eventLabel' : 'Whitepaper - Embedded Linux ' , 'eventValue' : '1' });">Embedded Linux: Yocto or Ubuntu Core?&nbsp;&rsaquo;</a></h3>
-    </div>
-    <div class="col-4 p-divider__block">
-      <div class="p-heading-icon--small">
-        <div class="p-heading-icon__header">
-          {{
-          image(
-          url="https://assets.ubuntu.com/v1/b061c401-White+paper.svg",
-          alt="",
-          height="28",
-          width="32",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class": "p-heading-icon__img"}
-          ) | safe
-          }}
-          <p class="p-heading-icon__title">Whitepaper</p>
-        </div>
-      </div>
-      <h3 class="p-heading--4"><a href="/engage/ubuntu-core-security-audit" onclick="dataLayer.push({' event' : 'GAEvent' , 'eventCategory' : 'Independent security audit' , 'eventAction' : 'core - left' , 'eventLabel' : 'Whitepaper - IMS Evolve ' , 'eventValue' : '1' });">An independent security audit of Ubuntu Core&nbsp;&rsaquo;</a></h3>
-    </div>
-    <div class="col-4 p-divider__block u-no-padding--bottom">
-      <div class="p-heading-icon--small">
-        <div class="p-heading-icon__header">
-          {{
-          image(
-          url="https://assets.ubuntu.com/v1/b061c401-White+paper.svg",
-          alt="",
-          height="28",
-          width="32",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class": "p-heading-icon__img"}
-          ) | safe
-          }}
-          <p class="p-heading-icon__title">Whitepaper</p>
-        </div>
-      </div>
-      <h3 class="p-heading--4"><a href="/engage/embedded-linux-make-or-buy/" onclick="dataLayer.push({' event' : 'GAEvent', 'eventCategory' : 'product page' , 'eventAction' : 'core - center' , 'eventLabel' : 'Whitepaper - Embedded Linux ' , 'eventValue' : '1' });">Embedded Linux: make or buy?&nbsp;&rsaquo;</a></h3>
-      <!-- rtp section center end -->
-    </div>
-  </div>
-
-  <div class="u-fixed-width">
-    <hr class="p-separator" />
-  </div>
-
-  <div class="row p-divider">
-    <div class="col-4 p-divider__block u-no-padding--top">
-      <!-- rtp section left start -->
-      <div class="p-heading-icon--small">
-        <div class="p-heading-icon__header">
+        <div class="p-logo-section__item">
           {{ image (
-          url="https://assets.ubuntu.com/v1/6e184942-Webinar.svg",
-          alt="",
-          width="88",
-          height="72",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class": "p-heading-icon__img"}
-          ) | safe
+            url="https://assets.ubuntu.com/v1/e7b81879-nvidia-logo.png",
+            alt="Nvidia",
+            width="94",
+            height="96",
+            hi_def=True,
+            attrs={"class": "p-logo-section__logo"},
+            loading="auto",
+            ) | safe
           }}
-          <p class="p-heading-icon__title">Webinar</p>
         </div>
-      </div>
-      <h3 class="p-heading--4"><a href="/engage/embedded-ubuntu-for-devices-webinar" onclick="dataLayer.push({' event' : 'GAEvent', 'eventCategory' : 'product page' , 'eventAction' : 'core - left' , 'eventLabel' : 'Webinar - Embedded Ubuntu for devices' , 'eventValue' : '1' });">Embedded Ubuntu for devices&nbsp;&rsaquo;</a></h3>
-      <!-- rtp section left end -->
-    </div>
-    <div class="col-4 p-divider__block">
-      <!-- rtp section left start -->
-      <div class="p-heading-icon--small">
-        <div class="p-heading-icon__header">
+        <div class="p-logo-section__item">
           {{ image (
-          url="https://assets.ubuntu.com/v1/6e184942-Webinar.svg",
-          alt="",
-          width="88",
-          height="72",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class": "p-heading-icon__img"}
-          ) | safe
+            url="https://assets.ubuntu.com/v1/9a25ec68-arm-logo.png",
+            alt="ARM",
+            width="47",
+            height="96",
+            hi_def=True,
+            attrs={"class": "p-logo-section__logo"},
+            loading="auto",
+            ) | safe
           }}
-          <p class="p-heading-icon__title">Webinar</p>
         </div>
-      </div>
-      <h3 class="p-heading--4"><a href="/engage/intro-to-ubuntu-core22-webinar" onclick="dataLayer.push({' event' : 'GAEvent' , 'eventCategory' : 'Independent security audit' , 'eventAction' : 'core - left' , 'eventLabel' : 'Webinar - Introduction to Ubuntu Core 22' , 'eventValue' : '1' });">Introduction to Ubuntu Core 22&nbsp;&rsaquo;</a></h3>
-      <!-- rtp section left end -->
-    </div>
-    <div class="col-4 p-divider__block">
-      <!-- rtp section center start -->
-      <div class="p-heading-icon--small">
-        <div class="p-heading-icon__header">
+        <div class="p-logo-section__item">
           {{ image (
-          url="https://assets.ubuntu.com/v1/6e184942-Webinar.svg",
-          alt="",
-          width="88",
-          height="72",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class": "p-heading-icon__img"}
-          ) | safe
+            url="https://assets.ubuntu.com/v1/31b259ec-qualcom-logo.png",
+            alt="Qualcom",
+            width="96",
+            height="96",
+            hi_def=True,
+            attrs={"class": "p-logo-section__logo"},
+            loading="auto",
+            ) | safe
           }}
-          <p class="p-heading-icon__title">Webinar</p>
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/d65da7f3-advantech-logo.png",
+            alt="Advantech",
+            width="95",
+            height="96",
+            hi_def=True,
+            attrs={"class": "p-logo-section__logo"},
+            loading="auto",
+            ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/6eff0263-adlink-logo.png",
+            alt="Adlink",
+            width="101",
+            height="96",
+            hi_def=True,
+            attrs={"class": "p-logo-section__logo"},
+            loading="auto",
+            ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/be8db080-nxp-logo.png",
+            alt="Nxp",
+            width="41",
+            height="96",
+            hi_def=True,
+            attrs={"class": "p-logo-section__logo"},
+            loading="auto",
+            ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
+            url="https://assets.ubuntu.com/v1/96d65ee2-mediatek-logo.png",
+            alt="Mediatech",
+            width="77",
+            height="96",
+            hi_def=True,
+            attrs={"class": "p-logo-section__logo"},
+            loading="auto",
+            ) | safe
+          }}
         </div>
       </div>
-      <h3 class="p-heading--4"><a href="https://www.brighttalk.com/webcast/6793/535454" onclick="dataLayer.push({'event' : 'GAEvent' , 'eventCategory' : 'product page' , 'eventAction' : 'core - center' , 'eventLabel' : 'Webinar - Yocto or Ubuntu Core?' , 'eventValue' : '1' });">Yocto or Ubuntu Core?&nbsp;&rsaquo;</a></h3>
-      <!-- rtp section center end -->
     </div>
   </div>
-</section>
-
-<section class="p-strip">
-  <div class="row u-vertically-center">
-    <div class="col-8">
-      <h2>Tamper-resistant and hardened</h2>
-      <p class="p-heading--4 u-no-margin--bottom">Every aspect of the system is checked and verified.</p>
-    </div>
-  </div>
-  <div class="row u-vertically-center">
-    <div class="col-6">
-      <p>You need to know your software is pristine; not just for installation, but for the lifetime of the device.</p>
-      <p>Immutable packages and persistent digital signatures mean Ubuntu Core can verify any software component at any time, to guard against corruption and attack.</p>
+  <div class="row">
+    <hr class="p-rule" />
+    <div class="col-start-large-7 col-3 col-medium-2 col-start-medium-3">
       <p>
-        <a href="/engage/ubuntu-core-security-audit">Read an independent security audit of Ubuntu Core&nbsp;&rsaquo;</a>
+        <a href="/certified">Browse all certified hardware&nbsp;&rsaquo;</a>
       </p>
     </div>
-    <div class="col-6 u-hide--medium u-hide--small u-align--center u-vertically-center">
-      {{
-        image(
-        url="https://assets.ubuntu.com/v1/ad33af0c-Shield.svg",
-        alt="",
-        height="200",
-        width="200",
-        hi_def=True,
-        loading="lazy"
-        ) | safe
-      }}
+    <div class="col-3 col-medium-2">
+      <p>
+        <a href="/core/contact-us">Contact us&nbsp;&rsaquo;</a>
+      </p>
     </div>
   </div>
 </section>
 
-
-<section class="p-strip--light is-deep" id="built-for-business">
-  <div class="row u-vertically-center">
-    <div class="col-8">
-      <h2>Built for business</h2>
-      <p class="p-heading--4 u-no-margin--bottom">Bring your applications, we take care of the rest.</p>
+<section class="p-section">
+  <div class="row--50-50">
+    <hr class="p-rule" />
+    <div class="col">
+      <h2>Learn more about Ubuntu Core</h2>
     </div>
-  </div>
-</section>
-
-<section class="p-strip">
-  <div class="row u-vertically-center u-equal-height">
-    <div class="col-6">
-      <h3 class="p-heading--4">Enterprise management</h3>
-      <p class="p-heading--5">Absolute control over every device in the building.</p>
-      <p>Enterprises gain complete control over every app on every device on the network, regardless of manufacturer. Know exactly which kernel version and which apps are running.</p>
-    </div>
-    <div class="col-6 u-hide--medium u-hide--small u-align--center u-vertically-center">
-      {{ image (
-        url="https://assets.ubuntu.com/v1/e68fd355-1+discovery_AW.svg",
-        alt="",
-        width="350",
-        height="200",
-        hi_def=True,
-        loading="lazy"
-        ) | safe
-      }}
-    </div>
-  </div>
-
-  <div class="u-fixed-width">
-    <hr class="p-separator" />
-  </div>
-
-  <div class="row u-vertically-center">
-    <div class="col-6 u-hide--medium u-hide--small u-align--center">
-      {{
-        image(
-        url="https://assets.ubuntu.com/v1/4e20332d-mission+critical+support.svg",
-        alt="",
-        height="200",
-        width="350",
-        hi_def=True,
-        loading="lazy"
-        ) | safe
-      }}
-    </div>
-    <div class="col-6">
-      <h3 class="p-heading--4">Mission critical support</h3>
-      <p class="p-heading--5">Canonical supports Ubuntu Core devices</p>
-      <p>World class support - for product teams and enterprise customers. Get to the heart of a problem faster, get fixes straight from the source.</p>
-      <p><a href="/core/contact-us?product=core-overview" class="p-button--positive js-invoke-modal">Contact us</a></p>
-    </div>
-  </div>
-</section>
-
-<section class="p-strip--light" id="developers-love-ubuntu">
-  <div class="row u-vertically-center">
-    <div class="col-8">
-      <h2>Developers love Ubuntu</h2>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-5">
-      <p class="p-heading--4">Your business is software defined.<br>Keep developers happy and productive.</p>
-    </div>
-    <div class="col-6 col-start-large-7">
-      <ul class="p-list">
-        <li class="p-list__item is-ticked">Happy developers create amazing products</li>
-        <li class="p-list__item is-ticked">Amazing products attract more great developers</li>
-        <li class="p-list__item is-ticked">8/10 Linux developers choose Ubuntu</li>
+    <div class="col">
+      <ul class="p-list--divided">
+        <li class="p-list__item">
+          <div class="row--50-50">
+            <div class="col">
+              <p class="p-heading--5">Docs</p>
+            </div>
+            <div class="col">
+              <p>
+                <a href="/core/docs/getting-started">Start your Core journey today</a>
+              </p>
+            </div>
+          </div>
+        </li>
+        <li class="p-list__item">
+          <div class="row--50-50">
+            <div class="col">
+              <p class="p-heading--5">Features</p>
+            </div>
+            <div class="col">
+              <p>
+                <a href="/core/features">Discover everything that Core offers you</a>
+              </p>
+            </div>
+          </div>
+        </li>
+        <li class="p-list__item">
+          <div class="row--50-50">
+            <div class="col">
+              <p class="p-heading--5">Customer stories</p>
+            </div>
+            <div class="col">
+              <p>
+                <a href="/core/stories">Find out how our users are finding success with Core</a>
+              </p>
+            </div>
+          </div>
+        </li>
+        <li class="p-list__item">
+          <div class="row--50-50">
+            <div class="col">
+              <p class="p-heading--5">White papers</p>
+            </div>
+            <div class="col">
+              <p>
+                <a href="/engage/ubuntu-core-security-audit">An independent security audit of Ubuntu Core</a>
+              </p>
+              <hr />
+              <p>
+                <a href="/engage/embedded-linux-make-or-buy/">Embedded Linux: make or buy?</a>
+              </p>
+            </div>
+          </div>
+        </li>
+        <li class="p-list__item">
+          <div class="row--50-50">
+            <div class="col">
+              <p class="p-heading--5">Webinar</p>
+            </div>
+            <div class="col">
+              <p>
+                <a href="/engage/intro-to-ubuntu-core22-webinar#:~:text=With%204%20releases%20behind%2C%20Ubuntu,edge%20devices%20makers%20must%20face.">Introduction to Ubuntu Core 22</a>
+              </p>
+            </div>
+          </div>
+        </li>
       </ul>
     </div>
   </div>
 </section>
 
-<section class="p-strip" style="padding-bottom: 150px;">
-  <div class="row u-vertically-center">
-    <div class="col-6">
-      <h3 class="p-heading--4">One platform from cloud to device</h3>
-      <p class="p-heading--5">Bring apps from Ubuntu Server to Ubuntu Core</p>
-      <p>Snaps run on Ubuntu Server, Desktop and Core. One platform, one process. Your developer workstation, your build farm, your cloud and servers all use snaps. Your appliances can too, with extra security.</p>
-      <p><a class="p-button" href="https://snapcraft.io/">Build your IoT application with Snapcraft</a></p>
+<section class="p-strip is-deep u-no-padding--top">
+  <div class="row--50-50">
+    <hr class="p-rule" />
+    <div class="col">
+      <h2>Ready to innovate?</h2>
     </div>
-    <div class="col-6 u-hide--medium u-hide--small u-align--center">
-      {{
-      image(
-      url="https://assets.ubuntu.com/v1/3089fff7-one+platform.svg",
-      alt="",
-      height="230",
-      width="350",
-      hi_def=True,
-      loading="lazy"
-      ) | safe
-      }}
-    </div>
-  </div>
-
-  <div class="u-fixed-width">
-    <hr class="p-separator" />
-  </div>
-
-  <div class="row u-vertically-center">
-    <div class="col-6 u-hide--medium u-hide--small u-align--center">
-      {{
-      image(
-      url="https://assets.ubuntu.com/v1/6ec5c97f-embedded-linux_AW.svg",
-      alt="",
-      height="200",
-      width="332",
-      hi_def=True,
-      loading="lazy"
-      ) | safe
-      }}
-    </div>
-    <div class="col-6">
-      <h3 class="p-heading--4">Embedded Linux is easy on Ubuntu</h3>
-      <p class="p-heading--5">We handle the board, you handle the apps</p>
-      <p>No bad BSPs. No maintenance nightmares. No integration delays. Just develop on Ubuntu. Embedded, but not as you knew it.</p>
-    </div>
-  </div>
-
-  <div class="u-fixed-width">
-    <hr class="p-separator" />
-  </div>
-
-  <div class="row u-vertically-center">
-    <div class="col-6">
-      <h3 class="p-heading--4">Deploy to devices as fast as the cloud</h3>
-      <p class="p-heading--5">Continuous deployment on devices</p>
-      <p>Put your devices on rails for rapid iteration with continuous deployment pipelines, beta testing and canary updates. Featuring Travis integration and a multi-arch build service.</p>
-      <p>
-        <a href="https://snapcraft.io/build" class="p-button"><span>More about CI/CD with Snapcraft</span></a>
-      </p>
-    </div>
-    <div class="col-6 u-hide--medium u-hide--small u-align--center">
-      {{
-      image(
-      url="https://assets.ubuntu.com/v1/f887a7db-deploy+fast.svg",
-      alt="",
-      height="200",
-      width="350",
-      hi_def=True,
-      loading="lazy"
-      ) | safe
-      }}
-    </div>
-  </div>
-
-  <div class="u-fixed-width">
-    <hr class="p-separator" />
-  </div>
-
-  <div class="row u-vertically-center">
-    <div class="col-6 u-hide--medium u-hide--small u-align--center">
-      {{
-      image(
-      url="https://assets.ubuntu.com/v1/e59fb1a3-GitHub_Logo.svg",
-      alt="",
-      height="54",
-      width="200",
-      hi_def=True,
-      loading="lazy"
-      ) | safe
-      }}
-    </div>
-    <div class="col-6">
-      <h3 class="p-heading--4">Harness all things open source</h3>
-      <p class="p-heading--5">From GitHub to Ubuntu Core in minutes.</p>
-      <p>Ride the open source wave, or build your own community. Open source projects default to Ubuntu, so building is easy.</p>
-      <p><a href="/core/contact-us?product=core-overview" class="p-button--positive js-invoke-modal">Contact us</a></p>
-    </div>
-  </div>
-</section>
-<section class="p-strip--square-suru is-slanted--top-right">
-  <div class="row">
-    <h2>Get to market fast with the strong ecosystem of our device partners and certified hardware</h2>
-    <p>
-      <a class="p-button--positive" href="/core/services">Launch your smart product</a>
-    </p>
-  </div>
-</section>
-<section class="p-strip">
-  <div class="row p-divider">
-    <div class="col-4 p-divider__block">
-      <h3 class="p-heading--4">Download Ubuntu Core</h3>
-      <p>Try Ubuntu Core 22 on a popular development board</p>
-      <p><a class="p-button" href="https://cdimage.ubuntu.com/ubuntu-core/22/stable/current/">Download and install Ubuntu Core 22</a></p>
-    </div>
-    <div class="col-4 p-divider__block">
-      <h3 class="p-heading--4">Make your own Ubuntu Core device</h3>
-      <p>Walk through the steps to build an image for a device.</p>
-      <p><a class="p-button" href="/core/docs/image-building">Build a custom Ubuntu Core image</a></p>
-    </div>
-    <div class="col-4 p-divider__block">
-      <h3 class="p-heading--4">Let's work together</h3>
-      <p>Talk to us about using Ubuntu Core for your next project.</p>
-      <p><a href="/core/contact-us?product=core-overview" class="p-button--positive js-invoke-modal">Get in touch</a>
-      </p>
+    <div class="col">
+      <p class="p-section--shallow">Whether you are a startup bringing your concept to market or already have large fleets of devices deployed in the field, we have the expertise and infrastructure to launch and support you.</p>
+      <hr />
+      <a class="p-button--positive" href="/core/contact-us">Get in touch</a>
     </div>
   </div>
 </section>
 
 <!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/internet-of-things" data-form-id="1266" data-lp-id="2166" data-return-url="https://ubuntu.com/core/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
+<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/internet-of-things"
+  data-form-id="1266" data-lp-id="2166" data-return-url="https://ubuntu.com/core/thank-you"
+  data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
-
-<script src="{{ versioned_static('js/dist/random-partner-logos.js') }}"></script>
 
 {% endblock content %}

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -25,15 +25,12 @@ meta_copydoc %}
                 <div class="p-section--shallow">
                     <p class="p-heading--2">
                         The embedded Linux OS
-                        <br />
+                        <br class="u-hide--small u-hide--medium"/>
                         for devices
                     </p>
                 </div>
                 <div class="p-section--shallow">
-                    <p class="p-heading--4 u-hide--small u-hide--medium">
-                        Ubuntu Core is a minimal, secure and strictly confined operating system powering devices around the world. Build your Ubuntu Core image today.
-                    </p>
-                    <p class="u-hide--large">
+                    <p>
                         Ubuntu Core is a minimal, secure and strictly confined operating system powering devices around the world. Build your Ubuntu Core image today.
                     </p>
                 </div>
@@ -75,90 +72,94 @@ meta_copydoc %}
                 <p>Ubuntu Core will transform the way you deploy devices with the longest support window in the industry.</p>
             </div>
         </div>
-        <div class="p-equal-height-row has-3rd-divider">
+        <div class="p-equal-height-row u-no-padding--bottom p-section--shallow">
             <div class="p-equal-height-row__col">
-                <div class="p-equal-height-row__item u-hide--small u-hide--medium">
-                    <div class="p-media-container">
+                <div class="p-equal-height-row__item">
+                    <div class="p-media-container u-hide--small u-hide--medium">
                         <img width="320"
                              src="https://assets.ubuntu.com/v1/834e417a-continuous-security.jpg"
                              alt="" />
                     </div>
-                </div>
-                <div class="p-equal-height-row__item">
-                    <hr class="p-rule--highlight u-hide--medium u-hide--small is-muted" />
-                    <h3 class="p-heading--5">Continuous security</h3>
+                    <div class="p-equal-height-row__item">
+                        <hr class="p-rule--highlight u-hide--medium u-hide--small is-muted" />
+                        <h3 class="p-heading--5">Continuous security</h3>
+                    </div>
                 </div>
                 <p class="p-equal-height-row__item">
                     Imagine a world where every device is trustworthy. We designed every aspect of Ubuntu Core to create the most
                     secure embedded Linux ever, with a 10 year LTS commitment.
                 </p>
                 <div class="p-equal-height-row__item">
+                    <hr class="p-rule is-muted u-hide--small">
                     <p>
                         <a href="/security">Learn more about Ubuntu security&nbsp;&rsaquo;</a>
                     </p>
                 </div>
             </div>
             <div class="p-equal-height-row__col">
-                <div class="p-equal-height-row__item u-hide--small u-hide--medium">
-                    <div class="p-media-container">
+                <div class="p-equal-height-row__item">
+                    <div class="p-media-container u-hide--small u-hide--medium">
                         <img width="320"
                              src="https://assets.ubuntu.com/v1/d1d161a9-fleet-management.jpg"
                              alt="" />
                     </div>
-                </div>
-                <div class="p-equal-height-row__item">
-                    <hr class="p-rule--highlight u-hide--medium u-hide--small is-muted" />
-                    <h3 class="p-heading--5">Device management</h3>
+                    <div class="p-equal-height-row__item">
+                        <hr class="p-rule--highlight u-hide--medium u-hide--small is-muted" />
+                        <h3 class="p-heading--5">Device management</h3>
+                    </div>
                 </div>
                 <p class="p-equal-height-row__item">
                     Enjoy reliable, remotely accessible and recoverable devices which are always up-to-date with mission-critical
                     OTA updates. In connected or air-gap environments.
                 </p>
                 <div class="p-equal-height-row__item">
+                    <hr class="p-rule is-muted u-hide--small">
                     <p>
                         <a href="/internet-of-things/management">Learn more about fleet management&nbsp;&rsaquo;</a>
                     </p>
                 </div>
             </div>
             <div class="p-equal-height-row__col">
-                <div class="p-equal-height-row__item u-hide--small u-hide--medium">
-                    <div class="p-media-container">
+                <div class="p-equal-height-row__item">
+                    <div class="p-media-container u-hide--small u-hide--medium">
                         <img width="320"
                              src="https://assets.ubuntu.com/v1/373f7039-agile-containerisation.png"
                              alt="" />
                     </div>
-                </div>
-                <div class="p-equal-height-row__item">
-                    <hr class="p-rule--highlight u-hide--medium u-hide--small is-muted" />
-                    <h3 class="p-heading--5">Agile containerisation</h3>
+                    <div class="p-equal-height-row__item">
+                        <hr class="p-rule--highlight u-hide--medium u-hide--small is-muted" />
+                        <h3 class="p-heading--5">Agile containerisation</h3>
+                    </div>
                 </div>
                 <p class="p-equal-height-row__item">
                     Ubuntu Core is immutable and strictly confined. There is a clean separation between the kernel, OS image and
                     applications, each updated independently and protected against corruption.
                 </p>
                 <div class="p-equal-height-row__item">
+                    <hr class="p-rule is-muted u-hide--small">
                     <p>
                         <a href="/core/docs/components#heading--confinement">Learn more about confinement&nbsp;&rsaquo;</a>
                     </p>
                 </div>
             </div>
             <div class="p-equal-height-row__col">
-                <div class="p-equal-height-row__item u-hide--small u-hide--medium">
-                    <div class="p-media-container">
+                <div class="p-equal-height-row__item">
+                    <div class="p-media-container u-hide--small u-hide--medium">
                         <img width="320"
                              src="https://assets.ubuntu.com/v1/166ec7c6-hardware-ecosystem.jpg"
                              alt="" />
                     </div>
-                </div>
-                <div class="p-equal-height-row__item">
-                    <hr class="p-rule--highlight u-hide--medium u-hide--small is-muted" />
-                    <h3 class="p-heading--5">A strong hardware ecosystem</h3>
+                    <div class="p-equal-height-row__item">
+                        <hr class="p-rule--highlight u-hide--medium u-hide--small is-muted" />
+                        <h3 class="p-heading--5">A strong hardware ecosystem</h3>
+                    </div>
                 </div>
                 <p class="p-equal-height-row__item">
                     We enable Ubuntu Core with the best ODMs and silicon vendors in the world. We continuously test it on leading
                     IoT and edge devices and hardware.
                 </p>
                 <div class="p-equal-height-row__item">
+                    <hr class="p-rule is-muted u-hide--small">
                     <p>
                         <a href="/certified">Browse all certified hardware&nbsp;&rsaquo;</a>
                     </p>
@@ -192,8 +193,8 @@ meta_copydoc %}
             </div>
         </div>
         <div class="row">
-            <hr class="is-muted col-9 col-start-large-4 col-medium-6 col-start-medium-2" />
-            <div class="col-3 col-medium-2 col-start-large-4 col-start-medium-2">
+            <hr class="is-muted col-9 col-start-large-4" />
+            <div class="col-3 col-medium-3 col-start-large-4">
                 <ul class="js-tabbed-content p-tabs--vertical is-black u-hide--small"
                     role="tablist"
                     aria-label="Dev to deployment">
@@ -246,8 +247,8 @@ meta_copydoc %}
             <div class="col-6 col-medium-3">{% include "core/tabs.html" %}</div>
         </div>
         <div class="row">
-            <hr class="is-muted col-9 col-start-large-4 col-medium-6 col-start-medium-2" />
-            <div class="col-6 col-start-large-7 col-medium-4 col-start-medium-4">
+            <div class="col-6 col-start-large-4">
+                <hr class="p-rule is-muted" />
                 <p>
                     <a href="/core/docs">Get started with Ubuntu Core&nbsp;&rsaquo;</a>
                 </p>
@@ -268,11 +269,11 @@ meta_copydoc %}
                         <a href="/automotive">
                             <h3 class="p-heading--5">Automotive</h3>
                             {{ image(url="https://assets.ubuntu.com/v1/f867c883-For-smart-use-cases__Automotivew.png",
-                                                        alt="",
-                                                        width="285",
-                                                        height="160",
-                                                        hi_def=True,
-                                                        loading="auto",) | safe
+                                alt="",
+                                width="285",
+                                height="160",
+                                hi_def=True,
+                                loading="auto",) | safe
                             }}
                         </a>
                     </div>
@@ -280,11 +281,11 @@ meta_copydoc %}
                         <a href="/industrial">
                             <h3 class="p-heading--5">Industrial</h3>
                             {{ image(url="https://assets.ubuntu.com/v1/0162bc71-For-smart-use-cases__Industrial.png",
-                                                        alt="",
-                                                        width="285",
-                                                        height="160",
-                                                        hi_def=True,
-                                                        loading="auto",) | safe
+                                alt="",
+                                width="285",
+                                height="160",
+                                hi_def=True,
+                                loading="auto",) | safe
                             }}
                         </a>
                     </div>
@@ -292,11 +293,11 @@ meta_copydoc %}
                         <a href="/robotics">
                             <h3 class="p-heading--5">Robotics</h3>
                             {{ image(url="https://assets.ubuntu.com/v1/aeeeb32d-For-smart-use-cases__Robotics.png",
-                                                        alt="",
-                                                        width="285",
-                                                        height="160",
-                                                        hi_def=True,
-                                                        loading="auto",) | safe
+                                alt="",
+                                width="285",
+                                height="160",
+                                hi_def=True,
+                                loading="auto",) | safe
                             }}
                         </a>
                     </div>
@@ -396,11 +397,11 @@ meta_copydoc %}
                 <div class="row u-no-margin--bottom">
                     <div class="col-3 col-medium-2">
                         {{ image(url="https://assets.ubuntu.com/v1/ffd88101-rexroth-for-testimonial.png",
-                                                alt="Rexroth",
-                                                width="284",
-                                                height="70",
-                                                hi_def=True,
-                                                loading="auto",) | safe
+                            alt="Rexroth",
+                            width="284",
+                            height="70",
+                            hi_def=True,
+                            loading="auto",) | safe
                         }}
                     </div>
                     <div class="col-9 col-medium-4 u-no-margin--top">
@@ -418,11 +419,11 @@ meta_copydoc %}
                         </div>
                         <div>
                             {{ image(url="https://assets.ubuntu.com/v1/2d152c25-rexroth-testimonial-image.jpg",
-                                                        alt="Rexroth",
-                                                        width="917",
-                                                        height="392",
-                                                        hi_def=True,
-                                                        loading="auto",) | safe
+                                alt="Rexroth",
+                                width="917",
+                                height="392",
+                                hi_def=True,
+                                loading="auto",) | safe
                             }}
                         </div>
                     </div>
@@ -435,12 +436,12 @@ meta_copydoc %}
                  aria-hidden="hidden">
                 <div class="row u-no-margin--bottom">
                     <div class="col-3 col-medium-2">
-                        {{ image(url="https://assets.ubuntu.com/v1/ea8fc1a8-pudo-testimonial-logo.png",
-                                                alt="Pudo",
-                                                width="125",
-                                                height="55",
-                                                hi_def=True,
-                                                loading="auto",) | safe
+                        {{ image(url="https://assets.ubuntu.com/v1/36c27b25-pudo-testimonial-logo-new.png",
+                            alt="Pudo",
+                            width="125",
+                            height="56",
+                            hi_def=True,
+                            loading="auto",) | safe
                         }}
                     </div>
                     <div class="col-9 col-medium-4 u-no-margin--top">
@@ -458,11 +459,11 @@ meta_copydoc %}
                         </div>
                         <div>
                             {{ image(url="https://assets.ubuntu.com/v1/576c8402-pudo-testimonial-image.jpg",
-                                                        alt="Pudo",
-                                                        width="917",
-                                                        height="392",
-                                                        hi_def=True,
-                                                        loading="auto",) | safe
+                                alt="Pudo",
+                                width="917",
+                                height="392",
+                                hi_def=True,
+                                loading="auto",) | safe
                             }}
                         </div>
                     </div>
@@ -476,11 +477,11 @@ meta_copydoc %}
                 <div class="row u-no-margin--bottom">
                     <div class="col-3 col-medium-2">
                         {{ image(url="https://assets.ubuntu.com/v1/80f5af45-rigado-testimonial-logo.png",
-                                                alt="Rigado",
-                                                width="170",
-                                                height="26",
-                                                hi_def=True,
-                                                loading="auto",) | safe
+                            alt="Rigado",
+                            width="217",
+                            height="51",
+                            hi_def=True,
+                            loading="auto",) | safe
                         }}
                     </div>
                     <div class="col-9 col-medium-4 u-no-margin--top">
@@ -498,11 +499,11 @@ meta_copydoc %}
                         </div>
                         <div>
                             {{ image(url="https://assets.ubuntu.com/v1/297369c0-rigado--testimonial-image.jpg",
-                                                        alt="Rigado",
-                                                        width="917",
-                                                        height="392",
-                                                        hi_def=True,
-                                                        loading="auto",) | safe
+                                alt="Rigado",
+                                width="917",
+                                height="392",
+                                hi_def=True,
+                                loading="auto",) | safe
                             }}
                         </div>
                     </div>
@@ -515,12 +516,12 @@ meta_copydoc %}
                  aria-hidden="hidden">
                 <div class="row u-no-margin--bottom">
                     <div class="col-3 col-medium-2">
-                        {{ image(url="https://assets.ubuntu.com/v1/e110996e-ibm-cloud-testimonial-logo.png",
-                                                alt="IBM",
-                                                width="190",
-                                                height="57",
-                                                hi_def=True,
-                                                loading="auto",) | safe
+                        {{ image(url="https://assets.ubuntu.com/v1/134756c3-ibm-cloud-testimonial-logo.png",
+                            alt="IBM",
+                            width="190",
+                            height="58",
+                            hi_def=True,
+                            loading="auto",) | safe
                         }}
                     </div>
                     <div class="col-9 col-medium-4 u-no-margin--top">
@@ -540,17 +541,16 @@ meta_copydoc %}
                         </div>
                         <div>
                             {{ image(url="https://assets.ubuntu.com/v1/534be2a2-ibm-leadspace.jpg",
-                                                        alt="IBM",
-                                                        width="917",
-                                                        height="392",
-                                                        hi_def=True,
-                                                        loading="auto",) | safe
+                                alt="IBM",
+                                width="917",
+                                height="392",
+                                hi_def=True,
+                                loading="auto",) | safe
                             }}
                         </div>
                     </div>
                 </div>
             </div>
-
         </div>
     </section>
 
@@ -564,92 +564,92 @@ meta_copydoc %}
                 <div class="p-logo-section__items">
                     <div class="p-logo-section__item">
                         {{ image(url="https://assets.ubuntu.com/v1/59996fad-intel-new-logo.png",
-                                                alt="Intel",
-                                                width="50",
-                                                height="96",
-                                                hi_def=True,
-                                                attrs={"class": "p-logo-section__logo"},
-                                                loading="auto",) | safe
+                            alt="Intel",
+                            width="50",
+                            height="96",
+                            hi_def=True,
+                            attrs={"class": "p-logo-section__logo"},
+                            loading="auto",) | safe
                         }}
                     </div>
                     <div class="p-logo-section__item">
                         {{ image(url="https://assets.ubuntu.com/v1/4bf8a9bc-amd-logo.png",
-                                                alt="AMD",
-                                                width="69",
-                                                height="96",
-                                                hi_def=True,
-                                                attrs={"class": "p-logo-section__logo"},
-                                                loading="auto",) | safe
+                            alt="AMD",
+                            width="69",
+                            height="96",
+                            hi_def=True,
+                            attrs={"class": "p-logo-section__logo"},
+                            loading="auto",) | safe
                         }}
                     </div>
                     <div class="p-logo-section__item">
                         {{ image(url="https://assets.ubuntu.com/v1/e7b81879-nvidia-logo.png",
-                                                alt="Nvidia",
-                                                width="94",
-                                                height="96",
-                                                hi_def=True,
-                                                attrs={"class": "p-logo-section__logo"},
-                                                loading="auto",) | safe
+                            alt="Nvidia",
+                            width="94",
+                            height="96",
+                            hi_def=True,
+                            attrs={"class": "p-logo-section__logo"},
+                            loading="auto",) | safe
                         }}
                     </div>
                     <div class="p-logo-section__item">
                         {{ image(url="https://assets.ubuntu.com/v1/9a25ec68-arm-logo.png",
-                                                alt="ARM",
-                                                width="47",
-                                                height="96",
-                                                hi_def=True,
-                                                attrs={"class": "p-logo-section__logo"},
-                                                loading="auto",) | safe
+                            alt="ARM",
+                            width="47",
+                            height="96",
+                            hi_def=True,
+                            attrs={"class": "p-logo-section__logo"},
+                            loading="auto",) | safe
                         }}
                     </div>
                     <div class="p-logo-section__item">
                         {{ image(url="https://assets.ubuntu.com/v1/31b259ec-qualcom-logo.png",
-                                                alt="Qualcom",
-                                                width="96",
-                                                height="96",
-                                                hi_def=True,
-                                                attrs={"class": "p-logo-section__logo"},
-                                                loading="auto",) | safe
+                            alt="Qualcom",
+                            width="96",
+                            height="96",
+                            hi_def=True,
+                            attrs={"class": "p-logo-section__logo"},
+                            loading="auto",) | safe
                         }}
                     </div>
                     <div class="p-logo-section__item">
                         {{ image(url="https://assets.ubuntu.com/v1/d65da7f3-advantech-logo.png",
-                                                alt="Advantech",
-                                                width="95",
-                                                height="96",
-                                                hi_def=True,
-                                                attrs={"class": "p-logo-section__logo"},
-                                                loading="auto",) | safe
+                            alt="Advantech",
+                            width="95",
+                            height="96",
+                            hi_def=True,
+                            attrs={"class": "p-logo-section__logo"},
+                            loading="auto",) | safe
                         }}
                     </div>
                     <div class="p-logo-section__item">
                         {{ image(url="https://assets.ubuntu.com/v1/6eff0263-adlink-logo.png",
-                                                alt="Adlink",
-                                                width="101",
-                                                height="96",
-                                                hi_def=True,
-                                                attrs={"class": "p-logo-section__logo"},
-                                                loading="auto",) | safe
+                            alt="Adlink",
+                            width="101",
+                            height="96",
+                            hi_def=True,
+                            attrs={"class": "p-logo-section__logo"},
+                            loading="auto",) | safe
                         }}
                     </div>
                     <div class="p-logo-section__item">
                         {{ image(url="https://assets.ubuntu.com/v1/be8db080-nxp-logo.png",
-                                                alt="NXP",
-                                                width="41",
-                                                height="96",
-                                                hi_def=True,
-                                                attrs={"class": "p-logo-section__logo"},
-                                                loading="auto",) | safe
+                            alt="NXP",
+                            width="41",
+                            height="96",
+                            hi_def=True,
+                            attrs={"class": "p-logo-section__logo"},
+                            loading="auto",) | safe
                         }}
                     </div>
                     <div class="p-logo-section__item">
                         {{ image(url="https://assets.ubuntu.com/v1/96d65ee2-mediatek-logo.png",
-                                                alt="MediaTeK",
-                                                width="77",
-                                                height="96",
-                                                hi_def=True,
-                                                attrs={"class": "p-logo-section__logo"},
-                                                loading="auto",) | safe
+                            alt="MediaTeK",
+                            width="77",
+                            height="96",
+                            hi_def=True,
+                            attrs={"class": "p-logo-section__logo"},
+                            loading="auto",) | safe
                         }}
                     </div>
                 </div>
@@ -678,58 +678,58 @@ meta_copydoc %}
             </div>
             <div class="col">
                 <div class="row">
-                    <div class="col-3">
+                    <div class="col-3 col-medium-1">
                         <h5 class="p-heading--5">Docs</h5>
                     </div>
-                    <div class="col-3">
+                    <div class="col-3 col-medium-2">
                         <p>
-                            <a href="/core/docs/getting-started">Start your Core journey today</a>
+                            <a href="/core/docs/getting-started">Start your&nbsp;Core journey today</a>
                         </p>
                     </div>
                 </div>
                 <hr class="is-muted p-rule" />
                 <div class="row">
-                    <div class="col-3">
+                    <div class="col-3 col-medium-1">
                         <h5 class="p-heading--5">Features</h5>
                     </div>
-                    <div class="col-3">
+                    <div class="col-3 col-medium-2">
                         <p>
-                            <a href="/core/features">Discover everything that Core offers you</a>
+                            <a href="/core/features">Discover everything that Core offers&nbsp;you</a>
                         </p>
                     </div>
                 </div>
                 <hr class="is-muted p-rule" />
                 <div class="row">
-                    <div class="col-3">
+                    <div class="col-3 col-medium-1">
                         <h5 class="p-heading--5">Customer stories</h5>
                     </div>
-                    <div class="col-3">
+                    <div class="col-3 col-medium-2">
                         <p>
-                            <a href="/core/stories">Find out how our users are finding success with Core</a>
+                            <a href="/core/stories">Find out how our users are finding success with&nbsp;Core</a>
                         </p>
                     </div>
                 </div>
                 <hr class="is-muted p-rule" />
                 <div class="row">
-                    <div class="col-3">
+                    <div class="col-3 col-medium-1">
                         <h5 class="p-heading--5">White papers</h5>
                     </div>
-                    <div class="col-3">
+                    <div class="col-3 col-medium-2">
                         <p>
-                            <a href="/engage/ubuntu-core-security-audit">An independent security audit of Ubuntu Core</a>
+                            <a href="/engage/ubuntu-core-security-audit">An independent security audit of Ubuntu&nbsp;Core</a>
                         </p>
-                        <hr class="is-muted" />
+                        <hr class="p-rule is-muted" />
                         <p>
-                            <a href="/engage/embedded-linux-make-or-buy/">Embedded Linux: make or buy?</a>
+                            <a href="/engage/embedded-linux-make-or-buy/">Embedded Linux: make or&nbsp;buy?</a>
                         </p>
                     </div>
                 </div>
                 <hr class="is-muted p-rule" />
                 <div class="row">
-                    <div class="col-3">
+                    <div class="col-3 col-medium-1">
                         <h5 class="p-heading--5">Webinar</h5>
                     </div>
-                    <div class="col-3">
+                    <div class="col-3 col-medium-2">
                         <p>
                             <a href="/engage/intro-to-ubuntu-core22-webinar#:~:text=With%204%20releases%20behind%2C%20Ubuntu,edge%20devices%20makers%20must%20face.">Introduction to Ubuntu Core 22</a>
                         </p>
@@ -746,7 +746,7 @@ meta_copydoc %}
                 <h2>Ready to innovate?</h2>
             </div>
             <div class="col">
-                <div class="-section--shallow">
+                <div class="p-section--shallow">
                     <p>
                         Whether you are a startup bringing your concept to market or already have large fleets of devices deployed in the field, we have the expertise and infrastructure to launch and support you.
                     </p>
@@ -772,22 +772,6 @@ meta_copydoc %}
       document.addEventListener('DOMContentLoaded', function() {
         const videoLink = document.querySelector('.p-hero-video-link');
         const style = document.querySelector("style");
-        style.textContent += `
-                          .p-hero-video-link {
-                            display: inline-block;
-                            overflow: hidden;
-                          }
-                          .p-hero-video-link img {
-                            display: block;
-                            transition: @include vf-transition($property: background-size, $duration: fast, $easing: out)
-                          }
-                          .p-hero-video-link:hover img {
-                            transform: scale(1.03);
-                          }
-                          .p-equal-height-row__col:before {
-                            content: none !important;
-                          }
-                        `;
         const video = document.querySelector('.p-hero-video');
         const videoContainer = document.querySelector('.p-hero-video-container');
         videoLink.addEventListener('click', function(e) {

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -15,7 +15,7 @@ meta_copydoc %}
     <div class="col">
       <h1 class="u-no-margin--bottom">Ubuntu Core</h1>
       <div class="p-section--shallow">
-        <h2>The embedded Linux OS for devices</h2>
+        <p class="p-heading--2">The embedded Linux OS for devices</p>
       </div>
       <div class="p-section--shallow">
         <p class="p-heading--4">Ubuntu Core is a minimal, secure and strictly confined operating system powering devices around the world. Build your Ubuntu Core image today.</p>
@@ -280,7 +280,7 @@ meta_copydoc %}
         </div>
         <div class="col-3 col-medium-2">
           <a href="/internet-of-things/smart-city">
-            <h3 class="p-heading--5">Smart Cities</h3>
+            <h3 class="p-heading--5">Smart cities</h3>
             {{ image (
                 url="https://assets.ubuntu.com/v1/8dd2f04d-For-smart-use-cases__Smart-cities.png",
                 alt="",

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -30,7 +30,10 @@ meta_copydoc %}
                     </p>
                 </div>
                 <div class="p-section--shallow">
-                    <p class="p-heading--4">
+                    <p class="p-heading--4 u-hide--small u-hide--medium">
+                        Ubuntu Core is a minimal, secure and strictly confined operating system powering devices around the world. Build your Ubuntu Core image today.
+                    </p>
+                    <p class="u-hide--large">
                         Ubuntu Core is a minimal, secure and strictly confined operating system powering devices around the world. Build your Ubuntu Core image today.
                     </p>
                 </div>
@@ -40,7 +43,7 @@ meta_copydoc %}
                     <a href="https://assets.ubuntu.com/v1/1870ea66-Ubuntu_Core22_DS.06.06.22.pdf">Read&nbsp;the&nbsp;Ubuntu&nbsp;Core&nbsp;datasheet</a>
                 </p>
             </div>
-            <div class="col u-hide--small">
+            <div class="col">
                 <a href="#" aria-label="What is Ubuntu Core" class="p-hero-video-link">
                     <img src="https://assets.ubuntu.com/v1/3a0f24b8-video-thumbnail-suru-bg.png"
                          alt=""
@@ -349,7 +352,7 @@ meta_copydoc %}
             <div class="row--25-75">
                 <div class="col">
                     <hr class="p-rule is-muted" />
-                    <div class="p-tabs__list js-tabbed-content"
+                    <div class="u-no-margin--bottom p-tabs__list js-tabbed-content"
                          role="tablist"
                          aria-label="Customer stories">
                         <div class="p-tabs__item">
@@ -390,8 +393,8 @@ meta_copydoc %}
                  role="tabpanel"
                  id="industrial-tab"
                  aria-labelledby="industrial">
-                <div class="row--25-75 u-no-margin--bottom">
-                    <div class="col">
+                <div class="row u-no-margin--bottom">
+                    <div class="col-3 col-medium-2">
                         {{ image(url="https://assets.ubuntu.com/v1/ffd88101-rexroth-for-testimonial.png",
                                                 alt="Rexroth",
                                                 width="284",
@@ -400,12 +403,12 @@ meta_copydoc %}
                                                 loading="auto",) | safe
                         }}
                     </div>
-                    <div class="col u-no-margin--top">
+                    <div class="col-9 col-medium-4 u-no-margin--top">
                         <div class="row">
-                            <div class="col-6">
+                            <div class="col-6 col-medium-2">
                                 <h3 class="p-heading--2">Bosch Rexroth reinvents automation</h3>
                             </div>
-                            <div class="col-3">
+                            <div class="col-3 col-medium-2">
                                 <p>Bosch adopts Ubuntu Core and snaps for app-based ctrl-X industry 4.0 platform.</p>
                                 <hr class="p-rule is-muted" />
                                 <p>
@@ -430,22 +433,22 @@ meta_copydoc %}
                  id="smart-kiosk-tab"
                  aria-labelledby="smart-kiosk"
                  aria-hidden="hidden">
-                <div class="row--25-75 u-no-margin--bottom">
-                    <div class="col">
+                <div class="row u-no-margin--bottom">
+                    <div class="col-3 col-medium-2">
                         {{ image(url="https://assets.ubuntu.com/v1/ea8fc1a8-pudo-testimonial-logo.png",
                                                 alt="Pudo",
-                                                width="180",
-                                                height="89",
+                                                width="125",
+                                                height="55",
                                                 hi_def=True,
                                                 loading="auto",) | safe
                         }}
                     </div>
-                    <div class="col u-no-margin--top">
+                    <div class="col-9 col-medium-4 u-no-margin--top">
                         <div class="row">
-                            <div class="col-6">
+                            <div class="col-6 col-medium-2">
                                 <h3 class="p-heading--2">Pudo deploys fleet for robust last-mile logistics</h3>
                             </div>
-                            <div class="col-3">
+                            <div class="col-3 col-medium-2">
                                 <p>Pudo chooses Ubuntu Core as the foundation for its IoT-based APMs to maximise security and uptime.</p>
                                 <hr class="is-muted p-rule" />
                                 <p>
@@ -470,22 +473,22 @@ meta_copydoc %}
                  id="network-tab"
                  aria-labelledby="network"
                  aria-hidden="hidden">
-                <div class="row--25-75 u-no-margin--bottom">
-                    <div class="col">
+                <div class="row u-no-margin--bottom">
+                    <div class="col-3 col-medium-2">
                         {{ image(url="https://assets.ubuntu.com/v1/80f5af45-rigado-testimonial-logo.png",
                                                 alt="Rigado",
-                                                width="200",
-                                                height="46",
+                                                width="170",
+                                                height="26",
                                                 hi_def=True,
                                                 loading="auto",) | safe
                         }}
                     </div>
-                    <div class="col u-no-margin--top">
+                    <div class="col-9 col-medium-4 u-no-margin--top">
                         <div class="row">
-                            <div class="col-6">
+                            <div class="col-6 col-medium-2">
                                 <h3 class="p-heading--2">Rigado cuts customers’ time to market</h3>
                             </div>
-                            <div class="col-3">
+                            <div class="col-3 col-medium-2">
                                 <p>Ubuntu Core enables Rigado to manage end-to-end security for commercial IoT gateways.</p>
                                 <hr class="is-muted p-rule" />
                                 <p>
@@ -510,22 +513,22 @@ meta_copydoc %}
                  id="cloud-tab"
                  aria-labelledby="cloud"
                  aria-hidden="hidden">
-                <div class="row--25-75 u-no-margin--bottom">
-                    <div class="col">
+                <div class="row u-no-margin--bottom">
+                    <div class="col-3 col-medium-2">
                         {{ image(url="https://assets.ubuntu.com/v1/e110996e-ibm-cloud-testimonial-logo.png",
                                                 alt="IBM",
-                                                width="200",
-                                                height="60",
+                                                width="190",
+                                                height="57",
                                                 hi_def=True,
                                                 loading="auto",) | safe
                         }}
                     </div>
-                    <div class="col u-no-margin--top">
+                    <div class="col-9 col-medium-4 u-no-margin--top">
                         <div class="row">
-                            <div class="col-6">
+                            <div class="col-6 col-medium-2">
                                 <h3 class="p-heading--2">IBM Cloud provides highly isolated and performant bare metal servers</h3>
                             </div>
-                            <div class="col-3">
+                            <div class="col-3 col-medium-2">
                                 <p>
                                     IBM Cloud's bare metal servers offer highly isolated and high-performing tenant-cloud isolation through the use of Ubuntu Core.
                                 </p>
@@ -674,44 +677,44 @@ meta_copydoc %}
                 <h2>Learn more about&nbsp;Ubuntu&nbsp;Core</h2>
             </div>
             <div class="col">
-                <div class="row--50-50">
-                    <div class="col">
+                <div class="row">
+                    <div class="col-3">
                         <h5 class="p-heading--5">Docs</h5>
                     </div>
-                    <div class="col">
+                    <div class="col-3">
                         <p>
                             <a href="/core/docs/getting-started">Start your Core journey today</a>
                         </p>
                     </div>
                 </div>
                 <hr class="is-muted p-rule" />
-                <div class="row--50-50">
-                    <div class="col">
+                <div class="row">
+                    <div class="col-3">
                         <h5 class="p-heading--5">Features</h5>
                     </div>
-                    <div class="col">
+                    <div class="col-3">
                         <p>
                             <a href="/core/features">Discover everything that Core offers you</a>
                         </p>
                     </div>
                 </div>
                 <hr class="is-muted p-rule" />
-                <div class="row--50-50">
-                    <div class="col">
+                <div class="row">
+                    <div class="col-3">
                         <h5 class="p-heading--5">Customer stories</h5>
                     </div>
-                    <div class="col">
+                    <div class="col-3">
                         <p>
                             <a href="/core/stories">Find out how our users are finding success with Core</a>
                         </p>
                     </div>
                 </div>
                 <hr class="is-muted p-rule" />
-                <div class="row--50-50">
-                    <div class="col">
+                <div class="row">
+                    <div class="col-3">
                         <h5 class="p-heading--5">White papers</h5>
                     </div>
-                    <div class="col">
+                    <div class="col-3">
                         <p>
                             <a href="/engage/ubuntu-core-security-audit">An independent security audit of Ubuntu Core</a>
                         </p>
@@ -722,11 +725,11 @@ meta_copydoc %}
                     </div>
                 </div>
                 <hr class="is-muted p-rule" />
-                <div class="row--50-50">
-                    <div class="col">
+                <div class="row">
+                    <div class="col-3">
                         <h5 class="p-heading--5">Webinar</h5>
                     </div>
-                    <div class="col">
+                    <div class="col-3">
                         <p>
                             <a href="/engage/intro-to-ubuntu-core22-webinar#:~:text=With%204%20releases%20behind%2C%20Ubuntu,edge%20devices%20makers%20must%20face.">Introduction to Ubuntu Core 22</a>
                         </p>

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -99,7 +99,7 @@ meta_copydoc %}
       </p>
       <div class="p-equal-height-row__item">
         <a href="/internet-of-things/management">
-          <p>Learn more about fleet Management&nbsp;›</p>
+          <p>Learn more about fleet management&nbsp;›</p>
         </a>
       </div>
     </div>
@@ -160,9 +160,9 @@ meta_copydoc %}
   </div>
   <div class="row--25-75">
     <div class="col">
+      <hr />
       <div class="row">
-        <hr />
-        <div class="col-4 col-medium-2">
+        <div class="col-3 col-medium-2">
           <ul class="js-tabbed-content p-tabs--vertical is-black u-hide--small" role="tablist"
             aria-label="Dev to deployment">
             <li>
@@ -191,7 +191,7 @@ meta_copydoc %}
             </select>
           </form>
         </div>
-        <div class="col-8 col-medium-4">
+        <div class="col-6 col-medium-4">
           {% include "core/tabs.html" %}
         </div>
       </div>
@@ -215,40 +215,46 @@ meta_copydoc %}
       <hr class="u-hide--small" />
       <div class="row">
         <div class="col-3 col-medium-2">
-          <h3 class="p-heading--5"><a href="/automotive">Automotive</a></h3>
-          {{ image (
-              url="https://assets.ubuntu.com/v1/f867c883-For-smart-use-cases__Automotivew.png",
-              alt="Automotive",
-              width="285",
-              height="160",
-              hi_def=True,
-              loading="auto",
-              ) | safe
+          <a href="/automotive">
+            <h3 class="p-heading--5">Automotive</h3>
+            {{ image (
+                url="https://assets.ubuntu.com/v1/f867c883-For-smart-use-cases__Automotivew.png",
+                alt="",
+                width="285",
+                height="160",
+                hi_def=True,
+                loading="auto",
+                ) | safe
             }}
+          </a>
         </div>
         <div class="col-3 col-medium-2">
-          <h3 class="p-heading--5"><a href="/industrial">Industrial</a></h3>
-          {{ image (
-              url="https://assets.ubuntu.com/v1/0162bc71-For-smart-use-cases__Industrial.png",
-              alt="Industrial",
-              width="285",
-              height="160",
-              hi_def=True,
-              loading="auto",
-              ) | safe
+          <a href="/industrial">
+            <h3 class="p-heading--5">Industrial</h3>
+            {{ image (
+                url="https://assets.ubuntu.com/v1/0162bc71-For-smart-use-cases__Industrial.png",
+                alt="",
+                width="285",
+                height="160",
+                hi_def=True,
+                loading="auto",
+                ) | safe
             }}
+          </a>
         </div>
         <div class="col-3 col-medium-2">
-          <h3 class="p-heading--5"><a href="/robotics">Robotics</a></h3>
-          {{ image (
-              url="https://assets.ubuntu.com/v1/aeeeb32d-For-smart-use-cases__Robotics.png",
-              alt="Robotics",
-              width="285",
-              height="160",
-              hi_def=True,
-              loading="auto",
-              ) | safe
+          <a href="/robotics">
+            <h3 class="p-heading--5">Robotics</h3>
+            {{ image (
+                url="https://assets.ubuntu.com/v1/aeeeb32d-For-smart-use-cases__Robotics.png",
+                alt="",
+                width="285",
+                height="160",
+                hi_def=True,
+                loading="auto",
+                ) | safe
             }}
+          </a>
         </div>
       </div>
     </div>
@@ -258,28 +264,32 @@ meta_copydoc %}
       <hr class="u-hide--small" />
       <div class="row">
         <div class="col-3 col-medium-2">
-          <h3 class="p-heading--5"><a href="/internet-of-things/digital-signage">Signage</a></h3>
-          {{ image (
-              url="https://assets.ubuntu.com/v1/9db3f004-For-smart-use-cases__Signage.png",
-              alt="Signage",
-              width="285",
-              height="160",
-              hi_def=True,
-              loading="auto",
-              ) | safe
+          <a href="/internet-of-things/digital-signage">
+            <h3 class="p-heading--5">Signage</h3>
+            {{ image (
+                url="https://assets.ubuntu.com/v1/9db3f004-For-smart-use-cases__Signage.png",
+                alt="",
+                width="285",
+                height="160",
+                hi_def=True,
+                loading="auto",
+                ) | safe
             }}
+          </a>
         </div>
         <div class="col-3 col-medium-2">
-          <h3 class="p-heading--5"><a href="/internet-of-things/smart-city">Smart Cities</a></h3>
+          <a href="/internet-of-things/smart-city">
+            <h3 class="p-heading--5">Smart Cities</h3>
             {{ image (
-              url="https://assets.ubuntu.com/v1/8dd2f04d-For-smart-use-cases__Smart-cities.png",
-              alt="Smart cities",
-              width="285",
-              height="160",
-              hi_def=True,
-              loading="auto",
-              ) | safe
+                url="https://assets.ubuntu.com/v1/8dd2f04d-For-smart-use-cases__Smart-cities.png",
+                alt="",
+                width="285",
+                height="160",
+                hi_def=True,
+                loading="auto",
+                ) | safe
             }}
+          </a>
         </div>
       </div>
     </div>

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -15,7 +15,7 @@ meta_copydoc %}
     <div class="col">
       <h1 class="u-no-margin--bottom">Ubuntu Core</h1>
       <div class="p-section--shallow">
-        <p class="p-heading--2">The embedded Linux OS for devices</p>
+        <p class="p-heading--2">The embedded Linux OS<br />for devices</p>
       </div>
       <div class="p-section--shallow">
         <p class="p-heading--4">Ubuntu Core is a minimal, secure and strictly confined operating system powering devices around the world. Build your Ubuntu Core image today.</p>
@@ -34,35 +34,6 @@ meta_copydoc %}
         <iframe class="p-hero-video u-embedded-media__element" src="https://www.youtube.com/embed/6NDWqH1SrGs" allow="autoplay;" frameborder="0" allowfullscreen=""></iframe>
       </div>
     </div>
-    <script>
-      document.addEventListener('DOMContentLoaded', function () {
-        const videoLink = document.querySelector('.p-hero-video-link');
-        const style = document.querySelector("style");
-        style.textContent += `
-                              .p-hero-video-link {
-                                display: inline-block;
-                                overflow: hidden;
-                              }
-                              .p-hero-video-link img {
-                                display: block;
-                                transition: .3s ease-in-out;
-                              }
-                              .p-hero-video-link:hover img {
-                                transform: scale(1.3);
-                              }
-                              .p-equal-height-row__col:before {
-                                content: none !important;
-                              }
-                            `;
-        const video = document.querySelector('.p-hero-video');
-        const videoContainer = document.querySelector('.p-hero-video-container');
-        videoLink.addEventListener('click', function(e) {
-          e.preventDefault();
-          videoContainer.classList.remove('u-hide');
-          videoLink.classList.add('u-hide');
-        });
-      });
-    </script>
   </div>
 </section>
 
@@ -81,14 +52,14 @@ meta_copydoc %}
   </div>
   <div class="p-equal-height-row has-3rd-divider">
     <div class="p-equal-height-row__col">
-      <div class="p-equal-height-row__item u-hide--small">
+      <div class="p-equal-height-row__item u-hide--small u-hide--medium">
         <div class="p-media-container">
           <img width="320" src="https://assets.ubuntu.com/v1/834e417a-continuous-security.jpg" alt="" />
         </div>
       </div>
       <div class="p-equal-height-row__item">
         <hr class="p-rule--highlight u-hide--medium u-hide--small is-muted" />
-        <h5 class="p-heading--5">Continuous security</h5>
+        <h3 class="p-heading--5">Continuous security</h3>
       </div>
       <p class="p-equal-height-row__item">
         Imagine a world where every device is trustworthy. We designed every aspect of Ubuntu Core to create the most
@@ -101,14 +72,14 @@ meta_copydoc %}
       </div>
     </div>
     <div class="p-equal-height-row__col">
-      <div class="p-equal-height-row__item u-hide--small">
+      <div class="p-equal-height-row__item u-hide--small u-hide--medium">
         <div class="p-media-container">
           <img width="320" src="https://assets.ubuntu.com/v1/d1d161a9-fleet-management.jpg" alt="" />
         </div>
       </div>
       <div class="p-equal-height-row__item">
         <hr class="p-rule--highlight u-hide--medium u-hide--small is-muted" />
-        <h5 class="p-heading--5">Device management</h5>
+        <h3 class="p-heading--5">Device management</h3>
       </div>
       <p class="p-equal-height-row__item">
         Enjoy reliable, remotely accessible and recoverable devices which are always up-to-date with mission-critical
@@ -121,14 +92,14 @@ meta_copydoc %}
       </div>
     </div>
     <div class="p-equal-height-row__col">
-      <div class="p-equal-height-row__item u-hide--small">
+      <div class="p-equal-height-row__item u-hide--small u-hide--medium">
         <div class="p-media-container">
           <img width="320" src="https://assets.ubuntu.com/v1/373f7039-agile-containerisation.png" alt="" />
         </div>
       </div>
       <div class="p-equal-height-row__item">
         <hr class="p-rule--highlight u-hide--medium u-hide--small is-muted" />
-        <h5 class="p-heading--5">Agile containerisation</h5>
+        <h3 class="p-heading--5">Agile containerisation</h3>
       </div>
       <p class="p-equal-height-row__item">
         Ubuntu Core is immutable and strictly confined. There is a clean separation between the kernel, OS image and
@@ -141,14 +112,14 @@ meta_copydoc %}
       </div>
     </div>
     <div class="p-equal-height-row__col">
-      <div class="p-equal-height-row__item u-hide--small">
+      <div class="p-equal-height-row__item u-hide--small u-hide--medium">
         <div class="p-media-container">
           <img width="320" src="https://assets.ubuntu.com/v1/166ec7c6-hardware-ecosystem.jpg" alt="" />
         </div>
       </div>
       <div class="p-equal-height-row__item">
         <hr class="p-rule--highlight u-hide--medium u-hide--small is-muted" />
-        <h5 class="p-heading--5">A strong hardware ecosystem</h5>
+        <h3 class="p-heading--5">A strong hardware ecosystem</h3>
       </div>
       <p class="p-equal-height-row__item">
         We enable Ubuntu Core with the best ODMs and silicon vendors in the world. We continuously test it on leading
@@ -159,6 +130,14 @@ meta_copydoc %}
           <a href="/certified">Browse all certified hardware&nbsp;&rsaquo;</a> 
         </p>
       </div>
+    </div>
+  </div>
+  <hr class="p-rule is-muted" />
+  <div class="row">
+    <div class="col-3 col-start-large-7">
+      <p>
+        <a href="/core/features">Discover the full feature list&nbsp;&rsaquo;</a>
+      </p>
     </div>
   </div>
 </section>
@@ -216,7 +195,7 @@ meta_copydoc %}
   </div>
   <div class="row">
     <hr class="is-muted col-9 col-start-large-4 col-medium-6 col-start-medium-2" />
-    <div class="col-6 col-start-large-4 col-medium-4 col-start-medium-3">
+    <div class="col-6 col-start-large-7 col-medium-4 col-start-medium-4">
       <p>
         <a href="/core/docs">Get started with Ubuntu Core&nbsp;&rsaquo;</a>
       </p>
@@ -236,7 +215,7 @@ meta_copydoc %}
         <div class="col-3 col-medium-2">
           <a href="/automotive">
             <h3 class="p-heading--5">Automotive</h3>
-            {{ image (
+            {{ image(
                 url="https://assets.ubuntu.com/v1/f867c883-For-smart-use-cases__Automotivew.png",
                 alt="",
                 width="285",
@@ -250,7 +229,7 @@ meta_copydoc %}
         <div class="col-3 col-medium-2">
           <a href="/industrial">
             <h3 class="p-heading--5">Industrial</h3>
-            {{ image (
+            {{ image(
                 url="https://assets.ubuntu.com/v1/0162bc71-For-smart-use-cases__Industrial.png",
                 alt="",
                 width="285",
@@ -264,7 +243,7 @@ meta_copydoc %}
         <div class="col-3 col-medium-2">
           <a href="/robotics">
             <h3 class="p-heading--5">Robotics</h3>
-            {{ image (
+            {{ image(
                 url="https://assets.ubuntu.com/v1/aeeeb32d-For-smart-use-cases__Robotics.png",
                 alt="",
                 width="285",
@@ -285,7 +264,7 @@ meta_copydoc %}
         <div class="col-3 col-medium-2">
           <a href="/internet-of-things/digital-signage">
             <h3 class="p-heading--5">Signage</h3>
-            {{ image (
+            {{ image(
                 url="https://assets.ubuntu.com/v1/9db3f004-For-smart-use-cases__Signage.png",
                 alt="",
                 width="285",
@@ -299,7 +278,7 @@ meta_copydoc %}
         <div class="col-3 col-medium-2">
           <a href="/internet-of-things/smart-city">
             <h3 class="p-heading--5">Smart cities</h3>
-            {{ image (
+            {{ image(
                 url="https://assets.ubuntu.com/v1/8dd2f04d-For-smart-use-cases__Smart-cities.png",
                 alt="",
                 width="285",
@@ -354,7 +333,7 @@ meta_copydoc %}
     <div tabindex="0" role="tabpanel" id="industrial-tab" aria-labelledby="industrial">
       <div class="row--25-75 u-no-margin--bottom">
         <div class="col">
-          {{ image (
+          {{ image(
             url="https://assets.ubuntu.com/v1/ffd88101-rexroth-for-testimonial.png",
             alt="Rexroth",
             width="284",
@@ -370,9 +349,7 @@ meta_copydoc %}
               <h3 class="p-heading--2">Bosch Rexroth reinvents automation</h3>
             </div>
             <div class="col-3">
-              <div>
-                <p>Bosch adopts Ubuntu Core and snaps for app-based ctrl-X industry 4.0 platform.</p>
-              </div>
+              <p>Bosch adopts Ubuntu Core and snaps for app-based ctrl-X industry 4.0 platform.</p>
               <hr class="p-rule is-muted" />
               <p>
                 <a href="/blog/bosch-rexroth-adopts-ubuntu-core-and-snaps-for-app-based-ctrlx-automation-platform">Read the press release&nbsp;&rsaquo;</a>
@@ -380,7 +357,7 @@ meta_copydoc %}
             </div>
           </div>
           <div>
-            {{ image (
+            {{ image(
               url="https://assets.ubuntu.com/v1/2d152c25-rexroth-testimonial-image.jpg",
               alt="Rexroth",
               width="917",
@@ -396,7 +373,7 @@ meta_copydoc %}
     <div tabindex="0" role="tabpanel" id="smart-kiosk-tab" aria-labelledby="smart-kiosk" aria-hidden="hidden">
       <div class="row--25-75 u-no-margin--bottom">
         <div class="col">
-          {{ image (
+          {{ image(
             url="https://assets.ubuntu.com/v1/ea8fc1a8-pudo-testimonial-logo.png",
             alt="Pudo",
             width="180",
@@ -412,9 +389,7 @@ meta_copydoc %}
               <h3 class="p-heading--2">Pudo deploys fleet for robust last-mile logistics</h3>
             </div>
             <div class="col-3">
-              <div>
-                <p>Pudo chooses Ubuntu Core as the foundation for its IoT-based APMs to maximise security and uptime.</p>
-              </div>
+              <p>Pudo chooses Ubuntu Core as the foundation for its IoT-based APMs to maximise security and uptime.</p>
               <hr class="is-muted p-rule" />
               <p>
                 <a href="/engage/pudo-case-study">Read the case study&nbsp;&rsaquo;</a>
@@ -422,7 +397,7 @@ meta_copydoc %}
             </div>
           </div>
           <div>
-            {{ image (
+            {{ image(
               url="https://assets.ubuntu.com/v1/576c8402-pudo-testimonial-image.jpg",
               alt="Pudo",
               width="917",
@@ -438,7 +413,7 @@ meta_copydoc %}
     <div tabindex="0" role="tabpanel" id="network-tab" aria-labelledby="network" aria-hidden="hidden">
       <div class="row--25-75 u-no-margin--bottom">
         <div class="col">
-          {{ image (
+          {{ image(
             url="https://assets.ubuntu.com/v1/80f5af45-rigado-testimonial-logo.png",
             alt="Rigado",
             width="200",
@@ -454,9 +429,7 @@ meta_copydoc %}
               <h3 class="p-heading--2">Rigado cuts customers’ time to market</h3>
             </div>
             <div class="col-3">
-              <div>
-                <p>Ubuntu Core enables Rigado to manage end-to-end security for commercial IoT gateways.</p>
-              </div>
+              <p>Ubuntu Core enables Rigado to manage end-to-end security for commercial IoT gateways.</p>
               <hr class="is-muted p-rule" />
               <p>
                 <a href="/engage/case-study-rigado">Read the case study&nbsp;&rsaquo;</a>
@@ -464,7 +437,7 @@ meta_copydoc %}
             </div>
           </div>
           <div>
-            {{ image (
+            {{ image(
               url="https://assets.ubuntu.com/v1/297369c0-rigado--testimonial-image.jpg",
               alt="Rigado",
               width="917",
@@ -480,7 +453,7 @@ meta_copydoc %}
     <div tabindex="0" role="tabpanel" id="cloud-tab" aria-labelledby="cloud" aria-hidden="hidden">
       <div class="row--25-75 u-no-margin--bottom">
         <div class="col">
-          {{ image (
+          {{ image(
             url="https://assets.ubuntu.com/v1/e110996e-ibm-cloud-testimonial-logo.png",
             alt="IBM",
             width="200",
@@ -496,17 +469,15 @@ meta_copydoc %}
               <h3 class="p-heading--2">IBM Cloud provides highly isolated and performant bare metal servers</h3>
             </div>
             <div class="col-3">
-              <div>
-                <p>IBM Cloud's bare metal servers offer highly isolated and high-performing tenant-cloud isolation through the use of Ubuntu Core.</p>
-              </div>
+              <p>IBM Cloud's bare metal servers offer highly isolated and high-performing tenant-cloud isolation through the use of Ubuntu Core.</p>
               <hr class="is-muted p-rule" />
               <p>
-                <a href="/engage/case-study-rigado">Read the press release&nbsp;&rsaquo;</a>
+                <a href="https://canonical.com/blog/cloud-isolation-ibm-bare-metal-ubuntu-core">Read the press release&nbsp;&rsaquo;</a>
               </p>
             </div>
           </div>
           <div>
-            {{ image (
+            {{ image(
               url="https://assets.ubuntu.com/v1/534be2a2-ibm-leadspace.jpg",
               alt="IBM",
               width="917",
@@ -532,7 +503,7 @@ meta_copydoc %}
     <div class="p-logo-section--dense">
       <div class="p-logo-section__items">
         <div class="p-logo-section__item">
-          {{ image (
+          {{ image(
               url="https://assets.ubuntu.com/v1/59996fad-intel-new-logo.png",
               alt="Intel",
               width="50",
@@ -544,7 +515,7 @@ meta_copydoc %}
           }}
         </div>
         <div class="p-logo-section__item">
-          {{ image (
+          {{ image(
               url="https://assets.ubuntu.com/v1/4bf8a9bc-amd-logo.png",
               alt="AMD",
               width="69",
@@ -556,7 +527,7 @@ meta_copydoc %}
           }}
         </div>
         <div class="p-logo-section__item">
-          {{ image (
+          {{ image(
             url="https://assets.ubuntu.com/v1/e7b81879-nvidia-logo.png",
             alt="Nvidia",
             width="94",
@@ -568,7 +539,7 @@ meta_copydoc %}
           }}
         </div>
         <div class="p-logo-section__item">
-          {{ image (
+          {{ image(
             url="https://assets.ubuntu.com/v1/9a25ec68-arm-logo.png",
             alt="ARM",
             width="47",
@@ -580,7 +551,7 @@ meta_copydoc %}
           }}
         </div>
         <div class="p-logo-section__item">
-          {{ image (
+          {{ image(
             url="https://assets.ubuntu.com/v1/31b259ec-qualcom-logo.png",
             alt="Qualcom",
             width="96",
@@ -592,7 +563,7 @@ meta_copydoc %}
           }}
         </div>
         <div class="p-logo-section__item">
-          {{ image (
+          {{ image(
             url="https://assets.ubuntu.com/v1/d65da7f3-advantech-logo.png",
             alt="Advantech",
             width="95",
@@ -604,7 +575,7 @@ meta_copydoc %}
           }}
         </div>
         <div class="p-logo-section__item">
-          {{ image (
+          {{ image(
             url="https://assets.ubuntu.com/v1/6eff0263-adlink-logo.png",
             alt="Adlink",
             width="101",
@@ -616,9 +587,9 @@ meta_copydoc %}
           }}
         </div>
         <div class="p-logo-section__item">
-          {{ image (
+          {{ image(
             url="https://assets.ubuntu.com/v1/be8db080-nxp-logo.png",
-            alt="Nxp",
+            alt="NXP",
             width="41",
             height="96",
             hi_def=True,
@@ -628,9 +599,9 @@ meta_copydoc %}
           }}
         </div>
         <div class="p-logo-section__item">
-          {{ image (
+          {{ image(
             url="https://assets.ubuntu.com/v1/96d65ee2-mediatek-logo.png",
-            alt="Mediatech",
+            alt="MediaTeK",
             width="77",
             height="96",
             hi_def=True,
@@ -661,7 +632,7 @@ meta_copydoc %}
   <div class="row--50-50">
     <hr class="p-rule" />
     <div class="col">
-      <h2>Learn more about Ubuntu Core</h2>
+      <h2>Learn more about&nbsp;Ubuntu&nbsp;Core</h2>
     </div>
     <div class="col">
       <div class="row--50-50">
@@ -736,7 +707,7 @@ meta_copydoc %}
       <div class="-section--shallow">
         <p>Whether you are a startup bringing your concept to market or already have large fleets of devices deployed in the field, we have the expertise and infrastructure to launch and support you.</p>
       </div>
-      <hr class="is-muted p-rule" />
+      <hr class="is-muted" />
       <p>
         <a class="p-button--positive" href="/core/contact-us">Get in touch</a>
       </p>
@@ -749,5 +720,35 @@ meta_copydoc %}
   data-form-id="1266" data-lp-id="2166" data-return-url="https://ubuntu.com/core/thank-you"
   data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
+
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    const videoLink = document.querySelector('.p-hero-video-link');
+    const style = document.querySelector("style");
+    style.textContent += `
+                          .p-hero-video-link {
+                            display: inline-block;
+                            overflow: hidden;
+                          }
+                          .p-hero-video-link img {
+                            display: block;
+                            transition: @include vf-transition($property: background-size, $duration: fast, $easing: out)
+                          }
+                          .p-hero-video-link:hover img {
+                            transform: scale(1.03);
+                          }
+                          .p-equal-height-row__col:before {
+                            content: none !important;
+                          }
+                        `;
+    const video = document.querySelector('.p-hero-video');
+    const videoContainer = document.querySelector('.p-hero-video-container');
+    videoLink.addEventListener('click', function(e) {
+      e.preventDefault();
+      videoContainer.classList.remove('u-hide');
+      videoLink.classList.add('u-hide');
+    });
+  });
+</script>
 
 {% endblock content %}

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -405,10 +405,10 @@ meta_copydoc %}
                     </div>
                     <div class="col-9 col-medium-4 u-no-margin--top">
                         <div class="row">
-                            <div class="col-6 col-medium-2">
+                            <div class="col-6 col-medium-4">
                                 <h3 class="p-heading--2">Bosch Rexroth reinvents automation</h3>
                             </div>
-                            <div class="col-3 col-medium-2">
+                            <div class="col-3 col-medium-4">
                                 <p>Bosch adopts Ubuntu Core and snaps for app-based ctrl-X industry 4.0 platform.</p>
                                 <hr class="p-rule is-muted" />
                                 <p>
@@ -445,10 +445,10 @@ meta_copydoc %}
                     </div>
                     <div class="col-9 col-medium-4 u-no-margin--top">
                         <div class="row">
-                            <div class="col-6 col-medium-2">
+                            <div class="col-6 col-medium-4">
                                 <h3 class="p-heading--2">Pudo deploys fleet for robust last-mile logistics</h3>
                             </div>
-                            <div class="col-3 col-medium-2">
+                            <div class="col-3 col-medium-4">
                                 <p>Pudo chooses Ubuntu Core as the foundation for its IoT-based APMs to maximise security and uptime.</p>
                                 <hr class="is-muted p-rule" />
                                 <p>
@@ -485,10 +485,10 @@ meta_copydoc %}
                     </div>
                     <div class="col-9 col-medium-4 u-no-margin--top">
                         <div class="row">
-                            <div class="col-6 col-medium-2">
+                            <div class="col-6 col-medium-4">
                                 <h3 class="p-heading--2">Rigado cuts customers’ time to market</h3>
                             </div>
-                            <div class="col-3 col-medium-2">
+                            <div class="col-3 col-medium-4">
                                 <p>Ubuntu Core enables Rigado to manage end-to-end security for commercial IoT gateways.</p>
                                 <hr class="is-muted p-rule" />
                                 <p>
@@ -525,10 +525,10 @@ meta_copydoc %}
                     </div>
                     <div class="col-9 col-medium-4 u-no-margin--top">
                         <div class="row">
-                            <div class="col-6 col-medium-2">
+                            <div class="col-6 col-medium-4">
                                 <h3 class="p-heading--2">IBM Cloud provides highly isolated and performant bare metal servers</h3>
                             </div>
-                            <div class="col-3 col-medium-2">
+                            <div class="col-3 col-medium-4">
                                 <p>
                                     IBM Cloud's bare metal servers offer highly isolated and high-performing tenant-cloud isolation through the use of Ubuntu Core.
                                 </p>

--- a/templates/core/tabs.html
+++ b/templates/core/tabs.html
@@ -2,29 +2,44 @@
 	<div class="u-fixed-width p-strip is-shallow u-no-padding--top">
 		<p>Deploying a device?</p>
         <p>Ubuntu is your development environment. Ubuntu Core is your deployment OS. Whether you develop your application using C++, Rust, Python, or others – whatever tech stack you use, package and deploy it seamlessly on Ubuntu Core.</p>
+		<div class="image-wrapper">
+			<img src="https://assets.ubuntu.com/v1/1eaa48e1-imge-1.jpg" alt="" />
+		</div>
 	</div>
 </div>
 <div tabindex="0" role="tabpanel" id="ubuntu-vision-tab" aria-labelledby="ubuntu-vision" aria-hidden="false">
 	<div class="u-fixed-width p-strip is-shallow u-no-padding--top">
 		<p>For more than 20 years, Ubuntu has provided the best development environment. Every aspect of the development process benefits from Ubuntu’s responsiveness, ease of use, regular software updates and a high degree of security.</p>
         <a href="/desktop">Learn more about Ubuntu&nbsp;&rsaquo;</a>
+		<div class="image-wrapper">
+			<img src="https://assets.ubuntu.com/v1/cca1bb10-image-2.jpg" alt="" />
+		</div>
 	</div>
 </div>
 <div tabindex="0" role="tabpanel" id="snapcraft-tab" aria-labelledby="snapcraft" aria-hidden="false">
 	<div class="u-fixed-width p-strip is-shallow u-no-padding--top">
 		<p>Snapcraft is the command-line tool for packaging your software as a snap. Snaps are containerised packages designed for deploying embedded applications, with increased performance compared to <a href="/engage/docker-containers-for-IoT-whitepaper">other technologies</a>. Ubuntu Core architecture is built on snaps and each element benefits from its tooling.</p>
         <a href="/core/docs/snaps-in-ubuntu-core">Learn more about snaps in Ubuntu Core&nbsp;&rsaquo;</a>
+		<div class="image-wrapper">
+			<img src="https://assets.ubuntu.com/v1/8ffeb339-image-3.jpg" alt="" />
+		</div>
 	</div>
 </div>
 <div tabindex="0" role="tabpanel" id="snap-store-tab" aria-labelledby="snap-store" aria-hidden="false">
 	<div class="u-fixed-width p-strip is-shallow u-no-padding--top">
 		<p>Canonical's Snap Store powers developers to host and manage software updates for their devices. It provides a trusted update infrastructure, including reliable OTA updates, delta updates, and more. Organisations can also create private marketplaces, with advanced software management for fleets of devices.</p>
         <a href="/internet-of-things/appstore">Learn more about Snap Stores&nbsp;&rsaquo;</a>
+		<div class="image-wrapper">
+			<img src="https://assets.ubuntu.com/v1/41bba4bb-image-5.jpg" alt="" />
+		</div>
 	</div>
 </div>
 <div tabindex="0" role="tabpanel" id="ubuntu-core-tab" aria-labelledby="ubuntu-core" aria-hidden="false">
 	<div class="u-fixed-width p-strip is-shallow u-no-padding--top">
 		<p>The right OS for your devices. Ubuntu Core is a strictly confined and immutable embedded Linux OS.  Build your Ubuntu Core image for your application and targeted hardware, and enjoy a fully managed, secure, and 10-year LTS production image.</p>
         <a href="/core">Learn more about Ubuntu Core&nbsp;&rsaquo;</a>
+		<div class="image-wrapper">
+			<img src="https://assets.ubuntu.com/v1/471f2211-image-4.jpg" alt="" />
+		</div>
 	</div>
 </div>

--- a/templates/core/tabs.html
+++ b/templates/core/tabs.html
@@ -1,45 +1,45 @@
 <div tabindex="0" role="tabpanel" id="overview-tab" aria-labelledby="overview" aria-hidden="false">
-	<div class="u-fixed-width p-strip is-shallow u-no-padding--top">
-		<p>Deploying a device?</p>
-        <p>Ubuntu is your development environment. Ubuntu Core is your deployment OS. Whether you develop your application using C++, Rust, Python, or others – whatever tech stack you use, package and deploy it seamlessly on Ubuntu Core.</p>
-		<div class="image-wrapper">
-			<img src="https://assets.ubuntu.com/v1/6e6a56d4-image-1.jpg" alt="" />
-		</div>
+  <div class="u-fixed-width p-strip is-shallow u-no-padding--top">
+	<div class="image-wrapper">
+		<img src="https://assets.ubuntu.com/v1/6e6a56d4-image-1.jpg" alt="" />
 	</div>
+	<p>Deploying a device?</p>
+    <p>Ubuntu is your development environment. Ubuntu Core is your deployment OS. Whether you develop your application using C++, Rust, Python, or others – whatever tech stack you use, package and deploy it seamlessly on Ubuntu Core.</p>
+  </div>
 </div>
 <div tabindex="0" role="tabpanel" id="ubuntu-vision-tab" aria-labelledby="ubuntu-vision" aria-hidden="false">
-	<div class="u-fixed-width p-strip is-shallow u-no-padding--top">
-		<p>For more than 20 years, Ubuntu has provided the best development environment. Every aspect of the development process benefits from Ubuntu’s responsiveness, ease of use, regular software updates and a high degree of security.</p>
-        <a href="/desktop">Learn more about Ubuntu&nbsp;&rsaquo;</a>
-		<div class="image-wrapper">
-			<img src="https://assets.ubuntu.com/v1/27f89818-image-2.jpg" alt="" />
-		</div>
+  <div class="u-fixed-width p-strip is-shallow u-no-padding--top">
+	<div class="image-wrapper">
+		<img src="https://assets.ubuntu.com/v1/27f89818-image-2.jpg" alt="" />
 	</div>
+	<p>For more than 20 years, Ubuntu has provided the best development environment. Every aspect of the development process benefits from Ubuntu’s responsiveness, ease of use, regular software updates and a high degree of security.</p>
+    <a href="/desktop">Learn more about Ubuntu&nbsp;&rsaquo;</a>
+  </div>
 </div>
 <div tabindex="0" role="tabpanel" id="snapcraft-tab" aria-labelledby="snapcraft" aria-hidden="false">
-	<div class="u-fixed-width p-strip is-shallow u-no-padding--top">
-		<p>Snapcraft is the command-line tool for packaging your software as a snap. Snaps are containerised packages designed for deploying embedded applications, with increased performance compared to <a href="/engage/docker-containers-for-IoT-whitepaper">other technologies</a>. Ubuntu Core architecture is built on snaps and each element benefits from its tooling.</p>
-        <a href="/core/docs/snaps-in-ubuntu-core">Learn more about snaps in Ubuntu Core&nbsp;&rsaquo;</a>
-		<div class="image-wrapper">
-			<img src="https://assets.ubuntu.com/v1/1b84970e-image-3.jpg" alt="" />
-		</div>
+  <div class="u-fixed-width p-strip is-shallow u-no-padding--top">
+	<div class="image-wrapper">
+	  <img src="https://assets.ubuntu.com/v1/1b84970e-image-3.jpg" alt="" />
 	</div>
+	<p>Snapcraft is the command-line tool for packaging your software as a snap. Snaps are containerised packages designed for deploying embedded applications, with increased performance compared to <a href="/engage/docker-containers-for-IoT-whitepaper">other technologies</a>. Ubuntu Core architecture is built on snaps and each element benefits from its tooling.</p>
+    <a href="/core/docs/snaps-in-ubuntu-core">Learn more about snaps in Ubuntu Core&nbsp;&rsaquo;</a>
+  </div>
 </div>
 <div tabindex="0" role="tabpanel" id="snap-store-tab" aria-labelledby="snap-store" aria-hidden="false">
-	<div class="u-fixed-width p-strip is-shallow u-no-padding--top">
-		<p>Canonical's Snap Store powers developers to host and manage software updates for their devices. It provides a trusted update infrastructure, including reliable OTA updates, delta updates, and more. Organisations can also create private marketplaces, with advanced software management for fleets of devices.</p>
-        <a href="/internet-of-things/appstore">Learn more about Snap Stores&nbsp;&rsaquo;</a>
-		<div class="image-wrapper">
-			<img src="https://assets.ubuntu.com/v1/4ad28fe2-image-5.jpg" alt="" />
-		</div>
+  <div class="u-fixed-width p-strip is-shallow u-no-padding--top">
+	<div class="image-wrapper">
+		<img src="https://assets.ubuntu.com/v1/27f8d290-image-6.jpg" alt="" />
 	</div>
+	<p>Canonical's Snap Store powers developers to host and manage software updates for their devices. It provides a trusted update infrastructure, including reliable OTA updates, delta updates, and more. Organisations can also create private marketplaces, with advanced software management for fleets of devices.</p>
+    <a href="/internet-of-things/appstore">Learn more about Snap Stores&nbsp;&rsaquo;</a>
+  </div>
 </div>
 <div tabindex="0" role="tabpanel" id="ubuntu-core-tab" aria-labelledby="ubuntu-core" aria-hidden="false">
-	<div class="u-fixed-width p-strip is-shallow u-no-padding--top">
-		<p>The right OS for your devices. Ubuntu Core is a strictly confined and immutable embedded Linux OS.  Build your Ubuntu Core image for your application and targeted hardware, and enjoy a fully managed, secure, and 10-year LTS production image.</p>
-        <a href="/core">Learn more about Ubuntu Core&nbsp;&rsaquo;</a>
-		<div class="image-wrapper">
-			<img src="https://assets.ubuntu.com/v1/60d58bf5-image-4.jpg" alt="" />
-		</div>
+  <div class="u-fixed-width p-strip is-shallow u-no-padding--top">
+	<div class="image-wrapper">
+		<img src="https://assets.ubuntu.com/v1/60d58bf5-image-4.jpg" alt="" />
 	</div>
+	<p>The right OS for your devices. Ubuntu Core is a strictly confined and immutable embedded Linux OS.  Build your Ubuntu Core image for your application and targeted hardware, and enjoy a fully managed, secure, and 10-year LTS production image.</p>
+    <a href="/core">Learn more about Ubuntu Core&nbsp;&rsaquo;</a>
+  </div>
 </div>

--- a/templates/core/tabs.html
+++ b/templates/core/tabs.html
@@ -3,7 +3,7 @@
 		<p>Deploying a device?</p>
         <p>Ubuntu is your development environment. Ubuntu Core is your deployment OS. Whether you develop your application using C++, Rust, Python, or others – whatever tech stack you use, package and deploy it seamlessly on Ubuntu Core.</p>
 		<div class="image-wrapper">
-			<img src="https://assets.ubuntu.com/v1/1eaa48e1-imge-1.jpg" alt="" />
+			<img src="https://assets.ubuntu.com/v1/6e6a56d4-image-1.jpg" alt="" />
 		</div>
 	</div>
 </div>
@@ -12,7 +12,7 @@
 		<p>For more than 20 years, Ubuntu has provided the best development environment. Every aspect of the development process benefits from Ubuntu’s responsiveness, ease of use, regular software updates and a high degree of security.</p>
         <a href="/desktop">Learn more about Ubuntu&nbsp;&rsaquo;</a>
 		<div class="image-wrapper">
-			<img src="https://assets.ubuntu.com/v1/cca1bb10-image-2.jpg" alt="" />
+			<img src="https://assets.ubuntu.com/v1/27f89818-image-2.jpg" alt="" />
 		</div>
 	</div>
 </div>
@@ -21,7 +21,7 @@
 		<p>Snapcraft is the command-line tool for packaging your software as a snap. Snaps are containerised packages designed for deploying embedded applications, with increased performance compared to <a href="/engage/docker-containers-for-IoT-whitepaper">other technologies</a>. Ubuntu Core architecture is built on snaps and each element benefits from its tooling.</p>
         <a href="/core/docs/snaps-in-ubuntu-core">Learn more about snaps in Ubuntu Core&nbsp;&rsaquo;</a>
 		<div class="image-wrapper">
-			<img src="https://assets.ubuntu.com/v1/8ffeb339-image-3.jpg" alt="" />
+			<img src="https://assets.ubuntu.com/v1/1b84970e-image-3.jpg" alt="" />
 		</div>
 	</div>
 </div>
@@ -30,7 +30,7 @@
 		<p>Canonical's Snap Store powers developers to host and manage software updates for their devices. It provides a trusted update infrastructure, including reliable OTA updates, delta updates, and more. Organisations can also create private marketplaces, with advanced software management for fleets of devices.</p>
         <a href="/internet-of-things/appstore">Learn more about Snap Stores&nbsp;&rsaquo;</a>
 		<div class="image-wrapper">
-			<img src="https://assets.ubuntu.com/v1/41bba4bb-image-5.jpg" alt="" />
+			<img src="https://assets.ubuntu.com/v1/4ad28fe2-image-5.jpg" alt="" />
 		</div>
 	</div>
 </div>
@@ -39,7 +39,7 @@
 		<p>The right OS for your devices. Ubuntu Core is a strictly confined and immutable embedded Linux OS.  Build your Ubuntu Core image for your application and targeted hardware, and enjoy a fully managed, secure, and 10-year LTS production image.</p>
         <a href="/core">Learn more about Ubuntu Core&nbsp;&rsaquo;</a>
 		<div class="image-wrapper">
-			<img src="https://assets.ubuntu.com/v1/471f2211-image-4.jpg" alt="" />
+			<img src="https://assets.ubuntu.com/v1/60d58bf5-image-4.jpg" alt="" />
 		</div>
 	</div>
 </div>

--- a/templates/core/tabs.html
+++ b/templates/core/tabs.html
@@ -1,0 +1,30 @@
+<div tabindex="0" role="tabpanel" id="overview-tab" aria-labelledby="overview" aria-hidden="false">
+	<div class="u-fixed-width p-strip is-shallow u-no-padding--top">
+		<p>Deploying a device?</p>
+        <p>Ubuntu is your development environment. Ubuntu Core is your deployment OS. Whether you develop your application using C++, Rust, Python, or others – whatever tech stack you use, package and deploy it seamlessly on Ubuntu Core.</p>
+	</div>
+</div>
+<div tabindex="0" role="tabpanel" id="ubuntu-vision-tab" aria-labelledby="ubuntu-vision" aria-hidden="false">
+	<div class="u-fixed-width p-strip is-shallow u-no-padding--top">
+		<p>For more than 20 years, Ubuntu has provided the best development environment. Every aspect of the development process benefits from Ubuntu’s responsiveness, ease of use, regular software updates and a high degree of security.</p>
+        <a href="/desktop">Learn more about Ubuntu&nbsp;&rsaquo;</a>
+	</div>
+</div>
+<div tabindex="0" role="tabpanel" id="snapcraft-tab" aria-labelledby="snapcraft" aria-hidden="false">
+	<div class="u-fixed-width p-strip is-shallow u-no-padding--top">
+		<p>Snapcraft is the command-line tool for packaging your software as a snap. Snaps are containerised packages designed for deploying embedded applications, with increased performance compared to <a href="/engage/docker-containers-for-IoT-whitepaper">other technologies</a>. Ubuntu Core architecture is built on snaps and each element benefits from its tooling.</p>
+        <a href="/core/docs/snaps-in-ubuntu-core">Learn more about snaps in Ubuntu Core&nbsp;&rsaquo;</a>
+	</div>
+</div>
+<div tabindex="0" role="tabpanel" id="snap-store-tab" aria-labelledby="snap-store" aria-hidden="false">
+	<div class="u-fixed-width p-strip is-shallow u-no-padding--top">
+		<p>Canonical's Snap Store powers developers to host and manage software updates for their devices. It provides a trusted update infrastructure, including reliable OTA updates, delta updates, and more. Organisations can also create private marketplaces, with advanced software management for fleets of devices.</p>
+        <a href="/internet-of-things/appstore">Learn more about Snap Stores&nbsp;&rsaquo;</a>
+	</div>
+</div>
+<div tabindex="0" role="tabpanel" id="ubuntu-core-tab" aria-labelledby="ubuntu-core" aria-hidden="false">
+	<div class="u-fixed-width p-strip is-shallow u-no-padding--top">
+		<p>The right OS for your devices. Ubuntu Core is a strictly confined and immutable embedded Linux OS.  Build your Ubuntu Core image for your application and targeted hardware, and enjoy a fully managed, secure, and 10-year LTS production image.</p>
+        <a href="/core">Learn more about Ubuntu Core&nbsp;&rsaquo;</a>
+	</div>
+</div>

--- a/templates/core/tabs.html
+++ b/templates/core/tabs.html
@@ -1,7 +1,7 @@
 <div tabindex="0" role="tabpanel" id="overview-tab" aria-labelledby="overview" aria-hidden="false">
   <div class="u-fixed-width p-strip is-shallow u-no-padding--top">
 	<div class="image-wrapper">
-		<img src="https://assets.ubuntu.com/v1/6e6a56d4-image-1.jpg" alt="" />
+		<img width="590" src="https://assets.ubuntu.com/v1/6e6a56d4-image-1.jpg" alt="" />
 	</div>
 	<p>Deploying a device?</p>
     <p>Ubuntu is your development environment. Ubuntu Core is your deployment OS. Whether you develop your application using C++, Rust, Python, or others – whatever tech stack you use, package and deploy it seamlessly on Ubuntu Core.</p>
@@ -10,7 +10,7 @@
 <div tabindex="0" role="tabpanel" id="ubuntu-vision-tab" aria-labelledby="ubuntu-vision" aria-hidden="false">
   <div class="u-fixed-width p-strip is-shallow u-no-padding--top">
 	<div class="image-wrapper">
-		<img src="https://assets.ubuntu.com/v1/27f89818-image-2.jpg" alt="" />
+		<img width="590" src="https://assets.ubuntu.com/v1/27f89818-image-2.jpg" alt="" />
 	</div>
 	<p>For more than 20 years, Ubuntu has provided the best development environment. Every aspect of the development process benefits from Ubuntu’s responsiveness, ease of use, regular software updates and a high degree of security.</p>
     <a href="/desktop">Learn more about Ubuntu&nbsp;&rsaquo;</a>
@@ -19,7 +19,7 @@
 <div tabindex="0" role="tabpanel" id="snapcraft-tab" aria-labelledby="snapcraft" aria-hidden="false">
   <div class="u-fixed-width p-strip is-shallow u-no-padding--top">
 	<div class="image-wrapper">
-	  <img src="https://assets.ubuntu.com/v1/1b84970e-image-3.jpg" alt="" />
+	  <img width="590" src="https://assets.ubuntu.com/v1/1b84970e-image-3.jpg" alt="" />
 	</div>
 	<p>Snapcraft is the command-line tool for packaging your software as a snap. Snaps are containerised packages designed for deploying embedded applications, with increased performance compared to <a href="/engage/docker-containers-for-IoT-whitepaper">other technologies</a>. Ubuntu Core architecture is built on snaps and each element benefits from its tooling.</p>
     <a href="/core/docs/snaps-in-ubuntu-core">Learn more about snaps in Ubuntu Core&nbsp;&rsaquo;</a>
@@ -28,7 +28,7 @@
 <div tabindex="0" role="tabpanel" id="snap-store-tab" aria-labelledby="snap-store" aria-hidden="false">
   <div class="u-fixed-width p-strip is-shallow u-no-padding--top">
 	<div class="image-wrapper">
-		<img src="https://assets.ubuntu.com/v1/27f8d290-image-6.jpg" alt="" />
+		<img width="590" src="https://assets.ubuntu.com/v1/27f8d290-image-6.jpg" alt="" />
 	</div>
 	<p>Canonical's Snap Store powers developers to host and manage software updates for their devices. It provides a trusted update infrastructure, including reliable OTA updates, delta updates, and more. Organisations can also create private marketplaces, with advanced software management for fleets of devices.</p>
     <a href="/internet-of-things/appstore">Learn more about Snap Stores&nbsp;&rsaquo;</a>
@@ -37,7 +37,7 @@
 <div tabindex="0" role="tabpanel" id="ubuntu-core-tab" aria-labelledby="ubuntu-core" aria-hidden="false">
   <div class="u-fixed-width p-strip is-shallow u-no-padding--top">
 	<div class="image-wrapper">
-		<img src="https://assets.ubuntu.com/v1/60d58bf5-image-4.jpg" alt="" />
+		<img width="590" src="https://assets.ubuntu.com/v1/60d58bf5-image-4.jpg" alt="" />
 	</div>
 	<p>The right OS for your devices. Ubuntu Core is a strictly confined and immutable embedded Linux OS.  Build your Ubuntu Core image for your application and targeted hardware, and enjoy a fully managed, secure, and 10-year LTS production image.</p>
     <a href="/core">Learn more about Ubuntu Core&nbsp;&rsaquo;</a>

--- a/yarn.lock
+++ b/yarn.lock
@@ -7995,15 +7995,15 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
+vanilla-framework@4.10.0:
+  version "4.10.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.10.0.tgz#09fba5c31f93f46306b51f519d0b5f3b7363d73d"
+  integrity sha512-mkf48XSjU11KxmikB63+vnHxncqyYEjl9ki5dCD/oL2AGdh53t2uHsh2z85jMyz8MMXcHlXo2/gWIsSQluS/Vg==
+
 vanilla-framework@4.9.0:
   version "4.9.0"
   resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.9.0.tgz#7566b42a22c2394ea1d7ea843d24ec305446cb3e"
   integrity sha512-iTmvqWlsX0ic69VZ1sR9NPQtYRR9+iM679HZCl7SDQhMQSsEeJEQ6Ejjen3JN5a7YxiYmeIhxaLlmC4rExRT1w==
-
-vanilla-framework@4.9.1:
-  version "4.9.1"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.9.1.tgz#98b33337d013d1e4b64e4aba58defdae68431d13"
-  integrity sha512-nY/wzAF1obHTH6pePo9OLslnyOsybiCnyHbr6JkfWHlahsukaA/Wj78yz9VEw1yuPDZzzTfxzXK3Eu771N+fCA==
 
 verbalize@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
## Done

Update core home page according to figma and copy doc

## QA

- [demo link](https://ubuntu-com-13754.demos.haus/core)
- [copy doc](https://docs.google.com/document/d/1UFpefDRSAcndNBnWp0hDyzqk74aciqhBWJEi05htWmU/edit)
- [figma](https://www.figma.com/file/5kDdBtPRqthyPz263YV91U/24.04-Ubuntu-Core-rebrand?type=design&node-id=711-3453&mode=design&t=3k9mbyENz2DBU0hh-0)
- View the site on demo
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check that the page is correct according to the demo and copy doc

## Issue / Card
[WD-9618](https://warthogs.atlassian.net/browse/WD-9618)

[WD-9618]: https://warthogs.atlassian.net/browse/WD-9618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ