### PR TITLE
Update /download/raspberry-pi copy and Core 24 checksums

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -11,7 +11,6 @@ latest:
   release_notes_url: "https://discourse.ubuntu.com/t/mantic-minotaur-release-notes/35534"
   iso_download_size: "4.5GB"
   server_iso_size: "2.5GB"
-  rasp_pi_core_22_size: "263MB"
   rasp_pi_core_24_size: "314MB"
 lts:
   slug: NobleNumbat

--- a/releases.yaml
+++ b/releases.yaml
@@ -4,7 +4,7 @@ latest:
   short_version: "23.10"
   full_version: "23.10"
   desktop_version: "23.10.1" # for 23.10 release only, because Desktop image for 23.10 release has version 23.10.1, while as all other images have version 23.10
-  core_version: "22"
+  core_version: "24"
   release_date: "October 2023"
   eol: "July 2024"
   past_eol_date: false
@@ -12,6 +12,7 @@ latest:
   iso_download_size: "4.5GB"
   server_iso_size: "2.5GB"
   rasp_pi_core_22_size: "263MB"
+  rasp_pi_core_24_size: "314MB"
 lts:
   slug: NobleNumbat
   name: "Noble Numbat"
@@ -82,7 +83,7 @@ checksums:
     "23.10": "5c300b9fff78f5d86fec06787e833573220165aeb310a8f1b5c56ca888bc91c2 *ubuntu-23.10-preinstalled-server-riscv64+unmatched.img.xz"
     "22.04.4": "fc86d5f6e1ddb1cb7f59255b4adc5872a103ba61fd6746a0fc1994d850f663c8 *ubuntu-22.04.4-preinstalled-server-riscv64+unmatched.img.xz"
     "21.10": "8067892fa627eb219b31dc629f31f3bda6b015dfeabf2fdc9b0ed150bf7984b8 *ubuntu-21.10-preinstalled-server-riscv64+unmatched.img.xz"
-  core-22-arm64+raspi:
-    "22": "7639f5ff8bb5c0d4cf0e86041b56dd0daa27a3d05b475a9a85c5d085b561fb8e *ubuntu-core-22-arm64+raspi.img.xz"
+  core-24-arm64+raspi:
+    "24": "f8e1c4882e7bb0b9357dd41789f94ea6f9ad7caa50ce7a16b32a1e628f591c74 *ubuntu-core-24-arm64+raspi.img.xz"
   core-22-armhf+raspi:
     "22": "4c4b3958626611aff85bfa5873c45ad22fdf7642be868b5722900fa88e6fca86 *ubuntu-core-22-armhf+raspi.img.xz"

--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -110,13 +110,16 @@
     <hr class="p-rule is-fixed-width" />
     <div class="row--50-50">
       <div class="col">
-        <h2>Ubuntu Core 22</h2>
+        <h2>Ubuntu Core 24</h2>
       </div>
       <div class="col">
         <p>
-          An immutable, strictly confined operating system designed for Internet of Things (IoT) use-cases with a focus on security and simplified maintenance, supported until 2032.
+          An immutable, strictly confined operating system designed for deploying Internet of Things (IoT) use-cases with a focus on security and simplified maintenance, supported until 2036.
         </p>
+        <p>Build your Ubuntu Core image for your application and targeted hardware.</p>
+        <a class="p-button--positive" href="/core/docs/build-an-image">Build your Core 24</a>
         <hr />
+        <p>Or try a pre-built Ubuntu Core image for the Raspberry Pi. Our pre-built Ubuntu Core images are an ideal way to experiment with Ubuntu Core.</p>
         <p class="u-responsive-realign">
           <a href="/download/raspberry-pi/thank-you?version={{ releases.latest.core_version }}&amp;architecture=core-22-arm64+raspi"
              onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 64-bit - Ubuntu Core', 'eventLabel' : '{{ releases.latest.core_version }}', 'eventValue' : undefined });"

--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -121,11 +121,11 @@
         <hr />
         <p>Or try a pre-built Ubuntu Core image for the Raspberry Pi. Our pre-built Ubuntu Core images are an ideal way to experiment with Ubuntu Core.</p>
         <p class="u-responsive-realign">
-          <a href="/download/raspberry-pi/thank-you?version={{ releases.latest.core_version }}&amp;architecture=core-22-arm64+raspi"
+          <a href="/download/raspberry-pi/thank-you?version={{ releases.latest.core_version }}&amp;architecture=core-24-arm64+raspi"
              onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 64-bit - Ubuntu Core', 'eventLabel' : '{{ releases.latest.core_version }}', 'eventValue' : undefined });"
              class="p-button">Download Ubuntu Core {{ releases.latest.core_version }}</a>
-          {% if releases.latest.rasp_pi_core_22_size %}
-            <span class="u-text--muted">{{ releases.latest.rasp_pi_core_22_size }}</span>
+          {% if releases.latest.rasp_pi_core_24_size %}
+            <span class="u-text--muted" style="margin-top: 0.5rem;">{{ releases.latest.rasp_pi_core_24_size }}</span>
           {% endif %}
         </p>
       </div>


### PR DESCRIPTION
## Done

- Applied updates as per [doc](https://docs.google.com/document/d/1KgnSBa8mbR7qwlxxtqbE5a1wXh5GjtVums8TIB7IGVw/edit)

## QA

- View the site locally in your web browser at: https://ubuntu-com-13986.demos.haus/download/raspberry-pi
- See that the requested changes have been made
- Click on the relevant download CTA and see that the correct version is downloaded

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-12461
