### PR TITLE
Show plus sign when maximum tracking is reached

### DIFF
--- a/static/js/src/advantage/api/types.ts
+++ b/static/js/src/advantage/api/types.ts
@@ -66,6 +66,7 @@ export type UserSubscription = {
   statuses: UserSubscriptionStatuses;
   subscription_id: string | null;
   type: UserSubscriptionType;
+  max_tracking_reached: boolean;
 };
 
 export type ContractToken = {

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/DetailsContent.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionDetails/DetailsContent/DetailsContent.tsx
@@ -147,6 +147,7 @@ const DetailsContent = ({ selectedId, setHasUnsavedChanges }: Props) => {
                   title: "Active machines",
                   value: (
                     <React.Fragment>
+                      {subscription.max_tracking_reached ? "+" : ""}
                       {subscription.number_of_active_machines}
                       <Tooltip
                         tooltipClassName="p-subscriptions-tooltip"

--- a/static/js/src/advantage/tests/factories/api.ts
+++ b/static/js/src/advantage/tests/factories/api.ts
@@ -78,6 +78,7 @@ export const userSubscriptionFactory = Factory.define<UserSubscription>(
     statuses: userSubscriptionStatusesFactory.build(),
     subscription_id: `VO7AyCYZzvjY3JaBWF0xmUu8vv5S684ZTeXMnJ${sequence}`,
     type: UserSubscriptionType.Yearly,
+    max_tracking_reached: false,
   })
 );
 
@@ -112,6 +113,7 @@ export const freeSubscriptionFactory = Factory.define<UserSubscription>(
     statuses: userSubscriptionStatusesFactory.build(),
     subscription_id: null,
     type: UserSubscriptionType.Free,
+    max_tracking_reached: false,
   })
 );
 

--- a/webapp/shop/api/ua_contracts/builders.py
+++ b/webapp/shop/api/ua_contracts/builders.py
@@ -273,6 +273,7 @@ def build_final_user_subscriptions(
             period=listing.period if listing else None,
             renewal_id=renewal.id if renewal else None,
             statuses=statuses,
+            max_tracking_reached=contract.max_tracking_reached,
         )
 
         # Do not return expired user subscriptions after 90 days

--- a/webapp/shop/api/ua_contracts/models.py
+++ b/webapp/shop/api/ua_contracts/models.py
@@ -88,6 +88,7 @@ class UserSubscription:
         period: str = None,
         listing_id: str = None,
         renewal_id: str = None,
+        max_tracking_reached: bool = False,
     ):
         self.id = id
         self.account_id = account_id
@@ -109,6 +110,7 @@ class UserSubscription:
         self.contract_id = contract_id
         self.listing_id = listing_id
         self.renewal_id = renewal_id
+        self.max_tracking_reached = max_tracking_reached
 
 
 class OfferItem:

--- a/webapp/shop/api/ua_contracts/parsers.py
+++ b/webapp/shop/api/ua_contracts/parsers.py
@@ -157,7 +157,11 @@ def parse_contract(raw_contract: Dict) -> Contract:
     if "activeMachines" in contract_info:
         active_machines = contract_info["activeMachines"]
         number_of_active_machines = active_machines["activeMachines"]
-        max_tracking_reached = active_machines["maximumTrackingReached"] if "maximumTrackingReached" in active_machines else False
+        max_tracking_reached = (
+            active_machines["maximumTrackingReached"]
+            if "maximumTrackingReached" in active_machines
+            else False
+        )
 
     return Contract(
         id=contract_info.get("id"),

--- a/webapp/shop/api/ua_contracts/parsers.py
+++ b/webapp/shop/api/ua_contracts/parsers.py
@@ -157,8 +157,7 @@ def parse_contract(raw_contract: Dict) -> Contract:
     if "activeMachines" in contract_info:
         active_machines = contract_info["activeMachines"]
         number_of_active_machines = active_machines["activeMachines"]
-        # WIP
-        active_machines["maximumTrackingReached"] = True
+        max_tracking_reached = active_machines["maximumTrackingReached"] if "maximumTrackingReached" in active_machines else False
 
     return Contract(
         id=contract_info.get("id"),

--- a/webapp/shop/api/ua_contracts/parsers.py
+++ b/webapp/shop/api/ua_contracts/parsers.py
@@ -153,9 +153,12 @@ def parse_contract(raw_contract: Dict) -> Contract:
     items = parse_contract_items(raw_items)
 
     number_of_active_machines = 0
+    max_tracking_reached = False
     if "activeMachines" in contract_info:
         active_machines = contract_info["activeMachines"]
         number_of_active_machines = active_machines["activeMachines"]
+        # WIP
+        active_machines["maximumTrackingReached"] = True
 
     return Contract(
         id=contract_info.get("id"),
@@ -165,6 +168,7 @@ def parse_contract(raw_contract: Dict) -> Contract:
         entitlements=entitlements,
         number_of_active_machines=number_of_active_machines,
         items=items,
+        max_tracking_reached=max_tracking_reached,
     )
 
 

--- a/webapp/shop/api/ua_contracts/primitives.py
+++ b/webapp/shop/api/ua_contracts/primitives.py
@@ -70,6 +70,7 @@ class Contract:
         entitlements: List[Entitlement],
         number_of_active_machines: int,
         items: List[ContractItem] = None,
+        max_tracking_reached: bool = False,
     ):
         self.id = id
         self.account_id = account_id
@@ -78,6 +79,7 @@ class Contract:
         self.entitlements = entitlements
         self.number_of_active_machines = number_of_active_machines
         self.items = items
+        self.max_tracking_reached = max_tracking_reached
 
 
 class SubscriptionItem:


### PR DESCRIPTION
## Done

- Blocked by missing attribute from ua-contracts API
- Hardcoded maxTracking value for now to show "+" in front of active machines number

## QA

- Check out this feature branch
- Go to /pro/dashboard
- See "+" in front of active machines number

## Issue / Card

Fixes [WD-10492](https://warthogs.atlassian.net/jira/software/c/projects/WD/boards/801?selectedIssue=WD-10492)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-10492]: https://warthogs.atlassian.net/browse/WD-10492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ