### PR TITLE
fix date and time issue in scheduling exam

### DIFF
--- a/templates/credentials/schedule.html
+++ b/templates/credentials/schedule.html
@@ -101,9 +101,12 @@ meta_copydoc %}
       const dateInput = document.querySelector("#exam-date");
       const timeInput = document.querySelector("#exam-time");
       const now = new Date();
-      const nowString = now.toISOString().split("T")[0];
-      dateInput.min = nowString;
-      dateInput.value = nowString;
+      const year = now.getFullYear();
+      const month = now.getMonth() + 1;
+      const day = now.getDate();
+      const dateString = `${year}-${month.toString().padStart(2, "0")}-${day.toString().padStart(2, "0")}`;
+      dateInput.min = dateString;
+      dateInput.value = dateString;
       timeInput.value = now.toTimeString().split(" ")[0].slice(0, 5);
     }
     document.addEventListener('DOMContentLoaded', setDateTime);


### PR DESCRIPTION
## Done

- Show today's date and current time in scheduling form

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to schedule an exam from `credentials/your-exams`
    - Date should be today
    - Time should be now
    - If you are in a timezone that is behind UTC, then also try scheduling at a later time around evening and confirm that minimum date still shows **today** rather than the **next day**

## Issue / Card

Fixes [Jira](https://warthogs.atlassian.net/browse/CRED-593)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
