### PR TITLE
enable buy button on credentials home

### DIFF
--- a/templates/credentials/index.html
+++ b/templates/credentials/index.html
@@ -34,9 +34,9 @@
             Develop and certify essential skills on Ubuntu, the world's most popular
             Linux OS.
           </p>
-          <!-- <p>
+          <p>
             <a href="/credentials/shop" class="p-button--positive">Buy an exam now!</a>
-          </p> -->
+          </p>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Done

- Enable purchase button on credentials home page `credentials/`

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Ensure there is a green _Buy an exam now!_ button on home page of credentials

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
