### PR TITLE
allow non canonical users to view shop

### DIFF
--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -842,7 +842,6 @@ def cred_submit_form(**_):
 
 
 @shop_decorator(area="cube", permission="user", response="html")
-@canonical_staff()
 def cred_shop(**kwargs):
     exams_file = open("webapp/shop/cred/exams.json", "r")
     exams = json.load(exams_file)

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -842,7 +842,7 @@ def cred_submit_form(**_):
 
 
 @shop_decorator(area="cube", permission="user", response="html")
-def cred_shop(**kwargs):
+def cred_shop(ua_contracts_api, **kwargs):
     exams_file = open("webapp/shop/cred/exams.json", "r")
     exams = json.load(exams_file)
     cue_products = get_cue_products(type="exam").json


### PR DESCRIPTION
## Done

- Allow users with non-canonical email domain to view shop

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Sign up with a non canonical.com email domain and visit `credentials/shop`
- You should see products and be able to buy the exam

## Issue / Card

Fixes [Jira](https://warthogs.atlassian.net/browse/WD-12792)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
