### PR TITLE
Update list numbering to match plain text version

### DIFF
--- a/templates/legal/font-licence/index.html
+++ b/templates/legal/font-licence/index.html
@@ -28,11 +28,11 @@
       <ol>
         <li>Each copy of the Font Software must contain the above copyright notice and this licence. These can be included either as stand-alone text files, human-readable headers or in the appropriate machine-readable metadata fields within text or binary files as long as those fields can be easily viewed by the user.</li>
         <li>The font name complies with the following:
-          <ol>
+          <ol type="a">
             <li>The Original Version must retain its name, unmodified.</li>
             <li>Modified Versions which are Substantially Changed must be renamed to avoid use of the name of the Original Version or similar names entirely.</li>
             <li>Modified Versions which are not Substantially Changed must be renamed to both
-              <ol>
+              <ol type="i">
                 <li>retain the name of the Original Version and</li>
                 <li>add additional naming elements to distinguish the Modified Version from the Original Version. The name of such Modified Versions must be the name of the Original Version, with "derivative X" where X represents the name of the new work, appended to that name.</li>
               </ol>
@@ -40,7 +40,7 @@
           </ol>
         </li>
         <li>The name(s) of the Copyright Holder(s) and any contributor to the Font Software shall not be used to promote, endorse or advertise any Modified Version, except
-          <ol>
+          <ol type="i">
             <li>as required by this licence,</li>
             <li>to acknowledge the contribution(s) of the Copyright Holder(s) or</li>
             <li>with their explicit written permission.</li>
@@ -75,7 +75,7 @@
       <p>You are most welcome to use the Ubuntu Font Family, in your documents, graphic designs, logos, or company stationary.  We'd like as many people as possible to have a better quality reading experience every day.</p>
 
       <h2>For those wishing to alter or expand the font itself</h2>
-      <p>The present Ubuntu Font Licence 1.0 is loosely inspired from the <a href="http://scripts.sil.org/OFL">SIL Open Font Licence (OFL)</a> version 1.1. Using the Ubuntu Font Licence 1.0 is an interim solution and the choice of licence will likely change as alternative licences become available in the future.</p>
+      <p>The present Ubuntu Font Licence 1.0 is loosely inspired from the <a href="https://scripts.sil.org/OFL">SIL Open Font Licence (OFL)</a> version 1.1. Using the Ubuntu Font Licence 1.0 is an interim solution and the choice of licence will likely change as alternative licences become available in the future.</p>
       <p>Note that the Ubuntu Font Licence and the SIL Open Font Licence are not identical (<a href="/legal/font-licence/differences">view the differences</a>) and should not be confused with each other. Please read the terms precisely and <a href="/legal/font-licence/faq">read through the FAQ</a> for more details.</p>
       <p>In order to properly license your font derivative under the Ubuntu Font Licence you should:</p>
       <ul class="p-list">


### PR DESCRIPTION
## Done

- Update list number to match plain text version
- Plain text version: https://assets.ubuntu.com/v1/81e5605d-ubuntu-font-licence-1.0.txt

## QA

- Go to https://ubuntu-com-14095.demos.haus/legal/font-licence
- Scroll to `Permissions & Conditions`, check that list numbering (e.g 2.a.i) matches the list numbering in the plain text version

## Issue / Card

Fixes #14068 and [WD-13146](https://warthogs.atlassian.net/browse/WD-13146)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-13146]: https://warthogs.atlassian.net/browse/WD-13146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ