### PR TITLE
Fix secondary nav selected items marker being mis-aligned

### DIFF
--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -651,10 +651,6 @@ $meganav-height: 3rem;
           @media (max-width: $breakpoint-medium) {
             padding-left: $row-margin-small;
           }
-
-          &::before {
-            left: $row-margin-small;
-          }
         }
       }
     }


### PR DESCRIPTION
## Done

- The little white strip that appears on the left of the selected page in the secondary nav was mis-aligned (see screenshots), this pr fixes this.

## QA

- Go to a page with a secondary nav, ex. https://ubuntu-com-13792.demos.haus/desktop/organisations
- Open the secondary nav and see the highlight page no longer looks broken

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-10558

## Screenshots

Before:
![image](https://github.com/canonical/ubuntu.com/assets/58276363/1bc5b935-e70c-4642-b731-917cee8202b5)
After:
![image](https://github.com/canonical/ubuntu.com/assets/58276363/d6d5468a-2fa1-4978-a0e8-a3337eba95df)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
