### PR TITLE
Removed is-dark class from code block

### DIFF
--- a/templates/kubernetes/_install-linux.html
+++ b/templates/kubernetes/_install-linux.html
@@ -4,8 +4,8 @@
       Install MicroK8s on Linux
     </h4>
     <div class="p-stepped-list__content">
-      <div class="p-code-snippet is-dark">
-        <pre class="p-code-snippet__block--icon is-dark"><code>sudo snap install microk8s --classic</code></pre>
+      <div class="p-code-snippet">
+        <pre class="p-code-snippet__block--icon"><code>sudo snap install microk8s --classic</code></pre>
       </div>
       <p>Don’t have the snap command? <a href="https://docs.snapcraft.io/installing-snapd">Get set for snaps</a></p>
     </div>


### PR DESCRIPTION
## Done

- Removes `is-dark` class from a div and pre elements to make text visible

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

No issue created

## Screenshots

### Before

![image](https://github.com/user-attachments/assets/7ccea92f-cbe7-4377-9a2e-59044ff1f25b)

### After

![image](https://github.com/user-attachments/assets/d0ec2f65-0bbf-4a7b-972b-21132d9386c9)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
