### PR TITLE
Add PO number in the checkout

### DIFF
--- a/static/js/src/advantage/distributor/components/DistributorBuyButton/DistributorBuyButton.test.tsx
+++ b/static/js/src/advantage/distributor/components/DistributorBuyButton/DistributorBuyButton.test.tsx
@@ -31,17 +31,11 @@ const mockContextValue = {
   offer: ChannelOfferFactory.build({ id: "offer-id-1" }),
 };
 
-const MockFormContext = ({ children }: { children: React.ReactNode }) => (
-  <FormContext.Provider value={mockContextValue}>
-    {children}
-  </FormContext.Provider>
-);
-
 test("Should display correct price per machine", () => {
   render(
-    <MockFormContext>
+    <FormContext.Provider value={mockContextValue}>
       <DistributorBuyButton />
-    </MockFormContext>,
+    </FormContext.Provider>,
   );
 
   const localStorageMock = {
@@ -90,4 +84,18 @@ test("Should display correct price per machine", () => {
 
   expect(window.location.href).toBe("/account/checkout");
   window.location = originalLocation;
+});
+
+test("Should disable button when no products are selected", async () => {
+  render(
+    <FormContext.Provider value={{ ...mockContextValue, products: [] }}>
+      <DistributorBuyButton />
+    </FormContext.Provider>,
+  );
+
+  const button = screen.getByText(/Proceed to checkout/i);
+
+  expect(button).toBeInTheDocument();
+  expect(button).toHaveAttribute("aria-disabled", "true");
+  expect(button).toHaveClass("is-disabled");
 });

--- a/static/js/src/advantage/distributor/components/DistributorBuyButton/DistributorBuyButton.tsx
+++ b/static/js/src/advantage/distributor/components/DistributorBuyButton/DistributorBuyButton.tsx
@@ -64,6 +64,7 @@ const DistributorBuyButton = () => {
           );
           location.href = "/account/checkout";
         }}
+        disabled={products?.length === 0}
       >
         Proceed to checkout
       </Button>

--- a/static/js/src/advantage/subscribe/checkout/components/AdditionalNotes/AdditionalNotes.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/AdditionalNotes/AdditionalNotes.tsx
@@ -1,0 +1,28 @@
+import { Field, useFormikContext } from "formik";
+import { Col, Input, Row } from "@canonical/react-components";
+import { FormValues } from "../../utils/types";
+
+const AdditionalNotes = () => {
+  const { values, setValues } = useFormikContext<FormValues>();
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setValues({ ...values, poNumber: e.target.value });
+  };
+
+  return (
+    <Row>
+      <Col size={12}>
+        <Field
+          name="additionalNotes"
+          id="additionalNotes"
+          as={Input}
+          placeholder="Ex: Internal reference number"
+          type="text"
+          onChange={handleChange}
+        />
+      </Col>
+    </Row>
+  );
+};
+
+export default AdditionalNotes;

--- a/static/js/src/advantage/subscribe/checkout/components/AdditionalNotes/index.ts
+++ b/static/js/src/advantage/subscribe/checkout/components/AdditionalNotes/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./AdditionalNotes";

--- a/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
@@ -47,6 +47,7 @@ const BuyButton = ({ setError, products, action, coupon }: Props) => {
   const postPurchaseMutation = postPurchase();
   const buyAction = values.FreeTrial === "useFreeTrial" ? "trial" : action;
   const queryClient = useQueryClient();
+  const poNumber = values.poNumber || null;
 
   const sessionData = {
     gclid: getSessionData("gclid"),
@@ -135,6 +136,7 @@ const BuyButton = ({ setError, products, action, coupon }: Props) => {
         products,
         action: buyAction,
         coupon,
+        poNumber,
       },
       {
         onSuccess: (purchaseId: string) => {

--- a/static/js/src/advantage/subscribe/checkout/components/Checkout/Checkout.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Checkout/Checkout.tsx
@@ -6,6 +6,7 @@ import {
   Notification,
   Row,
   Spinner,
+  Strip,
 } from "@canonical/react-components";
 import { checkoutEvent } from "advantage/ecom-events";
 import useCustomerInfo from "../../hooks/useCustomerInfo";
@@ -23,6 +24,7 @@ import Summary from "../Summary";
 import Taxes from "../Taxes";
 import UserInfoForm from "../UserInfoForm";
 import { UserSubscriptionMarketplace } from "advantage/api/enum";
+import AdditionalNotes from "../AdditionalNotes";
 
 type Props = {
   products: CheckoutProducts[];
@@ -130,6 +132,19 @@ const Checkout = ({ products, action, coupon }: Props) => {
                             title: "Free trial",
                             content: (
                               <FreeTrial products={products} action={action} />
+                            ),
+                          },
+                        ]
+                      : []),
+                    ...(marketplace ===
+                    UserSubscriptionMarketplace.CanonicalProChannel
+                      ? [
+                          {
+                            title: "Additional notes",
+                            content: (
+                              <Strip className="u-no-padding--top">
+                                <AdditionalNotes />
+                              </Strip>
                             ),
                           },
                         ]

--- a/static/js/src/advantage/subscribe/checkout/hooks/postPurchase.tsx
+++ b/static/js/src/advantage/subscribe/checkout/hooks/postPurchase.tsx
@@ -13,11 +13,12 @@ type Props = {
   products: CheckoutProducts[];
   action: Action;
   coupon?: Coupon;
+  poNumber?: string | null;
 };
 
 const postPurchase = () => {
   const mutation = useMutation<any, Error, Props>({
-    mutationFn: async ({ products, action, coupon }: Props) => {
+    mutationFn: async ({ products, action, coupon, poNumber }: Props) => {
       if (window.currentPaymentId) {
         await retryPurchase(window.currentPaymentId);
 
@@ -87,7 +88,7 @@ const postPurchase = () => {
           }),
         };
 
-        if (technicalUserContact) {
+        if (technicalUserContact || poNumber) {
           const channelMetaData: Array<{ key: string; value: string }> = [];
           if (technicalUserContact.name) {
             channelMetaData.push({
@@ -102,6 +103,14 @@ const postPurchase = () => {
               value: technicalUserContact.name,
             });
           }
+
+          if (poNumber) {
+            channelMetaData.push({
+              key: "poNumber",
+              value: poNumber,
+            });
+          }
+
           payload.metadata = channelMetaData;
         }
       }

--- a/static/js/src/advantage/subscribe/checkout/utils/types.ts
+++ b/static/js/src/advantage/subscribe/checkout/utils/types.ts
@@ -54,6 +54,7 @@ export interface FormValues {
   isTaxSaved: boolean;
   isCardValid: boolean;
   isInfoSaved: boolean;
+  poNumber?: string | null;
 }
 
 export type marketplace =

--- a/static/sass/_pattern_checkout.scss
+++ b/static/sass/_pattern_checkout.scss
@@ -14,12 +14,12 @@
       $bullet-width: map-get($line-heights, default-text);
       $bullet-width-mobile: map-get($line-heights, default-text);
       $bullet-margin: calc((map-get($line-heights, h#{$i}) - $bullet-width) / 2) +
-        map-get($nudges, h#{$i}) - 0.25rem;
-      $moblie-hight: (
+        map-get($nudges, h#{$i}) - 0.5rem;
+      $moblie-height: (
         map-get($line-heights, h#{$i}-mobile) - $bullet-width-mobile
       );
-      $bullet-margin-mobile: calc($moblie-hight / 2) + map-get($nudges, h#{$i}) -
-        0.25rem;
+      $bullet-margin-mobile: calc($moblie-height / 2) + map-get($nudges, h#{$i}) -
+        0.5rem;
 
       &::before {
         // Need to account for the 1px border:


### PR DESCRIPTION
## Done

- Add PO number in the checkout

## QA

- Go to /pro/distributor
- Initiate an order
- Go to checkout 
- Check Additional notes section shows in the step 4 
![image](https://github.com/user-attachments/assets/9f8061a4-a356-4838-bf92-3a3918981a5c)
- Additional notes should show only in the distributor store checkout


## Issue / Card

Fixes #https://warthogs.atlassian.net/browse/WD-14642?atlOrigin=eyJpIjoiNGQyYTgxOTlhYTgyNDNkNDkxZmY4OGZmZjY0ZmYwODciLCJwIjoiaiJ9
