### PR TITLE
Fix noble release notes URL

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -19,7 +19,7 @@ lts:
   full_version: "24.04"
   release_date: "April 2024"
   eol: "April 2029"
-  release_notes_url: "https://discourse.ubuntu.com/t/noble-numbat-release-notes/24668"
+  release_notes_url: "https://discourse.ubuntu.com/t/noble-numbat-release-notes/39890"
   iso_download_size: "6GB"
   server_iso_size: "2.7GB"
   raspi_desktop_iso_size: "2.6GB"


### PR DESCRIPTION
The variable is not used in ubuntu.com but referred by other variants such as jp.ubuntu.com. Let's fix it anyway so the merge in the future can be easier.

## Done

- Fix the URL

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
