### PR TITLE
Add CRA banners to security and certs pages

### DIFF
--- a/templates/security/certifications.html
+++ b/templates/security/certifications.html
@@ -34,14 +34,7 @@
  </div>
 </section>
 
-<section class="p-strip">
-
-  <div class="row p-card">
-    <p style="max-width: none;">Need information about the CRA? Canonical is committed to delivering Cyber Resilience Act (CRA) compliant Ubuntu. To learn more, 
-      <a href="#get-in-touch">contact our sales team.</a>
-    </p>
-  </div>
-</section>
+{% include "shared/_cra-banner.html" %}
 
 <section class="p-strip--light">
  <div class="row p-divider">

--- a/templates/security/certifications.html
+++ b/templates/security/certifications.html
@@ -34,6 +34,15 @@
  </div>
 </section>
 
+<section class="p-strip">
+
+  <div class="row p-card">
+    <p style="max-width: none;">Need information about the CRA? Canonical is committed to delivering Cyber Resilience Act (CRA) compliant Ubuntu. To learn more, 
+      <a href="#get-in-touch">contact our sales team.</a>
+    </p>
+  </div>
+</section>
+
 <section class="p-strip--light">
  <div class="row p-divider">
    <div class="col-4 p-divider__block">
@@ -85,7 +94,7 @@
 <section class="p-strip--light">
   <div class="row u-vertically-center">
     <div class="col-6">
-      <h2>How does Ubuntu enable your compliance with FIPS, and DISA-STIG?</h2>
+      <h2>How does Ubuntu enable your compliance with FedRAMP, FISMA, FIPS, and DISA-STIG?</h2>
       <p>Learn about the US government security standards and the common challenges faced by organisations in their implementation. See how the <a href="/security/certifications/docs/disa-stig">Ubuntu Security Guide</a> can transform systems compliance in a few minutes. Get to know how Ubuntu is a secure platform for government agencies and complying organisations to build, operate and innovate with open source applications and technologies.</p>
       <p><a class="p-button--positive js-invoke-modal" href="/security/contact-us">Contact us</a></p>
     </div>

--- a/templates/security/certifications.html
+++ b/templates/security/certifications.html
@@ -1,120 +1,153 @@
 {% extends "security/base_security.html" %}
 
-
 {% block title %}Canonical security certifications | Security{% endblock %}
-{% block meta_description %}Technical details on all of the security certifications for Ubuntu Pro subscribers.{% endblock %}
-{% block meta_copydoc %}https://docs.google.com/document/d/13RcVvHBAoywfk3o5Dy-16F3KrMytL9-2v6wWbW444Ko/edit{% endblock meta_copydoc %}
+
+{% block meta_description %}
+  Technical details on all of the security certifications for Ubuntu Pro subscribers.
+{% endblock %}
+
+{% block meta_copydoc %}
+  https://docs.google.com/document/d/13RcVvHBAoywfk3o5Dy-16F3KrMytL9-2v6wWbW444Ko/edit
+{% endblock meta_copydoc %}
 
 {% block content %}
 
-<section class="p-strip--suru-topped">
-  <div class="row u-equal-height u-vertically-center">
-    <div class="col-8">
-      <h1>Security Certifications & Hardening</h1>
-      <h2 class="p-heading--3">Run regulated and high security workloads on Ubuntu</h2>
-      <p>Whatever cybersecurity framework you have chosen, including ISO 27000, NIST, PCI or CIS Controls, <a href="/pro">Ubuntu Pro on-premise</a> or on <a href="/public-cloud">public clouds</a> enables your compliance and reduces your operational risk. Access automation for hardening and compliance profiles, such as CIS and DISA-STIG as well as the FIPS 140-2 and Common Criteria certifications.</p>
-      <p>
-        <a class="p-button--positive js-invoke-modal" href="/security/contact-us">Contact us</a>
-        <a href="/security/certifications/docs">Read the documentation&nbsp;&rsaquo;</a>
-      </p>
-   </div>
-   <div class="col-4 u-hide--medium u-hide--small u-align--center">
-     {{
-       image(
-         url="https://assets.ubuntu.com/v1/7953a068-security-1.svg",
-         alt="",
-         height="300",
-         width="250",
-         hi_def=True,
-         loading="auto",
-         attrs={"class": "u-hide--small u-hide--medium"}
-       ) | safe
-     }}
-   </div>
- </div>
-</section>
-
-{% include "shared/_cra-banner.html" %}
-
-<section class="p-strip--light">
- <div class="row p-divider">
-   <div class="col-4 p-divider__block">
-     <h3>Comply with established security baselines</h3>
-     <p>The default configuration of Ubuntu balances usability and security. However, systems carrying dedicated workloads can be further hardened to reduce their attack surface. Canonical works with DISA to ensure STIG guides are available for Ubuntu, as well as provides OpenSCAP tooling and automation for the Industry accepted CIS benchmark. Available with <a href="/pro">Ubuntu Pro on-premise</a> or on <a href="/public-cloud">public clouds</a>.</p>
-     <a class="p-button" href="#compliance-profiles">See our compliance profiles</a>
-   </div>
-   <div class="col-4 p-divider__block">
-     <h3>Know your defenses</h3>
-     <p>Each Ubuntu release enables state of the art protection against vulnerability exploitation and malware and we <a href="https://wiki.ubuntu.com/Security/Features">publicly detail our choices</a>. Canonical has a <a href="/security/disclosure-policy">public vulnerability disclosure policy</a> and vulnerabilities are not only fixed with automated security updates and <a href="/security/livepatch">livepatches</a> but also publicly disclosed with our <a href="/security/notices">security notices</a>. We further provide <a href="/security/oval">machine readable OVAL</a> CVE output to be used by OpenSCAP and other 3rd party vulnerability management tools.</p>
-     <a class="p-button" href="https://wiki.ubuntu.com/Security/Features">See our security features</a>
-   </div>
-   <div class="col-4 p-divider__block">
-     <h3>Access certifications for high security environments</h3>
-     <p>Access certification artifacts as well as the necessary tooling for regulated and high security environments. <a href="/pro">Ubuntu Pro</a> provides access to FIPS 140-2 certified cryptographic packages, allowing you to deploy workloads that need to operate under compliance regimes like FedRAMP, HIPAA, and PCI-DSS. Additionally, some Ubuntu versions have been certified under Common Criteria, providing 3rd party attestation of the security mechanisms in the operating system.</p>
-     <a class="p-button" href="#security-certifications">See our certifications</a>
-   </div>
- </div>
-</section>
-
-<section class="p-strip">
-  <div class="row p-divider">
-    <div class="col-3 p-divider__block">
-      <h2 class="p-heading--3">FIPS</h2>
-      <p>A US and Canada government cryptographic module certification of compliance with the FIPS 140 information processing standard</p>
-      <a href="/security/fips">Learn more&nbsp;&rsaquo;</a>
-    </div>
-
-    <div class="col-3 p-divider__block">
-      <h2 class="p-heading--3">Common Criteria</h2>
-      <p>3rd party attestation of the security mechanisms. Ubuntu has an EAL2 certification recognised by CCRA and EU SOGIS members</p>
-      <a href="/security/cc">Learn more&nbsp;&rsaquo;</a>
-    </div>
-
-    <div class="col-3 p-divider__block">
-      <h2 class="p-heading--3">DISA-STIG</h2>
-      <p>Ubuntu Pro has the necessary automated tooling to comply with DISA-STIG guidelines on Linux</p>
-      <a href="/security/disa-stig">Learn more&nbsp;&rsaquo;</a>
-    </div>
-
-    <div class="col-3 p-divider__block">
-      <h2 class="p-heading--3">CIS</h2>
-      <p>Canonical provides Ubuntu Security Guide (USG) for automated audit and compliance with the CIS benchmarks</p>
-      <a href="/security/cis">Learn more&nbsp;&rsaquo;</a>
-    </div>
-  </div>
-</section>
-
-<section class="p-strip--light">
-  <div class="row u-vertically-center">
-    <div class="col-6">
-      <h2>How does Ubuntu enable your compliance with FedRAMP, FISMA, FIPS, and DISA-STIG?</h2>
-      <p>Learn about the US government security standards and the common challenges faced by organisations in their implementation. See how the <a href="/security/certifications/docs/disa-stig">Ubuntu Security Guide</a> can transform systems compliance in a few minutes. Get to know how Ubuntu is a secure platform for government agencies and complying organisations to build, operate and innovate with open source applications and technologies.</p>
-      <p><a class="p-button--positive js-invoke-modal" href="/security/contact-us">Contact us</a></p>
-    </div>
-    <div class="col-6 u-hide--medium u-hide--small u-align--center">
-      <div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative;background: #ffffff;">
-        <script class="jsBrightTALKEmbedConfig" type="application/json">
-          { "channelId" : 6793, "language": "en-US", "commId" : 524647, "displayMode" : "standalone", "height" : "280" }
-        </script>
-        <script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script>
-        <script>
-          const iframe = document.querySelector('.jsBrightTALKEmbedWrapper iframe');
-          iframe.addEventListener('load', () => {
-            iframe.scrolling = "yes";
-          });
-        </script>        
+  <section class="p-strip--suru-topped">
+    <div class="row u-equal-height u-vertically-center">
+      <div class="col-8">
+        <h1>Security Certifications & Hardening</h1>
+        <h2 class="p-heading--3">Run regulated and high security workloads on Ubuntu</h2>
+        <p>
+          Whatever cybersecurity framework you have chosen, including ISO 27000, NIST, PCI or CIS Controls, <a href="/pro">Ubuntu Pro on-premise</a> or on <a href="/public-cloud">public clouds</a> enables your compliance and reduces your operational risk. Access automation for hardening and compliance profiles, such as CIS and DISA-STIG as well as the FIPS 140-2 and Common Criteria certifications.
+        </p>
+        <p>
+          <a class="p-button--positive js-invoke-modal"
+             href="/security/contact-us">Contact us</a>
+          <a href="/security/certifications/docs">Read the documentation&nbsp;&rsaquo;</a>
+        </p>
+      </div>
+      <div class="col-4 u-hide--medium u-hide--small u-align--center">
+        {{ image(url="https://assets.ubuntu.com/v1/7953a068-security-1.svg",
+                alt="",
+                height="300",
+                width="250",
+                hi_def=True,
+                loading="auto",
+                attrs={"class": "u-hide--small u-hide--medium"}) | safe
+        }}
       </div>
     </div>
-  </div>
-</section>
+  </section>
 
-<section class="p-strip" id="compliance-profiles">
-  <div class="u-fixed-width">
-    <h2>Ubuntu compliance &amp; hardening profiles</h2>
-    <p class="u-sv2">The default configuration of Ubuntu LTS releases, balances between usability, performance and security. However, non general purpose systems can be further hardened to reduce their attack surface. Reducing the attack surface is often part of the compliance with the organization’s cybersecurity framework, but is also a widely accepted security best practice. We recommend using the industry accepted benchmarks below. Click on each benchmark for more detailed information.</p>
+  {% include "shared/_cra-banner.html" %}
+
+  <section class="p-strip--light">
     <div class="row p-divider">
-      <div class="col-6 p-divider__block">
-        {{ image (
+      <div class="col-4 p-divider__block">
+        <h3>Comply with established security baselines</h3>
+        <p>
+          The default configuration of Ubuntu balances usability and security. However, systems carrying dedicated workloads can be further hardened to reduce their attack surface. Canonical works with DISA to ensure STIG guides are available for Ubuntu, as well as provides OpenSCAP tooling and automation for the Industry accepted CIS benchmark. Available with <a href="/pro">Ubuntu Pro on-premise</a> or on <a href="/public-cloud">public clouds</a>.
+        </p>
+        <a class="p-button" href="#compliance-profiles">See our compliance profiles</a>
+      </div>
+      <div class="col-4 p-divider__block">
+        <h3>Know your defenses</h3>
+        <p>
+          Each Ubuntu release enables state of the art protection against vulnerability exploitation and malware and we <a href="https://wiki.ubuntu.com/Security/Features">publicly detail our choices</a>. Canonical has a <a href="/security/disclosure-policy">public vulnerability disclosure policy</a> and vulnerabilities are not only fixed with automated security updates and <a href="/security/livepatch">livepatches</a> but also publicly disclosed with our <a href="/security/notices">security notices</a>. We further provide <a href="/security/oval">machine readable OVAL</a> CVE output to be used by OpenSCAP and other 3rd party vulnerability management tools.
+        </p>
+        <a class="p-button" href="https://wiki.ubuntu.com/Security/Features">See our security features</a>
+      </div>
+      <div class="col-4 p-divider__block">
+        <h3>Access certifications for high security environments</h3>
+        <p>
+          Access certification artifacts as well as the necessary tooling for regulated and high security environments. <a href="/pro">Ubuntu Pro</a> provides access to FIPS 140-2 certified cryptographic packages, allowing you to deploy workloads that need to operate under compliance regimes like FedRAMP, HIPAA, and PCI-DSS. Additionally, some Ubuntu versions have been certified under Common Criteria, providing 3rd party attestation of the security mechanisms in the operating system.
+        </p>
+        <a class="p-button" href="#security-certifications">See our certifications</a>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-strip">
+    <div class="row p-divider">
+      <div class="col-3 p-divider__block">
+        <h2 class="p-heading--3">FIPS</h2>
+        <p>
+          A US and Canada government cryptographic module certification of compliance with the FIPS 140 information processing standard
+        </p>
+        <a href="/security/fips">Learn more&nbsp;&rsaquo;</a>
+      </div>
+
+      <div class="col-3 p-divider__block">
+        <h2 class="p-heading--3">Common Criteria</h2>
+        <p>
+          3rd party attestation of the security mechanisms. Ubuntu has an EAL2 certification recognised by CCRA and EU SOGIS members
+        </p>
+        <a href="/security/cc">Learn more&nbsp;&rsaquo;</a>
+      </div>
+
+      <div class="col-3 p-divider__block">
+        <h2 class="p-heading--3">DISA-STIG</h2>
+        <p>Ubuntu Pro has the necessary automated tooling to comply with DISA-STIG guidelines on Linux</p>
+        <a href="/security/disa-stig">Learn more&nbsp;&rsaquo;</a>
+      </div>
+
+      <div class="col-3 p-divider__block">
+        <h2 class="p-heading--3">CIS</h2>
+        <p>Canonical provides Ubuntu Security Guide (USG) for automated audit and compliance with the CIS benchmarks</p>
+        <a href="/security/cis">Learn more&nbsp;&rsaquo;</a>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-strip--light">
+    <div class="row u-vertically-center">
+      <div class="col-6">
+        <h2>How does Ubuntu enable your compliance with FedRAMP, FISMA, FIPS, and DISA-STIG?</h2>
+        <p>
+          Learn about the US government security standards and the common challenges faced by organisations in their implementation. See how the <a href="/security/certifications/docs/disa-stig">Ubuntu Security Guide</a> can transform systems compliance in a few minutes. Get to know how Ubuntu is a secure platform for government agencies and complying organisations to build, operate and innovate with open source applications and technologies.
+        </p>
+        <p>
+          <a class="p-button--positive js-invoke-modal"
+             href="/security/contact-us">Contact us</a>
+        </p>
+      </div>
+      <div class="col-6 u-hide--medium u-hide--small u-align--center">
+        <div class="jsBrightTALKEmbedWrapper"
+             style="width:100%;
+                    height:100%;
+                    position:relative;
+                    background: #ffffff">
+          <script class="jsBrightTALKEmbedConfig" type="application/json">
+            {
+              "channelId": 6793,
+              "language": "en-US",
+              "commId": 524647,
+              "displayMode": "standalone",
+              "height": "280"
+            }
+          </script>
+          <script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js"
+                  class="jsBrightTALKEmbed"></script>
+          <script>
+            const iframe = document.querySelector('.jsBrightTALKEmbedWrapper iframe');
+            iframe.addEventListener('load', () => {
+              iframe.scrolling = "yes";
+            });
+          </script>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-strip" id="compliance-profiles">
+    <div class="u-fixed-width">
+      <h2>Ubuntu compliance &amp; hardening profiles</h2>
+      <p class="u-sv2">
+        The default configuration of Ubuntu LTS releases, balances between usability, performance and security. However, non general purpose systems can be further hardened to reduce their attack surface. Reducing the attack surface is often part of the compliance with the organization’s cybersecurity framework, but is also a widely accepted security best practice. We recommend using the industry accepted benchmarks below. Click on each benchmark for more detailed information.
+      </p>
+      <div class="row p-divider">
+        <div class="col-6 p-divider__block">
+          {{ image (
           url="https://assets.ubuntu.com/v1/f98af83d-cis-logo-removebg-preview.png",
           alt="",
           width="50",
@@ -122,18 +155,20 @@
           hi_def=True,
           loading="lazy"
           ) | safe
-        }}
-        <p><a href="/security/cis">Center for Internet Security (CIS) certified benchmarks for Ubuntu systems</a></p>
-        <p class="p-text--small-caps">Tooling &amp; automation</p>
-        <ul class="p-list">
-          <li class="p-list__item is-ticked">Ubuntu 22.04 LTS</li>
-          <li class="p-list__item is-ticked">Ubuntu 20.04 LTS</li>
-          <li class="p-list__item is-ticked">Ubuntu 18.04 LTS</li>
-          <li class="p-list__item is-ticked">Ubuntu 16.04 LTS</li>
-        </ul>
-      </div>
-      <div class="col-6 p-divider__block">
-        {{ image (
+          }}
+          <p>
+            <a href="/security/cis">Center for Internet Security (CIS) certified benchmarks for Ubuntu systems</a>
+          </p>
+          <p class="p-text--small-caps">Tooling &amp; automation</p>
+          <ul class="p-list">
+            <li class="p-list__item is-ticked">Ubuntu 22.04 LTS</li>
+            <li class="p-list__item is-ticked">Ubuntu 20.04 LTS</li>
+            <li class="p-list__item is-ticked">Ubuntu 18.04 LTS</li>
+            <li class="p-list__item is-ticked">Ubuntu 16.04 LTS</li>
+          </ul>
+        </div>
+        <div class="col-6 p-divider__block">
+          {{ image (
           url="https://assets.ubuntu.com/v1/ef01809f-DISA-logo-transparent.png",
           alt="",
           width="136",
@@ -141,86 +176,102 @@
           hi_def=True,
           loading="lazy"
           ) | safe
-        }}
-        <p><a href="https://ubuntu.com/security/disa-stig">Defence Information System Agency (DISA) Security Technical Implementation Guides (STIGs)</a></p>
-        <p class="p-text--small-caps">Tooling &amp; automation</p>
-        <ul class="p-list">
-          <li class="p-list__item is-ticked">Ubuntu 20.04 LTS</li>
-        </ul>
-        <p class="p-text--small-caps">Configuration guides</p>
-        <ul class="p-list">
-          <li class="p-list__item is-ticked">Ubuntu 18.04 LTS</li>
-          <li class="p-list__item is-ticked">Ubuntu 16.04 LTS</li>
-        </ul>
+          }}
+          <p>
+            <a href="https://ubuntu.com/security/disa-stig">Defence Information System Agency (DISA) Security Technical Implementation Guides (STIGs)</a>
+          </p>
+          <p class="p-text--small-caps">Tooling &amp; automation</p>
+          <ul class="p-list">
+            <li class="p-list__item is-ticked">Ubuntu 20.04 LTS</li>
+          </ul>
+          <p class="p-text--small-caps">Configuration guides</p>
+          <ul class="p-list">
+            <li class="p-list__item is-ticked">Ubuntu 18.04 LTS</li>
+            <li class="p-list__item is-ticked">Ubuntu 16.04 LTS</li>
+          </ul>
+        </div>
       </div>
+      <a href="/security/contact-us"
+         class="p-button--positive js-invoke-modal">Contact us</a>
     </div>
-    <a href="/security/contact-us" class="p-button--positive js-invoke-modal">Contact us</a>
-  </div>
-</section>
+  </section>
 
-<section class="p-strip--light" id="security-certifications">
- <div class="u-fixed-width">
-   <h2>Ubuntu security certifications</h2>
-   <p class="u-sv2">We strive to make Ubuntu the platform of choice in regulated and high security environments. Ubuntu Pro enables access to the certification artifacts as well as the necessary tooling for such environments. The following is a list of the certifications available with <a href="/pro">Ubuntu Pro</a>. Click on each for more detailed information.</p>
-   <table class="p-table--security-certifications">
-     <thead>
-       <th></th>
-       <th class="u-align--center">Ubuntu 16.04 LTS</th>
-       <th class="u-align--center">Ubuntu 18.04 LTS</th>
-       <th class="u-align--center">Ubuntu 20.04 LTS</th>
-     </thead>
-     <tbody>
-       <tr>
-         <td>
-           <a href="/security/fips">FIPS 140-2 Level 1 certification</a>: A US and Canada government cryptographic module certification of compliance with the FIPS 140 data protection standard. US agencies, their service providers or other institutions that comply with similar requirements (e.g., HIPAA, PCI-DSS) are required to comply with FIPS 140.
-         </td>
-         <td class="u-align--center">
-           <div class="u-sv2">
-             <i class="p-icon--success u-sv2">Yes: Tooling and automation</i>
-           </div>
-         </td>
-         <td class="u-align--center">
-           <div class="u-sv2">
-             <i class="p-icon--success">Yes: Tooling and automation</i>
-           </div>
-         </td>
-         <td class="u-align--center">
-           <div class="u-sv2">
-             <i class="p-icon--success">Yes: Tooling and automation</i>
-           </div>
-         </td>
-       </tr>
-       <tr>
-         <td>
-           <a href="/security/cc">Common Criteria, EAL2, an internationally accepted security certification</a>: A 3rd party attestation of the security mechanisms in the operating system. Ubuntu has a Common Criteria EAL2 certification recognized by CCRA and EU SOGIS members.
-         </td>
-         <td class="u-align--center"><i class="p-icon--success">Yes</i></td>
-         <td class="u-align--center"><i class="p-icon--success">Yes</i></td>
-         <td class="u-align--center">
-         </td>
-       </tr>
-     </tbody>
-   </table>
-   <a href="/security/contact-us" class="p-button--positive js-invoke-modal">Contact us</a>
- </div>
-</section>
+  <section class="p-strip--light" id="security-certifications">
+    <div class="u-fixed-width">
+      <h2>Ubuntu security certifications</h2>
+      <p class="u-sv2">
+        We strive to make Ubuntu the platform of choice in regulated and high security environments. Ubuntu Pro enables access to the certification artifacts as well as the necessary tooling for such environments. The following is a list of the certifications available with <a href="/pro">Ubuntu Pro</a>. Click on each for more detailed information.
+      </p>
+      <table class="p-table--security-certifications">
+        <thead>
+          <th></th>
+          <th class="u-align--center">Ubuntu 16.04 LTS</th>
+          <th class="u-align--center">Ubuntu 18.04 LTS</th>
+          <th class="u-align--center">Ubuntu 20.04 LTS</th>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <a href="/security/fips">FIPS 140-2 Level 1 certification</a>: A US and Canada government cryptographic module certification of compliance with the FIPS 140 data protection standard. US agencies, their service providers or other institutions that comply with similar requirements (e.g., HIPAA, PCI-DSS) are required to comply with FIPS 140.
+            </td>
+            <td class="u-align--center">
+              <div class="u-sv2">
+                <i class="p-icon--success u-sv2">Yes: Tooling and automation</i>
+              </div>
+            </td>
+            <td class="u-align--center">
+              <div class="u-sv2">
+                <i class="p-icon--success">Yes: Tooling and automation</i>
+              </div>
+            </td>
+            <td class="u-align--center">
+              <div class="u-sv2">
+                <i class="p-icon--success">Yes: Tooling and automation</i>
+              </div>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <a href="/security/cc">Common Criteria, EAL2, an internationally accepted security certification</a>: A 3rd party attestation of the security mechanisms in the operating system. Ubuntu has a Common Criteria EAL2 certification recognized by CCRA and EU SOGIS members.
+            </td>
+            <td class="u-align--center">
+              <i class="p-icon--success">Yes</i>
+            </td>
+            <td class="u-align--center">
+              <i class="p-icon--success">Yes</i>
+            </td>
+            <td class="u-align--center"></td>
+          </tr>
+        </tbody>
+      </table>
+      <a href="/security/contact-us"
+         class="p-button--positive js-invoke-modal">Contact us</a>
+    </div>
+  </section>
 
-<section class="p-strip">
- <div class="u-fixed-width">
-   <h2>Frequently asked questions about security certifications</h2>
-   <h3>How do I harden my Ubuntu system?</h3>
-   <p>Hardening always involves a tradeoff with usability and performance. The default configuration of Ubuntu LTS releases, as provided by Canonical, balances between usability, performance and security. However, systems with a dedicated workload are well positioned to benefit from hardening. You can reduce your workload’s attack surface by applying an Industry accepted baseline. At Canonical we recommend applying <a href="/security/cis">the Center for Internet Security (CIS) benchmarks</a> for hardening the configuration of Ubuntu.</p>
-   <h3>How do I comply with PCI-DSS?</h3>
-   <p>PCI-DSS is a payment industry standard and any company that stores, processes or transmits payment card or cardholder information is required to comply with it. The standard is defined by the Payment Card Industry council and defines measures and processes to secure online financial transactions. The standard is about making business as usual processes like monitoring of security controls, timely response, review of environmental and organizational changes, as well as review of hardware and software being under support by its vendors. For companies with large volumes of transactions compliance with the standard is enforced by an audit of a Qualified Security Assessor (QSA).</p>
-   <p>Achieving and maintaining compliance is a complex and costly process that involves business processes in addition to software requirements. Ubuntu by Canonical contains software and security controls, such as disk encryption, password settings configuration, <a href="/security/fips">cryptographic compliance with FIPS140-2</a>, <a href="/security/cis">CIS hardening</a> as well as <a href="/pro">a comprehensive Enterprise software maintenance program</a>, to achieve and maintain compliance with the standard.</p>
-   <a href="/security/contact-us" class="p-button--positive js-invoke-modal">Contact us</a>
- </div>
-</section>
+  <section class="p-strip">
+    <div class="u-fixed-width">
+      <h2>Frequently asked questions about security certifications</h2>
+      <h3>How do I harden my Ubuntu system?</h3>
+      <p>
+        Hardening always involves a tradeoff with usability and performance. The default configuration of Ubuntu LTS releases, as provided by Canonical, balances between usability, performance and security. However, systems with a dedicated workload are well positioned to benefit from hardening. You can reduce your workload’s attack surface by applying an Industry accepted baseline. At Canonical we recommend applying <a href="/security/cis">the Center for Internet Security (CIS) benchmarks</a> for hardening the configuration of Ubuntu.
+      </p>
+      <h3>How do I comply with PCI-DSS?</h3>
+      <p>
+        PCI-DSS is a payment industry standard and any company that stores, processes or transmits payment card or cardholder information is required to comply with it. The standard is defined by the Payment Card Industry council and defines measures and processes to secure online financial transactions. The standard is about making business as usual processes like monitoring of security controls, timely response, review of environmental and organizational changes, as well as review of hardware and software being under support by its vendors. For companies with large volumes of transactions compliance with the standard is enforced by an audit of a Qualified Security Assessor (QSA).
+      </p>
+      <p>
+        Achieving and maintaining compliance is a complex and costly process that involves business processes in addition to software requirements. Ubuntu by Canonical contains software and security controls, such as disk encryption, password settings configuration, <a href="/security/fips">cryptographic compliance with FIPS140-2</a>, <a href="/security/cis">CIS hardening</a> as well as <a href="/pro">a comprehensive Enterprise software maintenance program</a>, to achieve and maintain compliance with the standard.
+      </p>
+      <a href="/security/contact-us"
+         class="p-button--positive js-invoke-modal">Contact us</a>
+    </div>
+  </section>
 
-<section class="p-strip--light">
-  <div class="row">
-    <div class="col-4 u-hide--medium u-hide--small u-align--center">
-      {{ image (
+  <section class="p-strip--light">
+    <div class="row">
+      <div class="col-4 u-hide--medium u-hide--small u-align--center">
+        {{ image (
         url="https://assets.ubuntu.com/v1/7076ef2d-ubuntu-documents.svg",
         alt="",
         width="166",
@@ -228,19 +279,27 @@
         hi_def=True,
         loading="lazy"
         ) | safe
-      }}
+        }}
+      </div>
+      <div class="col-8">
+        <h2>Security Compliance and Certification documentation</h2>
+        <a href="/security/certifications/docs" class="p-button--positive">Read the docs</a>
+      </div>
     </div>
-    <div class="col-8">
-      <h2>Security Compliance and Certification documentation</h2>
-      <a href="/security/certifications/docs" class="p-button--positive">Read the docs</a>
-    </div>
+  </section>
+
+  {% with first_item="_security_discussion", second_item="_security_esm", third_item="_security_further_reading" %}
+    {% include "shared/contextual_footers/_contextual_footer.html" %}
+  {% endwith %}
+
+  <!-- Set default Marketo information for contact form below-->
+  <div class="u-hide"
+       id="contact-form-container"
+       data-form-location="/shared/forms/interactive/general"
+       data-form-id="1257"
+       data-lp-id="2154"
+       data-return-url="https://ubuntu.com/contact-us/form/thank-you"
+       data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
   </div>
-</section>
 
-
-{% with first_item="_security_discussion", second_item="_security_esm", third_item="_security_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
-
-<!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/general" data-form-id="1257" data-lp-id="2154" data-return-url="https://ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
-
-{% endblock content %}
+  {% endblock content %}

--- a/templates/security/index.html
+++ b/templates/security/index.html
@@ -1,97 +1,125 @@
 {% extends "security/base_security.html" %}
 
 {% block title %}Security{% endblock %}
-{% block meta_description %}Companies around the world rely on Ubuntu for secure open source solutions. We work with our customers to meet the highest security standards.{% endblock %}
-{% block meta_copydoc %}https://docs.google.com/document/d/1yEocR1WXQvN_B1L1yBYrG_0D7ikS6QhcOz27sYs-teI/edit{% endblock meta_copydoc %}
+
+{% block meta_description %}
+  Companies around the world rely on Ubuntu for secure open source solutions. We work with our customers to meet the highest security standards.
+{% endblock %}
+
+{% block meta_copydoc %}
+  https://docs.google.com/document/d/1yEocR1WXQvN_B1L1yBYrG_0D7ikS6QhcOz27sYs-teI/edit
+{% endblock meta_copydoc %}
 
 {% block content %}
-<section class="p-strip--suru is-deep">
-  <div class="row">
-    <div class="col-8">
-      <h1>Dedicated to the security of Ubuntu</h1>
-      <p>Since its inception in 2004, Ubuntu has been built on a foundation of enterprise-grade, industry leading security practices. From our toolchain to the suite of packages we use and from our update process to our industry standard certifications, Canonical never stops working to keep Ubuntu at the forefront of safety  and reliability.</p>
-      <p>
-        <a class="p-button--positive" href="/engage/ubuntu-cybersecurity-webinar" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Watch the Ubuntu security webinar', 'eventLabel' : 'Watch the Ubuntu security webinar', 'eventValue' : undefined });" >Watch the Ubuntu cybersecurity webinar</a>
-        <a class="p-button js-invoke-modal" href="/security/contact-us">Contact us</a>
-      </p>
-    </div>
+  <section class="p-strip--suru is-deep">
+    <div class="row">
+      <div class="col-8">
+        <h1>Dedicated to the security of Ubuntu</h1>
+        <p>
+          Since its inception in 2004, Ubuntu has been built on a foundation of enterprise-grade, industry leading security practices. From our toolchain to the suite of packages we use and from our update process to our industry standard certifications, Canonical never stops working to keep Ubuntu at the forefront of safety  and reliability.
+        </p>
+        <p>
+          <a class="p-button--positive"
+             href="/engage/ubuntu-cybersecurity-webinar"
+             onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Watch the Ubuntu security webinar', 'eventLabel' : 'Watch the Ubuntu security webinar', 'eventValue' : undefined });">Watch the Ubuntu cybersecurity webinar</a>
+          <a class="p-button js-invoke-modal" href="/security/contact-us">Contact us</a>
+        </p>
+      </div>
 
-    <div class="col-4 u-hide--small u-hide--medium u-vertically-center">
-      {{
-        image(
-          url="https://assets.ubuntu.com/v1/c3814c0a-shields-security-white.svg",
-          alt="",
-          height="185",
-          width="325",
-          hi_def=True,
-          loading="auto"
-        ) | safe
-      }}
-    </div>
-  </div>
-</section>
-
-{% include "shared/_cra-banner.html" %}
-
-<section class="p-strip is-deep">
-  <div class="row p-divider">
-    <div class="col-4 p-divider__block">
-      <h2 class="p-heading--3">Secure out of the box</h2>
-      <p>All Canonical products are built with unrivalled security in mind &mdash; and tested to ensure they deliver it. Your Ubuntu software is secure from the moment you install it, and will remain so as Canonical ensures security updates are always available on Ubuntu first.</p>
-      <p><a href="https://wiki.ubuntu.com/Security/Features">Learn more about Ubuntu’s security features</a></p>
-    </div>
-    <div class="col-4 p-divider__block">
-      <h2 class="p-heading--3">Hardening at scale</h2>
-      <p>The default configuration of Ubuntu LTS releases balances between usability, performance and security. However, non general purpose systems can be further hardened to reduce their attack surface. Canonical provides certified tooling for automated audit and hardening. Comply with widely accepted industry hardening profiles, including CIS and DISA-STIG.</p>
-      <p><a href="/security/certifications">Learn more about hardening Ubuntu&nbsp;&rsaquo;</a></p>
-    </div>
-    <div class="col-4 p-divider__block">
-      <h2 class="p-heading--3">Certified compliance</h2>
-      <p>Canonical offers a range of tools to enable organisations to manage their desktop fleet and cloud with specific compliance requirements. A FIPS (Federal Information Processing Standard) certified version of Ubuntu is also available to comply to US government standards.</p>
-      <p><a href="/security/fips">Learn more about Ubuntu with FIPS 140&nbsp;&rsaquo;</a></p>
-    </div>
-  </div>
-</section>
-
-<section class="p-strip--light is">
-  <div class="row u-equal-height">
-    <div class="col-6">
-      <h2>
-        Cybersecurity and Compliance with Ubuntu
-      </h2>
-      <p>
-        Learn about cybersecurity and zero trust as well as the common challenges faced in the implementation of cybersecurity programs, including challenges in vulnerability management, secure configuration of software and defenses against malware. See how Canonical and Ubuntu can help manage these challenges and lay the software foundation of a successful cybersecurity program.
-      </p>
-      <p>
-        <a class="p-button js-invoke-modal" href="/security/contact-us">Contact us</a>
-      </p>
-    </div>
-    <div class="col-6 u-hide--small u-hide--medium u-align--center">
-      <div class="jsBrightTALKEmbedWrapper" style="width:100%; height:100%; position:relative; background:#ffffff;">
-        <script class="jsBrightTALKEmbedConfig" type="application/json">
-          { "channelId" : 6793, "language": "en-US", "commId" : 516333, "displayMode" : "standalone", "height" : "280"}
-        </script>
-        <script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js" class="jsBrightTALKEmbed"></script>
-        <script>
-          const iframe = document.querySelector('.jsBrightTALKEmbedWrapper iframe');
-          iframe.addEventListener('load', () => {
-            iframe.scrolling = "yes";
-          });
-        </script>
+      <div class="col-4 u-hide--small u-hide--medium u-vertically-center">
+        {{ image(url="https://assets.ubuntu.com/v1/c3814c0a-shields-security-white.svg",
+                alt="",
+                height="185",
+                width="325",
+                hi_def=True,
+                loading="auto") | safe
+        }}
       </div>
     </div>
-  </div>
-</section>
+  </section>
 
-<section class="p-strip">
-  <div class="u-fixed-width">
-    <h2>Find out more</h2>
-  </div>
-  <div class="row u-equal-height">
-    <div class="col-4 p-card u-align--center">
-      <p>
-        <a>
-          {{ image (
+  {% include "shared/_cra-banner.html" %}
+
+  <section class="p-strip is-deep">
+    <div class="row p-divider">
+      <div class="col-4 p-divider__block">
+        <h2 class="p-heading--3">Secure out of the box</h2>
+        <p>
+          All Canonical products are built with unrivalled security in mind &mdash; and tested to ensure they deliver it. Your Ubuntu software is secure from the moment you install it, and will remain so as Canonical ensures security updates are always available on Ubuntu first.
+        </p>
+        <p>
+          <a href="https://wiki.ubuntu.com/Security/Features">Learn more about Ubuntu’s security features</a>
+        </p>
+      </div>
+      <div class="col-4 p-divider__block">
+        <h2 class="p-heading--3">Hardening at scale</h2>
+        <p>
+          The default configuration of Ubuntu LTS releases balances between usability, performance and security. However, non general purpose systems can be further hardened to reduce their attack surface. Canonical provides certified tooling for automated audit and hardening. Comply with widely accepted industry hardening profiles, including CIS and DISA-STIG.
+        </p>
+        <p>
+          <a href="/security/certifications">Learn more about hardening Ubuntu&nbsp;&rsaquo;</a>
+        </p>
+      </div>
+      <div class="col-4 p-divider__block">
+        <h2 class="p-heading--3">Certified compliance</h2>
+        <p>
+          Canonical offers a range of tools to enable organisations to manage their desktop fleet and cloud with specific compliance requirements. A FIPS (Federal Information Processing Standard) certified version of Ubuntu is also available to comply to US government standards.
+        </p>
+        <p>
+          <a href="/security/fips">Learn more about Ubuntu with FIPS 140&nbsp;&rsaquo;</a>
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-strip--light is">
+    <div class="row u-equal-height">
+      <div class="col-6">
+        <h2>Cybersecurity and Compliance with Ubuntu</h2>
+        <p>
+          Learn about cybersecurity and zero trust as well as the common challenges faced in the implementation of cybersecurity programs, including challenges in vulnerability management, secure configuration of software and defenses against malware. See how Canonical and Ubuntu can help manage these challenges and lay the software foundation of a successful cybersecurity program.
+        </p>
+        <p>
+          <a class="p-button js-invoke-modal" href="/security/contact-us">Contact us</a>
+        </p>
+      </div>
+      <div class="col-6 u-hide--small u-hide--medium u-align--center">
+        <div class="jsBrightTALKEmbedWrapper"
+             style="width:100%;
+                    height:100%;
+                    position:relative;
+                    background:#ffffff">
+          <script class="jsBrightTALKEmbedConfig" type="application/json">
+            {
+              "channelId": 6793,
+              "language": "en-US",
+              "commId": 516333,
+              "displayMode": "standalone",
+              "height": "280"
+            }
+          </script>
+          <script src="https://www.brighttalk.com/clients/js/player-embed/player-embed.js"
+                  class="jsBrightTALKEmbed"></script>
+          <script>
+            const iframe = document.querySelector('.jsBrightTALKEmbedWrapper iframe');
+            iframe.addEventListener('load', () => {
+              iframe.scrolling = "yes";
+            });
+          </script>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-strip">
+    <div class="u-fixed-width">
+      <h2>Find out more</h2>
+    </div>
+    <div class="row u-equal-height">
+      <div class="col-4 p-card u-align--center">
+        <p>
+          <a>
+            {{ image (
             url="https://assets.ubuntu.com/v1/b061c401-White+paper.svg",
             alt="",
             width="54",
@@ -99,16 +127,18 @@
             hi_def=True,
             loading="lazy"
             ) | safe
-          }}
-        </a>
-      </p>
+            }}
+          </a>
+        </p>
 
-       <h3 class="p-heading--4 u-no-margin--bottom"><a href="/engage/a-small-to-medium-size-business-guide-to-cybersecurity">A small to medium-size business guide to cybersecurity&nbsp;&rsaquo;</a></h3>
-    </div>
-    <div class="col-4 p-card u-align--center">
-      <p>
-        <a>
-          {{ image (
+        <h3 class="p-heading--4 u-no-margin--bottom">
+          <a href="/engage/a-small-to-medium-size-business-guide-to-cybersecurity">A small to medium-size business guide to cybersecurity&nbsp;&rsaquo;</a>
+        </h3>
+      </div>
+      <div class="col-4 p-card u-align--center">
+        <p>
+          <a>
+            {{ image (
             url="https://assets.ubuntu.com/v1/5edefef9-Datasheet.svg",
             alt="",
             width="54",
@@ -116,16 +146,18 @@
             hi_def=True,
             loading="lazy"
             ) | safe
-          }}
-        </a>
-      </p>
+            }}
+          </a>
+        </p>
 
-      <h3 class="p-heading--4 u-no-margin--bottom"><a href="https://assets.ubuntu.com/v1/8232357b-Cybersecurity.with.Ubuntu_07.12.21.1.pdf">Cybersecurity with Ubuntu datasheet&nbsp;&rsaquo;</a></h3>
-    </div>
-    <div class="col-4 p-card u-align--center">
-      <p>
-        <a>
-          {{ image (
+        <h3 class="p-heading--4 u-no-margin--bottom">
+          <a href="https://assets.ubuntu.com/v1/8232357b-Cybersecurity.with.Ubuntu_07.12.21.1.pdf">Cybersecurity with Ubuntu datasheet&nbsp;&rsaquo;</a>
+        </h3>
+      </div>
+      <div class="col-4 p-card u-align--center">
+        <p>
+          <a>
+            {{ image (
             url="https://assets.ubuntu.com/v1/b061c401-White+paper.svg",
             alt="",
             width="54",
@@ -133,341 +165,348 @@
             hi_def=True,
             loading="lazy"
             ) | safe
-          }}
-        </a>
-      </p>
-      <h3 class="p-heading--4 u-no-margin--bottom"><a href="https://assets.ubuntu.com/v1/66fcd858-canonical-ubuntu-core-security-2018-11-13.pdf">Ubuntu Core security&nbsp;&rsaquo;</a></h3>
-    </div>
-  </div>
-</section>
-
-<section class="p-strip--light is-deep">
-  <div class="u-fixed-width">
-    <h2>Canonical puts security at the heart of Ubuntu</h2>
-  </div>
-  <div class="u-fixed-width">
-    <ul class="p-matrix is-trisected">
-      <li class="p-matrix__item">
-        <div>
-          <h3 class="p-matrix__title p-heading--4">Fast fixes</h3>
-          <p class="p-matrix__desc">No system is 100% secure and vulnerabilities will always arise. What matters is the speed and success with which they are resolved &mdash; and nobody makes fixes available faster than Canonical.</p>
-        </div>
-      </li>
-      <li class="p-matrix__item">
-        <div>
-          <h3 class="p-matrix__title p-heading--4">Automatic updates</h3>
-          <p class="p-matrix__desc">Security updates are provided for ten years for long term support (LTS) releases. With the default configuration for unattended upgrades (16.04 and after), these updates get applied to your system automatically.</p>
-        </div>
-      </li>
-      <li class="p-matrix__item">
-        <div>
-          <h3 class="p-matrix__title p-heading--4">Livepatch</h3>
-          <p class="p-matrix__desc">The Ubuntu Livepatch Service enables live automatic security fixes to the kernel without rebooting. This service reduces unplanned downtime while maintaining compliance and security.</p>
-        </div>
-      </li>
-      <li class="p-matrix__item">
-        <div>
-          <h3 class="p-matrix__title p-heading--4">10 years of support</h3>
-          <p class="p-matrix__desc">A new LTS (Long Term Support) version of Ubuntu is released every two years, for desktop and server. Both versions receive updates and are supported for ten years.</p>
-        </div>
-      </li>
-      <li class="p-matrix__item">
-        <div>
-          <h3 class="p-matrix__title p-heading--4">Expanded security</h3>
-          <p class="p-matrix__desc">Canonical offers Expanded Security Maintenance (ESM) for infrastructure and applications to provide kernel livepatches and vulnerability fixes through a secure and private archive.</p>
-        </div>
-      </li>
-      <li class="p-matrix__item">
-        <div>
-          <h3 class="p-matrix__title p-heading--4">FIPS</h3>
-          <p class="p-matrix__desc">Ubuntu provides you with FIPS 140 certified cryptographic packages enabling Linux workloads to run on U.S. government regulated and high security environments.</p>
-        </div>
-      </li>
-      <li class="p-matrix__item">
-        <div>
-          <h3 class="p-matrix__title p-heading--4">Designed to be secure</h3>
-          <p class="p-matrix__desc">Linux is based on Unix. It inherits Discretionary Access Control and includes Mandatory Access Control via AppArmor.</p>
-        </div>
-      </li>
-      <li class="p-matrix__item">
-        <div>
-          <h3 class="p-matrix__title p-heading--4">Protected VMs</h3>
-          <!-- <p class="p-matrix__desc">LXD containers, libvirt VMs and OpenStack VMs are protected by AppArmor by default. A rich set of profiles are provided so users can opt-in to protection for other applications.</p> -->
-        </div>
-      </li>
-      <li class="p-matrix__item">
-        <div>
-          <h3 class="p-matrix__title p-heading--4">Secure snap packages</h3>
-          <p class="p-matrix__desc">Software packages delivered as strict-mode snaps are fully confined using AppArmor, device cgroups, and seccomp.</p>
-        </div>
-      </li>
-    </ul>
-  </div>
-</section>
-
-{% include "shared/_case-study-itstrategen.html" %}
-
-<section class="p-strip--light">
-  <div class="u-fixed-width">
-    <h2 class="p-muted-heading">Ubuntu is trusted by</h2>
-    <div class="p-logo-section has-misaligned-images">
-      <div class="p-logo-section__items">
-        <div class="p-logo-section__item">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/b7693339-logo-bloomberg.svg",
-              alt="Bloomberg",
-              height="28",
-              width="144",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-logo-section__logo"}
-            ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/d8f890fb-logo-at%26t.svg",
-              alt="AT&amp;T",
-              height="88",
-              width="88",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-logo-section__logo"}
-            ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/03a06060-logo-deutschetelekom.svg",
-              alt="Deutsche Telekom",
-              height="32",
-              width="144",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-logo-section__logo"}
-            ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/e0f7037f-logo-ebay.svg",
-              alt="Ebay",
-              height="55",
-              width="144",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-logo-section__logo"}
-            ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/4d6054f9-logo-cisco.svg",
-              alt="Cisco",
-              height="76",
-              width="144",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-logo-section__logo"}
-            ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/73135672-ntt-logo.svg",
-              alt="NTT",
-              height="53",
-              width="144",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-logo-section__logo"}
-            ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/8393d534-logo-bestbuy.svg",
-              alt="Best Buy",
-              height="84",
-              width="144",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-logo-section__logo"}
-            ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/0c18b0ae-paypal_logo.svg",
-              alt="PayPal",
-              height="36",
-              width="144",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-logo-section__logo"}
-            ) | safe
-          }}
-        </div>
+            }}
+          </a>
+        </p>
+        <h3 class="p-heading--4 u-no-margin--bottom">
+          <a href="https://assets.ubuntu.com/v1/66fcd858-canonical-ubuntu-core-security-2018-11-13.pdf">Ubuntu Core security&nbsp;&rsaquo;</a>
+        </h3>
       </div>
     </div>
-  </div>
-</section>
+  </section>
 
-<section class="p-strip is-deep u-image-position">
-  <div class="row">
-    <div class="col-7">
-      <h2>Find out why the UK Government puts Ubuntu in first place for security</h2>
-      <p><abbr title="Communications-Electronics Security Group">CESG</abbr>, the security arm of the UK government rated Ubuntu as the most secure operating system of the 11 they tested.</p>
-      <p><a class="p-button" href="/blog/ubuntu-scores-highest-in-uk-gov-security-assessment"><span>Read the <span class="u-off-screen">UK Gov Report Summary </span>case study</span></a></p>
+  <section class="p-strip--light is-deep">
+    <div class="u-fixed-width">
+      <h2>Canonical puts security at the heart of Ubuntu</h2>
     </div>
-    <div class="col-5 u-align--center u-vertically-center">
-      {{
-        image(
-          url="https://assets.ubuntu.com/v1/7953a068-security-1.svg",
-          alt="",
-          height="240",
-          width="200",
-          hi_def=True,
-          loading="lazy",
-          attrs={"class": "u-hide--small u-hide--medium"}
-        ) | safe
-      }}
-    </div>
-  </div>
-</section>
-
-<section class="p-strip--light is-deep">
-  <div class="row">
-    <div class="col-8">
-      <h2>Helping you manage security</h2>
-      <p>Every Long Term Support (LTS) release of Ubuntu comes with five years of free security and maintenance updates for the main OS. Canonical also offers a number of additional products and services to help manage the security of your Ubuntu systems.</p>
-    </div>
-  </div>
-  <div class="row u-equal-height">
-    <div class="col-6 p-card">
-      <h3>Reduce downtime and unplanned work</h3>
-      <p>The Ubuntu Livepatch service eliminates the need for unplanned maintenance windows for high and critical severity kernel vulnerabilities by patching the Linux kernel while the system runs. Reduce fire drills while keeping uninterrupted service with Ubuntu Livepatch service for up to ten years.</p>
-      <p>
-        <a href="/security/livepatch">
-          Learn more about the Livepatch Service&nbsp;&rsaquo;
-        </a>
-      </p>
-    </div>
-    <div class="col-6 p-card">
-      <h3>Be compliant and FIPS certified</h3>
-      <p>Developing and running workloads for high security and government regulated environments requires a long and expensive validation process. Reduce your accreditation timeline and pass on your validation costs with the FIPS 140 and Common Criteria certifications available with Ubuntu Advantage and Pro.</p>
-      <p>
-        <a href="/security/certifications">
-          Learn more about Ubuntu certifications&nbsp;&rsaquo;
-        </a>
-      </p>
-    </div>
-  </div>
-  <div class="row u-equal-height">
-    <div class="col-6 p-card">
-      <h3>Manage security updates with Landscape</h3>
-      <p>Landscape is the leading management tool to deploy, monitor and manage your Ubuntu servers and desktops. Landscape gives the ability to centrally view and manage the security updates that have been applied to their systems and, critically, the security updates which have not yet been applied.</p>
-      <p>
-        <a href="https://landscape.canonical.com">
-          Get Landscape
-        </a>
-      </p>
-    </div>
-    <div class="col-6 p-card">
-      <h3>Expand your Ubuntu security maintenance</h3>
-      <p>Canonical offers Expanded Security Maintenance (ESM), to Ubuntu Pro customers to provide important security fixes for the kernel and essential user space packages, toolchains, and applications. These updates are delivered via a secure, private archive exclusively available to Canonical customers.</p>
-      <p>
-        <a href="/engage/14-04-esm">
-          Watch our security compliance webinar now&nbsp;&rsaquo;
-        </a>
-      </p>
-    </div>
-  </div>
-</section>
-
-<section class="p-strip is-deep" id="ua-support">
-  <div class="row">
-    <div class="col-7">
-      <h2>Ubuntu Pro</h2>
-      <p class="p-heading--4">All of our security products are available for a one off fee.</p>
-      <p>Ubuntu Pro is the professional package of tools, technology and expertise from Canonical, helping organisations around the world get the most out of their Ubuntu deployments. It includes access to:</p>
-      <ul class="p-list">
-        <li class="p-list__item is-ticked">Livepatch: automatic kernel security hotfixes without rebooting</li>
-        <li class="p-list__item is-ticked">FIPS: certified cryptographic modules available for compliance requirements</li>
-        <li class="p-list__item is-ticked">Landscape: the systems management tool for using Ubuntu at scale</li>
-        <li class="p-list__item is-ticked">Expanded Security Maintenance: critical, high and selected medium security updates </li>
-        <li class="p-list__item is-ticked">Knowledge Base: a private archive of expert-written articles and tutorials</li>
-        <li class="p-list__item is-ticked">Optional support: phone and web-based support at multiple service levels</li>
-      </ul>
-      <p><a href="/pro" class="p-button--positive">Purchase Ubuntu Pro</a></p>
-      <p><a href="/support/contact-us" class="js-invoke-modal">Contact us about Ubuntu Pro&nbsp;&rsaquo;</a></p>
-    </div>
-  </div>
-</section>
-
-<section class="p-strip--light">
-  <div class="row u-equal-height">
-    <div class="col-8">
-      <h2>Talk to a member of our team</h2>
-      <p class="p-heading--4">We can recommend a security solution that best suits the needs of your&nbsp;organisation.</p>
-      <ul class="p-inline-list">
-        <li class="p-inline-list__item">
-          <a href="/support/contact-us" class="p-button js-invoke-modal">Contact us</a>
+    <div class="u-fixed-width">
+      <ul class="p-matrix is-trisected">
+        <li class="p-matrix__item">
+          <div>
+            <h3 class="p-matrix__title p-heading--4">Fast fixes</h3>
+            <p class="p-matrix__desc">
+              No system is 100% secure and vulnerabilities will always arise. What matters is the speed and success with which they are resolved &mdash; and nobody makes fixes available faster than Canonical.
+            </p>
+          </div>
+        </li>
+        <li class="p-matrix__item">
+          <div>
+            <h3 class="p-matrix__title p-heading--4">Automatic updates</h3>
+            <p class="p-matrix__desc">
+              Security updates are provided for ten years for long term support (LTS) releases. With the default configuration for unattended upgrades (16.04 and after), these updates get applied to your system automatically.
+            </p>
+          </div>
+        </li>
+        <li class="p-matrix__item">
+          <div>
+            <h3 class="p-matrix__title p-heading--4">Livepatch</h3>
+            <p class="p-matrix__desc">
+              The Ubuntu Livepatch Service enables live automatic security fixes to the kernel without rebooting. This service reduces unplanned downtime while maintaining compliance and security.
+            </p>
+          </div>
+        </li>
+        <li class="p-matrix__item">
+          <div>
+            <h3 class="p-matrix__title p-heading--4">10 years of support</h3>
+            <p class="p-matrix__desc">
+              A new LTS (Long Term Support) version of Ubuntu is released every two years, for desktop and server. Both versions receive updates and are supported for ten years.
+            </p>
+          </div>
+        </li>
+        <li class="p-matrix__item">
+          <div>
+            <h3 class="p-matrix__title p-heading--4">Expanded security</h3>
+            <p class="p-matrix__desc">
+              Canonical offers Expanded Security Maintenance (ESM) for infrastructure and applications to provide kernel livepatches and vulnerability fixes through a secure and private archive.
+            </p>
+          </div>
+        </li>
+        <li class="p-matrix__item">
+          <div>
+            <h3 class="p-matrix__title p-heading--4">FIPS</h3>
+            <p class="p-matrix__desc">
+              Ubuntu provides you with FIPS 140 certified cryptographic packages enabling Linux workloads to run on U.S. government regulated and high security environments.
+            </p>
+          </div>
+        </li>
+        <li class="p-matrix__item">
+          <div>
+            <h3 class="p-matrix__title p-heading--4">Designed to be secure</h3>
+            <p class="p-matrix__desc">
+              Linux is based on Unix. It inherits Discretionary Access Control and includes Mandatory Access Control via AppArmor.
+            </p>
+          </div>
+        </li>
+        <li class="p-matrix__item">
+          <div>
+            <h3 class="p-matrix__title p-heading--4">Protected VMs</h3>
+            <!-- <p class="p-matrix__desc">LXD containers, libvirt VMs and OpenStack VMs are protected by AppArmor by default. A rich set of profiles are provided so users can opt-in to protection for other applications.</p> -->
+          </div>
+        </li>
+        <li class="p-matrix__item">
+          <div>
+            <h3 class="p-matrix__title p-heading--4">Secure snap packages</h3>
+            <p class="p-matrix__desc">
+              Software packages delivered as strict-mode snaps are fully confined using AppArmor, device cgroups, and seccomp.
+            </p>
+          </div>
         </li>
       </ul>
     </div>
+  </section>
 
-    <div class="col-4 u-hide--medium u-hide--small u-align--center u-vertically-center">
-      {{
-        image(
-          url="https://assets.ubuntu.com/v1/c4b290c8-Contact+us.svg",
-          alt="",
-          height="178",
-          width="250",
-          hi_def=True,
-          loading="lazy",
-        ) | safe
-      }}
+  {% include "shared/_case-study-itstrategen.html" %}
+
+  <section class="p-strip--light">
+    <div class="u-fixed-width">
+      <h2 class="p-muted-heading">Ubuntu is trusted by</h2>
+      <div class="p-logo-section has-misaligned-images">
+        <div class="p-logo-section__items">
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/b7693339-logo-bloomberg.svg",
+                        alt="Bloomberg",
+                        height="28",
+                        width="144",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/d8f890fb-logo-at%26t.svg",
+                        alt="AT&amp;T",
+                        height="88",
+                        width="88",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/03a06060-logo-deutschetelekom.svg",
+                        alt="Deutsche Telekom",
+                        height="32",
+                        width="144",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/e0f7037f-logo-ebay.svg",
+                        alt="Ebay",
+                        height="55",
+                        width="144",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/4d6054f9-logo-cisco.svg",
+                        alt="Cisco",
+                        height="76",
+                        width="144",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/73135672-ntt-logo.svg",
+                        alt="NTT",
+                        height="53",
+                        width="144",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/8393d534-logo-bestbuy.svg",
+                        alt="Best Buy",
+                        height="84",
+                        width="144",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/0c18b0ae-paypal_logo.svg",
+                        alt="PayPal",
+                        height="36",
+                        width="144",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+        </div>
+      </div>
     </div>
-  </div>
-</section>
+  </section>
 
-<section class="p-strip is-deep">
-  <div class="row u-equal-height">
-    <div class="col-4 u-hide--medium u-hide--small u-align--center u-vertically-center">
-      {{
-        image(
-          url="https://assets.ubuntu.com/v1/7076ef2d-ubuntu-documents.svg",
-          alt="",
-          height="178",
-          width="145",
-          hi_def=True,
-          loading="lazy",
-        ) | safe
-      }}
+  <section class="p-strip is-deep u-image-position">
+    <div class="row">
+      <div class="col-7">
+        <h2>Find out why the UK Government puts Ubuntu in first place for security</h2>
+        <p>
+          <abbr title="Communications-Electronics Security Group">CESG</abbr>, the security arm of the UK government rated Ubuntu as the most secure operating system of the 11 they tested.
+        </p>
+        <p>
+          <a class="p-button"
+             href="/blog/ubuntu-scores-highest-in-uk-gov-security-assessment"><span>Read the <span class="u-off-screen">UK Gov Report Summary</span>case study</span></a>
+        </p>
+      </div>
+      <div class="col-5 u-align--center u-vertically-center">
+        {{ image(url="https://assets.ubuntu.com/v1/7953a068-security-1.svg",
+                alt="",
+                height="240",
+                width="200",
+                hi_def=True,
+                loading="lazy",
+                attrs={"class": "u-hide--small u-hide--medium"}) | safe
+        }}
+      </div>
     </div>
-    <div class="col-8">
-      <h2>Ubuntu security disclosure policy</h2>
-      <p>
-        Canonical and the Ubuntu Security Team participate in responsible disclosure and collaborate with the wider community on security issues.
-        For more information on how to contact the Ubuntu Security Team and expectations, please refer to our <a href="/security/disclosure-policy">Ubuntu Security disclosure and embargo policy</a>.
-      </p>
+  </section>
+
+  <section class="p-strip--light is-deep">
+    <div class="row">
+      <div class="col-8">
+        <h2>Helping you manage security</h2>
+        <p>
+          Every Long Term Support (LTS) release of Ubuntu comes with five years of free security and maintenance updates for the main OS. Canonical also offers a number of additional products and services to help manage the security of your Ubuntu systems.
+        </p>
+      </div>
     </div>
-  </div>
-</section>
+    <div class="row u-equal-height">
+      <div class="col-6 p-card">
+        <h3>Reduce downtime and unplanned work</h3>
+        <p>
+          The Ubuntu Livepatch service eliminates the need for unplanned maintenance windows for high and critical severity kernel vulnerabilities by patching the Linux kernel while the system runs. Reduce fire drills while keeping uninterrupted service with Ubuntu Livepatch service for up to ten years.
+        </p>
+        <p>
+          <a href="/security/livepatch">Learn more about the Livepatch Service&nbsp;&rsaquo;</a>
+        </p>
+      </div>
+      <div class="col-6 p-card">
+        <h3>Be compliant and FIPS certified</h3>
+        <p>
+          Developing and running workloads for high security and government regulated environments requires a long and expensive validation process. Reduce your accreditation timeline and pass on your validation costs with the FIPS 140 and Common Criteria certifications available with Ubuntu Advantage and Pro.
+        </p>
+        <p>
+          <a href="/security/certifications">Learn more about Ubuntu certifications&nbsp;&rsaquo;</a>
+        </p>
+      </div>
+    </div>
+    <div class="row u-equal-height">
+      <div class="col-6 p-card">
+        <h3>Manage security updates with Landscape</h3>
+        <p>
+          Landscape is the leading management tool to deploy, monitor and manage your Ubuntu servers and desktops. Landscape gives the ability to centrally view and manage the security updates that have been applied to their systems and, critically, the security updates which have not yet been applied.
+        </p>
+        <p>
+          <a href="https://landscape.canonical.com">Get Landscape</a>
+        </p>
+      </div>
+      <div class="col-6 p-card">
+        <h3>Expand your Ubuntu security maintenance</h3>
+        <p>
+          Canonical offers Expanded Security Maintenance (ESM), to Ubuntu Pro customers to provide important security fixes for the kernel and essential user space packages, toolchains, and applications. These updates are delivered via a secure, private archive exclusively available to Canonical customers.
+        </p>
+        <p>
+          <a href="/engage/14-04-esm">Watch our security compliance webinar now&nbsp;&rsaquo;</a>
+        </p>
+      </div>
+    </div>
+  </section>
 
-{% with first_item="_security_discussion", second_item="_security_esm", third_item="_security_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
+  <section class="p-strip is-deep" id="ua-support">
+    <div class="row">
+      <div class="col-7">
+        <h2>Ubuntu Pro</h2>
+        <p class="p-heading--4">All of our security products are available for a one off fee.</p>
+        <p>
+          Ubuntu Pro is the professional package of tools, technology and expertise from Canonical, helping organisations around the world get the most out of their Ubuntu deployments. It includes access to:
+        </p>
+        <ul class="p-list">
+          <li class="p-list__item is-ticked">Livepatch: automatic kernel security hotfixes without rebooting</li>
+          <li class="p-list__item is-ticked">FIPS: certified cryptographic modules available for compliance requirements</li>
+          <li class="p-list__item is-ticked">Landscape: the systems management tool for using Ubuntu at scale</li>
+          <li class="p-list__item is-ticked">
+            Expanded Security Maintenance: critical, high and selected medium security updates
+          </li>
+          <li class="p-list__item is-ticked">Knowledge Base: a private archive of expert-written articles and tutorials</li>
+          <li class="p-list__item is-ticked">Optional support: phone and web-based support at multiple service levels</li>
+        </ul>
+        <p>
+          <a href="/pro" class="p-button--positive">Purchase Ubuntu Pro</a>
+        </p>
+        <p>
+          <a href="/support/contact-us" class="js-invoke-modal">Contact us about Ubuntu Pro&nbsp;&rsaquo;</a>
+        </p>
+      </div>
+    </div>
+  </section>
 
-<!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/general" data-form-id="1257" data-lp-id="2154" data-return-url="https://ubuntu.com/contact-us/form/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
-</div>
+  <section class="p-strip--light">
+    <div class="row u-equal-height">
+      <div class="col-8">
+        <h2>Talk to a member of our team</h2>
+        <p class="p-heading--4">We can recommend a security solution that best suits the needs of your&nbsp;organisation.</p>
+        <ul class="p-inline-list">
+          <li class="p-inline-list__item">
+            <a href="/support/contact-us" class="p-button js-invoke-modal">Contact us</a>
+          </li>
+        </ul>
+      </div>
+
+      <div class="col-4 u-hide--medium u-hide--small u-align--center u-vertically-center">
+        {{ image(url="https://assets.ubuntu.com/v1/c4b290c8-Contact+us.svg",
+                alt="",
+                height="178",
+                width="250",
+                hi_def=True,
+                loading="lazy",) | safe
+        }}
+      </div>
+    </div>
+  </section>
+
+  <section class="p-strip is-deep">
+    <div class="row u-equal-height">
+      <div class="col-4 u-hide--medium u-hide--small u-align--center u-vertically-center">
+        {{ image(url="https://assets.ubuntu.com/v1/7076ef2d-ubuntu-documents.svg",
+                alt="",
+                height="178",
+                width="145",
+                hi_def=True,
+                loading="lazy",) | safe
+        }}
+      </div>
+      <div class="col-8">
+        <h2>Ubuntu security disclosure policy</h2>
+        <p>
+          Canonical and the Ubuntu Security Team participate in responsible disclosure and collaborate with the wider community on security issues.
+          For more information on how to contact the Ubuntu Security Team and expectations, please refer to our <a href="/security/disclosure-policy">Ubuntu Security disclosure and embargo policy</a>.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  {% with first_item="_security_discussion", second_item="_security_esm", third_item="_security_further_reading" %}
+    {% include "shared/contextual_footers/_contextual_footer.html" %}
+  {% endwith %}
+
+  <!-- Set default Marketo information for contact form below-->
+  <div class="u-hide"
+       id="contact-form-container"
+       data-form-location="/shared/forms/interactive/general"
+       data-form-id="1257"
+       data-lp-id="2154"
+       data-return-url="https://ubuntu.com/contact-us/form/thank-you"
+       data-lp-url="https://pages.ubuntu.com/things-contact-us.html"></div>
 
 {% endblock content %}

--- a/templates/security/index.html
+++ b/templates/security/index.html
@@ -31,13 +31,7 @@
   </div>
 </section>
 
-<section class="p-strip">
-  <div class="row p-card">
-    <p style="max-width: none;">Need information about the CRA? Canonical is committed to delivering Cyber Resilience Act (CRA) compliant Ubuntu. To learn more, 
-      <a href="#get-in-touch">contact our sales team.</a>
-    </p>
-  </div>
- </section>
+{% include "shared/_cra-banner.html" %}
 
 <section class="p-strip is-deep">
   <div class="row p-divider">
@@ -198,7 +192,7 @@
       <li class="p-matrix__item">
         <div>
           <h3 class="p-matrix__title p-heading--4">Protected VMs</h3>
-          <p class="p-matrix__desc">LXD containers, libvirt VMs and OpenStack VMs are protected by AppArmor by default. A rich set of profiles are provided so users can opt-in to protection for other applications.</p>
+          <!-- <p class="p-matrix__desc">LXD containers, libvirt VMs and OpenStack VMs are protected by AppArmor by default. A rich set of profiles are provided so users can opt-in to protection for other applications.</p> -->
         </div>
       </li>
       <li class="p-matrix__item">

--- a/templates/security/index.html
+++ b/templates/security/index.html
@@ -31,6 +31,14 @@
   </div>
 </section>
 
+<section class="p-strip">
+  <div class="row p-card">
+    <p style="max-width: none;">Need information about the CRA? Canonical is committed to delivering Cyber Resilience Act (CRA) compliant Ubuntu. To learn more, 
+      <a href="#get-in-touch">contact our sales team.</a>
+    </p>
+  </div>
+ </section>
+
 <section class="p-strip is-deep">
   <div class="row p-divider">
     <div class="col-4 p-divider__block">

--- a/templates/shared/_cra-banner.html
+++ b/templates/shared/_cra-banner.html
@@ -1,4 +1,4 @@
-<section class="p-strip">
+<section class="p-strip u-no-padding--bottom">
   <div class="row">
     <div class="p-notification--information">
       <div class="p-notification__content">

--- a/templates/shared/_cra-banner.html
+++ b/templates/shared/_cra-banner.html
@@ -1,8 +1,10 @@
 <section class="p-strip">
-  <div class="row p-notification--information">
-    <div class="p-notification__content">
-      <div class="p-notification__message">Need information about the CRA? Canonical is committed to delivering Cyber Resilience Act (CRA) compliant Ubuntu. To learn more, 
-        <a href="#get-in-touch">contact our sales team.</a>
+  <div class="row">
+    <div class="p-notification--information">
+      <div class="p-notification__content">
+        <div class="p-notification__message">Need information about the CRA? Canonical is committed to delivering Cyber Resilience Act (CRA) compliant Ubuntu. To learn more, 
+          <a href="/security/contact-us">contact our sales team.</a>
+        </div>
       </div>
     </div>
   </div>

--- a/templates/shared/_cra-banner.html
+++ b/templates/shared/_cra-banner.html
@@ -1,0 +1,9 @@
+<section class="p-strip">
+  <div class="row p-notification--information">
+    <div class="p-notification__content">
+      <div class="p-notification__message">Need information about the CRA? Canonical is committed to delivering Cyber Resilience Act (CRA) compliant Ubuntu. To learn more, 
+        <a href="#get-in-touch">contact our sales team.</a>
+      </div>
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
_Go live date June 3rd_
## Done

- Add CRA banners to `/security` and `/security/certification` pages

## QA
- Go to demos for `/security`, check that changes are updated as per [copy docs](https://docs.google.com/document/d/13RcVvHBAoywfk3o5Dy-16F3KrMytL9-2v6wWbW444Ko/edit)
- Go to demos for `/security/certification`, check that changes are updated as per [copy docs](https://docs.google.com/document/d/1yEocR1WXQvN_B1L1yBYrG_0D7ikS6QhcOz27sYs-teI/edit)

## Issue / Card

Fixes [WD-11271](https://warthogs.atlassian.net/browse/WD-11271)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-11271]: https://warthogs.atlassian.net/browse/WD-11271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ