### PR TITLE
WD-11765-remove-14-04-and-add-24-04-to-the-pro-shop

### DIFF
--- a/static/js/src/advantage/subscribe/react/components/Form/Feature/Feature.test.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Feature/Feature.test.tsx
@@ -7,7 +7,6 @@ import {
   IoTDevices,
   ProductListings,
   ProductTypes,
-  LTSVersions,
 } from "advantage/subscribe/react/utils/utils";
 import { productListFixture } from "advantage/subscribe/react/utils/test/Mocks";
 
@@ -36,44 +35,6 @@ test("Feature sections disables Infra + Apps if destkop is selected", () => {
   expect(screen.getByTestId("infra-only")).toBeDisabled();
 });
 
-test("Ubuntu pro is disabled if physical & 14.04 server is selected", () => {
-  render(
-    <FormProvider
-      initialType={ProductTypes.physical}
-      initialVersion={LTSVersions.trusty}
-    >
-      <Feature />
-    </FormProvider>
-  );
-
-  expect(screen.getByTestId("pro")).toBeDisabled();
-});
-
-test("Ubuntu pro is disabled if desktops & 14.04 server is selected", () => {
-  render(
-    <FormProvider
-      initialType={ProductTypes.desktop}
-      initialVersion={LTSVersions.trusty}
-    >
-      <Feature />
-    </FormProvider>
-  );
-
-  expect(screen.getByTestId("pro")).toBeDisabled();
-});
-
-test("Ubuntu pro infra only is not disabled if desktop and 14.04 server is selected", () => {
-  render(
-    <FormProvider
-      initialType={ProductTypes.desktop}
-      initialVersion={LTSVersions.trusty}
-    >
-      <Feature />
-    </FormProvider>
-  );
-
-  expect(screen.getByTestId("infra-only")).not.toBeDisabled();
-});
 
 test("The section is disabled if a public cloud is selected", () => {
   render(

--- a/static/js/src/advantage/subscribe/react/components/Form/Feature/Feature.test.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Feature/Feature.test.tsx
@@ -35,7 +35,6 @@ test("Feature sections disables Infra + Apps if destkop is selected", () => {
   expect(screen.getByTestId("infra-only")).toBeDisabled();
 });
 
-
 test("The section is disabled if a public cloud is selected", () => {
   render(
     <FormProvider initialType={ProductTypes.publicCloud}>

--- a/static/js/src/advantage/subscribe/react/components/Form/Feature/Feature.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Feature/Feature.tsx
@@ -4,12 +4,11 @@ import { Col, RadioInput, Row } from "@canonical/react-components";
 import {
   Features,
   ProductTypes,
-  LTSVersions,
 } from "advantage/subscribe/react/utils/utils";
 import { FormContext } from "advantage/subscribe/react/utils/FormContext";
 
 const Feature = () => {
-  const { productType, feature, setFeature, version } = useContext(FormContext);
+  const { productType, feature, setFeature } = useContext(FormContext);
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setFeature(event.target.value as Features);
@@ -19,10 +18,8 @@ const Feature = () => {
     );
   };
 
-  const infraOnlyDisabled =
-    productType === ProductTypes.desktop && version !== LTSVersions.trusty;
+  const infraOnlyDisabled = productType === ProductTypes.desktop;
 
-  const proDisabled = version === LTSVersions.trusty;
 
   return (
     <>
@@ -47,7 +44,7 @@ const Feature = () => {
               checked={feature === Features.pro}
               value={Features.pro}
               onChange={handleChange}
-              disabled={proDisabled}
+              disabled={false}
               data-testid="pro"
             />
             <hr />

--- a/static/js/src/advantage/subscribe/react/components/Form/Feature/Feature.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Feature/Feature.tsx
@@ -1,10 +1,7 @@
 import React, { useContext } from "react";
 import classNames from "classnames";
 import { Col, RadioInput, Row } from "@canonical/react-components";
-import {
-  Features,
-  ProductTypes,
-} from "advantage/subscribe/react/utils/utils";
+import { Features, ProductTypes } from "advantage/subscribe/react/utils/utils";
 import { FormContext } from "advantage/subscribe/react/utils/FormContext";
 
 const Feature = () => {
@@ -19,7 +16,6 @@ const Feature = () => {
   };
 
   const infraOnlyDisabled = productType === ProductTypes.desktop;
-
 
   return (
     <>

--- a/static/js/src/advantage/subscribe/react/components/Form/Form.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Form.tsx
@@ -61,7 +61,7 @@ const Form = () => {
                   <h2>What Ubuntu LTS version are you running?</h2>
                   <p style={{ marginLeft: "3.6rem" }}>
                     {" "}
-                    Ubuntu Pro is available for Ubuntu 14.04 and higher.
+                    Ubuntu Pro is available for Ubuntu 16.04 and higher.
                     <br />{" "}
                     <a href="/contact-us/form?product=pro">
                       Are you using an older version?

--- a/static/js/src/advantage/subscribe/react/components/Form/Support/Support.test.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Support/Support.test.tsx
@@ -38,17 +38,6 @@ test("Infra support is disabled if desktop is selected", () => {
   expect(screen.getByTestId("full-support")).not.toBeDisabled();
 });
 
-test("Infra and full support are disabled if Trusty is selected", () => {
-  render(
-    <FormProvider initialVersion={LTSVersions.trusty}>
-      <Support />
-    </FormProvider>
-  );
-
-  expect(screen.getByTestId("infra-support")).toBeDisabled();
-  expect(screen.getByTestId("full-support")).toBeDisabled();
-});
-
 test("Infra and full support are disabled if Xenial is selected", () => {
   render(
     <FormProvider initialVersion={LTSVersions.xenial}>

--- a/static/js/src/advantage/subscribe/react/components/Form/Support/Support.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Support/Support.tsx
@@ -31,12 +31,10 @@ const Support = () => {
 
   const isInfraOnlyDisabled =
     productType === ProductTypes.desktop ||
-    version === LTSVersions.trusty ||
     version === LTSVersions.xenial;
 
   const isFullSupportDisabled =
     feature === Features.infra ||
-    version === LTSVersions.trusty ||
     version === LTSVersions.xenial;
 
   return (

--- a/static/js/src/advantage/subscribe/react/components/Form/Support/Support.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Support/Support.tsx
@@ -30,12 +30,10 @@ const Support = () => {
   };
 
   const isInfraOnlyDisabled =
-    productType === ProductTypes.desktop ||
-    version === LTSVersions.xenial;
+    productType === ProductTypes.desktop || version === LTSVersions.xenial;
 
   const isFullSupportDisabled =
-    feature === Features.infra ||
-    version === LTSVersions.xenial;
+    feature === Features.infra || version === LTSVersions.xenial;
 
   return (
     <div

--- a/static/js/src/advantage/subscribe/react/components/Form/Version/Version.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Version/Version.tsx
@@ -33,6 +33,12 @@ const CIS = (
     Ubuntu Security Guide (USG) for certified CIS benchmark tooling & automation
   </>
 );
+const CISComingSoon = (
+  <>
+    Ubuntu Security Guide (USG) for certified CIS benchmark tooling & automation
+    <StatusLabel appearance="positive">Coming soon</StatusLabel>
+  </>
+);
 const CommonCriteria = "Common Criteria EAL2";
 const ESMEndDate =
   "Expanded Security Maintenance (ESM) for packages in 'main' repository until";
@@ -44,6 +50,15 @@ const AAD =
 const PhysicalServerVersionDetails: {
   [key in LTSVersions]: Array<React.ReactNode>;
 } = {
+  [LTSVersions.noble]: [
+    `${ESMEndDate} 2034`,
+    livepatch,
+    CISComingSoon,
+    KVMDrivers,
+    landscape,
+    knowledgeBase,
+    realtimeKernel,
+  ],
   [LTSVersions.jammy]: [
     `${ESMEndDate} 2032`,
     livepatch,
@@ -82,19 +97,21 @@ const PhysicalServerVersionDetails: {
     KVMDrivers,
     landscape,
     knowledgeBase,
-  ],
-  [LTSVersions.trusty]: [
-    `${ESMEndDate} 2024`,
-    livepatch,
-    KVMDrivers,
-    landscape,
-    knowledgeBase,
-  ],
+  ]
 };
 
 const DesktopVersionDetails: {
   [key in LTSVersions]: Array<React.ReactNode>;
 } = {
+  [LTSVersions.noble]: [
+    `${DesktopESMEndDate} 2034`,
+    AAD,
+    livepatch,
+    CISComingSoon,
+    landscape,
+    knowledgeBase,
+    realtimeKernel,
+  ],
   [LTSVersions.jammy]: [
     `${DesktopESMEndDate} 2032`,
     AAD,
@@ -131,13 +148,7 @@ const DesktopVersionDetails: {
     CommonCriteria,
     landscape,
     knowledgeBase,
-  ],
-  [LTSVersions.trusty]: [
-    `${ESMEndDate} 2024`,
-    livepatch,
-    landscape,
-    knowledgeBase,
-  ],
+  ]
 };
 
 const Version = () => {

--- a/static/js/src/advantage/subscribe/react/components/Form/Version/Version.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Version/Version.tsx
@@ -97,7 +97,7 @@ const PhysicalServerVersionDetails: {
     KVMDrivers,
     landscape,
     knowledgeBase,
-  ]
+  ],
 };
 
 const DesktopVersionDetails: {
@@ -148,7 +148,7 @@ const DesktopVersionDetails: {
     CommonCriteria,
     landscape,
     knowledgeBase,
-  ]
+  ],
 };
 
 const Version = () => {

--- a/static/js/src/advantage/subscribe/react/components/ProductSummary/ProductSummary.test.tsx
+++ b/static/js/src/advantage/subscribe/react/components/ProductSummary/ProductSummary.test.tsx
@@ -41,7 +41,7 @@ test("Should show Ubuntu Pro Desktop when 'Desktops' is selected ", async () => 
     <FormProvider
       initialType={ProductTypes.desktop}
       initialUser={ProductUsers.organisation}
-      initialVersion={LTSVersions.trusty}
+      initialVersion={LTSVersions.jammy}
     >
       <ProductSummary />
     </FormProvider>

--- a/static/js/src/advantage/subscribe/react/components/ProductSummary/ProductSummary.tsx
+++ b/static/js/src/advantage/subscribe/react/components/ProductSummary/ProductSummary.tsx
@@ -134,7 +134,7 @@ const ProductSummary = () => {
         </Row>
       </section>
       <section
-        className={`p-strip--light is-shallow p-shop-cart--small u-hide u-show--medium ${
+        className={`p-strip--light is-shallow p-shop-cart--small u-hide u-show--small u-show--medium ${
           isHidden ? "p-shop-cart--hidden" : ""
         }`}
         id="summary-section"

--- a/static/js/src/advantage/subscribe/react/utils/FormContext.tsx
+++ b/static/js/src/advantage/subscribe/react/utils/FormContext.tsx
@@ -133,9 +133,6 @@ export const FormProvider = ({
   }, [support, sla]);
 
   useEffect(() => {
-    if (version === LTSVersions.trusty) {
-      setSupport(Support.none);
-    }
     if (version === LTSVersions.xenial) {
       setSupport(Support.none);
     }
@@ -159,12 +156,9 @@ export const FormProvider = ({
 
   useEffect(() => {
     if (
-      productType === ProductTypes.desktop &&
-      version !== LTSVersions.trusty
+      productType === ProductTypes.desktop
     ) {
       setFeature(Features.pro);
-    } else if (version === LTSVersions.trusty) {
-      setFeature(Features.infra);
     }
   }, [productType, feature, version]);
 

--- a/static/js/src/advantage/subscribe/react/utils/FormContext.tsx
+++ b/static/js/src/advantage/subscribe/react/utils/FormContext.tsx
@@ -155,9 +155,7 @@ export const FormProvider = ({
   }, [productType, support]);
 
   useEffect(() => {
-    if (
-      productType === ProductTypes.desktop
-    ) {
+    if (productType === ProductTypes.desktop) {
       setFeature(Features.pro);
     }
   }, [productType, feature, version]);

--- a/static/js/src/advantage/subscribe/react/utils/utils.ts
+++ b/static/js/src/advantage/subscribe/react/utils/utils.ts
@@ -131,11 +131,11 @@ export enum PublicClouds {
 }
 
 export enum LTSVersions {
+  noble = "24.04",
   jammy = "22.04",
   focal = "20.04",
   bionic = "18.04",
   xenial = "16.04",
-  trusty = "14.04",
 }
 
 export enum Support {


### PR DESCRIPTION
## Done

- Remove 14.04 from and add 24.04 to the Ubuntu Pro Shop

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Visit /pro/subscribe
    - Make sure 14.04 is not there anymore 
    - Make sure the content for 24.04 is in line with [the copy doc](https://docs.google.com/document/d/1UqL8YJH9ywvOXnrt3syY0U8fiOakfAGWmLS9uerwAWk/edit)
- Try to purchase the server or desktop subscription for 24.04
    - Ensure purchase goes through and that the new subscription shows up in the dashboard 

## Issue / Card

Fixes [#WD-11765](https://warthogs.atlassian.net/browse/WD-11765)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
