### PR TITLE
bug: Move GADownloadImpressionsEvents trigger on /download/server from thank-you page to download page

### DIFF
--- a/templates/download/server/manual.html
+++ b/templates/download/server/manual.html
@@ -17,7 +17,7 @@
 {% block content %}
   <section class="p-strip is-shallow u-no-padding--bottom">
     <div class=" p-section u-fixed-width">
-      <h1>Get Ubuntu Server</h1>
+      <h1 class="js-download-option">Get Ubuntu Server</h1>
     </div>
   </section>
   <section class="p-section--shallow">

--- a/templates/download/server/thank-you.html
+++ b/templates/download/server/thank-you.html
@@ -21,7 +21,7 @@
   <section class="p-strip is-shallow u-no-padding--bottom">
     <div class="row--50-50">
       <div class="col">
-        <h1 class="js-download-option">Thank you for downloading Ubuntu Server {{ version }}{{ " LTS" if lts }}</h1>
+        <h1>Thank you for downloading Ubuntu Server {{ version }}{{ " LTS" if lts }}</h1>
         <p>
           Your download should start in the background. If it doesn't,
           <a href="https://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-live-server-amd64.iso">download&nbsp;now</a>.


### PR DESCRIPTION
## Done

- Moves where the GA event is triggered from the '/thank-you' page to the original '/download/server' page. This is done by moving the target class `js-download-option`

## QA

- Go to https://ubuntu-com-13965.demos.haus//download/server
- Open dev console and log 'dataLayer'
- Check that this object exists in the 'dataLayer':
 `{
    "event": "NonInteractiveGAEvent",
    "eventCategory": "www.ubuntu.com-impression-download-option",
    "eventAction": "Display option",
    "eventLabel": "Get Ubuntu Server",
    "gtm.uniqueEventId": 19
}`
- Click `Download` to navigate to the '/thank-you' page and check the object doesn't exist in the 'dataLayer' there

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-11960
