### PR TITLE
Update meganav yaml to include 24.04 links

### DIFF
--- a/meganav.yaml
+++ b/meganav.yaml
@@ -816,10 +816,10 @@ get_ubuntu:
           links:
             - title: Upgrade Ubuntu Desktop
               url: /tutorials/upgrading-ubuntu-desktop
-            - title: 22.04 desktop guide
+            - title: 24.04 desktop guide
               url: https://help.ubuntu.com/lts/ubuntu-help/index.html
-            - title: 20.04 desktop guide
-              url: https://help.ubuntu.com/20.04/ubuntu-help/index.html
+            - title: 22.04 desktop guide
+              url: https://help.ubuntu.com/22.04/ubuntu-help/index.html
             - title: Installation tutorial
               url: /tutorials/install-ubuntu-desktop
             - title: Try before installing

--- a/templates/templates/meganav/navigation-nojs.html
+++ b/templates/templates/meganav/navigation-nojs.html
@@ -6,100 +6,184 @@
 
 {% block outer_content %}
 
-<div class="p-strip nojs-meganav">
-  {% for section in nav %}
-  <hr class="is-dark is-fixed-width is-muted">
-  <nav class="dropdown-window__content-container desktop-dropdown-content">
-    <div class="dropdown-window__content row">
-      {% include "templates/meganav/_section-heading.html"%}
-      {% if "side_nav_sections" in nav[section] %}
-        <div class="dropdown-window__tab-panel col-3">
-          <div class="p-side-navigation is-dark">
-            <div class="p-side-navigation__drawer">
-              <ul class="p-side-navigation__list u-no-margin--bottom">
-                {% for side_nav_section in nav[section].side_nav_sections %}
-                  <li class="p-side-navigation__item">
-                    <a href="#{{section}}-{{format_to_id(side_nav_section.title)}}-navigation" class="p-side-navigation__link">{{ side_nav_section.title }}</a>
-                  </li>
-                {% endfor %}
-                </ul>
+  <div class="p-strip nojs-meganav is-dark">
+    {% for section in nav %}
+      <hr class="is-dark is-fixed-width is-muted" />
+      <nav class="dropdown-window__content-container desktop-dropdown-content">
+        <div class="dropdown-window__content row">
+          {% include "templates/meganav/_section-heading.html" %}
+          {% if "side_nav_sections" in nav[section] %}
+            <div class="dropdown-window__tab-panel col-3">
+              <div class="p-side-navigation is-dark">
+                <div class="p-side-navigation__drawer">
+                  <ul class="p-side-navigation__list u-no-margin--bottom">
+                    {% for side_nav_section in nav[section].side_nav_sections %}
+                      <li class="p-side-navigation__item">
+                        <a href="#{{ section }}-{{ format_to_id(side_nav_section.title) }}-navigation"
+                           class="p-side-navigation__link">{{ side_nav_section.title }}</a>
+                      </li>
+                    {% endfor %}
+                  </ul>
+                </div>
+              </div>
             </div>
-          </div>
-        </div>
-        
-        <div class="col-9 u-no-padding">
-          {% for side_nav_section in nav[section].side_nav_sections %}
-            <div class="dropdown-window__sidenav-content" id="{{section}}-{{format_to_id(side_nav_section.title)}}-navigation">
-              <hr class="is-dark is-fixed-width is-muted">
-              <h3 class="p-heading--2 u-no-padding--left">{{side_nav_section.title}}</h3>
-              <div class="row u-no-padding">
-                <div class="col-{% if side_nav_section.secondary_links %}6{% else %}9{% endif %} dropdown-window__main-panel">
-                  {% for links_section in side_nav_section.primary_links %}
-                    {% if links_section.title %}
-                      <p class="p-muted-heading">{{ links_section.title }}</p>
-                    {% endif %}
-                    
-                    <div class="row">
-                      {% if side_nav_section.secondary_links %}
-                        {% set split_links_list = split_list(links_section.links, 2) %}
-                      {% else %}
-                        {% set split_links_list = split_list(links_section.links, 3) %}
-                      {% endif %}
-  
-                      <div class="col-3">
-                        <ul class="p-list">
-                          {% for link in split_links_list[0] %}
-                            {% with 
-                              url = link.url, 
-                              title = link.title, 
-                              description = link.description,
-                              secondary_cta_url = link.secondary_cta_url,
-                              secondary_cta_title = link.secondary_cta_title 
-                            %}
-                              {% include "templates/meganav/_list-item.html" %}
-                            {% endwith %}
-                          {% endfor %}
-                        </ul>
-                      </div>
-  
-                      <div class="col-3">
-                        <ul class="p-list">
-                          {% for link in split_links_list[1] %}
-                            {% with 
-                              url = link.url, 
-                              title = link.title, 
-                              description = link.description 
-                            %}
-                              {% include "templates/meganav/_list-item.html" %}
-                            {% endwith %}
-                          {% endfor %}
-                        </ul>
-                      </div>
-  
-                      {% if secondary_links not in side_nav_section %}
-                        <div class="col-3">
+
+            <div class="col-9 u-no-padding">
+              {% for side_nav_section in nav[section].side_nav_sections %}
+                <div class="dropdown-window__sidenav-content"
+                     id="{{ section }}-{{ format_to_id(side_nav_section.title) }}-navigation">
+                  <hr class="is-dark is-fixed-width is-muted" />
+                  <h3 class="p-heading--2 u-no-padding--left">{{ side_nav_section.title }}</h3>
+                  <div class="row u-no-padding">
+                    <div class="col-{% if side_nav_section.secondary_links %}6{% else %}9{% endif %} dropdown-window__main-panel">
+                      {% for links_section in side_nav_section.primary_links %}
+                        {% if links_section.title %}<p class="p-muted-heading">{{ links_section.title }}</p>{% endif %}
+
+                        <div class="row">
+                          {% if side_nav_section.secondary_links %}
+                            {% set split_links_list = split_list(links_section.links, 2) %}
+                          {% else %}
+                            {% set split_links_list = split_list(links_section.links, 3) %}
+                          {% endif %}
+
+                          <div class="col-3">
+                            <ul class="p-list">
+                              {% for link in split_links_list[0] %}
+                                {% with
+                                  url = link.url,
+                                  title = link.title,
+                                  description = link.description,
+                                  secondary_cta_url = link.secondary_cta_url,
+                                  secondary_cta_title = link.secondary_cta_title
+                                  %}
+                                  {% include "templates/meganav/_list-item.html" %}
+                                {% endwith %}
+                              {% endfor %}
+                            </ul>
+                          </div>
+
+                          <div class="col-3">
+                            <ul class="p-list">
+                              {% for link in split_links_list[1] %}
+                                {% with
+                                  url = link.url,
+                                  title = link.title,
+                                  description = link.description
+                                  %}
+                                  {% include "templates/meganav/_list-item.html" %}
+                                {% endwith %}
+                              {% endfor %}
+                            </ul>
+                          </div>
+
+                          {% if secondary_links not in side_nav_section %}
+                            <div class="col-3">
+                              <ul class="p-list">
+                                {% for link in split_links_list[2] %}
+                                  {% with
+                                    url = link.url,
+                                    title = link.title,
+                                    description = link.description
+                                    %}
+                                    {% include "templates/meganav/_list-item.html" %}
+                                  {% endwith %}
+                                {% endfor %}
+                              </ul>
+                            </div>
+                          {% endif %}
+                        </div>
+                      {% endfor %}
+                    </div>
+
+                    {% if side_nav_section.secondary_links %}
+                      <div class="col-3 dropdown-window__side-panel">
+                        {% for links_section in side_nav_section.secondary_links %}
+                          <p class="p-muted-heading">{{ links_section.title }}</p>
+
                           <ul class="p-list">
-                            {% for link in split_links_list[2] %}
-                              {% with 
-                                url = link.url, 
-                                title = link.title, 
-                                description = link.description 
-                              %}
-                                {% include "templates/meganav/_list-item.html" %}
-                              {% endwith %}
+                            {% for link in links_section.links %}
+                              <li class="p-list__item">
+                                <a class="dropdown-window__side-panel-link" href="{{ link.url }}">{{ link.title }}</a>
+                              </li>
                             {% endfor %}
                           </ul>
-                        </div>
-                      {% endif %}
+                        {% endfor %}
+                      </div>
+                    {% endif %}
+                  </div>
+
+                  {% if side_nav_section.section_footer %}
+                    <div class="col-9 dropdown-window__footer">
+                      {% if "copy" in side_nav_section.section_footer %}<p>{{ side_nav_section.section_footer['copy'] }}</p>{% endif %}
+
+                      <a href="{{ side_nav_section.section_footer['cta_url'] }}"
+                         class="p-button is-dark">{{ side_nav_section.section_footer['cta_title'] }}</a>
                     </div>
-                  {% endfor %}
-                </div>      
-  
-                {% if side_nav_section.secondary_links %}
-                <div class="col-3 dropdown-window__side-panel">
-                  {% for links_section in side_nav_section.secondary_links %}
+                  {% endif %}
+                </div>
+              {% endfor %}
+            </div>
+          {% elif "primary_links" in nav[section] %}
+            <div class="row u-no-padding">
+              <div class="col-9 dropdown-window__main-panel">
+                {% for links_section in nav[section].primary_links %}
+                  {% if links_section.title %}<p class="p-muted-heading">{{ links_section.title }}</p>{% endif %}
+
+                  <div class="row">
+                    {% set split_links_list = split_list(links_section.links, 3) %}
+
+                    <div class="col-3">
+                      <ul class="p-list">
+                        {% for link in split_links_list[0] %}
+                          {% with
+                            url = link.url,
+                            title = link.title,
+                            description = link.description,
+                            secondary_cta_url = link.secondary_cta_url,
+                            secondary_cta_title = link.secondary_cta_title
+                            %}
+                            {% include "templates/meganav/_list-item.html" %}
+                          {% endwith %}
+                        {% endfor %}
+                      </ul>
+                    </div>
+
+                    <div class="col-3">
+                      <ul class="p-list">
+                        {% for link in split_links_list[1] %}
+                          {% with
+                            url = link.url,
+                            title = link.title,
+                            description = link.description
+                            %}
+                            {% include "templates/meganav/_list-item.html" %}
+                          {% endwith %}
+                        {% endfor %}
+                      </ul>
+                    </div>
+
+                    <div class="col-3">
+                      <ul class="p-list">
+                        {% for link in split_links_list[2] %}
+                          {% with
+                            url = link.url,
+                            title = link.title,
+                            description = link.description
+                            %}
+                            {% include "templates/meganav/_list-item.html" %}
+                          {% endwith %}
+                        {% endfor %}
+                      </ul>
+                    </div>
+                  </div>
+                {% endfor %}
+              </div>
+
+              <div class="col-3 dropdown-window__side-panel">
+                {% if nav[section].secondary_links %}
+                  {% for links_section in nav[section].secondary_links %}
                     <p class="p-muted-heading">{{ links_section.title }}</p>
-                    
+
                     <ul class="p-list">
                       {% for link in links_section.links %}
                         <li class="p-list__item">
@@ -108,115 +192,28 @@
                       {% endfor %}
                     </ul>
                   {% endfor %}
-                </div>
+                {% else %}
+                  {% for links_section in nav[section].highlighted_secondary_links %}
+                    <p class="p-muted-heading" style="padding-left:0.5rem;">{{ links_section.title }}</p>
+                    <ul class="p-list">
+                      {% for link in links_section.links %}
+                        {% with
+                          url = link.url,
+                          title = link.title,
+                          description = link.description
+                          %}
+                          {% include "templates/meganav/_list-item.html" %}
+                        {% endwith %}
+                      {% endfor %}
+                    </ul>
+                  {% endfor %}
                 {% endif %}
               </div>
-  
-              {% if side_nav_section.section_footer %}
-                <div class="col-9 dropdown-window__footer">
-                  {% if "copy" in side_nav_section.section_footer %}
-                    <p>{{ side_nav_section.section_footer['copy'] }}</p>
-                  {% endif %}
-  
-                  <a href="{{side_nav_section.section_footer['cta_url'] }}" class="p-button is-dark">{{ side_nav_section.section_footer['cta_title'] }}</a>
-                </div>
-              {% endif %}
             </div>
-          {% endfor %}
+          {% endif %}
         </div>
-      {% elif "primary_links" in nav[section] %}
-        <div class="row u-no-padding"> 
-          <div class="col-9 dropdown-window__main-panel">
-            {% for links_section in nav[section].primary_links %}
-              {% if links_section.title %}
-                <p class="p-muted-heading">{{ links_section.title }}</p>
-              {% endif %}
-              
-              <div class="row">
-                {% set split_links_list = split_list(links_section.links, 3) %}
-  
-                <div class="col-3">
-                  <ul class="p-list">
-                    {% for link in split_links_list[0] %}
-                      {% with 
-                        url = link.url, 
-                        title = link.title, 
-                        description = link.description,
-                        secondary_cta_url = link.secondary_cta_url,
-                        secondary_cta_title = link.secondary_cta_title 
-                      %}
-                        {% include "templates/meganav/_list-item.html" %}
-                      {% endwith %}
-                    {% endfor %}
-                  </ul>
-                </div>
-  
-                <div class="col-3">
-                  <ul class="p-list">
-                    {% for link in split_links_list[1] %}
-                      {% with 
-                        url = link.url, 
-                        title = link.title, 
-                        description = link.description 
-                      %}
-                        {% include "templates/meganav/_list-item.html" %}
-                      {% endwith %}
-                    {% endfor %}
-                  </ul>
-                </div>
-  
-                <div class="col-3">
-                  <ul class="p-list">
-                    {% for link in split_links_list[2] %}
-                      {% with 
-                        url = link.url, 
-                        title = link.title, 
-                        description = link.description 
-                      %}
-                        {% include "templates/meganav/_list-item.html" %}
-                      {% endwith %}
-                    {% endfor %}
-                  </ul>
-                </div>
-              </div>
-            {% endfor %}
-          </div>      
-  
-          <div class="col-3 dropdown-window__side-panel">
-            {% if nav[section].secondary_links %}
-              {% for links_section in nav[section].secondary_links %}
-                <p class="p-muted-heading">{{ links_section.title }}</p>
-                
-                <ul class="p-list">
-                  {% for link in links_section.links %}
-                    <li class="p-list__item">
-                      <a class="dropdown-window__side-panel-link" href="{{ link.url }}">{{ link.title }}</a>
-                    </li>
-                  {% endfor %}
-                </ul>
-              {% endfor %}
-            {% else %}
-              {% for links_section in nav[section].highlighted_secondary_links %}
-                <p class="p-muted-heading" style="padding-left:0.5rem;">{{ links_section.title }}</p>
-                <ul class="p-list">
-                  {% for link in links_section.links %}
-                    {% with 
-                      url = link.url, 
-                      title = link.title, 
-                      description = link.description 
-                    %}
-                      {% include "templates/meganav/_list-item.html" %}
-                    {% endwith %}
-                  {% endfor %}
-                </ul>
-              {% endfor %}
-            {% endif %}
-          </div>
-        </div>
-      {% endif %}
-    </div>
-  </nav>
-  {% endfor %}
-</div>
+      </nav>
+    {% endfor %}
+  </div>
 
 {% endblock %}


### PR DESCRIPTION
## Done

- Updates the `meganav.yaml` to include the 24.04 changes in the [copydoc](https://docs.google.com/document/d/1DCNvYHfC7AbOcqflTBaVd571iKAP_PaTfnqTENVEDVw/edit#heading=h.xn1ukikvpexx)
This bit:
![image](https://github.com/canonical/ubuntu.com/assets/58276363/1538574f-d4ae-4dfa-a56f-11ffc4960267)
- Adds 'is-dark' to to no js navigation to fix links appearing as black on black

## QA

- Check the links match those in the [copydoc](https://docs.google.com/document/d/1DCNvYHfC7AbOcqflTBaVd571iKAP_PaTfnqTENVEDVw/edit#heading=h.xn1ukikvpexx)

## Issue / Card

Fixes https://docs.google.com/document/d/1DCNvYHfC7AbOcqflTBaVd571iKAP_PaTfnqTENVEDVw/edit#heading=h.xn1ukikvpexx