### PR TITLE
Reinstate related engage pages

### DIFF
--- a/templates/engage/base.html
+++ b/templates/engage/base.html
@@ -31,7 +31,7 @@
   <div class="u-fixed-width navigation-logo-engage">
     <a href="/">
       {% if metadata['banner_class'] == 'light' %}
-        {{ image(url="https://assets.ubuntu.com/v1/43ef5c89-Canonical Ubuntu.svg",
+        {{ image(url="https://assets.ubuntu.com/v1/43ef5c89-Canonical%20Ubuntu.svg",
                   alt="Ubuntu",
                   width="300",
                   height="55",
@@ -39,7 +39,7 @@
                   loading="auto") | safe
         }}
       {% else %}
-        {{ image(url="https://assets.ubuntu.com/v1/b4f695ea-Canonical Ubuntu copy 2.svg",
+        {{ image(url="https://assets.ubuntu.com/v1/b4f695ea-Canonical%20Ubuntu%20copy%202.svg",
                   alt="Ubuntu",
                   width="300",
                   height="55",
@@ -149,18 +149,18 @@
   <section class="p-strip--light is-shallow">
     <div class="row">
       <div class="col-8">
-        <h3>Related engage pages</h3>
+        <h2 class="p-heading--3">Related engage pages</h2>
       </div>
     </div>
 
     <div class="row p-divider">
       {% for page in related_pages_metadata %}
       <div class="col-4 p-divider__block">
-        <h4>
+        <h3 class="p-heading--4">
           <a href="{{ page["path"] }}">
             {{ page["topic_name"] }}
           </a>
-        </h4>
+        </h3>
         <p>{{ page["subtitle"] }}</p>
       </div>
       {% endfor %}

--- a/templates/engage/base.html
+++ b/templates/engage/base.html
@@ -31,26 +31,20 @@
   <div class="u-fixed-width navigation-logo-engage">
     <a href="/">
       {% if metadata['banner_class'] == 'light' %}
-        {{
-          image(
-            url="https://assets.ubuntu.com/v1/43ef5c89-Canonical Ubuntu.svg",
-            alt="Ubuntu",
-            width="300",
-            height="55",
-            hi_def=True,
-            loading="auto"
-          ) | safe
+        {{ image(url="https://assets.ubuntu.com/v1/43ef5c89-Canonical Ubuntu.svg",
+                  alt="Ubuntu",
+                  width="300",
+                  height="55",
+                  hi_def=True,
+                  loading="auto") | safe
         }}
       {% else %}
-        {{
-          image(
-            url="https://assets.ubuntu.com/v1/b4f695ea-Canonical Ubuntu copy 2.svg",
-            alt="Ubuntu",
-            width="300",
-            height="55",
-            hi_def=True,
-            loading="auto"
-          ) | safe
+        {{ image(url="https://assets.ubuntu.com/v1/b4f695ea-Canonical Ubuntu copy 2.svg",
+                  alt="Ubuntu",
+                  width="300",
+                  height="55",
+                  hi_def=True,
+                  loading="auto") | safe
         }}
       {% endif %}
     </a>
@@ -150,4 +144,28 @@
   </div>
 </section>
 {% endif %}
+
+{% if related_pages_metadata %}
+  <section class="p-strip--light is-shallow">
+    <div class="row">
+      <div class="col-8">
+        <h3>Related posts</h3>
+      </div>
+    </div>
+
+    <div class="row p-divider">
+      {% for page in related_pages_metadata %}
+      <div class="col-4 p-divider__block">
+        <h4>
+          <a href="{{ page["path"] }}">
+            {{ page["topic_name"] }}
+          </a>
+        </h4>
+        <p>{{ page["subtitle"] }}</p>
+      </div>
+      {% endfor %}
+    </div>
+  </section>
+{% endif %}
+
 {% endblock content %}

--- a/templates/engage/base.html
+++ b/templates/engage/base.html
@@ -149,7 +149,7 @@
   <section class="p-strip--light is-shallow">
     <div class="row">
       <div class="col-8">
-        <h3>Related posts</h3>
+        <h3>Related engage pages</h3>
       </div>
     </div>
 

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -473,8 +473,7 @@ def build_engage_page(engage_pages):
                 if metadata["related_urls"].strip() != "":
                     related_urls = metadata["related_urls"].split(",")
                     # Only show maximum of 3 related pages
-                    for i in range(3):
-                        url = related_urls[i]
+                    for url in related_urls[:3]:
                         page_metadata = engage_pages.get_engage_page(
                             url.strip()
                         )

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -472,14 +472,14 @@ def build_engage_page(engage_pages):
             if "related_urls" in metadata:
                 if metadata["related_urls"].strip() != "":
                     related_urls = metadata["related_urls"].split(",")
-
                     # Only show maximum of 3 related pages
                     for i in range(3):
                         url = related_urls[i]
                         page_metadata = engage_pages.get_engage_page(
                             url.strip()
                         )
-                        related_pages_metadata.append(page_metadata)
+                        if page_metadata is not None:
+                            related_pages_metadata.append(page_metadata)
 
             return flask.render_template(
                 "engage/base.html",

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -468,12 +468,26 @@ def build_engage_page(engage_pages):
         if not metadata:
             flask.abort(404)
         else:
+            related_pages_metadata = []
+            if "related_urls" in metadata:
+                if metadata["related_urls"].strip() != "":
+                    related_urls = metadata["related_urls"].split(",")
+
+                    # Only show maximum of 3 related pages
+                    for i in range(3):
+                        url = related_urls[i]
+                        page_metadata = engage_pages.get_engage_page(
+                            url.strip()
+                        )
+                        related_pages_metadata.append(page_metadata)
+
             return flask.render_template(
                 "engage/base.html",
                 forum_url=engage_pages.api.base_url,
                 metadata=metadata,
                 language=metadata["language"],
                 resource=metadata["type"],
+                related_pages_metadata=related_pages_metadata,
             )
 
     return engage_page


### PR DESCRIPTION
## Done

- Add "Related posts" section to individual engage pages
- Allows stakeholders to choose top 3 posts to show in the related section
- Added `related_urls` field to the [engage template](https://discourse.ubuntu.com/c/design/engage-pages/51) on discourse.u.com 

## QA

- Go to https://ubuntu-com-14246.demos.haus/engage/azure-ubuntu-pro-fips-whitepaper
- Scroll down to see the "Related Posts" section
- Check that it is similar to the `related_urls` added to the [discourse post](https://discourse.ubuntu.com/t/staying-compliant-while-delivering-innovation-in-government-services/19960)
- Related Posts section only shows when stakeholders add `related_urls`, otherwise the section will not exist

## Issue / Card

Fixes [WD-13259](https://warthogs.atlassian.net/browse/WD-13259)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-7151]: https://warthogs.atlassian.net/browse/WD-7151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[WD-13259]: https://warthogs.atlassian.net/browse/WD-13259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ