### PR TITLE
Account for cves with ignored-low summarized statuses

### DIFF
--- a/webapp/security/helpers.py
+++ b/webapp/security/helpers.py
@@ -69,7 +69,7 @@ def get_summarized_status(
             key_with_non_zero_value = key
 
     if count == 1:
-        if key_with_non_zero_value == "ignored-high":
+        if key_with_non_zero_value == "ignored-high" or key_with_non_zero_value == "ignored-low":
             return friendly_names["ignored"]
         else:
             return friendly_names[key_with_non_zero_value]


### PR DESCRIPTION
## Done

- Add flag for cves with summarized status set to "ignored-low"

## QA

- No qa, this issue was flagged in [sentry](https://sentry.is.canonical.com/canonical/ubuntu-security/issues/92145/) but I can't seem to reproduce locally. Some users are running queries wherein the summarized status is something the view can't make sense of when rendering the front-end friendly names and this flag addresses that

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
