### PR TITLE
WD-12794 - update link on /what-is-kubeflow

### DIFF
--- a/templates/ai/what-is-kubeflow.html
+++ b/templates/ai/what-is-kubeflow.html
@@ -156,7 +156,7 @@
         </div>
         <div class="col-3 col-medium-2">
           <h3 class="p-heading--5">Experiments, Runs and Recurring Runs</h3>
-          <p>Experiments, groups of <a href="https://www.kubeflow.org/docs/pipelines/pipelines-quickstart/#run-an-ml-pipeline">Kubeflow Pipeline 'Runs'</a> and <a href="https://www.kubeflow.org/docs/components/pipelines/overview/concepts/run/">Recurring Runs</a>, allow you to find the right parameters for your model, compare and replicate results.</p>
+          <p>Experiments, groups of <a href="https://www.kubeflow.org/docs/pipelines/pipelines-quickstart/#run-an-ml-pipeline">Kubeflow Pipeline 'Runs'</a> and <a href="https://www.kubeflow.org/docs/components/pipelines/concepts/run/">Recurring Runs</a>, allow you to find the right parameters for your model, compare and replicate results.</p>
         </div>
         <div class="col-3 col-medium-2">
           <h3 class="p-heading--5">Hyperparameter tuning / AutoML</h3>


### PR DESCRIPTION
## Done

Update link on /what-is-kubeflow

## QA

- [demo link](https://ubuntu-com-14023.demos.haus/ai/what-is-kubeflow)
- [copy doc](https://docs.google.com/document/d/1m-96RlGkbzFa1KaGAxYFpY0ztIlsTuViCjXSAlErQlg/edit)
- View the site on demo
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check that the link is correct according to copy doc

## Issue / Card
[WD-12794](https://warthogs.atlassian.net/browse/WD-12794)

[WD-12794]: https://warthogs.atlassian.net/browse/WD-12794?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ