### PR TITLE
Replace OpenStack releases with codenames

### DIFF
--- a/templates/about/openstack-release-cycle.html
+++ b/templates/about/openstack-release-cycle.html
@@ -14,21 +14,21 @@
       </thead>
       <tbody>
         <tr>
-          <td>OpenStack 2024.1</td>
+          <td>OpenStack Caracal LTS</td>
           <td>&nbsp;</td>
           <td>Apr 2024</td>
           <td>Apr 2027</td>
           <td>&nbsp;</td>
         </tr>
         <tr>
-          <td>OpenStack 2023.2</td>
+          <td>OpenStack Bobcat</td>
           <td>&nbsp;</td>
           <td>Oct 2023</td>
           <td>Apr 2025</td>
           <td>&nbsp;</td>
         </tr>
         <tr>
-          <td>OpenStack 2023.1</td>
+          <td>OpenStack Antelope</td>
           <td>&nbsp;</td>
           <td>Apr 2023</td>
           <td>Oct 2024</td>


### PR DESCRIPTION
## Done

- Replaced the last 3 supported OpenStack releases with their codenames:
  - 2023.1 >  Antelope
  - 2023.2 > Bobcat
  - 2024.1 > Caracal
 
- This is to bring uniformity to the [release cycle page](https://ubuntu.com/about/release-cycle#openstack-release-cycle).

Fixes:

![image](https://github.com/user-attachments/assets/72a72441-a4de-466b-a75f-de1b3909662d)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
