### PR TITLE
Fix meganav use-cases section headings

### DIFF
--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -311,10 +311,6 @@ $meganav-height: 3rem;
               left: calc(1.5rem + $row-margin-medium);
             }
           }
-
-          .p-muted-heading {
-            padding-left: 0;
-          }
         }
 
         @media (max-width: $breakpoint-medium) {
@@ -344,10 +340,6 @@ $meganav-height: 3rem;
             &::before {
               left: calc(1.5rem + $row-margin-small);
             }
-          }
-
-          .p-muted-heading {
-            padding-left: 0;
           }
         }
 


### PR DESCRIPTION
## Done

- Removes some styling that was overriding the padding needed for section headings in the meganav (see screenshots)

## QA

- Go to [the demo](https://ubuntu-com-13794.demos.haus/) on mobile size screen
- Open the menu and click 'use-cases'
- See their is the appropriate padding for the heading 'By solution'

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-10559

## Screenshots

Before:
![image](https://github.com/canonical/ubuntu.com/assets/58276363/4edb32c4-48a6-4203-8bb4-adaf760f690c)
After:
![image](https://github.com/canonical/ubuntu.com/assets/58276363/b1d9512e-2ac2-4a7d-b6be-b39b524dc064)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
