### PR TITLE
Update ubuntu.com/download/desktop with 24.10 download section. WD-14861

### DIFF
--- a/static/js/src/tabbed-content.js
+++ b/static/js/src/tabbed-content.js
@@ -56,6 +56,7 @@
       Attaches a number of events that each trigger
       the reveal of the chosen tab content
       @param {Array} tabs an array of tabs within a container
+      @param {Boolean} persistURLHash whether to add the tab ID to the URL
     */
   const attachEvents = (tabs, persistURLHash) => {
     tabs.forEach(function (tab, index) {
@@ -106,7 +107,7 @@
     */
   const setActiveTab = (tab, tabs) => {
     tabs.forEach((tabElement) => {
-      var tabContent = document.querySelectorAll(
+      const tabContent = document.querySelectorAll(
         "#" + tabElement.getAttribute("aria-controls"),
       );
       tabContent.forEach((content) => {
@@ -134,30 +135,38 @@
     containing the tabs we want to attach events to
   */
   const initTabs = (selector) => {
-    var tabContainers = [].slice.call(document.querySelectorAll(selector));
+    const tabContainers = [].slice.call(document.querySelectorAll(selector));
 
     tabContainers.forEach((tabContainer) => {
       // if the tab container has this data attribute, the id of the tab
       // is added to the URL, and a particular tab can be directly linked
-      var persistURLHash = tabContainer.getAttribute("data-maintain-hash");
-      var currentHash = window.location.hash;
+      const persistURLHash =
+        "true" === tabContainer.getAttribute("data-maintain-hash");
+      const currentHash = window.location.hash;
 
-      var tabs = [].slice.call(
+      const tabs = [].slice.call(
         tabContainer.querySelectorAll("[aria-controls]"),
       );
+
       attachEvents(tabs, persistURLHash);
 
-      if (persistURLHash && currentHash) {
-        var activeTab = document.querySelector(
+      const isInsideCurrentContainer =
+        null !==
+        tabContainer.querySelector(".p-tabs__link[href='" + currentHash + "']");
+
+      if (persistURLHash && currentHash && isInsideCurrentContainer) {
+        const activeTab = document.querySelector(
           ".p-tabs__link[href='" + currentHash + "']",
         );
 
         if (activeTab) {
           setActiveTab(activeTab, tabs);
         }
-      } else {
-        setActiveTab(tabs[0], tabs);
+
+        return;
       }
+
+      setActiveTab(tabs[0], tabs);
     });
   };
 
@@ -176,9 +185,9 @@
     on the page
   */
   const isScriptIncluded = (scriptName) => {
-    var scripts = document.scripts;
+    const scripts = document.scripts;
 
-    for (var i = 0; i < scripts.length; i++) {
+    for (let i = 0; i < scripts.length; i++) {
       if (scripts[i].src.includes(scriptName)) {
         return true;
       }
@@ -213,7 +222,7 @@
   const boards = document.querySelectorAll(`[role=tabpanel]`);
   const dropdownSelect = document.getElementById("boardSelect");
 
-  dropdownSelect?.addEventListener("change", (event) => {
+  dropdownSelect?.addEventListener("change", () => {
     selectBoard();
   });
 

--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -18,7 +18,7 @@
         <p>
           The open source desktop operating system that powers millions of PCs and laptops around the world. Find out more about Ubuntu's features and how we support developers and organisations below.
         </p>
-        <hr class="p-rule" />
+        <hr class="p-rule--muted" />
         <p class="u-responsive-realign">
           <a href="/desktop" class="p-button">Discover Ubuntu Desktop</a>
           <a href="/blog/desktop">Check out the blog&nbsp;&rsaquo;</a>
@@ -48,9 +48,9 @@
           <p>
             The latest <abbr title="Long-term support">LTS</abbr> version of Ubuntu, for desktop
             PCs and laptops. LTS stands for long-term support &mdash; which means five years of free security and
-            maintenance updates, extended to 10 years with <a href="/pro">Ubuntu Pro</a>.
+            maintenance updates, extended up to 12 years with <a href="/pro">Ubuntu Pro</a>.
           </p>
-          <hr class="p-rule" />
+          <hr class="p-rule--muted" />
           <p class="u-responsive-realign">
             <a class="p-button--positive"
                href="/download/desktop/thank-you?version={{ releases.lts.full_version }}&amp;architecture=amd64&amp;lts=true"
@@ -78,26 +78,26 @@
                 <a class="p-tabs__link"
                    role="tab"
                    aria-selected="true"
-                   id="release-notes-tab"
-                   href="#release-notes"
-                   aria-controls="release-notes">What's new</a>
+                   id="release-notes-tab-{{ releases.lts.slug }}"
+                   href="#release-notes-{{ releases.lts.slug }}"
+                   aria-controls="release-notes-{{ releases.lts.slug }}">What's new</a>
               </li>
               <li class="p-tabs__item">
                 <a class="p-tabs__link"
                    role="tab"
                    aria-selected="false"
-                   id="system-requirements-tab"
-                   href="#system-requirements"
-                   aria-controls="system-requirements"
+                   id="system-requirements-tab-{{ releases.lts.slug }}"
+                   href="#system-requirements-{{ releases.lts.slug }}"
+                   aria-controls="system-requirements-{{ releases.lts.slug }}"
                    tabindex="-1">System requirements</a>
               </li>
               <li class="p-tabs__item">
                 <a class="p-tabs__link"
                    role="tab"
                    aria-selected="false"
-                   id="how-to-install-tab"
-                   href="#how-to-install"
-                   aria-controls="how-to-install"
+                   id="how-to-install-tab-{{ releases.lts.slug }}"
+                   href="#how-to-install-{{ releases.lts.slug }}"
+                   aria-controls="how-to-install-{{ releases.lts.slug }}"
                    tabindex="-1">How to install</a>
               </li>
             </ul>
@@ -105,10 +105,10 @@
         </div>
         <!-- End tab container -->
         <!-- tab 1 -->
-        <div id="release-notes"
+        <div id="release-notes-{{ releases.lts.slug }}"
              class="p-tabs__content"
              role="tabpanel"
-             aria-labelledby="release-notes-tab">
+             aria-labelledby="release-notes-tab-{{ releases.lts.slug }}">
           <ul class="p-list--divided">
             <li class="p-list__item is-ticked">New Desktop installer with support for autoinstall</li>
             <li class="p-list__item is-ticked">New App Center and Firmware Updater applications</li>
@@ -116,21 +116,21 @@
             <li class="p-list__item is-ticked">Advanced Active Directory Group Policy Object support for Ubuntu Pro users</li>
             <li class="p-list__item is-ticked">Experimental support for TPM-backed Full Disc Encryption and ZFS encryption</li>
           </ul>
-          <hr class="p-rule" />
+          <hr class="p-rule--muted" />
           <ul class="u-responsive-realign p-inline-list">
             <li class="p-inline-list__item">
-              <a href="/blog/ubuntu-desktop-24-04-noble-numbat-deep-dive">Ubuntu {{ releases.lts.full_version }} LTS deep dive&nbsp;&rsaquo;</a>
+              <a href="/blog/ubuntu-desktop-24-04-noble-numbat-deep-dive" aria-label="{{ releases.lts.full_version }} LTS deep dive">Deep dive&nbsp;&rsaquo;</a>
             </li>
             <li class="p-inline-list__item">
-              <a href="https://discourse.ubuntu.com/t/noble-numbat-release-notes/39890">Release notes&nbsp;&rsaquo;</a>
+              <a href="https://discourse.ubuntu.com/t/noble-numbat-release-notes/39890" aria-label="{{ releases.lts.full_version }} LTS release notes">Release notes&nbsp;&rsaquo;</a>
             </li>
           </ul>
         </div>
         <!-- tab 2 -->
-        <div class="p-tabs__content"
-             id="system-requirements"
+        <div id="system-requirements-{{ releases.lts.slug }}"
+             class="p-tabs__content"
              role="tabpanel"
-             aria-labelledby="system-requirements-tab">
+             aria-labelledby="system-requirements-tab-{{ releases.lts.slug }}">
           <ul class="p-list--divided">
             <li class="p-list__item is-ticked">2 GHz dual-core processor or better</li>
             <li class="p-list__item is-ticked">4 GB system memory</li>
@@ -140,10 +140,10 @@
           </ul>
         </div>
         <!-- tab 3 -->
-        <div class=" p-tabs__content"
-             id="how-to-install"
+        <div id="how-to-install-{{ releases.lts.slug }}"
+             class="p-tabs__content"
              role="tabpanel"
-             aria-labelledby="how-to-install-tab">
+             aria-labelledby="how-to-install-tab-{{ releases.lts.slug }}">
           <p>To install or try Ubuntu Desktop:</p>
           <ol class="p-list--divided">
             <li class="p-list__item">Download the ISO image</li>
@@ -152,7 +152,139 @@
             </li>
             <li class="p-list__item">Boot your laptop or PC from the USB flash drive</li>
           </ol>
-          <hr class="p-rule" />
+          <hr class="p-rule--muted" />
+          <p>
+            <a href="/tutorials/install-ubuntu-desktop">Follow the step-by-step tutorial&nbsp;&rsaquo;</a>
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <div class="p-section">
+          <h2>Ubuntu {{ releases.latest.full_version }}</h2>
+        </div>
+        <div class="p-image-wrapper u-hide--small u-hide--medium">
+          {{ image(url="https://assets.ubuntu.com/v1/91be1162-Oracular%20Oriole%20Mascot%20transparent%20background.png",
+          alt="Oracular Oriole",
+          width="200",
+          height="200",
+          hi_def=True,
+          loading="auto") | safe
+          }}
+        </div>
+      </div>
+      <div class="col">
+        <div class="p-section--shallow">
+          <p>
+            The latest version of the Ubuntu operating system for desktop PCs and laptops, Ubuntu 24.10 comes with nine months of security and maintenance updates, until July 2025.
+          </p>
+          <hr class="p-rule--muted" />
+          <p class="u-responsive-realign">
+            <a class="p-button--positive"
+               href="/download/desktop/thank-you?version={{ releases.latest.full_version }}&amp;architecture=amd64&amp;lts=true"
+               onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">Download
+              {{ releases.latest.full_version }}
+            </a>
+            {% if releases.latest.iso_download_size %}
+            <span class="u-text--muted">{{ releases.latest.iso_download_size }}</span>
+            {% endif %}
+            <script>
+              performance.mark("Download (Desktop) button rendered")
+            </script>
+          </p>
+          <p class="p-text--small">
+            For other versions of Ubuntu Desktop including torrents, the network installer, a list of local mirrors and past releases <a href="/download/alternative-downloads">check out our alternative downloads</a>.
+          </p>
+        </div>
+        <!-- Start tab container -->
+        <div class="js-tab-container">
+          <nav class="p-tabs">
+
+            <ul class="p-tabs__list js-tabbed-content u-no-margin--bottom"
+                role="tablist"
+                data-maintain-hash="true">
+              <li class="p-tabs__item">
+                <a class="p-tabs__link"
+                   role="tab"
+                   aria-selected="true"
+                   id="release-notes-tab-{{ releases.latest.slug }}"
+                   href="#release-notes-{{ releases.latest.slug }}"
+                   aria-controls="release-notes-{{ releases.latest.slug }}">What's new</a>
+              </li>
+              <li class="p-tabs__item">
+                <a class="p-tabs__link"
+                   role="tab"
+                   aria-selected="false"
+                   id="system-requirements-tab-{{ releases.latest.slug }}"
+                   href="#system-requirements-{{ releases.latest.slug }}"
+                   aria-controls="system-requirements-{{ releases.latest.slug }}"
+                   tabindex="-1">System requirements</a>
+              </li>
+              <li class="p-tabs__item">
+                <a class="p-tabs__link"
+                   role="tab"
+                   aria-selected="false"
+                   id="how-to-install-tab-{{ releases.latest.slug }}"
+                   href="#how-to-install-{{ releases.latest.slug }}"
+                   aria-controls="how-to-install-{{ releases.latest.slug }}"
+                   tabindex="-1">How to install</a>
+              </li>
+            </ul>
+          </nav>
+        </div>
+        <!-- End tab container -->
+        <!-- tab 1 -->
+        <div id="release-notes-{{ releases.latest.slug }}"
+             class="p-tabs__content"
+             role="tabpanel"
+             aria-labelledby="release-notes-tab-{{ releases.latest.slug }}">
+          <ul class="p-list--divided">
+            <li class="p-list__item is-ticked">Linux Kernel 6.11 with support for the latest hardware</li>
+            <li class="p-list__item is-ticked">GNOME 47 desktop environment</li>
+            <li class="p-list__item is-ticked">New Security Center application with experimental permissions prompting</li>
+            <li class="p-list__item is-ticked">Updated software management features in the App Center</li>
+          </ul>
+          <hr class="p-rule--muted" />
+          <ul class="u-responsive-realign p-inline-list">
+            <li class="p-inline-list__item">
+              <a href="/blog/canonical-releases-ubuntu-24-10-oracular-oriole" aria-label="Ubuntu {{ releases.latest.full_version }} press release">Press release&nbsp;&rsaquo;</a>
+            </li>
+            <li class="p-inline-list__item">
+              <a href="https://discourse.ubuntu.com/t/oracular-oriole-release-notes/44878" aria-label="{{ releases.latest.full_version }} release notes">Release notes&nbsp;&rsaquo;</a>
+            </li>
+          </ul>
+        </div>
+        <!-- tab 2 -->
+        <div id="system-requirements-{{ releases.latest.slug }}"
+             class="p-tabs__content"
+             role="tabpanel"
+             aria-labelledby="system-requirements-tab-{{ releases.latest.slug }}">
+          <ul class="p-list--divided">
+            <li class="p-list__item is-ticked">2 GHz dual-core processor or better</li>
+            <li class="p-list__item is-ticked">4 GB system memory</li>
+            <li class="p-list__item is-ticked">25 GB of free hard drive space</li>
+            <li class="p-list__item is-ticked">Either a USB port or a DVD drive for the installer media</li>
+            <li class="p-list__item is-ticked">Internet access is helpful</li>
+          </ul>
+        </div>
+        <!-- tab 3 -->
+        <div id="how-to-install-{{ releases.latest.slug }}"
+             class=" p-tabs__content"
+             role="tabpanel"
+             aria-labelledby="how-to-install-tab-{{ releases.latest.slug }}">
+          <p>To install or try Ubuntu Desktop:</p>
+          <ol class="p-list--divided">
+            <li class="p-list__item">Download the ISO image</li>
+            <li class="p-list__item">
+              Create a bootable USB flash drive with <a href="https://etcher.balena.io/">balenaEtcher</a> or similar
+            </li>
+            <li class="p-list__item">Boot your laptop or PC from the USB flash drive</li>
+          </ol>
+          <hr class="p-rule--muted" />
           <p>
             <a href="/tutorials/install-ubuntu-desktop">Follow the step-by-step tutorial&nbsp;&rsaquo;</a>
           </p>

--- a/templates/download/shared/_more-from-canonical.html
+++ b/templates/download/shared/_more-from-canonical.html
@@ -22,7 +22,7 @@
         </div>
         <div class="col-6 col-medium-3">
           <p>Use the Ubuntu terminal and run Linux applications on Windows.</p>
-          <hr class="p-rule" />
+          <hr class="p-rule--muted" />
           <p>
             <a href="/desktop/wsl">Learn about Ubuntu on WSL&nbsp;&rsaquo;</a>
           </p>
@@ -48,7 +48,7 @@
         </div>
         <div class="col-6 col-medium-3">
           <p>Use your Raspberry Pi as a desktop, server or IoT device with Ubuntu.</p>
-          <hr class="p-rule" />
+          <hr class="p-rule--muted" />
           <p>
             <a href="/download/raspberry-pi">Learn about Ubuntu for Raspberry Pi&nbsp;&rsaquo;</a>
           </p>
@@ -74,7 +74,7 @@
         </div>
         <div class="col-6 col-medium-3">
           <p>Spin up Ubuntu VMs on Windows, Mac and Linux.</p>
-          <hr class="p-rule" />
+          <hr class="p-rule--muted" />
           <p>
             <a href="https://multipass.run/">Learn about Multipass&nbsp;&rsaquo;</a>
           </p>
@@ -100,7 +100,7 @@
         </div>
         <div class="col-6 col-medium-3">
           <p>Fast, dense, and secure container and VM management at any scale.</p>
-          <hr class="p-rule" />
+          <hr class="p-rule--muted" />
           <p>
             <a href="https://canonical.com/lxd">Learn about LXD&nbsp;&rsaquo;</a>
           </p>

--- a/templates/download/shared/_secure-enterprise-management.html
+++ b/templates/download/shared/_secure-enterprise-management.html
@@ -20,7 +20,7 @@
     </div>
     <div class="col">
       <p>Ubuntu Pro Desktop is a comprehensive subscription delivering enterprise-grade security, management tooling, and extended support for developers and organisations. Ubuntu Pro Desktop is free for personal use on up to five machines.</p>
-      <hr class="p-rule" />
+      <hr class="p-rule--muted" />
       <ul class="p-list--divided u-no-padding--bottom">
         <li class="p-list__item is-ticked">Security updates for the <a href="/esm">full open source stack</a></li>
         <li class="p-list__item is-ticked">Advanced <a href="/engage/microsoft-active-directory">Active Directory</a> and LDAP integration</li>
@@ -29,7 +29,7 @@
         <li class="p-list__item is-ticked">Minimise rolling reboots with <a href="/livepatch">Kernel Livepatch</a></li>
         <li class="p-list__item is-ticked">Optional weekday or 24/7 support tiers</li>
       </ul>
-      <hr class="p-rule" />
+      <hr class="p-rule--muted" />
       <a href="/pro" class="p-button--positive">Get Ubuntu Pro</a>
       <a href="/engage/adopting-secure-enterprise-linux-desktop" class="p-button">Download our whitepaper</a>
     </div>


### PR DESCRIPTION
## Done

Update ubuntu.com/download/desktop with 24.10 download section.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: https://ubuntu-com-14350.demos.haus/download/desktop and check against [copy doc](https://docs.google.com/document/d/1ScuTtdrm3-iAvizTDxksVTAerV6QkCUN8Sg60uUlJsk/edit)
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes [#WD-14861](https://warthogs.atlassian.net/browse/WD-14861)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
