### PR TITLE
Update homepage notification banner

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -60,10 +60,10 @@
         <div class="p-notification--information u-no-margin--bottom">
           <div class="p-notification__content">
             <h5 class="p-notification__title">
-              <a href="/18-04">End of standard support for 18.04 LTS - 31 May 2023</a>
+              <a href="https://canonical.com/blog/canonical-offers-12-year-lts-for-any-open-source-docker-image">Canonical announces 12 year LTS for open source Docker images</a>
             </h5>
             <p class="p-notification__message">
-              <span>Upgrade to the latest Ubuntu LTS or get extended coverage until 2028 with Ubuntu Pro</span>
+              <span>Get a custom built container and let us handle the maintenance.</span>
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Done

- Updated notification banner copy as per [doc](https://docs.google.com/document/d/1ySJxQbqVdeH4Tra0zwBm2Tn0s56kFGnEF7d8xDRTxwU/edit#heading=h.g8inespqhurp)
 _Note: Suggested change for "Energise your engineers" is not relevant for this pr_

## QA

- View the site locally in your web browser at: https://ubuntu-com-14005.demos.haus/
- See that the banner copy has been updated as requested

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-12531