### PR TITLE
Standarise the padding of secondary navigaiton items in the meganav

### DIFF
--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -635,6 +635,7 @@ $meganav-height: 3rem;
 
     .p-navigation__item > .p-navigation__link {
       padding-left: $row-margin-small;
+      padding-right: $row-margin-small;
     }
 
     .p-navigation__nav {


### PR DESCRIPTION
## Done

- The padding in the meganav secondary nav was different on each side, this PR makes it the same.

## QA

- Go to a page in the demo with a secondary nav, ex: https://ubuntu-com-13791.demos.haus/support
- Inspect the secondary nav items and see they have the same padding on each side

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-10551

## Screenshots
Before:
![image](https://github.com/canonical/ubuntu.com/assets/58276363/f98b32b0-c0b8-4ddd-9652-da645d7cc5ff)
After:
![image](https://github.com/canonical/ubuntu.com/assets/58276363/837b3414-00b0-46e6-b658-96e20ef33cd2)
