### PR TITLE
Update speaker list section

### DIFF
--- a/templates/summit/index.html
+++ b/templates/summit/index.html
@@ -135,7 +135,7 @@
           <a href="https://events.canonical.com/event/51/contributions/510/">
             <h3 class="p-heading--5">Thomas Crider</h3>
           </a>
-          <p>Red Hat / Proton-GE</p>
+          <p>Proton-GE</p>
         </div>
       </div>
       <div class="col-2 p-card">
@@ -215,13 +215,13 @@
       <div class="col-2 p-card">
         <div class="p-card__content">
           <div class="p-card__image">
-            <img src="https://events.canonical.com/user/2898/picture-3390215267"
-                 alt="Vinodh Raghunathan" />
+            <img src="https://events.canonical.com/user/1645/picture-12244883"
+                 alt="Christian Holsing" />
           </div>
           <a href="https://events.canonical.com/event/51/contributions/588/">
-            <h3 class="p-heading--5">Vinodh Raghunathan</h3>
+            <h3 class="p-heading--5">Christian Holsing</h3>
           </a>
-          <p>Intel / OPEA</p>
+          <p>Intel</p>
         </div>
       </div>
       <div class="col-2 p-card">
@@ -239,8 +239,8 @@
     </div>
     <div class="row">
       <div class="col-12">
-        <a href="https://events.canonical.com/event/51/contributions/"
-           class="p-button">Full speaker list</a>
+        <a href="https://events.canonical.com/event/51/timetable/?layout=room#20241025.detailed"
+           class="p-button">Full timetable</a>
       </div>
     </div>
 

--- a/templates/summit/index.html
+++ b/templates/summit/index.html
@@ -54,7 +54,7 @@
         </p>
         <p>
           <a href="https://events.canonical.com/event/51/registrations/"
-             class="p-button--positive">Register for free</a>
+             class="p-button--positive">Join for free</a>
         </p>
       </div>
       <div class="col-4 u-vertically-center">
@@ -89,7 +89,7 @@
   <section class="p-section">
     <div class="row">
       <hr class="p-rule" />
-      <h2>Featured Speakers</h2>
+      <h2>Featured speakers</h2>
       <div class="col-2 p-card">
         <div class="p-card__content">
           <div class="p-card__image">


### PR DESCRIPTION
Update speaker list section with current session information and associated links.

## Done

- Updated multiple featured speaker affiliation, name, photo and associated links.
- Changed "Full speaker list" link to "Full timetable" now that it's published.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes # CT-1214

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
