### PR TITLE
Fix missing timezone errors

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -1042,8 +1042,26 @@ def get_user_country_by_tz():
     ) as file:
         countries = json.load(file)
 
-    _country = timezones[timezone]["c"][0]
-    country = countries[_country]
+    # Fallback to GB if timezone is invalid
+    try:
+        country_tz = timezones[timezone]
+    except KeyError:
+        country_tz = timezones["Europe/London"]
+
+    # Check timezone of country alias if country code not found
+    try:
+        _country = country_tz["c"][0]
+        country = countries[_country]
+    except KeyError:
+        try:
+            alias = country_tz["a"]
+            alias_tz = timezones[alias]
+            _country = alias_tz["c"][0]
+            country = countries[_country]
+        except KeyError:
+            country = "United Kingdom"
+            _country = "GB"
+
     return flask.jsonify(
         {
             "country": country,


### PR DESCRIPTION
## Done

- Some countries are missing timezone values, but they have country aliases that has the same timezone values
- Check if country has missing timezone and get the timezone from their respective aliases
- Added fallback country (GB) for invalid timezone queries

## QA

- Check out https://ubuntu-com-14000.demos.haus/
- For valid timezones, check that the country code and country shown is as expected. 
   Query:
  - `/user-country-tz.json?tz=Asia/Kuala_Lumpur`
  - `/user-country-tz.json?tz=America/Mendoza`
- For invalid timezones, the fallback value should be **{ "country": "United Kingdom",  "country_code": "GB" }**.
   Query:
  - `/user-country-tz.json?tz=Etc/GMT-8`
  - `/user-country-tz.json?tz=test`

## Issue / Card

Fixes [WD-12073](https://warthogs.atlassian.net/browse/WD-12073)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-12073]: https://warthogs.atlassian.net/browse/WD-12073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ