### PR TITLE
chore: Exclude all /search endpoints from google indexing

### DIFF
--- a/static/files/robots.txt
+++ b/static/files/robots.txt
@@ -2,4 +2,5 @@ User-Agent: *
 Disallow: /search
 Disallow: /search*
 Disallow: /server/docs/search*
+Disallow: /*/search*
 Sitemap: https://ubuntu.com/sitemap.xml


### PR DESCRIPTION
## Done

- Add a wildcard for all search endpoints, `Disallow: /*/search*`

## QA

- Monitor google indexing and make sure no `/search` endpoints are getting through. It is possible some get through as this wont ignore searches that are linked. But these should be very few

## Issue / Card

Fixes https://warthogs.atlassian.net/jira/software/c/projects/WD/boards/932?assignee=62860507c217e200698de3e5&selectedIssue=WD-12318
