### PR TITLE
WD-13010 - fix search icon on u.com

### DIFF
--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -102,7 +102,7 @@ $meganav-height: 3rem;
       }
 
       .p-navigation__link--search-toggle::after {
-        right: 1.5rem;
+        right: 0.75rem;
 
         @media (max-width: $breakpoint-navigation-threshold - 1) {
           right: 0.5rem;


### PR DESCRIPTION
## Done

Fix search icon position in the nav bar

## QA

- [demo link](https://ubuntu-com-14045.demos.haus/)
- View the site on demo
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check that the icon is correctly showing

## Issue / Card
[WD-13010](https://warthogs.atlassian.net/browse/WD-13010)

[WD-13010]: https://warthogs.atlassian.net/browse/WD-13010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ