### PR TITLE
/aws fix Ubuntu version typo

### DIFF
--- a/templates/aws/index.html
+++ b/templates/aws/index.html
@@ -95,7 +95,7 @@
             <li class="p-list__item is-ticked">Updates mirrored and images published in all AWS regions worldwide</li>
             <li class="p-list__item is-ticked">5-year lifetime</li>
           </ul>
-          <p><a href="https://aws.amazon.com/marketplace/pp/prodview-s4zvkzmlirbga">Run Ubuntu Server 20.04 LTS</a></p>
+          <p><a href="https://aws.amazon.com/marketplace/pp/prodview-s4zvkzmlirbga">Run Ubuntu Server 24.04 LTS</a></p>
         </div>
       </div>
       <div class="col-6 p-card">


### PR DESCRIPTION
## Done

- Updated copy as per [doc](https://docs.google.com/document/d/1lkH-MSPmgjCMP4gI0FW29YIKVDvBuddxA63iQhmsYIU/edit?disco=AAABPDMgmic)

## QA

- View the site locally in your web browser at: https://ubuntu-com-13971.demos.haus/aws
- See that the requested change 

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-12253