### PR TITLE
Fix broken thumbnail links

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -105,7 +105,7 @@ jobs:
         id: changed-files
         uses: tj-actions/changed-files@v43
         with:
-          files: templates/**/*.html
+          files: templates/**
 
       - name: Lint jinja
         if: steps.changed-files.outputs.any_changed == 'true'
@@ -113,7 +113,7 @@ jobs:
           CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
           echo "The following files have changed: $CHANGED_FILES"
-          djlint $CHANGED_FILES --lint --profile="jinja"
+          djlint $CHANGED_FILES --lint
 
   validate-deploy:
     runs-on: ubuntu-latest
@@ -181,7 +181,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 16
 
       - name: Install dependencies
         run: yarn install --immutable

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -105,7 +105,7 @@ jobs:
         id: changed-files
         uses: tj-actions/changed-files@v43
         with:
-          files: templates/**
+          files: templates/**/*.html
 
       - name: Lint jinja
         if: steps.changed-files.outputs.any_changed == 'true'
@@ -113,7 +113,7 @@ jobs:
           CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
           echo "The following files have changed: $CHANGED_FILES"
-          djlint $CHANGED_FILES --lint
+          djlint $CHANGED_FILES --lint --profile="jinja"
 
   validate-deploy:
     runs-on: ubuntu-latest
@@ -181,7 +181,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
 
       - name: Install dependencies
         run: yarn install --immutable

--- a/templates/kubernetes/charmed-k8s.html
+++ b/templates/kubernetes/charmed-k8s.html
@@ -333,7 +333,7 @@
           </div>
         </div>
         <a class="p-link--inverted"
-           href="https://www.brighttalk.com/webcast/6793/435999/how-to-accelerate-kubernetes-deployment-in-the-enterprise">How to accelerate Kubernetes deployment in the enterprise</a>
+           href="https://www.brighttalk.com/webcast/6793/435999">How to accelerate Kubernetes deployment in the enterprise</a>
       </div>
       <div class="col-4">
         <div class="p-heading-icon">

--- a/templates/kubernetes/compare.html
+++ b/templates/kubernetes/compare.html
@@ -442,7 +442,7 @@
           </div>
         </div>
         <p class="p-heading--4">
-          <a href="https://www.brighttalk.com/webcast/6793/435999/how-to-accelerate-kubernetes-deployment-in-the-enterprise">How to accelerate Kubernetes deployment in the enterprise</a>
+          <a href="https://www.brighttalk.com/webcast/6793/435999">How to accelerate Kubernetes deployment in the enterprise</a>
         </p>
       </div>
 

--- a/templates/kubernetes/resources.html
+++ b/templates/kubernetes/resources.html
@@ -67,7 +67,7 @@
       <div class="row">
         <div class="col-4">
           <h3 id="what-is-microk8s" class="p-heading--4">
-            <a href="https://www.brighttalk.com/webcast/6793/435999/how-to-accelerate-kubernetes-deployment-in-the-enterprise">How to accelerate Kubernetes deployment in the enterprise</a>
+            <a href="/engage/kubernetes-deployment-enterprise-whitepaper">How to accelerate Kubernetes deployment in the enterprise</a>
           </h3>
         </div>
         <div class="col-4">
@@ -78,8 +78,8 @@
         </div>
         <div class="col-4">
           <div class="u-hide--small u-hide--medium u-align--center">
-            <a href="https://www.brighttalk.com/webcast/6793/378029">
-              <img src="https://www.brighttalk.com/communication/435999/preview_1598433480.png"
+            <a href="/engage/kubernetes-deployment-enterprise-whitepaper">
+            <img src="https://www.brighttalk.com/service/player/_next/image?url=https%3A%2F%2Fcdn.brighttalk.com%2Fams%2Fcalifornia%2Fimages%2Fcommunication%2Fsan%2F435999%2Fpreview_1598433480.png%3Fwidth%3D640%26height%3D360&w=2048&q=75"
                    alt="How to accelerate Kubernetes deployment in the enterprise"
                    width="560"
                    height="302" />
@@ -107,7 +107,7 @@
         <div class="col-4">
           <div class="u-hide--small u-hide--medium u-align--center">
             <a href="/engage/kubernetes-use-cases-webinar">
-              <img src="https://www.brighttalk.com/communication/512224/preview_1634033946.png"
+              <img src="https://www.brighttalk.com/service/player/_next/image?url=https%3A%2F%2Fcdn.brighttalk.com%2Fams%2Fcalifornia%2Fimages%2Fcommunication%2Fsan%2F512224%2Fpreview_1634033946.png%3Fwidth%3D640%26height%3D360&w=2048&q=75"
                    alt="Enterprise Kubernetes use cases: 4 real-world stories"
                    width="560"
                    height="302" />
@@ -133,7 +133,7 @@
         <div class="col-4">
           <div class="u-hide--small u-hide--medium u-align--center">
             <a href="/engage/dell-kubernetes-webinar">
-              <img src="https://www.brighttalk.com/communication/383698/preview_1581443383.png"
+              <img src="https://www.brighttalk.com/service/player/_next/image?url=https%3A%2F%2Fcdn.brighttalk.com%2Fams%2Fcalifornia%2Fimages%2Fcommunication%2Fsan%2F383698%2Fpreview_1581443383.png%3Fwidth%3D640%26height%3D360&w=2048&q=75"
                    alt="A decision maker's guide to Kubernetes deployment in your data centre"
                    width="560"
                    height="302" />
@@ -189,7 +189,7 @@
         <div class="col-4">
           <div class="u-hide--small u-hide--medium u-align--center">
             <a href="/engage/containers-as-a-service-webinar">
-              <img src="https://www.brighttalk.com/communication/507143/preview_1631023263.png"
+              <img src="https://www.brighttalk.com/service/player/_next/image?url=https%3A%2F%2Fcdn.brighttalk.com%2Fams%2Fcalifornia%2Fimages%2Fcommunication%2Fsan%2F507143%2Fpreview_1631023263.png%3Fwidth%3D640%26height%3D360&w=2048&q=75"
                    alt="Containers-as-a-service: deploy faster with Canonical and Portainer"
                    width="560"
                    height="302" />
@@ -246,7 +246,7 @@
         <div class="col-4">
           <div class="u-hide--small u-hide--medium u-align--center">
             <a href="/engage/container-orchestration-edge">
-              <img src="https://www.brighttalk.com/communication/470152/preview_1613133266.png"
+              <img src="https://www.brighttalk.com/service/player/_next/image?url=https%3A%2F%2Fcdn.brighttalk.com%2Fams%2Fcalifornia%2Fimages%2Fcommunication%2Fsan%2F470152%2Fpreview_1613133266.png%3Fwidth%3D640%26height%3D360&w=2048&q=75"
                    alt="Micro clouds: Secure container orchestration at the edge"
                    width="560"
                    height="302" />
@@ -271,7 +271,7 @@
         <div class="col-4">
           <div class="u-hide--small u-hide--medium u-align--center">
             <a href="/engage/edge-kubernetes-raspberry-pi-webinar">
-              <img src="https://www.brighttalk.com/communication/488796/preview_1621331611.png"
+              <img src="https://www.brighttalk.com/service/player/_next/image?url=https%3A%2F%2Fcdn.brighttalk.com%2Fams%2Fcalifornia%2Fimages%2Fcommunication%2Fsan%2F488796%2Fpreview_1621331611.png%3Fwidth%3D640%26height%3D360&w=2048&q=75"
                    alt="K8s at the edge"
                    width="560"
                    height="302" />


### PR DESCRIPTION
## Done

- Fix broken thumbnail link for webinars
- Copy doc https://docs.google.com/document/d/1enaCJ4Vt9a_2_l6xYccnZ-fBVUejPSmfMi8LP2aDA9c/edit

## QA

- Go to https://ubuntu-com-14086.demos.haus/kubernetes/resources
- Scroll to the "Videos and Webinars" section
- Check that the "[How to accelerate Kubernetes deployment in the enterprise](https://ubuntu-com-14086.demos.haus/engage/kubernetes-deployment-enterprise-whitepaper)" link opens to its relevant engage page
- Check that all thumbnail images are loaded 

## Issue / Card

Fixes [WD-13394](https://warthogs.atlassian.net/browse/WD-13394)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-13394]: https://warthogs.atlassian.net/browse/WD-13394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ