### PR TITLE
allow cred admins to schedule exam within maintenance window

### DIFF
--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -237,6 +237,7 @@ def cred_schedule(
     cred_is_in_maintenance,
     cred_maintenance_start,
     cred_maintenance_end,
+    is_cred_admin,
     trueability_api,
     **_,
 ):
@@ -295,7 +296,8 @@ def cred_schedule(
             parse(cred_maintenance_end) if cred_maintenance_end else None
         )
         if (
-            show_cred_maintenance_alert
+            not is_cred_admin
+            and show_cred_maintenance_alert
             and cred_maintenance_start
             and cred_maintenance_end
             and (cred_maintenance_start <= starts_at <= cred_maintenance_end)

--- a/webapp/shop/decorators.py
+++ b/webapp/shop/decorators.py
@@ -154,9 +154,13 @@ def shop_decorator(area=None, permission=None, response="json", redirect=None):
             )
             advantage_mapper = AdvantageMapper(ua_contracts_api)
             is_community_member = False
+            is_cred_admin = False
             if user_info(flask.session):
                 is_community_member = user_info(flask.session).get(
                     "is_community_member", False
+                )
+                is_cred_admin = user_info(flask.session).get(
+                    "is_credentials_admin", False
                 )
 
             return func(
@@ -177,6 +181,7 @@ def shop_decorator(area=None, permission=None, response="json", redirect=None):
                 is_community_member=is_community_member,
                 show_cred_maintenance_alert=bool(cred_maintenance),
                 cred_is_in_maintenance=cred_is_in_maintenance,
+                is_cred_admin=is_cred_admin,
                 cred_maintenance_start=cred_maintenance_start,
                 cred_maintenance_end=cred_maintenance_end,
                 *args,


### PR DESCRIPTION
## Done

- Previously, exams were not allowed to be scheduled during the maintenance window but this caused an issue because if admins wanted to test the exam scheduling during the maintenance window, they weren't able to do so.
- This PR allows cred admins to schedule and take exam during the maintenance window

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Make sure you are a cred admin
- During the maintenance window, schedule an exam during the window and it should work

## Issue / Card

Fixes [#14888](https://warthogs.atlassian.net/browse/WD-14888)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
