### PR TITLE
Create ALTERNATIVE_ISSUE_TEMPLATE.yaml

### DIFF
--- a/.github/ISSUE_TEMPLATE/ALTERNATIVE_ISSUE_TEMPLATE.yaml
+++ b/.github/ISSUE_TEMPLATE/ALTERNATIVE_ISSUE_TEMPLATE.yaml
@@ -1,0 +1,58 @@
+name: Alternative issue template
+description: Issue from anywhere, perhaps from the footer of the site
+title: ''
+labels: ''
+assignees: ''
+body:
+- type: markdown
+  attributes:
+    value: |
+      Note - filling in this form will file an issue against the www.ubuntu.com website, not against Ubuntu itself, for Ubuntu OS related bugs please [go here](https://help.ubuntu.com/community/ReportingBugs).
+- type: markdown
+  attributes:
+    value: |
+      Please provide as many details as possible in order to provide maintainers more context about the issue. Don't skip/remove any of the sections below. If there is no data to provide in one of the sections, please specify it by typing "N/A" or similar. That will help maintainers reproduce the issue and be able to help quickly. Thanks.
+- type: textarea
+  id: summary
+  attributes:
+    label: Summary
+    description: Please describe the issue
+  validations:
+    required: true
+- type: textarea
+  id: steps
+  attributes:
+    label: Steps to reproduce the behavior
+    placeholder: |
+      1. Go to '...'
+      2. Click on '....'
+      3. Scroll down to '....'
+      4. See error
+  validations:
+    required: true
+- type: textarea
+  id: behavior
+  attributes:
+    label: Expected behavior
+    description: A clear and concise description of what you expected to happen
+  validations:
+    required: true
+- type: textarea
+  id: browser
+  attributes:
+    label: Browser/device details
+    placeholder: |
+      - Device: [e.g. iPhone6]
+      - OS: [e.g. iOS8.1]
+      - Browser [e.g. stock browser, safari]
+      - Version [e.g. 22]
+  validations:
+    required: true
+- type: markdown
+  attributes:
+    value: Please provide a screenshot in the comments after you have created an issue to help the maintainers debug the issue quicker.
+- type: input
+  id: reported_from
+  attributes:
+    label: Reported from
+    value: GitHub


### PR DESCRIPTION
## Done

- This file is added to check the issue form functionality that GitHub provides as an alternative to a regular issue template (https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms).  Issue form has validations and in general looks better that a plain text. We need to add this file to be able to test it. Without having it it's impossible to test even locally.

## QA

- It can be QA-ed only after this file appears in the main branch.

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-14301

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
