### PR TITLE
Store should check for cube purchase account and not ua purchase account

### DIFF
--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -847,6 +847,7 @@ def cred_submit_form(**_):
 
 @shop_decorator(area="cube", permission="user", response="html")
 def cred_shop(ua_contracts_api, advantage_mapper, **kwargs):
+    ua_contracts_api.ensure_purchase_account("canonical-cube")
     account = advantage_mapper.get_purchase_account("canonical-cube")
     if (account.hasChannelStoreAccess) is True:
         return flask.render_template(
@@ -866,7 +867,6 @@ def cred_shop(ua_contracts_api, advantage_mapper, **kwargs):
                 exam["periodQuantity"] = 30
 
     # purchase account required for purchasing from marketplace
-    ua_contracts_api.ensure_purchase_account("canonical-cube")
 
     return flask.render_template(
         "credentials/shop/index.html",

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -847,7 +847,7 @@ def cred_submit_form(**_):
 
 @shop_decorator(area="cube", permission="user", response="html")
 def cred_shop(ua_contracts_api, advantage_mapper, **kwargs):
-    account = advantage_mapper.get_purchase_account("canonical-ua")
+    account = advantage_mapper.get_purchase_account("canonical-cube")
     if (account.hasChannelStoreAccess) is True:
         return flask.render_template(
             "account/forbidden.html", reason="channel_account"


### PR DESCRIPTION
## Done

- Fix UAContractsUserHasNoAccount error on credentials shop

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Create a new account
- Try to visit /credentials/shop
- Should not see error

## Issue / Card

Fixes #WD-13587

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
