### PR TITLE
Update offer model and types

### DIFF
--- a/static/js/src/advantage/offers/types.ts
+++ b/static/js/src/advantage/offers/types.ts
@@ -7,6 +7,11 @@ export type Item = {
   price: number;
 };
 
+export type ExternalId = {
+  origin: string;
+  ids: string[];
+};
+
 export type Offer = {
   account_id: string;
   actionable: boolean;
@@ -16,4 +21,11 @@ export type Offer = {
   marketplace: UserSubscriptionMarketplace;
   total: number;
   discount: number | null;
+  can_change_items?: boolean;
+  external_ids?: ExternalId[] | null;
+  activation_account_id?: string | null;
+  distributor_account_name?: string | null;
+  reseller_account_name?: string | null;
+  end_user_account_name?: string | null;
+  technical_contact?: string | null;
 };

--- a/tests/shop/advantage/fixtures/channel-offer.json
+++ b/tests/shop/advantage/fixtures/channel-offer.json
@@ -1,0 +1,75 @@
+{
+  "accountID": "account-id-aAbBcCdDeEfFgG",
+  "actionable": true,
+  "activationAccountID": "activation-account-id-aAbBcCdDeEfFgG",
+  "canChangeItems": true,
+  "createdAt": "2024-04-22T17:44:36Z",
+  "discount": 10,
+  "distributorAccountName": "Distributor, Ltd.",
+  "endUserAccountName": "End Users, Ltd.",
+  "externalIDs": [
+    {
+      "IDs": [
+        "zift-id-test"
+      ],
+      "origin": "Zift"
+    }
+  ],
+  "id": "id-aAbBcCdDeEfFgG",
+  "items": [
+    {
+      "productListingID": "product-id-AaBbCcDdEeFfGg",
+      "value": 2
+    }
+  ],
+  "lastModified": "0001-01-01T00:00:00Z",
+  "marketplace": "canonical-pro-channel",
+  "productListings": [
+    {
+      "allowanceMetric": "units",
+      "bundleQuantity": 1,
+      "createdAt": "2024-04-22T16:53:17.162Z",
+      "effectiveDays": 365,
+      "externalIDs": [
+        {
+          "IDs": [
+            "abcdef"
+          ],
+          "origin": "Salesforce"
+        }
+      ],
+      "externalMarketplaceIDs": {
+        "IDs": [
+          "efghij"
+        ],
+        "origin": "Salesforce"
+      },
+      "externalPricingID": {
+        "IDs": [
+          "price_abc"
+        ],
+        "origin": "Stripe"
+      },
+      "id": "product-id-AaBbCcDdEeFfGg",
+      "lastModifiedAt": "2024-04-22T16:53:17.162Z",
+      "marketplace": "canonical-pro-channel",
+      "metadata": [
+        {
+          "key": "sfLOB",
+          "value": "Personal Devices"
+        }
+      ],
+      "name": "uai-advanced-desktop-channel-two-year-usd",
+      "period": "none",
+      "price": {
+        "currency": "USD",
+        "value": 30000
+      },
+      "productID": "uai-advanced-desktop",
+      "productName": "Ubuntu Pro Desktop + Support (24/7)",
+      "status": "active"
+    }
+  ],
+  "resellerAccountName": "Resellers, Inc.",
+  "technicalContact": "contact@example.com"
+}

--- a/tests/shop/advantage/fixtures/channel-offers.json
+++ b/tests/shop/advantage/fixtures/channel-offers.json
@@ -1,0 +1,77 @@
+[
+  {
+    "accountID": "account-id-aAbBcCdDeEfFgG",
+    "actionable": true,
+    "activationAccountID": "activation-account-id-aAbBcCdDeEfFgG",
+    "canChangeItems": true,
+    "createdAt": "2024-04-22T17:44:36Z",
+    "discount": 10,
+    "distributorAccountName": "Distributor, Ltd.",
+    "endUserAccountName": "End Users, Ltd.",
+    "externalIDs": [
+      {
+        "IDs": [
+          "zift-id-test"
+        ],
+        "origin": "Zift"
+      }
+    ],
+    "id": "id-aAbBcCdDeEfFgG",
+    "items": [
+      {
+        "productListingID": "product-id-AaBbCcDdEeFfGg",
+        "value": 2
+      }
+    ],
+    "lastModified": "0001-01-01T00:00:00Z",
+    "marketplace": "canonical-pro-channel",
+    "productListings": [
+      {
+        "allowanceMetric": "units",
+        "bundleQuantity": 1,
+        "createdAt": "2024-04-22T16:53:17.162Z",
+        "effectiveDays": 365,
+        "externalIDs": [
+          {
+            "IDs": [
+              "abcdef"
+            ],
+            "origin": "Salesforce"
+          }
+        ],
+        "externalMarketplaceIDs": {
+          "IDs": [
+            "efghij"
+          ],
+          "origin": "Salesforce"
+        },
+        "externalPricingID": {
+          "IDs": [
+            "price_abc"
+          ],
+          "origin": "Stripe"
+        },
+        "id": "product-id-AaBbCcDdEeFfGg",
+        "lastModifiedAt": "2024-04-22T16:53:17.162Z",
+        "marketplace": "canonical-pro-channel",
+        "metadata": [
+          {
+            "key": "sfLOB",
+            "value": "Personal Devices"
+          }
+        ],
+        "name": "uai-advanced-desktop-channel-two-year-usd",
+        "period": "none",
+        "price": {
+          "currency": "USD",
+          "value": 30000
+        },
+        "productID": "uai-advanced-desktop",
+        "productName": "Ubuntu Pro Desktop + Support (24/7)",
+        "status": "active"
+      }
+    ],
+    "resellerAccountName": "Resellers, Inc.",
+    "technicalContact": "contact@example.com"
+  }
+]

--- a/tests/shop/advantage/test_parsers.py
+++ b/tests/shop/advantage/test_parsers.py
@@ -622,6 +622,7 @@ class TestParsers(unittest.TestCase):
             ],
         )
 
+        self.assertFalse(expectation.check_is_channel_offer())
         self.assertIsInstance(parsed_offer, Offer)
         self.assertEqual(to_dict(expectation), to_dict(parsed_offer))
 
@@ -654,12 +655,49 @@ class TestParsers(unittest.TestCase):
                 ],
             )
         ]
-
+        self.assertFalse(expectation[0].check_is_channel_offer())
         self.assertIsInstance(parsed_offers, List)
         self.assertEqual(to_dict(expectation), to_dict(parsed_offers))
 
-    # Channel offers
+    # Channel offer
     def test_parse_channel_offer(self):
+        raw_offer = get_fixture("channel-offer")
+
+        parsed_offer = parse_offer(raw_offer)
+
+        expectation = Offer(
+            id="id-aAbBcCdDeEfFgG",
+            account_id="account-id-aAbBcCdDeEfFgG",
+            total=60000,
+            discount=10,
+            actionable=True,
+            created_at="2024-04-22T17:44:36Z",
+            marketplace="canonical-pro-channel",
+            can_change_items=True,
+            external_ids=[
+                ExternalID(origin="Zift", ids=["zift-id-test"]),
+            ],
+            activation_account_id="activation-account-id-aAbBcCdDeEfFgG",
+            distributor_account_name="Distributor, Ltd.",
+            reseller_account_name="Resellers, Inc.",
+            end_user_account_name="End Users, Ltd.",
+            technical_contact="contact@example.com",
+            items=[
+                OfferItem(
+                    id="product-id-AaBbCcDdEeFfGg",
+                    name="uai-advanced-desktop-channel-two-year-usd",
+                    price=60000,
+                    allowance=2,
+                ),
+            ],
+        )
+
+        self.assertTrue(expectation.check_is_channel_offer())
+        self.assertIsInstance(parsed_offer, Offer)
+        self.assertEqual(to_dict(expectation), to_dict(parsed_offer))
+
+    # Channel offers
+    def test_parse_channel_offers(self):
         raw_offers = get_fixture("channel-offers")
 
         parsed_offers = parse_offers(raw_offers)
@@ -693,5 +731,6 @@ class TestParsers(unittest.TestCase):
             )
         ]
 
+        self.assertTrue(expectation[0].check_is_channel_offer())
         self.assertIsInstance(parsed_offers, List)
         self.assertEqual(to_dict(expectation), to_dict(parsed_offers))

--- a/tests/shop/advantage/test_parsers.py
+++ b/tests/shop/advantage/test_parsers.py
@@ -10,6 +10,7 @@ from webapp.shop.api.ua_contracts.models import (
     Product,
     OfferItem,
     Offer,
+    ExternalID,
 )
 from webapp.shop.api.ua_contracts.parsers import (
     parse_offer_items,
@@ -649,6 +650,44 @@ class TestParsers(unittest.TestCase):
                         name="uai-advanced-physical-oneoff",
                         price=750000,
                         allowance=5,
+                    ),
+                ],
+            )
+        ]
+
+        self.assertIsInstance(parsed_offers, List)
+        self.assertEqual(to_dict(expectation), to_dict(parsed_offers))
+
+    # Channel offers
+    def test_parse_channel_offer(self):
+        raw_offers = get_fixture("channel-offers")
+
+        parsed_offers = parse_offers(raw_offers)
+
+        expectation = [
+            Offer(
+                id="id-aAbBcCdDeEfFgG",
+                account_id="account-id-aAbBcCdDeEfFgG",
+                total=60000,
+                discount=10,
+                actionable=True,
+                created_at="2024-04-22T17:44:36Z",
+                marketplace="canonical-pro-channel",
+                can_change_items=True,
+                external_ids=[
+                    ExternalID(origin="Zift", ids=["zift-id-test"]),
+                ],
+                activation_account_id="activation-account-id-aAbBcCdDeEfFgG",
+                distributor_account_name="Distributor, Ltd.",
+                reseller_account_name="Resellers, Inc.",
+                end_user_account_name="End Users, Ltd.",
+                technical_contact="contact@example.com",
+                items=[
+                    OfferItem(
+                        id="product-id-AaBbCcDdEeFfGg",
+                        name="uai-advanced-desktop-channel-two-year-usd",
+                        price=60000,
+                        allowance=2,
                     ),
                 ],
             )

--- a/webapp/shop/api/ua_contracts/models.py
+++ b/webapp/shop/api/ua_contracts/models.py
@@ -1,6 +1,12 @@
-from typing import List
+from typing import List, Optional
 
 from dateutil.parser import parse
+
+
+class ExternalID:
+    def __init__(self, origin: str, ids: List[str]):
+        self.origin = origin
+        self.ids = ids
 
 
 class Entitlement:
@@ -124,6 +130,13 @@ class Offer:
         total: int,
         items: List[OfferItem],
         discount: int = None,
+        can_change_items: Optional[bool] = False,
+        external_ids: Optional[List[ExternalID]] = None,
+        activation_account_id: Optional[str] = None,
+        distributor_account_name: Optional[str] = None,
+        reseller_account_name: Optional[str] = None,
+        end_user_account_name: Optional[str] = None,
+        technical_contact: Optional[str] = None,
     ):
         self.id = id
         self.account_id = account_id
@@ -133,6 +146,16 @@ class Offer:
         self.created_at = created_at
         self.actionable = actionable
         self.discount = discount
+        # Properties below apply only to channel offers.
+        # If activation_account_id exist, it's a channel offer.
+        if activation_account_id is not None:
+            self.can_change_items = can_change_items
+            self.external_ids = external_ids
+            self.activation_account_id = activation_account_id
+            self.distributor_account_name = distributor_account_name
+            self.reseller_account_name = reseller_account_name
+            self.end_user_account_name = end_user_account_name
+            self.technical_contact = technical_contact
 
 
 class Invoice:

--- a/webapp/shop/api/ua_contracts/models.py
+++ b/webapp/shop/api/ua_contracts/models.py
@@ -146,9 +146,12 @@ class Offer:
         self.created_at = created_at
         self.actionable = actionable
         self.discount = discount
-        # Properties below apply only to channel offers.
+
         # If activation_account_id exist, it's a channel offer.
-        if activation_account_id is not None:
+        self.is_channel_offer = activation_account_id is not None
+
+        # Properties below apply only to channel offers.
+        if self.is_channel_offer:
             self.can_change_items = can_change_items
             self.external_ids = external_ids
             self.activation_account_id = activation_account_id
@@ -156,6 +159,9 @@ class Offer:
             self.reseller_account_name = reseller_account_name
             self.end_user_account_name = end_user_account_name
             self.technical_contact = technical_contact
+
+    def check_is_channel_offer(self) -> bool:
+        return self.is_channel_offer
 
 
 class Invoice:


### PR DESCRIPTION
## Done

- Update Offer model and types according to the changes in [ua_contracts](https://github.com/canonical/ua-contracts/blob/d32984c23db25bb09858ca59b939cb2dbb3d493f/docs/contracts.yaml#L2614-L2721)
- Add test to parse [channel offer](https://github.com/canonical/ua-contracts/blob/develop/docs/howtos/work-with-offers.md#channel-offers). 
 
## QA
1. Checkout this branch and run 
2. Go to `/webapp/shop/advantage/views.py` 
- for normal offer, 
    - line 573, replace `account.id` to account id on [here](https://pastebin.canonical.com/p/ztMSjGWM7n/)

- for channel offer
    - line 573, replace `account.id` to account id on [here](https://pastebin.canonical.com/p/ztMSjGWM7n/)
    - line 562  replace "canonical-ua" to "canonical-pro-channel"
4. Go to `/static/js/src/advantage/offers/components/OffersList/OffersList.tsx`, 
    Write `console.log("offerList", offerList)`
6. Compare normal offer and channel offer 

## Issue / Card

Fixes #https://warthogs.atlassian.net/jira/software/c/projects/WD/boards/801?selectedIssue=WD-10736