### PR TITLE
copy update: Update /download/risc-v download link

### DIFF
--- a/templates/download/risc-v/qemu-emulator.html
+++ b/templates/download/risc-v/qemu-emulator.html
@@ -29,7 +29,7 @@
     <div class="col-6">
       <p class="u-sv3">
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/24.04.1/release/ubuntu-24.04.1-preinstalled-server-riscv64+unmatched.img.xz">Download 24.04.1</a>
+           href="https://cdimage.ubuntu.com/releases/noble/release/ubuntu-24.04.1-preinstalled-server-riscv64.img.xz">Download 24.04</a>
       </p>
     </div>
   </div>

--- a/templates/download/risc-v/qemu-emulator.html
+++ b/templates/download/risc-v/qemu-emulator.html
@@ -29,7 +29,7 @@
     <div class="col-6">
       <p class="u-sv3">
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/noble/release/ubuntu-24.04.1-preinstalled-server-riscv64.img.xz">Download 24.04</a>
+           href="https://cdimage.ubuntu.com/releases/noble/release/ubuntu-24.04.1-preinstalled-server-riscv64.img.xz">Download 24.04.1</a>
       </p>
     </div>
   </div>


### PR DESCRIPTION
## Done

- Updated link as per [doc](https://docs.google.com/document/d/1kkJeq9HdH3iWV35HwihcJd3CxZw9Jy21W66lJl8VbWs/edit)

## QA

- View the site locally in your web browser at: https://ubuntu-com-14250.demos.haus/download/risc-v and click on the QEMU emulator tab
- Check that the update was made

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-14459