### PR TITLE
Update navigation in core bubble

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -272,14 +272,14 @@ core:
   path: /core
 
   children:
-    - title: Services
-      path: /core/services
     - title: Overview
       path: /core
-    - title: Success stories
-      path: /core/stories
     - title: Features
       path: /core/features
+    - title: Success stories
+      path: /core/stories
+    - title: Services
+      path: /core/services
     - title: Docs
       path: /core/docs
 

--- a/templates/core/features/index.html
+++ b/templates/core/features/index.html
@@ -20,7 +20,7 @@
       <hr class="is-muted" />
       <p>
         <a class="p-button--positive" href="/core/docs/getting-started">Try Ubuntu Core</a>
-        <a href="https://assets.ubuntu.com/v1/1870ea66-Ubuntu_Core22_DS.06.06.22.pdf">Read&nbsp;the&nbsp;Ubuntu&nbsp;Core&nbsp;datasheet</a>
+        <a href="https://assets.ubuntu.com/v1/e7f9bb41-Ubuntu%20Core%20DS%201.5.2024.pdf">Read&nbsp;the&nbsp;Ubuntu&nbsp;Core&nbsp;datasheet</a>
       </p>
     </div>
   </div>
@@ -86,7 +86,7 @@
         </div>
         <div class="p-equal-height-row__col">
           <h3 class="p-heading--5 p-equal-height-row__item">
-            <a href="/internet-of-things/management">Fleet management&nbsp;&rsaquo;</a>
+            <a href="/internet-of-things/management">Device management&nbsp;&rsaquo;</a>
           </h3>
           <p class="p-equal-height-row__item">Landscape delivers comprehensive management capabilities across the full scope of your device fleets. Stay in control with features including canary releases, remote device remodelling and system monitoring.</p>
         </div>

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -37,7 +37,7 @@ meta_copydoc %}
                 <hr class="is-muted" />
                 <p>
                     <a class="p-button--positive" href="/core/docs/getting-started">Try Ubuntu Core</a>
-                    <a href="https://assets.ubuntu.com/v1/1870ea66-Ubuntu_Core22_DS.06.06.22.pdf">Read&nbsp;the&nbsp;Ubuntu&nbsp;Core&nbsp;datasheet</a>
+                    <a href="https://assets.ubuntu.com/v1/e7f9bb41-Ubuntu%20Core%20DS%201.5.2024.pdf">Read&nbsp;the&nbsp;Ubuntu&nbsp;Core&nbsp;datasheet</a>
                 </p>
             </div>
             <div class="col">


### PR DESCRIPTION
## Done

Updates navigaton from:
`Services, Success stories, Features, Docs`

To: 
`Features, Success Stories, Services, Docs`

- Updates the `Read the Ubuntu Core datasheet` link in https://ubuntu-com-13839.demos.haus/core and https://ubuntu-com-13839.demos.haus/core/features. see [core copydoc](https://docs.google.com/document/d/1UFpefDRSAcndNBnWp0hDyzqk74aciqhBWJEi05htWmU/edit#heading=h.il7ddqhjlzrs) and [core/features copydoc](https://docs.google.com/document/d/10S6FGVRA1R1qi9v859CnFrl8rS25Za2SjEmSpPVQkzY/edit)

## QA

- Go to https://ubuntu-com-13839.demos.haus/core and check the navigation is explained above
- Check the datasheet links on both /core and /core/features

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-10917


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
