### PR TITLE
chore: Upgrade canonicalwebteam.search to 2.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 canonicalwebteam.flask-base==2.0.0
 canonicalwebteam.http==1.0.4
 canonicalwebteam.blog==6.4.1
-canonicalwebteam.search==2.0.0
+canonicalwebteam.search==2.1.1
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.3.1
 canonicalwebteam.discourse==5.7.2

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -434,7 +434,6 @@ app.add_url_rule(
         session=session,
         template_path="search.html",
         search_engine_id=search_engine_id,
-        request_limit="1/day",
     ),
 )
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -434,7 +434,7 @@ app.add_url_rule(
         session=session,
         template_path="search.html",
         search_engine_id=search_engine_id,
-        request_limit="2000/day",
+        request_limit="1/day",
     ),
 )
 
@@ -714,7 +714,6 @@ app.add_url_rule(
         site="ubuntu.com/community",
         template_path="/community/docs/search-results.html",
         search_engine_id=search_engine_id,
-        request_limit="2000/day",
     ),
 )
 
@@ -769,7 +768,6 @@ app.add_url_rule(
         site="ubuntu.com/ceph/docs",
         template_path="ceph/docs/search-results.html",
         search_engine_id=search_engine_id,
-        request_limit="2000/day",
     ),
 )
 
@@ -792,7 +790,6 @@ app.add_url_rule(
         site="ubuntu.com/core/docs",
         template_path="/core/docs/search-results.html",
         search_engine_id=search_engine_id,
-        request_limit="2000/day",
     ),
 )
 core_docs.init_app(app)
@@ -1055,7 +1052,6 @@ app.add_url_rule(
         site="ubuntu.com/openstack/docs",
         template_path="openstack/docs/search-results.html",
         search_engine_id=search_engine_id,
-        request_limit="2000/day",
     ),
 )
 
@@ -1083,7 +1079,6 @@ app.add_url_rule(
         site="ubuntu.com/security/livepatch/docs",
         template_path="/security/livepatch/docs/search-results.html",
         search_engine_id=search_engine_id,
-        request_limit="2000/day",
     ),
 )
 
@@ -1111,7 +1106,6 @@ app.add_url_rule(
         site="ubuntu.com/security/certifications/docs",
         template_path="/security/certifications/docs/search-results.html",
         search_engine_id=search_engine_id,
-        request_limit="2000/day",
     ),
 )
 
@@ -1139,7 +1133,6 @@ app.add_url_rule(
         site="ubuntu.com/landscape/docs",
         template_path="/landscape/docs/search-results.html",
         search_engine_id=search_engine_id,
-        request_limit="2000/day",
     ),
 )
 


### PR DESCRIPTION

## Done

- Upgrade canonicalwebteam.search to 2.1.1
- Removed the custom `request_limit` configurations. These are now handled by the search module

## QA

- Go to https://ubuntu-com-14314.demos.haus/
- Search something
- See rate limit is hit (currently set to 1, so you can search 1 time before hitting it)
**Note:** In some cases you get an extra search. So you will be able to search 2 times before hitting the rate limit of 1 per day. However, in our current use case of the rate limiter this is not a problem, so can be ignored.


## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-15010
