### PR TITLE
Add macros for hero section

### DIFF
--- a/templates/case-studies/index.html
+++ b/templates/case-studies/index.html
@@ -43,4 +43,13 @@
   }}
 
   
+<!--This index page will be using macros to build an example case study -->
+  <!-- Hero section-->
+  {% import "case-studies/templates/_macros-hero.jinja" as hero_template %}
+  {{ hero_template.hero(title="Hero title",
+                        subtitle="Hero description",
+                        logo="https://assets.ubuntu.com/v1/8b33ba49-dell-technologies-logo-resize.png",
+                        logo_alt="Dell logo") 
+  }}
+
 {% endblock %}

--- a/templates/case-studies/index.html
+++ b/templates/case-studies/index.html
@@ -3,6 +3,15 @@
 {% block title %}Case Studies{% endblock %}
 
 {% block content %}
+  <!--This index page will be using macros to build an example case study -->
+  <!-- Hero section-->
+  {% import "case-studies/templates/_macros-hero.jinja" as hero_template %}
+  {{ hero_template.hero(title="Canonical deploys infrastructure solutions and managed IT services for critical space mission operations",
+                        subtitle="Hero description",
+                        logo="https://assets.ubuntu.com/v1/8b33ba49-dell-technologies-logo-resize.png",
+                        logo_alt="Dell logo") 
+  }}
+
 
   <!-- Text + list section -->
   {% import "case-studies/templates/_macros-text-list.jinja" as text_list_template %}
@@ -16,13 +25,6 @@
 
   <!-- Highlights section -->
   {% import "case-studies/templates/_macros-highlights.jinja" as highlights_template %}
-  {{ highlights_template.highlights(list_items=[
-    "Architecture, design, and deployment of Canonical’s distributions of Ceph and Kubernetes.",
-    "Timely updates and 24/7 monitoring of missioncritical equipment.",
-    "ESA has operated more than 87 missions from ESOC, ranging from understanding our own planet to exploring our solar system and beyond to help advance scientific knowledge.",
-    ]) 
-  }}
-
   {{ highlights_template.highlights(list_items=[
     "Architecture, design, and deployment of Canonical’s distributions of Ceph and Kubernetes.",
     "Timely updates and 24/7 monitoring of missioncritical equipment.",
@@ -41,15 +43,4 @@
                                      The systems Canonical deployed and now manage for ESA mean that ESOC engineering teams can quickly and centrally manage and deploy mission-critical infrastructure and software, with more security, reliability, and control, and with less downtime and reduced risk of system failures."
                       )
   }}
-
-  
-<!--This index page will be using macros to build an example case study -->
-  <!-- Hero section-->
-  {% import "case-studies/templates/_macros-hero.jinja" as hero_template %}
-  {{ hero_template.hero(title="Hero title",
-                        subtitle="Hero description",
-                        logo="https://assets.ubuntu.com/v1/8b33ba49-dell-technologies-logo-resize.png",
-                        logo_alt="Dell logo") 
-  }}
-
 {% endblock %}

--- a/templates/case-studies/index.html
+++ b/templates/case-studies/index.html
@@ -6,13 +6,18 @@
   <!--This index page will be using macros to build an example case study -->
   <!-- Hero section-->
   {% import "case-studies/templates/_macros-hero.jinja" as hero_template %}
-  {{ hero_template.hero(title="Canonical deploys infrastructure solutions and managed IT services for critical space mission operations",
+  {{ hero_template.hero(title="Hero title",
                         subtitle="Hero description",
                         logo="https://assets.ubuntu.com/v1/8b33ba49-dell-technologies-logo-resize.png",
                         logo_alt="Dell logo") 
   }}
 
-
+  {{ hero_template.hero(title="Canonical deploys infrastructure solutions and managed IT services for critical space mission operations",
+                        subtitle="Hero description",
+                        logo="https://assets.ubuntu.com/v1/5b46609e-layer1.png",
+                        logo_alt="ESM logo") 
+  }}
+  
   <!-- Text + list section -->
   {% import "case-studies/templates/_macros-text-list.jinja" as text_list_template %}
   {{ text_list_template.text_list(title="About the European Space Agency (ESA)",

--- a/templates/case-studies/index.html
+++ b/templates/case-studies/index.html
@@ -6,16 +6,12 @@
   <!--This index page will be using macros to build an example case study -->
   <!-- Hero section-->
   {% import "case-studies/templates/_macros-hero.jinja" as hero_template %}
-  {{ hero_template.hero(title="Hero title",
-                        subtitle="Hero description",
-                        logo="https://assets.ubuntu.com/v1/8b33ba49-dell-technologies-logo-resize.png",
-                        logo_alt="Dell logo") 
-  }}
-
   {{ hero_template.hero(title="Canonical deploys infrastructure solutions and managed IT services for critical space mission operations",
                         subtitle="Hero description",
                         logo="https://assets.ubuntu.com/v1/5b46609e-layer1.png",
-                        logo_alt="ESM logo") 
+                        logo_alt="ESM logo",
+                        logo_width="107",
+                        logo_height="39")
   }}
   
   <!-- Text + list section -->

--- a/templates/case-studies/templates/_macros-hero.jinja
+++ b/templates/case-studies/templates/_macros-hero.jinja
@@ -17,7 +17,9 @@
   <section class="p-section--hero">
     <div class="row--25-75">
       <div class="col">
-        <img src={{ logo }} alt={{ logo_alt }} width={{ logo_width }} height={{ logo_height }} />
+        <div class="p-image-wrapper">
+          <img src={{ logo }} alt="{{ logo_alt }}" width="{{ logo_width }}" height="{{ logo_height }}" />
+        </div>
       </div>
       <div class="col">
         <h1>{{ title }}</h1>

--- a/templates/case-studies/templates/_macros-hero.jinja
+++ b/templates/case-studies/templates/_macros-hero.jinja
@@ -1,0 +1,29 @@
+# Params
+# title: Hero title text (required)
+# subtitle: Hero subtitle text
+# logo: Path to logo image
+# logo_alt: Alt text for logo image
+# logo_width: Width of logo image (128 by default)
+# logo_height: Width of logo image (128 by default)
+
+{%- macro hero(
+  title,
+  subtitle,
+  logo,
+  logo_alt="",
+  logo_width="128",
+  logo_height="128"
+  ) -%}
+  <section class="p-strip">
+    <div class="row--25-75">
+      <div class="col">
+        <img src={{ logo }} alt={{ logo_alt }} width={{ logo_width }} height={{ logo_height }} />
+      </div>
+      <div class="col">
+        <h1>{{ title }}</h1>
+        <p>{{ subtitle }}</p>
+      </div>
+    </div>
+  </section>
+
+{%- endmacro -%}

--- a/templates/case-studies/templates/_macros-hero.jinja
+++ b/templates/case-studies/templates/_macros-hero.jinja
@@ -14,7 +14,7 @@
   logo_width="128",
   logo_height="128"
   ) -%}
-  <section class="p-strip">
+  <section class="p-section--hero">
     <div class="row--25-75">
       <div class="col">
         <img src={{ logo }} alt={{ logo_alt }} width={{ logo_width }} height={{ logo_height }} />

--- a/templates/case-studies/templates/_macros-hero.jinja
+++ b/templates/case-studies/templates/_macros-hero.jinja
@@ -22,7 +22,9 @@
         </div>
       </div>
       <div class="col">
-        <h1>{{ title }}</h1>
+        <div class="p-section--shallow">
+          <h1>{{ title }}</h1>
+        </div>
         <p>{{ subtitle }}</p>
       </div>
     </div>

--- a/templates/case-studies/templates/_macros-text-list.jinja
+++ b/templates/case-studies/templates/_macros-text-list.jinja
@@ -7,7 +7,9 @@
     <div class="row">
       <div class="col-start-large-4 col-9">
         <hr class="p-rule" />
-        <h2 class="p-strip is-shallow">{{ title }}</h2>
+        <div class="p-section--shallow">
+          <h2>{{ title }}</h2>
+        </div>
         <ul class="p-list--divided">
           {% for item in list_items %}<li class="p-list__item has-bullet">{{ item }}</li>{% endfor %}
         </ul>

--- a/templates/case-studies/templates/_macros-text.jinja
+++ b/templates/case-studies/templates/_macros-text.jinja
@@ -7,7 +7,9 @@
     <div class="row">
       <div class="col-start-large-4 col-9">
         <hr class="p-rule"/>
-        <h2 class="p-strip is-shallow">{{ title }}</h2>
+        <div class="p-section--shallow">
+          <h2>{{ title }}</h2>
+        </div>
         <p>{{ description }}</p>
       </div>
     </div>


### PR DESCRIPTION
## Done

- Add macros for hero section
- Import macro on index and build an example of the hero section with base template

## QA

- Go to https://ubuntu-com-14138.demos.haus/case-studies
- See that hero section design matches with [Figma](https://www.figma.com/design/AeIJ3GsqnJCHtiBYhkTuTV/24.10-Case-study-template?node-id=1-716&t=wlZAf1AkHWJJl0TN-0)
- See if there is any improvements to be done with the macro file: `_macros-hero.jinja` especially for image import. I am limiting the logo size as per the Figma design for now.

## Issue / Card

Fixes [WD-13118](https://warthogs.atlassian.net/browse/WD-13118)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-13118]: https://warthogs.atlassian.net/browse/WD-13118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ