### PR TITLE
chore: add desktop flavours images on /desktop/flavours

### DIFF
--- a/templates/desktop/flavours.html
+++ b/templates/desktop/flavours.html
@@ -1,536 +1,551 @@
 {% extends "download/_base_download.html" %}
 
 {% block title %}Ubuntu flavours{% endblock %}
-{% block meta_description %}Ubuntu flavours are different installations of Ubuntu - each with a choice of packages and applications included by default. Here you are able to choose and download the officially recognised flavour that would best suit your particular industry and unique needs.{% endblock %}
-{% block meta_copydoc %}https://docs.google.com/document/d/1M5nkigcSRzq1YVjiXOZkeU4EUCqT0uYBR3Y_sjxM-wM/edit{% endblock meta_copydoc %}
+
+{% block meta_description %}
+  Ubuntu flavours are different installations of Ubuntu - each with a choice of packages and applications included by default. Here you are able to choose and download the officially recognised flavour that would best suit your particular industry and unique needs.
+{% endblock %}
+
+{% block meta_copydoc %}
+  https://docs.google.com/document/d/1M5nkigcSRzq1YVjiXOZkeU4EUCqT0uYBR3Y_sjxM-wM/edit
+{% endblock meta_copydoc %}
 
 {% block body_class %}is-paper{% endblock %}
 
 {% block content %}
 
-<section class="p-strip--whitesuru is-shallow u-no-padding--bottom">
-  <div class="p-section--deep">
-    <div class="row">
-      <div class="col-start-large-4 col-9">
-        <div class="row">
-          <div class="col-medium-3">
-            <h1>Ubuntu flavours</h1>
-          </div>
-          <div class="col-medium-3">
-            <div class="p-section--shallow">
-              <p class="p-heading--2">What are Ubuntu flavours?</p>
-              <p>Ubuntu flavours offer a unique way to experience Ubuntu, each with their own choice of default applications and settings. Ubuntu flavours are owned and developed by members of our global community and backed by the full Ubuntu archive for packages and updates.</p>
+  <section class="p-strip--whitesuru is-shallow u-no-padding--bottom">
+    <div class="p-section--deep">
+      <div class="row">
+        <div class="col-start-large-4 col-9">
+          <div class="row">
+            <div class="col-medium-3">
+              <h1>Ubuntu flavours</h1>
             </div>
-            {{
-              image (
-                url="https://assets.ubuntu.com/v1/8527100a-ubuntu-flavours-23.png",
-                alt="",
-                width="518",
-                height="173",
-                hi_def=True,
-                loading="auto",
-                ) | safe
+            <div class="col-medium-3">
+              <div class="p-section--shallow">
+                <p class="p-heading--2">What are Ubuntu flavours?</p>
+                <p>
+                  Ubuntu flavours offer a unique way to experience Ubuntu, each with their own choice of default applications and settings. Ubuntu flavours are owned and developed by members of our global community and backed by the full Ubuntu archive for packages and updates.
+                </p>
+              </div>
+              {{ image(url="https://assets.ubuntu.com/v1/8527100a-ubuntu-flavours-23.png",
+                            alt="",
+                            width="518",
+                            height="173",
+                            hi_def=True,
+                            loading="auto",) | safe
               }}
             </div>
+          </div>
         </div>
       </div>
     </div>
-  </div>
-</section>
+  </section>
 
-<section class="p-section">
-  <div class="row--50-50">
-    <hr class="p-rule" />
-    <div class="col">
-      <div class="p-heading-icon">
-        <div class="p-heading-icon__header">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/a2f090ef-edubuntu-logo.svg",
-              alt="",
-              height="64",
-              width="64",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-heading-icon__img u-image-separation"},
-            ) | safe
-          }}
-          <h2 class="p-heading-icon__title">Edubuntu</h2>
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <div class="p-heading-icon">
+          <div class="p-heading-icon__header">
+            {{ image(url="https://assets.ubuntu.com/v1/a2f090ef-edubuntu-logo.svg",
+                        alt="",
+                        height="64",
+                        width="64",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-heading-icon__img u-image-separation"},) | safe
+            }}
+            <h2 class="p-heading-icon__title">Edubuntu</h2>
+          </div>
         </div>
       </div>
+      <div class="col">
+        <p>
+          Edubuntu is an official flavour of Ubuntu crafted for use in the education world. Teachers and students will have access to a huge ecosystem of learning software and educational tools built on a familiar and usable desktop. Edubuntu provides a fast, stable, secure and privacy conscious option for schools and universities.
+        </p>
+        <a href="https://edubuntu.org/" class="p-button--positive">Get Edubuntu</a>
+        <ul class="p-list--divided">
+          <li class="p-list__item">
+            <a href="https://ubuntuforums.org/forumdisplay.php?f=329&pp=20&prefixid=edubuntu">Join the Edubuntu community&nbsp;&rsaquo;</a>
+          </li>
+          <li class="p-list__item">
+            <a href="https://twitter.com/edubuntuproject">Follow Edubuntu&nbsp;&rsaquo;</a>
+          </li>
+        </ul>
+      </div>
     </div>
-    <div class="col">
-      <p>Edubuntu is an official flavour of Ubuntu crafted for use in the education world. Teachers and students will have access to a huge ecosystem of learning software and educational tools built on a familiar and usable desktop. Edubuntu provides a fast, stable, secure and privacy conscious option for schools and universities.</p>
-      <a href="https://edubuntu.org/" class="p-button--positive">Get Edubuntu</a>
-      <ul class="p-list--divided">
-        <li class="p-list__item"><a href="https://ubuntuforums.org/forumdisplay.php?f=329&pp=20&prefixid=edubuntu">Join the Edubuntu community&nbsp;&rsaquo;</a></li>
-        <li class="p-list__item"><a href="https://twitter.com/edubuntuproject">Follow Edubuntu&nbsp;&rsaquo;</a></li>
-      </ul>
+    <div class="row">
+      <div class="col-start-large-4 col-9">
+        {{ image(url="https://assets.ubuntu.com/v1/40f53f96-edubuntu-2410.png",
+                alt="",
+                width="2560",
+                height="1440",
+                hi_def=True,
+                loading="lazy") | safe
+        }}
+      </div>
     </div>
-  </div>
-  <div class="row">
-    <div class="col-start-large-4 col-9">
-      {{
-        image (
-        url="https://assets.ubuntu.com/v1/40f53f96-edubuntu-2410.png",
-        alt="",
-        width="2560",
-        height="1440",
-        hi_def=True,
-        loading="lazy"
-        ) | safe
-      }}
-    </div>
-  </div>
-</section>
+  </section>
 
-<section class="p-section">
-  <div class="row--50-50">
-    <hr class="p-rule" />
-    <div class="col">
-      <div class="p-heading-icon">
-        <div class="p-heading-icon__header">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/267e8693-Kubuntu_logo.svg",
-              alt="",
-              height="64",
-              width="64",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-heading-icon__img u-image-separation"},
-            ) | safe
-          }}
-          <h2 class="p-heading-icon__title">Kubuntu</h2>
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <div class="p-heading-icon">
+          <div class="p-heading-icon__header">
+            {{ image(url="https://assets.ubuntu.com/v1/267e8693-Kubuntu_logo.svg",
+                        alt="",
+                        height="64",
+                        width="64",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-heading-icon__img u-image-separation"},) | safe
+            }}
+            <h2 class="p-heading-icon__title">Kubuntu</h2>
+          </div>
         </div>
       </div>
+      <div class="col">
+        <p>
+          Kubuntu unites Ubuntu with KDE and the Plasma desktop, bringing you a full set of applications including productivity, office, email, graphics, photography, and music applications ready to use at startup with extensive additional software installed from not one, but two desktop package managers.
+        </p>
+        <p>
+          Built using the Qt toolkit, Kubuntu is fast, slick and beautiful. Kubuntu is mobile-ready, enabling easy integration between your PC desktop and phone or tablet with KDE Connect.
+        </p>
+        <a href="https://kubuntu.org/getkubuntu/" class="p-button--positive">Get Kubuntu</a>
+        <ul class="p-list--divided">
+          <li class="p-list__item">
+            <a href="https://www.kubuntuforums.net/forum">Join the Kubuntu community&nbsp;&rsaquo;</a>
+          </li>
+          <li class="p-list__item">
+            <a href="https://twitter.com/kubuntu">Follow Kubuntu&nbsp;&rsaquo;</a>
+          </li>
+        </ul>
+      </div>
     </div>
-    <div class="col">
-      <p>Kubuntu unites Ubuntu with KDE and the Plasma desktop, bringing you a full set of applications including productivity, office, email, graphics, photography, and music applications ready to use at startup with extensive additional software installed from not one, but two desktop package managers. </p>
-      <p>Built using the Qt toolkit, Kubuntu is fast, slick and beautiful. Kubuntu is mobile-ready, enabling easy integration between your PC desktop and phone or tablet with KDE Connect.</p>
-      <a href="https://kubuntu.org/getkubuntu/" class="p-button--positive">Get Kubuntu</a>
-      <ul class="p-list--divided">
-        <li class="p-list__item"><a href="https://www.kubuntuforums.net/forum">Join the Kubuntu community&nbsp;&rsaquo;</a></li>
-        <li class="p-list__item"><a href="https://twitter.com/kubuntu">Follow Kubuntu&nbsp;&rsaquo;</a></li>
-      </ul>
+    <div class="row">
+      <div class="col-start-large-4 col-9">
+        {{ image(url="https://assets.ubuntu.com/v1/ad62f263-kubuntu-2410.png",
+                alt="",
+                width="2560",
+                height="1440",
+                hi_def=True,
+                loading="lazy") | safe
+        }}
+      </div>
     </div>
-  </div>
-  <div class="row">
-    <div class="col-start-large-4 col-9">
-      {{
-        image (
-        url="https://assets.ubuntu.com/v1/ad62f263-kubuntu-2410.png",
-        alt="",
-        width="2560",
-        height="1440",
-        hi_def=True,
-        loading="lazy"
-        ) | safe
-      }}
-    </div>
-  </div>
-</section>
+  </section>
 
-<section class="p-section">
-  <div class="row--50-50">
-    <hr class="p-rule" />
-    <div class="col">
-      <div class="p-heading-icon">
-        <div class="p-heading-icon__header">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/6ac4ba34-lubuntu-logo.svg",
-              alt="",
-              height="64",
-              width="64",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-heading-icon__img u-image-separation"},
-            ) | safe
-          }}
-          <h2 class="p-heading-icon__title">Lubuntu</h2>
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <div class="p-heading-icon">
+          <div class="p-heading-icon__header">
+            {{ image(url="https://assets.ubuntu.com/v1/6ac4ba34-lubuntu-logo.svg",
+                        alt="",
+                        height="64",
+                        width="64",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-heading-icon__img u-image-separation"},) | safe
+            }}
+            <h2 class="p-heading-icon__title">Lubuntu</h2>
+          </div>
         </div>
       </div>
+      <div class="col">
+        <p>
+          Lubuntu is designed to be a simple, easy to use system that is light, fast and modern. Lubuntu provides the LXQt desktop environment which is focused on Qt technologies. Lubuntu comes with the essential applications and services needed to browse the Internet, chat, play and be productive.
+        </p>
+        <a href="https://lubuntu.me" class="p-button--positive">Get Lubuntu</a>
+        <ul class="p-list--divided">
+          <li class="p-list__item">
+            <a href="https://discourse.lubuntu.me">Join the Lubuntu community&nbsp;&rsaquo;</a>
+          </li>
+          <li class="p-list__item">
+            <a href="https://twitter.com/lubuntuofficial">Follow Lubuntu&nbsp;&rsaquo;</a>
+          </li>
+        </ul>
+      </div>
     </div>
-    <div class="col">
-      <p>Lubuntu is designed to be a simple, easy to use system that is light, fast and modern. Lubuntu provides the LXQt desktop environment which is focused on Qt technologies. Lubuntu comes with the essential applications and services needed to browse the Internet, chat, play and be productive.</p>
-      <a href="https://lubuntu.me" class="p-button--positive">Get Lubuntu</a>
-      <ul class="p-list--divided">
-        <li class="p-list__item"><a href="https://discourse.lubuntu.me">Join the Lubuntu community&nbsp;&rsaquo;</a></li>
-        <li class="p-list__item"><a href="https://twitter.com/lubuntuofficial">Follow Lubuntu&nbsp;&rsaquo;</a></li>
-      </ul>
+    <div class="row">
+      <div class="col-start-large-4 col-9">
+        {{ image(url="https://assets.ubuntu.com/v1/f614a439-lubuntu-2410.png",
+                alt="",
+                width="1920",
+                height="1080",
+                hi_def=True,
+                loading="lazy") | safe
+        }}
+      </div>
     </div>
-  </div>
-  <div class="row">
-    <div class="col-start-large-4 col-9">
-      {{
-        image (
-        url="https://assets.ubuntu.com/v1/f614a439-lubuntu-2410.png",
-        alt="",
-        width="1920",
-        height="1080",
-        hi_def=True,
-        loading="lazy"
-        ) | safe
-      }}
-    </div>
-  </div>
-</section>
+  </section>
 
-<section class="p-section">
-  <div class="row--50-50">
-    <hr class="p-rule" />
-    <div class="col">
-      <div class="p-heading-icon">
-        <div class="p-heading-icon__header">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/49e647f4-budgie-remix-logo-medium.svg",
-              alt="",
-              height="64",
-              width="64",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-heading-icon__img u-image-separation"},
-            ) | safe
-          }}
-          <h2 class="p-heading-icon__title">Ubuntu Budgie</h2>
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <div class="p-heading-icon">
+          <div class="p-heading-icon__header">
+            {{ image(url="https://assets.ubuntu.com/v1/49e647f4-budgie-remix-logo-medium.svg",
+                        alt="",
+                        height="64",
+                        width="64",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-heading-icon__img u-image-separation"},) | safe
+            }}
+            <h2 class="p-heading-icon__title">Ubuntu Budgie</h2>
+          </div>
         </div>
       </div>
+      <div class="col">
+        <p>
+          Ubuntu Budgie is a proud official Ubuntu flavour. We combine the simplicity and elegance of the Budgie desktop environment with the power and familiarity of an Ubuntu based operative system.
+        </p>
+        <p>The result is a modern and fast desktop distribution with great defaults, yet fully customisable.</p>
+        <a href="https://ubuntubudgie.org/downloads/" class="p-button--positive">Get Ubuntu Budgie</a>
+        <ul class="p-list--divided">
+          <li class="p-list__item">
+            <a href="https://discourse.ubuntubudgie.org/">Join the Ubuntu Budgie community&nbsp;&rsaquo;</a>
+          </li>
+          <li class="p-list__item">
+            <a href="https://twitter.com/ubuntubudgie">Follow Ubuntu Budgie&nbsp;&rsaquo;</a>
+          </li>
+        </ul>
+      </div>
     </div>
-    <div class="col">
-      <p>Ubuntu Budgie is a proud official Ubuntu flavour. We combine the simplicity and elegance of the Budgie desktop environment with the power and familiarity of an Ubuntu based operative system.</p>
-      <p>The result is a modern and fast desktop distribution with great defaults, yet fully customisable.</p>
-      <a href="https://ubuntubudgie.org/downloads/" class="p-button--positive">Get Ubuntu Budgie</a>
-      <ul class="p-list--divided">
-        <li class="p-list__item"><a href="https://discourse.ubuntubudgie.org/">Join the Ubuntu Budgie community&nbsp;&rsaquo;</a></li>
-        <li class="p-list__item"><a href="https://twitter.com/ubuntubudgie">Follow Ubuntu Budgie&nbsp;&rsaquo;</a></li>
-      </ul>
+    <div class="row">
+      <div class="col-start-large-4 col-9">
+        {{ image(url="https://assets.ubuntu.com/v1/d4ea8bb8-ubuntu-budgie-2410.png",
+                alt="",
+                width="1920",
+                height="1080",
+                hi_def=True,
+                loading="lazy") | safe
+        }}
+      </div>
     </div>
-  </div>
-  <div class="row">
-    <div class="col-start-large-4 col-9">
-      {{
-        image (
-        url="https://assets.ubuntu.com/v1/d4ea8bb8-ubuntu-budgie-2410.png",
-        alt="",
-        width="1920",
-        height="1080",
-        hi_def=True,
-        loading="lazy"
-        ) | safe
-      }}
-    </div>
-  </div>
-</section>
+  </section>
 
-<section class="p-section">
-  <div class="row--50-50">
-    <hr class="p-rule" />
-    <div class="col">
-      <div class="p-heading-icon">
-        <div class="p-heading-icon__header">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/504cc54e-ubuntu-cinnamon-logo.svg",
-              alt="",
-              height="64",
-              width="64",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-heading-icon__img u-image-separation"},
-            ) | safe
-          }}
-          <h2 class="p-heading-icon__title">Ubuntu Cinnamon</h2>
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <div class="p-heading-icon">
+          <div class="p-heading-icon__header">
+            {{ image(url="https://assets.ubuntu.com/v1/504cc54e-ubuntu-cinnamon-logo.svg",
+                        alt="",
+                        height="64",
+                        width="64",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-heading-icon__img u-image-separation"},) | safe
+            }}
+            <h2 class="p-heading-icon__title">Ubuntu Cinnamon</h2>
+          </div>
         </div>
       </div>
+      <div class="col">
+        <p>
+          Ubuntu Cinnamon combines Ubuntu with the Cinnamon desktop, built upon GNOME 2 to provide a traditionally modern experience. It is made for all home users alike, with intuitive software, and a simpler, customisable desktop suited with many personalization options and addons for some extra spice.
+        </p>
+        <a href="https://ubuntucinnamon.org/" class="p-button--positive">Get Ubuntu Cinnamon</a>
+        <ul class="p-list--divided">
+          <li class="p-list__item">
+            <a href="https://t.me/ubuntucinnamon">Join the Ubuntu Cinnamon community&nbsp;&rsaquo;</a>
+          </li>
+          <li class="p-list__item">
+            <a href="https://twitter.com/UbuntuCinnamon">Follow Ubuntu Cinnamon&nbsp;&rsaquo;</a>
+          </li>
+        </ul>
+      </div>
     </div>
-    <div class="col">
-      <p>Ubuntu Cinnamon combines Ubuntu with the Cinnamon desktop, built upon GNOME 2 to provide a traditionally modern experience. It is made for all home users alike, with intuitive software, and a simpler, customisable desktop suited with many personalization options and addons for some extra spice.</p>
-      <a href="https://ubuntucinnamon.org/" class="p-button--positive">Get Ubuntu Cinnamon</a>
-      <ul class="p-list--divided">
-        <li class="p-list__item"><a href="https://t.me/ubuntucinnamon">Join the Ubuntu Cinnamon community&nbsp;&rsaquo;</a></li>
-        <li class="p-list__item"><a href="https://twitter.com/UbuntuCinnamon">Follow Ubuntu Cinnamon&nbsp;&rsaquo;</a></li>
-      </ul>
+    <div class="row">
+      <div class="col-start-large-4 col-9">
+        {{ image(url="https://assets.ubuntu.com/v1/af09e2c4-ubuntu-cinnamon-2410.png",
+                alt="",
+                width="1920",
+                height="1080",
+                hi_def=True,
+                loading="lazy") | safe
+        }}
+      </div>
     </div>
-  </div>
-  <div class="row">
-    <div class="col-start-large-4 col-9">
-      {{
-        image (
-        url="https://assets.ubuntu.com/v1/af09e2c4-ubuntu-cinnamon-2410.png",
-        alt="",
-        width="1920",
-        height="1080",
-        hi_def=True,
-        loading="lazy"
-        ) | safe
-      }}
-    </div>
-  </div>
-</section>
+  </section>
 
-<section class="p-section">
-  <div class="row--50-50">
-    <hr class="p-rule" />
-    <div class="col">
-      <div class="p-heading-icon">
-        <div class="p-heading-icon__header">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/a9914e3f-ubuntu-kylin.svg",
-              alt="",
-              height="64",
-              width="64",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-heading-icon__img u-image-separation"},
-            ) | safe
-          }}
-          <h2 class="p-heading-icon__title">Ubuntu Kylin</h2>
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <div class="p-heading-icon">
+          <div class="p-heading-icon__header">
+            {{ image(url="https://assets.ubuntu.com/v1/a9914e3f-ubuntu-kylin.svg",
+                        alt="",
+                        height="64",
+                        width="64",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-heading-icon__img u-image-separation"},) | safe
+            }}
+            <h2 class="p-heading-icon__title">Ubuntu Kylin</h2>
+          </div>
         </div>
       </div>
+      <div class="col">
+        <p>
+          The Ubuntu Kylin project is tuned to the needs of Chinese users, providing a thoughtful and elegant experience out-of-the-box. The lightweight Ubuntu Kylin User Interface (UKUI) is perfect for older machines, and an ideal introduction to Linux for first-time users.
+        </p>
+        <a href="https://www.ubuntukylin.com/downloads/download-en.html" class="p-button--positive">Get Ubuntu Kylin</a>
+        <ul class="p-list--divided">
+          <li class="p-list__item">
+            <a href="https://www.ubuntukylin.com/community/community-en.html">Join the Ubuntu Kylin community&nbsp;&rsaquo;</a>
+          </li>
+          <li class="p-list__item">
+            <a href="https://twitter.com/Ubuntu_Kylin">Follow Ubuntu Kylin&nbsp;&rsaquo;</a>
+          </li>
+        </ul>
+      </div>
     </div>
-    <div class="col">
-      <p>The Ubuntu Kylin project is tuned to the needs of Chinese users, providing a thoughtful and elegant experience out-of-the-box. The lightweight Ubuntu Kylin User Interface (UKUI) is perfect for older machines, and an ideal introduction to Linux for first-time users.</p>
-      <a href="https://www.ubuntukylin.com/downloads/download-en.html" class="p-button--positive">Get Ubuntu Kylin</a>
-      <ul class="p-list--divided">
-        <li class="p-list__item"><a href="https://www.ubuntukylin.com/community/community-en.html">Join the Ubuntu Kylin community&nbsp;&rsaquo;</a></li>
-        <li class="p-list__item"><a href="https://twitter.com/Ubuntu_Kylin">Follow Ubuntu Kylin&nbsp;&rsaquo;</a></li>
-      </ul>
+    <div class="row">
+      <div class="col-start-large-4 col-9">
+        {{ image(url="https://assets.ubuntu.com/v1/34284c9d-ubuntu-kylin-2410.png",
+                alt="",
+                width="1360",
+                height="768",
+                hi_def=True,
+                loading="lazy") | safe
+        }}
+      </div>
     </div>
-  </div>
-  <div class="row">
-    <div class="col-start-large-4 col-9">
-      {{
-        image (
-        url="https://assets.ubuntu.com/v1/34284c9d-ubuntu-kylin-2410.png",
-        alt="",
-        width="1360",
-        height="768",
-        hi_def=True,
-        loading="lazy"
-        ) | safe
-      }}
-    </div>
-  </div>
-</section>
+  </section>
 
-<section class="p-section">
-  <div class="row--50-50">
-    <hr class="p-rule" />
-    <div class="col">
-      <div class="p-heading-icon">
-        <div class="p-heading-icon__header">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/b89d0c93-mate.svg",
-              alt="",
-              height="64",
-              width="64",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-heading-icon__img u-image-separation"},
-            ) | safe
-          }}
-          <h2 class="p-heading-icon__title">Ubuntu MATE</h2>
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <div class="p-heading-icon">
+          <div class="p-heading-icon__header">
+            {{ image(url="https://assets.ubuntu.com/v1/b89d0c93-mate.svg",
+                        alt="",
+                        height="64",
+                        width="64",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-heading-icon__img u-image-separation"},) | safe
+            }}
+            <h2 class="p-heading-icon__title">Ubuntu MATE</h2>
+          </div>
         </div>
       </div>
+      <div class="col">
+        <p>
+          Ubuntu MATE is a stable, easy-to-use operating system with a configurable desktop environment. It is ideal for those who want the most out of their computers and prefer a traditional desktop metaphor. With modest hardware requirements it is suitable for modern workstations, single board computers and older hardware alike. Ubuntu MATE makes modern computers fast and old computers usable.
+        </p>
+        <a href="https://ubuntu-mate.org/" class="p-button--positive">Get Ubuntu MATE</a>
+        <ul class="p-list--divided">
+          <li class="p-list__item">
+            <a href="https://ubuntu-mate.community">Join the Ubuntu MATE community&nbsp;&rsaquo;</a>
+          </li>
+          <li class="p-list__item">
+            <a href="https://twitter.com/ubuntu_mate">Follow Ubuntu MATE&nbsp;&rsaquo;</a>
+          </li>
+        </ul>
+      </div>
     </div>
-    <div class="col">
-      <p>Ubuntu MATE is a stable, easy-to-use operating system with a configurable desktop environment. It is ideal for those who want the most out of their computers and prefer a traditional desktop metaphor. With modest hardware requirements it is suitable for modern workstations, single board computers and older hardware alike. Ubuntu MATE makes modern computers fast and old computers usable.</p>
-      <a href="https://ubuntu-mate.org/" class="p-button--positive">Get Ubuntu MATE</a>
-      <ul class="p-list--divided">
-        <li class="p-list__item"><a href="https://ubuntu-mate.community">Join the Ubuntu MATE community&nbsp;&rsaquo;</a></li>
-        <li class="p-list__item"><a href="https://twitter.com/ubuntu_mate">Follow Ubuntu MATE&nbsp;&rsaquo;</a></li>
-      </ul>
+    <div class="row">
+      <div class="col-start-large-4 col-9">
+        {{ image(url="https://assets.ubuntu.com/v1/6dd459ba-ubuntu-mate-2410.png",
+                alt="",
+                width="1664",
+                height="936",
+                hi_def=True,
+                loading="lazy") | safe
+        }}
+      </div>
     </div>
-  </div>
-  <div class="row">
-    <div class="col-start-large-4 col-9">
-      {{
-        image (
-        url="https://assets.ubuntu.com/v1/6dd459ba-ubuntu-mate-2410.png",
-        alt="",
-        width="1664",
-        height="936",
-        hi_def=True,
-        loading="lazy"
-        ) | safe
-      }}
-    </div>
-  </div>
-</section>
+  </section>
 
-<section class="p-section">
-  <div class="row--50-50">
-    <hr class="p-rule" />
-    <div class="col">
-      <div class="p-heading-icon">
-        <div class="p-heading-icon__header">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/4a512076-ubuntustudio.svg",
-              alt="",
-              height="64",
-              width="64",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-heading-icon__img u-image-separation"},
-            ) | safe
-          }}
-          <h2 class="p-heading-icon__title">Ubuntu Studio</h2>
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <div class="p-heading-icon">
+          <div class="p-heading-icon__header">
+            {{ image(url="https://assets.ubuntu.com/v1/4a512076-ubuntustudio.svg",
+                        alt="",
+                        height="64",
+                        width="64",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-heading-icon__img u-image-separation"},) | safe
+            }}
+            <h2 class="p-heading-icon__title">Ubuntu Studio</h2>
+          </div>
         </div>
       </div>
+      <div class="col">
+        <p>
+          Ubuntu Studio is pre-configured for content creation of all kinds. Whether you're an audio engineer, musician, graphic designer, photographer, video producer, or streamer, this is a full-fledged desktop computing system that will fit your needs. If you can dream it, you can create it with Ubuntu Studio.
+        </p>
+        <a href="https://ubuntustudio.org/" class="p-button--positive">Get Ubuntu Studio</a>
+        <ul class="p-list--divided">
+          <li class="p-list__item">
+            <a href="https://ubuntustudio.org/community/">Join the Ubuntu Studio community&nbsp;&rsaquo;</a>
+          </li>
+          <li class="p-list__item">
+            <a href="https://twitter.com/ubuntustudio">Follow Ubuntu Studio&nbsp;&rsaquo;</a>
+          </li>
+        </ul>
+      </div>
     </div>
-    <div class="col">
-      <p>Ubuntu Studio is pre-configured for content creation of all kinds. Whether you're an audio engineer, musician, graphic designer, photographer, video producer, or streamer, this is a full-fledged desktop computing system that will fit your needs. If you can dream it, you can create it with Ubuntu Studio.</p>
-      <a href="https://ubuntustudio.org/" class="p-button--positive">Get Ubuntu Studio</a>
-      <ul class="p-list--divided">
-        <li class="p-list__item"><a href="https://ubuntustudio.org/community/">Join the Ubuntu Studio community&nbsp;&rsaquo;</a></li>
-        <li class="p-list__item"><a href="https://twitter.com/ubuntustudio">Follow Ubuntu Studio&nbsp;&rsaquo;</a></li>
-      </ul>
+    <div class="row">
+      <div class="col-start-large-4 col-9">
+        {{ image(url="https://assets.ubuntu.com/v1/bf9a44c0-ubuntu-studio-2410.png",
+                alt="",
+                width="1920",
+                height="1080",
+                hi_def=True,
+                loading="lazy") | safe
+        }}
+      </div>
     </div>
-  </div>
-  <div class="row">
-    <div class="col-start-large-4 col-9">
-      {{
-        image (
-        url="https://assets.ubuntu.com/v1/bf9a44c0-ubuntu-studio-2410.png",
-        alt="",
-        width="1920",
-        height="1080",
-        hi_def=True,
-        loading="lazy"
-        ) | safe
-      }}
-    </div>
-  </div>
-</section>
+  </section>
 
-<section class="p-section">
-  <div class="row--50-50">
-    <hr class="p-rule" />
-    <div class="col">
-      <div class="p-heading-icon">
-        <div class="p-heading-icon__header">
-          {{
-            image (
-            url="https://assets.ubuntu.com/v1/219d06b0-ubuntu-unity-logo.png",
-            alt="",
-            width="64",
-            height="64",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-heading-icon__img u-image-separation"},
-            ) | safe
-          }}
-          <h2 class="p-heading-icon__title">Ubuntu Unity</h2>
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <div class="p-heading-icon">
+          <div class="p-heading-icon__header">
+            {{ image(url="https://assets.ubuntu.com/v1/219d06b0-ubuntu-unity-logo.png",
+                        alt="",
+                        width="64",
+                        height="64",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-heading-icon__img u-image-separation"},) | safe
+            }}
+            <h2 class="p-heading-icon__title">Ubuntu Unity</h2>
+          </div>
         </div>
       </div>
+      <div class="col">
+        <p>
+          Bringing the best of Ubuntu and Unity together, Ubuntu Unity is a beautiful, slick and lightweight Ubuntu flavour. With its beautiful design, efficient and elegant workflow, and features like the heads-up display (HUD), the Global Menu, powerful search and a high level of customizability (using the Unity Tweak Tool), you'll be able to work with an unparalleled level of efficiency. You can also choose from a wide range of window animations and effects available in Compiz.
+        </p>
+        <a href="https://ubuntuunity.org" class="p-button--positive">Get Ubuntu Unity</a>
+        <ul class="p-list--divided">
+          <li class="p-list__item">
+            <a href="https://discourse.ruds.io/c/ubuntu-unity/5">Join the Ubuntu Unity community&nbsp;&rsaquo;</a>
+          </li>
+          <li class="p-list__item">
+            <a href="https://twitter.com/ubuntu_unity">Follow Ubuntu Unity&nbsp;&rsaquo;</a>
+          </li>
+        </ul>
+      </div>
     </div>
-    <div class="col">
-      <p>Bringing the best of Ubuntu and Unity together, Ubuntu Unity is a beautiful, slick and lightweight Ubuntu flavour. With its beautiful design, efficient and elegant workflow, and features like the heads-up display (HUD), the Global Menu, powerful search and a high level of customizability (using the Unity Tweak Tool), you'll be able to work with an unparalleled level of efficiency. You can also choose from a wide range of window animations and effects available in Compiz.</p>
-      <a href="https://ubuntuunity.org" class="p-button--positive">Get Ubuntu Unity</a>
-      <ul class="p-list--divided">
-        <li class="p-list__item"><a href="https://discourse.ruds.io/c/ubuntu-unity/5">Join the Ubuntu Unity community&nbsp;&rsaquo;</a></li>
-        <li class="p-list__item"><a href="https://twitter.com/ubuntu_unity">Follow Ubuntu Unity&nbsp;&rsaquo;</a></li>
-      </ul>
+    <div class="row">
+      <div class="col-start-large-4 col-9">
+        {{ image(url="https://assets.ubuntu.com/v1/5cfb071c-ubuntu-unity-2410.png",
+                alt="",
+                width="1920",
+                height="1080",
+                hi_def=True,
+                loading="lazy") | safe
+        }}
+      </div>
     </div>
-  </div>
-  <div class="row">
-    <div class="col-start-large-4 col-9">
-      {{
-        image (
-        url="https://assets.ubuntu.com/v1/5cfb071c-ubuntu-unity-2410.png",
-        alt="",
-        width="1920",
-        height="1080",
-        hi_def=True,
-        loading="lazy"
-        ) | safe
-      }}
-    </div>
-  </div>
-</section>
+  </section>
 
-<section class="p-section">
-  <div class="row--50-50">
-    <hr class="p-rule" />
-    <div class="col">
-      <div class="p-heading-icon">
-        <div class="p-heading-icon__header">
-          {{
-            image(
-              url="https://assets.ubuntu.com/v1/36e8f12b-Xubuntu_logo.svg",
-              alt="",
-              height="64",
-              width="64",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-heading-icon__img u-image-separation"},
-            ) | safe
-          }}
-          <h2 class="p-heading-icon__title">Xubuntu</h2>
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <div class="p-heading-icon">
+          <div class="p-heading-icon__header">
+            {{ image(url="https://assets.ubuntu.com/v1/36e8f12b-Xubuntu_logo.svg",
+                        alt="",
+                        height="64",
+                        width="64",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-heading-icon__img u-image-separation"},) | safe
+            }}
+            <h2 class="p-heading-icon__title">Xubuntu</h2>
+          </div>
         </div>
       </div>
+      <div class="col">
+        <p>
+          Xubuntu comes with Xfce, which is a stable, light and configurable desktop environment with a lot of consideration for usability. Whether you have a high-end computer or even a moderately older machine, Xubuntu is able to provide you with a smooth and usable desktop experience. Xubuntu has an expansive list of customization options so you can make the desktop your own.
+        </p>
+        <a href="https://xubuntu.org/" class="p-button--positive">Get Xubuntu</a>
+        <ul class="p-list--divided">
+          <li class="p-list__item">
+            <a href="https://ubuntuforums.org/forumdisplay.php?f=329&pp=20&prefixid=xubuntu">Join the Xubuntu community&nbsp;&rsaquo;</a>
+          </li>
+          <li class="p-list__item">
+            <a href="https://twitter.com/xubuntu">Follow Xubuntu&nbsp;&rsaquo;</a>
+          </li>
+        </ul>
+      </div>
     </div>
-    <div class="col">
-      <p>Xubuntu comes with Xfce, which is a stable, light and configurable desktop environment with a lot of consideration for usability. Whether you have a high-end computer or even a moderately older machine, Xubuntu is able to provide you with a smooth and usable desktop experience. Xubuntu has an expansive list of customization options so you can make the desktop your own.</p>
-      <a href="https://xubuntu.org/" class="p-button--positive">Get Xubuntu</a>
-      <ul class="p-list--divided">
-        <li class="p-list__item"><a href="https://ubuntuforums.org/forumdisplay.php?f=329&pp=20&prefixid=xubuntu">Join the Xubuntu community&nbsp;&rsaquo;</a></li>
-        <li class="p-list__item"><a href="https://twitter.com/xubuntu">Follow Xubuntu&nbsp;&rsaquo;</a></li>
-      </ul>
+    <div class="row">
+      <div class="col-start-large-4 col-9">
+        {{ image(url="https://assets.ubuntu.com/v1/2415943d-xubuntu-2410.png",
+                alt="",
+                width="1920",
+                height="1080",
+                hi_def=True,
+                loading="lazy") | safe
+        }}
+      </div>
     </div>
-  </div>
-  <div class="row">
-    <div class="col-start-large-4 col-9">
-      {{
-        image (
-        url="https://assets.ubuntu.com/v1/2415943d-xubuntu-2410.png",
-        alt="",
-        width="1920",
-        height="1080",
-        hi_def=True,
-        loading="lazy"
-        ) | safe
-      }}
-    </div>
-  </div>
-</section>
+  </section>
 
-<section class="p-section">
-  <div class="u-fixed-width p-section--shallow">
-    <hr class="p-rule" />
-    <h2>More ways to experience Ubuntu</h2>
-  </div>
-  <div class="row">
-    <div class="col-start-large-4 col-9 col-medium-5 col-start-medium-2">
-      <hr class="p-rule"/>
-      <div class="row p-section--shallow">
-        <div class="col-3 col-medium-2">
-          <h3 class="p-heading--5">Ubuntu-based variants</h3>
+  <section class="p-section">
+    <div class="u-fixed-width p-section--shallow">
+      <hr class="p-rule" />
+      <h2>More ways to experience Ubuntu</h2>
+    </div>
+    <div class="row">
+      <div class="col-start-large-4 col-9 col-medium-5 col-start-medium-2">
+        <hr class="p-rule" />
+        <div class="row p-section--shallow">
+          <div class="col-3 col-medium-2">
+            <h3 class="p-heading--5">Ubuntu-based variants</h3>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              In addition to the officially recognised flavours, dozens of other Linux distributions take Ubuntu as a base for their own distinctive ideas and approaches.
+            </p>
+            <p>
+              A complete list of known flavours, editions and customizations is maintained on the <a href="https://wiki.ubuntu.com/UbuntuFlavors">Ubuntu Wiki's UbuntuFlavors page&nbsp;&rsaquo;</a>
+            </p>
+          </div>
         </div>
-        <div class="col-6 col-medium-3">
-          <p>In addition to the officially recognised flavours, dozens of other Linux distributions take Ubuntu as a base for their own distinctive ideas and approaches.</p>
-          <p>A complete list of known flavours, editions and customizations is maintained on the <a href="https://wiki.ubuntu.com/UbuntuFlavors">Ubuntu Wiki's UbuntuFlavors page&nbsp;&rsaquo;</a></p>
-        </div>
-      </div>
-      <hr class="p-rule"/>
-      <div class="row p-section--shallow">
-        <div class="col-3 col-medium-2">
-          <h3 class="p-heading--5">Looking for Ubuntu?</h3>
-        </div>
-        <div class="col-6 col-medium-3">
-          <p>Download the latest release of Ubuntu desktop, the open source operating system that powers millions of PCs and laptops around the world. It's easy to install on Windows or macOS, or run Ubuntu alongside them!</p>
-          <p><a href="/download/desktop" class="p-button">Download now</a></p>
+        <hr class="p-rule" />
+        <div class="row p-section--shallow">
+          <div class="col-3 col-medium-2">
+            <h3 class="p-heading--5">Looking for Ubuntu?</h3>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              Download the latest release of Ubuntu desktop, the open source operating system that powers millions of PCs and laptops around the world. It's easy to install on Windows or macOS, or run Ubuntu alongside them!
+            </p>
+            <p>
+              <a href="/download/desktop" class="p-button">Download now</a>
+            </p>
+          </div>
         </div>
       </div>
     </div>
-  </div>
-</section>
+  </section>
 
-{% include "desktop/partial/_desktop-latest-news.html" %}
+  {% include "desktop/partial/_desktop-latest-news.html" %}
 
 {% endblock content %}

--- a/templates/desktop/flavours.html
+++ b/templates/desktop/flavours.html
@@ -119,7 +119,7 @@
     <div class="col-start-large-4 col-9">
       {{
         image (
-        url="https://assets.ubuntu.com/v1/eced5d77-kubuntu-2404.png",
+        url="https://assets.ubuntu.com/v1/40f53f96-edubuntu-2410.png",
         alt="",
         width="2560",
         height="1440",

--- a/templates/desktop/flavours.html
+++ b/templates/desktop/flavours.html
@@ -119,7 +119,7 @@
     <div class="col-start-large-4 col-9">
       {{
         image (
-        url="https://assets.ubuntu.com/v1/40f53f96-edubuntu-2410.png",
+        url="https://assets.ubuntu.com/v1/ad62f263-kubuntu-2410.png",
         alt="",
         width="2560",
         height="1440",
@@ -165,7 +165,7 @@
     <div class="col-start-large-4 col-9">
       {{
         image (
-        url="https://assets.ubuntu.com/v1/2b5ea6f3-lubuntu-24.04.png",
+        url="https://assets.ubuntu.com/v1/f614a439-lubuntu-2410.png",
         alt="",
         width="1920",
         height="1080",
@@ -212,7 +212,7 @@
     <div class="col-start-large-4 col-9">
       {{
         image (
-        url="https://assets.ubuntu.com/v1/5fb92f07-ubuntu-budgie-2404.png",
+        url="https://assets.ubuntu.com/v1/d4ea8bb8-ubuntu-budgie-2410.png",
         alt="",
         width="1920",
         height="1080",
@@ -258,7 +258,7 @@
     <div class="col-start-large-4 col-9">
       {{
         image (
-        url="https://assets.ubuntu.com/v1/0c3800a7-ubuntu-cinnamon-2404.png",
+        url="https://assets.ubuntu.com/v1/af09e2c4-ubuntu-cinnamon-2410.png",
         alt="",
         width="1920",
         height="1080",
@@ -304,7 +304,7 @@
     <div class="col-start-large-4 col-9">
       {{
         image (
-        url="https://assets.ubuntu.com/v1/0baa36b7-ubuntu-kylin-2404.png",
+        url="https://assets.ubuntu.com/v1/34284c9d-ubuntu-kylin-2410.png",
         alt="",
         width="1360",
         height="768",
@@ -350,7 +350,7 @@
     <div class="col-start-large-4 col-9">
       {{
         image (
-        url="https://assets.ubuntu.com/v1/5a3f4e43-ubuntu-mate-24.04.png",
+        url="https://assets.ubuntu.com/v1/6dd459ba-ubuntu-mate-2410.png",
         alt="",
         width="1664",
         height="936",
@@ -396,7 +396,7 @@
     <div class="col-start-large-4 col-9">
       {{
         image (
-        url="https://assets.ubuntu.com/v1/538a67c8-ubuntu-studio-2404.png",
+        url="https://assets.ubuntu.com/v1/bf9a44c0-ubuntu-studio-2410.png",
         alt="",
         width="1920",
         height="1080",
@@ -442,7 +442,7 @@
     <div class="col-start-large-4 col-9">
       {{
         image (
-        url="https://assets.ubuntu.com/v1/56c2851e-ubuntu-unity-24.04.png",
+        url="https://assets.ubuntu.com/v1/5cfb071c-ubuntu-unity-2410.png",
         alt="",
         width="1920",
         height="1080",
@@ -488,7 +488,7 @@
     <div class="col-start-large-4 col-9">
       {{
         image (
-        url="https://assets.ubuntu.com/v1/cb61126a-xubuntu-24.04.png",
+        url="https://assets.ubuntu.com/v1/2415943d-xubuntu-2410.png",
         alt="",
         width="1920",
         height="1080",


### PR DESCRIPTION
## Done

- replaced ubuntu desktop flavours images on `/desktop/flavours`

## QA

- Go to https://ubuntu-com-14400.demos.haus/desktop/flavours
- Check if the images from [copy doc](https://docs.google.com/document/d/1M5nkigcSRzq1YVjiXOZkeU4EUCqT0uYBR3Y_sjxM-wM/edit) are updated correctly
- **note**: `Edubuntu` image update is done in another PR.

## Issue / Card

Fixes #https://warthogs.atlassian.net/browse/WD-14870
