### PR TITLE
ui: Added a link to download arm architectures

### DIFF
--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -64,7 +64,8 @@
               performance.mark("Download (Desktop) button rendered")
             </script>
           </p>
-          <p class="p-text--small">
+          <p class="p-text--small"></p>
+            For arm based computers, please download the <a href="https://cdimage.ubuntu.com/daily-live/current/oracular-desktop-arm64.iso">Ubuntu Desktop for ARM</a>.
             For other versions of Ubuntu Desktop including torrents, the network installer, a list of local mirrors and past releases <a href="/download/alternative-downloads">check out our alternative downloads</a>.
           </p>
         </div>


### PR DESCRIPTION
## Done

- [List of work items including drive-bys - remember to add the why and what of this work.]

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card
 
Fixes #13681 

## Screenshots

[If relevant, please include a screenshot.]
<img width="1280" alt="image" src="https://github.com/user-attachments/assets/e3ddc5dc-21f6-4b45-a7ae-1ed98e6a4b4c">


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
