### PR TITLE
WD-14962 - update links on /what-is-kubeflow

### DIFF
--- a/templates/ai/what-is-kubeflow.html
+++ b/templates/ai/what-is-kubeflow.html
@@ -141,7 +141,7 @@
           <p>Kubeflow is compatible with your choice of data science libraries and frameworks.
             <a href="https://www.kubeflow.org/docs/components/training/tftraining/">TensorFlow</a>,
             <a href="https://www.kubeflow.org/docs/components/training/pytorch/">PyTorch</a>,
-            <a href="https://www.kubeflow.org/docs/components/training/mxnet/">MXNet</a>,
+            <a href="https://pypi.org/project/mxnet/">MXNet</a>,
             <a href="https://github.com/kubeflow/xgboost-operator">XGBoost</a>,
             <a href="https://scikit-learn.org/stable/">scikit-learn</a> and more.</p>
         </div>
@@ -319,7 +319,7 @@
       <p>Try-out Kubeflow on your Kubernetes environment. Or on MicroK8s - Zero-ops Kubernetes with high availability.</p>
       <p class="p-section--shallow">Deploy locally on your workstation, cloud VM or on-prem server.</p>
       <hr />
-      <a class="p-button--positive" href="https://charmed-kubeflow.io/docs/quickstart">Try Kubeflow on MicroK8s</a>
+      <a class="p-button--positive" href="https://charmed-kubeflow.io/docs/get-started-with-charmed-kubeflow">Try Kubeflow on MicroK8s</a>
       <a class="p-button" href="https://charmed-kubeflow.io/#get-in-touch">Contact us now</a>
     </div>
   </div>


### PR DESCRIPTION
## Done

Changed links according to copy doc

## QA

- [demo link](https://ubuntu-com-14305.demos.haus/ai/what-is-kubeflow)
- [copy doc](https://docs.google.com/document/d/1m-96RlGkbzFa1KaGAxYFpY0ztIlsTuViCjXSAlErQlg/edit?pli=1)
- View the site on demo
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check that the page is correct according to copy doc

## Issue / Card
[WD-14962](https://warthogs.atlassian.net/browse/WD-14962)

[WD-14962]: https://warthogs.atlassian.net/browse/WD-14962?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ