### PR TITLE
change finalized to finalised in your exams

### DIFF
--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -51,7 +51,7 @@ RESERVATION_STATES = {
     "scheduled": "Scheduled",
     "processed": "Processed",
     "canceled": "Cancelled",
-    "finalized": "Finalized",
+    "finalized": "Finalised",
     "provisioning": "Provisioning",
     "provisioned": "Provisioned",
     "in_progress": "In Progress",


### PR DESCRIPTION
## Done

- change `Finalized` to `Finalised` in exam status

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Confirm that a finalised exam status shows up as `Finalised` rather than `Finalized`

## Issue / Card

Fixes [Jira](https://warthogs.atlassian.net/browse/WD-12756)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
