### PR TITLE
chore: Update to use dynamic fonts and don't preload fonts

### DIFF
--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -56,21 +56,45 @@
         head_extra %}
       {% endblock %}
 
-      <link as="font"
+      <link rel="preload"
+            as="font"
             type="font/woff2"
-            href="https://assets.ubuntu.com/v1/46ed6870-Ubuntu-L-subset.woff2"
+            href="https://assets.ubuntu.com/v1/f1ea362b-Ubuntu%5Bwdth,wght%5D-latin-v0.896a.woff2"
             crossorigin />
-      <link as="font"
+      <link rel="preload"
+            as="font"
             type="font/woff2"
-            href="https://assets.ubuntu.com/v1/3baab91b-Ubuntu-Th-subset.woff2"
+            href="https://assets.ubuntu.com/v1/90b59210-Ubuntu-Italic%5Bwdth,wght%5D-latin-v0.896a.woff2"
             crossorigin />
-      <link as="font"
+      <link rel="preload"
+            as="font"
             type="font/woff2"
-            href="https://assets.ubuntu.com/v1/6113b69a-Ubuntu-LI-subset.woff2"
+            href="https://assets.ubuntu.com/v1/d5fc1819-UbuntuMono%5Bwght%5D-latin-v0.869.woff2"
             crossorigin />
-      <link as="font"
+      <link rel="preload"
+            as="font"
             type="font/woff2"
-            href="https://assets.ubuntu.com/v1/0c7b8dc0-Ubuntu-R-subset.woff2"
+            href="https://assets.ubuntu.com/v1/77cd6650-Ubuntu%5Bwdth,wght%5D-cyrillic-extended-v0.896a.woff2"
+            crossorigin />
+      <link rel="preload"
+            as="font"
+            type="font/woff2"
+            href="https://assets.ubuntu.com/v1/2702fce5-Ubuntu%5Bwdth,wght%5D-cyrillic-v0.896a.woff2"
+            crossorigin />
+      <link rel="preload"
+            as="font"
+            type="font/woff2"
+            href="https://assets.ubuntu.com/v1/5c108b7d-Ubuntu%5Bwdth,wght%5D-greek-extended-v0.896a.woff2"
+            crossorigin />
+      <link rel="preload"
+            as="font"
+            type="font/woff2"
+            href="https://assets.ubuntu.com/v1/0a14c405-Ubuntu%5Bwdth,wght%5D-greek-v0.896a.woff2"
+            crossorigin />
+      <link rel="preload"
+            as="font"
+            type="font/woff2"
+            href="https://assets.ubuntu.com/v1/19f68eeb-Ubuntu%5Bwdth,wght%5D-latin-extended-v0.896a.woff2"
             crossorigin />
 
       <meta name="description" content=" 

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -56,23 +56,19 @@
         head_extra %}
       {% endblock %}
 
-      <link rel="preload"
-            as="font"
+      <link as="font"
             type="font/woff2"
             href="https://assets.ubuntu.com/v1/46ed6870-Ubuntu-L-subset.woff2"
             crossorigin />
-      <link rel="preload"
-            as="font"
+      <link as="font"
             type="font/woff2"
             href="https://assets.ubuntu.com/v1/3baab91b-Ubuntu-Th-subset.woff2"
             crossorigin />
-      <link rel="preload"
-            as="font"
+      <link as="font"
             type="font/woff2"
             href="https://assets.ubuntu.com/v1/6113b69a-Ubuntu-LI-subset.woff2"
             crossorigin />
-      <link rel="preload"
-            as="font"
+      <link as="font"
             type="font/woff2"
             href="https://assets.ubuntu.com/v1/0c7b8dc0-Ubuntu-R-subset.woff2"
             crossorigin />

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -71,27 +71,27 @@
             type="font/woff2"
             href="https://assets.ubuntu.com/v1/d5fc1819-UbuntuMono%5Bwght%5D-latin-v0.869.woff2"
             crossorigin />
-      <link rel="preload"
+      <link rel="preconnect"
             as="font"
             type="font/woff2"
             href="https://assets.ubuntu.com/v1/77cd6650-Ubuntu%5Bwdth,wght%5D-cyrillic-extended-v0.896a.woff2"
             crossorigin />
-      <link rel="preload"
+      <link rel="preconnect"
             as="font"
             type="font/woff2"
             href="https://assets.ubuntu.com/v1/2702fce5-Ubuntu%5Bwdth,wght%5D-cyrillic-v0.896a.woff2"
             crossorigin />
-      <link rel="preload"
+      <link rel="preconnect"
             as="font"
             type="font/woff2"
             href="https://assets.ubuntu.com/v1/5c108b7d-Ubuntu%5Bwdth,wght%5D-greek-extended-v0.896a.woff2"
             crossorigin />
-      <link rel="preload"
+      <link rel="preconnect"
             as="font"
             type="font/woff2"
             href="https://assets.ubuntu.com/v1/0a14c405-Ubuntu%5Bwdth,wght%5D-greek-v0.896a.woff2"
             crossorigin />
-      <link rel="preload"
+      <link rel="preconnect"
             as="font"
             type="font/woff2"
             href="https://assets.ubuntu.com/v1/19f68eeb-Ubuntu%5Bwdth,wght%5D-latin-extended-v0.896a.woff2"


### PR DESCRIPTION
## Done

- I have updated the inline font references to match those in Vanilla and removed the preload attribute from lesser used font types (greek, cryllic)

## QA

- Go https://ubuntu-com-14216.demos.haus/ to and see there are no font related errors in the console

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-14349
https://github.com/canonical/ubuntu.com/issues/10312
