### PR TITLE
WD-12895 - update 10 to 12 years support

### DIFF
--- a/templates/certified/index.html
+++ b/templates/certified/index.html
@@ -3,7 +3,7 @@
 {% block title %}Certified hardware{% endblock %}
 
 {% block meta_description %}
-  Ubuntu Certified Hardware has passed our extensive testing and review process, ensuring that Ubuntu runs optimally out of the box, ready for your organisation. Canonical provides continuous support throughout the lifecycle of the Ubuntu release to ensure quality, functionality, and maintenance for up to 10 years
+  Ubuntu Certified Hardware has passed our extensive testing and review process, ensuring that Ubuntu runs optimally out of the box, ready for your organisation. Canonical provides continuous support throughout the lifecycle of the Ubuntu release to ensure quality, functionality, and maintenance for up to 12 years
 {% endblock meta_description %}
 
 {% block meta_copydoc %}
@@ -422,7 +422,7 @@
         <h2>
           Regular testing
           <br />
-          for up to 10 years
+          for up to 12 years
         </h2>
         <p>
           Roughly every 3 weeks, Ubuntu releases <a href="https://wiki.ubuntu.com/StableReleaseUpdates">Stable Release Updates</a>, ensuring a secure and reliable experience. These updates are carefully tested by the Hardware Certification team to make sure that systems work well with Ubuntu.
@@ -436,7 +436,7 @@
         <div class="p-strip--light">
           <div class="u-fixed-width">
             {{ image (
-            url="https://assets.ubuntu.com/v1/aa1dc625-10+Year+shield+trio_AW.svg",
+            url="https://assets.ubuntu.com/v1/6f00ed05-12%20years%20shields.png",
             alt="",
             width="293",
             height="161",

--- a/templates/embedded/index.html
+++ b/templates/embedded/index.html
@@ -330,11 +330,11 @@
     <div class="row u-equal-height">
       <div class="col-6">
         <h3>Security matters most</h3>
-        <p>Get 10 years of automatic security updates for every major CVE.</p>
+        <p>Get 12 years of automatic security updates for every major CVE.</p>
         <p>Any compromise of your device puts your reputation on the line.</p>
       </div>
       <div class="col-6 u-hide--medium u-hide--small u-align--center u-vertically-center">
-        {{ image(url="https://assets.ubuntu.com/v1/aa1dc625-10+Year+shield+trio_AW.svg",
+        {{ image(url="https://assets.ubuntu.com/v1/6f00ed05-12%20years%20shields.png",
                 alt="",
                 height="200",
                 width="350",
@@ -388,7 +388,7 @@
         </li>
         <li class="p-matrix__item">
           <div>
-            <h4 class="p-matrix__title">10 year maintenance</h4>
+            <h4 class="p-matrix__title">12 year maintenance</h4>
             <p class="p-matrix__desc">No other embedded Linux comes close to Canonical's commitment to long term security.</p>
           </div>
         </li>
@@ -714,7 +714,7 @@
         <ul class="p-list">
           <li class="p-list__item is-ticked">Get Ubuntu on your preferred board</li>
           <li class="p-list__item is-ticked">Activate standard and custom capabilities</li>
-          <li class="p-list__item is-ticked">Security updates for 10 years</li>
+          <li class="p-list__item is-ticked">Security updates for 12 years</li>
           <li class="p-list__item is-ticked">Supported by Canonical</li>
         </ul>
         <p>
@@ -910,7 +910,7 @@
       }
     }
 
-    @media only screen and (min-width 460px) {
+    @media only screen and (min-width: 460px) {
       .u-margin--core {
         margin-top: 2rem;
       }


### PR DESCRIPTION
## Done

Update 10 to 12 year support on /embedded and /certified pages

## QA

- [demo link](https://ubuntu-com-14037.demos.haus/)
- copy doc: [certified](https://docs.google.com/document/d/1Cq9RLNjSbX83WB5fFKYCFRvo_1JEfMydMecqrVeKBP8/edit#heading=h.ml1wyj4mfeh7), [embedded](https://docs.google.com/document/d/15Tz87YRg4SnX4DWGOSl2TDTHLSStJoma879xHnF0nuo/edit)
- View the site on demo
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check that the section is correct according to copy doc

## Issue / Card
Fixes #13964
[WD-12895](https://warthogs.atlassian.net/browse/WD-12895)


[WD-12895]: https://warthogs.atlassian.net/browse/WD-12895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ