### PR TITLE
[WD-10513] update download raspberry pi

### DIFF
--- a/templates/download/cloud/index.html
+++ b/templates/download/cloud/index.html
@@ -1,165 +1,200 @@
 {% extends "download/_base_download.html" %}
 
 {% block title %}Use Ubuntu in public clouds | Download{% endblock %}
-{% block meta_description %}How to use Ubuntu in the public cloud and where to find our customised cloud images for development.{% endblock %}
-{% block meta_copydoc %}https://docs.google.com/document/d/1kp7QQXst1EbCjZjzWZP3YZwfmG0EIXLfQoRUVaMEZng/edit{% endblock meta_copydoc %}
+
+{% block meta_description %}
+  How to use Ubuntu in the public cloud and where to find our customised cloud images for development.
+{% endblock %}
+
+{% block meta_copydoc %}
+  https://docs.google.com/document/d/1kp7QQXst1EbCjZjzWZP3YZwfmG0EIXLfQoRUVaMEZng/edit
+{% endblock meta_copydoc %}
 
 {% block content %}
-<section class="p-strip--suru-topped is-bordered">
-  <div class="row u-equal-height">
-    <div class="col-8">
-      <h1>Optimised Ubuntu on&nbsp;public&nbsp;clouds</h1>
-      <p>Ubuntu builds optimised and certified server images for partners like Amazon AWS, Microsoft Azure, Google Cloud Platform, IBM Cloud and Oracle. In addition, Canonical offers Ubuntu Pro, enterprise-grade commercial support, on these images.</p>
+  <section class="p-strip--suru-topped is-bordered">
+    <div class="row u-equal-height">
+      <div class="col-8">
+        <h1>Optimised Ubuntu on&nbsp;public&nbsp;clouds</h1>
+        <p>
+          Ubuntu builds optimised and certified server images for partners like Amazon AWS, Microsoft Azure, Google Cloud Platform, IBM Cloud and Oracle. In addition, Canonical offers Ubuntu Pro, enterprise-grade commercial support, on these images.
+        </p>
+      </div>
+      <div class="col-4 u-align--center u-vertically-center u-hide--medium u-hide--small">
+        {{ image(url="https://assets.ubuntu.com/v1/f0028afb-ubuntu-cloud.svg",
+                alt="ubuntu cloud illustration",
+                width="303",
+                height="198",
+                hi_def=True,) | safe
+        }}
+      </div>
     </div>
-    <div class="col-4 u-align--center u-vertically-center u-hide--medium u-hide--small">
-      {{
-        image(
-          url="https://assets.ubuntu.com/v1/f0028afb-ubuntu-cloud.svg",
-          alt="ubuntu cloud illustration",
-          width="303",
-          height="198",
-          hi_def=True,
-        ) | safe
-      }}
-    </div>
-  </div>
-</section>
+  </section>
 
-{% include "/shared/_ubuntu_pro_on_public_cloud.html" %}
+  {% include "/shared/_ubuntu_pro_on_public_cloud.html" %}
 
-<section class="p-strip is-deep is-bordered">
-  <div class="row">
-    <div class="col-10">
-      <h2>Use Ubuntu in the cloud</h2>
-      <p>Here are some shortcuts to get you up and running with Ubuntu on various public clouds. You can also use our <a href="https://cloud-images.ubuntu.com/locator/">Ubuntu Cloud image finder</a> to search for the ids of specific Ubuntu images on various public clouds by location, architecture, release and more.</p>
-    </div>
-  </div>
-  <div class="row u-equal-height">
-    <div class="p-card col-4">
-      <div class="p-card__content">
-        <h4>
-          <a class="u-align--center u-vertically-center" style="min-height:10rem;display: flex;" href="http://cloud-images.ubuntu.com/locator/ec2/">
-            {{
-              image(
-                  url="https://assets.ubuntu.com/v1/a82add58-profile-aws.svg",
-                  alt="Amazon Web Services logo",
-                  width="84",
-                  height="50",
-                  hi_def=True,
-                  loading="lazy",
-                  attrs={"style": "align-self: center;max-height: 10rem; max-width:10rem;"},
-                ) | safe
-            }}
-          </a>
-        </h4>
-        <p>Amazon Web Services offers reliable, scalable, and inexpensive cloud computing services.</p>
+  <section class="p-strip is-deep is-bordered">
+    <div class="row">
+      <div class="col-10">
+        <h2>Use Ubuntu in the cloud</h2>
+        <p>
+          Here are some shortcuts to get you up and running with Ubuntu on various public clouds. You can also use our <a href="https://cloud-images.ubuntu.com/locator/">Ubuntu Cloud image finder</a> to search for the ids of specific Ubuntu images on various public clouds by location, architecture, release and more.
+        </p>
       </div>
-      <ul class="p-list">
-        <li class="p-list__item u-no-margin--top"><a href="https://documentation.ubuntu.com/aws/en/latest/aws-how-to/instances">Ubuntu's guide to using EC2</a></li>
-        <li class="p-list__item"><a href="http://cloud-images.ubuntu.com/locator/ec2/">Amazon EC2 AMI Locator</a></li>
-        <li class="p-list__item"><a href="/aws/pro">Launch Ubuntu Pro for AWS&nbsp;&rsaquo;</a></li>
-      </ul>
     </div>
-    <div class="p-card col-4">
-      <div class="p-card__content">
-        <h4>
-          <a class="u-align--center u-vertically-center" style="min-height:10rem;display: flex;" href="https://azuremarketplace.microsoft.com/en-gb/marketplace/apps?search=Canonical+linux+for+the+cloud+Ubuntu%20Server&page=1">
-            {{
-              image(
-                  url="https://assets.ubuntu.com/v1/22fd6473-MicrosoftAzure_logo.svg",
-                  alt="Microsoft Azure logo",
-                  width="130",
-                  height="38",
-                  hi_def=True,
-                  loading="lazy",
-                  attrs={"style": "align-self: center;max-height: 10rem; max-width:12rem;"},
-                ) | safe
-            }}
-          </a>
-        </h4>
-        <p>Microsoft Azure is an open, flexible, enterprise-grade cloud computing platform.</p>
+    <div class="row u-equal-height">
+      <div class="p-card col-4">
+        <div class="p-card__content">
+          <h4>
+            <a class="u-align--center u-vertically-center"
+               style="min-height:10rem;
+                      display: flex"
+               href="https://cloud-images.ubuntu.com/locator/ec2/">
+              {{ image(url="https://assets.ubuntu.com/v1/a82add58-profile-aws.svg",
+                            alt="Amazon Web Services logo",
+                            width="84",
+                            height="50",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"style": "align-self: center;max-height: 10rem; max-width:10rem;"},) | safe
+              }}
+            </a>
+          </h4>
+          <p>Amazon Web Services offers reliable, scalable, and inexpensive cloud computing services.</p>
+        </div>
+        <ul class="p-list">
+          <li class="p-list__item u-no-margin--top">
+            <a href="https://documentation.ubuntu.com/aws/en/latest/aws-how-to/instances">Ubuntu's guide to using EC2</a>
+          </li>
+          <li class="p-list__item">
+            <a href="https://cloud-images.ubuntu.com/locator/ec2/">Amazon EC2 AMI Locator</a>
+          </li>
+          <li class="p-list__item">
+            <a href="/aws/pro">Launch Ubuntu Pro for AWS&nbsp;&rsaquo;</a>
+          </li>
+        </ul>
       </div>
-      <ul class="p-list">
-        <li class="p-list__item u-no-margin--top"><a href="/azure">Ubuntu on Azure&nbsp;&rsaquo;</a></li>
-        <li class="p-list__item"><a href="https://azuremarketplace.microsoft.com/en-gb/marketplace/apps?search=Canonical+linux+for+the+cloud+Ubuntu%20Server&page=1" >Launch Ubuntu on Azure&nbsp;&rsaquo;</a></li>
-        <li class="p-list__item"><a href="/azure/pro">Launch Ubuntu Pro for Azure&nbsp;&rsaquo;</a></li>
-      </ul>
-    </div>
-    <div class="p-card col-4">
-      <div class="p-card__content">
-        <h4>
-          <a class="u-align--center u-vertically-center" style="min-height:10rem;display: flex;" href="https://console.cloud.google.com/launcher/browse?q=ubuntu&filter=category:os&filter=price:free">
-            {{
-              image(
-                  url="https://assets.ubuntu.com/v1/e795fc84-Google_Cloud_Logo.svg",
-                  alt="Google Cloud Platform logo",
-                  width="259",
-                  height="40",
-                  hi_def=True,
-                  loading="lazy",
-                  attrs={"style": "align-self: center; max-height: 10rem;"},
-                ) | safe
-            }}
-          </a>
-        </h4>
-        <p>Google Cloud Platform lets you build and host applications and websites, store data, and analyze data on Google's scalable infrastructure.</p>
+      <div class="p-card col-4">
+        <div class="p-card__content">
+          <h4>
+            <a class="u-align--center u-vertically-center"
+               style="min-height:10rem;
+                      display: flex"
+               href="https://azuremarketplace.microsoft.com/en-gb/marketplace/apps?search=Canonical+linux+for+the+cloud+Ubuntu%20Server&page=1">
+              {{ image(url="https://assets.ubuntu.com/v1/22fd6473-MicrosoftAzure_logo.svg",
+                            alt="Microsoft Azure logo",
+                            width="130",
+                            height="38",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"style": "align-self: center;max-height: 10rem; max-width:12rem;"},) | safe
+              }}
+            </a>
+          </h4>
+          <p>Microsoft Azure is an open, flexible, enterprise-grade cloud computing platform.</p>
+        </div>
+        <ul class="p-list">
+          <li class="p-list__item u-no-margin--top">
+            <a href="/azure">Ubuntu on Azure&nbsp;&rsaquo;</a>
+          </li>
+          <li class="p-list__item">
+            <a href="https://azuremarketplace.microsoft.com/en-gb/marketplace/apps?search=Canonical+linux+for+the+cloud+Ubuntu%20Server&page=1">Launch Ubuntu on Azure&nbsp;&rsaquo;</a>
+          </li>
+          <li class="p-list__item">
+            <a href="/azure/pro">Launch Ubuntu Pro for Azure&nbsp;&rsaquo;</a>
+          </li>
+        </ul>
       </div>
-      <ul class="p-list">
-        <li class="p-list__item u-no-margin--top"><a href="https://cloud.google.com/sdk/docs/quickstart-debian-ubuntu">Guide to using GCP</a></li>
-        <li class="p-list__item"><a href="https://console.cloud.google.com/launcher/browse?q=ubuntu&filter=category:os&filter=price:free">Get started on GCP</a></li>
-        <li class="p-list__item"><a href="https://console.cloud.google.com/marketplace/product/ubuntu-os-cloud/ubuntu-focal">Launch Ubuntu on GCP</a></li>
-        <li class="p-list__item"><a href="https://console.cloud.google.com/marketplace/product/ubuntu-os-pro-cloud/ubuntu-pro-focal">Launch Ubuntu Pro on GCP</a></li>
-      </ul>
-    </div>
-  </div>
-  <div class="row u-equal-height">
-    <div class="p-card col-4">
-      <div class="p-card__content">
-        <h4>
-          <a class="u-align--center u-vertically-center" style="min-height:10rem;display: flex;" href="https://www.ibm.com/cloud/">
-            {{
-             image(
-                 url="https://assets.ubuntu.com/v1/5e91ff73-ibm-cloud-logo.svg",
-                 alt="IBM Cloud",
-                 width="192",
-                 height="45",
-                 hi_def=True,
-                 loading="lazy",
-                 attrs={"style": "align-self: center;max-height: 10rem; max-width:12rem;"},
-               ) | safe
-            }}
-          </a>
-        </h4>
+      <div class="p-card col-4">
+        <div class="p-card__content">
+          <h4>
+            <a class="u-align--center u-vertically-center"
+               style="min-height:10rem;
+                      display: flex"
+               href="https://console.cloud.google.com/launcher/browse?q=ubuntu&filter=category:os&filter=price:free">
+              {{ image(url="https://assets.ubuntu.com/v1/e795fc84-Google_Cloud_Logo.svg",
+                            alt="Google Cloud Platform logo",
+                            width="259",
+                            height="40",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"style": "align-self: center; max-height: 10rem;"},) | safe
+              }}
+            </a>
+          </h4>
+          <p>
+            Google Cloud Platform lets you build and host applications and websites, store data, and analyze data on Google's scalable infrastructure.
+          </p>
+        </div>
+        <ul class="p-list">
+          <li class="p-list__item u-no-margin--top">
+            <a href="https://cloud.google.com/sdk/docs/quickstart-debian-ubuntu">Guide to using GCP</a>
+          </li>
+          <li class="p-list__item">
+            <a href="https://console.cloud.google.com/launcher/browse?q=ubuntu&filter=category:os&filter=price:free">Get started on GCP</a>
+          </li>
+          <li class="p-list__item">
+            <a href="https://console.cloud.google.com/marketplace/product/ubuntu-os-cloud/ubuntu-focal">Launch Ubuntu on GCP</a>
+          </li>
+          <li class="p-list__item">
+            <a href="https://console.cloud.google.com/marketplace/product/ubuntu-os-pro-cloud/ubuntu-pro-focal">Launch Ubuntu Pro on GCP</a>
+          </li>
+        </ul>
       </div>
-      <ul class="p-list">
-        <li class="p-list__item u-no-margin--top"><a href="https://www.ibm.com/cloud/">Get started on IBM Cloud</a></li>
-      </ul>
     </div>
-    <div class="p-card col-4">
-      <div class="p-card__content">
-        <h4>
-          <a class="u-align--center u-vertically-center" style="min-height:10rem;display: flex;" href="https://docs.oracle.com/en/cloud/get-started/index.html">
-            {{
-              image(
-                  url="https://assets.ubuntu.com/v1/08646a72-logo-oracle.svg",
-                  alt="Oracle",
-                  width="192",
-                  height="27",
-                  hi_def=True,
-                  loading="lazy",
-                  attrs={"style": "align-self: center;max-height: 10rem; max-width:12rem;"},
-                ) | safe
-            }}
-          </a>
-        </h4>
+    <div class="row u-equal-height">
+      <div class="p-card col-4">
+        <div class="p-card__content">
+          <h4>
+            <a class="u-align--center u-vertically-center"
+               style="min-height:10rem;
+                      display: flex"
+               href="https://www.ibm.com/cloud/">
+              {{ image(url="https://assets.ubuntu.com/v1/5e91ff73-ibm-cloud-logo.svg",
+                            alt="IBM Cloud",
+                            width="192",
+                            height="45",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"style": "align-self: center;max-height: 10rem; max-width:12rem;"},) | safe
+              }}
+            </a>
+          </h4>
+        </div>
+        <ul class="p-list">
+          <li class="p-list__item u-no-margin--top">
+            <a href="https://www.ibm.com/cloud/">Get started on IBM Cloud</a>
+          </li>
+        </ul>
       </div>
-      <ul class="p-list">
-        <li class="p-list__item u-no-margin--top"><a href="https://docs.oracle.com/en/cloud/get-started/index.html">Guide to using Oracle Cloud</a></li>
-      </ul>
+      <div class="p-card col-4">
+        <div class="p-card__content">
+          <h4>
+            <a class="u-align--center u-vertically-center"
+               style="min-height:10rem;
+                      display: flex"
+               href="https://docs.oracle.com/en/cloud/get-started/index.html">
+              {{ image(url="https://assets.ubuntu.com/v1/08646a72-logo-oracle.svg",
+                            alt="Oracle",
+                            width="192",
+                            height="27",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"style": "align-self: center;max-height: 10rem; max-width:12rem;"},) | safe
+              }}
+            </a>
+          </h4>
+        </div>
+        <ul class="p-list">
+          <li class="p-list__item u-no-margin--top">
+            <a href="https://docs.oracle.com/en/cloud/get-started/index.html">Guide to using Oracle Cloud</a>
+          </li>
+        </ul>
+      </div>
     </div>
-  </div>
-</section>
+  </section>
 
-{% with first_item="_download_cloud_ubuntu_advantage", second_item="_cloud_newsletter", third_item="_download_helping_hands" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
+  {% with first_item="_download_cloud_ubuntu_advantage", second_item="_cloud_newsletter", third_item="_download_helping_hands" %}
+    {% include "shared/contextual_footers/_contextual_footer.html" %}
+  {% endwith %}
 
 {% endblock content %}

--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -1,352 +1,333 @@
 {% extends "download/_base_download.html" %}
+
 {% block title %}Install Ubuntu on a Raspberry Pi{% endblock %}
+
 {% block meta_image %}
   https://assets.ubuntu.com/v1/f60f86c4-Embedded+social+media+banner+.jpg
 {% endblock meta_image %}
+
 {% block meta_description %}
   Ubuntu is an open-source operating system for cross-platform development, there's no better place to get started than with Ubuntu on a Raspberry Pi
 {% endblock meta_description %}
+
 {% block meta_copydoc %}
   https://docs.google.com/document/d/1KgnSBa8mbR7qwlxxtqbE5a1wXh5GjtVums8TIB7IGVw/edit#
 {% endblock meta_copydoc %}
+
 {% block body_class %}is-paper{% endblock %}
+
 {% block content %}
-<section class="p-strip is-shallow u-no-margin--bottom">
-  <div class="row--50-50">
-    <div class="col">
-      <h1>
-        Install Ubuntu
-        <br class="u-hide--small" />
-        on a Raspberry Pi
-      </h1>
-    </div>
-    <div class="col">
-      <p>
-        Versatile and affordable, the Raspberry Pi is one of the most popular devices available on the market, with uses that range from education to industry.
-      </p>
-      <p>
-        With full Ubuntu support, open source developers have everything they need to get up and running quickly and securely.
-      </p>
-      <div class="p-section">
-        {{
-          image(
-            url="https://assets.ubuntu.com/v1/016b770d-raspberry+pi+horizontal.svg",
-            alt="Raspberry Pi",
-            height="48",
-            width="36",
-            hi_def=True,
-            loading="auto"
-          ) | safe
-        }}
+  <section class="p-strip is-shallow u-no-margin--bottom">
+    <div class="row--50-50">
+      <div class="col">
+        <h1>
+          Install Ubuntu
+          <br class="u-hide--small" />
+          on a Raspberry Pi
+        </h1>
+      </div>
+      <div class="col">
+        <p>
+          Versatile and affordable, the Raspberry Pi is one of the most popular devices available on the market, with uses that range from education to industry.
+        </p>
+        <p>
+          With full Ubuntu support, open source developers have everything they need to get up and running quickly and securely.
+        </p>
+        <div class="p-section">
+          {{ image(url="https://assets.ubuntu.com/v1/016b770d-raspberry+pi+horizontal.svg",
+                    alt="Raspberry Pi",
+                    height="48",
+                    width="36",
+                    hi_def=True,
+                    loading="auto") | safe
+          }}
+        </div>
       </div>
     </div>
-  </div>
-</section>
-<section class="p-section">
-  <hr class="p-rule is-fixed-width" />
-  <div class="row--50-50">
-    <div class="col">
-      <h2>First time installing Ubuntu on Raspberry Pi?</h2>
-    </div>
-    <div class="col">
-      <p>
-        The simplest way is to use the <a href="https://www.raspberrypi.com/software/">Raspberry Pi Imager</a> which enables you to select an Ubuntu image when flashing your SD card.
-      </p>
-      <p>If you are on Ubuntu, open the terminal and run:</p>
-      <pre><code>sudo snap install rpi-imager</code></pre>
-      <p>
-        And follow our <a href="/tutorials/how-to-install-ubuntu-desktop-on-raspberry-pi-4#1-overview">Desktop</a>, <a href="/tutorials/how-to-install-ubuntu-on-your-raspberry-pi#1-overview">Server</a> and <a href="/download/raspberry-pi-core">Core</a> tutorials to get started.
-      </p>
-      <div class="p-image--wrapper p-section--shallow">
-        <img src="https://assets.ubuntu.com/v1/e24d92fc-raspberry-pi-imager-2024.png"
-              alt="Screenshot of the Raspberry Pi Imager, with three buttons letting you choose the Raspberry Pi device, operating system and storage where to write the image" />
+  </section>
+  <section class="p-section">
+    <hr class="p-rule is-fixed-width" />
+    <div class="row--50-50">
+      <div class="col">
+        <h2>First time installing Ubuntu on Raspberry Pi?</h2>
+      </div>
+      <div class="col">
+        <p>
+          The simplest way is to use the <a href="https://www.raspberrypi.com/software/">Raspberry Pi Imager</a> which enables you to select an Ubuntu image when flashing your SD card.
+        </p>
+        <p>If you are on Ubuntu, open the terminal and run:</p>
+        <pre><code>sudo snap install rpi-imager</code></pre>
+        <p>
+          And follow our <a href="/tutorials/how-to-install-ubuntu-desktop-on-raspberry-pi-4#1-overview">Desktop</a>, <a href="/tutorials/how-to-install-ubuntu-on-your-raspberry-pi#1-overview">Server</a> and <a href="/download/raspberry-pi-core">Core</a> tutorials to get started.
+        </p>
+        <div class="p-image--wrapper p-section--shallow">
+          <img src="https://assets.ubuntu.com/v1/e24d92fc-raspberry-pi-imager-2024.png"
+               alt="Screenshot of the Raspberry Pi Imager, with three buttons letting you choose the Raspberry Pi device, operating system and storage where to write the image" />
+        </div>
       </div>
     </div>
-  </div>
-</section>
-<hr class="p-rule is-fixed-width" />
-<section class="p-section">
-  <div class="row--50-50 p-section">
-    <div class="col u-image-position">
-      <h2>Ubuntu {{ releases.lts.full_version }} LTS</h2>
-      <div class="u-image-position--bottom">
-        {{
-          image(
-            url="https://assets.ubuntu.com/v1/3b5fa561-mascot-numbat@2x.png",
-            alt="Noble Numbat",
-            width="182",
-            height="135",
-            hi_def=True,
-            loading="auto"
-          ) | safe
-        }}
+  </section>
+  <hr class="p-rule is-fixed-width" />
+  <section class="p-section">
+    <div class="row--50-50 p-section">
+      <div class="col u-image-position">
+        <h2>Ubuntu {{ releases.lts.full_version }} LTS</h2>
+        <div class="u-image-position--bottom">
+          {{ image(url="https://assets.ubuntu.com/v1/3b5fa561-mascot-numbat@2x.png",
+                    alt="Noble Numbat",
+                    width="182",
+                    height="135",
+                    hi_def=True,
+                    loading="auto") | safe
+          }}
+        </div>
+      </div>
+      <div class="col">
+        <p>
+          The latest LTS version of Ubuntu, for desktop PCs and laptops. LTS stands for long-term support — which means five years of free security and maintenance updates, extended to 10 years with <a href="/pro">Ubuntu Pro</a>.
+        </p>
+        <hr />
+        <p class="u-responsive-realign">
+          <a href="/download/raspberry-pi/thank-you?version={{ releases.lts.full_version }}&amp;architecture=desktop-arm64+raspi"
+             onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 64-bit - Ubuntu Desktop', 'eventLabel' : '{{ releases.lts.full_version }}', 'eventValue' : undefined });"
+             class="p-button--positive u-no-margin--bottom">Download Ubuntu Desktop {{ releases.lts.full_version }} LTS</a>
+          {% if releases.lts.raspi_desktop_iso_size %}
+            <span class="u-text--muted">{{ releases.lts.raspi_desktop_iso_size }}</span>
+          {% endif %}
+        </p>
+        <p>Minimum 2GBs of RAM and 16GB storage required</p>
+        <hr />
+        <p class="u-responsive-realign">
+          <a href="/download/raspberry-pi/thank-you?version={{ releases.lts.full_version }}&amp;architecture=server-arm64+raspi"
+             onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 64-bit - Ubuntu Server', 'eventLabel' : '{{ releases.lts.full_version }}', 'eventValue' : undefined });"
+             class="p-button">Download Ubuntu Server {{ releases.lts.full_version }} LTS</a>
+          {% if releases.lts.raspi_desktop_iso_size %}
+            <span class="u-text--muted">{{ releases.lts.raspi_server_iso_size }}</span>
+          {% endif %}
+        </p>
       </div>
     </div>
-    <div class="col">
-      <p>
-        The latest LTS version of Ubuntu, for desktop PCs and laptops. LTS stands for long-term support — which means five years of free security and maintenance updates, extended to 10 years with <a href="/pro">Ubuntu Pro</a>.
-      </p>
-      <hr />
-      <p class="u-responsive-realign">
-        <a href="/download/raspberry-pi/thank-you?version={{ releases.lts.full_version }}&amp;architecture=desktop-arm64+raspi"
-            onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 64-bit - Ubuntu Desktop', 'eventLabel' : '{{ releases.lts.full_version }}', 'eventValue' : undefined });"
-            class="p-button--positive u-no-margin--bottom">Download Ubuntu Desktop {{ releases.lts.full_version }} LTS</a>
-        {% if releases.lts.raspi_desktop_iso_size %}
-          <span class="u-text--muted">{{ releases.lts.raspi_desktop_iso_size }}</span>
-        {% endif %}
-      </p>
-      <p>Minimum 2GBs of RAM and 16GB storage required</p>
-      <hr />
-      <p class="u-responsive-realign">
-        <a href="/download/raspberry-pi/thank-you?version={{ releases.lts.full_version }}&amp;architecture=server-arm64+raspi"
-            onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 64-bit - Ubuntu Server', 'eventLabel' : '{{ releases.lts.full_version }}', 'eventValue' : undefined });"
-            class="p-button">Download Ubuntu Server {{ releases.lts.full_version }} LTS</a>
-        {% if releases.lts.raspi_desktop_iso_size %}
-          <span class="u-text--muted">{{ releases.lts.raspi_server_iso_size }}</span>
-        {% endif %}
-      </p>
-    </div>
-  </div>
-  <hr class="p-rule is-fixed-width" />
-  <div class="row--50-50">
-    <div class="col">
-      <h2>Ubuntu Core 22</h2>
-    </div>
-    <div class="col">
-      <p>
-        An immutable, strictly confined operating system designed for Internet of Things (IoT) use-cases with a focus on security and simplified maintenance, supported until 2032.
-      </p>
-      <hr />
-      <p class="u-responsive-realign">
-        <a href="/download/raspberry-pi/thank-you?version={{ releases.latest.core_version }}&amp;architecture=core-22-arm64+raspi"
-            onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 64-bit - Ubuntu Core', 'eventLabel' : '{{ releases.latest.core_version }}', 'eventValue' : undefined });"
-            class="p-button">Download Ubuntu Core {{ releases.latest.core_version }}</a>
-        <span class="u-text--muted">263MB</span>
-      </p>
-    </div>
-  </div>
-</section>
-<section class="p-section">
-  <hr class="p-rule is-fixed-width" />
-  <div class="row--50-50">
-    <div class="col">
-      <h2>Supported devices</h2>
-    </div>
-    <div class="col">
-      <p>
-        Certified devices are tested for reliability and performance, ensuring you have the best out-of-the-box Ubuntu experience. Ubuntu <abbr title="Long-term support">LTS</abbr> releases are certified on select Raspberry Pi hardware.
-      </p>
-      <hr />
-      <ul class="p-inline-list u-responsive-realign">
-        <li class="p-inline-list__item">
-          <a href="/certified">Learn more about Ubuntu Certified&nbsp;&rsaquo;</a>
-        </li>
-        <li class="p-inline-list__item">
-          <a href="/certified/iot?q=&limit=13&vendor=Raspberry+Pi+Foundation">All certified Raspberry Pi hardware&nbsp;&rsaquo;</a>
-        </li>
-      </ul>
-    </div>
-  </div>
-</section>
-<section class="p-section">
-  <div class="row">
-    <div class="col-medium-6 col-9 col-start-large-4 u-table-horizontal-scroll">
-      <table class="u-table-horizontal-scroll__table" aria-label="Raspberry Pi support with Ubuntu">
-        <thead>
-          <tr>
-            <th style="width: 15%;"></th>
-            <th style="width: 10%;"></th>
-            <th style="width: 26%">
-              Ubuntu {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr>
-            </th>
-            <th style="width: 20%">Ubuntu Core {{ releases.latest.core_version }}</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th>
-              <p>Raspberry Pi 5</p>
-            </th>
-            <td>
-              {{
-                image (
-                  url="https://assets.ubuntu.com/v1/14667b44-raspberry-pi_5.png",
-                  alt="Raspberry Pi 5",
-                  width="61",
-                  height="46",
-                  hi_def=True,
-                  loading="lazy",
-                  attrs={"class": "u-hide--small"},
-              ) | safe
-              }}
-            </td>
-            <td>Yes, certified</td>
-            <td>-</td>
-          </tr>
-          <tr>
-            <th>
-              <p>Raspberry Pi Zero 2 W</p>
-            </th>
-            <td>
-              {{
-                image (
-                  url="https://assets.ubuntu.com/v1/a79a3cee-raspberry-pi-z-2.png",
-                  alt="Raspberry Pi Zero 2 W",
-                  width="70",
-                  height="46",
-                  hi_def=True,
-                  loading="lazy",
-                  attrs={"class": "u-hide--small"},
-                ) | safe
-              }}
-            </td>
-            <td>Yes, certified</td>
-            <td>Yes, certified</td>
-          </tr>
-          <tr>
-            <th>
-              <p>Raspberry Pi CM4</p>
-            </th>
-            <td>
-              {{
-                image (
-                  url="https://assets.ubuntu.com/v1/3be8f179-Raspberry-Pi-CM4.png",
-                  alt="Raspberry Pi CM4",
-                  height="48",
-                  width="68",
-                  hi_def=True,
-                  loading="lazy",
-                  attrs={"class": "u-hide--small"},
-                ) | safe
-              }}
-            </td>
-            <td>Yes, certified</td>
-            <td>Yes, certified</td>
-          </tr>
-          <tr>
-            <th>
-              <p>Raspberry Pi 400</p>
-            </th>
-            <td>
-              {{
-                image(
-                  url="https://assets.ubuntu.com/v1/cfdcd6c7-Raspberry-Pi-400-back--1536x1097.png",
-                  alt="Raspberry Pi 400",
-                  height="48",
-                  width="93",
-                  hi_def=True,
-                  loading="lazy",
-                  attrs={"class": "u-hide--small"},
-                ) | safe
-              }}
-            </td>
-            <td>Yes, certified</td>
-            <td>Yes, certified</td>
-          </tr>
-          <tr>
-            <th>
-              <p>Raspberry Pi 4</p>
-            </th>
-            <td>
-              {{
-                image(
-                  url="https://assets.ubuntu.com/v1/a999bb5f-Raspberry+Pi+4.png",
-                  alt="Raspberry Pi 4",
-                  height="48",
-                  width="75",
-                  hi_def=True,
-                  loading="lazy",
-                  attrs={"class": "u-hide--small"},
-                ) | safe
-              }}
-            </td>
-            <td>Yes, certified</td>
-            <td>Yes, certified</td>
-          </tr>
-          <tr>
-            <th>
-              <p>Raspberry Pi 3</p>
-            </th>
-            <td>
-              {{
-                image(
-                  url="https://assets.ubuntu.com/v1/c4a007b6-Raspberry+Pi+3.png",
-                  alt="Rapsberry Pi 3",
-                  height="48",
-                  width="75",
-                  hi_def=True,
-                  loading="lazy",
-                  attrs={"class": "u-hide--small"},
-                ) | safe
-              }}
-            </td>
-            <td>-</td>
-            <td>Yes, certified</td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-  </div>
-</section>
-<section class="p-section">
-  <hr class="p-rule is-fixed-width" />
-  <div class="row--50-50">
-    <div class="col">
-      <h2>Make something great today</h2>
-    </div>
-    <div class="col">
-      <ul class="p-list--divided">
-        <li class="p-list__item">
-          <a href="/blog/linux-gaming-tutorial-raspberry-pi-minecraft-server-on-ubuntu-desktop">Raspberry Pi Tutorial: Host a Minecraft server on Ubuntu Desktop</a>
-        </li>
-        <li class="p-list__item">
-          <a href="/blog/common-sense-using-the-raspberry-pi-sense-hat-on-ubuntu-impish-indri">Common Sense &mdash; using the Raspberry Pi Sense HAT on Ubuntu Impish Indri</a>
-        </li>
-        <li class="p-list__item">
-          <a href="/blog/homelab-clusters-lxd-micro-cloud-on-raspberry-pi">Homelab clusters: LXD micro cloud on Raspberry Pi</a>
-        </li>
-        <li class="p-list__item">
-          <a href="https://maas.io/tutorials/build-your-own-bare-metal-cloud-using-a-raspberry-pi-cluster-with-maas#1-overview">Build your own bare metal cloud using a Raspberry Pi cluster with MAAS</a>
-        </li>
-      </ul>
-    </div>
-  </div>
-</section>
-<section class="p-section--deep">
-  <hr class="p-rule is-fixed-width" />
-  <div class="row">
-    <div class="col-3 col-medium-6">
-      <div class="p-section--shallow">
-        <h2 class="p-text--small-caps">
-          <a href="/blog/tag/raspberry-pi">Latest from&nbsp;our&nbsp;blog&nbsp;&rsaquo;</a>
-        </h2>
+    <hr class="p-rule is-fixed-width" />
+    <div class="row--50-50">
+      <div class="col">
+        <h2>Ubuntu Core 22</h2>
+      </div>
+      <div class="col">
+        <p>
+          An immutable, strictly confined operating system designed for Internet of Things (IoT) use-cases with a focus on security and simplified maintenance, supported until 2032.
+        </p>
+        <hr />
+        <p class="u-responsive-realign">
+          <a href="/download/raspberry-pi/thank-you?version={{ releases.latest.core_version }}&amp;architecture=core-22-arm64+raspi"
+             onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 64-bit - Ubuntu Core', 'eventLabel' : '{{ releases.latest.core_version }}', 'eventValue' : undefined });"
+             class="p-button">Download Ubuntu Core {{ releases.latest.core_version }}</a>
+          <span class="u-text--muted">263MB</span>
+        </p>
       </div>
     </div>
-    <div class="col-9 col-medium-6">
-      <div class="row p-section--shallow" id="blog-latest"></div>
+  </section>
+  <section class="p-section">
+    <hr class="p-rule is-fixed-width" />
+    <div class="row--50-50">
+      <div class="col">
+        <h2>Supported devices</h2>
+      </div>
+      <div class="col">
+        <p>
+          Certified devices are tested for reliability and performance, ensuring you have the best out-of-the-box Ubuntu experience. Ubuntu <abbr title="Long-term support">LTS</abbr> releases are certified on select Raspberry Pi hardware.
+        </p>
+        <hr />
+        <ul class="p-inline-list u-responsive-realign">
+          <li class="p-inline-list__item">
+            <a href="/certified">Learn more about Ubuntu Certified&nbsp;&rsaquo;</a>
+          </li>
+          <li class="p-inline-list__item">
+            <a href="/certified/iot?q=&limit=13&vendor=Raspberry+Pi+Foundation">All certified Raspberry Pi hardware&nbsp;&rsaquo;</a>
+          </li>
+        </ul>
+      </div>
     </div>
-  </div>
-  <template style="display:none" id="blog-template">
-    <div class="col-3 col-medium-2">
-      <div class="article-image u-blog-thumbnails p-image-wrapper"></div>
+  </section>
+  <section class="p-section">
+    <div class="row">
+      <div class="col-medium-6 col-9 col-start-large-4 u-table-horizontal-scroll">
+        <table class="u-table-horizontal-scroll__table"
+               aria-label="Raspberry Pi support with Ubuntu">
+          <thead>
+            <tr>
+              <th style="width: 15%;"></th>
+              <th style="width: 10%;"></th>
+              <th style="width: 26%">
+                Ubuntu {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr>
+              </th>
+              <th style="width: 20%">Ubuntu Core {{ releases.latest.core_version }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th>
+                <p>Raspberry Pi 5</p>
+              </th>
+              <td>
+                {{ image(url="https://assets.ubuntu.com/v1/14667b44-raspberry-pi_5.png",
+                                alt="Raspberry Pi 5",
+                                width="61",
+                                height="46",
+                                hi_def=True,
+                                loading="lazy",
+                                attrs={"class": "u-hide--small"},) | safe
+                }}
+              </td>
+              <td>Yes, certified</td>
+              <td>-</td>
+            </tr>
+            <tr>
+              <th>
+                <p>Raspberry Pi Zero 2 W</p>
+              </th>
+              <td>
+                {{ image(url="https://assets.ubuntu.com/v1/a79a3cee-raspberry-pi-z-2.png",
+                                alt="Raspberry Pi Zero 2 W",
+                                width="70",
+                                height="46",
+                                hi_def=True,
+                                loading="lazy",
+                                attrs={"class": "u-hide--small"},) | safe
+                }}
+              </td>
+              <td>Yes</td>
+              <td>Yes, certified</td>
+            </tr>
+            <tr>
+              <th>
+                <p>Raspberry Pi CM4</p>
+              </th>
+              <td>
+                {{ image(url="https://assets.ubuntu.com/v1/3be8f179-Raspberry-Pi-CM4.png",
+                                alt="Raspberry Pi CM4",
+                                height="48",
+                                width="68",
+                                hi_def=True,
+                                loading="lazy",
+                                attrs={"class": "u-hide--small"},) | safe
+                }}
+              </td>
+              <td>Yes, certified</td>
+              <td>Yes, certified</td>
+            </tr>
+            <tr>
+              <th>
+                <p>Raspberry Pi 400</p>
+              </th>
+              <td>
+                {{ image(url="https://assets.ubuntu.com/v1/cfdcd6c7-Raspberry-Pi-400-back--1536x1097.png",
+                                alt="Raspberry Pi 400",
+                                height="48",
+                                width="93",
+                                hi_def=True,
+                                loading="lazy",
+                                attrs={"class": "u-hide--small"},) | safe
+                }}
+              </td>
+              <td>Yes, certified</td>
+              <td>Yes, certified</td>
+            </tr>
+            <tr>
+              <th>
+                <p>Raspberry Pi 4</p>
+              </th>
+              <td>
+                {{ image(url="https://assets.ubuntu.com/v1/a999bb5f-Raspberry+Pi+4.png",
+                                alt="Raspberry Pi 4",
+                                height="48",
+                                width="75",
+                                hi_def=True,
+                                loading="lazy",
+                                attrs={"class": "u-hide--small"},) | safe
+                }}
+              </td>
+              <td>Yes, certified</td>
+              <td>Yes, certified</td>
+            </tr>
+            <tr>
+              <th>
+                <p>Raspberry Pi 3</p>
+              </th>
+              <td>
+                {{ image(url="https://assets.ubuntu.com/v1/c4a007b6-Raspberry+Pi+3.png",
+                                alt="Rapsberry Pi 3",
+                                height="48",
+                                width="75",
+                                hi_def=True,
+                                loading="lazy",
+                                attrs={"class": "u-hide--small"},) | safe
+                }}
+              </td>
+              <td>-</td>
+              <td>Yes, certified</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </section>
+  <section class="p-section">
+    <hr class="p-rule is-fixed-width" />
+    <div class="row--50-50">
+      <div class="col">
+        <h2>Make something great today</h2>
+      </div>
+      <div class="col">
+        <ul class="p-list--divided">
+          <li class="p-list__item">
+            <a href="/blog/linux-gaming-tutorial-raspberry-pi-minecraft-server-on-ubuntu-desktop">Raspberry Pi Tutorial: Host a Minecraft server on Ubuntu Desktop</a>
+          </li>
+          <li class="p-list__item">
+            <a href="/blog/common-sense-using-the-raspberry-pi-sense-hat-on-ubuntu-impish-indri">Common Sense &mdash; using the Raspberry Pi Sense HAT on Ubuntu Impish Indri</a>
+          </li>
+          <li class="p-list__item">
+            <a href="/blog/homelab-clusters-lxd-micro-cloud-on-raspberry-pi">Homelab clusters: LXD micro cloud on Raspberry Pi</a>
+          </li>
+          <li class="p-list__item">
+            <a href="https://maas.io/tutorials/build-your-own-bare-metal-cloud-using-a-raspberry-pi-cluster-with-maas#1-overview">Build your own bare metal cloud using a Raspberry Pi cluster with MAAS</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </section>
+  <section class="p-section--deep">
+    <hr class="p-rule is-fixed-width" />
+    <div class="row">
+      <div class="col-3 col-medium-6">
+        <div class="p-section--shallow">
+          <h2 class="p-text--small-caps">
+            <a href="/blog/tag/raspberry-pi">Latest from&nbsp;our&nbsp;blog&nbsp;&rsaquo;</a>
+          </h2>
+        </div>
+      </div>
+      <div class="col-9 col-medium-6">
+        <div class="row p-section--shallow" id="blog-latest"></div>
+      </div>
+    </div>
+    <template style="display:none" id="blog-template">
+      <div class="col-3 col-medium-2">
+        <div class="article-image u-blog-thumbnails p-image-wrapper"></div>
         <h3 class="p-heading--5">
-        <a class="article-link article-title"></a>
-      </h3>
-      <p class="article-excerpt"></p>
-    </div>
-  </template>
-</section>
-<script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-<script>
-  canonicalLatestNews.fetchLatestNews(
-    {
+          <a class="article-link article-title"></a>
+        </h3>
+        <p class="article-excerpt"></p>
+      </div>
+    </template>
+  </section>
+  <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
+  <script>
+    canonicalLatestNews.fetchLatestNews({
       articlesContainerSelector: "#blog-latest",
       articleTemplateSelector: "#blog-template",
       excerptLength: 200,
       tagId: 1672,
       limit: 3,
       linkImage: true,
-    }
-  )
-</script>
+    })
+  </script>
 {% endblock %}

--- a/templates/download/risc-v/index.html
+++ b/templates/download/risc-v/index.html
@@ -2,78 +2,129 @@
 
 {% block title %}Download Ubuntu for RISC-V Platforms{% endblock %}
 
-{% block meta_description %}Use Ubuntu on RISC-V platforms for the familiar developer experience and an accelerated path to production{% endblock meta_description %}
+{% block meta_description %}
+  Use Ubuntu on RISC-V platforms for the familiar developer experience and an accelerated path to production
+{% endblock meta_description %}
 
-{% block meta_copydoc%} https://docs.google.com/document/d/1kkJeq9HdH3iWV35HwihcJd3CxZw9Jy21W66lJl8VbWs/ {% endblock meta_copydoc %}
+{% block meta_copydoc %}
+  https://docs.google.com/document/d/1kkJeq9HdH3iWV35HwihcJd3CxZw9Jy21W66lJl8VbWs/
+{% endblock meta_copydoc %}
 
 {% block content %}
 
-<section class="p-strip is-deep">
-  <div class="row">
-    <div class="col-3 col-medium-2">
-      <div class="p-strip is-shallow u-no-padding--top">
-        {{
-          image (
-          url="https://assets.ubuntu.com/v1/4d5b8d51-riscv-color.svg",
-          alt="",
-          width="200",
-          height="32",
-          hi_def=True,
-          loading="auto",
-          attrs={"style": "padding-top: 1rem"},
-          ) | safe
-        }}
+  <section class="p-strip is-deep">
+    <div class="row">
+      <div class="col-3 col-medium-2">
+        <div class="p-strip is-shallow u-no-padding--top">
+          {{ image(url="https://assets.ubuntu.com/v1/4d5b8d51-riscv-color.svg",
+                    alt="",
+                    width="200",
+                    height="32",
+                    hi_def=True,
+                    loading="auto",
+                    attrs={"style": "padding-top: 1rem"},) | safe
+          }}
+        </div>
       </div>
-  </div>
-  <div class="col-9 col-medium-4">
-    <h1 class="p-heading--2"><strong>Download Ubuntu for RISC-V Platforms</strong></h1>
-    <p>Run Ubuntu with your favourite RISC-V boards. Pick the OS image to match your hardware, flash it onto SD/microSD card, load it onto your board and away you go.</p>
-    <p>All images are 64-bit developer preview builds of Ubuntu Server.</p>
-    <p>
-      <a href="/download/contact-us" class="js-invoke-modal p-button">Get in touch</a>
-    </p>
-  </div>
-  </div>
-</section>
-
-<section class="p-strip is-deep u-no-padding--top">
-  <hr class="is-fixed-width u-no-margin--bottom">
-  <div class="row">
-    <div class="col-3 col-medium-2">
-      <div class="p-strip is-shallow u-no-padding--top"><h2 class="p-text--small-caps">Choose a board</h2></div>
-      <ul class="js-tabbed-content p-tabs--vertical is-black u-hide--small" role="tablist" aria-label="Robotics features">
-        <li><button class="p-tabs__item" id="allwinner-nezha" role="tab" aria-selected="true" aria-controls="allwinner-nezha-tab">AllWinner Nezha</button></li>
-        <li><button class="p-tabs__item" id="microchip-polarfire-soc-fpga-icicle-kit" role="tab" aria-selected="false" aria-controls="microchip-polarfire-soc-fpga-icicle-kit-tab">Polarfire SoC FPGA Icicle</button></li>
-        <li><button class="p-tabs__item" id="qemu" role="tab" aria-selected="false" aria-controls="qemu-tab">QEMU emulator</button></li>
-        <li><button class="p-tabs__item" id="quemu-sifive-image" role="tab" aria-selected="false" aria-controls="quemu-sifive-image-tab">SiFive Unmatched</button></li>
-        <li><button class="p-tabs__item" id="sipeed-licheerv-dock" role="tab" aria-selected="false" aria-controls="sipeed-licheerv-dock-tab">Sipeed LicheeRV Dock</button></li>
-        <li><button class="p-tabs__item" id="starfive-visionfive-2" role="tab" aria-selected="false" aria-controls="starfive-visionfive-2-tab">StarFive VisionFive 2</button></li>
-      </ul>
-      <form class="u-hide--large u-hide--medium">
-        <select name="boardSelect" id="boardSelect">
-          <option value="allwinner-nezha-tab" selected="">AllWinner Nezha</option>
-          <option value="microchip-polarfire-soc-fpga-icicle-kit-tab">Polarfire SoC FPGA Icicle</option>
-          <option value="qemu-tab">QEMU emulator</option>
-          <option value="quemu-sifive-image-tab">SiFive Unmatched</option>
-          <option value="sipeed-licheerv-dock-tab">Sipeed LicheeRV Dock</option>
-          <option value="starfive-visionfive-2-tab">StarFive VisionFive 2</option>
-        </select>
-      </form>
+      <div class="col-9 col-medium-4">
+        <h1 class="p-heading--2">
+          <strong>Download Ubuntu for RISC-V Platforms</strong>
+        </h1>
+        <p>
+          Run Ubuntu with your favourite RISC-V boards. Pick the OS image to match your hardware, flash it onto SD/microSD card, load it onto your board and away you go.
+        </p>
+        <p>All images are 64-bit developer preview builds of Ubuntu Server.</p>
+        <p>
+          <a href="/download/contact-us" class="js-invoke-modal p-button">Get in touch</a>
+        </p>
+      </div>
     </div>
-    <div class="col-9 col-medium-4">
-      {% include "download/risc-v/tab-1.html" %}
-      {% include "download/risc-v/tab-2.html" %}
-      {% include "download/risc-v/tab-3.html" %}
-      {% include "download/risc-v/tab-4.html" %}
-      {% include "download/risc-v/tab-5.html" %}
-      {% include "download/risc-v/tab-6.html" %}
+  </section>
+
+  <section class="p-strip is-deep u-no-padding--top">
+    <hr class="is-fixed-width u-no-margin--bottom" />
+    <div class="row">
+      <div class="col-3 col-medium-2">
+        <div class="p-strip is-shallow u-no-padding--top">
+          <h2 class="p-text--small-caps">Choose a board</h2>
+        </div>
+        <ul class="js-tabbed-content p-tabs--vertical is-black u-hide--small"
+            role="tablist"
+            aria-label="Robotics features">
+          <li>
+            <button class="p-tabs__item"
+                    id="allwinner-nezha"
+                    role="tab"
+                    aria-selected="true"
+                    aria-controls="allwinner-nezha-tab">AllWinner Nezha</button>
+          </li>
+          <li>
+            <button class="p-tabs__item"
+                    id="microchip-polarfire-soc-fpga-icicle-kit"
+                    role="tab"
+                    aria-selected="false"
+                    aria-controls="microchip-polarfire-soc-fpga-icicle-kit-tab">Polarfire SoC FPGA Icicle</button>
+          </li>
+          <li>
+            <button class="p-tabs__item"
+                    id="qemu"
+                    role="tab"
+                    aria-selected="false"
+                    aria-controls="qemu-tab">QEMU emulator</button>
+          </li>
+          <li>
+            <button class="p-tabs__item"
+                    id="quemu-sifive-image"
+                    role="tab"
+                    aria-selected="false"
+                    aria-controls="quemu-sifive-image-tab">SiFive Unmatched</button>
+          </li>
+          <li>
+            <button class="p-tabs__item"
+                    id="sipeed-licheerv-dock"
+                    role="tab"
+                    aria-selected="false"
+                    aria-controls="sipeed-licheerv-dock-tab">Sipeed LicheeRV Dock</button>
+          </li>
+          <li>
+            <button class="p-tabs__item"
+                    id="starfive-visionfive-2"
+                    role="tab"
+                    aria-selected="false"
+                    aria-controls="starfive-visionfive-2-tab">StarFive VisionFive 2</button>
+          </li>
+        </ul>
+        <form class="u-hide--large u-hide--medium">
+          <select name="boardSelect" id="boardSelect">
+            <option value="allwinner-nezha-tab" selected="">AllWinner Nezha</option>
+            <option value="microchip-polarfire-soc-fpga-icicle-kit-tab">Polarfire SoC FPGA Icicle</option>
+            <option value="qemu-tab">QEMU emulator</option>
+            <option value="quemu-sifive-image-tab">SiFive Unmatched</option>
+            <option value="sipeed-licheerv-dock-tab">Sipeed LicheeRV Dock</option>
+            <option value="starfive-visionfive-2-tab">StarFive VisionFive 2</option>
+          </select>
+        </form>
+      </div>
+      <div class="col-9 col-medium-4">
+        {% include "download/risc-v/tab-1.html" %}
+        {% include "download/risc-v/tab-2.html" %}
+        {% include "download/risc-v/tab-3.html" %}
+        {% include "download/risc-v/tab-4.html" %}
+        {% include "download/risc-v/tab-5.html" %}
+        {% include "download/risc-v/tab-6.html" %}
+      </div>
     </div>
-  </div>
-</section>
+  </section>
 
-<!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/risc-v" data-form-id="4532" data-lp-id="" data-return-url="https://ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html"></div>
+  <!-- Set default Marketo information for contact form below-->
+  <div class="u-hide"
+       id="contact-form-container"
+       data-form-location="/shared/forms/interactive/risc-v"
+       data-form-id="4532"
+       data-lp-id=""
+       data-return-url="https://ubuntu.com/contact-us/form/thank-you"
+       data-lp-url="https://pages.ubuntu.com/things-contact-us.html"></div>
 
-<script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
+  <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
 
 {% endblock content %}

--- a/templates/download/risc-v/tab-1.html
+++ b/templates/download/risc-v/tab-1.html
@@ -1,31 +1,40 @@
-<div tabindex="0" role="tabpanel" id="allwinner-nezha-tab" aria-labelledby="allwinner-nezha" aria-hidden="true">
+<div tabindex="0"
+     role="tabpanel"
+     id="allwinner-nezha-tab"
+     aria-labelledby="allwinner-nezha"
+     aria-hidden="true">
   <div class="row p-strip is-shallow u-no-padding--top">
     <div class="col-3">
       <h2 class="u-hide--small">AllWinner Nezha</h2>
     </div>
     <div class="col-6 risc-v-container u-vertically-center u-align--center">
-      {{ image (
-        url="https://assets.ubuntu.com/v1/5207975e-0cc9bac3-Allwinner+Nezha+Board.png",
-        alt="",
-        width="400",
-        height="240",
-        hi_def=True,
-        loading="auto",
-        attrs={"class": "risc-v-image"}
-        ) | safe
+      {{ image(url="https://assets.ubuntu.com/v1/5207975e-0cc9bac3-Allwinner+Nezha+Board.png",
+            alt="",
+            width="400",
+            height="240",
+            hi_def=True,
+            loading="auto",
+            attrs={"class": "risc-v-image"}) | safe
       }}
     </div>
   </div>
   <div class="row p-strip u-no-padding--top">
-    <hr class="col-9">
+    <hr class="col-9" />
     <div class="col-3">
-      <h3 class="p-heading--5 u-no-padding--top">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
+      <h3 class="p-heading--5 u-no-padding--top">
+        Ubuntu Server
+        <br class="u-hide--small" />
+        preinstalled image
+      </h3>
     </div>
     <div class="col-6">
       <p>
-				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/24.04/release/ubuntu-24.04-preinstalled-server-riscv64+nezha.img.xz">Download 24.04</a>
-			</p>
-			<p><a href="https://wiki.ubuntu.com/RISC-V/Nezha%20D1">How to install Ubuntu on the Nezha</a></p>
+        <a class="p-button--positive"
+           href="https://cdimage.ubuntu.com/releases/24.04/release/ubuntu-24.04-preinstalled-server-riscv64+nezha.img.xz">Download 24.04</a>
+      </p>
+      <p>
+        <a href="https://wiki.ubuntu.com/RISC-V/Nezha%20D1">How to install Ubuntu on the Nezha</a>
+      </p>
     </div>
   </div>
 </div>

--- a/templates/download/risc-v/tab-2.html
+++ b/templates/download/risc-v/tab-2.html
@@ -1,37 +1,51 @@
-<div tabindex="0" role="tabpanel" id="microchip-polarfire-soc-fpga-icicle-kit-tab" aria-labelledby="microchip-polarfire-soc-fpga-icicle-kit" aria-hidden="true">
-	<div class="row p-strip is-shallow u-no-padding--top">
+<div tabindex="0"
+     role="tabpanel"
+     id="microchip-polarfire-soc-fpga-icicle-kit-tab"
+     aria-labelledby="microchip-polarfire-soc-fpga-icicle-kit"
+     aria-hidden="true">
+  <div class="row p-strip is-shallow u-no-padding--top">
     <div class="col-3">
-      <h2 class="u-hide--small">Microchip Polarfire SoC <br>FPGA Icicle Kit</h2>
+      <h2 class="u-hide--small">
+        Microchip Polarfire SoC
+        <br />
+        FPGA Icicle Kit
+      </h2>
     </div>
     <div class="col-6 risc-v-container u-vertically-center u-align--center">
-      {{
-        image (
-        url="https://assets.ubuntu.com/v1/0f48dfd1-Microchip+PolarFire.png",
-        alt="",
-        width="400",
-        height="207",
-        hi_def=True,
-        loading="lazy",
-        attrs={"class": "risc-v-image"}
-        ) | safe
+      {{ image(url="https://assets.ubuntu.com/v1/0f48dfd1-Microchip+PolarFire.png",
+            alt="",
+            width="400",
+            height="207",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "risc-v-image"}) | safe
       }}
     </div>
   </div>
   <div class="row p-strip u-no-padding--top">
-    <hr class="col-9">
+    <hr class="col-9" />
     <div class="col-3">
-      <h3 class="p-heading--5 u-no-padding--top">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
+      <h3 class="p-heading--5 u-no-padding--top">
+        Ubuntu Server
+        <br class="u-hide--small" />
+        preinstalled image
+      </h3>
     </div>
     <div class="col-6">
       <p>Works on:</p>
-			<ul class="p-list">
-				<li class="p-list__item is-ticked">The Microchip Polarfire SoC FPGA Icicle Kit with <a href="https://github.com/polarfire-soc/hart-software-services/releases/tag/v2022.10">HSS v2022.10</a></li>
-			</ul>
-      <hr class="is-fixed-width col-6">
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">
+          The Microchip Polarfire SoC FPGA Icicle Kit with <a href="https://github.com/polarfire-soc/hart-software-services/releases/tag/v2022.10">HSS v2022.10</a>
+        </li>
+      </ul>
+      <hr class="is-fixed-width col-6" />
       <p>
-				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/24.04/release/ubuntu-24.04-preinstalled-server-riscv64+icicle.img.xz">Download 24.04</a>
-			</p>
-      <p><a href="https://wiki.ubuntu.com/RISC-V/PolarFire%20SoC%20FPGA%20Icicle%20Kit">How to install Ubuntu on the Microchip Polarfire SoC FPGA Icicle Kit</a></p>
+        <a class="p-button--positive"
+           href="https://cdimage.ubuntu.com/releases/24.04/release/ubuntu-24.04-preinstalled-server-riscv64+icicle.img.xz">Download 24.04</a>
+      </p>
+      <p>
+        <a href="https://wiki.ubuntu.com/RISC-V/PolarFire%20SoC%20FPGA%20Icicle%20Kit">How to install Ubuntu on the Microchip Polarfire SoC FPGA Icicle Kit</a>
+      </p>
     </div>
   </div>
 </div>

--- a/templates/download/risc-v/tab-3.html
+++ b/templates/download/risc-v/tab-3.html
@@ -1,42 +1,55 @@
-<div tabindex="0" role="tabpanel" id="qemu-tab" aria-labelledby="qemu" aria-hidden="true">
+<div tabindex="0"
+     role="tabpanel"
+     id="qemu-tab"
+     aria-labelledby="qemu"
+     aria-hidden="true">
   <div class="row p-strip is-shallow u-no-padding--top">
     <div class="col-3">
       <h2 class="u-hide--small">QEMU emulator</h2>
     </div>
     <div class="col-6 risc-v-container u-vertically-center u-align--center">
-      {{
-				image (
-				url="https://assets.ubuntu.com/v1/308d48cd-Qemu-logo.png",
-				alt="",
-				width="377",
-				height="120",
-				hi_def=True,
-				loading="lazy",
-				) | safe
-			  }}
+      {{ image(url="https://assets.ubuntu.com/v1/308d48cd-Qemu-logo.png",
+            alt="",
+            width="377",
+            height="120",
+            hi_def=True,
+            loading="lazy",) | safe
+      }}
     </div>
   </div>
   <div class="row p-strip u-no-padding--top">
-    <hr class="col-9">
+    <hr class="col-9" />
     <div class="col-3">
-      <h3 class="p-heading--5 u-no-padding--top">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
+      <h3 class="p-heading--5 u-no-padding--top">
+        Ubuntu Server
+        <br class="u-hide--small" />
+        preinstalled image
+      </h3>
     </div>
     <div class="col-6">
       <p class="u-sv3">
-				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/24.04/release/ubuntu-24.04-preinstalled-server-riscv64+unmatched.img.xz">Download 24.04</a>
-			</p>
+        <a class="p-button--positive"
+           href="https://cdimage.ubuntu.com/releases/24.04/release/ubuntu-24.04-preinstalled-server-riscv64+unmatched.img.xz">Download 24.04</a>
+      </p>
     </div>
   </div>
   <div class="row p-strip u-no-padding--top">
-    <hr class="is-fixed-width col-9">
+    <hr class="is-fixed-width col-9" />
     <div class="col-3">
-      <h3 class="p-heading--5 u-no-padding--top">Ubuntu Server <br class="u-hide--small">live installer</h3>
+      <h3 class="p-heading--5 u-no-padding--top">
+        Ubuntu Server
+        <br class="u-hide--small" />
+        live installer
+      </h3>
     </div>
     <div class="col-6">
       <p>
-				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/24.04/release/ubuntu-24.04-live-server-riscv64.img.gz">Download 24.04 live installer</a>
-			</p>
-      <p><a href="https://wiki.ubuntu.com/RISC-V/QEMU">How to install Ubuntu on QEMU RISC-V</a></p>
+        <a class="p-button--positive"
+           href="https://cdimage.ubuntu.com/releases/24.04/release/ubuntu-24.04-live-server-riscv64.img.gz">Download 24.04 live installer</a>
+      </p>
+      <p>
+        <a href="https://wiki.ubuntu.com/RISC-V/QEMU">How to install Ubuntu on QEMU RISC-V</a>
+      </p>
     </div>
   </div>
 </div>

--- a/templates/download/risc-v/tab-4.html
+++ b/templates/download/risc-v/tab-4.html
@@ -1,43 +1,58 @@
-<div tabindex="0" role="tabpanel" id="quemu-sifive-image-tab" aria-labelledby="quemu-sifive-image">
+<div tabindex="0"
+     role="tabpanel"
+     id="quemu-sifive-image-tab"
+     aria-labelledby="quemu-sifive-image">
   <div class="row p-strip is-shallow u-no-padding--top">
     <div class="col-3">
       <h2 class="u-hide--small">SiFive Unmatched</h2>
     </div>
     <div class="col-6 risc-v-container u-vertically-center u-align--center">
-      {{ image (
-        url="https://assets.ubuntu.com/v1/37c094a9-SiFive+Unmatched+Board.jpg",
-        alt="",
-        width="504",
-        height="286",
-        hi_def=True,
-        loading="auto",
-        attrs={"class": "risc-v-image"}
-        ) | safe
-        }}
+      {{ image(url="https://assets.ubuntu.com/v1/37c094a9-SiFive+Unmatched+Board.jpg",
+            alt="",
+            width="504",
+            height="286",
+            hi_def=True,
+            loading="auto",
+            attrs={"class": "risc-v-image"}) | safe
+      }}
     </div>
   </div>
   <div class="row p-strip u-no-padding--top">
-    <hr class="col-9">
+    <hr class="col-9" />
     <div class="col-3">
-      <h3 class="p-heading--5 u-no-padding--top">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
+      <h3 class="p-heading--5 u-no-padding--top">
+        Ubuntu Server
+        <br class="u-hide--small" />
+        preinstalled image
+      </h3>
     </div>
     <div class="col-6">
-      <p class="p-notification__message"><i class="p-icon--information"></i> If you have an NVMe drive, we advise you to use the Ubuntu Server live installer.</p>
+      <p class="p-notification__message">
+        <i class="p-icon--information"></i> If you have an NVMe drive, we advise you to use the Ubuntu Server live installer.
+      </p>
       <p class="u-sv3">
-        <a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/24.04/release/ubuntu-24.04-preinstalled-server-riscv64+unmatched.img.xz">Download 24.04</a>
+        <a class="p-button--positive"
+           href="https://cdimage.ubuntu.com/releases/24.04/release/ubuntu-24.04-preinstalled-server-riscv64+unmatched.img.xz">Download 24.04</a>
       </p>
     </div>
   </div>
   <div class="row p-strip u-no-padding--top">
-    <hr class="col-9">
+    <hr class="col-9" />
     <div class="col-3">
-      <h3 class="p-heading--5 u-no-padding--top">Ubuntu Server <br class="u-hide--small">live installer</h3>
+      <h3 class="p-heading--5 u-no-padding--top">
+        Ubuntu Server
+        <br class="u-hide--small" />
+        live installer
+      </h3>
     </div>
     <div class="col-6">
       <p>
-				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/24.04/release/ubuntu-24.04-live-server-riscv64.img.gz">Download 24.04 live installer</a>
-			</p>
-			<p><a href="https://wiki.ubuntu.com/RISC-V/SiFive%20HiFive%20Unmatched">How to install Ubuntu on SiFive HiFive Unmatched</a></p>
+        <a class="p-button--positive"
+           href="https://cdimage.ubuntu.com/releases/24.04/release/ubuntu-24.04-live-server-riscv64.img.gz">Download 24.04 live installer</a>
+      </p>
+      <p>
+        <a href="https://wiki.ubuntu.com/RISC-V/SiFive%20HiFive%20Unmatched">How to install Ubuntu on SiFive HiFive Unmatched</a>
+      </p>
     </div>
   </div>
 </div>

--- a/templates/download/risc-v/tab-5.html
+++ b/templates/download/risc-v/tab-5.html
@@ -1,32 +1,40 @@
-<div tabindex="0" role="tabpanel" id="sipeed-licheerv-dock-tab" aria-labelledby="sipeed-licheerv-dock" aria-hidden="true">
-	<div class="row p-strip is-shallow u-no-padding--top">
+<div tabindex="0"
+     role="tabpanel"
+     id="sipeed-licheerv-dock-tab"
+     aria-labelledby="sipeed-licheerv-dock"
+     aria-hidden="true">
+  <div class="row p-strip is-shallow u-no-padding--top">
     <div class="col-3">
       <h2 class="u-hide--small">Sipeed LicheeRV Dock</h2>
     </div>
     <div class="col-6 risc-v-container u-vertically-center u-align--center">
-      {{
-        image (
-        url="https://assets.ubuntu.com/v1/4c609299-Sipeed+LicheeRV+-+Edited.png",
-        alt="",
-        width="400",
-        height="400",
-        hi_def=True,
-        loading="lazy",
-        attrs={"class": "risc-v-image"}
-        ) | safe
+      {{ image(url="https://assets.ubuntu.com/v1/4c609299-Sipeed+LicheeRV+-+Edited.png",
+            alt="",
+            width="400",
+            height="400",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "risc-v-image"}) | safe
       }}
     </div>
   </div>
   <div class="row p-strip u-no-padding--top">
-    <hr class="col-9">
+    <hr class="col-9" />
     <div class="col-3">
-      <h3 class="p-heading--5 u-no-padding--top">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
+      <h3 class="p-heading--5 u-no-padding--top">
+        Ubuntu Server
+        <br class="u-hide--small" />
+        preinstalled image
+      </h3>
     </div>
     <div class="col-6">
       <p>
-				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/24.04/release/ubuntu-24.04-preinstalled-server-riscv64+licheerv.img.xz">Download 24.04</a>
-			</p>
-			<p><a href="https://wiki.ubuntu.com/RISC-V/LicheeRV">How to install Ubuntu on the LicheeRV Dock</a></p>
+        <a class="p-button--positive"
+           href="https://cdimage.ubuntu.com/releases/24.04/release/ubuntu-24.04-preinstalled-server-riscv64+licheerv.img.xz">Download 24.04</a>
+      </p>
+      <p>
+        <a href="https://wiki.ubuntu.com/RISC-V/LicheeRV">How to install Ubuntu on the LicheeRV Dock</a>
+      </p>
     </div>
   </div>
 </div>

--- a/templates/download/risc-v/tab-6.html
+++ b/templates/download/risc-v/tab-6.html
@@ -1,40 +1,56 @@
-<div tabindex="0" role="tabpanel" id="starfive-visionfive-2-tab" aria-labelledby="starfive-visionfive-2" aria-hidden="true">
-	<div class="row p-strip is-shallow u-no-padding--top">
+<div tabindex="0"
+     role="tabpanel"
+     id="starfive-visionfive-2-tab"
+     aria-labelledby="starfive-visionfive-2"
+     aria-hidden="true">
+  <div class="row p-strip is-shallow u-no-padding--top">
     <div class="col-3">
       <h2 class="u-hide--small">StarFive VisionFive 2</h2>
     </div>
     <div class="col-6 risc-v-container u-vertically-center u-align--center">
-      {{ image (
-        url="https://assets.ubuntu.com/v1/f63441ac-risc-v_star-five-board.png",
-        alt="",
-        width="400",
-        height="300",
-        hi_def=True,
-        loading="lazy",
-        attrs={"class": "risc-v-image"}
-        ) | safe
+      {{ image(url="https://assets.ubuntu.com/v1/f63441ac-risc-v_star-five-board.png",
+            alt="",
+            width="400",
+            height="300",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "risc-v-image"}) | safe
       }}
     </div>
   </div>
   <div class="row p-strip u-no-padding--top">
-    <hr class="col-9">
+    <hr class="col-9" />
     <div class="col-3">
-      <h3 class="p-heading--5 u-no-padding--top">Ubuntu Server <br class="u-hide--small">preinstalled image</h3>
-    </div>
-    <div class="col-6">
-      <p><a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/24.04/release/ubuntu-24.04-preinstalled-server-riscv64+visionfive2.img.xz">Download 24.04</a></p>
-    </div>
-  </div>
-  <div class="row p-strip u-no-padding--top">
-    <hr class="col-9">
-    <div class="col-3">
-      <h3 class="p-heading--5 u-no-padding--top">Ubuntu Server <br class="u-hide--small">live installer</h3>
+      <h3 class="p-heading--5 u-no-padding--top">
+        Ubuntu Server
+        <br class="u-hide--small" />
+        preinstalled image
+      </h3>
     </div>
     <div class="col-6">
       <p>
-				<a class="p-button--positive" href="https://cdimage.ubuntu.com/releases/24.04/release/ubuntu-24.04-live-server-riscv64.img.gz">Download 24.04 live installer</a>
-			</p>
-      <p><a href="https://wiki.ubuntu.com/RISC-V/StarFive%20VisionFive%202">How to install Ubuntu on the VisionFive 2</a></p>
+        <a class="p-button--positive"
+           href="https://cdimage.ubuntu.com/releases/24.04/release/ubuntu-24.04-preinstalled-server-riscv64+visionfive2.img.xz">Download 24.04</a>
+      </p>
+    </div>
+  </div>
+  <div class="row p-strip u-no-padding--top">
+    <hr class="col-9" />
+    <div class="col-3">
+      <h3 class="p-heading--5 u-no-padding--top">
+        Ubuntu Server
+        <br class="u-hide--small" />
+        live installer
+      </h3>
+    </div>
+    <div class="col-6">
+      <p>
+        <a class="p-button--positive"
+           href="https://cdimage.ubuntu.com/releases/24.04/release/ubuntu-24.04-live-server-riscv64.img.gz">Download 24.04 live installer</a>
+      </p>
+      <p>
+        <a href="https://wiki.ubuntu.com/RISC-V/StarFive%20VisionFive%202">How to install Ubuntu on the VisionFive 2</a>
+      </p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Done

Removed word "certified" from "Raspberry Pi Zero 2 W" line for 24.04 LTS release on /download/raspberry-pi page according to the [copy doc](https://docs.google.com/document/d/1KgnSBa8mbR7qwlxxtqbE5a1wXh5GjtVums8TIB7IGVw/edit).
I will highlight the actual change with the comment, the rest is formatting by djLint.

## QA

- Navigate to https://ubuntu-com-13768.demos.haus/download/raspberry-pi
- Scroll down to "Supported devices" section
- Check that it says "Yes" next to "Raspberry Pi Zero 2 W" line for 24.04 LTS release

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-10513

## Screenshots

![Screenshot 2024-04-18 at 16 26 41](https://github.com/canonical/ubuntu.com/assets/15943863/dce1ff55-6fe5-4129-8093-361ea7389fd7)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
