### PR TITLE
change to orange

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -1104,7 +1104,7 @@ export var microStackReleases = [
 ];
 
 export var desktopServerStatus = {
-  HARDWARE_AND_MAINTENANCE_UPDATES: "chart__bar--black",
+  HARDWARE_AND_MAINTENANCE_UPDATES: "chart__bar--orange",
   MAINTENANCE_UPDATES: "chart__bar--orange-light",
   ESM: "chart__bar--aubergine-light",
   MAIN_UNIVERSE: "chart__bar--aubergine-mid-light",

--- a/static/js/src/release-chart-old.js
+++ b/static/js/src/release-chart-old.js
@@ -382,7 +382,7 @@ function formatKeyLabel(key) {
   );
   formattedKey = formattedKey.replace(
     "Main universe",
-    "LTS Expanded Security Maintenance (ESM) for Ubuntu Universe (10 years)"
+    "Expanded Security Maintenance (ESM) for Ubuntu Universe (10 years)"
   );
   formattedKey = formattedKey.replace(
     "Microstack esm",

--- a/static/js/src/release-chart.js
+++ b/static/js/src/release-chart.js
@@ -468,7 +468,7 @@ function formatKeyLabel(key) {
   );
   formattedKey = formattedKey.replace(
     "Main universe",
-    "LTS Expanded Security Maintenance (ESM) for Ubuntu Universe (10 years)"
+    "Expanded Security Maintenance (ESM) for Ubuntu Universe (10 years)"
   );
   formattedKey = formattedKey.replace(
     "Pro legacy support",


### PR DESCRIPTION
## Done

- Change colour in release chart for LTS from black to orange

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Visit /about/release-cycle and look at the chart

## Issue / Card

Fixes [WD-11189](https://warthogs.atlassian.net/browse/WD-11189)

## Screenshots

From:
![image](https://github.com/canonical/ubuntu.com/assets/30973042/62f1f7d8-b58d-46d3-8d9d-88447923b24f)
To:
![image](https://github.com/canonical/ubuntu.com/assets/30973042/91348ecd-45d5-4d4c-bcf7-ea16cb23604d)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-11189]: https://warthogs.atlassian.net/browse/WD-11189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ