### PR TITLE
WD-15383 shortned URL for blogpost

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -926,6 +926,8 @@ kubernetes/docs/charm-vsphere-integrator/?: "https://charmhub.io/vsphere-integra
 blog/search/?: /search
 blog/canonical-announces-ubuntu-22-04-lts-support-for-flexran-reference-software-2/?: /blog/canonical-announces-ubuntu-22-04-lts-support-for-flexran-reference-software
 blog/intel-compute-stick-now-comes-with-ubuntu: /download/iot/intel-iot
+/blog/cups-remote-code-execution: /blog/cups-remote-code-execution-vulnerability-fix-available
+
 # Copied from https://github.com/canonical-web-and-design/blog.ubuntu.com/blob/master/redirects.yaml
 
 # Wordpress CMS pages & resources


### PR DESCRIPTION
## Done

- shortned URL for blogpost

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check if https://ubuntu-com-14354.demos.haus/blog/cups-remote-code-execution redirects to https://ubuntu-com-14354.demos.haus/blog/cups-remote-code-execution-vulnerability-fix-available 

## Issue / Card

Fixes # [WD-5383](https://warthogs.atlassian.net/browse/WD-15383)



## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-5383]: https://warthogs.atlassian.net/browse/WD-5383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ