### PR TITLE
Decouple cve pagination from certified pages

### DIFF
--- a/templates/certified/search-results.html
+++ b/templates/certified/search-results.html
@@ -216,7 +216,14 @@
           <div class="row">
             <div class="col-5">
               {% with total_results=total_results, total_pages=total_pages, offset=offset, limit=limit, align="u-align--left" %}
-                {% include "security/cves/_pagination.html" %}
+                {% if offset >= total_results %}
+                    {% set current_page = 1 %}
+                  {% else %}
+                    {% set current_page = ((offset / limit) + 1) | int %}
+                  {% endif %}
+                {% if total_results > limit %}
+                  {% include "shared/_pagination.html" %}
+                {% endif %}
               {% endwith %}
             </div>
             <div class="col-4 u-align--right">

--- a/templates/certified/shared/category-search-results.html
+++ b/templates/certified/shared/category-search-results.html
@@ -206,7 +206,14 @@
           <div class="row">
             <div class="col-5">
               {% with total_results=total_results, total_pages=total_pages, offset=offset, limit=limit, align="u-align--left" %}
-                {% include "security/cves/_pagination.html" %}
+                {% if offset >= total_results %}
+                    {% set current_page = 1 %}
+                  {% else %}
+                    {% set current_page = ((offset / limit) + 1) | int %}
+                  {% endif %}
+                {% if total_results > limit %}
+                  {% include "shared/_pagination.html" %}
+                {% endif %}
               {% endwith %}
             </div>
             <div class="col-4 u-align--right">

--- a/templates/shared/_pagination.html
+++ b/templates/shared/_pagination.html
@@ -1,6 +1,6 @@
 <div class="u-fixed-width">
   {% if current_page and total_pages and total_pages > 1 %}
-    <ol class="p-pagination u-align--center">
+    <ol class="p-pagination {% if align %} {{ align }} {% else %} u-align--center {% endif %}">
       <li class="p-pagination__item">
         {% if current_page > 1 %}
           {% if limit %}


### PR DESCRIPTION
## Done

- Refactored the certified search results pages to use the default pagination instead of sharing the cve pagination  

## QA

- View the site locally in your web browser at: http://0.0.0.0:8001/certified?q=
- Check that pagination works as expected 

## Issue / Card

Fixes #

