### PR TITLE
remove coupon and discount for cred exams

### DIFF
--- a/templates/credentials/schedule.html
+++ b/templates/credentials/schedule.html
@@ -51,7 +51,7 @@ meta_copydoc %}
                   name="timezone"
                   required></select>
           <label class="p-heading--5 u-no-margin" for="exam-date">Select your preferred day</label>
-          <p>You can schedule your exam to begin {{ time_delay }} from now or later. {{max_date}}</p>
+          <p>You can schedule your exam to begin {{ time_delay }} from now or later.</p>
           <input class="spaced-bottom--smaller is-paper--input"
                  type="date"
                  id="exam-date"

--- a/templates/credentials/schedule.html
+++ b/templates/credentials/schedule.html
@@ -51,7 +51,7 @@ meta_copydoc %}
                   name="timezone"
                   required></select>
           <label class="p-heading--5 u-no-margin" for="exam-date">Select your preferred day</label>
-          <p>You can schedule your exam to begin {{ time_delay }} from now or later.</p>
+          <p>You can schedule your exam to begin {{ time_delay }} from now or later. {{max_date}}</p>
           <input class="spaced-bottom--smaller is-paper--input"
                  type="date"
                  id="exam-date"

--- a/templates/credentials/shop/index.html
+++ b/templates/credentials/shop/index.html
@@ -165,10 +165,6 @@
           product: exams[index],
           quantity: 1,
         }, ],
-        coupon: {
-          "origin": "Stripe",
-          "IDs": ["81IlzzhQ"]
-        },
         action: "purchase",
       };
       localStorage.setItem(

--- a/webapp/shop/cred/exams.json
+++ b/webapp/shop/cred/exams.json
@@ -4,7 +4,7 @@
     "name": "CUE.01 Linux",
     "displayName": "CUE.01 Linux",
     "price": {
-      "value": 0,
+      "value": 100,
       "currency": "USD"
     },
     "metadata": [
@@ -15,7 +15,6 @@
       },
       {
         "originalPrice": "100.00",
-        "discountPrice": "0.00" ,
         "currency": "$"
       }
     ]

--- a/webapp/shop/cred/exams.json
+++ b/webapp/shop/cred/exams.json
@@ -4,7 +4,7 @@
     "name": "CUE.01 Linux",
     "displayName": "CUE.01 Linux",
     "price": {
-      "value": 100,
+      "value": 10000,
       "currency": "USD"
     },
     "metadata": [

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -242,10 +242,17 @@ def cred_schedule(
     **_,
 ):
     error = None
+    
+    contract_long_id = flask.request.args.get("contractLongID")
+    contract_detail = ua_contracts_api.get_contract(contract_long_id)
+
     now = datetime.utcnow()
     min_date = (now + timedelta(minutes=30)).strftime("%Y-%m-%d")
-    max_date = (now + timedelta(days=365)).strftime("%Y-%m-%d")
-    contract_long_id = flask.request.args.get("contractLongID")
+    max_date = datetime.strptime(
+                    f"{contract_detail['contractInfo']['effectiveTo']}",
+                    "%Y-%m-%dT%H:%M:%SZ",
+                ).strftime("%Y-%m-%d")
+
     is_staging = "staging" in os.getenv(
         "CONTRACTS_API_URL", "https://contracts.staging.canonical.com/"
     )
@@ -317,7 +324,6 @@ def cred_schedule(
             between the contract effectiveness window"""
             if not contract_long_id:
                 return flask.redirect("/credentials/your-exams")
-            contract_detail = ua_contracts_api.get_contract(contract_long_id)
             effective_from = now.astimezone(tz_info) + timedelta(
                 hours=time_delta
             )

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -244,7 +244,7 @@ def cred_schedule(
     error = None
     now = datetime.utcnow()
     min_date = (now + timedelta(minutes=30)).strftime("%Y-%m-%d")
-    max_date = (now + timedelta(days=30)).strftime("%Y-%m-%d")
+    max_date = (now + timedelta(days=365)).strftime("%Y-%m-%d")
     contract_long_id = flask.request.args.get("contractLongID")
     is_staging = "staging" in os.getenv(
         "CONTRACTS_API_URL", "https://contracts.staging.canonical.com/"

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -242,16 +242,16 @@ def cred_schedule(
     **_,
 ):
     error = None
-    
+
     contract_long_id = flask.request.args.get("contractLongID")
     contract_detail = ua_contracts_api.get_contract(contract_long_id)
 
     now = datetime.utcnow()
     min_date = (now + timedelta(minutes=30)).strftime("%Y-%m-%d")
     max_date = datetime.strptime(
-                    f"{contract_detail['contractInfo']['effectiveTo']}",
-                    "%Y-%m-%dT%H:%M:%SZ",
-                ).strftime("%Y-%m-%d")
+        f"{contract_detail['contractInfo']['effectiveTo']}",
+        "%Y-%m-%dT%H:%M:%SZ",
+    ).strftime("%Y-%m-%d")
 
     is_staging = "staging" in os.getenv(
         "CONTRACTS_API_URL", "https://contracts.staging.canonical.com/"

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -928,10 +928,13 @@ def cred_shop(ua_contracts_api, advantage_mapper, **kwargs):
         for exam in exams:
             if product["id"] == exam["id"]:
                 exam["longId"] = product["longId"]
-                exam["period"] = "monthly"
+                if product["period"] == "none":
+                    exam["period"] = "monthly"
+                else:
+                    exam["period"] = product["period"]
                 exam["marketplace"] = product["marketplace"]
                 exam["name"] = product["name"]
-                exam["periodQuantity"] = 30
+                exam["periodQuantity"] = product["effectiveDays"]
 
     # purchase account required for purchasing from marketplace
 
@@ -1313,9 +1316,10 @@ def get_cue_products(ua_contracts_api, type, **kwargs):
         {
             "id": listing.get("productID", ""),
             "longId": listing.get("id", ""),
-            "period": listing.get("period", ""),
+            "period": listing.get("period", "yearly"),
             "marketplace": listing.get("marketplace", ""),
             "name": listing.get("name", ""),
+            "effectiveDays": listing.get("effectiveDays", 365),
             "price": listing.get("price", {"currency": "USD", "value": "0"}),
         }
         for listing in listings


### PR DESCRIPTION
## Done

- Remove coupon for CUE.01 Linux exam

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to /credentials/shop
    - Price should be 100$
- proceed to checkout. 
    - The price should be 100$ everywhere. VAT is yet to be determined.

## Issue / Card

Fixes [#WD-15553](https://warthogs.atlassian.net/browse/WD-15553)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
