### PR TITLE
fix your-exams view

### DIFF
--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -468,24 +468,6 @@ def cred_your_exams(
     cred_maintenance_end,
     **kwargs,
 ):
-    response = flask.make_response(
-        flask.render_template(
-            "credentials/your-exams.html",
-            agreement_notification=False,
-            exams=[],
-            show_cred_maintenance_alert=show_cred_maintenance_alert,
-            cred_is_in_maintenance=cred_is_in_maintenance,
-            cred_maintenance_start=cred_maintenance_start,
-            cred_maintenance_end=cred_maintenance_end,
-        )
-    )
-
-    # Do not cache this view
-    response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"
-    response.headers["Pragma"] = "no-cache"
-
-    return response
-
     email = flask.request.args.get("email", None)
 
     agreement_notification = False


### PR DESCRIPTION
## Done

- Remove unused code that was unintentionally left there when merging another [PR](https://github.com/canonical/ubuntu.com/pull/14306)
- The above code was added to quickly test for empty exams

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Make sure your exams page works as expected (`/credentials/your-exams`)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
