### PR TITLE
Add k8s 1.30 to support lifecycle

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -1008,6 +1008,18 @@ export var kubernetesReleases = [
     taskName: "Kubernetes 1.29",
     status: "CANONICAL_KUBERNETES_EXPANDED_SECURITY_MAINTENANCE",
   },
+  {
+    startDate: new Date("2024-04-15T00:00:00"),
+    endDate: new Date("2025-04-28T00:00:00"),
+    taskName: "Kubernetes 1.30",
+    status: "CANONICAL_KUBERNETES_SUPPORT",
+  },
+  {
+    startDate: new Date("2025-04-28T00:00:00"),
+    endDate: new Date("2025-12-28T00:00:00"),
+    taskName: "Kubernetes 1.30",
+    status: "CANONICAL_KUBERNETES_EXPANDED_SECURITY_MAINTENANCE",
+  },
 ];
 
 export var microStackReleases = [
@@ -1281,6 +1293,7 @@ export var microStackReleaseNames = [
 ];
 
 export var kubernetesReleaseNames = [
+  "Kubernetes 1.30",
   "Kubernetes 1.29",
   "Kubernetes 1.28",
   "Kubernetes 1.27",

--- a/templates/about/release_cycles/k8s-eol.html
+++ b/templates/about/release_cycles/k8s-eol.html
@@ -12,6 +12,12 @@
       </thead>
       <tbody>
         <tr>
+          <td><strong>1.30.x</strong></td>
+          <td>Apr 2024</td>
+          <td>Apr 2025</td>
+          <td>Dec 2025</td>
+        </tr>
+        <tr>
           <td><strong>1.29.x</strong></td>
           <td>Dec 2023</td>
           <td>Dec 2024</td>


### PR DESCRIPTION
## Done

- Added Kubernetes 1.30 release and support lifecycle dates

## QA

- Go to `/about/release-cycle#canonical-kubernetes-release-cycle`
- Check that Kubernetes 1.30 is present on chart and table with the correct dates:
  - release date: April 2024
  - end of n-2 support in April 2025
  - end of n-4 support in December 2025

## Issue / Card

Fixes [WD-11377](https://warthogs.atlassian.net/jira/software/c/projects/WD/boards/932?assignee=712020%3A55efc110-e0f6-401a-bcb0-b48a794b6dae&selectedIssue=WD-11377)

## Screenshots

<img width="1079" alt="Screenshot 2024-05-29 at 2 17 05 PM" src="https://github.com/canonical/ubuntu.com/assets/62298176/ee6894d9-1948-4fac-8cde-c211d9aaa578">


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-11377]: https://warthogs.atlassian.net/browse/WD-11377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ