### PR TITLE
Fix /training typo

### DIFF
--- a/templates/training/index.html
+++ b/templates/training/index.html
@@ -22,7 +22,7 @@
         <div class="col-7">
           <div>
             <p>
-              Train your sysadmins and devops engineers to become experts in developing and operating open source software. Canonical runs training programmes to suit all environments and all levels of experience. Explore, prototype and design with cloud technologies so you can get the most out of your environment. All classes and materials are provided in English. They can be performed remotely or ON your premises at extra cost.
+              Train your sysadmins and devops engineers to become experts in developing and operating open source software. Canonical runs training programmes to suit all environments and all levels of experience. Explore, prototype and design with cloud technologies so you can get the most out of your environment. All classes and materials are provided in English. They can be performed remotely or on your premises at extra cost.
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Done

- Changes 'ON' to 'on'

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
