### PR TITLE
Update playwright.yaml

### DIFF
--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -20,7 +20,7 @@ jobs:
 
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 20
 
     - name: Install dependencies
       run: yarn install --immutablee


### PR DESCRIPTION
Update playwright node version to node 20

## Done

- Updated node version in the playwright CI to node 20. This is to prevent dependency installation problems with node 16.

## QA

- Check that all checks are passing

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
