### PR TITLE
WD-14152 - Add link to free trial contact form in /pro/subscribe

### DIFF
--- a/static/js/src/advantage/subscribe/react/components/ProductSummary/ProductSummary.tsx
+++ b/static/js/src/advantage/subscribe/react/components/ProductSummary/ProductSummary.tsx
@@ -120,9 +120,11 @@ const ProductSummary = () => {
             style={{ display: "flex", alignItems: "center" }}
           >
             {product?.canBeTrialled && productUser !== ProductUsers.myself ? (
-              <StatusLabel appearance="positive">
-                Free trial available
-              </StatusLabel>
+              <a href="/engage/Ubuntu-Pro-1-month-trial">
+                <StatusLabel appearance="positive">
+                  Free trial available
+                </StatusLabel>
+              </a>
             ) : null}
             <PaymentButton />
           </Col>
@@ -203,9 +205,11 @@ const ProductSummary = () => {
           </Col>
           {product?.canBeTrialled && productUser !== ProductUsers.myself ? (
             <Col size={12}>
-              <StatusLabel appearance="positive">
-                Free trial available
-              </StatusLabel>
+              <a href="/engage/Ubuntu-Pro-1-month-trial">
+                <StatusLabel appearance="positive">
+                  Free trial available
+                </StatusLabel>
+              </a>
             </Col>
           ) : null}
         </Row>

--- a/static/js/src/advantage/subscribe/react/components/ProductSummary/ProductSummary.tsx
+++ b/static/js/src/advantage/subscribe/react/components/ProductSummary/ProductSummary.tsx
@@ -120,11 +120,11 @@ const ProductSummary = () => {
             style={{ display: "flex", alignItems: "center" }}
           >
             {product?.canBeTrialled && productUser !== ProductUsers.myself ? (
-              <a href="/engage/Ubuntu-Pro-1-month-trial">
-                <StatusLabel appearance="positive">
+              <StatusLabel appearance="positive">
+                <a href="/engage/Ubuntu-Pro-1-month-trial">
                   Free trial available
-                </StatusLabel>
-              </a>
+                </a>
+              </StatusLabel>
             ) : null}
             <PaymentButton />
           </Col>
@@ -205,11 +205,11 @@ const ProductSummary = () => {
           </Col>
           {product?.canBeTrialled && productUser !== ProductUsers.myself ? (
             <Col size={12}>
-              <a href="/engage/Ubuntu-Pro-1-month-trial">
-                <StatusLabel appearance="positive">
+              <StatusLabel appearance="positive">
+                <a href="/engage/Ubuntu-Pro-1-month-trial">
                   Free trial available
-                </StatusLabel>
-              </a>
+                </a>
+              </StatusLabel>
             </Col>
           ) : null}
         </Row>


### PR DESCRIPTION
## Done

- Added link to [Free Trial Contact Form](https://ubuntu.com/engage/Ubuntu-Pro-1-month-trial) on the Free Trial Available button.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/pro/subscribe
    - Be sure to test on mobile, tablet and desktop screen sizes
- Scroll down to the "**Buy Now**" button and click the Free trial available button. You should be redirected to the free trial contact form.
- Try logging out if you can't see the "Free trial available" button.

## Issue / Card

Fixes [WD-14152](https://warthogs.atlassian.net/browse/WD-14152)

## Screenshots

![image](https://github.com/user-attachments/assets/470ae964-d4ce-4ff5-b797-fc80620f7cdb)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-14152]: https://warthogs.atlassian.net/browse/WD-14152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ