### PR TITLE
Remove releases table for larger screens

### DIFF
--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -69,7 +69,9 @@
   </div>
   <div class="u-fixed-width">
     <div class="u-hide--small" id="server-desktop-eol"></div>
-    {% include "about/release_cycles/releases-table.html" %}
+    <div class="u-hide--large u-hide--medium">
+      {% include "about/release_cycles/releases-table.html" %}
+    </div>
   </div>
 </section>
 

--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -55,6 +55,7 @@
       </ul>
       <hr class="is-extra-muted" />
       <a href="/about/release-cycle">The Ubuntu release cycle&nbsp;&rsaquo;</a>
+    </div>
   </div>
 </section>
 
@@ -486,7 +487,7 @@
   </div>
   <div class="row--50-50 u-hide--medium u-hide--small">
     <div class="col">
-      <hr class="is-muted">
+      <hr class="is-muted" />
       <p>Source: <a
         href="https://recruit-c7ff.kxcdn.com/recruit/wp-content/uploads/2020/05/he-developer-survey-2020.pdf">The 2020
         HackerEarth Developer Survey</a></p>

--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -465,7 +465,7 @@
       </div>
       
       <div class="u-hide--large">
-        <hr class="is-muted">
+        <hr class="is-muted" />
         <p>Source: <a
           href="https://recruit-c7ff.kxcdn.com/recruit/wp-content/uploads/2020/05/he-developer-survey-2020.pdf">The 2020
           HackerEarth Developer Survey</a></p>
@@ -478,7 +478,7 @@
         {% include "desktop/partial/_hackearth-table.html" %}
       </div>
       <div class="u-hide--large">
-        <hr class="is-muted">
+        <hr class="is-muted" />
         <p>Source: <a
           href="https://www.openlogic.com/system/files/ebook-openlogic-the-2022-state-of-open-source-report.pdf">The
           2022 State of Open Source Report &ndash; OpenLogic</a></p>
@@ -493,7 +493,7 @@
         HackerEarth Developer Survey</a></p>
     </div>
     <div class="col">
-      <hr class="is-muted">
+      <hr class="is-muted" />
       <p>Source: <a
         href="https://www.openlogic.com/system/files/ebook-openlogic-the-2022-state-of-open-source-report.pdf">The
         2022 State of Open Source Report &ndash; OpenLogic</a></p>
@@ -513,7 +513,7 @@
       </div>
       <div class="col">
         <p>Ubuntu Pro Desktop is a comprehensive subscription delivering enterprise-grade security, management tooling, and extended support for developers and organisations. Ubuntu Pro Desktop is free for personal use on up to five machines.</p>
-        <hr class="is-extra-muted u-no-margin--bottom">
+        <hr class="is-extra-muted u-no-margin--bottom" />
         <ul class="p-list--divided u-no-margin--bottom">
           <li class="p-list__item is-ticked">Security updates for the <a href="/esm">full open source stack</a></li>
           <li class="p-list__item is-ticked">Advanced <a href="/engage/microsoft-active-directory">Active Directory</a> and LDAP integration</li>
@@ -535,7 +535,7 @@
         <p>
           <a href="/pro">Get started with a free subscription&nbsp;&rsaquo;</a>
         </p>
-        <hr class="is-muted">
+        <hr class="is-muted" />
         <p>
           <a href="/desktop/organisations">Ubuntu Desktop for organisations&nbsp;&rsaquo;</a>
         </p>


### PR DESCRIPTION
## Done

Removed releases table [according to request](https://warthogs.atlassian.net/browse/WD-10408)

## QA

- Go to  https://ubuntu-com-13760.demos.haus/desktop/developers and check that the table below the "Security support
" graph is no longer showing. Compare with prod https://ubuntu.com/desktop/developers
- Test that on mobile it doesn't show https://ubuntu-com-13760.demos.haus/desktop/developers

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-10408


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
