### PR TITLE
style: Remove excess padding between footer items

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1778,4 +1778,8 @@ legend {
 
 .u-no-wrap {
   white-space: nowrap;
+
+// Fix for spacing in the footer
+.p-footer-list {
+  @extend %paragraph;
 }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1778,6 +1778,7 @@ legend {
 
 .u-no-wrap {
   white-space: nowrap;
+}
 
 // Fix for spacing in the footer
 .p-footer-list {

--- a/templates/templates/_footer_item.html
+++ b/templates/templates/_footer_item.html
@@ -27,7 +27,7 @@
     </h2>
   </div>
   <div class="col-9 col-medium-4 u-hide--small">
-    <ul class="p-inline-list p-footer-list" id="{{ section.path }}-footer-nav">
+    <ul class="p-inline-list p-footer-list u-no-margin--bottom" id="{{ section.path }}-footer-nav">
       {% for child in section.children %}
       {% if child.title != 'Overview' %}
       {% if not child.hidden %}

--- a/templates/templates/_footer_item.html
+++ b/templates/templates/_footer_item.html
@@ -1,5 +1,5 @@
 <div class="row">
-  <hr class="p-rule--muted" />
+  <hr class="p-rule--muted u-no-margin--bottom" />
   <div class="col-3 col-medium-2">
     <h2 class="p-heading--5">
       <a class="u-hide--small" href="{{ section.path }}">

--- a/templates/templates/_footer_item.html
+++ b/templates/templates/_footer_item.html
@@ -27,7 +27,7 @@
     </h2>
   </div>
   <div class="col-9 col-medium-4 u-hide--small">
-    <ul class="p-inline-list p-footer-list u-no-margin--bottom" id="{{ section.path }}-footer-nav">
+    <ul class="p-inline-list p-footer-list" id="{{ section.path }}-footer-nav">
       {% for child in section.children %}
       {% if child.title != 'Overview' %}
       {% if not child.hidden %}


### PR DESCRIPTION
## Done

- This addresses an [issue reported on github](https://github.com/canonical/ubuntu.com/issues/14371) by @lyubomir-popov  about excess padding between footer items

## QA

- Check that the space between footer items is meets @lyubomir-popov requirements
- Check on all screen sizes

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-15498
https://github.com/canonical/ubuntu.com/issues/14371
