### PR TITLE
Reorder ascending notices data

### DIFF
--- a/webapp/security/api.py
+++ b/webapp/security/api.py
@@ -90,8 +90,8 @@ class SecurityAPI:
         """
         Makes request for all releases with ongoing support,
         returns json object if found
-        
-        The api returns notices ordered by ascending order of 
+
+        The api returns notices ordered by ascending order of
         their published date, so the most recent notices are
         at the end of the list
         """
@@ -120,21 +120,21 @@ class SecurityAPI:
             raise SecurityAPIError(error)
 
         return notices_response.json()
-    
+
     def get_total_notices(self, show_hidden: bool = False):
         """
         Makes request for total number of notices which aren't hidden,
         returns json object if found
         """
 
-        parameters = {
-            "show_hidden": show_hidden
-        }
+        parameters = {"show_hidden": show_hidden}
 
         filtered_parameters = urlencode(parameters)
 
         try:
-            notices_response = self._get(f"notices/total.json?{filtered_parameters}")
+            notices_response = self._get(
+                f"notices/total.json?{filtered_parameters}"
+            )
         except HTTPError as error:
             raise SecurityAPIError(error)
 

--- a/webapp/security/api.py
+++ b/webapp/security/api.py
@@ -90,7 +90,17 @@ class SecurityAPI:
         """
         Makes request for all releases with ongoing support,
         returns json object if found
+        
+        The api returns notices ordered by ascending order of 
+        their published date, so the most recent notices are
+        at the end of the list
         """
+
+        # We get the total number of releases
+        total_notices = self.get_total_notices()
+
+        # We calculate the offset to get the most recent notices
+        offset = total_notices["total"] - offset
 
         parameters = {
             "limit": limit,
@@ -106,6 +116,25 @@ class SecurityAPI:
 
         try:
             notices_response = self._get(f"notices.json?{filtered_parameters}")
+        except HTTPError as error:
+            raise SecurityAPIError(error)
+
+        return notices_response.json()
+    
+    def get_total_notices(self, show_hidden: bool = False):
+        """
+        Makes request for total number of notices which aren't hidden,
+        returns json object if found
+        """
+
+        parameters = {
+            "show_hidden": show_hidden
+        }
+
+        filtered_parameters = urlencode(parameters)
+
+        try:
+            notices_response = self._get(f"notices/total.json?{filtered_parameters}")
         except HTTPError as error:
             raise SecurityAPIError(error)
 


### PR DESCRIPTION
## Done

- Added a request to get total number of notices
- This is relevant to [this PR](https://github.com/canonical/ubuntu-com-security-api/pull/152), which reorders notices by ascending order

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes

## Notes
- To be merged after [this PR](https://github.com/canonical/ubuntu-com-security-api/pull/152) on the security API 