### PR TITLE
WD-12132-create-decorator-to-restrict-views

### DIFF
--- a/templates/credentials/dashboard.html
+++ b/templates/credentials/dashboard.html
@@ -16,19 +16,20 @@
         <th>Name</th>
         <th>Email</th>
         <th>Starts At</th>
+        <th>Exam Name</th>
       </tr>
     </thead>
     <tbody>
-      {% for reservation in latest_reservations["assessment_reservations"] %}
+      {% for reservation in latest_reservations %}
       <tr>
         <td>{{ reservation["user"]["full_name"] }}</td>
         <td>{{ reservation["user"]["email"] }}</td>
         <td>{{ reservation["starts_at"] }}</td>
+        <td>{{ reservation["ability_screen"]["display_name"] }}</td>
       </tr>
       {% endfor %}
     </tbody>
   </table>
 </section>
-{{ latest_reservations }}
 
 {% endblock %}

--- a/templates/credentials/dashboard.html
+++ b/templates/credentials/dashboard.html
@@ -1,0 +1,34 @@
+{% extends "credentials/base_cred.html" %}
+
+{% block title %}Canonical Credentials -- Dashboard{% endblock %}
+
+{% block meta_description %}
+    The Canonical Ubuntu Essentials exams certify knowledge and verify skills in general Linux,
+    Ubuntu Desktop, and Ubuntu Server topics.
+{% endblock meta_description %}
+
+{% block content %}
+
+<section class="p-strip is-paper">
+  <table>
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Email</th>
+        <th>Starts At</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for reservation in latest_reservations["assessment_reservations"] %}
+      <tr>
+        <td>{{ reservation["user"]["full_name"] }}</td>
+        <td>{{ reservation["user"]["email"] }}</td>
+        <td>{{ reservation["starts_at"] }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</section>
+{{ latest_reservations }}
+
+{% endblock %}

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -68,6 +68,7 @@ from webapp.shop.cred.views import (
     cred_assessments,
     cred_beta_activation,
     cred_cancel_exam,
+    cred_dashboard,
     cred_exam,
     cred_home,
     cred_redeem_code,
@@ -931,6 +932,11 @@ app.add_url_rule(
     "/credentials/assessment_passed",
     view_func=issue_badges,
     methods=["POST"],
+)
+app.add_url_rule(
+    "/credentials/dashboard",
+    view_func=cred_dashboard,
+    methods=["GET"]
 )
 
 app.add_url_rule(

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -934,9 +934,7 @@ app.add_url_rule(
     methods=["POST"],
 )
 app.add_url_rule(
-    "/credentials/dashboard",
-    view_func=cred_dashboard,
-    methods=["GET"]
+    "/credentials/dashboard", view_func=cred_dashboard, methods=["GET"]
 )
 
 app.add_url_rule(

--- a/webapp/login.py
+++ b/webapp/login.py
@@ -14,6 +14,7 @@ from webapp.macaroons import (
 )
 
 COMMUNITY_TEAM = "ubuntumembers"
+CREDENTIALS_TEAM = "canonical-credentials"
 
 login_url = os.getenv("CANONICAL_LOGIN_URL", "https://login.ubuntu.com")
 
@@ -39,6 +40,9 @@ def user_info(user_session):
             "is_community_member": (
                 user_session["openid"].get("is_community_member", False)
             ),
+            "is_credentials_admin": (
+                user_session["openid"].get("is_credentials_admin", False)
+            )
         }
     else:
         return None
@@ -86,7 +90,7 @@ def login_handler():
         extensions=[
             openid_macaroon,
             TeamsRequest(
-                query_membership=[COMMUNITY_TEAM],
+                query_membership=[COMMUNITY_TEAM, CREDENTIALS_TEAM],
                 lp_ns_uri="http://ns.launchpad.net/2007/openid-teams",
             ),
         ],
@@ -116,6 +120,7 @@ def after_login(resp):
         return flask.redirect(login_url)
 
     is_community_member = COMMUNITY_TEAM in resp.extensions["lp"].is_member
+    is_credentials_admin = CREDENTIALS_TEAM in resp.extensions["lp"].is_member
 
     flask.session["openid"] = {
         "identity_url": resp.identity_url,
@@ -124,6 +129,7 @@ def after_login(resp):
         "image": resp.image,
         "email": resp.email,
         "is_community_member": is_community_member,
+        "is_credentials_admin": is_credentials_admin,
     }
 
     return flask.redirect(open_id.get_next_url())

--- a/webapp/login.py
+++ b/webapp/login.py
@@ -42,7 +42,7 @@ def user_info(user_session):
             ),
             "is_credentials_admin": (
                 user_session["openid"].get("is_credentials_admin", False)
-            )
+            ),
         }
     else:
         return None

--- a/webapp/shop/api/trueability/api.py
+++ b/webapp/shop/api/trueability/api.py
@@ -74,7 +74,7 @@ class TrueAbilityAPI:
         return self.make_request("GET", uri).json()
 
     def get_assessment_reservations(
-        self, ability_screen_id: int = 4229, page: int = 1, per_page: int = 500
+        self, ability_screen_id: int = None, page: int = 1, per_page: int = 50
     ):
         params = {
             "ability_screen_id": ability_screen_id,

--- a/webapp/shop/api/trueability/api.py
+++ b/webapp/shop/api/trueability/api.py
@@ -70,11 +70,11 @@ class TrueAbilityAPI:
         pass
 
     def get_assessment_reservation(self, uuid: str = ""):
-        uri = f"/api/v1//assessment_reservations/{uuid}"
+        uri = f"/api/v1/assessment_reservations/{uuid}"
         return self.make_request("GET", uri).json()
 
     def get_assessment_reservations(
-        self, ability_screen_id: int = None, page: int = 1, per_page: int = 500
+        self, ability_screen_id: int = 4229, page: int = 1, per_page: int = 500
     ):
         params = {
             "ability_screen_id": ability_screen_id,

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -1058,11 +1058,14 @@ def get_cue_products(ua_contracts_api, type, **kwargs):
 @shop_decorator(area="cred", permission="user", response="html")
 @credentials_group()
 def cred_dashboard(trueability_api, **_):
-    first_reservations = trueability_api.get_assessment_reservations(per_page=10)
+    first_reservations = trueability_api.get_assessment_reservations(
+        per_page=10
+    )
     last_page = first_reservations["meta"]["total_pages"]
     latest_reservations = trueability_api.get_assessment_reservations(
         page=last_page, per_page=10
     )
     return flask.render_template(
-        "credentials/dashboard.html", latest_reservations=latest_reservations["assessment_reservations"]
+        "credentials/dashboard.html",
+        latest_reservations=latest_reservations["assessment_reservations"],
     )

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -1058,12 +1058,11 @@ def get_cue_products(ua_contracts_api, type, **kwargs):
 @shop_decorator(area="cred", permission="user", response="html")
 @credentials_group()
 def cred_dashboard(trueability_api, **_):
-    ability_screen_id = int(
-        flask.request.args.get("ability_screen_id", "4229")
-    )
+    first_reservations = trueability_api.get_assessment_reservations(per_page=10)
+    last_page = first_reservations["meta"]["total_pages"]
     latest_reservations = trueability_api.get_assessment_reservations(
-        ability_screen_id=ability_screen_id, per_page=10
+        page=last_page, per_page=10
     )
     return flask.render_template(
-        "credentials/dashboard.html", latest_reservations=latest_reservations
+        "credentials/dashboard.html", latest_reservations=latest_reservations["assessment_reservations"]
     )

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -16,6 +16,7 @@ from webapp.shop.api.datastore import (
     has_filed_confidentiality_agreement,
 )
 from webapp.shop.decorators import (
+    credentials_group,
     shop_decorator,
     canonical_staff,
     get_trueability_api_instance,
@@ -1052,3 +1053,8 @@ def get_cue_products(ua_contracts_api, type, **kwargs):
         or (type == "exam")
     ]
     return flask.jsonify(filtered_products)
+
+@shop_decorator(area="cred", permission="user", response="html")
+@credentials_group()
+def cred_dashboard(trueability_api, **_):
+    return "<p>Dashboard</p>"

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -1054,7 +1054,16 @@ def get_cue_products(ua_contracts_api, type, **kwargs):
     ]
     return flask.jsonify(filtered_products)
 
+
 @shop_decorator(area="cred", permission="user", response="html")
 @credentials_group()
 def cred_dashboard(trueability_api, **_):
-    return "<p>Dashboard</p>"
+    ability_screen_id = int(
+        flask.request.args.get("ability_screen_id", "4229")
+    )
+    latest_reservations = trueability_api.get_assessment_reservations(
+        ability_screen_id=ability_screen_id, per_page=10
+    )
+    return flask.render_template(
+        "credentials/dashboard.html", latest_reservations=latest_reservations
+    )

--- a/webapp/shop/decorators.py
+++ b/webapp/shop/decorators.py
@@ -170,6 +170,25 @@ def canonical_staff():
     return decorator
 
 
+def credentials_group():
+    def decorator(func):
+        @wraps(func)
+        def decorated_function(*args, **kwargs):
+            sso_user = user_info(flask.session)
+            if (
+                sso_user
+                and sso_user.get("is_credentials_admin", False) is True
+            ):
+                return func(*args, **kwargs)
+
+            message = {"error": "unauthorized"}
+            return flask.jsonify(message), 403
+
+        return decorated_function
+
+    return decorator
+
+
 def init_badgr_session(area) -> Session:
     if area != "cred":
         return None


### PR DESCRIPTION
## Done

- Created a `@credentials-group` decorator that restricts views to only the credentials group on Lunchpad

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Login as user who is in the lp credentials group
    - Go to /credentials/dashboard
    - Page should be visible
- Logout and login as someone not in credentials group
    - Go to /credentials/dashboard
    - Page should be visible


## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
