### PR TITLE
Fix CVE detailed view bug

### DIFF
--- a/static/js/src/cve/cve.js
+++ b/static/js/src/cve/cve.js
@@ -261,7 +261,7 @@ function handleLimitSelect() {
       window.location.href = url.href;
     };
   }
-  }
+}
 handleLimitSelect();
 
 function handleOrderSelect() {

--- a/static/js/src/cve/cve.js
+++ b/static/js/src/cve/cve.js
@@ -253,13 +253,15 @@ function handleLimitSelect() {
     limitSelect.value = urlParams.get("limit");
   }
 
-  limitSelect.onchange = function (event) {
-    limitSelect.value = event.target.value;
-    urlParams.set("limit", limitSelect.value);
-    url.search = urlParams.toString();
-    window.location.href = url.href;
-  };
-}
+  if (limitSelect) {
+    limitSelect.onchange = function (event) {
+      limitSelect.value = event.target.value;
+      urlParams.set("limit", limitSelect.value);
+      url.search = urlParams.toString();
+      window.location.href = url.href;
+    };
+  }
+  }
 handleLimitSelect();
 
 function handleOrderSelect() {
@@ -267,21 +269,25 @@ function handleOrderSelect() {
     orderSelect.value = urlParams.get("order");
   }
 
-  orderSelect.onchange = function (event) {
-    orderSelect.value = event.target.value;
-    urlParams.set("order", orderSelect.value);
-    url.search = urlParams.toString();
-    window.location.href = url.href;
-  };
+  if (orderSelect) {
+    orderSelect.onchange = function (event) {
+      orderSelect.value = event.target.value;
+      urlParams.set("order", orderSelect.value);
+      url.search = urlParams.toString();
+      window.location.href = url.href;
+    };
+  }
 }
 handleOrderSelect();
 
 function exportToJSON() {
-  exportLink.onclick = function (event) {
-    event.preventDefault();
-    let apiURL = new URL(url.search, apiBase);
-    window.location.href = apiURL.href;
-  };
+  if (exportLink) {
+    exportLink.onclick = function (event) {
+      event.preventDefault();
+      let apiURL = new URL(url.search, apiBase);
+      window.location.href = apiURL.href;
+    };
+  }
 }
 exportToJSON();
 

--- a/static/sass/_pattern_cve.scss
+++ b/static/sass/_pattern_cve.scss
@@ -371,5 +371,5 @@
       position: absolute;
       width: 100%;
     }
-  }  
+  }
 }

--- a/static/sass/_pattern_cve.scss
+++ b/static/sass/_pattern_cve.scss
@@ -207,6 +207,10 @@
     }
   }
 
+  .cve-footer-link {
+    font-size: 0.875rem;
+  }
+
   .cve-pagination-footer {
     display: flex;
     flex-wrap: wrap;
@@ -367,9 +371,5 @@
       position: absolute;
       width: 100%;
     }
-  }
-
-  .cve-footer-link {
-    font-size: 0.875rem;
-  }
+  }  
 }

--- a/templates/security/cve/_cve-table.html
+++ b/templates/security/cve/_cve-table.html
@@ -1,3 +1,4 @@
+{% set expand_table = cve.packages|length > 6 %}
 <table class="cve-table" aria-label="Detailed view of CVE card" id="table--{{ cve.id }}">
   <thead>
     <tr>
@@ -17,7 +18,7 @@
     {% for package in cve.packages %}
       {% set row_index = loop.index %}
       <tr class="{% if row_index > 6 %}expandable-row u-hide{% endif %}">
-        <td class="{% if row_index == 6 %}blurred-row cve-table-blur {% endif %}">{{ package.name }}</td>
+        <td class="{% if row_index == 6 and expand_table %}blurred-row cve-table-blur {% endif %}">{{ package.name }}</td>
         {% for release in selected_releases %}
           {% if versions|length == 0 %}
               {% set status = package.release_statuses[release.codename] %}
@@ -25,11 +26,11 @@
             {% set status = package.release_statuses[release.codename] %}
           {% endif %}
           {% if status %}
-            <td class="{% if row_index == 6 %}blurred-row cve-table-blur {% endif %}{% if status.slug == "DNE" %}u-text--muted{% endif %}">
+            <td class="{% if row_index == 6 and expand_table %}blurred-row cve-table-blur {% endif %}{% if status.slug == "DNE" %}u-text--muted{% endif %}">
               <i class="p-icon--{{ status.icon }}"></i> {{ status.name }}
             </td>
           {% elif versions|length > 0 or (versions|length == 0 and loop.index0 < 5) %}
-            <td class="{% if row_index == 6 %}blurred-row cve-table-blur{% endif %}">&mdash;</td>
+            <td class="{% if row_index == 6 and expand_table %}blurred-row cve-table-blur{% endif %}">&mdash;</td>
           {% endif %}
         {% endfor %}
       </tr>
@@ -37,7 +38,7 @@
     <tr />
   </tbody>
 </table>
-{% if cve.packages|length > 5 %}
+{% if expand_table %}
   <a href="" id="show--{{ cve.id }}" class="cve-footer-link p-link--soft js-show-packages">
     Show all {{ cve.packages | length }} packages
   </a>


### PR DESCRIPTION
## Done

- Apply blur effect and display "Show more packages" only if there are more than 6 packages
- Fix JS errors from missing footer actions by adding a check

## QA

- Go to `/security/cves?q=39331`
- Toggle detailed view and see that it works (previous JS errors was preventing this)
- Check that `CVE-2024-39331` detailed view shows without the blur effect and hides "Show more packages" button


## Issue / Card

Fixes [WD-12714](https://warthogs.atlassian.net/browse/WD-12714)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-12714]: https://warthogs.atlassian.net/browse/WD-12714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ