### PR TITLE
Update outdated pricing example and 404 link on AWS page

### DIFF
--- a/templates/aws/pro.html
+++ b/templates/aws/pro.html
@@ -333,7 +333,7 @@
           </tr>
         </tbody>
       </table>
-      <p>For complete pricing, <a href="https://aws.amazon.com/marketplace/pp/B0821T9RL2">see Ubuntu Pro 18.04 LTS on the AWS Marketplace</a></p>
+      <p>For complete pricing, <a href="https://aws.amazon.com/marketplace/pp/prodview-dxdx74ozlxsl2">see Ubuntu Pro 22.04 LTS on the AWS Marketplace</a></p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done
- add working link to aws 22.04 lts page, update link text

## QA

- go to https://ubuntu.com/aws/pro
- click the link at the bottom of the page titled "see Ubuntu Pro 22.04 LTS on the AWS Marketplace"
- check that link leads to correct page 

## Issue / Card

Fixes #14263

## Screenshots

![Screenshot from 2024-09-04 11-30-12](https://github.com/user-attachments/assets/b6786bcb-1646-4586-85ce-0b9c5123dd8e)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
