### PR TITLE
Removed duplicate tab from syllabus page

### DIFF
--- a/templates/credentials/syllabus.html
+++ b/templates/credentials/syllabus.html
@@ -56,25 +56,6 @@
       </div>
     </div>
   </div>
-  <div class="p-tabs">
-    <div class="row">
-      <div class="p-tabs__list u-no-margin--bottom"
-           role="tablist"
-           aria-label="CUE Syllabus">
-        {% for exam in syllabus_data %}
-          <div class="p-tabs__item">
-            <button class="p-tabs__link"
-                    role="tab"
-                    aria-controls="{{ exam['exam_name'] }}-tab"
-                    id="{{ exam['exam_name'] }}"
-                    {% if (exam_name and exam_name!=exam["exam_name"]) or (not exam_name and loop.index!=1) %}aria-selected="false"{% else %}aria-selected="true"{% endif %}>
-              {{ exam["exam_name"] }}
-            </button>
-          </div>
-        {% endfor %}
-      </div>
-    </div>
-  </div>
   <section class="p-strip u-no-padding--top">
     <div class="u-fixed-width">
       {% for exam in syllabus_data %}


### PR DESCRIPTION
## Done

- Remove duplicate tabs from /credentials/syllabus

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to /credentials/syllabus
    - There should only be one line of tabs

## Issue / Card

Fixes [#WD-11185](https://warthogs.atlassian.net/browse/WD-11185)

## Screenshots

From:
![image](https://github.com/canonical/ubuntu.com/assets/30973042/ba3b0f0a-4571-40ee-b8cf-631fd1e46016)

To:
![image](https://github.com/canonical/ubuntu.com/assets/30973042/36ebd939-5b35-4a7b-a621-2fa87094ce1c)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
