### PR TITLE
set credentials maintenance window for sep11-sep12 2024

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -16,10 +16,10 @@ env:
     value: true
 
   - name: CRED_MAINTENANCE_START
-    value: 2024-08-14T03:00:00Z
+    value: 2024-09-11T01:00:00Z
 
   - name: CRED_MAINTENANCE_END
-    value: 2024-08-14T05:00:00Z
+    value: 2024-09-12T08:00:00Z
 
   - name: SEARCH_API_KEY
     secretKeyRef:
@@ -303,10 +303,10 @@ production:
           value: true
 
         - name: CRED_MAINTENANCE_START
-          value: 2024-08-14T03:00:00Z
+          value: 2024-09-11T01:00:00Z
 
         - name: CRED_MAINTENANCE_END
-          value: 2024-08-14T05:00:00Z
+          value: 2024-09-12T08:00:00Z
 
     - paths: [/tutorials]
       name: ubuntu-com-tutorials
@@ -544,10 +544,10 @@ staging:
       value: true
 
     - name: CRED_MAINTENANCE_START
-      value: 2024-08-14T03:00:00Z
+      value: 2024-09-11T01:00:00Z
 
     - name: CRED_MAINTENANCE_END
-      value: 2024-08-14T05:00:00Z
+      value: 2024-09-12T08:00:00Z
 
     - name: SEARCH_API_KEY
       secretKeyRef:
@@ -836,10 +836,10 @@ staging:
           value: true
 
         - name: CRED_MAINTENANCE_START
-          value: 2024-08-14T03:00:00Z
+          value: 2024-09-11T01:00:00Z
 
         - name: CRED_MAINTENANCE_END
-          value: 2024-08-14T05:00:00Z
+          value: 2024-09-12T08:00:00Z
 
     - paths: [/tutorials]
       name: ubuntu-com-tutorials
@@ -1054,10 +1054,10 @@ demo:
       value: true
 
     - name: CRED_MAINTENANCE_START
-      value: 2024-08-14T03:00:00Z
+      value: 2024-09-11T01:00:00Z
 
     - name: CRED_MAINTENANCE_END
-      value: 2024-08-14T05:00:00Z
+      value: 2024-09-12T08:00:00Z
 
     - name: SEARCH_API_KEY
       secretKeyRef:


### PR DESCRIPTION
## Done

- Set a maintenance window for credentials starting from Sept 11, 1:00 (UTC) - Sept 12, 8:00 (UTC) 

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Confirm that there is a banner alert shown on `/credentials` home page which shows a maintenance window in the above timeframe

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
