### PR TITLE
Remove unused fields on engage forms

### DIFF
--- a/templates/engage/shared/_de_engage_form.html
+++ b/templates/engage/shared/_de_engage_form.html
@@ -35,7 +35,6 @@
       </li>
       <li>
         <p>Mit der Absendung dieses Formulars bestätige ich, dass ich die <a href="/legal/data-privacy" target="_blank" rel="noopener noreferrer" class="mchNoDecorate">Datenschutzrichtlinie von Canonical</a> gelesen habe und ihr zustimme.</p>
-        <input name="RichText" type="hidden" aria-label="RichText">
       </li>
       {# These are honey pot fields to catch bots #}
       <li class="u-off-screen">

--- a/templates/engage/shared/_de_engage_form.html
+++ b/templates/engage/shared/_de_engage_form.html
@@ -5,31 +5,31 @@
     <ul class="p-list u-no-margin--bottom">
       <li>
         <label for="firstName">Vorname:</label>
-        <input required id="firstName" name="firstName" maxlength="255" type="text" aria-label="First Name">
+        <input required id="firstName" name="firstName" maxlength="255" type="text" aria-label="First Name" />
       </li>
       <li>
         <label for="lastName">Nachname:</label>
-        <input required id="lastName" name="lastName" maxlength="255" type="text" aria-label="Last Name">
+        <input required id="lastName" name="lastName" maxlength="255" type="text" aria-label="Last Name" />
       </li>
       <li>
         <label for="email">Email beruflich:</label>
-        <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" aria-label="Email">
+        <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" aria-label="Email" />
       </li>
       <li>
         <label for="company">Name des Unternehmens:</label>
-        <input required id="company" name="company" maxlength="255" type="text" aria-label="Company Name">
+        <input required id="company" name="company" maxlength="255" type="text" aria-label="Company Name" />
       </li>
       <li>
         <label for="title">Tätigkeitsbezeichnung:</label>
-        <input required id="title" name="title" maxlength="255" type="text" aria-label="Job Title">
+        <input required id="title" name="title" maxlength="255" type="text" aria-label="Job Title" />
       </li>
       <li>
         <label for="phone">Handynummer:</label>
-        <input required id="phone" name="phone" maxlength="255" type="tel" aria-label="Phone Number">
+        <input required id="phone" name="phone" maxlength="255" type="tel" aria-label="Phone Number" />
       </li>
       <li>
         <label class="p-checkbox">
-          <input class="p-checkbox__input" name="canonicalUpdatesOptIn" aria-labelledby="canonicalUpdatesOptIn" value="yes" type="checkbox">
+          <input class="p-checkbox__input" name="canonicalUpdatesOptIn" aria-labelledby="canonicalUpdatesOptIn" value="yes" type="checkbox" />
           <span class="p-checkbox__label" id="canonicalUpdatesOptIn">Ich erkläre mich damit einverstanden, Informationen zu Produkten und Services von Canoncical zu erhalten.</span>
         </label>
       </li>
@@ -47,17 +47,17 @@
       </li>
       {# End of honey pots #}
       <li>
-        <input name="Consent_to_Processing__c" value="Yes" type="hidden" aria-label="Consent_to_Processing__c">
+        <input name="Consent_to_Processing__c" value="Yes" type="hidden" aria-label="Consent_to_Processing__c" />
       </li>
       <li>
         <button type="submit">eBook herunterladen</button>
-        <input name="formid" value="{{ id }}" type="hidden" aria-label="formid">
-        <input type="hidden" name="returnURL" value="{{ returnURL }}" aria-label="returnURL">
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="{{utm_campaign}}" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="{{utm_medium}}" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="{{utm_source}}" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="{{utm_content}}" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="{{utm_term}}" />
+        <input name="formid" value="{{ id }}" type="hidden" aria-label="formid" />
+        <input type="hidden" name="returnURL" value="{{ returnURL }}" aria-label="returnURL" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="{{ utm_campaign }}" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="{{ utm_medium }}" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="{{ utm_source }}" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="{{ utm_content }}" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="{{ utm_term }}" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Facebook_Click_ID__c" id="Facebook_Click_ID__c" value="" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" id="preferredLanguage" name="preferredLanguage" maxlength="255" value="" />

--- a/templates/engage/shared/_en_engage_form.html
+++ b/templates/engage/shared/_en_engage_form.html
@@ -5,34 +5,33 @@
     <ul class="p-list">
       <li>
         <label for="firstName">First name:</label>
-        <input required id="firstName" name="firstName" maxlength="255" type="text" value="">
+        <input required id="firstName" name="firstName" maxlength="255" type="text" value="" />
       </li>
       <li>
         <label for="lastName">Last name:</label>
-        <input required id="lastName" name="lastName" maxlength="255" type="text">
+        <input required id="lastName" name="lastName" maxlength="255" type="text" />
       </li>
       <li>
         <label for="email">Work email:</label>
-        <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" value="">
+        <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" value="" />
       </li>
       <li>
         <label for="company">Company name:</label>
-        <input required id="company" name="company" maxlength="255" type="text">
+        <input required id="company" name="company" maxlength="255" type="text" />
       </li>
       <li>
         <label for="jobTitle">Job title:</label>
-        <input required id="jobTitle" name="title" maxlength="255" type="text">
+        <input required id="jobTitle" name="title" maxlength="255" type="text" />
       </li>
       <li>
         <label for="phone">Mobile/cell phone number:</label>
-        <input required id="phone" name="phone" maxlength="255" type="tel">
+        <input required id="phone" name="phone" maxlength="255" type="tel" />
       </li>
 
       {% include "shared/forms/_country.html" %}
       <li>
-        
         <label class="p-checkbox">
-          <input class="p-checkbox__input" name="canonicalUpdatesOptIn" aria-labelledby="canonicalUpdatesOptIn" value="yes" type="checkbox">
+          <input class="p-checkbox__input" name="canonicalUpdatesOptIn" aria-labelledby="canonicalUpdatesOptIn" value="yes" type="checkbox" />
           <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
         </label>
       </li>
@@ -47,12 +46,12 @@
       </li>
       {# End of honey pots #}
       <li>
-        <input name="Consent_to_Processing__c" aria-label="Consent" value="Yes" type="hidden">
+        <input name="Consent_to_Processing__c" aria-label="Consent" value="Yes" type="hidden" />
       </li>
       {% if "partner_permission" in metadata %}
         <li>
           <label class="p-checkbox">
-            <input class="p-checkbox__input" name="Partner_Marketing_Opt_in__c" aria-label="Partner Permission" value="true" type="checkbox">
+            <input class="p-checkbox__input" name="Partner_Marketing_Opt_in__c" aria-label="Partner Permission" value="true" type="checkbox" />
             <span class="p-checkbox__label" id="Partner_Marketing_Opt_in__c">From time to time, Canonical or the identified co-host(s) may wish to contact you by email to provide you with information about events and other news or product updates that may be of interest to you. If you are happy to be contacted by Canonical or the identified co-host(s) for these purposes please select the check box. Further information on Canonical's processing of your personal data can be found in <a href="/legal/data-privacy/newsletter">Canonical's privacy notice</a>. If you choose to give your consent, you may withdraw it at any time by clicking "unsubscribe" at the bottom of any Canonical email. See Canonical's <a href="/legal/data-privacy">data privacy policy</a>.</span>
           </label>
         </li>
@@ -63,13 +62,13 @@
       </li>
       <li>
         <button type="submit" class="u-no-margin--bottom {% if cta_class %}{{ cta_class }}{% endif %}" >{% if cta %}{{ cta }}{% else %}Download the whitepaper{% endif %}</button>
-        <input name="formid" aria-label="formid" value="{{ id }}" type="hidden">
+        <input name="formid" aria-label="formid" value="{{ id }}" type="hidden" />
         <input type="hidden" name="returnURL" aria-label="returnURL" value="{{ returnURL }}" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="{{utm_campaign}}" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="{{utm_medium}}" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="{{utm_source}}" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="{{utm_content}}" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="{{utm_term}}" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="{{ utm_campaign }}" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="{{ utm_medium }}" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="{{ utm_source }}" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="{{ utm_content }}" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="{{ utm_term }}" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Facebook_Click_ID__c" id="Facebook_Click_ID__c" value="" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" id="preferredLanguage" name="preferredLanguage" maxlength="255" value="" />

--- a/templates/engage/shared/_en_engage_form.html
+++ b/templates/engage/shared/_en_engage_form.html
@@ -59,7 +59,6 @@
       {% endif %}
       <li>
         <p>In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.
-          <input name="RichText" aria-label="RichText" type="hidden">
         </p>
       </li>
       <li>

--- a/templates/engage/shared/_es_engage_form.html
+++ b/templates/engage/shared/_es_engage_form.html
@@ -6,35 +6,35 @@
       <li>
         <label for="firstName">Nombre:</label>
         <input required id="firstName" name="firstName" maxlength="255" type="text"
-          aria-label="Nombre">
+          aria-label="Nombre" />
       </li>
       <li>
         <label for="lastName">Apellido:</label>
         <input required id="lastName" name="lastName" maxlength="255" type="text"
-          aria-label="Apellido">
+          aria-label="Apellido" />
       </li>
       <li>
         <label for="email">E-mail de trabajo:</label>
         <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"
-          aria-label="E-mail de trabajo">
+          aria-label="E-mail de trabajo" />
       </li>
       <li>
         <label for="company">Nombre de la compañía:</label>
         <input required id="company" name="company" maxlength="255" type="text"
-          aria-label="Nombre de la compañía">
+          aria-label="Nombre de la compañía" />
       </li>
       <li>
         <label for="title">Título del puesto de trabajo:</label>
-        <input required id="title" name="title" maxlength="255" type="text" aria-label="Título del puesto de trabajo">
+        <input required id="title" name="title" maxlength="255" type="text" aria-label="Título del puesto de trabajo" />
       </li>
       <li>
         <label for="phone">Número del teléfono móvil/celular:</label>
         <input required id="phone" name="phone" maxlength="255" type="tel"
-          aria-label="Número de teléfono">
+          aria-label="Número de teléfono" />
       </li>
       <li>
         <label class="p-checkbox">
-          <input class="p-checkbox__input" name="canonicalUpdatesOptIn" aria-labelledby="canonicalUpdatesOptIn" value="yes" type="checkbox">
+          <input class="p-checkbox__input" name="canonicalUpdatesOptIn" aria-labelledby="canonicalUpdatesOptIn" value="yes" type="checkbox" />
           <span class="p-checkbox__label" id="canonicalUpdatesOptIn">Acepto recibir información sobre los productos y servicios de Canonical</span>
         </label>
       </li>
@@ -53,17 +53,17 @@
       </li>
       {# End of honey pots #}
       <li>
-        <input name="Consent_to_Processing__c" aria-label="Consent" value="Yes" type="hidden">
+        <input name="Consent_to_Processing__c" aria-label="Consent" value="Yes" type="hidden" />
       </li>
       <li>
         <button type="submit" class="u-no-margin--bottom">{% if cta %}{{ cta }}{% else %}Descargar el documento técnico{% endif %}</button>
-        <input name="formid" aria-label="formid" value="{{ id }}" type="hidden">
+        <input name="formid" aria-label="formid" value="{{ id }}" type="hidden" />
         <input type="hidden" name="returnURL" aria-label="returnURL" value="{{ returnURL }}" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="{{utm_campaign}}" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="{{utm_medium}}" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="{{utm_source}}" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="{{utm_content}}" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="{{utm_term}}" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="{{ utm_campaign }}" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="{{ utm_medium }}" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="{{ utm_source }}" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="{{ utm_content }}" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="{{ utm_term }}" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Facebook_Click_ID__c" id="Facebook_Click_ID__c" value="" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" id="preferredLanguage" name="preferredLanguage" maxlength="255" value="" />

--- a/templates/engage/shared/_es_engage_form.html
+++ b/templates/engage/shared/_es_engage_form.html
@@ -40,7 +40,6 @@
       </li>
       <li>
         <p>Al enviar este formulario, confirmo que he leído y acepto el <a href="/legal/data-privacy/contact">Aviso de Privacidad</a> y la <a href="/legal/data-privacy">Política de Privacidad</a> de Canonical.
-          <input name="RichText" aria-label="RichText" type="hidden">
         </p>
       </li>
       {# These are honey pot fields to catch bots #}

--- a/templates/engage/shared/_it_engage_form.html
+++ b/templates/engage/shared/_it_engage_form.html
@@ -6,35 +6,35 @@
       <li>
         <label for="firstName">Nome:</label>
         <input required id="firstName" name="firstName" maxlength="255" type="text"
-          aria-label="Nome">
+          aria-label="Nome" />
       </li>
       <li>
         <label for="lastName">Cognome:</label>
         <input required id="lastName" name="lastName" maxlength="255" type="text"
-          aria-label="Cognome">
+          aria-label="Cognome" />
       </li>
       <li>
         <label for="email">E-mail lavorativa:</label>
         <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"
-          aria-label="E-mail lavorativa">
+          aria-label="E-mail lavorativa" />
       </li>
       <li>
         <label for="company">Nome società:</label>
         <input required id="company" name="company" maxlength="255" type="text"
-          aria-label="Nome società">
+          aria-label="Nome società" />
       </li>
       <li>
         <label for="title">Titolo lavorativo:</label>
-        <input required id="title" name="title" maxlength="255" type="text" aria-label="Titolo lavorativo">
+        <input required id="title" name="title" maxlength="255" type="text" aria-label="Titolo lavorativo" />
       </li>
       <li>
         <label for="phone">Numero di telefono:</label>
         <input required id="phone" name="phone" maxlength="255" type="tel"
-          aria-label="Numero di telefono">
+          aria-label="Numero di telefono" />
       </li>
       <li>
         <label class="p-checkbox">
-          <input class="p-checkbox__input" name="canonicalUpdatesOptIn" aria-labelledby="canonicalUpdatesOptIn" value="yes" type="checkbox">
+          <input class="p-checkbox__input" name="canonicalUpdatesOptIn" aria-labelledby="canonicalUpdatesOptIn" value="yes" type="checkbox" />
           <span class="p-checkbox__label" id="canonicalUpdatesOptIn">Accetto di ricevere informazioni sui prodotti e servizi Canonical.</span>
         </label>
       </li>
@@ -53,17 +53,17 @@
       </li>
       {# End of honey pots #}
       <li>
-        <input name="Consent_to_Processing__c" aria-label="Consent" value="Yes" type="hidden">
+        <input name="Consent_to_Processing__c" aria-label="Consent" value="Yes" type="hidden" />
       </li>
       <li>
         <button type="submit" class="u-no-margin--bottom" >{% if cta %}{{ cta }}{% else %}Scarica il whitepaper{% endif %}</button>
-        <input name="formid" aria-label="formid" value="{{ id }}" type="hidden">
+        <input name="formid" aria-label="formid" value="{{ id }}" type="hidden" />
         <input type="hidden" name="returnURL" aria-label="returnURL" value="{{ returnURL }}" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="{{utm_campaign}}" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="{{utm_medium}}" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="{{utm_source}}" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="{{utm_content}}" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="{{utm_term}}" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="{{ utm_campaign }}" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="{{ utm_medium }}" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="{{ utm_source }}" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="{{ utm_content }}" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="{{ utm_term }}" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Facebook_Click_ID__c" id="Facebook_Click_ID__c" value="" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" id="preferredLanguage" name="preferredLanguage" maxlength="255" value="" />

--- a/templates/engage/shared/_it_engage_form.html
+++ b/templates/engage/shared/_it_engage_form.html
@@ -40,7 +40,6 @@
       </li>
       <li>
         <p>Inviando questo modulo, confermo di aver letto e di accettare la Nota sulla <a href="/legal/data-privacy/contact">Privacy e l'Informativa</a> sulla <a href="/legal/data-privacy">Privacy di Canonical.</a>
-          <input name="RichText" aria-label="RichText" type="hidden">
         </p>
       </li>
       {# These are honey pot fields to catch bots #}

--- a/templates/engage/shared/_pt_engage_form.html
+++ b/templates/engage/shared/_pt_engage_form.html
@@ -40,7 +40,6 @@
       </li>
       <li>
         <p>Ao submeter este formulário, confirmo que li e concordo com o <a href="/legal/data-privacy/contact">Aviso de privacidade</a> e a <a href="/legal/data-privacy">Política de privacidade da Canonical</a>.
-          <input name="RichText" aria-label="RichText" type="hidden">
         </p>
       </li>
       {# These are honey pot fields to catch bots #}

--- a/templates/engage/shared/_pt_engage_form.html
+++ b/templates/engage/shared/_pt_engage_form.html
@@ -6,35 +6,35 @@
       <li>
         <label for="firstName">Primeiro Nome:</label>
         <input required id="firstName" name="firstName" maxlength="255" type="text"
-          aria-label="First Name">
+          aria-label="First Name" />
       </li>
       <li>
         <label for="lastName">Último Nome:</label>
         <input required id="lastName" name="lastName" maxlength="255" type="text"
-          aria-label="Last Name">
+          aria-label="Last Name" />
       </li>
       <li>
         <label for="email">Email do trabalho:</label>
         <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"
-          aria-label="Email">
+          aria-label="Email" />
       </li>
       <li>
         <label for="company">Nome da Empresa:</label>
         <input required id="company" name="company" maxlength="255" type="text"
-          aria-label="Company Name">
+          aria-label="Company Name" />
       </li>
       <li>
         <label for="title">Titulo do trabalho:</label>
-        <input required id="title" name="title" maxlength="255" type="text" aria-label="Job Title">
+        <input required id="title" name="title" maxlength="255" type="text" aria-label="Job Title" />
       </li>
       <li>
         <label for="phone">Telemóvel:</label>
         <input required id="phone" name="phone" maxlength="255" type="tel"
-          aria-label="Phone Number">
+          aria-label="Phone Number" />
       </li>
       <li>
         <label class="p-checkbox">
-          <input class="p-checkbox__input" name="canonicalUpdatesOptIn" aria-labelledby="canonicalUpdatesOptIn" value="yes" type="checkbox">
+          <input class="p-checkbox__input" name="canonicalUpdatesOptIn" aria-labelledby="canonicalUpdatesOptIn" value="yes" type="checkbox" />
           <span class="p-checkbox__label" id="canonicalUpdatesOptIn">Concordo em receber informações sobre os produtos e serviços da Canonical.</span>
         </label>
       </li>
@@ -53,17 +53,17 @@
       </li>
       {# End of honey pots #}
       <li>
-        <input name="Consent_to_Processing__c" aria-label="Consent" value="Yes" type="hidden">
+        <input name="Consent_to_Processing__c" aria-label="Consent" value="Yes" type="hidden" />
       </li>
       <li>
         <button type="submit" class="u-no-margin--bottom">{% if cta %}{{ cta }}{% else %}Descarregue o documento{% endif %}</button>
-        <input name="formid" aria-label="formid" value="{{ id }}" type="hidden">
+        <input name="formid" aria-label="formid" value="{{ id }}" type="hidden" />
         <input type="hidden" name="returnURL" aria-label="returnURL" value="{{ returnURL }}" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="{{utm_campaign}}" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="{{utm_medium}}" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="{{utm_source}}" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="{{utm_content}}" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="{{utm_term}}" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="{{ utm_campaign }}" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="{{ utm_medium }}" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="{{ utm_source }}" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="{{ utm_content }}" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="{{ utm_term }}" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Facebook_Click_ID__c" id="Facebook_Click_ID__c" value="" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" id="preferredLanguage" name="preferredLanguage" maxlength="255" value="" />

--- a/templates/engage/shared/_ru_engage_form.html
+++ b/templates/engage/shared/_ru_engage_form.html
@@ -35,7 +35,6 @@
         </li>
         <li>
             <p>Отправляя эту форму, я подтверждаю, что прочитал и принимаю <a href="/legal/data-privacy/contact">Уведомление о конфиденциальности</a> and <a href="/legal/data-privacy">Политику конфиденциальности</a>.
-            <input name="RichText" aria-label="RichText" type="hidden">
             </p>
         </li>
         {# These are honey pot fields to catch bots #}

--- a/templates/engage/shared/_ru_engage_form.html
+++ b/templates/engage/shared/_ru_engage_form.html
@@ -5,37 +5,37 @@
         <ul class="p-list">
         <li>
             <label for="firstName">Имя:</label>
-            <input required id="firstName" name="firstName" maxlength="255" type="text">
+            <input required id="firstName" name="firstName" maxlength="255" type="text" />
         </li>
         <li>
             <label for="lastName">Фамилия:</label>
-            <input required id="lastName" name="lastName" maxlength="255" type="text">
+            <input required id="lastName" name="lastName" maxlength="255" type="text" />
         </li>
         <li>
             <label for="email">Рабочая электронная почта:</label>
-            <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$">
+            <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
         </li>
         <li>
             <label for="company">Компания:</label>
-            <input required id="company" name="company" maxlength="255" type="text">
+            <input required id="company" name="company" maxlength="255" type="text" />
         </li>
         <li>
             <label for="jobTitle">Должность:</label>
-            <input required id="jobTitle" name="title" maxlength="255" type="text">
+            <input required id="jobTitle" name="title" maxlength="255" type="text" />
         </li>
         <li>
             <label for="phone">Номер телефона:</label>
-            <input required id="phone" name="phone" maxlength="255" type="tel">
+            <input required id="phone" name="phone" maxlength="255" type="tel" />
         </li>
         <li>
             <label class="p-checkbox">
-                <input class="p-checkbox__input" name="canonicalUpdatesOptIn" aria-labelledby="canonicalUpdatesOptIn" value="yes" type="checkbox">
+                <input class="p-checkbox__input" name="canonicalUpdatesOptIn" aria-labelledby="canonicalUpdatesOptIn" value="yes" type="checkbox" />
                 <span class="p-checkbox__label" id="canonicalUpdatesOptIn">Я согласен получать информацию о продуктах и услугах Canonical.</span>
             </label>
         </li>
         <li>
-            <p>Отправляя эту форму, я подтверждаю, что прочитал и принимаю <a href="/legal/data-privacy/contact">Уведомление о конфиденциальности</a> and <a href="/legal/data-privacy">Политику конфиденциальности</a>.
-            </p>
+          <p>Отправляя эту форму, я подтверждаю, что прочитал и принимаю <a href="/legal/data-privacy/contact">Уведомление о конфиденциальности</a> and <a href="/legal/data-privacy">Политику конфиденциальности</a>.
+          </p>
         </li>
         {# These are honey pot fields to catch bots #}
         <li class="u-off-screen">
@@ -48,17 +48,17 @@
         </li>
         {# End of honey pots #}
         <li>
-            <input name="Consent_to_Processing__c" aria-label="Consent" value="Yes" type="hidden">
+            <input name="Consent_to_Processing__c" aria-label="Consent" value="Yes" type="hidden" />
         </li>
         <li>
             <button type="submit" class="u-no-margin--bottom" >{% if cta %}{{ cta }}{% else %}Загрузить документ{% endif %}</button>
-            <input name="formid" aria-label="formid" value="{{ id }}" type="hidden">
+            <input name="formid" aria-label="formid" value="{{ id }}" type="hidden" />
             <input type="hidden" name="returnURL" aria-label="returnURL" value="{{ returnURL }}" />
-            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="{{utm_campaign}}" />
-            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="{{utm_medium}}" />
-            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="{{utm_source}}" />
-            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="{{utm_content}}" />
-            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="{{utm_term}}" />
+            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="{{ utm_campaign }}" />
+            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="{{ utm_medium }}" />
+            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="{{ utm_source }}" />
+            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="{{ utm_content }}" />
+            <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="{{ utm_term }}" />
             <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
             <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Facebook_Click_ID__c" id="Facebook_Click_ID__c" value="" />
             <input type="hidden" aria-hidden="true" aria-label="hidden field" id="preferredLanguage" name="preferredLanguage" maxlength="255" value="" />

--- a/templates/engage/shared/_zh-TW_engage_form.html
+++ b/templates/engage/shared/_zh-TW_engage_form.html
@@ -5,31 +5,31 @@
     <ul class="p-list">
       <li>
         <label for="firstName">First name:</label>
-        <input required id="firstName" name="firstName" maxlength="255" type="text" value="">
+        <input required id="firstName" name="firstName" maxlength="255" type="text" value="" />
       </li>
       <li>
         <label for="lastName">Last name:</label>
-        <input required id="lastName" name="lastName" maxlength="255" type="text">
+        <input required id="lastName" name="lastName" maxlength="255" type="text" />
       </li>
       <li>
         <label for="email">Work email:</label>
-        <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" value="">
+        <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" value="" />
       </li>
       <li>
         <label for="company">Company name:</label>
-        <input required id="company" name="company" maxlength="255" type="text">
+        <input required id="company" name="company" maxlength="255" type="text" />
       </li>
       <li>
         <label for="jobTitle">Job title:</label>
-        <input required id="jobTitle" name="title" maxlength="255" type="text">
+        <input required id="jobTitle" name="title" maxlength="255" type="text" />
       </li>
       <li>
         <label for="phone">Mobile/cell phone number:</label>
-        <input required id="phone" name="phone" maxlength="255" type="tel">
+        <input required id="phone" name="phone" maxlength="255" type="tel" />
       </li>
       <li>
         <label class="p-checkbox">
-          <input class="p-checkbox__input" name="canonicalUpdatesOptIn" aria-labelledby="canonicalUpdatesOptIn" value="yes" type="checkbox">
+          <input class="p-checkbox__input" name="canonicalUpdatesOptIn" aria-labelledby="canonicalUpdatesOptIn" value="yes" type="checkbox" />
           <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
         </label>
       </li>
@@ -48,17 +48,17 @@
       </li>
       {# End of honey pots #}
       <li>
-        <input name="Consent_to_Processing__c" aria-label="Consent" value="Yes" type="hidden">
+        <input name="Consent_to_Processing__c" aria-label="Consent" value="Yes" type="hidden" />
       </li>
       <li>
         <button type="submit" class="u-no-margin--bottom {% if cta_class %}{{ cta_class }}{% endif %}" >{% if cta %}{{ cta }}{% else %}Download the whitepaper{% endif %}</button>
-        <input name="formid" aria-label="formid" value="{{ id }}" type="hidden">
+        <input name="formid" aria-label="formid" value="{{ id }}" type="hidden" />
         <input type="hidden" name="returnURL" aria-label="returnURL" value="{{ returnURL }}" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="{{utm_campaign}}" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="{{utm_medium}}" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="{{utm_source}}" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="{{utm_content}}" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="{{utm_term}}" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="{{ utm_campaign }}" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="{{ utm_medium }}" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="{{ utm_source }}" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="{{ utm_content }}" />
+        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="{{ utm_term }}" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Facebook_Click_ID__c" id="Facebook_Click_ID__c" value="" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" id="preferredLanguage" name="preferredLanguage" maxlength="255" value="" />

--- a/templates/engage/shared/_zh-TW_engage_form.html
+++ b/templates/engage/shared/_zh-TW_engage_form.html
@@ -35,7 +35,6 @@
       </li>
       <li>
         <p>In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.
-          <input name="RichText" aria-label="RichText" type="hidden">
         </p>
       </li>
       {# These are honey pot fields to catch bots #}


### PR DESCRIPTION
## Done

- Remove "RichText" hidden field on engage forms
- Fix djlint errors throughout the forms

## QA

- Go to https://ubuntu-com-14228.demos.haus/engage/iot-management-landscape
- Submit the form
- Check that payload does not include "RichText"

## Issue / Card

Fixes [WD-14468](https://warthogs.atlassian.net/browse/WD-14468)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-14468]: https://warthogs.atlassian.net/browse/WD-14468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ