### PR TITLE
WD-13922-copy-update-for-faq-page-on-credentials

### DIFF
--- a/templates/credentials/faq.html
+++ b/templates/credentials/faq.html
@@ -171,9 +171,6 @@
         <p>
           Once the environment is loaded, it will appear to be a default installation of Ubuntu 22.04 LTS (Jammy Jellyfish) with a GNOME Desktop, Terminal, and other relevant tools. All other nodes in the exam environment are running Ubuntu Server 22.04 LTS.
         </p>
-        <p><i>
-          [NOTE: The exam environment will be updated to Ubuntu 24.04 LTS (Noble Numbat) in the CUE.01 Linux 24.10 version, targeted for October of 2024.]
-        </i></p>
         <h3>Are there any technical restrictions?</h3>
         <p>
           Please note that due to the nature of a browser-based environment, some shortcuts may not be available. Of particular note is Ctrl-W, commonly used in text editors but also used to close your tab.

--- a/templates/credentials/faq.html
+++ b/templates/credentials/faq.html
@@ -47,10 +47,14 @@
         <h2 id="about">About the exam</h2>
         <h3>How long is each exam?</h3>
         <p>
-          Each Quick Certification (QC) exam is between 60-90 minutes long, depending on the exam, although more experienced candidates may finish in approximately 45 minutes. The CUE.01 Linux exam is 60 minutes long.
+          Each Quick Certification (QC) exam is between 60-90 minutes long, depending on the exam, although more experienced candidates may finish in approximately 45 minutes. The CUE.01 Linux exam is currently 75 minutes long.
         </p>
         <p>
           The Canonical Ubuntu Essentials credential requires a passing score on all three Quick Certification (QC) exams: CUE.01 Linux, CUE.02 Desktop, and CUE.03 Server.
+        </p>
+        <h3>How are scores determined?</h3>
+        <p>
+          For CUE.01 Linux a passing score is currently 70.0 and is based on all Multiple Choice and Lab items. Each item’s score is weighted based on the steps, complexity, and importance to the occupational role as determined by a panel of industry experts. Items are also reviewed continuously for item quality using industry-standard assessment metrics.
         </p>
         <h3>Do you have to take the exams in numerical order?</h3>
         <p>
@@ -62,7 +66,7 @@
         </p>
         <h3>What is the profile of a credential holder?</h3>
         <p>
-          Successful completion of all three exams indicates a well-rounded knowledge of vendor neutral Linux, Ubuntu Desktop, and Ubuntu Server. Credential holders are able to troubleshoot, configure, install, and maintain systems, processes, and general activities associated with using Linux, Ubuntu Desktop, and Ubuntu Server as an early career system administrator or IT professional. Subject matter depth is validated by several practical hands-on challenges and subject matter breadth is evaluated by a number of multiple-choice questions.
+          Successful completion of all three exams indicates a well-rounded knowledge of Linux Terminal, Ubuntu Desktop, and Ubuntu Server. Credential holders are able to troubleshoot, configure, install, and maintain systems, processes, and general activities associated with using Linux, Ubuntu Desktop, and Ubuntu Server as an early career system administrator or IT professional. Subject matter depth is validated by several practical hands-on challenges and subject matter breadth is evaluated by a number of multiple-choice questions.
         </p>
         <h3>What is each Quick Certification (QC) exam like?</h3>
         <p>
@@ -108,14 +112,14 @@
 
         <h3>Are there study materials available?</h3>
         <p>
-          This exam certifies that you have the essential vendor-neutral Linux knowledge expected of early career administrators and operators. Professionals with equivalent experience should not require additional training.
+          Each exam certifies that you have the essential Linux Terminal, Ubuntu Desktop, and Ubuntu Server knowledge expected of early career administrators and operators. Professionals with equivalent experience should not require additional training.
         </p>
         <p>
           Test-takers interested in the types of material covered on each exam can review links to tutorials and documentation on our website: <a href="https://ubuntu.com/credentials/self-study">https://ubuntu.com/credentials/self-study</a>.
         </p>
         <h3>Am I able to schedule the exam in advance?</h3>
         <p>
-          Yes. Once purchased, exams can be scheduled up to one year in the future. Exam bookings require a minimum of 30 minutes notice before taking your exam to allow for the environment to be provisioned.
+          Yes. Once purchased, exams can be scheduled up to one year in the future. <i>[Note that preview releases, including CUE.01 Linux 24.04 exam version, are only available for 30 days after purchase.] </i> Exam bookings require a minimum of 60 minutes notice before taking your exam to allow for the environment to be provisioned and checked.
         </p>
         <h3>Can I reschedule if the time slot I chose doesn’t work for me?</h3>
         <p>
@@ -139,11 +143,11 @@
         }}
         <h3>What resources am I allowed to use while in an exam?</h3>
         <p>
-          You are allowed to use man pages and other resources, but be advised that this will come out of your exam time. Individuals are discouraged from using reference materials from outside of the exam environment. All exam tasks, including connecting to other nodes, will occur within the browser-based exam environment and will not require any resources from the host system. Exam securing or proctoring features may ask for permissions to your web camera or microphone.
+          Individuals are discouraged from using reference materials from outside of the exam environment. All exam tasks, including connecting to other nodes, will occur within the browser-based exam environment and will not require any resources from the user's host system. Exam securing or proctoring features may ask for permissions to your web camera, desktop screen, or microphone.
         </p>
         <h3>May I use man pages?</h3>
         <p>
-          Exam environments use Minimal Ubuntu images and do not have man pages pre-loaded. While you are welcome to install and use them, this will consume some of your exam time.
+          Exam environments use <a href="https://wiki.ubuntu.com/Minimal" target="_blank">Minimal Ubuntu images</a> and have man pages pre-loaded on the initial node only.
         </p>
         <h3>Do I have to significantly alter my physical environment by covering up items on my wall or on my desk?</h3>
         <p>No. Exams do not need to be taken in a “clean room” environment.</p>
@@ -153,12 +157,13 @@
         </p>
         <h3>Is this exam proctored?</h3>
         <p>
-          Yes. Once released, exams will use AI-based proctoring technology to detect and escalate abnormalities. Exam securing or proctoring features may ask for permissions to your web camera or microphone. All exams are recorded for auditing purposes, and exams with activity that looks fraudulent will be flagged for further evaluation.
+          Yes. Once released, exams will use AI-based proctoring technology to detect and escalate abnormalities. Exam securing or proctoring features may ask for permissions to your web camera or microphone, as well as to your desktop screen. All exams are recorded for auditing purposes, and exams with activity that looks fraudulent will be flagged for further evaluation.
         </p>
         <p>
           Participants caught cheating will be excluded from this and all future Canonical Credentials exams, whether in beta or general release.
         </p>
         <h3>What are the technical requirements of our environment?</h3>
+        <p><i>[NOTE: There is a known issue with keyboards and Firefox in the CUE.01 Linux 24.04 preview release at this time, which will be resolved in the CUE.01 Linux 24.10 exam release. We recommend using Chrome-based browsers at this time.]</i></p>
         <p>
           The exam is conducted via web browser, and any operating system capable of running a modern browser is acceptable.
         </p>
@@ -166,9 +171,9 @@
         <p>
           Once the environment is loaded, it will appear to be a default installation of Ubuntu 22.04 LTS (Jammy Jellyfish) with a GNOME Desktop, Terminal, and other relevant tools. All other nodes in the exam environment are running Ubuntu Server 22.04 LTS.
         </p>
-        <p>
-          The exam environment will be updated to Ubuntu 24.04 LTS (Noble Numbat) in the CUE.01 Linux 24.10 version, targeted for October of 2024.
-        </p>
+        <p><i>
+          [NOTE: The exam environment will be updated to Ubuntu 24.04 LTS (Noble Numbat) in the CUE.01 Linux 24.10 version, targeted for October of 2024.]
+        </i></p>
         <h3>Are there any technical restrictions?</h3>
         <p>
           Please note that due to the nature of a browser-based environment, some shortcuts may not be available. Of particular note is Ctrl-W, commonly used in text editors but also used to close your tab.
@@ -179,7 +184,7 @@
         </p>
         <h3>Do I have to answer in a particular order?</h3>
         <p>
-          No. Questions may be answered in any order and you may move between sections or menus as you like. Once you have completed your exam, you will not be able to go back.
+          No. Questions may be answered in any order and you may move between sections or menus as you like. We recommend reviewing the questions, answering those you are most comfortable with first, and then returning to other questions. The last tab of the exam will show any questions that do not have an answer submitted. Once you have completed your exam, you will not be able to go back.
         </p>
         <h3>Can I change my answers to multiple choice questions?</h3>
         <p>
@@ -203,25 +208,28 @@
         <h2 id="after">After the exam</h2>
         <h3>When will I receive my result?</h3>
         <p>
-          After your exam is completed, successful submissions are verified by the Credentials & Curriculum team and a badge is issued within 4 business days.
+          CUE.01 Linux Preview Release 24.04: After your exam is completed, successful submissions are verified by the Credentials & Curriculum team and a badge is issued within 4 business days. We anticipate a more rapid review process for the CUE.01 Linux exam release 24.10.
         </p>
         <h3>How are badges issues?</h3>
         <p>
-          Digital badges are issued through Credly. If successful, an email with your badge information will be sent to the email used to take the exam.
+          Digital badges are issued through Credly. If you successfully pass your exam with a score of 70 or higher, an email with your badge information will be sent to the email used to take the exam.
         </p>
         <h3>Can I know which questions I got wrong?</h3>
         <p>No. Only the overall exam result is communicated to candidates. Detailed question scores are not made available.</p>
         <h3>Will each question have the same score value?</h3>
         <p>
-          No. Questions are graded based on complexity of steps or variety of skills needed to answer. Performance-based questions are more heavily weighted than multiple choice. Final scores will be determined after item quality metrics have been performed.
+          No. Questions are graded based on complexity of steps or variety of skills needed to answer. Performance-based questions are more heavily weighted than multiple choice. Each exam item and lab step is scored based on how critical the skill is to the target occupation, as determined by a panel of industry experts. Items undergo further evaluation via item quality metrics, and exam scoring and individual items are improved or optimised on a regular and continuous basis. Final scores will be determined after item quality metrics have been performed.
         </p>
         <h3>Am I allowed to retake exams?</h3>
         <p>
           Yes. Quick Certification (QC) exams may be retaken one time within a calendar year. Please contact cue@canonical.com if you have any concerns about retaking the exam.
         </p>
+        <p>
+          If you have experienced a problem with your exam during the Preview Release phase (CUE.01 Linux exam release 24.04), please contact cue@canonical.com to ask about an exception and potential for additional retake.
+        </p>
         <h3>Will I get the same exam over again if I retake it?</h3>
         <p>
-          No. There are multiple versions of each question, and exam variations are tracked and assigned accordingly. Retake exams will be pulled from a comparable, but different, group of questions.
+          No. There are multiple versions of each question, and exam variations are tracked and assigned accordingly. Retake exams will be pulled from a comparable, but different, group of questions, and our question bank is continuously reviewed and improved based on data gathered through item quality metrics and panel reviews by industry experts..
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Done

- Update the FAQ page for Credentials 

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- visit [/credentials/faq](https://ubuntu-com-14151.demos.haus/credentials/faq)
- compare with copy doc

## Issue / Card

Fixes #WD-13922

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
