### PR TITLE
fix: Optimize summit website images

### DIFF
--- a/templates/summit/index.html
+++ b/templates/summit/index.html
@@ -58,9 +58,12 @@
         </p>
       </div>
       <div class="col-4 u-vertically-center">
-        <img src="https://assets.ubuntu.com/v1/9e91caf9-Canonical%20Ubuntu%20Summit%20Logo%202024%20with%20text.svg"
-             width="350"
-             alt="Ubuntu Summit 2024 Logo" />
+        {{ image(url="https://assets.ubuntu.com/v1/048df0ca-Canonical%20Ubuntu%20Summit%20Logo%202024%20with%20text.png",
+                  alt="Ubuntu Summit 2024 Logo",
+                  width="350",
+                  hi_def=True,
+                  loading="auto") | safe
+        }}
       </div>
     </div>
   </div>
@@ -93,8 +96,12 @@
       <div class="col-2 p-card">
         <div class="p-card__content">
           <div class="p-card__image">
-            <img src="https://events.canonical.com/user/1666/picture-895558193"
-                 alt="Mark Jackels" />
+            {{ image(url="https://events.canonical.com/user/1666/picture-895558193",
+                    alt="Mark Jackels",
+                    width="165",
+                    hi_def=True,
+                    loading="lazy") | safe
+            }}
           </div>
           <a href="https://events.canonical.com/event/51/contributions/545/">
             <h3 class="p-heading--5">Mark Jackels</h3>
@@ -105,8 +112,12 @@
       <div class="col-2 p-card">
         <div class="p-card__content">
           <div class="p-card__image">
-            <img src="https://events.canonical.com/user/3099/picture-1004041007"
-                 alt="David Morin" />
+            {{ image(url="https://events.canonical.com/user/3099/picture-1004041007",
+                    alt="David Morin",
+                    width="165",
+                    hi_def=True,
+                    loading="lazy") | safe
+            }}
           </div>
           <a href="https://events.canonical.com/event/51/contributions/590/">
             <h3 class="p-heading--5">David Morin</h3>
@@ -117,8 +128,12 @@
       <div class="col-2 p-card">
         <div class="p-card__content">
           <div class="p-card__image">
-            <img src="https://events.canonical.com/user/2990/picture-3687146351"
-                 alt="Jose Blanquicet" />
+            {{ image(url="https://events.canonical.com/user/2990/picture-3687146351",
+                    alt="Jose Blanquicet",
+                    width="165",
+                    hi_def=True,
+                    loading="lazy") | safe
+            }}
           </div>
           <a href="https://events.canonical.com/event/51/contributions/519/">
             <h3 class="p-heading--5">Jose Blanquicet</h3>
@@ -129,8 +144,12 @@
       <div class="col-2 p-card">
         <div class="p-card__content">
           <div class="p-card__image">
-            <img src="https://events.canonical.com/user/2835/picture-4162133408"
-                 alt="Thomas Crider" />
+            {{ image(url="https://events.canonical.com/user/2835/picture-4162133408",
+                    alt="Thomas Crider",
+                    width="165",
+                    hi_def=True,
+                    loading="lazy") | safe
+            }}
           </div>
           <a href="https://events.canonical.com/event/51/contributions/510/">
             <h3 class="p-heading--5">Thomas Crider</h3>
@@ -141,8 +160,12 @@
       <div class="col-2 p-card">
         <div class="p-card__content">
           <div class="p-card__image">
-            <img src="https://events.canonical.com/user/270/picture-1215077797"
-                 alt="Carl Richell" />
+            {{ image(url="https://events.canonical.com/user/270/picture-1215077797",
+                    alt="Carl Richell",
+                    width="165",
+                    hi_def=True,
+                    loading="lazy") | safe
+            }}
           </div>
           <a href="https://events.canonical.com/event/51/contributions/509/">
             <h3 class="p-heading--5">Carl Richell</h3>
@@ -153,8 +176,12 @@
       <div class="col-2 p-card">
         <div class="p-card__content">
           <div class="p-card__image">
-            <img src="https://events.canonical.com/user/2933/picture-4115884446"
-                 alt="Dr. Kevin Ottens" />
+            {{ image(url="https://events.canonical.com/user/2933/picture-4115884446",
+                    alt="Dr. Kevin Ottens",
+                    width="165",
+                    hi_def=True,
+                    loading="lazy") | safe
+            }}
           </div>
           <a href="https://events.canonical.com/event/51/contributions/549/">
             <h3 class="p-heading--5">Dr. Kevin Ottens</h3>
@@ -167,8 +194,12 @@
       <div class="col-2 p-card">
         <div class="p-card__content">
           <div class="p-card__image">
-            <img src="https://events.canonical.com/user/2994/picture-4096009663"
-                 alt="Dongge Liu" />
+            {{ image(url="https://events.canonical.com/user/2994/picture-4096009663",
+                    alt="Dongge Liu",
+                    width="165",
+                    hi_def=True,
+                    loading="lazy") | safe
+            }}
           </div>
           <a href="https://events.canonical.com/event/51/contributions/540/">
             <h3 class="p-heading--5">Dongge Liu</h3>
@@ -179,8 +210,12 @@
       <div class="col-2 p-card">
         <div class="p-card__content">
           <div class="p-card__image">
-            <img src="https://events.canonical.com/user/2947/picture-4051697592"
-                 alt="Matthew Hodgson" />
+            {{ image(url="https://events.canonical.com/user/2947/picture-4051697592",
+                    alt="Matthew Hodgson",
+                    width="165",
+                    hi_def=True,
+                    loading="lazy") | safe
+            }}
           </div>
           <a href="https://events.canonical.com/event/51/contributions/512/">
             <h3 class="p-heading--5">Matthew Hodgson</h3>
@@ -191,8 +226,12 @@
       <div class="col-2 p-card">
         <div class="p-card__content">
           <div class="p-card__image">
-            <img src="https://events.canonical.com/user/3019/picture-407386855"
-                 alt="Eric Holk" />
+            {{ image(url="https://events.canonical.com/user/3019/picture-407386855",
+                    alt="Eric Holk",
+                    width="165",
+                    hi_def=True,
+                    loading="lazy") | safe
+            }}
           </div>
           <a href="https://events.canonical.com/event/51/contributions/544/">
             <h3 class="p-heading--5">Eric Holk</h3>
@@ -203,8 +242,12 @@
       <div class="col-2 p-card">
         <div class="p-card__content">
           <div class="p-card__image">
-            <img src="https://events.canonical.com/user/2988/picture-3300584080"
-                 alt="Rakhi Sharma" />
+            {{ image(url="https://events.canonical.com/user/2988/picture-3300584080",
+                    alt="Rakhi Sharma",
+                    width="165",
+                    hi_def=True,
+                    loading="lazy") | safe
+            }}
           </div>
           <a href="https://events.canonical.com/event/51/contributions/516/">
             <h3 class="p-heading--5">Rakhi Sharma</h3>
@@ -215,8 +258,12 @@
       <div class="col-2 p-card">
         <div class="p-card__content">
           <div class="p-card__image">
-            <img src="https://events.canonical.com/user/1645/picture-12244883"
-                 alt="Christian Holsing" />
+            {{ image(url="https://events.canonical.com/user/1645/picture-12244883",
+                    alt="Christian Holsing",
+                    width="165",
+                    hi_def=True,
+                    loading="lazy") | safe
+            }}
           </div>
           <a href="https://events.canonical.com/event/51/contributions/588/">
             <h3 class="p-heading--5">Christian Holsing</h3>
@@ -227,8 +274,12 @@
       <div class="col-2 p-card">
         <div class="p-card__content">
           <div class="p-card__image">
-            <img src="https://events.canonical.com/user/2964/picture-2653677503"
-                 alt="Nirav Patel" />
+            {{ image(url="https://events.canonical.com/user/2964/picture-2653677503",
+                    alt="Nirav Patel",
+                    width="165",
+                    hi_def=True,
+                    loading="lazy") | safe
+            }}
           </div>
           <a href="https://events.canonical.com/event/51/contributions/557/">
             <h3 class="p-heading--5">Nirav Patel</h3>
@@ -257,64 +308,100 @@
       <div class="p-logo-section has-misaligned-images">
         <div class="p-logo-section__items">
           <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/d86e845a-Canonical_logo_2023.svg"
-                 width="104"
-                 alt="Canonical" />
+            {{ image(url="https://assets.ubuntu.com/v1/d86e845a-Canonical_logo_2023.svg",
+                    alt="Canonical",
+                    width="104",
+                    hi_def=True,
+                    loading="lazy") | safe
+            }}
           </div>
           <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/477b9b52-microsoft-logo.svg"
-                 width="104"
-                 alt="Microsoft" />
+            {{ image(url="https://assets.ubuntu.com/v1/92c89bba-microsoft-logo.png",
+                    alt="Microsoft",
+                    width="104",
+                    hi_def=True,
+                    loading="lazy") | safe
+            }}
           </div>
           <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/df00697d-Thunderbird_2023_icon.png"
-                 width="104"
-                 alt="Thunderbird" />
+            {{ image(url="https://assets.ubuntu.com/v1/df00697d-Thunderbird_2023_icon.png",
+                    alt="Thunderbird",
+                    width="104",
+                    hi_def=True,
+                    loading="lazy") | safe
+            }}
           </div>
           <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/a3dd06e7-AsahiLinux_logo_darkbg.svg"
-                 width="104"
-                 alt="Asahi Linux" />
+            {{ image(url="https://assets.ubuntu.com/v1/647ef6e6-AsahiLinux_logo_darkbg.png",
+                    alt="Asahi Linux",
+                    width="104",
+                    hi_def=True,
+                    loading="lazy") | safe
+            }}
           </div>
           <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/7844834d-Intel_logo_2023.svg.png"
-                 width="104"
-                 alt="Intel" />
+            {{ image(url="https://assets.ubuntu.com/v1/7844834d-Intel_logo_2023.svg.png",
+                    alt="Intel",
+                    width="104",
+                    hi_def=True,
+                    loading="lazy") | safe
+            }}
           </div>
           <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/669623f8-UBports.png"
-                 width="104"
-                 alt="UBPorts" />
+            {{ image(url="https://assets.ubuntu.com/v1/669623f8-UBports.png",
+                    alt="UBPorts",
+                    width="104",
+                    hi_def=True,
+                    loading="lazy") | safe
+            }}
           </div>
           <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/7b309b98-system76.png"
-                 width="104"
-                 alt="System76" />
+            {{ image(url="https://assets.ubuntu.com/v1/7b309b98-system76.png",
+                    alt="System76",
+                    width="104",
+                    hi_def=True,
+                    loading="lazy") | safe
+            }}
           </div>
           <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/6bda45fc-Framework_Computer_logo.svg"
-                 width="104"
-                 alt="Framework" />
+            {{ image(url="https://assets.ubuntu.com/v1/e8c86767-Framework_Computer_logo.png",
+                    alt="Framework",
+                    width="104",
+                    hi_def=True,
+                    loading="lazy") | safe
+            }}
           </div>
           <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/c4ad31db-lutris.png"
-                 width="104"
-                 alt="Lutris" />
+            {{ image(url="https://assets.ubuntu.com/v1/c4ad31db-lutris.png",
+                    alt="Lutris",
+                    width="104",
+                    hi_def=True,
+                    loading="lazy") | safe
+            }}
           </div>
           <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/7dfd7dbe-Fairphone_logo.svg.png"
-                 width="104"
-                 alt="Fairphone" />
+            {{ image(url="https://assets.ubuntu.com/v1/7dfd7dbe-Fairphone_logo.svg.png",
+                    alt="Fairphone",
+                    width="104",
+                    hi_def=True,
+                    loading="lazy") | safe
+            }}
           </div>
           <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/11e66fc8-Opensearch_Logo.svg"
-                 width="104"
-                 alt="OpenSearch" />
+            {{ image(url="https://assets.ubuntu.com/v1/11e66fc8-Opensearch_Logo.svg",
+                    alt="OpenSearch",
+                    width="104",
+                    hi_def=True,
+                    loading="lazy") | safe
+            }}
           </div>
           <div class="p-logo-section__item">
-            <img src="https://assets.ubuntu.com/v1/ab8ba220-snapcrafters.png"
-                 width="104"
-                 alt="Snapcrafters" />
+            {{ image(url="https://assets.ubuntu.com/v1/ab8ba220-snapcrafters.png",
+                    alt="Snapcrafters",
+                    width="104",
+                    hi_def=True,
+                    loading="lazy") | safe
+            }}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Done

- Use [canonicalwebteam.image-template](https://github.com/canonical/canonicalwebteam.image-template) to optimise the images.
- Converted incompatible images from svg format to png. See https://github.com/canonical/canonicalwebteam.image-template/issues/4

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check if all images are rendering well and there are no bottlenecks.

## Issue / Card

Ref #14316 


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
