### PR TITLE
[Fix] Handle deprecated products on checkout

### DIFF
--- a/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
@@ -198,6 +198,18 @@ const BuyButton = ({ setError, quantity, product, action }: Props) => {
           problem persists.
         </>
       );
+    } else if (
+      error.message.includes(
+        "missing one-off product listing for renewal product"
+      )
+    ) {
+      setError(
+        <>
+          The chosen product cannot be renewed as it has been deprecated.
+          Contact <a href="https://ubuntu.com/contact-us">Canonical sales</a>
+          to choose a substitute offering.
+        </>
+      );
     } else {
       const knownErrorMessage = getErrorMessage({
         message: "",

--- a/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
@@ -206,7 +206,7 @@ const BuyButton = ({ setError, quantity, product, action }: Props) => {
       setError(
         <>
           The chosen product cannot be renewed as it has been deprecated.
-          Contact <a href="https://ubuntu.com/contact-us">Canonical sales</a>
+          Contact <a href="https://ubuntu.com/contact-us">Canonical sales </a>
           to choose a substitute offering.
         </>
       );

--- a/static/js/src/advantage/subscribe/checkout/components/Summary/Summary.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Summary/Summary.tsx
@@ -94,7 +94,7 @@ function Summary({ quantity, product, action, setError }: Props) {
           <>
             {" "}
             The chosen product cannot be renewed as it has been deprecated.
-            Contact <a href="https://ubuntu.com/contact-us">Canonical sales</a>
+            Contact <a href="https://ubuntu.com/contact-us">Canonical sales </a>
             to choose a substitute offering.
           </>
         );

--- a/static/js/src/advantage/subscribe/checkout/components/Summary/Summary.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Summary/Summary.tsx
@@ -85,6 +85,19 @@ function Summary({ quantity, product, action, setError }: Props) {
             purchase, cancel your current trial subscription.
           </>
         );
+      } else if (
+        error.message.includes(
+          "missing one-off product listing for renewal product"
+        )
+      ) {
+        message = (
+          <>
+            {" "}
+            The chosen product cannot be renewed as it has been deprecated.
+            Contact <a href="https://ubuntu.com/contact-us">Canonical sales</a>
+            to choose a substitute offering.
+          </>
+        );
       } else {
         message = <>Sorry, there was an unknown error with your purchase.</>;
       }


### PR DESCRIPTION
## Description

When a customer tries to renew a subscription for now a deprecated product, the `ubuntu.com` website gets a similar error from the Ubuntu Pro backend: `missing one-off product listing for renewal product: "uaia-essential-virtual": product listing not found` The current front-end code does not handle this error message correctly, so the opaque `Sorry, there was an unknown error with your credit card` error message is shown on UI. This PR handles the case of a missing offering correctly and proposes the customer choose another product.

## TODO / considerations

It is too late to show such an error at checkout. I believe some validation should be added before going to checkout to ensure that the product is among `ValidProducts`. However, even despite this consideration, this PR is still relevant to handle integration errors on all levels.
