### PR TITLE
Bump discourse module 5.6.1 & Vanilla 4.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "typescript": "4.5.4",
     "url-polyfill": "1.1.12",
     "url-search-params-polyfill": "8.1.1",
-    "vanilla-framework": "4.13.0",
+    "vanilla-framework": "4.14.0",
     "yup": "0.32.11"
   },
   "resolutions": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ canonicalwebteam.blog==6.4.1
 canonicalwebteam.search==1.3.0
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.3.1
-canonicalwebteam.discourse==5.5.0
+canonicalwebteam.discourse @ git+https://github.com/canonical/canonicalwebteam.discourse.git@nested-heading-fix
 python-dateutil==2.8.2
 pytz==2022.7.1
 maxminddb-geolite2==2018.703

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ canonicalwebteam.blog==6.4.1
 canonicalwebteam.search==1.3.0
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.3.1
-canonicalwebteam.discourse @ git+https://github.com/canonical/canonicalwebteam.discourse.git@nested-heading-fix
+canonicalwebteam.discourse==5.6.1
 python-dateutil==2.8.2
 pytz==2022.7.1
 maxminddb-geolite2==2018.703

--- a/yarn.lock
+++ b/yarn.lock
@@ -7975,10 +7975,10 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-vanilla-framework@4.13.0:
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.13.0.tgz#3901952faf819be42b24d2efc719c73de384a8ab"
-  integrity sha512-mUSJqs56ycxpEZwplTOiy4SfihjWsPiAddnQZ9b0s0ak8mLHVxnJF1aNIpPixPWK/NvhD9jVACn5qa2pGabRMQ==
+vanilla-framework@4.14.0:
+  version "4.14.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.14.0.tgz#dca425c806462179467030ac30ef496997e2d8cb"
+  integrity sha512-YctHWwH1SbIltBMMVdeiVW1QtxVjaU15jLKiubgVjE9AByuK/EriyZnPQkXtb/+Rwf1mtF24rae+mmG8aFqUJw==
 
 vanilla-framework@4.9.0:
   version "4.9.0"


### PR DESCRIPTION
## Done

- Bump discourse module 5.6.1
- Vanilla 4.14.0

## QA

- Go to https://ubuntu-com-14036.demos.haus/ceph/docs
- Hover over a h2/h3 and see that the [vanilla anchor link](https://vanillaframework.io/docs/patterns/links#anchor-link) style works
- Click the link and see it adds the anchor to the url

## Issue / Card

Fixes 
