### PR TITLE
Update ubuntu.com/download/raspberry-pi with 24.10 download section [WD-14863]

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -3,8 +3,8 @@ latest:
   name: "Oracular Oriole"
   short_version: "24.10"
   full_version: "24.10"
-  desktop_version: "TBA"
-  core_version: "TBA"
+  desktop_version: "24.10"
+  core_version: "24"
   release_date: "October 2024"
   eol: "July 2025"
   past_eol_date: false
@@ -13,7 +13,7 @@ latest:
   server_iso_size: "TBA"
   raspi_desktop_iso_size: "TBA"
   raspi_server_iso_size: "TBA"
-  rasp_pi_core_24_size: "TBA"
+  rasp_pi_core_24_size: "314MB"
 lts:
   slug: NobleNumbat
   name: "Noble Numbat"

--- a/releases.yaml
+++ b/releases.yaml
@@ -1,17 +1,19 @@
 latest:
-  slug: ManticMinotaur
-  name: "Mantic Minotaur"
-  short_version: "23.10"
-  full_version: "23.10"
-  desktop_version: "23.10.1" # for 23.10 release only, because Desktop image for 23.10 release has version 23.10.1, while as all other images have version 23.10
-  core_version: "24"
-  release_date: "October 2023"
-  eol: "July 2024"
+  slug: OracularOriole
+  name: "Oracular Oriole"
+  short_version: "24.10"
+  full_version: "24.10"
+  desktop_version: "TBA"
+  core_version: "TBA"
+  release_date: "October 2024"
+  eol: "July 2025"
   past_eol_date: false
-  release_notes_url: "https://discourse.ubuntu.com/t/mantic-minotaur-release-notes/35534"
-  iso_download_size: "4.5GB"
-  server_iso_size: "2.5GB"
-  rasp_pi_core_24_size: "314MB"
+  release_notes_url: "TBA"
+  iso_download_size: "TBA"
+  server_iso_size: "TBA"
+  raspi_desktop_iso_size: "TBA"
+  raspi_server_iso_size: "TBA"
+  rasp_pi_core_24_size: "TBA"
 lts:
   slug: NobleNumbat
   name: "Noble Numbat"

--- a/releases.yaml
+++ b/releases.yaml
@@ -8,7 +8,7 @@ latest:
   release_date: "October 2024"
   eol: "July 2025"
   past_eol_date: false
-  release_notes_url: "TBA"
+  release_notes_url: "https://discourse.ubuntu.com/t/oracular-oriole-release-notes/44878"
   iso_download_size: "TBA"
   server_iso_size: "TBA"
   raspi_desktop_iso_size: "TBA"

--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -202,10 +202,10 @@
               <th style="width: 15%;"></th>
               <th style="width: 10%;"></th>
               <th style="width: 18%">
-                Ubuntu {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr>
+                Ubuntu {{ releases.lts.short_version }} <abbr title="Long-term support">LTS</abbr>
               </th>
               <th style="width: 15%">
-                Ubuntu {{ releases.latest.full_version }}
+                Ubuntu {{ releases.latest.short_version }}
               </th>
               <th style="width: 15%">
                 Ubuntu Core {{ releases.latest.core_version }}

--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -149,7 +149,7 @@
     <hr class="p-rule is-fixed-width" />
     <div class="row--50-50">
       <div class="col">
-        <h2>Ubuntu Core 24</h2>
+        <h2>Ubuntu Core {{ releases.latest.core_version }}</h2>
       </div>
       <div class="col">
         <p>
@@ -201,10 +201,15 @@
             <tr>
               <th style="width: 15%;"></th>
               <th style="width: 10%;"></th>
-              <th style="width: 26%">
+              <th style="width: 18%">
                 Ubuntu {{ releases.lts.full_version }} <abbr title="Long-term support">LTS</abbr>
               </th>
-              <th style="width: 20%">Ubuntu Core {{ releases.latest.core_version }}</th>
+              <th style="width: 15%">
+                Ubuntu {{ releases.latest.full_version }}
+              </th>
+              <th style="width: 15%">
+                Ubuntu Core {{ releases.latest.core_version }}
+              </th>
             </tr>
           </thead>
           <tbody>
@@ -223,7 +228,8 @@
                 }}
               </td>
               <td>Yes, certified</td>
-              <td>-</td>
+              <td>Yes</td>
+              <td>Yes, certified</td>
             </tr>
             <tr>
               <th>
@@ -239,6 +245,7 @@
                                 attrs={"class": "u-hide--small"},) | safe
                 }}
               </td>
+              <td>Yes</td>
               <td>Yes</td>
               <td>Yes, certified</td>
             </tr>
@@ -257,6 +264,7 @@
                 }}
               </td>
               <td>Yes, certified</td>
+              <td>Yes</td>
               <td>Yes, certified</td>
             </tr>
             <tr>
@@ -274,6 +282,7 @@
                 }}
               </td>
               <td>Yes, certified</td>
+              <td>Yes</td>
               <td>Yes, certified</td>
             </tr>
             <tr>
@@ -291,23 +300,7 @@
                 }}
               </td>
               <td>Yes, certified</td>
-              <td>Yes, certified</td>
-            </tr>
-            <tr>
-              <th>
-                <p>Raspberry Pi 3</p>
-              </th>
-              <td>
-                {{ image(url="https://assets.ubuntu.com/v1/c4a007b6-Raspberry+Pi+3.png",
-                                alt="Rapsberry Pi 3",
-                                height="48",
-                                width="75",
-                                hi_def=True,
-                                loading="lazy",
-                                attrs={"class": "u-hide--small"},) | safe
-                }}
-              </td>
-              <td>-</td>
+              <td>Yes</td>
               <td>Yes, certified</td>
             </tr>
           </tbody>

--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -84,7 +84,7 @@
       </div>
       <div class="col">
         <p>
-          The latest LTS version of Ubuntu, for desktop PCs and laptops. LTS stands for long-term support — which means five years of free security and maintenance updates, extended to 10 years with <a href="/pro">Ubuntu Pro</a>.
+          The latest LTS version of Ubuntu, for desktop PCs and laptops. LTS stands for long-term support — which means five years of free security and maintenance updates, extended up to 12 years with <a href="/pro">Ubuntu Pro</a>.
         </p>
         <hr />
         <p class="u-responsive-realign">
@@ -103,6 +103,45 @@
              class="p-button">Download Ubuntu Server {{ releases.lts.full_version }} LTS</a>
           {% if releases.lts.raspi_server_iso_size %}
             <span class="u-text--muted">{{ releases.lts.raspi_server_iso_size }}</span>
+          {% endif %}
+        </p>
+      </div>
+    </div>
+    <hr class="p-rule is-fixed-width" />
+    <div class="row--50-50 p-section">
+      <div class="col u-image-position">
+        <h2>Ubuntu {{ releases.latest.full_version }}</h2>
+        <div class="u-image-position--bottom">
+          {{ image(url="https://assets.ubuntu.com/v1/0749ce0e-Orange%20O_no%20background-resized.png",
+                    alt="Oracular Oriole",
+                    width="125",
+                    height="132",
+                    hi_def=True,
+                    loading="auto") | safe
+          }}
+        </div>
+      </div>
+      <div class="col">
+        <p>
+          The latest version of the Ubuntu operating system for desktop PCs and laptops, Ubuntu 24.10 comes with nine months of security and maintenance updates, until July 2025.
+        </p>
+        <hr />
+        <p class="u-responsive-realign">
+          <a href="/download/raspberry-pi/thank-you?version={{ releases.latest.full_version }}&amp;architecture=desktop-arm64+raspi"
+             onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 64-bit - Ubuntu Desktop', 'eventLabel' : '{{ releases.latest.full_version }}', 'eventValue' : undefined });"
+             class="p-button--positive u-no-margin--bottom">Download Ubuntu Desktop {{ releases.latest.full_version }}</a>
+          {% if releases.latest.raspi_desktop_iso_size %}
+            <span class="u-text--muted">{{ releases.latest.raspi_desktop_iso_size }}</span>
+          {% endif %}
+        </p>
+        <p>Minimum 4GBs of RAM and 16GB storage required</p>
+        <hr />
+        <p class="u-responsive-realign">
+          <a href="/download/raspberry-pi/thank-you?version={{ releases.latest.full_version }}&amp;architecture=server-arm64+raspi"
+             onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Raspberry Pi 64-bit - Ubuntu Server', 'eventLabel' : '{{ releases.latest.full_version }}', 'eventValue' : undefined });"
+             class="p-button">Download Ubuntu Server {{ releases.latest.full_version }}</a>
+          {% if releases.latest.raspi_server_iso_size %}
+            <span class="u-text--muted">{{ releases.latest.raspi_server_iso_size }}</span>
           {% endif %}
         </p>
       </div>


### PR DESCRIPTION
## Done

- Added download section for Ubuntu 24.10 to [/download/raspberry-pi](https://ubuntu-com-14290.demos.haus/download/raspberry-pi) page (click link for a demo)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Open this: [demo page](https://ubuntu-com-14290.demos.haus/download/raspberry-pi)
- Check that the changes in the [copy doc](https://docs.google.com/document/d/1KgnSBa8mbR7qwlxxtqbE5a1wXh5GjtVums8TIB7IGVw/edit) are implemented

## Issue / Card

Fixes [WD-14863](https://warthogs.atlassian.net/browse/WD-14863)

## Screenshots

![image](https://github.com/user-attachments/assets/070d5d84-3266-4486-b648-2c0a417cbda9)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-14863]: https://warthogs.atlassian.net/browse/WD-14863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ