### PR TITLE
fix: Fix typo on /20years

### DIFF
--- a/templates/20years/index.html
+++ b/templates/20years/index.html
@@ -865,7 +865,7 @@
               </p>
               <hr class="p-rule--muted" />
               <p>
-                <a href="https://drive.google.com/drive/folders/1dKGvGgFp4ymGNBPU6LRScfBm4KuwIn2c">Get all our whitepapers&nbsp;&rsaquo;</a>
+                <a href="https://drive.google.com/drive/folders/1dKGvGgFp4ymGNBPU6LRScfBm4KuwIn2c">Get all our wallpapers&nbsp;&rsaquo;</a>
               </p>
             </div>
           </div>


### PR DESCRIPTION
## Done

- replace 'whitepapers' with 'wallpapers'

## QA

- Go to 
- ctrl+f 'Get all our '
- see that it says 'Get all our wallpapers'
