### PR TITLE
feat: Add lsn notices to list of references

### DIFF
--- a/templates/security/cve/cve.html
+++ b/templates/security/cve/cve.html
@@ -1,378 +1,401 @@
 {% extends "security/cve/base_cve.html" %}
+
 {% block title %}{{ cve.id }}{% endblock %}
 
 {% block content %}
-{% if cve.impact %}
- {% set cvssV3 = cve.impact.baseMetricV3.cvssV3 %}
-{% endif %}
+  {% if cve.impact %}
+    {% set cvssV3 = cve.impact.baseMetricV3.cvssV3 %}
+  {% endif %}
 
-{% if cve.status == 'rejected' or cve.status == 'not-in-ubuntu' %}
-  <section class="p-strip--light is-bordered--top">
-{% else %}
-  <section class="p-strip">
-{% endif %}
-  <div class="row">
-    <div class="col-9">
-      <h1>{{ cve.id }}</h1>
+  <section class="p-strip{% if cve.status == 'rejected' or cve.status == 'not-in-ubuntu' %}p--light is-bordered--top{% endif %}">
+    <div class="row">
+      <div class="col-9">
+        <h1>{{ cve.id }}</h1>
 
-      {% if cve.published %}
-      <p>Published: <strong>{{ cve.published }}</strong></p>
-      {% endif %}
-
-      {% if cve.status == 'not-in-ubuntu' %}
-        <p>This CVE does not apply to software in Ubuntu archives.</p>
-      {% endif %}
-
-      {% if cve.description %}
-      <p>{{ cve.description }}</p>
-      {% endif %}
-
-      {% if cve.ubuntu_description %}
-      <h2>From the Ubuntu Security Team</h2>
-      <p>{{ cve.ubuntu_description }}</p>
-      {% endif %}
-
-      {% if cve.status == 'active' and cve.notes %}
-        <h2>Notes</h2>
-        <table>
-          <tr><th style="width: 10em;">Author</th><th>Note</th></tr>
-          {% for note in cve.notes %}
-          <tr>
-            <td><a href="https://launchpad.net/~{{ note.author }}">{{ note.author }}</a></td>
-            <td><pre>{{ note.note }}</pre></td>
-          </tr>
-          {% endfor %}
-        </table>
-      {% endif %}
-
-      {%if cve.mitigation %}
-      <h2>Mitigation</h2>
-      <pre>{{ cve.mitigation }}</pre>
-      {% endif %}
-    </div>
-
-    <div class="col-3">
-      {% if cve.status == 'active' and cve.priority %}
-      <div class="cve-status-box">
-        <h2 class="p-muted-heading">Priority</h2>
-        <div class="p-heading-icon--small">
-          <div class="p-heading-icon__header">
-            {% if cve.priority == 'unknown' %}
-              <img src="https://assets.ubuntu.com/v1/2dff197f-CVE-Priority-icon-Unknown.svg" alt="" class="p-heading-icon__img">
-            {% endif %}
-
-            {% if cve.priority == 'negligible' %}
-              <img src="https://assets.ubuntu.com/v1/ef6c75b8-CVE-Priority-icon-Negligible.svg" alt="" class="p-heading-icon__img">
-            {% endif %}
-
-            {% if cve.priority == 'low' %}
-              <img src="https://assets.ubuntu.com/v1/03ac6f86-CVE-Priority-icon-Low.svg" alt="" class="p-heading-icon__img">
-            {% endif %}
-
-            {% if cve.priority == 'medium' %}
-              <img src="https://assets.ubuntu.com/v1/8010f9e0-CVE-Priority-icon-Medium.svg" alt="" class="p-heading-icon__img">
-            {% endif %}
-
-            {% if cve.priority == 'high' %}
-              <img src="https://assets.ubuntu.com/v1/3887354e-CVE-Priority-icon-High.svg" alt="" class="p-heading-icon__img">
-            {% endif %}
-
-            {% if cve.priority == 'critical' %}
-              <img src="https://assets.ubuntu.com/v1/c96f27b9-CVE-Priority-icon-Critical.svg" alt="" class="p-heading-icon__img">
-            {% endif %}
-            <p class="p-heading-icon__title u-no-margin--bottom p-heading--4">
-              {{ cve.priority | capitalize }}
-            </p>
-          </div>
-        </div>
-      </div>
-        {% if cvssV3 %}
-        <div class="cve-status-box u-no-margin--bottom">
-          <h2 class="p-muted-heading">Cvss 3 Severity Score</h2>
-          <p class="u-no-margin--bottom p-heading--4">{{cvssV3.baseScore}}</p>
-          <p class="p-heading--5 u-no-margin--bottom"><a href="#impact-score">Score breakdown</a></p>
-        </div>
-        {% elif cve.cvss3 %}
-          <p>CVSS 3 base score: {{ cve.cvss3 }}</p>
+        {% if cve.published %}
+          <p>
+            Published: <strong>{{ cve.published }}</strong>
+          </p>
         {% endif %}
 
-      {% endif %}
+        {% if cve.status == 'not-in-ubuntu' %}<p>This CVE does not apply to software in Ubuntu archives.</p>{% endif %}
 
-      {% if cve.status == 'rejected' %}
-      <div class="cve-status-box--highlight">
-        <div class="p-heading--4 u-no-margin--bottom">
-          Rejected
-        </div>
-      </div>
-      {% endif %}
+        {% if cve.description %}<p>{{ cve.description }}</p>{% endif %}
 
-      {% if cve.status == 'not-in-ubuntu' %}
-      <div class="cve-status-box--highlight">
-        <div class="p-heading--4 u-no-margin--bottom">
-          Not in Ubuntu
-        </div>
+        {% if cve.ubuntu_description %}
+          <h2>From the Ubuntu Security Team</h2>
+          <p>{{ cve.ubuntu_description }}</p>
+        {% endif %}
+
+        {% if cve.status == 'active' and cve.notes %}
+          <h2>Notes</h2>
+          <table>
+            <tr>
+              <th style="width: 10em;">Author</th>
+              <th>Note</th>
+            </tr>
+            {% for note in cve.notes %}
+              <tr>
+                <td>
+                  <a href="https://launchpad.net/~{{ note.author }}">{{ note.author }}</a>
+                </td>
+                <td>
+                  <pre>{{ note.note }}</pre>
+                </td>
+              </tr>
+            {% endfor %}
+          </table>
+        {% endif %}
+
+        {% if cve.mitigation %}
+          <h2>Mitigation</h2>
+          <pre>{{ cve.mitigation }}</pre>
+        {% endif %}
       </div>
-      {% endif %}
+
+      <div class="col-3">
+        {% if cve.status == 'active' and cve.priority %}
+          <div class="cve-status-box">
+            <h2 class="p-muted-heading">Priority</h2>
+            <div class="p-heading-icon--small">
+              <div class="p-heading-icon__header">
+                {% if cve.priority == 'unknown' %}
+                  <img src="https://assets.ubuntu.com/v1/2dff197f-CVE-Priority-icon-Unknown.svg"
+                       alt=""
+                       class="p-heading-icon__img" />
+                {% endif %}
+
+                {% if cve.priority == 'negligible' %}
+                  <img src="https://assets.ubuntu.com/v1/ef6c75b8-CVE-Priority-icon-Negligible.svg"
+                       alt=""
+                       class="p-heading-icon__img" />
+                {% endif %}
+
+                {% if cve.priority == 'low' %}
+                  <img src="https://assets.ubuntu.com/v1/03ac6f86-CVE-Priority-icon-Low.svg"
+                       alt=""
+                       class="p-heading-icon__img" />
+                {% endif %}
+
+                {% if cve.priority == 'medium' %}
+                  <img src="https://assets.ubuntu.com/v1/8010f9e0-CVE-Priority-icon-Medium.svg"
+                       alt=""
+                       class="p-heading-icon__img" />
+                {% endif %}
+
+                {% if cve.priority == 'high' %}
+                  <img src="https://assets.ubuntu.com/v1/3887354e-CVE-Priority-icon-High.svg"
+                       alt=""
+                       class="p-heading-icon__img" />
+                {% endif %}
+
+                {% if cve.priority == 'critical' %}
+                  <img src="https://assets.ubuntu.com/v1/c96f27b9-CVE-Priority-icon-Critical.svg"
+                       alt=""
+                       class="p-heading-icon__img" />
+                {% endif %}
+                <p class="p-heading-icon__title u-no-margin--bottom p-heading--4">{{ cve.priority | capitalize }}</p>
+              </div>
+            </div>
+          </div>
+          {% if cvssV3 %}
+            <div class="cve-status-box u-no-margin--bottom">
+              <h2 class="p-muted-heading">Cvss 3 Severity Score</h2>
+              <p class="u-no-margin--bottom p-heading--4">{{ cvssV3.baseScore }}</p>
+              <p class="p-heading--5 u-no-margin--bottom">
+                <a href="#impact-score">Score breakdown</a>
+              </p>
+            </div>
+          {% elif cve.cvss3 %}
+            <p>CVSS 3 base score: {{ cve.cvss3 }}</p>
+          {% endif %}
+
+        {% endif %}
+
+        {% if cve.status == 'rejected' %}
+          <div class="cve-status-box--highlight">
+            <div class="p-heading--4 u-no-margin--bottom">Rejected</div>
+          </div>
+        {% endif %}
+
+        {% if cve.status == 'not-in-ubuntu' %}
+          <div class="cve-status-box--highlight">
+            <div class="p-heading--4 u-no-margin--bottom">Not in Ubuntu</div>
+          </div>
+        {% endif %}
+      </div>
+
     </div>
-
-  </div>
 
     {% if cve.status == 'active' %}
-    <div class="row">
-      <div class="col-9">
-        <h2>Status</h2>
-        <table class="cve-table">
-          <thead>
-            <tr>
-              <th>Package</th>
-              <th>Release</th>
-              <th>Status</th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for package in cve.packages %}
-              {% for status in package.statuses %}
-                <tr>
-                  {% if status.release_codename %}
-                    {% if loop.index == 1 %}
-                      <td rowspan="{{ package.statuses | length }}">
-                        <a href="/security/cves?q=&package={{ package["name"] }}">{{ package["name"] }}</a><br>
-                        <small>
-                        {% if package["name"] in kenetic_packages or package["name"] in melodic_packages  %}
-                          <a href="/robotics/ros-esm">ROS ESM</a>
+      <div class="row">
+        <div class="col-9">
+          <h2>Status</h2>
+          <table class="cve-table">
+            <thead>
+              <tr>
+                <th>Package</th>
+                <th>Release</th>
+                <th>Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for package in cve.packages %}
+                {% for status in package.statuses %}
+                  <tr>
+                    {% if status.release_codename %}
+                      {% if loop.index == 1 %}
+                        <td rowspan="{{ package.statuses | length }}">
+                          <a href="/security/cves?q=&package={{ package["name"] }}">{{ package["name"] }}</a>
+                          <br />
+                          <small>
+                            {% if package["name"] in kenetic_packages or package["name"] in melodic_packages %}
+                              <a href="/robotics/ros-esm">ROS ESM</a>
+                            {% else %}
+                              <a href="https://launchpad.net/ubuntu/+source/{{ package["name"] }}">Launchpad</a>,
+                              <a href="https://packages.ubuntu.com/search?suite=all&section=all&arch=any&searchon=sourcenames&keywords={{ package["name"] }}">Ubuntu</a>,
+                              <a href="https://tracker.debian.org/{{ package["name"] }}">Debian</a>
+                            {% endif %}
+                          </small>
+                        </td>
+                      {% endif %}
+                      <td>{{ status.release_codename }}</td>
+                      {% if status.status == "DNE" or status.status == "not-affected" %}
+                        <td class="cve-table-cell--muted">
                         {% else %}
-                          <a href="https://launchpad.net/ubuntu/+source/{{ package["name"] }}">Launchpad</a>,
-                          <a href="https://packages.ubuntu.com/search?suite=all&section=all&arch=any&searchon=sourcenames&keywords={{ package["name"] }}">Ubuntu</a>,
-                          <a href="https://tracker.debian.org/{{ package["name"] }}">Debian</a>
-                        {% endif %}
+                          <td class="cve-table-cell">
+                          {% endif %}
+                          {% if status.status == "DNE" %}
+                            Does not exist
+                            <div class="cve-color-strip--dne"></div>
+                          {% elif status.status == "needs-triage" %}
+                            Needs triage
+                            <div class="cve-color-strip--needs-triage"></div>
+                          {% elif status.status == "not-affected" %}
+                            Not vulnerable
+                            <div class="cve-color-strip--not-affected"></div>
+                          {% elif status.status == "needed" %}
+                            Needed
+                            <div class="cve-color-strip--needed"></div>
+                          {% elif status.status == "deferred" %}
+                            Deferred
+                            <div class="cve-color-strip--deferred"></div>
+                          {% elif status.status == "ignored" %}
+                            Ignored
+                            <div class="cve-color-strip--ignored"></div>
+                          {% elif status.status == "pending" %}
+                            Pending
+                            <div class="cve-color-strip--pending"></div>
+                          {% elif status.status == "released" %}
+                            <div class="cve-color-strip--released"></div>
+                            Released
+                          {% endif %}
+                          {% if status.description %}({{ status.description }}){% endif %}
+                          <br />
+                          <small>
+                            {% if status.pocket == "esm-infra" %}
+                              <a href="/pro">Available with Ubuntu Pro or Ubuntu Pro (Infra-only)</a>
+                            {% endif %}
+                            {% if status.pocket == "esm-apps" %}<a href="/pro">Available with Ubuntu Pro</a>{% endif %}
+                          </small>
+                        </td>
+                      {% endif %}
+                    </tr>
+                  {% endfor %}
+                  {% if package["name"] in patches|map(attribute="name") %}
+                    <tr>
+                      <td style="border-top: 0px"></td>
+                      <td colspan="2">
+                        Patches:
+                        <br />
+                        <small>
+                          {% for patch in patches %}
+                            {% if patch.name == package["name"] %}
+                              {% if patch.type == "text" %}
+                                {{ patch.content }}
+                              {% elif patch.type == "break-fix" %}
+                                Introduced by
+                                <p>
+                                  <a href="https://git.kernel.org/linus/{{ patch.content.introduced }}">{{ patch.content.introduced }}</a>
+                                  <br />
+                                </p>
+                                Fixed by
+                                <a href="https://git.kernel.org/linus/{{ patch.content.fixed }}">{{ patch.content.fixed }}</a>
+                              {% elif patch.type == "link" %}
+                                {{ patch.content.prefix }}:
+                                {% if patch.content.suffix %}
+                                  <a href="{{ patch.content.suffix }}">{{ patch.content.suffix }}</a>
+                                {% else %}
+                                  {{ patch.content.suffix }}
+                                {% endif %}
+                              {% endif %}
+                            {% endif %}
+                            <br />
+                          {% endfor %}
                         </small>
                       </td>
-                    {% endif %}
-                    <td>
-                      {{ status.release_codename }}
-                    </td>
-                    {% if status.status == "DNE" or status.status == "not-affected" %}
-                      <td class="cve-table-cell--muted">
-                    {% else %}
-                      <td class="cve-table-cell">
-                    {% endif %}
-                    {% if status.status == "DNE" %}
-                      Does not exist
-                      <div class="cve-color-strip--dne"></div>
-                    {% elif status.status == "needs-triage" %}
-                      Needs triage
-                      <div class="cve-color-strip--needs-triage"></div>
-                    {% elif status.status == "not-affected" %}
-                      Not vulnerable
-                      <div class="cve-color-strip--not-affected"></div>
-                    {% elif status.status == "needed" %}
-                      Needed
-                      <div class="cve-color-strip--needed"></div>
-                    {% elif status.status == "deferred" %}
-                      Deferred
-                      <div class="cve-color-strip--deferred"></div>
-                    {% elif status.status == "ignored" %}
-                      Ignored
-                      <div class="cve-color-strip--ignored"></div>
-                    {% elif status.status == "pending" %}
-                      Pending
-                      <div class="cve-color-strip--pending"></div>
-                    {% elif status.status == "released" %}
-                      <div class="cve-color-strip--released"></div>
-                      Released
-                    {% endif %}
-                    {% if status.description %}
-                      ({{ status.description }})
-                    {% endif %}
-                    <br>
-                    <small>
-                      {% if status.pocket == "esm-infra" %}
-                        <a href="/pro">Available with Ubuntu Pro or Ubuntu Pro (Infra-only)</a>
-                      {% endif %}
-                      {% if status.pocket == "esm-apps" %}
-                        <a href="/pro">Available with Ubuntu Pro</a>
-                      {% endif %}
-                    </small>
-                    </td>
+                    </tr>
                   {% endif %}
-                </tr>
-              {% endfor %}
-              {% if package["name"] in patches|map(attribute="name")%}
-                <tr>
-                  <td style="border-top: 0px"></td>
-                  <td colspan="2">
-                    Patches: <br>
-                    <small>
-                      {% for patch in patches %}
-                        {% if patch.name == package["name"]%}
-                          {% if patch.type == "text" %}
-                            {{ patch.content }}
-                          {% elif patch.type == "break-fix" %}
-                            Introduced by
-                            <p><a href="https://git.kernel.org/linus/{{ patch.content.introduced }}">{{ patch.content.introduced }}</a><br>
-                            </p>
-                              Fixed by
-                            <a href="https://git.kernel.org/linus/{{ patch.content.fixed }}">{{ patch.content.fixed }}</a>
-                          {% elif patch.type == "link" %}
-                            {{ patch.content.prefix }}:
-                            {% if patch.content.suffix %}
-                              <a href="{{ patch.content.suffix }}">{{ patch.content.suffix }}</a>
-                            {% else %}
-                              {{ patch.content.suffix }}
+                  {% if package["name"] in tags|map(attribute="name") %}
+                    <tr>
+                      <td style="border-top: 0px"></td>
+                      <td colspan="2" style="border-top: 5px double #cdcdcd">
+                        <small>
+                          {% for tag in tags %}
+                            {% if tag.name == package["name"] %}
+                              {% if tag.text == "not-ue" %}
+                                This package is not directly supported by the Ubuntu Security Team
+                              {% elif tag.text == "universe-binary" %}
+                                Binaries built from this source package are in <a href="https://wiki.ubuntu.com/SecurityTeam/FAQ#Official_Support">Universe</a> and so are supported by the community.
+                              {% elif tag.text == "apparmor" %}
+                                This vulnerability is mitigated in part by an <a href="https://wiki.ubuntu.com/Security/Features#apparmor">AppArmor</a> profile.
+                              {% elif tag.text == "stack-protector" %}
+                                This vulnerability is mitigated in part by the use of gcc's <a href="https://wiki.ubuntu.com/Security/Features#stack-protector">stack protector</a> in Ubuntu.
+                              {% elif tag.text == "fortify-source" %}
+                                This vulnerability is mitigated in part by the use of <a href="https://wiki.ubuntu.com/Security/Features#fortify-source">-D_FORTIFY_SOURCE=2</a> in Ubuntu.
+                              {% elif tag.text == "symlink-restriction" %}
+                                This vulnerability is mitigated in part by the use of <a href="https://wiki.ubuntu.com/Security/Features#symlink">symlink</a> restrictions in Ubuntu.
+                              {% elif tag.text == "hardlink-restriction" %}
+                                This vulnerability is mitigated in part by the use of <a href="https://wiki.ubuntu.com/Security/Features#hardlink">hardlink</a> restrictions in Ubuntu.
+                              {% elif tag.text == "heap-protector" %}
+                                This vulnerability is mitigated in part by the use of GNU C Library <a href="https://wiki.ubuntu.com/Security/Features#heap-protector">heap protector</a> in Ubuntu.
+                              {% elif tag.text == "pie" %}
+                                This vulnerability is mitigated in part by the use of <a href="https://wiki.ubuntu.com/Security/Features#pie">Position Independent Executables</a> in Ubuntu.
+                              {% else %}
+                                {{ tag.text }}
+                              {% endif %}
                             {% endif %}
-                          {% endif %}
-                        {% endif %}
-                        <br>
-                      {% endfor %}
-                    </small>
-                  </td>
-                </tr>
-              {% endif%}
-              {% if package["name"] in tags|map(attribute="name") %}
+                          {% endfor %}
+                        </small>
+                      </td>
+                    </tr>
+                  {% endif %}
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      {% endif %}
+
+      {% if cvssV3 %}
+        <div class="row" id="impact-score">
+          <div class="col-9">
+            <h2>Severity score breakdown</h2>
+            <table>
+              <thead>
                 <tr>
-                  <td style="border-top: 0px"></td>
-                  <td colspan="2" style="border-top: 5px double #cdcdcd">
-                    <small>
-                        {% for tag in tags %}
-                          {% if tag.name == package["name"] %}
-                            {% if tag.text == "not-ue" %}
-                              This package is not directly supported by the Ubuntu Security Team
-                            {% elif tag.text == "universe-binary" %}
-                              Binaries built from this source package are in <a href="https://wiki.ubuntu.com/SecurityTeam/FAQ#Official_Support">Universe</a> and so are supported by the community.
-                            {% elif tag.text == "apparmor" %}
-                              This vulnerability is mitigated in part by an <a href="https://wiki.ubuntu.com/Security/Features#apparmor">AppArmor</a> profile.
-                            {% elif tag.text == "stack-protector" %}
-                              This vulnerability is mitigated in part by the use of gcc's <a href="https://wiki.ubuntu.com/Security/Features#stack-protector">stack protector</a> in Ubuntu.
-                            {% elif tag.text == "fortify-source" %}
-                              This vulnerability is mitigated in part by the use of <a href="https://wiki.ubuntu.com/Security/Features#fortify-source">-D_FORTIFY_SOURCE=2</a> in Ubuntu.
-                            {% elif tag.text == "symlink-restriction" %}
-                              This vulnerability is mitigated in part by the use of <a href="https://wiki.ubuntu.com/Security/Features#symlink">symlink</a> restrictions in Ubuntu.
-                            {% elif tag.text == "hardlink-restriction" %}
-                              This vulnerability is mitigated in part by the use of <a href="https://wiki.ubuntu.com/Security/Features#hardlink">hardlink</a> restrictions in Ubuntu.
-                            {% elif tag.text == "heap-protector" %}
-                              This vulnerability is mitigated in part by the use of GNU C Library <a href="https://wiki.ubuntu.com/Security/Features#heap-protector">heap protector</a> in Ubuntu.
-                            {% elif tag.text == "pie" %}
-                              This vulnerability is mitigated in part by the use of <a href="https://wiki.ubuntu.com/Security/Features#pie">Position Independent Executables</a> in Ubuntu.
-                            {% else %}
-                              {{ tag.text }}
-                            {% endif %}
-                          {% endif %}
-                        {% endfor %}
-                    </small>
-                  </td>
+                  <th style="width: 17rem;">Parameter</th>
+                  <th class="u-align--left">Value</th>
                 </tr>
-              {% endif %}
-              {% endfor %}
-          </tbody>
-        </table>
-      </div>
-    </div>
-    {% endif %}
+              </thead>
+              <tbody>
+                <tr>
+                  <th>Base score</th>
+                  <td>{{ cvssV3.baseScore }}</td>
+                </tr>
+                <tr>
+                  <th>Attack vector</th>
+                  <td>{{ cvssV3.attackVector | capitalize }}</td>
+                </tr>
+                <tr>
+                  <th>Attack complexity</th>
+                  <td>{{ cvssV3.attackComplexity | capitalize }}</td>
+                </tr>
+                <tr>
+                  <th>Privileges required</th>
+                  <td>{{ cvssV3.privilegesRequired | capitalize }}</td>
+                </tr>
+                <tr>
+                  <th>User interaction</th>
+                  <td>{{ cvssV3.userInteraction | capitalize }}</td>
+                </tr>
+                <tr>
+                  <th>Scope</th>
+                  <td>{{ cvssV3.scope | capitalize }}</td>
+                </tr>
+                <tr>
+                  <th>Confidentiality</th>
+                  <td>{{ cvssV3.confidentialityImpact | capitalize }}</td>
+                </tr>
+                <tr>
+                  <th>Integrity impact</th>
+                  <td>{{ cvssV3.integrityImpact | capitalize }}</td>
+                </tr>
+                <tr>
+                  <th>Availability impact</th>
+                  <td>{{ cvssV3.availabilityImpact | capitalize }}</td>
+                </tr>
+                <tr>
+                  <th>Vector</th>
+                  <td>{{ cvssV3.vectorString }}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      {% endif %}
 
-    {% if cvssV3 %}
-    <div class="row" id="impact-score">
-      <div class="col-9">
-        <h2>Severity score breakdown</h2>
-        <table>
-          <thead>
-            <tr>
-              <th style="width: 17rem;">Parameter</th>
-              <th class="u-align--left">Value</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <th>Base score</th>
-              <td>{{cvssV3.baseScore}}</td>
-            </tr>
-            <tr>
-              <th>Attack vector</th>
-              <td>{{cvssV3.attackVector | capitalize}}</td>
-            </tr>
-            <tr>
-              <th>Attack complexity</th>
-              <td>{{cvssV3.attackComplexity | capitalize}}</td>
-            </tr>
-            <tr>
-              <th>Privileges required</th>
-              <td>{{cvssV3.privilegesRequired | capitalize}}</td>
-            </tr>
-            <tr>
-              <th>User interaction</th>
-              <td>{{cvssV3.userInteraction | capitalize}}</td>
-            </tr>
-            <tr>
-              <th>Scope</th>
-              <td>{{cvssV3.scope | capitalize}}</td>
-            </tr>
-            <tr>
-              <th>Confidentiality</th>
-              <td>{{cvssV3.confidentialityImpact | capitalize}}</td>
-            </tr>
-            <tr>
-              <th>Integrity impact</th>
-              <td>{{cvssV3.integrityImpact | capitalize}}</td>
-            </tr>
-            <tr>
-              <th>Availability impact</th>
-              <td>{{cvssV3.availabilityImpact | capitalize}}</td>
-            </tr>
-            <tr>
-              <th>Vector</th>
-              <td>{{cvssV3.vectorString}}</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </div>
-    {% endif %}
-
-    <div class="row">
-      <div class="col-9">
-        <h2>References</h2>
-        <ul>
-          {% if cve.references %}
-            {% for reference in cve.references %}
-              
-                <li><a href="{{ reference }}">{{ reference }}</a></li>
-    
-            {% endfor %}
-          {% else %}
-            <li>
-              <a href="https://cve.mitre.org/cgi-bin/cvename.cgi?name={{ cve.id }}">
-                MITRE
-              </a>
-            </li>
-          {% endif %}
-          <li>
-            <a href="https://nvd.nist.gov/vuln/detail/{{ cve.id }}">
-              NVD
-            </a>
-          </li>
-          <li>
-            <a href="https://launchpad.net/bugs/cve/{{ cve.id }}">
-              Launchpad
-            </a>
-          </li>
-          <li>
-            <a href="https://security-tracker.debian.org/tracker/{{ cve.id }}">Debian</a>
-          </li>
-        </ul>
-
-        {% if cve.bugs and "" not in cve.bugs %}
-          <h2>Bugs</h2>
+      <div class="row">
+        <div class="col-9">
+          <h2>References</h2>
           <ul>
-            {% for bug in cve.bugs %}
-              {% if 'http' in bug %}
-                <li><a href="{{ bug }}">{{ bug }}</a></li>
-              {% endif %}
-            {% endfor %}
-          </ul>
-        {% endif %}
-      </div>
-    </div>
-  </section>
+            {% if cve.references %}
+              {% for reference in cve.references %}
 
-  {% with first_item="_security_discussion", second_item="_security_esm",
-third_item="_security_further_reading" %}{% include
-"shared/contextual_footers/_contextual_footer.html" %}{% endwith %} {% endblock %}
+                <li>
+                  <a href="{{ reference }}">{{ reference }}</a>
+                </li>
+
+              {% endfor %}
+            {% else %}
+              <li>
+                <a href="https://cve.mitre.org/cgi-bin/cvename.cgi?name={{ cve.id }}">MITRE</a>
+              </li>
+            {% endif %}
+
+            {% if cve.notices_ids %}
+              {% for notice in cve.notices_ids %}
+                {% if 'LSN' in notice %}
+                  <li>
+                    <a href="https://ubuntu.com/security/notices/{{ notice }}">https://ubuntu.com/security/notices/{{ notice }}</a>
+                  </li>
+                {% endif %}
+              {% endfor %}
+            {% endif %}
+
+            <li>
+              <a href="https://nvd.nist.gov/vuln/detail/{{ cve.id }}">NVD</a>
+            </li>
+            <li>
+              <a href="https://launchpad.net/bugs/cve/{{ cve.id }}">Launchpad</a>
+            </li>
+            <li>
+              <a href="https://security-tracker.debian.org/tracker/{{ cve.id }}">Debian</a>
+            </li>
+          </ul>
+
+          {{ cve.notices_ids }}
+
+          {% if cve.bugs and "" not in cve.bugs %}
+            <h2>Bugs</h2>
+            <ul>
+              {% for bug in cve.bugs %}
+                {% if 'http' in bug %}
+                  <li>
+                    <a href="{{ bug }}">{{ bug }}</a>
+                  </li>
+                {% endif %}
+              {% endfor %}
+            </ul>
+          {% endif %}
+        </div>
+      </div>
+    </section>
+
+    {% with first_item="_security_discussion", second_item="_security_esm",
+      third_item="_security_further_reading" %}
+      {% include
+      "shared/contextual_footers/_contextual_footer.html" %}
+    {% endwith %}
+
+  {% endblock %}

--- a/templates/security/cve/cve.html
+++ b/templates/security/cve/cve.html
@@ -160,242 +160,240 @@
                         </td>
                       {% endif %}
                       <td>{{ status.release_codename }}</td>
-                      {% if status.status == "DNE" or status.status == "not-affected" %}
-                        <td class="cve-table-cell--muted">
-                        {% else %}
-                          <td class="cve-table-cell">
-                          {% endif %}
-                          {% if status.status == "DNE" %}
-                            Does not exist
-                            <div class="cve-color-strip--dne"></div>
-                          {% elif status.status == "needs-triage" %}
-                            Needs triage
-                            <div class="cve-color-strip--needs-triage"></div>
-                          {% elif status.status == "not-affected" %}
-                            Not vulnerable
-                            <div class="cve-color-strip--not-affected"></div>
-                          {% elif status.status == "needed" %}
-                            Needed
-                            <div class="cve-color-strip--needed"></div>
-                          {% elif status.status == "deferred" %}
-                            Deferred
-                            <div class="cve-color-strip--deferred"></div>
-                          {% elif status.status == "ignored" %}
-                            Ignored
-                            <div class="cve-color-strip--ignored"></div>
-                          {% elif status.status == "pending" %}
-                            Pending
-                            <div class="cve-color-strip--pending"></div>
-                          {% elif status.status == "released" %}
-                            <div class="cve-color-strip--released"></div>
-                            Released
-                          {% endif %}
-                          {% if status.description %}({{ status.description }}){% endif %}
-                          <br />
-                          <small>
-                            {% if status.pocket == "esm-infra" %}
-                              <a href="/pro">Available with Ubuntu Pro or Ubuntu Pro (Infra-only)</a>
-                            {% endif %}
-                            {% if status.pocket == "esm-apps" %}<a href="/pro">Available with Ubuntu Pro</a>{% endif %}
-                          </small>
-                        </td>
-                      {% endif %}
-                    </tr>
-                  {% endfor %}
-                  {% if package["name"] in patches|map(attribute="name") %}
-                    <tr>
-                      <td style="border-top: 0px"></td>
-                      <td colspan="2">
-                        Patches:
+
+                      <td class="cve-table-cell{% if status.status == "DNE" or status.status == "not-affected" %}--muted{% endif %}">
+
+                        {% if status.status == "DNE" %}
+                          Does not exist
+                          <div class="cve-color-strip--dne"></div>
+                        {% elif status.status == "needs-triage" %}
+                          Needs triage
+                          <div class="cve-color-strip--needs-triage"></div>
+                        {% elif status.status == "not-affected" %}
+                          Not vulnerable
+                          <div class="cve-color-strip--not-affected"></div>
+                        {% elif status.status == "needed" %}
+                          Needed
+                          <div class="cve-color-strip--needed"></div>
+                        {% elif status.status == "deferred" %}
+                          Deferred
+                          <div class="cve-color-strip--deferred"></div>
+                        {% elif status.status == "ignored" %}
+                          Ignored
+                          <div class="cve-color-strip--ignored"></div>
+                        {% elif status.status == "pending" %}
+                          Pending
+                          <div class="cve-color-strip--pending"></div>
+                        {% elif status.status == "released" %}
+                          <div class="cve-color-strip--released"></div>
+                          Released
+                        {% endif %}
+                        {% if status.description %}({{ status.description }}){% endif %}
                         <br />
                         <small>
-                          {% for patch in patches %}
-                            {% if patch.name == package["name"] %}
-                              {% if patch.type == "text" %}
-                                {{ patch.content }}
-                              {% elif patch.type == "break-fix" %}
-                                Introduced by
-                                <p>
-                                  <a href="https://git.kernel.org/linus/{{ patch.content.introduced }}">{{ patch.content.introduced }}</a>
-                                  <br />
-                                </p>
-                                Fixed by
-                                <a href="https://git.kernel.org/linus/{{ patch.content.fixed }}">{{ patch.content.fixed }}</a>
-                              {% elif patch.type == "link" %}
-                                {{ patch.content.prefix }}:
-                                {% if patch.content.suffix %}
-                                  <a href="{{ patch.content.suffix }}">{{ patch.content.suffix }}</a>
-                                {% else %}
-                                  {{ patch.content.suffix }}
-                                {% endif %}
-                              {% endif %}
-                            {% endif %}
-                            <br />
-                          {% endfor %}
+                          {% if status.pocket == "esm-infra" %}
+                            <a href="/pro">Available with Ubuntu Pro or Ubuntu Pro (Infra-only)</a>
+                          {% endif %}
+                          {% if status.pocket == "esm-apps" %}<a href="/pro">Available with Ubuntu Pro</a>{% endif %}
                         </small>
                       </td>
-                    </tr>
-                  {% endif %}
-                  {% if package["name"] in tags|map(attribute="name") %}
-                    <tr>
-                      <td style="border-top: 0px"></td>
-                      <td colspan="2" style="border-top: 5px double #cdcdcd">
-                        <small>
-                          {% for tag in tags %}
-                            {% if tag.name == package["name"] %}
-                              {% if tag.text == "not-ue" %}
-                                This package is not directly supported by the Ubuntu Security Team
-                              {% elif tag.text == "universe-binary" %}
-                                Binaries built from this source package are in <a href="https://wiki.ubuntu.com/SecurityTeam/FAQ#Official_Support">Universe</a> and so are supported by the community.
-                              {% elif tag.text == "apparmor" %}
-                                This vulnerability is mitigated in part by an <a href="https://wiki.ubuntu.com/Security/Features#apparmor">AppArmor</a> profile.
-                              {% elif tag.text == "stack-protector" %}
-                                This vulnerability is mitigated in part by the use of gcc's <a href="https://wiki.ubuntu.com/Security/Features#stack-protector">stack protector</a> in Ubuntu.
-                              {% elif tag.text == "fortify-source" %}
-                                This vulnerability is mitigated in part by the use of <a href="https://wiki.ubuntu.com/Security/Features#fortify-source">-D_FORTIFY_SOURCE=2</a> in Ubuntu.
-                              {% elif tag.text == "symlink-restriction" %}
-                                This vulnerability is mitigated in part by the use of <a href="https://wiki.ubuntu.com/Security/Features#symlink">symlink</a> restrictions in Ubuntu.
-                              {% elif tag.text == "hardlink-restriction" %}
-                                This vulnerability is mitigated in part by the use of <a href="https://wiki.ubuntu.com/Security/Features#hardlink">hardlink</a> restrictions in Ubuntu.
-                              {% elif tag.text == "heap-protector" %}
-                                This vulnerability is mitigated in part by the use of GNU C Library <a href="https://wiki.ubuntu.com/Security/Features#heap-protector">heap protector</a> in Ubuntu.
-                              {% elif tag.text == "pie" %}
-                                This vulnerability is mitigated in part by the use of <a href="https://wiki.ubuntu.com/Security/Features#pie">Position Independent Executables</a> in Ubuntu.
-                              {% else %}
-                                {{ tag.text }}
-                              {% endif %}
-                            {% endif %}
-                          {% endfor %}
-                        </small>
-                      </td>
-                    </tr>
-                  {% endif %}
+                    {% endif %}
+                  </tr>
                 {% endfor %}
-              </tbody>
-            </table>
-          </div>
-        </div>
-      {% endif %}
-
-      {% if cvssV3 %}
-        <div class="row" id="impact-score">
-          <div class="col-9">
-            <h2>Severity score breakdown</h2>
-            <table>
-              <thead>
-                <tr>
-                  <th style="width: 17rem;">Parameter</th>
-                  <th class="u-align--left">Value</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <th>Base score</th>
-                  <td>{{ cvssV3.baseScore }}</td>
-                </tr>
-                <tr>
-                  <th>Attack vector</th>
-                  <td>{{ cvssV3.attackVector | capitalize }}</td>
-                </tr>
-                <tr>
-                  <th>Attack complexity</th>
-                  <td>{{ cvssV3.attackComplexity | capitalize }}</td>
-                </tr>
-                <tr>
-                  <th>Privileges required</th>
-                  <td>{{ cvssV3.privilegesRequired | capitalize }}</td>
-                </tr>
-                <tr>
-                  <th>User interaction</th>
-                  <td>{{ cvssV3.userInteraction | capitalize }}</td>
-                </tr>
-                <tr>
-                  <th>Scope</th>
-                  <td>{{ cvssV3.scope | capitalize }}</td>
-                </tr>
-                <tr>
-                  <th>Confidentiality</th>
-                  <td>{{ cvssV3.confidentialityImpact | capitalize }}</td>
-                </tr>
-                <tr>
-                  <th>Integrity impact</th>
-                  <td>{{ cvssV3.integrityImpact | capitalize }}</td>
-                </tr>
-                <tr>
-                  <th>Availability impact</th>
-                  <td>{{ cvssV3.availabilityImpact | capitalize }}</td>
-                </tr>
-                <tr>
-                  <th>Vector</th>
-                  <td>{{ cvssV3.vectorString }}</td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </div>
-      {% endif %}
-
-      <div class="row">
-        <div class="col-9">
-          <h2>References</h2>
-          <ul>
-            {% if cve.references %}
-              {% for reference in cve.references %}
-
-                <li>
-                  <a href="{{ reference }}">{{ reference }}</a>
-                </li>
-
-              {% endfor %}
-            {% else %}
-              <li>
-                <a href="https://cve.mitre.org/cgi-bin/cvename.cgi?name={{ cve.id }}">MITRE</a>
-              </li>
-            {% endif %}
-
-            {% if cve.notices_ids %}
-              {% for notice in cve.notices_ids %}
-                {% if 'LSN' in notice %}
-                  <li>
-                    <a href="https://ubuntu.com/security/notices/{{ notice }}">https://ubuntu.com/security/notices/{{ notice }}</a>
-                  </li>
+                {% if package["name"] in patches|map(attribute="name") %}
+                  <tr>
+                    <td style="border-top: 0px"></td>
+                    <td colspan="2">
+                      Patches:
+                      <br />
+                      <small>
+                        {% for patch in patches %}
+                          {% if patch.name == package["name"] %}
+                            {% if patch.type == "text" %}
+                              {{ patch.content }}
+                            {% elif patch.type == "break-fix" %}
+                              Introduced by
+                              <p>
+                                <a href="https://git.kernel.org/linus/{{ patch.content.introduced }}">{{ patch.content.introduced }}</a>
+                                <br />
+                              </p>
+                              Fixed by
+                              <a href="https://git.kernel.org/linus/{{ patch.content.fixed }}">{{ patch.content.fixed }}</a>
+                            {% elif patch.type == "link" %}
+                              {{ patch.content.prefix }}:
+                              {% if patch.content.suffix %}
+                                <a href="{{ patch.content.suffix }}">{{ patch.content.suffix }}</a>
+                              {% else %}
+                                {{ patch.content.suffix }}
+                              {% endif %}
+                            {% endif %}
+                          {% endif %}
+                          <br />
+                        {% endfor %}
+                      </small>
+                    </td>
+                  </tr>
+                {% endif %}
+                {% if package["name"] in tags|map(attribute="name") %}
+                  <tr>
+                    <td style="border-top: 0px"></td>
+                    <td colspan="2" style="border-top: 5px double #cdcdcd">
+                      <small>
+                        {% for tag in tags %}
+                          {% if tag.name == package["name"] %}
+                            {% if tag.text == "not-ue" %}
+                              This package is not directly supported by the Ubuntu Security Team
+                            {% elif tag.text == "universe-binary" %}
+                              Binaries built from this source package are in <a href="https://wiki.ubuntu.com/SecurityTeam/FAQ#Official_Support">Universe</a> and so are supported by the community.
+                            {% elif tag.text == "apparmor" %}
+                              This vulnerability is mitigated in part by an <a href="https://wiki.ubuntu.com/Security/Features#apparmor">AppArmor</a> profile.
+                            {% elif tag.text == "stack-protector" %}
+                              This vulnerability is mitigated in part by the use of gcc's <a href="https://wiki.ubuntu.com/Security/Features#stack-protector">stack protector</a> in Ubuntu.
+                            {% elif tag.text == "fortify-source" %}
+                              This vulnerability is mitigated in part by the use of <a href="https://wiki.ubuntu.com/Security/Features#fortify-source">-D_FORTIFY_SOURCE=2</a> in Ubuntu.
+                            {% elif tag.text == "symlink-restriction" %}
+                              This vulnerability is mitigated in part by the use of <a href="https://wiki.ubuntu.com/Security/Features#symlink">symlink</a> restrictions in Ubuntu.
+                            {% elif tag.text == "hardlink-restriction" %}
+                              This vulnerability is mitigated in part by the use of <a href="https://wiki.ubuntu.com/Security/Features#hardlink">hardlink</a> restrictions in Ubuntu.
+                            {% elif tag.text == "heap-protector" %}
+                              This vulnerability is mitigated in part by the use of GNU C Library <a href="https://wiki.ubuntu.com/Security/Features#heap-protector">heap protector</a> in Ubuntu.
+                            {% elif tag.text == "pie" %}
+                              This vulnerability is mitigated in part by the use of <a href="https://wiki.ubuntu.com/Security/Features#pie">Position Independent Executables</a> in Ubuntu.
+                            {% else %}
+                              {{ tag.text }}
+                            {% endif %}
+                          {% endif %}
+                        {% endfor %}
+                      </small>
+                    </td>
+                  </tr>
                 {% endif %}
               {% endfor %}
-            {% endif %}
-
-            <li>
-              <a href="https://nvd.nist.gov/vuln/detail/{{ cve.id }}">NVD</a>
-            </li>
-            <li>
-              <a href="https://launchpad.net/bugs/cve/{{ cve.id }}">Launchpad</a>
-            </li>
-            <li>
-              <a href="https://security-tracker.debian.org/tracker/{{ cve.id }}">Debian</a>
-            </li>
-          </ul>
-
-          {{ cve.notices_ids }}
-
-          {% if cve.bugs and "" not in cve.bugs %}
-            <h2>Bugs</h2>
-            <ul>
-              {% for bug in cve.bugs %}
-                {% if 'http' in bug %}
-                  <li>
-                    <a href="{{ bug }}">{{ bug }}</a>
-                  </li>
-                {% endif %}
-              {% endfor %}
-            </ul>
-          {% endif %}
+            </tbody>
+          </table>
         </div>
       </div>
-    </section>
+    {% endif %}
 
-    {% with first_item="_security_discussion", second_item="_security_esm",
-      third_item="_security_further_reading" %}
-      {% include
-      "shared/contextual_footers/_contextual_footer.html" %}
-    {% endwith %}
+    {% if cvssV3 %}
+      <div class="row" id="impact-score">
+        <div class="col-9">
+          <h2>Severity score breakdown</h2>
+          <table>
+            <thead>
+              <tr>
+                <th style="width: 17rem;">Parameter</th>
+                <th class="u-align--left">Value</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th>Base score</th>
+                <td>{{ cvssV3.baseScore }}</td>
+              </tr>
+              <tr>
+                <th>Attack vector</th>
+                <td>{{ cvssV3.attackVector | capitalize }}</td>
+              </tr>
+              <tr>
+                <th>Attack complexity</th>
+                <td>{{ cvssV3.attackComplexity | capitalize }}</td>
+              </tr>
+              <tr>
+                <th>Privileges required</th>
+                <td>{{ cvssV3.privilegesRequired | capitalize }}</td>
+              </tr>
+              <tr>
+                <th>User interaction</th>
+                <td>{{ cvssV3.userInteraction | capitalize }}</td>
+              </tr>
+              <tr>
+                <th>Scope</th>
+                <td>{{ cvssV3.scope | capitalize }}</td>
+              </tr>
+              <tr>
+                <th>Confidentiality</th>
+                <td>{{ cvssV3.confidentialityImpact | capitalize }}</td>
+              </tr>
+              <tr>
+                <th>Integrity impact</th>
+                <td>{{ cvssV3.integrityImpact | capitalize }}</td>
+              </tr>
+              <tr>
+                <th>Availability impact</th>
+                <td>{{ cvssV3.availabilityImpact | capitalize }}</td>
+              </tr>
+              <tr>
+                <th>Vector</th>
+                <td>{{ cvssV3.vectorString }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    {% endif %}
 
-  {% endblock %}
+    <div class="row">
+      <div class="col-9">
+        <h2>References</h2>
+        <ul>
+          {% if cve.references %}
+            {% for reference in cve.references %}
+
+              <li>
+                <a href="{{ reference }}">{{ reference }}</a>
+              </li>
+
+            {% endfor %}
+          {% else %}
+            <li>
+              <a href="https://cve.mitre.org/cgi-bin/cvename.cgi?name={{ cve.id }}">MITRE</a>
+            </li>
+          {% endif %}
+
+          {% if cve.notices_ids %}
+            {% for notice in cve.notices_ids %}
+              {% if 'LSN' in notice %}
+                <li>
+                  <a href="https://ubuntu.com/security/notices/{{ notice }}">https://ubuntu.com/security/notices/{{ notice }}</a>
+                </li>
+              {% endif %}
+            {% endfor %}
+          {% endif %}
+
+          <li>
+            <a href="https://nvd.nist.gov/vuln/detail/{{ cve.id }}">NVD</a>
+          </li>
+          <li>
+            <a href="https://launchpad.net/bugs/cve/{{ cve.id }}">Launchpad</a>
+          </li>
+          <li>
+            <a href="https://security-tracker.debian.org/tracker/{{ cve.id }}">Debian</a>
+          </li>
+        </ul>
+
+        {{ cve.notices_ids }}
+
+        {% if cve.bugs and "" not in cve.bugs %}
+          <h2>Bugs</h2>
+          <ul>
+            {% for bug in cve.bugs %}
+              {% if 'http' in bug %}
+                <li>
+                  <a href="{{ bug }}">{{ bug }}</a>
+                </li>
+              {% endif %}
+            {% endfor %}
+          </ul>
+        {% endif %}
+      </div>
+    </div>
+  </section>
+
+  {% with first_item="_security_discussion", second_item="_security_esm",
+    third_item="_security_further_reading" %}
+    {% include
+    "shared/contextual_footers/_contextual_footer.html" %}
+  {% endwith %}
+
+{% endblock %}

--- a/templates/security/cve/cve.html
+++ b/templates/security/cve/cve.html
@@ -372,8 +372,6 @@
           </li>
         </ul>
 
-        {{ cve.notices_ids }}
-
         {% if cve.bugs and "" not in cve.bugs %}
           <h2>Bugs</h2>
           <ul>


### PR DESCRIPTION
## Done

- This addresses an issue of CVE pages not having a link back to LSN's
- Loop through notice_ids and if an LSN exists, add it to the list of references
- DJLint

## QA

- Go to https://ubuntu-com-14212.demos.haus/security/notices/LSN-0104-1 (or any LSN)
- Scroll down to 'References' and click any internal link, for example https://ubuntu-com-14212.demos.haus/security/CVE-2023-6270
- Again scroll down to 'References' and see there is a link back to the original notices page, https://ubuntu-com-14212.demos.haus/security/notices/LSN-0104-1 

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-14292

