### PR TITLE
feat: Assign users to 'control' or 'variant' group and track with GA

### DIFF
--- a/static/js/src/main.js
+++ b/static/js/src/main.js
@@ -11,3 +11,4 @@ import "./mobile-footer-navigation.js";
 import "./smart-quotes.js";
 import "./prepare-form-inputs.js";
 import "./tabbed-content.js";
+import "./takeover-tracking.js";

--- a/static/js/src/takeover-tracking.js
+++ b/static/js/src/takeover-tracking.js
@@ -1,0 +1,20 @@
+import { getCookie, setCookie} from "./utils/cookies";
+
+(function() {
+  // check if user doesn't already have a group
+  if (!getCookie("control_or_variant")) {
+
+    // randomly assign to 'control' or 'variant' group
+    const group = Math.random() > 0.5 ? "control" : "variant";
+
+    // store group as cookie for 365 days
+    setCookie("control_or_variant", group, 365);
+
+    // send group info in GA event
+    dataLayer.push({
+      'event' : 'test',
+      'test_type' : 'element visibility',
+      'control_or_variant' : group,
+    });
+  }
+})();


### PR DESCRIPTION
## Done

- Add functionality to assign users to either a 'control' or 'variant' group, if they do not already belong to one, and stores it in their cookies for 365 days. The assignment is then sent to google analytics.

## QA

- Go to [demo]() and use chrome dev tools (or equivalent) to find the stored cookies for that page. Check that a cookie named 'control_or_variant' exists and has the value 'control' or 'variant'.
- Delete cookies a few times to check it randomly assigns one of the two values

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-11544

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
