### PR TITLE
fix: Fire control_or_variant tracking event on window load

### DIFF
--- a/static/js/src/takeover-tracking.js
+++ b/static/js/src/takeover-tracking.js
@@ -1,6 +1,6 @@
 import { getCookie, setCookie } from "./utils/cookies";
 
-(function () {
+window.onload = function () {
   // check if user doesn't already have a group
   if (!getCookie("control_or_variant")) {
     // randomly assign to 'control' or 'variant' group
@@ -16,4 +16,4 @@ import { getCookie, setCookie } from "./utils/cookies";
       control_or_variant: group,
     });
   }
-})();
+};


### PR DESCRIPTION
## Done

- [List of work items including drive-bys - remember to add the why and what of this work.]

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
