### PR TITLE
WD-15536 Remove space from old blog posts' notice

### DIFF
--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -137,9 +137,9 @@
               <div class="p-notification__content">
                 <p class="p-notification__message u-text--muted" id="date-notice">
                   {% if blog_notice.updated %}
-                    This article was last updated <strong>{{ blog_notice.difference_in_years }} year{% if blog_notice.difference_in_years > 1 %}s {% endif %}ago.</strong>
+                    This article was last updated <strong>{{ blog_notice.difference_in_years }} year{% if blog_notice.difference_in_years > 1 %}s{% endif %} ago.</strong>
                 {% else %}
-                  This article is more than <strong>{{ blog_notice.difference_in_years }} year {% if blog_notice.difference_in_years > 1 %}s {% endif %}old.</strong>
+                  This article is more than <strong>{{ blog_notice.difference_in_years }} year{% if blog_notice.difference_in_years > 1 %}s{% endif %} old.</strong>
               {% endif %}
             </p>
           </div>

--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -137,9 +137,9 @@
               <div class="p-notification__content">
                 <p class="p-notification__message u-text--muted" id="date-notice">
                   {% if blog_notice.updated %}
-                    This article was last updated <strong>{{ blog_notice.difference_in_years }} year{% if blog_notice.difference_in_years > 1 %}s{% endif %} ago.</strong>
+                    This article was last updated <strong>{{ blog_notice.difference_in_years }} year{% if blog_notice.difference_in_years > 1 %}s{% endif %} ago</strong>.
                 {% else %}
-                  This article is more than <strong>{{ blog_notice.difference_in_years }} year{% if blog_notice.difference_in_years > 1 %}s{% endif %} old.</strong>
+                  This article is more than <strong>{{ blog_notice.difference_in_years }} year{% if blog_notice.difference_in_years > 1 %}s{% endif %} old</strong>.
               {% endif %}
             </p>
           </div>


### PR DESCRIPTION
## Done

Fix notice in old blog posts so it reads "years" instead of "year s"

Demo: https://ubuntu-com-14380.demos.haus/blog/ubuntu-20-04-survey-results

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes WD-15536

## Screenshots

![Screenshot 2024-10-02 at 10 51 21](https://github.com/user-attachments/assets/d3eaf036-c5d7-4aa6-8107-93bcd2ff9691)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
