### PR TITLE
WD-14869 - Add new interim release 24.10 and discard 23.10

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -114,12 +114,6 @@ export var serverAndDesktopReleases = [
     status: "PRO_LEGACY_SUPPORT",
   },
   {
-    startDate: new Date("2023-10-20T00:00:00"),
-    endDate: new Date("2024-07-20T00:00:00"),
-    taskName: "23.10 (Mantic Minotaur)",
-    status: "INTERIM_RELEASE",
-  },
-  {
     startDate: new Date("2024-04-25T00:00:00"),
     endDate: new Date("2034-04-25T00:00:00"),
     taskName: "24.04 LTS (Noble Numbat)",
@@ -142,6 +136,12 @@ export var serverAndDesktopReleases = [
     endDate: new Date("2036-04-25T00:00:00"),
     taskName: "24.04 LTS (Noble Numbat)",
     status: "PRO_LEGACY_SUPPORT",
+  },
+  {
+    startDate: new Date("2024-10-01T00:00:00"),
+    endDate: new Date("2025-07-01T00:00:00"),
+    taskName: "24.10 (Oracular Oriole)",
+    status: "INTERIM_RELEASE",
   },
 ];
 
@@ -1165,8 +1165,8 @@ export var microStackStatus = {
 };
 
 export var desktopServerReleaseNames = [
+  "24.10 (Oracular Oriole)",
   "24.04 LTS (Noble Numbat)",
-  "23.10 (Mantic Minotaur)",
   "22.04 LTS (Jammy Jellyfish)",
   "20.04 LTS (Focal Fossa)",
   "18.04 LTS (Bionic Beaver)",

--- a/templates/about/release_cycles/releases-table.html
+++ b/templates/about/release_cycles/releases-table.html
@@ -10,17 +10,17 @@
     </thead>
     <tbody>
         <tr>
+            <td colspan="2">24.10 LTS (Oracular Oriole)</td>
+            <td>Oct 2024</td>
+            <td>Jul 2025</td>
+            <td>&nbsp;</td>
+        </tr>
+        <tr>
             <td colspan="2"><strong>24.04 LTS (Noble Numbat)</strong></td>
             <td>Apr 2024</td>
             <td>Apr 2029</td>
             <td>Apr 2034</td>
             <td>Apr 2036</td>
-        </tr>
-        <tr>
-            <td colspan="2">23.10 (Mantic Minotaur)</td>
-            <td>Oct 2023</td>
-            <td>Jul 2024</td>
-            <td>&nbsp;</td>
         </tr>
         <tr>
             <td colspan="2"><strong>22.04 LTS (Jammy Jellyfish)</strong></td>


### PR DESCRIPTION
## Done

- This replaces the passed interim release 23.10 with the new release 24.10 on the Ubuntu releases graph and table

## QA

- Navigate to https://ubuntu-com-14360.demos.haus/about/release-cycle#ubuntu
- Check that the new interim Ubuntu release (24.10) is in the chart and the table and that the old interim release has been removed
  - Ensure all details are correct (release dates and spelling)

## Issue / Card

- [WD-14869](https://warthogs.atlassian.net/browse/WD-14869)

## Screenshots

Before:
![Screenshot from 2024-09-28 21-24-11](https://github.com/user-attachments/assets/95048865-bec3-4b20-9e44-c44b85ed7c13)

After:
![Screenshot from 2024-09-28 21-24-03](https://github.com/user-attachments/assets/988ff5e2-a084-44ab-ae8a-bb791a694544)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-14869]: https://warthogs.atlassian.net/browse/WD-14869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ