### PR TITLE
WD-12783 - add intel logo to intel-iot page

### DIFF
--- a/templates/download/iot/intel-iot.html
+++ b/templates/download/iot/intel-iot.html
@@ -18,7 +18,14 @@
   <section class="p-strip is-shallow u-no-padding--bottom">
     <div class="row--50-50">
       <div class="col">
-        <h1>Download Ubuntu for Intel IoT platforms</h1>
+        <h1 class="p-section">Download Ubuntu for Intel IoT platforms</h1>
+        {{ image(url="https://assets.ubuntu.com/v1/c6a46f74-logo.jpg",
+                      alt="Intel",
+                      width="76",
+                      hi_def=True,
+                      loading="lazy",
+                      attrs="" | safe
+        }}
       </div>
       <div class="col">
         <p class="p-heading--5">Accelerate industrial compute with Ubuntu on Intel processors</p>

--- a/templates/download/iot/intel-iot.html
+++ b/templates/download/iot/intel-iot.html
@@ -23,7 +23,7 @@
                       alt="Intel",
                       width="76",
                       hi_def=True,
-                      loading="lazy", )
+                      loading="lazy") | safe
                       | safe 
         }}
       </div>

--- a/templates/download/iot/intel-iot.html
+++ b/templates/download/iot/intel-iot.html
@@ -24,7 +24,6 @@
                       width="76",
                       hi_def=True,
                       loading="lazy") | safe
-                      | safe 
         }}
       </div>
       <div class="col">

--- a/templates/download/iot/intel-iot.html
+++ b/templates/download/iot/intel-iot.html
@@ -23,8 +23,8 @@
                       alt="Intel",
                       width="76",
                       hi_def=True,
-                      loading="lazy",
-                      attrs="" | safe
+                      loading="lazy", )
+                      | safe 
         }}
       </div>
       <div class="col">


### PR DESCRIPTION
## Done

Add logo to intel-not page

## QA

- [demo link](https://ubuntu-com-14015.demos.haus/download/iot/intel-iot)
- [figma](https://www.figma.com/design/cVGimTPHky4h3BPXfrT6GB/24.04-U.com---download-(rebranding)?node-id=1693-6726&t=z6oMayhly8e9P4zj-0)
- View the site on demo
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check that the logo is correctly added

## Issue / Card
[WD-12783](https://warthogs.atlassian.net/browse/WD-12783)


[WD-12783]: https://warthogs.atlassian.net/browse/WD-12783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ