### PR TITLE
Release fixes

### DIFF
--- a/templates/download/risc-v/sifive-unmatched.html
+++ b/templates/download/risc-v/sifive-unmatched.html
@@ -34,7 +34,7 @@
         <a class="p-button--positive"
            href="https://cdimage.ubuntu.com/releases/24.10/release/ubuntu-24.10-preinstalled-server-riscv64+unmatched.img.xz">Download 24.10</a>
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/24.04/release/ubuntu-24.04-preinstalled-server-riscv64+unmatched.img.xz">Download 24.04.1 LTS</a>
+           href="https://cdimage.ubuntu.com/releases/24.04.1/release/ubuntu-24.04.1-live-server-riscv64.img.gz">Download 24.04.1 LTS</a>
       </p>
     </div>
   </div>

--- a/templates/download/risc-v/sifive-unmatched.html
+++ b/templates/download/risc-v/sifive-unmatched.html
@@ -34,7 +34,7 @@
         <a class="p-button--positive"
            href="https://cdimage.ubuntu.com/releases/24.10/release/ubuntu-24.10-preinstalled-server-riscv64+unmatched.img.xz">Download 24.10</a>
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/24.04/release/ubuntu-24.04-preinstalled-server-riscv64+unmatched.img.xz">Download 24.04.1 LTS</a>
+           href="https://cdimage.ubuntu.com/releases/24.04/release/ubuntu-24.04-preinstalled-server-riscv64+unmatched.img.xz">Download 24.04 LTS</a>
       </p>
     </div>
   </div>

--- a/templates/download/risc-v/sifive-unmatched.html
+++ b/templates/download/risc-v/sifive-unmatched.html
@@ -34,7 +34,7 @@
         <a class="p-button--positive"
            href="https://cdimage.ubuntu.com/releases/24.10/release/ubuntu-24.10-preinstalled-server-riscv64+unmatched.img.xz">Download 24.10</a>
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/24.04.1/release/ubuntu-24.04.1-live-server-riscv64.img.gz">Download 24.04.1 LTS</a>
+           href="https://cdimage.ubuntu.com/releases/24.04/release/ubuntu-24.04-preinstalled-server-riscv64+unmatched.img.xz">Download 24.04.1 LTS</a>
       </p>
     </div>
   </div>

--- a/templates/download/risc-v/starfive-visionfive.html
+++ b/templates/download/risc-v/starfive-visionfive.html
@@ -33,7 +33,7 @@
       </p>
       <p>
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/24.04/release/ubuntu-24.04-preinstalled-server-riscv64+visionfive2.img.xz">Download 24.10</a>
+           href="https://cdimage.ubuntu.com/releases/24.10/release/ubuntu-24.10-preinstalled-server-riscv64+visionfive2.img.xz">Download 24.10</a>
         <a class="p-button--positive"
            href="https://cdimage.ubuntu.com/releases/24.04.1/release/ubuntu-24.04.1-preinstalled-server-riscv64+visionfive2.img.xz">Download 24.04.1 LTS</a>
       </p>

--- a/templates/download/server/manual.html
+++ b/templates/download/server/manual.html
@@ -149,7 +149,7 @@
           </ul>
           <hr class="p-rule" />
           <p>
-            <a href="https://discourse.ubuntu.com/t/noble-numbat-release-notes/39890"> [{{ releases.lts.short_version }} LTS] Release notes&nbsp;&rsaquo;</a>
+            <a href="{{ releases.lts.release_notes_url }}" aria-label="{{ releases.lts.short_version }} LTS release notes">Release notes&nbsp;&rsaquo;</a>
           </p>
         </div>
 
@@ -272,7 +272,7 @@
               <a href="/blog/canonical-releases-ubuntu-24-10-oracular-oriole" aria-label="24.10 Press Release">Press release&nbsp;&rsaquo;</a>
             </li>
             <li class="p-inline-list__item">
-              <a href="https://discourse.ubuntu.com/t/noble-numbat-release-notes/39890" aria-label="24.04 LTS Release notes">Release notes&nbsp;&rsaquo;</a>
+              <a href="{{ releases.latest.release_notes_url }}" aria-label="{{ releases.latest.short_version }} release notes">Release notes&nbsp;&rsaquo;</a>
             </li>
           </ul>
         </div>


### PR DESCRIPTION
## Done

- Applied fixes for issues flagged in this [thread](https://chat.canonical.com/canonical/pl/nboi8oorkbb8dpe8z3u5djsdacc)

## QA

- View the site locally in your web browser at: https://ubuntu-com-14408.demos.haus/download/server and see that release notes links point to the correct url
- View the site locally in your web browser at: https://ubuntu-com-14408.demos.haus/download/risc-v and see that unmatched tab and starfive 2 tab have the correct links for 24/10

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
