### PR TITLE
Change nVidia to NVIDIA and add corresponding redirect

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -136,6 +136,7 @@ certified/iot/models/?: "/certified/iot"
 certified/soc/models/?: "/certified/socs"
 certified/why-certified/?: "/certified/why-certify"
 certified/devices/?: "/certified/iot"
+certified/vendors/nVidia/?: "/certified/vendors/NVIDIA"
 certification/?: "/certified"
 
 cc/?: "/security/certifications"

--- a/webapp/certified/views.py
+++ b/webapp/certified/views.py
@@ -176,7 +176,6 @@ def get_vendors_releases_filters():
         vendors,
         releases,
     ) = get_filters(request.args)
-
     new_certified_params = _parse_query_params(vendors, releases)
     if not new_certified_params:
         vendor_filters = []
@@ -210,6 +209,8 @@ def get_vendors_releases_filters():
                 cat = "soc"
 
             for vendor in certified_makes:
+                if vendor["make"] == "nVidia":
+                    vendor["make"] = "NVIDIA"
                 make = vendor["make"]
 
                 if (
@@ -933,6 +934,10 @@ def certified_vendors(vendor):
         # Replace "Ubuntu Core" with "Device"
         if model["category"] == "Ubuntu Core":
             results[index]["category"] = "Device"
+
+        # Replace "nVidia" with "NVIDIA"
+        if model["make"] == "nVidia":
+            model["make"] = "NVIDIA"
 
     total_results = models["count"]
 


### PR DESCRIPTION
## Done

- Changed "nVidia" to "NVIDIA"

## QA

- View the site locally in your web browser at: https://ubuntu-com-13898.demos.haus/certified/vendors/nVidia
- See that you are redirected and the url now reads `.../NVIDIA` instead
- Check that the capitalization is correct in the hero, vendor filter, and results table

## Issue / Card

Fixes# https://warthogs.atlassian.net/browse/WD-11476

## Screenshots

![image](https://github.com/canonical/ubuntu.com/assets/17607612/4bc725bd-1179-437b-9eee-587553414c3d)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
