### PR TITLE
WD-13371 -  add /data-science to navigation

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -210,6 +210,8 @@ ai:
       path: /ai/mlflow
     - title: Consulting
       path: /ai/consulting
+    - title: Data Science
+      path: /ai/data-science
 
 kubernetes:
   title: Canonical Kubernetes


### PR DESCRIPTION
## Done

Added /data-science to /ai navigation

## QA

- [demo link](https://ubuntu-com-14170.demos.haus/ai)
- View the site on demo
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check that the images data science tab is on navigation

## Issue / Card
[WD-13371](https://warthogs.atlassian.net/browse/WD-13371)

[WD-13371]: https://warthogs.atlassian.net/browse/WD-13371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ