### PR TITLE
WD-11797-missing-buy-exam-button-from-credentials-index-page

### DIFF
--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -88,7 +88,7 @@ def cred_home(ua_contracts_api, **_):
     user_purchasing = False
     enterprise_purchasing = False
     for product in available_products:
-        if product.get("name") == "CUE Linux Essentials":
+        if product.get("name") == "cue-linux-essentials":
             user_purchasing = True
         if product.get("name") == "CUE Activation Key":
             enterprise_purchasing = True


### PR DESCRIPTION
## Done

- Buy button was missing from credentials index page

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Visit /credentials
- Make sure there is a buy button in green which redirects to the exam product selection page  
- Make sure there is a buy button on the 3rd section of the page too

## Issue / Card

Fixes [#WD-11797](https://warthogs.atlassian.net/browse/WD-11797)

## Screenshots

![image](https://github.com/canonical/ubuntu.com/assets/30973042/d70bb02d-4de2-4331-bcf6-7bd6c6bb8db3)
![image](https://github.com/canonical/ubuntu.com/assets/30973042/8bc93890-1b26-4f4c-9348-ec6b54ad9f42)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
