### PR TITLE
Redirected usn updates traffic to separate service

### DIFF
--- a/.env
+++ b/.env
@@ -3,6 +3,7 @@ FLASK_DEBUG=true
 DEVEL=true
 SECRET_KEY=insecure_dev_key
 CONTRACTS_API_URL=https://contracts.staging.canonical.com/
+SECURITY_API_URL=https://ubuntu.com/security/
 STRIPE_PUBLISHABLE_KEY=pk_test_yndN9H0GcJffPe0W58Nm64cM00riYG4N46
 STORE_MAINTENANCE=false
 BADGR_URL=https://api.test.badgr.com

--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -116,6 +116,9 @@ env:
 
   - name: CONTRACTS_API_URL
     value: https://contracts.canonical.com/
+  
+  - name: SECURITY_API_URL
+    value: https://ubuntu.com/security/
 
   - name: STRIPE_PUBLISHABLE_KEY
     value: pk_live_68aXqowUeX574aGsVck8eiIE
@@ -208,6 +211,9 @@ production:
 
         - name: CONTRACTS_API_URL
           value: https://contracts.canonical.com/
+        
+        - name: SECURITY_API_URL
+          value: https://ubuntu.com/security/
 
         - name: STRIPE_PUBLISHABLE_KEY
           value: pk_live_68aXqowUeX574aGsVck8eiIE
@@ -409,6 +415,9 @@ production:
 
         - name: CONTRACTS_API_URL
           value: https://contracts.canonical.com/
+        
+        - name: SECURITY_API_URL
+          value: https://ubuntu.com/security/
 
         - name: STRIPE_PUBLISHABLE_KEY
           value: pk_live_68aXqowUeX574aGsVck8eiIE
@@ -603,6 +612,9 @@ staging:
 
     - name: CONTRACTS_API_URL
       value: https://contracts.staging.canonical.com/
+    
+    - name: SECURITY_API_URL
+      value: https://staging.ubuntu.com/security/
 
     - name: STRIPE_PUBLISHABLE_KEY
       value: pk_test_yndN9H0GcJffPe0W58Nm64cM00riYG4N46
@@ -698,6 +710,9 @@ staging:
 
         - name: CONTRACTS_API_URL
           value: https://contracts.staging.canonical.com/
+        
+        - name: SECURITY_API_URL
+          value: https://staging.ubuntu.com/security/
 
         - name: STRIPE_PUBLISHABLE_KEY
           value: pk_test_yndN9H0GcJffPe0W58Nm64cM00riYG4N46
@@ -919,6 +934,9 @@ staging:
 
         - name: CONTRACTS_API_URL
           value: https://contracts.staging.canonical.com/
+        
+        - name: SECURITY_API_URL
+          value: https://staging.ubuntu.com/security/
 
         - name: STRIPE_PUBLISHABLE_KEY
           value: pk_test_yndN9H0GcJffPe0W58Nm64cM00riYG4N46
@@ -1048,6 +1066,9 @@ demo:
 
     - name: CONTRACTS_API_URL
       value: https://contracts.staging.canonical.com/
+    
+    - name: SECURITY_API_URL
+      value: https://staging.ubuntu.com/security/
 
     - name: STRIPE_PUBLISHABLE_KEY
       value: pk_test_yndN9H0GcJffPe0W58Nm64cM00riYG4N46

--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -416,9 +416,6 @@ production:
         - name: CONTRACTS_API_URL
           value: https://contracts.canonical.com/
         
-        - name: SECURITY_API_URL
-          value: https://ubuntu.com/security/
-
         - name: STRIPE_PUBLISHABLE_KEY
           value: pk_live_68aXqowUeX574aGsVck8eiIE
 
@@ -710,9 +707,6 @@ staging:
 
         - name: CONTRACTS_API_URL
           value: https://contracts.staging.canonical.com/
-        
-        - name: SECURITY_API_URL
-          value: https://staging.ubuntu.com/security/
 
         - name: STRIPE_PUBLISHABLE_KEY
           value: pk_test_yndN9H0GcJffPe0W58Nm64cM00riYG4N46
@@ -897,6 +891,9 @@ staging:
 
         - name: SENTRY_DSN
           value: https://08dea8b1d0414fb89b28844cdb1e16a0@sentry.is.canonical.com//53
+        
+        - name: SECURITY_API_URL
+          value: https://staging.ubuntu.com/security/
 
     - paths: [/advantage, /account, /pro]
       name: ubuntu-com-advantage

--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -333,6 +333,9 @@ production:
 
     - paths: [/security/notices\.json]
       service_name: ubuntu-com-security-api-notices
+    
+    - paths: [/security/updates/.*]
+      service_name: ubuntu-com-security-api-updates
 
     - paths:
         [
@@ -839,6 +842,9 @@ staging:
 
     - paths: [/security/notices\.json]
       service_name: ubuntu-com-security-api-notices
+    
+    - paths: [/security/updates/.*]
+      service_name: ubuntu-com-security-api-updates
 
     - paths:
         [

--- a/webapp/security/api.py
+++ b/webapp/security/api.py
@@ -1,6 +1,11 @@
+import os
 from requests import Session
 from requests.exceptions import HTTPError
 from urllib.parse import urlencode
+
+SECURITY_API_URL = os.getenv(
+    "SECURITY_API_URL", "https://ubuntu.com/security/"
+)
 
 
 class SecurityAPIError(HTTPError):
@@ -12,7 +17,7 @@ class SecurityAPI:
     def __init__(
         self,
         session: Session,
-        base_url: str,
+        base_url=SECURITY_API_URL,
     ):
         self.session = session
         self.base_url = base_url

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -22,10 +22,7 @@ markdown_parser = Markdown(
 )
 session = talisker.requests.get_session()
 
-security_api = SecurityAPI(
-    session=session,
-    base_url="https://ubuntu.com/security/",
-)
+security_api = SecurityAPI(session=session)
 
 
 def get_processed_details(notice):


### PR DESCRIPTION
## Done

- Added a redirect for `/security/updates/.*` that sends traffic for usn updates to a dedicated service
- This PR should first be tested on staging, and only after [this](https://github.com/canonical/ubuntu-com-security-api/pull/161) has been merged to staging as well
- Declared the security api url as an env variable

## QA

- Check that the demo runs
- After merging to staging, test insertions on `/security/updates/*`
- Test that CVEs and Notices can be accessed on staging.ubuntu.com

## Notes
Before merging
- [ ] The U.C Jenkins job has been updated to deploy to prod only as we test - it should be changed back
- [ ] The security api Jenkins job should also be changed back

