### PR TITLE
chore: restrict badge issuing api to credential admins

### DIFF
--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -1202,7 +1202,7 @@ def get_test_taker_stats(trueability_api, **kwargs):
 
 
 @shop_decorator(area="cred", permission="user", response="json")
-@credentials_group()
+@credentials_admin()
 def issue_credly_badge(credly_api, **kwargs):
     badge_data = flask.request.json
     try:


### PR DESCRIPTION
## Done

- restrict badge issuing api to credential admins

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
