### PR TITLE
Update LTS links for /gcp

### DIFF
--- a/templates/gcp/index.html
+++ b/templates/gcp/index.html
@@ -181,7 +181,7 @@
           <div class="col-3">
             <ul class="p-list--divided">
               <li class="p-list__item">
-                24.04 LTS
+                <a href="https://console.cloud.google.com/compute/instancesAdd?imageId=4629240575064276470&imageProjectId=ubuntu-os-cloud">24.04 LTS</a>
               </li>
               <li class="p-list__item">
                 <a href="https://console.cloud.google.com/marketplace/product/ubuntu-os-cloud/ubuntu-jammy">22.04 LTS</a>
@@ -190,13 +190,10 @@
                 <a href="https://console.cloud.google.com/marketplace/product/ubuntu-os-cloud/ubuntu-focal">20.04 LTS</a>
               </li>
               <li class="p-list__item">
-                18.04 LTS
+                <a href="https://console.cloud.google.com/compute/instancesAdd?imageId=5888154029922191724&imageProjectId=ubuntu-os-cloud">18.04 LTS</a>
               </li>
               <li class="p-list__item">
-                16.04 LTS
-              </li>
-              <li class="p-list__item">
-                14.04 LTS
+                <a href="https://console.cloud.google.com/compute/instancesAdd?imageId=1548661323355716045&imageProjectId=ubuntu-os-cloud">16.04 LTS</a>
               </li>
             </ul>
           </div>


### PR DESCRIPTION
## Done

- Update LTS links for /gcp

## QA

- Go to https://ubuntu-com-14317.demos.haus/gcp
- Check that the LTS links are all available and matches with the new links provided in [copy doc](https://docs.google.com/document/d/1Gvt9tNFDZkqkBcP0k79C6ueTJCmNZvwoXQoU19WEa8E/edit)

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
