### PR TITLE
hide vat in checkout if product price is zero

### DIFF
--- a/static/js/src/advantage/subscribe/checkout/components/Taxes/Taxes.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Taxes/Taxes.tsx
@@ -25,7 +25,7 @@ type TaxesProps = {
   setError: React.Dispatch<React.SetStateAction<React.ReactNode>>;
 };
 
-const Taxes = ({ setError }: TaxesProps) => {
+const Taxes = ({ product, setError }: TaxesProps) => {
   const {
     values,
     initialValues,
@@ -190,7 +190,8 @@ const Taxes = ({ setError }: TaxesProps) => {
           </Row>
         </>
       ) : null}
-      {vatCountries.includes(values.country ?? "") ? (
+      {vatCountries.includes(values.country ?? "") &&
+      product?.price?.value !== 0 ? (
         <>
           <hr />
           <Row>
@@ -252,19 +253,20 @@ const Taxes = ({ setError }: TaxesProps) => {
           error={touched?.caProvince && errors?.caProvince}
         />
       )}
-      {vatCountries.includes(values.country ?? "") && (
-        <Field
-          data-testid="field-vat-number"
-          as={Input}
-          type="text"
-          id="VATNumber"
-          name="VATNumber"
-          label="VAT number:"
-          stacked
-          help="e.g. GB 123 1234 12 123 or GB 123 4567 89 1234"
-          error={touched?.VATNumber && errors?.VATNumber}
-        />
-      )}
+      {vatCountries.includes(values.country ?? "") &&
+        product?.price?.value !== 0 && (
+          <Field
+            data-testid="field-vat-number"
+            as={Input}
+            type="text"
+            id="VATNumber"
+            name="VATNumber"
+            label="VAT number:"
+            stacked
+            help="e.g. GB 123 1234 12 123 or GB 123 4567 89 1234"
+            error={touched?.VATNumber && errors?.VATNumber}
+          />
+        )}
     </>
   );
 


### PR DESCRIPTION
## Done

- Don't show VAT input if product's price is zero

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to `credentials/shop` and click **Buy Now** button
    - Select a country that needs a VAT number such as United Kingdom
    - It should **not** show VAT input

## Issue / Card

Fixes [Jira](https://warthogs.atlassian.net/browse/WD-13017)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
