### PR TITLE
Update flavour screenshots for Noble release

### DIFF
--- a/templates/desktop/flavours.html
+++ b/templates/desktop/flavours.html
@@ -72,7 +72,7 @@
     <div class="col-start-large-4 col-9">
       {{ 
         image (
-        url="https://assets.ubuntu.com/v1/54331fa0-edubuntu-2304-screenshot.png",
+        url="https://assets.ubuntu.com/v1/ab7e24df-edubuntu-2404.png",
         alt="",
         width="2560",
         height="1440",
@@ -119,7 +119,7 @@
     <div class="col-start-large-4 col-9">
       {{ 
         image (
-        url="https://assets.ubuntu.com/v1/7c6fa2da-kubuntu-2204-screenshot.png",
+        url="https://assets.ubuntu.com/v1/eced5d77-kubuntu-2404.png",
         alt="",
         width="2560",
         height="1440",
@@ -165,7 +165,7 @@
     <div class="col-start-large-4 col-9">
       {{ 
         image (
-        url="https://assets.ubuntu.com/v1/8d50725a-lubuntu-2204-screenshot.png",
+        url="https://assets.ubuntu.com/v1/2b5ea6f3-lubuntu-24.04.png",
         alt="",
         width="1920",
         height="1080",
@@ -212,7 +212,7 @@
     <div class="col-start-large-4 col-9">
       {{ 
         image (
-        url="https://assets.ubuntu.com/v1/eb97c55b-Ubuntu_Budgie.png",
+        url="https://assets.ubuntu.com/v1/5fb92f07-ubuntu-budgie-2404.png",
         alt="",
         width="1920",
         height="1080",
@@ -258,7 +258,7 @@
     <div class="col-start-large-4 col-9">
       {{ 
         image (
-        url="https://assets.ubuntu.com/v1/70b28e5e-ubuntu-cinnamon-2304-screenshot.png",
+        url="https://assets.ubuntu.com/v1/0c3800a7-ubuntu-cinnamon-2404.png",
         alt="",
         width="1920",
         height="1080",
@@ -304,7 +304,7 @@
     <div class="col-start-large-4 col-9">
       {{
         image (
-        url="https://assets.ubuntu.com/v1/0bd4870d-Kylin2204.png",
+        url="https://assets.ubuntu.com/v1/0baa36b7-ubuntu-kylin-2404.png",
         alt="",
         width="1360",
         height="768",
@@ -350,7 +350,7 @@
     <div class="col-start-large-4 col-9">
       {{ 
         image (
-        url="https://assets.ubuntu.com/v1/1d7a53b1-UbuntuMATE-screenshot.png",
+        url="https://assets.ubuntu.com/v1/5a3f4e43-ubuntu-mate-24.04.png",
         alt="",
         width="1664",
         height="936",
@@ -396,7 +396,7 @@
     <div class="col-start-large-4 col-9">
       {{ 
         image (
-        url="https://assets.ubuntu.com/v1/777dd5d3-UbuntuStudio.png",
+        url="https://assets.ubuntu.com/v1/538a67c8-ubuntu-studio-2404.png",
         alt="",
         width="1920",
         height="1080",
@@ -442,7 +442,7 @@
     <div class="col-start-large-4 col-9">
       {{ 
         image (
-        url="https://assets.ubuntu.com/v1/e96f6b6d-ubuntu-unity-desktop-screenshot.png",
+        url="https://assets.ubuntu.com/v1/56c2851e-ubuntu-unity-24.04.png",
         alt="",
         width="1920",
         height="1080",
@@ -488,7 +488,7 @@
     <div class="col-start-large-4 col-9">
       {{ 
         image (
-        url="https://assets.ubuntu.com/v1/5f23328b-xubuntu-2204-screenshot.png",
+        url="https://assets.ubuntu.com/v1/cb61126a-xubuntu-24.04.png",
         alt="",
         width="1920",
         height="1080",


### PR DESCRIPTION
## Done

- Added screenshot images to asset manager
- Updated img src for each respective flavour 

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card
As part of:
https://warthogs.atlassian.net/browse/DESPM-1969

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
