### PR TITLE
WD-14096 - update dell logo on home page

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -704,7 +704,7 @@
                        alt="ARM" />
                 </div>
                 <div class="p-logo-section__item">
-                  <img src="https://assets.ubuntu.com/v1/86519d71-DellTech_Logo_Stk_Wht_rgb.png"
+                  <img src="https://assets.ubuntu.com/v1/703330cd-dell-technologies-logo-white.png"
                        class="p-logo-section__logo"
                        alt="Dell" />
                 </div>

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -704,7 +704,7 @@
                        alt="ARM" />
                 </div>
                 <div class="p-logo-section__item">
-                  <img src="https://assets.ubuntu.com/v1/43635925-dell-technologies-logo.png"
+                  <img src="https://assets.ubuntu.com/v1/86519d71-DellTech_Logo_Stk_Wht_rgb.png"
                        class="p-logo-section__logo"
                        alt="Dell" />
                 </div>


### PR DESCRIPTION
## Done

Updated dell logo on home page

## QA

- [demo link](https://ubuntu-com-14172.demos.haus/)
- [copy doc](https://docs.google.com/document/d/1ySJxQbqVdeH4Tra0zwBm2Tn0s56kFGnEF7d8xDRTxwU/edit)
- View the site on demo
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check that the logo is white

## Issue / Card
[WD-14096](https://warthogs.atlassian.net/browse/WD-14096)

[WD-14096]: https://warthogs.atlassian.net/browse/WD-14096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ