### PR TITLE
chore: Bump canonicalwebteam.discourse to 5.5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ canonicalwebteam.blog==6.4.1
 canonicalwebteam.search==1.3.0
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.3.1
-canonicalwebteam.discourse==5.4.9
+canonicalwebteam.discourse==5.5.0
 python-dateutil==2.8.2
 pytz==2022.7.1
 maxminddb-geolite2==2018.703


### PR DESCRIPTION
## Done

- Bump canonicalwebteam.discourse to 5.5.0

## QA

- Go to https://ubuntu-com-13978.demos.haus/ceph/docs
- Use chrome dev tools to see that the anchor link in heading don't have trailing numbers
