### PR TITLE
Remove preview call from the purchase hook

### DIFF
--- a/static/js/src/advantage/subscribe/checkout/hooks/postPurchase.tsx
+++ b/static/js/src/advantage/subscribe/checkout/hooks/postPurchase.tsx
@@ -106,31 +106,6 @@ const postPurchase = () => {
         }
       }
 
-      // preview
-      const previewReq = await fetch(
-        `/pro/purchase/preview${window.location.search}`,
-        {
-          method: "POST",
-          cache: "no-store",
-          credentials: "include",
-          headers: {
-            Accept: "application/json",
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify(payload),
-        },
-      );
-      const previewRes = await previewReq.json();
-
-      if (previewRes.errors) {
-        if (
-          previewRes.errors != "no invoice would be issued for this purchase"
-        ) {
-          throw new Error(previewRes.errors);
-        }
-      }
-
-      // purhcase
       const pruchaseReq = await fetch(
         `/pro/purchase${window.location.search}`,
         {


### PR DESCRIPTION
## Done

- Remove preview call from the purchase hook

## QA

- Need to make sure purchases are working properly in all checkout (pro, credentials, distributor) 

## Issue / Card

Fixes #https://warthogs.atlassian.net/browse/WD-14644
