### PR TITLE
WD-13710 Corrected link at /containers/chiselled

### DIFF
--- a/templates/containers/chiselled/index.html
+++ b/templates/containers/chiselled/index.html
@@ -516,7 +516,7 @@
                 a chiselled Ubuntu base image for C/C++, Go and Rust applications</a>
               </li>
               <li class="p-list__item">
-                <a href="https://canonical-rockcraft.readthedocs-hosted.com/en/latest/tutorials/chisel/">Install packages
+                <a href="https://documentation.ubuntu.com/rockcraft/en/latest/how-to/chisel/install-slice/">Install packages
                 slices into a rock</a>
               </li>
             </ul>


### PR DESCRIPTION
## Done

- Corrected link at /containers/chiselled

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [Copydoc](https://docs.google.com/document/d/1ZkQ-UFTwsPkMnQn8IEEjZOXMy40tkgBscw_-qq9K3nc/edit)
- [Demo](https://ubuntu-com-14118.demos.haus/containers/chiselled)

## Issue / Card

Fixes # [WD-13710](https://warthogs.atlassian.net/browse/WD-13710)



## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-13710]: https://warthogs.atlassian.net/browse/WD-13710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ