### PR TITLE
Add link to smart displays screenly section

### DIFF
--- a/templates/internet-of-things/smart-displays.html
+++ b/templates/internet-of-things/smart-displays.html
@@ -261,6 +261,7 @@
           Screenly provides the hardware and software you need to manage digital signs at scale. Update and schedule content, monitor screen health, and show content from your existing tech stack.
         </p>
         <a href="https://www.screenly.io/">Learn more about Screenly&nbsp;&rsaquo;</a>
+        <a href="/engage/screenly-empowers-security-conscious-enterprises">Read about the case study&nbsp;&rsaquo;</a>
       </div>
       <div class="col-4 p-card">
         <header class="no-border u-align--center u-vertically-center u-hide--small"


### PR DESCRIPTION
## Done

Add new link to screely section

## QA

- Go to https://ubuntu-com-13872.demos.haus/internet-of-things/smart-displays and [check Lizzi's comment has been addressed](https://docs.google.com/document/d/1fFvBl-ZZvKDFV6OMv7O4kudQKtyxfvSU60rfVdKluAQ/edit) in this PR

- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-10989

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
