### PR TITLE
Fix input text color

### DIFF
--- a/templates/templates/_navigation.html
+++ b/templates/templates/_navigation.html
@@ -96,7 +96,7 @@
                     </li>
                 </ul>
                 <div class="p-navigation__search">
-                    <form action="/search" class="p-search-box">
+                    <form action="/search" class="p-search-box is-light">
                         <input type="search"
                                class="p-search-box__input"
                                name="q"


### PR DESCRIPTION
## Done

- Added `is-light` class to fix input text color

## QA

- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Use the search bar and see that the text is no longer white

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-10523

## Screenshots
![Screenshot from 2024-04-18 15-39-19](https://github.com/canonical/ubuntu.com/assets/17607612/52f1d20b-15b4-48f7-906c-df649a108c3a)
vs 
![image](https://github.com/canonical/ubuntu.com/assets/17607612/d1e8b44f-e45b-45df-99fd-dc44520ac555)