### PR TITLE
exam cancellation in cred dashboard

### DIFF
--- a/static/js/src/advantage/credentials/dashboard/api/queryFns.ts
+++ b/static/js/src/advantage/credentials/dashboard/api/queryFns.ts
@@ -194,3 +194,24 @@ export async function getUserPermissions() {
     throw new Error(error as string);
   }
 }
+
+export async function cancelScheduledExam(reservationId: string) {
+  try {
+    const URL = `/credentials/api/cancel-scheduled-exam/${reservationId}`;
+    const response = await fetch(URL, {
+      method: "DELETE",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+    });
+
+    const data = await response.json();
+    if (!response.ok) {
+      throw new Error(data.error);
+    }
+    return data;
+  } catch (error) {
+    throw new Error(error as string);
+  }
+}

--- a/static/js/src/advantage/credentials/dashboard/api/queryKeys.ts
+++ b/static/js/src/advantage/credentials/dashboard/api/queryKeys.ts
@@ -1,3 +1,8 @@
 export const getBulkBadgesCredly = () => ["credlyIssuedBadgesBulk"];
 export const postIssueCredlyBadge = () => ["credlyIssueBadge"];
 export const getUserPermissionsKey = () => ["userPermissions"];
+export const cancelScheduledExamKey = (reservationId: string) => [
+  "cancelScheduledExamKey",
+  reservationId,
+];
+export const getUpcomingExamsKey = (page: number) => ["upcomingExams", page];

--- a/static/js/src/advantage/credentials/dashboard/components/UpcomingExams/components/ActionsMenu.tsx
+++ b/static/js/src/advantage/credentials/dashboard/components/UpcomingExams/components/ActionsMenu.tsx
@@ -1,0 +1,125 @@
+import { useMemo, Fragment, useState } from "react";
+import {
+  ContextualMenu,
+  Spinner,
+  ConfirmationModal,
+} from "@canonical/react-components";
+import { ExamResultsTA } from "advantage/credentials/dashboard/utils/types";
+import {
+  useQueryClient,
+  useMutation,
+  useIsMutating,
+} from "@tanstack/react-query";
+import {
+  getUpcomingExamsKey,
+  cancelScheduledExamKey,
+} from "advantage/credentials/dashboard/api/queryKeys";
+import { cancelScheduledExam } from "advantage/credentials/dashboard/api/queryFns";
+
+type Props = {
+  exam: ExamResultsTA;
+  setNotificationState: (state: undefined | "negative" | "positive") => void;
+  setNotificationError: (error: string | null) => void;
+};
+
+const ActionsMenu = (props: Props) => {
+  const { exam, setNotificationState, setNotificationError } = props;
+  const qClient = useQueryClient();
+  const isMutating = Boolean(
+    useIsMutating({
+      mutationKey: cancelScheduledExamKey(exam.uuid),
+    }),
+  );
+  const [loading, setLoading] = useState(false);
+  const [showConfirmationModal, setShowConfirmationModal] = useState(false);
+
+  const mutation = useMutation({
+    mutationKey: cancelScheduledExamKey(exam.uuid),
+    mutationFn: () => {
+      return cancelScheduledExam(exam.uuid);
+    },
+    onMutate: () => {
+      setLoading(true);
+    },
+    onSuccess: () => {
+      setNotificationError(null);
+      setNotificationState("positive");
+      qClient.invalidateQueries({
+        queryKey: [getUpcomingExamsKey(0)[0]],
+      });
+      setLoading(false);
+    },
+    onError: (error) => {
+      setNotificationError(error.message);
+      setLoading(false);
+      setNotificationState("negative");
+    },
+    onSettled: () => {
+      setShowConfirmationModal(false);
+      setTimeout(() => {
+        setNotificationState(undefined);
+        setNotificationError(null);
+      }, 3000);
+    },
+  });
+  const isExamCancelled = useMemo(() => exam.state === "Canceled", [exam]);
+
+  const links = useMemo(
+    () => [
+      {
+        children: (
+          <Fragment>
+            <span>Cancel Exam</span>
+          </Fragment>
+        ),
+        onClick: () => setShowConfirmationModal(true),
+        hasIcon: true,
+        disabled: isExamCancelled,
+      },
+    ],
+    [isMutating, isExamCancelled],
+  );
+
+  const handleConfirm = () => {
+    mutation.mutate();
+  };
+
+  if (loading) return <Spinner />;
+
+  return (
+    <>
+      {showConfirmationModal && (
+        <ConfirmationModal
+          confirmButtonLabel="Confirm"
+          cancelButtonLabel="Cancel"
+          onConfirm={handleConfirm}
+          close={() => setShowConfirmationModal(false)}
+          title="Confirm cancel"
+        >
+          <p>
+            This will cancel the exam for <strong>{exam.user.full_name}</strong>{" "}
+            with ID <strong>{exam.id}</strong>.
+            <br />
+            You cannot undo this action.
+          </p>
+        </ConfirmationModal>
+      )}
+      <ContextualMenu
+        toggleProps={{
+          className: "u-no-margin--bottom",
+          dense: true,
+          style: {
+            opacity: isExamCancelled ? 0.5 : 1,
+          },
+        }}
+        hasToggleIcon
+        links={links}
+        position="right"
+        toggleLabel="Actions"
+        disabled={isMutating}
+      />
+    </>
+  );
+};
+
+export default ActionsMenu;

--- a/static/js/src/advantage/credentials/dashboard/utils/types.ts
+++ b/static/js/src/advantage/credentials/dashboard/utils/types.ts
@@ -55,6 +55,7 @@ export type AssessmentReservationMeta = {
 export type ExamResultsTA = {
   id: number;
   user_email: string;
+  state: string;
   completed_at: string;
   score: number;
   duration_in_minutes: number;

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -101,6 +101,7 @@ from webapp.shop.cred.views import (
     get_webhook_response,
     issue_badges,
     rotate_activation_key,
+    cancel_scheduled_exam,
 )
 from webapp.shop.views import (
     account_view,
@@ -1012,6 +1013,11 @@ app.add_url_rule(
     "/credentials/api/user-permissions",
     view_func=get_cred_user_permissions,
     methods=["GET"],
+)
+app.add_url_rule(
+    "/credentials/api/cancel-scheduled-exam/<reservation_id>",
+    view_func=cancel_scheduled_exam,
+    methods=["DELETE"],
 )
 
 app.add_url_rule(


### PR DESCRIPTION
## Done

- Allow cred admins to cancel an already scheduled exam

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to `credentials/dashboard/exams/upcoming`
    - Make sure you are a cred admin!
    - For each upcoming exam you can see an action menu which will have a Cancel action
    - Click that cancel action and it will show you a confirmation
    - Click the confirmation and it will cancel that exam and reload the data to reflect that change
    - If you don't confirm and exit without cancelling the exam, it should not cancel the exam

## Issue / Card

Fixes [WD-15269](https://warthogs.atlassian.net/browse/WD-15269)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-15269]: https://warthogs.atlassian.net/browse/WD-15269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ