### PR TITLE
Add missing param and disable empty status option

### DIFF
--- a/templates/security/cve/_status-fields.html
+++ b/templates/security/cve/_status-fields.html
@@ -1,4 +1,4 @@
-<option value="">Any</option>
+<option value="" disabled selected>Any</option>
 <option value="DNE" {% if statuses[index] == "DNE" %}selected{% endif %}>
   Does not exist
 </option>

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -132,6 +132,7 @@ def notices():
         offset=offset,
         details=details,
         release=release,
+        order=order,
     )
 
     # get notices and total results from response object


### PR DESCRIPTION
## Done

- Removed the empty status option which is not needed anymore
- Add missing order param

## QA

- View the site locally in your web browser at: https://ubuntu-com-14010.demos.haus/security/cves
- Filter by Ubuntu version and see that the "any" option is just a placeholder


## Issue / Card

Fixes https://sentry.is.canonical.com/canonical/ubuntu-security/issues/76522/?query=is%3Aunresolved, https://warthogs.atlassian.net/browse/WD-12658
