### PR TITLE
Add invoice menu in the navigation

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -344,6 +344,8 @@ Distributor:
       path: /pro/distributor
     - title: Account users
       path: /pro/distributor/users
+    - title: Invoices
+      path: /pro/distributor/invoice
     - title: Docs
       path: https://documentation.ubuntu.com/pro
     - title: Discourse

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -321,6 +321,7 @@ app.add_url_rule(
     "/account/invoices",
     view_func=invoices_view,
 )
+app.add_url_rule("/pro/distributor/invoice", view_func=invoices_view)
 app.add_url_rule(
     "/account/invoices/download/<purchase_id>",
     view_func=download_invoice,


### PR DESCRIPTION
## Done

- Add invoice menu in the navigation

## QA

- Go to /pro/distributor
- Check Invoice exist in the navigation and the page shows properly on `/pro/distributor/invoice`
<img width="953" alt="image" src="https://github.com/user-attachments/assets/fbbf4a40-8e19-4459-b2be-61b0bfba7cda">

## Issue / Card

Fixes #https://warthogs.atlassian.net/browse/WD-14641?atlOrigin=eyJpIjoiODUxNDhhM2I5YjE1NDM5OWEzNzljNmU4ZWEyNjA0MjEiLCJwIjoiaiJ9
