### PR TITLE
Wd 15447 update https ubuntu com aws workspaces with copy relevant for 24 04 lts

### DIFF
--- a/templates/aws/workspaces.html
+++ b/templates/aws/workspaces.html
@@ -40,10 +40,10 @@
 
   <div class="row p-divider">
     <div class="col-4 p-divider__block">
-      <h3 class="p-heading--4">Ubuntu Desktop 22.04 LTS</h3>
+      <h3 class="p-heading--4">Ubuntu Desktop 24.04 LTS</h3>
       <ul class="p-list">
         <li class="p-list__item is-ticked">A common OS for development, testing and deployment</li>
-        <li class="p-list__item is-ticked">Linux 5.15 kernel alongside the latest toolchains for Python, PGP, Rust and Go</li>
+        <li class="p-list__item is-ticked">Linux 6.8 kernel alongside the latest toolchains for Python, PGP, Rust and Go</li>
         <li class="p-list__item is-ticked">Target platform for cutting edge applications in fields like Data Science, AI/ML, Cloud and IoT</li>
         <li class="p-list__item is-ticked">Active Directory integration</li>
       </ul>


### PR DESCRIPTION
## Done

- Copy Updates for /aws/workspaces

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Visit /aws/workspaces
- Ensure it matches https://docs.google.com/document/d/1qC22TM6KZTlxK3CScf-RQ4RUiMUhIBcjSWGur-dbYVA/edit

## Issue / Card

Fixes [#WD-15447](https://warthogs.atlassian.net/browse/WD-15447)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
