### PR TITLE
WD-10785-cred-surface-ta-exams-status-instead-of-resorting-to-mapping

### DIFF
--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -362,7 +362,7 @@ def cred_your_exams(ua_contracts_api, trueability_api, **kwargs):
                     exam_contract["cueContext"]["reservation"]["IDs"][-1]
                 )
                 if "assessment_reservation" not in response:
-                    exams_not_taken.append(
+                    exams_expired.append(
                         {
                             "name": name,
                             "state": "Cannot fetch information",

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -45,21 +45,21 @@ EXAM_NAMES = {
 }
 
 RESERVATION_STATES = {
-    "created": "Scheduled",
-    "notified": "Scheduled",
+    "created": "Created",
+    "notified": "Notified",
     "scheduled": "Scheduled",
-    "processed": "Complete",
+    "processed": "Processed",
     "canceled": "Cancelled",
-    "finalized": "Complete",
-    "provisioning": "Pending",
-    "provisioned": "Pending",
+    "finalized": "Finalized",
+    "provisioning": "Provisioning",
+    "provisioned": "Provisioned",
     "in_progress": "In Progress",
-    "completed": "Complete",
-    "grading": "Complete",
-    "graded": "Complete",
-    "archiving": "Complete",
-    "archived": "Complete",
-    "canceling": "Cancelled",
+    "completed": "Completed",
+    "grading": "Grading",
+    "graded": "Graded",
+    "archiving": "Archiving",
+    "archived": "Archived",
+    "canceling": "Canceling",
 }
 
 
@@ -471,7 +471,13 @@ def cred_your_exams(ua_contracts_api, trueability_api, **kwargs):
                             "actions": actions,
                         }
                     )
-                elif state == "Complete":
+                elif state in (
+                    "Completed",
+                    "Graded",
+                    "Grading",
+                    "Finalized",
+                    "Processed",
+                ):
                     exams_complete.append(
                         {
                             "name": name,
@@ -483,14 +489,11 @@ def cred_your_exams(ua_contracts_api, trueability_api, **kwargs):
                             "actions": actions,
                         }
                     )
-                elif state == "Cancelled":
-                    actions = [
-                        {
-                            "text": "Take",
-                            "button_class": "p-button--base",
-                            "href": "",
-                        }
-                    ]
+                elif state in (
+                    "Cancelled",
+                    "Archiving",
+                    "Archived",
+                ):
                     exams_cancelled.append(
                         {
                             "name": name,
@@ -499,7 +502,7 @@ def cred_your_exams(ua_contracts_api, trueability_api, **kwargs):
                             "timezone": timezone,
                             "state": state,
                             "uuid": r["uuid"],
-                            "actions": actions,
+                            "actions": [],
                         }
                     )
             elif (


### PR DESCRIPTION
## Done

- Surface status for exams directly from TA 
- Handle errors fetching info from TA

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Break TA API calls locally
- Visit /credentials/your-pages
  - Check if page still loads 
- Fix TA calls
  - Check if the exam status is the same as TA

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
