### PR TITLE
Fix button styling on /security

### DIFF
--- a/templates/security/index.html
+++ b/templates/security/index.html
@@ -5,7 +5,7 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/1yEocR1WXQvN_B1L1yBYrG_0D7ikS6QhcOz27sYs-teI/edit{% endblock meta_copydoc %}
 
 {% block content %}
-<section class="p-strip--suru is-dark is-deep">
+<section class="p-strip--suru is-deep">
   <div class="row">
     <div class="col-8">
       <h1>Dedicated to the security of Ubuntu</h1>


### PR DESCRIPTION
## Done

- Removes 'is-dark' from suru

## QA

- Go to https://ubuntu-com-13863.demos.haus/security and see the button doesn't look broken

## Screenshots

![image](https://github.com/canonical/ubuntu.com/assets/58276363/b91e0757-130e-442c-9588-d3e15af2732e)



## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
