### PR TITLE
WD-10546 - change desktop background image

### DIFF
--- a/templates/desktop/index.html
+++ b/templates/desktop/index.html
@@ -50,12 +50,13 @@
     </div>
     <div class="col">
       <div class="p-image-wrapper">
-        {{ image(url="https://assets.ubuntu.com/v1/dcd03b72-noble-desktop.png",
-                  alt="",
-                  width="720",
-                  height="406",
-                  hi_def=True,
-                  loading="auto") | safe
+        {{ image(
+          url="https://assets.ubuntu.com/v1/e629fd1d-numbat-screenshot.jpg",
+          alt="",
+          width="720",
+          height="406",
+          hi_def=True,
+          loading="auto") | safe
         }}
       </div>
     </div>


### PR DESCRIPTION
## Done

Replace Ubuntu background desktop image on u.com/desktop

## QA

- [demo link](https://ubuntu-com-13776.demos.haus/desktop)
- View the site on demo
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check that the image is correctly updated

## Issue / Card
[WD-10546](https://warthogs.atlassian.net/browse/WD-10546)

[WD-10546]: https://warthogs.atlassian.net/browse/WD-10546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ