### PR TITLE
fix(a11y): Fix broken lang attribute

### DIFF
--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 
 <html prefix="og: http://ogp.me/ns#" class=" 
-  {% block extra_html_class %}{% endblock %}" lang=" 
-  {% block meta_lang %}en{% endblock %}" dir="ltr">
+  {% block extra_html_class %}{% endblock %}" 
+  lang="{% block meta_lang %}en{% endblock %}" dir="ltr">
   <head>
     <meta charset="UTF-8" />
     <meta name="keywords" content="index, follow" />


### PR DESCRIPTION
## Done

- [x] Replaced lang=" en" to lang="en".
- [x] This fixes the accessibility error "Language missing or invalid" detected using WAVE.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check markup of any website on ubuntu.com and check if lang attribute is correctly set and valid.


## Issue / Card

Fixes #

## Screenshots

<img width="1980" alt="image" src="https://github.com/user-attachments/assets/46f97eaa-5320-4f67-8a9b-fed30c580693">



## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
