### PR TITLE
Set generic USN and CVE values and remove api call

### DIFF
--- a/templates/16-04/index.html
+++ b/templates/16-04/index.html
@@ -34,14 +34,12 @@
         </p>
       </div>
       <div class="col-5 u-hide--medium u-hide--small u-align--center">
-        {{ image (
-        url="https://assets.ubuntu.com/v1/41cb88c9-xerus_orange_hex.svg",
-        alt="",
-        width="200",
-        height="203",
-        hi_def=True,
-        loading="auto"
-        ) | safe
+        {{ image(url="https://assets.ubuntu.com/v1/41cb88c9-xerus_orange_hex.svg",
+                alt="",
+                width="200",
+                height="203",
+                hi_def=True,
+                loading="auto") | safe
         }}
         <div style="margin: auto; width: 70%;">
           <hr class="p-separator u-no-margin--bottom" />
@@ -71,39 +69,20 @@
     </div>
     <div class="row" style="margin-top: 1rem">
       <div class="col-4 u-sv3">
-        <span style="font-size: 3rem; line-height: 4rem">{{ notices_since_esm }}</span>
+        <span style="font-size: 3rem; line-height: 4rem">900&plus;</span>
         <hr />
-        <span class="p-muted-heading">USNS ISSUED<sup><a href="#os-footnote">*</a></sup></span>
+        <span class="p-muted-heading"><a href="/security/notices?release=xenial">Security notices</a> issued<sup>*</sup></span>
       </div>
       <div class="col-4">
-        <!-- Hardcoded for now until this issue is fixed https://github.com/canonical-web-and-design/ubuntu-com-security-api/issues/56 -->
-        <span style="font-size: 3rem; line-height: 4rem">343</span>
+        <span style="font-size: 3rem; line-height: 4rem">300&plus;</span>
         <hr />
-        <span class="p-muted-heading">CVES ADDRESSED<sup><a href="#os-footnote">*</a></sup></span>
+        <span class="p-muted-heading"><a href="/security/cves?version=xenial">CVES</a> ADDRESSED<sup>*</sup></span>
       </div>
     </div>
     <div class="u-fixed-width">
       <p id="os-footnote">
         <small>* Since the start of the ESM phase</small>
       </p>
-    </div>
-    <div class="row" id="notice-feed" style="margin-top: 3rem">
-      {% for notice in latest_notices %}
-        <hr />
-        <div class="col-6">
-          <strong><span><a href="/security/notices/{{ notice.id }}">{{ notice.title }}</a></span></strong>
-          <br />
-          <span class="p-muted-heading">{{ notice.date }}</span>
-          <br />
-          <br />
-        </div>
-        <div class="col-6">
-          <p>{{ notice.summary }}</p>
-        </div>
-      {% endfor %}
-    </div>
-    <div class="row" style="margin-top: 2rem">
-      <a href="/security/notices?release=xenial">View the full list&nbsp;&rsaquo;</a>
     </div>
   </section>
 
@@ -123,14 +102,12 @@
         </p>
       </div>
       <div class="col-6 u-hide--medium u-hide--small u-align--center u-vertically-center">
-        {{ image (
-        url="https://assets.ubuntu.com/v1/69d31769-updates-security-maintenance.svg",
-        alt="",
-        width="190",
-        height="190",
-        hi_def=True,
-        loading="lazy"
-        ) | safe
+        {{ image(url="https://assets.ubuntu.com/v1/69d31769-updates-security-maintenance.svg",
+                alt="",
+                width="190",
+                height="190",
+                hi_def=True,
+                loading="lazy") | safe
         }}
       </div>
     </div>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -140,7 +140,6 @@ from webapp.views import (
     releasenotes_redirect,
     show_template,
     sitemap_index,
-    sixteen_zero_four,
     spanish_why_openstack,
     subscription_centre,
     thank_you,
@@ -601,7 +600,6 @@ def takeovers_index():
     )
 
 
-app.add_url_rule("/16-04", view_func=sixteen_zero_four)
 app.add_url_rule("/takeovers.json", view_func=takeovers_json)
 app.add_url_rule("/takeovers", view_func=takeovers_index)
 

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -86,44 +86,6 @@ def _build_mirror_list(local=False, country_code=None):
     return mirror_list
 
 
-def sixteen_zero_four():
-    total_notices_issued = "0"
-    latest_notices = []
-
-    try:
-        response = session.request(
-            method="GET",
-            url=(
-                "https://ubuntu.com/security/"
-                "notices.json?release=xenial&limit=5"
-            ),
-        )
-
-        total_notices_issued = response.json().get("total_results")
-        latest_notices = [
-            {
-                "id": notice.get("id"),
-                "title": notice.get("title"),
-                "date": dateutil.parser.parse(
-                    notice.get("published")
-                ).strftime("%d %B %Y"),
-                "summary": notice.get("summary"),
-            }
-            for notice in response.json().get("notices")
-        ]
-    except HTTPError:
-        flask.current_app.extensions["sentry"].captureException()
-
-    # Can only assume there were 1477 notices before ESM
-    notices_since_esm = total_notices_issued - 1477
-    context = {
-        "latest_notices": latest_notices,
-        "notices_since_esm": notices_since_esm,
-    }
-
-    return flask.render_template("16-04/index.html", **context)
-
-
 def show_template(filename):
     try:
         template_content = flask.render_template(f"templates/{filename}.html")


### PR DESCRIPTION
## Done

- Hard coded USN and CVE numbers for xenial
- Removed recent notices list
- Removed call to notices endpoint from this page

## Rationale

These values have been incorrect for some time and it was decided that we don't really need to show the exact number of USNs that were addressed for this release after the ESM phase, a general value will suffice for the purposes of this page. We also decided to remove the recent notices table so that this page does not need to make a call to the notices endpoint at all.   

## QA

- View the site locally in your web browser at: https://ubuntu-com-14026.demos.haus/16-04
- See that the above changes have been made and that remaining links work as expected

## Issue / Card

Fixes https://github.com/canonical/ubuntu-com-security-api/issues/56, https://warthogs.atlassian.net/browse/WD-12901

## Screenshots
![image](https://github.com/canonical/ubuntu.com/assets/17607612/bf052430-a4ba-4cd4-ad21-01a5cf8debc9)


