### PR TITLE
change get to post for schedule api endpoint

### DIFF
--- a/webapp/shop/api/ua_contracts/api.py
+++ b/webapp/shop/api/ua_contracts/api.py
@@ -372,7 +372,7 @@ class UAContractsAPI:
         country_code,
     ) -> dict:
         req = self._request(
-            method="get",
+            method="post",
             path="v1/cue/schedule",
             json={
                 "contractItemID": int(contract_item_id),


### PR DESCRIPTION
## Done

- Simple endpoint method change

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Purchase an exam at /credentials/shop
- Schedule exam
- Scheduling should work normally

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
