### PR TITLE
WD-10904 - different language answers in desktop download form

### DIFF
--- a/templates/shared/_download-newsletter.html
+++ b/templates/shared/_download-newsletter.html
@@ -119,7 +119,7 @@
 
       checkboxes.forEach(function(checkbox) {
         if (checkbox.children[0].checked) {
-          const text = checkbox.children[1].innerHTML;
+          const text = checkbox.children[1].id;
           usageOptions.push(text);
         }
       });

--- a/templates/shared/_download-newsletter.html
+++ b/templates/shared/_download-newsletter.html
@@ -125,8 +125,7 @@
       });
 
       if (usageOptions.length) {
-        textarea.value +=
-          " \r\n" + "Signed up for newsletter via desktop download page. Planned Desktop usage: " + usageOptions.join(', ').toLowerCase() + " \r\n";
+        textarea.value += usageOptions.join(', ').toLowerCase();
       }
     }
   </script>

--- a/templates/shared/_download-newsletter.html
+++ b/templates/shared/_download-newsletter.html
@@ -18,7 +18,6 @@
     <textarea class="u-hide"
               id="ubuntu_desktop_usage"
               name="UbuntuDesktopPlannedUsage"
-              rows="5"
               maxlength="2000"></textarea>
     <label for="ubuntu_desktop_usage_fields" id="ubuntu_desktop_usage">How do you plan to use Ubuntu Desktop?</label>
     <div class="row p-section--shallow" id="ubuntu_desktop_usage_fields">

--- a/templates/shared/_download-newsletter.html
+++ b/templates/shared/_download-newsletter.html
@@ -3,33 +3,131 @@
   <p>Get the latest Ubuntu news and updates in your inbox.</p>
 </div>
 
-<form action="/marketo/submit" method="post" id="mktoForm_4960" onsubmit="ga('send', 'Newsletter', 'Signup', '{{ ga_event_title }} newsletter signup');">
+<form action="/marketo/submit"
+      method="post"
+      id="mktoForm_5883"
+      onsubmit="stringifyCustomFields(); ga('send', 'Newsletter', 'Signup', '{{ ga_event_title }} newsletter signup');">
   <label for="email">Email*:</label>
-  <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
-
+  <input required
+         id="email"
+         name="email"
+         maxlength="255"
+         type="email"
+         pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
+  {% if request.path == '/download/desktop/thank-you' %}
+    <textarea class="u-hide"
+              id="ubuntu_desktop_usage"
+              name="UbuntuDesktopPlannedUsage"
+              rows="5"
+              maxlength="2000"></textarea>
+    <label for="ubuntu_desktop_usage_fields" id="ubuntu_desktop_usage">How do you plan to use Ubuntu Desktop?</label>
+    <div class="row p-section--shallow" id="ubuntu_desktop_usage_fields">
+      <div class="col-2">
+        <label class="p-checkbox js-checkbox">
+          <input type="checkbox" aria-labelledby="work" class="p-checkbox__input" />
+          <span class="p-checkbox__label" id="work">Work</span>
+        </label>
+      </div>
+      <div class="col-2">
+        <label class="p-checkbox js-checkbox">
+          <input type="checkbox" aria-labelledby="education" class="p-checkbox__input" />
+          <span class="p-checkbox__label" id="education">Education</span>
+        </label>
+      </div>
+      <div class="col-2">
+        <label class="p-checkbox js-checkbox">
+          <input type="checkbox" aria-labelledby="personal" class="p-checkbox__input" />
+          <span class="p-checkbox__label" id="personal">Personal use</span>
+        </label>
+      </div>
+    </div>
+    <hr />
+  {% endif %}
   <div class="p-section--shallow">
     <label class="p-checkbox">
-      <input required class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
+      <input required
+             class="p-checkbox__input"
+             value="yes"
+             aria-labelledby="canonicalUpdatesOptIn"
+             name="canonicalUpdatesOptIn"
+             type="checkbox" />
       <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
     </label>
-    <p>By submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</p>
+    <p>
+      By submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.
+    </p>
     <hr />
     <button type="submit" class="p-button--positive">Subscribe now</button>
   </div>
 
   <div class="p-section--shallow">
-    <input value="4960" name="formid" type="hidden">
+    <input value="5883" name="formid" type="hidden" />
     <input type="hidden" name="Consent_to_Processing__c" value="yes" />
-    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="{{ returnUrl }}#newsletter-signup" />
-    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign"
-      value="" />
-    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
-    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
-    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
-    <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
-    <input type="hidden" aria-hidden="true" aria-label="hidden field" id="preferredLanguage" name="preferredLanguage"
-      maxlength="255" value="" />
-    <input type="hidden" name="thankyoumessage"
-      value="Thank you for signing up for our newsletter!<br/>In these regular emails you will find the latest updates from Ubuntu and upcoming events where you can meet our team.">
-  </div>
-</form>
+    <input type="hidden"
+           aria-hidden="true"
+           aria-label="hidden field"
+           name="returnURL"
+           value="{{ returnUrl }}#newsletter-signup" />
+    <input type="hidden"
+           aria-hidden="true"
+           aria-label="hidden field"
+           name="utm_campaign"
+           id="utm_campaign"
+           value="" />
+    <input type="hidden"
+           aria-hidden="true"
+           aria-label="hidden field"
+           name="utm_medium"
+           id="utm_medium"
+           value="" />
+    <input type="hidden"
+           aria-hidden="true"
+           aria-label="hidden field"
+           name="utm_source"
+           id="utm_source"
+           value="" />
+    <input type="hidden"
+           aria-hidden="true"
+           aria-label="hidden field"
+           name="utm_content"
+           id="utm_content"
+           value="" />
+    <input type="hidden"
+           aria-hidden="true"
+           aria-label="hidden field"
+           name="utm_term"
+           id="utm_term"
+           value="" />
+    <input type="hidden"
+           aria-hidden="true"
+           aria-label="hidden field"
+           id="preferredLanguage"
+           name="preferredLanguage"
+           maxlength="255"
+           value="" />
+    <input type="hidden" name="thankyoumessage" value="Thank you for signing up for our newsletter!
+      <br/>
+      In these regular emails you will find the latest updates from Ubuntu and upcoming events where you can meet our team." />
+    </div>
+  </form>
+
+  <script>
+    function stringifyCustomFields() {
+      const checkboxes = document.querySelectorAll(".js-checkbox");
+      const textarea = document.getElementById("ubuntu_desktop_usage");
+      textarea.value = "";
+      let usageOptions = [];
+
+      checkboxes.forEach(function(checkbox) {
+        if (checkbox.children[0].checked) {
+          const text = checkbox.children[1].innerHTML;
+          usageOptions.push(text);
+        }
+      });
+
+      if (usageOptions.length) {
+        textarea.value +=
+          " \r\n" + "Signed up for newsletter via desktop download page. Planned Desktop usage: " + usageOptions.join(', ').toLowerCase() + " \r\n";
+      }
+    }
+  </script>


### PR DESCRIPTION
## Done

Fixed data sent for usage options to /download/desktop/thank-you newsletter signup form

## QA

- [demo link](https://ubuntu-com-13914.demos.haus/download/desktop/thank-you?version=24.04&architecture=amd64&lts=true)
- View the site on demo
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check that the data sent according to the expectation

## Issue / Card
[WD-11786](https://warthogs.atlassian.net/browse/WD-11786)


[WD-11786]: https://warthogs.atlassian.net/browse/WD-11786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ