### PR TITLE
[WD-10663] add 24.04.0 LTS release to Kernel chart

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -111,6 +111,20 @@ export var serverAndDesktopReleases = [
 
 export var kernelReleases = [
   {
+    startDate: new Date("2024-04-01T00:00:00"),
+    endDate: new Date("2029-04-01T00:00:00"),
+    taskName: "24.04.0 LTS",
+    taskVersion: "6.8 kernel",
+    status: "LTS",
+  },
+  {
+    startDate: new Date("2029-04-01T00:00:00"),
+    endDate: new Date("2034-03-31T00:00:00"),
+    taskName: "24.04.0 LTS",
+    taskVersion: "6.8 kernel",
+    status: "ESM",
+  },
+  {
     startDate: new Date("2024-02-01T00:00:00"),
     endDate: new Date("2024-08-01T00:00:00"),
     taskName: "22.04.4 LTS",
@@ -1148,6 +1162,7 @@ export var desktopServerReleaseNames = [
 ];
 
 export var kernelReleaseNames = [
+  "24.04.0 LTS",
   "22.04.4 LTS",
   "23.10",
   "20.04.5 LTS",
@@ -1165,6 +1180,7 @@ export var kernelReleaseNames = [
 ];
 
 export var kernelVersionNames = [
+  "6.8",
   "6.5",
   "",
   "5.15",

--- a/templates/about/release_cycles/kernel-eol.html
+++ b/templates/about/release_cycles/kernel-eol.html
@@ -14,6 +14,13 @@
       </thead>
       <tbody>
         <tr>
+          <td><strong>6.8</strong></td>
+          <td><strong>24.04.0 LTS</strong></td>
+          <td>Apr 2024</td>
+          <td>Apr 2029</td>
+          <td>Mar 2034</td>
+        </tr>
+        <tr>
           <td rowspan="2"><strong>6.5</strong></td>
           <td><strong>22.04.4 LTS</strong></td>
           <td>Feb 2024</td>
@@ -31,7 +38,7 @@
           <td><strong>22.04.1 LTS</strong></td>
           <td>Aug 2022</td>
           <td>Apr 2027</td>
-          <td>&nbsp;</td>
+          <td>Mar 2032</td>
         </tr>
         <tr>
           <td><strong>20.04.5 LTS</strong></td>


### PR DESCRIPTION
## Done

- Update kernel chart at /about/release-cycle according to the [spreadsheet](https://docs.google.com/spreadsheets/d/1KIuOAa620yseE0uhIl67u2SlS0bWlPI_d98bvYM2Yl8/edit#gid=550510389)

## QA

- Check if the chart has the latest 24.04 release data

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-10663

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
