### PR TITLE
WIP Fix templates choose default template

### DIFF
--- a/templates/templates/_footer-copyright-and-legal.html
+++ b/templates/templates/_footer-copyright-and-legal.html
@@ -12,7 +12,7 @@
       <a href="" class="p-link--soft js-revoke-cookie-manager"><small>Manage your tracker settings</small></a>
     </li>
     <li class="p-inline-list__item">
-      <a class="p-link--soft" href="https://github.com/canonical/ubuntu.com/issues/new" id="report-a-bug">
+      <a class="p-link--soft" href="https://github.com/canonical/ubuntu.com/issues/new?template=ISSUE_TEMPLATE.md" id="report-a-bug">
         <small>Report a bug on this site</small>
       </a>
     </li>


### PR DESCRIPTION
## Done

Modified new issue url in the footer from https://github.com/canonical/canonical.com/issues/new to https://github.com/canonical/ubuntu.com/issues/new?template=ISSUE_TEMPLATE.md which uses a default template.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
