### PR TITLE
copy update: kernel support

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -147,6 +147,41 @@ export var serverAndDesktopReleases = [
 
 export var kernelReleases = [
   {
+    startDate: new Date("2024-10-01T00:00:00"),
+    endDate: new Date("2025-07-01T00:00:00"),
+    taskName: "24.10",
+    taskVersion: "6.11 kernel",
+    status: "INTERIM_RELEASE",
+  },
+  {
+    startDate: new Date("2024-08-01T00:00:00"),
+    endDate: new Date("2027-04-01T00:00:00"),
+    taskName: "22.04.5 LTS (HWE)",
+    taskVersion: "6.8 kernel",
+    status: "LTS",
+  },
+  {
+    startDate: new Date("2027-04-01T00:00:00"),
+    endDate: new Date("2032-03-31T00:00:00"),
+    taskName: "22.04.5 LTS (HWE)",
+    taskVersion: "6.8 kernel",
+    status: "ESM",
+  },
+  {
+    startDate: new Date("2024-08-01T00:00:00"),
+    endDate: new Date("2029-04-01T00:00:00"),
+    taskName: "24.04.1 LTS",
+    taskVersion: "6.8 kernel",
+    status: "LTS",
+  },
+  {
+    startDate: new Date("2029-04-01T00:00:00"),
+    endDate: new Date("2034-03-31T00:00:00"),
+    taskName: "24.04.1 LTS",
+    taskVersion: "6.8 kernel",
+    status: "ESM",
+  },
+  {
     startDate: new Date("2024-04-01T00:00:00"),
     endDate: new Date("2029-04-01T00:00:00"),
     taskName: "24.04.0 LTS",
@@ -159,20 +194,6 @@ export var kernelReleases = [
     taskName: "24.04.0 LTS",
     taskVersion: "6.8 kernel",
     status: "ESM",
-  },
-  {
-    startDate: new Date("2024-02-01T00:00:00"),
-    endDate: new Date("2024-08-01T00:00:00"),
-    taskName: "22.04.4 LTS (HWE)",
-    taskVersion: "6.5 kernel",
-    status: "LTS",
-  },
-  {
-    startDate: new Date("2023-10-01T00:00:00"),
-    endDate: new Date("2024-07-01T00:00:00"),
-    taskName: "23.10",
-    taskVersion: "",
-    status: "INTERIM_RELEASE",
   },
   {
     startDate: new Date("2022-08-01T00:00:00"),
@@ -1175,9 +1196,10 @@ export var desktopServerReleaseNames = [
 ];
 
 export var kernelReleaseNames = [
+  "24.10",
+  "22.04.5 LTS (HWE)",
+  "24.04.1 LTS",
   "24.04.0 LTS",
-  "22.04.4 LTS (HWE)",
-  "23.10",
   "22.04.1 LTS",
   "20.04.5 LTS (HWE)",
   "22.04.0 LTS",
@@ -1193,8 +1215,9 @@ export var kernelReleaseNames = [
 ];
 
 export var kernelVersionNames = [
+  "6.11",
   "6.8",
-  "6.5",
+  "",
   "",
   "5.15",
   "",

--- a/templates/shared/_kernel-release-diagram.html
+++ b/templates/shared/_kernel-release-diagram.html
@@ -12,33 +12,41 @@
   <tbody>
     <tr>
       <td>
+        <strong>6.11</strong>
+      </td>
+      <td>
+        <strong>24.10</strong>
+      </td>
+      <td>Oct 2024</td>
+      <td>Jul 2025</td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td rowspan="3">
         <strong>6.8</strong>
       </td>
+      <td>
+        <strong>22.04.5 LTS (HWE)</strong>
+      </td>
+      <td>Aug 2024</td>
+      <td>Apr 2027</td>
+      <td>Mar 2032</td>
+    </tr>
+    <tr>
+      <td>
+        <strong>24.04.1 LTS</strong>
+      </td>
+      <td>Aug 2024</td>
+      <td>Apr 2029</td>
+      <td>Mar 2034</td>
+    </tr>
+    <tr>
       <td>
         <strong>24.04.0 LTS</strong>
       </td>
       <td>Apr 2024</td>
       <td>Apr 2029</td>
       <td>Mar 2034</td>
-    </tr>
-    <tr>
-      <td rowspan="2">
-        <strong>6.5</strong>
-      </td>
-      <td>
-        <strong>22.04.4 LTS (HWE)</strong>
-      </td>
-      <td>Feb 2024</td>
-      <td>Aug 2024</td>
-      <td>&nbsp;</td>
-    </tr>
-    <tr>
-      <td>
-        <strong>23.10</strong>
-      </td>
-      <td>Oct 2023</td>
-      <td>Jul 2024</td>
-      <td>&nbsp;</td>
     </tr>
     <tr>
       <td rowspan="3">


### PR DESCRIPTION
## Done
- [Copy doc](https://docs.google.com/document/d/1-l3B7AoyDoETaL80UhlfEWCVKmMWPdy3zoF5LpsGcYQ/edit#heading=h.yy70h36s0ivx) - **this PR only includes the changes for [Ubuntu kernel tab](https://ubuntu-com-14337.demos.haus/about/release-cycle#ubuntu-kernel-release-cycle)**
- Updates kernel support graph and table according to [this sheet](https://docs.google.com/spreadsheets/d/1KIuOAa620yseE0uhIl67u2SlS0bWlPI_d98bvYM2Yl8/edit?gid=550510389#gid=550510389)
- Also removes kernel version 6.5 as it is no longer supported

## QA

- Check that the dates, kernel versions and Ubuntu versions on the graph and table match those in the spreadsheet

## Issue / Card

Fixes [WD-15102](https://warthogs.atlassian.net/browse/WD-15102)


[WD-15102]: https://warthogs.atlassian.net/browse/WD-15102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ