### PR TITLE
Fix button active

### DIFF
--- a/static/sass/_pattern_navigation-dropdown.scss
+++ b/static/sass/_pattern_navigation-dropdown.scss
@@ -131,6 +131,7 @@
     }
 
     .p-navigation__dropdown-item {
+      background-color: transparent;
       border-bottom: $dropdown-border;
       line-height: 1.5rem;
       margin: 0;


### PR DESCRIPTION
## Done

Button applies active styling to parent when clicked on.

If reviewer has any ideas, I'm all ears. The more things I try the weirder it gets, I'm not sure anymore if I should treat it as a bug or as missing feature, so left a [comment in the Vanilla channel](https://chat.canonical.com/canonical/pl/mtycdaw7jpfjfr9w3n6zbnk69c)
- Currently this PR treats it as a bug, so it overrides that additional background
- If it's not a bug, another possibility is to add the new background on top of it.

This seems inherited from Vanilla https://codepen.io/carkod/pen/qBwGbWo  I can’t change it at that level, so I can only override it on u.com

[Reported in Vanilla](https://github.com/canonical/vanilla-framework/issues/5068)


## QA

- Go to https://ubuntu-com-13826.demos.haus/ and click on "Get ubuntu".
- When you click on the "Download Ubuntu Desktop" button, it should no longer highlight the background. 

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-10572

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
