### PR TITLE
WD-11694 - add new takeover template

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -549,7 +549,7 @@ summary {
 }
 
 .p-list--divided .p-list__item {
-  box-shadow: inset 0 1px 0 0 $colors--theme--border-low-contrast;
+  box-shadow: inset 0px 1px 0px 0px $colors--theme--border-low-contrast;
 }
 
 .p-list--no-borders {
@@ -1659,8 +1659,4 @@ ol.p-list--divided .p-list__item::before {
 
 .u-darker-background {
   background-color: rgba(0, 0, 0, 0.03);
-}
-
-.p-list--divided .p-list__item {
-  box-shadow: inset 0px 1px 0px 0px $colors--theme--border-low-contrast;
 }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1661,6 +1661,6 @@ ol.p-list--divided .p-list__item::before {
   background-color: rgba(0, 0, 0, 0.03);
 }
 
-.p-list--divided .p-list__item { 
-  box-shadow: inset 0px 1px 0px 0px $colors--theme--border-low-contrast; 
+.p-list--divided .p-list__item {
+  box-shadow: inset 0px 1px 0px 0px $colors--theme--border-low-contrast;
 }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -549,7 +549,7 @@ summary {
 }
 
 .p-list--divided .p-list__item {
-  box-shadow: inset 0px 1px 0px 0px $colors--theme--border-low-contrast;
+  box-shadow: inset 0 1px 0 0 $colors--theme--border-low-contrast;
 }
 
 .p-list--no-borders {

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -25,15 +25,16 @@
 
   {% block content %}
 
-    <!-- Default Takeover: Download the latest Ubuntu -->
-    {% block test_takeover_content %}
+    <!-- Test takeover template -->
+    <!-- {% block test_takeover_content %}
     {% with title_1="A CTO's guide", title_2="to real-time Linux", subtitle='Understanding real-time systems, their use
     cases and inner workings.', button_url="/", button_text="Download now",
     img_url="https://assets.ubuntu.com/v1/fb1ea84e-Kernelt%20industries@2x.png", img_width="508", img_height="364" %}
     {% include "takeovers/_test_template.html" %}
     {% endwith %}
-    {% endblock test_takeover_content %}
-    <!-- <section data-lang="all" id="takeover" class="p-strip">
+    {% endblock test_takeover_content %} -->
+    <!-- Default Takeover: Download the latest Ubuntu -->
+    <section data-lang="all" id="takeover" class="p-strip">
       <div class="row p-takeover-animation" id="takeover-animaition">
         <div class="col-9">
           <div class="p-section--shallow">
@@ -57,7 +58,7 @@
                alt="" />
         </div>
       </div>
-    </section> -->
+    </section>
 
     <section class="p-section notice">
       <div class="u-fixed-width">

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -26,7 +26,14 @@
   {% block content %}
 
     <!-- Default Takeover: Download the latest Ubuntu -->
-    <section data-lang="all" id="takeover" class="p-strip">
+    {% block test_takeover_content %}
+    {% with title_1="A CTO's guide", title_2="to real-time Linux", subtitle='Understanding real-time systems, their use
+    cases and inner workings.', button_url="/", button_text="Download now",
+    img_url="https://assets.ubuntu.com/v1/fb1ea84e-Kernelt%20industries@2x.png", img_width="508", img_height="364" %}
+    {% include "takeovers/_test_template.html" %}
+    {% endwith %}
+    {% endblock test_takeover_content %}
+    <!-- <section data-lang="all" id="takeover" class="p-strip">
       <div class="row p-takeover-animation" id="takeover-animaition">
         <div class="col-9">
           <div class="p-section--shallow">
@@ -50,7 +57,7 @@
                alt="" />
         </div>
       </div>
-    </section>
+    </section> -->
 
     <section class="p-section notice">
       <div class="u-fixed-width">

--- a/templates/takeovers/_test_template.html
+++ b/templates/takeovers/_test_template.html
@@ -1,0 +1,61 @@
+<section class="p-section--hero js-takeover">
+  <div class="row--50-50 p-section">
+    <div class="col">
+      <h1 class="u-no-margin--bottom">
+        {{ title_1 }}
+        <br />
+        {{ title_2 }}
+      </h1>
+    </div>
+    <div class="col">
+      <div class="p-section--shallow u-no-padding--top">
+        <h2>{{ subtitle }}</h2>
+      </div>
+      <hr class="is-muted" />
+      {% if button_url %}<a href="{{ button_url }}" class="p-button--positive">{{ button_text }}</a>{% endif %}
+    </div>
+  </div>
+  <div class="u-align--center">
+    <img class=""
+         src="{{ img_url }}"
+         alt=""
+         width="{{ img_width }}"
+         height="{{ img_height }}" />
+  </div>
+</section>
+<!-- 
+        </div>
+      </div>
+      {% if header_image %}
+        <div class="col-3 {% if image_hide_small is sameas true %}u-hide--small{% endif %} u-align--center u-align--left-medium {% if stacked_image %}u-hide--small{% endif %}">
+          {% if 'http' not in header_image %}
+            {% set image_url = "https://assets.ubuntu.com/v1/" + header_image %}
+          {% else %}
+            {% set image_url = header_image %}
+          {% endif %}
+          {#
+            To make it look as close as possible to homepage takeover we can't use image-template
+            the homepage takeover uses JS to populate the HTML attributes
+          #}
+          <img src="{{ header_image }}" alt="" width="{{ image_width }}" height="{{ image_height }}" />
+        </div>
+      {% endif %}
+      <div class="u-hide--medium u-hide--large">
+        {% if button_url %}
+          <p>
+            <a href="{{ button_url }}" class="{% if primary_cta_class %}{{ primary_cta_class }}{% else %}p-button--positive{% endif %}">
+              {% if 'http' in button_url %}<span>{% endif %}
+                {{ primary_cta }}
+                {% if 'http' in button_url %}</span>{% endif %}
+            </a>
+          </p>
+        {% endif %}
+        {% if secondary_url %}
+          <p>
+            <a href="{{ secondary_url }}" class="p-link--inverted">{{ secondary_cta }}&nbsp;&rsaquo;</a>
+          </p>
+        {% endif %}
+      </div>
+    </div>
+  </section>
+   -->

--- a/templates/takeovers/_test_template.html
+++ b/templates/takeovers/_test_template.html
@@ -16,46 +16,9 @@
     </div>
   </div>
   <div class="u-align--center">
-    <img class=""
-         src="{{ img_url }}"
+    <img src="{{ img_url }}"
          alt=""
          width="{{ img_width }}"
          height="{{ img_height }}" />
   </div>
 </section>
-<!-- 
-        </div>
-      </div>
-      {% if header_image %}
-        <div class="col-3 {% if image_hide_small is sameas true %}u-hide--small{% endif %} u-align--center u-align--left-medium {% if stacked_image %}u-hide--small{% endif %}">
-          {% if 'http' not in header_image %}
-            {% set image_url = "https://assets.ubuntu.com/v1/" + header_image %}
-          {% else %}
-            {% set image_url = header_image %}
-          {% endif %}
-          {#
-            To make it look as close as possible to homepage takeover we can't use image-template
-            the homepage takeover uses JS to populate the HTML attributes
-          #}
-          <img src="{{ header_image }}" alt="" width="{{ image_width }}" height="{{ image_height }}" />
-        </div>
-      {% endif %}
-      <div class="u-hide--medium u-hide--large">
-        {% if button_url %}
-          <p>
-            <a href="{{ button_url }}" class="{% if primary_cta_class %}{{ primary_cta_class }}{% else %}p-button--positive{% endif %}">
-              {% if 'http' in button_url %}<span>{% endif %}
-                {{ primary_cta }}
-                {% if 'http' in button_url %}</span>{% endif %}
-            </a>
-          </p>
-        {% endif %}
-        {% if secondary_url %}
-          <p>
-            <a href="{{ secondary_url }}" class="p-link--inverted">{{ secondary_cta }}&nbsp;&rsaquo;</a>
-          </p>
-        {% endif %}
-      </div>
-    </div>
-  </section>
-   -->

--- a/templates/takeovers/_test_template.html
+++ b/templates/takeovers/_test_template.html
@@ -1,5 +1,5 @@
 <section class="p-section--hero js-takeover">
-  <div class="row--50-50 p-section">
+  <div class="row--50-50 p-section--shallow">
     <div class="col">
       <h1 class="u-no-margin--bottom">
         {{ title_1 }}


### PR DESCRIPTION
## Done

Added a new takeover template. DO NOT MERGE until takeover removed from main page

## QA

- [demo link](https://ubuntu-com-13958.demos.haus/)
- [figma](https://www.figma.com/design/Le4TTzyOFbcbqTPJ1tVoZT/U.com---Home-and-footer-(rebranding)?node-id=0-1&m=dev)
- View the site on demo
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check that the takeover is according to the design

## Issue / Card
[WD-11694](https://warthogs.atlassian.net/browse/WD-11694)

[WD-11694]: https://warthogs.atlassian.net/browse/WD-11694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ