### PR TITLE
Update core download link

### DIFF
--- a/templates/download/index.html
+++ b/templates/download/index.html
@@ -139,7 +139,7 @@ meta_copydoc %}
         <div class="p-section--shallow">
           <div class="row">
             <div class="col-3 col-medium-2">
-              <a href="/download/iot">
+              <a href="/download/core">
                 <h2>Core&nbsp;&rsaquo;</h2>
               </a>
             </div>


### PR DESCRIPTION
## Done

- Update download link for Core - [copy docs](https://docs.google.com/document/d/1egsCcmFiz8czeHsvwoB9Jz815Ij5Urtf7Ngrru6Zd4o/edit#heading=h.o0ts125bxkxo)

## QA

- Go to `/download`
- Click on Core hyperlink, should redirect to `/download/core`
## Issue / Card

Fixes [WD-11634](https://warthogs.atlassian.net/jira/software/c/projects/WD/boards/932?assignee=712020%3A55efc110-e0f6-401a-bcb0-b48a794b6dae&selectedIssue=WD-11634)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-11634]: https://warthogs.atlassian.net/browse/WD-11634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ