### PR TITLE
WD-14066 - remove pro devices from meganav

### DIFF
--- a/meganav.yaml
+++ b/meganav.yaml
@@ -66,9 +66,6 @@ products:
             - title: Ubuntu Pro
               description: Security & compliance subscription
               url: /pro
-            - title: Ubuntu Pro for Devices
-              description: Security maintenance for IoT
-              url: /pro/devices
             - title: Enterprise-grade support
               description: 24/7 support for the full-stack
               url: /support


### PR DESCRIPTION
## Done

Remove Ubuntu Pro for devices from navigation

## QA

- [demo link](https://ubuntu-com-14171.demos.haus/)
- [copy doc](https://docs.google.com/document/d/1DCNvYHfC7AbOcqflTBaVd571iKAP_PaTfnqTENVEDVw/edit)
- View the site on demo
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check that the tab is not shown in navigation

## Issue / Card
[WD-14066](https://warthogs.atlassian.net/browse/WD-14066)

[WD-14066]: https://warthogs.atlassian.net/browse/WD-14066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ