### PR TITLE
[WD-10663] fix ESM date on the kernel chart

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -146,6 +146,13 @@ export var kernelReleases = [
     status: "LTS",
   },
   {
+    startDate: new Date("2027-04-01T00:00:00"),
+    endDate: new Date("2032-03-01T00:00:00"),
+    taskName: "22.04.1 LTS",
+    taskVersion: "5.15 kernel",
+    status: "ESM",
+  },
+  {
     startDate: new Date("2022-08-01T00:00:00"),
     endDate: new Date("2025-04-30T00:00:00"),
     taskName: "20.04.5 LTS",
@@ -1165,8 +1172,8 @@ export var kernelReleaseNames = [
   "24.04.0 LTS",
   "22.04.4 LTS",
   "23.10",
-  "20.04.5 LTS",
   "22.04.1 LTS",
+  "20.04.5 LTS",
   "22.04.0 LTS",
   "18.04.5 LTS",
   "20.04.1 LTS",


### PR DESCRIPTION
## Done

- Added ESM support for 22.04.1 LTS on 5.15 kernel version in Kernel chart at /about/release-cycle (it was only added to the table by mistake)

## QA

- Navigate to /about/release-cycle and open Ubuntu Kernel tab
- Check that there is a bar for ESM support on line that stands for 5.15 kernel version and 22.04.1 LTS Ubuntu release

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-10663

## Screenshots

![Screenshot 2024-04-26 at 10 12 34](https://github.com/canonical/ubuntu.com/assets/15943863/beb4bf89-69f2-4ba8-b922-c1807cded142)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
