### PR TITLE
reduce time delay in scheduling exam on staging

### DIFF
--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -248,8 +248,8 @@ def cred_schedule(
     is_staging = "staging" in os.getenv(
         "CONTRACTS_API_URL", "https://contracts.staging.canonical.com/"
     )
-    time_delta = 6 if is_staging else 1
-    time_delay = f"{time_delta} hour{'s' if time_delta > 1 else ''}"
+    time_delta = 0.5 if is_staging else 1
+    time_delay = "30 minutes" if is_staging else "1 hour"
 
     if flask.request.method == "POST":
         data = flask.request.form
@@ -276,7 +276,7 @@ def cred_schedule(
             assessment_reservation_uuid = flask.request.args.get("uuid")
 
         if starts_at <= datetime.now(pytz.UTC).astimezone(tz_info) + timedelta(
-            hours=6 if is_staging else 1
+            hours=time_delta
         ):
             error = (
                 f"Start time should be at least {time_delay}"


### PR DESCRIPTION
## Done

- Reduce the time delay for scheduling an exam to 30 minutes for staging environment

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Schedule an exam in staging and it should not allow you to schedule it within 30 minutes from now

## Issue / Card

Fixes [14891](https://warthogs.atlassian.net/browse/WD-14891)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
