### PR TITLE
refactor: Rebrand /pricing

### DIFF
--- a/templates/pricing/index.html
+++ b/templates/pricing/index.html
@@ -3,7 +3,7 @@
 {% block title %}Pricing{% endblock %}
 
 {% block meta_description %}
-  Ubuntu Advantage for Infrastructure offers a single, per-node packaging of the most comprehensive software, security and IaaS support in the industry, with OpenStack support, Kubernetes support included, and Livepatch, Landscape and Expanded Security Maintenance to address security and compliance concerns.
+  Ubuntu Pro for Infrastructure offers a single, per-node packaging of the most comprehensive software, security and IaaS support in the industry, with OpenStack support, Kubernetes support included, and Livepatch, Landscape and Expanded Security Maintenance to address security and compliance concerns.
 {% endblock %}
 
 {% block meta_copydoc %}
@@ -62,13 +62,13 @@
         <ul class="p-list--divided">
           <li class="p-list__item is-ticked">Multi-cloud K8s</li>
           <li class="p-list__item is-ticked">Managed private cloud</li>
-          <li class="p-list__item is-ticked">Data center automation</li>
+          <li class="p-list__item is-ticked">Data centre automation</li>
           <li class="p-list__item is-ticked">Logging, alerting, monitoring</li>
         </ul>
         <div class="p-cta-block">
           <a class="p-button"
-             href="/pricing/infra#managed"
-             aira-label="Explore our fully managed open infrastructure">Managed open infrastructure</a>
+             href="/pricing/infra"
+             aria-label="Explore our fully managed open infrastructure">Managed open infrastructure</a>
         </div>
       </div>
     </div>
@@ -81,7 +81,7 @@
         <h2>IoT and device services</h2>
       </div>
       <div class="col">
-        <p>Ubuntu is the new standard for embedded Linux development and the intelligent edge</p>
+        <p>Ubuntu is the new standard for embedded Linux development and the intelligent edge.</p>
         <ul class="p-list--divided">
           <li class="p-list__item is-ticked">Hardware enablement</li>
           <li class="p-list__item is-ticked">White-label app stores for IoT devices</li>

--- a/templates/pricing/index.html
+++ b/templates/pricing/index.html
@@ -1,94 +1,123 @@
 {% extends "pricing/base_pricing.html" %}
 
-
 {% block title %}Pricing{% endblock %}
-{% block meta_description %}Ubuntu Advantage for Infrastructure offers a single, per-node packaging of the most comprehensive software, security and IaaS support in the industry, with OpenStack support, Kubernetes support included, and Livepatch, Landscape and Expanded Security Maintenance to address security and compliance concerns.{% endblock %}
-{% block meta_copydoc %}https://docs.google.com/document/d/1iOM6oBqsTkptsst3yG-U3sGaYLQqs27go_8yJQdhMBE{% endblock meta_copydoc %}
+
+{% block meta_description %}
+  Ubuntu Advantage for Infrastructure offers a single, per-node packaging of the most comprehensive software, security and IaaS support in the industry, with OpenStack support, Kubernetes support included, and Livepatch, Landscape and Expanded Security Maintenance to address security and compliance concerns.
+{% endblock %}
+
+{% block meta_copydoc %}
+  https://docs.google.com/document/d/1iOM6oBqsTkptsst3yG-U3sGaYLQqs27go_8yJQdhMBE
+{% endblock meta_copydoc %}
+
+{% block body_class %}
+  is-paper
+{% endblock body_class %}
 
 {% block content %}
-  <section class="p-strip--suru-topped">
-    <div class="u-fixed-width">
+  <section class="p-section--hero">
+    <div class="p-section u-fixed-width">
       <h1>Plans and pricing</h1>
     </div>
-    <div class="u-fixed-width"><hr style="margin-top: 4rem; margin-bottom: 2rem;"/></div>
-    <div class="row">
-      <div class="col-5">
-        <h2 class="p-heading--3">Ubuntu Pro and support</h2>
-        <p>10 years of security maintenance for over 25,000 packages, kernel livepatch, landscape, FIPS certified modules, CIS and DISA-STIG profiles, and more.</p>
-        <p>Optional telephone/email support for Ubuntu OS, infrastructure and application.</p>
+  </section>
+
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <h2>Ubuntu Pro and support</h2>
       </div>
-      <div class="col-6 col-start-large-7">
-        <ul class="p-list">
+      <div class="col">
+        <p>
+          10 years of security maintenance for over 25,000 packages, kernel livepatch, landscape, FIPS certified modules, CIS and DISA-STIG profiles, and more.
+        </p>
+        <p>Optional telephone/email support for Ubuntu OS, infrastructure and application.</p>
+        <ul class="p-list--divided">
           <li class="p-list__item is-ticked">Ubuntu base OS</li>
           <li class="p-list__item is-ticked">Kernel</li>
           <li class="p-list__item is-ticked">Kubernetes</li>
           <li class="p-list__item is-ticked">OpenStack</li>
           <li class="p-list__item is-ticked">Docker</li>
-          <li class="p-list__item is-ticked">Storage</li>
+          <li class="p-list__item is-ticked">Ceph and Swift Storage</li>
           <li class="p-list__item is-ticked">Applications</li>
         </ul>
-        <ul class="p-inline-list u-no-margin--bottom">
-          <li class="p-inline-list__item"><a class="p-button--positive u-no-margin--bottom" href="/pro">Purchase Ubuntu Pro</a></li>
-          <li class="p-inline-list__item"><a class="p-button u-no-margin--bottom" href="/pricing/infra">See our services</a></li>
-        </ul>
+        <div class="p-cta-block">
+          <a class="p-button--positive" href="/pro">Purchase Ubuntu Pro</a>
+          <a class="p-button"
+             href="/pricing/infra"
+             aria-label="See our Ubuntu Pro infrastructure services">See our services</a>
+        </div>
       </div>
     </div>
-    <div class="u-fixed-width">
-      <hr style="margin: 2rem 0;" />
-    </div>
-    <div class="row">
-      <div class="col-5">
-        <h2 class="p-heading--3">Fully managed infrastructure</h2>
+  </section>
+
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <h2>Fully managed infrastructure</h2>
+      </div>
+      <div class="col">
         <p>Fully managed OpenStack and Kubernetes.</p>
-      </div>
-      <div class="col-6 col-start-large-7">
-        <ul class="p-list">
+        <ul class="p-list--divided">
           <li class="p-list__item is-ticked">Multi-cloud K8s</li>
           <li class="p-list__item is-ticked">Managed private cloud</li>
           <li class="p-list__item is-ticked">Data center automation</li>
           <li class="p-list__item is-ticked">Logging, alerting, monitoring</li>
         </ul>
-        <p class="u-no-margin--bottom"><a class="p-button u-no-margin--bottom" href="/pricing/infra#managed">Managed open infrastructure</a></p>
+        <div class="p-cta-block">
+          <a class="p-button"
+             href="/pricing/infra#managed"
+             aira-label="Explore our fully managed open infrastructure">Managed open infrastructure</a>
+        </div>
       </div>
     </div>
-    <div class="u-fixed-width"><hr style="margin: 2rem 0;"/></div>
-    <div class="row">
-      <div class="col-5">
-        <h2 class="p-heading--3">IoT and device services</h2>
-        <p>Ubuntu is the new standard for embedded Linux development and the intelligent edge.</p>
+  </section>
+
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <h2>IoT and device services</h2>
       </div>
-      <div class="col-6 col-start-large-7">
-        <ul class="p-list">
+      <div class="col">
+        <p>Ubuntu is the new standard for embedded Linux development and the intelligent edge</p>
+        <ul class="p-list--divided">
           <li class="p-list__item is-ticked">Hardware enablement</li>
           <li class="p-list__item is-ticked">White-label app stores for IoT devices</li>
           <li class="p-list__item is-ticked">Long-term OTA software updates</li>
           <li class="p-list__item is-ticked">24/7 maintenance and support</li>
           <li class="p-list__item is-ticked">Consulting services</li>
         </ul>
-        <p class="u-no-margin--bottom"><a class="p-button u-no-margin--bottom" href="/pricing/devices">Get SMART with Canonical</a></p>
-      </div>
-    </div>
-    <div class="u-fixed-width"><hr style="margin: 2rem 0;"/></div>
-    <div class="row">
-      <div class="col-5">
-        <h2 class="p-heading--3">Consulting and deployment</h2>
-        <p>Architecture design and deployment, training and integration.</p>
-      </div>
-      <div class="col-6 col-start-large-7">
-        <ul class="p-list">
-          <li class="p-list__item is-ticked">OpenStack</li>
-          <li class="p-list__item is-ticked">Kubernetes</li>
-          <li class="p-list__item is-ticked">Kubeflow</li>
-        </ul>
-        <p class="u-no-margin--bottom"><a class="p-button u-no-margin--bottom" href="/pricing/consulting">Dive in with Canonical</a></p>
+        <div class="p-cta-block">
+          <a class="p-button"
+             href="/pricing/devices"
+             aria-label="Explore our IoT and device services">Get SMART with Canonical</a>
+        </div>
       </div>
     </div>
   </section>
 
-  <!-- Set default Marketo information for contact form below-->
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/support" data-form-id="1240" data-lp-id="2065" data-return-url="https://ubuntu.com/support/thank-you" data-lp-url="https://pages.ubuntu.com/things-contact-us.html">
-  </div>
-
-
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <h2>Consulting and deployment</h2>
+      </div>
+      <div class="col">
+        <p>Architecture design and deployment, training and integration.</p>
+        <ul class="p-list--divided">
+          <li class="p-list__item is-ticked">OpenStack</li>
+          <li class="p-list__item is-ticked">Kubernetes</li>
+          <li class="p-list__item is-ticked">Kubeflow</li>
+        </ul>
+        <div class="p-cta-block">
+          <a class="p-button "
+             href="/pricing/consulting"
+             aria-label="Explore our open infrastructure consulting services">Dive in with Canonical</a>
+        </div>
+      </div>
+    </div>
+  </section>
 
 {% endblock content %}


### PR DESCRIPTION
## Done

- Rebrand to match the [figma design](https://www.figma.com/design/vxxQijDub9nQrU3ZAYcXri/Pricing?node-id=0-1&node-type=canvas&t=d56gqalDTAh6lMNY-0)
- Although this is not supposed to update the content, I noticed one change was missing. 'Storage' > 'Ceph and Swift Storage'. I have highlighted it in the [copydoc](https://docs.google.com/document/d/1iOM6oBqsTkptsst3yG-U3sGaYLQqs27go_8yJQdhMBE/edit#heading=h.8p0ngpm6ijf0)
- Added `aria-labels` to links
- Removed marketo forms setup as it was not needed

## QA

- Go to [the demo link](https://ubuntu-com-14328.demos.haus/pricing)
- Compare against the design
- Test the content works on all screen sizes
- Test the links with a screen reader

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-12860
