### PR TITLE
Reinstate notice order param

### DIFF
--- a/webapp/security/api.py
+++ b/webapp/security/api.py
@@ -86,6 +86,7 @@ class SecurityAPI:
         offset: int,
         details: str,
         release: str,
+        order: str,
     ):
         """
         Makes request for all releases with ongoing support,
@@ -97,6 +98,7 @@ class SecurityAPI:
             "offset": offset,
             "details": details,
             "release": release,
+            "order": order,
         }
 
         # Remove falsey items from dictionary

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -122,6 +122,7 @@ def notices():
     release = flask.request.args.get("release", type=str)
     limit = flask.request.args.get("limit", default=10, type=int)
     offset = flask.request.args.get("offset", default=0, type=int)
+    order = flask.request.args.get("order", type=str)
 
     # call endpopint to get all releases and notices
     all_releases = security_api.get_releases()
@@ -165,6 +166,7 @@ def notices():
         page_first_result=offset + 1,
         page_last_result=offset + len(notices),
         offset=offset,
+        order=order,
     )
 
 


### PR DESCRIPTION
## Done

- Reinstate order param as per sec. api revert https://github.com/canonical/ubuntu-com-security-api/pull/159

## QA

- View the site locally in your web browser at: https://ubuntu-com-13992.demos.haus/security/notices/rss.xml
- See that recent (25th June) notices are shown

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-12492, https://github.com/canonical/ubuntu.com/issues/13983
