### PR TITLE
chore: add 24.10 edubuntu image on /desktop/flavours

### DIFF
--- a/templates/desktop/flavours.html
+++ b/templates/desktop/flavours.html
@@ -70,9 +70,9 @@
   </div>
   <div class="row">
     <div class="col-start-large-4 col-9">
-      {{ 
+      {{
         image (
-        url="https://assets.ubuntu.com/v1/ab7e24df-edubuntu-2404.png",
+        url="https://assets.ubuntu.com/v1/40f53f96-edubuntu-2410.png",
         alt="",
         width="2560",
         height="1440",
@@ -117,7 +117,7 @@
   </div>
   <div class="row">
     <div class="col-start-large-4 col-9">
-      {{ 
+      {{
         image (
         url="https://assets.ubuntu.com/v1/eced5d77-kubuntu-2404.png",
         alt="",
@@ -163,7 +163,7 @@
   </div>
   <div class="row">
     <div class="col-start-large-4 col-9">
-      {{ 
+      {{
         image (
         url="https://assets.ubuntu.com/v1/2b5ea6f3-lubuntu-24.04.png",
         alt="",
@@ -210,7 +210,7 @@
   </div>
   <div class="row">
     <div class="col-start-large-4 col-9">
-      {{ 
+      {{
         image (
         url="https://assets.ubuntu.com/v1/5fb92f07-ubuntu-budgie-2404.png",
         alt="",
@@ -256,7 +256,7 @@
   </div>
   <div class="row">
     <div class="col-start-large-4 col-9">
-      {{ 
+      {{
         image (
         url="https://assets.ubuntu.com/v1/0c3800a7-ubuntu-cinnamon-2404.png",
         alt="",
@@ -348,7 +348,7 @@
   </div>
   <div class="row">
     <div class="col-start-large-4 col-9">
-      {{ 
+      {{
         image (
         url="https://assets.ubuntu.com/v1/5a3f4e43-ubuntu-mate-24.04.png",
         alt="",
@@ -394,7 +394,7 @@
   </div>
   <div class="row">
     <div class="col-start-large-4 col-9">
-      {{ 
+      {{
         image (
         url="https://assets.ubuntu.com/v1/538a67c8-ubuntu-studio-2404.png",
         alt="",
@@ -414,7 +414,7 @@
     <div class="col">
       <div class="p-heading-icon">
         <div class="p-heading-icon__header">
-          {{ 
+          {{
             image (
             url="https://assets.ubuntu.com/v1/219d06b0-ubuntu-unity-logo.png",
             alt="",
@@ -440,7 +440,7 @@
   </div>
   <div class="row">
     <div class="col-start-large-4 col-9">
-      {{ 
+      {{
         image (
         url="https://assets.ubuntu.com/v1/56c2851e-ubuntu-unity-24.04.png",
         alt="",
@@ -486,7 +486,7 @@
   </div>
   <div class="row">
     <div class="col-start-large-4 col-9">
-      {{ 
+      {{
         image (
         url="https://assets.ubuntu.com/v1/cb61126a-xubuntu-24.04.png",
         alt="",


### PR DESCRIPTION
## Done
- added 24.10 edubuntu image on `/desktop/flavours`

## QA

- Go to https://ubuntu-com-14396.demos.haus/desktop/flavours 
- Check if the new 24.10 image from the [copy doc](https://docs.google.com/document/d/1M5nkigcSRzq1YVjiXOZkeU4EUCqT0uYBR3Y_sjxM-wM/edit) is updated

## Issue / Card

Fixes #https://warthogs.atlassian.net/browse/WD-14870
