### PR TITLE
Switch from ip to tz for takeovers.

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -1139,7 +1139,7 @@
               ) {
                 var userCountry = JSON.parse(fetchUserCountry.responseText).country_code;
                 var selectedTakeovers = takeovers.filter(function(item) {
-                  if (item.target_country && item.target_country == userCountry) {
+                  if (item.target_country && item.target_country.toLowerCase() == userCountry.toLowerCase()) {
                     return true;
                   } else if (item.lang === primaryParentLanguage || item.lang === "") {
                     return true;
@@ -1185,7 +1185,8 @@
 
         xhr.open("GET", "/takeovers.json", true);
         xhr.send();
-        fetchUserCountry.open("GET", "/user-country.json", true);
+        const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+        fetchUserCountry.open("GET", `/user-country-tz.json?tz=${timezone}`, true);
         fetchUserCountry.send();
         takeoverAnimation.className += " is-loading";
       }

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -128,7 +128,6 @@ from webapp.views import (
     engage_thank_you,
     french_why_openstack,
     german_why_openstack,
-    get_user_country_by_ip,
     get_user_country_by_tz,
     json_asset_query,
     marketo_submit,
@@ -630,7 +629,6 @@ app.add_url_rule(
 core_services_guide.init_app(app)
 
 
-app.add_url_rule("/user-country.json", view_func=get_user_country_by_ip)
 app.add_url_rule("/user-country-tz.json", view_func=get_user_country_by_tz)
 
 # All other routes

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -1052,39 +1052,6 @@ def get_user_country_by_tz():
     )
 
 
-def get_user_country_by_ip():
-    x_forwarded_for = flask.request.headers.get("X-Forwarded-For")
-
-    if x_forwarded_for:
-        client_ip = x_forwarded_for.split(",")[0]
-    else:
-        client_ip = flask.request.remote_addr
-
-    ip_location = ip_reader.get(client_ip)
-
-    try:
-        country_code = ip_location["country"]["iso_code"]
-    except KeyError:
-        # geolite2 can't identify IP address
-        country_code = None
-    except Exception as error:
-        # Errors not documented in the geolite2 module
-        country_code = None
-        flask.current_app.extensions["sentry"].captureException(
-            extra={"ip_location object": ip_location, "error": error}
-        )
-
-    response = flask.jsonify(
-        {
-            "client_ip": client_ip,
-            "country_code": country_code,
-        }
-    )
-    response.cache_control.private = True
-
-    return response
-
-
 def subscription_centre():
     sfdcLeadId = flask.request.args.get("id")
     return_url = flask.request.form.get("returnURL")


### PR DESCRIPTION
## Done

- As a follow-up of [Sam's work](https://github.com/canonical/ubuntu.com/pull/13636), move to the timezone system for takeovers instead of IP addresses.
- Remove IP address geolocation

## QA

- Go to https://discourse.ubuntu.com/t/takeover-french-business-guide-to-multicloud/34968
- Edit the post and set `target_country` to your country code
- Go to the [demo homepage](https://ubuntu-com-13899.demos.haus/), reload a bunch of time until you see that takeover.
- Please if you not in too much of a hurry, revert back the Discourse takeover change.

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-7175

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
