### PR TITLE
Fix image stretching text

### DIFF
--- a/templates/containers/chiselled/index.html
+++ b/templates/containers/chiselled/index.html
@@ -50,6 +50,7 @@ containers with 6x smaller attack surface and the advantages of a vendor-support
           <a href="/containers/contact-us" class="js-invoke-modal">Get support for chiselled
             containers&nbsp;&rsaquo;</a>
         </li>
+      </ul>
     </div>
   </div>
 </section>
@@ -68,7 +69,7 @@ containers with 6x smaller attack surface and the advantages of a vendor-support
     <hr class="p-rule" />
     <div class="col">
       <h2 class="p-text--small-caps u-no-margin--bottom">How to reduce container image size</h2>
-      <h3 class="p-heading--2">Chisel trims up to 80% of your containers’ attack surface.</h3>
+      <h3 class="p-heading--2">Chisel trims up to 80% of your containers' attack surface.</h3>
     </div>
     <div class="col">
       <div class="u-embedded-media ">
@@ -77,7 +78,7 @@ containers with 6x smaller attack surface and the advantages of a vendor-support
           allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
           allowfullscreen></iframe>
       </div>
-      <hr class="p-rule">
+      <hr class="p-rule" />
       <p>Mark Lewis, VP Application Services at Canonical, explains how chisel works.</p>
     </div>
   </div>
@@ -96,7 +97,7 @@ containers with 6x smaller attack surface and the advantages of a vendor-support
           image increases, so does the potential for vulnerabilities and known security issues.</p>
         <p>According to Sysdig, 87% of container images have high or critical vulnerabilities.</p>
       </div>
-      <hr class="p-rule">
+      <hr class="p-rule" />
       <p>
         <a href="/blog/chiselled-containers-perfect-gift-cloud-applications">Explore the benefits of smaller container
           images&nbsp;&rsaquo;</a>
@@ -374,7 +375,7 @@ containers with 6x smaller attack surface and the advantages of a vendor-support
             href="https://hub.docker.com/r/ubuntu/jre">Java</a>
         </li>
       </ul>
-      <hr class="p-rule">
+      <hr class="p-rule" />
       <p>
         <a href="https://canonical-oci.readthedocs-hosted.com/en/latest/oci-how-to/create-chiselled-ubuntu-image/">Get
           started today&nbsp;&rsaquo;</a>
@@ -399,7 +400,7 @@ containers with 6x smaller attack surface and the advantages of a vendor-support
         </li>
         <li class="p-list__item has-bullet">24/7 phone and ticket customer support</li>
       </ul>
-      <hr class="p-rule">
+      <hr class="p-rule" />
       <p><a href="/security/docker-images">Read more about our support commitments&nbsp;&rsaquo;</a></p>
     </div>
   </div>
@@ -439,7 +440,7 @@ containers with 6x smaller attack surface and the advantages of a vendor-support
             </li>
             <li class="p-list__item">
               <a href="https://canonical-rockcraft.readthedocs-hosted.com/en/latest/tutorials/chisel/">Install packages
-                slices into a ROCK</a>
+                slices into a rock</a>
             </li>
           </ul>
         </div>

--- a/templates/engage/base.html
+++ b/templates/engage/base.html
@@ -3,9 +3,9 @@
 {% set section_title="Engage Page" %}
 {% set section_path="/engage" %}
 
-{% block title %}{{metadata['topic_name']}}{% endblock %}
-{% block meta_description %}{{metadata['subtitle']}}{% endblock %}
-{% block meta_image %}{{metadata['meta_image']}}{% endblock %}
+{% block title %}{{ metadata['topic_name'] }}{% endblock %}
+{% block meta_description %}{{ metadata['subtitle'] }}{% endblock %}
+{% block meta_image %}{{ metadata['meta_image'] }}{% endblock %}
 
 {% block head_extra %}
   {% if 'active' in metadata and metadata['active'] == "false" %}
@@ -22,9 +22,9 @@
 
 {% block content %}
 
-<span id="publish_date" class="u-hide">{{metadata["publish_date"]}}</span>
-<span id="created_date" class="u-hide">{{metadata["created_at"]}}</span>
-<section class="p-strip p-engage-banner--{{metadata['banner_class']}}">
+<span id="publish_date" class="u-hide">{{ metadata["publish_date"] }}</span>
+<span id="created_date" class="u-hide">{{ metadata["created_at"] }}</span>
+<section class="p-strip p-engage-banner--{{ metadata['banner_class'] }}">
   <div class="u-fixed-width navigation-logo-engage">
     <a href="/">
       {% if metadata['banner_class'] == 'light' %}
@@ -53,7 +53,7 @@
     </a>
   </div>
   <div class="row">
-    <div class="col-7 u-vertically-center">
+    <div class="col-7">
       <h1>{{ metadata["topic_name"] }}</h1>
       <p class="u-no-padding--top p-heading--4">
         {{ metadata['subtitle'] }}
@@ -73,7 +73,7 @@
     </div>
     {% if metadata["image"] != '' %}
     <div class="col-5 u-hide--small u-hide--medium u-vertically-center u-align--center">
-      <img src="{{metadata['image']}}" alt="" width="{{metadata['image_width']}}"/>
+      <img src="{{ metadata['image'] }}" alt="" width="{{ metadata['image_width'] }}"/>
     </div>
     {% endif %}
   </div>


### PR DESCRIPTION
## QA

- Go to https://ubuntu-com-13910.demos.haus/engage/exploring-edge-computing-in-automotive and check that the image is not stretching anymore.
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-7416

## Screenshots

Previous:
![screenshot-article-author](https://github.com/canonical/ubuntu.com/assets/14939793/2c160f79-79d4-4993-b9e1-cf731a94ccab)

Fix:

<img width="1154" alt="Screenshot 2024-06-05 at 11 37 33" src="https://github.com/canonical/ubuntu.com/assets/14939793/29d4bf62-dd55-48a9-9bc4-994ba98a54e2">


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
