### PR TITLE
fix dates in the release cycle table at /about/release-cycle

### DIFF
--- a/templates/about/release_cycles/releases-table.html
+++ b/templates/about/release_cycles/releases-table.html
@@ -11,8 +11,8 @@
         <tr>
             <td><strong>24.04 LTS (Noble Numbat)</strong></td>
             <td>Apr 2024</td>
+            <td>Apr 2029</td>
             <td>Apr 2034</td>
-            <td>&nbsp;</td>
         </tr>
         <tr>
             <td>23.10 (Mantic Minotaur)</td>


### PR DESCRIPTION
## Done

- Fixed the dates for Noble Numbat release on /about/release-cycle page's Ubuntu tab

## QA

- Navigate to /about/release-cycle
- By default Ubuntu tab is open
- Check the Noble Numbat support dates in the table below the chart
- Standard support should be from Apr 2024 till Apr 2029
- Extended Pro support should be from Apr 2029 till Apr 2034


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
