### PR TITLE
feat(/kernel): Build new banner for the RTF guide

### DIFF
--- a/templates/kernel/index.html
+++ b/templates/kernel/index.html
@@ -144,14 +144,12 @@
         <p class="p-text--small-caps">Whitepaper</p>
         <h2 class="p-heading--1 u-no-padding--top">
           A CTO's guide to real-time kernel
-        </h2 class="p-heading--1">
+        </h2>
         <h3 class="p-heading--4">Understanding real-time systems, their cases and inner workings</h3>
-        <div class="u-hide--small">
-          <p>
-            <a href="/engage/cto-guide-real-time-kernel?utm_source=kernelpage"
-               class="p-button--positive u-no-margin--bottom">Download <span class="u-off-screen">the RTF guide</span> now</a>
-          </p>
-        </div>
+        <p>
+          <a href="/engage/cto-guide-real-time-kernel?utm_source=kernelpage"
+              class="p-button--positive u-no-margin--bottom">Download <span class="u-off-screen">the RTF guide</span> now</a>
+        </p>
       </div>
       <div class="col-6 col-medium-3 u-vertically-center u-align--center u-align--left-medium u-hide--small">
         <a href="/engage/cto-guide-real-time-kernel?utm_source=kernelpage"

--- a/templates/kernel/index.html
+++ b/templates/kernel/index.html
@@ -148,13 +148,13 @@
         <h3 class="p-heading--4">Understanding real-time systems, their cases and inner workings</h3>
         <div class="u-hide--small">
           <p>
-            <a href="https://canonical.com/blog/worlds-first-risc-v-laptop-gets-a-massive-upgrade-and-equips-with-ubuntu?utm_source=takeover"
+            <a href="/engage/cto-guide-real-time-kernel?utm_source=kernelpage"
                class="p-button--positive u-no-margin--bottom">Download <span class="u-off-screen">the RTF guide</span> now</a>
           </p>
         </div>
       </div>
       <div class="col-6 col-medium-3 u-vertically-center u-align--center u-align--left-medium u-hide--small">
-        <a href="https://canonical.com/blog/worlds-first-risc-v-laptop-gets-a-massive-upgrade-and-equips-with-ubuntu?utm_source=takeover"
+        <a href="/engage/cto-guide-real-time-kernel?utm_source=kernelpage"
            aria-label="Download the RTF guide now">
           <img src="https://assets.ubuntu.com/v1/3fa3e0f0-RTK-wp-cover.png"
                width="250"

--- a/templates/kernel/index.html
+++ b/templates/kernel/index.html
@@ -137,4 +137,31 @@
       </p>
     </div>
   </section>
+
+  <section class="is-active p-takeover--dark js-takeover is-dark">
+    <div class="row u-equal-height">
+      <div class="col-6 u-vertically-center">
+        <p class="p-text--small-caps">Whitepaper</p>
+        <h2 class="p-heading--1 u-no-padding--top">
+          A CTO's guide to real-time kernel
+        </h2 class="p-heading--1">
+        <h3 class="p-heading--4">Understanding real-time systems, their cases and inner workings</h3>
+        <div class="u-hide--small">
+          <p>
+            <a href="https://canonical.com/blog/worlds-first-risc-v-laptop-gets-a-massive-upgrade-and-equips-with-ubuntu?utm_source=takeover"
+               class="p-button--positive u-no-margin--bottom">Download <span class="u-off-screen">the RTF guide</span> now</a>
+          </p>
+        </div>
+      </div>
+      <div class="col-6 u-vertically-center u-align--center u-align--left-medium u-hide--small u-hide--medium">
+        <a href="https://canonical.com/blog/worlds-first-risc-v-laptop-gets-a-massive-upgrade-and-equips-with-ubuntu?utm_source=takeover"
+           aria-label="Download the RTF guide now">
+          <img src="https://assets.ubuntu.com/v1/3fa3e0f0-RTK-wp-cover.png"
+               width="250"
+               height="354" 
+               alt=""/>
+        </a>
+      </div>
+    </div>
+  </section>
 {% endblock %}

--- a/templates/kernel/index.html
+++ b/templates/kernel/index.html
@@ -140,7 +140,7 @@
 
   <section class="is-active p-takeover--dark js-takeover is-dark">
     <div class="row u-equal-height">
-      <div class="col-6 u-vertically-center">
+      <div class="col-6 col-medium-3 u-vertically-center">
         <p class="p-text--small-caps">Whitepaper</p>
         <h2 class="p-heading--1 u-no-padding--top">
           A CTO's guide to real-time kernel
@@ -153,7 +153,7 @@
           </p>
         </div>
       </div>
-      <div class="col-6 u-vertically-center u-align--center u-align--left-medium u-hide--small u-hide--medium">
+      <div class="col-6 col-medium-3 u-vertically-center u-align--center u-align--left-medium u-hide--small">
         <a href="https://canonical.com/blog/worlds-first-risc-v-laptop-gets-a-massive-upgrade-and-equips-with-ubuntu?utm_source=takeover"
            aria-label="Download the RTF guide now">
           <img src="https://assets.ubuntu.com/v1/3fa3e0f0-RTK-wp-cover.png"


### PR DESCRIPTION
## Done

- Build new banner for the RTF guide based on [copydoc](https://docs.google.com/document/d/1XLdk2Slh4vi4AjGnatcK1BmJGmMNKIjN27KwbTwG5iI/edit) which is sort of also the design

## QA

- Go to https://ubuntu-com-14067.demos.haus/kernel and compare the content against the design
- Make sure the button and image act as links
- Check when using a screen reader the description on the links makes sense

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-12929
