### PR TITLE
fix(20years): Add the new page to the sitemap

### DIFF
--- a/static/files/sitemap.xml
+++ b/static/files/sitemap.xml
@@ -23,6 +23,10 @@
           <lastmod>2024-02-22T08:45:57+00:00</lastmod>
      </url>
      <url>
+          <loc>https://ubuntu.com/20years</loc>
+          <lastmod>2024-10-09T13:54:57+00:00</lastmod>
+     </url>
+     <url>
           <loc>https://ubuntu.com/pro</loc>
           <lastmod>2024-02-22T08:45:57+00:00</lastmod>
      </url>


### PR DESCRIPTION
## Done

- Add the new [/20years](https://ubuntu.com/20years) page to the [sitemap](https://ubuntu.com/static/files/sitemap.xml)

## QA

- Open the sitemap
- Check the new page exists
