### PR TITLE
24.04 release quick changes

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -11,7 +11,7 @@ latest:
   release_notes_url: "https://discourse.ubuntu.com/t/mantic-minotaur-release-notes/35534"
   iso_download_size: "4.5GB"
   server_iso_size: "2.5GB"
-  rasp_pi_core_22_size: "263GB"
+  rasp_pi_core_22_size: "263MB"
 lts:
   slug: NobleNumbat
   name: "Noble Numbat"

--- a/templates/desktop/wsl.html
+++ b/templates/desktop/wsl.html
@@ -1,229 +1,356 @@
 {% extends 'base_index.html' %}
 
-{% block meta_copydoc %}https://docs.google.com/document/d/1M7e2B08GgPA7K6Wx0ThE6s9_xQINM0MSkarfdKUTEYI/edit#{% endblock meta_copydoc %}
+{% block meta_copydoc %}
+  https://docs.google.com/document/d/1M7e2B08GgPA7K6Wx0ThE6s9_xQINM0MSkarfdKUTEYI/edit#
+{% endblock meta_copydoc %}
 
 {% block title %}WSL{% endblock %}
 
-{% block meta_description %}Access the Ubuntu terminal on Windows with WSL. Develop cross-platform applications and manage IT infrastructure without leaving Windows.{% endblock %}
+{% block meta_description %}
+  Access the Ubuntu terminal on Windows with WSL. Develop cross-platform applications and manage IT infrastructure without leaving Windows.
+{% endblock %}
 
-{% block body_class %}is-paper{% endblock body_class %}
+{% block body_class %}
+  is-paper
+{% endblock body_class %}
 
 {% block content %}
 
-<section class="p-strip is-shallow">
-	<div class="row--50-50 p-section--shallow">
-		<div class="col">
-			<h1>The full Ubuntu experience, now&nbsp;available on Windows</h1>
-		</div>
-		<div class="col">
-			<div class="p-section--shallow">
-					<p>Access the power of a full Ubuntu terminal environment on Windows with Windows Subsystem for Linux (WSL).</p>
-					<p>Streamline web application development, leverage cutting-edge AI/ML tooling, develop cross-platform applications and manage IT infrastructure without leaving Windows.</p>
-			</div>
-			<hr>
-			<a class="p-button--positive" href="https://www.microsoft.com/p/ubuntu/9pdxgncfsczv">Download from the Microsoft Store</a>
-			<a class="js-invoke-modal" href="/wsl/contact-us">Looking&nbsp;for&nbsp;support?&nbsp;Contact&nbsp;us&nbsp;&rsaquo;</a>
-		</div>
-	</div>
-	<div class="u-fixed-width p-section">
-		{{
-			image (
-			url="https://assets.ubuntu.com/v1/a815b856-Screenshot 2024-01-26 114801.png",
-			alt="Terminal window running Ubuntu on WSL on top of the Windows 11 desktop",
-			width="2560",
-			height="1440",
-			hi_def=True,
-			loading="lazy"
-			) | safe
-			}}
-	</div>
-</section>
+  <section class="p-strip is-shallow">
 
-<section class="p-section">
-	<div class="u-fixed-width p-section--shallow">
-		<hr class="p-rule">
-    <h2>Develop with the best of both worlds</h2>
-  </div>
-  <div class="row">
-    <div class="col-9 col-start-large-4 col-medium-5 col-start-medium-2">
-      <hr class="p-rule">
-      <div class="row">
-        <div class="col-3 col-medium-2">
-          <h3 class="p-heading--5">The freedom of Ubuntu</h3>
-        </div>
-        <div class="col-6 col-medium-3">
-          <p>Run your choice of Linux text editors, including vim, emacs, and nano. Install applications, compilers and libraries from the Ubuntu repository, securely maintained by Canonical.</p>
-        </div>
+    <div class="row--50-50 p-section--shallow">
+
+      <div class="col">
+
+        <h1>The full Ubuntu experience, now&nbsp;available on Windows</h1>
+
       </div>
-     <hr class="p-rule">
-      <div class="row">
-        <div class="col-3 col-medium-2">
-          <h3 class="p-heading--5">Highly performant AI/ML</h3>
+
+      <div class="col">
+
+        <div class="p-section--shallow">
+
+          <p>Access the power of a full Ubuntu terminal environment on Windows with Windows Subsystem for Linux (WSL).</p>
+
+          <p>
+            Streamline web application development, leverage cutting-edge AI/ML tooling, develop cross-platform applications and manage IT infrastructure without leaving Windows.
+          </p>
+
         </div>
-        <div class="col-6 col-medium-3">
-          <p>Ubuntu is the target platform for all major open source AI/ML frameworks. NVIDIA Data Science Stack lets you maximise the performance of your Data Science and Machine Learning projects on top of native Windows NVIDIA drivers.</p>
-        </div>
+
+        <hr />
+        <a class="p-button--positive"
+           href="https://www.microsoft.com/p/ubuntu/9pdxgncfsczv">Download from the Microsoft Store</a>
+        <a class="js-invoke-modal" href="/wsl/contact-us">Looking&nbsp;for&nbsp;support?&nbsp;Contact&nbsp;us&nbsp;&rsaquo;</a>
+
       </div>
-      <hr class="p-rule">
-      <div class="row">
-        <div class="col-3 col-medium-2">
-          <h3 class="p-heading--5">Fully flexible web applications</h3>
-        </div>
-        <div class="col-6 col-medium-3">
-          <p>Build, test, and deploy Kubernetes clusters on Windows. Develop in WSL using native Windows IDEs including VS Code and IntelliJ. Use containers to improve your workflow and benefit from full NodeJS and Ruby support.</p>
-        </div>
-      </div>
-      <hr class="p-rule">
-      <div class="row">
-        <div class="col-3 col-medium-2">
-          <h3 class="p-heading--5">Ideal for cross-platform development</h3>
-        </div>
-        <div class="col-6 col-medium-3">
-          <p>Create and test your CI/CD pipelines locally on an Ubuntu WSL instance. When ready, publish to a cloud production environment running Ubuntu VMs. Develop and test graphical Linux applications using WSLg and development frameworks like Flutter or React Native.</p>
-        </div>
-      </div>
-      <hr class="p-rule">
-      <div class="row">
-        <div class="col-3 col-medium-2">
-          <h3 class="p-heading--5">Critical tools for security specialists</h3>
-        </div>
-        <div class="col-6 col-medium-3">
-          <p>Leverage Linux security tools to test and harden your network. Achieve the same first-class, out-of-the-box, compliant security that is synonymous with Ubuntu.</p>
-        </div>
-      </div>
-			<hr class="p-rule">
-      <div class="row">
-        <div class="col-3 col-medium-2">
-          <h3 class="p-heading--5">Mixed IT infrastructure management</h3>
-        </div>
-        <div class="col-6 col-medium-3">
-          <p>From the same workstation, manage mixed Linux and Windows infrastructure both on-prem and across public clouds.</p>
-        </div>
-      </div>
+
     </div>
-  </div>
-</section>
 
-<section class="p-section">
-	<div class="u-fixed-width p-section--shallow">
-		<hr class="p-rule">
-		<h2>Get started with Ubuntu WSL today</h2>
-	</div>
-	<div class="row">
-		<div class="col-3 col-medium-3 col-small-4">
-			<div class="u-embedded-media u-no-margin--bottom">
-				<iframe class="u-embedded-media__element" width="560" height="315" src="https://www.youtube.com/embed/QkA9zLm17bs" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-			</div>
-			<h3 class="p-heading--5">
-				<a href="https://www.youtube.com/watch?v=QkA9zLm17bs">Windows Subsystem for Linux (WSL) - Make an awesome Linux environment directly on Windows</a>
-			</h3>
-		</div>
-		<div class="col-3 col-medium-3 col-small-4">
-			<div class="u-embedded-media u-no-margin--bottom">
-				<iframe class="u-embedded-media__element" width="560" height="315" src="https://www.youtube.com/embed/-tAelKpya4g" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-			</div>
-			<h3 class="p-heading--5">
-				<a href="https://www.youtube.com/watch?v=-tAelKpya4g">Ubuntu Summit 2022 | The Windows Subsystem for Linux WSL Latest updates and future improvements</a>
-			</h3>
-		</div>
-		<div class="col-3 col-medium-3 col-small-4">
-			<div class="u-embedded-media u-no-margin--bottom">
-				<iframe class="u-embedded-media__element" width="560" height="315" src="https://www.youtube.com/embed/LViy7x2Gpc4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-			</div>
-			<h3 class="p-heading--5">
-				<a href="https://www.youtube.com/watch?v=LViy7x2Gpc4&t=55s">Ubuntu on WSL | An FAQ for Data Scientists and Developers</a>
-			</h3>
-		</div>
-		<div class="col-3 col-medium-3 col-small-4">
-			<div class="u-embedded-media u-no-margin--bottom">
-				<iframe class="u-embedded-media__element" width="560" height="315" src="https://www.youtube.com/embed/Ja3qikzd-as" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-			</div>
-			<h3 class="p-heading--5">
-				<a href="https://www.youtube.com/watch?v=Ja3qikzd-as">WWSL: Partnering with Canonical to support systemd</a>
-			</h3>
-		</div>
-	</div>
-</section>
+    <div class="u-fixed-width p-section">
+      {{ image(url="https://assets.ubuntu.com/v1/a815b856-Screenshot 2024-01-26 114801.png",
+            alt="Terminal window running Ubuntu on WSL on top of the Windows 11 desktop",
+            width="2560",
+            height="1440",
+            hi_def=True,
+            loading="lazy") | safe
+      }}
 
-<section class="p-section--deep">
-  <hr class="p-rule is-fixed-width" />
-  <div class="row">
-    <div class="col-3 col-medium-3">
-      <h3 class="p-heading--2">Resources</h3>
     </div>
-    <div class="col-9 col-medium-3">
-      <div class="row">
-        <div class="col-3 col-medium-3">
-          <h3 class="p-heading--5 p-text--small-caps">Tutorials</h3>
-        </div>
-        <div class="col-6 col-medium-3">
-					<ul class="p-list--divided u-no-margin--bottom">
-						<li class="p-list__item">
-							<a href="https://canonical-ubuntu-wsl.readthedocs-hosted.com/en/latest/guides/install-ubuntu-wsl2/">Install Ubuntu on WSL2</a>
-						</li>
-						<li class="p-list__item">
-							<a href="https://www.youtube.com/watch?v=08WDGV0u58Y">An introduction to numerical computation applications using Ubuntu WSL</a>
-						</li>
-						<li class="p-list__item">
-							<a href="https://canonical-ubuntu-wsl.readthedocs-hosted.com/en/latest/tutorials/vscode/">Working with Visual Studio Code</a>
-						</li>
-						<li class="p-list__item">
-							<a href="https://canonical-ubuntu-wsl.readthedocs-hosted.com/en/latest/tutorials/interop/">Windows and Ubuntu interoperability</a>
-						</li>
-						<li class="p-list__item">
-							<a href="https://canonical-ubuntu-wsl.readthedocs-hosted.com/en/latest/tutorials/gpu-cuda/">Enabling GPU acceleration with NVIDIA CUDA</a>
-						</li>
-						<li class="p-list__item">
-							<a href="https://canonical-ubuntu-wsl.readthedocs-hosted.com/en/latest/tutorials/data-science-and-engineering/">Using WSL for data science and engineering</a>
-						</li>
-					</ul>
-        </div>
-      </div>
+  </section>
+
+  <section class="p-section">
+
+    <div class="u-fixed-width p-section--shallow">
+
       <hr class="p-rule" />
-      <div class="row">
-        <div class="col-3 col-medium-3">
-          <h3 class="p-heading--5 p-text--small-caps">Documentation</h3>
+      <h2>Develop with the best of both worlds</h2>
+    </div>
+    <div class="row">
+      <div class="col-9 col-start-large-4 col-medium-5 col-start-medium-2">
+        <hr class="p-rule" />
+        <div class="row">
+          <div class="col-3 col-medium-2">
+            <h3 class="p-heading--5">The freedom of Ubuntu</h3>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              Run your choice of Linux text editors, including vim, emacs, and nano. Install applications, compilers and libraries from the Ubuntu repository, securely maintained by Canonical.
+            </p>
+          </div>
         </div>
-        <div class="col-6 col-medium-3">
-					<ul class="p-list--divided u-no-margin--bottom">
-						<li class="p-list__item">
-							<a href="https://canonical-ubuntu-wsl.readthedocs-hosted.com/en/latest/">Ubuntu on WSL</a>
-						</li>
-						<li class="p-list__item">
-							<a href="https://canonical-ubuntu-wsl.readthedocs-hosted.com/en/latest/tutorials/">Ubuntu on WSL tutorials</a>
-						</li>
-						<li class="p-list__item">
-							<a href="https://ubuntu.com/landscape/docs/windows-subsystem-for-linux-in-landscape">Landscape WSL integration</a>
-						</li>
-						<li class="p-list__item">
-							<a href="https://learn.microsoft.com/en-us/windows/wsl/">Microsoft documentation for WSL</a>
-						</li>
-					</ul>
+        <hr class="p-rule" />
+        <div class="row">
+          <div class="col-3 col-medium-2">
+            <h3 class="p-heading--5">Highly performant AI/ML</h3>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              Ubuntu is the target platform for all major open source AI/ML frameworks. NVIDIA Data Science Stack lets you maximise the performance of your Data Science and Machine Learning projects on top of native Windows NVIDIA drivers.
+            </p>
+          </div>
         </div>
-      </div>
-	    <hr class="p-rule" />
-      <div class="row">
-        <div class="col-3 col-medium-3">
-          <h3 class="p-heading--5 p-text--small-caps">Contact us</h3>
+        <hr class="p-rule" />
+        <div class="row">
+          <div class="col-3 col-medium-2">
+            <h3 class="p-heading--5">Fully flexible web applications</h3>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              Build, test, and deploy Kubernetes clusters on Windows. Develop in WSL using native Windows IDEs including VS Code and IntelliJ. Use containers to improve your workflow and benefit from full NodeJS and Ruby support.
+            </p>
+          </div>
         </div>
-        <div class="col-6 col-medium-3">
-					<p>If you have further questions around Ubuntu on WSL or want to share your experiences, join the conversation on the <a href="https://discourse.ubuntu.com/c/wsl/27">Ubuntu Discourse</a>.</p>
-					<p>If you want to hear more about the benefits of securing Ubuntu on WSL at your organisation, please <a class="js-invoke-modal" href="/wsl/contact-us">get in touch</a>.</p>
+        <hr class="p-rule" />
+        <div class="row">
+          <div class="col-3 col-medium-2">
+            <h3 class="p-heading--5">Ideal for cross-platform development</h3>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              Create and test your CI/CD pipelines locally on an Ubuntu WSL instance. When ready, publish to a cloud production environment running Ubuntu VMs. Develop and test graphical Linux applications using WSLg and development frameworks like Flutter or React Native.
+            </p>
+          </div>
+        </div>
+        <hr class="p-rule" />
+        <div class="row">
+          <div class="col-3 col-medium-2">
+            <h3 class="p-heading--5">Critical tools for security specialists</h3>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              Leverage Linux security tools to test and harden your network. Achieve the same first-class, out-of-the-box, compliant security that is synonymous with Ubuntu.
+            </p>
+          </div>
+        </div>
+
+        <hr class="p-rule" />
+        <div class="row">
+          <div class="col-3 col-medium-2">
+            <h3 class="p-heading--5">Mixed IT infrastructure management</h3>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>From the same workstation, manage mixed Linux and Windows infrastructure both on-prem and across public clouds.</p>
+          </div>
         </div>
       </div>
     </div>
-  </div>
-</section>
+  </section>
 
-<script src="/static/js/src/render-tutorials.js" type="text/javascript"></script>
-<script>
-  document.addEventListener("DOMContentLoaded", function() {
-    renderTutorials('wsl');
-  });
-</script>
+  <section class="p-section">
 
-<script defer src="{{ versioned_static('js/modals.js') }}"></script>
+    <div class="u-fixed-width p-section--shallow">
 
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/wsl.html" data-form-id="3755" data-lp-id="" data-return-url="https://ubuntu.com/wsl/thank-you" data-lp-url="">
-</div>
+      <hr class="p-rule" />
+
+      <h2>Get started with Ubuntu WSL today</h2>
+
+    </div>
+
+    <div class="row">
+
+      <div class="col-3 col-medium-3 col-small-4">
+
+        <div class="u-embedded-media u-no-margin--bottom">
+          <iframe class="u-embedded-media__element"
+                  width="560"
+                  height="315"
+                  src="https://www.youtube.com/embed/QkA9zLm17bs"
+                  title="YouTube video player"
+                  frameborder="0"
+                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                  allowfullscreen></iframe>
+
+        </div>
+
+        <h3 class="p-heading--5">
+          <a href="https://www.youtube.com/watch?v=QkA9zLm17bs">Windows Subsystem for Linux (WSL) - Make an awesome Linux environment directly on Windows</a>
+
+        </h3>
+
+      </div>
+
+      <div class="col-3 col-medium-3 col-small-4">
+
+        <div class="u-embedded-media u-no-margin--bottom">
+          <iframe class="u-embedded-media__element"
+                  width="560"
+                  height="315"
+                  src="https://www.youtube.com/embed/-tAelKpya4g"
+                  title="YouTube video player"
+                  frameborder="0"
+                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                  allowfullscreen></iframe>
+
+        </div>
+
+        <h3 class="p-heading--5">
+          <a href="https://www.youtube.com/watch?v=-tAelKpya4g">Ubuntu Summit 2022 | The Windows Subsystem for Linux WSL Latest updates and future improvements</a>
+
+        </h3>
+
+      </div>
+
+      <div class="col-3 col-medium-3 col-small-4">
+
+        <div class="u-embedded-media u-no-margin--bottom">
+          <iframe class="u-embedded-media__element"
+                  width="560"
+                  height="315"
+                  src="https://www.youtube.com/embed/LViy7x2Gpc4"
+                  title="YouTube video player"
+                  frameborder="0"
+                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                  allowfullscreen></iframe>
+
+        </div>
+
+        <h3 class="p-heading--5">
+          <a href="https://www.youtube.com/watch?v=LViy7x2Gpc4&t=55s">Ubuntu on WSL | An FAQ for Data Scientists and Developers</a>
+
+        </h3>
+
+      </div>
+
+      <div class="col-3 col-medium-3 col-small-4">
+
+        <div class="u-embedded-media u-no-margin--bottom">
+          <iframe class="u-embedded-media__element"
+                  width="560"
+                  height="315"
+                  src="https://www.youtube.com/embed/Ja3qikzd-as"
+                  title="YouTube video player"
+                  frameborder="0"
+                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                  allowfullscreen></iframe>
+
+        </div>
+
+        <h3 class="p-heading--5">
+          <a href="https://www.youtube.com/watch?v=Ja3qikzd-as">WWSL: Partnering with Canonical to support systemd</a>
+
+        </h3>
+
+      </div>
+
+    </div>
+  </section>
+
+  <section class="p-section--deep">
+    <hr class="p-rule is-fixed-width" />
+    <div class="row">
+      <div class="col-3 col-medium-3">
+        <h3 class="p-heading--2">Resources</h3>
+      </div>
+      <div class="col-9 col-medium-3">
+        <div class="row">
+          <div class="col-3 col-medium-3">
+            <h3 class="p-heading--5 p-text--small-caps">Tutorials</h3>
+          </div>
+          <div class="col-6 col-medium-3">
+
+            <ul class="p-list--divided u-no-margin--bottom">
+
+              <li class="p-list__item">
+                <a href="https://canonical-ubuntu-wsl.readthedocs-hosted.com/en/latest/guides/install-ubuntu-wsl2/">Install Ubuntu on WSL2</a>
+
+              </li>
+
+              <li class="p-list__item">
+                <a href="https://www.youtube.com/watch?v=08WDGV0u58Y">An introduction to numerical computation applications using Ubuntu WSL</a>
+
+              </li>
+
+              <li class="p-list__item">
+                <a href="https://canonical-ubuntu-wsl.readthedocs-hosted.com/en/latest/tutorials/vscode/">Working with Visual Studio Code</a>
+
+              </li>
+
+              <li class="p-list__item">
+                <a href="https://canonical-ubuntu-wsl.readthedocs-hosted.com/en/latest/tutorials/interop/">Windows and Ubuntu interoperability</a>
+
+              </li>
+
+              <li class="p-list__item">
+                <a href="https://canonical-ubuntu-wsl.readthedocs-hosted.com/en/latest/tutorials/gpu-cuda/">Enabling GPU acceleration with NVIDIA CUDA</a>
+
+              </li>
+
+              <li class="p-list__item">
+                <a href="https://canonical-ubuntu-wsl.readthedocs-hosted.com/en/latest/tutorials/data-science-and-engineering/">Using WSL for data science and engineering</a>
+
+              </li>
+
+            </ul>
+          </div>
+        </div>
+        <hr class="p-rule" />
+        <div class="row">
+          <div class="col-3 col-medium-3">
+            <h3 class="p-heading--5 p-text--small-caps">Documentation</h3>
+          </div>
+          <div class="col-6 col-medium-3">
+
+            <ul class="p-list--divided u-no-margin--bottom">
+
+              <li class="p-list__item">
+                <a href="https://canonical-ubuntu-wsl.readthedocs-hosted.com/en/latest/">Ubuntu on WSL</a>
+
+              </li>
+
+              <li class="p-list__item">
+                <a href="https://canonical-ubuntu-wsl.readthedocs-hosted.com/en/latest/tutorials/">Ubuntu on WSL tutorials</a>
+
+              </li>
+
+              <li class="p-list__item">
+                <a href="https://ubuntu.com/landscape/docs/windows-subsystem-for-linux-in-landscape">Landscape WSL integration</a>
+
+              </li>
+
+              <li class="p-list__item">
+                <a href="https://learn.microsoft.com/en-us/windows/wsl/">Microsoft documentation for WSL</a>
+
+              </li>
+
+            </ul>
+          </div>
+        </div>
+
+        <hr class="p-rule" />
+        <div class="row">
+          <div class="col-3 col-medium-3">
+            <h3 class="p-heading--5 p-text--small-caps">Contact us</h3>
+          </div>
+          <div class="col-6 col-medium-3">
+
+            <p>
+              If you have further questions around Ubuntu on WSL or want to share your experiences, join the conversation on the <a href="https://discourse.ubuntu.com/c/wsl/27">Ubuntu Discourse</a>.
+            </p>
+
+            <p>
+              If you want to hear more about the benefits of securing Ubuntu on WSL at your organisation, please <a class="js-invoke-modal" href="/wsl/contact-us">get in touch</a>.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <script src="/static/js/src/render-tutorials.js" type="text/javascript"></script>
+  <script>
+    document.addEventListener("DOMContentLoaded", function() {
+      renderTutorials('wsl');
+    });
+  </script>
+
+  <script defer src="{{ versioned_static('js/modals.js') }}"></script>
+
+  <div class="u-hide"
+       id="contact-form-container"
+       data-form-location="/shared/forms/interactive/wsl.html"
+       data-form-id="3755"
+       data-lp-id=""
+       data-return-url="https://ubuntu.com/wsl/thank-you"
+       data-lp-url=""></div>
 {% endblock %}

--- a/templates/download/alternative-downloads.html
+++ b/templates/download/alternative-downloads.html
@@ -1,246 +1,284 @@
 {% extends "download/_base_download.html" %}
 
 {% block title %}Alternative downloads{% endblock %}
-{% block meta_description %}Want to download via-bitTorrent links, get images with more language packs, use the
-text-based alternate installer or find previous versions of Ubuntu?{% endblock %}
-{% block meta_copydoc %}https://docs.google.com/document/d/1VhmFVE3dK81mE3zcC9FVA6f5SGJ-DHan7WWlrlfRcvo/edit{% endblock
+
+{% block meta_description %}
+  Want to download via-bitTorrent links, get images with more language packs, use the
+  text-based alternate installer or find previous versions of Ubuntu?
+{% endblock %}
+
+{% block meta_copydoc %}
+  https://docs.google.com/document/d/1VhmFVE3dK81mE3zcC9FVA6f5SGJ-DHan7WWlrlfRcvo/edit
+{% endblock
 meta_copydoc %}
 
-{% block body_class %}is-paper{% endblock body_class %}
+{% block body_class %}
+  is-paper
+{% endblock body_class %}
 
 {% block content %}
-<div class="p-strip--suru-shape-light is-shallow">
+  <div class="p-strip--suru-shape-light is-shallow">
+    <div class="p-section">
+      <div class="row">
+        <div class="col-9 col-start-large-4">
+          <h1>Alternative downloads</h1>
+          <p>
+            There are several other ways to get Ubuntu including torrents, which can potentially mean a quicker download, our network installer for older systems and special configurations and links to our regional mirrors for our older (and newer) releases.
+          </p>
+          <p>
+            If you don't specifically require any of these installers, we recommend using our <a href="/download">standard downloads</a>.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <div class="p-section">
     <div class="row">
-      <div class="col-9 col-start-large-4">
-        <h1>Alternative downloads</h1>
-        <p>There are several other ways to get Ubuntu including torrents, which can potentially mean a quicker download, our network installer for older systems and special configurations and links to our regional mirrors for our older (and newer) releases.</p> 
-        <p>If you don't specifically require any of these installers, we recommend using our <a href="/download">standard downloads</a>.</p>
-      </div>
-    </div>
-  </div>
-</div>
-
-<div class="p-section">
-  <div class="row">
-    <div class="col-3">
-      <div class="p-side-navigation--raw-html is-sticky" id="drawer" style="top: 80px;">
-        <button class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">
-          Toggle table of contents
-        </button>
-        <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="drawer"></div>
-        <nav class="p-side-navigation__drawer" aria-label="documentation side navigation">
-          <div class="p-side-navigation__drawer-header">
-            <button class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="drawer">
-              Toggle table of contents
-            </button>
-          </div>
-          <ul>
-            <li class="p-side-navigation__item">
-              <a class="highlight-link is-active" href="#bit-torrent">BitTorrent</a>
-            </li>
-            <li class="p-side-navigation__item">
-              <a class="highlight-link" href="#other-images-and-mirrors">Other images and mirrors</a>
-            </li>
-            <li class="p-side-navigation__item">
-              <a class="highlight-link" href="#past-releases-and-other-flavours">Past releases and other flavours</a>
-            </li>
-            <li class="p-side-navigation__item">
-              <a class="highlight-link" href="#network-installer">Network installer</a>
-            </li>
-          </ul>
-        </nav>
-      </div>
-    </div>
-    <div class="col-9">
-      <div class="p-section">
-        <hr class="p-rule"/>
-        <div class="p-section--shallow">
-          <h2 id="bit-torrent" class="question-heading" style="scroll-margin-top: 3.4rem;">BitTorrent</h2>
-        </div>
-        <div class="p-section--shallow">
-          <p>BitTorrent is a peer-to-peer download network that sometimes enables higher download speeds and more reliable downloads of large files. You need a BitTorrent client on your computer to enable this download method.</p>
-        </div>
-        <hr class="p-rule"/>
-        <div class="row">
-          {% if releases.latest.short_version > releases.lts.short_version %}
-          <div class="col-3 col-medium-2">
-            <h3 class="p-heading--5">Ubuntu {{ releases.latest.full_version }}</h3>
-            <p>
-              <a class="download-torrent"
-                href="https://releases.ubuntu.com/{{ releases.latest.desktop_version }}/ubuntu-{{ releases.latest.desktop_version }}-desktop-amd64.iso.torrent">Ubuntu
-                {{ releases.latest.full_version }} Desktop (64-bit)</a>
-            </p>
-            <p>
-              <a class="download-torrent"
-                href="https://releases.ubuntu.com/{{ releases.latest.short_version }}/ubuntu-{{ releases.latest.full_version }}-live-server-amd64.iso.torrent">Ubuntu
-                Server {{ releases.latest.full_version }}</a>
-            </p>
-          </div>
-          {% endif %}
-          <div class="col-3 col-medium-2">
-            <h3 class="p-heading--5">
-              Ubuntu {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr>
-            </h3>
-            <p>
-              <a class="download-torrent"
-                href="https://releases.ubuntu.com/{{ releases.lts.short_version }}/ubuntu-{{ releases.lts.full_version }}-desktop-amd64.iso.torrent">Ubuntu
-                {{ releases.lts.full_version }} Desktop (64-bit)</a>
-            </p>
-            <p>
-              <a class="download-torrent"
-                href="https://releases.ubuntu.com/{{ releases.lts.short_version }}/ubuntu-{{ releases.lts.full_version }}-live-server-amd64.iso.torrent">Ubuntu
-                Server {{ releases.lts.full_version }} LTS</a>
-            </p>
-          </div>
-          <div class="col-3 col-medium-2">
-            <h3 class="p-heading--5">
-              Ubuntu {{ releases.previous_lts.full_version }} <abbr title="Long-term support">LTS</abbr>
-            </h3>
-            <p>
-              <a class="download-lts"
-                href="https://releases.ubuntu.com/{{ releases.previous_lts.short_version }}/ubuntu-{{ releases.previous_lts.full_version }}-desktop-amd64.iso.torrent">Ubuntu
-                {{ releases.previous_lts.full_version }} Desktop (64-bit)</a>
-            </p>
-            <p>
-              <a class="download-lts"
-                href="https://releases.ubuntu.com/{{ releases.previous_lts.short_version }}/ubuntu-{{ releases.previous_lts.full_version }}-live-server-amd64.iso.torrent">Ubuntu
-                Server {{ releases.previous_lts.full_version }} LTS</a>
-            </p>
-          </div>
-        </div>
-      </div>
-
-      <div class="p-section">
-        <div class="row">
-          <hr class="p-rule">
-          <div class="col-7">
-            <div class="p-section--shallow">
-              <h2 id="other-images-and-mirrors" class="question-heading" style="scroll-margin-top: 3.4rem;">Other images and mirrors</h2>
+      <div class="col-3">
+        <div class="p-side-navigation--raw-html is-sticky"
+             id="drawer"
+             style="top: 80px">
+          <button class="p-side-navigation__toggle js-drawer-toggle"
+                  aria-controls="drawer">Toggle table of contents</button>
+          <div class="p-side-navigation__overlay js-drawer-toggle"
+               aria-controls="drawer"></div>
+          <nav class="p-side-navigation__drawer"
+               aria-label="documentation side navigation">
+            <div class="p-side-navigation__drawer-header">
+              <button class="p-side-navigation__toggle--in-drawer js-drawer-toggle"
+                      aria-controls="drawer">Toggle table of contents</button>
             </div>
-            <p>For the full list of available Ubuntu images, we recommend you select a mirror local to you.</p>
-            <hr class="is-muted"/>
-            <p>
-              <a href="https://launchpad.net/ubuntu/+cdmirrors">All Ubuntu mirrors&nbsp;&rsaquo;</a>
-            </p>
-          </div>
-        </div>
-      </div>
-
-      <div class="p-section">
-        <div class="row">
-          <hr class="p-rule">
-          <div class="col-7">
-            <div class="p-section--shallow">
-              <h2 id="past-releases-and-other-flavours" class="question-heading" style="scroll-margin-top: 3.4rem;">Past releases and other flavours</h2>
-            </div>
-            <p>Looking for an older release of Ubuntu? Whether you need a POWER, IBMz (s390x), ARM, an obsolete release or a previous LTS point release with its original stack, you can find them in past releases.</p>
-            <hr class="p-rule is-muted"/>
-            <p>
-              <a href="https://releases.ubuntu.com/20.04.6/?_gl=1*19ip6hm*_gcl_au*MTE4NTIyOTI0MS4xNzA3MTMxMDQx&_ga=2.149898549.2084151835.1707729318-1126754318.1683186906">Ubuntu 20.04 LTS (Focal Fossa)</a>
-            </p>
-            <hr class="p-rule is-muted"/>
-            <p>
-              <a href="https://releases.ubuntu.com/18.04.6/?_gl=1*19ip6hm*_gcl_au*MTE4NTIyOTI0MS4xNzA3MTMxMDQx&_ga=2.149898549.2084151835.1707729318-1126754318.1683186906">Ubuntu 18.04 LTS (Bionic Beaver)</a>
-            </p>
-            <hr class="p-rule is-muted"/>
-            <p>
-              <a href="https://releases.ubuntu.com/?_gl=1*19ip6hm*_gcl_au*MTE4NTIyOTI0MS4xNzA3MTMxMDQx&_ga=2.149898549.2084151835.1707729318-1126754318.1683186906">All past releases&nbsp;&rsaquo;</a>
-            </p>
+            <ul>
+              <li class="p-side-navigation__item">
+                <a class="highlight-link is-active" href="#bit-torrent">BitTorrent</a>
+              </li>
+              <li class="p-side-navigation__item">
+                <a class="highlight-link" href="#other-images-and-mirrors">Other images and mirrors</a>
+              </li>
+              <li class="p-side-navigation__item">
+                <a class="highlight-link" href="#past-releases-and-other-flavours">Past releases and other flavours</a>
+              </li>
+              <li class="p-side-navigation__item">
+                <a class="highlight-link" href="#network-installer">Network installer</a>
+              </li>
             </ul>
-          </div>
+          </nav>
         </div>
       </div>
-
-      <div class="p-section">
-        <div class="row">
-          <hr class="p-rule">
-          <div class="col-7">
-            <div class="p-section--shallow">
-              <h2 id="network-installer" class="question-heading" style="scroll-margin-top: 3.4rem;">Network installer</h2>
+      <div class="col-9">
+        <div class="p-section">
+          <hr class="p-rule" />
+          <div class="p-section--shallow">
+            <h2 id="bit-torrent"
+                class="question-heading"
+                style="scroll-margin-top: 3.4rem">BitTorrent</h2>
+          </div>
+          <div class="p-section--shallow">
+            <p>
+              BitTorrent is a peer-to-peer download network that sometimes enables higher download speeds and more reliable downloads of large files. You need a BitTorrent client on your computer to enable this download method.
+            </p>
+          </div>
+          <hr class="p-rule" />
+          <div class="row">
+            {% if releases.latest.short_version > releases.lts.short_version %}
+              <div class="col-3 col-medium-2">
+                <h3 class="p-heading--5">Ubuntu {{ releases.latest.full_version }}</h3>
+                <p>
+                  <a class="download-torrent"
+                     href="https://releases.ubuntu.com/{{ releases.latest.desktop_version }}/ubuntu-{{ releases.latest.desktop_version }}-desktop-amd64.iso.torrent">Ubuntu
+                  {{ releases.latest.full_version }} Desktop (64-bit)</a>
+                </p>
+                <p>
+                  <a class="download-torrent"
+                     href="https://releases.ubuntu.com/{{ releases.latest.short_version }}/ubuntu-{{ releases.latest.full_version }}-live-server-amd64.iso.torrent">Ubuntu
+                  Server {{ releases.latest.full_version }}</a>
+                </p>
+              </div>
+            {% endif %}
+            <div class="col-3 col-medium-2">
+              <h3 class="p-heading--5">
+                Ubuntu {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr>
+              </h3>
+              <p>
+                <a class="download-torrent"
+                   href="https://releases.ubuntu.com/{{ releases.lts.short_version }}/ubuntu-{{ releases.lts.full_version }}-desktop-amd64.iso.torrent">Ubuntu
+                {{ releases.lts.full_version }} Desktop (64-bit)</a>
+              </p>
+              <p>
+                <a class="download-torrent"
+                   href="https://releases.ubuntu.com/{{ releases.lts.short_version }}/ubuntu-{{ releases.lts.full_version }}-live-server-amd64.iso.torrent">Ubuntu
+                Server {{ releases.lts.full_version }} LTS</a>
+              </p>
             </div>
-            <p>The network installer lets you install Ubuntu over a network. It includes the minimal set of packages needed to start and the rest of the packages are downloaded over the network. Since only current packages are downloaded, there is no need to upgrade packages immediately after installation.</p>
-            <p>The network installer is ideal if you have a computer that cannot run the graphical installer. It is also useful if you want to install Ubuntu on a large number of computers at once.</p>
-            <p>For 22.04 LTS, users can use the new Ubuntu Live installer to setup and configure a network install.</p>
-            <hr class="p-rule is-muted">
-            <p><a href="https://discourse.ubuntu.com/t/netbooting-the-live-server-installer?_gl=1*1t2mr3n*_gcl_au*MTE4NTIyOTI0MS4xNzA3MTMxMDQx&_ga=2.204825875.2084151835.1707729318-1126754318.1683186906">Instructions for the 22.04 LTS Ubuntu Live installer&nbsp;&rsaquo;</a></p>
-            <hr class="p-rule is-muted">
-            <p><a href="https://discourse.ubuntu.com/t/netbooting-the-live-server-installer">Instructions for the 20.04 Ubuntu Live installer&nbsp;&rsaquo;</a></p>
-            <hr class="p-rule is-muted">
-            <p><a href="http://cdimage.ubuntu.com/netboot/18.04/">Download the network installer for 18.04 LTS&nbsp;&rsaquo;</a></p>
+            <div class="col-3 col-medium-2">
+              <h3 class="p-heading--5">
+                Ubuntu {{ releases.previous_lts.full_version }} <abbr title="Long-term support">LTS</abbr>
+              </h3>
+              <p>
+                <a class="download-lts"
+                   href="https://releases.ubuntu.com/{{ releases.previous_lts.short_version }}/ubuntu-{{ releases.previous_lts.full_version }}-desktop-amd64.iso.torrent">Ubuntu
+                {{ releases.previous_lts.full_version }} Desktop (64-bit)</a>
+              </p>
+              <p>
+                <a class="download-lts"
+                   href="https://releases.ubuntu.com/{{ releases.previous_lts.short_version }}/ubuntu-{{ releases.previous_lts.full_version }}-live-server-amd64.iso.torrent">Ubuntu
+                Server {{ releases.previous_lts.full_version }} LTS</a>
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div class="p-section">
+          <div class="row">
+            <hr class="p-rule" />
+            <div class="col-7">
+              <div class="p-section--shallow">
+                <h2 id="other-images-and-mirrors"
+                    class="question-heading"
+                    style="scroll-margin-top: 3.4rem">Other images and mirrors</h2>
+              </div>
+              <p>For the full list of available Ubuntu images, we recommend you select a mirror local to you.</p>
+              <hr class="is-muted" />
+              <p>
+                <a href="https://launchpad.net/ubuntu/+cdmirrors">All Ubuntu mirrors&nbsp;&rsaquo;</a>
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div class="p-section">
+          <div class="row">
+            <hr class="p-rule" />
+            <div class="col-7">
+              <div class="p-section--shallow">
+                <h2 id="past-releases-and-other-flavours"
+                    class="question-heading"
+                    style="scroll-margin-top: 3.4rem">Past releases and other flavours</h2>
+              </div>
+              <p>
+                Looking for an older release of Ubuntu? Whether you need a POWER, IBMz (s390x), ARM, an obsolete release or a previous LTS point release with its original stack, you can find them in past releases.
+              </p>
+              <hr class="p-rule is-muted" />
+              <p>
+                <a href="https://releases.ubuntu.com/22.04/?_gl=1*19ip6hm*_gcl_au*MTE4NTIyOTI0MS4xNzA3MTMxMDQx&_ga=2.149898549.2084151835.1707729318-1126754318.1683186906">Ubuntu 22.04 LTS (Jammy Jellyfish)</a>
+              </p>
+              <hr class="p-rule is-muted" />
+              <p>
+                <a href="https://releases.ubuntu.com/20.04.6/?_gl=1*19ip6hm*_gcl_au*MTE4NTIyOTI0MS4xNzA3MTMxMDQx&_ga=2.149898549.2084151835.1707729318-1126754318.1683186906">Ubuntu 20.04 LTS (Focal Fossa)</a>
+              </p>
+              <hr class="p-rule is-muted" />
+              <p>
+                <a href="https://releases.ubuntu.com/18.04.6/?_gl=1*19ip6hm*_gcl_au*MTE4NTIyOTI0MS4xNzA3MTMxMDQx&_ga=2.149898549.2084151835.1707729318-1126754318.1683186906">Ubuntu 18.04 LTS (Bionic Beaver)</a>
+              </p>
+              <hr class="p-rule is-muted" />
+              <p>
+                <a href="https://releases.ubuntu.com/?_gl=1*19ip6hm*_gcl_au*MTE4NTIyOTI0MS4xNzA3MTMxMDQx&_ga=2.149898549.2084151835.1707729318-1126754318.1683186906">All past releases&nbsp;&rsaquo;</a>
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div class="p-section">
+          <div class="row">
+            <hr class="p-rule" />
+            <div class="col-7">
+              <div class="p-section--shallow">
+                <h2 id="network-installer"
+                    class="question-heading"
+                    style="scroll-margin-top: 3.4rem">Network installer</h2>
+              </div>
+              <p>
+                The network installer lets you install Ubuntu over a network. It includes the minimal set of packages needed to start and the rest of the packages are downloaded over the network. Since only current packages are downloaded, there is no need to upgrade packages immediately after installation.
+              </p>
+              <p>
+                The network installer is ideal if you have a computer that cannot run the graphical installer. It is also useful if you want to install Ubuntu on a large number of computers at once.
+              </p>
+              <p>For 22.04 LTS, users can use the new Ubuntu Live installer to setup and configure a network install.</p>
+              <hr class="p-rule is-muted" />
+              <p>
+                <a href="https://discourse.ubuntu.com/t/netbooting-the-live-server-installer?_gl=1*1t2mr3n*_gcl_au*MTE4NTIyOTI0MS4xNzA3MTMxMDQx&_ga=2.204825875.2084151835.1707729318-1126754318.1683186906">Instructions for the 22.04 LTS Ubuntu Live installer&nbsp;&rsaquo;</a>
+              </p>
+              <hr class="p-rule is-muted" />
+              <p>
+                <a href="https://discourse.ubuntu.com/t/netbooting-the-live-server-installer">Instructions for the 20.04 Ubuntu Live installer&nbsp;&rsaquo;</a>
+              </p>
+              <hr class="p-rule is-muted" />
+              <p>
+                <a href="https://cdimage.ubuntu.com/netboot/18.04/">Download the network installer for 18.04 LTS&nbsp;&rsaquo;</a>
+              </p>
+            </div>
           </div>
         </div>
       </div>
     </div>
   </div>
-</div>
 
-{% include "download/shared/_footer.html" %}
+  {% include "download/shared/_footer.html" %}
 
-<script type="text/javascript">
-  function setUpTogglableSideNav() {
-    var navigationDrawer = document.querySelector("#drawer");
-    var navigationDrawerToggles = Array.prototype.slice.call(
-      document.querySelectorAll(".js-drawer-toggle")
-    );
-
-    if (navigationDrawer) {
-      var navigationLinks = Array.prototype.slice.call(
-        navigationDrawer.querySelectorAll("a")
+  <script type="text/javascript">
+    function setUpTogglableSideNav() {
+      var navigationDrawer = document.querySelector("#drawer");
+      var navigationDrawerToggles = Array.prototype.slice.call(
+        document.querySelectorAll(".js-drawer-toggle")
       );
 
-      navigationDrawerToggles.forEach(function(toggle) {
-        toggle.addEventListener("click", function() {
-          navigationDrawer.classList.toggle("is-expanded");
-        });
-      });
+      if (navigationDrawer) {
+        var navigationLinks = Array.prototype.slice.call(
+          navigationDrawer.querySelectorAll("a")
+        );
 
-      navigationLinks.forEach(function(link) {
-        link.addEventListener("click", function() {
-          navigationDrawer.classList.remove("is-expanded");
-        });
-      });
-    }
-  };
-
-  function setUpDynamicSideNav(viewPortHeight) {
-    const questions = Array.prototype.slice.call(
-      document.querySelectorAll(".question-heading")
-    );
-
-    const navigationLinks = Array.prototype.slice.call(
-      document.querySelectorAll(".highlight-link")
-    );
-
-    questions.forEach(function(question) {
-      const observer = new IntersectionObserver(function(entry) {
-        if (entry[0].isIntersecting) {
-          const questionId = entry[0].target.id;
-          navigationLinks.forEach(function(link) {
-            if (link.getAttribute("href") === `#${questionId}`) {
-              link.classList.add("is-active");
-            } else {
-              link.classList.remove("is-active");
-            }
+        navigationDrawerToggles.forEach(function(toggle) {
+          toggle.addEventListener("click", function() {
+            navigationDrawer.classList.toggle("is-expanded");
           });
-        }
-      }, {
-        rootMargin: `0px 0px -80%`,
-        threshold: 0.5,
+        });
+
+        navigationLinks.forEach(function(link) {
+          link.addEventListener("click", function() {
+            navigationDrawer.classList.remove("is-expanded");
+          });
+        });
+      }
+    };
+
+    function setUpDynamicSideNav(viewPortHeight) {
+      const questions = Array.prototype.slice.call(
+        document.querySelectorAll(".question-heading")
+      );
+
+      const navigationLinks = Array.prototype.slice.call(
+        document.querySelectorAll(".highlight-link")
+      );
+
+      questions.forEach(function(question) {
+        const observer = new IntersectionObserver(function(entry) {
+          if (entry[0].isIntersecting) {
+            const questionId = entry[0].target.id;
+            navigationLinks.forEach(function(link) {
+              if (link.getAttribute("href") === `#${questionId}`) {
+                link.classList.add("is-active");
+              } else {
+                link.classList.remove("is-active");
+              }
+            });
+          }
+        }, {
+          rootMargin: `0px 0px -80%`,
+          threshold: 0.5,
+        });
+
+        observer.observe(question);
       });
+    };
 
-      observer.observe(question);
-    });
-  };
-
-  (function() {
-    setUpTogglableSideNav();
-    setUpDynamicSideNav();
-  })();
+    (function() {
+      setUpTogglableSideNav();
+      setUpDynamicSideNav();
+    })();
 
 
-// start observing a DOM node
-
-</script>
+    // start observing a DOM node
+  </script>
 
 {% endblock content %}

--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -119,8 +119,8 @@
           <hr class="p-rule" />
           <ul class="u-responsive-realign p-inline-list">
             <li class="p-inline-list__item">
-              <a href="/blog/ubuntu-desktop-24-04-noble-numbat-deep-dive">{{ releases.lts.full_version }} deep dive&nbsp;&rsaquo;</a>
-            </li>   
+              <a href="/blog/ubuntu-desktop-24-04-noble-numbat-deep-dive">Ubuntu {{ releases.lts.full_version }} LTS deep dive&nbsp;&rsaquo;</a>
+            </li>
             <li class="p-inline-list__item">
               <a href="https://discourse.ubuntu.com/t/noble-numbat-release-notes/39890">Release notes&nbsp;&rsaquo;</a>
             </li>

--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -95,7 +95,7 @@
             <span class="u-text--muted">{{ releases.lts.raspi_desktop_iso_size }}</span>
           {% endif %}
         </p>
-        <p>Minimum 2GBs of RAM and 16GB storage required</p>
+        <p>Minimum 4GBs of RAM and 16GB storage required</p>
         <hr />
         <p class="u-responsive-realign">
           <a href="/download/raspberry-pi/thank-you?version={{ releases.lts.full_version }}&amp;architecture=server-arm64+raspi"
@@ -121,7 +121,9 @@
           <a href="/download/raspberry-pi/thank-you?version={{ releases.latest.core_version }}&amp;architecture=core-22-arm64+raspi"
              onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 64-bit - Ubuntu Core', 'eventLabel' : '{{ releases.latest.core_version }}', 'eventValue' : undefined });"
              class="p-button">Download Ubuntu Core {{ releases.latest.core_version }}</a>
-          {% if releases.latest.rasp_pi_core_22_size %}<span class="u-text--muted">{{ releases.latest.rasp_pi_core_22_size }}</span>{% endif %}
+          {% if releases.latest.rasp_pi_core_22_size %}
+            <span class="u-text--muted">{{ releases.latest.rasp_pi_core_22_size }}</span>
+          {% endif %}
         </p>
       </div>
     </div>

--- a/templates/download/server/manual.html
+++ b/templates/download/server/manual.html
@@ -142,7 +142,7 @@
               Frame pointers enabled by default for the majority of packages on x86 architectures
             </li>
             <li class="p-list__item is-ticked">
-              Rust 1.78, .NET 8 and OpenJDK 21 with TCK certification in addition to other toolchain upgrades
+              Rust 1.75, .NET 8 and OpenJDK 21 with TCK certification in addition to other toolchain upgrades
             </li>
             <li class="p-list__item is-ticked">64-bit time_t by default on armhf to address the year 2038 issue</li>
             <li class="p-list__item is-ticked">AppArmor-enforced unprivileged user namespaces restricted by default</li>
@@ -526,7 +526,7 @@
         const releaseNotesTabContainer = document.getElementById("release-notes");
         releaseNotesTabContainer.classList.remove("u-hide")
       })
-    } 
+    }
     showBaseNestedTab()
 
     addEventListener("DOMContentLoaded", () => {

--- a/templates/download/server/manual.html
+++ b/templates/download/server/manual.html
@@ -160,7 +160,7 @@
           <ul class="p-list--divided">
             <li class="p-list__item is-ticked">1 GHz processor or better</li>
             <li class="p-list__item is-ticked">1 GB system memory</li>
-            <li class="p-list__item is-ticked">2.5 GB of free hard drive space</li>
+            <li class="p-list__item is-ticked">5 GB of free hard drive space</li>
             <li class="p-list__item is-ticked">Either a USB port or a DVD drive for the installer media</li>
           </ul>
         </div>


### PR DESCRIPTION
## Done

Received a request from Oliver to fix the following:
- change amount of RAM from 2 to 4 on /download/raspberry-pi page
![raspberry1](https://github.com/canonical/ubuntu.com/assets/15943863/847970bc-d9b0-45e1-8477-4f85b454e32f)
- Change the size of Core 22 from 263GB to 263MB on /download/raspberry-pi page
![raspberry2](https://github.com/canonical/ubuntu.com/assets/15943863/7ea583f3-3f9b-4139-a1a4-ec5814068d3b)
- Change link text to "Ubuntu 24.04 LTS deep dive >" on /download/desktop
![desktop](https://github.com/canonical/ubuntu.com/assets/15943863/d1709ec6-926d-49fe-8d77-90a081922636)
- Added link to Ubuntu 22.04 on /download/alternative-downloads
![alternative](https://github.com/canonical/ubuntu.com/assets/15943863/98373ebe-0880-4304-9342-8bec5e2d1635)
- Change Rust version from 1.78 to 1.75 on /download/server
![rust](https://github.com/canonical/ubuntu.com/assets/15943863/2f857d0e-76d2-4261-a621-2fc3e7116368)
- Change the amount of free hard drive space from 2.5GB to 5GB on System Requirements tab on /download/server
![server2](https://github.com/canonical/ubuntu.com/assets/15943863/7df060e7-4000-48eb-b8b1-b01278b43663)


## QA

Check that all above mentioned changes are in place

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
