### PR TITLE
Update Ubuntu logo on README.md and remove test badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ![ubuntu](https://assets.ubuntu.com/v1/d4015bc3-Canonical-Ubuntu-Dark-Theme-Large.svg "Ubuntu").com codebase
+# ubuntu.com codebase
 
 [![Code coverage](https://codecov.io/gh/canonical-web-and-design/ubuntu.com/branch/master/graph/badge.svg)](https://codecov.io/gh/canonical-web-and-design/ubuntu.com)
 [![Cypress checks](https://github.com/canonical-web-and-design/ubuntu.com/workflows/Cypress%20checks/badge.svg)](https://github.com/canonical-web-and-design/ubuntu.com/actions?query=workflow%3A%22Cypress+checks%22)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Code coverage](https://codecov.io/gh/canonical-web-and-design/ubuntu.com/branch/master/graph/badge.svg)](https://codecov.io/gh/canonical-web-and-design/ubuntu.com)
 [![Cypress checks](https://github.com/canonical-web-and-design/ubuntu.com/workflows/Cypress%20checks/badge.svg)](https://github.com/canonical-web-and-design/ubuntu.com/actions?query=workflow%3A%22Cypress+checks%22)
-[![Cypress checks / main](https://github.com/canonical-web-and-design/ubuntu.com/workflows/Cypress%20main%20checks/badge.svg)](https://github.com/canonical-web-and-design/ubuntu.com/actions/workflows/cypress-main.yaml?query=workflow%3A%22Cypress+checks%22)
 
 Ubuntu is an open source software operating system that runs from the desktop, to the cloud, to all your internet connected things. [Ubuntu.com](https://ubuntu.com) is the website that helps people learn about, download and get started with Ubuntu. This repo is the codebase and content for the [ubuntu.com](https://ubuntu.com) website.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ![ubuntu](https://assets.ubuntu.com/v1/9f61b97f-logo-ubuntu.svg "Ubuntu").com codebase
+# ![ubuntu](https://assets.ubuntu.com/v1/d4015bc3-Canonical-Ubuntu-Dark-Theme-Large.svg "Ubuntu").com codebase
 
 [![Code coverage](https://codecov.io/gh/canonical-web-and-design/ubuntu.com/branch/master/graph/badge.svg)](https://codecov.io/gh/canonical-web-and-design/ubuntu.com)
 [![Cypress checks](https://github.com/canonical-web-and-design/ubuntu.com/workflows/Cypress%20checks/badge.svg)](https://github.com/canonical-web-and-design/ubuntu.com/actions?query=workflow%3A%22Cypress+checks%22)


### PR DESCRIPTION
## Done

- Remove old Ubuntu logo on README.md and replace with plain text "ubuntu.com"
- Remove Cypress test badge
  - The Cypress test for forms were removed in this PR #12921 

## QA

- Clone this branch
- Preview the README.md locally
- See that it uses the new Canonical Ubuntu logo
- Check that Cypress / main badge is removed

## Issue / Card

Fixes #12872 and [WD-13489](https://warthogs.atlassian.net/browse/WD-13489)

## Screenshots

<img width="417" alt="Screenshot 2024-07-23 at 1 22 49 PM" src="https://github.com/user-attachments/assets/c03d1e5c-7ce6-4da7-9edb-778b8e057b28">




## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-13489]: https://warthogs.atlassian.net/browse/WD-13489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ