### PR TITLE
WD-12841 - rebrand /aws/outposts

### DIFF
--- a/templates/aws/outposts.html
+++ b/templates/aws/outposts.html
@@ -104,8 +104,8 @@
           <hr class="is-muted" />
           <ul class="p-inline-list u-responsive-realign u-no-margin--bottom">
             <li class="p-inline-list__item">
-              <a href="https://aws.amazon.com/marketplace/pp/B087L1R4G4"
-                 class="p-button--positive"><span>Launch Ubuntu Pro 20.04 LTS</span></a>
+              <a href="https://aws.amazon.com/marketplace/pp/prodview-kbkyvwyqubv2g"
+                 class="p-button--positive"><span>Launch Ubuntu Pro 24.04 LTS</span></a>
             </li>
             <li class="p-inline-list__item">
               <p>
@@ -135,14 +135,14 @@
         <hr class="p-rule--muted u-hide--large" />
         <h3 class="p-heading--5">Security built in</h3>
         <p>
-          Our security teams track alerts 24x7 and release- patches to system components and applications continuously. Canonical operates a worldwide distribution network ensuring that package updates are delivered in-region quickly.
+          Our security teams track alerts 24/7 and release- patches to system components and applications continuously. Canonical operates a worldwide distribution network ensuring that package updates are delivered in-region quickly.
         </p>
       </div>
       <div class="col-3">
         <hr class="p-rule--muted u-hide--large" />
         <h3 class="p-heading--5">Compliance ready</h3>
         <p>
-          Ubuntu Pro for AWS offers  long term maintenance, compliance (FIPS, CIS), expanded security coverage and optional 24x7 support;  covering any extra requirements you have for your on-premises workloads.
+          Ubuntu Pro for AWS offers  long term maintenance, compliance (FIPS, CIS), expanded security coverage and optional 24/7 support;  covering any extra requirements you have for your on-premises workloads.
         </p>
       </div>
     </div>
@@ -152,7 +152,7 @@
     <div class="row--50-50">
       <hr />
       <div class="col">
-        <h2>Get Ubuntu on AWS Outposts now:</h2>
+        <h2>Get Ubuntu on AWS now:</h2>
       </div>
       <div class="col">
         <div class="p-tabs js-tabbed-content">
@@ -220,7 +220,7 @@
     <div class="row--50-50">
       <hr />
       <div class="col">
-        <h2>Get Ubuntu on AWS Outposts now:</h2>
+        <h2>Get Ubuntu Pro on AWS now:</h2>
       </div>
       <div class="col">
         <div class="row">

--- a/templates/aws/outposts.html
+++ b/templates/aws/outposts.html
@@ -318,6 +318,7 @@
         <ol class="p-stepped-list--detailed">
           <li class="p-stepped-list__item">
             <div class="row">
+              <hr class="is--muted u-hide--large" />
               <div class="col-3 col-medium-2 col-start-medium-2">
                 <h3 class="p-stepped-list__title p-heading--5">Select the region your AWS Outpost is attached</h3>
               </div>
@@ -336,6 +337,7 @@
           </li>
           <li class="p-stepped-list__item">
             <div class="row">
+              <hr class="is--muted u-hide--large" />
               <div class="col-3 col-medium-2 col-start-medium-2">
                 <h3 class="p-stepped-list__title p-heading--5">Select the Ubuntu version you want to launch</h3>
               </div>
@@ -356,6 +358,7 @@
           </li>
           <li class="p-stepped-list__item">
             <div class="row">
+              <hr class="is--muted u-hide--large" />
               <div class="col-3 col-medium-2 col-start-medium-2">
                 <h3 class="p-stepped-list__title p-heading--5">Select the subnet of VPC your AWS Outposts resides</h3>
               </div>

--- a/templates/aws/outposts.html
+++ b/templates/aws/outposts.html
@@ -231,25 +231,25 @@
                   <button class="p-tabs__link"
                           role="tab"
                           aria-selected="true"
-                          aria-controls="AMD-tab"
-                          id="AMD"
-                          data-maintain-hash="AMD">AMD64</button>
+                          aria-controls="AMD-pro-tab"
+                          id="AMD-pro"
+                          data-maintain-hash="AMD-pro">AMD64</button>
                 </div>
                 <div class="p-tabs__item">
                   <button class="p-tabs__link"
                           role="tab"
                           aria-selected="false"
-                          aria-controls="ARM-tab"
-                          id="ARM"
-                          data-maintain-hash="ARM"
+                          aria-controls="ARM-pro-tab"
+                          id="ARM-pro"
+                          data-maintain-hash="ARM-pro"
                           tabindex="-1">ARM64</button>
                 </div>
               </div>
 
               <div tabindex="0"
                    role="tabpanel"
-                   id="AMD-tab"
-                   aria-labelledby="AMD"
+                   id="AMD-pro-tab"
+                   aria-labelledby="AMD-pro"
                    aria-hidden="false">
                 <ul class="p-list--divided">
                   <li class="p-list__item">
@@ -278,8 +278,8 @@
 
               <div tabindex="0"
                    role="tabpanel"
-                   id="ARM-tab"
-                   aria-labelledby="ARM"
+                   id="ARM-pro-tab"
+                   aria-labelledby="ARM-pro"
                    aria-hidden="false">
                 <ul class="p-list--divided">
                   <li class="p-list__item">

--- a/templates/aws/outposts.html
+++ b/templates/aws/outposts.html
@@ -1,202 +1,374 @@
 {% extends "aws/base_aws.html" %}
 
 {% block title %}Ubuntu Pro & Ubuntu on AWS Outposts{% endblock %}
-{% block meta_description %}The most popular Operating System in the public cloud, running on your premises with a consistent AWS experience. {% endblock %}
-{% block meta_copydoc %}https://docs.google.com/document/d/1aXtrGHw7AcZ_qrov3kJahRtgsmbNx7eH5aWFlIySpfE/edit#{% endblock meta_copydoc %}
+
+{% block meta_description %}
+  The most popular Operating System in the public cloud, running on your premises with a consistent AWS experience.
+{% endblock %}
+
+{% block meta_copydoc %}
+  https://docs.google.com/document/d/1aXtrGHw7AcZ_qrov3kJahRtgsmbNx7eH5aWFlIySpfE/edit#
+{% endblock meta_copydoc %}
+
+{% block body_class %}
+  is-paper
+{% endblock body_class %}
 
 {% block content %}
-<section class="p-strip u-no-padding--top u-no-padding--bottom">
-  <div class="p-strip--suru-topped">
-    <div class="row u-equal-height">
-      <div class="col-7 col-medium-4">
-        <h1>Ubuntu on AWS Outposts</h1>
-        <p>The most popular operating system in the public cloud, running on your premises with a consistent AWS experience.</p>
-        <p>Security, compliance and support available for all enterprise scenarios.</p>
+  <section class="p-section--hero">
+    <div class="row--50-50">
+      <div class="col">
+        <div class="p-section--shallow">
+          <h1>Ubuntu on AWS Outposts</h1>
+          <p>
+            The most popular operating system in AWS, running on your premises with a consistent hybrid
+            experience.
+          </p>
+          <p>Security, compliance and support available for all enterprise scenarios.</p>
+        </div>
+        <hr class="is-muted" />
         <a href="/aws/contact-us" class="p-button--positive js-invoke-modal">Talk to us about Ubuntu on AWS Outposts</a>
       </div>
-      <div class="col-5 u-align--center u-vertically-center u-hide--medium u-hide--small">
-        {{
-          image(
-            url="https://assets.ubuntu.com/v1/6c8b8dd4-AWS-outposts.svg",
-            alt="",
-            width="200",
-            height="220",
-            hi_def=True,
-            loading="auto",
-          ) | safe
-        }}
-      </div>
-    </div>
-  </div>
-</section>
-
-
-<section class="p-strip--light">
-  <div class="row">
-    <div class="col-6">
-      <h2>Choose the right Ubuntu for you</h2>
-      <p>Select between the standard Ubuntu Server and the Pro edition, which includes expanded security, compliance and AWS integration:</p>
-    </div>
-  </div>
-
-  <div class="row u-equal-height">
-    <div class="col-6 p-card">
-      <h3 class="p-card__title">Ubuntu</h3>
-      <p class="p-heading--2">Free to use</p>
-      <hr class="u-sv1">
-      <div class="p-card__content">
-        <ul class="p-list">
-          <li class="p-list__item is-ticked">AWS service ready solution for AWS Outposts</li>
-          <li class="p-list__item is-ticked">AWS-optimised kernel and userspace components built from the latest releases</li>
-          <li class="p-list__item is-ticked">Broad set of open source application components available for development</li>
-          <li class="p-list__item is-ticked">Security patches for the kernel and key infrastructure components</li>
-          <li class="p-list__item is-ticked">Updates mirrored and images published in all AWS regions worldwide</li>
-          <li class="p-list__item is-ticked">5-year lifetime</li>
-        </ul>
-        <p><a href="https://aws.amazon.com/marketplace/pp/B087QQNGF1">Run Ubuntu Server 20.04 LTS</a></p>
-      </div>
-    </div>
-    <div class="col-6 p-card">
-      <h3 class="p-card__title">Ubuntu Pro for AWS</h3>
-      <p class="p-heading--2">Starting at 0.1c/hour</p>
-      <hr class="u-sv1">
-      <div class="p-card__content">
-        <ul class="p-list">
-          <li class="p-list__item is-ticked">AWS service ready solution for AWS Outposts</li>
-          <li class="p-list__item is-ticked">Includes all Ubuntu optimisations and updates of the free version</li>
-          <li class="p-list__item is-ticked">Expanded security covering application components delivered with Ubuntu, including  Apache Kafka, NGINX, MongoDB, Redis and PostgreSQL</li>
-          <li class="p-list__item is-ticked">Kernel live patching for instant security and longer uptimes</li>
-          <li class="p-list__item is-ticked">FIPS 140-2 and CC-EAL certified components</li>
-          <li class="p-list__item is-ticked">10-year lifetime</li>
-        </ul>
-        <p><a href="https://aws.amazon.com/marketplace/pp/B087L1R4G4" class="p-button--positive"><span>Launch Ubuntu Pro 20.04 LTS</span></a></p>
-        <p><a href="/aws/pro">More about Ubuntu Pro for AWS&nbsp;&rsaquo;</a></p>
-      </div>
-    </div>
-  </div>
-</section>
-
-<section class="p-strip">
-  <div class="row">
-    <div class="col-12">
-      <h2>Features</h2>
-    </div>
-  </div>
-  <div class="row p-divider">
-    <div class="col-4 p-divider__block">
-      <h3 class="p-heading--4">Optimised</h3>
-      <p>Ubuntu on AWS Outposts runs on an AWS-optimised kernel, which includes improved device drivers, like <a href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking-ena.html">ENA</a>, and out of the box support for accelerators like GPUs. This means faster instance starts and better runtime performance for your workloads.</p>
-    </div>
-    <div class="col-4 p-divider__block">
-      <h3 class="p-heading--4">Security built in</h3>
-      <p>Our security teams track alerts 24x7 and release- patches to system components and applications continuously. Canonical operates a worldwide distribution network ensuring that package updates are delivered in-region quickly.</p>
-    </div>
-    <div class="col-4 p-divider__block">
-      <h3 class="p-heading--4">Compliance ready</h3>
-      <p>Ubuntu Pro for AWS offers  long term maintenance, compliance (FIPS, CIS), expanded security coverage and optional 24x7 support;  covering any extra requirements you have for your on-premises workloads.</p>
-    </div>
-  </div>
-</section>
-
-<section class="p-strip--light">
-  <div class="row u-sv2">
-    <div class="col-12">
-      <h2>Get Ubuntu on AWS Outposts now:</h2>
-    </div>
-  </div>
-  <div class="row p-divider">
-    <div class="col-3 p-divider__block">
-      <h3 class="p-heading--4"><a href="https://aws.amazon.com/marketplace/pp/B087L1R4G4">20.04 LTS</a></h3>
-    </div>
-    <div class="col-3 p-divider__block">
-      <h3 class="p-heading--4"><a href="https://aws.amazon.com/marketplace/pp/B0821T9RL2">18.04 LTS</a></h3>
-    </div>
-    <div class="col-3 p-divider__block">
-      <h3 class="p-heading--4"><a href="https://aws.amazon.com/marketplace/pp/B0821WW873">16.04 LTS</a></h3>
-    </div>
-  </div>
-  <div class="row u-sv2">
-    <div class="col-12">
-      <h2>Get Ubuntu Pro on AWS Outposts now:</h2>
-    </div>
-  </div>
-  <div class="row p-divider">
-    <div class="col-3 p-divider__block">
-      <h3 class="p-heading--4"><a href="https://aws.amazon.com/marketplace/pp/B087L1R4G4">20.04 LTS</a></h3>
-    </div>
-    <div class="col-3 p-divider__block">
-      <h3 class="p-heading--4"><a href="https://aws.amazon.com/marketplace/pp/B0821T9RL2">18.04 LTS</a></h3>
-    </div>
-    <div class="col-3 p-divider__block">
-      <h3 class="p-heading--4"><a href="https://aws.amazon.com/marketplace/pp/B0821T9RL2">18.04 FIPS LTS</a></h3>
-    </div>
-    <div class="col-3 p-divider__block">
-      <h3 class="p-heading--4"><a href="https://aws.amazon.com/marketplace/pp/B0821WW873">16.04 LTS</a></h3>
-    </div>
-    <div class="col-3 p-divider__block">
-      <h3 class="p-heading--4"><a href="https://aws.amazon.com/marketplace/pp/B0821WW873">16.04 FIPS LTS</a></h3>
-    </div>
-    <div class="col-3 p-divider__block">
-      <h3 class="p-heading--4"><a href="https://aws.amazon.com/marketplace/pp/B0821V7QJP">14.04 LTS</a></h3>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-12">
-      <p class="u-no-margin--bottom"><strong>Read more about</strong> <a href="/aws/pro">Ubuntu Pro&nbsp;&rsaquo;</a></p>
-    </div>
-  </div>
-</section>
-
-<section class="p-strip">
-  <div class="u-fixed-width">
-    <h2 class="u-sv2">Launching Ubuntu on AWS Outposts</h2>
-    <ol class="p-stepped-list">
-      <li class="p-stepped-list__item">
-        <h3 class="p-stepped-list__title">
-          Select the region your AWS Outpost is attached
-        </h3>
-        <div class="p-stepped-list__content">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/78ea4b05-aws-outposts-regions.png",
-              alt="",
-              width="300",
-              height="150",
-              hi_def=True,
-              loading="auto",
-            ) | safe
-          }}
+      <div class="col u-hide--small">
+        <div class="p-image-container--16-9 is-highlighted">
+          <img class="p-image-container__image"
+               src="https://assets.ubuntu.com/v1/6c8b8dd4-AWS-outposts.svg"
+               alt="" />
         </div>
-      </li>
-    
-      <li class="p-stepped-list__item">
-        <h3 class="p-stepped-list__title">
-          Select the Ubuntu version you want to launch
-        </h3>
-        <div class="p-stepped-list__content">
-        <p>Launch an EC2 instance and select Ubuntu from the instance launch quickstart, or visit the marketplace for more Ubuntu options.</p>
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/03238ea8-aws-outputs-ubuntu-image.png",
-              alt="",
-              width="940",
-              height="170",
-              hi_def=True,
-              loading="auto",
-              attrs={"class": "u-hide--small"}
-            ) | safe
-          }}
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="row--50-50 p-section--shallow">
+      <hr />
+      <div class="col">
+        <h2>Choose the right Ubuntu for you</h2>
+      </div>
+      <div class="col">
+        <p>
+          Select between the standard Ubuntu Server and the Pro edition, which includes expanded security, compliance and AWS integration:
+        </p>
+      </div>
+    </div>
+    <div class="row--50-50">
+      <div class="col">
+        <hr class="p-rule--highlight" />
+        <div class="p-card--overlay u-no-padding--top" style="padding: 1.5rem;">
+          <div class="row p-section">
+            <div class="col-3 col-medium-1 col-small-2">
+              <h3>Ubuntu</h3>
+            </div>
+            <div class="col-3 col-medium-2 col-small-2">
+              <p class="p-heading--4 u-align-text--right u-no-margin--bottom">Free to use</p>
+            </div>
+          </div>
+          <hr class="p-rule--muted" />
+          <ul class="p-list--divided">
+            <li class="p-list__item is-ticked">AWS service ready solution for AWS Outposts</li>
+            <li class="p-list__item is-ticked">AWS-optimised kernel and userspace components built from the latest releases</li>
+            <li class="p-list__item is-ticked">Broad set of open source application components available for development</li>
+            <li class="p-list__item is-ticked">Security patches for the kernel and key infrastructure components</li>
+            <li class="p-list__item is-ticked">Updates mirrored and images published in all AWS regions worldwide</li>
+            <li class="p-list__item is-ticked">5-year lifetime</li>
+          </ul>
+          <hr class="is-muted" />
+          <p>
+            <a href="https://aws.amazon.com/marketplace/pp/prodview-s4zvkzmlirbga"
+               class="p-button">Launch Ubuntu Server 24.04 LTS</a>
+          </p>
         </div>
-      </li>
-    
-      <li class="p-stepped-list__item">
-        <h3 class="p-stepped-list__title">
-          Select the VPC your AWS Outposts resides
-        </h3>
-      <p class="p-stepped-list__content">When configuring the instance launch, make sure to select the network for your Outpost, and your instance will automatically be launched.</p>
-      </li>
-    </ol>
-  </div>
-</section>
+      </div>
+      <div class="col">
+        <hr class="p-rule--highlight" />
+        <div class="p-card--overlay u-no-padding--top" style="padding: 1.5rem;">
+          <div class="row p-section--shallow">
+            <div class="col-3 col-medium-1 col-small-2">
+              <h3>Ubuntu Pro for AWS</h3>
+            </div>
+            <div class="col-3 col-medium-2 col-small-2">
+              <p class="p-heading--4 u-align-text--right">From $0.001/hour (Equivalent to $9/year)</p>
+            </div>
+          </div>
+          <hr class="p-rule--muted" />
+          <ul class="p-list--divided">
+            <li class="p-list__item is-ticked">AWS service ready solution for AWS Outposts</li>
+            <li class="p-list__item is-ticked">Includes all Ubuntu optimisations and updates of the free version</li>
+            <li class="p-list__item is-ticked">
+              Expanded security covering application components delivered with Ubuntu, including  Apache Kafka, NGINX, MongoDB, Redis and PostgreSQL
+            </li>
+            <li class="p-list__item is-ticked">Kernel live patching for instant security and longer uptimes</li>
+            <li class="p-list__item is-ticked">FIPS 140-2 and CC-EAL certified components</li>
+            <li class="p-list__item is-ticked">10-year lifetime</li>
+          </ul>
+          <hr class="is-muted" />
+          <ul class="p-inline-list u-responsive-realign u-no-margin--bottom">
+            <li class="p-inline-list__item">
+              <a href="https://aws.amazon.com/marketplace/pp/B087L1R4G4"
+                 class="p-button--positive"><span>Launch Ubuntu Pro 20.04 LTS</span></a>
+            </li>
+            <li class="p-inline-list__item">
+              <p>
+                <a href="/aws/pro">More about Ubuntu Pro for AWS&nbsp;&rsaquo;</a>
+              </p>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="row">
+      <hr />
+      <div class="col-3">
+        <h2>Features</h2>
+      </div>
+      <div class="col-3">
+        <hr class="p-rule--muted u-hide--large" />
+        <h3 class="p-heading--5">Optimised</h3>
+        <p>
+          Ubuntu on AWS Outposts runs on an AWS-optimised kernel, which includes improved device drivers, like <a href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking-ena.html">ENA</a>, and out of the box support for accelerators like GPUs. This means faster instance starts and better runtime performance for your workloads.
+        </p>
+      </div>
+      <div class="col-3">
+        <hr class="p-rule--muted u-hide--large" />
+        <h3 class="p-heading--5">Security built in</h3>
+        <p>
+          Our security teams track alerts 24x7 and release- patches to system components and applications continuously. Canonical operates a worldwide distribution network ensuring that package updates are delivered in-region quickly.
+        </p>
+      </div>
+      <div class="col-3">
+        <hr class="p-rule--muted u-hide--large" />
+        <h3 class="p-heading--5">Compliance ready</h3>
+        <p>
+          Ubuntu Pro for AWS offers  long term maintenance, compliance (FIPS, CIS), expanded security coverage and optional 24x7 support;  covering any extra requirements you have for your on-premises workloads.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr />
+      <div class="col">
+        <h2>Get Ubuntu on AWS Outposts now:</h2>
+      </div>
+      <div class="col">
+        <div class="p-tabs js-tabbed-content">
+          <div class="p-tabs__list" role="tablist" aria-label="AWS outposts">
+            <div class="p-tabs__item">
+              <button class="p-tabs__link"
+                      role="tab"
+                      aria-selected="true"
+                      aria-controls="AMD-tab"
+                      id="AMD"
+                      data-maintain-hash="AMD">AMD64</button>
+            </div>
+            <div class="p-tabs__item">
+              <button class="p-tabs__link"
+                      role="tab"
+                      aria-selected="false"
+                      aria-controls="ARM-tab"
+                      id="ARM"
+                      data-maintain-hash="ARM"
+                      tabindex="-1">ARM64</button>
+            </div>
+          </div>
+
+          <div tabindex="0"
+               role="tabpanel"
+               id="AMD-tab"
+               aria-labelledby="AMD"
+               aria-hidden="false">
+            <ul class="p-list--divided">
+              <li class="p-list__item">
+                <a href="https://aws.amazon.com/marketplace/pp/prodview-s4zvkzmlirbga">24.04 LTS&nbsp;&rsaquo;</a>
+              </li>
+              <li class="p-list__item">
+                <a href="https://aws.amazon.com/marketplace/pp/prodview-f2if34z3a4e3i">22.04 LTS&nbsp;&rsaquo;</a>
+              </li>
+              <li class="p-list__item">
+                <a href="https://aws.amazon.com/marketplace/pp/prodview-iftkyuwv2sjxi">20.04 LTS&nbsp;&rsaquo;</a>
+              </li>
+            </ul>
+          </div>
+
+          <div tabindex="0"
+               role="tabpanel"
+               id="ARM-tab"
+               aria-labelledby="ARM"
+               aria-hidden="false">
+            <ul class="p-list--divided">
+              <li class="p-list__item">
+                <a href="https://aws.amazon.com/marketplace/pp/prodview-ppkztkiaeuede">24.04 LTS&nbsp;&rsaquo;</a>
+              </li>
+              <li class="p-list__item">
+                <a href="https://aws.amazon.com/marketplace/pp/prodview-l7oree6b32tde">22.04 LTS&nbsp;&rsaquo;</a>
+              </li>
+              <li class="p-list__item">
+                <a href="https://aws.amazon.com/marketplace/pp/prodview-fzujhxzys54w6">20.04 LTS&nbsp;&rsaquo;</a>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr />
+      <div class="col">
+        <h2>Get Ubuntu on AWS Outposts now:</h2>
+      </div>
+      <div class="col">
+        <div class="row">
+          <div class="col-3">
+            <div class="p-tabs js-tabbed-content">
+              <div class="p-tabs__list" role="tablist" aria-label="AWS outposts">
+                <div class="p-tabs__item">
+                  <button class="p-tabs__link"
+                          role="tab"
+                          aria-selected="true"
+                          aria-controls="AMD-tab"
+                          id="AMD"
+                          data-maintain-hash="AMD">AMD64</button>
+                </div>
+                <div class="p-tabs__item">
+                  <button class="p-tabs__link"
+                          role="tab"
+                          aria-selected="false"
+                          aria-controls="ARM-tab"
+                          id="ARM"
+                          data-maintain-hash="ARM"
+                          tabindex="-1">ARM64</button>
+                </div>
+              </div>
+
+              <div tabindex="0"
+                   role="tabpanel"
+                   id="AMD-tab"
+                   aria-labelledby="AMD"
+                   aria-hidden="false">
+                <ul class="p-list--divided">
+                  <li class="p-list__item">
+                    <a href="https://aws.amazon.com/marketplace/pp/prodview-kbkyvwyqubv2g">24.04 LTS&nbsp;&rsaquo;</a>
+                  </li>
+                  <li class="p-list__item">
+                    <a href="https://aws.amazon.com/marketplace/pp/prodview-dxdx74ozlxsl2">22.04 LTS&nbsp;&rsaquo;</a>
+                  </li>
+                  <li class="p-list__item">
+                    <a href="https://aws.amazon.com/marketplace/pp/prodview-ngmnrama2krsg">20.04 LTS&nbsp;&rsaquo;</a>
+                  </li>
+                  <li class="p-list__item">
+                    <a href="https://aws.amazon.com/marketplace/pp/prodview-322njmk4u5jam">18.04 LTS&nbsp;&rsaquo;</a>
+                  </li>
+                  <li class="p-list__item">
+                    <a href="https://aws.amazon.com/marketplace/pp/prodview-pfsgbblavhjc4">18.04 FIPS LTS&nbsp;&rsaquo;</a>
+                  </li>
+                  <li class="p-list__item">
+                    <a href="https://aws.amazon.com/marketplace/pp/prodview-vmuff4yhmwfna">16.04 LTS&nbsp;&rsaquo;</a>
+                  </li>
+                  <li class="p-list__item">
+                    <a href="https://aws.amazon.com/marketplace/pp/prodview-wzhyxs72ie52u">16.04 FIPS LTS&nbsp;&rsaquo;</a>
+                  </li>
+                </ul>
+              </div>
+
+              <div tabindex="0"
+                   role="tabpanel"
+                   id="ARM-tab"
+                   aria-labelledby="ARM"
+                   aria-hidden="false">
+                <ul class="p-list--divided">
+                  <li class="p-list__item">
+                    <a href="https://aws.amazon.com/marketplace/pp/prodview-sqzrozpuvycoy">24.04 LTS&nbsp;&rsaquo;</a>
+                  </li>
+                  <li class="p-list__item">
+                    <a href="https://aws.amazon.com/marketplace/pp/prodview-6mbxuppzbkdoe">22.04 LTS&nbsp;&rsaquo;</a>
+                  </li>
+                  <li class="p-list__item">
+                    <a href="https://aws.amazon.com/marketplace/pp/prodview-5ro6tr7t2dnfu">20.04 LTS&nbsp;&rsaquo;</a>
+                  </li>
+                  <li class="p-list__item">
+                    <a href="https://aws.amazon.com/marketplace/pp/prodview-5daaremvkenwg">18.04 LTS&nbsp;&rsaquo;</a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+          <div class="col-3">
+            <p>
+              <a href="/aws/pro">Learn more about Ubuntu Pro&nbsp;&rsaquo;</a>
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section--deep">
+    <div class="u-fixed-width p-section--shallow">
+      <hr />
+      <h2>Launching Ubuntu on AWS Outposts</h2>
+    </div>
+    <div class="row--25-75">
+      <div class="col">
+        <ol class="p-stepped-list--detailed">
+          <li class="p-stepped-list__item">
+            <div class="row">
+              <div class="col-3 col-medium-2 col-start-medium-2">
+                <h3 class="p-stepped-list__title p-heading--5">Select the region your AWS Outpost is attached</h3>
+              </div>
+              <div class="col-6 col-medium-3 col-start-medium-4 p-stepped-list__content">
+                <div style="margin-top: 0.5rem;">
+                  {{ image(url="https://assets.ubuntu.com/v1/78ea4b05-aws-outposts-regions.png",
+                                    alt="",
+                                    width="300",
+                                    height="150",
+                                    hi_def=True,
+                                    loading="auto",) | safe
+                  }}
+                </div>
+              </div>
+            </div>
+          </li>
+          <li class="p-stepped-list__item">
+            <div class="row">
+              <div class="col-3 col-medium-2 col-start-medium-2">
+                <h3 class="p-stepped-list__title p-heading--5">Select the Ubuntu version you want to launch</h3>
+              </div>
+              <div class="col-6 col-medium-3 col-start-medium-4 p-stepped-list__content">
+                <p>
+                  Launch an EC2 instance and select Ubuntu from the instance launch quickstart, or visit the marketplace for more Ubuntu options.
+                </p>
+                {{ image(url="https://assets.ubuntu.com/v1/03238ea8-aws-outputs-ubuntu-image.png",
+                                alt="",
+                                width="940",
+                                height="170",
+                                hi_def=True,
+                                loading="auto",
+                                attrs={"class": "u-hide--small"}) | safe
+                }}
+              </div>
+            </div>
+          </li>
+          <li class="p-stepped-list__item">
+            <div class="row">
+              <div class="col-3 col-medium-2 col-start-medium-2">
+                <h3 class="p-stepped-list__title p-heading--5">Select the subnet of VPC your AWS Outposts resides</h3>
+              </div>
+              <div class="col-6 col-medium-3 col-start-medium-4 p-stepped-list__content">
+                <p>
+                  When configuring the instance launch, make sure to select the network for your Outpost, and your instance will automatically be launched.
+                </p>
+              </div>
+            </div>
+          </li>
+        </ol>
+      </div>
+    </div>
+  </section>
 
 {% endblock content %}


### PR DESCRIPTION
## Done

Rebrand  /aws/outposts.

## QA

- [demo link](https://ubuntu-com-14276.demos.haus/aws/outposts)
- [copy doc](https://docs.google.com/document/d/1aXtrGHw7AcZ_qrov3kJahRtgsmbNx7eH5aWFlIySpfE/edit)
- [figma](https://www.figma.com/design/FoWXkNxxdri9EgSsLdtTrH/24.10-ubuntu.com%2Faws?node-id=292-4378&node-type=CANVAS&t=x3XTatpQwVH96832-0)
- View the site on demo
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check that the page is correct according to figma and copy doc

## Issue / Card
[WD-12841](https://warthogs.atlassian.net/browse/WD-12841)

[WD-12841]: https://warthogs.atlassian.net/browse/WD-12841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ