### PR TITLE
 GROWENG-3933 refactor dataLayer.push for GA4 structure #13998 

### DIFF
--- a/static/js/src/contributions.js
+++ b/static/js/src/contributions.js
@@ -143,29 +143,22 @@ function sendContributionFormAnalytics() {
   const inputs = document.querySelectorAll(".p-slider__input");
   const total = document.querySelector(".js-total-amount").innerText;
 
+  let dataLayerObject = {
+    event: "contribution",
+    total: total
+  };
+
   // add the individual items
   inputs.forEach((amountElement) => {
     const name = amountElement.parentNode.parentNode.id;
     let value = amountElement.value || 0;
 
     if (value > 0) {
-      dataLayer.push({
-        event: "GAEvent",
-        eventCategory: "Contributions",
-        eventAction: "Item",
-        eventLabel: name,
-        eventValue: value,
-      });
+      dataLayerObject.name =  value;
     }
   });
 
-  dataLayer.push({
-    event: "GAEvent",
-    eventCategory: "Contributions",
-    eventAction: "Paid",
-    eventLabel: "Total",
-    eventValue: total,
-  });
+  dataLayer.push(dataLayerObject);
 }
 
 function detectBrowser() {

--- a/static/js/src/contributions.js
+++ b/static/js/src/contributions.js
@@ -145,7 +145,7 @@ function sendContributionFormAnalytics() {
 
   let dataLayerObject = {
     event: "contribution",
-    total: total
+    total: total,
   };
 
   // add the individual items
@@ -154,7 +154,7 @@ function sendContributionFormAnalytics() {
     let value = amountElement.value || 0;
 
     if (value > 0) {
-      dataLayerObject[name] =  value;
+      dataLayerObject[name] = value;
     }
   });
 

--- a/static/js/src/contributions.js
+++ b/static/js/src/contributions.js
@@ -154,7 +154,7 @@ function sendContributionFormAnalytics() {
     let value = amountElement.value || 0;
 
     if (value > 0) {
-      dataLayerObject.name =  value;
+      dataLayerObject[name] =  value;
     }
   });
 


### PR DESCRIPTION
## Done
- Recreated #13998 

- Refactored sendContributionFormAnalytics function not to send multiple GAEvent pushes to the dataLayer but to send one push with the data as key-value pairs within that push in order to respect GA4 event parameter data model

## QA

- Visit https://ubuntu-com-14030.demos.haus/download/desktop/thank-you?version=24.04&architecture=amd64&lts=true
- Click on contribution with various contribution amount settings (including 0)
- Check the value of the dataLayer array in the console whether the "contribution" event object in the array appears and whether it has the correct data

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
