### PR TITLE
Add macros for text section

### DIFF
--- a/templates/case-studies/base_case-studies.html
+++ b/templates/case-studies/base_case-studies.html
@@ -5,10 +5,6 @@
 
 {% block outer_content %}
   {% block content %}{% endblock %}
-  <section class="p-strip is-deep">
-    <div class="row">
-    </div>
-  </section>
 
   <hr class="is-fixed-width" />
   <section class="p-strip is-deep">

--- a/templates/case-studies/index.html
+++ b/templates/case-studies/index.html
@@ -1,4 +1,16 @@
 {% extends "case-studies/base_case-studies.html" %}
 
 {% block title %}Case Studies{% endblock %}
-{% block content %}{% endblock %}
+
+{% block content %}
+  <!-- Text section -->
+  {% import "case-studies/templates/_macros-text.jinja" as text_template %}
+  {{ text_template.text(title="About the European Space Agency (ESA)",
+                        description="Founded in 1987, the European Space Agency (ESA) is an intergovernmental organization 
+                                     dedicated to the exploration of space. With 22 member states, ESA is one of the largest 
+                                     space organizations in the world. The agency’s mission is to shape the development of Europe’s 
+                                     space capability and ensure that investment in space continues to deliver benefits to the citizens 
+                                     of Europe and the world.")
+  }}
+
+{% endblock %}

--- a/templates/case-studies/templates/_macros-text.jinja
+++ b/templates/case-studies/templates/_macros-text.jinja
@@ -1,0 +1,22 @@
+# Params
+# title: Title of text section (required)
+# description: Description of text section (required)
+
+{%- macro text(
+  title,
+  description
+) -%}
+
+  <section class="p-strip is-deep">
+    <div class="row--25-75">
+      <div class="col">
+      </div>
+      <div class="col">
+        <hr class="p-rule"/>
+        <h2 class="u-sv3">{{ title }}</h2>
+        <p>{{ description }}</p>
+      </div>
+    </div>
+  </section>
+
+{%- endmacro -%}

--- a/templates/case-studies/templates/_macros-text.jinja
+++ b/templates/case-studies/templates/_macros-text.jinja
@@ -3,11 +3,11 @@
 # description: Description of text section (required)
 
 {%- macro text(title, description) -%}
-  <section class="p-strip is-deep">
+  <section class="p-strip">
     <div class="row">
       <div class="col-start-large-4 col-9">
         <hr class="p-rule"/>
-        <h2 class="u-sv3">{{ title }}</h2>
+        <h2 class="p-strip is-shallow">{{ title }}</h2>
         <p>{{ description }}</p>
       </div>
     </div>

--- a/templates/case-studies/templates/_macros-text.jinja
+++ b/templates/case-studies/templates/_macros-text.jinja
@@ -2,21 +2,14 @@
 # title: Title of text section (required)
 # description: Description of text section (required)
 
-{%- macro text(
-  title,
-  description
-) -%}
-
+{%- macro text(title, description) -%}
   <section class="p-strip is-deep">
-    <div class="row--25-75">
-      <div class="col">
-      </div>
-      <div class="col">
+    <div class="row">
+      <div class="col-start-large-4 col-9">
         <hr class="p-rule"/>
         <h2 class="u-sv3">{{ title }}</h2>
         <p>{{ description }}</p>
       </div>
     </div>
   </section>
-
 {%- endmacro -%}


### PR DESCRIPTION
## Done

- Add macros for text section
- Import macro on index and build an example of the text section with base template

## QA
- Go to https://ubuntu-com-14143.demos.haus/case-studies
- See that text section design matches with [Figma](https://www.figma.com/design/AeIJ3GsqnJCHtiBYhkTuTV/24.10-Case-study-template?node-id=1-716&t=ocgEedog4898THvX-0)


## Issue / Card

Fixes [WD-13119](https://warthogs.atlassian.net/browse/WD-13119)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-13119]: https://warthogs.atlassian.net/browse/WD-13119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[WD-13120]: https://warthogs.atlassian.net/browse/WD-13120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WD-13121]: https://warthogs.atlassian.net/browse/WD-13121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ