### PR TITLE
fix the link for 64k 24.10 arm image

### DIFF
--- a/templates/download/server/arm.html
+++ b/templates/download/server/arm.html
@@ -67,7 +67,7 @@
              onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'ARM server download', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });">
             Download {{ releases.lts.full_version }} LTS (64k page size)
           </a>
-          <a href="https://cdimage.ubuntu.com/ubuntu-server/oracular/daily-live/current"
+          <a href="https://cdimage.ubuntu.com/releases/{{ releases.latest.short_version }}/release/ubuntu-{{ releases.latest.full_version }}-live-server-arm64+largemem.iso"
              class="p-button"
              onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'ARM server download', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });">
             Download {{ releases.latest.full_version }} (64k page size)


### PR DESCRIPTION
## Done

- Fix the link for 64k 24.10 ARM image

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Download 64k 24.10 ARM image on /download/arm and check if it downloads an image

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
