### PR TITLE
Update broken link on landing

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -139,7 +139,7 @@
         <div class="col-4 u-vertically-center u-hide--medium u-hide--small u-align--left">
           <div>
             <p>
-              <a href="https://recruit-c7ff.kxcdn.com/recruit/wp-content/uploads/2020/05/he-developer-survey-2020.pdf"
+              <a href="https://media.hackerearth.com/recruit/wp-content/uploads/2020/05/he-developer-survey-2020.pdf"
                  aria-label="Visit the PDF file for 2020 HackerEarth Developer Survey">
                 The 2020 HackerEarth Developer Survey
               </a>


### PR DESCRIPTION
## Done

- Updated link as per [doc](https://docs.google.com/document/d/1ySJxQbqVdeH4Tra0zwBm2Tn0s56kFGnEF7d8xDRTxwU/edit)

## QA

- View the site locally in your web browser at: https://ubuntu-com-13781.demos.haus/
- See that the link no longer 404s

## Issue / Card

Fixes https://github.com/canonical/ubuntu.com/issues/13752 , https://warthogs.atlassian.net/browse/WD-10665