### PR TITLE
[WD-10167] update checksums for 24.04 LTS, add sizes for new Ubuntu images

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -22,6 +22,8 @@ lts:
   release_notes_url: "https://discourse.ubuntu.com/t/noble-numbat-release-notes/24668"
   iso_download_size: "6GB"
   server_iso_size: "2.7GB"
+  raspi_desktop_iso_size: "2.6GB"
+  raspi_server_iso_size: "1GB"
 previous_lts:
   slug: JammyJellyfish
   name: "Jammy Jellyfish"

--- a/releases.yaml
+++ b/releases.yaml
@@ -20,6 +20,8 @@ lts:
   release_date: "April 2024"
   eol: "April 2029"
   release_notes_url: "https://discourse.ubuntu.com/t/noble-numbat-release-notes/24668"
+  iso_download_size: "6GB"
+  server_iso_size: "2.7GB"
 previous_lts:
   slug: JammyJellyfish
   name: "Jammy Jellyfish"
@@ -44,22 +46,26 @@ core_lts:
 
 checksums:
   desktop:
+    "24.04": "81fae9cc21e2b1e3a9a4526c7dad3131b668e346c580702235ad4d02645d9455 *ubuntu-24.04-desktop-amd64.iso"
     "23.10.1": "3b6c5275366d02160554fa5703add462da3b8ce9be1749f8806e8dbbffaa2b5a *ubuntu-23.10.1-desktop-amd64.iso"
     "22.04.4": "071d5a534c1a2d61d64c6599c47c992c778e08b054daecc2540d57929e4ab1fd *ubuntu-22.04.4-desktop-amd64.iso"
     "21.10": "f8d3ab0faeaecb5d26628ae1aa21c9a13e0a242c381aa08157db8624d574b830 *ubuntu-21.10-desktop-amd64.iso"
     "20.04.6": "510ce77afcb9537f198bc7daa0e5b503b6e67aaed68146943c231baeaab94df1 *ubuntu-20.04.6-desktop-amd64.iso"
   live-server:
+    "24.04": "8762f7e74e4d64d72fceb5f70682e6b069932deedb4949c6975d0f0fe0a91be3 *ubuntu-24.04-live-server-amd64.iso"
     "23.10": "d2fb80d9ce77511ed500bcc1f813e6f676d4a3577009dfebce24269ca23346a5 *ubuntu-23.10-live-server-amd64.iso"
     "22.04.4": "45f873de9f8cb637345d6e66a583762730bbea30277ef7b32c9c3bd6700a32b2 *ubuntu-22.04.4-live-server-amd64.iso"
     "21.10": "e84f546dfc6743f24e8b1e15db9cc2d2c698ec57d9adfb852971772d1ce692d4 *ubuntu-21.10-live-server-amd64.iso"
     "20.04.6": "b8f31413336b9393ad5d8ef0282717b2ab19f007df2e9ed5196c13d8f9153c8b *ubuntu-20.04.6-live-server-amd64.iso"
     "18.04.6": "6c647b1ab4318e8c560d5748f908e108be654bad1e165f7cf4f3c1fc43995934 *ubuntu-18.04.6-live-server-amd64.iso"
   desktop-arm64+raspi:
+    "24.04": "016e508f44f3c82605747ad1e621710bd224df91dddf37f27903b0cd8ec3a11f *ubuntu-24.04-preinstalled-desktop-arm64+raspi.img.xz"
     "23.10": "92cbd905c36114effcec6943d3438845dfac07e3bb238cde4c510b41a71f694b *ubuntu-23.10-preinstalled-desktop-arm64+raspi.img.xz"
     "22.04.4": "9a4dbf8644d96fc55c0214454be8f50cb3cbf8b15d4475bba8f74679e2cd4411 *ubuntu-22.04.4-preinstalled-desktop-arm64+raspi.img.xz"
     "21.10": "5187d507099f26bc4d8218085109af498fae5ff93b40c668f83bab5c7574d954 *ubuntu-21.10-preinstalled-desktop-arm64+raspi.img.xz"
     "21.04": "d89ee327a00b98d7166b1a8cc95d17762aaacd3b4d0fc756c5b6b65df1708f48 *ubuntu-21.04-preinstalled-desktop-arm64+raspi.img.xz"
   server-arm64+raspi:
+    "24.04": "9b12b0e3a297ac8a0e13aef7cee0902102f3e2b925a0f3acaa28a32cddc73f4f *ubuntu-24.04-preinstalled-server-arm64+raspi.img.xz"
     "23.10": "81886cefc6b7abe5baf26dbc353bc69924dfc76416c15c3c3d03cf5ba30c90e8 *ubuntu-23.10-preinstalled-server-arm64+raspi.img.xz"
     "22.04.4": "8985915e3840d1e3971780aa160791e0665f64a2ee7e52ef8285c0701a8f6d6b *ubuntu-22.04.4-preinstalled-server-arm64+raspi.img.xz"
     "21.10": "126f940d3b270a6c1fc5a183ac8a3d193805fead4f517296a7df9d3e7d691a03 *ubuntu-21.10-preinstalled-server-arm64+raspi.img.xz"
@@ -70,6 +76,7 @@ checksums:
     "21.10": "341593c9607ed20744cd86941d94d73e3ba4f74e8ef2633eec63ce9b0cfac5a1 *ubuntu-21.10-preinstalled-server-armhf+raspi.img.xz"
     "20.04.5": "065c41846ddf7a1c636a1aac5a7d49ebcee819b141f9d57fd586c5f84b9b7942 *ubuntu-20.04.5-preinstalled-server-armhf+raspi.img.xz"
   server-riscv64:
+    "24.04": "4ba148baaef02a477c723771a26c9a1a3dd0736ad160fac3dc06fa91c20e3216 *ubuntu-24.04-live-server-riscv64.img.gz"
     "23.10": "5c300b9fff78f5d86fec06787e833573220165aeb310a8f1b5c56ca888bc91c2 *ubuntu-23.10-preinstalled-server-riscv64+unmatched.img.xz"
     "22.04.4": "fc86d5f6e1ddb1cb7f59255b4adc5872a103ba61fd6746a0fc1994d850f663c8 *ubuntu-22.04.4-preinstalled-server-riscv64+unmatched.img.xz"
     "21.10": "8067892fa627eb219b31dc629f31f3bda6b015dfeabf2fdc9b0ed150bf7984b8 *ubuntu-21.10-preinstalled-server-riscv64+unmatched.img.xz"

--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -116,7 +116,7 @@
             <li class="p-list__item is-ticked">Advanced Active Directory Group Policy Object support for Ubuntu Pro users</li>
             <li class="p-list__item is-ticked">Experimental support for TPM-backed Full Disc Encryption and ZFS encryption</li>
           </ul>
-          <hr class="p-rule" />
+          <hr />
           <ul class="u-responsive-realign p-inline-list">
             <li class="p-inline-list__item">
               <a href="/blog/ubuntu-desktop-24-04-noble-numbat-deep-dive">Ubuntu {{ releases.lts.full_version }} LTS deep dive&nbsp;&rsaquo;</a>

--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -101,7 +101,7 @@
           <a href="/download/raspberry-pi/thank-you?version={{ releases.lts.full_version }}&amp;architecture=server-arm64+raspi"
              onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 64-bit - Ubuntu Server', 'eventLabel' : '{{ releases.lts.full_version }}', 'eventValue' : undefined });"
              class="p-button">Download Ubuntu Server {{ releases.lts.full_version }} LTS</a>
-          {% if releases.lts.raspi_desktop_iso_size %}
+          {% if releases.lts.raspi_server_iso_size %}
             <span class="u-text--muted">{{ releases.lts.raspi_server_iso_size }}</span>
           {% endif %}
         </p>

--- a/templates/download/risc-v/tab-1.html
+++ b/templates/download/risc-v/tab-1.html
@@ -30,7 +30,7 @@
     <div class="col-6">
       <p>
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/24.04/release/ubuntu-24.04-preinstalled-server-riscv64+nezha.img.xz">Download 24.04</a>
+           href="https://cdimage.ubuntu.com/releases/noble/release/ubuntu-24.04-preinstalled-server-riscv64+nezha.img.xz">Download 24.04</a>
       </p>
       <p>
         <a href="https://wiki.ubuntu.com/RISC-V/Nezha%20D1">How to install Ubuntu on the Nezha</a>

--- a/templates/download/risc-v/tab-2.html
+++ b/templates/download/risc-v/tab-2.html
@@ -41,7 +41,7 @@
       <hr class="is-fixed-width col-6" />
       <p>
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/24.04/release/ubuntu-24.04-preinstalled-server-riscv64+icicle.img.xz">Download 24.04</a>
+           href="https://cdimage.ubuntu.com/releases/noble/release/ubuntu-24.04-preinstalled-server-riscv64+icicle.img.xz">Download 24.04</a>
       </p>
       <p>
         <a href="https://wiki.ubuntu.com/RISC-V/PolarFire%20SoC%20FPGA%20Icicle%20Kit">How to install Ubuntu on the Microchip Polarfire SoC FPGA Icicle Kit</a>

--- a/templates/download/risc-v/tab-3.html
+++ b/templates/download/risc-v/tab-3.html
@@ -29,7 +29,7 @@
     <div class="col-6">
       <p class="u-sv3">
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/24.04/release/ubuntu-24.04-preinstalled-server-riscv64+unmatched.img.xz">Download 24.04</a>
+           href="https://cdimage.ubuntu.com/releases/noble/release/ubuntu-24.04-preinstalled-server-riscv64+unmatched.img.xz">Download 24.04</a>
       </p>
     </div>
   </div>
@@ -45,7 +45,7 @@
     <div class="col-6">
       <p>
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/24.04/release/ubuntu-24.04-live-server-riscv64.img.gz">Download 24.04 live installer</a>
+           href="https://cdimage.ubuntu.com/releases/noble/release/ubuntu-24.04-live-server-riscv64.img.gz">Download 24.04 live installer</a>
       </p>
       <p>
         <a href="https://wiki.ubuntu.com/RISC-V/QEMU">How to install Ubuntu on QEMU RISC-V</a>

--- a/templates/download/risc-v/tab-4.html
+++ b/templates/download/risc-v/tab-4.html
@@ -32,7 +32,7 @@
       </p>
       <p class="u-sv3">
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/24.04/release/ubuntu-24.04-preinstalled-server-riscv64+unmatched.img.xz">Download 24.04</a>
+           href="https://cdimage.ubuntu.com/releases/noble/release/ubuntu-24.04-preinstalled-server-riscv64+unmatched.img.xz">Download 24.04</a>
       </p>
     </div>
   </div>
@@ -48,7 +48,7 @@
     <div class="col-6">
       <p>
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/24.04/release/ubuntu-24.04-live-server-riscv64.img.gz">Download 24.04 live installer</a>
+           href="https://cdimage.ubuntu.com/releases/noble/release/ubuntu-24.04-live-server-riscv64.img.gz">Download 24.04 live installer</a>
       </p>
       <p>
         <a href="https://wiki.ubuntu.com/RISC-V/SiFive%20HiFive%20Unmatched">How to install Ubuntu on SiFive HiFive Unmatched</a>

--- a/templates/download/risc-v/tab-5.html
+++ b/templates/download/risc-v/tab-5.html
@@ -30,7 +30,7 @@
     <div class="col-6">
       <p>
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/24.04/release/ubuntu-24.04-preinstalled-server-riscv64+licheerv.img.xz">Download 24.04</a>
+           href="https://cdimage.ubuntu.com/releases/noble/release/ubuntu-24.04-preinstalled-server-riscv64+licheerv.img.xz">Download 24.04</a>
       </p>
       <p>
         <a href="https://wiki.ubuntu.com/RISC-V/LicheeRV">How to install Ubuntu on the LicheeRV Dock</a>

--- a/templates/download/risc-v/tab-6.html
+++ b/templates/download/risc-v/tab-6.html
@@ -30,7 +30,7 @@
     <div class="col-6">
       <p>
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/24.04/release/ubuntu-24.04-preinstalled-server-riscv64+visionfive2.img.xz">Download 24.04</a>
+           href="https://cdimage.ubuntu.com/releases/noble/release/ubuntu-24.04-preinstalled-server-riscv64+visionfive2.img.xz">Download 24.04</a>
       </p>
     </div>
   </div>
@@ -46,7 +46,7 @@
     <div class="col-6">
       <p>
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/24.04/release/ubuntu-24.04-live-server-riscv64.img.gz">Download 24.04 live installer</a>
+           href="https://cdimage.ubuntu.com/releases/noble/release/ubuntu-24.04-live-server-riscv64.img.gz">Download 24.04 live installer</a>
       </p>
       <p>
         <a href="https://wiki.ubuntu.com/RISC-V/StarFive%20VisionFive%202">How to install Ubuntu on the VisionFive 2</a>


### PR DESCRIPTION
## Done

- Updated checksums for 24.04 release according to https://paste.ubuntu.com/p/P2xqsW3Pnd/
- Updated sizes for new LTS images in releases.yaml
- Changed links for RISC-V according to https://docs.google.com/document/d/1CfhMbNC-LQtsY_gEm1jG3Vpo9MaY15kwulASMs1aCVQ/edit

## QA

- Navigate to 
   - /download/desktop
   - /download/server
   - /download/raspberry-pi
   - /download/risc-v
, and check that:
   - the images download
   - checksums correspond
   - sizes are shown

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-10167

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
