### PR TITLE
Fix: Display navigation search icon correctly on large breakpoints

### DIFF
--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -102,8 +102,6 @@ $meganav-height: 3rem;
       }
 
       .p-navigation__link--search-toggle::after {
-        right: 1.5rem;
-
         @media (max-width: $breakpoint-navigation-threshold - 1) {
           right: 0.5rem;
         }


### PR DESCRIPTION
## Done

- Remove a line in navigation bar media query that makes search icon look non-centered on breakpoints greater than 1212px

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes

## Screenshots

In the top-right corner you can see the icon is not centered. Screenshot taken from the active ubuntu.com website on 1680px display:
![image](https://github.com/canonical/ubuntu.com/assets/95718239/37c4b8d2-84e3-4c37-9825-7d0b32d157f2)

Screenshot taken after change:
![image](https://github.com/canonical/ubuntu.com/assets/95718239/6eaa6672-0f7a-4bb9-bdb7-75f0963ff447)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
