### PR TITLE
WD-12833 - rebrand /azure/support

### DIFF
--- a/templates/azure/support.html
+++ b/templates/azure/support.html
@@ -37,7 +37,8 @@
                alt="" />
         </div>
       </div>
-    </section>
+    </div>
+  </section>
 
     <section class="p-section">
       <div class="row--50-50">

--- a/templates/azure/support.html
+++ b/templates/azure/support.html
@@ -1,145 +1,163 @@
 {% extends "azure/base_azure.html" %}
 
 {% block title %}Ubuntu Pro with Support{% endblock %}
-{% block meta_description %}Ubuntu Pro for Azure, the Ubuntu image optimised for production and professional use on public cloud. Including broad security coverage, live kernel patching, certified components with hardening profiles, and backed by a 10-years maintenance commitment by Canonical. Get it on the Azure marketplace.{% endblock %}
-{% block meta_copydoc %}https://docs.google.com/document/d/1XjmCkpSjHMLdc6Hdn4L8ml9sQL2wZWfwZg_h94dcgMU/edit#{% endblock meta_copydoc %}
+
+{% block meta_description %}
+  Ubuntu Pro for Azure, the Ubuntu image optimised for production and professional use on public cloud. Including broad security coverage, live kernel patching, certified components with hardening profiles, and backed by a 10-years maintenance commitment by Canonical. Get it on the Azure marketplace.
+{% endblock %}
+
+{% block meta_copydoc %}
+  https://docs.google.com/document/d/1XjmCkpSjHMLdc6Hdn4L8ml9sQL2wZWfwZg_h94dcgMU/edit#
+{% endblock meta_copydoc %}
+
+{% block body_class %}
+  is-paper
+{% endblock body_class %}
 
 {% block content %}
-<section class="p-strip--square-darksuru is-dark">
-  <div class="row">
-    <div class="col-6">
-      <h1>Ubuntu Pro with Support</h1>
-      <p>Ubuntu Pro with Support provides a supported, secure foundation for modern applications by adding 24x7 technical support for your Ubuntu Pro workloads on Azure, metered by the hour as a Private Offer.</p>
-      <p><a href="/contact-us" class="p-button--positive js-invoke-modal">Contact us</a></p>
-    </div>
-    <div class="col-6 u-align--center u-vertically-center u-hide--medium u-hide--small">
-      {{ image (
-        url="https://assets.ubuntu.com/v1/8c1c8f00-2021-Microsoft+Azure-wht.svg",
-        alt="",
-        width="300",
-        height="89",
-        hi_def=True,
-        loading="auto"
-        ) | safe
-      }}
-    </div>
-  </div>
-</section>
+  <section class="p-section--hero">
+    <div class="row--50-50">
+      <div class="col">
+        <h1>Ubuntu Pro with Support</h1>
+        <div class="p-section--shallow">
+          <p>
+            Ubuntu Pro with Support provides a supported, secure foundation for modern applications by adding 24x7
+            technical support for your Ubuntu Pro workloads on Azure, metered by the hour as a Private Offer.
+          </p>
+        </div>
+        <hr class="is-muted" />
+        <p>
+          <a href="/contact-us" class="p-button--positive js-invoke-modal">Contact us</a>
+        </p>
+      </div>
+      <div class="col">
+        <div class="p-image-container u-hide--small">
+          <img class="p-image-container__image"
+               src="https://assets.ubuntu.com/v1/7cc420dc-ubuntu-pro-azure.png"
+               alt="" />
+        </div>
+      </div>
+    </section>
 
-<section class="p-strip is-bordered">
-  <div class="row">
-    <div class="col-6">
-      <h2>Ubuntu Pro</h2>
-      <p>Ubuntu Pro for Azure is a premium image delivering the most comprehensive open source security and Azure compliance. Ubuntu Pro is suitable for small to large-scale Linux enterprise operations offering pay-as-you-go billing on your existing Azure invoice.</p>
-      <p>For more information about Ubuntu Pro on Azure, see <a href="/azure/pro">https://ubuntu.com/azure/pro</a>.</p>
-    </div>
-    <div class="col-6 u-align--center u-vertically-center u-hide--medium u-hide--small">
-      {{ image (
-        url="https://assets.ubuntu.com/v1/d649019e-u+pro+logo+158x40.png",
-        alt="",
-        width="395",
-        height="100",
-        hi_def=True,
-        loading="lazy"
-        ) | safe
-      }}
-    </div>
-  </div>
-  <div class="u-fixed-width">
-    <hr class="p-separator" />
-  </div>
-  <div class="row">
-    <div class="col-6">
-      <h2>Ubuntu Pro with 24x7 Support</h2>
-      <p>With 24x7 SLAed support and the widest open source security patching, teams can build on Ubuntu Pro with Support to secure their application's open source supply chain and receive expert assistance when they need it.</p>
-      <p>24x7 Support is available for the Ubuntu operating system (infrastructure) and can be extended to include application support for <a href="/support#apps-support">key open source applications</a>.</p>
-      <p>See more details at <a href="/support">https://ubuntu.com/support</a>.</p>
-      <p>If you already purchase support from Azure, speak to us about adding and integrating Canonical's Support into your existing Azure support &mdash; ensuring you have vendor-backed, SLAed support above the hypervisor for your workloads, without having to make any changes to end user issue reporting.</p>
-    </div>
-    <div class="col-6 u-align--center u-vertically-center u-hide--medium u-hide--small">
-      {{ image (
-        url="https://assets.ubuntu.com/v1/e9d3cf66-We+support+your+operations.svg",
-        alt="",
-        width="150",
-        height="150",
-        hi_def=True,
-        loading="lazy"
-        ) | safe
-      }}
-    </div>
-  </div>
-</section>
+    <section class="p-section">
+      <div class="row--50-50">
+        <hr />
+        <div class="col">
+          <h2>Ubuntu Pro</h2>
+        </div>
+        <div class="col">
+          <p>
+            Ubuntu Pro for Azure is a premium image delivering the most comprehensive open source security and Azure compliance. Ubuntu Pro is suitable for small to large-scale Linux enterprise operations offering pay-as-you-go billing on your existing Azure invoice.
+          </p>
+          <p>
+            For more information about Ubuntu Pro on Azure, see <a href="/azure/pro">https://ubuntu.com/azure/pro</a>.
+          </p>
+        </div>
+      </div>
+    </section>
 
-<section class="p-strip">
-  <div class="u-fixed-width">
-    <h2 class="u-sv3">Features</h2>
-    <table class="p-table">
-      <thead>
-        <tr>
-          <th style="width: 50%;">Feature</th>
-          <th>Ubuntu</th>
-          <th>Ubuntu Pro</th>
-          <th>Ubuntu Pro with Support</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <th>Security patches for 2,300+ Ubuntu infrastructure packages</th>
-          <td>Yes</td>
-          <td>Yes</td>
-          <td>Yes</td>
-        </tr>
-        <tr>
-          <th>Security patches for 28,000+ open source packages, including Apache Kafka, MongoDB, RabbitMQ, Redis and NodeJS and key language ecosystems including Java, Python, Ruby and Javascript/Node.js</th>
-          <td>No</td>
-          <td>Yes</td>
-          <td>Yes</td>
-        </tr>
-        <tr>
-          <th>Livepatch for instant kernel security and higher uptimes</th>
-          <td>No</td>
-          <td>Yes</td>
-          <td>Yes</td>
-        </tr>
-        <tr>
-          <th>FIPS 140-2 and Common Criteria EAL2 certified components</th>
-          <td>No</td>
-          <td>Yes</td>
-          <td>Yes</td>
-        </tr>
-        <tr>
-          <th>Hardening profiles, including CIS and DISA STIG, with CIS and other Shell security recommendations for production environments built into hardened images in the gallery</th>
-          <td>No</td>
-          <td>Yes</td>
-          <td>Yes</td>
-        </tr>
-        <tr>
-          <th>Landscape fleet management</th>
-          <td>No</td>
-          <td>On request</td>
-          <td>On request</td>
-        </tr>
-        <tr>
-          <th>Maintenance period</th>
-          <td>5 years</td>
-          <td>10 years</td>
-          <td>10 years</td>
-        </tr>
-        <tr>
-          <th>Knowledge Base</th>
-          <td>No</td>
-          <td>No</td>
-          <td>Yes</td>
-        </tr>
-        <tr>
-          <th>Canonical-backed 24x7 Support with enterprise grade SLA, with possibilities to integrate into existing Azure support workflows</th>
-          <td>No</td>
-          <td>No</td>
-          <td>Yes</td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
-</section>
+    <section class="p-section">
+      <div class="row--50-50">
+        <hr />
+        <div class="col">
+          <h2>Ubuntu Pro with 24x7 Support</h2>
+        </div>
+        <div class="col">
+          <p>
+            With 24x7 SLAed support and the widest open source security patching, teams can build on Ubuntu Pro with Support to secure their application's open source supply chain and receive expert assistance when they need it.
+          </p>
+          <p>
+            24x7 Support is available for the Ubuntu operating system (infrastructure) and can be extended to include application support for <a href="/support#apps-support">key open source applications</a>.
+          </p>
+          <p>
+            See more details at <a href="/support">https://ubuntu.com/support</a>.
+          </p>
+          <p>
+            If you already purchase support from Azure, speak to us about adding and integrating Canonical's Support into your existing Azure support &mdash; ensuring you have vendor-backed, SLAed support above the hypervisor for your workloads, without having to make any changes to end user issue reporting.
+          </p>
+        </div>
+      </div>
+    </section>
 
-{% endblock content %}
+    <section class="p-section--deep">
+      <div class="u-fixed-width">
+        <hr />
+        <div class="p-section--shallow">
+          <h2>Features</h2>
+        </div>
+        <table class="p-table">
+          <thead>
+            <tr>
+              <th style="width: 50%;">Feature</th>
+              <th>Ubuntu</th>
+              <th>Ubuntu Pro</th>
+              <th>Ubuntu Pro with Support</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th>Security patches for 2,300+ Ubuntu infrastructure packages</th>
+              <td>Yes</td>
+              <td>Yes</td>
+              <td>Yes</td>
+            </tr>
+            <tr>
+              <th>
+                Security patches for 28,000+ open source packages, including Apache Kafka, MongoDB, RabbitMQ, Redis and NodeJS and key language ecosystems including Java, Python, Ruby and Javascript/Node.js
+              </th>
+              <td>No</td>
+              <td>Yes</td>
+              <td>Yes</td>
+            </tr>
+            <tr>
+              <th>Livepatch for instant kernel security and higher uptimes</th>
+              <td>No</td>
+              <td>Yes</td>
+              <td>Yes</td>
+            </tr>
+            <tr>
+              <th>FIPS 140-2 and Common Criteria EAL2 certified components</th>
+              <td>No</td>
+              <td>Yes</td>
+              <td>Yes</td>
+            </tr>
+            <tr>
+              <th>
+                Hardening profiles, including CIS and DISA STIG, with CIS and other Shell security recommendations for production environments built into hardened images in the gallery
+              </th>
+              <td>No</td>
+              <td>Yes</td>
+              <td>Yes</td>
+            </tr>
+            <tr>
+              <th>Landscape fleet management</th>
+              <td>No</td>
+              <td>On request</td>
+              <td>On request</td>
+            </tr>
+            <tr>
+              <th>Maintenance period</th>
+              <td>5 years</td>
+              <td>10 years</td>
+              <td>10 years</td>
+            </tr>
+            <tr>
+              <th>Knowledge Base</th>
+              <td>No</td>
+              <td>No</td>
+              <td>Yes</td>
+            </tr>
+            <tr>
+              <th>
+                Canonical-backed 24x7 Support with enterprise grade SLA, with possibilities to integrate into existing Azure support workflows
+              </th>
+              <td>No</td>
+              <td>No</td>
+              <td>Yes</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+  {% endblock content %}

--- a/templates/azure/support.html
+++ b/templates/azure/support.html
@@ -33,7 +33,7 @@
       <div class="col">
         <div class="p-image-container u-hide--small">
           <img class="p-image-container__image"
-               src="https://assets.ubuntu.com/v1/7cc420dc-ubuntu-pro-azure.png"
+               src="https://assets.ubuntu.com/v1/3ec9a6b0-ubuntu-pro-azure-@3x.png"
                alt="" />
         </div>
       </div>

--- a/templates/azure/support.html
+++ b/templates/azure/support.html
@@ -34,7 +34,7 @@
         <div class="p-image-container u-hide--small">
           <img class="p-image-container__image"
                src="https://assets.ubuntu.com/v1/3ec9a6b0-ubuntu-pro-azure-@3x.png"
-               alt="" />
+               alt="Ubuntu pro and Azure logo" />
         </div>
       </div>
     </div>
@@ -68,7 +68,7 @@
             With 24x7 SLAed support and the widest open source security patching, teams can build on Ubuntu Pro with Support to secure their application's open source supply chain and receive expert assistance when they need it.
           </p>
           <p>
-            24x7 Support is available for the Ubuntu operating system (infrastructure) and can be extended to include application support for <a href="/support#apps-support">key open source applications</a>.
+            24x7 Support is available for the Ubuntu operating system (infrastructure) and can be extended to include application support for <a href="/support">key open source applications</a>.
           </p>
           <p>
             See more details at <a href="/support">https://ubuntu.com/support</a>.


### PR DESCRIPTION
## Done

Rebrand /azure/support. No content was changed, layout only

## QA

- [demo link](https://ubuntu-com-14175.demos.haus/azure/support)
- [figma](https://www.figma.com/design/FoWXkNxxdri9EgSsLdtTrH/24.10-AWS-bubble?node-id=120-4710&t=WOaNUpdi7g9kYqma-0)
- View the site on demo
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check that the page is correct according to figma

## Issue / Card
[WD-12833](https://warthogs.atlassian.net/browse/WD-12833)

[WD-12833]: https://warthogs.atlassian.net/browse/WD-12833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ