### PR TITLE
fix: Show search on search icon click on medium and small screens

### DIFF
--- a/static/js/src/navigation.js
+++ b/static/js/src/navigation.js
@@ -711,11 +711,7 @@ function openSearch(e) {
   Array.from(searchButtons).forEach((searchButton) => {
     searchButton.setAttribute("aria-pressed", true);
   });
-
   addClassesToElements([navigation], ["has-search-open"]);
-  if (secondaryNav) {
-    addClassesToElements([secondaryNav], ["u-hide"]);
-  }
   searchInput.focus();
   document.addEventListener("keyup", escKeyPressHandler);
 }
@@ -724,13 +720,7 @@ function closeSearch() {
   searchButtons.forEach((searchButton) => {
     searchButton.removeAttribute("aria-pressed");
   });
-
   navigation.classList.remove("has-search-open");
-
-  if (secondaryNav) {
-    secondaryNav.classList.remove("u-hide");
-  }
-
   document.removeEventListener("keyup", escKeyPressHandler);
 }
 

--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -60,6 +60,12 @@ $meganav-height: 3rem;
       font-weight: 400;
     }
 
+    &.has-search-open .p-navigation__search {
+      @media (max-width: $breakpoint-navigation-threshold - 1) {
+        position: fixed;
+      }
+    }
+
     .p-navigation__row--25-75 {
       @media (min-width: $breakpoint-navigation-threshold - 1) {
         .p-navigation__items:first-child {
@@ -357,19 +363,6 @@ $meganav-height: 3rem;
           margin-left: auto;
         }
       }
-
-      .p-search-box__input {
-        background-color: $color-light !important;
-
-        &:focus,
-        &:hover {
-          background-color: $color-light !important;
-        }
-      }
-
-      .p-search-box__input::placeholder {
-        color: #000;
-      }
     }
 
     .p-navigation__banner {
@@ -419,11 +412,10 @@ $meganav-height: 3rem;
 
       .p-navigation__search {
         align-items: center;
-        background-color: #262626;
         display: flex;
         justify-content: center;
         left: 0;
-        padding: 1rem;
+        padding: 0.6rem 5rem 0.6rem 0;
         position: absolute;
         top: 2rem;
         width: 100%;


### PR DESCRIPTION
*note: this is very much a hack to make it work. The actual fix is to migrate to using the Vanilla patterns we recently developed and are using on c.com. But this will take a long time*

## Done

- Adjusts CSS and JS to allow the search to be visible when triggered.

## QA

- open [the demo](https://ubuntu-com-14285.demos.haus/) on medium/small screen size
- Click the search icon, the search bar should appear
- Open [the demo in a bubble page](https://ubuntu-com-14285.demos.haus/desktop)
- repeat above process

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-14826
https://github.com/canonical/ubuntu.com/issues/14282
