### PR TITLE
Load smaller cves on notices page

### DIFF
--- a/webapp/security/api.py
+++ b/webapp/security/api.py
@@ -86,6 +86,7 @@ class SecurityAPI:
         offset: int,
         details: str,
         release: str,
+        reduce_cves: bool,
     ):
         """
         Makes request for all releases with ongoing support,
@@ -97,6 +98,7 @@ class SecurityAPI:
             "offset": offset,
             "details": details,
             "release": release,
+            "reduce_cves": reduce_cves,
         }
 
         # Remove falsey items from dictionary

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -131,6 +131,7 @@ def notices():
         offset=offset,
         details=details,
         release=release,
+        reduce_cves=True,
     )
 
     # get notices and total results from response object


### PR DESCRIPTION
## Done

- Use the new `reduced_cves` parameter to load smaller cves on the /security/notices page
- Will only work after https://github.com/canonical/ubuntu-com-security-api/pull/155 is merged

## QA

- Run the demo and check that the /security/notices page opens correctly
- Should load most recent notices first