### PR TITLE
Use the security notices api service

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -337,7 +337,11 @@ production:
         - name: SENTRY_DSN
           value: https://0293bb7fc3104e56bafd2422e155790c@sentry.is.canonical.com//13
 
-    - paths: [/security/notices\.json]
+    - paths: 
+        [
+          /security/notices\.json,
+          /security/notices/.*\.json
+        ]
       service_name: ubuntu-com-security-api-notices
     
     - paths: [/security/updates/.*]
@@ -347,7 +351,6 @@ production:
         [
           /security/cves\.json,
           /security/cves/.*\.json,
-          /security/notices/.*\.json,
           /security/releases\.json,
           /security/releases/.*\.json,
           /security/api/.*,
@@ -850,7 +853,11 @@ staging:
           value: https://0293bb7fc3104e56bafd2422e155790c@sentry.is.canonical.com//13
 
 
-    - paths: [/security/notices\.json]
+    - paths:
+        [
+          /security/notices\.json,
+          /security/notices/.*\.json
+        ]
       service_name: ubuntu-com-security-api-notices
     
     - paths: [/security/updates/.*]
@@ -860,7 +867,6 @@ staging:
         [
           /security/cves\.json,
           /security/cves/.*\.json,
-          /security/notices/.*\.json,
           /security/releases\.json,
           /security/releases/.*\.json,
           /security/api/.*,

--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -337,12 +337,8 @@ production:
         - name: SENTRY_DSN
           value: https://0293bb7fc3104e56bafd2422e155790c@sentry.is.canonical.com//13
 
-    - paths:
-        [
-          /security/notices\.json,
-          /security/page/.*\.json,
-        ]
-      service_name: ubuntu-com-security-api
+    - paths: [/security/notices\.json]
+      service_name: ubuntu-com-security-api-notices
     
     - paths: [/security/updates/.*]
       service_name: ubuntu-com-security-api-updates
@@ -355,6 +351,7 @@ production:
           /security/releases\.json,
           /security/releases/.*\.json,
           /security/api/.*,
+          /security/page/.*\.json,
         ]
       service_name: ubuntu-com-security-api
 
@@ -853,12 +850,8 @@ staging:
           value: https://0293bb7fc3104e56bafd2422e155790c@sentry.is.canonical.com//13
 
 
-    - paths: 
-        [
-          /security/notices\.json,
-          /security/page/.*\.json,
-        ]
-      service_name: ubuntu-com-security-api
+    - paths: [/security/notices\.json]
+      service_name: ubuntu-com-security-api-notices
     
     - paths: [/security/updates/.*]
       service_name: ubuntu-com-security-api-updates
@@ -867,11 +860,11 @@ staging:
         [
           /security/cves\.json,
           /security/cves/.*\.json,
-          /security/notices\.json,
           /security/notices/.*\.json,
           /security/releases\.json,
           /security/releases/.*\.json,
           /security/api/.*,
+          /security/page/.*\.json,
         ]
       service_name: ubuntu-com-security-api
 


### PR DESCRIPTION
## Done

- Use the service `ubuntu-com-security-api-notices` for `/security/notices.json`
- Use the service `ubuntu-com-security-api` for the rest of `/security` endpoints
