### PR TITLE
remove canonical_staff decorator from thank you page

### DIFF
--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -1087,7 +1087,6 @@ def get_webhook_response(trueability_api, **kwargs):
 @canonical_staff()
 def get_issued_badges(credly_api, **kwargs):
     badges = credly_api.get_issued_badges()
-    print(badges)
     return flask.jsonify(badges["data"])
 
 

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -873,7 +873,6 @@ def cred_manage_shop(**kwargs):
 
 
 @shop_decorator(area="cube", permission="user", response="html")
-@canonical_staff()
 def cred_shop_thank_you(**kwargs):
     quantity = flask.request.args.get("quantity", "")
     product = flask.request.args.get("productName", "")
@@ -1088,6 +1087,7 @@ def get_webhook_response(trueability_api, **kwargs):
 @canonical_staff()
 def get_issued_badges(credly_api, **kwargs):
     badges = credly_api.get_issued_badges()
+    print(badges)
     return flask.jsonify(badges["data"])
 
 


### PR DESCRIPTION
## Done

- Remove canonical_staff decorator from thank you view

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Purchase an exam and it should show you thank you page after purchase goes through

## Issue / Card

Fixes [Jira](https://warthogs.atlassian.net/browse/WD-12985)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
