### PR TITLE
disable shop for external users and buy button

### DIFF
--- a/templates/credentials/index.html
+++ b/templates/credentials/index.html
@@ -34,9 +34,9 @@
             Develop and certify essential skills on Ubuntu, the world's most popular
             Linux OS.
           </p>
-          <p>
+          <!-- <p>
             <a href="/credentials/shop" class="p-button--positive">Buy an exam now!</a>
-          </p>
+          </p> -->
         </div>
       </div>
     </section>

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -842,6 +842,7 @@ def cred_submit_form(**_):
 
 
 @shop_decorator(area="cube", permission="user", response="html")
+@canonical_staff()
 def cred_shop(ua_contracts_api, **kwargs):
     exams_file = open("webapp/shop/cred/exams.json", "r")
     exams = json.load(exams_file)


### PR DESCRIPTION
## Done

- Remove buy button
- Disable shop for non canonical users

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to `/credentials`, Buy button should not show up
- Sign in as a non canonical.com user and `/credentials/shop` should throw an Unauthorised error message

## Issue / Card

Fixes [Jira](https://warthogs.atlassian.net/browse/WD-12994)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
