### PR TITLE
bug: fix missing status description for ignored status and update switch functionality  

### DIFF
--- a/templates/security/cves/cve.html
+++ b/templates/security/cves/cve.html
@@ -279,7 +279,7 @@
                             <td style="overflow: visible; display: flex;" class="{% if status.maintained == False %} js-unmaintained-cell u-hide--cell{% endif %} cve-td-status" >
                               <i class="p-icon--{{ status.icon }}" style="margin-top: .2rem; margin-right: 0.5rem;"></i>
                               <div style="display: block;">
-                                {{ status.name }} {% if status.name == "Fixed" or status.status == "ignored" %}<span class="u-text--muted">{{ status.description }} </span> {% endif %}
+                                {{ status.name }} {% if status.name == "Fixed" %}<span class="u-text--muted">{{ status.description }} </span> {% endif %}
                                 {% if status.pocket_desc and status.pocket_desc.label == "Ubuntu Pro" %}
                                   <div>
                                     <a class="p-chip p-tooltip--top-center u-no-margin--bottom" href="/pro" aria-describedby="{{ status.pocket }}-tooltip">
@@ -292,7 +292,7 @@
                             </td>     
                           {% else %}
                             <td class="{% if status.maintained == False %}js-unmaintained-cell u-hide--cell{% endif %} cve-td-status {% if status.status == 'DNE' %}u-text--muted{% endif %}" style="padding-left: 2rem;">
-                              {{ status.name }}
+                              {{ status.name }} {% if status.status == "ignored" %} <span class="u-text--muted">{{ status.description }} </span> {% endif %}
                             </td>
                           {% endif %}
 
@@ -577,8 +577,9 @@
     // Updates notification text and aria-describedby attribute for the switch
     // depending on if the releases are all maintained, unmaintained or only upstream
     function handleNotificationText(maintainedCount, isOnlyUpstream, hiddenCells, maintainedReleasesSwitch) {
-      let notification = document.querySelector(".js-conditional-notification");
-
+      const notification = document.querySelector(".js-conditional-notification");
+      const maintainedReleasesSwitchLabel = document.querySelector(".p-switch");
+      
       if (maintainedCount < 1 && !isOnlyUpstream) {
         notification.classList.remove("u-hide");
         notification.querySelector(".p-notification__message").textContent = "No maintained releases are affected by this CVE.";
@@ -586,9 +587,7 @@
       }
             
       if (hiddenCells.length === 0 && !isOnlyUpstream) {
-        notification.classList.remove("u-hide");
-        notification.querySelector(".p-notification__message").textContent = "No unmaintained releases are affected by this CVE.";
-        notification.id = "disabled-switch-notification-only-maintained";
+        maintainedReleasesSwitchLabel.classList.add("u-hide");
       }
       
       if (isOnlyUpstream) {


### PR DESCRIPTION
## Done

- Reinstated status description for "ignored" statuses
- Hid releases switch and removed notification for CVEs with no unmaintained releases

## QA

- View the site locally in your web browser at: 
  - https://ubuntu-com-14329.demos.haus/security/CVE-2024-7254 and see that the "Show unmaintained releases" and corresponding notification has been removed (compared against [prod](https://ubuntu.com/security/CVE-2024-7254) )
  - https://ubuntu-com-14329.demos.haus/security/CVE-2024-38630 and see that the status description is rendered next to "ignored" statuses (compared against [prod](https://ubuntu.com/security/CVE-2024-38630))

## Issue / Card

Fixes # https://warthogs.atlassian.net/browse/WD-14901, https://warthogs.atlassian.net/browse/WD-14911

## Screenshots
![image](https://github.com/user-attachments/assets/f889d9cc-70dd-47e4-89bb-23a56f48348f)
