### PR TITLE
chore: Bump flask-base to test Flask 2.3.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-canonicalwebteam.flask-base==1.1.0
+# canonicalwebteam.flask-base==1.1.0
+canonicalwebteam.flask-base @ git+https://github.com/canonical/canonicalwebteam.flask-base.git@wd-12659
 canonicalwebteam.http==1.0.4
 canonicalwebteam.blog==6.4.1
 canonicalwebteam.search==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-# canonicalwebteam.flask-base==1.1.0
-canonicalwebteam.flask-base @ git+https://github.com/canonical/canonicalwebteam.flask-base.git@wd-12659
+canonicalwebteam.flask-base==2.0.0
 canonicalwebteam.http==1.0.4
 canonicalwebteam.blog==6.4.1
 canonicalwebteam.search==1.3.0

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -15,11 +15,11 @@ class LogoutRedirects(unittest.TestCase):
 
         self.assertEqual(302, response.status_code)
 
-        self.assertEqual("http://localhost/", response.location)
+        self.assertEqual("/", response.location)
 
     def test_logout_with_return(self):
         response = self.client.get("/logout?return_to=/pro")
 
         self.assertEqual(302, response.status_code)
 
-        self.assertEqual("http://localhost/pro", response.location)
+        self.assertEqual("/pro", response.location)


### PR DESCRIPTION
## Done

- Bumps to the latest version of [flask-base](https://github.com/canonical/canonicalwebteam.flask-base) 2.0.0

Removes 'localhost' ref in some tests - [2.3.3](https://flask.palletsprojects.com/en/2.3.x/changes/#version-2-3-3)

## QA

- Go around the pro

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-13081

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
