### PR TITLE
Add href to mobile footer navigation

### DIFF
--- a/templates/templates/_footer_item.html
+++ b/templates/templates/_footer_item.html
@@ -13,7 +13,7 @@
           {{ section.title }}
         {% endif %}
       </a>
-      <a class="u-hide--medium u-hide--large js-footer-accordion-cta" href="#" aria-controls="{{ section.path }}-footer-nav">        
+      <a class="u-hide--medium u-hide--large js-footer-accordion-cta" href="{{ section.path }}" aria-controls="{{ section.path }}-footer-nav">        
         {% if section.title == "Canonical OpenStack" %}
           OpenStack
         {% elif section.title == "Canonical Ceph" %}


### PR DESCRIPTION
## Done

- Fix broken href links on mobile footer navigation
- Add the paths to their respective hrefs

## QA

- Go to https://ubuntu-com-14111.demos.haus/
- Go on mobile view
- Scroll to footer, click on footer links and see that it redirects as expected

## Issue / Card

Fixes [WD-13667](https://warthogs.atlassian.net/browse/WD-13667)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-13667]: https://warthogs.atlassian.net/browse/WD-13667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ