### PR TITLE
WD-15253 fix the download cheat sheet

### DIFF
--- a/templates/download/server/download.html
+++ b/templates/download/server/download.html
@@ -52,15 +52,12 @@
       </div>
       <div class="col">
         <div class="p-section--shallow p-image-wrapper">
-          {{
-          image (
-          url="https://assets.ubuntu.com/v1/639c1f12-server-cli-cheatsheet.png",
-          alt="CLI cheat sheet",
-          width="1200",
-          height="849",
-          hi_def=True,
-          loading="auto"
-          ) | safe
+          {{ image(url="https://assets.ubuntu.com/v1/639c1f12-server-cli-cheatsheet.png",
+                    alt="CLI cheat sheet",
+                    width="1200",
+                    height="849",
+                    hi_def=True,
+                    loading="auto") | safe
           }}
         </div>
       </div>
@@ -113,15 +110,12 @@
           <div class="col-6 col-medium-2">
             <h3>
               <a href="https://maas.io/?_gl=1*1y3394w*_gcl_au*Mzg2MjE3ODk3LjE3MDI0NjY1NDY.&_ga=2.256850242.873815666.1709630805-805571671.1709630804">
-                {{
-                image (
-                url="https://assets.ubuntu.com/v1/d3039f38-MAAS-logo.svg",
-                alt="MAAS",
-                width="104",
-                height="42",
-                hi_def=True,
-                loading="auto"
-                ) | safe
+                {{ image(url="https://assets.ubuntu.com/v1/d3039f38-MAAS-logo.svg",
+                                alt="MAAS",
+                                width="104",
+                                height="42",
+                                hi_def=True,
+                                loading="auto") | safe
                 }}
               </a>
             </h3>
@@ -140,15 +134,12 @@
           <div class="col-6 col-medium-2">
             <h3>
               <a href="https://canonical.com/lxd">
-                {{
-                image (
-                url="https://assets.ubuntu.com/v1/84ed7eb1-LXD-logo.svg",
-                alt="LXD",
-                width="80",
-                height="42",
-                hi_def=True,
-                loading="auto"
-                ) | safe
+                {{ image(url="https://assets.ubuntu.com/v1/84ed7eb1-LXD-logo.svg",
+                                alt="LXD",
+                                width="80",
+                                height="42",
+                                hi_def=True,
+                                loading="auto") | safe
                 }}
               </a>
             </h3>
@@ -167,15 +158,12 @@
           <div class="col-6 col-medium-2">
             <h3>
               <a href="https://juju.is/">
-                {{
-                image (
-                url="https://assets.ubuntu.com/v1/35f593dd-Juju-logo.svg",
-                alt="Juju",
-                width="79",
-                height="42",
-                hi_def=True,
-                loading="auto"
-                ) | safe
+                {{ image(url="https://assets.ubuntu.com/v1/35f593dd-Juju-logo.svg",
+                                alt="Juju",
+                                width="79",
+                                height="42",
+                                hi_def=True,
+                                loading="auto") | safe
                 }}
               </a>
             </h3>
@@ -194,15 +182,12 @@
           <div class="col-6 col-medium-2">
             <h3>
               <a href="https://multipass.run/">
-                {{
-                image (
-                url="https://assets.ubuntu.com/v1/ede1a596-Multipass-logo.svg",
-                alt="Multipass",
-                width="141",
-                height="42",
-                hi_def=True,
-                loading="auto"
-                ) | safe
+                {{ image(url="https://assets.ubuntu.com/v1/ede1a596-Multipass-logo.svg",
+                                alt="Multipass",
+                                width="141",
+                                height="42",
+                                hi_def=True,
+                                loading="auto") | safe
                 }}
               </a>
             </h3>

--- a/templates/download/server/download.html
+++ b/templates/download/server/download.html
@@ -2,54 +2,57 @@
 
 {% block title %}Thank you for downloading Ubuntu Server{% endblock %}
 
-{% block meta_copydoc %}https://docs.google.com/document/d/1S5zY7HN_Q8eQWch0mCEfLICfj8pW1bct9_wGArCNIqc/edit{% endblock meta_copydoc %}
+{% block meta_copydoc %}
+  https://docs.google.com/document/d/1S5zY7HN_Q8eQWch0mCEfLICfj8pW1bct9_wGArCNIqc/edit
+{% endblock meta_copydoc %}
 
-{% block body_class %}is-paper{% endblock body_class %}
+{% block body_class %}
+  is-paper
+{% endblock body_class %}
 
-{% block head_extra %}
-  <meta name="robots" content="noindex" />
-{% endblock %}
+{% block head_extra %}<meta name="robots" content="noindex" />{% endblock %}
 
 {% block content %}
-<noscript>
-  <meta
-    http-equiv="refresh"
-    content="3;url=https://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-live-server-amd64.iso"
-  />
-</noscript>
+  <noscript>
+    <meta http-equiv="refresh"
+          content="3;url=https://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-live-server-amd64.iso" />
+  </noscript>
 
-<section class="p-strip is-shallow u-no-padding--bottom">
-  <div class="row--50-50">
-    <div class="col">
-      <h1 class="js-download-option">Thank you for downloading Ubuntu Server {{ version }}</h1>
-      <p>Your download should start in the background. If it doesn't,
-        <a href="https://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-live-server-amd64.iso">download&nbsp;now</a>.<br />
-        {% with version=version, system="live-server", architecture="amd64" %}
-          {% include "download/shared/_verify-checksums.html" %}
-        {% endwith %}
-      </p>
-    </div>
-    <div class="col">
-      {% include 'shared/_server-download-newsletter.html' %}
-    </div>
-  </div>
-</section>
-
-{% include 'download/shared/_server_weekly_news.html' %}
-
-<section class="p-section">
-  <hr class="p-rule is-fixed-width" />
-  <div class="row--50-50">
-    <div class="col">
-      <h2>Ubuntu CLI cheatsheet</h2>
-      <div class="p-section--shallow">
-        <p>Learn how to use the command line efficiently and get started with DevOps &mdash; from basic file management to LXD virtualisation and Ubuntu Pro.</p>
+  <section class="p-strip is-shallow u-no-padding--bottom">
+    <div class="row--50-50">
+      <div class="col">
+        <h1 class="js-download-option">Thank you for downloading Ubuntu Server {{ version }}</h1>
+        <p>
+          Your download should start in the background. If it doesn't,
+          <a href="https://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-live-server-amd64.iso">download&nbsp;now</a>.
+          <br />
+          {% with version=version, system="live-server", architecture="amd64" %}
+            {% include "download/shared/_verify-checksums.html" %}
+          {% endwith %}
+        </p>
       </div>
-      <button class="p-button--positive" onclick="toggleModal()">Download the CLI cheat sheet</button>
+      <div class="col">{% include 'shared/_server-download-newsletter.html' %}</div>
     </div>
-    <div class="col">
-      <div class="p-section--shallow p-image-wrapper">
-        {{
+  </section>
+
+  {% include 'download/shared/_server_weekly_news.html' %}
+
+  <section class="p-section">
+    <hr class="p-rule is-fixed-width" />
+    <div class="row--50-50">
+      <div class="col">
+        <h2>Ubuntu CLI cheatsheet</h2>
+        <div class="p-section--shallow">
+          <p>
+            Learn how to use the command line efficiently and get started with DevOps &mdash; from basic file management to LXD virtualisation and Ubuntu Pro.
+          </p>
+        </div>
+        <a class="p-button--positive"
+           href="https://assets.ubuntu.com/v1/3bd0daaf-Ubuntu%20Server%20CLI%20cheat%20sheet%202024%20v6.pdf">Download the CLI cheat sheet</a>
+      </div>
+      <div class="col">
+        <div class="p-section--shallow p-image-wrapper">
+          {{
           image (
           url="https://assets.ubuntu.com/v1/639c1f12-server-cli-cheatsheet.png",
           alt="CLI cheat sheet",
@@ -58,53 +61,59 @@
           hi_def=True,
           loading="auto"
           ) | safe
-        }}
+          }}
+        </div>
       </div>
     </div>
-  </div>
-</section>
+  </section>
 
-<section class="p-section">
-  <hr class="p-rule is-fixed-width" />
-  <div class="row">
-    <div class="col-3 col-medium-2">
-      <div class="p-section">
-        <h2 class="p-muted-heading">Resources</h2>
+  <section class="p-section">
+    <hr class="p-rule is-fixed-width" />
+    <div class="row">
+      <div class="col-3 col-medium-2">
+        <div class="p-section">
+          <h2 class="p-muted-heading">Resources</h2>
+        </div>
+      </div>
+      <div class="col-9">
+        <div class="row">
+          <div class="col-3 col-medium-2">
+            <h3 class="p-heading--5">
+              <a href="/server/docs">Ubuntu Server documentation</a>
+            </h3>
+            <p>The Ubuntu Server documentation, curated by community and Ubuntu developers.</p>
+          </div>
+          <div class="col-3 col-medium-2">
+            <h3 class="p-heading--5">
+              <a href="https://askubuntu.com/">Ask Ubuntu</a>
+            </h3>
+            <p>Stuck somewhere? Get your Ubuntu questions answered by power users.</p>
+          </div>
+          <div class="col-3 col-medium-2">
+            <h3 class="p-heading--5">
+              <a href="https://discourse.ubuntu.com/">Community Discourse</a>
+            </h3>
+            <p>Join the Ubuntu developers community and make your voice heard.</p>
+          </div>
+        </div>
       </div>
     </div>
-    <div class="col-9">
-     <div class="row">
-      <div class="col-3 col-medium-2">
-        <h3 class="p-heading--5"><a href="/server/docs">Ubuntu Server documentation</a></h3>
-        <p>The Ubuntu Server documentation, curated by community and Ubuntu developers.</p>
-      </div>
-      <div class="col-3 col-medium-2">
-        <h3 class="p-heading--5"><a href="https://askubuntu.com/">Ask Ubuntu</a></h3>
-        <p>Stuck somewhere? Get your Ubuntu questions answered by power users.</p>
-      </div>
-      <div class="col-3 col-medium-2">
-        <h3 class="p-heading--5"><a href="https://discourse.ubuntu.com/">Community Discourse</a></h3>
-        <p>Join the Ubuntu developers community and make your voice heard.</p>
-      </div>  
-     </div> 
+  </section>
+
+  {% include 'shared/_download-ubuntu-thank-you-pro-section.html' %}
+
+  <section class="p-section">
+    <div class="p-section--shallow u-fixed-width">
+      <hr class="p-rule" />
+      <h2 class="p-muted-heading">More from Canonical</h2>
     </div>
-  </div>
-</section>
-
-{% include 'shared/_download-ubuntu-thank-you-pro-section.html' %}
-
-<section class="p-section">
-  <div class="p-section--shallow u-fixed-width">
-    <hr class="p-rule" />
-    <h2 class="p-muted-heading">More from Canonical</h2>
-  </div>
-  <div class="row">
-    <div class="col-3 col-medium-6">
-      <div class="row">
-        <div class="col-6 col-medium-2">
-          <h3>
-            <a href="https://maas.io/?_gl=1*1y3394w*_gcl_au*Mzg2MjE3ODk3LjE3MDI0NjY1NDY.&_ga=2.256850242.873815666.1709630805-805571671.1709630804">
-              {{
+    <div class="row">
+      <div class="col-3 col-medium-6">
+        <div class="row">
+          <div class="col-6 col-medium-2">
+            <h3>
+              <a href="https://maas.io/?_gl=1*1y3394w*_gcl_au*Mzg2MjE3ODk3LjE3MDI0NjY1NDY.&_ga=2.256850242.873815666.1709630805-805571671.1709630804">
+                {{
                 image (
                 url="https://assets.ubuntu.com/v1/d3039f38-MAAS-logo.svg",
                 alt="MAAS",
@@ -113,149 +122,150 @@
                 hi_def=True,
                 loading="auto"
                 ) | safe
-              }}
-            </a>
-          </h3>
-        </div>
-        <div class="col-6 col-medium-4">
-          <p>Build a bare metal cloud with super fast server provisioning.</p>
-          <hr class="p-rule" />
-          <p>
-            <a href="https://maas.io/">Learn more about MAAS&nbsp;&rsaquo;</a>
-          </p>
+                }}
+              </a>
+            </h3>
+          </div>
+          <div class="col-6 col-medium-4">
+            <p>Build a bare metal cloud with super fast server provisioning.</p>
+            <hr class="p-rule" />
+            <p>
+              <a href="https://maas.io/">Learn more about MAAS&nbsp;&rsaquo;</a>
+            </p>
+          </div>
         </div>
       </div>
-    </div>
-    <div class="col-3 col-medium-6">
-      <div class="row">
-        <div class="col-6 col-medium-2">
-          <h3>
-            <a href="https://canonical.com/lxd">
-              {{
+      <div class="col-3 col-medium-6">
+        <div class="row">
+          <div class="col-6 col-medium-2">
+            <h3>
+              <a href="https://canonical.com/lxd">
+                {{
                 image (
-                  url="https://assets.ubuntu.com/v1/84ed7eb1-LXD-logo.svg",
-                  alt="LXD",
-                  width="80",
-                  height="42",
-                  hi_def=True,
-                  loading="auto"
+                url="https://assets.ubuntu.com/v1/84ed7eb1-LXD-logo.svg",
+                alt="LXD",
+                width="80",
+                height="42",
+                hi_def=True,
+                loading="auto"
                 ) | safe
-              }}
-            </a>
-          </h3>
-        </div>
-        <div class="col-6 col-medium-4">
-          <p>Fast, dense, and secure container and VM management at any scale.</p>
-          <hr class="p-rule" />
-          <p>
-            <a href="https://canonical.com/lxd">Learn more about LXD&nbsp;&rsaquo;</a>
-          </p>
+                }}
+              </a>
+            </h3>
+          </div>
+          <div class="col-6 col-medium-4">
+            <p>Fast, dense, and secure container and VM management at any scale.</p>
+            <hr class="p-rule" />
+            <p>
+              <a href="https://canonical.com/lxd">Learn more about LXD&nbsp;&rsaquo;</a>
+            </p>
+          </div>
         </div>
       </div>
-    </div>
-    <div class="col-3 col-medium-6">
-      <div class="row">
-        <div class="col-6 col-medium-2">
-          <h3>
-            <a href="https://juju.is/">
-            {{
-              image (
+      <div class="col-3 col-medium-6">
+        <div class="row">
+          <div class="col-6 col-medium-2">
+            <h3>
+              <a href="https://juju.is/">
+                {{
+                image (
                 url="https://assets.ubuntu.com/v1/35f593dd-Juju-logo.svg",
                 alt="Juju",
                 width="79",
                 height="42",
                 hi_def=True,
                 loading="auto"
-              ) | safe
-            }}
-            </a>
-          </h3>
-        </div>
-        <div class="col-6 col-medium-4">
-          <p>Design and deploy entire workloads in just a few clicks.</p>
-          <hr class="p-rule" />
-          <p>
-            <a href="https://juju.is/">Learn more about Juju&nbsp;&rsaquo;</a>
-          </p>
+                ) | safe
+                }}
+              </a>
+            </h3>
+          </div>
+          <div class="col-6 col-medium-4">
+            <p>Design and deploy entire workloads in just a few clicks.</p>
+            <hr class="p-rule" />
+            <p>
+              <a href="https://juju.is/">Learn more about Juju&nbsp;&rsaquo;</a>
+            </p>
+          </div>
         </div>
       </div>
-    </div>
-    <div class="col-3 col-medium-6">
-      <div class="row">
-        <div class="col-6 col-medium-2">
-          <h3>
-            <a href="https://multipass.run/">
-            {{
-              image (
+      <div class="col-3 col-medium-6">
+        <div class="row">
+          <div class="col-6 col-medium-2">
+            <h3>
+              <a href="https://multipass.run/">
+                {{
+                image (
                 url="https://assets.ubuntu.com/v1/ede1a596-Multipass-logo.svg",
                 alt="Multipass",
                 width="141",
                 height="42",
                 hi_def=True,
                 loading="auto"
-              ) | safe
-            }}
-            </a>
-          </h3>
+                ) | safe
+                }}
+              </a>
+            </h3>
+          </div>
+          <div class="col-6 col-medium-4">
+            <p>Spin up Ubuntu VMs on Windows, Mac and Linux.</p>
+            <hr class="p-rule" />
+            <p>
+              <a href="https://multipass.run/">Learn more about Multipass&nbsp;&rsaquo;</a>
+            </p>
+          </div>
         </div>
-        <div class="col-6 col-medium-4">
-          <p>Spin up Ubuntu VMs on Windows, Mac and Linux.</p>
-          <hr class="p-rule" />
-          <p>
-            <a href="https://multipass.run/">Learn more about Multipass&nbsp;&rsaquo;</a>
-          </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section--deep">
+    <div class="row">
+      <hr class="p-rule" />
+      <div class="col-3 col-medium-6">
+        <div class="p-section--shallow">
+          <h2 class="p-text--small-caps">
+            <a href="/blog/tag/ubuntu-server">Latest from&nbsp;our&nbsp;blog&nbsp;&rsaquo;</a>
+          </h2>
         </div>
       </div>
-    </div>
-  </div>
-</section>
-
-<section class="p-section--deep">
-  <div class="row">
-    <hr class="p-rule"/>
-    <div class="col-3 col-medium-6">
-      <div class="p-section--shallow">
-        <h2 class="p-text--small-caps"><a href="/blog/tag/ubuntu-server">Latest from&nbsp;our&nbsp;blog&nbsp;&rsaquo;</a></h2>
+      <div class="col-9 col-medium-6">
+        <div class="row p-section--shallow" id="ubuntu-server-latest"></div>
       </div>
     </div>
-    <div class="col-9 col-medium-6">
-      <div class="row p-section--shallow" id="ubuntu-server-latest">
+
+    <template style="display:none" id="ubuntu-server-template">
+      <div class="col-3 col-medium-2">
+        <h3 class="p-heading--5">
+          <a class="article-link article-title"></a>
+        </h3>
+        <p class="article-excerpt"></p>
       </div>
-    </div>
-  </div>
+    </template>
+  </section>
 
-  <template style="display:none" id="ubuntu-server-template">
-    <div class="col-3 col-medium-2">
-      <h3 class="p-heading--5"><a class="article-link article-title"></a></h3>
-      <p class="article-excerpt"></p>
-    </div>
-  </template>
-</section>
-
-<script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-<script>
-  canonicalLatestNews.fetchLatestNews(
-    {
+  <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
+  <script>
+    canonicalLatestNews.fetchLatestNews({
       articlesContainerSelector: "#ubuntu-server-latest",
       articleTemplateSelector: "#ubuntu-server-template",
       excerptLength: 200,
       tagId: 1610,
       limit: 3
-    }
-  )
-</script>
+    })
+  </script>
 
 {% endblock content %}
 
 {% block footer_extra %}
-<script src="{{ versioned_static('js/dist/image-download.js') }}"></script>
+  <script src="{{ versioned_static('js/dist/image-download.js') }}"></script>
 
-<script defer>
-  var version = '{{ version }}';
+  <script defer>
+    var version = '{{ version }}';
 
-  var GAlabel = version + '-server-amd64';
-  var imagePath = version + '/ubuntu-' + version + '-live-server-amd64.iso';
+    var GAlabel = version + '-server-amd64';
+    var imagePath = version + '/ubuntu-' + version + '-live-server-amd64.iso';
 
-  window.initImageDownload(imagePath, GAlabel);
-</script>
+    window.initImageDownload(imagePath, GAlabel);
+  </script>
 {% endblock footer_extra %}

--- a/templates/download/server/thank-you.html
+++ b/templates/download/server/thank-you.html
@@ -51,7 +51,8 @@
             Learn how to use the command line efficiently and get started with DevOps &mdash; from basic file management to LXD virtualisation and Ubuntu Pro.
           </p>
         </div>
-        <button class="p-button--positive" onclick="toggleModal()">Download the CLI cheat sheet</button>
+        <a class="p-button--positive"
+           href="https://assets.ubuntu.com/v1/3bd0daaf-Ubuntu%20Server%20CLI%20cheat%20sheet%202024%20v6.pdf">Download the CLI cheat sheet</a>
       </div>
       <div class="col">
         <div class="p-section--shallow p-image-wrapper">


### PR DESCRIPTION
## Done

- Added link to download the CLI Cheat sheet for server thank-you page.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [Demo](https://ubuntu-com-14352.demos.haus/download/server/thank-you)

## Issue / Card

Fixes #14333 
Issue [WD-15253](https://warthogs.atlassian.net/browse/WD-15253?atlOrigin=eyJpIjoiNTM1ZmQyOGRhZTM0NDVjNTllODkxMWQzNDkwYzZhN2UiLCJwIjoiaiJ9)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-15253]: https://warthogs.atlassian.net/browse/WD-15253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ