### PR TITLE
fix typos on download thank-you pages, fix link on risc-v page

### DIFF
--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -185,7 +185,7 @@
           <hr class="p-rule--muted" />
           <p class="u-responsive-realign">
             <a class="p-button--positive"
-               href="/download/desktop/thank-you?version={{ releases.latest.full_version }}&amp;architecture=amd64&amp;lts=true"
+               href="/download/desktop/thank-you?version={{ releases.latest.full_version }}&amp;architecture=amd64"
                onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });">Download
               {{ releases.latest.full_version }}
             </a>

--- a/templates/download/risc-v/sifive-unmatched.html
+++ b/templates/download/risc-v/sifive-unmatched.html
@@ -34,7 +34,7 @@
         <a class="p-button--positive"
            href="https://cdimage.ubuntu.com/releases/24.10/release/ubuntu-24.10-preinstalled-server-riscv64+unmatched.img.xz">Download 24.10</a>
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/24.04/release/ubuntu-24.04-preinstalled-server-riscv64+unmatched.img.xz">Download 24.04 LTS</a>
+           href="https://cdimage.ubuntu.com/releases/24.04.1/release/ubuntu-24.04.1-preinstalled-server-riscv64+unmatched.img.xz">Download 24.04.1 LTS</a>
       </p>
     </div>
   </div>

--- a/templates/download/server/manual.html
+++ b/templates/download/server/manual.html
@@ -210,7 +210,7 @@
           <hr />
           <p class="u-responsive-realign">
             <a class="p-button--positive"
-               href="/download/server/thank-you?version={{ releases.latest.full_version }}&amp;architecture=amd64&amp;lts=true"
+               href="/download/server/thank-you?version={{ releases.latest.full_version }}&amp;architecture=amd64"
                onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Server download', 'eventAction' : 'Select option', 'eventLabel' : '{{ releases.latest.full_version }}', 'eventValue' : undefined });">Download {{ releases.latest.full_version }}
             </a>
             {% if releases.latest.server_iso_size %}


### PR DESCRIPTION
## Done

- Fix type on /download/desktop/thank-you and /download/server/thank-you
- Fix link on /download/risc-v

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
