### PR TITLE
Fix engage sitemap 500

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -506,7 +506,13 @@ def build_engage_pages_sitemap(engage_pages):
 
     def ep_sitemap():
         links = []
-        metadata = engage_pages.get_index()
+        (
+            metadata,
+            count,
+            active_count,
+            current_total,
+        ) = engage_pages.get_index()
+
         if len(metadata) == 0:
             flask.abort(404)
 
@@ -580,7 +586,12 @@ def openstack_install():
 
 def openstack_engage(engage_pages):
     def openstack_resource_data():
-        metadata = engage_pages.get_index()
+        (
+            metadata,
+            count,
+            active_count,
+            current_total,
+        ) = engage_pages.get_index()
 
         resource_tags = [
             "openstack",


### PR DESCRIPTION
## Done

- Updated engage pages to use new version of `get_index`
https://github.com/canonical/canonicalwebteam.discourse/commit/49eee8f8a4ba2b398667a3623a45763370bd917b

## QA

- Open the demo at [https://ubuntu-com-14189.demos.haus/engage/sitemap.xml](https://ubuntu-com-14189.demos.haus/engage/sitemap.xml)
- Also check [https://ubuntu-com-14189.demos.haus/openstack/resources/](https://ubuntu-com-14189.demos.haus/openstack/resources/)
and confirm that there are no 500 errors

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
