### PR TITLE
feat: Update fallback takeover to 24.04

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -25,7 +25,7 @@
 
   {% block content %}
 
-    <section id="test-takeover" class="p-section--hero">
+    <section id="test-takeover" class="p-section--hero" hidden>
       <div class="row p-takeover-animation" id="test-takeover-animaition">
         <div class="row--50-50 p-section--shallow">
           <div class="col">
@@ -58,24 +58,21 @@
       <div class="row p-takeover-animation" id="takeover-animaition">
         <div class="col-6">
           <div class="p-section--shallow">
-            <h1 id="takeover-title" class="u-no-margin--bottom">What's new in Ubuntu {{ releases.latest.short_version }}?</h1>
+            <h1 id="takeover-title" class="u-no-margin--bottom">Ubuntu 24.04 LTS Noble Numbat is available for download</h1>
             <p class="p-heading--2" id="takeover-subtitle">
-              Introducing the Ubuntu Desktop for Raspberry Pi, the latest desktop features and micro clouds.
+              Discover the latest and greatest features in our most recent long term supported release.
             </p>
           </div>
-          <hr class="is-muted" />
+          <hr class="p-rule--muted" />
           <div id="takeover-ctas">
             <p>
-              <a id="takeover-primary-url" href="/download" class="p-button--positive">Get Ubuntu {{ releases.latest.short_version }}</a>
-              <a id="takeover-secondary-url" href="/raspberry-pi">Learn more about Ubuntu on the Raspberry Pi&nbsp;&rsaquo;</a>
+              <a id="takeover-primary-url" href="/download" class="p-button--positive"> Download for free </a>
+              <a id="takeover-secondary-url" href="/blog/ubuntu-desktop-24-04-noble-numbat-deep-dive">Read the deep dive&nbsp;&rsaquo;</a>
             </p>
           </div>
         </div>
         <div class="col-6 u-vertically-center u-align--center u-hide--medium u-hide--small">
-          <img id="takeover-image"
-               src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs="
-               width="200"
-               alt="" />
+          <img src="https://assets.ubuntu.com/v1/d9fc87f3-Numbat.svg" width="300" alt="" />
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Done

- Update fallback takeover to 24.04 based on [copydoc](https://docs.google.com/document/d/1ySJxQbqVdeH4Tra0zwBm2Tn0s56kFGnEF7d8xDRTxwU/edit)
- Add `hidden` the test takeover by default, so if JS fails it wont display 2 takeovers

## QA

- Go to
- Disable JS in dev tools
- Refresh and see the fallback takeover detailed in the [copydoc](https://docs.google.com/document/d/1ySJxQbqVdeH4Tra0zwBm2Tn0s56kFGnEF7d8xDRTxwU/edit)

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
