### PR TITLE
Try getting the user location client side

### DIFF
--- a/static/js/src/image-download.js
+++ b/static/js/src/image-download.js
@@ -20,7 +20,10 @@ function initImageDownload(imagePath, GAlabel) {
     )
     .then((response) => response.json())
     .then((mirrors) => startDownload(mirrors, imagePath))
-    .catch(() => startDownload([], imagePath));
+    .catch(() => {
+      // in case of error just download the default image
+      startDownload([], imagePath);
+    });
 }
 
 function startDownload(mirrors, imagePath) {

--- a/static/js/src/image-download.js
+++ b/static/js/src/image-download.js
@@ -7,15 +7,28 @@ function initImageDownload(imagePath, GAlabel) {
     eventValue: undefined,
   });
 
-  fetch("/mirrors.json?local=True")
-    .then((response) => response.json())
-    .then((mirrors) => {
-      startDownload(mirrors, imagePath);
-    })
-    .catch(() => {
-      // in case of error just download the default image
-      startDownload([], imagePath);
-    });
+  const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  fetch("/user-country-tz.json?tz=" + timezone)
+  .then((response) => {
+    return response.json();
+  })
+  .then((userData) => {
+    if (userData && userData.country_code) {
+      return fetch("/mirrors.json?local=True&country_code=" + userData.country_code);
+    } else {
+      throw new Error('Country code is missing');
+    }
+  })
+  .then((response) => {
+    return response.json();
+  })
+  .then((mirrors) => {
+    startDownload(mirrors, imagePath);
+  })
+  .catch((error) => {
+    startDownload([], imagePath);
+  });
+
 }
 
 function startDownload(mirrors, imagePath) {
@@ -30,7 +43,7 @@ function startDownload(mirrors, imagePath) {
   }
 
   var downloadLink = downloadLocation + imagePath;
-
+  console.log(" DOWNLOAD LINK", downloadLink);
   // Start download
   delayStartDownload(downloadLink, 3000);
 }

--- a/static/js/src/image-download.js
+++ b/static/js/src/image-download.js
@@ -7,28 +7,20 @@ function initImageDownload(imagePath, GAlabel) {
     eventValue: undefined,
   });
 
+  // Get the user's timezone and use this to find the country_code before fetching the mirrors
   const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-  fetch("/user-country-tz.json?tz=" + timezone)
-  .then((response) => {
-    return response.json();
-  })
-  .then((userData) => {
-    if (userData && userData.country_code) {
-      return fetch("/mirrors.json?local=True&country_code=" + userData.country_code);
-    } else {
-      throw new Error('Country code is missing');
-    }
-  })
-  .then((response) => {
-    return response.json();
-  })
-  .then((mirrors) => {
-    startDownload(mirrors, imagePath);
-  })
-  .catch((error) => {
-    startDownload([], imagePath);
-  });
-
+  fetch(`/user-country-tz.json?tz=${timezone}`)
+    .then((response) => response.json())
+    .then((userData) =>
+      fetch(
+        `/mirrors.json?local=${!!userData?.country_code}&country_code=${
+          userData?.country_code || ""
+        }`
+      )
+    )
+    .then((response) => response.json())
+    .then((mirrors) => startDownload(mirrors, imagePath))
+    .catch(() => startDownload([], imagePath));
 }
 
 function startDownload(mirrors, imagePath) {
@@ -43,7 +35,6 @@ function startDownload(mirrors, imagePath) {
   }
 
   var downloadLink = downloadLocation + imagePath;
-  console.log(" DOWNLOAD LINK", downloadLink);
   // Start download
   delayStartDownload(downloadLink, 3000);
 }

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -47,7 +47,7 @@ marketo_api = MarketoAPI(
 )
 
 
-def _build_mirror_list(local=False):
+def _build_mirror_list(local=False, country_code=None):
     # Build mirror list
     mirrors = []
     mirror_list = []
@@ -55,12 +55,9 @@ def _build_mirror_list(local=False):
     try:
         with open(f"{os.getcwd()}/etc/ubuntu-mirrors-rss.xml") as rss:
             mirrors = feedparser.parse(rss.read()).entries
+            
     except IOError:
         pass
-
-    ip_location = ip_reader.get(
-        flask.request.headers.get("X-Real-IP", flask.request.remote_addr)
-    )
 
     # get all mirrors
     if not local:
@@ -74,9 +71,7 @@ def _build_mirror_list(local=False):
         return mirror_list
 
     # get local mirrors based on IP location
-    if ip_location and "country" in ip_location:
-        country_code = ip_location["country"]["iso_code"]
-
+    if country_code:
         for mirror in mirrors:
             is_local_mirror = mirror["mirror_countrycode"] == country_code
             is_https = mirror["link"].startswith("https")
@@ -255,6 +250,7 @@ def mirrors_query():
     A JSON endpoint to request list of Ubuntu mirrors
     """
     local = flask.request.args.get("local", default=False)
+    country = flask.request.args.get("country_code", default=None)
 
     if not local or local.lower() != "true":
         local = False
@@ -262,7 +258,7 @@ def mirrors_query():
         local = True
 
     return (
-        flask.jsonify(_build_mirror_list(local)),
+        flask.jsonify(_build_mirror_list(local, country)),
         {"Cache-Control": "private"},
     )
 

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -55,7 +55,6 @@ def _build_mirror_list(local=False, country_code=None):
     try:
         with open(f"{os.getcwd()}/etc/ubuntu-mirrors-rss.xml") as rss:
             mirrors = feedparser.parse(rss.read()).entries
-            
     except IOError:
         pass
 
@@ -1033,12 +1032,15 @@ def get_user_country_by_tz():
     APP_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     timezone = flask.request.args.get("tz")
 
-    timezones = json.load(
-        open(os.path.join(APP_ROOT, "static/files/timezones.json"))
-    )
-    countries = json.load(
-        open(os.path.join(APP_ROOT, "static/files/countries.json"))
-    )
+    with open(
+        os.path.join(APP_ROOT, "static/files/timezones.json"), "r"
+    ) as file:
+        timezones = json.load(file)
+
+    with open(
+        os.path.join(APP_ROOT, "static/files/countries.json"), "r"
+    ) as file:
+        countries = json.load(file)
 
     _country = timezones[timezone]["c"][0]
     country = countries[_country]


### PR DESCRIPTION
## Done

**Context**: Ubuntu download mirrors are not being hit, for example when you download from https://ubuntu.com/download/desktop/thank-you?version=24.04&architecture=amd64&lts=true it always downloads from releases. This aims to fix that.

- Fetch the users location on the client side and passes it to the mirror fetching function. As opposed to getting the location on the backend which I think was causing the problem. This should also be more consistent.

## QA

- Go to https://ubuntu-com-13831.demos.haus/download/desktop/thank-you?version=24.04&architecture=amd64&lts=true
- This will trigger a download, check the download location is from a mirror that is close to your country

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-8090

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
