### PR TITLE
WD-12827 - rebrand /azure/private-offer

### DIFF
--- a/static/sass/_pattern_lists.scss
+++ b/static/sass/_pattern_lists.scss
@@ -11,6 +11,7 @@
   @include ubuntu-p-list-ticked;
   @include ubuntu-p-list-horizontal-divided;
   @include ubuntu-p-faq-stepped-list--detailed;
+  @include vf-list-item-divided;
 }
 
 @mixin ubuntu-p-inline-list-icons {
@@ -419,5 +420,11 @@
       display: inline-block;
       max-width: $text-max-width;
     }
+  }
+}
+
+@mixin vf-list-item-divided {
+  .p-list--divided.is-homepage > .p-list__item:first-child {
+    box-shadow: inset 0 1px 0 0 $colors--theme--border-low-contrast;
   }
 }

--- a/templates/azure/ebook/index.html
+++ b/templates/azure/ebook/index.html
@@ -35,15 +35,13 @@
         </div>
       </div>
       <div class="col-5 u-hide--small u-vertically-center u-align--center">
-        {{ image (
-        url="https://assets.ubuntu.com/v1/0959ce33-NEW_Ubuntu_ebook_1.png",
-        alt="",
-        width="214",
-        height="300",
-        hi_def=True,
-        loading="auto",
-        attrs={ "class": "p-image--bordered"}
-        ) | safe
+        {{ image(url="https://assets.ubuntu.com/v1/0959ce33-NEW_Ubuntu_ebook_1.png",
+                alt="",
+                width="214",
+                height="300",
+                hi_def=True,
+                loading="auto",
+                attrs={ "class": "p-image--bordered"}) | safe
         }}
       </div>
     </div>
@@ -98,14 +96,12 @@
       </div>
 
       <div class="col-5 u-align--center">
-        {{ image (
-        url="https://assets.ubuntu.com/v1/71fe6a11-private-offer-shield.svg",
-        alt="",
-        width="206",
-        height="234",
-        hi_def=True,
-        loading="lazy"
-        ) | safe
+        {{ image(url="https://assets.ubuntu.com/v1/71fe6a11-private-offer-shield.svg",
+                alt="",
+                width="206",
+                height="234",
+                hi_def=True,
+                loading="lazy") | safe
         }}
       </div>
     </div>

--- a/templates/azure/ebook/index.html
+++ b/templates/azure/ebook/index.html
@@ -1,8 +1,14 @@
 {% extends "azure/base_azure.html" %}
 
 {% block title %}Why do Cloud innovators migrate to Pro? Get the eBook.{% endblock %}
-{% block meta_description %}Learn about the security compliance and support features of the Linux based Ubuntu Pro image on Azure.{% endblock %}
-{% block meta_copydoc %}https://docs.google.com/document/d/1JL_TeFBg1tSqiYIiXU0IwJTKWRDKJEXWtEgLRWFnToI/edit#{% endblock meta_copydoc %}
+
+{% block meta_description %}
+  Learn about the security compliance and support features of the Linux based Ubuntu Pro image on Azure.
+{% endblock %}
+
+{% block meta_copydoc %}
+  https://docs.google.com/document/d/1JL_TeFBg1tSqiYIiXU0IwJTKWRDKJEXWtEgLRWFnToI/edit#
+{% endblock meta_copydoc %}
 
 {% block head_extra %}
   <style>
@@ -15,21 +21,21 @@
 
 {% block content %}
 
-<section class="p-strip--suru-bottomed">
-  <div class="row">
-    <div class="col-7 u-vertically-center">
-      <div>
-        <h1>Why do cloud innovators migrate to Ubuntu Pro?</h1>
+  <section class="p-strip--suru-bottomed">
+    <div class="row">
+      <div class="col-7 u-vertically-center">
+        <div>
+          <h1>Why do cloud innovators migrate to Ubuntu Pro?</h1>
 
-        <p class="u-no-padding--top p-heading--4">Get our eBook to find out</p>
+          <p class="u-no-padding--top p-heading--4">Get our eBook to find out</p>
 
-        <p>
-          <a href="#ubuntu-pro-ebook" class="p-button--positive">Download<span class="u-off-screen"> the Why do Cloud innovators migrate to Pro? eBook by completing this form</span></a>
-        </p>
+          <p>
+            <a href="#ubuntu-pro-ebook" class="p-button--positive">Download<span class="u-off-screen">the Why do Cloud innovators migrate to Pro? eBook by completing this form</span></a>
+          </p>
+        </div>
       </div>
-    </div>
-    <div class="col-5 u-hide--small u-vertically-center u-align--center">
-      {{ image (
+      <div class="col-5 u-hide--small u-vertically-center u-align--center">
+        {{ image (
         url="https://assets.ubuntu.com/v1/0959ce33-NEW_Ubuntu_ebook_1.png",
         alt="",
         width="214",
@@ -38,53 +44,61 @@
         loading="auto",
         attrs={ "class": "p-image--bordered"}
         ) | safe
-      }}
+        }}
+      </div>
+    </div>
+  </section>
+
+  {% include "azure/shared/_azure-logo-strip.html" %}
+
+  <div class="p-strip--light">
+    <div class="row">
+      <div class="col-7">
+        <h2 class="p-heading--4">
+          Ubuntu Pro for Azure is a premium image delivering the most comprehensive open source security and compliance
+        </h2>
+
+        <hr class="p-separator u-no-margin--top" />
+
+        <p class="p-heading--4">
+          <strong>70% of Azure virtual machines are running on Ubuntu due to reliability and ease of use</strong>
+        </p>
+
+        <p>
+          As the publishers of Ubuntu, we went one step further and developed a premium Ubuntu Pro image in partnership with public cloud providers, to deliver a preferred open-source solution for cloud innovators.
+        </p>
+
+        <p>
+          Here is our latest eBook, where we share the details of how Ubuntu Pro on Azure delivers extended open-source security, enterprise compliance, 10 years of extended maintenance and more.
+        </p>
+      </div>
+
+      <div class="col-5" id="ubuntu-pro-ebook">
+        {% with id="4393", returnURL="/azure/ebook/thank-you", cta="Get the eBook", cta_class="p-button--positive" %}
+          {% include "engage/shared/_en_engage_form.html" %}
+        {% endwith %}
+      </div>
     </div>
   </div>
-</section>
 
-{% include "azure/shared/_azure-logo-strip.html" %}
-
-<div class="p-strip--light">
-  <div class="row">
-    <div class="col-7">
-      <h2 class="p-heading--4">Ubuntu Pro for Azure is a premium image delivering the most comprehensive open source security and compliance</h2>
-
-      <hr class="p-separator u-no-margin--top" />
-
-      <p class="p-heading--4"><strong>70% of Azure virtual machines are running on Ubuntu due to reliability and ease of use</strong></p>
-
-      <p>As the publishers of Ubuntu, we went one step further and developed a premium Ubuntu Pro image in partnership with public cloud providers, to deliver a preferred open-source solution for cloud innovators.</p>
-
-      <p>Here is our latest eBook, where we share the details of how Ubuntu Pro on Azure delivers extended open-source security, enterprise compliance, 10 years of extended maintenance and more.</p>
-    </div>
-
-    <div class="col-5" id="ubuntu-pro-ebook">
-      {% with id="4393", returnURL="/azure/ebook/thank-you", cta="Get the eBook", cta_class="p-button--positive" %}
-        {% include "engage/shared/_en_engage_form.html" %}
-      {% endwith %}
-    </div>
+  <div class="p-strip">
+    <div class="row--50-50">{% include "azure/shared/_how-ubuntu-pro-helps-you.html" %}</div>
   </div>
-</div>
 
-<div class="p-strip">
-  {% include "azure/shared/_how-ubuntu-pro-helps-you.html" %}
-</div>
+  <div class="p-strip--light">
+    <div class="row">
+      <div class="col-7">
+        <h2>Level up your Ubuntu journey by activating this private Azure Marketplace offer</h2>
 
-<div class="p-strip--light">
-  <div class="row">
-    <div class="col-7">
-      <h2>Level up your Ubuntu journey by activating this private Azure Marketplace offer</h2>
+        <p>Already running Ubuntu on Microsoft Azure, or planning a migration to the public cloud?</p>
 
-      <p>Already running Ubuntu on Microsoft Azure, or planning a migration to the public cloud?</p>
+        <p>Leverage Canonical's expert service and all the features of Ubuntu Pro with this exclusive private offer.</p>
 
-      <p>Leverage Canonical's expert service and all the features of Ubuntu Pro with this exclusive private offer.</p>
+        <a href="/azure/private-offer" class="p-button--positive">Learn more</a>
+      </div>
 
-      <a href="/azure/private-offer" class="p-button--positive">Learn more</a>
-    </div>
-    
-    <div class="col-5 u-align--center">
-      {{ image (
+      <div class="col-5 u-align--center">
+        {{ image (
         url="https://assets.ubuntu.com/v1/71fe6a11-private-offer-shield.svg",
         alt="",
         width="206",
@@ -92,8 +106,8 @@
         hi_def=True,
         loading="lazy"
         ) | safe
-      }}
+        }}
+      </div>
     </div>
   </div>
-</div>
 {% endblock %}

--- a/templates/azure/private-offer.html
+++ b/templates/azure/private-offer.html
@@ -18,7 +18,9 @@
   <section class="p-section--hero">
     <div class="u-fixed-width">
       <h1>Get 24/7 SLA support and enhanced security with our private offer</h1>
-      <h2 class="u-no-padding--top">Choose the broadest open-source security coverage in the cloud</h2>
+      <div class="p-section--shallow">
+        <h2 class="u-no-padding--top">Choose the broadest open-source security coverage in the cloud</h2>
+      </div>
       <hr class="is-muted" />
       <p>
         <a href="#private-offer-form" class="p-button--positive">Get private offer</a>

--- a/templates/azure/private-offer.html
+++ b/templates/azure/private-offer.html
@@ -104,7 +104,7 @@
         <h2>Bonus! Retire on your MACC agreement with Microsoft</h2>
       </div>
       <div class="col">
-        <div class="p-image-container--3-2 u-hide--small p-section--shallow">
+        <div class="p-image-container u-hide--small p-section--shallow">
           <img class="p-image-container__image"
                src="https://assets.ubuntu.com/v1/9ec8c60f-azure-heroi.png" alt="" />
         </div>
@@ -127,7 +127,7 @@
         </p>
       </div>
       <div class="col">
-        <div class="p-image-container--3-2 u-hide--small p-section--shallow">
+        <div class="p-image-container u-hide--small p-section--shallow">
           <img class="p-image-container__image"
                src="https://assets.ubuntu.com/v1/cc50969e-azure-private-offer-graphic.png" alt="" />
         </div>

--- a/templates/azure/private-offer.html
+++ b/templates/azure/private-offer.html
@@ -89,7 +89,7 @@
           The private offer also supports an ability to work from a set of images that have been hardened and optimised for security and operations for the whole organisation. This simplifies IT governance and allows all your internal users to seamlessly follow your strategy.
         </p>
       </div>
-      <div class="col" id="private-offer-form">
+      <div class="col" id="private-offer-form" style="scroll-margin-top: 4rem">
         {% with id="4394", returnURL="/azure/thank-you", cta="Get private offer", cta_class="p-button--positive" %}
           {% include "engage/shared/_en_engage_form.html" %}
         {% endwith %}

--- a/templates/azure/private-offer.html
+++ b/templates/azure/private-offer.html
@@ -106,7 +106,7 @@
       <div class="col">
         <div class="p-image-container--3-2 u-hide--small p-section--shallow">
           <img class="p-image-container__image"
-               src="https://assets.ubuntu.com/v1/9ec8c60f-azure-heroi.png" />
+               src="https://assets.ubuntu.com/v1/9ec8c60f-azure-heroi.png" alt="" />
         </div>
         <p>
           If your organisation has a Microsoft Azure Commitment to Consume (MACC), Canonical's private offer in Microsoft's Azure Marketplace will help you retire quota on this commitment.
@@ -129,7 +129,7 @@
       <div class="col">
         <div class="p-image-container--3-2 u-hide--small p-section--shallow">
           <img class="p-image-container__image"
-               src="https://assets.ubuntu.com/v1/cc50969e-azure-private-offer-graphic.png" />
+               src="https://assets.ubuntu.com/v1/cc50969e-azure-private-offer-graphic.png" alt="" />
         </div>
         <hr class="is-muted" />
         <p>

--- a/templates/azure/private-offer.html
+++ b/templates/azure/private-offer.html
@@ -1,132 +1,165 @@
 {% extends "azure/base_azure.html" %}
 
 {% block title %}Azure Private Offer{% endblock %}
-{% block meta_description %}Ubuntu on Azure Private Offer - Get exclusive services and support for your large scale Linux operation{% endblock %}
-{% block meta_copydoc %}https://docs.google.com/document/d/1P4sqhsi6jqWwbqjrBDuAOABGIcbJDM6Efy59ztaroVk/edit{% endblock meta_copydoc %}
 
-{% block head_extra %}
-  <style>
-    h2,
-    .p-heading--2 {
-      font-weight: 300;
-    }
-  </style>
+{% block meta_description %}
+  Ubuntu on Azure Private Offer - Get exclusive services and support for your large scale Linux operation
 {% endblock %}
 
+{% block meta_copydoc %}
+  https://docs.google.com/document/d/1P4sqhsi6jqWwbqjrBDuAOABGIcbJDM6Efy59ztaroVk/edit
+{% endblock meta_copydoc %}
+
+{% block body_class %}
+  is-paper
+{% endblock body_class %}
+
 {% block content %}
-<section class="p-strip--suru-blog-header">
-  <div class="row">
-    <div class="col-7 u-vertically-center">
+  <section class="p-section--hero">
+    <div class="u-fixed-width">
       <h1>Get 24/7 SLA support and enhanced security with our private offer</h1>
-
-      <p class="u-no-padding--top p-heading--4">Choose the broadest open-source security coverage in the cloud</p>
-
+      <h2 class="u-no-padding--top">Choose the broadest open-source security coverage in the cloud</h2>
+      <hr class="is-muted" />
       <p>
         <a href="#private-offer-form" class="p-button--positive">Get private offer</a>
       </p>
     </div>
-    <div class="col-5 u-hide--small u-hide--medium u-vertically-center u-align--center">
-      {{ image (
-        url="https://assets.ubuntu.com/v1/71fe6a11-private-offer-shield.svg",
-        alt="",
-        width="206",
-        height="232",
-        hi_def=True,
-        loading="auto"
-        ) | safe
-      }}
+  </section>
+
+  <section class="p-section">
+    <div class="u-fixed-width">
+      <hr />
+      <h2 class="p-text--small-caps">Get Ubuntu Pro for Azure</h2>
+      <div class="p-logo-section">
+        <div class="p-logo-section__items u-no-margin--bottom">
+          <div class="p-logo-section__item">
+            {{ image (
+            url="https://assets.ubuntu.com/v1/bd03aa14-canonical-logo.png",
+            alt="Canonical",
+            width="177",
+            hi_def=True,
+            attrs={"class": "p-logo-section__logo"},
+            loading="auto"
+            ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image (
+            url="https://assets.ubuntu.com/v1/6c560fe0-ubuntu-logo.png",
+            alt="Ubuntu",
+            width="146",
+            hi_def=True,
+            attrs={"class": "p-logo-section__logo"},
+            loading="auto"
+            ) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image (
+            url="https://assets.ubuntu.com/v1/2feccb6f-microsoft-azure-2021.png",
+            alt="Microsoft Azure",
+            width="48",
+            hi_def=True,
+            attrs={"class": "p-logo-section__logo"},
+            loading="auto"
+            ) | safe
+            }}
+          </div>
+        </div>
+      </div>
     </div>
-  </div>
-</section>
+  </section>
 
-{% include "azure/shared/_azure-logo-strip.html" %}
-
-<section class="p-strip--light">
-  <div class="row">
-    <div class="col-7">
-      <h2 class="p-heading--4">Ubuntu Pro for Azure is a premium image delivering the most comprehensive open source security and compliance</h2>
-
-      <hr class="p-separator u-no-margin--top" />
-      
-      <h2 class="p-heading--4"><strong>Get Azure integrated support with SLA from Canonical to gain 24/7 open-source expertise at your disposal with the private offer</strong></h2>
-
-      <p>OS level support from Canonical enhances Microsoft support and utilises the existing workflows for Ubuntu-based operational or break-fix support issues.</p>
-
-      <p>The private offer also supports an ability to work from a set of images that have been hardened and optimised for security and operations for the whole organisation. This simplifies IT governance and allows all your internal users to seamlessly follow your strategy.</p>
+  <section class="p-section">
+    <div class="u-fixed-width p-section--shallow">
+      <hr />
+      <h2>Ubuntu Pro for Azure is a premium image delivering the most comprehensive open source security and compliance</h2>
     </div>
-    <div class="col-5" id="private-offer-form">
-      {% with id="4394", returnURL="/azure/thank-you", cta="Get private offer", cta_class="p-button--positive" %}
-        {% include "engage/shared/_en_engage_form.html" %}
-      {% endwith %}
+    <div class="row--50-50">
+      <div class="col">
+        <h3 class="p-heading--5">
+          Get Azure integrated support with SLA from Canonical to gain 24/7 open-source expertise at your disposal with the private offer
+        </h3>
+        <p>
+          OS level support from Canonical enhances Microsoft support and utilises the existing workflows for Ubuntu-based operational or break-fix support issues.
+        </p>
+        <p>
+          The private offer also supports an ability to work from a set of images that have been hardened and optimised for security and operations for the whole organisation. This simplifies IT governance and allows all your internal users to seamlessly follow your strategy.
+        </p>
+      </div>
+      <div class="col" id="private-offer-form">
+        {% with id="4394", returnURL="/azure/thank-you", cta="Get private offer", cta_class="p-button--positive" %}
+          {% include "engage/shared/_en_engage_form.html" %}
+        {% endwith %}
+      </div>
     </div>
-  </div>
-</section>
+  </section>
 
-<section class="p-strip">
-  <div class="row">
-    <div class="col-6">
-      <h2>Bonus! Retire on your MACC agreement with Microsoft</h2>
-
-      <p>If your organisation has a Microsoft Azure Commitment to Consume (MACC), Canonical's private offer in Microsoft's Azure Marketplace will help you retire quota on this commitment.</p>
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr />
+      <div class="col">
+        <h2>Bonus! Retire on your MACC agreement with Microsoft</h2>
+      </div>
+      <div class="col">
+        <div class="p-image-container--3-2 u-hide--small p-section--shallow">
+          <img class="p-image-container__image"
+               src="https://assets.ubuntu.com/v1/9ec8c60f-azure-heroi.png" />
+        </div>
+        <p>
+          If your organisation has a Microsoft Azure Commitment to Consume (MACC), Canonical's private offer in Microsoft's Azure Marketplace will help you retire quota on this commitment.
+        </p>
+      </div>
     </div>
-    <div class="col-6 u-vertically-center u-hide--medium u-hide--small u-align--center">
-      {{ image (
-        url="https://assets.ubuntu.com/v1/da9a1344-Microsoft-Azure-logo_stacked_transparent.png",
-        alt="",
-        width="240",
-        height="68",
-        hi_def=True,
-        loading="lazy"
-        ) | safe
-      }}
+  </section>
+
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr />
+      <div class="col">
+        <h2>Level up your Ubuntu journey by activating this private Azure Marketplace offer</h2>
+        <p>Already running Ubuntu on Microsoft Azure, or planning a migration to the public cloud?</p>
+        <p>Leverage Canonical's expertise and all features of Ubuntu Pro with this exclusive private offer.</p>
+        <p>
+          Canonical has the expertise to assist you in your project, whether it involves compliance, application architecture, optimisation or streaming operations at scale.
+        </p>
+      </div>
+      <div class="col">
+        <div class="p-image-container--3-2 u-hide--small p-section--shallow">
+          <img class="p-image-container__image"
+               src="https://assets.ubuntu.com/v1/cc50969e-azure-private-offer-graphic.png" />
+        </div>
+        <hr class="is-muted" />
+        <p>
+          <a href="#private-offer-form" class="p-button">Get private offer</a>
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <div class="p-section">
+    <div class="row--50-50">
+      <hr />
+      {% include "azure/shared/_how-ubuntu-pro-helps-you.html" %}
     </div>
   </div>
 
   <div class="u-fixed-width">
-    <hr class="p-separator" />
+    <hr />
   </div>
 
-  <div class="row">
-    <div class="col-6 u-vertically-center u-hide--medium u-hide--small u-align--center">
-      {{ image (
-        url="https://assets.ubuntu.com/v1/c7f65894-Ubuntu+Pro+benefits+diagram.svg",
-        alt="",
-        width="308",
-        height="236",
-        hi_def=True,
-        loading="lazy"
-        ) | safe
-      }}
-    </div>
-    <div class="col-6">
-      <h2>Level up your Ubuntu journey by activating this private Azure Marketplace offer</h2>
-
-      <p>Already running Ubuntu on Microsoft Azure, or planning a migration to the public cloud?</p>
-
-      <p>Leverage Canonical's expertise and all features of Ubuntu Pro with this exclusive private offer.</p>
-
-      <p>Canonical has the expertise to assist you in your project, whether it involves compliance, application architecture, optimisation or streaming operations at scale.</p>
-
+  <div class="p-strip is-deep">
+    <div class="u-fixed-width">
+      <h2>
+        Claim your private Azure Marketplace offer
+        <br />
+        from Canonical
+      </h2>
+      <p>Upgrade to Ubuntu Pro + Support and get the protection your enterprise needs today</p>
+      <hr class="is-muted" />
       <p>
-        <a href="#private-offer-form" class="p-button--positive">Get private offer</a>
+        <a href="#private-offer-form" class="p-button--positive">Claim private offer</a>
       </p>
     </div>
   </div>
-</section>
-
-<div class="p-strip--light">
-  {% include "azure/shared/_how-ubuntu-pro-helps-you.html" %}
-</div>
-
-<div class="p-strip p-engage-banner--grad">
-  <div class="u-fixed-width">
-    <h2>Claim your private Azure Marketplace offer from Canonical</h2>
-
-    <p>Upgrade to Ubuntu Pro + Support and get the protection your enterprise needs today</p>
-
-    <p>
-      <a href="#private-offer-form" class="p-button--positive">Claim private offer</a>
-    </p>
-  </div>
-</div>
 {% endblock %}

--- a/templates/azure/private-offer.html
+++ b/templates/azure/private-offer.html
@@ -35,36 +35,30 @@
       <div class="p-logo-section">
         <div class="p-logo-section__items u-no-margin--bottom">
           <div class="p-logo-section__item">
-            {{ image (
-            url="https://assets.ubuntu.com/v1/bd03aa14-canonical-logo.png",
-            alt="Canonical",
-            width="177",
-            hi_def=True,
-            attrs={"class": "p-logo-section__logo"},
-            loading="auto"
-            ) | safe
+            {{ image(url="https://assets.ubuntu.com/v1/bd03aa14-canonical-logo.png",
+                        alt="Canonical",
+                        width="177",
+                        hi_def=True,
+                        attrs={"class": "p-logo-section__logo"},
+                        loading="auto") | safe
             }}
           </div>
           <div class="p-logo-section__item">
-            {{ image (
-            url="https://assets.ubuntu.com/v1/6c560fe0-ubuntu-logo.png",
-            alt="Ubuntu",
-            width="146",
-            hi_def=True,
-            attrs={"class": "p-logo-section__logo"},
-            loading="auto"
-            ) | safe
+            {{ image(url="https://assets.ubuntu.com/v1/6c560fe0-ubuntu-logo.png",
+                        alt="Ubuntu",
+                        width="146",
+                        hi_def=True,
+                        attrs={"class": "p-logo-section__logo"},
+                        loading="auto") | safe
             }}
           </div>
           <div class="p-logo-section__item">
-            {{ image (
-            url="https://assets.ubuntu.com/v1/2feccb6f-microsoft-azure-2021.png",
-            alt="Microsoft Azure",
-            width="48",
-            hi_def=True,
-            attrs={"class": "p-logo-section__logo"},
-            loading="auto"
-            ) | safe
+            {{ image(url="https://assets.ubuntu.com/v1/2feccb6f-microsoft-azure-2021.png",
+                        alt="Microsoft Azure",
+                        width="48",
+                        hi_def=True,
+                        attrs={"class": "p-logo-section__logo"},
+                        loading="auto") | safe
             }}
           </div>
         </div>
@@ -106,7 +100,8 @@
       <div class="col">
         <div class="p-image-container u-hide--small p-section--shallow">
           <img class="p-image-container__image"
-               src="https://assets.ubuntu.com/v1/9ec8c60f-azure-heroi.png" alt="" />
+               src="https://assets.ubuntu.com/v1/9ec8c60f-azure-heroi.png"
+               alt="" />
         </div>
         <p>
           If your organisation has a Microsoft Azure Commitment to Consume (MACC), Canonical's private offer in Microsoft's Azure Marketplace will help you retire quota on this commitment.
@@ -129,7 +124,8 @@
       <div class="col">
         <div class="p-image-container u-hide--small p-section--shallow">
           <img class="p-image-container__image"
-               src="https://assets.ubuntu.com/v1/cc50969e-azure-private-offer-graphic.png" alt="" />
+               src="https://assets.ubuntu.com/v1/cc50969e-azure-private-offer-graphic.png"
+               alt="" />
         </div>
         <hr class="is-muted" />
         <p>

--- a/templates/azure/shared/_how-ubuntu-pro-helps-you.html
+++ b/templates/azure/shared/_how-ubuntu-pro-helps-you.html
@@ -1,82 +1,25 @@
-<div class="row">
-  <div class="col-12">
-    <h2>How Ubuntu Pro helps you</h2>
-  </div>
-
-  <div class="col-4">
-    {{ image (
-      url="https://assets.ubuntu.com/v1/ec3f53f7-extended-security-maintenance.svg",
-      alt="",
-      width="60",
-      height="60",
-      hi_def=True,
-      loading="lazy",
-      attrs={"class": "u-hide--small"}
-      ) | safe
-    }}
-
-    <p>Ubuntu Pro enables instant up-to-date security by default with security patches for thousands of open source applications</p>
-  </div>
-
-  <div class="col-4">
-    {{ image (
-      url="https://assets.ubuntu.com/v1/4f70dabc-Kernel.svg",
-      alt="",
-      width="52",
-      height="60",
-      hi_def=True,
-      loading="lazy",
-      attrs={"class": "u-hide--small"}
-      ) | safe
-    }}
-
-    <p>Azure-optimised kernel for improved performance</p>
-  </div>
-
-  <div class="col-4">
-    {{ image (
-      url="https://assets.ubuntu.com/v1/1d5f293c-compliance.svg",
-      alt="",
-      width="105",
-      height="60",
-      hi_def=True,
-      loading="lazy",
-      attrs={"class": "u-hide--small"}
-      ) | safe
-    }}
-
-    <p>Full compliance checklist: FIPS, HIPAA, PCI, ISO and DISA-STIGs</p>
-  </div>
-
-  <div class="col-4">
-    {{ image (
-      url="https://assets.ubuntu.com/v1/b0af9ede-UA_24-7_Support.svg",
-      alt="",
-      width="60",
-      height="60",
-      hi_def=True,
-      loading="lazy",
-      attrs={"class": "u-hide--small"}
-      ) | safe
-    }}
-
-    <p>24/7 support straight from the publisher of Ubuntu*</p>
-
-    <small>* Only available with the private offer</small>
-  </div>
-
-  <div class="col-4">
-    {{ image (
-      url="https://assets.ubuntu.com/v1/ceb481d1-10+years.svg",
-      alt="",
-      width="60",
-      height="60",
-      hi_def=True,
-      loading="lazy",
-      attrs={"class": "u-hide--small"}
-      ) | safe
-    }}
-
-    <p>10 years of extended maintenance</p>
-  </div>
+<div class="col">
+  <h2>How Ubuntu Pro helps you</h2>
+</div>
+<div class="col">
+  <ul class="p-list--divided u-no-margin--bottom">
+    <li class="p-list__item is-ticked" style="box-shadow: unset;">
+      <p class="u-no-padding u-no-margin--bottom">
+        Ubuntu Pro enables instant up-to-date security by default with security patches for thousands of open source applications
+      </p>
+    </li>
+    <li class="p-list__item is-ticked">
+      <p class="u-no-padding--top u-no-margin--bottom">Azure-optimised kernel for improved performance</p>
+    </li>
+    <li class="p-list__item is-ticked">
+      <p class="u-no-padding--top u-no-margin--bottom">Full compliance checklist: FIPS, HIPAA, PCI, ISO and DISA-STIGs</p>
+    </li>
+    <li class="p-list__item is-ticked">
+      <p class="u-no-padding--top u-no-margin--bottom">24/7 support straight from the publisher of Ubuntu*</p>
+    </li>
+    <li class="p-list__item is-ticked">
+      <p class="u-no-padding--top u-no-margin--bottom">10 years of extended maintenance</p>
+    </li>
+  </ul>
+  <p>* Only available with the private offer</p>
 </div>

--- a/templates/azure/shared/_how-ubuntu-pro-helps-you.html
+++ b/templates/azure/shared/_how-ubuntu-pro-helps-you.html
@@ -4,21 +4,19 @@
 <div class="col">
   <ul class="p-list--divided u-no-margin--bottom">
     <li class="p-list__item is-ticked">
-      <p class="u-no-padding u-no-margin--bottom">
-        Ubuntu Pro enables instant up-to-date security by default with security patches for thousands of open source applications
-      </p>
+      Ubuntu Pro enables instant up-to-date security by default with security patches for thousands of open source applications
     </li>
     <li class="p-list__item is-ticked">
-      <p class="u-no-padding--top u-no-margin--bottom">Azure-optimised kernel for improved performance</p>
+      Azure-optimised kernel for improved performance
     </li>
     <li class="p-list__item is-ticked">
-      <p class="u-no-padding--top u-no-margin--bottom">Full compliance checklist: FIPS, HIPAA, PCI, ISO and DISA-STIGs</p>
+      Full compliance checklist: FIPS, HIPAA, PCI, ISO and DISA-STIGs
     </li>
     <li class="p-list__item is-ticked">
-      <p class="u-no-padding--top u-no-margin--bottom">24/7 support straight from the publisher of Ubuntu*</p>
+      24/7 support straight from the publisher of Ubuntu*
     </li>
     <li class="p-list__item is-ticked">
-      <p class="u-no-padding--top u-no-margin--bottom">10 years of extended maintenance</p>
+      10 years of extended maintenance
     </li>
   </ul>
   <p>* Only available with the private offer</p>

--- a/templates/azure/shared/_how-ubuntu-pro-helps-you.html
+++ b/templates/azure/shared/_how-ubuntu-pro-helps-you.html
@@ -3,7 +3,7 @@
 </div>
 <div class="col">
   <ul class="p-list--divided u-no-margin--bottom">
-    <li class="p-list__item is-ticked" style="box-shadow: unset;">
+    <li class="p-list__item is-ticked">
       <p class="u-no-padding u-no-margin--bottom">
         Ubuntu Pro enables instant up-to-date security by default with security patches for thousands of open source applications
       </p>


### PR DESCRIPTION
## Done

Rebrand /azure/private-offer. No content was changed, layout only

## QA

- [demo link](https://ubuntu-com-14156.demos.haus/azure/private-offer)
- [figma](https://www.figma.com/design/MinLlXouBnEDqaoAL3bTWC/24.10-Azure-bubble?node-id=1-6057&t=gyQr0wjIOwcXzRPS-0)
- View the site on demo
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check that the page is correct according to figma

## Issue / Card
[WD-12827](https://warthogs.atlassian.net/browse/WD-12827)

[WD-12827]: https://warthogs.atlassian.net/browse/WD-12827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ