### PR TITLE
Add Ubuntu Pro Devices to sitemap and meganav

### DIFF
--- a/meganav.yaml
+++ b/meganav.yaml
@@ -410,6 +410,9 @@ products:
             - title: Ubuntu Frame
               description: Embedded graphical displays
               url: https://mir-server.io/ubuntu-frame
+            - title: Ubuntu Pro for Devices
+              description: Security maintenance for IoT
+              url: /pro/devices
             - title: ROS ESM
               description: Expanded security for robots
               url: /robotics/ros-esm
@@ -419,9 +422,6 @@ products:
             - title: IoT Professional Services
               description: Bring IoT devices to market
               url: /core/services
-            - title: Ubuntu Pro Devices
-              description: Secure IoT devices
-              url: /pro/devices
 
       secondary_links:
         - title: Quick links

--- a/meganav.yaml
+++ b/meganav.yaml
@@ -419,6 +419,9 @@ products:
             - title: IoT Professional Services
               description: Bring IoT devices to market
               url: /core/services
+            - title: Ubuntu Pro Devices
+              description: Secure IoT devices
+              url: /pro/devices
 
       secondary_links:
         - title: Quick links

--- a/static/files/sitemap.xml
+++ b/static/files/sitemap.xml
@@ -1010,4 +1010,8 @@
           <loc>https://ubuntu.com/download/nvidia-jetson</loc>
           <lastmod>2024-03-06T00:00:00+00:00</lastmod>
      </url>
+     <url>
+          <loc>https://ubuntu.com/pro/devices</loc>
+          <lastmod>2024-07-08T00:00:00+00:00</lastmod>
+     </url>
 </urlset>


### PR DESCRIPTION
## Done

- Add /pro/devices to sitemap.xml and meganav

## QA

- Go to https://ubuntu-com-14091.demos.haus/
- Go to meganav: Products > IoT and Edge
- See that Ubuntu Pro Devices is listed and redirects to /pro/devices correctly
- Check against [meganav copy doc](https://docs.google.com/document/d/1DCNvYHfC7AbOcqflTBaVd571iKAP_PaTfnqTENVEDVw/edit#heading=h.56uhd6l1cqzh)

## Issue / Card

Fixes [WD-13520](https://warthogs.atlassian.net/browse/WD-13520)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-13520]: https://warthogs.atlassian.net/browse/WD-13520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ