### PR TITLE
allow non canonical users access to shop

### DIFF
--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -842,7 +842,6 @@ def cred_submit_form(**_):
 
 
 @shop_decorator(area="cube", permission="user", response="html")
-@canonical_staff()
 def cred_shop(ua_contracts_api, **kwargs):
     exams_file = open("webapp/shop/cred/exams.json", "r")
     exams = json.load(exams_file)


### PR DESCRIPTION
## Done

- Remove canonical_staff decorator on shop

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- visit `credentials/shop` as non canonical user and the shop should show up

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
