### PR TITLE
WD-14867: adds secondary download links

### DIFF
--- a/templates/download/risc-v/allwinner-nezha.html
+++ b/templates/download/risc-v/allwinner-nezha.html
@@ -30,7 +30,9 @@
     <div class="col-6">
       <p>
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/24.04.1/release/ubuntu-24.04.1-preinstalled-server-riscv64+nezha.img.xz">Download 24.04.1</a>
+           href="https://cdimage.ubuntu.com/releases/24.10/release/ubuntu-24.10-preinstalled-server-riscv64+nezha.img.xz">Download 24.10</a>
+        <a class="p-button--positive"
+           href="https://cdimage.ubuntu.com/releases/24.04.1/release/ubuntu-24.04.1-preinstalled-server-riscv64+nezha.img.xz">Download 24.04.1 LTS</a>
       </p>
       <p>
         <a href="https://wiki.ubuntu.com/RISC-V/Nezha%20D1">How to install Ubuntu on the Nezha</a>

--- a/templates/download/risc-v/microchip-curiosity.html
+++ b/templates/download/risc-v/microchip-curiosity.html
@@ -30,7 +30,9 @@
     <div class="col-6">
       <p>
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/24.04.1/release/ubuntu-24.04.1-preinstalled-server-riscv64+pic64gx.img.xz">Download 24.04.1</a>
+           href="https://cdimage.ubuntu.com/releases/24.10/release/ubuntu-24.10-preinstalled-server-riscv64+pic64gx.img.xz">Download 24.10</a>
+        <a class="p-button--positive"
+           href="https://cdimage.ubuntu.com/releases/24.04.1/release/ubuntu-24.04.1-preinstalled-server-riscv64+pic64gx.img.xz">Download 24.04.1 LTS</a>
       </p>
       <p>
         <a href="https://wiki.ubuntu.com/RISC-V/Microchip%20PIC64GX1000%20Curiosity%20Kit">How to install Ubuntu on the Microchip PIC64GX1000 Curiosity Kit</a>

--- a/templates/download/risc-v/microchip-polarfire.html
+++ b/templates/download/risc-v/microchip-polarfire.html
@@ -41,7 +41,9 @@
       <hr class="p-rule--muted is-fixed-width col-6" />
       <p>
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/24.04.1/release/ubuntu-24.04.1-preinstalled-server-riscv64+icicle.img.xz">Download 24.04.1</a>
+           href="https://cdimage.ubuntu.com/releases/24.10/release/ubuntu-24.10-preinstalled-server-riscv64+icicle.img.xz">Download 24.10</a>
+        <a class="p-button--positive"
+           href="https://cdimage.ubuntu.com/releases/24.04.1/release/ubuntu-24.04.1-preinstalled-server-riscv64+icicle.img.xz">Download 24.04.1 LTS</a>
       </p>
       <p>
         <a href="https://wiki.ubuntu.com/RISC-V/PolarFire%20SoC%20FPGA%20Icicle%20Kit">How to install Ubuntu on the Microchip Polarfire SoC FPGA Icicle Kit</a>

--- a/templates/download/risc-v/milk-v-mars.html
+++ b/templates/download/risc-v/milk-v-mars.html
@@ -34,7 +34,9 @@
       </p>
       <p>
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/24.04.1/release/ubuntu-24.04.1-preinstalled-server-riscv64+milkvmars.img.xz">Download 24.04.1</a>
+           href="https://cdimage.ubuntu.com/releases/24.10/release/ubuntu-24.10-preinstalled-server-riscv64+milkvmars.img.xz">Download 24.10</a>
+        <a class="p-button--positive"
+           href="https://cdimage.ubuntu.com/releases/24.04.1/release/ubuntu-24.04.1-preinstalled-server-riscv64+milkvmars.img.xz">Download 24.04.1 LTS</a>
       </p>
     </div>
   </div>
@@ -50,7 +52,9 @@
     <div class="col-6">
       <p>
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/24.04.1/release/ubuntu-24.04.1-live-server-riscv64.img.gz">Download 24.04.1 live installer</a>
+           href="https://cdimage.ubuntu.com/releases/24.10/release/ubuntu-24.10-live-server-riscv64.img.gz">Download 24.10 live installer</a>
+        <a class="p-button--positive"
+           href="https://cdimage.ubuntu.com/releases/24.04.1/release/ubuntu-24.04.1-live-server-riscv64.img.gz">Download 24.04.1 LTS live installer</a>
       </p>
       <p>
         <a href="https://wiki.ubuntu.com/RISC-V/Milk-V%20Mars">How to install Ubuntu on the Milk-V Mars</a>

--- a/templates/download/risc-v/qemu-emulator.html
+++ b/templates/download/risc-v/qemu-emulator.html
@@ -29,7 +29,9 @@
     <div class="col-6">
       <p class="u-sv3">
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/noble/release/ubuntu-24.04.1-preinstalled-server-riscv64.img.xz">Download 24.04.1</a>
+           href="https://cdimage.ubuntu.com/releases/24.10/release/ubuntu-24.10-preinstalled-server-riscv64.img.xz">Download 24.10</a>
+        <a class="p-button--positive"
+           href="https://cdimage.ubuntu.com/releases/24.04.1/release/ubuntu-24.04.1-preinstalled-server-riscv64.img.xz">Download 24.04.1 LTS</a>
       </p>
     </div>
   </div>
@@ -45,7 +47,9 @@
     <div class="col-6">
       <p>
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/24.04.1/release/ubuntu-24.04.1-live-server-riscv64.img.gz">Download 24.04.1 live installer</a>
+           href="https://cdimage.ubuntu.com/releases/24.10/release/ubuntu-24.10-live-server-riscv64.img.gz">Download 24.10 live installer</a>
+        <a class="p-button--positive"
+           href="https://cdimage.ubuntu.com/releases/24.04.1/release/ubuntu-24.04.1-live-server-riscv64.img.gz">Download 24.04.1 LTS live installer</a>
       </p>
       <p>
         <a href="https://wiki.ubuntu.com/RISC-V/QEMU">How to install Ubuntu on QEMU RISC-V</a>

--- a/templates/download/risc-v/sifive-unmatched.html
+++ b/templates/download/risc-v/sifive-unmatched.html
@@ -32,7 +32,9 @@
       </p>
       <p class="u-sv3">
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/24.04.1/release/ubuntu-24.04.1-preinstalled-server-riscv64+unmatched.img.xz">Download 24.04.1</a>
+           href="https://cdimage.ubuntu.com/releases/24.10/release/ubuntu-24.10-preinstalled-server-riscv64+unmatched.img.xz">Download 24.10</a>
+        <a class="p-button--positive"
+           href="https://cdimage.ubuntu.com/releases/24.04/release/ubuntu-24.04-preinstalled-server-riscv64+unmatched.img.xz">Download 24.04.1 LTS</a>
       </p>
     </div>
   </div>
@@ -48,7 +50,9 @@
     <div class="col-6">
       <p>
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/24.04.1/release/ubuntu-24.04.1-live-server-riscv64.img.gz">Download 24.04.1 live installer</a>
+           href="https://cdimage.ubuntu.com/releases/24.10/release/ubuntu-24.10-live-server-riscv64.img.gz">Download 24.10 live installer</a>
+        <a class="p-button--positive"
+           href="https://cdimage.ubuntu.com/releases/24.04.1/release/ubuntu-24.04.1-live-server-riscv64.img.gz">Download 24.04.1 LTS live installer</a>
       </p>
       <p>
         <a href="https://wiki.ubuntu.com/RISC-V/SiFive%20HiFive%20Unmatched">How to install Ubuntu on SiFive HiFive Unmatched</a>

--- a/templates/download/risc-v/sipeed-licheerv.html
+++ b/templates/download/risc-v/sipeed-licheerv.html
@@ -30,7 +30,9 @@
     <div class="col-6">
       <p>
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/24.04.1/release/ubuntu-24.04.1-preinstalled-server-riscv64+licheerv.img.xz">Download 24.04.1</a>
+           href="https://cdimage.ubuntu.com/releases/24.10/release/ubuntu-24.10-preinstalled-server-riscv64+licheerv.img.xz">Download 24.10</a>
+        <a class="p-button--positive"
+           href="https://cdimage.ubuntu.com/releases/24.04.1/release/ubuntu-24.04.1-preinstalled-server-riscv64+licheerv.img.xz">Download 24.04.1 LTS</a>
       </p>
       <p>
         <a href="https://wiki.ubuntu.com/RISC-V/LicheeRV">How to install Ubuntu on the LicheeRV Dock</a>

--- a/templates/download/risc-v/starfive-visionfive.html
+++ b/templates/download/risc-v/starfive-visionfive.html
@@ -33,7 +33,9 @@
       </p>
       <p>
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/24.04.1/release/ubuntu-24.04.1-preinstalled-server-riscv64+visionfive2.img.xz">Download 24.04.1</a>
+           href="https://cdimage.ubuntu.com/releases/24.04/release/ubuntu-24.04-preinstalled-server-riscv64+visionfive2.img.xz">Download 24.10</a>
+        <a class="p-button--positive"
+           href="https://cdimage.ubuntu.com/releases/24.04.1/release/ubuntu-24.04.1-preinstalled-server-riscv64+visionfive2.img.xz">Download 24.04.1 LTS</a>
       </p>
     </div>
   </div>
@@ -49,7 +51,9 @@
     <div class="col-6">
       <p>
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/24.04.1/release/ubuntu-24.04.1-live-server-riscv64.img.gz">Download 24.04.1 live installer</a>
+           href="https://cdimage.ubuntu.com/releases/24.10/release/ubuntu-24.10-live-server-riscv64.img.gz">Download 24.10 live installer</a>
+        <a class="p-button--positive"
+           href="https://cdimage.ubuntu.com/releases/24.04.1/release/ubuntu-24.04.1-live-server-riscv64.img.gz">Download 24.04.1 LTS live installer</a>
       </p>
       <p>
         <a href="https://wiki.ubuntu.com/RISC-V/StarFive%20VisionFive%202">How to install Ubuntu on the VisionFive 2</a>


### PR DESCRIPTION
## Done

- Updates ubuntu.com/download/risc-v with secondary 24.10 download options

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/risc-v
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check that the links are correct for each board