### PR TITLE
WD-11828-add-lts-to-16-04-in-pro-product-selector

### DIFF
--- a/static/js/src/advantage/subscribe/react/components/Form/Form.tsx
+++ b/static/js/src/advantage/subscribe/react/components/Form/Form.tsx
@@ -61,7 +61,7 @@ const Form = () => {
                   <h2>What Ubuntu LTS version are you running?</h2>
                   <p style={{ marginLeft: "3.6rem" }}>
                     {" "}
-                    Ubuntu Pro is available for Ubuntu 16.04 and higher.
+                    Ubuntu Pro is available for Ubuntu 16.04 LTS and higher.
                     <br />{" "}
                     <a href="/contact-us/form?product=pro">
                       Are you using an older version?


### PR DESCRIPTION
## Done

- Add LTS to 16.04 below product selector

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- visit /pro/subscribe
- Point 2 subheading should say 
"Ubuntu Pro is available for Ubuntu 16.04 LTS and higher".


## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
