### PR TITLE
Update copy on /support

### DIFF
--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -614,7 +614,7 @@
         </div>
         <div class="row">
           <div class="col-3 col-medium-2 col-start-medium-2">
-            <h3 class="p-heading--5">ROCKs</h3>
+            <h3 class="p-heading--5">Rocks</h3>
           </div>
           <div class="col-6 col-medium-3">
             <p>
@@ -622,7 +622,7 @@
             </p>
             <ul class="p-list--divided">
               <li class="p-list__item has-bullet">
-                <a href="https://canonical-rockcraft.readthedocs-hosted.com/en/latest/explanation/rocks/">ROCKs</a>, Canonical's new generation of OCI-compliant, container images, built on top of Ubuntu LTS and optimised to run applications
+                <a href="https://canonical-rockcraft.readthedocs-hosted.com/en/latest/explanation/rocks/">Rocks</a>, Canonical's new generation of OCI-compliant, container images, built on top of Ubuntu LTS and optimised to run applications
               </li>
               <li class="p-list__item has-bullet">
                 <a href="https://ubuntu.com/engage/chiselled-ubuntu-images-for-containers">Chiselled Ubuntu</a>, Canonical's distroless container images that only fit the strictly required dependencies


### PR DESCRIPTION
## Done

- Update content on /support based on [copydoc](https://docs.google.com/document/d/1AU2dwTXpQk2UuEvSuAqRKrbPWYb-LR0ZGvWu6xw95I8/edit)

## QA

- Go to https://ubuntu-com-13891.demos.haus/support and check the content. It just changes 'ROCKS' to 'rocks' in 2 places

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-11516

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
