### PR TITLE
WD-14793 - add new /azure/confidential-computing page

### DIFF
--- a/static/files/sitemap.xml
+++ b/static/files/sitemap.xml
@@ -1018,4 +1018,8 @@
           <loc>https://ubuntu.com/pro/devices</loc>
           <lastmod>2024-07-08T00:00:00+00:00</lastmod>
      </url>
+     <url>
+          <loc>https://ubuntu.com/azure/confidential-computing</loc>
+          <lastmod>2024-10-04T00:00:00+00:00</lastmod>
+     </url>
 </urlset>

--- a/templates/azure/confidential-computing.html
+++ b/templates/azure/confidential-computing.html
@@ -23,7 +23,9 @@
       <div class="col">
         <p>Secure your data, code and AI models at run- time with Ubuntu confidential VMs on Microsoft Azure.</p>
         <hr class="p-rule--muted" />
-        <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps?search=Canonical%20Ubuntu%20confidential%20VM&page=1">Try Ubuntu confidential VMs today&nbsp;&rsaquo;</a>
+        <p>
+          <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps?search=Canonical%20Ubuntu%20confidential%20VM&page=1">Try Ubuntu confidential VMs today&nbsp;&rsaquo;</a>
+        </p>
       </div>
     </div>
   </section>
@@ -79,7 +81,9 @@
           </li>
         </ul>
         <hr class="p-rule--muted" />
-        <a href="/confidential-computing#get-in-touch">Don’t see what you’re looking for? Contact us to learn more&nbsp;&rsaquo;</a>
+        <p>
+          <a href="/confidential-computing#get-in-touch">Don’t see what you’re looking for? Contact us to learn more&nbsp;&rsaquo;</a>
+        </p>
       </div>
     </div>
   </section>
@@ -95,7 +99,9 @@
           While confidential VMs can protect your workload from external threats, vulnerabilities from within their boundaries remain a concern. With Ubuntu Pro, you can keep your guest CVM software stack continuously patched and up-to-date for up to 12 years, covering 30,000 open source packages with a single subscription.
         </p>
         <hr class="p-rule--muted" />
-        <a href="/pro">Learn more about Ubuntu Pro&nbsp;&rsaquo;</a>
+        <p>
+          <a href="/pro">Learn more about Ubuntu Pro&nbsp;&rsaquo;</a>
+        </p>
       </div>
     </div>
   </section>
@@ -112,7 +118,7 @@
   </section>
 
   <section class="p-section">
-    <div class="u-fixed-width p-section--shallow">
+    <div class="u-fixed-width">
       <hr class="p-rule" />
       <h2>
         Confidential computing enables AI with Ubuntu and NVIDIA GPUs
@@ -129,7 +135,6 @@
         </div>
       </div>
       <div class="col">
-
         <p class="u-no-padding--top">
           Businesses using machine learning on Azure are prioritizing data security and model protection. Strict regulations often prevent sharing sensitive information, holding back AI’s full capabilities in key sectors.
         </p>
@@ -137,7 +142,9 @@
           To address this challenge on Azure, we introduce a confidential AI preview featuring Ubuntu VMs with AMD 4th Gen EPYC processors and NVIDIA H100 GPUs, delivering stronger security and performance for advanced AI workloads.
         </p>
         <hr class="p-rule--muted" />
-        <a href="https://aka.ms/accgpusignup">Sign up for the Azure preview of confidential AI with Ubuntu&nbsp;&rsaquo;</a>
+        <p>
+          <a href="https://aka.ms/accgpusignup">Sign up for the Azure preview of confidential AI with Ubuntu&nbsp;&rsaquo;</a>
+        </p>
       </div>
     </div>
   </section>

--- a/templates/azure/confidential-computing.html
+++ b/templates/azure/confidential-computing.html
@@ -34,7 +34,7 @@ https://docs.google.com/document/d/1sVaQQlm6LHyRf-Q3VSVTmqGRi0SV7gwBVczCTPWq3CE/
         </div>
         <div class="col">
             <p>With zero-trust being the norm in cybersecurity for global businesses, using  confidential VMs in the cloud takes this one step further.</p>
-            <ul class="p-list">
+            <ul class="p-list--divided">
                 <li class="p-list__item is-ticked">Strengthen protection against cloud privileged software, including hypervisors</li>
                 <li class="p-list__item is-ticked">Enhance your VM’s isolation against other tenant VMs</li>
                 <li class="p-list__item is-ticked">Build data clean rooms for collaborative AI analytics</li>
@@ -51,12 +51,12 @@ https://docs.google.com/document/d/1sVaQQlm6LHyRf-Q3VSVTmqGRi0SV7gwBVczCTPWq3CE/
             <h2>Get Ubuntu confidential VMs on the Microsoft Azure marketplace</h2>
         </div>
         <div class="col">
-<div class="p-image-container is-highlighted">
-    <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/1d39a40e-microsoft-azure-logo%20%5BDEPRECATED%5D.png" alt="" />
+<div class="p-image-container is-highlighted" style="margin-top: 0.55rem;">
+    <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/32561600-azure-logo.png" alt="" />
 </div>
 <p>Ubuntu offers the following confidential VMs:</p>
-        <ul class="p-list--divided u-no-margin--bottom">
-            <li class="p-list__item" style="box-shadow: inset 0 1px 0 0 var(--vf-color-border-low-contrast)"><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.ubuntu-24_04-lts?tab=Overview">Get Ubuntu 24.04 LTS confidential VMs</a></li>
+        <ul class="p-list--divided">
+            <li class="p-list__item"><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.ubuntu-24_04-lts?tab=Overview">Get Ubuntu 24.04 LTS confidential VMs</a></li>
             <li class="p-list__item"><a href="https://forms.office.com/pages/responsepage.aspx?id=v4j5cvGGr0GRqy180BHbR9_qJVF-zyZCqvwR_iaG2EFUME1BT1hJN0I1VjhGWE9QNUJGREQ5QUlMNS4u">Get Intel TDX in private preview with 22.04 LTS</a></li>
             <li class="p-list__item"><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-confidential-vm-jammy">Get AMD SEV SNP with Ubuntu 22.04 LTS on Azure</a></li>
             <li class="p-list__item"><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-confidential-vm-focal?tab=Overview">Get AMD SEV SNP with Ubuntu  20.04 LTS on Azure</a></li>
@@ -93,16 +93,19 @@ https://docs.google.com/document/d/1sVaQQlm6LHyRf-Q3VSVTmqGRi0SV7gwBVczCTPWq3CE/
 </section>
 
 <section class="p-section">
-    <div class="row--50-50">
+    <div class="u-fixed-width p-section--shallow">
         <hr class="p-rule" />
+        <h2>Confidential computing enables AI with Ubuntu and NVIDIA GPUs on Microsoft Azure</h2>
+    </div>
+    <div class="row--50-50">
         <div class="col">
-            <h2>Confidential computing enables AI with Ubuntu and NVIDIA GPUs on Microsoft Azure</h2>
+      <div class="p-image-container is-highlighted">
+    <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/472acf08-chart.png" alt="Ubuntu confidential VMs establish a secure encrypted communication channel with Nvidia H100 GPUs" />
+</div>      
         </div>
         <div class="col">
-<div class="p-image-container is-highlighted">
-    <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/fc0006be-cvm-diagram@2x.png" alt="Ubuntu confidential VMs establish a secure encrypted communication channel with Nvidia H100 GPUs" />
-</div>
-<p>Businesses using machine learning on Azure are prioritizing data security and model protection. Strict regulations often prevent sharing sensitive information, holding back AI’s full capabilities in key sectors.</p>
+
+<p class="u-no-padding--top">Businesses using machine learning on Azure are prioritizing data security and model protection. Strict regulations often prevent sharing sensitive information, holding back AI’s full capabilities in key sectors.</p>
 <p>To address this challenge on Azure, we introduce a confidential AI preview featuring Ubuntu VMs with AMD 4th Gen EPYC processors and NVIDIA H100 GPUs, delivering stronger security and performance for advanced AI workloads.</p>
         <hr class="p-rule--muted" />
             <a href="https://aka.ms/accgpusignup">Sign up for the Azure preview of confidential AI with Ubuntu&nbsp;&rsaquo;</a>

--- a/templates/azure/confidential-computing.html
+++ b/templates/azure/confidential-computing.html
@@ -3,140 +3,179 @@
 {% block title %}Confidential computing on Microsoft Azure{% endblock %}
 
 {% block meta_description %}
-    Protect your security sensitive workloads on Microsoft Azure with Ubuntu confidential VMs
+  Protect your security sensitive workloads on Microsoft Azure with Ubuntu confidential VMs
 {% endblock %}
 
 {% block meta_copydoc %}
-https://docs.google.com/document/d/1sVaQQlm6LHyRf-Q3VSVTmqGRi0SV7gwBVczCTPWq3CE/edit
+  https://docs.google.com/document/d/1sVaQQlm6LHyRf-Q3VSVTmqGRi0SV7gwBVczCTPWq3CE/edit
 {% endblock meta_copydoc %}
 
-{% block body_class %}is-paper{% endblock body_class %}
+{% block body_class %}
+  is-paper
+{% endblock body_class %}
 
 {% block content %}
-<section class="p-section--hero p-suru">
+  <section class="p-section--hero p-suru">
     <div class="row--50-50">
-        <div class="col">
-            <h1>Confidential computing with Ubuntu on Microsoft Azure</h1>
-        </div>
-        <div class="col">
-            <p>Secure your data, code and AI models at run- time with Ubuntu confidential VMs on Microsoft Azure.</p>
-            <hr class="p-rule--muted" />
-            <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps?search=Canonical%20Ubuntu%20confidential%20VM&page=1">Try Ubuntu confidential VMs today&nbsp;&rsaquo;</a>
-        </div>
+      <div class="col">
+        <h1>Confidential computing with Ubuntu on Microsoft Azure</h1>
+      </div>
+      <div class="col">
+        <p>Secure your data, code and AI models at run- time with Ubuntu confidential VMs on Microsoft Azure.</p>
+        <hr class="p-rule--muted" />
+        <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps?search=Canonical%20Ubuntu%20confidential%20VM&page=1">Try Ubuntu confidential VMs today&nbsp;&rsaquo;</a>
+      </div>
     </div>
-</section>
+  </section>
 
-<section class="p-section">
+  <section class="p-section">
     <div class="row--50-50">
-        <hr class="p-rule" />
-        <div class="col">
-            <h2>Why enable zero trust computing within Azure?</h2>
-        </div>
-        <div class="col">
-            <p>With zero-trust being the norm in cybersecurity for global businesses, using  confidential VMs in the cloud takes this one step further.</p>
-            <ul class="p-list--divided">
-                <li class="p-list__item is-ticked">Strengthen protection against cloud privileged software, including hypervisors</li>
-                <li class="p-list__item is-ticked">Enhance your VM’s isolation against other tenant VMs</li>
-                <li class="p-list__item is-ticked">Build data clean rooms for collaborative AI analytics</li>
-                <li class="p-list__item is-ticked">Strengthen your compliance posture</li>
-            </ul>
-        </div>
-    </div>
-</section>
-
-<section class="p-section">
-    <div class="row--50-50">
-        <hr class="p-rule" />
-        <div class="col">
-            <h2>Get Ubuntu confidential VMs on the Microsoft Azure marketplace</h2>
-        </div>
-        <div class="col">
-<div class="p-image-container is-highlighted" style="margin-top: 0.55rem;">
-    <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/32561600-azure-logo.png" alt="" />
-</div>
-<p>Ubuntu offers the following confidential VMs:</p>
+      <hr class="p-rule" />
+      <div class="col">
+        <h2>Why enable zero trust computing within Azure?</h2>
+      </div>
+      <div class="col">
+        <p>
+          With zero-trust being the norm in cybersecurity for global businesses, using  confidential VMs in the cloud takes this one step further.
+        </p>
         <ul class="p-list--divided">
-            <li class="p-list__item"><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.ubuntu-24_04-lts?tab=Overview">Get Ubuntu 24.04 LTS confidential VMs</a></li>
-            <li class="p-list__item"><a href="https://forms.office.com/pages/responsepage.aspx?id=v4j5cvGGr0GRqy180BHbR9_qJVF-zyZCqvwR_iaG2EFUME1BT1hJN0I1VjhGWE9QNUJGREQ5QUlMNS4u">Get Intel TDX in private preview with 22.04 LTS</a></li>
-            <li class="p-list__item"><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-confidential-vm-jammy">Get AMD SEV SNP with Ubuntu 22.04 LTS on Azure</a></li>
-            <li class="p-list__item"><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-confidential-vm-focal?tab=Overview">Get AMD SEV SNP with Ubuntu  20.04 LTS on Azure</a></li>
+          <li class="p-list__item is-ticked">Strengthen protection against cloud privileged software, including hypervisors</li>
+          <li class="p-list__item is-ticked">Enhance your VM’s isolation against other tenant VMs</li>
+          <li class="p-list__item is-ticked">Build data clean rooms for collaborative AI analytics</li>
+          <li class="p-list__item is-ticked">Strengthen your compliance posture</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <h2>Get Ubuntu confidential VMs on the Microsoft Azure marketplace</h2>
+      </div>
+      <div class="col">
+        <div class="p-section--shallow">
+          <div class="p-image-container is-highlighted" style="margin-top: 0.55rem;">
+            <img class="p-image-container__image"
+                 src="https://assets.ubuntu.com/v1/bee89574-azure-logo-updated.png"
+                 alt="" />
+          </div>
+        </div>
+
+        <p>Ubuntu offers the following confidential VMs:</p>
+        <ul class="p-list--divided">
+          <li class="p-list__item has-bullet">
+            <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.ubuntu-24_04-lts?tab=Overview">Get Ubuntu 24.04 LTS confidential VMs</a>
+          </li>
+          <li class="p-list__item has-bullet">
+            <a href="https://forms.office.com/pages/responsepage.aspx?id=v4j5cvGGr0GRqy180BHbR9_qJVF-zyZCqvwR_iaG2EFUME1BT1hJN0I1VjhGWE9QNUJGREQ5QUlMNS4u">Get Intel TDX in private preview with 22.04 LTS</a>
+          </li>
+          <li class="p-list__item has-bullet">
+            <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-confidential-vm-jammy">Get AMD SEV SNP with Ubuntu 22.04 LTS on Azure</a>
+          </li>
+          <li class="p-list__item has-bullet">
+            <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-confidential-vm-focal?tab=Overview">Get AMD SEV SNP with Ubuntu  20.04 LTS on Azure</a>
+          </li>
         </ul>
         <hr class="p-rule--muted" />
-            <a href="/confidential-computing#get-in-touch">Don’t see what you’re looking for? Contact us to learn more&nbsp;&rsaquo;</a>
-        </div>
+        <a href="/confidential-computing#get-in-touch">Don’t see what you’re looking for? Contact us to learn more&nbsp;&rsaquo;</a>
+      </div>
     </div>
-</section>
+  </section>
 
-<section class="p-section">
+  <section class="p-section">
     <div class="row--50-50">
-        <hr class="p-rule" />
-        <div class="col">
-            <h2>Use Ubuntu Pro to further harden your confidential VMs</h2>
-        </div>
-        <div class="col">
-            <p>While confidential VMs can protect your workload from external threats, vulnerabilities from within their boundaries remain a concern. With Ubuntu Pro, you can keep your guest CVM software stack continuously patched and up-to-date for up to 12 years, covering 30,000 open source packages with a single subscription.</p>
-            <hr class="p-rule--muted" />
-            <a href="/pro"> Learn more about Ubuntu Pro&nbsp;&rsaquo;</a>
-        </div>
-    </div>
-</section>
-
-<div class="u-fixed-width">
-   <hr class="p-rule" /> 
-</div>
-<section class="p-strip is-deep">
-    <div class="u-fixed-width">
-        <h2>
-            <a href="https://ubuntu.com/confidential-computing">Learn about other confidential computing offerings from Canonical&nbsp;&rsaquo;</a>
-        </h2>
-    </div>
-</section>
-
-<section class="p-section">
-    <div class="u-fixed-width p-section--shallow">
-        <hr class="p-rule" />
-        <h2>Confidential computing enables AI with Ubuntu and NVIDIA GPUs on Microsoft Azure</h2>
-    </div>
-    <div class="row--50-50">
-        <div class="col">
-      <div class="p-image-container is-highlighted">
-    <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/472acf08-chart.png" alt="Ubuntu confidential VMs establish a secure encrypted communication channel with Nvidia H100 GPUs" />
-</div>      
-        </div>
-        <div class="col">
-
-<p class="u-no-padding--top">Businesses using machine learning on Azure are prioritizing data security and model protection. Strict regulations often prevent sharing sensitive information, holding back AI’s full capabilities in key sectors.</p>
-<p>To address this challenge on Azure, we introduce a confidential AI preview featuring Ubuntu VMs with AMD 4th Gen EPYC processors and NVIDIA H100 GPUs, delivering stronger security and performance for advanced AI workloads.</p>
+      <hr class="p-rule" />
+      <div class="col">
+        <h2>Use Ubuntu Pro to further harden your confidential VMs</h2>
+      </div>
+      <div class="col">
+        <p>
+          While confidential VMs can protect your workload from external threats, vulnerabilities from within their boundaries remain a concern. With Ubuntu Pro, you can keep your guest CVM software stack continuously patched and up-to-date for up to 12 years, covering 30,000 open source packages with a single subscription.
+        </p>
         <hr class="p-rule--muted" />
-            <a href="https://aka.ms/accgpusignup">Sign up for the Azure preview of confidential AI with Ubuntu&nbsp;&rsaquo;</a>
-        </div>
+        <a href="/pro">Learn more about Ubuntu Pro&nbsp;&rsaquo;</a>
+      </div>
     </div>
-</section>
+  </section>
 
-<section class="p-section">
+  <div class="u-fixed-width">
+    <hr class="p-rule" />
+  </div>
+  <section class="p-strip is-deep">
+    <div class="u-fixed-width">
+      <h2>
+        <a href="https://ubuntu.com/confidential-computing">Learn about other confidential computing offerings from Canonical&nbsp;&rsaquo;</a>
+      </h2>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="u-fixed-width p-section--shallow">
+      <hr class="p-rule" />
+      <h2>
+        Confidential computing enables AI with Ubuntu and NVIDIA GPUs
+        <br />
+        on Microsoft Azure
+      </h2>
+    </div>
     <div class="row--50-50">
-        <hr class="p-rule" />
-        <div class="col">
-            <h2>Learn more about confidential computing</h2>
+      <div class="col">
+        <div class="p-image-container is-highlighted">
+          <img class="p-image-container__image"
+               src="https://assets.ubuntu.com/v1/472acf08-chart.png"
+               alt="Ubuntu confidential VMs establish a secure encrypted communication channel with Nvidia H100 GPUs" />
         </div>
-        <div class="col">
-            <ul class="p-list--divided u-no-margin--bottom">
-                <li class="p-list__item"><a href="/engage/confidential-ai-webinar">Secure your AI workloads with confidential computing</a></li>
-                <li class="p-list__item"><a href="https://canonical.com/blog/confidential-computing-in-public-clouds-isolation-and-remote-attestation-explained">Learn about the importance of remote attestation</a></li>
-                <li class="p-list__item"><a href="https://canonical.com/blog/ephemeral-ubuntu-confidential-vms-azure">Deep dive into the technical implementation of Ubuntu CVMs with ephemeral vTPMS</a></li>
-            </ul>
-        </div>
-    </div>
-</section>
+      </div>
+      <div class="col">
 
-<div class="u-fixed-width">
-    <hr class="u-fixed-width" /> 
- </div>
- <section class="p-strip is-deep">
-     <div class="u-fixed-width">
-         <h2>
-             <a href="/confidential-computing/ai#get-in-touch">Contact us to discuss your use case&nbsp;&rsaquo;</a>
-         </h2>
-     </div>
- </section>
+        <p class="u-no-padding--top">
+          Businesses using machine learning on Azure are prioritizing data security and model protection. Strict regulations often prevent sharing sensitive information, holding back AI’s full capabilities in key sectors.
+        </p>
+        <p>
+          To address this challenge on Azure, we introduce a confidential AI preview featuring Ubuntu VMs with AMD 4th Gen EPYC processors and NVIDIA H100 GPUs, delivering stronger security and performance for advanced AI workloads.
+        </p>
+        <hr class="p-rule--muted" />
+        <a href="https://aka.ms/accgpusignup">Sign up for the Azure preview of confidential AI with Ubuntu&nbsp;&rsaquo;</a>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <h2>
+          Learn more about
+          <br />
+          confidential computing
+        </h2>
+      </div>
+      <div class="col">
+        <ul class="p-list--divided u-no-margin--bottom">
+          <li class="p-list__item">
+            <a href="/engage/confidential-ai-webinar">Secure your AI workloads with confidential computing</a>
+          </li>
+          <li class="p-list__item">
+            <a href="https://canonical.com/blog/confidential-computing-in-public-clouds-isolation-and-remote-attestation-explained">Learn about the importance of remote attestation</a>
+          </li>
+          <li class="p-list__item">
+            <a href="https://canonical.com/blog/ephemeral-ubuntu-confidential-vms-azure">Deep dive into the technical implementation of Ubuntu CVMs with ephemeral vTPMS</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <div class="u-fixed-width">
+    <hr class="u-fixed-width" />
+  </div>
+  <section class="p-strip is-deep">
+    <div class="u-fixed-width">
+      <h2>
+        <a href="/confidential-computing/ai#get-in-touch">Contact us to discuss your use case&nbsp;&rsaquo;</a>
+      </h2>
+    </div>
+  </section>
 {% endblock content %}

--- a/templates/azure/confidential-computing.html
+++ b/templates/azure/confidential-computing.html
@@ -1,0 +1,139 @@
+{% extends "azure/base_azure.html" %}
+
+{% block title %}Confidential computing on Microsoft Azure{% endblock %}
+
+{% block meta_description %}
+    Protect your security sensitive workloads on Microsoft Azure with Ubuntu confidential VMs
+{% endblock %}
+
+{% block meta_copydoc %}
+https://docs.google.com/document/d/1sVaQQlm6LHyRf-Q3VSVTmqGRi0SV7gwBVczCTPWq3CE/edit
+{% endblock meta_copydoc %}
+
+{% block body_class %}is-paper{% endblock body_class %}
+
+{% block content %}
+<section class="p-section--hero p-suru">
+    <div class="row--50-50">
+        <div class="col">
+            <h1>Confidential computing with Ubuntu on Microsoft Azure</h1>
+        </div>
+        <div class="col">
+            <p>Secure your data, code and AI models at run- time with Ubuntu confidential VMs on Microsoft Azure.</p>
+            <hr class="p-rule--muted" />
+            <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps?search=Canonical%20Ubuntu%20confidential%20VM&page=1">Try Ubuntu confidential VMs today&nbsp;&rsaquo;</a>
+        </div>
+    </div>
+</section>
+
+<section class="p-section">
+    <div class="row--50-50">
+        <hr class="p-rule" />
+        <div class="col">
+            <h2>Why enable zero trust computing within Azure?</h2>
+        </div>
+        <div class="col">
+            <p>With zero-trust being the norm in cybersecurity for global businesses, using  confidential VMs in the cloud takes this one step further.</p>
+            <ul class="p-list">
+                <li class="p-list__item is-ticked">Strengthen protection against cloud privileged software, including hypervisors</li>
+                <li class="p-list__item is-ticked">Enhance your VM’s isolation against other tenant VMs</li>
+                <li class="p-list__item is-ticked">Build data clean rooms for collaborative AI analytics</li>
+                <li class="p-list__item is-ticked">Strengthen your compliance posture</li>
+            </ul>
+        </div>
+    </div>
+</section>
+
+<section class="p-section">
+    <div class="row--50-50">
+        <hr class="p-rule" />
+        <div class="col">
+            <h2>Get Ubuntu confidential VMs on the Microsoft Azure marketplace</h2>
+        </div>
+        <div class="col">
+<div class="p-image-container is-highlighted">
+    <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/1d39a40e-microsoft-azure-logo%20%5BDEPRECATED%5D.png" alt="" />
+</div>
+<p>Ubuntu offers the following confidential VMs:</p>
+        <ul class="p-list--divided u-no-margin--bottom">
+            <li class="p-list__item" style="box-shadow: inset 0 1px 0 0 var(--vf-color-border-low-contrast)"><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.ubuntu-24_04-lts?tab=Overview">Get Ubuntu 24.04 LTS confidential VMs</a></li>
+            <li class="p-list__item"><a href="https://forms.office.com/pages/responsepage.aspx?id=v4j5cvGGr0GRqy180BHbR9_qJVF-zyZCqvwR_iaG2EFUME1BT1hJN0I1VjhGWE9QNUJGREQ5QUlMNS4u">Get Intel TDX in private preview with 22.04 LTS</a></li>
+            <li class="p-list__item"><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-confidential-vm-jammy">Get AMD SEV SNP with Ubuntu 22.04 LTS on Azure</a></li>
+            <li class="p-list__item"><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-confidential-vm-focal?tab=Overview">Get AMD SEV SNP with Ubuntu  20.04 LTS on Azure</a></li>
+        </ul>
+        <hr class="p-rule--muted" />
+            <a href="/confidential-computing#get-in-touch">Don’t see what you’re looking for? Contact us to learn more&nbsp;&rsaquo;</a>
+        </div>
+    </div>
+</section>
+
+<section class="p-section">
+    <div class="row--50-50">
+        <hr class="p-rule" />
+        <div class="col">
+            <h2>Use Ubuntu Pro to further harden your confidential VMs</h2>
+        </div>
+        <div class="col">
+            <p>While confidential VMs can protect your workload from external threats, vulnerabilities from within their boundaries remain a concern. With Ubuntu Pro, you can keep your guest CVM software stack continuously patched and up-to-date for up to 12 years, covering 30,000 open source packages with a single subscription.</p>
+            <hr class="p-rule--muted" />
+            <a href="/pro"> Learn more about Ubuntu Pro&nbsp;&rsaquo;</a>
+        </div>
+    </div>
+</section>
+
+<div class="u-fixed-width">
+   <hr class="p-rule" /> 
+</div>
+<section class="p-strip is-deep">
+    <div class="u-fixed-width">
+        <h2>
+            <a href="https://ubuntu.com/confidential-computing">Learn about other confidential computing offerings from Canonical&nbsp;&rsaquo;</a>
+        </h2>
+    </div>
+</section>
+
+<section class="p-section">
+    <div class="row--50-50">
+        <hr class="p-rule" />
+        <div class="col">
+            <h2>Confidential computing enables AI with Ubuntu and NVIDIA GPUs on Microsoft Azure</h2>
+        </div>
+        <div class="col">
+<div class="p-image-container is-highlighted">
+    <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/fc0006be-cvm-diagram@2x.png" alt="Ubuntu confidential VMs establish a secure encrypted communication channel with Nvidia H100 GPUs" />
+</div>
+<p>Businesses using machine learning on Azure are prioritizing data security and model protection. Strict regulations often prevent sharing sensitive information, holding back AI’s full capabilities in key sectors.</p>
+<p>To address this challenge on Azure, we introduce a confidential AI preview featuring Ubuntu VMs with AMD 4th Gen EPYC processors and NVIDIA H100 GPUs, delivering stronger security and performance for advanced AI workloads.</p>
+        <hr class="p-rule--muted" />
+            <a href="https://aka.ms/accgpusignup">Sign up for the Azure preview of confidential AI with Ubuntu&nbsp;&rsaquo;</a>
+        </div>
+    </div>
+</section>
+
+<section class="p-section">
+    <div class="row--50-50">
+        <hr class="p-rule" />
+        <div class="col">
+            <h2>Learn more about confidential computing</h2>
+        </div>
+        <div class="col">
+            <ul class="p-list--divided u-no-margin--bottom">
+                <li class="p-list__item"><a href="/engage/confidential-ai-webinar">Secure your AI workloads with confidential computing</a></li>
+                <li class="p-list__item"><a href="https://canonical.com/blog/confidential-computing-in-public-clouds-isolation-and-remote-attestation-explained">Learn about the importance of remote attestation</a></li>
+                <li class="p-list__item"><a href="https://canonical.com/blog/ephemeral-ubuntu-confidential-vms-azure">Deep dive into the technical implementation of Ubuntu CVMs with ephemeral vTPMS</a></li>
+            </ul>
+        </div>
+    </div>
+</section>
+
+<div class="u-fixed-width">
+    <hr class="u-fixed-width" /> 
+ </div>
+ <section class="p-strip is-deep">
+     <div class="u-fixed-width">
+         <h2>
+             <a href="/confidential-computing/ai#get-in-touch">Contact us to discuss your use case&nbsp;&rsaquo;</a>
+         </h2>
+     </div>
+ </section>
+{% endblock content %}


### PR DESCRIPTION
## Done

Add new /azure/confidential-computing page according to the copy doc and figma

## QA
- [demo link](https://ubuntu-com-14365.demos.haus/azure/confidential-computing)
- [copy doc](https://docs.google.com/document/d/1sVaQQlm6LHyRf-Q3VSVTmqGRi0SV7gwBVczCTPWq3CE/edit#heading=h.3hmfjtayfrqm)
- [figma](https://www.figma.com/design/MinLlXouBnEDqaoAL3bTWC/24.10-ubuntu.com%2Fazure?node-id=543-1498&node-type=frame&t=GMkgEW8xbup8LJql-0)
- Check the site on the demo
- Run through the following [QA steps](https://discourse.canonical.com/t/qa-steps/152)
- Check that the page is correct according to copy doc and figma

## Issue / Card
[WD-14793](https://warthogs.atlassian.net/browse/WD-14793)

[WD-14793]: https://warthogs.atlassian.net/browse/WD-14793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ