### PR TITLE
WD-15300 ui overlap fix and minor upgrades

### DIFF
--- a/templates/containers/chiselled/dotnet.html
+++ b/templates/containers/chiselled/dotnet.html
@@ -1,305 +1,397 @@
 {% extends "containers/chiselled/_base_chiselled.html" %}
 
-{% block title %}Chiselled Ubuntu and .NET Containers{% endblock title %}
+{% block title %}
+  Chiselled Ubuntu and .NET Containers
+{% endblock title %}
 
-{% block meta_description %}Chiselled Ubuntu for .NET is a game-changing technology that delivers the best advantages of Distroless containers with Ubuntu's reliability and ease of use.{% endblock meta_description %}
+{% block meta_description %}
+  Chiselled Ubuntu for .NET is a game-changing technology that delivers the best advantages of Distroless containers with Ubuntu's reliability and ease of use.
+{% endblock meta_description %}
 
-{% block meta_copydoc %}https://docs.google.com/document/d/1fUG2SpbfdVDMAdbe7zfuzzvji4oWm-P18D85V2A3F8c/edit{% endblock meta_copydoc %}
+{% block meta_copydoc %}
+  https://docs.google.com/document/d/1fUG2SpbfdVDMAdbe7zfuzzvji4oWm-P18D85V2A3F8c/edit
+{% endblock meta_copydoc %}
 
-{% block body_class %}is-paper{% endblock body_class %}
+{% block body_class %}
+  is-paper
+{% endblock body_class %}
 
 {% block content %}
-<section class="p-strip">
-  <div class="row">
-    <div class="col-6 col-medium-3">
-      <h1 class="p-heading--bold p-heading--2">Migrate .NET to <br class="u-hide--small"/>chiselled Ubuntu containers</h1>
+  <section class="p-strip">
+    <div class="row">
+      <div class="col-6 col-medium-3">
+        <h1 class="p-heading--bold p-heading--2">
+          Migrate .NET to
+          <br class="u-hide--small" />
+          chiselled Ubuntu containers
+        </h1>
+      </div>
+      <div class="col-6 col-medium-3">
+        <p class="p-block">
+          Reliable and secure .NET applications with Ubuntu containers. Reduce memory footprint, lower subscription and network costs, and get faster start-up times. Open source and backed by Canonical security, stability, and quality assurance.
+        </p>
+        <p>
+          <a href="/containers/contact-us"
+             class="p-button--positive js-invoke-modal">Get in touch</a>
+        </p>
+      </div>
     </div>
-    <div class="col-6 col-medium-3">
-      <p class="p-block">Reliable and secure .NET applications with Ubuntu containers. Reduce memory footprint, lower subscription and network costs, and get faster start-up times. Open source and backed by Canonical security, stability, and quality assurance.</p>
-      <p>
-        <a href="/containers/contact-us" class="p-button--positive js-invoke-modal">Get in touch</a>
-      </p>
-    </div>
-  </div>
-</section>
+  </section>
 
-<section class="p-strip u-no-padding--top">
-  <div class="row">
-    <div class="col-3 col-medium-3 p-block">
-      <div class="p-rule--highlight">
-        <p class="p-heading--2 u-no-margin"><strong>20%</strong></p>
+  <section class="p-strip u-no-padding--top">
+    <div class="row">
+      <div class="col-3 col-medium-3 p-section--shallow">
+        <hr class="p-rule--highlight" />
+        <p class="p-heading--2 u-no-margin">
+          <strong>20%</strong>
+        </p>
         <p class="p-heading--4 u-no-margin">Better memory usage</p>
       </div>
-    </div>
-    <div class="col-3 col-medium-3 p-block">
-      <div class="p-rule--highlight">
-        <p class="p-heading--2 u-no-margin"><strong>40%</strong></p>
+      <div class="col-3 col-medium-3 p-section--shallow">
+        <hr class="p-rule--highlight" />
+        <p class="p-heading--2 u-no-margin">
+          <strong>40%</strong>
+        </p>
         <p class="p-heading--4 u-no-margin">Better response time</p>
       </div>
-    </div>
-    <div class="col-3 col-medium-3 p-block">
-      <div class="p-rule--highlight">
-        <p class="p-heading--2 u-no-margin"><strong>25%</strong></p>
+      <div class="col-3 col-medium-3 p-section--shallow">
+        <hr class="p-rule--highlight" />
+        <p class="p-heading--2 u-no-margin">
+          <strong>25%</strong>
+        </p>
         <p class="p-heading--4 u-no-margin">Fewer resources</p>
       </div>
-    </div>
-    <div class="col-3 col-medium-3 p-block">
-      <div class="p-rule--highlight">
-        <p class="p-heading--2 u-no-margin"><strong>50%</strong></p>
+      <div class="col-3 col-medium-3 p-section--shallow">
+        <hr class="p-rule--highlight" />
+        <p class="p-heading--2 u-no-margin">
+          <strong>50%</strong>
+        </p>
         <p class="p-heading--4 u-no-margin">Less costs</p>
       </div>
-    </div>
-    <p>Data is based on migration from servers to containers <br class="u-hide--small u-hide--medium"/>and from Windows to Ubuntu with chiselled Ubuntu.</p>
-  </div>
-</section>
-
-<section class="p-strip u-no-padding--top">
-  <div class="row">
-    <hr class="p-rule" />
-    <div class="col-6 col-medium-3">
-      <h2>What is chiselled Ubuntu</h2>
-    </div>
-    <div class="col-6 col-medium-3">
-      <p>Chiselled Ubuntu is inspired by the Distroless concept - providing ultra-small OCI images with only your application and its runtime dependencies, and no other operating system-level packages or libraries. This makes them lightweight, secure, and efficient.</p>
-      <p>There’s an infinite number of slices of the Ubuntu distribution. You can chisel Ubuntu for your exact needs, or rely on our set of pre-built chiselled Ubuntu runtime images.</p>
-      <p>In August 2022, we released the <a href="/blog/install-dotnet-on-ubuntu">first set of pre-built chiselled Ubuntu runtime images</a> for the .NET ecosystem in collaboration with Microsoft.</p>
-      <div class="u-embedded-media">
-        <iframe width="560" height="315" src="https://www.youtube.com/embed/pnsYc8GskCw" class="u-embedded-media__element" title=".NET in Ubuntu and Chiseled Containers - Canonical & Microsoft" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-      </div>
-    </div>
-  </div>
-</section>
-
-<section class="p-strip u-no-padding--top">
-  <div class="row">
-    <hr class="p-rule" />
-    <div class="col-6 col-medium-3">
-      <h2>Why choose chiselled Ubuntu</h2>
-    </div>
-    <div class="col-6 col-medium-3">
-      <p>Chiselled Ubuntu images are made using Canonical’s regular high-quality components and are updated within the same release cycle and with the same support guarantees.</p>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-9 col-start-large-4 col-medium-3 col-start-medium-4">
-      <div class="p-block">
-        <hr class="p-rule" />
-        <div class="row">
-          <div class="col-3 col-medium-3">
-            <h3 class="p-heading--5">Ultra-small image size</h3>
-          </div>
-          <div class="col-6 col-medium-3">
-            <p>Reduces the attack surface of chiselled Ubuntu images, so they’re less vulnerable, need fewer security updates, and your users have less downtime.</p>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-9 col-start-large-4 col-medium-3 col-start-medium-4 col-medium-3 col-start-medium-4">
-      <div class="p-block">
-        <hr class="p-rule" />
-        <div class="row">
-          <div class="col-3 col-medium-3">
-            <h3 class="p-heading--5">No package manager and no shell</h3>
-          </div>
-          <div class="col-6 col-medium-3">
-            <p>Meaning, no apt or bash in the final image removes entire classes of attack, fully disarming potential attackers.</p>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-9 col-start-large-4 col-medium-3 col-start-medium-4">
-      <hr class="p-rule" />
-      <div class="row">
-        <div class="col-3 col-medium-3">
-          <h3 class="p-heading--5">Faster transfer times</h3>
-        </div>
-        <div class="col-6 col-medium-3">
-          <p>Means applications are always up-to-date and ready to handle the increased traffic and workload.</p>
-        </div>
-      </div>
-    </div>
-  </div>
-</section>
-
-<section class="p-strip is-deep u-no-padding--top">
-  <div class="row">
-    <hr class="p-rule" />
-    <div class="col-6 col-medium-3">
-      <h2>Lower costs by up to 50%</h2>
-    </div>
-    <div class="col-6 col-medium-3">
-      <div class="p-block">
-        <p>Use chiselled Ubuntu to lower costs when you migrate from Windows to Ubuntu and Azure. Find out how chiselled Ubuntu can support your migration from servers to containers.</p>
-      </div>
-      <p><a href="/containers/contact-us" class="p-heading--2 js-invoke-modal">Get in touch&nbsp;&rsaquo;</a></p>
-    </div>
-  </div>
-</section>
-
-<section class="p-strip u-no-padding--top">
-  <div class="row">
-    <hr class="p-rule" />
-    <div class="col-6 col-medium-3">
-      <h2>Peace of mind with <br class="u-hide--small" />Ubuntu Pro</h2>
-    </div>
-    <div class="col-6 col-medium-3">
-      <div class="p-block">
-        <p>Ubuntu Pro offers an end-to-end capability from development workstation, applications and toolchains through to production-ready, secure-by-design ultra-small supported container images, starting with the .NET platform and with full support, security and uptime guaranteed by Canonical.</p>
-      </div>
       <p>
-        <a href="/pro" class="p-button">Get Ubuntu Pro</a>
+        Data is based on migration from servers to containers
+        <br class="u-hide--small u-hide--medium" />
+        and from Windows to Ubuntu with chiselled Ubuntu.
       </p>
     </div>
-  </div>
-  <div class="row">
-    <div class="col-9 col-start-large-4 col-medium-3 col-start-medium-4">
-      <div class="p-block">
-        <hr class="p-rule" />
-        <div class="row">
-          <div class="col-3 col-medium-3">
-            <div class="p-heading-icon--small">
-              <div class="p-heading-icon__header">
-                <div class="p-heading-icon__img u-hide--small u-hide--medium">
-                  {{ image (
-                    url="https://assets.ubuntu.com/v1/6d45f794-shields-security.png",
-                    alt="",
-                    width="32",
-                    height="51",
-                    hi_def=True,
-                    loading="lazy",
-                    ) | safe
-                  }}
-                </div>
-                <h3 class="p-heading-icon__title p-heading--5">Full security <br class="u-hide--small u-hide--medium" />coverage</h3>
-              </div>
-            </div>
-          </div>
-          <div class="col-6 col-medium-3">
-            <p>Since its inception in 2004, Ubuntu has been built on a foundation of enterprise-grade, industry-leading security practices. With Ubuntu Pro, we offer peace-of-mind with full security coverage.</p>
-            <p>Reduce your average CVE exposure time from 98 days to one with expanded CVE patching and 10years of security maintenance.</p>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-9 col-start-large-4 col-medium-3 col-start-medium-4">
-      <div class="p-block">
-        <hr class="p-rule" />
-        <div class="row">
-          <div class="col-3 col-medium-3">
-            <div class="p-heading-icon--small">
-              <div class="p-heading-icon__header">
-                <div class="p-heading-icon__img u-hide--small u-hide--medium">
-                  {{ image (
-                    url="https://assets.ubuntu.com/v1/bf2672b5-developer.png",
-                    alt="",
-                    width="32",
-                    height="41",
-                    hi_def=True,
-                    loading="lazy"
-                    ) | safe
-                  }}
-                </div>
-                <h3 class="p-heading-icon__title p-heading--5">Full stack <br class="u-hide--small u-hide--medium" />support</h3>
-              </div>
-            </div>
-          </div>
-          <div class="col-6 col-medium-3">
-            <p>Open source your full stack with confidence, from the data centre to the cloud, from containers to the database, taking in LMA, server, and cloud-native applications along the way, all with support from Canonical.</p>
-            <p>The support services ensure a seamless open source experience from development to production.</p>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-9 col-start-large-4 col-medium-3 col-start-medium-4">
+  </section>
+
+  <section class="p-section">
+    <div class="row">
       <hr class="p-rule" />
-      <div class="row">
-        <div class="col-3 col-medium-3">
-          <div class="p-heading-icon--small">
-            <div class="p-heading-icon__header">
-              <div class="p-heading-icon__img u-hide--small u-hide--medium" style="margin-top: 0.7rem;">
-                {{ 
-                  image (
-                  url="https://assets.ubuntu.com/v1/30798854-settings.svg",
-                  alt="",
-                  width="32",
-                  height="33",
-                  hi_def=True,
-                  loading="lazy"
-                  ) | safe
-                }}
-              </div>
-              <h3 class="p-heading-icon__title p-heading--5">Bug fixing and <br class="u-hide--small u-hide--medium" />troubleshooting</h3>
-            </div>
-          </div>
-        </div>
-        <div class="col-6 col-medium-3">
-          <p>Managing your containers can be tiring and daunting. Our experts offer support for bug fixes and troubleshooting to help you every step of the way.</p>
-          <p>At Canonical, we offer direct 24/7 access to a world-class, enterprise open-source support team by phone, online, or with our knowledge base.</p>
+      <div class="col-6 col-medium-3">
+        <h2>What is chiselled Ubuntu</h2>
+      </div>
+      <div class="col-6 col-medium-3">
+        <p>
+          Chiselled Ubuntu is inspired by the Distroless concept - providing ultra-small OCI images with only your application and its runtime dependencies, and no other operating system-level packages or libraries. This makes them lightweight, secure, and efficient.
+        </p>
+        <p>
+          There’s an infinite number of slices of the Ubuntu distribution. You can chisel Ubuntu for your exact needs, or rely on our set of pre-built chiselled Ubuntu runtime images.
+        </p>
+        <p>
+          In August 2022, we released the <a href="/blog/install-dotnet-on-ubuntu">first set of pre-built chiselled Ubuntu runtime images</a> for the .NET ecosystem in collaboration with Microsoft.
+        </p>
+        <div class="u-embedded-media">
+          <iframe width="560"
+                  height="315"
+                  src="https://www.youtube.com/embed/pnsYc8GskCw"
+                  class="u-embedded-media__element"
+                  title=".NET in Ubuntu and Chiseled Containers - Canonical & Microsoft"
+                  frameborder="0"
+                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                  allowfullscreen></iframe>
         </div>
       </div>
     </div>
-  </div>
-</section>
+  </section>
 
-<section class="p-strip u-no-padding--top">
-  <div class="row">
-    <hr class="p-rule" />
-    <div class="col-6 col-medium-3">
-      <h2>Proven success with <br class="u-hide--small" />chiselled Ubuntu</h2>
+  <section class="p-section">
+    <div class="row">
+      <hr class="p-rule" />
+      <div class="col-6 col-medium-3">
+        <h2>Why choose chiselled Ubuntu</h2>
+      </div>
+      <div class="col-6 col-medium-3">
+        <p>
+          Chiselled Ubuntu images are made using Canonical’s regular high-quality components and are updated within the same release cycle and with the same support guarantees.
+        </p>
+      </div>
     </div>
-    <div class="col-6 col-medium-3">
-      <p>Chiselled Ubuntu and .NET reduced 100MB off the official .NET containers, with base images for self-contained .NET applications weighing in at less than 6MB compressed. This achievement rivals Alpine, Busybox, and Distroless images while offering a rich-to-lean, seamless development-to-production experience.</p>
-      <p>Experiments with Microsoft's ASP.NET demo eShop application revealed a <a href="/blog/benefits-chiselled-ubuntu-images-aspnet-eshop-demo">20% improvement in memory usage and startup time</a> when using chiselled Ubuntu.</p>
+    <div class="row">
+      <div class="col-9 col-start-large-4 col-medium-3 col-start-medium-4">
+        <div class="p-block">
+          <hr class="p-rule--muted" />
+          <div class="row">
+            <div class="col-3 col-medium-3">
+              <h3 class="p-heading--5">Ultra-small image size</h3>
+            </div>
+            <div class="col-6 col-medium-3">
+              <p>
+                Reduces the attack surface of chiselled Ubuntu images, so they’re less vulnerable, need fewer security updates, and your users have less downtime.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
-  </div>
-</section>
+    <div class="row">
+      <div class="col-9 col-start-large-4 col-medium-3 col-start-medium-4 col-medium-3 col-start-medium-4">
+        <div class="p-block">
+          <hr class="p-rule--muted" />
+          <div class="row">
+            <div class="col-3 col-medium-3">
+              <h3 class="p-heading--5">No package manager and no shell</h3>
+            </div>
+            <div class="col-6 col-medium-3">
+              <p>
+                Meaning, no apt or bash in the final image removes entire classes of attack, fully disarming potential attackers.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-9 col-start-large-4 col-medium-3 col-start-medium-4">
+        <hr class="p-rule--muted" />
+        <div class="row">
+          <div class="col-3 col-medium-3">
+            <h3 class="p-heading--5">Faster transfer times</h3>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>Means applications are always up-to-date and ready to handle the increased traffic and workload.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
 
-<section class="p-strip u-no-padding--top">
-  <div class="row">
-    <hr class="p-rule" />
-    <div class="p-block">
-      <h2>For .NET developers: start your Linux journey <br class="u-hide--small" />with Ubuntu containers</h2>
+  <section class="p-section--deep">
+    <div class="row">
+      <hr class="p-rule" />
+      <div class="col-6 col-medium-3">
+        <h2>Lower costs by up to 50%</h2>
+      </div>
+      <div class="col-6 col-medium-3">
+        <div class="p-block">
+          <p>
+            Use chiselled Ubuntu to lower costs when you migrate from Windows to Ubuntu and Azure. Find out how chiselled Ubuntu can support your migration from servers to containers.
+          </p>
+        </div>
+        <p>
+          <a href="/containers/contact-us" class="p-heading--2 js-invoke-modal">Get in touch&nbsp;&rsaquo;</a>
+        </p>
+      </div>
     </div>
-    <div class="col-6 col-medium-3 u-hide--small">
-      {{ image (
-        url="https://assets.ubuntu.com/v1/4c448eff-containers.png",
-        alt="",
-        width="1090",
-        height="712",
-        hi_def=True,
-        loading="lazy"
-        ) | safe
-      }}
-    </div>
-    <div class="col-6 col-medium-3">
-      <p>Chiselled Ubuntu containers for .NET and ASP.NET runtime are now available on Arm-based platforms, offering precision-engineered, production-aimed containers to the Arm community.</p>
-      <hr class="p-rule--muted" />
-      <ul class="p-list--ticked">
-        <li class="p-list__item-padded has-bullet">Timely security patches</li>
-        <li class="p-list__item-padded has-bullet">Latest and long-term supported releases</li>
-        <li class="p-list__item-padded has-bullet">Development environment that mimics production</li>
-      </ul>
-      <p>Shipping only the binaries needed to run .NET applications means a smaller attack surface and lets you focus your added value: layering on your world-class applications and shipping to any platform.</p>
-      <p><a href="https://hub.docker.com/r/ubuntu/dotnet-runtime">Start using chiselled Ubuntu for OCI image&nbsp;&rsaquo;</a></p>
-    </div>
-  </div>
-</section>
+  </section>
 
-<section class="p-strip--white is-deep">
-  <div class="row">
-    <p><a href="/containers/contact-us" class="p-heading--2 js-invoke-modal">Get in touch&nbsp;&rsaquo;</a></p>
-  </div>
-</section>
+  <section class="p-section">
+    <div class="row">
+      <hr class="p-rule" />
+      <div class="col-6 col-medium-3">
+        <h2>
+          Peace of mind with
+          <br class="u-hide--small" />
+          Ubuntu Pro
+        </h2>
+      </div>
+      <div class="col-6 col-medium-3">
+        <div class="p-block">
+          <p>
+            Ubuntu Pro offers an end-to-end capability from development workstation, applications and toolchains through to production-ready, secure-by-design ultra-small supported container images, starting with the .NET platform and with full support, security and uptime guaranteed by Canonical.
+          </p>
+        </div>
+        <p>
+          <a href="/pro" class="p-button">Get Ubuntu Pro</a>
+        </p>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-9 col-start-large-4 col-medium-3 col-start-medium-4">
+        <div class="p-block">
+          <hr class="p-rule--muted" />
+          <div class="row">
+            <div class="col-3 col-medium-3">
+              <div class="p-heading-icon--small">
+                <div class="p-heading-icon__header">
+                  <div class="p-heading-icon__img u-hide--small u-hide--medium">
+                    {{ image(url="https://assets.ubuntu.com/v1/6d45f794-shields-security.png",
+                                        alt="",
+                                        width="32",
+                                        height="51",
+                                        hi_def=True,
+                                        loading="lazy",) | safe
+                    }}
+                  </div>
+                  <h3 class="p-heading-icon__title p-heading--5">
+                    Full security
+                    <br class="u-hide--small u-hide--medium" />
+                    coverage
+                  </h3>
+                </div>
+              </div>
+            </div>
+            <div class="col-6 col-medium-3">
+              <p>
+                Since its inception in 2004, Ubuntu has been built on a foundation of enterprise-grade, industry-leading security practices. With Ubuntu Pro, we offer peace-of-mind with full security coverage.
+              </p>
+              <p>
+                Reduce your average CVE exposure time from 98 days to one with expanded CVE patching and 10years of security maintenance.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-9 col-start-large-4 col-medium-3 col-start-medium-4">
+        <div class="p-block">
+          <hr class="p-rule--muted" />
+          <div class="row">
+            <div class="col-3 col-medium-3">
+              <div class="p-heading-icon--small">
+                <div class="p-heading-icon__header">
+                  <div class="p-heading-icon__img u-hide--small u-hide--medium">
+                    {{ image(url="https://assets.ubuntu.com/v1/bf2672b5-developer.png",
+                                        alt="",
+                                        width="32",
+                                        height="41",
+                                        hi_def=True,
+                                        loading="lazy") | safe
+                    }}
+                  </div>
+                  <h3 class="p-heading-icon__title p-heading--5">
+                    Full stack
+                    <br class="u-hide--small u-hide--medium" />
+                    support
+                  </h3>
+                </div>
+              </div>
+            </div>
+            <div class="col-6 col-medium-3">
+              <p>
+                Open source your full stack with confidence, from the data centre to the cloud, from containers to the database, taking in LMA, server, and cloud-native applications along the way, all with support from Canonical.
+              </p>
+              <p>The support services ensure a seamless open source experience from development to production.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-9 col-start-large-4 col-medium-3 col-start-medium-4">
+        <hr class="p-rule--muted" />
+        <div class="row">
+          <div class="col-3 col-medium-3">
+            <div class="p-heading-icon--small">
+              <div class="p-heading-icon__header">
+                <div class="p-heading-icon__img u-hide--small u-hide--medium"
+                     style="margin-top: 0.7rem">
+                  {{ image(url="https://assets.ubuntu.com/v1/30798854-settings.svg",
+                                    alt="",
+                                    width="32",
+                                    height="33",
+                                    hi_def=True,
+                                    loading="lazy") | safe
+                  }}
+                </div>
+                <h3 class="p-heading-icon__title p-heading--5">
+                  Bug fixing and
+                  <br class="u-hide--small u-hide--medium" />
+                  troubleshooting
+                </h3>
+              </div>
+            </div>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              Managing your containers can be tiring and daunting. Our experts offer support for bug fixes and troubleshooting to help you every step of the way.
+            </p>
+            <p>
+              At Canonical, we offer direct 24/7 access to a world-class, enterprise open-source support team by phone, online, or with our knowledge base.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
 
-<!-- Set default Marketo information for contact form below-->
-<div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/containers-chiselled-dotnet" data-form-id="5272" data-lp-id="" data-return-url="https://ubuntu.com/containers/chiselled/dotnet#success" data-lp-url="https://pages.ubuntu.com/things-contact-us.html"></div>
+  <section class="p-section">
+    <div class="row">
+      <hr class="p-rule" />
+      <div class="col-6 col-medium-3">
+        <h2>
+          Proven success with
+          <br class="u-hide--small" />
+          chiselled Ubuntu
+        </h2>
+      </div>
+      <div class="col-6 col-medium-3">
+        <p>
+          Chiselled Ubuntu and .NET reduced 100MB off the official .NET containers, with base images for self-contained .NET applications weighing in at less than 6MB compressed. This achievement rivals Alpine, Busybox, and Distroless images while offering a rich-to-lean, seamless development-to-production experience.
+        </p>
+        <p>
+          Experiments with Microsoft's ASP.NET demo eShop application revealed a <a href="/blog/benefits-chiselled-ubuntu-images-aspnet-eshop-demo">20% improvement in memory usage and startup time</a> when using chiselled Ubuntu.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="row">
+      <hr class="p-rule" />
+      <div class="p-block">
+        <h2>
+          For .NET developers: start your Linux journey
+          <br class="u-hide--small" />
+          with Ubuntu containers
+        </h2>
+      </div>
+      <div class="col-6 col-medium-3 u-hide--small">
+        {{ image(url="https://assets.ubuntu.com/v1/4c448eff-containers.png",
+                alt="",
+                width="1090",
+                height="712",
+                hi_def=True,
+                loading="lazy") | safe
+        }}
+      </div>
+      <div class="col-6 col-medium-3">
+        <p>
+          Chiselled Ubuntu containers for .NET and ASP.NET runtime are now available on Arm-based platforms, offering precision-engineered, production-aimed containers to the Arm community.
+        </p>
+        <hr class="p-rule--muted" />
+        <ul class="p-list--ticked">
+          <li class="p-list__item-padded has-bullet">Timely security patches</li>
+          <li class="p-list__item-padded has-bullet">Latest and long-term supported releases</li>
+          <li class="p-list__item-padded has-bullet">Development environment that mimics production</li>
+        </ul>
+        <p>
+          Shipping only the binaries needed to run .NET applications means a smaller attack surface and lets you focus your added value: layering on your world-class applications and shipping to any platform.
+        </p>
+        <p>
+          <a href="https://hub.docker.com/r/ubuntu/dotnet-runtime">Start using chiselled Ubuntu for OCI image&nbsp;&rsaquo;</a>
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-strip--white is-deep">
+    <div class="row">
+      <p>
+        <a href="/containers/contact-us" class="p-heading--2 js-invoke-modal">Get in touch&nbsp;&rsaquo;</a>
+      </p>
+    </div>
+  </section>
+
+  <!-- Set default Marketo information for contact form below-->
+  <div class="u-hide"
+       id="contact-form-container"
+       data-form-location="/shared/forms/interactive/containers-chiselled-dotnet"
+       data-form-id="5272"
+       data-lp-id=""
+       data-return-url="https://ubuntu.com/containers/chiselled/dotnet#success"
+       data-lp-url="https://pages.ubuntu.com/things-contact-us.html"></div>
 
 {% endblock content %}


### PR DESCRIPTION
## Done

- UI overlap buxfix
## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [Demo](https://ubuntu-com-14345.demos.haus/containers/chiselled/dotnet)
## Issue / Card

Fixes # [WD-15300](https://warthogs.atlassian.net/browse/WD-15300)

## Screenshots
Previously
![image](https://github.com/user-attachments/assets/c18be910-62f2-4595-8f55-2a11aea0bb50)

Fixed
![image](https://github.com/user-attachments/assets/e0604d76-7b24-4fff-b003-b3d1996559b5)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-15300]: https://warthogs.atlassian.net/browse/WD-15300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ