### PR TITLE
Block channel user from accessing regular pro shop

### DIFF
--- a/templates/account/forbidden.html
+++ b/templates/account/forbidden.html
@@ -19,6 +19,10 @@
           </p>
         {% elif reason=="is_only_personal" %}
           <p>This feature is accessible only by users with enterprise subscriptions for commercial use.</p>
+        {% elif reason=="channel_account" %}
+          <p>
+            You are a channel account user. Channel users are not allowed to access this page. Please contact your account administrator for more information, or go to <a href="/pro/distibutor">the distributor's home page.</a>
+          </p>
         {% else %}
           <p>You need administrator rights to the account to access this feature.</p>
         {% endif %}

--- a/webapp/shop/advantage/views.py
+++ b/webapp/shop/advantage/views.py
@@ -72,6 +72,13 @@ def pro_page_view(advantage_mapper, **kwargs):
 def advantage_view(advantage_mapper, is_in_maintenance, **kwargs):
     is_technical = False
     try:
+        channel_account = advantage_mapper.get_purchase_account(
+            "canonical-pro-channel"
+        )
+        if channel_account:
+            return flask.render_template(
+                "account/forbidden.html", reason="channel_account"
+            )
         advantage_mapper.get_purchase_account("canonical-ua")
     except UAContractsUserHasNoAccount:
         pass
@@ -196,6 +203,13 @@ def advantage_shop_view(advantage_mapper, **kwargs):
     account = None
     if user_info(flask.session):
         try:
+            channel_account = advantage_mapper.get_purchase_account(
+                "canonical-pro-channel"
+            )
+            if channel_account:
+                return flask.render_template(
+                    "account/forbidden.html", reason="channel_account"
+                )
             account = advantage_mapper.get_purchase_account("canonical-ua")
         except UAContractsUserHasNoAccount:
             # There is no purchase account yet for this user.
@@ -592,8 +606,15 @@ def get_distributor_view(advantage_mapper, **kwargs):
 
 
 @shop_decorator(area="advantage", permission="user", response="json")
-def get_account_offers(advantage_mapper, ua_contracts_api, **kwargs):
+def get_account_offers(advantage_mapper, **kwargs):
     try:
+        channel_account = advantage_mapper.get_purchase_account(
+            "canonical-pro-channel"
+        )
+        if channel_account:
+            return flask.render_template(
+                "account/forbidden.html", reason="channel_account"
+            )
         account = advantage_mapper.get_purchase_account("canonical-ua")
     except UAContractsUserHasNoAccount:
         return flask.jsonify({"error": "User has no purchase account"}), 400


### PR DESCRIPTION
## Done

- Blocked channel user from accessing regular pro shop
- Blocking regular users from accessing distributor shop will be done by a separate PR ([ticket](https://warthogs.atlassian.net/browse/WD-10786)). 

## QA

- Login with channel account
- Go to `/pro/subscribe`, `/account/checkout`, `/pro/dashboard`
- Check forbidden page shows 
![image](https://github.com/canonical/ubuntu.com/assets/57550290/cd63c1fd-fce3-4cc7-af7f-e33f822414b3)

- Login with normal account
- Check `/pro/subscribe` page accessible

## Issue / Card

Fixes #https://warthogs.atlassian.net/browse/WD-10782
