### PR TITLE
Add secrets for marketo to credentials

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -260,6 +260,16 @@ production:
           secretKeyRef:
             key: api-key
             name: trueability
+            
+        - name: MARKETO_API_CLIENT
+          secretKeyRef:
+            key: api_client
+            name: marketo
+            
+        - name: MARKETO_API_SECRET
+          secretKeyRef:
+            key: api_secret
+            name: marketo
 
     - paths: [/tutorials]
       name: ubuntu-com-tutorials
@@ -753,6 +763,16 @@ staging:
           secretKeyRef:
             key: organization
             name: credly
+
+        - name: MARKETO_API_CLIENT
+          secretKeyRef:
+            key: api_client
+            name: marketo
+
+        - name: MARKETO_API_SECRET
+          secretKeyRef:
+            key: api_secret
+            name: marketo
 
     - paths: [/tutorials]
       name: ubuntu-com-tutorials


### PR DESCRIPTION
## Done

- Added Marketo secrets to /credentials

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- 

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
