### PR TITLE
Remove stale link at /community/community-support

### DIFF
--- a/templates/support/community-support.html
+++ b/templates/support/community-support.html
@@ -1,55 +1,68 @@
 {% extends "support/base_support.html" %}
 
-
 {% block title %}Community support{% endblock %}
-{% block meta_copydoc %}https://docs.google.com/document/d/1vrnljXUx71ZZhz3cQ6NupUNw6yNqW2OWkyY8Ozx2bqw/edit{% endblock meta_copydoc %}
+
+{% block meta_copydoc %}
+  https://docs.google.com/document/d/1vrnljXUx71ZZhz3cQ6NupUNw6yNqW2OWkyY8Ozx2bqw/edit
+{% endblock meta_copydoc %}
 
 {% block content %}
-<div class="p-strip--suru-bottomed">
-  <div class="row u-vertically-center">
-    <div class="col-7">
-      <h1>Community support</h1>
-      <p>You can find support from a variety of sources. Take a look &ndash; you're likely to find an answer to every question. If you can't find an answer, just ask the people in our active forums.</p>
-    </div>
-    <div class="col-4 col-start-large-9 u-hide--medium u-hide--small u-align--center">
-      {{
-        image(
-            url="https://assets.ubuntu.com/v1/5552afb7-community-support.svg",
-            alt="Community",
-            width="200",
-            height="200",
-            hi_def=True,
-            loading="auto"
-        ) | safe
-      }}
-    </div>
-  </div>
-</div>
-
-<div class="p-strip is-deep">
-  <div class="row u-equal-height">
-    <div class="col-4 p-card">
-      <h3><a href="/community/support">Find community support</a></h3>
-      <p><a href="https://askubuntu.com/">Ask Ubuntu</a> and <a href="https://ubuntuforums.org/">Ubuntu Forums</a> are great sources of answers to common questions about installing, troubleshooting and optimising Ubuntu. For more info on support forums, including IRC channels, see <a href="/community/support">our community docs</a>.</p>
-    </div>
-    <div class="col-4 p-card">
-      <h3><a href="https://help.ubuntu.com/">Read the docs</a></h3>
-      <p>If you're stuck on a problem, someone else has probably encountered it too. Take a look at the <a href="https://help.ubuntu.com">official documentation</a>  or our other <a href="https://docs.ubuntu.com">product docs</a>.</p>
-    </div>
-    <div class="col-4 p-card">
-      <h3><a href="https://answers.launchpad.net/ubuntu">Technical answers system</a></h3>
-      <p>Use Launchpad to add your support question. Keep your query active until you get an answer or browse and search historical questions and answers.</p>
+  <div class="p-strip--suru-bottomed">
+    <div class="row u-vertically-center">
+      <div class="col-7">
+        <h1>Community support</h1>
+        <p>
+          You can find support from a variety of sources. Take a look &ndash; you're likely to find an answer to every question. If you can't find an answer, just ask the people in our active forums.
+        </p>
+      </div>
+      <div class="col-4 col-start-large-9 u-hide--medium u-hide--small u-align--center">
+        {{ image(url="https://assets.ubuntu.com/v1/5552afb7-community-support.svg",
+                alt="Community",
+                width="200",
+                height="200",
+                hi_def=True,
+                loading="auto") | safe
+        }}
+      </div>
     </div>
   </div>
-</div>
 
-{% with first_item="_support_landscape", second_item="_support_contact_us", third_item="_further_reading" %}{% include "shared/contextual_footers/_contextual_footer.html" %}{% endwith %}
+  <div class="p-strip is-deep">
+    <div class="row u-equal-height">
+      <div class="col-6 p-card">
+        <h3>
+          <a href="/community/support">Find community support</a>
+        </h3>
+        <p>
+          <a href="https://askubuntu.com/">Ask Ubuntu</a> and <a href="https://ubuntuforums.org/">Ubuntu Forums</a> are great sources of answers to common questions about installing, troubleshooting and optimising Ubuntu. For more info on support forums, including IRC channels, see <a href="/community/support">our community docs</a>.
+        </p>
+      </div>
+      <div class="col-6 p-card">
+        <h3>
+          <a href="https://help.ubuntu.com/">Read the docs</a>
+        </h3>
+        <p>
+          If you're stuck on a problem, someone else has probably encountered it too. Take a look at the <a href="https://help.ubuntu.com">official documentation</a>  or our other <a href="https://docs.ubuntu.com">product docs</a>.
+        </p>
+      </div>
+    </div>
+  </div>
 
-<!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/support" data-form-id="1240" data-lp-id="2065" data-return-url="https://ubuntu.com/support/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
-</div>
+  {% with first_item="_support_landscape", second_item="_support_contact_us", third_item="_further_reading" %}
+    {% include "shared/contextual_footers/_contextual_footer.html" %}
+  {% endwith %}
 
-
+  <!-- Set default Marketo information for contact form below-->
+  <div class="u-hide"
+       id="contact-form-container"
+       data-form-location="/shared/forms/interactive/support"
+       data-form-id="1240"
+       data-lp-id="2065"
+       data-return-url="https://ubuntu.com/support/thank-you"
+       data-lp-url="https://pages.ubuntu.com/things-contact-us.html"></div>
 
 {% endblock content %}
-{% block footer_extra %}{{ marketo }}{% endblock footer_extra %}
+
+{% block footer_extra %}
+  {{ marketo }}
+{% endblock footer_extra %}

--- a/templates/support/community-support.html
+++ b/templates/support/community-support.html
@@ -30,17 +30,17 @@
   <div class="p-strip is-deep">
     <div class="row u-equal-height">
       <div class="col-6 p-card">
-        <h3>
+        <h2 class="p-heading--3">
           <a href="/community/support">Find community support</a>
-        </h3>
+        </h2>
         <p>
           <a href="https://askubuntu.com/">Ask Ubuntu</a> and <a href="https://ubuntuforums.org/">Ubuntu Forums</a> are great sources of answers to common questions about installing, troubleshooting and optimising Ubuntu. For more info on support forums, including IRC channels, see <a href="/community/support">our community docs</a>.
         </p>
       </div>
       <div class="col-6 p-card">
-        <h3>
+        <h2 class="p-heading--3">
           <a href="https://help.ubuntu.com/">Read the docs</a>
-        </h3>
+        </h2>
         <p>
           If you're stuck on a problem, someone else has probably encountered it too. Take a look at the <a href="https://help.ubuntu.com">official documentation</a>  or our other <a href="https://docs.ubuntu.com">product docs</a>.
         </p>
@@ -62,7 +62,3 @@
        data-lp-url="https://pages.ubuntu.com/things-contact-us.html"></div>
 
 {% endblock content %}
-
-{% block footer_extra %}
-  {{ marketo }}
-{% endblock footer_extra %}


### PR DESCRIPTION
## Done

- Removed stale link (see discussion in ticket) and updated the [doc](https://docs.google.com/document/d/1vrnljXUx71ZZhz3cQ6NupUNw6yNqW2OWkyY8Ozx2bqw/edit) to reflect the change 
- Ran djlint

## QA

- View the site locally in your web browser at: https://ubuntu-com-14256.demos.haus/support/community-support
- See that the link has been removed 

## Issue / Card

Fixes https://github.com/canonical/ubuntu.com/issues/13655, https://warthogs.atlassian.net/browse/WD-9502

## Screenshots 
![image](https://github.com/user-attachments/assets/8dc04c80-0828-4265-8fe2-d8ff76320f47)

