### PR TITLE
Use smaller notices on notices page

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -337,7 +337,11 @@ production:
         - name: SENTRY_DSN
           value: https://0293bb7fc3104e56bafd2422e155790c@sentry.is.canonical.com//13
 
-    - paths: [/security/notices\.json]
+    - paths:
+        [
+          /security/notices\.json,
+          /security/page/.*\.json,
+        ]
       service_name: ubuntu-com-security-api-notices
     
     - paths: [/security/updates/.*]
@@ -849,7 +853,11 @@ staging:
           value: https://0293bb7fc3104e56bafd2422e155790c@sentry.is.canonical.com//13
 
 
-    - paths: [/security/notices\.json]
+    - paths: 
+        [
+          /security/notices\.json,
+          /security/page/.*\.json,
+        ]
       service_name: ubuntu-com-security-api-notices
     
     - paths: [/security/updates/.*]

--- a/package.json
+++ b/package.json
@@ -133,5 +133,6 @@
     "transform": {
       "^.+\\.(js|jsx|ts|tsx)$": "babel-jest"
     }
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/templates/security/_notice-brief.html
+++ b/templates/security/_notice-brief.html
@@ -4,17 +4,17 @@
   <p class="u-no-margin u-no-padding--top" style="padding-bottom: 16px;">{{ notice.summary | safe }}</p>
   <p class="u-no-margin u-no-padding--top" style="padding-bottom: 16px;">
     <small>
-      {% for cve in notice.cves %}
+      {% for cve_id in notice.cves_ids %}
         {% if loop.index <= 3 %}
-          <a href="/security/{{ cve.id }}">{{ cve.id }}</a>{% if loop.index < notice.cves|length or (notice.cves|length > 3 and loop.index == 3) %}<span style="color: #666; font-size: 14px; padding-bottom: 8px;">,</span>{% endif %}
+          <a href="/security/{{ cve_id }}">{{ cve_id }}</a>{% if loop.index < notice.cves_ids|length or (notice.cves_ids|length > 3 and loop.index == 3) %}<span style="color: #666; font-size: 14px; padding-bottom: 8px;">,</span>{% endif %}
         {% endif %}
         <span style="color: #666; font-size: 14px; padding-bottom: 8px;">
           {% if loop.index == 3 %}
-            {% if notice.cves|length - 3 == 1 %}
-              and {{ notice.cves|length - 3}} other
+            {% if notice.cves_ids|length - 3 == 1 %}
+              and {{ notice.cves_ids|length - 3}} other
             {% endif %}
-            {% if notice.cves|length - 3 > 1 %}
-              and {{ notice.cves|length - 3}} others
+            {% if notice.cves_ids|length - 3 > 1 %}
+              and {{ notice.cves_ids|length - 3}} others
             {% endif %}
           {% endif %}
         </span>

--- a/templates/security/_notice-brief.html
+++ b/templates/security/_notice-brief.html
@@ -1,21 +1,25 @@
 <article class="notice" style="padding-bottom: 32px;">
-  <h3 class="u-no-margin p-heading--4" style="padding-bottom: 8px;"><a href="/security/notices/{{notice.id}}">{{ notice.id }}: {{ notice.title }} ›</a></h3>
-  <p class="u-no-margin u-no-padding--top" style="color: #666; font-size: 14px; padding-bottom: 8px;">{{ notice.published }}</p>
+  <h3 class="u-no-margin p-heading--4" style="padding-bottom: 8px;">
+    <a href="/security/notices/{{ notice.id }}">{{ notice.id }}: {{ notice.title }} ›</a>
+  </h3>
+  <p class="u-no-margin u-no-padding--top"
+     style="color: #666;
+            font-size: 14px;
+            padding-bottom: 8px">{{ notice.published }}</p>
   <p class="u-no-margin u-no-padding--top" style="padding-bottom: 16px;">{{ notice.summary | safe }}</p>
   <p class="u-no-margin u-no-padding--top" style="padding-bottom: 16px;">
     <small>
       {% for cve_id in notice.cves_ids %}
         {% if loop.index <= 3 %}
-          <a href="/security/{{ cve_id }}">{{ cve_id }}</a>{% if loop.index < notice.cves_ids|length or (notice.cves_ids|length > 3 and loop.index == 3) %}<span style="color: #666; font-size: 14px; padding-bottom: 8px;">,</span>{% endif %}
+          <a href="/security/{{ cve_id }}">{{ cve_id }}</a>
+          {% if loop.index < notice.cves_ids|length or (notice.cves_ids|length > 3 and loop.index == 3) %}
+            <span style="color: #666; font-size: 14px; padding-bottom: 8px;">,</span>
+          {% endif %}
         {% endif %}
         <span style="color: #666; font-size: 14px; padding-bottom: 8px;">
           {% if loop.index == 3 %}
-            {% if notice.cves_ids|length - 3 == 1 %}
-              and {{ notice.cves_ids|length - 3}} other
-            {% endif %}
-            {% if notice.cves_ids|length - 3 > 1 %}
-              and {{ notice.cves_ids|length - 3}} others
-            {% endif %}
+            {% if notice.cves_ids|length - 3 == 1 %}and {{ notice.cves_ids|length - 3 }} other{% endif %}
+            {% if notice.cves_ids|length - 3 > 1 %}and {{ notice.cves_ids|length - 3 }} others{% endif %}
           {% endif %}
         </span>
       {% endfor %}
@@ -24,7 +28,7 @@
   <ul class="p-inline-list u-no-margin">
     {% for release in notice.releases %}
       <li class="p-inline-list__item">
-        <a href="/security/notices?release={{release.codename}}">
+        <a href="/security/notices?release={{ release.codename }}">
           <small>Ubuntu {{ release.version }} {{ release.support_tag }}</small>
         </a>
       </li>

--- a/webapp/security/api.py
+++ b/webapp/security/api.py
@@ -118,6 +118,42 @@ class SecurityAPI:
 
         return notices_response.json()
 
+    def get_page_notices(
+        self,
+        limit: int,
+        offset: int,
+        details: str,
+        release: str,
+        order: str,
+    ):
+        """
+        Makes request for all notices with ongoing support,
+        returns json object if found.
+        Note that these notices are missing the 'cves' fields.
+        """
+
+        parameters = {
+            "limit": limit,
+            "offset": offset,
+            "details": details,
+            "release": release,
+            "order": order,
+        }
+
+        # Remove falsey items from dictionary
+        parameters = {k: v for k, v in parameters.items() if v}
+
+        filtered_parameters = urlencode(parameters)
+
+        try:
+            notices_response = self._get(
+                f"page/notices.json?{filtered_parameters}"
+            )
+        except HTTPError as error:
+            raise SecurityAPIError(error)
+
+        return notices_response.json()
+
     def get_cves(
         self,
         query: str,

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -124,7 +124,7 @@ def notices():
     # call endpopint to get all releases and notices
     all_releases = security_api.get_releases()
 
-    notices_response = security_api.get_notices(
+    notices_response = security_api.get_page_notices(
         limit=limit,
         offset=offset,
         details=details,

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -210,7 +210,7 @@ def notices_feed(feed_type):
 
         return entry
 
-    notices = security_api.get_notices(
+    notices = security_api.get_page_notices(
         limit=10, offset="", details="", release="", order=""
     ).get("notices")
 
@@ -225,7 +225,7 @@ def notices_feed(feed_type):
 # ===
 def single_notices_sitemap(offset):
     # max limit is 100
-    notices = security_api.get_notices(
+    notices = security_api.get_page_notices(
         limit="100",
         offset=offset,
         details="",
@@ -261,7 +261,7 @@ def single_notices_sitemap(offset):
 
 
 def notices_sitemap():
-    notices_response = security_api.get_notices(
+    notices_response = security_api.get_page_notices(
         limit="", offset="", details="", release="", order=""
     )
 


### PR DESCRIPTION
## Note
- Should **only** be reviewed after https://github.com/canonical/ubuntu-com-security-api/pull/163 has been merged

## Done
- Load notices on the `/security/notices` page from a new datasource `get_page_notice`
- This returns a smaller notice, _without_ the `cves` and `packages` fields which are not required on this page, and have a significant effect on page speed, especially when a `notice` has hundreds of `cves`.

## QA

- Check that the demo runs
- Open https://ubuntu-com-14041.demos.haus/security/notices and click through the pagination
- Pages should open quickly without timeouts
