### PR TITLE
Update to Vanilla 4.11 (and fix equal heights component)

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "typescript": "4.5.4",
     "url-polyfill": "1.1.12",
     "url-search-params-polyfill": "8.1.1",
-    "vanilla-framework": "4.10.0",
+    "vanilla-framework": "4.11.0",
     "yup": "0.32.11"
   },
   "resolutions": {

--- a/templates/desktop/index.html
+++ b/templates/desktop/index.html
@@ -367,27 +367,33 @@
       <a href="/desktop/organisations">Learn more about Ubuntu Desktop for organisations&nbsp;&rsaquo;</a>
     </div>
   </div>
-  <div class="row">
-    <div class="col-start-large-4 col-9">
-      <div class="p-equal-height-row has-1st-divider">
+  <div class="row--25-75-on-large">
+    <div class="col">
+      <div class="p-equal-height-row has-divider-1">
         <div class="p-equal-height-row__col">
           <div class="p-equal-height-row__item">
-            <div class="p-media-container p-section--shallow">
-              {{ image(url="https://assets.ubuntu.com/v1/2f32b5f5-Ubuntu-Pro-logo.svg",
-                              alt="Ubuntu Pro",
-                              width="170",
-                              height="42",
-                              hi_def=True,
-                              loading="lazy") | safe
-              }}
+            <div class="p-section--shallow">
+              <div class="p-media-container">
+                {{ image(url="https://assets.ubuntu.com/v1/2f32b5f5-Ubuntu-Pro-logo.svg",
+                                alt="Ubuntu Pro",
+                                width="170",
+                                height="42",
+                                hi_def=True,
+                                loading="lazy") | safe
+                }}
+              </div>
             </div>
           </div>
-          <h3 class="p-equal-height-row__item p-heading--5">Ubuntu Pro Desktop</h3>
-          <p class="p-equal-height-row__item">
-            A comprehensive subscription delivering enterprise-grade security, management tooling, and extended support for developers and organisations. Ubuntu Pro Desktop is free for personal use on up to five machines.
-          </p>
           <div class="p-equal-height-row__item">
-            <hr class="p-rule is-muted" />
+            <h3 class="p-heading--5">Ubuntu Pro Desktop</h3>
+          </div>
+          <div class="p-equal-height-row__item">
+            <p>
+              A comprehensive subscription delivering enterprise-grade security, management tooling, and extended support for developers and organisations. Ubuntu Pro Desktop is free for personal use on up to five machines.
+            </p>
+          </div>
+          <div class="p-equal-height-row__item">
+            <hr class="p-rule--muted" />
             <p>
               <a href="/pro">Learn more about Ubuntu Pro&nbsp;&rsaquo;</a>
             </p>
@@ -395,22 +401,28 @@
         </div>
         <div class="p-equal-height-row__col">
           <div class="p-equal-height-row__item">
-            <div class="p-media-container p-section--shallow">
-              {{ image(url="https://assets.ubuntu.com/v1/7a019410-ms logo.png",
-                              alt="",
-                              width="40",
-                              height="41",
-                              hi_def=True,
-                              loading="auto|lazy") | safe
-              }}
+            <div class="p-section--shallow">
+              <div class="p-media-container">
+                {{ image(url="https://assets.ubuntu.com/v1/7a019410-ms logo.png",
+                                alt="",
+                                width="40",
+                                height="41",
+                                hi_def=True,
+                                loading="auto|lazy") | safe
+                }}
+              </div>
             </div>
           </div>
-          <h3 class="p-equal-height-row__item p-heading--5">Ubuntu on Windows with WSL</h3>
-          <p class="p-equal-height-row__item">
-            The power of a full Ubuntu terminal environment on Windows with Windows Subsystem for Linux. Streamline web application development, leverage cutting-edge AI/ML tooling, develop cross-platform applications and manage IT infrastructure without leaving Windows.
-          </p>
           <div class="p-equal-height-row__item">
-            <hr class="p-rule is-muted" />
+            <h3 class="p-heading--5">Ubuntu on Windows with WSL</h3>
+          </div>
+          <div class="p-equal-height-row__item">
+            <p>
+              The power of a full Ubuntu terminal environment on Windows with Windows Subsystem for Linux. Streamline web application development, leverage cutting-edge AI/ML tooling, develop cross-platform applications and manage IT infrastructure without leaving Windows.
+            </p>
+          </div>
+          <div class="p-equal-height-row__item">
+            <hr class="p-rule--muted" />
             <p>
               <a href="/wsl">How we support Ubuntu on WSL&nbsp;&rsaquo;</a>
             </p>
@@ -418,22 +430,28 @@
         </div>
         <div class="p-equal-height-row__col">
           <div class="p-equal-height-row__item">
-            <div class="p-media-container p-section--shallow">
-              {{ image(url="https://assets.ubuntu.com/v1/476cc8de-amazon-workspaces-icon.png",
-                              alt="Amazon Workspaces",
-                              width="40",
-                              height="51",
-                              hi_def=True,
-                              loading="lazy") | safe
-              }}
+            <div class="p-section--shallow">
+              <div class="p-media-container">
+                {{ image(url="https://assets.ubuntu.com/v1/476cc8de-amazon-workspaces-icon.png",
+                                alt="Amazon Workspaces",
+                                width="40",
+                                height="51",
+                                hi_def=True,
+                                loading="lazy") | safe
+                }}
+              </div>
             </div>
           </div>
-          <h3 class="p-equal-height-row__item p-heading--5">Virtual desktops with Amazon WorkSpaces</h3>
-          <p class="p-equal-height-row__item">
-            Amazon WorkSpaces offers developers an optimised Ubuntu Desktop environment to rapidly build, test and deploy code. Applications and data remain secured in the AWS cloud, even when your developers are working remotely.
-          </p>
           <div class="p-equal-height-row__item">
-            <hr class="p-rule is-muted" />
+            <h3 class="p-heading--5">Virtual desktops with Amazon WorkSpaces</h3>
+          </div>
+          <div class="p-equal-height-row__item">
+            <p>
+              Amazon WorkSpaces offers developers an optimised Ubuntu Desktop environment to rapidly build, test and deploy code. Applications and data remain secured in the AWS cloud, even when your developers are working remotely.
+            </p>
+          </div>
+          <div class="p-equal-height-row__item">
+            <hr class="p-rule--muted" />
             <p>
               <a href="/aws/workspaces">Learn more about Ubuntu WorkSpaces&nbsp;&rsaquo;</a>
             </p>

--- a/yarn.lock
+++ b/yarn.lock
@@ -7995,10 +7995,10 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-vanilla-framework@4.10.0:
-  version "4.10.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.10.0.tgz#09fba5c31f93f46306b51f519d0b5f3b7363d73d"
-  integrity sha512-mkf48XSjU11KxmikB63+vnHxncqyYEjl9ki5dCD/oL2AGdh53t2uHsh2z85jMyz8MMXcHlXo2/gWIsSQluS/Vg==
+vanilla-framework@4.11.0:
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.11.0.tgz#81636d58bacbd3320a4eb6bf5bef00409cfdc008"
+  integrity sha512-S0AAHNVphn3YJ7BQhyHmvKhrqiZcncQBPedwMan18uavB4VfAT8UN0dwgrHQvY/ypUuJiq/GPA0Xe1xcd+E7dg==
 
 vanilla-framework@4.9.0:
   version "4.9.0"


### PR DESCRIPTION
## Done

- Updates to latest Vanilla 4.11
- Updates the divider class name in equal heights row component from `has-1st-divider` to `has-divider-1` (as per change in Vanilla 4.11)
- As a drive-by updates the HTML structure of the equal heights row component

**NOTE:** The reason for the drive-by HTML changes was combining multiple component class names on single element. This is a bad practice. Even if it works now, may potentially break in future if both components affect the same CSS properties. As a rule of thumb a single HTML element should not have class names coming from 2 different components. Ideally there should be only one `p-…` class name on element, if there are multiple, they should be from same component `p-the-same-…`.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to desktop page: https://ubuntu-com-13849.demos.haus/desktop#:~:text=Enterprise%2Dgrade%20support%20and%20integration (Enterprise grade support)
- Check if the equal heights row component looks as expected

<img width="1163" alt="image" src="https://github.com/canonical/ubuntu.com/assets/83575/ea0c2de9-f23e-4b6a-ba1f-cdc846b66b0d">



## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
