### PR TITLE
disable button while loading

### DIFF
--- a/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
@@ -76,6 +76,7 @@ const BuyButton = ({ setError, products, action, coupon }: Props) => {
   }, [values.country]);
 
   const onPayClick = async () => {
+    setIsLoading(true);
     confirmNavigateListener.set();
     validateForm().then((errors) => {
       const possibleErrors = Object.keys(errors);
@@ -86,11 +87,13 @@ const BuyButton = ({ setError, products, action, coupon }: Props) => {
       if (!(possibleErrors.length === 0)) {
         setError(<>Please make sure all fields are filled in correctly.</>);
         document.querySelector("h1")?.scrollIntoView();
+        setIsLoading(false);
         return;
       }
     });
 
     if (!(Object.keys(errors).length === 0)) {
+      setIsLoading(false);
       return;
     }
 
@@ -386,6 +389,7 @@ const BuyButton = ({ setError, products, action, coupon }: Props) => {
       style={{ marginTop: "calc(.5rem - 1.5px)" }}
       onClick={onPayClick}
       loading={isLoading}
+      disabled={isLoading}
     >
       Buy now
     </ActionButton>


### PR DESCRIPTION
## Done

- disable buy button while loading and also loading should show as soon as button is clicked

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Visit /pro/subscribe
    - Select any product and proceed to checkout
    - Fill in details 
    - Open the network tab in Inspect panel
    - Double click on the buy button
    - It should send only one purchase request in the background
    - The buy button should be disabled while the request is processing
- Try the same steps in /credentials/shop
- Also try to make errors and check the buy button recovers from the errors and is not stuck in loading state. 
    
## Issue / Card

Fixes [#WD-14573](https://warthogs.atlassian.net/browse/WD-14573)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
