### PR TITLE
bug: Fix broken link on '/download/server/arm

### DIFF
--- a/templates/download/server/arm.html
+++ b/templates/download/server/arm.html
@@ -68,7 +68,7 @@
             Download {{ releases.lts.full_version }} LTS (64k page size)
           </a>
           <p>
-            <a href="/server/docs/choosing-between-the-arm64-and-arm64+largemem-installer-options">Find out if 64k page size is for you&nbsp;&rsaquo;</a>
+            <a href="/server/docs/choosing-between-the-arm64-and-arm64-largemem-installer-options">Find out if 64k page size is for you&nbsp;&rsaquo;</a>
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Done

- Fix broken link on '/download/server/arm', based on [copydoc](https://docs.google.com/document/d/1whVU3DvB9j5k6Ed3UvLZCEN6BU-lZcow4ZefqKQqokg/edit)

## QA

- Go to /download/server/arm
- Compare the changes in the [copydoc](https://docs.google.com/document/d/1whVU3DvB9j5k6Ed3UvLZCEN6BU-lZcow4ZefqKQqokg/edit) to demo

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-12715
