### PR TITLE
WD-13834 update navigation for /pro/distributor pages

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -333,6 +333,20 @@ pro:
     - title: Discourse
       path: https://discourse.ubuntu.com/c/ubuntu-pro
 
+Distributor:
+  title: Ubuntu Pro Distributor
+  path: /pro/distributor
+
+  children:
+    - title: Overview
+      path: /pro/distributor
+    - title: Account users
+      path: /pro/distributor/users
+    - title: Docs
+      path: https://documentation.ubuntu.com/pro
+    - title: Discourse
+      path: https://discourse.ubuntu.com/c/ubuntu-pro
+
 account:
   title: Account
   path: /account

--- a/static/js/src/advantage/distributor/Distributor.tsx
+++ b/static/js/src/advantage/distributor/Distributor.tsx
@@ -28,6 +28,8 @@ const Distributor = () => {
               <a
                 className="p-button--positive"
                 href="https://www.partner.canonical.com/#/deals/new"
+                target="_blank"
+                rel="noopener noreferrer"
               >
                 <Icon
                   name={ICONS.externalLink}

--- a/templates/templates/_navigation.html
+++ b/templates/templates/_navigation.html
@@ -148,7 +148,7 @@
             {% endif %}
           {% endif %}
         </div>
-
+        
         <nav class="p-navigation__nav"
              aria-label="{{ breadcrumbs.section.title | replace(' ', '&nbsp;') | safe }} navigation">
           {% if breadcrumbs.children %}
@@ -179,12 +179,21 @@
                   {% elif child.path != '/blog/archives' and child.path != '/blog/upcoming' %}
                     {% set has_access = not child.login_required or child.login_required and user_info %}
                     {% if has_access %}
+                      {% if breadcrumbs.section.title == "Ubuntu Pro Distributor" and child.title == "Docs" or child.title == "Discourse" %}
+                        <li class="p-navigation__item {% if child.active %}is-selected{% endif %}">
+                          <a class="p-navigation__link"
+                            href="{{ child.path }}" target="_blank"
+                            {% if child.active %}aria-current="page"{% endif %}>{{
+                          child.title }}</a>
+                        </li>
+                      {% else %}
                       <li class="p-navigation__item {% if child.active %}is-selected{% endif %}">
                         <a class="p-navigation__link"
                            href="{{ child.path }}"
                            {% if child.active %}aria-current="page"{% endif %}>{{
                         child.title }}</a>
                       </li>
+                      {% endif %}
                     {% endif %}
                   {% endif %}
                 {% endif %}

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -220,6 +220,9 @@ app.add_url_rule(
     "/pro/contracts/<contract_id>/token", view_func=get_contract_token
 )
 app.add_url_rule("/pro/users", view_func=advantage_account_users_view)
+app.add_url_rule(
+    "/pro/distributor/users", view_func=advantage_account_users_view
+)
 app.add_url_rule("/pro/account-users", view_func=get_account_users)
 app.add_url_rule(
     "/pro/accounts/<account_id>/user",


### PR DESCRIPTION
## Done

- Update navigation for /pro/distributor pages
- Display Register new deal in a new tab

## QA

- Go to /pro/distributor 
- Check navigation items are correct and the urls are working fine. 
- Check Docs, Discourse, and "Register new deal" button opens in an new tab

## Issue / Card

Fixes #https://warthogs.atlassian.net/browse/WD-13834

## Screenshots

![Your subscriptions Account users Pricing Docs Discourse](https://github.com/user-attachments/assets/cc320343-0405-4f57-9f4a-1a84127318f3)