### PR TITLE
Add fallback URL for referrer

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -869,8 +869,6 @@ def shorten_acquisition_url(acquisition_url):
     """
     Shorten the acquisition URL sent when submitting forms
     """
-    if acquisition_url is None:
-        return None
 
     if len(acquisition_url) > 255:
         url_without_params = acquisition_url.split("?")[0]
@@ -939,7 +937,11 @@ def marketo_submit():
     visitor_data = {
         "userAgentString": flask.request.headers.get("User-Agent"),
     }
-    referrer = flask.request.referrer
+    referrer = (
+        flask.request.referrer
+        if flask.request.referrer
+        else "https://ubuntu.com"
+    )
     client_ip = flask.request.headers.get(
         "X-Real-IP", flask.request.remote_addr
     )

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -869,6 +869,8 @@ def shorten_acquisition_url(acquisition_url):
     """
     Shorten the acquisition URL sent when submitting forms
     """
+    if acquisition_url is None:
+        return None
 
     if len(acquisition_url) > 255:
         url_without_params = acquisition_url.split("?")[0]


### PR DESCRIPTION
## Done

- Fixes this Sentry error https://sentry.is.canonical.com/canonical/ubuntu-com/issues/86589/events/5125836/
- Sets the fallback acquisition_url to https://ubuntu.com

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes [WD-14683](https://warthogs.atlassian.net/browse/WD-14683)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-14683]: https://warthogs.atlassian.net/browse/WD-14683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ