### PR TITLE
Add links to certification programme docs on Certified page

### DIFF
--- a/templates/certified/index.html
+++ b/templates/certified/index.html
@@ -261,6 +261,9 @@
           <p>
             Canonical's certification team performs an extensive set of over 500 OS compatibility focused hardware tests to ensure the best Ubuntu experience. Every aspect of the system is checked and verified.
           </p>
+          <p>
+            <a href="https://certification.canonical.com/docs/programmes/">Learn more about the certification test coverage</a>
+          </p>
         </div>
       </div>
     </div>
@@ -485,6 +488,8 @@
           Drive differentiation for your hardware by certifying with the world's most widely used Linux. Our certification programme increases customer confidence that your products integrate seamlessly with Ubuntu.
         </p>
         <a href="/certified/why-certify" class="p-button--positive">Discover the benefits</a>
+        <a href="https://certification.canonical.com/docs/programmes/"
+           class="p-button is-dark">Learn about the programme</a>
       </div>
     </div>
   </section>

--- a/templates/certified/index.html
+++ b/templates/certified/index.html
@@ -489,7 +489,7 @@
         </p>
         <a href="/certified/why-certify" class="p-button--positive">Discover the benefits</a>
         <a href="https://certification.canonical.com/docs/programmes/"
-           class="p-button is-dark">Learn about the programme</a>
+           class="p-button is-dark">Learn about the <span class="u-off-screen">hardware certification </span>programme</a>
       </div>
     </div>
   </section>

--- a/templates/certified/why-certify.html
+++ b/templates/certified/why-certify.html
@@ -50,6 +50,8 @@
         <p class="u-no-margin--bottom">
           <a href="https://canonical.com/partners/become-a-partner"
              class="p-button--positive u-no-margin--bottom">Certify your hardware</a>
+          <a href="https://certification.canonical.com/docs/programmes/"
+            class="p-button u-no-margin--bottom">Learn about the programme</a>
         </p>
       </div>
 
@@ -246,6 +248,8 @@
         </p>
         <a href="https://canonical.com/partners/become-a-partner"
            class="p-button--positive">Discover the benefits</a>
+        <a href="https://certification.canonical.com/docs/programmes/"
+           class="p-button is-paper">Learn about the programme</a>
       </div>
     </div>
   </section>
@@ -307,7 +311,7 @@
           </div>
           <div class="col-6">
             <p>
-              Make your hardware stand out. Talk to us about certifying your products. <a href="https://canonical.com/partners/become-a-partner">Learn more about becoming certifed</a>
+              Make your hardware stand out. Talk to us about certifying your products. <a href="https://canonical.com/partners/become-a-partner">Learn more about becoming certified</a>
             </p>
           </div>
         </div>

--- a/templates/certified/why-certify.html
+++ b/templates/certified/why-certify.html
@@ -51,7 +51,7 @@
           <a href="https://canonical.com/partners/become-a-partner"
              class="p-button--positive u-no-margin--bottom">Certify your hardware</a>
           <a href="https://certification.canonical.com/docs/programmes/"
-            class="p-button u-no-margin--bottom">Learn about the programme</a>
+            class="p-button u-no-margin--bottom">Learn about the <span class="u-off-screen">hardware certification </span>programme</a>
         </p>
       </div>
 
@@ -249,7 +249,7 @@
         <a href="https://canonical.com/partners/become-a-partner"
            class="p-button--positive">Discover the benefits</a>
         <a href="https://certification.canonical.com/docs/programmes/"
-           class="p-button is-paper">Learn about the programme</a>
+           class="p-button is-paper">Learn about the <span class="u-off-screen">hardware certification </span>programme</a>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Done

- Add buttons on `templates/certified/index.html` and `templates/certified/why-certify.html` to direct users to the certification programme documentation on the certification website (https://certification.canonical.com/)
- (Drive-by) fix typo

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #[CDOC-154](https://warthogs.atlassian.net/browse/CDOC-154)

## Screenshots

* URL: http://0.0.0.0:8001/certified
  ![image](https://github.com/user-attachments/assets/ab6c2d57-088d-4231-826d-9ff29462a1d2)
  ![image](https://github.com/user-attachments/assets/57c18100-1797-42c9-a9df-e784903fdee0)

* URL: http://0.0.0.0:8001/certified/why-certify
  ![image](https://github.com/user-attachments/assets/e5bb5008-615f-458f-8baf-aca39130918e)
  ![image](https://github.com/user-attachments/assets/d92adbf9-3bc2-4492-8f71-63837d25bd00)



## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[CDOC-154]: https://warthogs.atlassian.net/browse/CDOC-154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ