### PR TITLE
feat: Run '/search' endpoint through Flask-Limiter

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,4 @@ bleach==6.0.0
 numpy==1.24.4
 python-slugify==8.0.1
 djlint==1.34.1
+Flask-Limiter==1.4

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -408,12 +408,13 @@ app.add_url_rule("/getubuntu/releasenotes", view_func=releasenotes_redirect)
 app.add_url_rule(
     "/search",
     "search",
-    limiter.limit("500/day")
-    (build_search_view(
-        session=session,
-        template_path="search.html",
-        search_engine_id=search_engine_id,
-    )),
+    limiter.limit("500/day")(
+        build_search_view(
+            session=session,
+            template_path="search.html",
+            search_engine_id=search_engine_id,
+        )
+    ),
 )
 
 app.add_url_rule(

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -408,7 +408,7 @@ app.add_url_rule("/getubuntu/releasenotes", view_func=releasenotes_redirect)
 app.add_url_rule(
     "/search",
     "search",
-    limiter.limit("500/day")(
+    limiter.limit("3/day")(
         build_search_view(
             session=session,
             template_path="search.html",

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -7,6 +7,8 @@ import os
 import flask
 import requests
 import talisker.requests
+from flask_limiter import Limiter
+from flask_limiter.util import get_remote_address
 from canonicalwebteam.blog import BlogAPI, BlogViews, build_blueprint
 from canonicalwebteam.discourse import (
     DiscourseAPI,
@@ -164,6 +166,8 @@ app = FlaskBase(
     template_500="500.html",
     static_folder="../static",
 )
+
+limiter = Limiter(app, key_func=get_remote_address, headers_enabled=True)
 
 sentry = app.extensions["sentry"]
 session = talisker.requests.get_session()
@@ -404,12 +408,12 @@ app.add_url_rule("/getubuntu/releasenotes", view_func=releasenotes_redirect)
 app.add_url_rule(
     "/search",
     "search",
-    build_search_view(
+    limiter.limit("500/day")
+    (build_search_view(
         session=session,
         template_path="search.html",
         search_engine_id=search_engine_id,
-        request_limit="2000/day",
-    ),
+    )),
 )
 
 app.add_url_rule(


### PR DESCRIPTION
## Done

- Runs '/search' endpoint through [Flask-Limiter](https://pypi.org/project/Flask-Limiter/1.4/)
- Implementation based on discussion here: https://github.com/alisaifee/flask-limiter/issues/401

## QA

- Open demo and go to `/search`
- Do 3 search's and see they go through
- Try to do a 4th search and see you hit the rate limit

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-12317

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
