### PR TITLE
set scrolling to yes for testing

### DIFF
--- a/templates/credentials/exam.html
+++ b/templates/credentials/exam.html
@@ -17,7 +17,7 @@
             class="u-no-margin"
             id="exam-iframe"
             onload="setIframeHeight()"
-            scrolling="no"
+            scrolling="yes"
             width="100%"
             src="{{ url }}"></iframe>
   </section>


### PR DESCRIPTION
## Done

- Make exam iFrame scrollable for testing in staging

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes

## Issue / Card

Fixes [Jira](https://warthogs.atlassian.net/browse/WD-13016)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
