### PR TITLE
Add link to Pro documentation

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -342,8 +342,8 @@ pro:
       path: /pro/users
     - title: Pricing
       path: /pricing/pro
-    - title: Tutorial
-      path: /pro/tutorial
+    - title: Docs
+      path: https://documentation.ubuntu.com/pro
     - title: Discourse
       path: https://discourse.ubuntu.com/c/ubuntu-pro
 

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.test.tsx
@@ -88,8 +88,8 @@ describe("DetailsTabs", () => {
     // Switch to the docs tab:
     wrapper.find("[data-test='docs-tab']").simulate("click");
     const docsLinks = wrapper.find("[data-test='doc-link']");
-    expect(docsLinks.length).toBe(11);
-    expect(docsLinks.at(0).text()).toBe("Knowledge Base");
+    expect(docsLinks.length).toBe(12);
+    expect(docsLinks.at(0).text()).toBe("Ubuntu Pro documentation");
   });
 
   it("only displays one link to ESM docs", () => {
@@ -114,8 +114,8 @@ describe("DetailsTabs", () => {
     // Switch to the docs tab:
     wrapper.find("[data-test='docs-tab']").simulate("click");
     const docsLinks = wrapper.find("[data-test='doc-link']");
-    expect(docsLinks.length).toBe(11);
-    expect(docsLinks.at(0).text()).toBe("Knowledge Base");
+    expect(docsLinks.length).toBe(12);
+    expect(docsLinks.at(0).text()).toBe("Ubuntu Pro documentation");
   });
 
   it("reorders FIPS, CC-EAL, and CIS to the end", () => {
@@ -152,11 +152,12 @@ describe("DetailsTabs", () => {
     // Switch to the docs tab:
     wrapper.find("[data-test='docs-tab']").simulate("click");
     const docsLinks = wrapper.find("[data-test='doc-link']");
-    expect(docsLinks.at(0).text()).toBe("Knowledge Base");
-    expect(docsLinks.at(1).text()).toBe("Ubuntu Assurance Program");
-    expect(docsLinks.at(2).text()).toBe("Ubuntu Pro network requirements");
-    expect(docsLinks.at(3).text()).toBe("ESM");
-    expect(docsLinks.at(4).text()).toBe("USG ");
+    expect(docsLinks.at(0).text()).toBe("Ubuntu Pro documentation");
+    expect(docsLinks.at(1).text()).toBe("Knowledge Base");
+    expect(docsLinks.at(2).text()).toBe("Ubuntu Assurance Program");
+    expect(docsLinks.at(3).text()).toBe("Ubuntu Pro network requirements");
+    expect(docsLinks.at(4).text()).toBe("ESM");
+    expect(docsLinks.at(5).text()).toBe("USG ");
   });
 
   it("Display tutorial link for the free subscription", () => {

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsTabs/DetailsTabs.tsx
@@ -111,6 +111,14 @@ const DetailsTabs = ({
               </thead>
               <tbody>
                 <tr>
+                  <td data-test="doc-link">Ubuntu Pro documentation</td>
+                  <td>
+                    <a href="https://documentation.ubuntu.com/pro">
+                      Ubuntu Pro documentation
+                    </a>
+                  </td>
+                </tr>
+                <tr>
                   <td data-test="doc-link">Knowledge Base</td>
                   <td>
                     <a href="https://support-portal.canonical.com/knowledge-base">


### PR DESCRIPTION
## Done

- Add link to Pro documentation on /pro navigation and /pro/dashboard

## QA

- Check out this feature branch
- Go to `/pro`
- Click on Docs and see that it redirects to https://documentation.ubuntu.com/pro/
- Go to `/pro/dashboard`
- Go to Support and Documentation section, see that `Ubuntu Pro documentation` is at the top of list and redirects to https://documentation.ubuntu.com/pro/

## Issue / Card

Fixes [WD-10726](https://warthogs.atlassian.net/browse/WD-10726)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-10726]: https://warthogs.atlassian.net/browse/WD-10726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ