### PR TITLE
chore: Update meganav reference from Multipass to MicroCloud

### DIFF
--- a/meganav.yaml
+++ b/meganav.yaml
@@ -61,7 +61,7 @@ products:
               description: Enterprise-grade cloud platform
               url: /openstack
             - title: MicroCloud
-              description: Lightweight, automated cloudsux
+              description: Lightweight, automated clouds
               url: https://canonical.com/microcloud
             - title: Ubuntu Pro
               description: Security & compliance subscription

--- a/meganav.yaml
+++ b/meganav.yaml
@@ -60,9 +60,9 @@ products:
             - title: OpenStack
               description: Enterprise-grade cloud platform
               url: /openstack
-            - title: Multipass
-              description: VMs for Windows, macOS & Linux
-              url: https://multipass.run/
+            - title: MicroCloud
+              description: Lightweight, automated cloudsux
+              url: https://canonical.com/microcloud
             - title: Ubuntu Pro
               description: Security & compliance subscription
               url: /pro


### PR DESCRIPTION
## Done

-  Update meganav reference from Multipass to MicroCloud based on [copydoc](https://docs.google.com/document/d/1DCNvYHfC7AbOcqflTBaVd571iKAP_PaTfnqTENVEDVw/edit)

## QA

- Open [the demo]()
- Open 'products' and then 'featured'
- See 'Multipass' has been removed and 'MicroCloud' is in its place

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-14183
