### PR TITLE
Update checkout data

### DIFF
--- a/static/js/src/advantage/credentials/components/CredExamShop/CredExamShop.tsx
+++ b/static/js/src/advantage/credentials/components/CredExamShop/CredExamShop.tsx
@@ -74,8 +74,12 @@ const CredExamShop = () => {
     localStorage.setItem(
       "shop-checkout-data",
       JSON.stringify({
-        product: ExamProducts[exam],
-        quantity: 1,
+        products: [
+          {
+            product: ExamProducts[exam],
+            quantity: 1,
+          },
+        ],
         action: "purchase",
       })
     );

--- a/static/js/src/advantage/offers/components/PaymentButton/PaymentButton.test.tsx
+++ b/static/js/src/advantage/offers/components/PaymentButton/PaymentButton.test.tsx
@@ -24,7 +24,7 @@ describe("PaymentButton", () => {
 
     expect(window.location.href).toBe("/account/checkout");
     expect(localStorage.getItem("shop-checkout-data")).toBe(
-      '{"product":{"longId":"oAaBbCcDdEe","period":"yearly","marketplace":"canonical-ua","id":"oAaBbCcDdEe","name":"1x Ubuntu Pro, 2x Ubuntu Pro (Infra)","price":{"value":50000},"canBeTrialled":false},"quantity":1,"action":"offer"}'
+      '{"products":[{"product":{"longId":"oAaBbCcDdEe","period":"yearly","marketplace":"canonical-ua","id":"oAaBbCcDdEe","name":"1x Ubuntu Pro, 2x Ubuntu Pro (Infra)","price":{"value":50000},"canBeTrialled":false},"quantity":1}],"action":"offer"}'
     );
   });
 });

--- a/static/js/src/advantage/offers/components/PaymentButton/PaymentButton.tsx
+++ b/static/js/src/advantage/offers/components/PaymentButton/PaymentButton.tsx
@@ -8,8 +8,12 @@ type Prop = {
 
 export default function PaymentButton({ product }: Prop) {
   const shopCheckoutData = {
-    product: product,
-    quantity: 1,
+    products: [
+      {
+        product,
+        quantity: 1,
+      },
+    ],
     action: "offer",
   };
 

--- a/static/js/src/advantage/react/components/Subscriptions/Content/Content.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/Content/Content.test.tsx
@@ -152,7 +152,7 @@ describe("Content", () => {
 
     expect(window.accountId).toBe("aAaBbCcDd");
     expect(localStorage.getItem("shop-checkout-data")).toBe(
-      '{"product":{"canBeTrialled":false,"longId":"lAaBbCcDdEe","name":"Ubuntu Pro","period":"yearly","price":{"value":7500},"id":"physical-uai-essential-weekday-yearly","marketplace":"canonical-ua"},"quantity":12,"action":"purchase"}'
+      '{"products":[{"product":{"canBeTrialled":false,"longId":"lAaBbCcDdEe","name":"Ubuntu Pro","period":"yearly","price":{"value":7500},"id":"physical-uai-essential-weekday-yearly","marketplace":"canonical-ua"},"quantity":12}],"action":"purchase"}'
     );
     expect(window.location.href).toBe("/account/checkout");
   });

--- a/static/js/src/advantage/react/components/Subscriptions/Content/Content.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/Content/Content.tsx
@@ -104,8 +104,12 @@ const Content = () => {
     };
 
     const shopCheckoutData = {
-      product: product,
-      quantity: parseInt(units),
+      products: [
+        {
+          product: product,
+          quantity: parseInt(units),
+        },
+      ],
       action: "purchase",
     };
 

--- a/static/js/src/advantage/react/components/Subscriptions/RenewalButton/RenewalButton.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/RenewalButton/RenewalButton.tsx
@@ -35,8 +35,12 @@ export default function RenewalButton({
   };
 
   const shopCheckoutData = {
-    product: product,
-    quantity: subscription.current_number_of_machines,
+    products: [
+      {
+        product: product,
+        quantity: subscription.current_number_of_machines,
+      },
+    ],
     action: action,
   };
 

--- a/static/js/src/advantage/subscribe/blender/components/PaymentButton/PaymentButton.test.tsx
+++ b/static/js/src/advantage/subscribe/blender/components/PaymentButton/PaymentButton.test.tsx
@@ -40,7 +40,7 @@ describe("PaymentButton", () => {
 
     expect(window.location.href).toBe("/account/checkout");
     expect(localStorage.getItem("shop-checkout-data")).toBe(
-      '{"product":{"longId":"lANXjQ-H8fzvf_Ea8bIK1KW7Wi2W0VHnV0ZUsrEGbUiQ","period":"yearly","marketplace":"blender","id":"blender-support-standard-yearly","name":"Blender Support Yearly","price":{"value":50000},"canBeTrialled":false},"quantity":2,"action":"purchase"}'
+      '{"products":[{"product":{"longId":"lANXjQ-H8fzvf_Ea8bIK1KW7Wi2W0VHnV0ZUsrEGbUiQ","period":"yearly","marketplace":"blender","id":"blender-support-standard-yearly","name":"Blender Support Yearly","price":{"value":50000},"canBeTrialled":false},"quantity":2}],"action":"purchase"}'
     );
   });
 });

--- a/static/js/src/advantage/subscribe/blender/components/PaymentButton/PaymentButton.tsx
+++ b/static/js/src/advantage/subscribe/blender/components/PaymentButton/PaymentButton.tsx
@@ -6,8 +6,12 @@ export default function PaymentButton() {
   const { quantity, product } = useContext(FormContext);
 
   const shopCheckoutData = {
-    product: product,
-    quantity: Number(quantity) ?? 0,
+    products: [
+      {
+        product: product,
+        quantity: Number(quantity) ?? 0,
+      },
+    ],
     action: "purchase",
   };
 

--- a/static/js/src/advantage/subscribe/checkout/app.tsx
+++ b/static/js/src/advantage/subscribe/checkout/app.tsx
@@ -8,7 +8,7 @@ import { Elements } from "@stripe/react-stripe-js";
 import { loadStripe } from "@stripe/stripe-js";
 import { UserSubscriptionMarketplace } from "advantage/api/enum";
 import Checkout from "./components/Checkout";
-import { Action, LoginSession, Product } from "./utils/types";
+import { Action, CheckoutProducts, LoginSession } from "./utils/types";
 
 const oneHour = 1000 * 60 * 60;
 const queryClient = new QueryClient({
@@ -57,8 +57,18 @@ declare global {
 const checkoutData = localStorage.getItem("shop-checkout-data") || "";
 const parsedCheckoutData = JSON.parse(checkoutData);
 const stripePromise = loadStripe(window.stripePublishableKey || "");
-const product: Product = parsedCheckoutData?.product;
-const quantity: number = parsedCheckoutData?.quantity;
+const checkoutProducts: CheckoutProducts[] = parsedCheckoutData?.products;
+
+const products = checkoutProducts.map((product) => {
+  return {
+    product: product?.product,
+    quantity: product?.quantity,
+  };
+});
+
+const product = products[0].product;
+const quantity = products[0].quantity;
+
 const action: Action = parsedCheckoutData?.action;
 
 window.previousPurchaseIds = {
@@ -83,7 +93,7 @@ const App = () => {
     <Sentry.ErrorBoundary>
       <QueryClientProvider client={queryClient}>
         <Elements stripe={stripePromise}>
-          <Checkout product={product} quantity={quantity} action={action} />
+          <Checkout products={products} action={action} />
         </Elements>
         <ReactQueryDevtools initialIsOpen={false} />
       </QueryClientProvider>

--- a/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
@@ -12,16 +12,15 @@ import postPurchase from "../../hooks/postPurchase";
 import postPurchaseAccount from "../../hooks/postPurchaseAccount";
 import useCustomerInfo from "../../hooks/useCustomerInfo";
 import usePollPurchaseStatus from "../../hooks/usePollPurchaseStatus";
-import { Action, FormValues, Product } from "../../utils/types";
+import { Action, CheckoutProducts, FormValues } from "../../utils/types";
 
 type Props = {
   setError: React.Dispatch<React.SetStateAction<React.ReactNode>>;
-  quantity: number;
-  product: Product;
+  products: CheckoutProducts[];
   action: Action;
 };
 
-const BuyButton = ({ setError, quantity, product, action }: Props) => {
+const BuyButton = ({ setError, products, action }: Props) => {
   const [isLoading, setIsLoading] = useState(false);
 
   const {
@@ -121,8 +120,7 @@ const BuyButton = ({ setError, quantity, product, action }: Props) => {
     // Attempt or re-attempt the purchase
     await postPurchaseMutation.mutateAsync(
       {
-        product,
-        quantity,
+        products,
         action: buyAction,
       },
       {
@@ -314,6 +312,8 @@ const BuyButton = ({ setError, quantity, product, action }: Props) => {
       request.onreadystatechange = () => {
         if (request.readyState === 4) {
           localStorage.removeItem("shop-checkout-data");
+          const product = products[0].product;
+          const quantity = products[0].quantity;
           if (product.marketplace == "canonical-cube") {
             if (product.name === "cue-linux-essentials-free") {
               location.href = `/credentials/shop/order-thank-you?productName=${encodeURIComponent(

--- a/static/js/src/advantage/subscribe/checkout/components/Checkout/Checkout.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Checkout/Checkout.tsx
@@ -10,7 +10,11 @@ import {
 import { checkoutEvent } from "advantage/ecom-events";
 import useCustomerInfo from "../../hooks/useCustomerInfo";
 import { canBeTrialled, getInitialFormValues } from "../../utils/helpers";
-import { Action, marketplaceDisplayName, Product } from "../../utils/types";
+import {
+  Action,
+  CheckoutProducts,
+  marketplaceDisplayName,
+} from "../../utils/types";
 import BuyButton from "../BuyButton";
 import ConfirmAndBuy from "../ConfirmAndBuy";
 import FreeTrial from "../FreeTrial";
@@ -19,15 +23,15 @@ import Taxes from "../Taxes";
 import UserInfoForm from "../UserInfoForm";
 
 type Props = {
-  product: Product;
-  quantity: number;
+  products: CheckoutProducts[];
   action: Action;
 };
 
-const Checkout = ({ product, quantity, action }: Props) => {
+const Checkout = ({ products, action }: Props) => {
   const [error, setError] = useState<React.ReactNode>(null);
   const { data: userInfo, isLoading: isUserInfoLoading } = useCustomerInfo();
   const userCanTrial = window.canTrial;
+  const product = products[0].product;
   const productCanBeTrialled = product?.canBeTrialled;
   const canTrial = canBeTrialled(productCanBeTrialled, userCanTrial);
   const initialValues = getInitialFormValues(product, canTrial, userInfo);
@@ -85,19 +89,14 @@ const Checkout = ({ product, quantity, action }: Props) => {
                     {
                       title: "Region and taxes",
                       content: (
-                        <Taxes
-                          product={product}
-                          quantity={quantity}
-                          setError={setError}
-                        />
+                        <Taxes products={products} setError={setError} />
                       ),
                     },
                     {
                       title: "Your purchase",
                       content: (
                         <Summary
-                          quantity={quantity}
-                          product={product}
+                          products={products}
                           action={action}
                           setError={setError}
                         />
@@ -112,11 +111,7 @@ const Checkout = ({ product, quantity, action }: Props) => {
                           {
                             title: "Free trial",
                             content: (
-                              <FreeTrial
-                                quantity={quantity}
-                                product={product}
-                                action={action}
-                              />
+                              <FreeTrial products={products} action={action} />
                             ),
                           },
                         ]
@@ -125,12 +120,11 @@ const Checkout = ({ product, quantity, action }: Props) => {
                       title: "Confirm and buy",
                       content: (
                         <>
-                          <ConfirmAndBuy product={product} action={action} />
+                          <ConfirmAndBuy products={products} action={action} />
                           <Row>
                             <Col emptyLarge={7} size={6}>
                               <BuyButton
-                                product={product}
-                                quantity={quantity}
+                                products={products}
                                 action={action}
                                 setError={setError}
                               ></BuyButton>

--- a/static/js/src/advantage/subscribe/checkout/components/ConfirmAndBuy/ConfirmAndBuy.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/ConfirmAndBuy/ConfirmAndBuy.tsx
@@ -2,14 +2,19 @@ import React from "react";
 import ReCAPTCHA from "react-google-recaptcha";
 import { Field, useFormikContext } from "formik";
 import { CheckboxInput, Col, Input, Row } from "@canonical/react-components";
-import { Action, FormValues, Product } from "../../utils/types";
+import {
+  Action,
+  CheckoutProducts,
+  FormValues,
+  Product,
+} from "../../utils/types";
 
 type Props = {
-  product: Product;
+  products: CheckoutProducts[];
   action: Action;
 };
 
-const ConfirmAndBuy = ({ product, action }: Props) => {
+const ConfirmAndBuy = ({ products, action }: Props) => {
   const {
     values,
     touched,
@@ -20,6 +25,7 @@ const ConfirmAndBuy = ({ product, action }: Props) => {
     window.captcha = value;
     setFieldValue("captchaValue", window.captcha);
   };
+  const product = products[0].product;
 
   const { termsLabel, descriptionLabel, marketingLabel } = getLabels(
     product,

--- a/static/js/src/advantage/subscribe/checkout/components/FreeTrial/FreeTrial.test.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/FreeTrial/FreeTrial.test.tsx
@@ -17,13 +17,19 @@ describe("FreeTrial", () => {
 
   it("displays a message explaining the trial if free trial is selected", () => {
     queryClient.setQueryData("calculate", taxes);
+    const products = [
+      {
+        product: UAProduct,
+        quantity: 1,
+      },
+    ];
     render(
       <QueryClientProvider client={queryClient}>
         <Formik
           initialValues={{ FreeTrial: "useFreeTrial" }}
           onSubmit={jest.fn()}
         >
-          <FreeTrial quantity={1} product={UAProduct} action={"purchase"} />
+          <FreeTrial products={products} action={"purchase"} />
         </Formik>
       </QueryClientProvider>
     );
@@ -41,10 +47,16 @@ describe("FreeTrial", () => {
   });
 
   it("does not display the message if pay now is selected", () => {
+    const products = [
+      {
+        product: UAProduct,
+        quantity: 1,
+      },
+    ];
     render(
       <QueryClientProvider client={queryClient}>
         <Formik initialValues={{}} onSubmit={jest.fn()}>
-          <FreeTrial quantity={1} product={UAProduct} action={"purchase"} />
+          <FreeTrial products={products} action={"purchase"} />
         </Formik>
       </QueryClientProvider>
     );

--- a/static/js/src/advantage/subscribe/checkout/components/FreeTrial/FreeTrial.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/FreeTrial/FreeTrial.tsx
@@ -5,18 +5,24 @@ import { Col, RadioInput, Row } from "@canonical/react-components";
 import { currencyFormatter } from "advantage/react/utils";
 import useCalculate from "../../hooks/useCalculate";
 import usePreview from "../../hooks/usePreview";
-import { Action, FormValues, Product, TaxInfo } from "../../utils/types";
+import {
+  Action,
+  CheckoutProducts,
+  FormValues,
+  TaxInfo,
+} from "../../utils/types";
 
 type Props = {
-  product: Product;
-  quantity: number;
+  products: CheckoutProducts[];
   action: Action;
 };
 
 const DATE_FORMAT = "dd MMMM yyyy";
 
-const FreeTrial = ({ quantity, product, action }: Props) => {
+const FreeTrial = ({ products, action }: Props) => {
   const { values } = useFormikContext<FormValues>();
+  const product = products[0].product;
+  const quantity = products[0].quantity;
   const { data: calculate } = useCalculate({
     quantity: quantity,
     marketplace: product.marketplace,

--- a/static/js/src/advantage/subscribe/checkout/components/Summary/Summary.test.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Summary/Summary.test.tsx
@@ -58,14 +58,18 @@ describe("Summary", () => {
         isFetching: false,
       };
     });
-
+    const products = [
+      {
+        product: UAProduct,
+        quantity: 3,
+      },
+    ];
     render(
       <QueryClientProvider client={queryClient}>
         <Formik initialValues={{}} onSubmit={jest.fn()}>
           <Elements stripe={stripePromise}>
             <Summary
-              quantity={3}
-              product={UAProduct}
+              products={products}
               action={"purchase"}
               setError={jest.fn()}
             />
@@ -106,13 +110,18 @@ describe("Summary", () => {
         isFetching: false,
       };
     });
+    const products = [
+      {
+        product: UAProduct,
+        quantity: 3,
+      },
+    ];
     render(
       <QueryClientProvider client={queryClient}>
         <Formik initialValues={{}} onSubmit={jest.fn()}>
           <Elements stripe={stripePromise}>
             <Summary
-              quantity={3}
-              product={UAProduct}
+              products={products}
               action={"purchase"}
               setError={jest.fn()}
             />
@@ -141,13 +150,18 @@ describe("Summary", () => {
         isFetching: false,
       };
     });
+    const products = [
+      {
+        product: UAProduct,
+        quantity: 3,
+      },
+    ];
     render(
       <QueryClientProvider client={queryClient}>
         <Formik initialValues={{}} onSubmit={jest.fn()}>
           <Elements stripe={stripePromise}>
             <Summary
-              quantity={3}
-              product={UAProduct}
+              products={products}
               action={"purchase"}
               setError={jest.fn()}
             />
@@ -178,13 +192,18 @@ describe("Summary", () => {
         isFetching: false,
       };
     });
+    const products = [
+      {
+        product: UAProduct,
+        quantity: 3,
+      },
+    ];
     render(
       <QueryClientProvider client={queryClient}>
         <Formik initialValues={{}} onSubmit={jest.fn()}>
           <Elements stripe={stripePromise}>
             <Summary
-              quantity={3}
-              product={UAProduct}
+              products={products}
               action={"purchase"}
               setError={jest.fn()}
             />
@@ -214,14 +233,19 @@ describe("Summary", () => {
         isFetching: false,
       };
     });
+    const products = [
+      {
+        product: UAProduct,
+        quantity: 3,
+      },
+    ];
     const setError = jest.fn();
     render(
       <QueryClientProvider client={queryClient}>
         <Formik initialValues={{}} onSubmit={jest.fn()}>
           <Elements stripe={stripePromise}>
             <Summary
-              quantity={3}
-              product={UAProduct}
+              products={products}
               action={"purchase"}
               setError={setError}
             />
@@ -256,14 +280,19 @@ describe("Summary", () => {
         isFetching: false,
       };
     });
+    const products = [
+      {
+        product: UAProduct,
+        quantity: 3,
+      },
+    ];
     const setError = jest.fn();
     render(
       <QueryClientProvider client={queryClient}>
         <Formik initialValues={{}} onSubmit={jest.fn()}>
           <Elements stripe={stripePromise}>
             <Summary
-              quantity={3}
-              product={UAProduct}
+              products={products}
               action={"purchase"}
               setError={setError}
             />
@@ -298,14 +327,19 @@ describe("Summary", () => {
         isFetching: false,
       };
     });
+    const products = [
+      {
+        product: UAProduct,
+        quantity: 3,
+      },
+    ];
     const setError = jest.fn();
     render(
       <QueryClientProvider client={queryClient}>
         <Formik initialValues={{}} onSubmit={jest.fn()}>
           <Elements stripe={stripePromise}>
             <Summary
-              quantity={3}
-              product={UAProduct}
+              products={products}
               action={"purchase"}
               setError={setError}
             />

--- a/static/js/src/advantage/subscribe/checkout/components/Summary/Summary.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Summary/Summary.tsx
@@ -6,19 +6,26 @@ import * as Sentry from "@sentry/react";
 import { currencyFormatter } from "advantage/react/utils";
 import useCalculate from "../../hooks/useCalculate";
 import usePreview from "../../hooks/usePreview";
-import { Action, FormValues, Product, TaxInfo } from "../../utils/types";
+import {
+  Action,
+  CheckoutProducts,
+  FormValues,
+  TaxInfo,
+} from "../../utils/types";
 
 const DATE_FORMAT = "dd MMMM yyyy";
 
 type Props = {
-  product: Product;
-  quantity: number;
+  products: CheckoutProducts[];
   action: Action;
   setError: React.Dispatch<React.SetStateAction<React.ReactNode>>;
 };
 
-function Summary({ quantity, product, action, setError }: Props) {
+function Summary({ products, action, setError }: Props) {
   const { values } = useFormikContext<FormValues>();
+  const product = products[0].product;
+  const quantity = products[0].quantity;
+
   const { data: calculate, isFetching: isCalculateFetching } = useCalculate({
     quantity: quantity,
     marketplace: product.marketplace,

--- a/static/js/src/advantage/subscribe/checkout/components/Taxes/Taxes.test.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Taxes/Taxes.test.tsx
@@ -16,11 +16,17 @@ describe("TaxesTests", () => {
   });
 
   it("renders country select correctly", () => {
+    const products = [
+      {
+        product: UAProduct,
+        quantity: 1,
+      },
+    ];
     render(
       <QueryClientProvider client={queryClient}>
         <Formik initialValues={{}} onSubmit={jest.fn()}>
           <Elements stripe={stripePromise}>
-            <Taxes product={UAProduct} quantity={1} setError={jest.fn()} />
+            <Taxes products={products} setError={jest.fn()} />
           </Elements>
         </Formik>
       </QueryClientProvider>
@@ -31,11 +37,17 @@ describe("TaxesTests", () => {
   });
 
   it("When non VAT Country is selected, VAT Number input does not displays", () => {
+    const products = [
+      {
+        product: UAProduct,
+        quantity: 1,
+      },
+    ];
     render(
       <QueryClientProvider client={queryClient}>
         <Formik initialValues={{}} onSubmit={jest.fn()}>
           <Elements stripe={stripePromise}>
-            <Taxes product={UAProduct} quantity={1} setError={jest.fn()} />
+            <Taxes products={products} setError={jest.fn()} />
           </Elements>
         </Formik>
       </QueryClientProvider>
@@ -48,11 +60,17 @@ describe("TaxesTests", () => {
   });
 
   it("When VAT country is selected, VAT Number input displays", () => {
+    const products = [
+      {
+        product: UAProduct,
+        quantity: 1,
+      },
+    ];
     render(
       <QueryClientProvider client={queryClient}>
         <Formik initialValues={{}} onSubmit={jest.fn()}>
           <Elements stripe={stripePromise}>
-            <Taxes product={UAProduct} quantity={1} setError={jest.fn()} />
+            <Taxes products={products} setError={jest.fn()} />
           </Elements>
         </Formik>
       </QueryClientProvider>
@@ -67,11 +85,17 @@ describe("TaxesTests", () => {
   });
 
   it("When USA is selected, State select displays", () => {
+    const products = [
+      {
+        product: UAProduct,
+        quantity: 1,
+      },
+    ];
     const { getByTestId } = render(
       <QueryClientProvider client={queryClient}>
         <Formik initialValues={{}} onSubmit={jest.fn()}>
           <Elements stripe={stripePromise}>
-            <Taxes product={UAProduct} quantity={1} setError={jest.fn()} />
+            <Taxes products={products} setError={jest.fn()} />
           </Elements>
         </Formik>
       </QueryClientProvider>
@@ -92,12 +116,17 @@ describe("TaxesTests", () => {
     const intialValues = {
       country: "GB",
     };
-
+    const products = [
+      {
+        product: UAProduct,
+        quantity: 1,
+      },
+    ];
     render(
       <QueryClientProvider client={queryClient}>
         <Formik initialValues={intialValues} onSubmit={jest.fn()}>
           <Elements stripe={stripePromise}>
-            <Taxes product={UAProduct} quantity={1} setError={jest.fn()} />
+            <Taxes products={products} setError={jest.fn()} />
           </Elements>
         </Formik>
       </QueryClientProvider>
@@ -107,11 +136,17 @@ describe("TaxesTests", () => {
   });
 
   it("sets status right if country is not stored", () => {
+    const products = [
+      {
+        product: UAProduct,
+        quantity: 1,
+      },
+    ];
     render(
       <QueryClientProvider client={queryClient}>
         <Formik initialValues={{}} onSubmit={jest.fn()}>
           <Elements stripe={stripePromise}>
-            <Taxes product={UAProduct} quantity={1} setError={jest.fn()} />
+            <Taxes products={products} setError={jest.fn()} />
           </Elements>
         </Formik>
       </QueryClientProvider>
@@ -129,11 +164,17 @@ describe("TaxesTests", () => {
       VATNumber: "GB123123123",
     };
 
+    const products = [
+      {
+        product: UAProduct,
+        quantity: 1,
+      },
+    ];
     render(
       <QueryClientProvider client={queryClient}>
         <Formik initialValues={intialValues} onSubmit={jest.fn()}>
           <Elements stripe={stripePromise}>
-            <Taxes product={UAProduct} quantity={1} setError={jest.fn()} />
+            <Taxes products={products} setError={jest.fn()} />
           </Elements>
         </Formik>
       </QueryClientProvider>

--- a/static/js/src/advantage/subscribe/checkout/components/Taxes/Taxes.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Taxes/Taxes.tsx
@@ -17,11 +17,10 @@ import {
 } from "advantage/countries-and-states";
 import { getLabel } from "advantage/subscribe/react/utils/utils";
 import postCustomerTaxInfo from "../../hooks/postCustomerTaxInfo";
-import { FormValues, Product } from "../../utils/types";
+import { CheckoutProducts, FormValues } from "../../utils/types";
 
 type TaxesProps = {
-  product: Product;
-  quantity: number;
+  products: CheckoutProducts[];
   setError: React.Dispatch<React.SetStateAction<React.ReactNode>>;
 };
 

--- a/static/js/src/advantage/subscribe/checkout/hooks/postPurchase.tsx
+++ b/static/js/src/advantage/subscribe/checkout/hooks/postPurchase.tsx
@@ -1,16 +1,15 @@
 import { useMutation } from "react-query";
 import { retryPurchase } from "advantage/api/contracts";
-import { Action, PaymentPayload, Product } from "../utils/types";
+import { Action, CheckoutProducts, PaymentPayload } from "../utils/types";
 
 type Props = {
-  product: Product;
-  quantity: number;
+  products: CheckoutProducts[];
   action: Action;
 };
 
 const postPurchase = () => {
   const mutation = useMutation<any, Error, Props>(
-    async ({ product, quantity, action }: Props) => {
+    async ({ products, action }: Props) => {
       if (window.currentPaymentId) {
         await retryPurchase(window.currentPaymentId);
 
@@ -18,31 +17,37 @@ const postPurchase = () => {
         return window.currentPaymentId;
       }
 
-      let payload: PaymentPayload = {
-        account_id: window.accountId,
-        marketplace: product.marketplace,
-        action: action,
-        previous_purchase_id: window.previousPurchaseIds?.[product.period],
-      };
+      let payload: PaymentPayload | null = null;
 
-      if (action === "purchase" || action === "trial") {
+      if (products && products.length === 1) {
+        const product = products[0].product;
+        const quantity = products[0].quantity;
         payload = {
-          ...payload,
-          products: [
-            {
-              product_listing_id: product.longId,
-              quantity: quantity,
-            },
-          ],
+          account_id: window.accountId,
+          marketplace: product.marketplace,
+          action: action,
+          previous_purchase_id: window.previousPurchaseIds?.[product.period],
         };
-      }
 
-      if (action === "renewal") {
-        payload = { ...payload, renewal_id: product.longId };
-      }
+        if (action === "purchase" || action === "trial") {
+          payload = {
+            ...payload,
+            products: [
+              {
+                product_listing_id: product.longId,
+                quantity: quantity,
+              },
+            ],
+          };
+        }
 
-      if (action === "offer") {
-        payload = { ...payload, offer_id: product.longId };
+        if (action === "renewal") {
+          payload = { ...payload, renewal_id: product.longId };
+        }
+
+        if (action === "offer") {
+          payload = { ...payload, offer_id: product.longId };
+        }
       }
 
       // preview

--- a/static/js/src/advantage/subscribe/checkout/utils/helpers.ts
+++ b/static/js/src/advantage/subscribe/checkout/utils/helpers.ts
@@ -2,7 +2,7 @@ import { FormValues, Product, UserInfo } from "./types";
 
 export function getInitialFormValues(
   product: Product,
-  canTrial: boolean,
+  canTrial?: boolean,
   userInfo?: UserInfo
 ): FormValues {
   const accountName = userInfo?.accountInfo?.name;
@@ -27,13 +27,15 @@ export function getInitialFormValues(
     TermsAndConditions: false,
     MarketingOptIn: false,
     Description: false,
-    FreeTrial: canTrial && !window.currentPaymentId ? "useFreeTrial" : "payNow",
     marketplace: product.marketplace,
     isTaxSaved: !!userInfo?.customerInfo?.address?.country,
     isCardValid: !!userInfo?.customerInfo?.defaultPaymentMethod,
     isInfoSaved: !!userInfo?.customerInfo?.defaultPaymentMethod,
     TermsOfService: false,
     DataPrivacy: false,
+    ...(canTrial && {
+      FreeTrial: !window.currentPaymentId ? "useFreeTrial" : "payNow",
+    }),
   };
 }
 

--- a/static/js/src/advantage/subscribe/checkout/utils/types.ts
+++ b/static/js/src/advantage/subscribe/checkout/utils/types.ts
@@ -50,7 +50,7 @@ export interface FormValues {
   MarketingOptIn: boolean;
   Description: boolean;
   marketplace: UserSubscriptionMarketplace;
-  FreeTrial: string;
+  FreeTrial?: string;
   isTaxSaved: boolean;
   isCardValid: boolean;
   isInfoSaved: boolean;
@@ -82,6 +82,11 @@ export interface Product {
   };
   canBeTrialled?: boolean;
 }
+
+export type CheckoutProducts = {
+  product: Product;
+  quantity: number;
+};
 
 export type Cart = {
   items: Product[];

--- a/static/js/src/advantage/subscribe/react/components/PaymentButton/PaymentButton.tsx
+++ b/static/js/src/advantage/subscribe/react/components/PaymentButton/PaymentButton.tsx
@@ -7,8 +7,12 @@ export default function PaymentButton() {
   const { quantity, product, productUser } = useContext(FormContext);
 
   const shopCheckoutData = {
-    product: product,
-    quantity: Number(quantity) ?? 0,
+    products: [
+      {
+        product: product,
+        quantity: Number(quantity) ?? 0,
+      },
+    ],
     action: "purchase",
   };
 


### PR DESCRIPTION
## Done
- This PR was part of #13889. I separated one commit into this PR because #13889 is getting larger.
- The `/account/checkout` page seems to be used by both the pro shop and the credential shop, but it also needs to be used for the distributor store as well. Since the distributor store handles multiple products with different quantities, I updated the `shopCheckoutData` to support multiple products on the `/account/checkout` page.

## QA

- Ensure purchases in the pro shop and credential shop work properly (Ensure the purchase processes in the pro shop and credential shop are not broken due to this PR)
