### PR TITLE
fix grammar on nda box

### DIFF
--- a/templates/credentials/your-exams.html
+++ b/templates/credentials/your-exams.html
@@ -34,7 +34,8 @@
           <div class="p-notification__content">
             <h5 class="p-notification__title">Attention:</h5>
             <p class="p-notification__message">
-              Before start your exam you need to sign our <a href="/legal/confidentiality-agreement?tfa_7=cue%40canonical.com" target="_blank">confidentiality agreement.</a>
+              Before you start your exam you need to sign our <a href="/legal/confidentiality-agreement?tfa_7=cue%40canonical.com"
+    target="_blank">confidentiality agreement.</a>
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Done

- Fix grammatical error on nda box

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Confirm that when you are on `credentials/your-exams` and the NDA alert shows, it says "Before you start your exam you need to sign our confidentiality agreement" rather than "Before start your exam you need to sign our confidentiality agreement"

## Issue / Card

Fixes [Jira](https://warthogs.atlassian.net/browse/WD-13018)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
