### PR TITLE
Fix typo in Juju command

### DIFF
--- a/templates/kubernetes/docs/quickstart.md
+++ b/templates/kubernetes/docs/quickstart.md
@@ -50,7 +50,7 @@ Kubernetes cluster running on the cloud of your choice in minutes!
 deploying, configuring, and operating complex software on public or private
 clouds. It can be installed with a snap:
           <div class="p-code-snippet">
-            <pre class="p-code-snippet__block--icon"><code>sudo snap install juju ---channel=3.1/stable</code></pre>
+            <pre class="p-code-snippet__block--icon"><code>sudo snap install juju --channel=3.1/stable</code></pre>
           </div>
           <script id="asciicast-254739" src="https://asciinema.org/a/254739.js" async data-autoplay="true" data-rows="4"></script>
         </div>


### PR DESCRIPTION
## Done

- Fixes a simple typo in the command for installing Juju 

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
