### PR TITLE
add configuration for indentation for djLint

### DIFF
--- a/.djlintrc
+++ b/.djlintrc
@@ -4,6 +4,7 @@
   "close_void_tags": true,
   "ignore": "J018,H006,H021,H023,H029,T002,T003,T028,D018",
   "include": "H017",
+  "indent": "2",
   "max_blank_lines": 1,
   "max_line_length": "120",
   "profile": "jinja",


### PR DESCRIPTION
## Done

- Added configuration that defines indentation for HTML files when formatting using djLint.

## QA

- The formatting should now use 2 spaces as an indentation instead of 4 by default.

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
