### PR TITLE
WD-11786 - different language answers in desktop download form

### DIFF
--- a/templates/shared/_download-newsletter.html
+++ b/templates/shared/_download-newsletter.html
@@ -113,7 +113,7 @@
 
       checkboxes.forEach(function(checkbox) {
         if (checkbox.children[0].checked) {
-          const text = checkbox.children[1].innerHTML;
+          const text = checkbox.children[1].id;
           usageOptions.push(text);
         }
       });

--- a/templates/shared/_download-newsletter.html
+++ b/templates/shared/_download-newsletter.html
@@ -20,25 +20,19 @@
               name="UbuntuDesktopPlannedUsage"
               maxlength="2000"></textarea>
     <label for="ubuntu_desktop_usage_fields" id="ubuntu_desktop_usage">How do you plan to use Ubuntu Desktop?</label>
-    <div class="row p-section--shallow" id="ubuntu_desktop_usage_fields">
-      <div class="col-2">
-        <label class="p-checkbox js-checkbox">
+    <div class="p-section--shallow" id="ubuntu_desktop_usage_fields" style="display: flex; align-items: center; gap: 24px;">
+        <label class="p-checkbox js-checkbox" style="margin: 0;">
           <input type="checkbox" aria-labelledby="work" class="p-checkbox__input" />
           <span class="p-checkbox__label" id="work">Work</span>
         </label>
-      </div>
-      <div class="col-2">
-        <label class="p-checkbox js-checkbox">
+        <label class="p-checkbox js-checkbox" style="margin: 0;">
           <input type="checkbox" aria-labelledby="education" class="p-checkbox__input" />
           <span class="p-checkbox__label" id="education">Education</span>
         </label>
-      </div>
-      <div class="col-2">
-        <label class="p-checkbox js-checkbox">
+        <label class="p-checkbox js-checkbox" style="margin: 0;">
           <input type="checkbox" aria-labelledby="personal" class="p-checkbox__input" />
           <span class="p-checkbox__label" id="personal">Personal use</span>
         </label>
-      </div>
     </div>
     <hr />
   {% endif %}

--- a/templates/shared/_download-newsletter.html
+++ b/templates/shared/_download-newsletter.html
@@ -21,15 +21,15 @@
               maxlength="2000"></textarea>
     <label for="ubuntu_desktop_usage_fields" id="ubuntu_desktop_usage">How do you plan to use Ubuntu Desktop?</label>
     <div class="p-section--shallow" id="ubuntu_desktop_usage_fields" style="display: flex; align-items: center; gap: 24px;">
-        <label class="p-checkbox js-checkbox" style="margin: 0;">
+        <label class="p-checkbox js-checkbox u-no-margin">
           <input type="checkbox" aria-labelledby="work" class="p-checkbox__input" />
           <span class="p-checkbox__label" id="work">Work</span>
         </label>
-        <label class="p-checkbox js-checkbox" style="margin: 0;">
+        <label class="p-checkbox js-checkbox u-no-margin">
           <input type="checkbox" aria-labelledby="education" class="p-checkbox__input" />
           <span class="p-checkbox__label" id="education">Education</span>
         </label>
-        <label class="p-checkbox js-checkbox" style="margin: 0;">
+        <label class="p-checkbox js-checkbox u-no-margin">
           <input type="checkbox" aria-labelledby="personal" class="p-checkbox__input" />
           <span class="p-checkbox__label" id="personal">Personal use</span>
         </label>


### PR DESCRIPTION
## Done

Fixed data sent for usage options to /download/desktop/thank-you newsletter signup form

## QA

- [demo link](https://ubuntu-com-13935.demos.haus/download/desktop/thank-you?version=24.04&architecture=amd64&lts=true)
- View the site on demo
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check that the data sent according to the expectation

## Issue / Card
[WD-11786](https://warthogs.atlassian.net/browse/WD-11786)


[WD-11786]: https://warthogs.atlassian.net/browse/WD-11786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ