### PR TITLE
Add macros for text list and highlights section

### DIFF
--- a/templates/case-studies/base_case-studies.html
+++ b/templates/case-studies/base_case-studies.html
@@ -5,7 +5,6 @@
 
 {% block outer_content %}
   {% block content %}{% endblock %}
-
   <hr class="is-fixed-width" />
   <section class="p-strip is-deep">
     <div class="row">

--- a/templates/case-studies/index.html
+++ b/templates/case-studies/index.html
@@ -29,7 +29,16 @@
     "Architecture, design, and deployment of Canonical’s distributions of Ceph and Kubernetes.",
     "Timely updates and 24/7 monitoring of missioncritical equipment.",
     "ESA has operated more than 87 missions from ESOC, ranging from understanding our own planet to exploring our solar system and beyond to help advance scientific knowledge.",
+    ]) 
+  }}
+
+  {{ highlights_template.highlights(list_items=[
+    "Architecture, design, and deployment of Canonical’s distributions of Ceph and Kubernetes.",
+    "Timely updates and 24/7 monitoring of missioncritical equipment.",
+    "ESA has operated more than 87 missions from ESOC, ranging from understanding our own planet to exploring our solar system and beyond to help advance scientific knowledge.",
     "ESOC is responsible for a wide range of IT infrastructure and systems to help fly these unique missions, having been responsible for flying more than 80 custom-built satellites since it was established."
     ]) 
   }}
+
+  
 {% endblock %}

--- a/templates/case-studies/index.html
+++ b/templates/case-studies/index.html
@@ -3,15 +3,6 @@
 {% block title %}Case Studies{% endblock %}
 
 {% block content %}
-  <!-- Text section -->
-  {% import "case-studies/templates/_macros-text.jinja" as text_template %}
-  {{ text_template.text(title="About the European Space Agency (ESA)",
-                        description="Founded in 1987, the European Space Agency (ESA) is an intergovernmental organization 
-                                     dedicated to the exploration of space. With 22 member states, ESA is one of the largest 
-                                     space organizations in the world. The agency’s mission is to shape the development of Europe’s 
-                                     space capability and ensure that investment in space continues to deliver benefits to the citizens 
-                                     of Europe and the world.")
-  }}
 
   <!-- Text + list section -->
   {% import "case-studies/templates/_macros-text-list.jinja" as text_list_template %}
@@ -38,6 +29,17 @@
     "ESA has operated more than 87 missions from ESOC, ranging from understanding our own planet to exploring our solar system and beyond to help advance scientific knowledge.",
     "ESOC is responsible for a wide range of IT infrastructure and systems to help fly these unique missions, having been responsible for flying more than 80 custom-built satellites since it was established."
     ]) 
+  }}
+
+  <!-- Text section -->
+  {% import "case-studies/templates/_macros-text.jinja" as text_template %}
+  {{ text_template.text(title="You can’t explore space without infrastructure.",
+                        description="It’s not just expert personnel, satellites and spacecraft: it takes mountains of software, computer systems, data and networks to get these missions off the ground. These missions are often unique – testing the limits of our technological know-how, having never been done before with each mission presenting its own unique challenges. Building and deploying these systems on a mission-bymission basis often involves significant complexity and costs.<br/><br/>
+                                     ESA decided to embark on an ambitious challenge: to fly double the number of satellites it does currently by 2030, looking to technology to help it achieve this goal, with more rapid and automated software delivery, shared services, more efficient use of resources and lower costs of deployment.<br/><br/>
+                                     To meet this goal, ESA engaged Canonical to deliver the architecture, design and deployment of Kubernetes and Ceph for persistent storage. ESA also chose Canonical’s Ceph distribution to consolidate the various storage technologies in use. Canonical’s Kubernetes distribution allowed ESA’s Missions Operations Infrastructure – IT (MOI-IT) team to easily deploy its workloads, integrated with the existing IT infrastructure services, giving it a greater ability to support ESA missions and those of its partners, with automatic updates and deployment, 24/7 monitoring and reduced system complexity.<br/><br/>
+                                     Kubernetes was perfect for ESA’s next generation multi-mission platform at ESOC. This open source system helps organisations orchestrate their workloads more efficiently with automation. However, Kubernetes’ fast-moving and steep learning curve makes it more demanding to manage. To reduce the engineering workload and management requirements of this new system, ESA chose Canonical to manage its Kubernetes deployments, providing updates, monitoring and maintenance.<br/><br/>
+                                     The systems Canonical deployed and now manage for ESA mean that ESOC engineering teams can quickly and centrally manage and deploy mission-critical infrastructure and software, with more security, reliability, and control, and with less downtime and reduced risk of system failures."
+                      )
   }}
 
   

--- a/templates/case-studies/index.html
+++ b/templates/case-studies/index.html
@@ -13,4 +13,14 @@
                                      of Europe and the world.")
   }}
 
+  <!-- Text + list section -->
+  {% import "case-studies/templates/_macros-text-list.jinja" as text_list_template %}
+  {{ text_list_template.text_list(
+      title="About the European Space Agency (ESA)",
+      list_items=[
+        "Founded in 1975, ESA is a 22-member intergovernmental space exploration organisation.",
+        "The European Space Operations Centre (ESOC), one of ESA’s premises in Germany, is home to the engineering teams that control spacecraft in orbit, manage the global tracking station network, and design and build the systems on the ground that support missions in space.",
+        "ESOC is responsible for a wide range of IT infrastructure and systems to help fly these unique missions, having been responsible for flying more than 80 custom-built satellites since it was established."
+    ]) 
+  }}
 {% endblock %}

--- a/templates/case-studies/index.html
+++ b/templates/case-studies/index.html
@@ -15,12 +15,21 @@
 
   <!-- Text + list section -->
   {% import "case-studies/templates/_macros-text-list.jinja" as text_list_template %}
-  {{ text_list_template.text_list(
-      title="About the European Space Agency (ESA)",
-      list_items=[
-        "Founded in 1975, ESA is a 22-member intergovernmental space exploration organisation.",
-        "The European Space Operations Centre (ESOC), one of ESA’s premises in Germany, is home to the engineering teams that control spacecraft in orbit, manage the global tracking station network, and design and build the systems on the ground that support missions in space.",
-        "ESOC is responsible for a wide range of IT infrastructure and systems to help fly these unique missions, having been responsible for flying more than 80 custom-built satellites since it was established."
+  {{ text_list_template.text_list(title="About the European Space Agency (ESA)",
+    list_items=[
+    "Founded in 1975, ESA is a 22-member intergovernmental space exploration organisation.",
+    "The European Space Operations Centre (ESOC), one of ESA’s premises in Germany, is home to the engineering teams that control spacecraft in orbit, manage the global tracking station network, and design and build the systems on the ground that support missions in space.",
+    "ESOC is responsible for a wide range of IT infrastructure and systems to help fly these unique missions, having been responsible for flying more than 80 custom-built satellites since it was established."
+    ]) 
+  }}
+
+  <!-- Highlights section -->
+  {% import "case-studies/templates/_macros-highlights.jinja" as highlights_template %}
+  {{ highlights_template.highlights(list_items=[
+    "Architecture, design, and deployment of Canonical’s distributions of Ceph and Kubernetes.",
+    "Timely updates and 24/7 monitoring of missioncritical equipment.",
+    "ESA has operated more than 87 missions from ESOC, ranging from understanding our own planet to exploring our solar system and beyond to help advance scientific knowledge.",
+    "ESOC is responsible for a wide range of IT infrastructure and systems to help fly these unique missions, having been responsible for flying more than 80 custom-built satellites since it was established."
     ]) 
   }}
 {% endblock %}

--- a/templates/case-studies/templates/_macros-highlights.jinja
+++ b/templates/case-studies/templates/_macros-highlights.jinja
@@ -1,16 +1,12 @@
 # Params
 # list_items: List of highlight items (requires 3-4 items)
 
-{%- macro highlights(
-  list_items
-  ) -%}
-
-  <section class="p-strip is-deep">
+{%- macro highlights(list_items) -%}
+  <section class="p-strip">
     <div class="row">
       <p class="p-text--small-caps">Highlights</p>
       <hr />
     </div>
-
     {% if list_items | length == 3 %}
       {% set col_size = "col-4" %}
     {% elif list_items | length == 4 %}
@@ -24,5 +20,4 @@
       {% endfor %}
     </div>
   </section>
-
 {%- endmacro -%}

--- a/templates/case-studies/templates/_macros-highlights.jinja
+++ b/templates/case-studies/templates/_macros-highlights.jinja
@@ -5,7 +5,7 @@
   list_items
   ) -%}
 
-  <section class="p-strip">
+  <section class="p-strip is-deep">
     <div class="row">
       <p class="p-text--small-caps">Highlights</p>
       <hr />

--- a/templates/case-studies/templates/_macros-highlights.jinja
+++ b/templates/case-studies/templates/_macros-highlights.jinja
@@ -1,0 +1,28 @@
+# Params
+# list_items: List of highlight items (requires 3-4 items)
+
+{%- macro highlights(
+  list_items
+  ) -%}
+
+  <section class="p-strip">
+    <div class="row">
+      <p class="p-text--small-caps">Highlights</p>
+      <hr />
+    </div>
+
+    {% if list_items | length == 3 %}
+      {% set col_size = "col-4" %}
+    {% elif list_items | length == 4 %}
+      {% set col_size = "col-3" %}
+    {% endif %}
+    <div class="row">
+      {% for item in list_items %}
+        <div class="{{ col_size }}">
+          <p class="p-list__item is-ticked">{{ item }}</p>
+        </div>
+      {% endfor %}
+    </div>
+  </section>
+
+{%- endmacro -%}

--- a/templates/case-studies/templates/_macros-text-list.jinja
+++ b/templates/case-studies/templates/_macros-text-list.jinja
@@ -2,15 +2,10 @@
 # title: Title of text section (required)
 # list_items: Description of text section (required)
 
-{%- macro text_list(
-  title,
-  list_items
-  ) -%}
-
+{%- macro text_list(title, list_items) -%}
   <section class="p-strip">
-    <div class="row--25-75">
-      <div class="col"></div>
-      <div class="col">
+    <div class="row">
+      <div class="col-start-large-4 col-9">
         <hr class="p-rule" />
         <h2 class="u-sv3">{{ title }}</h2>
         <ul class="p-list--divided">
@@ -19,5 +14,4 @@
       </div>
     </div>
   </section>
-
 {%- endmacro -%}

--- a/templates/case-studies/templates/_macros-text-list.jinja
+++ b/templates/case-studies/templates/_macros-text-list.jinja
@@ -7,7 +7,7 @@
   list_items
   ) -%}
 
-  <section class="p-strip is-deep">
+  <section class="p-strip">
     <div class="row--25-75">
       <div class="col"></div>
       <div class="col">

--- a/templates/case-studies/templates/_macros-text-list.jinja
+++ b/templates/case-studies/templates/_macros-text-list.jinja
@@ -1,0 +1,26 @@
+# Params
+# title: Title of text section (required)
+# list_items: Description of text section (required)
+
+{%- macro text_list(
+  title,
+  list_items
+) -%}
+
+  <section class="p-strip is-deep">
+    <div class="row--25-75">
+      <div class="col">
+      </div>
+      <div class="col">
+        <hr class="p-rule"/>
+        <h2 class="">{{ title }}</h2>
+        <ul>
+          {% for item in list_items %}
+            <li>{{ item }}</li>
+          {% endfor %}
+        </ul>
+      </div>
+    </div>
+  </section>
+
+{%- endmacro -%}

--- a/templates/case-studies/templates/_macros-text-list.jinja
+++ b/templates/case-studies/templates/_macros-text-list.jinja
@@ -5,19 +5,16 @@
 {%- macro text_list(
   title,
   list_items
-) -%}
+  ) -%}
 
   <section class="p-strip is-deep">
     <div class="row--25-75">
+      <div class="col"></div>
       <div class="col">
-      </div>
-      <div class="col">
-        <hr class="p-rule"/>
-        <h2 class="">{{ title }}</h2>
-        <ul>
-          {% for item in list_items %}
-            <li>{{ item }}</li>
-          {% endfor %}
+        <hr class="p-rule" />
+        <h2 class="u-sv3">{{ title }}</h2>
+        <ul class="p-list--divided">
+          {% for item in list_items %}<li class="p-list__item has-bullet">{{ item }}</li>{% endfor %}
         </ul>
       </div>
     </div>

--- a/templates/case-studies/templates/_macros-text-list.jinja
+++ b/templates/case-studies/templates/_macros-text-list.jinja
@@ -7,7 +7,7 @@
     <div class="row">
       <div class="col-start-large-4 col-9">
         <hr class="p-rule" />
-        <h2 class="u-sv3">{{ title }}</h2>
+        <h2 class="p-strip is-shallow">{{ title }}</h2>
         <ul class="p-list--divided">
           {% for item in list_items %}<li class="p-list__item has-bullet">{{ item }}</li>{% endfor %}
         </ul>


### PR DESCRIPTION
## Done

- Added macros for text + list and highlights section
- Added examples for macros usage

## QA

- Go to https://ubuntu-com-14148.demos.haus/case-studies
- See that text + list and highlights section design matches with [Figma](https://www.figma.com/design/AeIJ3GsqnJCHtiBYhkTuTV/24.10-Case-study-template?node-id=1-716&t=ocgEedog4898THvX-0)

## Issue / Card

Fixes [WD-13120](https://warthogs.atlassian.net/browse/WD-13120) and [WD-13121](https://warthogs.atlassian.net/browse/WD-13121)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-13120]: https://warthogs.atlassian.net/browse/WD-13120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WD-13121]: https://warthogs.atlassian.net/browse/WD-13121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ