### PR TITLE
Align macros usage with Vanilla standards

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -285,7 +285,6 @@ fieldset:last-child {
 // XXX Steve: Pull quote colour override
 .p-pull-quote,
 .p-pull-quote--large {
-
   .p-pull-quote__quote:first-of-type::before,
   .p-pull-quote__quote:last-of-type::after {
     color: $color-brand;

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -285,11 +285,6 @@ fieldset:last-child {
 // XXX Steve: Pull quote colour override
 .p-pull-quote,
 .p-pull-quote--large {
-  // Keep default quote colour for case studies
-  .case-studies-quote::before,
-  .case-studies-quote::after {
-    color: $colors--light-theme--text-muted !important;
-  }
 
   .p-pull-quote__quote:first-of-type::before,
   .p-pull-quote__quote:last-of-type::after {

--- a/templates/case-study/example.html
+++ b/templates/case-study/example.html
@@ -109,8 +109,8 @@
   {%- call(slot) quote_wrapper(
     quote_heading_level=4,
     quote_text="Enterprises need modular, cloud-native application platforms that accelerate how they build, run, and manage their applications without compromising on their compliance, security, or support requirements.",
-    citation_source_name="Justin Boitano",
-    citation_source_title="Vice President and General Manager of Customer and Ecosystem Enabling Division, Intel's Network and Edge Solutions Group"
+    citation_source_name_text="Justin Boitano",
+    citation_source_title_text="Vice President and General Manager of Customer and Ecosystem Enabling Division, Intel's Network and Edge Solutions Group"
     ) 
   -%}
   {%- endcall -%}
@@ -164,8 +164,8 @@
   {%- call(slot) quote_wrapper(
     quote_heading_level=4,
     quote_text="Enterprises need modular, cloud-native application platforms that accelerate how they build, run, and manage their applications without compromising on their compliance, security, or support requirements.",
-    citation_source_name="Justin Boitano",
-    citation_source_title="Vice President and General Manager of Customer and Ecosystem Enabling Division, Intel's Network and Edge Solutions Group"
+    citation_source_name_text="Justin Boitano",
+    citation_source_title_text="Vice President and General Manager of Customer and Ecosystem Enabling Division, Intel's Network and Edge Solutions Group"
     ) 
   -%}
   {%- endcall -%}  
@@ -206,8 +206,8 @@
   {%- call(slot) quote_wrapper(
     quote_heading_level=4,
     quote_text="Enterprises need modular, cloud-native application platforms that accelerate how they build, run, and manage their applications without compromising on their compliance, security, or support requirements.",
-    citation_source_name="Justin Boitano",
-    citation_source_title="Vice President and General Manager of Customer and Ecosystem Enabling Division, Intel's Network and Edge Solutions Group"
+    citation_source_name_text="Justin Boitano",
+    citation_source_title_text="Vice President and General Manager of Customer and Ecosystem Enabling Division, Intel's Network and Edge Solutions Group"
     ) 
   -%}
   {%- endcall -%}

--- a/templates/case-study/example.html
+++ b/templates/case-study/example.html
@@ -15,10 +15,10 @@
   <!-- Hero section -->
   {%- call(slot) hero(title="Canonical deploys infrastructure solutions and managed IT services for critical space mission operations", layout="25/75") -%}
     {% if slot == "signpost_image" %}
-      {{ image(url="https://assets.ubuntu.com/v1/58a67d07-esa-logo.png",
+      {{ image(url="https://assets.ubuntu.com/v1/17238501-esa-with-whitespace.png",
                   alt="European Space Agency",
                   width="107",
-                  height="39",
+                  height="48",
                   hi_def=True,
                   loading="lazy") | safe
       }}

--- a/templates/case-study/example.html
+++ b/templates/case-study/example.html
@@ -15,13 +15,13 @@
   <!-- Hero section -->
   {%- call(slot) hero(title="Canonical deploys infrastructure solutions and managed IT services for critical space mission operations", layout="25/75") -%}
     {% if slot == "signpost_image" %}
-        {{ image (url="https://assets.ubuntu.com/v1/58a67d07-esa-logo.png",
-                    alt="European Space Agency",
-                    width="107",
-                    height="39",
-                    hi_def=True,
-                    loading="lazy") | safe
-        }}
+      {{ image(url="https://assets.ubuntu.com/v1/58a67d07-esa-logo.png",
+                  alt="European Space Agency",
+                  width="107",
+                  height="39",
+                  hi_def=True,
+                  loading="lazy") | safe
+      }}
     {% endif %}
   {%- endcall -%}
 
@@ -39,18 +39,58 @@
   {%- endcall -%}
 
   <!-- Highlights section -->
-  {%- call(slot) highlights(num_items=4) -%}
+  {%- call(slot) highlights(num_items=3) -%}
     {%- if slot == 'highlights_item_content_1' -%}
-      <p>Architecture, design, and deployment of Canonical’s distributions of Ceph and Kubernetes.</p>
+      Architecture, design, and deployment of Canonical’s distributions of Ceph and Kubernetes.
     {%- endif -%}
     {%- if slot == 'highlights_item_content_2' -%}
-      <p>Timely updates and 24/7 monitoring of mission critical equipment.</p>
+      Timely updates and 24/7 monitoring of mission critical equipment.
     {%- endif -%}
     {%- if slot == 'highlights_item_content_3' -%}
-      <p>ESA has operated more than 87 missions from ESOC, ranging from understanding our own planet to exploring our solar system and beyond to help advance scientific knowledge.</p>
+      ESA has operated more than 87 missions from ESOC, ranging from understanding our own planet to exploring our solar system and beyond to help advance scientific knowledge.
+    {%- endif -%}
+  {%- endcall %}
+
+  {%- call(slot) highlights(num_items=4) -%}
+    {%- if slot == 'highlights_item_content_1' -%}
+      Architecture, design, and deployment of Canonical’s distributions of Ceph and Kubernetes.
+    {%- endif -%}
+    {%- if slot == 'highlights_item_content_2' -%}
+      Timely updates and 24/7 monitoring of mission critical equipment.
+    {%- endif -%}
+    {%- if slot == 'highlights_item_content_3' -%}
+      ESA has operated more than 87 missions from ESOC, ranging from understanding our own planet to exploring our solar system and beyond to help advance scientific knowledge.
     {%- endif -%}
     {%- if slot == 'highlights_item_content_4' -%}
-      <p>ESOC is responsible for a wide range of IT infrastructure and systems to help fly these unique missions, having been responsible for flying more than 80 custom-built satellites since it was established.</p>
+      ESOC is responsible for a wide range of IT infrastructure and systems to help fly these unique missions, having been responsible for flying more than 80 custom-built satellites since it was established.
+    {%- endif -%}
+  {%- endcall %}
+
+  <!-- Edge cases -->
+  {%- call(slot) highlights(num_items=2) -%}
+    {%- if slot == 'highlights_item_content_1' -%}
+      Architecture, design, and deployment of Canonical’s distributions of Ceph and Kubernetes.
+    {%- endif -%}
+    {%- if slot == 'highlights_item_content_2' -%}
+      Architecture, design, and deployment of Canonical’s distributions of Ceph and Kubernetes.
+    {%- endif -%}
+  {%- endcall %}
+
+  {%- call(slot) highlights(num_items=5) -%}
+    {%- if slot == 'highlights_item_content_1' -%}
+      Architecture, design, and deployment of Canonical’s distributions of Ceph and Kubernetes.
+    {%- endif -%}
+    {%- if slot == 'highlights_item_content_2' -%}
+      Timely updates and 24/7 monitoring of mission critical equipment.
+    {%- endif -%}
+    {%- if slot == 'highlights_item_content_3' -%}
+      ESA has operated more than 87 missions from ESOC, ranging from understanding our own planet to exploring our solar system and beyond to help advance scientific knowledge.
+    {%- endif -%}
+    {%- if slot == 'highlights_item_content_4' -%}
+      ESOC is responsible for a wide range of IT infrastructure and systems to help fly these unique missions, having been responsible for flying more than 80 custom-built satellites since it was established.
+    {%- endif -%}
+    {%- if slot == 'highlights_item_content_5' -%}
+      ESOC is responsible for a wide range of IT infrastructure and systems to help fly these unique missions, having been responsible for flying more than 80 custom-built satellites since it was established.
     {%- endif -%}
   {%- endcall %}
 

--- a/templates/macros/_macros-hero.jinja
+++ b/templates/macros/_macros-hero.jinja
@@ -72,10 +72,7 @@
   {% endif %}
 
   {%- macro _hero_title_block() -%}
-    {%- if layout == '25-75' and has_signpost_image -%}
-      {#- On 25-75 signpost, header top should align with top of the signpost to its left. -#}
-      {% set title_class = "u-no-padding--top" %}
-    {%- elif has_full_width_image -%}
+    {%- if has_full_width_image -%}
       {#- On full-width-image, the h1 and h2 are in separate columns, so there must be no margin-bottom to keep h1 close to h2 on smaller screens  -#}
       {% set title_class = "u-no-margin--bottom" %}
     {%- endif -%}

--- a/templates/macros/_macros-highlights.jinja
+++ b/templates/macros/_macros-highlights.jinja
@@ -5,29 +5,56 @@
 
 {%- macro highlights(num_items) -%}
   <section class="p-section">
-    <div class="row">
-      <h2 class="p-text--small-caps">Highlights</h2>
-      <hr />
-    </div>
     {% if num_items == 3 %}
       {% set col_size = "col-4" %}
     {% elif num_items == 4 %}
       {% set col_size = "col-3" %}
-    {% endif %}
-    <ul class="p-list">
+    {% else %}
+      {% set col_size = "col" %}
       <div class="row">
-        {% for number in range(1, 5) %}
-          {%- set highlights_item_content = caller('highlights_item_content_' + number|string) -%}
-          {%- set has_highlights_item_content = highlights_item_content|trim|length > 0 -%}
+        <hr />
+        <div class="col-start-large-4 col-3">
+          <h2>Highlights</h2>
+        </div>
 
-          {%- if has_highlights_item_content -%}
-            <div class="{{ col_size }}">
-              <li class="p-list__item is-ticked">{{ highlights_item_content }}</li>
+        <div class="col-6">
+          <ul class="p-list--divided">
+            <div class="row">
+              {% for number in range (1, num_items+1) %}
+
+                {%- set highlights_item_content = caller('highlights_item_content_' + number|string) -%}
+                {%- set has_highlights_item_content = highlights_item_content|trim|length > 0 -%}
+
+                {%- if has_highlights_item_content -%}<li class="p-list__item is-ticked">{{ highlights_item_content }}</li>{% endif %}
+              {% endfor %}
+
             </div>
-          {%- endif %}
-
-        {% endfor %}
+          </ul>
+        </div>
       </div>
-    </ul>
+    {% endif %}
+
+    {% if num_items == 3 or num_items == 4 %}
+      <div class="row">
+        <h2 class="p-text--small-caps">Highlights</h2>
+        <hr />
+      </div>
+
+      <ul class="p-list">
+        <div class="row">
+          {% for number in range(1, num_items+1) %}
+            {%- set highlights_item_content = caller('highlights_item_content_' + number|string) -%}
+            {%- set has_highlights_item_content = highlights_item_content|trim|length > 0 -%}
+
+            {%- if has_highlights_item_content -%}
+              {% if num_items == 3 or num_items == 4 %}<div class="{{ col_size }}">{% endif %}
+                <li class="p-list__item is-ticked">{{ highlights_item_content }}</li>
+                {% if num_items == 3 or num_items == 4 %}</div>{% endif %}
+            {%- endif %}
+
+          {% endfor %}
+        </div>
+      </ul>
+    {% endif %}
   </section>
 {%- endmacro -%}

--- a/templates/macros/_macros-highlights.jinja
+++ b/templates/macros/_macros-highlights.jinja
@@ -5,56 +5,54 @@
 
 {%- macro highlights(num_items) -%}
   <section class="p-section">
-    {% if num_items == 3 %}
-      {% set col_size = "col-4" %}
-    {% elif num_items == 4 %}
-      {% set col_size = "col-3" %}
-    {% else %}
-      {% set col_size = "col" %}
+    {% if num_items <= 4 %}
       <div class="row">
-        <hr class="is-muted"/>
-        <div class="col-start-large-4 col-3">
-          <h2>Highlights</h2>
-        </div>
-
-        <div class="col-6">
-          <ul class="p-list--divided">
-            <div class="row">
-              {% for number in range (1, num_items+1) %}
-
-                {%- set highlights_item_content = caller('highlights_item_content_' + number|string) -%}
-                {%- set has_highlights_item_content = highlights_item_content|trim|length > 0 -%}
-
-                {%- if has_highlights_item_content -%}<li class="p-list__item is-ticked">{{ highlights_item_content }}</li>{% endif %}
-              {% endfor %}
-
-            </div>
-          </ul>
-        </div>
+        {% if num_items == 4 %}<h2 class="p-text--small-caps">Highlights</h2>{% endif %}
+        <hr class="is-muted" />
       </div>
-    {% endif %}
-
-    {% if num_items == 3 or num_items == 4 %}
-      <div class="row">
-        <h2 class="p-text--small-caps">Highlights</h2>
-        <hr class="is-muted"/>
-      </div>
-
       <ul class="p-list">
         <div class="row">
+          {% if num_items < 4 %}
+            <div class="col-3">
+              <h2 class="p-text--small-caps">Highlights</h2>
+            </div>
+          {% endif %}
+
           {% for number in range(1, num_items+1) %}
             {%- set highlights_item_content = caller('highlights_item_content_' + number|string) -%}
             {%- set has_highlights_item_content = highlights_item_content|trim|length > 0 -%}
 
             {%- if has_highlights_item_content -%}
-              {% if num_items == 3 or num_items == 4 %}<div class="{{ col_size }}">{% endif %}
+              <div class="col-3">
                 <li class="p-list__item is-ticked">{{ highlights_item_content }}</li>
-                {% if num_items == 3 or num_items == 4 %}</div>{% endif %}
+              </div>
             {%- endif %}
-
           {% endfor %}
         </div>
       </ul>
+    {% else %}
+      <div class="row">
+        <div class="col-9">
+          <hr class="is-muted" />
+          <div class="row">
+            <div class="col-3">
+              <h2 class="p-text--small-caps">Highlights</h2>
+            </div>
+            <div class="col-6">
+              <ul class="p-list--divided">
+                <div class="row">
+                  {% for number in range (1, num_items+1) %}
+                    {%- set highlights_item_content = caller('highlights_item_content_' + number|string) -%}
+                    {%- set has_highlights_item_content = highlights_item_content|trim|length > 0 -%}
+
+                    {%- if has_highlights_item_content -%}<li class="p-list__item is-ticked">{{ highlights_item_content }}</li>{% endif %}
+                  {% endfor %}
+                </div>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
     {% endif %}
   </section>
 {%- endmacro -%}

--- a/templates/macros/_macros-highlights.jinja
+++ b/templates/macros/_macros-highlights.jinja
@@ -12,7 +12,7 @@
     {% else %}
       {% set col_size = "col" %}
       <div class="row">
-        <hr />
+        <hr class="is-muted"/>
         <div class="col-start-large-4 col-3">
           <h2>Highlights</h2>
         </div>
@@ -37,7 +37,7 @@
     {% if num_items == 3 or num_items == 4 %}
       <div class="row">
         <h2 class="p-text--small-caps">Highlights</h2>
-        <hr />
+        <hr class="is-muted"/>
       </div>
 
       <ul class="p-list">

--- a/templates/macros/_macros-image.jinja
+++ b/templates/macros/_macros-image.jinja
@@ -14,7 +14,7 @@
         </div>
       {% endif %}
       <div class="col-start-large-4 col-9">
-        <small>{{ caption }}</small>
+        <small class="u-text--muted">{{ caption }}</small>
       </div>
     </div>
   </section>

--- a/templates/macros/_macros-quote.jinja
+++ b/templates/macros/_macros-quote.jinja
@@ -129,21 +129,23 @@
     {% endif -%}
     {#- Skip to fourth column if the signpost_image (which takes up first three columns) is missing -#}
     <div class="col-9{% if not has_signpost_image %} col-start-large-4{% endif %}">
-      <hr class="u-hide--medium u-hide--small">
-      {% if has_citation -%}
-        <!-- When a citation is present, wrap the quote and citation in a nested grid to space them properly -->
-        <div class="row">
-          <div class="col-6">
-            {{ _quote_body() }}
+      <hr class="u-hide--medium u-hide--small is-muted">
+      <div class="p-section--shallow">
+        {% if has_citation -%}
+          <!-- When a citation is present, wrap the quote and citation in a nested grid to space them properly -->
+          <div class="row">
+            <div class="col-6">
+              {{ _quote_body() }}
+            </div>
+            <div class="col-3">
+              {{ _citation_block() }}
+            </div>
           </div>
-          <div class="col-3">
-            {{ _citation_block() }}
-          </div>
-        </div>
-      {% else -%}
-        <!-- When no citation is present, display quote body without a nested grid -->
-        {{ _quote_body() }}
-      {% endif -%}
+        {% else -%}
+          <!-- When no citation is present, display quote body without a nested grid -->
+          {{ _quote_body() }}
+        {% endif -%}
+      </div>
 
       {%- if has_cta or has_image -%}
         <!-- Optional CTA and/or image block -->

--- a/templates/macros/_macros-quote.jinja
+++ b/templates/macros/_macros-quote.jinja
@@ -1,10 +1,10 @@
 {#
   Params
-  - title (string) (optional): The text to be displayed as the heading
-  - quote_heading_level (int) (optional): The heading level used for the quote text. Can be 2 or 4. Defaults to 2.
+  - title_text (string) (optional): The text to be displayed as the heading
+  - quote_heading_level (int) (optional): The heading level used for the quote text. Can be [2,4,6]. Defaults to 2.
   - quote_text (string) (required): The text of the quote. The macro will surround it with quotes, so there is no need to quote it yourself.
-  - citation_source_name (string) (optional): The name of the source being quoted
-  - citation_source_title (string) (optional): The title of the source being quoted
+  - citation_source_name_text (string) (optional): The name of the source being quoted
+  - citation_source_title_text (string) (optional): The title of the source being quoted
   Slots
   - signpost_image (optional): The signpost_image of the source being quoted
   - heading_link (optional): Link to be displayed beside the heading text
@@ -12,125 +12,122 @@
   - image (optional): An image to be displayed below the quote
 #}
 {%- macro quote_wrapper(
-  title="",
+  title_text="",
   quote_heading_level=2,
   quote_text="",
-  citation_source_name="",
-  citation_source_title=""
+  citation_source_name_text="",
+  citation_source_title_text=""
 ) -%}
   {% set heading_link_content = caller('heading_link') %}
   {% set has_heading_link =  heading_link_content|trim|length > 0 %}
-  {% set has_title = title|length > 0 %}
+  {% set has_title = title_text|length > 0 %}
   {% set has_heading_row = has_title or has_heading_link %}
   {% set signpost_image_content = caller('signpost_image') %}
   {% set has_signpost_image = signpost_image_content|trim|length > 0 %}
-  {% set has_citation_source_name = citation_source_name|trim|length > 0 %}
-  {% set has_citation_source_title = citation_source_title|trim|length > 0 %}
-  {% set has_citation = has_citation_source_name or has_citation_source_title %}
+  {% set has_citation_source_name_text = citation_source_name_text|trim|length > 0 %}
+  {% set has_citation_source_title_text = citation_source_title_text|trim|length > 0 %}
+  {% set has_citation = has_citation_source_name_text or has_citation_source_title_text %}
   {% set cta_content = caller('cta') %}
   {% set has_cta = cta_content|trim|length > 0 %}
   {% set image_content = caller('image') %}
   {% set has_image = image_content|trim|length > 0 %}
 
   {# Validate heading level selection #}
-  {% if quote_heading_level not in [2, 4] %}
+  {% if quote_heading_level not in [2, 4, 6] %}
     {% set quote_heading_level = 2 %}
   {% endif %}
 
   {%- macro _quote_body() -%}
-    <div class="p-section--shallow">
-      <blockquote class="p-pull-quote u-no-margin--top u-no-padding--left">
-        <p class="p-heading--{{ quote_heading_level }} u-no-padding--top">
-          <i>
-            &#8220{{ quote_text }}&#8221
-          </i>
-        </p>
-      </blockquote>
-    </div>
+    <p class="p-heading--{{ quote_heading_level }}">
+      <i>
+        &#8220;{{ quote_text }}&#8221;
+      </i>
+    </p>
   {%- endmacro %}
 
   {%- macro _citation_block() -%}
     {%- if has_citation -%}
-      <!--Optional citation block-->
       {#- Source name and title must be wrapped in grid if they are both present, for responsive view -#}
       {%- macro _citation_block_source_name() -%}
         <!--Optional citation source name-->
-        <h5 class="u-no-margin--bottom u-no-padding--top">{{ citation_source_name }}</h5>
+        <h5>{{ citation_source_name_text }}</h5>
       {%- endmacro -%}
       {%- macro _citation_block_source_title() -%}
         <!--Optional citation source title-->
-        <p class="u-text--muted u-no-padding u-no-margin">{{ citation_source_title }}</p>
+        <p class="u-text--muted">{{ citation_source_title_text }}</p>
       {%- endmacro -%}
-      <div class="p-section--shallow">
-        <hr class="u-hide--large is-muted">
-        {%- if has_citation_source_name and has_citation_source_title %}
-          <!-- When source name and title are both present, wrap them in a 50/50 row to split them on medium -->
-          <div class="row">
-            <div class="col-3 col-medium-3">
-              {{ _citation_block_source_name() }}
-            </div>
-            <div class="col-3 col-medium-3">
-              {{ _citation_block_source_title() }}
-            </div>
-          </div>
-        {%- else -%}
-          {%- if has_citation_source_name %}
-            <!--Optional citation source name-->
+      <!--Optional citation block-->
+      <hr class="u-hide--large is-muted">
+      {%- if has_citation_source_name_text and has_citation_source_title_text %}
+        <!-- When source name and title are both present, wrap them in a 50/50 row to split them on medium -->
+        <div class="row">
+          <div class="col-3 col-medium-3">
             {{ _citation_block_source_name() }}
-          {%- endif -%}
-          {%- if has_citation_source_title %}
-            <!--Optional citation source title-->
+          </div>
+          <div class="col-3 col-medium-3">
             {{ _citation_block_source_title() }}
-          {%- endif -%}
+          </div>
+        </div>
+      {%- else -%}
+        {%- if has_citation_source_name_text %}
+          <!--Optional citation source name-->
+          {{ _citation_block_source_name() }}
         {%- endif -%}
-      </div>
+        {%- if has_citation_source_title_text %}
+          <!--Optional citation source title-->
+          {{ _citation_block_source_title() }}
+        {%- endif -%}
+      {%- endif -%}
+
     {%- endif -%}
   {%- endmacro %}
 
-  {% if has_heading_row %}
-    <!--Optional heading -->
-    <div class="p-section--shallow">
-      <hr class="p-rule--highlight">
-      <div class="row">
-        {%- if has_title %}
-          <!--Optional heading text-->
-          <div class="col-3 col-medium-3">
-            <div class="p-section--shallow">
-              <p class="p-muted-heading">{{ title }}</p>
-            </div>
-          </div>
-        {%- endif -%}
-
-        {%- if has_heading_link %}
-          <!--Optional heading link -->
-          <div class="col-3 col-medium-3 col-start-large-10 col-start-medium-5">
-            <div class="p-section--shallow">
-              <p class="p-text--default">
-                {{ heading_link_content }}
-              </p>
-            </div>
-          </div>
-        {% endif -%}
-      </div>
-    </div>
-  {% endif -%}
-  <div class="row">
-    {% if has_signpost_image -%}
-      <!--Optional signpost image-->
-      <div class="col-3">
+  {%- macro _heading_block() %}
+    {% if has_heading_row -%}
+      <!--Optional heading -->
+      <div class="p-section--shallow">
+        <hr class="is-highlighted is-fixed-width">
         <div class="row">
-          <div class="col-2">
-            <div class="p-section--shallow">
+          {%- if has_title %}
+            <!--Optional heading text-->
+            <div class="col-3 col-medium-3">
+              <div class="p-section--shallow">
+                <p class="p-muted-heading">{{ title_text }}</p>
+              </div>
+            </div>
+          {%- endif -%}
+
+          {%- if has_heading_link %}
+            <!--Optional heading link -->
+            <div class="col-3 col-medium-3 col-start-large-10 col-start-medium-5">
+              <div class="p-section--shallow">
+                <p class="p-text--default">
+                  {{ heading_link_content }}
+                </p>
+              </div>
+            </div>
+          {% endif -%}
+        </div>
+      </div>
+    {% endif -%}
+  {%- endmacro %}
+
+  <div class="p-section">
+    {{- _heading_block() -}}
+    <div class="row">
+      {% if has_signpost_image -%}
+        <!--Optional signpost image-->
+        <div class="col-3">
+          <div class="row">
+            <div class="col-2 col-medium-2 col-small-2">
               {{ signpost_image_content }}
             </div>
           </div>
         </div>
-      </div>
-    {% endif -%}
-    {#- Skip to fourth column if the signpost_image (which takes up first three columns) is missing -#}
-    <div class="col-9{% if not has_signpost_image %} col-start-large-4{% endif %}">
-      <hr class="u-hide--medium u-hide--small is-muted">
-      <div class="p-section--shallow">
+      {% endif -%}
+      {#- Skip to fourth column if the signpost_image (which takes up first three columns) is missing -#}
+      <div class="col-9{% if not has_signpost_image %} col-start-large-4{% endif %}">
+        <hr class="u-hide--medium u-hide--small is-muted">
         {% if has_citation -%}
           <!-- When a citation is present, wrap the quote and citation in a nested grid to space them properly -->
           <div class="row">
@@ -145,26 +142,26 @@
           <!-- When no citation is present, display quote body without a nested grid -->
           {{ _quote_body() }}
         {% endif -%}
-      </div>
 
-      {%- if has_cta or has_image -%}
-        <!-- Optional CTA and/or image block -->
-        <div class="p-section--shallow">
-          <div class="row">
-            {%- if has_cta %}
-              <!-- Optional CTA block-->
-              <div class="p-cta-block">
-                {{ cta_content }}
-              </div>
-            {% endif -%}
+        {%- if has_cta or has_image -%}
+          <!-- Optional CTA and/or image block -->
+          <div class="p-section--shallow">
+            <div class="row">
+              {%- if has_cta %}
+                <!-- Optional CTA block-->
+                <div class="p-cta-block">
+                  {{ cta_content }}
+                </div>
+              {% endif -%}
 
-            {% if has_image -%}
-              <!-- Optional image block -->
-              {{ image_content }}
-            {% endif -%}
+              {% if has_image -%}
+                <!-- Optional image block -->
+                {{ image_content }}
+              {% endif -%}
+            </div>
           </div>
-        </div>
-      {% endif -%}
+        {% endif -%}
+      </div>
     </div>
   </div>
 {% endmacro -%}

--- a/templates/macros/_macros-quote.jinja
+++ b/templates/macros/_macros-quote.jinja
@@ -62,7 +62,7 @@
         <p class="u-text--muted u-no-padding u-no-margin">{{ citation_source_title }}</p>
       {%- endmacro -%}
       <div class="p-section--shallow">
-        <hr class="u-hide--large p-rule--muted">
+        <hr class="u-hide--large is-muted">
         {%- if has_citation_source_name and has_citation_source_title %}
           <!-- When source name and title are both present, wrap them in a 50/50 row to split them on medium -->
           <div class="row">

--- a/templates/macros/_macros-text-list.jinja
+++ b/templates/macros/_macros-text-list.jinja
@@ -8,7 +8,7 @@
     <div class="row">
       <div class="col-start-large-4 col-9">
         <hr class="p-rule is-muted" />
-        <h2>{{ title }}</h2>
+        <h2 class="p-section--shallow">{{ title }}</h2>
         <ul class="p-list--divided">
           {% for number in range(1, 11)%}
             {%- set list_item_content = caller('list_item_content_' + number|string) -%}

--- a/templates/macros/_macros-text-list.jinja
+++ b/templates/macros/_macros-text-list.jinja
@@ -7,10 +7,8 @@
   <section class="p-section">
     <div class="row">
       <div class="col-start-large-4 col-9">
-        <hr class="p-rule" />
-        <div class="p-section--shallow">
-          <h2>{{ title }}</h2>
-        </div>
+        <hr class="p-rule is-muted" />
+        <h2>{{ title }}</h2>
         <ul class="p-list--divided">
           {% for number in range(1, 11)%}
             {%- set list_item_content = caller('list_item_content_' + number|string) -%}

--- a/templates/macros/_macros-text.jinja
+++ b/templates/macros/_macros-text.jinja
@@ -8,7 +8,7 @@
     <div class="row">
       <div class="col-start-large-4 col-9">
         {% if title %}
-          <hr class="p-rule"/>
+          <hr class="p-rule is-muted"/>
           <h2 class="p-strip is-shallow">{{ title }}</h2>
         {% endif %}
         {%- set paragraph_content = caller('content') -%}

--- a/templates/macros/_macros-text.jinja
+++ b/templates/macros/_macros-text.jinja
@@ -9,7 +9,7 @@
       <div class="col-start-large-4 col-9">
         {% if title %}
           <hr class="p-rule is-muted"/>
-          <h2 class="p-strip is-shallow">{{ title }}</h2>
+          <h2 class="p-section--shallow">{{ title }}</h2>
         {% endif %}
         {%- set paragraph_content = caller('content') -%}
         {%- set has_paragraph_content = paragraph_content|trim|length > 0 %}


### PR DESCRIPTION
## Done
- Use Vanilla defined macros for hero section

## To-do
- [x] Figure out a better way to import macros from Vanilla, currently just copy-pasting the macros code directly
- [x] Remove inline styles and use utilities where possible (done for modal styles)
- [x] Update highlights macro to limit list items (refer to [Tiered List](https://github.com/canonical/vanilla-framework/blob/3885de3af2c1393b5a51302142b3a17dc6e8dd4d/templates/_macros/tiered-list.jinja#L59))
- [x] Update highlights list parent and children tags
- [x] Refactor text macros to accept paragraphs as slots
- [x] Refactor image macro to use the standard image loader
- [x] Align with quotes section that is currently WIP: https://github.com/canonical/vanilla-framework/pull/5275

## QA

- Go to https://ubuntu-com-14166.demos.haus/case-study/example
- [Figma design](https://www.figma.com/design/AeIJ3GsqnJCHtiBYhkTuTV/24.10-Case-study-template?node-id=1-716&t=43Yuf8LEb6wYh1pC-0)

## Issue / Card

Fixes [WD-14166](https://github.com/canonical/ubuntu.com/pull/14166)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-14166]: https://warthogs.atlassian.net/browse/WD-14166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ