### PR TITLE
[WD-10461] add lts

### DIFF
--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -9,7 +9,6 @@
 {% block body_class %}is-paper{% endblock %}
 
 {% block content %}
-
   <section class="p-strip is-shallow u-no-padding--bottom">
     <div class="row--50-50 p-section">
       <div class="col">
@@ -17,21 +16,16 @@
       </div>
       <div class="col">
         <p>
-          The open-source desktop operating system that powers millions of PCs and laptops around the world. Find out more about Ubuntu's features and how we support developers and organisations below.
+          The open source desktop operating system that powers millions of PCs and laptops around the world. Find out more about Ubuntu's features and how we support developers and organisations below.
         </p>
         <hr />
-        <ul class="p-inline-list u-responsive-realign">
-          <li class="p-inline-list__item">
-            <a href="/desktop">About Ubuntu Desktop&nbsp;&rsaquo;</a>
-          </li>
-          <li class="p-inline-list__item">
-            <a href="/blog/desktop">Check out the blog&nbsp;&rsaquo;</a>
-          </li>
-        </ul>
+        <p class="u-responsive-realign">
+          <a href="/desktop" class="p-button">Discover Ubuntu Desktop</a>
+          <a href="/blog/desktop">Check out the blog&nbsp;&rsaquo;</a>
+        </p>
       </div>
     </div>
   </section>
-
   <section class="p-section">
     <div class="row--50-50">
       <hr class="p-rule" />
@@ -40,14 +34,12 @@
           <h2>Ubuntu {{ releases.lts.full_version }} LTS</h2>
         </div>
         <div class="p-image-wrapper">
-          {{ image (
-          url="https://assets.ubuntu.com/v1/b743f1ee-jj-in-circle.png",
-          alt="",
-          width="200",
-          height="200",
-          hi_def=True,
-          loading="auto"
-          ) | safe
+          {{ image(url="https://assets.ubuntu.com/v1/3b5fa561-mascot-numbat@2x.png",
+                    alt="Noble Numbat",
+                    width="182",
+                    height="135",
+                    hi_def=True,
+                    loading="auto") | safe
           }}
         </div>
       </div>
@@ -61,11 +53,13 @@
           <hr />
           <p class="u-responsive-realign">
             <a class="p-button--positive"
-               href="/download/desktop/thank-you?version={{ releases.lts.full_version }}&amp;architecture=amd64"
+               href="/download/desktop/thank-you?version={{ releases.lts.full_version }}&amp;architecture=amd64&amp;lts=true"
                onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });">Download
               {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr>
             </a>
-            <span class="u-text--muted">ISO image, {{ releases.lts.iso_download_size }}</span>
+            {% if releases.lts.iso_download_size %}
+              <span class="u-text--muted">{{ releases.lts.iso_download_size }}</span>
+            {% endif %}
             <script>
               performance.mark("Download (Desktop) button rendered")
             </script>
@@ -86,7 +80,7 @@
                    aria-selected="true"
                    id="release-notes-tab"
                    href="#release-notes"
-                   aria-controls="release-notes">Release notes</a>
+                   aria-controls="release-notes">What's new</a>
               </li>
               <li class="p-tabs__item">
                 <a class="p-tabs__link"
@@ -116,23 +110,15 @@
              role="tabpanel"
              aria-labelledby="release-notes-tab">
           <ul class="p-list--divided">
-            <li class="p-list__item is-ticked">Linux 5.15 kernel</li>
-            <li class="p-list__item is-ticked">
-              New Ubuntu theme with accent colours, improved integration for snaps and system-wide dark style preference support
-            </li>
-            <li class="p-list__item is-ticked">GNOME Shell and most GNOME libraries updated to the 42 release</li>
-            <li class="p-list__item is-ticked">GNOME desktop performance improvements most notably on the Raspberry Pi</li>
-            <li class="p-list__item is-ticked">
-              Wayland as the default display server for most systems (X11 remains the default for those with an NVIDIA discrete GPU)
-            </li>
-            <li class="p-list__item is-ticked">Active Directory integration with the Ubuntu installer</li>
-            <li class="p-list__item is-ticked">
-              Policy-based administration using Microsoft Active Directory Group Policy (GPO) and advanced policy support for Ubuntu Pro Desktop users
-            </li>
+            <li class="p-list__item is-ticked">New Desktop installer with support for autoinstall</li>
+            <li class="p-list__item is-ticked">New App Center and Firmware Updater applications</li>
+            <li class="p-list__item is-ticked">GNOME 46 with support for quarter screen tiling</li>
+            <li class="p-list__item is-ticked">Advanced Active Directory Group Policy Object support for Ubuntu Pro users</li>
+            <li class="p-list__item is-ticked">Experimental support for TPM-backed Full Disc Encryption and ZFS encryption</li>
           </ul>
           <hr class="p-rule" />
           <p>
-            <a href="https://discourse.ubuntu.com/t/jammy-jellyfish-release-notes/24668">Full {{ releases.lts.full_version }} release notes&nbsp;&rsaquo;</a>
+            <a href="https://discourse.ubuntu.com/t/noble-numbat-release-notes/39890">{{ releases.lts.full_version }} release notes&nbsp;&rsaquo;</a>
           </p>
         </div>
         <!-- tab 2 -->
@@ -169,42 +155,7 @@
       </div>
     </div>
   </section>
-
-  <section class="p-section">
-    <div class="row--50-50">
-      <hr class="p-rule" />
-      <div class="col">
-        <h2>Ubuntu {{ releases.latest.full_version }}</h2>
-      </div>
-      <div class="col">
-        <p>
-          The latest version of the Ubuntu operating system for desktop PCs and laptops, Ubuntu 23.10 comes with nine months of security and maintenance updates, until July 2024. <a href="{{ releases.latest.release_notes_url }}">Ubuntu {{ releases.latest.short_version }} release notes</a>.
-        </p>
-        <p>Recommended system requirements are the same as for Ubuntu {{ releases.lts.short_version }} LTS.</p>
-        <hr />
-        <p class="u-responsive-realign">
-          <a class="p-button--positive"
-             href="/download/desktop/thank-you?version={{ releases.latest.desktop_version }}&amp;architecture=amd64"
-             onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">
-            Download {{ releases.latest.full_version }}
-          </a>
-          <script>
-            performance.mark("Download (Desktop) button rendered")
-          </script>
-          <a href="https://cdimage.ubuntu.com/releases/mantic/release/ubuntu-{{ releases.latest.short_version }}-desktop-legacy-amd64.iso"
-             onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{ releases.latest.short_version }} legacy installer', 'eventValue' : undefined });">
-            Download {{ releases.latest.short_version }} (Legacy Desktop Installer)&nbsp;&rsaquo;
-          </a>
-        </p>
-        <p class="p-text--small">
-          For other versions of Ubuntu Desktop including torrents, the network installer, a list of local mirrors and past releases <a href="/download/alternative-downloads">check out our alternative downloads</a>.
-        </p>
-      </div>
-    </div>
-  </section>
-
   {% include "download/shared/_downloads-resources.html" %}
-
   <section class="p-section">
     <div class="row--50-50">
       <hr class="p-rule" />
@@ -221,55 +172,43 @@
         <div class="p-logo-section">
           <div class="p-logo-section__items">
             <div class="p-logo-section__item">
-              {{
-              image (
-              url="https://assets.ubuntu.com/v1/f76dd871-ubuntu-certified.png",
-              alt="Ubuntu Certified",
-              width="317",
-              height="449",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-logo-section__logo"}
-              ) | safe
+              {{ image(url="https://assets.ubuntu.com/v1/f76dd871-ubuntu-certified.png",
+                            alt="Ubuntu Certified",
+                            width="317",
+                            height="449",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"class": "p-logo-section__logo"}) | safe
               }}
             </div>
             <div class="p-logo-section__item">
-              {{
-              image (
-              url="https://assets.ubuntu.com/v1/a5bec84b-hp-logo.png",
-              alt="HP",
-              width="159",
-              height="372",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-logo-section__logo"}
-              ) | safe
+              {{ image(url="https://assets.ubuntu.com/v1/a5bec84b-hp-logo.png",
+                            alt="HP",
+                            width="159",
+                            height="372",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"class": "p-logo-section__logo"}) | safe
               }}
             </div>
             <div class="p-logo-section__item">
-              {{
-              image (
-              url="https://assets.ubuntu.com/v1/25514caf-dell-logo.svg",
-              alt="Dell",
-              width="71",
-              height="144",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-logo-section__logo"}
-              ) | safe
+              {{ image(url="https://assets.ubuntu.com/v1/25514caf-dell-logo.svg",
+                            alt="Dell",
+                            width="71",
+                            height="144",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"class": "p-logo-section__logo"}) | safe
               }}
             </div>
             <div class="p-logo-section__item">
-              {{
-              image (
-              url="https://assets.ubuntu.com/v1/3b24973b-lenovo-logo.png",
-              alt="Lenovo",
-              width="169",
-              height="256",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-logo-section__logo"}
-              ) | safe
+              {{ image(url="https://assets.ubuntu.com/v1/3b24973b-lenovo-logo.png",
+                            alt="Lenovo",
+                            width="169",
+                            height="256",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"class": "p-logo-section__logo"}) | safe
               }}
             </div>
           </div>
@@ -277,15 +216,10 @@
       </div>
     </div>
   </section>
-
   {% include "download/shared/_secure-enterprise-management.html" %}
-
   {% include "download/shared/_more-from-canonical.html" %}
-
   {% with title_link="/blog/desktop", group_id="1479" %}
     {% include "download/shared/_latest-blogs_download.html" %}
   {% endwith %}
-
   <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
-
 {% endblock content %}

--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -23,12 +23,12 @@
       s.className += ' ' + y;
       h.start = 1 * new Date;
       h.end = i = function() {
-        s.className = s.className.replace(RegExp(' ?' + y), '')
+        s.className = s.className.replace(RegExp(' ?' + y), '');
       };
       (a[n] = a[n] || []).hide = h;
       setTimeout(function() {
         i();
-        h.end = null
+        h.end = null;
       }, c);
       h.timeout = c;
     })(window, document.documentElement, 'async-hide', 'dataLayer', 1000, {
@@ -55,7 +55,7 @@
     <div class="row--50-50">
       <div class="col">
         {% if version %}
-          <h1>Thank you for downloading Ubuntu Desktop {{ version }}</h1>
+          <h1>Thank you for downloading Ubuntu Desktop {{ version }}{{ " LTS" if lts }}</h1>
           <p>
             Your download should start automatically. If it doesn't,
             {% if architecture == 'amd64+mac' %}
@@ -65,10 +65,8 @@
                 <a href="https://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-desktop-{{ architecture }}.iso">download
                   now</a>.
                 {% endif %}
-
                 <br />
                 You can <a href="/tutorials/tutorial-how-to-verify-ubuntu">verify your download</a>, or <a href="/tutorials/install-ubuntu-desktop">get help installing</a>.
-
               </p>
             {% else %}
               <h1>Thank you for your contribution</h1>

--- a/templates/download/server/manual.html
+++ b/templates/download/server/manual.html
@@ -3,541 +3,525 @@
 {% block title %}Get Ubuntu Server | Download{% endblock %}
 
 {% block meta_description %}
-    Get Ubuntu Server one of three ways; by using Multipass on your desktop, using MAAS to provision machines in your data centre or installing it directly on a server.
+  Get Ubuntu Server one of three ways; by using Multipass on your desktop, using MAAS to provision machines in your data centre or installing it directly on a server.
 {% endblock meta_description %}
 
 {% block meta_copydoc %}
-    https://docs.google.com/document/d/1Qob4Ni_y1ffIdSWqaw2xH0dxiHZQmkRGP5nuoBhIfyM/edit
+  https://docs.google.com/document/d/1Qob4Ni_y1ffIdSWqaw2xH0dxiHZQmkRGP5nuoBhIfyM/edit
 {% endblock meta_copydoc %}
 
 {% block body_class %}
-    is-paper
+  is-paper
 {% endblock body_class %}
 
 {% block content %}
-
-<section class="p-strip is-shallow u-no-padding--bottom">
+  <section class="p-strip is-shallow u-no-padding--bottom">
     <div class=" p-section u-fixed-width">
-        <h1>Get Ubuntu Server</h1>
+      <h1>Get Ubuntu Server</h1>
     </div>
-</section>
-<section class="p-section--shallow">
+  </section>
+  <section class="p-section--shallow">
     <div class="js-tab-container u-fixed-width">
-        <nav class="p-tabs">
+      <nav class="p-tabs">
+        <ul class="p-tabs__list js-tabbed-content u-no-margin--bottom"
+            role="tablist"
+            data-maintain-hash="true">
+          <li class="p-tabs__item">
+            <a class="p-tabs__link"
+               role="tab"
+               aria-selected="true"
+               id="manual-install-tab"
+               href="#manual-install"
+               aria-controls="manual-install">Manual installation</a>
+          </li>
+          <li class="p-tabs__item">
+            <a class="p-tabs__link"
+               role="tab"
+               aria-selected="false"
+               id="instant-vms-tab"
+               href="#instant-vms"
+               aria-controls="instant-vms"
+               tabindex="-1">Instant VMs</a>
+          </li>
+          <li class="p-tabs__item">
+            <a class="p-tabs__link"
+               role="tab"
+               aria-selected="false"
+               id="automated-provisioning-tab"
+               href="#automated-provisioning"
+               aria-controls="automated-provisioning"
+               tabindex="-1">Automated provisioning</a>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  </section>
+
+  <section class="p-tabs__content p-section"
+           id="manual-install"
+           role="tabpanel"
+           aria-labelledby="manual-install-tab">
+    <div class="row--50-50">
+      <div class="col">
+        <div class="p-section">
+          <h2>Ubuntu {{ releases.lts.full_version }} LTS</h2>
+        </div>
+        <div class="p-image-wrapper">
+          {{ image(url="https://assets.ubuntu.com/v1/3b5fa561-mascot-numbat@2x.png",
+                    alt="Noble Numbat",
+                    width="182",
+                    height="135",
+                    hi_def=True,
+                    loading="auto") | safe
+          }}
+        </div>
+      </div>
+      <div class="col">
+        <div class="p-section--shallow">
+          <p>
+            The latest <abbr title="Long-term support">LTS</abbr> version of Ubuntu Server. LTS stands for long-term support &mdash; which means five years of free security and maintenance updates, extended to 10 years with <a href="/pro">Ubuntu Pro</a>.
+          </p>
+          <hr />
+          <p class="u-responsive-realign">
+            <a class="p-button--positive"
+               href="/download/server/thank-you?version={{ releases.lts.full_version }}&amp;architecture=amd64&amp;lts=true"
+               onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Server download', 'eventAction' : 'Select option', 'eventLabel' : '{{ releases.lts.full_version }}', 'eventValue' : undefined });">Download {{ releases.lts.full_version }} LTS
+            </a>
+            {% if releases.lts.server_iso_size %}<span class="u-text--muted">{{ releases.lts.server_iso_size }}</span>{% endif %}
+          </p>
+          <p>
+            <a href="/download/alternative-downloads">Alternative downloads&nbsp;&rsaquo;</a>
+          </p>
+          <p>
+            <a href="#architectures">Alternative architectures&nbsp;&rsaquo;</a>
+          </p>
+        </div>
+
+        <div class="js-tab-container">
+          <nav class="p-tabs">
             <ul class="p-tabs__list js-tabbed-content u-no-margin--bottom"
                 role="tablist"
                 data-maintain-hash="true">
-                <li class="p-tabs__item">
-                    <a class="p-tabs__link"
-                        role="tab"
-                        aria-selected="true"
-                        id="manual-install-tab"
-                        href="#manual-install"
-                        aria-controls="manual-install">Manual installation</a>
-                </li>
-                <li class="p-tabs__item">
-                    <a class="p-tabs__link"
-                        role="tab"
-                        aria-selected="false"
-                        id="instant-vms-tab"
-                        href="#instant-vms"
-                        aria-controls="instant-vms"
-                        tabindex="-1">Instant VMs</a>
-                </li>
-                <li class="p-tabs__item">
-                    <a class="p-tabs__link"
-                        role="tab"
-                        aria-selected="false"
-                        id="automated-provisioning-tab"
-                        href="#automated-provisioning"
-                        aria-controls="automated-provisioning"
-                        tabindex="-1">Automated provisioning</a>
-                </li>
+              <li class="p-tabs__item">
+                <a class="p-tabs__link"
+                   role="tab"
+                   aria-selected="true"
+                   id="release-notes-tab"
+                   href="#release-notes"
+                   aria-controls="release-notes">What's new</a>
+              </li>
+              <li class="p-tabs__item">
+                <a class="p-tabs__link"
+                   role="tab"
+                   aria-selected="false"
+                   id="system-requirements-tab"
+                   href="#system-requirements"
+                   aria-controls="system-requirements"
+                   tabindex="-1">System requirements</a>
+              </li>
+              <li class="p-tabs__item">
+                <a class="p-tabs__link"
+                   role="tab"
+                   aria-selected="false"
+                   id="how-to-install-tab"
+                   href="#how-to-install"
+                   aria-controls="how-to-install"
+                   tabindex="-1">How to install</a>
+              </li>
             </ul>
-        </nav>
-    </div>
-</section>
-
-<section class="p-tabs__content p-section"
-          id="manual-install"
-          role="tabpanel"
-          aria-labelledby="manual-install-tab">
-    <div class="row--50-50">
-        <div class="col">
-            <div class="p-section">
-                <h2>Ubuntu {{ releases.lts.full_version }} LTS</h2>
-            </div>
-            <div class="p-image-wrapper">
-                {{
-                image (
-                url="https://assets.ubuntu.com/v1/3b5fa561-mascot-numbat@2x.png",
-                alt="Noble Numbat",
-                width="182",
-                height="135",
-                hi_def=True,
-                loading="auto"
-                ) | safe
-                }}
-            </div>
+          </nav>
         </div>
-        <div class="col">
-            <div class="p-section--shallow">
-                <p>
-                    The latest <abbr title="Long-term support">LTS</abbr> version of Ubuntu Server. LTS stands for long-term support &mdash; which means five years of free security and maintenance updates, extended to 10 years with <a href="/pro">Ubuntu Pro</a>.
-                </p>
-                <hr />
-                <p class="u-responsive-realign">
-                  <a class="p-button--positive"
-                      href="/download/server/thank-you?version={{ releases.lts.full_version }}&amp;architecture=amd64"
-                      onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Server download', 'eventAction' : 'Select option', 'eventLabel' : '{{ releases.lts.full_version }}', 'eventValue' : undefined });">Download {{ releases.lts.full_version }} LTS
-                  </a>
-                  {% if releases.lts.server_iso_size %}<span class="u-text--muted">{{ releases.lts.server_iso_size }}</span>{% endif %}
-                </p>
-                <p>
-                    <a href="/download/alternative-downloads">Alternative downloads&nbsp;&rsaquo;</a>
-                </p>
-                <p>
-                    <a href="#architectures">Alternative architectures&nbsp;&rsaquo;</a>
-                </p>
-            </div>
 
-            <div class="js-tab-container">
-                <nav class="p-tabs">
-                    <ul class="p-tabs__list js-tabbed-content u-no-margin--bottom"
-                        role="tablist"
-                        data-maintain-hash="true">
-                        <li class="p-tabs__item">
-                            <a class="p-tabs__link"
-                                role="tab"
-                                aria-selected="true"
-                                id="release-notes-tab"
-                                href="#release-notes"
-                                aria-controls="release-notes">What's new</a>
-                        </li>
-                        <li class="p-tabs__item">
-                            <a class="p-tabs__link"
-                                role="tab"
-                                aria-selected="false"
-                                id="system-requirements-tab"
-                                href="#system-requirements"
-                                aria-controls="system-requirements"
-                                tabindex="-1">System requirements</a>
-                        </li>
-                        <li class="p-tabs__item">
-                            <a class="p-tabs__link"
-                                role="tab"
-                                aria-selected="false"
-                                id="how-to-install-tab"
-                                href="#how-to-install"
-                                aria-controls="how-to-install"
-                                tabindex="-1">How to install</a>
-                        </li>
-                    </ul>
-                </nav>
-            </div>
-
-            <div class="p-tabs__content p-section"
-                  id="release-notes"
-                  role="tabpanel"
-                  aria-labelledby="release-notes-tab">
-                <ul class="p-list--divided">
-                    <li class="p-list__item is-ticked">Linux 6.8 kernel with low latency kernel features enabled by default</li>
-                    <li class="p-list__item is-ticked">
-                        Frame pointers enabled by default for the majority of packages on x86 architectures
-                    </li>
-                    <li class="p-list__item is-ticked">
-                        Rust 1.78, .NET 8 and OpenJDK 21 with TCK certification in addition to other toolchain upgrades
-                    </li>
-                    <li class="p-list__item is-ticked">64-bit time_t by default on armhf to address the year 2038 issue</li>
-                    <li class="p-list__item is-ticked">AppArmor-enforced unprivileged user namespaces restricted by default</li>
-                </ul>
-                <hr class="p-rule" />
-                <p>
-                    <a href="https://discourse.ubuntu.com/t/noble-numbat-release-notes/39890">{{ releases.lts.short_version }} release notes&nbsp;&rsaquo;</a>
-                </p>
-            </div>
-
-            <div class="p-tabs__content p-section"
-                  id="system-requirements"
-                  role="tabpanel"
-                  aria-labelledby="system-requirements-tab">
-                <ul class="p-list--divided">
-                    <li class="p-list__item is-ticked">1 GHz processor or better</li>
-                    <li class="p-list__item is-ticked">1 GB system memory</li>
-                    <li class="p-list__item is-ticked">2.5 GB of free hard drive space</li>
-                    <li class="p-list__item is-ticked">Either a USB port or a DVD drive for the installer media</li>
-                </ul>
-            </div>
-
-            <div class="p-tabs__content p-section"
-                  id="how-to-install"
-                  role="tabpanel"
-                  aria-labelledby="how-to-install-tab">
-                <p>To install Ubuntu Server:</p>
-                <ol class="p-list--divided">
-                    <li class="p-list__item">Download the ISO image</li>
-                    <li class="p-list__item">
-                        Create a bootable USB flash drive with <a href="https://etcher.balena.io/">balenaEtcher</a> or similar
-                    </li>
-                    <li class="p-list__item">Boot from the USB flash drive</li>
-                </ol>
-                <hr class="p-rule" />
-                <p>
-                    <a href="/tutorials/install-ubuntu-server">Follow the step-by-step tutorial&nbsp;&rsaquo;</a>
-                </p>
-            </div>
+        <div class="p-tabs__content p-section"
+             id="release-notes"
+             role="tabpanel"
+             aria-labelledby="release-notes-tab">
+          <ul class="p-list--divided">
+            <li class="p-list__item is-ticked">Linux 6.8 kernel with low latency kernel features enabled by default</li>
+            <li class="p-list__item is-ticked">
+              Frame pointers enabled by default for the majority of packages on x86 architectures
+            </li>
+            <li class="p-list__item is-ticked">
+              Rust 1.78, .NET 8 and OpenJDK 21 with TCK certification in addition to other toolchain upgrades
+            </li>
+            <li class="p-list__item is-ticked">64-bit time_t by default on armhf to address the year 2038 issue</li>
+            <li class="p-list__item is-ticked">AppArmor-enforced unprivileged user namespaces restricted by default</li>
+          </ul>
+          <hr class="p-rule" />
+          <p>
+            <a href="https://discourse.ubuntu.com/t/noble-numbat-release-notes/39890">{{ releases.lts.short_version }} release notes&nbsp;&rsaquo;</a>
+          </p>
         </div>
+
+        <div class="p-tabs__content p-section"
+             id="system-requirements"
+             role="tabpanel"
+             aria-labelledby="system-requirements-tab">
+          <ul class="p-list--divided">
+            <li class="p-list__item is-ticked">1 GHz processor or better</li>
+            <li class="p-list__item is-ticked">1 GB system memory</li>
+            <li class="p-list__item is-ticked">2.5 GB of free hard drive space</li>
+            <li class="p-list__item is-ticked">Either a USB port or a DVD drive for the installer media</li>
+          </ul>
+        </div>
+
+        <div class="p-tabs__content p-section"
+             id="how-to-install"
+             role="tabpanel"
+             aria-labelledby="how-to-install-tab">
+          <p>To install Ubuntu Server:</p>
+          <ol class="p-list--divided">
+            <li class="p-list__item">Download the ISO image</li>
+            <li class="p-list__item">
+              Create a bootable USB flash drive with <a href="https://etcher.balena.io/">balenaEtcher</a> or similar
+            </li>
+            <li class="p-list__item">Boot from the USB flash drive</li>
+          </ol>
+          <hr class="p-rule" />
+          <p>
+            <a href="/tutorials/install-ubuntu-server">Follow the step-by-step tutorial&nbsp;&rsaquo;</a>
+          </p>
+        </div>
+      </div>
     </div>
 
     <section class="p-section">
-        <div class="row">
-            <hr class="p-rule" />
-            <div class="col-3 p-section--shallow">
-                <h3 class="p-text--small-caps">Alternative downloads</h3>
-            </div>
-            <div class="col-9 col-medium-6">
-                <div class="row p-section--shallow">
-                    <div class="col-3 col-medium-3">
-                        <h4 class="p-heading--5">BitTorrent</h4>
-                    </div>
-                    <div class="col-6 col-medium-3">
-                        <p>BitTorrent sometimes enables higher download speeds and more reliable downloads of large files.</p>
-                        <hr />
-                        <a class="p-button"
-                            href="https://releases.ubuntu.com/{{ releases.lts.short_version }}/ubuntu-{{ releases.lts.full_version }}-live-server-amd64.iso.torrent">Torrent for {{ releases.lts.full_version }} LTS</a>
-                    </div>
-                </div>
-                <hr class="p-rule" />
-                <div class="row p-section--shallow">
-                    <div class="col-3 col-medium-3">
-                        <h4 class="p-heading--5">Previous releases</h4>
-                    </div>
-                    <div class="col-6 col-medium-3">
-                        <p>Previous long-term support versions of Ubuntu Server, still supported.</p>
-                        <hr />
-                        <a class="p-button"
-                            href="/download/server/thank-you?version={{ releases.previous_lts.full_version }}&amp;architecture=amd64"
-                            onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Server download', 'eventAction' : 'Select option', 'eventLabel' : '{{ releases.previous_lts.full_version }}', 'eventValue' : undefined });">Download {{ releases.previous_lts.full_version }} LTS
-                        </a>
-                        <a class="p-button"
-                            href="/download/server/thank-you?version={{ releases.previous_previous_lts.full_version }}&amp;architecture=amd64"
-                            onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Server download', 'eventAction' : 'Select option', 'eventLabel' : '{{ releases.previous_previous_lts.full_version }}', 'eventValue' : undefined });">Download {{ releases.previous_previous_lts.full_version }} LTS
-                        </a>
-                    </div>
-                </div>
-                <hr class="p-rule" />
-                <div class="row p-section--shallow">
-                    <div class="col-3 col-medium-3">
-                        <h4 class="p-heading--5">
-                            <a href="/download/alternative-downloads">Other versions&nbsp;&rsaquo;</a>
-                        </h4>
-                    </div>
-                    <div class="col-6 col-medium-3">
-                        <p>
-                            Other versions of Ubuntu Server including torrents, the network installer, a list of local mirrors and past releases.
-                        </p>
-                    </div>
-                </div>
-            </div>
+      <div class="row">
+        <hr class="p-rule" />
+        <div class="col-3 p-section--shallow">
+          <h3 class="p-text--small-caps">Alternative downloads</h3>
         </div>
+        <div class="col-9 col-medium-6">
+          <div class="row p-section--shallow">
+            <div class="col-3 col-medium-3">
+              <h4 class="p-heading--5">BitTorrent</h4>
+            </div>
+            <div class="col-6 col-medium-3">
+              <p>BitTorrent sometimes enables higher download speeds and more reliable downloads of large files.</p>
+              <hr />
+              <a class="p-button"
+                 href="https://releases.ubuntu.com/{{ releases.lts.short_version }}/ubuntu-{{ releases.lts.full_version }}-live-server-amd64.iso.torrent">Torrent for {{ releases.lts.full_version }} LTS</a>
+            </div>
+          </div>
+          <hr class="p-rule" />
+          <div class="row p-section--shallow">
+            <div class="col-3 col-medium-3">
+              <h4 class="p-heading--5">Previous releases</h4>
+            </div>
+            <div class="col-6 col-medium-3">
+              <p>Previous long-term support versions of Ubuntu Server, still supported.</p>
+              <hr />
+              <a class="p-button"
+                 href="/download/server/thank-you?version={{ releases.previous_lts.full_version }}&amp;architecture=amd64&amp;lts=true"
+                 onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Server download', 'eventAction' : 'Select option', 'eventLabel' : '{{ releases.previous_lts.full_version }}', 'eventValue' : undefined });">Download {{ releases.previous_lts.full_version }} LTS
+              </a>
+              <a class="p-button"
+                 href="/download/server/thank-you?version={{ releases.previous_previous_lts.full_version }}&amp;architecture=amd64&amp;lts=true"
+                 onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Server download', 'eventAction' : 'Select option', 'eventLabel' : '{{ releases.previous_previous_lts.full_version }}', 'eventValue' : undefined });">Download {{ releases.previous_previous_lts.full_version }} LTS
+              </a>
+            </div>
+          </div>
+          <hr class="p-rule" />
+          <div class="row p-section--shallow">
+            <div class="col-3 col-medium-3">
+              <h4 class="p-heading--5">
+                <a href="/download/alternative-downloads">Other versions&nbsp;&rsaquo;</a>
+              </h4>
+            </div>
+            <div class="col-6 col-medium-3">
+              <p>
+                Other versions of Ubuntu Server including torrents, the network installer, a list of local mirrors and past releases.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
     </section>
 
     <section class="p-section"
-              id="architectures"
-              style="scroll-margin-top: 3.4rem">
-        <div class="row">
-            <hr class="p-rule" />
-            <div class="col-3 p-section--shallow">
-                <h3 class="p-text--small-caps">Alternative architectures</h3>
-            </div>
-            <div class="col-9 col-medium-6">
-                <div class="row p-section--shallow">
-                    <div class="col-3 col-medium-3">
-                        <h4 class="p-heading--5">
-                            <a href="/download/server/arm">ARM&nbsp;&rsaquo;</a>
-                        </h4>
-                    </div>
-                    <div class="col-6 col-medium-3">
-                        <p>
-                            Optimised for hyperscale deployments and certified on ARM chipsets &mdash; Ubuntu Server for ARM includes the 64-bit ARMv7 and ARMv8 platforms.
-                        </p>
-                    </div>
-                </div>
-                <hr class="p-rule" />
-                <div class="row p-section--shallow">
-                    <div class="col-3 col-medium-3">
-                        <h4 class="p-heading--5">
-                            <a href="/download/server/power">IBM POWER&nbsp;&rsaquo;</a>
-                        </h4>
-                    </div>
-                    <div class="col-6 col-medium-3">
-                        <p>Ubuntu is available on the IBM POWER platform, bringing the entire Ubuntu ecosystem to IBM POWER.</p>
-                    </div>
-                </div>
-                <hr class="p-rule" />
-                <div class="row p-section--shallow">
-                    <div class="col-3 col-medium-3">
-                        <h4 class="p-heading--5">
-                            <a href="/download/server/s390x">IBM Z (s390x)&nbsp;&rsaquo;</a>
-                        </h4>
-                    </div>
-                    <div class="col-6 col-medium-3">
-                        <p>
-                            IBM Z and LinuxONE leverage open technology solutions to meet the demands of the new application economy. Ubuntu is now available on those platforms with Multipass, MicroK8s and more.
-                        </p>
-                    </div>
-                </div>
-                <hr class="p-rule" />
-                <div class="row p-section--shallow">
-                    <div class="col-3 col-medium-3">
-                        <h4 class="p-heading--5">
-                            <a href="/download/risc-v">RISC-V&nbsp;&rsaquo;</a>
-                        </h4>
-                    </div>
-                    <div class="col-6 col-medium-3">
-                        <p>Ubuntu &mdash; now available for multiple RISC-V platforms to accelerate innovation.</p>
-                    </div>
-                </div>
-            </div>
+             id="architectures"
+             style="scroll-margin-top: 3.4rem">
+      <div class="row">
+        <hr class="p-rule" />
+        <div class="col-3 p-section--shallow">
+          <h3 class="p-text--small-caps">Alternative architectures</h3>
         </div>
+        <div class="col-9 col-medium-6">
+          <div class="row p-section--shallow">
+            <div class="col-3 col-medium-3">
+              <h4 class="p-heading--5">
+                <a href="/download/server/arm">ARM&nbsp;&rsaquo;</a>
+              </h4>
+            </div>
+            <div class="col-6 col-medium-3">
+              <p>
+                Optimised for hyperscale deployments and certified on ARM chipsets &mdash; Ubuntu Server for ARM includes the 64-bit ARMv7 and ARMv8 platforms.
+              </p>
+            </div>
+          </div>
+          <hr class="p-rule" />
+          <div class="row p-section--shallow">
+            <div class="col-3 col-medium-3">
+              <h4 class="p-heading--5">
+                <a href="/download/server/power">IBM POWER&nbsp;&rsaquo;</a>
+              </h4>
+            </div>
+            <div class="col-6 col-medium-3">
+              <p>Ubuntu is available on the IBM POWER platform, bringing the entire Ubuntu ecosystem to IBM POWER.</p>
+            </div>
+          </div>
+          <hr class="p-rule" />
+          <div class="row p-section--shallow">
+            <div class="col-3 col-medium-3">
+              <h4 class="p-heading--5">
+                <a href="/download/server/s390x">IBM Z (s390x)&nbsp;&rsaquo;</a>
+              </h4>
+            </div>
+            <div class="col-6 col-medium-3">
+              <p>
+                IBM Z and LinuxONE leverage open technology solutions to meet the demands of the new application economy. Ubuntu is now available on those platforms with Multipass, MicroK8s and more.
+              </p>
+            </div>
+          </div>
+          <hr class="p-rule" />
+          <div class="row p-section--shallow">
+            <div class="col-3 col-medium-3">
+              <h4 class="p-heading--5">
+                <a href="/download/risc-v">RISC-V&nbsp;&rsaquo;</a>
+              </h4>
+            </div>
+            <div class="col-6 col-medium-3">
+              <p>Ubuntu &mdash; now available for multiple RISC-V platforms to accelerate innovation.</p>
+            </div>
+          </div>
+        </div>
+      </div>
     </section>
 
     {% include 'shared/_download-ubuntu-thank-you-pro-section.html' %}
 
     <section class="p-section">
-        <div class="p-section--shallow u-fixed-width">
-            <hr class="p-rule" />
-            <h2 class="p-muted-heading">More from Canonical</h2>
+      <div class="p-section--shallow u-fixed-width">
+        <hr class="p-rule" />
+        <h2 class="p-muted-heading">More from Canonical</h2>
+      </div>
+      <div class="row">
+        <div class="col-3 col-medium-6">
+          <div class="row">
+            <div class="col-6 col-medium-2">
+              <h3>
+                <a href="https://maas.io/?_gl=1*1y3394w*_gcl_au*Mzg2MjE3ODk3LjE3MDI0NjY1NDY.&_ga=2.256850242.873815666.1709630805-805571671.1709630804">
+                  {{ image(url="https://assets.ubuntu.com/v1/d3039f38-MAAS-logo.svg",
+                                    alt="MAAS",
+                                    width="104",
+                                    height="42",
+                                    hi_def=True,
+                                    loading="auto") | safe
+                  }}
+                </a>
+              </h3>
+            </div>
+            <div class="col-6 col-medium-4">
+              <p>Build a bare metal cloud with super fast server provisioning.</p>
+              <hr class="p-rule" />
+              <p>
+                <a href="https://maas.io/">Learn more about MAAS&nbsp;&rsaquo;</a>
+              </p>
+            </div>
+          </div>
         </div>
-        <div class="row">
-            <div class="col-3 col-medium-6">
-                <div class="row">
-                    <div class="col-6 col-medium-2">
-                        <h3>
-                            <a href="https://maas.io/?_gl=1*1y3394w*_gcl_au*Mzg2MjE3ODk3LjE3MDI0NjY1NDY.&_ga=2.256850242.873815666.1709630805-805571671.1709630804">
-                                {{
-                                image (
-                                url="https://assets.ubuntu.com/v1/d3039f38-MAAS-logo.svg",
-                                alt="MAAS",
-                                width="104",
-                                height="42",
-                                hi_def=True,
-                                loading="auto"
-                                ) | safe
-                                }}
-                            </a>
-                        </h3>
-                    </div>
-                    <div class="col-6 col-medium-4">
-                        <p>Build a bare metal cloud with super fast server provisioning.</p>
-                        <hr class="p-rule" />
-                        <p>
-                            <a href="https://maas.io/">Learn more about MAAS&nbsp;&rsaquo;</a>
-                        </p>
-                    </div>
-                </div>
+        <div class="col-3 col-medium-6">
+          <div class="row">
+            <div class="col-6 col-medium-2">
+              <h3>
+                <a href="https://canonical.com/lxd">
+                  {{ image(url="https://assets.ubuntu.com/v1/84ed7eb1-LXD-logo.svg",
+                                    alt="LXD",
+                                    width="80",
+                                    height="42",
+                                    hi_def=True,
+                                    loading="auto") | safe
+                  }}
+                </a>
+              </h3>
             </div>
-            <div class="col-3 col-medium-6">
-                <div class="row">
-                    <div class="col-6 col-medium-2">
-                        <h3>
-                            <a href="https://canonical.com/lxd">
-                                {{
-                                image (
-                                url="https://assets.ubuntu.com/v1/84ed7eb1-LXD-logo.svg",
-                                alt="LXD",
-                                width="80",
-                                height="42",
-                                hi_def=True,
-                                loading="auto"
-                                ) | safe
-                                }}
-                            </a>
-                        </h3>
-                    </div>
-                    <div class="col-6 col-medium-4">
-                        <p>Fast, dense, and secure container and VM management at any scale.</p>
-                        <hr class="p-rule" />
-                        <p>
-                            <a href="https://canonical.com/lxd">Learn more about LXD&nbsp;&rsaquo;</a>
-                        </p>
-                    </div>
-                </div>
+            <div class="col-6 col-medium-4">
+              <p>Fast, dense, and secure container and VM management at any scale.</p>
+              <hr class="p-rule" />
+              <p>
+                <a href="https://canonical.com/lxd">Learn more about LXD&nbsp;&rsaquo;</a>
+              </p>
             </div>
-            <div class="col-3 col-medium-6">
-                <div class="row">
-                    <div class="col-6 col-medium-2">
-                        <h3>
-                            <a href="https://juju.is/">
-                                {{
-                                image (
-                                url="https://assets.ubuntu.com/v1/35f593dd-Juju-logo.svg",
-                                alt="Juju",
-                                width="79",
-                                height="42",
-                                hi_def=True,
-                                loading="auto"
-                                ) | safe
-                                }}
-                            </a>
-                        </h3>
-                    </div>
-                    <div class="col-6 col-medium-4">
-                        <p>Design and deploy entire workloads in just a few clicks.</p>
-                        <hr class="p-rule" />
-                        <p>
-                            <a href="https://juju.is/">Learn more about Juju&nbsp;&rsaquo;</a>
-                        </p>
-                    </div>
-                </div>
-            </div>
-            <div class="col-3 col-medium-6">
-                <div class="row">
-                    <div class="col-6 col-medium-2">
-                        <h3>
-                            <a href="https://multipass.run/">
-                                {{
-                                image (
-                                url="https://assets.ubuntu.com/v1/ede1a596-Multipass-logo.svg",
-                                alt="Multipass",
-                                width="141",
-                                height="42",
-                                hi_def=True,
-                                loading="auto"
-                                ) | safe
-                                }}
-                            </a>
-                        </h3>
-                    </div>
-                    <div class="col-6 col-medium-4">
-                        <p>Spin up Ubuntu VMs on Windows, Mac and Linux.</p>
-                        <hr class="p-rule" />
-                        <p>
-                            <a href="https://multipass.run/">Learn more about Multipass&nbsp;&rsaquo;</a>
-                        </p>
-                    </div>
-                </div>
-            </div>
+          </div>
         </div>
+        <div class="col-3 col-medium-6">
+          <div class="row">
+            <div class="col-6 col-medium-2">
+              <h3>
+                <a href="https://juju.is/">
+                  {{ image(url="https://assets.ubuntu.com/v1/35f593dd-Juju-logo.svg",
+                                    alt="Juju",
+                                    width="79",
+                                    height="42",
+                                    hi_def=True,
+                                    loading="auto") | safe
+                  }}
+                </a>
+              </h3>
+            </div>
+            <div class="col-6 col-medium-4">
+              <p>Design and deploy entire workloads in just a few clicks.</p>
+              <hr class="p-rule" />
+              <p>
+                <a href="https://juju.is/">Learn more about Juju&nbsp;&rsaquo;</a>
+              </p>
+            </div>
+          </div>
+        </div>
+        <div class="col-3 col-medium-6">
+          <div class="row">
+            <div class="col-6 col-medium-2">
+              <h3>
+                <a href="https://multipass.run/">
+                  {{ image(url="https://assets.ubuntu.com/v1/ede1a596-Multipass-logo.svg",
+                                    alt="Multipass",
+                                    width="141",
+                                    height="42",
+                                    hi_def=True,
+                                    loading="auto") | safe
+                  }}
+                </a>
+              </h3>
+            </div>
+            <div class="col-6 col-medium-4">
+              <p>Spin up Ubuntu VMs on Windows, Mac and Linux.</p>
+              <hr class="p-rule" />
+              <p>
+                <a href="https://multipass.run/">Learn more about Multipass&nbsp;&rsaquo;</a>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
     </section>
 
     <section class="p-section">
-        <hr class="p-rule is-fixed-width" />
-        <div class="row">
+      <hr class="p-rule is-fixed-width" />
+      <div class="row">
+        <div class="col-3 col-medium-2">
+          <div class="p-section">
+            <h2 class="p-muted-heading">Resources</h2>
+          </div>
+        </div>
+        <div class="col-9">
+          <div class="row">
             <div class="col-3 col-medium-2">
-                <div class="p-section">
-                    <h2 class="p-muted-heading">Resources</h2>
-                </div>
+              <h3 class="p-heading--5">
+                <a href="/server/docs">Ubuntu Server documentation</a>
+              </h3>
+              <p>The Ubuntu Server documentation, curated by community and Ubuntu developers.</p>
             </div>
-            <div class="col-9">
-                <div class="row">
-                    <div class="col-3 col-medium-2">
-                        <h3 class="p-heading--5">
-                            <a href="/server/docs">Ubuntu Server documentation</a>
-                        </h3>
-                        <p>The Ubuntu Server documentation, curated by community and Ubuntu developers.</p>
-                    </div>
-                    <div class="col-3 col-medium-2">
-                        <h3 class="p-heading--5">
-                            <a href="https://askubuntu.com/">Ask Ubuntu</a>
-                        </h3>
-                        <p>Stuck somewhere? Get your Ubuntu questions answered by power users.</p>
-                    </div>
-                    <div class="col-3 col-medium-2">
-                        <h3 class="p-heading--5">
-                            <a href="https://discourse.ubuntu.com/">Community Discourse</a>
-                        </h3>
-                        <p>Discuss with Ubuntu developers and make your voice heard.</p>
-                    </div>
-                </div>
+            <div class="col-3 col-medium-2">
+              <h3 class="p-heading--5">
+                <a href="https://askubuntu.com/">Ask Ubuntu</a>
+              </h3>
+              <p>Stuck somewhere? Get your Ubuntu questions answered by power users.</p>
             </div>
+            <div class="col-3 col-medium-2">
+              <h3 class="p-heading--5">
+                <a href="https://discourse.ubuntu.com/">Community Discourse</a>
+              </h3>
+              <p>Discuss with Ubuntu developers and make your voice heard.</p>
+            </div>
+          </div>
         </div>
+      </div>
     </section>
-</section>
+  </section>
 
-{% include 'download/server/multipass.html' %}
+  {% include 'download/server/multipass.html' %}
 
-{% include 'download/server/choose.html' %}
+  {% include 'download/server/choose.html' %}
 
-<section class="p-section--deep">
+  <section class="p-section--deep">
     <div class="row">
-        <hr class="p-rule" />
-        <div class="col-3 col-medium-6">
-            <div class="p-section--shallow">
-                <h2 class="p-text--small-caps">
-                    <a href="/blog/tag/ubuntu-server">Latest from&nbsp;our&nbsp;blog&nbsp;&rsaquo;</a>
-                </h2>
-            </div>
+      <hr class="p-rule" />
+      <div class="col-3 col-medium-6">
+        <div class="p-section--shallow">
+          <h2 class="p-text--small-caps">
+            <a href="/blog/tag/ubuntu-server">Latest from&nbsp;our&nbsp;blog&nbsp;&rsaquo;</a>
+          </h2>
         </div>
-        <div class="col-9 col-medium-6">
-            <div class="row p-section--shallow" id="ubuntu-server-latest"></div>
-        </div>
+      </div>
+      <div class="col-9 col-medium-6">
+        <div class="row p-section--shallow" id="ubuntu-server-latest"></div>
+      </div>
     </div>
 
     <template style="display:none" id="ubuntu-server-template">
-        <div class="col-3 col-medium-2">
-            <div class="u-crop--16-9">
-                <div class="article-image p-image-wrapper"></div>
-            </div>
-            <h3 class="p-heading--5">
-                <a class="article-link article-title"></a>
-            </h3>
-            <p class="article-excerpt"></p>
+      <div class="col-3 col-medium-2">
+        <div class="u-crop--16-9">
+          <div class="article-image p-image-wrapper"></div>
         </div>
+        <h3 class="p-heading--5">
+          <a class="article-link article-title"></a>
+        </h3>
+        <p class="article-excerpt"></p>
+      </div>
     </template>
-</section>
+  </section>
 
-<script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-<script>
-  canonicalLatestNews.fetchLatestNews({
-    articlesContainerSelector: "#ubuntu-server-latest",
-    articleTemplateSelector: "#ubuntu-server-template",
-    excerptLength: 200,
-    tagId: 1610,
-    limit: 3
-  })
+  <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
+  <script>
+    canonicalLatestNews.fetchLatestNews({
+      articlesContainerSelector: "#ubuntu-server-latest",
+      articleTemplateSelector: "#ubuntu-server-template",
+      excerptLength: 200,
+      tagId: 1610,
+      limit: 3
+    })
 
-  // This page has a nested tab section, this script will show 
-  // the default parent tab when the page is loaded if the hash is a child tab
-  function showParentTab() {
-    const currentHash = window.location.hash;
-    const activeTab = document.querySelector(
-      ".p-tabs__link[href='" + currentHash + "']"
-    );
-    const targetIds = ["release-notes", "system-requirements", "how-to-install"];
+    // This page has a nested tab section, this script will show 
+    // the default parent tab when the page is loaded if the hash is a child tab
+    function showParentTab() {
+      const currentHash = window.location.hash;
+      const activeTab = document.querySelector(
+        ".p-tabs__link[href='" + currentHash + "']"
+      );
+      const targetIds = ["release-notes", "system-requirements", "how-to-install"];
 
-    if (activeTab) {
-      const targetControl = activeTab.getAttribute("aria-controls")
+      if (activeTab) {
+        const targetControl = activeTab.getAttribute("aria-controls")
 
-      if (targetIds.includes(targetControl)) {
-        indexTab = document.getElementById("manual-install")
-        indexTab.classList.remove("u-hide")
+        if (targetIds.includes(targetControl)) {
+          indexTab = document.getElementById("manual-install")
+          indexTab.classList.remove("u-hide")
+        }
       }
     }
-  }
 
-  // Prevents non-tab hash links from hiding the tab content
-  function handleNonTabHashClick() {
-    const currentHash = window.location.hash;
-    const activeTab = document.querySelector(
-      ".p-tabs__link[href='#release-notes']"
-    );
-    const targetControl = activeTab.getAttribute("aria-controls")
-    const tabContentContainers = document.querySelectorAll(".p-tabs__content");
+    // Prevents non-tab hash links from hiding the tab content
+    function handleNonTabHashClick() {
+      const currentHash = window.location.hash;
+      const activeTab = document.querySelector(
+        ".p-tabs__link[href='#release-notes']"
+      );
+      const targetControl = activeTab.getAttribute("aria-controls")
+      const tabContentContainers = document.querySelectorAll(".p-tabs__content");
 
-    if (currentHash && currentHash == "#architectures") {
-      tabContentContainers.forEach(container => {
-        if (container.id !== targetControl && container.id !== "manual-install") {
-          container.classList.add("u-hide")
-        }
-      })
+      if (currentHash && currentHash == "#architectures") {
+        tabContentContainers.forEach(container => {
+          if (container.id !== targetControl && container.id !== "manual-install") {
+            container.classList.add("u-hide")
+          }
+        })
+      }
     }
-  }
 
-  addEventListener("DOMContentLoaded", () => {
-    handleNonTabHashClick()
-    showParentTab()
-  });
-</script>
+    addEventListener("DOMContentLoaded", () => {
+      handleNonTabHashClick()
+      showParentTab()
+    });
+  </script>
 
 {% endblock %}

--- a/templates/download/server/thank-you.html
+++ b/templates/download/server/thank-you.html
@@ -2,262 +2,258 @@
 
 {% block title %}Thank you for downloading Ubuntu Server{% endblock %}
 
-{% block meta_copydoc %}https://docs.google.com/document/d/1S5zY7HN_Q8eQWch0mCEfLICfj8pW1bct9_wGArCNIqc/edit{% endblock meta_copydoc %}
+{% block meta_copydoc %}
+  https://docs.google.com/document/d/1S5zY7HN_Q8eQWch0mCEfLICfj8pW1bct9_wGArCNIqc/edit
+{% endblock meta_copydoc %}
 
-{% block body_class %}is-paper{% endblock body_class %}
+{% block body_class %}
+  is-paper
+{% endblock body_class %}
 
-{% block head_extra %}
-  <meta name="robots" content="noindex" />
-{% endblock %}
+{% block head_extra %}<meta name="robots" content="noindex" />{% endblock %}
 
 {% block content %}
-<noscript>
-  <meta
-    http-equiv="refresh"
-    content="3;url=https://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-live-server-amd64.iso"
-  />
-</noscript>
+  <noscript>
+    <meta http-equiv="refresh"
+          content="3;url=https://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-live-server-amd64.iso" />
+  </noscript>
 
-<section class="p-strip is-shallow u-no-padding--bottom">
-  <div class="row--50-50">
-    <div class="col">
-      <h1 class="js-download-option">Thank you for downloading Ubuntu Server {{ version }}</h1>
-      <p>Your download should start in the background. If it doesn't,
-        <a href="https://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-live-server-amd64.iso">download&nbsp;now</a>.<br />
-        {% with version=version, system="live-server", architecture="amd64" %}
-          {% include "download/shared/_verify-checksums.html" %}
+  <section class="p-strip is-shallow u-no-padding--bottom">
+    <div class="row--50-50">
+      <div class="col">
+        <h1 class="js-download-option">Thank you for downloading Ubuntu Server {{ version }}{{ " LTS" if lts }}</h1>
+        <p>
+          Your download should start in the background. If it doesn't,
+          <a href="https://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-live-server-amd64.iso">download&nbsp;now</a>.
+          <br />
+          {% with version=version, system="live-server", architecture="amd64" %}
+            {% include "download/shared/_verify-checksums.html" %}
+          {% endwith %}
+        </p>
+      </div>
+      <div class="col">
+        {% with returnUrl="/download/server", ga_event_title="Ubuntu Server download" %}
+          {% include 'shared/_download-newsletter.html' %}
         {% endwith %}
-      </p>
-    </div>
-    <div class="col">
-      {% with returnUrl="/download/server", ga_event_title="Ubuntu Server download" %}
-        {% include 'shared/_download-newsletter.html' %}
-      {% endwith %}
-    </div>
-  </div>
-</section>
-
-{% include 'download/shared/_server_weekly_news.html' %}
-
-<section class="p-section">
-  <hr class="p-rule is-fixed-width" />
-  <div class="row--50-50">
-    <div class="col">
-      <h2>Ubuntu CLI cheatsheet</h2>
-      <div class="p-section--shallow">
-        <p>Learn how to use the command line efficiently and get started with DevOps &mdash; from basic file management to LXD virtualisation and Ubuntu Pro.</p>
-      </div>
-      <button class="p-button--positive" onclick="toggleModal()">Download the CLI cheat sheet</button>
-    </div>
-    <div class="col">
-      <div class="p-section--shallow p-image-wrapper">
-        {{
-          image (
-          url="https://assets.ubuntu.com/v1/639c1f12-server-cli-cheatsheet.png",
-          alt="CLI cheat sheet",
-          width="1200",
-          height="849",
-          hi_def=True,
-          loading="auto"
-          ) | safe
-        }}
       </div>
     </div>
-  </div>
-</section>
+  </section>
 
-<section class="p-section">
-  <hr class="p-rule is-fixed-width" />
-  <div class="row">
-    <div class="col-3 col-medium-2">
-      <div class="p-section">
-        <h2 class="p-muted-heading">Resources</h2>
+  {% include 'download/shared/_server_weekly_news.html' %}
+
+  <section class="p-section">
+    <hr class="p-rule is-fixed-width" />
+    <div class="row--50-50">
+      <div class="col">
+        <h2>Ubuntu CLI cheatsheet</h2>
+        <div class="p-section--shallow">
+          <p>
+            Learn how to use the command line efficiently and get started with DevOps &mdash; from basic file management to LXD virtualisation and Ubuntu Pro.
+          </p>
+        </div>
+        <button class="p-button--positive" onclick="toggleModal()">Download the CLI cheat sheet</button>
+      </div>
+      <div class="col">
+        <div class="p-section--shallow p-image-wrapper">
+          {{ image(url="https://assets.ubuntu.com/v1/639c1f12-server-cli-cheatsheet.png",
+                    alt="CLI cheat sheet",
+                    width="1200",
+                    height="849",
+                    hi_def=True,
+                    loading="auto") | safe
+          }}
+        </div>
       </div>
     </div>
-    <div class="col-9">
-     <div class="row">
+  </section>
+
+  <section class="p-section">
+    <hr class="p-rule is-fixed-width" />
+    <div class="row">
       <div class="col-3 col-medium-2">
-        <h3 class="p-heading--5"><a href="/server/docs">Ubuntu Server documentation</a></h3>
-        <p>The Ubuntu Server documentation, curated by community and Ubuntu developers.</p>
+        <div class="p-section">
+          <h2 class="p-muted-heading">Resources</h2>
+        </div>
       </div>
+      <div class="col-9">
+        <div class="row">
+          <div class="col-3 col-medium-2">
+            <h3 class="p-heading--5">
+              <a href="/server/docs">Ubuntu Server documentation</a>
+            </h3>
+            <p>The Ubuntu Server documentation, curated by community and Ubuntu developers.</p>
+          </div>
+          <div class="col-3 col-medium-2">
+            <h3 class="p-heading--5">
+              <a href="https://askubuntu.com/">Ask Ubuntu</a>
+            </h3>
+            <p>Stuck somewhere? Get your Ubuntu questions answered by power users.</p>
+          </div>
+          <div class="col-3 col-medium-2">
+            <h3 class="p-heading--5">
+              <a href="https://discourse.ubuntu.com/">Community Discourse</a>
+            </h3>
+            <p>Discuss with Ubuntu developers and make your voice heard.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  {% include 'shared/_download-ubuntu-thank-you-pro-section.html' %}
+
+  <section class="p-section">
+    <div class="p-section--shallow u-fixed-width">
+      <hr class="p-rule" />
+      <h2 class="p-muted-heading">More from Canonical</h2>
+    </div>
+    <div class="row">
+      <div class="col-3 col-medium-6">
+        <div class="row">
+          <div class="col-6 col-medium-2">
+            <h3>
+              <a href="https://maas.io/?_gl=1*1y3394w*_gcl_au*Mzg2MjE3ODk3LjE3MDI0NjY1NDY.&_ga=2.256850242.873815666.1709630805-805571671.1709630804">
+                {{ image(url="https://assets.ubuntu.com/v1/d3039f38-MAAS-logo.svg",
+                                alt="MAAS",
+                                width="104",
+                                height="42",
+                                hi_def=True,
+                                loading="auto") | safe
+                }}
+              </a>
+            </h3>
+          </div>
+          <div class="col-6 col-medium-4">
+            <p>Build a bare metal cloud with super fast server provisioning.</p>
+            <hr class="p-rule" />
+            <p>
+              <a href="https://maas.io/">Learn more about MAAS&nbsp;&rsaquo;</a>
+            </p>
+          </div>
+        </div>
+      </div>
+      <div class="col-3 col-medium-6">
+        <div class="row">
+          <div class="col-6 col-medium-2">
+            <h3>
+              <a href="https://canonical.com/lxd">
+                {{ image(url="https://assets.ubuntu.com/v1/84ed7eb1-LXD-logo.svg",
+                                alt="LXD",
+                                width="80",
+                                height="42",
+                                hi_def=True,
+                                loading="auto") | safe
+                }}
+              </a>
+            </h3>
+          </div>
+          <div class="col-6 col-medium-4">
+            <p>Fast, dense, and secure container and VM management at any scale.</p>
+            <hr class="p-rule" />
+            <p>
+              <a href="https://canonical.com/lxd">Learn more about LXD&nbsp;&rsaquo;</a>
+            </p>
+          </div>
+        </div>
+      </div>
+      <div class="col-3 col-medium-6">
+        <div class="row">
+          <div class="col-6 col-medium-2">
+            <h3>
+              <a href="https://juju.is/">
+                {{ image(url="https://assets.ubuntu.com/v1/35f593dd-Juju-logo.svg",
+                                alt="Juju",
+                                width="79",
+                                height="42",
+                                hi_def=True,
+                                loading="auto") | safe
+                }}
+              </a>
+            </h3>
+          </div>
+          <div class="col-6 col-medium-4">
+            <p>Design and deploy entire workloads in just a few clicks.</p>
+            <hr class="p-rule" />
+            <p>
+              <a href="https://juju.is/">Learn more about Juju&nbsp;&rsaquo;</a>
+            </p>
+          </div>
+        </div>
+      </div>
+      <div class="col-3 col-medium-6">
+        <div class="row">
+          <div class="col-6 col-medium-2">
+            <h3>
+              <a href="https://multipass.run/">
+                {{ image(url="https://assets.ubuntu.com/v1/ede1a596-Multipass-logo.svg",
+                                alt="Multipass",
+                                width="141",
+                                height="42",
+                                hi_def=True,
+                                loading="auto") | safe
+                }}
+              </a>
+            </h3>
+          </div>
+          <div class="col-6 col-medium-4">
+            <p>Spin up Ubuntu VMs on Windows, Mac and Linux.</p>
+            <hr class="p-rule" />
+            <p>
+              <a href="https://multipass.run/">Learn more about Multipass&nbsp;&rsaquo;</a>
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section--deep">
+    <div class="row">
+      <hr class="p-rule" />
+      <div class="col-3 col-medium-6">
+        <div class="p-section--shallow">
+          <h2 class="p-text--small-caps">
+            <a href="/blog/tag/ubuntu-server">Latest from&nbsp;our&nbsp;blog&nbsp;&rsaquo;</a>
+          </h2>
+        </div>
+      </div>
+      <div class="col-9 col-medium-6">
+        <div class="row p-section--shallow" id="ubuntu-server-latest"></div>
+      </div>
+    </div>
+
+    <template style="display:none" id="ubuntu-server-template">
       <div class="col-3 col-medium-2">
-        <h3 class="p-heading--5"><a href="https://askubuntu.com/">Ask Ubuntu</a></h3>
-        <p>Stuck somewhere? Get your Ubuntu questions answered by power users.</p>
+        <h3 class="p-heading--5">
+          <a class="article-link article-title"></a>
+        </h3>
+        <p class="article-excerpt"></p>
       </div>
-      <div class="col-3 col-medium-2">
-        <h3 class="p-heading--5"><a href="https://discourse.ubuntu.com/">Community Discourse</a></h3>
-        <p>Discuss with Ubuntu developers and make your voice heard.</p>
-      </div>  
-     </div> 
-    </div>
-  </div>
-</section>
+    </template>
+  </section>
 
-{% include 'shared/_download-ubuntu-thank-you-pro-section.html' %}
-
-<section class="p-section">
-  <div class="p-section--shallow u-fixed-width">
-    <hr class="p-rule" />
-    <h2 class="p-muted-heading">More from Canonical</h2>
-  </div>
-  <div class="row">
-    <div class="col-3 col-medium-6">
-      <div class="row">
-        <div class="col-6 col-medium-2">
-          <h3>
-            <a href="https://maas.io/?_gl=1*1y3394w*_gcl_au*Mzg2MjE3ODk3LjE3MDI0NjY1NDY.&_ga=2.256850242.873815666.1709630805-805571671.1709630804">
-              {{
-                image (
-                url="https://assets.ubuntu.com/v1/d3039f38-MAAS-logo.svg",
-                alt="MAAS",
-                width="104",
-                height="42",
-                hi_def=True,
-                loading="auto"
-                ) | safe
-              }}
-            </a>
-          </h3>
-        </div>
-        <div class="col-6 col-medium-4">
-          <p>Build a bare metal cloud with super fast server provisioning.</p>
-          <hr class="p-rule" />
-          <p>
-            <a href="https://maas.io/">Learn more about MAAS&nbsp;&rsaquo;</a>
-          </p>
-        </div>
-      </div>
-    </div>
-    <div class="col-3 col-medium-6">
-      <div class="row">
-        <div class="col-6 col-medium-2">
-          <h3>
-            <a href="https://canonical.com/lxd">
-              {{
-                image (
-                  url="https://assets.ubuntu.com/v1/84ed7eb1-LXD-logo.svg",
-                  alt="LXD",
-                  width="80",
-                  height="42",
-                  hi_def=True,
-                  loading="auto"
-                ) | safe
-              }}
-            </a>
-          </h3>
-        </div>
-        <div class="col-6 col-medium-4">
-          <p>Fast, dense, and secure container and VM management at any scale.</p>
-          <hr class="p-rule" />
-          <p>
-            <a href="https://canonical.com/lxd">Learn more about LXD&nbsp;&rsaquo;</a>
-          </p>
-        </div>
-      </div>
-    </div>
-    <div class="col-3 col-medium-6">
-      <div class="row">
-        <div class="col-6 col-medium-2">
-          <h3>
-            <a href="https://juju.is/">
-            {{
-              image (
-                url="https://assets.ubuntu.com/v1/35f593dd-Juju-logo.svg",
-                alt="Juju",
-                width="79",
-                height="42",
-                hi_def=True,
-                loading="auto"
-              ) | safe
-            }}
-            </a>
-          </h3>
-        </div>
-        <div class="col-6 col-medium-4">
-          <p>Design and deploy entire workloads in just a few clicks.</p>
-          <hr class="p-rule" />
-          <p>
-            <a href="https://juju.is/">Learn more about Juju&nbsp;&rsaquo;</a>
-          </p>
-        </div>
-      </div>
-    </div>
-    <div class="col-3 col-medium-6">
-      <div class="row">
-        <div class="col-6 col-medium-2">
-          <h3>
-            <a href="https://multipass.run/">
-            {{
-              image (
-                url="https://assets.ubuntu.com/v1/ede1a596-Multipass-logo.svg",
-                alt="Multipass",
-                width="141",
-                height="42",
-                hi_def=True,
-                loading="auto"
-              ) | safe
-            }}
-            </a>
-          </h3>
-        </div>
-        <div class="col-6 col-medium-4">
-          <p>Spin up Ubuntu VMs on Windows, Mac and Linux.</p>
-          <hr class="p-rule" />
-          <p>
-            <a href="https://multipass.run/">Learn more about Multipass&nbsp;&rsaquo;</a>
-          </p>
-        </div>
-      </div>
-    </div>
-  </div>
-</section>
-
-<section class="p-section--deep">
-  <div class="row">
-    <hr class="p-rule"/>
-    <div class="col-3 col-medium-6">
-      <div class="p-section--shallow">
-        <h2 class="p-text--small-caps"><a href="/blog/tag/ubuntu-server">Latest from&nbsp;our&nbsp;blog&nbsp;&rsaquo;</a></h2>
-      </div>
-    </div>
-    <div class="col-9 col-medium-6">
-      <div class="row p-section--shallow" id="ubuntu-server-latest">
-      </div>
-    </div>
-  </div>
-
-  <template style="display:none" id="ubuntu-server-template">
-    <div class="col-3 col-medium-2">
-      <h3 class="p-heading--5"><a class="article-link article-title"></a></h3>
-      <p class="article-excerpt"></p>
-    </div>
-  </template>
-</section>
-
-<script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-<script>
-  canonicalLatestNews.fetchLatestNews(
-    {
+  <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
+  <script>
+    canonicalLatestNews.fetchLatestNews({
       articlesContainerSelector: "#ubuntu-server-latest",
       articleTemplateSelector: "#ubuntu-server-template",
       excerptLength: 200,
       tagId: 1610,
       limit: 3
-    }
-  )
-</script>
+    })
+  </script>
 
 {% endblock content %}
 
 {% block footer_extra %}
-<script src="{{ versioned_static('js/dist/image-download.js') }}"></script>
+  <script src="{{ versioned_static('js/dist/image-download.js') }}"></script>
 
-<script defer>
-  var version = '{{ version }}';
+  <script defer>
+    var version = '{{ version }}';
 
-  var GAlabel = version + '-server-amd64';
-  var imagePath = version + '/ubuntu-' + version + '-live-server-amd64.iso';
+    var GAlabel = version + '-server-amd64';
+    var imagePath = version + '/ubuntu-' + version + '-live-server-amd64.iso';
 
-  window.initImageDownload(imagePath, GAlabel);
-</script>
+    window.initImageDownload(imagePath, GAlabel);
+  </script>
 {% endblock footer_extra %}

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -162,6 +162,7 @@ def download_server_steps():
 def download_thank_you(category):
     version = flask.request.args.get("version", "")
     architecture = flask.request.args.get("architecture", "").replace(" ", "+")
+    lts = flask.request.args.get("lts", "")
 
     if version and not architecture:
         flask.abort(400)
@@ -171,6 +172,7 @@ def download_thank_you(category):
             f"download/{category}/thank-you.html",
             version=version,
             architecture=architecture,
+            lts=lts,
         ),
         {"Cache-Control": "no-cache"},
     )


### PR DESCRIPTION
## Done

Added the word "LTS" at the end of the title of the Thank You page for downloading desktop and server images. It will only add it if the release is actually LTS. For interim and non-LTS releases that word will not be added.

## QA

- Navigate to either /download/desktop or /download/server
- Click on download button
- On redirected Thank You page check that it shows "LTS" at the end of the title

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-10461

## Screenshots

![Screenshot 2024-04-17 at 17 46 14](https://github.com/canonical/ubuntu.com/assets/15943863/5826506e-3ec0-4b75-802c-6e7e172a6408)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
