### PR TITLE
update the heading for exam content

### DIFF
--- a/templates/credentials/index.html
+++ b/templates/credentials/index.html
@@ -113,7 +113,7 @@
     <section class="p-strip--light">
       <div class="row">
         <div class="col-3">
-          <h2 class="u-sv2">Complete Syllabus</h2>
+          <h2 class="u-sv2">Complete Exam Content</h2>
         </div>
       </div>
       <div class="row--25-75-on-large">


### PR DESCRIPTION
## Done

- Update the header for exam content

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Make sure the header says Complete Exam Content

## Issue / Card

Fixes [#15583](https://warthogs.atlassian.net/browse/WD-15583)

## Screenshots

Before
<img width="1450" alt="Screenshot 2024-10-04 at 2 29 52 pm" src="https://github.com/user-attachments/assets/07ab1b0e-a7a9-40f4-bb55-ec61295faf7e">


After
<img width="1461" alt="Screenshot 2024-10-04 at 2 09 43 pm" src="https://github.com/user-attachments/assets/ded22cd0-6d20-4602-bb0b-9a4b0e49f4b8">


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
