### PR TITLE
WD-13707 Changed the logo for google cloud on homepage

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -485,7 +485,7 @@
                        class="p-logo-section__logo" />
                 </div>
                 <div class="p-logo-section__item">
-                  <img src="https://assets.ubuntu.com/v1/01edb5d4-google-cloud-logo.png"
+                  <img src="https://assets.ubuntu.com/v1/8e354832-is-dark=true.png"
                        alt="GCP"
                        class="p-logo-section__logo" />
                 </div>


### PR DESCRIPTION
## Done

- Changed the logo for google cloud on homepage(ubuntu.com) as part of copyupdate.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [copydoc](https://docs.google.com/document/d/1ySJxQbqVdeH4Tra0zwBm2Tn0s56kFGnEF7d8xDRTxwU/edit?disco=AAABSVcibVg)
- [Demo](https://ubuntu-com-14119.demos.haus/)

## Issue / Card

Fixes # [WD-13707](https://warthogs.atlassian.net/browse/WD-13707)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-13707]: https://warthogs.atlassian.net/browse/WD-13707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ