### PR TITLE
Remove empty values from CVE filter params

### DIFF
--- a/templates/security/cve/_version-and-status-row.html
+++ b/templates/security/cve/_version-and-status-row.html
@@ -8,7 +8,7 @@
       <label for="version">Ubuntu version</label>
     {% endif %}
     <select name="version" class="js-ubuntu-version-input" {% if show_labels %}id="version"{% endif %}>
-      <option value="">Any</option>
+      <option value="" selected disabled>Any</option>
       {% with versions=versions, releases=releases, index=index %}
       {% include "security/cve/_version-fields.html" %}
       {% endwith %}

--- a/templates/security/cve/index.html
+++ b/templates/security/cve/index.html
@@ -10,125 +10,124 @@
 
 {% block content %}
 
-<section class="p-strip--suru-topped u-no-padding--bottom">
-  <div class="u-fixed-width">
-    {% if query or package or component or priority or versions or statuses %}
-      <h1>CVE search results</h1>
-    {% else %}
-      <h1>CVE reports</h1>
-
-      <p>The Common Vulnerabilities and Exposures (CVE) system is used to identify, define, and catalog publicly disclosed cybersecurity vulnerabilities. Canonical keeps track of all CVEs affecting Ubuntu, and releases a <a href="/security/notices">security notice</a> when an issue is fixed.</p>
-
-      <p>Canonical also produces <a href="/security/oval">Open Vulnerability and Assessment Language (OVAL)</a> data, which is machine-readable, to enable auditing for CVEs and to determine whether a particular patch, via an Ubuntu Security Notice (USN), is appropriate for the local system.</p>
-    {% endif %}
-  </div>
-</section>
-
-<section class="p-strip is-shallow">
-  <div class="u-fixed-width">
-    {% if query or package or component or priority or versions or statuses %}
-      <!-- has to be this way because query string can exist with empty values -->
-    {% else %}
-      <h2>Search</h2>
-    {% endif %}
-  </div>
-  <form id = "searchForm">
-    <div class="row">
-      <div class="col-6">
-        <label for="q">CVE ID or description contains:</label>
-        <input type="text" name="q" id="q" value="{{ query or '' }}">
-      </div>
-      <div class="col-3">
-        <label for="package">Package:</label>
-        <input type="text" name="package" id="package" value="{{ package or '' }}" placeholder="Any">
-      </div>
-      <div class="col-3">
-        <label for="priority">Priority:</label>
-        <select name="priority" id="priority">
-          <option value="" disabled selected>Any</option>
-          <option value="critical" {% if priority == 'critical' %}selected{% endif %}>
-            Critical
-          </option>
-          <option value="high" {% if priority == 'high' %}selected{% endif %}>
-            High
-          </option>
-          <option value="medium" {% if priority == 'medium' %}selected{% endif %}>
-            Medium
-          </option>
-          <option value="low" {% if priority == 'low' %}selected{% endif %}>
-            Low
-          </option>
-          <option value="negligible" {% if priority == 'negligible' %}selected{% endif %}>
-            Negligible
-          </option>
-        </select>
-      </div>
-    </div>
-    {% if versions | length > 0 %}
-      {% for version in versions %}
-        {% with versions=versions, statuses=statuses, releases=releases, index=loop.index - 1 %}
-        {% include "security/cve/_version-and-status-row.html" %}
-        {% endwith %}
-      {% endfor %}
-    {% else %}
-      {% with versions=versions, statuses=statuses, releases=releases, index=0 %}
-      {% include "security/cve/_version-and-status-row.html" %}
-      {% endwith %}
-    {% endif %}
-    <div id="new-row-container"></div>
+  <section class="p-strip--suru-topped u-no-padding--bottom">
     <div class="u-fixed-width">
-      <button type="submit" class="p-button--positive" id="cve-search-button">
-        <span class="cve-search-text">Search</span>
-        <span class="cve-search-valid-cve-text u-hide">Go to CVE</span>
-      </button>
-    </div>
-  </form>
-</section>
+      {% if query or package or component or priority or versions or statuses %}
+        <h1>CVE search results</h1>
+      {% else %}
+        <h1>CVE reports</h1>
 
-<section class="p-strip is-shallow u-overflow-inherit">
-  <div class="u-fixed-width">
-    {% if query or package or priority %}
-    <h2>
-      {% if total_results > 1 %}
-        {{ offset + 1 }}
-        &ndash;
-        {% if offset + limit > total_results %}
-          {{ total_results }}
-        {% else %}
-          {{ offset + limit }}
-        {% endif %}
-        of
+        <p>
+          The Common Vulnerabilities and Exposures (CVE) system is used to identify, define, and catalog publicly disclosed cybersecurity vulnerabilities. Canonical keeps track of all CVEs affecting Ubuntu, and releases a <a href="/security/notices">security notice</a> when an issue is fixed.
+        </p>
+
+        <p>
+          Canonical also produces <a href="/security/oval">Open Vulnerability and Assessment Language (OVAL)</a> data, which is machine-readable, to enable auditing for CVEs and to determine whether a particular patch, via an Ubuntu Security Notice (USN), is appropriate for the local system.
+        </p>
       {% endif %}
-      {{ total_results }} result{% if total_results != 1 %}s{% endif %}
-    </h2>
-    {% else %}
-    <h2>Recent CVEs affecting Ubuntu</h2>
+    </div>
+  </section>
+
+  <section class="p-strip is-shallow">
+    <div class="u-fixed-width">
+      {% if query or package or component or priority or versions or statuses %}
+        <!-- has to be this way because query string can exist with empty values -->
+      {% else %}
+        <h2>Search</h2>
+      {% endif %}
+    </div>
+    <form id="searchForm">
+      <div class="row">
+        <div class="col-6">
+          <label for="q">CVE ID or description contains:</label>
+          <input type="text" name="q" id="q" value="{{ query or '' }}" />
+        </div>
+        <div class="col-3">
+          <label for="package">Package:</label>
+          <input type="text"
+                 name="package"
+                 id="package"
+                 value="{{ package or '' }}"
+                 placeholder="Any" />
+        </div>
+        <div class="col-3">
+          <label for="priority">Priority:</label>
+          <select name="priority" id="priority">
+            <option value="" disabled selected>Any</option>
+            <option value="critical" {% if priority == 'critical' %}selected{% endif %}>Critical</option>
+            <option value="high" {% if priority == 'high' %}selected{% endif %}>High</option>
+            <option value="medium" {% if priority == 'medium' %}selected{% endif %}>Medium</option>
+            <option value="low" {% if priority == 'low' %}selected{% endif %}>Low</option>
+            <option value="negligible" {% if priority == 'negligible' %}selected{% endif %}>Negligible</option>
+          </select>
+        </div>
+      </div>
+      {% if versions | length > 0 %}
+        {% for version in versions %}
+          {% with versions=versions, statuses=statuses, releases=releases, index=loop.index - 1 %}
+            {% include "security/cve/_version-and-status-row.html" %}
+          {% endwith %}
+        {% endfor %}
+      {% else %}
+        {% with versions=versions, statuses=statuses, releases=releases, index=0 %}
+          {% include "security/cve/_version-and-status-row.html" %}
+        {% endwith %}
+      {% endif %}
+      <div id="new-row-container"></div>
+      <div class="u-fixed-width">
+        <button type="submit" class="p-button--positive" id="cve-search-button">
+          <span class="cve-search-text">Search</span>
+          <span class="cve-search-valid-cve-text u-hide">Go to CVE</span>
+        </button>
+      </div>
+    </form>
+  </section>
+
+  <section class="p-strip is-shallow u-overflow-inherit">
+    <div class="u-fixed-width">
+      {% if query or package or priority %}
+        <h2>
+          {% if total_results > 1 %}
+            {{ offset + 1 }}
+            &ndash;
+            {% if offset + limit > total_results %}
+              {{ total_results }}
+            {% else %}
+              {{ offset + limit }}
+            {% endif %}
+            of
+          {% endif %}
+          {{ total_results }} result
+          {% if total_results != 1 %}s{% endif %}
+        </h2>
+      {% else %}
+        <h2>Recent CVEs affecting Ubuntu</h2>
+      {% endif %}
+    </div>
+
+    {% if total_results > 0 %}
+      <div class="u-fixed-width">
+        {% with cves=cves, releases=releases %}
+          {% include "security/cve/_cve-table.html" %}
+        {% endwith %}
+
+        {% with %}
+          {% include "security/cve/_pagination.html" %}
+        {% endwith %}
+      </div>
     {% endif %}
-  </div>
+  </section>
 
-  {% if total_results > 0 %}
-  <div class="u-fixed-width">
-    {% with cves=cves, releases=releases %}
-    {% include "security/cve/_cve-table.html" %}
+  <template id="version-field-row-template">
+    {% with versions=versions, statuses=statuses, releases=releases %}
+      {% include "security/cve/_version-and-status-row.html" %}
     {% endwith %}
+  </template>
 
-    {% with %}
-    {% include "security/cve/_pagination.html" %}
-    {% endwith %}
-  </div>
-  {% endif %}
-</section>
+  <script src="{{ versioned_static('js/dist/cve.js') }}" defer></script>
 
-<template id="version-field-row-template">
-  {% with versions=versions, statuses=statuses, releases=releases %}
-  {% include "security/cve/_version-and-status-row.html" %}
+  {% with first_item="_security_discussion", second_item="_security_esm", third_item="_security_further_reading" %}
+    {% include "shared/contextual_footers/_contextual_footer.html" %}
   {% endwith %}
-</template>
-
-<script src="{{ versioned_static('js/dist/cve.js') }}" defer></script>
-
-{% with first_item="_security_discussion", second_item="_security_esm", third_item="_security_further_reading" %}
-{% include "shared/contextual_footers/_contextual_footer.html" %}
-{% endwith %}
 
 {% endblock %}

--- a/templates/security/cve/index.html
+++ b/templates/security/cve/index.html
@@ -45,7 +45,7 @@
       <div class="col-3">
         <label for="priority">Priority:</label>
         <select name="priority" id="priority">
-          <option value="">Any</option>
+          <option value="" disabled selected>Any</option>
           <option value="critical" {% if priority == 'critical' %}selected{% endif %}>
             Critical
           </option>


### PR DESCRIPTION
## Done

- Removed default empty values for `version` and `priority` param

## QA

- View the site locally in your web browser at: https://ubuntu-com-14027.demos.haus/security/cves
- Click search and see that empty version and priority values are not passed by default and that the CVE list remains unchanged
- Using the form, search for the package "mysql" and see that you get 1359 results
- Do the same thing but for package "ssh" and see that you get 139 results

## Issue / Card

Fixes https://github.com/canonical/ubuntu.com/issues/14020, https://warthogs.atlassian.net/browse/WD-12819