### PR TITLE
chore: Bump cookie-policy to v3.6.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   },
   "dependencies": {
     "@axe-core/playwright": "^4.8.5",
-    "@canonical/cookie-policy": "^3.6.3",
+    "@canonical/cookie-policy": "^3.6.4",
     "@canonical/global-nav": "3.6.4",
     "@canonical/latest-news": "1.5.0",
     "@canonical/react-components": "^0.38.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1076,10 +1076,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@canonical/cookie-policy@^3.6.3":
-  version "3.6.3"
-  resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.6.3.tgz#b242dd3cd838564be16e20c6bfadb92f6058950d"
-  integrity sha512-an3od9wrtESgbexSu4Cc81vyHExZaeDeDJWd0+g2SANSAt3OFMt+gsT2c78rGep9J7+a1qhuvQRC43koSVWACQ==
+"@canonical/cookie-policy@^3.6.4":
+  version "3.6.4"
+  resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.6.4.tgz#895c3770f621b73d88b0d5843c43a32d99e4a462"
+  integrity sha512-kfwamTpAaBhtH5TzlMb8wE814a8lIbONUuSYnS7VPiHDfcdmw4NoBPNpldmNY1j3CAT5vMKOx5kulRTWpEXpag==
 
 "@canonical/global-nav@3.6.4":
   version "3.6.4"


### PR DESCRIPTION
## Done

- Bump cookie-policy to v3.6.4

## QA

- Check out 
- Delete cookies so you get the cookie policy pop up
- Accept nothing and check that in cookies there exists `_cookies_accepted=essential`
- Repeat with only accept 'performance', only accepting 'functional' and finally 'all'

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-11997?atlOrigin=eyJpIjoiMjZiZWI5N2FjYzI3NGMyZDg4YjM1ZTM4YzkyZjk3YzkiLCJwIjoiaiJ9
