### PR TITLE
Add Milk-V tab

### DIFF
--- a/templates/download/risc-v/index.html
+++ b/templates/download/risc-v/index.html
@@ -63,7 +63,16 @@
                     id="microchip-polarfire-soc-fpga-icicle-kit"
                     role="tab"
                     aria-selected="false"
-                    aria-controls="microchip-polarfire-soc-fpga-icicle-kit-tab">Polarfire SoC FPGA Icicle</button>
+                    aria-controls="microchip-polarfire-soc-fpga-icicle-kit-tab">
+              Microchip Polarfire SoC FPGA Icicle
+            </button>
+          </li>
+          <li>
+            <button class="p-tabs__item"
+                    id="milk-v-mars"
+                    role="tab"
+                    aria-selected="false"
+                    aria-controls="milk-v-mars-tab">Milk-V Mars</button>
           </li>
           <li>
             <button class="p-tabs__item"
@@ -97,7 +106,8 @@
         <form class="u-hide--large u-hide--medium">
           <select name="boardSelect" id="boardSelect">
             <option value="allwinner-nezha-tab" selected="">AllWinner Nezha</option>
-            <option value="microchip-polarfire-soc-fpga-icicle-kit-tab">Polarfire SoC FPGA Icicle</option>
+            <option value="microchip-polarfire-soc-fpga-icicle-kit-tab">Microchip Polarfire SoC FPGA Icicle</option>
+            <option value="milk-v-mars-tab">Milk-V Mars</option>
             <option value="qemu-tab">QEMU emulator</option>
             <option value="quemu-sifive-image-tab">SiFive Unmatched</option>
             <option value="sipeed-licheerv-dock-tab">Sipeed LicheeRV Dock</option>
@@ -108,6 +118,7 @@
       <div class="col-9 col-medium-4">
         {% include "download/risc-v/tab-1.html" %}
         {% include "download/risc-v/tab-2.html" %}
+        {% include "download/risc-v/milk-v-mars.html" %}
         {% include "download/risc-v/tab-3.html" %}
         {% include "download/risc-v/tab-4.html" %}
         {% include "download/risc-v/tab-5.html" %}

--- a/templates/download/risc-v/milk-v-mars.html
+++ b/templates/download/risc-v/milk-v-mars.html
@@ -1,20 +1,21 @@
 <div tabindex="0"
      role="tabpanel"
-     id="starfive-visionfive-2-tab"
-     aria-labelledby="starfive-visionfive-2"
+     id="milk-v-mars-tab"
+     aria-labelledby="milk-v-mars"
      aria-hidden="true">
-  <div class="row p-strip is-shallow u-no-padding--top">
+  <div class="row p-section--shallow u-no-padding--top">
     <div class="col-3">
-      <h2 class="u-hide--small">StarFive VisionFive 2</h2>
+      <h2 class="u-hide--small">Milk-V Mars</h2>
     </div>
     <div class="col-6 risc-v-container u-vertically-center u-align--center">
-      {{ image(url="https://assets.ubuntu.com/v1/f63441ac-risc-v_star-five-board.png",
-            alt="",
-            width="400",
-            height="300",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "risc-v-image"}) | safe
+      {{ image (
+      url="https://assets.ubuntu.com/v1/34878485-(6).png",
+      alt="Milk-V Mars",
+      width="452",
+      height="300",
+      hi_def=True,
+      loading="lazy",
+      attrs={"class": "risc-v-image"}) | safe
       }}
     </div>
   </div>
@@ -33,7 +34,7 @@
       </p>
       <p>
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/noble/release/ubuntu-24.04-preinstalled-server-riscv64+visionfive2.img.xz">Download 24.04</a>
+           href="https://cdimage.ubuntu.com/releases/24.04/release/ubuntu-24.04-preinstalled-server-riscv64+milkvmars.img.xz">Download 24.04</a>
       </p>
     </div>
   </div>
@@ -49,10 +50,10 @@
     <div class="col-6">
       <p>
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/noble/release/ubuntu-24.04-live-server-riscv64.img.gz">Download 24.04 live installer</a>
+           href="https://cdimage.ubuntu.com/releases/24.04/release/ubuntu-24.04-live-server-riscv64.img.gz">Download 24.04 live installer</a>
       </p>
       <p>
-        <a href="https://wiki.ubuntu.com/RISC-V/StarFive%20VisionFive%202">How to install Ubuntu on the VisionFive 2</a>
+        <a href="https://wiki.ubuntu.com/RISC-V/Milk-V%20Mars">How to install Ubuntu on the Milk-V Mars</a>
       </p>
     </div>
   </div>

--- a/templates/security/index.html
+++ b/templates/security/index.html
@@ -5,7 +5,7 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/1yEocR1WXQvN_B1L1yBYrG_0D7ikS6QhcOz27sYs-teI/edit{% endblock meta_copydoc %}
 
 {% block content %}
-<section class="p-strip--suru is-dark is-deep">
+<section class="p-strip--suru is-deep">
   <div class="row">
     <div class="col-8">
       <h1>Dedicated to the security of Ubuntu</h1>
@@ -467,7 +467,5 @@
 <!-- Set default Marketo information for contact form below-->
 <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/general" data-form-id="1257" data-lp-id="2154" data-return-url="https://ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
 </div>
-
-
 
 {% endblock content %}


### PR DESCRIPTION
To be deployed 27th of May

## Done

- Add new tab to the navigation
- Add content to the tab

## QA

- Go to https://ubuntu-com-13861.demos.haus/download/risc-v, click on Milk-V tab and compare with [copy doc comments](https://docs.google.com/document/d/1kkJeq9HdH3iWV35HwihcJd3CxZw9Jy21W66lJl8VbWs/edit)
  - Check navigation item shows for both large and small screens
  - Check content (Milk-V tab) is added correctly
  - Check links are correct


## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-10765

