### PR TITLE
Update logos on /security/certifications 

### DIFF
--- a/templates/security/certifications.html
+++ b/templates/security/certifications.html
@@ -81,8 +81,8 @@
         </p>
       </div>
       <div class="col-4 col-medium-2 p-divider__block">
-        <img src="https://assets.ubuntu.com/v1/36a0cd3b-microsoft-azure-2021.png"
-             alt="Azure"
+        <img src="https://assets.ubuntu.com/v1/21c19804-microsoft-azure-logo.png"
+             alt="Microsoft Azure"
              style="width:auto;
                     height: 6.5rem"
              loading="lazy" />
@@ -91,10 +91,12 @@
         </p>
       </div>
       <div class="col-4 col-medium-2 p-divider__block">
-        <img src="https://assets.ubuntu.com/v1/497cabc1-google-cloud-logo.png"
+        <img src="https://assets.ubuntu.com/v1/92c62d40-lockup_GoogleCloud_FullColor_rgb_544x96px.png"
+             alt="Google Cloud"
              style="width:auto;
-                    height: 6.5rem"
-             alt="GoogleCloud"
+                    height: 2rem;
+                    margin-top: 2rem;
+                    margin-bottom: 2.5rem"
              loading="lazy" />
         <p>
           <a href="/gcp">Learn more about Ubuntu on Google Cloud Platform&nbsp;></a>


### PR DESCRIPTION
## Done

- Updated logos as per [doc](https://docs.google.com/document/d/13RcVvHBAoywfk3o5Dy-16F3KrMytL9-2v6wWbW444Ko/edit)

## QA

- View the site locally in your web browser at: https://ubuntu-com-14071.demos.haus/security/certifications
- See that the requested changes have been made

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-12916