### PR TITLE
Wd 12322 modify credentials shop to use the new products and coupons

### DIFF
--- a/static/js/src/advantage/subscribe/checkout/app.tsx
+++ b/static/js/src/advantage/subscribe/checkout/app.tsx
@@ -84,7 +84,12 @@ const App = () => {
     <Sentry.ErrorBoundary>
       <QueryClientProvider client={queryClient}>
         <Elements stripe={stripePromise}>
-          <Checkout product={product} quantity={quantity} action={action} coupon={coupon}/>
+          <Checkout
+            product={product}
+            quantity={quantity}
+            action={action}
+            coupon={coupon}
+          />
         </Elements>
         <ReactQueryDevtools initialIsOpen={false} />
       </QueryClientProvider>

--- a/static/js/src/advantage/subscribe/checkout/app.tsx
+++ b/static/js/src/advantage/subscribe/checkout/app.tsx
@@ -8,7 +8,7 @@ import { Elements } from "@stripe/react-stripe-js";
 import { loadStripe } from "@stripe/stripe-js";
 import { UserSubscriptionMarketplace } from "advantage/api/enum";
 import Checkout from "./components/Checkout";
-import { Action, LoginSession, Product } from "./utils/types";
+import { Action, Coupon, LoginSession, Product } from "./utils/types";
 
 const oneHour = 1000 * 60 * 60;
 const queryClient = new QueryClient({
@@ -60,6 +60,7 @@ const stripePromise = loadStripe(window.stripePublishableKey || "");
 const product: Product = parsedCheckoutData?.product;
 const quantity: number = parsedCheckoutData?.quantity;
 const action: Action = parsedCheckoutData?.action;
+const coupon: Coupon = parsedCheckoutData?.coupon || undefined;
 
 window.previousPurchaseIds = {
   monthly: "",
@@ -83,7 +84,7 @@ const App = () => {
     <Sentry.ErrorBoundary>
       <QueryClientProvider client={queryClient}>
         <Elements stripe={stripePromise}>
-          <Checkout product={product} quantity={quantity} action={action} />
+          <Checkout product={product} quantity={quantity} action={action} coupon={coupon}/>
         </Elements>
         <ReactQueryDevtools initialIsOpen={false} />
       </QueryClientProvider>

--- a/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
@@ -19,7 +19,7 @@ type Props = {
   quantity: number;
   product: Product;
   action: Action;
-  coupon: Coupon | null;
+  coupon?: Coupon;
 };
 
 const BuyButton = ({ setError, quantity, product, action, coupon }: Props) => {

--- a/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
@@ -19,7 +19,7 @@ type Props = {
   quantity: number;
   product: Product;
   action: Action;
-  coupon: Coupon | null
+  coupon: Coupon | null;
 };
 
 const BuyButton = ({ setError, quantity, product, action, coupon }: Props) => {

--- a/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
@@ -12,16 +12,17 @@ import postPurchase from "../../hooks/postPurchase";
 import postPurchaseAccount from "../../hooks/postPurchaseAccount";
 import useCustomerInfo from "../../hooks/useCustomerInfo";
 import usePollPurchaseStatus from "../../hooks/usePollPurchaseStatus";
-import { Action, FormValues, Product } from "../../utils/types";
+import { Action, Coupon, FormValues, Product } from "../../utils/types";
 
 type Props = {
   setError: React.Dispatch<React.SetStateAction<React.ReactNode>>;
   quantity: number;
   product: Product;
   action: Action;
+  coupon: Coupon | null
 };
 
-const BuyButton = ({ setError, quantity, product, action }: Props) => {
+const BuyButton = ({ setError, quantity, product, action, coupon }: Props) => {
   const [isLoading, setIsLoading] = useState(false);
 
   const {
@@ -124,6 +125,7 @@ const BuyButton = ({ setError, quantity, product, action }: Props) => {
         product,
         quantity,
         action: buyAction,
+        coupon,
       },
       {
         onSuccess: (purchaseId: string) => {

--- a/static/js/src/advantage/subscribe/checkout/components/Checkout/Checkout.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Checkout/Checkout.tsx
@@ -123,7 +123,6 @@ const Checkout = ({ product, quantity, action, coupon }: Props) => {
                                 quantity={quantity}
                                 product={product}
                                 action={action}
-                                coupon={null}
                               />
                             ),
                           },

--- a/static/js/src/advantage/subscribe/checkout/components/Checkout/Checkout.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Checkout/Checkout.tsx
@@ -10,7 +10,7 @@ import {
 import { checkoutEvent } from "advantage/ecom-events";
 import useCustomerInfo from "../../hooks/useCustomerInfo";
 import { canBeTrialled, getInitialFormValues } from "../../utils/helpers";
-import { Action, marketplaceDisplayName, Product } from "../../utils/types";
+import { Action, Coupon, marketplaceDisplayName, Product } from "../../utils/types";
 import BuyButton from "../BuyButton";
 import ConfirmAndBuy from "../ConfirmAndBuy";
 import FreeTrial from "../FreeTrial";
@@ -22,9 +22,10 @@ type Props = {
   product: Product;
   quantity: number;
   action: Action;
+  coupon: Coupon;
 };
 
-const Checkout = ({ product, quantity, action }: Props) => {
+const Checkout = ({ product, quantity, action, coupon }: Props) => {
   const [error, setError] = useState<React.ReactNode>(null);
   const { data: userInfo, isLoading: isUserInfoLoading } = useCustomerInfo();
   const userCanTrial = window.canTrial;
@@ -99,6 +100,7 @@ const Checkout = ({ product, quantity, action }: Props) => {
                           quantity={quantity}
                           product={product}
                           action={action}
+                          coupon={coupon}
                           setError={setError}
                         />
                       ),
@@ -116,6 +118,7 @@ const Checkout = ({ product, quantity, action }: Props) => {
                                 quantity={quantity}
                                 product={product}
                                 action={action}
+                                coupon={null}
                               />
                             ),
                           },
@@ -133,6 +136,7 @@ const Checkout = ({ product, quantity, action }: Props) => {
                                 quantity={quantity}
                                 action={action}
                                 setError={setError}
+                                coupon={coupon}
                               ></BuyButton>
                             </Col>
                           </Row>

--- a/static/js/src/advantage/subscribe/checkout/components/Checkout/Checkout.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Checkout/Checkout.tsx
@@ -10,7 +10,12 @@ import {
 import { checkoutEvent } from "advantage/ecom-events";
 import useCustomerInfo from "../../hooks/useCustomerInfo";
 import { canBeTrialled, getInitialFormValues } from "../../utils/helpers";
-import { Action, Coupon, marketplaceDisplayName, Product } from "../../utils/types";
+import {
+  Action,
+  Coupon,
+  marketplaceDisplayName,
+  Product,
+} from "../../utils/types";
 import BuyButton from "../BuyButton";
 import ConfirmAndBuy from "../ConfirmAndBuy";
 import FreeTrial from "../FreeTrial";

--- a/static/js/src/advantage/subscribe/checkout/components/FreeTrial/FreeTrial.test.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/FreeTrial/FreeTrial.test.tsx
@@ -23,7 +23,7 @@ describe("FreeTrial", () => {
           initialValues={{ FreeTrial: "useFreeTrial" }}
           onSubmit={jest.fn()}
         >
-          <FreeTrial quantity={1} product={UAProduct} action={"purchase"} />
+          <FreeTrial quantity={1} product={UAProduct} action={"purchase"} coupon={null} />
         </Formik>
       </QueryClientProvider>
     );
@@ -44,7 +44,7 @@ describe("FreeTrial", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <Formik initialValues={{}} onSubmit={jest.fn()}>
-          <FreeTrial quantity={1} product={UAProduct} action={"purchase"} />
+          <FreeTrial quantity={1} product={UAProduct} action={"purchase"} coupon={null}/>
         </Formik>
       </QueryClientProvider>
     );

--- a/static/js/src/advantage/subscribe/checkout/components/FreeTrial/FreeTrial.test.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/FreeTrial/FreeTrial.test.tsx
@@ -23,7 +23,12 @@ describe("FreeTrial", () => {
           initialValues={{ FreeTrial: "useFreeTrial" }}
           onSubmit={jest.fn()}
         >
-          <FreeTrial quantity={1} product={UAProduct} action={"purchase"} coupon={null} />
+          <FreeTrial
+            quantity={1}
+            product={UAProduct}
+            action={"purchase"}
+            coupon={null}
+          />
         </Formik>
       </QueryClientProvider>
     );
@@ -44,7 +49,12 @@ describe("FreeTrial", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <Formik initialValues={{}} onSubmit={jest.fn()}>
-          <FreeTrial quantity={1} product={UAProduct} action={"purchase"} coupon={null}/>
+          <FreeTrial
+            quantity={1}
+            product={UAProduct}
+            action={"purchase"}
+            coupon={null}
+          />
         </Formik>
       </QueryClientProvider>
     );

--- a/static/js/src/advantage/subscribe/checkout/components/FreeTrial/FreeTrial.test.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/FreeTrial/FreeTrial.test.tsx
@@ -23,11 +23,7 @@ describe("FreeTrial", () => {
           initialValues={{ FreeTrial: "useFreeTrial" }}
           onSubmit={jest.fn()}
         >
-          <FreeTrial
-            quantity={1}
-            product={UAProduct}
-            action={"purchase"}
-          />
+          <FreeTrial quantity={1} product={UAProduct} action={"purchase"} />
         </Formik>
       </QueryClientProvider>
     );
@@ -48,11 +44,7 @@ describe("FreeTrial", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <Formik initialValues={{}} onSubmit={jest.fn()}>
-          <FreeTrial
-            quantity={1}
-            product={UAProduct}
-            action={"purchase"}
-          />
+          <FreeTrial quantity={1} product={UAProduct} action={"purchase"} />
         </Formik>
       </QueryClientProvider>
     );

--- a/static/js/src/advantage/subscribe/checkout/components/FreeTrial/FreeTrial.test.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/FreeTrial/FreeTrial.test.tsx
@@ -27,7 +27,6 @@ describe("FreeTrial", () => {
             quantity={1}
             product={UAProduct}
             action={"purchase"}
-            coupon={null}
           />
         </Formik>
       </QueryClientProvider>
@@ -53,7 +52,6 @@ describe("FreeTrial", () => {
             quantity={1}
             product={UAProduct}
             action={"purchase"}
-            coupon={null}
           />
         </Formik>
       </QueryClientProvider>

--- a/static/js/src/advantage/subscribe/checkout/components/FreeTrial/FreeTrial.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/FreeTrial/FreeTrial.tsx
@@ -5,17 +5,18 @@ import { Col, RadioInput, Row } from "@canonical/react-components";
 import { currencyFormatter } from "advantage/react/utils";
 import useCalculate from "../../hooks/useCalculate";
 import usePreview from "../../hooks/usePreview";
-import { Action, FormValues, Product, TaxInfo } from "../../utils/types";
+import { Action, Coupon, FormValues, Product, TaxInfo } from "../../utils/types";
 
 type Props = {
   product: Product;
   quantity: number;
   action: Action;
+  coupon: Coupon | null;
 };
 
 const DATE_FORMAT = "dd MMMM yyyy";
 
-const FreeTrial = ({ quantity, product, action }: Props) => {
+const FreeTrial = ({ quantity, product, action, coupon }: Props) => {
   const { values } = useFormikContext<FormValues>();
   const { data: calculate } = useCalculate({
     quantity: quantity,
@@ -30,6 +31,7 @@ const FreeTrial = ({ quantity, product, action }: Props) => {
     quantity,
     product,
     action,
+    coupon,
   });
   const taxData: TaxInfo | undefined = preview || calculate;
 

--- a/static/js/src/advantage/subscribe/checkout/components/FreeTrial/FreeTrial.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/FreeTrial/FreeTrial.tsx
@@ -5,7 +5,13 @@ import { Col, RadioInput, Row } from "@canonical/react-components";
 import { currencyFormatter } from "advantage/react/utils";
 import useCalculate from "../../hooks/useCalculate";
 import usePreview from "../../hooks/usePreview";
-import { Action, Coupon, FormValues, Product, TaxInfo } from "../../utils/types";
+import {
+  Action,
+  Coupon,
+  FormValues,
+  Product,
+  TaxInfo,
+} from "../../utils/types";
 
 type Props = {
   product: Product;

--- a/static/js/src/advantage/subscribe/checkout/components/FreeTrial/FreeTrial.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/FreeTrial/FreeTrial.tsx
@@ -17,7 +17,7 @@ type Props = {
   product: Product;
   quantity: number;
   action: Action;
-  coupon: Coupon | null;
+  coupon?: Coupon;
 };
 
 const DATE_FORMAT = "dd MMMM yyyy";

--- a/static/js/src/advantage/subscribe/checkout/components/Summary/Summary.test.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Summary/Summary.test.tsx
@@ -68,6 +68,7 @@ describe("Summary", () => {
               product={UAProduct}
               action={"purchase"}
               setError={jest.fn()}
+              coupon={{origin:"", IDs:[]}}
             />
           </Elements>
         </Formik>
@@ -115,6 +116,7 @@ describe("Summary", () => {
               product={UAProduct}
               action={"purchase"}
               setError={jest.fn()}
+              coupon={{origin:"", IDs:[]}}
             />
           </Elements>
         </Formik>
@@ -150,6 +152,7 @@ describe("Summary", () => {
               product={UAProduct}
               action={"purchase"}
               setError={jest.fn()}
+              coupon={{origin:"", IDs:[]}}
             />
           </Elements>
         </Formik>
@@ -187,6 +190,7 @@ describe("Summary", () => {
               product={UAProduct}
               action={"purchase"}
               setError={jest.fn()}
+              coupon={{origin:"", IDs:[]}}
             />
           </Elements>
         </Formik>
@@ -224,6 +228,7 @@ describe("Summary", () => {
               product={UAProduct}
               action={"purchase"}
               setError={setError}
+              coupon={{origin:"", IDs:[]}}
             />
           </Elements>
         </Formik>
@@ -266,6 +271,7 @@ describe("Summary", () => {
               product={UAProduct}
               action={"purchase"}
               setError={setError}
+              coupon={{origin:"", IDs:[]}}
             />
           </Elements>
         </Formik>
@@ -308,6 +314,7 @@ describe("Summary", () => {
               product={UAProduct}
               action={"purchase"}
               setError={setError}
+              coupon={{origin:"", IDs:[]}}
             />
           </Elements>
         </Formik>

--- a/static/js/src/advantage/subscribe/checkout/components/Summary/Summary.test.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Summary/Summary.test.tsx
@@ -68,7 +68,7 @@ describe("Summary", () => {
               product={UAProduct}
               action={"purchase"}
               setError={jest.fn()}
-              coupon={{origin:"", IDs:[]}}
+              coupon={{ origin: "", IDs: [] }}
             />
           </Elements>
         </Formik>
@@ -116,7 +116,7 @@ describe("Summary", () => {
               product={UAProduct}
               action={"purchase"}
               setError={jest.fn()}
-              coupon={{origin:"", IDs:[]}}
+              coupon={{ origin: "", IDs: [] }}
             />
           </Elements>
         </Formik>
@@ -152,7 +152,7 @@ describe("Summary", () => {
               product={UAProduct}
               action={"purchase"}
               setError={jest.fn()}
-              coupon={{origin:"", IDs:[]}}
+              coupon={{ origin: "", IDs: [] }}
             />
           </Elements>
         </Formik>
@@ -190,7 +190,7 @@ describe("Summary", () => {
               product={UAProduct}
               action={"purchase"}
               setError={jest.fn()}
-              coupon={{origin:"", IDs:[]}}
+              coupon={{ origin: "", IDs: [] }}
             />
           </Elements>
         </Formik>
@@ -228,7 +228,7 @@ describe("Summary", () => {
               product={UAProduct}
               action={"purchase"}
               setError={setError}
-              coupon={{origin:"", IDs:[]}}
+              coupon={{ origin: "", IDs: [] }}
             />
           </Elements>
         </Formik>
@@ -271,7 +271,7 @@ describe("Summary", () => {
               product={UAProduct}
               action={"purchase"}
               setError={setError}
-              coupon={{origin:"", IDs:[]}}
+              coupon={{ origin: "", IDs: [] }}
             />
           </Elements>
         </Formik>
@@ -314,7 +314,7 @@ describe("Summary", () => {
               product={UAProduct}
               action={"purchase"}
               setError={setError}
-              coupon={{origin:"", IDs:[]}}
+              coupon={{ origin: "", IDs: [] }}
             />
           </Elements>
         </Formik>

--- a/static/js/src/advantage/subscribe/checkout/components/Summary/Summary.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Summary/Summary.tsx
@@ -149,7 +149,7 @@ function Summary({ quantity, product, action, setError, coupon }: Props) {
             <>
               {total == 0 &&
                 priceData !== undefined &&
-                product?.name !== "cue-linux-essentials-free" &&
+                product?.id !== "cue-01-linux" &&
                 "This is because you have likely already paid for this product for the current billing period."}
             </>
           </p>

--- a/static/js/src/advantage/subscribe/checkout/components/Summary/Summary.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Summary/Summary.tsx
@@ -6,7 +6,13 @@ import * as Sentry from "@sentry/react";
 import { currencyFormatter } from "advantage/react/utils";
 import useCalculate from "../../hooks/useCalculate";
 import usePreview from "../../hooks/usePreview";
-import { Action, Coupon, FormValues, Product, TaxInfo } from "../../utils/types";
+import {
+  Action,
+  Coupon,
+  FormValues,
+  Product,
+  TaxInfo,
+} from "../../utils/types";
 
 const DATE_FORMAT = "dd MMMM yyyy";
 
@@ -37,7 +43,7 @@ function Summary({ quantity, product, action, setError, coupon }: Props) {
     quantity,
     product,
     action,
-    coupon
+    coupon,
   });
 
   const isSummaryLoading = isPreviewFetching || isCalculateFetching;

--- a/static/js/src/advantage/subscribe/checkout/components/Summary/Summary.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Summary/Summary.tsx
@@ -6,7 +6,7 @@ import * as Sentry from "@sentry/react";
 import { currencyFormatter } from "advantage/react/utils";
 import useCalculate from "../../hooks/useCalculate";
 import usePreview from "../../hooks/usePreview";
-import { Action, FormValues, Product, TaxInfo } from "../../utils/types";
+import { Action, Coupon, FormValues, Product, TaxInfo } from "../../utils/types";
 
 const DATE_FORMAT = "dd MMMM yyyy";
 
@@ -15,9 +15,10 @@ type Props = {
   quantity: number;
   action: Action;
   setError: React.Dispatch<React.SetStateAction<React.ReactNode>>;
+  coupon: Coupon;
 };
 
-function Summary({ quantity, product, action, setError }: Props) {
+function Summary({ quantity, product, action, setError, coupon }: Props) {
   const { values } = useFormikContext<FormValues>();
   const { data: calculate, isFetching: isCalculateFetching } = useCalculate({
     quantity: quantity,
@@ -36,6 +37,7 @@ function Summary({ quantity, product, action, setError }: Props) {
     quantity,
     product,
     action,
+    coupon
   });
 
   const isSummaryLoading = isPreviewFetching || isCalculateFetching;

--- a/static/js/src/advantage/subscribe/checkout/hooks/postPurchase.tsx
+++ b/static/js/src/advantage/subscribe/checkout/hooks/postPurchase.tsx
@@ -6,7 +6,7 @@ type Props = {
   product: Product;
   quantity: number;
   action: Action;
-  coupon: Coupon | null;
+  coupon?: Coupon;
 };
 
 const postPurchase = () => {

--- a/static/js/src/advantage/subscribe/checkout/hooks/postPurchase.tsx
+++ b/static/js/src/advantage/subscribe/checkout/hooks/postPurchase.tsx
@@ -1,16 +1,17 @@
 import { useMutation } from "react-query";
 import { retryPurchase } from "advantage/api/contracts";
-import { Action, PaymentPayload, Product } from "../utils/types";
+import { Action, Coupon, PaymentPayload, Product } from "../utils/types";
 
 type Props = {
   product: Product;
   quantity: number;
   action: Action;
+  coupon: Coupon | null;
 };
 
 const postPurchase = () => {
   const mutation = useMutation<any, Error, Props>(
-    async ({ product, quantity, action }: Props) => {
+    async ({ product, quantity, action, coupon }: Props) => {
       if (window.currentPaymentId) {
         await retryPurchase(window.currentPaymentId);
 
@@ -23,6 +24,7 @@ const postPurchase = () => {
         marketplace: product.marketplace,
         action: action,
         previous_purchase_id: window.previousPurchaseIds?.[product.period],
+        coupon: coupon,
       };
 
       if (action === "purchase" || action === "trial") {

--- a/static/js/src/advantage/subscribe/checkout/hooks/usePreview.tsx
+++ b/static/js/src/advantage/subscribe/checkout/hooks/usePreview.tsx
@@ -1,5 +1,11 @@
 import { useQuery } from "react-query";
-import { Action, Coupon, PaymentPayload, Product, TaxInfo } from "../utils/types";
+import {
+  Action,
+  Coupon,
+  PaymentPayload,
+  Product,
+  TaxInfo,
+} from "../utils/types";
 import useCustomerInfo from "./useCustomerInfo";
 
 type Props = {

--- a/static/js/src/advantage/subscribe/checkout/hooks/usePreview.tsx
+++ b/static/js/src/advantage/subscribe/checkout/hooks/usePreview.tsx
@@ -12,7 +12,7 @@ type Props = {
   quantity: number;
   product: Product;
   action: Action;
-  coupon: Coupon | null;
+  coupon?: Coupon;
 };
 
 const usePreview = ({ quantity, product, action, coupon }: Props) => {

--- a/static/js/src/advantage/subscribe/checkout/hooks/usePreview.tsx
+++ b/static/js/src/advantage/subscribe/checkout/hooks/usePreview.tsx
@@ -1,14 +1,15 @@
 import { useQuery } from "react-query";
-import { Action, PaymentPayload, Product, TaxInfo } from "../utils/types";
+import { Action, Coupon, PaymentPayload, Product, TaxInfo } from "../utils/types";
 import useCustomerInfo from "./useCustomerInfo";
 
 type Props = {
   quantity: number;
   product: Product;
   action: Action;
+  coupon: Coupon | null;
 };
 
-const usePreview = ({ quantity, product, action }: Props) => {
+const usePreview = ({ quantity, product, action, coupon }: Props) => {
   const { data: userInfo, isError: isUserInfoError } = useCustomerInfo();
   const { isLoading, isError, isSuccess, data, error, isFetching } = useQuery(
     ["preview", product],
@@ -18,6 +19,7 @@ const usePreview = ({ quantity, product, action }: Props) => {
         marketplace: product.marketplace,
         action: action,
         previous_purchase_id: window.previousPurchaseIds?.[product.period],
+        coupon: coupon,
       };
 
       if (action === "purchase" || action === "trial") {

--- a/static/js/src/advantage/subscribe/checkout/utils/types.ts
+++ b/static/js/src/advantage/subscribe/checkout/utils/types.ts
@@ -81,7 +81,7 @@ export interface Product {
 export type Coupon = {
   origin: string;
   IDs: string[];
-}
+};
 
 export type Cart = {
   items: Product[];

--- a/static/js/src/advantage/subscribe/checkout/utils/types.ts
+++ b/static/js/src/advantage/subscribe/checkout/utils/types.ts
@@ -78,6 +78,11 @@ export interface Product {
   canBeTrialled?: boolean;
 }
 
+export type Coupon = {
+  origin: string;
+  IDs: string[];
+}
+
 export type Cart = {
   items: Product[];
 };
@@ -98,6 +103,7 @@ export type PaymentPayload = {
   ];
   renewal_id?: string;
   offer_id?: string;
+  coupon: Coupon | null;
 };
 
 export type TaxInfo = {

--- a/static/js/src/advantage/subscribe/checkout/utils/types.ts
+++ b/static/js/src/advantage/subscribe/checkout/utils/types.ts
@@ -103,7 +103,7 @@ export type PaymentPayload = {
   ];
   renewal_id?: string;
   offer_id?: string;
-  coupon: Coupon | null;
+  coupon?: Coupon;
 };
 
 export type TaxInfo = {

--- a/templates/credentials/redeem_with_form.html
+++ b/templates/credentials/redeem_with_form.html
@@ -84,9 +84,17 @@
             option.text = item.name;
             select.appendChild(option);
           });
-          select.value(data.activatableProducts[0].id);
+          select.value = data.activatableProducts[0].id;
         })
-    }
+        .catch((error)=>{
+          let select = document.getElementById("exam");
+          select.innerHTML = "";
+          let option = document.createElement("option");
+          option.value = "";
+          option.text = "No products found";
+          select.appendChild(option);
+        });
+      }
 
     const debouncedKeyHandler = debounce(checkKeyProduct, 500);
     document.getElementById("activation-key").addEventListener("input", (event) => {

--- a/templates/credentials/redeem_with_form.html
+++ b/templates/credentials/redeem_with_form.html
@@ -17,7 +17,7 @@
         </div>
       </div>
     </div>
-    <div class="u-fixed-width">
+    <div class="row">
       <form class="p-form p-form--stacked"
             action="/credentials/redeem"
             method="POST">
@@ -40,7 +40,7 @@
           </div>
           <div class="col-3">
             <select id="exam" name="exam" required>
-              <option value="cue-linux-essentials">CUE.01 Linux</option>
+              <option value="" disabled>Looking for products</option>
             </select>
           </div>
         </div>
@@ -53,4 +53,44 @@
       </form>
     </div>
   </div>
+
+  <script>
+    function debounce(func, delay) {
+      // A timer variable to track the delay period
+      let timer;
+      // Return a function that takes arguments
+      return function(...args) {
+        // Clear the previous timer if any
+        clearTimeout(timer);
+        // Set a new timer that will execute the function after the delay period
+        timer = setTimeout(() => {
+          // Apply the function with arguments
+          func.apply(this, args);
+        }, delay);
+      };
+    }
+
+    function checkKeyProduct(key) {
+      fetch("/credentials/keys/" + key)
+        .then((response) => {
+          return response.json();
+        })
+        .then((data) => {
+          let select = document.getElementById("exam");
+          select.innerHTML = "";
+          data.activatableProducts.forEach((item) => {
+            let option = document.createElement("option");
+            option.value = item.id;
+            option.text = item.name;
+            select.appendChild(option);
+          });
+          select.value(data.activatableProducts[0].id);
+        })
+    }
+
+    const debouncedKeyHandler = debounce(checkKeyProduct, 500);
+    document.getElementById("activation-key").addEventListener("input", (event) => {
+      debouncedKeyHandler(event.target.value);
+    });
+  </script>
 {% endblock %}

--- a/templates/credentials/shop/index.html
+++ b/templates/credentials/shop/index.html
@@ -161,16 +161,17 @@
     event.preventDefault();
     const index = document.querySelector('input[name="exam-radio"]:checked').value;
 
-    localStorage.setItem(
-      "shop-checkout-data",
-      JSON.stringify({
-        product: exams[index],
-        quantity: 1,
-        action: "purchase",
-      })
-    );
-    location.href = "/account/checkout";
-  };
+      localStorage.setItem(
+        "shop-checkout-data",
+        JSON.stringify({
+          product: exams[index],
+          quantity: 1,
+          action: "purchase",
+          coupon: {"origin": "Stripe", "IDs": ["81IlzzhQ"]}
+        })
+      );
+      location.href = "/account/checkout";
+    };
 
   document.getElementsByName("exam-radio").forEach(function(e) {
     e.addEventListener("click", function() {

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -924,7 +924,7 @@ app.add_url_rule(
 app.add_url_rule(
     "/credentials/keys/<key_id>",
     view_func=get_activation_key_info,
-    methods=["GET"]
+    methods=["GET"],
 )
 app.add_url_rule(
     "/credentials/beta/activation",

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -83,6 +83,7 @@ from webapp.shop.cred.views import (
     cred_submit_form,
     cred_syllabus_data,
     cred_your_exams,
+    get_activation_key_info,
     get_activation_keys,
     get_cue_products,
     get_issued_badges,
@@ -919,6 +920,11 @@ app.add_url_rule(
     "/credentials/keys/activate",
     view_func=activate_activation_key,
     methods=["POST"],
+)
+app.add_url_rule(
+    "/credentials/keys/<key_id>",
+    view_func=get_activation_key_info,
+    methods=["GET"]
 )
 app.add_url_rule(
     "/credentials/beta/activation",

--- a/webapp/shop/advantage/views.py
+++ b/webapp/shop/advantage/views.py
@@ -265,7 +265,6 @@ def post_advantage_purchase(advantage_mapper: AdvantageMapper, **kwargs):
     marketplace = kwargs.get("marketplace", "canonical-ua")
     action = kwargs.get("action", "purchase")
     coupon = kwargs.get("coupon")
-    print(coupon)
 
     subscribed_quantities = {}
     if action == "purchase":

--- a/webapp/shop/advantage/views.py
+++ b/webapp/shop/advantage/views.py
@@ -264,7 +264,9 @@ def post_advantage_purchase(advantage_mapper: AdvantageMapper, **kwargs):
     account_id = kwargs.get("account_id")
     marketplace = kwargs.get("marketplace", "canonical-ua")
     action = kwargs.get("action", "purchase")
-
+    coupon = kwargs.get("coupon")
+    print(coupon)
+    
     subscribed_quantities = {}
     if action == "purchase":
         try:
@@ -299,6 +301,7 @@ def post_advantage_purchase(advantage_mapper: AdvantageMapper, **kwargs):
         "accountID": account_id,
         "purchaseItems": purchase_items,
         "previousPurchaseID": kwargs.get("previous_purchase_id"),
+        "coupon": coupon,
     }
 
     if action == "trial":

--- a/webapp/shop/advantage/views.py
+++ b/webapp/shop/advantage/views.py
@@ -266,7 +266,7 @@ def post_advantage_purchase(advantage_mapper: AdvantageMapper, **kwargs):
     action = kwargs.get("action", "purchase")
     coupon = kwargs.get("coupon")
     print(coupon)
-    
+
     subscribed_quantities = {}
     if action == "purchase":
         try:

--- a/webapp/shop/api/credly/api.py
+++ b/webapp/shop/api/credly/api.py
@@ -35,7 +35,6 @@ class CredlyAPI:
         uri = f"{self.base_url}{path}"
         headers["Content-type"] = "application/json"
         auth = HTTPBasicAuth(self.auth_token, "")
-        print(self.auth_token)
 
         response = self.session.request(
             method,
@@ -60,7 +59,6 @@ class CredlyAPI:
         return response
 
     def get_issued_badges(self, filter: dict = {}):
-        print(filter)
         filter_params = ""
         for k, v in filter.items():
             filter_params += f"{k}::{quote_plus(v)}"

--- a/webapp/shop/api/ua_contracts/api.py
+++ b/webapp/shop/api/ua_contracts/api.py
@@ -443,6 +443,13 @@ class UAContractsAPI:
 
         return {}
 
+    def get_activation_key_info(self, key_id: str) -> dict:
+        return self._request(
+            method="get",
+            path=f"v1/keys/{key_id}",
+            error_rules=["default"],
+        ).json()
+
     def get_annotated_contract_items(
         self, email: str = "", product_tags: List[str] = []
     ) -> List[dict]:

--- a/webapp/shop/api/ua_contracts/models.py
+++ b/webapp/shop/api/ua_contracts/models.py
@@ -217,6 +217,7 @@ class Purchase:
         items: List[PurchaseItem],
         subscription_id: str = None,
         invoice: Invoice = None,
+        coupon: dict = None,
     ):
         self.account_id = account_id
         self.created_at = created_at
@@ -226,6 +227,7 @@ class Purchase:
         self.marketplace = marketplace
         self.status = status
         self.subscription_id = subscription_id
+        self.coupon = coupon
 
     def get_period(self):
         listing = self.items[0].listing

--- a/webapp/shop/api/ua_contracts/schema.py
+++ b/webapp/shop/api/ua_contracts/schema.py
@@ -89,7 +89,6 @@ class PurchaseSchema(BaseSchema):
 
     @post_load
     def make_purchase(self, data, **kwargs) -> Purchase:
-        print(data)
         return Purchase(**data)
 
 

--- a/webapp/shop/api/ua_contracts/schema.py
+++ b/webapp/shop/api/ua_contracts/schema.py
@@ -84,6 +84,7 @@ class PurchaseSchema(BaseSchema):
 
     @post_load
     def make_purchase(self, data, **kwargs) -> Purchase:
+        print(data)
         return Purchase(**data)
 
 

--- a/webapp/shop/api/ua_contracts/schema.py
+++ b/webapp/shop/api/ua_contracts/schema.py
@@ -65,9 +65,11 @@ class PurchaseItemSchema(BaseSchema):
     def make_purchase_item(self, data, **kwargs) -> PurchaseItem:
         return PurchaseItem(**data)
 
+
 class CouponSchema(BaseSchema):
     origin = String(attribute="origin")
     IDs = List(String(), attribute="IDs")
+
 
 class PurchaseSchema(BaseSchema):
     accountID = String(required=True, attribute="account_id")

--- a/webapp/shop/api/ua_contracts/schema.py
+++ b/webapp/shop/api/ua_contracts/schema.py
@@ -65,6 +65,9 @@ class PurchaseItemSchema(BaseSchema):
     def make_purchase_item(self, data, **kwargs) -> PurchaseItem:
         return PurchaseItem(**data)
 
+class CouponSchema(BaseSchema):
+    origin = String(attribute="origin")
+    IDs = List(String(), attribute="IDs")
 
 class PurchaseSchema(BaseSchema):
     accountID = String(required=True, attribute="account_id")
@@ -80,7 +83,7 @@ class PurchaseSchema(BaseSchema):
         validate=validate.OneOf(["canonical-ua", "canonical-cube", "blender"]),
         required=True,
     )
-    coupon = dict()
+    coupon = Nested(CouponSchema)
 
     @post_load
     def make_purchase(self, data, **kwargs) -> Purchase:

--- a/webapp/shop/api/ua_contracts/schema.py
+++ b/webapp/shop/api/ua_contracts/schema.py
@@ -80,6 +80,7 @@ class PurchaseSchema(BaseSchema):
         validate=validate.OneOf(["canonical-ua", "canonical-cube", "blender"]),
         required=True,
     )
+    coupon = dict()
 
     @post_load
     def make_purchase(self, data, **kwargs) -> Purchase:

--- a/webapp/shop/cred/exams.json
+++ b/webapp/shop/cred/exams.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": "cue-linux-essentials",
+    "id": "cue-01-linux",
     "name": "CUE.01 Linux",
     "displayName": "CUE.01 Linux",
     "metadata": [

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -888,7 +888,7 @@ def cred_shop(**kwargs):
                 exam["period"] = product["period"]
                 exam["marketplace"] = product["marketplace"]
                 exam["name"] = product["name"]
-
+    print(cue_products)
     return flask.render_template(
         "credentials/shop/index.html",
         exams=exams,

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -1081,12 +1081,12 @@ def activate_activation_key(ua_contracts_api, **kwargs):
         }
     )
 
+
 @shop_decorator(area="cube", permission="user", response="json")
 def get_activation_key_info(ua_contracts_api, **kwargs):
     activation_key = kwargs.get("key_id")
-    return ua_contracts_api.get_activation_key_info(
-        activation_key
-    )
+    return ua_contracts_api.get_activation_key_info(activation_key)
+
 
 @shop_decorator(area="cred", permission="user", response="html")
 @canonical_staff()

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -1071,7 +1071,7 @@ def rotate_activation_key(ua_contracts_api, **kwargs):
     return flask.jsonify(new_activation_key)
 
 
-@shop_decorator(area="cube", permission="user", response=json)
+@shop_decorator(area="cube", permission="user", response="json")
 def activate_activation_key(ua_contracts_api, **kwargs):
     data = flask.request.json
     activation_key = data["activationKey"]
@@ -1081,6 +1081,12 @@ def activate_activation_key(ua_contracts_api, **kwargs):
         }
     )
 
+@shop_decorator(area="cube", permission="user", response="json")
+def get_activation_key_info(ua_contracts_api, **kwargs):
+    activation_key = kwargs.get("key_id")
+    return ua_contracts_api.get_activation_key_info(
+        activation_key
+    )
 
 @shop_decorator(area="cred", permission="user", response="html")
 @canonical_staff()

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -888,7 +888,7 @@ def cred_shop(**kwargs):
                 exam["period"] = product["period"]
                 exam["marketplace"] = product["marketplace"]
                 exam["name"] = product["name"]
-    print(cue_products)
+
     return flask.render_template(
         "credentials/shop/index.html",
         exams=exams,

--- a/webapp/shop/schemas.py
+++ b/webapp/shop/schemas.py
@@ -70,7 +70,9 @@ account_purhcase = {
         required=True,
     ),
     "action": String(
-        validate=validate.OneOf(["purchase", "resize", "trial", "offer", "renewal"])
+        validate=validate.OneOf(
+            ["purchase", "resize", "trial", "offer", "renewal"]
+        )
     ),
     "coupon": Nested(CouponSchema),
 }
@@ -133,13 +135,17 @@ ensure_purchase_account = {
 
 get_purchase_account_status = {
     "marketplace": String(
-        validate=validate.OneOf(["", "canonical-ua", "canonical-cube", "blender"])
+        validate=validate.OneOf(
+            ["", "canonical-ua", "canonical-cube", "blender"]
+        )
     ),
 }
 
 invoice_view = {
     "marketplace": String(
-        validate=validate.OneOf(["", "canonical-ua", "canonical-cube", "blender"])
+        validate=validate.OneOf(
+            ["", "canonical-ua", "canonical-cube", "blender"]
+        )
     ),
     "page": Int(),
 }

--- a/webapp/shop/schemas.py
+++ b/webapp/shop/schemas.py
@@ -54,7 +54,7 @@ class PurchaseTotalSchema(Schema):
 
 
 class CouponSchema(Schema):
-    origin = String(required=True)
+    origin = String()
     IDs = List(String())
 
 
@@ -72,7 +72,7 @@ account_purhcase = {
     "action": String(
         validate=validate.OneOf(["purchase", "resize", "trial", "offer", "renewal"])
     ),
-    "coupon": CouponSchema(),
+    "coupon": Nested(CouponSchema),
 }
 
 

--- a/webapp/shop/schemas.py
+++ b/webapp/shop/schemas.py
@@ -53,6 +53,11 @@ class PurchaseTotalSchema(Schema):
     total = Int(required=True)
 
 
+class CouponSchema(Schema):
+    origin = String(required=True)
+    IDs = List(String())
+
+
 account_purhcase = {
     "account_id": String(),
     "products": List(Nested(ProductListing)),
@@ -65,10 +70,9 @@ account_purhcase = {
         required=True,
     ),
     "action": String(
-        validate=validate.OneOf(
-            ["purchase", "resize", "trial", "offer", "renewal"]
-        )
+        validate=validate.OneOf(["purchase", "resize", "trial", "offer", "renewal"])
     ),
+    "coupon": CouponSchema(),
 }
 
 
@@ -129,17 +133,13 @@ ensure_purchase_account = {
 
 get_purchase_account_status = {
     "marketplace": String(
-        validate=validate.OneOf(
-            ["", "canonical-ua", "canonical-cube", "blender"]
-        )
+        validate=validate.OneOf(["", "canonical-ua", "canonical-cube", "blender"])
     ),
 }
 
 invoice_view = {
     "marketplace": String(
-        validate=validate.OneOf(
-            ["", "canonical-ua", "canonical-cube", "blender"]
-        )
+        validate=validate.OneOf(["", "canonical-ua", "canonical-cube", "blender"])
     ),
     "page": Int(),
 }


### PR DESCRIPTION
## Done

- Credentials now uses coupons to make the products freely available to everyone instead of a 0 price product

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- visit /credentials/shop
    - Purchase an exam
    - Exam should be priced at 0 and should be purchased successfully
- visit /credentials/redeem
    - Redeem enter an activation key
    - See that the dropdown is populated with valid exam products
    - Redeem the key
        - Check if exam is redeemed and visible in `/credentials/your-exams`  

## Issue / Card

Fixes #WD-12322

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
