### PR TITLE
WD-10580-time-zone-on-schedule-page-no-longer-selectable

### DIFF
--- a/templates/credentials/schedule.html
+++ b/templates/credentials/schedule.html
@@ -81,19 +81,11 @@ meta_copydoc %}
     </section>
 
     <script>
-      {
-        %
-        if timezone and timezone != "" %
-      }
+      {% if timezone and timezone != "" %}
       const timezone = "{{ timezone }}";
-      {
-        %
-        else %
-      }
+      {% else %}
       const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-      {
-        % endif %
-      }
+      {% endif %}
       const timezoneInput = document.querySelector("#exam-timezone");
       const allTimezones = Intl.supportedValuesOf('timeZone');
       allTimezones.map((tz) => {


### PR DESCRIPTION
## Done

- Cannot select timezone in credentials exam scheduler

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Try to schedule an exam or simply go to /credentials/schedule?contractItemID=<any random string>
    - Verify that there is a dropdown for selecting timezones

## Issue / Card

Fixes [#WD-10580](https://warthogs.atlassian.net/browse/WD-10580)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
