### PR TITLE
WD-12753 - rebrand /core and /core/services thank-you pages

### DIFF
--- a/templates/core/services/thank-you.html
+++ b/templates/core/services/thank-you.html
@@ -2,49 +2,50 @@
 
 {% block title %}Thank you | AWS{% endblock %}
 
-{% block head_extra%}<meta name="robots" content="noindex" />{% endblock %}
+{% block head_extra %}<meta name="robots" content="noindex" />{% endblock %}
 
 {% block content %}
-<div class="p-strip is-bordered is-deep">
-  <div class="row">
-    <div class="col-7">
-      <h1>Thank you for your interest in SMART START</h1>
-      <p class="p-heading--4">A member of our team will be in touch within one working day.</p>
-    </div>
-    <div class="col-5 u-vertically-center u-hide--medium u-hide--small u-align--center">
-      {{
-        image(
-          url="https://assets.ubuntu.com/v1/52d53696-picto-thankyou-midaubergine.svg",
-          alt="",
-          width="200",
-          height="200",
-          hi_def=True,
-          loading="auto"
-        ) | safe
-      }}
+  <div class="p-section--hero">
+    <div class="row--50-50">
+      <div class="col">
+        <h1 class="u-no-margin--bottom">Thank you for your interest in SMART START.</h1>
+        <h2>A member of our team will be in touch within one working day.</h2>
+      </div>
+      <div class="col">
+        <div class="p-image-container u-hide--small">
+          <img class="p-image-container__image p-strip is-shallow"
+               src="https://assets.ubuntu.com/v1/b0fa63e9-christina-wocintechchat-com-LQ1t-8Ms5PY-unsplash.png"
+               alt="" />
+        </div>
+      </div>
     </div>
   </div>
-</div>
 
-{% include "shared/_thank_you_footer.html" %}
+  {% include "shared/_thank_you_footer.html" %}
 
 {% endblock content %}
+
 {% block footer_extra %}
-<!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-<script>
-  /* <![CDATA[ */
-  var google_conversion_id = 1012391776;
-  var google_conversion_language = "en";
-  var google_conversion_format = "3";
-  var google_conversion_color = "ffffff";
-  var google_conversion_label = "-mBBCIC5vwMQ4L7f4gM";
-  var google_conversion_value = 0;
-  /* ]]> */
-</script>
-<script type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js"></script>
-<noscript>
-  <div style="display:inline;">
-    <img height="1" width="1" style="border-style:none;" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
-  </div>
-</noscript>
+  <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
+  <script>
+    /* <![CDATA[ */
+    var google_conversion_id = 1012391776;
+    var google_conversion_language = "en";
+    var google_conversion_format = "3";
+    var google_conversion_color = "ffffff";
+    var google_conversion_label = "-mBBCIC5vwMQ4L7f4gM";
+    var google_conversion_value = 0;
+    /* ]]> */
+  </script>
+  <script type="text/javascript"
+          src="https://www.googleadservices.com/pagead/conversion.js"></script>
+  <noscript>
+    <div style="display:inline;">
+      <img height="1"
+           width="1"
+           style="border-style:none"
+           alt=""
+           src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0" />
+    </div>
+  </noscript>
 {% endblock footer_extra %}

--- a/templates/core/services/thank-you.html
+++ b/templates/core/services/thank-you.html
@@ -9,7 +9,7 @@
     <div class="row--50-50">
       <div class="col">
         <h1 class="u-no-margin--bottom">Thank you for your interest in SMART START.</h1>
-        <h2>A member of our team will be in touch within one working day.</h2>
+        <h2>A member of our team will be in touch shortly.</h2>
       </div>
       <div class="col">
         <div class="p-image-container u-hide--small">

--- a/templates/core/services/thank-you.html
+++ b/templates/core/services/thank-you.html
@@ -12,8 +12,8 @@
         <h2>A member of our team will be in touch shortly.</h2>
       </div>
       <div class="col">
-        <div class="p-image-container u-hide--small">
-          <img class="p-image-container__image p-strip is-shallow"
+        <div class="p-image-container is-cover u-hide--small">
+          <img class="p-image-container__image"
                src="https://assets.ubuntu.com/v1/b0fa63e9-christina-wocintechchat-com-LQ1t-8Ms5PY-unsplash.png"
                alt="" />
         </div>

--- a/templates/core/thank-you.html
+++ b/templates/core/thank-you.html
@@ -4,47 +4,52 @@
 
 {% block head_extra %}<meta name="robots" content="noindex" />{% endblock %}
 
+{% block body_class %}
+  is-paper
+{% endblock body_class %}
+
 {% block content %}
-<div class="p-strip is-bordered is-deep">
-  <div class="row">
-    <div class="col-7">
-      <h1>Thank you for contacting our team.</h1>
-      <p class="p-heading--4">We will be in touch shortly.</p>
-    </div>
-    <div class="col-5 u-vertically-center u-hide--medium u-hide--small u-align--center">
-      {{
-        image(
-          url="https://assets.ubuntu.com/v1/52d53696-picto-thankyou-midaubergine.svg",
-          alt="",
-          height="200",
-          width="200",
-          hi_def=True,
-          loading="auto"
-        ) | safe
-      }}
+  <div class="p-section--hero">
+    <div class="row--50-50">
+      <div class="col">
+        <h1 class="u-no-margin--bottom">Thank you for contacting our team.</h1>
+        <h2>We will be in touch shortly.</h2>
+      </div>
+      <div class="col">
+        <div class="p-image-container u-hide--small">
+          <img class="p-image-container__image p-strip is-shallow"
+               src="https://assets.ubuntu.com/v1/b0fa63e9-christina-wocintechchat-com-LQ1t-8Ms5PY-unsplash.png"
+               alt="" />
+        </div>
+      </div>
     </div>
   </div>
-</div>
 
-{% include "shared/_thank_you_footer.html" %}
+  {% include "shared/_thank_you_footer.html" %}
 
 {% endblock content %}
+
 {% block footer_extra %}
-<!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
-<script>
-  /* <![CDATA[ */
-  var google_conversion_id = 1012391776;
-  var google_conversion_language = "en";
-  var google_conversion_format = "3";
-  var google_conversion_color = "ffffff";
-  var google_conversion_label = "-mBBCIC5vwMQ4L7f4gM";
-  var google_conversion_value = 0;
-  /* ]]> */
-</script>
-<script type="text/javascript" src="https://www.googleadservices.com/pagead/conversion.js"></script>
-<noscript>
-  <div style="display:inline;">
-    <img height="1" width="1" style="border-style:none;" alt="" src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0"/>
-  </div>
-</noscript>
+  <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
+  <script>
+    /* <![CDATA[ */
+    var google_conversion_id = 1012391776;
+    var google_conversion_language = "en";
+    var google_conversion_format = "3";
+    var google_conversion_color = "ffffff";
+    var google_conversion_label = "-mBBCIC5vwMQ4L7f4gM";
+    var google_conversion_value = 0;
+    /* ]]> */
+  </script>
+  <script type="text/javascript"
+          src="https://www.googleadservices.com/pagead/conversion.js"></script>
+  <noscript>
+    <div style="display:inline;">
+      <img height="1"
+           width="1"
+           style="border-style:none"
+           alt=""
+           src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0" />
+    </div>
+  </noscript>
 {% endblock footer_extra %}

--- a/templates/core/thank-you.html
+++ b/templates/core/thank-you.html
@@ -16,8 +16,8 @@
         <h2>We will be in touch shortly.</h2>
       </div>
       <div class="col">
-        <div class="p-image-container u-hide--small">
-          <img class="p-image-container__image p-strip is-shallow"
+        <div class="p-image-container is-cover u-hide--small">
+          <img class="p-image-container__image"
                src="https://assets.ubuntu.com/v1/b0fa63e9-christina-wocintechchat-com-LQ1t-8Ms5PY-unsplash.png"
                alt="" />
         </div>

--- a/templates/shared/_thank_you_footer.html
+++ b/templates/shared/_thank_you_footer.html
@@ -51,7 +51,7 @@
           <div class="p-equal-height-row__item">
             <hr class="is-muted" />
             <p>
-              <a href="https://buy.ubuntu.com/">Purchase from our store</a>
+              <a href="https://buy.ubuntu.com/">Purchase from our store&nbsp;&rsaquo;</a>
             </p>
           </div>
         </div>

--- a/templates/shared/_thank_you_footer.html
+++ b/templates/shared/_thank_you_footer.html
@@ -1,26 +1,61 @@
-<section class="p-strip--light">
-  <div class="row">
-    <div class="col-10">
-      <h2>More about our enterprise services</h2>
-    </div>
+<section class="p-section--deep">
+  <div class="u-fixed-width p-section--shallow">
+    <hr />
+    <h2>More about our enterprise services</h2>
   </div>
-  <div class="row p-divider">
-    <div class="col-4 p-divider__block">
-      <h3 class="p-heading--4">Fully managed infrastructure</h3>
-      <p>Canonical offers fully managed infrastructure, including Kubernetes, OpenStack, Ceph and SWIFT storage and the recommended LMA stack.</p>
-      <p><a href="/pricing/infra#managed">Managed open infrastructure&nbsp;&rsaquo;</a></p>
-    </div>
-    <div class="col-4 p-divider__block">
-      <h3 class="p-heading--4">Consulting and deployment</h3>
-      <p>Open infrastructure consulting and training is also provided by Canonical, with optimal and custom architecture design and deployment.</p>
-      <p><a href="/pricing/consulting">Consulting, deployment from Canonical&nbsp;&rsaquo;</a></p>
-      <p><a href="/training">OpenStack, K8s, Kubeflow consulting &amp; training&nbsp;&rsaquo;</a></p>
-    </div>
-    <div class="col-4 p-divider__block">
-      <h3 class="p-heading--4">Infrastructure support &amp; security</h3>
-      <p>Access critical security fixes, legal assurance and phone and ticket support for OpenStack, K8s, Docker, Ceph and more through UA Infrastructure.</p>
-      <p><a href="/pricing/infra">Security maintenance and support&nbsp;&rsaquo;</a></p>
-      <p><a href="https://buy.ubuntu.com/">Purchase from our store</a></p>
+  <div class="row--25-75-on-large">
+    <div class="col">
+      <hr class="is-muted u-hide--small u-hide--medium" />
+      <div class="p-equal-height-row">
+        <div class="p-equal-height-row__col">
+          <h3 class="p-heading--5 p-equal-height-row__item">Fully managed infrastructure</h3>
+          <p class="p-equal-height-row__item">
+            Canonical offers fully managed infrastructure, including Kubernetes, OpenStack, Ceph and SWIFT storage and the recommended LMA stack.
+          </p>
+          <div class="p-equal-height-row__item">
+            <hr class="is-muted" />
+            <p>
+              <a href="/pricing/infra#managed">Managed open infrastructure&nbsp;&rsaquo;</a>
+            </p>
+          </div>
+        </div>
+        <div class="p-equal-height-row__col">
+          <h3 class="p-heading--5 p-equal-height-row__item">Consulting and deployment</h3>
+          <p class="p-equal-height-row__item">
+            Open infrastructure consulting and training is also provided by Canonical, with optimal and custom architecture design and deployment.
+          </p>
+          <div class="p-equal-height-row__item">
+            <hr class="is-muted" />
+            <p>
+              <a href="/pricing/consulting">Consulting, deployment from Canonical&nbsp;&rsaquo;</a>
+            </p>
+          </div>
+          <div class="p-equal-height-row__item">
+            <hr class="is-muted" />
+            <p>
+              <a href="/training">OpenStack, K8s, Kubeflow consulting &amp; training&nbsp;&rsaquo;</a>
+            </p>
+          </div>
+        </div>
+        <div class="p-equal-height-row__col">
+          <h3 class="p-heading--5 p-equal-height-row__item">Infrastructure support &amp; security</h3>
+          <p class="p-equal-height-row__item">
+            Access critical security fixes, legal assurance and phone and ticket support for OpenStack, K8s, Docker, Ceph and more through UA Infrastructure.
+          </p>
+          <div class="p-equal-height-row__item">
+            <hr class="is-muted" />
+            <p>
+              <a href="/pricing/infra">Security maintenance and support&nbsp;&rsaquo;</a>
+            </p>
+          </div>
+          <div class="p-equal-height-row__item">
+            <hr class="is-muted" />
+            <p>
+              <a href="https://buy.ubuntu.com/">Purchase from our store</a>
+            </p>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

Rebrand /core and /core/services thank-you pages. No content was changed, layout only

## QA

- [demo link](https://ubuntu-com-14232.demos.haus/core/thank-you)
- [figma](https://www.figma.com/design/FoWXkNxxdri9EgSsLdtTrH/24.10-AWS-bubble?node-id=120-4373&t=Op4AXNfuaK7SqOU2-0)
- View the site on demo
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check that the page is correct according to figma

## Issue / Card
[WD-12753](https://warthogs.atlassian.net/browse/WD-12753)

[WD-12753]: https://warthogs.atlassian.net/browse/WD-12753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ