### PR TITLE
Enforce older version of requests when installing dotrun

### DIFF
--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -29,7 +29,7 @@ jobs:
       run: npm install -g yarn && yarn
 
     - name: Install dotrun
-      uses: canonical/install-dotrun@main
+      run: sudo pip3 install dotrun requests==2.31.0 # requests version is pinned to avoid breaking changes, can be removed once issue is resolved: https://github.com/docker/docker-py/issues/3256resolved: https://github.com/docker/docker-py/issues/3256
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install dotrun
-        uses: canonical/install-dotrun@main
+        run: sudo pip3 install dotrun requests==2.31.0 # requests version is pinned to avoid breaking changes, can be removed once issue is resolved: https://github.com/docker/docker-py/issues/3256
 
       - name: Install dependencies
         run: |
@@ -74,7 +74,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install dotrun
-        uses: canonical/install-dotrun@main
+        run: sudo pip3 install dotrun requests==2.31.0 # requests version is pinned to avoid breaking changes, can be removed once issue is resolved: https://github.com/docker/docker-py/issues/3256
 
       - name: Install dependencies
         run: |
@@ -151,8 +151,7 @@ jobs:
           sudo pip3 install -r requirements.txt
 
       - name: Install dotrun
-        uses: canonical/install-dotrun@main
-
+        run: sudo pip3 install dotrun requests==2.31.0 # requests version is pinned to avoid breaking changes, can be removed once issue is resolved: https://github.com/docker/docker-py/issues/3256
       - name: Install node dependencies
         run: |
           sudo chmod -R 777 .


### PR DESCRIPTION
## Done

- Apply a temporary workaround for the CI issue caused by a recent bug in the requests library.

## QA

- Ensure CI is passing