### PR TITLE
feat: Create /pricing/contact-us

### DIFF
--- a/static/js/src/prepare-form-inputs.js
+++ b/static/js/src/prepare-form-inputs.js
@@ -63,7 +63,6 @@ function addInputValidation(phoneInput) {
   const mobileInput = document.querySelector(".iti");
   mobileInput.parentNode.classList.add("p-form-validation");
   phoneInput.classList.add("p-form-validation__input");
-  phoneInput.setAttribute("aria-describedby", "invalid-number-message");
 
   const errorElement = createErrorMessage();
   phoneInput.addEventListener("blur", () =>
@@ -99,6 +98,7 @@ function validateInput(phoneInput, errorElement) {
   if (!isValid) {
     phoneInput.parentNode.parentNode.classList.add("is-error");
     phoneInput.parentNode.after(errorElement);
+    phoneInput.setAttribute("aria-describedby", "invalid-number-message");
   }
 }
 
@@ -120,6 +120,7 @@ function isValidNumber(number) {
  */
 function resetErrorState(errorElement, phoneInput) {
   phoneInput?.parentNode?.parentNode.classList.remove("is-error");
+  phoneInput.removeAttribute("aria-describedby", "invalid-number-message");
   if (errorElement.parentNode) {
     errorElement.remove();
   }

--- a/templates/pricing/contact-us.html
+++ b/templates/pricing/contact-us.html
@@ -1,0 +1,13 @@
+{% extends "pricing/base_pricing.html" %}
+
+{% block title %}Contact us | Pricing{% endblock %}
+
+{% block content %}
+  {% with h1="Contact us about pricing",
+    intro_text="Fill in your details below and a member of our sales team will be in touch.",
+    formid="1240",
+    lpId="2065",
+    returnURL="/pricing/thank-you" %}
+    {% include "shared/_default-contact-us-form.html" %}
+  {% endwith %}
+{% endblock content %}

--- a/templates/shared/_default-contact-us-form.html
+++ b/templates/shared/_default-contact-us-form.html
@@ -40,7 +40,7 @@
                        aria-labelledby="24-04"
                        class="p-checkbox__input js-checkbox-visibility"
                        value="24.04 LTS" />
-                <span class="p-checkbox__label" id="22-04">24.04 LTS</span>
+                <span class="p-checkbox__label" id="24-04">24.04 LTS</span>
               </label>
               <label class="p-checkbox">
                 <input type="checkbox"
@@ -134,13 +134,13 @@
             <label class="p-checkbox">
               <input class="p-checkbox__input"
                      type="checkbox"
-                     aria-labelledby="desktop/workstation"
+                     aria-labelledby="desktop-workstation"
                      value="desktop/workstation" />
               <span class="p-checkbox__label" id="desktop-workstation">Desktop/workstation</span>
             </label>
             <label class="p-checkbox">
               <input type="checkbox"
-                     aria-labelledby="physical server"
+                     aria-labelledby="physical-server"
                      class="p-checkbox__input"
                      value="physical server" />
               <span class="p-checkbox__label" id="physical-server">Physical server</span>


### PR DESCRIPTION
## Done

- Create a contact-us form, this uses the default form template

## QA

- Check [the form](https://ubuntu-com-14387.demos.haus/pricing/contact-us) submits and goes to the same place as the other pricing contact us forms

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-15540 


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
