### PR TITLE
[WD-14593] update download links for Risc-V for 24.04.1

### DIFF
--- a/templates/download/risc-v/allwinner-nezha.html
+++ b/templates/download/risc-v/allwinner-nezha.html
@@ -30,7 +30,7 @@
     <div class="col-6">
       <p>
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/noble/release/ubuntu-24.04-preinstalled-server-riscv64+nezha.img.xz">Download 24.04</a>
+           href="https://cdimage.ubuntu.com/releases/24.04.1/release/ubuntu-24.04.1-preinstalled-server-riscv64+nezha.img.xz">Download 24.04.1</a>
       </p>
       <p>
         <a href="https://wiki.ubuntu.com/RISC-V/Nezha%20D1">How to install Ubuntu on the Nezha</a>

--- a/templates/download/risc-v/microchip-curiosity.html
+++ b/templates/download/risc-v/microchip-curiosity.html
@@ -30,7 +30,7 @@
     <div class="col-6">
       <p>
         <a class="p-button--positive"
-           href="https://people.canonical.com/~platform/images/microchip/pic64gx1000_curiosity_kit/ubuntu-24.04-preinstalled-server-riscv64+pic64gx.img.xz">Download 24.04</a>
+           href="https://cdimage.ubuntu.com/releases/24.04.1/release/ubuntu-24.04.1-preinstalled-server-riscv64+pic64gx.img.xz">Download 24.04.1</a>
       </p>
       <p>
         <a href="https://wiki.ubuntu.com/RISC-V/Microchip%20PIC64GX1000%20Curiosity%20Kit">How to install Ubuntu on the Microchip PIC64GX1000 Curiosity Kit</a>

--- a/templates/download/risc-v/microchip-polarfire.html
+++ b/templates/download/risc-v/microchip-polarfire.html
@@ -41,7 +41,7 @@
       <hr class="is-fixed-width col-6" />
       <p>
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/noble/release/ubuntu-24.04-preinstalled-server-riscv64+icicle.img.xz">Download 24.04</a>
+           href="https://cdimage.ubuntu.com/releases/24.04.1/release/ubuntu-24.04.1-preinstalled-server-riscv64+icicle.img.xz">Download 24.04.1</a>
       </p>
       <p>
         <a href="https://wiki.ubuntu.com/RISC-V/PolarFire%20SoC%20FPGA%20Icicle%20Kit">How to install Ubuntu on the Microchip Polarfire SoC FPGA Icicle Kit</a>

--- a/templates/download/risc-v/milk-v-mars.html
+++ b/templates/download/risc-v/milk-v-mars.html
@@ -34,7 +34,7 @@
       </p>
       <p>
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/24.04.1/release/ubuntu-24.04-preinstalled-server-riscv64+milkvmars.img.xz">Download 24.04.1</a>
+           href="https://cdimage.ubuntu.com/releases/24.04.1/release/ubuntu-24.04.1-preinstalled-server-riscv64+milkvmars.img.xz">Download 24.04.1</a>
       </p>
     </div>
   </div>

--- a/templates/download/risc-v/milk-v-mars.html
+++ b/templates/download/risc-v/milk-v-mars.html
@@ -34,7 +34,7 @@
       </p>
       <p>
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/24.04/release/ubuntu-24.04-preinstalled-server-riscv64+milkvmars.img.xz">Download 24.04</a>
+           href="https://cdimage.ubuntu.com/releases/24.04.1/release/ubuntu-24.04-preinstalled-server-riscv64+milkvmars.img.xz">Download 24.04.1</a>
       </p>
     </div>
   </div>
@@ -50,7 +50,7 @@
     <div class="col-6">
       <p>
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/24.04/release/ubuntu-24.04-live-server-riscv64.img.gz">Download 24.04 live installer</a>
+           href="https://cdimage.ubuntu.com/releases/24.04.1/release/ubuntu-24.04.1-live-server-riscv64.img.gz">Download 24.04.1 live installer</a>
       </p>
       <p>
         <a href="https://wiki.ubuntu.com/RISC-V/Milk-V%20Mars">How to install Ubuntu on the Milk-V Mars</a>

--- a/templates/download/risc-v/qemu-emulator.html
+++ b/templates/download/risc-v/qemu-emulator.html
@@ -29,7 +29,7 @@
     <div class="col-6">
       <p class="u-sv3">
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/noble/release/ubuntu-24.04-preinstalled-server-riscv64+unmatched.img.xz">Download 24.04</a>
+           href="https://cdimage.ubuntu.com/releases/24.04.1/release/ubuntu-24.04.1-preinstalled-server-riscv64+unmatched.img.xz">Download 24.04.1</a>
       </p>
     </div>
   </div>
@@ -45,7 +45,7 @@
     <div class="col-6">
       <p>
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/noble/release/ubuntu-24.04-live-server-riscv64.img.gz">Download 24.04 live installer</a>
+           href="https://cdimage.ubuntu.com/releases/24.04.1/release/ubuntu-24.04.1-live-server-riscv64.img.gz">Download 24.04.1 live installer</a>
       </p>
       <p>
         <a href="https://wiki.ubuntu.com/RISC-V/QEMU">How to install Ubuntu on QEMU RISC-V</a>

--- a/templates/download/risc-v/sifive-unmatched.html
+++ b/templates/download/risc-v/sifive-unmatched.html
@@ -32,7 +32,7 @@
       </p>
       <p class="u-sv3">
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/noble/release/ubuntu-24.04-preinstalled-server-riscv64+unmatched.img.xz">Download 24.04</a>
+           href="https://cdimage.ubuntu.com/releases/24.04.1/release/ubuntu-24.04.1-preinstalled-server-riscv64+unmatched.img.xz">Download 24.04.1</a>
       </p>
     </div>
   </div>
@@ -48,7 +48,7 @@
     <div class="col-6">
       <p>
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/noble/release/ubuntu-24.04-live-server-riscv64.img.gz">Download 24.04 live installer</a>
+           href="https://cdimage.ubuntu.com/releases/24.04.1/release/ubuntu-24.04.1-live-server-riscv64.img.gz">Download 24.04.1 live installer</a>
       </p>
       <p>
         <a href="https://wiki.ubuntu.com/RISC-V/SiFive%20HiFive%20Unmatched">How to install Ubuntu on SiFive HiFive Unmatched</a>

--- a/templates/download/risc-v/sipeed-licheerv.html
+++ b/templates/download/risc-v/sipeed-licheerv.html
@@ -30,7 +30,7 @@
     <div class="col-6">
       <p>
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/noble/release/ubuntu-24.04-preinstalled-server-riscv64+licheerv.img.xz">Download 24.04</a>
+           href="https://cdimage.ubuntu.com/releases/24.04.1/release/ubuntu-24.04.1-preinstalled-server-riscv64+licheerv.img.xz">Download 24.04.1</a>
       </p>
       <p>
         <a href="https://wiki.ubuntu.com/RISC-V/LicheeRV">How to install Ubuntu on the LicheeRV Dock</a>

--- a/templates/download/risc-v/starfive-visionfive.html
+++ b/templates/download/risc-v/starfive-visionfive.html
@@ -33,7 +33,7 @@
       </p>
       <p>
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/noble/release/ubuntu-24.04-preinstalled-server-riscv64+visionfive2.img.xz">Download 24.04</a>
+           href="https://cdimage.ubuntu.com/releases/24.04.1/release/ubuntu-24.04.1-preinstalled-server-riscv64+visionfive2.img.xz">Download 24.04.1</a>
       </p>
     </div>
   </div>
@@ -49,7 +49,7 @@
     <div class="col-6">
       <p>
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/noble/release/ubuntu-24.04-live-server-riscv64.img.gz">Download 24.04 live installer</a>
+           href="https://cdimage.ubuntu.com/releases/24.04.1/release/ubuntu-24.04.1-live-server-riscv64.img.gz">Download 24.04.1 live installer</a>
       </p>
       <p>
         <a href="https://wiki.ubuntu.com/RISC-V/StarFive%20VisionFive%202">How to install Ubuntu on the VisionFive 2</a>


### PR DESCRIPTION
## Done

- Updates links for downloading Ubuntu 24.04.1 image for Risc-V

## QA

Navigate to https://ubuntu-com-14245.demos.haus/download/risc-v and check that it downloads new images for Ubuntu 24.04.1

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-14593

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
