### PR TITLE
Add optional CTA button for engage pages

### DIFF
--- a/templates/engage/base.html
+++ b/templates/engage/base.html
@@ -56,7 +56,7 @@
         {{ metadata['subtitle'] }}
       </p>
       {% if ("primary_cta" in metadata) and (metadata["primary_cta"] != "") %}
-      <p class="{% if ('show_cta_on_banner' in metadata) and (metadata["show_cta_on_banner"] == "true" ) %}u-show--large{% else %}u-hide--large{% endif %}">
+      <p class="{% if ('show_cta_on_banner' in metadata) and (metadata["show_cta_on_banner"] == "true" ) %}u-show--large{% else %}u-hide--large{% endif %} u-hide--medium u-hide--small">
           <a href="{{ metadata['primary_link'] }}" class="p-button--positive">
             {{ metadata["primary_cta"] }}
           </a>

--- a/templates/engage/base.html
+++ b/templates/engage/base.html
@@ -56,7 +56,7 @@
         {{ metadata['subtitle'] }}
       </p>
       {% if ("primary_cta" in metadata) and (metadata["primary_cta"] != "") %}
-      <p class="{% if ('show_cta_on_large_banner' in metadata) and (metadata["show_cta_on_large_banner"] == "true" ) %}u-show--large{% else %}u-hide--large{% endif %} u-hide--medium u-hide--small">
+      <p class="{% if ('show_cta_on_banner' in metadata) and (metadata["show_cta_on_banner"] == "true" ) %}u-show{% else %}u-hide{% endif %}">
           <a href="{{ metadata['primary_link'] }}" class="p-button--positive">
             {{ metadata["primary_cta"] }}
           </a>

--- a/templates/engage/base.html
+++ b/templates/engage/base.html
@@ -56,7 +56,7 @@
         {{ metadata['subtitle'] }}
       </p>
       {% if ("primary_cta" in metadata) and (metadata["primary_cta"] != "") %}
-      <p class="{% if 'secondary_cta' not in metadata %}u-hide--large{% endif %}">
+      <p class="{% if ('show_cta_on_banner' in metadata) and (metadata["show_cta_on_banner"] == "true" ) %}u-show--large{% else %}u-hide--large{% endif %}">
           <a href="{{ metadata['primary_link'] }}" class="p-button--positive">
             {{ metadata["primary_cta"] }}
           </a>

--- a/templates/engage/base.html
+++ b/templates/engage/base.html
@@ -56,7 +56,7 @@
         {{ metadata['subtitle'] }}
       </p>
       {% if ("primary_cta" in metadata) and (metadata["primary_cta"] != "") %}
-      <p class="{% if ('show_cta_on_banner' in metadata) and (metadata["show_cta_on_banner"] == "true" ) %}u-show--large{% else %}u-hide--large{% endif %} u-hide--medium u-hide--small">
+      <p class="{% if ('show_cta_on_large_banner' in metadata) and (metadata["show_cta_on_large_banner"] == "true" ) %}u-show--large{% else %}u-hide--large{% endif %} u-hide--medium u-hide--small">
           <a href="{{ metadata['primary_link'] }}" class="p-button--positive">
             {{ metadata["primary_cta"] }}
           </a>


### PR DESCRIPTION
## Done

- Add optional CTA button on engage page banners

## QA

- Go to [engage page template](https://discourse.canonical.com/t/engage-pages-and-takeovers-v2/358) on discourse
- Check that the `show_cta_on_banner` doc is added 
- Create a "New Topic" on discourse engage pages [here](https://discourse.ubuntu.com/c/design/engage-pages/51)
- See that `show_cta_on_banner` shows up on the template
- Go to https://ubuntu-com-14252.demos.haus/engage/microk8s-nvidia-tech-stack
- See that the primary CTA button shows up on banner and that the [original discourse post](https://discourse.ubuntu.com/t/simplifying-kubernetes-across-the-clouds/22260) sets `show_cta_on_banner` to true
- Go to https://ubuntu-com-14252.demos.haus/engage/redhat-openstack-comparison-whitepaper
- See that the primary CTA button doesnt show up and that the [original discourse post](https://discourse.ubuntu.com/t/red-hat-openstack-platform-vs-canonicals-charmed-openstack/18159) sets `show_cta_on_banner` to false
- Go to https://ubuntu-com-14252.demos.haus/engage/cra-yocto-core
- See that the primary CTA button doesnt show up and that the [original discourse post](https://discourse.ubuntu.com/t/whitepaper-yocto-vs-core-refresh-cra/47610) does not have `show_cta_on_banner` set

## Issue / Card

Fixes [WD-7421](https://warthogs.atlassian.net/browse/WD-7421)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-7421]: https://warthogs.atlassian.net/browse/WD-7421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ