### PR TITLE
WD-11514 Modified "Rock" to "rock" and linted the /ceph/install.html

### DIFF
--- a/templates/ceph/install.html
+++ b/templates/ceph/install.html
@@ -68,8 +68,9 @@
           <hr class="p-separator is-shallow"/>
           <ol class="p-stepped-list">
             <li class="p-stepped-list__item">
-              <p class="p-stepped-list__title p-heading--4"/>
+              <p class="p-stepped-list__title p-heading--4">
                 To get started, install the MicroCeph snap with the following command on each node to be used in the cluster:
+              </p>
               <div class="p-stepped-list__content">
                 <div class="p-code-snippet">
                   <pre class="p-code-snippet__block"><code>sudo snap install microceph</code></pre>
@@ -77,8 +78,9 @@
               </div>
             </li>
             <li class="p-stepped-list__item">
-              <p class="p-stepped-list__title p-heading--4"/>
+              <p class="p-stepped-list__title p-heading--4">
                 Then bootstrap the cluster:
+              </p>
               <div class="p-stepped-list__content">
                 <div class="p-code-snippet">
                   <pre class="p-code-snippet__block"><code>sudo microceph cluster bootstrap</code></pre>
@@ -86,8 +88,9 @@
               </div>
             </li>
             <li class="p-stepped-list__item">
-              <p class="p-stepped-list__title p-heading--4"/>
+              <p class="p-stepped-list__title p-heading--4">
                 Check the cluster status with the following command:
+              </p>
               <div class="p-stepped-list__content">
                 <div class="p-code-snippet">
                   <pre class="p-code-snippet__block"><code>sudo microceph.ceph status</code></pre>
@@ -98,8 +101,9 @@
               </div>
             </li>
             <li class="p-stepped-list__item">
-              <p class="p-stepped-list__title p-heading--4"/>
+              <p class="p-stepped-list__title p-heading--4">
                 To use MicroCeph as a single node, the default CRUSH rules need to be modified:
+              </p>
               <div class="p-stepped-list__content">
                 <div class="p-code-snippet">
                   <pre class="p-code-snippet__block"><code>sudo microceph.ceph osd crush rule rm replicated_rule<br/>sudo microceph.ceph osd crush rule create-replicated single default osd</code></pre>
@@ -107,8 +111,9 @@
               </div>
             </li>
             <li class="p-stepped-list__item">
-              <p class="p-stepped-list__title p-heading--4"/>
+              <p class="p-stepped-list__title p-heading--4">
                 Next, add some disks that will be used as OSDs:
+              </p>
               <div class="p-stepped-list__content">
                 <div class="p-code-snippet">
                   <pre class="p-code-snippet__block"><code>sudo microceph disk add /dev/sd[x] --wipe</code></pre>
@@ -144,8 +149,9 @@
           <hr class="p-separator is-shallow"/>
           <ol class="p-stepped-list">
             <li class="p-stepped-list__item">
-              <p class="p-stepped-list__title p-heading--4"/>
+              <p class="p-stepped-list__title p-heading--4">
                 To get started, install the MicroCeph snap with the following command on each node to be used in the cluster:
+              </p>
               <div class="p-stepped-list__content">
                 <div class="p-code-snippet">
                   <pre class="p-code-snippet__block"><code>sudo snap install microceph</code></pre>
@@ -153,8 +159,9 @@
               </div> 
             </li>
             <li class="p-stepped-list__item">
-              <p class="p-stepped-list__title p-heading--4"/>
+              <p class="p-stepped-list__title p-heading--4">
                 Then bootstrap the cluster from the first node:
+              </p>
               <div class="p-stepped-list__content">
                 <div class="p-code-snippet">
                   <pre class="p-code-snippet__block"><code>sudo microceph cluster bootstrap</code></pre>
@@ -162,8 +169,9 @@
               </div>
             </li>
             <li class="p-stepped-list__item">
-              <p class="p-stepped-list__title p-heading--4"/>
+              <p class="p-stepped-list__title p-heading--4">
                 On the first node, add other nodes to the cluster:
+              </p>
 \              <div class="p-stepped-list__content">
                 <div class="p-code-snippet">
                   <pre class="p-code-snippet__block"><code>sudo microceph cluster add node[x]</code></pre>
@@ -171,8 +179,9 @@
               </div>
             </li>
             <li class="p-stepped-list__item">
-              <p class="p-stepped-list__title p-heading--4"/>
+              <p class="p-stepped-list__title p-heading--4">
                 Copy the resulting output to be used on node[x]:
+              </p>
 \              <div class="p-stepped-list__content">
                 <div class="p-code-snippet">
                   <pre class="p-code-snippet__block"><code>sudo microceph cluster join pasted-output-from-node1</code></pre>
@@ -181,8 +190,9 @@
               </div>
             </li>
             <li class="p-stepped-list__item">
-              <p class="p-stepped-list__title p-heading--4"/>
+              <p class="p-stepped-list__title p-heading--4">
                 Check the cluster status with the following command:
+              </p>
 \              <div class="p-stepped-list__content">
                 <div class="p-code-snippet">
                   <pre class="p-code-snippet__block"><code>sudo microceph.ceph status</code></pre>
@@ -190,8 +200,9 @@
               </div>
             </li>
             <li class="p-stepped-list__item">
-              <p class="p-stepped-list__title p-heading--4"/>
+              <p class="p-stepped-list__title p-heading--4">
                 Next, add some disks to each node that will be used as OSDs:
+              </p>
 \              <div class="p-stepped-list__content">
                 <div class="p-code-snippet">
                   <pre class="p-code-snippet__block"><code>sudo microceph disk add /dev/sd[x] --wipe</code></pre>

--- a/templates/ceph/install.html
+++ b/templates/ceph/install.html
@@ -214,7 +214,7 @@
             <li class="p-list__item is-ticked">Works with cephadm and rook</li>
             <li class="p-list__item is-ticked">Suitable for all types of containerised deployments</li>
           </ul>
-          <p>These installation instructions use the Canonical produced and supplied Ceph rock &ndash; this OCI compliant image provides a drop in replacement for the upstream Ceph OCI image.</p>
+          <p>These installation instructions use the Canonical produced and supplied Ceph rock &mdash; this OCI compliant image provides a drop in replacement for the upstream Ceph OCI image.</p>
           <p><a href="https://github.com/canonical/ceph-containers">Read the container image documentation&nbsp;&rsaquo;</a></p>
         </section>
       </div>

--- a/templates/ceph/install.html
+++ b/templates/ceph/install.html
@@ -65,12 +65,11 @@
               <p class="p-notification__message"> You will need a multi-core processor and at least 8GiB of memory and 100GB of disk space.  MicroCeph has been tested on x86-based physical and virtual machines running Ubuntu 22.04 LTS.</p>
             </div>
           </div>
-          <hr class="p-separator is-shallow">
+          <hr class="p-separator is-shallow"/>
           <ol class="p-stepped-list">
             <li class="p-stepped-list__item">
-              <p class="p-stepped-list__title p-heading--4">
+              <p class="p-stepped-list__title p-heading--4"/>
                 To get started, install the MicroCeph snap with the following command on each node to be used in the cluster:
-              </h3>
               <div class="p-stepped-list__content">
                 <div class="p-code-snippet">
                   <pre class="p-code-snippet__block"><code>sudo snap install microceph</code></pre>
@@ -78,9 +77,8 @@
               </div>
             </li>
             <li class="p-stepped-list__item">
-              <p class="p-stepped-list__title p-heading--4">
+              <p class="p-stepped-list__title p-heading--4"/>
                 Then bootstrap the cluster:
-              </h3>
               <div class="p-stepped-list__content">
                 <div class="p-code-snippet">
                   <pre class="p-code-snippet__block"><code>sudo microceph cluster bootstrap</code></pre>
@@ -88,9 +86,8 @@
               </div>
             </li>
             <li class="p-stepped-list__item">
-              <p class="p-stepped-list__title p-heading--4">
+              <p class="p-stepped-list__title p-heading--4"/>
                 Check the cluster status with the following command:
-              </h3>
               <div class="p-stepped-list__content">
                 <div class="p-code-snippet">
                   <pre class="p-code-snippet__block"><code>sudo microceph.ceph status</code></pre>
@@ -101,9 +98,8 @@
               </div>
             </li>
             <li class="p-stepped-list__item">
-              <p class="p-stepped-list__title p-heading--4">
+              <p class="p-stepped-list__title p-heading--4"/>
                 To use MicroCeph as a single node, the default CRUSH rules need to be modified:
-              </h3>
               <div class="p-stepped-list__content">
                 <div class="p-code-snippet">
                   <pre class="p-code-snippet__block"><code>sudo microceph.ceph osd crush rule rm replicated_rule<br/>sudo microceph.ceph osd crush rule create-replicated single default osd</code></pre>
@@ -111,9 +107,8 @@
               </div>
             </li>
             <li class="p-stepped-list__item">
-              <p class="p-stepped-list__title p-heading--4">
+              <p class="p-stepped-list__title p-heading--4"/>
                 Next, add some disks that will be used as OSDs:
-              </h3>
               <div class="p-stepped-list__content">
                 <div class="p-code-snippet">
                   <pre class="p-code-snippet__block"><code>sudo microceph disk add /dev/sd[x] --wipe</code></pre>
@@ -146,22 +141,20 @@
               <p class="p-notification__message">You will need 4 physical machines with multi-core processors and at least 8GiB of memory and 100GB of disk space. MicroCeph has been tested on x86-based physical machines running Ubuntu 22.04 LTS.</p>
             </div>
           </div>
-          <hr class="p-separator is-shallow">
+          <hr class="p-separator is-shallow"/>
           <ol class="p-stepped-list">
             <li class="p-stepped-list__item">
-              <p class="p-stepped-list__title p-heading--4">
+              <p class="p-stepped-list__title p-heading--4"/>
                 To get started, install the MicroCeph snap with the following command on each node to be used in the cluster:
-              </h3>
               <div class="p-stepped-list__content">
                 <div class="p-code-snippet">
                   <pre class="p-code-snippet__block"><code>sudo snap install microceph</code></pre>
                 </div>
-              </div>
+              </div> 
             </li>
             <li class="p-stepped-list__item">
-              <p class="p-stepped-list__title p-heading--4">
+              <p class="p-stepped-list__title p-heading--4"/>
                 Then bootstrap the cluster from the first node:
-              </h3>
               <div class="p-stepped-list__content">
                 <div class="p-code-snippet">
                   <pre class="p-code-snippet__block"><code>sudo microceph cluster bootstrap</code></pre>
@@ -169,20 +162,18 @@
               </div>
             </li>
             <li class="p-stepped-list__item">
-              <p class="p-stepped-list__title p-heading--4">
+              <p class="p-stepped-list__title p-heading--4"/>
                 On the first node, add other nodes to the cluster:
-              </h3>
-              <div class="p-stepped-list__content">
+\              <div class="p-stepped-list__content">
                 <div class="p-code-snippet">
                   <pre class="p-code-snippet__block"><code>sudo microceph cluster add node[x]</code></pre>
                 </div>
               </div>
             </li>
             <li class="p-stepped-list__item">
-              <p class="p-stepped-list__title p-heading--4">
+              <p class="p-stepped-list__title p-heading--4"/>
                 Copy the resulting output to be used on node[x]:
-              </h3>
-              <div class="p-stepped-list__content">
+\              <div class="p-stepped-list__content">
                 <div class="p-code-snippet">
                   <pre class="p-code-snippet__block"><code>sudo microceph cluster join pasted-output-from-node1</code></pre>
                 </div>
@@ -190,20 +181,18 @@
               </div>
             </li>
             <li class="p-stepped-list__item">
-              <p class="p-stepped-list__title p-heading--4">
+              <p class="p-stepped-list__title p-heading--4"/>
                 Check the cluster status with the following command:
-              </h3>
-              <div class="p-stepped-list__content">
+\              <div class="p-stepped-list__content">
                 <div class="p-code-snippet">
                   <pre class="p-code-snippet__block"><code>sudo microceph.ceph status</code></pre>
                 </div>
               </div>
             </li>
             <li class="p-stepped-list__item">
-              <p class="p-stepped-list__title p-heading--4">
+              <p class="p-stepped-list__title p-heading--4"/>
                 Next, add some disks to each node that will be used as OSDs:
-              </h3>
-              <div class="p-stepped-list__content">
+\              <div class="p-stepped-list__content">
                 <div class="p-code-snippet">
                   <pre class="p-code-snippet__block"><code>sudo microceph disk add /dev/sd[x] --wipe</code></pre>
                 </div>
@@ -221,11 +210,11 @@
         <section class="p-strip u-no-padding--top">
           <h2>Containerised deployment</h2>
           <ul class="p-list">
-            <li class="p-list__item is-ticked">Uses a Canonical-supplied and maintained ROCK (OCI image)</li>
+            <li class="p-list__item is-ticked">Uses a Canonical-supplied and maintained rock (OCI image)</li>
             <li class="p-list__item is-ticked">Works with cephadm and rook</li>
             <li class="p-list__item is-ticked">Suitable for all types of containerised deployments</li>
           </ul>
-          <p>These installation instructions use the Canonical produced and supplied Ceph ROCK &ndash; this OCI compliant image provides a drop in replacement for the upstream Ceph OCI image.</p>
+          <p>These installation instructions use the Canonical produced and supplied Ceph rock &ndash; this OCI compliant image provides a drop in replacement for the upstream Ceph OCI image.</p>
           <p><a href="https://github.com/canonical/ceph-containers">Read the container image documentation&nbsp;&rsaquo;</a></p>
         </section>
       </div>


### PR DESCRIPTION
## Done
- Changed occurance of "ROCKs" to "rocks" in ceph/install.html

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Also the [copydoc](https://docs.google.com/document/d/1EmOtHjuEMKhVLQA7GwyrKfCzOKfc8UCEyh-p04-PxzA/edit) for the change.
- [Demo](https://ubuntu-com-13892.demos.haus/ceph/install)

## Issue / Card
[WD-11514](https://warthogs.atlassian.net/browse/WD-11514)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)



[WD-11513]: https://warthogs.atlassian.net/browse/WD-11513?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[WD-11514]: https://warthogs.atlassian.net/browse/WD-11514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ