### PR TITLE
WD-13803 Add /pro/devices to featured meganav

### DIFF
--- a/meganav.yaml
+++ b/meganav.yaml
@@ -66,6 +66,9 @@ products:
             - title: Ubuntu Pro
               description: Security & compliance subscription
               url: /pro
+            - title: Ubuntu Pro for Devices
+              description: Security maintenance for IoT
+              url: /pro/devices
             - title: Enterprise-grade support
               description: 24/7 support for the full-stack
               url: /support


### PR DESCRIPTION
## Done

-  Added /pro/devices to featured meganav 
## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [Copydoc](https://docs.google.com/document/d/1DCNvYHfC7AbOcqflTBaVd571iKAP_PaTfnqTENVEDVw/edit)
- [Demo](https://ubuntu-com-14137.demos.haus/)

## Issue / Card

Fixes # [WD-13803](https://warthogs.atlassian.net/browse/WD-13803)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-13803]: https://warthogs.atlassian.net/browse/WD-13803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ