### PR TITLE
Redirect page traffic to regular api backend

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -342,7 +342,7 @@ production:
           /security/notices\.json,
           /security/page/.*\.json,
         ]
-      service_name: ubuntu-com-security-api-notices
+      service_name: ubuntu-com-security-api
     
     - paths: [/security/updates/.*]
       service_name: ubuntu-com-security-api-updates
@@ -858,7 +858,7 @@ staging:
           /security/notices\.json,
           /security/page/.*\.json,
         ]
-      service_name: ubuntu-com-security-api-notices
+      service_name: ubuntu-com-security-api
     
     - paths: [/security/updates/.*]
       service_name: ubuntu-com-security-api-updates


### PR DESCRIPTION
## Done

- Switched the backend for `security/page/notices.json` to the regular security-api backend. 
- This prevents search from competing for resources with regular notices

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
