### PR TITLE
remove credit card requirement if product price is 0

### DIFF
--- a/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
@@ -68,7 +68,6 @@ const BuyButton = ({ setError, quantity, product, action, coupon }: Props) => {
   const onPayClick = async () => {
     validateForm().then((errors) => {
       const possibleErrors = Object.keys(errors);
-
       possibleErrors.forEach((error) => {
         setFieldTouched(error, true);
       });
@@ -108,7 +107,7 @@ const BuyButton = ({ setError, quantity, product, action, coupon }: Props) => {
     }
 
     // Update customer information
-    if (!values.defaultPaymentMethod) {
+    if (!values.defaultPaymentMethod && product?.price?.value!=0) {
       await postCustomerInfoMutation.mutateAsync(
         { formData: values },
         {

--- a/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
@@ -107,7 +107,7 @@ const BuyButton = ({ setError, quantity, product, action, coupon }: Props) => {
     }
 
     // Update customer information
-    if (!values.defaultPaymentMethod && product?.price?.value!=0) {
+    if (!values.defaultPaymentMethod && product?.price?.value != 0) {
       await postCustomerInfoMutation.mutateAsync(
         { formData: values },
         {

--- a/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
@@ -107,7 +107,7 @@ const BuyButton = ({ setError, quantity, product, action, coupon }: Props) => {
     }
 
     // Update customer information
-    if (!values.defaultPaymentMethod && product?.price?.value != 0) {
+    if (!values.defaultPaymentMethod && product?.price?.value !== 0) {
       await postCustomerInfoMutation.mutateAsync(
         { formData: values },
         {

--- a/static/js/src/advantage/subscribe/checkout/components/Checkout/Checkout.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Checkout/Checkout.tsx
@@ -110,10 +110,14 @@ const Checkout = ({ product, quantity, action, coupon }: Props) => {
                         />
                       ),
                     },
-                    ...(product?.price?.value==0?[]:[{
-                      title: "Your information",
-                      content: <UserInfoForm setError={setError} />,
-                    }]),
+                    ...(product?.price?.value == 0
+                      ? []
+                      : [
+                          {
+                            title: "Your information",
+                            content: <UserInfoForm setError={setError} />,
+                          },
+                        ]),
                     ...(canTrial
                       ? [
                           {

--- a/static/js/src/advantage/subscribe/checkout/components/Checkout/Checkout.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Checkout/Checkout.tsx
@@ -110,10 +110,10 @@ const Checkout = ({ product, quantity, action, coupon }: Props) => {
                         />
                       ),
                     },
-                    {
+                    ...(product?.price?.value==0?[]:[{
                       title: "Your information",
                       content: <UserInfoForm setError={setError} />,
-                    },
+                    }]),
                     ...(canTrial
                       ? [
                           {

--- a/webapp/shop/cred/exams.json
+++ b/webapp/shop/cred/exams.json
@@ -3,6 +3,10 @@
     "id": "cue-01-linux",
     "name": "CUE.01 Linux",
     "displayName": "CUE.01 Linux",
+    "price": {
+      "value": 0,
+      "currency": "USD"
+    },
     "metadata": [
       {
         "key": "description",

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -854,8 +854,8 @@ def cred_shop(ua_contracts_api, **kwargs):
                 exam["period"] = product["period"]
                 exam["marketplace"] = product["marketplace"]
                 exam["name"] = product["name"]
-    
-    # purchase account required for purchasing from marketplace 
+
+    # purchase account required for purchasing from marketplace
     ua_contracts_api.ensure_purchase_account("canonical-cube")
 
     return flask.render_template(

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -843,7 +843,7 @@ def cred_submit_form(**_):
 
 @shop_decorator(area="cube", permission="user", response="html")
 @canonical_staff()
-def cred_shop(**kwargs):
+def cred_shop(ua_contracts_api, **kwargs):
     exams_file = open("webapp/shop/cred/exams.json", "r")
     exams = json.load(exams_file)
     cue_products = get_cue_products(type="exam").json
@@ -854,6 +854,9 @@ def cred_shop(**kwargs):
                 exam["period"] = product["period"]
                 exam["marketplace"] = product["marketplace"]
                 exam["name"] = product["name"]
+    
+    # purchase account required for purchasing from marketplace 
+    ua_contracts_api.ensure_purchase_account("canonical-cube")
 
     return flask.render_template(
         "credentials/shop/index.html",


### PR DESCRIPTION
## Done

- Remove card requirement if product value is 0

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- Create a new account on Ubuntu One
// Positive QA
- visit /credentials/shop
    - Click on buy
    - Check that the checkout shows all the values correctly
    - Click on Buy Now
    -  Verify that the purchase goes through
// Negative QA
- visit /pro/subscribe
    - Purchase any product
    - Verify the price is right
    - Verify that card is required for purchasing
    - Verify that the purchase goes through
   
## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
