### PR TITLE
Fix /real-time dynamic forms

### DIFF
--- a/static/js/src/dynamic-forms.js
+++ b/static/js/src/dynamic-forms.js
@@ -262,7 +262,7 @@ import { prepareInputFields } from "./prepare-form-inputs.js";
           ".js-other-container__checkbox",
         );
         var input = otherContainer.querySelector(".js-other-container__input");
-        checkbox.addEventListener("change", function (e) {
+        checkbox?.addEventListener("change", function (e) {
           if (e.target.checked) {
             input.style.opacity = 1;
             input.focus();

--- a/templates/shared/forms/interactive/real-time.html
+++ b/templates/shared/forms/interactive/real-time.html
@@ -113,7 +113,7 @@
               </div>
             </div>
             <div class="js-formfield">
-              <label for="tell-us-about-your-project">Tell us more about your project</label>
+              <label class="p-heading--5" for="tell-us-about-your-project">Tell us more about your project</label>
               <textarea id="tell-us-about-your-project" rows="5" maxlength="2000"></textarea>
             </div>
 

--- a/templates/shared/forms/interactive/real-time.html
+++ b/templates/shared/forms/interactive/real-time.html
@@ -45,70 +45,76 @@
               <p class="u-no-margin--bottom">Tell us about your project so we can bring the right Canonical team members to the conversation to help you.</p>
               <h4 class="p-heading--5">In which industry do you operate?</h4>
               <label class="p-radio">
-                <input class="p-radio__input" type="radio" aria-labelledby="your-industry-is-industrial" name="your-industry-is" value="Industrial">
+                <input class="p-radio__input" type="radio" aria-labelledby="your-industry-is-industrial" value="Industrial">
                 <span class="p-radio__label" id="your-industry-is-industrial">Industrial</span>
               </label>
               <label class="p-radio">
-                <input class="p-radio__input" type="radio" aria-labelledby="your-industry-is-automotive" name="your-industry-is" value="Automotive">
+                <input class="p-radio__input" type="radio" aria-labelledby="your-industry-is-automotive" value="Automotive">
                 <span class="p-radio__label" id="your-industry-is-automotive">Automotive</span>
               </label>
               <label class="p-radio">
-                <input class="p-radio__input" type="radio" aria-labelledby="your-industry-is-telco" name="your-industry-is" value="Telco">
+                <input class="p-radio__input" type="radio" aria-labelledby="your-industry-is-telco" value="Telco">
                 <span class="p-radio__label" id="your-industry-is-telco">Telco</span>
               </label>
               <label class="p-radio u-no-margin--bottom">
-                <input class="p-radio__input" type="radio" aria-labelledby="your-industry-is-public-sector" name="your-industry-is" value="Public sector">
+                <input class="p-radio__input" type="radio" aria-labelledby="your-industry-is-public-sector" value="Public sector">
                 <span class="p-radio__label" id="your-industry-is-public-sector">Public sector</span>
               </label>
               <div class="js-other-container">
                 <label class="p-radio">
-                  <input class="p-radio__input js-other-container__other-toggle" type="radio" aria-labelledby="your-industry-is-other" name="your-industry-is" value="other">
+                  <input class="p-radio__input js-other-container__other-toggle" type="radio" aria-labelledby="your-industry-is-other" value="other">
                   <span class="p-radio__label" id="your-industry-is-other">Other</span>
                 </label>
-                <input type="text" id="your-industry-is-other-specified" class="js-other-container__input u-hide" name="your-industry-is" placeholder="Please specify" style="margin-top: .25rem;" aria-label="Other industry specified">
+                <input type="text" id="your-industry-is-other-specified" class="js-other-container__input u-hide" placeholder="Please specify" style="margin-top: .25rem;" aria-label="Other industry specified">
               </div>
+            </div>
+            <div class="js-formfield">
               <h4 class="p-heading--5">Which architecture are you using?</h4>
               <label class="p-radio">
-                <input class="p-radio__input" type="radio" aria-labelledby="architecture-using-arm" name="architecture-using" value="arm">
+                <input class="p-radio__input" type="radio" aria-labelledby="architecture-using-arm" value="arm">
                 <span class="p-radio__label" id="architecture-using-arm">arm</span>
               </label>
               <label class="p-radio u-no-margin--bottom">
-                <input class="p-radio__input" type="radio" aria-labelledby="architecture-using-x86" name="architecture-using" value="x86">
+                <input class="p-radio__input" type="radio" aria-labelledby="architecture-using-x86" value="x86">
                 <span class="p-radio__label" id="architecture-using-x86">x86</span>
               </label>
               <div class="js-other-container">
                 <label class="p-radio">
-                  <input class="p-radio__input js-other-container__other-toggle" type="radio" aria-labelledby="architecture-using-other" name="architecture-using" value="other">
+                  <input class="p-radio__input js-other-container__other-toggle" type="radio" aria-labelledby="architecture-using-other" value="other">
                   <span class="p-radio__label" id="architecture-using-other">Other</span>
                 </label>
-                <input type="text" id="architecture-using-other-specified" class="js-other-container__input u-hide" name="architecture-using" placeholder="Please specify" style="margin-top: .25rem;" aria-label="Other architecture using specified">
+                <input type="text" id="architecture-using-other-specified" class="js-other-container__input u-hide" placeholder="Please specify" style="margin-top: .25rem;" aria-label="Other architecture using specified">
               </div>
+            </div>
+            <div class="js-formfield">
               <h4 class="p-heading--5">How are you currently meeting your latency requirements?</h4>
               <label class="p-radio">
-                <input class="p-radio__input" type="radio" aria-labelledby="meeting-latency-requirements-rtos" name="meeting-latency-requirements" value="RTOS">
+                <input class="p-radio__input" type="radio" aria-labelledby="meeting-latency-requirements-rtos" value="RTOS">
                 <span class="p-radio__label" id="meeting-latency-requirements-rtos">RTOS</span>
               </label>
               <label class="p-radio">
-                <input class="p-radio__input" type="radio" aria-labelledby="meeting-latency-requirements-commercially-supported-real-time-linux" name="meeting-latency-requirements" value="Commercially-supported real-time Linux">
+                <input class="p-radio__input" type="radio" aria-labelledby="meeting-latency-requirements-commercially-supported-real-time-linux" value="Commercially-supported real-time Linux">
                 <span class="p-radio__label" id="meeting-latency-requirements-commercially-supported-real-time-linux">Commercially-supported real-time Linux</span>
               </label>
               <label class="p-radio">
-                <input class="p-radio__input" type="radio" aria-labelledby="meeting-latency-requirements-patching-own-linux-kernel" name="meeting-latency-requirements" value="Patching own Linux kernel">
+                <input class="p-radio__input" type="radio" aria-labelledby="meeting-latency-requirements-patching-own-linux-kernel" value="Patching own Linux kernel">
                 <span class="p-radio__label" id="meeting-latency-requirements-patching-own-linux-kernel">Patching own Linux kernel</span>
               </label>
               <label class="p-radio u-no-margin--bottom">
-                <input class="p-radio__input" type="radio" aria-labelledby="meeting-latency-requirements-no-solution" name="meeting-latency-requirements" value="No solution">
+                <input class="p-radio__input" type="radio" aria-labelledby="meeting-latency-requirements-no-solution" value="No solution">
                 <span class="p-radio__label" id="meeting-latency-requirements-no-solution">No solution</span>
               </label>
               <div class="js-other-container">
                 <label class="p-radio">
-                  <input class="p-radio__input js-other-container__other-toggle" type="radio" aria-labelledby="meeting-latency-requirements-other" name="meeting-latency-requirements"  value="other">
+                  <input class="p-radio__input js-other-container__other-toggle" type="radio" aria-labelledby="meeting-latency-requirements-other" value="other">
                   <span class="p-radio__label" id="meeting-latency-requirements-other">Other</span>
                 </label>
-                <input type="text" id="meeting-latency-requirements-other-specified" class="js-other-container__input u-hide" name="meeting-latency-requirements" placeholder="Please specify" style="margin-top: .25rem;" aria-label="Other meeting latency specified">
+                <input type="text" id="meeting-latency-requirements-other-specified" class="js-other-container__input u-hide" placeholder="Please specify" style="margin-top: .25rem;" aria-label="Other meeting latency specified">
               </div>
+            </div>
+            <div class="js-formfield">
               <label for="tell-us-about-your-project">Tell us more about your project</label>
-              <textarea id="tell-us-about-your-project" name="tell-us-about-your-project" rows="5" maxlength="2000"></textarea>
+              <textarea id="tell-us-about-your-project" rows="5" maxlength="2000"></textarea>
             </div>
 
             <ul class="p-list">

--- a/templates/shared/forms/interactive/real-time.html
+++ b/templates/shared/forms/interactive/real-time.html
@@ -45,71 +45,71 @@
               <p class="u-no-margin--bottom">Tell us about your project so we can bring the right Canonical team members to the conversation to help you.</p>
               <h4 class="p-heading--5">In which industry do you operate?</h4>
               <label class="p-radio">
-                <input class="p-radio__input" type="radio" aria-labelledby="your-industry-is-industrial" value="Industrial">
+                <input class="p-radio__input" type="radio" aria-labelledby="your-industry-is-industrial" value="Industrial" />
                 <span class="p-radio__label" id="your-industry-is-industrial">Industrial</span>
               </label>
               <label class="p-radio">
-                <input class="p-radio__input" type="radio" aria-labelledby="your-industry-is-automotive" value="Automotive">
+                <input class="p-radio__input" type="radio" aria-labelledby="your-industry-is-automotive" value="Automotive" />
                 <span class="p-radio__label" id="your-industry-is-automotive">Automotive</span>
               </label>
               <label class="p-radio">
-                <input class="p-radio__input" type="radio" aria-labelledby="your-industry-is-telco" value="Telco">
+                <input class="p-radio__input" type="radio" aria-labelledby="your-industry-is-telco" value="Telco" />
                 <span class="p-radio__label" id="your-industry-is-telco">Telco</span>
               </label>
               <label class="p-radio u-no-margin--bottom">
-                <input class="p-radio__input" type="radio" aria-labelledby="your-industry-is-public-sector" value="Public sector">
+                <input class="p-radio__input" type="radio" aria-labelledby="your-industry-is-public-sector" value="Public sector" />
                 <span class="p-radio__label" id="your-industry-is-public-sector">Public sector</span>
               </label>
               <div class="js-other-container">
                 <label class="p-radio">
-                  <input class="p-radio__input js-other-container__other-toggle" type="radio" aria-labelledby="your-industry-is-other" value="other">
+                  <input class="p-radio__input js-other-container__other-toggle" type="radio" aria-labelledby="your-industry-is-other" value="other" />
                   <span class="p-radio__label" id="your-industry-is-other">Other</span>
                 </label>
-                <input type="text" id="your-industry-is-other-specified" class="js-other-container__input u-hide" placeholder="Please specify" style="margin-top: .25rem;" aria-label="Other industry specified">
+                <input type="text" id="your-industry-is-other-specified" class="js-other-container__input u-hide" placeholder="Please specify" style="margin-top: .25rem;" aria-label="Other industry specified" />
               </div>
             </div>
             <div class="js-formfield">
               <h4 class="p-heading--5">Which architecture are you using?</h4>
               <label class="p-radio">
-                <input class="p-radio__input" type="radio" aria-labelledby="architecture-using-arm" value="arm">
+                <input class="p-radio__input" type="radio" aria-labelledby="architecture-using-arm" value="arm" />
                 <span class="p-radio__label" id="architecture-using-arm">arm</span>
               </label>
               <label class="p-radio u-no-margin--bottom">
-                <input class="p-radio__input" type="radio" aria-labelledby="architecture-using-x86" value="x86">
+                <input class="p-radio__input" type="radio" aria-labelledby="architecture-using-x86" value="x86" />
                 <span class="p-radio__label" id="architecture-using-x86">x86</span>
               </label>
               <div class="js-other-container">
                 <label class="p-radio">
-                  <input class="p-radio__input js-other-container__other-toggle" type="radio" aria-labelledby="architecture-using-other" value="other">
+                  <input class="p-radio__input js-other-container__other-toggle" type="radio" aria-labelledby="architecture-using-other" value="other" />
                   <span class="p-radio__label" id="architecture-using-other">Other</span>
                 </label>
-                <input type="text" id="architecture-using-other-specified" class="js-other-container__input u-hide" placeholder="Please specify" style="margin-top: .25rem;" aria-label="Other architecture using specified">
+                <input type="text" id="architecture-using-other-specified" class="js-other-container__input u-hide" placeholder="Please specify" style="margin-top: .25rem;" aria-label="Other architecture using specified" />
               </div>
             </div>
             <div class="js-formfield">
               <h4 class="p-heading--5">How are you currently meeting your latency requirements?</h4>
               <label class="p-radio">
-                <input class="p-radio__input" type="radio" aria-labelledby="meeting-latency-requirements-rtos" value="RTOS">
+                <input class="p-radio__input" type="radio" aria-labelledby="meeting-latency-requirements-rtos" value="RTOS" />
                 <span class="p-radio__label" id="meeting-latency-requirements-rtos">RTOS</span>
               </label>
               <label class="p-radio">
-                <input class="p-radio__input" type="radio" aria-labelledby="meeting-latency-requirements-commercially-supported-real-time-linux" value="Commercially-supported real-time Linux">
+                <input class="p-radio__input" type="radio" aria-labelledby="meeting-latency-requirements-commercially-supported-real-time-linux" value="Commercially-supported real-time Linux" /> 
                 <span class="p-radio__label" id="meeting-latency-requirements-commercially-supported-real-time-linux">Commercially-supported real-time Linux</span>
               </label>
               <label class="p-radio">
-                <input class="p-radio__input" type="radio" aria-labelledby="meeting-latency-requirements-patching-own-linux-kernel" value="Patching own Linux kernel">
+                <input class="p-radio__input" type="radio" aria-labelledby="meeting-latency-requirements-patching-own-linux-kernel" value="Patching own Linux kernel" />
                 <span class="p-radio__label" id="meeting-latency-requirements-patching-own-linux-kernel">Patching own Linux kernel</span>
               </label>
               <label class="p-radio u-no-margin--bottom">
-                <input class="p-radio__input" type="radio" aria-labelledby="meeting-latency-requirements-no-solution" value="No solution">
+                <input class="p-radio__input" type="radio" aria-labelledby="meeting-latency-requirements-no-solution" value="No solution" />
                 <span class="p-radio__label" id="meeting-latency-requirements-no-solution">No solution</span>
               </label>
               <div class="js-other-container">
                 <label class="p-radio">
-                  <input class="p-radio__input js-other-container__other-toggle" type="radio" aria-labelledby="meeting-latency-requirements-other" value="other">
+                  <input class="p-radio__input js-other-container__other-toggle" type="radio" aria-labelledby="meeting-latency-requirements-other" value="other" />
                   <span class="p-radio__label" id="meeting-latency-requirements-other">Other</span>
                 </label>
-                <input type="text" id="meeting-latency-requirements-other-specified" class="js-other-container__input u-hide" placeholder="Please specify" style="margin-top: .25rem;" aria-label="Other meeting latency specified">
+                <input type="text" id="meeting-latency-requirements-other-specified" class="js-other-container__input u-hide" placeholder="Please specify" style="margin-top: .25rem;" aria-label="Other meeting latency specified" />
               </div>
             </div>
             <div class="js-formfield">
@@ -120,7 +120,7 @@
             <ul class="p-list">
               <li class="p-list__item">
                 <label class="p-checkbox">
-                  <input class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
+                  <input class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
                   <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
                 </label>
               </li>

--- a/templates/shared/forms/interactive/real-time.html
+++ b/templates/shared/forms/interactive/real-time.html
@@ -13,27 +13,27 @@
                 <h3 class="p-heading--5">How should we get in touch?</h3>
                 <ul class="p-list">
                   <li class="p-list__item">
-                    <label for="firstName">First name:</label>
+                    <label class="is-required" for="firstName">First name:</label>
                     <input required id="firstName" name="firstName" maxlength="255" type="text" />
                   </li>
                   <li class="p-list__item">
-                    <label for="lastName">Last name:</label>
+                    <label class="is-required" for="lastName">Last name:</label>
                     <input required id="lastName" name="lastName" maxlength="255" type="text" />
                   </li>
                   <li class="p-list__item">
-                      <label for="company">Company:</label>
+                      <label class="is-required" for="company">Company:</label>
                       <input required id="company" name="company" maxlength="255" type="text" />
                     </li>
                   <li class="p-list__item">
-                    <label for="title">Job title:</label>
+                    <label class="is-required" for="title">Job title:</label>
                     <input required id="title" name="title" maxlength="255" type="text" />
                   </li>
                   <li class="p-list__item">
-                    <label for="email">Email address:</label>
+                    <label class="is-required" for="email">Email address:</label>
                     <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
                   </li>
                   <li class="p-list__item">
-                    <label for="phone">Mobile/cell phone number:</label>
+                    <label class="is-required" for="phone">Mobile/cell phone number:</label>
                     <input required id="phone" name="phone" maxlength="255" type="tel" />
                   </li>
                 </ul>


### PR DESCRIPTION
## Done

- Remove name attributes on fields that do not need to be included in the payload
- Add js-formfield to sections that need to be consolidated into `Comments_from_lead__c`

## QA

- Go to https://ubuntu-com-14253.demos.haus/real-time
- Click on `Get in touch` to invoke the contact modal
- Submit the form, check that the radio items are under `Comments_from_lead__c` with the field title and value
- Check on marketo that the form submits as expected

## Issue / Card

Fixes [WD-14614](https://warthogs.atlassian.net/browse/WD-14614)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-14614]: https://warthogs.atlassian.net/browse/WD-14614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ