### PR TITLE
Fix link in credentials index.html

### DIFF
--- a/templates/credentials/index.html
+++ b/templates/credentials/index.html
@@ -130,7 +130,7 @@
               <div class="p-equal-height-row__item">
                 <hr class="is-muted" />
                 <p>
-                  <a href="/credentials/sign-up"
+                  <a href="/credentials/shop"
                      class="p-button--positive u-no-margin--bottom">Get Certification</a>
                   <a href="/credentials/exam-content?exam=CUE.01%20Linux"
                      class="p-button--link">Syllabus&nbsp;&rsaquo;</a>


### PR DESCRIPTION
## Done

- Fix the link for Get Certification button

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Make sure Get Certification button takes user to shop

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
