### PR TITLE
WD-12823 - rebrand /azure/ebook

### DIFF
--- a/templates/azure/ebook/index.html
+++ b/templates/azure/ebook/index.html
@@ -10,100 +10,68 @@
   https://docs.google.com/document/d/1JL_TeFBg1tSqiYIiXU0IwJTKWRDKJEXWtEgLRWFnToI/edit#
 {% endblock meta_copydoc %}
 
-{% block head_extra %}
-  <style>
-    h2,
-    .p-heading--2 {
-      font-weight: 300;
-    }
-  </style>
-{% endblock %}
+{% block body_class %}is-paper{% endblock body_class %}
 
 {% block content %}
-
-  <section class="p-strip--suru-bottomed">
-    <div class="row">
-      <div class="col-7 u-vertically-center">
-        <div>
-          <h1>Why do cloud innovators migrate to Ubuntu Pro?</h1>
-
-          <p class="u-no-padding--top p-heading--4">Get our eBook to find out</p>
-
-          <p>
-            <a href="#ubuntu-pro-ebook" class="p-button--positive">Download<span class="u-off-screen">the Why do Cloud innovators migrate to Pro? eBook by completing this form</span></a>
-          </p>
-        </div>
-      </div>
-      <div class="col-5 u-hide--small u-vertically-center u-align--center">
-        {{ image(url="https://assets.ubuntu.com/v1/0959ce33-NEW_Ubuntu_ebook_1.png",
-                alt="",
-                width="214",
-                height="300",
-                hi_def=True,
-                loading="auto",
-                attrs={ "class": "p-image--bordered"}) | safe
-        }}
-      </div>
+<section class="p-section--hero">
+  <div class="u-fixed-width">
+    <h1 class="u-no-margin--bottom">Why do cloud innovators migrate to Ubuntu Pro?</h1>
+    <div class="p-section--shallow">
+    <h2>Get our eBook to find out</h2>
     </div>
-  </section>
+    <hr class="is-muted" />
+    <p>
+      <a href="#ubuntu-pro-ebook" class="p-button--positive">Download<span class="u-off-screen"> the Why do Cloud
+          innovators migrate to Pro? eBook by completing this form</span></a>
+    </p>
+  </div>
+</section>
 
   {% include "azure/shared/_azure-logo-strip.html" %}
 
-  <div class="p-strip--light">
-    <div class="row">
-      <div class="col-7">
-        <h2 class="p-heading--4">
-          Ubuntu Pro for Azure is a premium image delivering the most comprehensive open source security and compliance
-        </h2>
-
-        <hr class="p-separator u-no-margin--top" />
-
-        <p class="p-heading--4">
-          <strong>70% of Azure virtual machines are running on Ubuntu due to reliability and ease of use</strong>
-        </p>
-
-        <p>
-          As the publishers of Ubuntu, we went one step further and developed a premium Ubuntu Pro image in partnership with public cloud providers, to deliver a preferred open-source solution for cloud innovators.
-        </p>
-
-        <p>
-          Here is our latest eBook, where we share the details of how Ubuntu Pro on Azure delivers extended open-source security, enterprise compliance, 10 years of extended maintenance and more.
-        </p>
-      </div>
-
-      <div class="col-5" id="ubuntu-pro-ebook">
-        {% with id="4393", returnURL="/azure/ebook/thank-you", cta="Get the eBook", cta_class="p-button--positive" %}
-          {% include "engage/shared/_en_engage_form.html" %}
-        {% endwith %}
-      </div>
+<section class="p-section">
+  <div class="u-fixed-width p-section--shallow">
+    <hr />
+    <h2>Ubuntu Pro for Azure is a premium image delivering the most comprehensive open source security and compliance</h2>
+  </div>
+  <div class="row--50-50">
+    <div class="col">
+      <p class="p-heading--5">70% of Azure virtual machines are running on Ubuntu due to reliability and ease of use</p>
+      <p>As the publishers of Ubuntu, we went one step further and developed a premium Ubuntu Pro image in partnership with public cloud providers, to deliver a preferred open-source solution for cloud innovators.</p>
+      <p>Here is our latest eBook, where we share the details of how Ubuntu Pro on Azure delivers extended open-source security, enterprise compliance, 10 years of extended maintenance and more.</p>
+    </div>
+    <div class="col" id="ubuntu-pro-ebook">
+      {% with id="4393", returnURL="/azure/ebook/thank-you", cta="Get the eBook", cta_class="p-button--positive" %}
+        {% include "engage/shared/_en_engage_form.html" %}
+      {% endwith %}
     </div>
   </div>
+</section>
 
-  <div class="p-strip">
-    <div class="row--50-50">{% include "azure/shared/_how-ubuntu-pro-helps-you.html" %}</div>
+<section class="p-section">
+  <div class="row--50-50">
+    <hr />
+    {% include "azure/shared/_how-ubuntu-pro-helps-you.html" %}
   </div>
+</section>
 
-  <div class="p-strip--light">
-    <div class="row">
-      <div class="col-7">
-        <h2>Level up your Ubuntu journey by activating this private Azure Marketplace offer</h2>
-
-        <p>Already running Ubuntu on Microsoft Azure, or planning a migration to the public cloud?</p>
-
-        <p>Leverage Canonical's expert service and all the features of Ubuntu Pro with this exclusive private offer.</p>
-
-        <a href="/azure/private-offer" class="p-button--positive">Learn more</a>
-      </div>
-
-      <div class="col-5 u-align--center">
-        {{ image(url="https://assets.ubuntu.com/v1/71fe6a11-private-offer-shield.svg",
-                alt="",
-                width="206",
-                height="234",
-                hi_def=True,
-                loading="lazy") | safe
-        }}
-      </div>
+<section class="p-section--deep">
+  <div class="row--50-50">
+    <hr />
+    <div class="col">
+      <h2>Level up your Ubuntu journey by activating this private Azure Marketplace offer</h2>
     </div>
-  </div>
+    <div class="col">
+      <div class="p-section--shallow">
+        <div class="p-image-container--3-2 is-highlighted u-hide--small">
+          <img class="p-image-container__image p-strip is-shallow" style="width: 30%;"
+            src="https://assets.ubuntu.com/v1/71fe6a11-private-offer-shield.svg" alt="" />
+        </div>
+      </div>
+      <p>Already running Ubuntu on Microsoft Azure, or planning a migration to the public cloud?</p>
+      <p>Leverage Canonical's expert service and all the features of Ubuntu Pro with this exclusive private offer.</p>
+      <hr class="is-muted" />
+      <a href="/azure/private-offer" class="p-button">Learn more</a>
+    </div>
+</section>
 {% endblock %}

--- a/templates/azure/ebook/index.html
+++ b/templates/azure/ebook/index.html
@@ -14,16 +14,23 @@
 
 {% block content %}
 <section class="p-section--hero">
-  <div class="u-fixed-width">
-    <h1 class="u-no-margin--bottom">Why do cloud innovators migrate to Ubuntu Pro?</h1>
-    <div class="p-section--shallow">
-    <h2>Get our eBook to find out</h2>
+  <div class="row--50-50">
+    <div class="col">
+      <h1 class="u-no-margin--bottom">Why do cloud innovators migrate to Ubuntu Pro?</h1>
+      <h2>Get our eBook to find out</h2>
+      <hr class="is-muted" />
+      <p>
+        <a href="#ubuntu-pro-ebook" class="p-button--positive">Download<span class="u-off-screen"> the Why do Cloud innovators migrate to Pro? eBook by completing this form</span></a>
+      </p>
     </div>
-    <hr class="is-muted" />
-    <p>
-      <a href="#ubuntu-pro-ebook" class="p-button--positive">Download<span class="u-off-screen"> the Why do Cloud
-          innovators migrate to Pro? eBook by completing this form</span></a>
-    </p>
+    <div class="col">
+      <div class="col">
+        <div class="p-image-container u-hide--small">
+          <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/d5af1f9f-ebook-azure.png"
+            alt="Ubuntu pro and Azure logo" />
+        </div>
+      </div>
+    </div>
   </div>
 </section>
 
@@ -49,10 +56,7 @@
 </section>
 
 <section class="p-section">
-  <div class="row--50-50">
-    <hr />
     {% include "azure/shared/_how-ubuntu-pro-helps-you.html" %}
-  </div>
 </section>
 
 <section class="p-section--deep">

--- a/templates/azure/ebook/index.html
+++ b/templates/azure/ebook/index.html
@@ -77,5 +77,6 @@
       <hr class="is-muted" />
       <a href="/azure/private-offer" class="p-button">Learn more</a>
     </div>
+  </div>
 </section>
 {% endblock %}

--- a/templates/azure/ebook/index.html
+++ b/templates/azure/ebook/index.html
@@ -10,73 +10,80 @@
   https://docs.google.com/document/d/1JL_TeFBg1tSqiYIiXU0IwJTKWRDKJEXWtEgLRWFnToI/edit#
 {% endblock meta_copydoc %}
 
-{% block body_class %}is-paper{% endblock body_class %}
+{% block body_class %}
+  is-paper
+{% endblock body_class %}
 
 {% block content %}
-<section class="p-section--hero">
-  <div class="row--50-50">
-    <div class="col">
-      <h1 class="u-no-margin--bottom">Why do cloud innovators migrate to Ubuntu Pro?</h1>
-      <h2>Get our eBook to find out</h2>
-      <hr class="is-muted" />
-      <p>
-        <a href="#ubuntu-pro-ebook" class="p-button--positive">Download<span class="u-off-screen"> the Why do Cloud innovators migrate to Pro? eBook by completing this form</span></a>
-      </p>
-    </div>
-    <div class="col">
+  <section class="p-section--hero">
+    <div class="row--50-50">
+      <div class="col">
+        <h1 class="u-no-margin--bottom">Why do cloud innovators migrate to Ubuntu Pro?</h1>
+        <h2>Get our eBook to find out</h2>
+        <hr class="is-muted" />
+        <p>
+          <a href="#ubuntu-pro-ebook" class="p-button--positive">Download<span class="u-off-screen">the Why do Cloud innovators migrate to Pro? eBook by completing this form</span></a>
+        </p>
+      </div>
       <div class="col">
         <div class="p-image-container u-hide--small">
-          <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/d5af1f9f-ebook-azure.png"
-            alt="Ubuntu pro and Azure logo" />
+          <img class="p-image-container__image"
+               src="https://assets.ubuntu.com/v1/d5af1f9f-ebook-azure.png"
+               alt="Ubuntu Pro and Azure logo" />
         </div>
       </div>
     </div>
-  </div>
-</section>
+  </section>
 
   {% include "azure/shared/_azure-logo-strip.html" %}
 
-<section class="p-section">
-  <div class="u-fixed-width p-section--shallow">
-    <hr />
-    <h2>Ubuntu Pro for Azure is a premium image delivering the most comprehensive open source security and compliance</h2>
-  </div>
-  <div class="row--50-50">
-    <div class="col">
-      <p class="p-heading--5">70% of Azure virtual machines are running on Ubuntu due to reliability and ease of use</p>
-      <p>As the publishers of Ubuntu, we went one step further and developed a premium Ubuntu Pro image in partnership with public cloud providers, to deliver a preferred open-source solution for cloud innovators.</p>
-      <p>Here is our latest eBook, where we share the details of how Ubuntu Pro on Azure delivers extended open-source security, enterprise compliance, 10 years of extended maintenance and more.</p>
+  <section class="p-section">
+    <div class="u-fixed-width p-section--shallow">
+      <hr />
+      <h2>Ubuntu Pro for Azure is a premium image delivering the most comprehensive open source security and compliance</h2>
     </div>
-    <div class="col" id="ubuntu-pro-ebook">
-      {% with id="4393", returnURL="/azure/ebook/thank-you", cta="Get the eBook", cta_class="p-button--positive" %}
-        {% include "engage/shared/_en_engage_form.html" %}
-      {% endwith %}
-    </div>
-  </div>
-</section>
-
-<section class="p-section">
-    {% include "azure/shared/_how-ubuntu-pro-helps-you.html" %}
-</section>
-
-<section class="p-section--deep">
-  <div class="row--50-50">
-    <hr />
-    <div class="col">
-      <h2>Level up your Ubuntu journey by activating this private Azure Marketplace offer</h2>
-    </div>
-    <div class="col">
-      <div class="p-section--shallow">
-        <div class="p-image-container--3-2 is-highlighted u-hide--small">
-          <img class="p-image-container__image p-strip is-shallow" style="width: 30%;"
-            src="https://assets.ubuntu.com/v1/71fe6a11-private-offer-shield.svg" alt="" />
-        </div>
+    <div class="row--50-50">
+      <div class="col">
+        <p class="p-heading--5">70% of Azure virtual machines are running on Ubuntu due to reliability and ease of use</p>
+        <p>
+          As the publishers of Ubuntu, we went one step further and developed a premium Ubuntu Pro image in partnership with public cloud providers, to deliver a preferred open-source solution for cloud innovators.
+        </p>
+        <p>
+          Here is our latest eBook, where we share the details of how Ubuntu Pro on Azure delivers extended open-source security, enterprise compliance, 10 years of extended maintenance and more.
+        </p>
       </div>
-      <p>Already running Ubuntu on Microsoft Azure, or planning a migration to the public cloud?</p>
-      <p>Leverage Canonical's expert service and all the features of Ubuntu Pro with this exclusive private offer.</p>
-      <hr class="is-muted" />
-      <a href="/azure/private-offer" class="p-button">Learn more</a>
+      <div class="col" id="ubuntu-pro-ebook" style="scroll-margin-top: 4rem">
+        {% with id="4393", returnURL="/azure/ebook/thank-you", cta="Get the eBook", cta_class="p-button--positive" %}
+          {% include "engage/shared/_en_engage_form.html" %}
+        {% endwith %}
+      </div>
     </div>
-  </div>
-</section>
+  </section>
+
+  <section class="p-section">
+    {% include "azure/shared/_how-ubuntu-pro-helps-you.html" %}
+  </section>
+
+  <section class="p-section--deep">
+    <div class="row--50-50">
+      <hr />
+      <div class="col">
+        <h2>Level up your Ubuntu journey by activating this private Azure Marketplace offer</h2>
+      </div>
+      <div class="col">
+        <div class="p-section--shallow">
+          <div class="p-image-container--3-2 is-highlighted u-hide--small">
+            <img class="p-image-container__image p-strip is-shallow"
+                 style="width: 30%"
+                 src="https://assets.ubuntu.com/v1/71fe6a11-private-offer-shield.svg"
+                 alt="" />
+          </div>
+        </div>
+        <p>Already running Ubuntu on Microsoft Azure, or planning a migration to the public cloud?</p>
+        <p>Leverage Canonical's expert service and all the features of Ubuntu Pro with this exclusive private offer.</p>
+        <hr class="is-muted" />
+        <a href="/azure/private-offer" class="p-button">Learn more <span class="u-off-screen">about our Azure Marketplace private offer</span></a>
+      </div>
+    </div>
+  </section>
 {% endblock %}

--- a/templates/azure/private-offer.html
+++ b/templates/azure/private-offer.html
@@ -28,44 +28,8 @@
     </div>
   </section>
 
-  <section class="p-section">
-    <div class="u-fixed-width">
-      <hr />
-      <h2 class="p-text--small-caps">Get Ubuntu Pro for Azure</h2>
-      <div class="p-logo-section">
-        <div class="p-logo-section__items u-no-margin--bottom">
-          <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/bd03aa14-canonical-logo.png",
-                        alt="Canonical",
-                        width="177",
-                        hi_def=True,
-                        attrs={"class": "p-logo-section__logo"},
-                        loading="auto") | safe
-            }}
-          </div>
-          <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/6c560fe0-ubuntu-logo.png",
-                        alt="Ubuntu",
-                        width="146",
-                        hi_def=True,
-                        attrs={"class": "p-logo-section__logo"},
-                        loading="auto") | safe
-            }}
-          </div>
-          <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/2feccb6f-microsoft-azure-2021.png",
-                        alt="Microsoft Azure",
-                        width="48",
-                        hi_def=True,
-                        attrs={"class": "p-logo-section__logo"},
-                        loading="auto") | safe
-            }}
-          </div>
-        </div>
-      </div>
-    </div>
-  </section>
-
+  {% include "azure/shared/_azure-logo-strip.html" %}
+  
   <section class="p-section">
     <div class="u-fixed-width p-section--shallow">
       <hr />

--- a/templates/azure/private-offer.html
+++ b/templates/azure/private-offer.html
@@ -100,10 +100,7 @@
   </section>
 
   <div class="p-section">
-    <div class="row--50-50">
-      <hr />
       {% include "azure/shared/_how-ubuntu-pro-helps-you.html" %}
-    </div>
   </div>
 
   <div class="u-fixed-width">

--- a/templates/azure/shared/_azure-logo-strip.html
+++ b/templates/azure/shared/_azure-logo-strip.html
@@ -1,41 +1,34 @@
-<section class="p-strip is-shallow u-no-padding">
+<section class="p-section">
   <div class="u-fixed-width">
+    <hr />
+    <h2 class="p-text--small-caps">Get Ubuntu Pro for Azure</h2>
     <div class="p-logo-section">
       <div class="p-logo-section__items u-no-margin--bottom">
-        <div class="p-logo-section__item"> 
-          {{ image (
-            url="https://assets.ubuntu.com/v1/d5a5c48f-canonical-logo.png",
-            alt="Canonical",
-            width="288",
-            height="288",
-            hi_def=True,
-            attrs={"class": "p-logo-section__logo"},
-            loading="auto"
-            ) | safe
+        <div class="p-logo-section__item">
+          {{ image(url="https://assets.ubuntu.com/v1/bd03aa14-canonical-logo.png",
+          alt="Canonical",
+          width="177",
+          hi_def=True,
+          attrs={"class": "p-logo-section__logo"},
+          loading="auto") | safe
           }}
         </div>
         <div class="p-logo-section__item">
-          {{ image (
-            url="https://assets.ubuntu.com/v1/6e9151f5-ubuntu-logo.png",
-            alt="Ubuntu",
-            width="288",
-            height="288",
-            hi_def=True,
-            attrs={"class": "p-logo-section__logo"},
-            loading="auto"
-            ) | safe
+          {{ image(url="https://assets.ubuntu.com/v1/6c560fe0-ubuntu-logo.png",
+          alt="Ubuntu",
+          width="146",
+          hi_def=True,
+          attrs={"class": "p-logo-section__logo"},
+          loading="auto") | safe
           }}
         </div>
         <div class="p-logo-section__item">
-          {{ image (
-            url="https://assets.ubuntu.com/v1/6ef81e08-microsoft-azure-new-logo.png",
-            alt="Microsoft Azure",
-            width="288",
-            height="288",
-            hi_def=True,
-            attrs={"class": "p-logo-section__logo"},
-            loading="auto"
-            ) | safe
+          {{ image(url="https://assets.ubuntu.com/v1/2feccb6f-microsoft-azure-2021.png",
+          alt="Microsoft Azure",
+          width="48",
+          hi_def=True,
+          attrs={"class": "p-logo-section__logo"},
+          loading="auto") | safe
           }}
         </div>
       </div>

--- a/templates/azure/shared/_azure-logo-strip.html
+++ b/templates/azure/shared/_azure-logo-strip.html
@@ -6,29 +6,29 @@
       <div class="p-logo-section__items u-no-margin--bottom">
         <div class="p-logo-section__item">
           {{ image(url="https://assets.ubuntu.com/v1/bd03aa14-canonical-logo.png",
-          alt="Canonical",
-          width="177",
-          hi_def=True,
-          attrs={"class": "p-logo-section__logo"},
-          loading="auto") | safe
+                    alt="Canonical",
+                    width="177",
+                    hi_def=True,
+                    attrs={"class": "p-logo-section__logo"},
+                    loading="auto") | safe
           }}
         </div>
         <div class="p-logo-section__item">
           {{ image(url="https://assets.ubuntu.com/v1/6c560fe0-ubuntu-logo.png",
-          alt="Ubuntu",
-          width="146",
-          hi_def=True,
-          attrs={"class": "p-logo-section__logo"},
-          loading="auto") | safe
+                    alt="Ubuntu",
+                    width="146",
+                    hi_def=True,
+                    attrs={"class": "p-logo-section__logo"},
+                    loading="auto") | safe
           }}
         </div>
         <div class="p-logo-section__item">
           {{ image(url="https://assets.ubuntu.com/v1/2feccb6f-microsoft-azure-2021.png",
-          alt="Microsoft Azure",
-          width="48",
-          hi_def=True,
-          attrs={"class": "p-logo-section__logo"},
-          loading="auto") | safe
+                    alt="Microsoft Azure",
+                    width="48",
+                    hi_def=True,
+                    attrs={"class": "p-logo-section__logo"},
+                    loading="auto") | safe
           }}
         </div>
       </div>

--- a/templates/azure/shared/_how-ubuntu-pro-helps-you.html
+++ b/templates/azure/shared/_how-ubuntu-pro-helps-you.html
@@ -2,7 +2,7 @@
   <h2>How Ubuntu Pro helps you</h2>
 </div>
 <div class="col">
-  <ul class="p-list--divided u-no-margin--bottom">
+  <ul class="p-list--divided u-no-margin--bottom remove-first-hr">
     <li class="p-list__item is-ticked">
       Ubuntu Pro enables instant up-to-date security by default with security patches for thousands of open source applications
     </li>

--- a/templates/azure/shared/_how-ubuntu-pro-helps-you.html
+++ b/templates/azure/shared/_how-ubuntu-pro-helps-you.html
@@ -8,18 +8,10 @@
       <li class="p-list__item is-ticked">
         Ubuntu Pro enables instant up-to-date security by default with security patches for thousands of open source applications
       </li>
-      <li class="p-list__item is-ticked">
-        Azure-optimised kernel for improved performance
-      </li>
-      <li class="p-list__item is-ticked">
-        Full compliance checklist: FIPS, HIPAA, PCI, ISO and DISA-STIGs
-      </li>
-      <li class="p-list__item is-ticked">
-        24/7 support straight from the publisher of Ubuntu*
-      </li>
-      <li class="p-list__item is-ticked">
-        10 years of extended maintenance
-      </li>
+      <li class="p-list__item is-ticked">Azure-optimised kernel for improved performance</li>
+      <li class="p-list__item is-ticked">Full compliance checklist: FIPS, HIPAA, PCI, ISO and DISA-STIGs</li>
+      <li class="p-list__item is-ticked">24/7 support straight from the publisher of Ubuntu*</li>
+      <li class="p-list__item is-ticked">10 years of extended maintenance</li>
     </ul>
     <p>* Only available with the private offer</p>
   </div>

--- a/templates/azure/shared/_how-ubuntu-pro-helps-you.html
+++ b/templates/azure/shared/_how-ubuntu-pro-helps-you.html
@@ -1,23 +1,26 @@
-<div class="col">
-  <h2>How Ubuntu Pro helps you</h2>
-</div>
-<div class="col">
-  <ul class="p-list--divided u-no-margin--bottom remove-first-hr">
-    <li class="p-list__item is-ticked">
-      Ubuntu Pro enables instant up-to-date security by default with security patches for thousands of open source applications
-    </li>
-    <li class="p-list__item is-ticked">
-      Azure-optimised kernel for improved performance
-    </li>
-    <li class="p-list__item is-ticked">
-      Full compliance checklist: FIPS, HIPAA, PCI, ISO and DISA-STIGs
-    </li>
-    <li class="p-list__item is-ticked">
-      24/7 support straight from the publisher of Ubuntu*
-    </li>
-    <li class="p-list__item is-ticked">
-      10 years of extended maintenance
-    </li>
-  </ul>
-  <p>* Only available with the private offer</p>
+<div class="row--50-50">
+  <hr />
+  <div class="col">
+    <h2>How Ubuntu Pro helps you</h2>
+  </div>
+  <div class="col">
+    <ul class="p-list--divided remove-first-hr">
+      <li class="p-list__item is-ticked">
+        Ubuntu Pro enables instant up-to-date security by default with security patches for thousands of open source applications
+      </li>
+      <li class="p-list__item is-ticked">
+        Azure-optimised kernel for improved performance
+      </li>
+      <li class="p-list__item is-ticked">
+        Full compliance checklist: FIPS, HIPAA, PCI, ISO and DISA-STIGs
+      </li>
+      <li class="p-list__item is-ticked">
+        24/7 support straight from the publisher of Ubuntu*
+      </li>
+      <li class="p-list__item is-ticked">
+        10 years of extended maintenance
+      </li>
+    </ul>
+    <p>* Only available with the private offer</p>
+  </div>
 </div>


### PR DESCRIPTION
## Done

Rebrand /azure/ebook. No content was changed, layout only

## QA

- [demo link](https://ubuntu-com-14186.demos.haus/azure/ebook)
- [figma](https://www.figma.com/design/MinLlXouBnEDqaoAL3bTWC/24.10-Azure-bubble?node-id=1-2&t=e0pNuFr29DP74s75-0)
- View the site on demo
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check that the page is correct according to figma

## Issue / Card
[WD-12823](https://warthogs.atlassian.net/browse/WD-12823)

[WD-12823]: https://warthogs.atlassian.net/browse/WD-12823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ