### PR TITLE
WD-14967: updates kubernetes release chart and table

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -949,18 +949,6 @@ export var openStackReleases = [
 
 export var kubernetesReleases = [
   {
-    startDate: new Date("2022-09-01T00:00:00"),
-    endDate: new Date("2023-08-28T00:00:00"),
-    taskName: "Kubernetes 1.25",
-    status: "CANONICAL_KUBERNETES_SUPPORT",
-  },
-  {
-    startDate: new Date("2023-08-28T00:00:00"),
-    endDate: new Date("2024-04-28T00:00:00"),
-    taskName: "Kubernetes 1.25",
-    status: "CANONICAL_KUBERNETES_EXPANDED_SECURITY_MAINTENANCE",
-  },
-  {
     startDate: new Date("2022-12-15T00:00:00"),
     endDate: new Date("2023-12-28T00:00:00"),
     taskName: "Kubernetes 1.26",
@@ -1018,6 +1006,18 @@ export var kubernetesReleases = [
     startDate: new Date("2025-04-28T00:00:00"),
     endDate: new Date("2025-12-28T00:00:00"),
     taskName: "Kubernetes 1.30",
+    status: "CANONICAL_KUBERNETES_EXPANDED_SECURITY_MAINTENANCE",
+  },
+  {
+    startDate: new Date("2024-08-01T00:00:00"),
+    endDate: new Date("2025-08-28T00:00:00"),
+    taskName: "Kubernetes 1.31",
+    status: "CANONICAL_KUBERNETES_SUPPORT",
+  },
+  {
+    startDate: new Date("2025-08-28T00:00:00"),
+    endDate: new Date("2026-04-28T00:00:00"),
+    taskName: "Kubernetes 1.31",
     status: "CANONICAL_KUBERNETES_EXPANDED_SECURITY_MAINTENANCE",
   },
 ];
@@ -1293,12 +1293,12 @@ export var microStackReleaseNames = [
 ];
 
 export var kubernetesReleaseNames = [
+  "Kubernetes 1.31",
   "Kubernetes 1.30",
   "Kubernetes 1.29",
   "Kubernetes 1.28",
   "Kubernetes 1.27",
   "Kubernetes 1.26",
-  "Kubernetes 1.25",
 ];
 
 export var kernelReleaseScheduleNames = [

--- a/templates/about/release_cycles/k8s-eol.html
+++ b/templates/about/release_cycles/k8s-eol.html
@@ -12,6 +12,12 @@
       </thead>
       <tbody>
         <tr>
+          <td><strong>1.31.x</strong></td>
+          <td>Aug 2024</td>
+          <td>Aug 2025</td>
+          <td>Apr 2026</td>
+        </tr>
+        <tr>
           <td><strong>1.30.x</strong></td>
           <td>Apr 2024</td>
           <td>Apr 2025</td>
@@ -40,12 +46,6 @@
           <td>Dec 2022</td>
           <td>Dec 2023</td>
           <td>Aug 2024</td>
-        </tr>
-        <tr>
-          <td><strong>1.25.x</strong></td>
-          <td>Sep 2022</td>
-          <td>Aug 2023</td>
-          <td>Apr 2024</td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
## Done

- Updates kubernetes release chart and table to include 1.31 and remove 1.25

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Navigate to https://ubuntu.com/about/release-cycle#canonical-kubernetes-release-cycle and check that the table and chart are updated

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
