### PR TITLE
[WD-14757] Prevent user navigation on checkout page

### DIFF
--- a/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
@@ -22,6 +22,7 @@ import {
   DISTRIBUTOR_SELECTOR_KEYS,
   PRO_SELECTOR_KEYS,
 } from "advantage/distributor/utils/utils";
+import { confirmNavigateListener } from "../../utils/helpers";
 
 type Props = {
   setError: React.Dispatch<React.SetStateAction<React.ReactNode>>;
@@ -75,6 +76,7 @@ const BuyButton = ({ setError, products, action, coupon }: Props) => {
   }, [values.country]);
 
   const onPayClick = async () => {
+    confirmNavigateListener.set();
     validateForm().then((errors) => {
       const possibleErrors = Object.keys(errors);
       possibleErrors.forEach((error) => {
@@ -156,6 +158,7 @@ const BuyButton = ({ setError, products, action, coupon }: Props) => {
   };
 
   const handleError = (error: Error) => {
+    confirmNavigateListener.clear();
     setIsLoading(false);
     setFieldValue("Description", false);
     setFieldValue("TermsAndConditions", false);
@@ -338,6 +341,7 @@ const BuyButton = ({ setError, products, action, coupon }: Props) => {
 
       request.onreadystatechange = () => {
         if (request.readyState === 4) {
+          confirmNavigateListener.clear();
           localStorage.removeItem("shop-checkout-data");
           const product = products[0].product;
           const quantity = products[0].quantity;

--- a/static/js/src/advantage/subscribe/checkout/utils/helpers.ts
+++ b/static/js/src/advantage/subscribe/checkout/utils/helpers.ts
@@ -54,3 +54,20 @@ export const canBeTrialled = (
 
   return userCanTrial && productCanBeTrialled;
 };
+
+const beforeUnloadHandler = (event: Event) => {
+  // Recommended
+  event.preventDefault();
+
+  // Included for legacy support, e.g. Chrome/Edge < 119
+  event.returnValue = true;
+};
+
+export const confirmNavigateListener = {
+  set: () => {
+    window.addEventListener("beforeunload", beforeUnloadHandler);
+  },
+  clear: () => {
+    window.removeEventListener("beforeunload", beforeUnloadHandler);
+  },
+};


### PR DESCRIPTION
## Done

- Prevent user navigation on checkout page.

## QA

- Go to https://ubuntu-com-14273.demos.haus/pro/subscribe
- Scroll to the bottom and click on the **Buy now** button
- Fill in the form and click the **Buy now** button
- Reload the page after you see the loading icon on the button
- Check if you get a confirmation alert

## Issue / Card

Fixes [WD-14757](https://warthogs.atlassian.net/browse/WD-14757)

## Screenshots

![image](https://github.com/user-attachments/assets/9107b15b-1186-4136-a9f5-815195067d69)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-14757]: https://warthogs.atlassian.net/browse/WD-14757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ