### PR TITLE
Add description to CVE

### DIFF
--- a/templates/security/cve/index.html
+++ b/templates/security/cve/index.html
@@ -24,6 +24,9 @@
         <p>
           Canonical also produces <a href="/security/oval">Open Vulnerability and Assessment Language (OVAL)</a> data, which is machine-readable, to enable auditing for CVEs and to determine whether a particular patch, via an Ubuntu Security Notice (USN), is appropriate for the local system.
         </p>
+        <p>
+          See our <a href="/engage/vulnerability-management">guide to open source vulnerability management</a> for best practices to improving your security posture with a comprehensive approach based on NIST’s cybersecurity framework.
+        </p>
       {% endif %}
     </div>
   </section>


### PR DESCRIPTION
## Done

- Add description to CVE per copy update request
- https://docs.google.com/document/d/1IJyzz5hi90UJwzJ4zJuVLpLAFEvqgreSAPasJvluaAs/edit
- Note from requester on copy doc forms: Please IGNORE the first suggested edit from Juan, this is an older request from last year. The ONLY requested change to the page is the edit from me below Juan’s.

## QA

- Go to https://ubuntu-com-14109.demos.haus/security/cves
- Check that the additional paragraph is added to the CVE description as per copy docs

## Issue / Card

Fixes [WD-13666](https://warthogs.atlassian.net/browse/WD-13666)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-13666]: https://warthogs.atlassian.net/browse/WD-13666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ