### PR TITLE
Fix broken sections in /containers

### DIFF
--- a/templates/containers/index.html
+++ b/templates/containers/index.html
@@ -34,12 +34,7 @@
         <a href="/containers/contact-us" class="js-invoke-modal" >Get a secure, custom-built container&nbsp;&rsaquo;</a>
       </div>
     </div>
-    <div class="p-rule u-fixed-width u-no-padding u-hide--small u-hide--medium">
-      <img src="https://assets.ubuntu.com/v1/7f34ade9-website_suru_25.jpg"
-           alt=""
-           style="aspect-ratio: 5.1775700934579;
-                  width: 100%" />
-    </div>
+    <div class="p-suru"></div>
   </div>
 
   <div class="p-section">
@@ -125,22 +120,18 @@
     </div>
   </div>
 
-  <div class="row">
-    <hr class="p-rule u-fixed-width" />
-  </div>
+  <hr class="p-rule is-fixed-width" />
   <div class="p-strip is-deep">
-    <div class="p-rule u-fixed-width">
+    <div class="u-fixed-width">
       <h2>
         <a href="/engage/container-security-guide">Read our whitepaper about container security&nbsp;&rsaquo;</a>
       </h2>
     </div>
   </div>
-  <div class="row">
-    <hr class="p-rule u-fixed-width" />
-  </div>
 
   <div class="p-section">
-    <div class="p-rule u-fixed-width">
+    <div class="u-fixed-width">
+      <hr class="p-rule" />
       <p class="p-text--small-caps">Trusted by industry leaders</p>
       <div class="p-logo-section">
         <div class="p-logo-section__items">


### PR DESCRIPTION
## Done

- Fix suru section by importing the suru from Vanilla directly
- Update `p-rule` usage

## QA

- Go to https://ubuntu-com-14404.demos.haus/containers
- Check that the suru is showing in hero and does not have scroll behaviour
- Scroll down and check that sections do not overlap with one another

## Issue / Card

Fixes [WD-15771](https://warthogs.atlassian.net/browse/WD-15771)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-15771]: https://warthogs.atlassian.net/browse/WD-15771?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ