### PR TITLE
Remove notices order param

### DIFF
--- a/webapp/security/api.py
+++ b/webapp/security/api.py
@@ -86,7 +86,6 @@ class SecurityAPI:
         offset: int,
         details: str,
         release: str,
-        order: str,
     ):
         """
         Makes request for all releases with ongoing support,
@@ -98,7 +97,6 @@ class SecurityAPI:
             "offset": offset,
             "details": details,
             "release": release,
-            "order": order,
         }
 
         # Remove falsey items from dictionary

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -120,7 +120,6 @@ def notice(notice_id):
 def notices():
     details = flask.request.args.get("details", type=str)
     release = flask.request.args.get("release", type=str)
-    order = flask.request.args.get("order", type=str)
     limit = flask.request.args.get("limit", default=10, type=int)
     offset = flask.request.args.get("offset", default=0, type=int)
 
@@ -132,7 +131,6 @@ def notices():
         offset=offset,
         details=details,
         release=release,
-        order=order,
     )
 
     # get notices and total results from response object


### PR DESCRIPTION
## Done

- Remove order param to comply with https://github.com/canonical/ubuntu-com-security-api/pull/146 

## QA

- View the site locally in your web browser at: http://0.0.0.0:8001/security/notices
- See that the page is not broken
