### PR TITLE
/download copy changes from UX research

### DIFF
--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -19,14 +19,10 @@
                 The open source desktop operating system that powers millions of PCs and laptops around the world. Find out more about Ubuntu's features and how we support developers and organisations below.
             </p>
             <hr />
-            <ul class="p-inline-list u-responsive-realign">
-                <li class="p-inline-list__item">
-                    <a href="/desktop">About Ubuntu Desktop&nbsp;&rsaquo;</a>
-                </li>
-                <li class="p-inline-list__item">
-                    <a href="/blog/desktop">Check out the blog&nbsp;&rsaquo;</a>
-                </li>
-            </ul>
+            <p class="u-responsive-realign">
+                <a href="/desktop" class="p-button">Discover Ubuntu Desktop</a>
+                <a href="/blog/desktop">Check out the blog&nbsp;&rsaquo;</a>
+            </p>
         </div>
     </div>
 </section>
@@ -64,7 +60,7 @@
                         onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });">Download
                         {{ releases.lts.full_version }} LTS
                     </a>
-                    <span class="u-text--muted">ISO image, {{ releases.lts.iso_download_size }}</span>
+                    {% if releases.lts.iso_download_size %}<span class="u-text--muted">{{ releases.lts.iso_download_size }}</span>{% endif %}
                     <script>
                       performance.mark("Download (Desktop) button rendered")
                     </script>

--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -90,9 +90,9 @@
       <p class="u-responsive-realign">
         <a href="/download/raspberry-pi/thank-you?version={{ releases.lts.full_version }}&amp;architecture=desktop-arm64+raspi"
             onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 64-bit - Ubuntu Desktop', 'eventLabel' : '{{ releases.lts.full_version }}', 'eventValue' : undefined });"
-            class="p-button--positive u-no-margin--bottom">Download Ubuntu Desktop {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr></a>
+            class="p-button--positive u-no-margin--bottom">Download Ubuntu Desktop {{ releases.lts.full_version }} LTS</a>
         {% if releases.lts.raspi_desktop_iso_size %}
-          <span class="u-text--muted">ISO image, {{ releases.lts.raspi_desktop_iso_size }}</span>
+          <span class="u-text--muted">{{ releases.lts.raspi_desktop_iso_size }}</span>
         {% endif %}
       </p>
       <p>Minimum 2GBs of RAM and 16GB storage required</p>
@@ -100,9 +100,9 @@
       <p class="u-responsive-realign">
         <a href="/download/raspberry-pi/thank-you?version={{ releases.lts.full_version }}&amp;architecture=server-arm64+raspi"
             onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 64-bit - Ubuntu Server', 'eventLabel' : '{{ releases.lts.full_version }}', 'eventValue' : undefined });"
-            class="p-button">Download Ubuntu Server {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr></a>
+            class="p-button">Download Ubuntu Server {{ releases.lts.full_version }} LTS</a>
         {% if releases.lts.raspi_desktop_iso_size %}
-          <span class="u-text--muted">ISO image, {{ releases.lts.raspi_server_iso_size }}</span>
+          <span class="u-text--muted">{{ releases.lts.raspi_server_iso_size }}</span>
         {% endif %}
       </p>
     </div>
@@ -121,7 +121,7 @@
         <a href="/download/raspberry-pi/thank-you?version={{ releases.latest.core_version }}&amp;architecture=core-22-arm64+raspi"
             onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 64-bit - Ubuntu Core', 'eventLabel' : '{{ releases.latest.core_version }}', 'eventValue' : undefined });"
             class="p-button">Download Ubuntu Core {{ releases.latest.core_version }}</a>
-        <span class="u-text--muted">ISO image, 263MB</span>
+        <span class="u-text--muted">263MB</span>
       </p>
     </div>
   </div>

--- a/templates/download/server/manual.html
+++ b/templates/download/server/manual.html
@@ -86,13 +86,13 @@
                     The latest <abbr title="Long-term support">LTS</abbr> version of Ubuntu Server. LTS stands for long-term support &mdash; which means five years of free security and maintenance updates, extended to 10 years with <a href="/pro">Ubuntu Pro</a>.
                 </p>
                 <hr />
-                <a class="p-button--positive"
-                    href="/download/server/thank-you?version={{ releases.lts.full_version }}&amp;architecture=amd64"
-                    onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Server download', 'eventAction' : 'Select option', 'eventLabel' : '{{ releases.lts.full_version }}', 'eventValue' : undefined });">Download {{ releases.lts.full_version }} LTS
-                </a>
-                <span class="u-text--muted">ISO image
-                    {% if releases.lts.server_iso_size %}, {{ releases.lts.server_iso_size }}{% endif %}
-                </span>
+                <p class="u-responsive-realign">
+                  <a class="p-button--positive"
+                      href="/download/server/thank-you?version={{ releases.lts.full_version }}&amp;architecture=amd64"
+                      onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Server download', 'eventAction' : 'Select option', 'eventLabel' : '{{ releases.lts.full_version }}', 'eventValue' : undefined });">Download {{ releases.lts.full_version }} LTS
+                  </a>
+                  {% if releases.lts.server_iso_size %}<span class="u-text--muted">{{ releases.lts.server_iso_size }}</span>{% endif %}
+                </p>
                 <p>
                     <a href="/download/alternative-downloads">Alternative downloads&nbsp;&rsaquo;</a>
                 </p>


### PR DESCRIPTION
## Done

- Turn Desktop link into button and update copy on /download/desktop, based on A/B test results
- Remove "ISO image" from the labels next to download CTAs, based on heatmaps
- Apply minor consistency tweaks (use paragraphs instead of lists, conditionals)

https://ubuntu-com-13759.demos.haus/download/desktop
https://ubuntu-com-13759.demos.haus/download/server
https://ubuntu-com-13759.demos.haus/download/raspberry-pi

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
