### PR TITLE
feat: add resources section for /security/livepatch

### DIFF
--- a/templates/security/livepatch.html
+++ b/templates/security/livepatch.html
@@ -93,26 +93,6 @@ meta_copydoc %}
     </div>
   </section>
 
-  <section class="p-strip--light is-shallow u-equal-height">
-    <div class="row">
-      <div class="col-2 u-hide--medium u-hide--small u-align--center">
-        {{ image(url="https://assets.ubuntu.com/v1/7076ef2d-ubuntu-documents.svg",
-                alt="",
-                width="100",
-                height="120",
-                hi_def=True,
-                loading="auto") | safe
-        }}
-      </div>
-      <div class="col-10 u-vertically-center">
-        <div>
-          <h2 class="p-heading--3">Read the Livepatch documentation</h2>
-          <a href="/security/livepatch/docs">Read the docs</a>
-        </div>
-      </div>
-    </div>
-  </section>
-
   <section class="p-strip--suru-accent is-dark">
     <div class="row u-equal-height">
       <div class="col-10">

--- a/templates/security/livepatch.html
+++ b/templates/security/livepatch.html
@@ -43,6 +43,55 @@ meta_copydoc %}
       </div>
     </div>
   </section>
+  
+  <section class="p-strip">
+    <div class="row p-divider">
+      <div class="col-4 p-divider__block">
+        <h2 class="p-heading--4">Learn more about Livepatch</h2>
+      </div>
+      <div class="col-4 p-divider__block">
+        <div class="p-heading-icon--muted">
+          <div class="p-heading-icon__header">
+            {{ image(url="https://assets.ubuntu.com/v1/6e184942-Webinar.svg",
+                        alt="",
+                        width="32",
+                        height="28",
+                        hi_def=True,
+                        attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
+                        loading="lazy",) | safe
+            }}
+            <h3 class="p-heading-icon__title p-heading--4">Webinar</h3>
+          </div>
+        </div>
+        <ul class="p-list">
+          <li class="p-list__item">
+            <a href="/engage/patching-automations-best-practices">Best practices for security patching automations</a>
+          </li>
+        </ul>
+      </div>
+      <div class="col-4 p-divider__block">
+        <div class="p-heading-icon--muted">
+          <div class="p-heading-icon__header">
+            {{ image(url="https://assets.ubuntu.com/v1/e2315503-tutorial.svg",
+                        alt="",
+                        width="46",
+                        height="30",
+                        hi_def=True,
+                        attrs={"class": "p-heading-icon", "style": "margin-top: 0.3rem;"},
+                        loading="lazy") | safe
+            }}
+            &nbsp;&nbsp;
+            <h3 class="p-heading-icon__title p-heading--4">Documentation</h3>
+          </div>
+        </div>
+        <ul class="p-list">
+          <li class="p-list__item">
+            <a href="/security/livepatch/docs">Read the Livepatch documentation</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </section>
 
   <section class="p-strip--light is-shallow u-equal-height">
     <div class="row">


### PR DESCRIPTION
## Done

- Added section per [doc](https://docs.google.com/document/d/1g_Ip5MzlBRpbM2wULpSnsR5XaHJVWgLPLdq8_7fCHrs/edit?tab=t.0) and [design](https://www.figma.com/design/pc4AcZqcXvWJqrm4t1x1y6/24.10-Ubuntu.com%2Fsecurity?node-id=74-44&node-type=canvas&t=1ou0VCTDq0kWJVTp-0)

## QA

- View the site locally in your web browser at: https://ubuntu-com-14402.demos.haus/livepatch
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check against doc and design

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-15117

## Screenshots

![Screenshot from 2024-10-09 13-36-03](https://github.com/user-attachments/assets/fafedac0-22a7-43f6-b83e-2400e120f285)



## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
