### PR TITLE
feat: add security headers

### DIFF
--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -64,6 +64,8 @@ CSP = {
         "d3js.org",
         "www.brighttalk.com",
         "cdnjs.cloudflare.com",
+        "static.ads-twitter.com",
+        "*.cdn.digitaloceanspaces.com",
         # This is necessary for Google Tag Manager to function properly.
         "'unsafe-inline'",
     ],

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -291,7 +291,7 @@ def init_handlers(app, sentry):
         - Cross-Origin-Resource-Policy: allowing cross-origin requests to
         access the resource
         - X-Permitted-Cross-Domain-Policies: disallows cross-domain access to
-        resources
+        resources.
         """
 
         def get_csp_as_str(csp={}):

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -95,6 +95,7 @@ CSP = {
         "js.zi-scripts.com",
         "*.mktoresp.com",
         "prompts.maze.co",
+        "*.google-analytics.com",
     ],
     "frame-src": [
         "'self'",

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -114,6 +114,7 @@ CSP = {
     ],
 }
 
+
 def init_handlers(app, sentry):
     @app.after_request
     def cache_headers(response):
@@ -272,7 +273,6 @@ def init_handlers(app, sentry):
     def utility_processor():
         return {"image": image_template}
 
-    
     @app.after_request
     def add_headers(response):
         """
@@ -297,10 +297,8 @@ def init_handlers(app, sentry):
                 csp_value = " ".join(values)
                 csp_str += f"{key} {csp_value}; "
             return csp_str.strip()
-        
-        response.headers["Content-Security-Policy"] = get_csp_as_str(
-            CSP
-        )
+
+        response.headers["Content-Security-Policy"] = get_csp_as_str(CSP)
 
         response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
         response.headers["Cross-Origin-Embedder-Policy"] = "unsafe-none"

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -66,6 +66,9 @@ CSP = {
         "cdnjs.cloudflare.com",
         "static.ads-twitter.com",
         "*.cdn.digitaloceanspaces.com",
+        "www.redditstatic.com",
+        "snap.licdn.com",
+        "connect.facebook.net",
         # This is necessary for Google Tag Manager to function properly.
         "'unsafe-inline'",
     ],
@@ -105,6 +108,7 @@ CSP = {
         "player.vimeo.com",
         "js.stripe.com",
         "www.googletagmanager.com",
+        "www.google.com",
         "www.brighttalk.com",
     ],
     "style-src": [

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -30,6 +30,89 @@ from webapp.shop.api.ua_contracts.api import (
 )
 from webapp.shop.flaskparser import UAContractsValidationError
 
+CSP = {
+    "default-src": ["'self'"],
+    "img-src": [
+        "data: blob:",
+        # This is needed to allow images from
+        # https://www.google.*/ads/ga-audiences to load.
+        "*",
+    ],
+    "script-src-elem": [
+        "'self'",
+        "assets.ubuntu.com",
+        "www.google-analytics.com",
+        "www.googletagmanager.com",
+        "dev.visualwebsiteoptimizer.com",
+        "www.youtube.com",
+        "asciinema.org",
+        "player.vimeo.com",
+        "script.crazyegg.com",
+        "w.usabilla.com",
+        "munchkin.marketo.net",
+        "serve.nrich.ai",
+        "ml314.com",
+        "scout-cdn.salesloft.com",
+        "snippet.maze.co",
+        "www.googleadservices.com",
+        "js.zi-scripts.com",
+        "*.g.doubleclick.net",
+        "www.google.com",
+        "www.gstatic.com",
+        "*.googlesyndication.com",
+        "js.stripe.com",
+        "d3js.org",
+        "www.brighttalk.com",
+        "cdnjs.cloudflare.com",
+        # This is necessary for Google Tag Manager to function properly.
+        "'unsafe-inline'",
+    ],
+    "font-src": [
+        "'self'",
+        "assets.ubuntu.com",
+    ],
+    "script-src": [
+        "'self'",
+        "blob:",
+        "'unsafe-eval'",
+        "'unsafe-hashes'",
+        "'unsafe-inline'",
+    ],
+    "connect-src": [
+        "'self'",
+        "*.googlesyndication.com",
+        "www.google.com",
+        "ubuntu.com",
+        "analytics.google.com",
+        "www.googletagmanager.com",
+        "sentry.is.canonical.com",
+        "www.google-analytics.com",
+        "*.crazyegg.com",
+        "scout.salesloft.com",
+        "*.g.doubleclick.net",
+        "js.zi-scripts.com",
+        "*.mktoresp.com",
+        "prompts.maze.co",
+    ],
+    "frame-src": [
+        "'self'",
+        "*.doubleclick.net",
+        "www.youtube.com/",
+        "asciinema.org",
+        "player.vimeo.com",
+        "js.stripe.com",
+        "www.googletagmanager.com",
+        "www.brighttalk.com",
+    ],
+    "style-src": [
+        "'self'",
+        "'unsafe-inline'",
+    ],
+    "media-src": [
+        "'self'",
+        "res.cloudinary.com",
+    ],
+}
 
 def init_handlers(app, sentry):
     @app.after_request
@@ -188,6 +271,45 @@ def init_handlers(app, sentry):
     @app.context_processor
     def utility_processor():
         return {"image": image_template}
+
+    
+    @app.after_request
+    def add_headers(response):
+        """
+        Generic rules for headers to add to all requests
+        - Content-Security-Policy: Restrict resources (e.g., JavaScript, CSS,
+        Images) and URLs
+        - Referrer-Policy: Limit referrer data for security while preserving
+        full referrer for same-origin requests
+        - Cross-Origin-Embedder-Policy: allows embedding cross-origin
+        resources
+        - Cross-Origin-Opener-Policy: enable the page to open pop-ups while
+        maintaining same-origin policy
+        - Cross-Origin-Resource-Policy: allowing cross-origin requests to
+        access the resource
+        - X-Permitted-Cross-Domain-Policies: disallows cross-domain access to
+        resources
+        """
+
+        def get_csp_as_str(csp={}):
+            csp_str = ""
+            for key, values in csp.items():
+                csp_value = " ".join(values)
+                csp_str += f"{key} {csp_value}; "
+            return csp_str.strip()
+        
+        response.headers["Content-Security-Policy"] = get_csp_as_str(
+            CSP
+        )
+
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        response.headers["Cross-Origin-Embedder-Policy"] = "unsafe-none"
+        response.headers["Cross-Origin-Opener-Policy"] = (
+            "same-origin-allow-popups"
+        )
+        response.headers["Cross-Origin-Resource-Policy"] = "cross-origin"
+        response.headers["X-Permitted-Cross-Domain-Policies"] = "none"
+        return response
 
     app.add_template_filter(date_has_passed)
 


### PR DESCRIPTION
## Done

Added security headers.

- Content-Security-Policy: Restrict resources (e.g., JavaScript, CSS, Images) and URLs
-  Referrer-Policy: Limit referrer data for security while preserving full referrer for same-origin requests
- Cross-Origin-Embedder-Policy: allows embedding cross-origin resources
- Cross-Origin-Opener-Policy: enable the page to open pop-ups while maintaining same-origin policy
- Cross-Origin-Resource-Policy: allowing cross-origin requests to access the resource
- X-Permitted-Cross-Domain-Policies: disallows cross-domain access to
resources

Read more from [here](https://docs.google.com/document/d/15ajij_jStQ4oUTEo7pT4TgaW5zRH4SOMaW9TDyy0dGE).

## QA

- Open : https://ubuntu-com-14411.demos.haus/
- Verify no security header error is shown in the console.
- Verify all the images, videos, iframes and other resources are shown correctly
- Verify there is no behavior change (such as a link doesnt open)
- Open [header analyzer](https://dri.es/headers?url=https%3A%2F%2Fubuntu-com-14411.demos.haus%2F)
- Verify Referrer-Policy, Cross-Origin-Embedder-Policy, Cross-Origin-Opener-Policy, Cross-Origin-Resource-Policy and X-Permitted-Cross-Domain-Policies headers arent missing

## Issue / Card

Fixes [#14446](https://warthogs.atlassian.net/browse/WD-14446), [#14447](https://warthogs.atlassian.net/browse/WD-14447), [#14448](https://warthogs.atlassian.net/browse/WD-14448), [#14449](https://warthogs.atlassian.net/browse/WD-14449), [#14450](https://warthogs.atlassian.net/browse/WD-14450), [#14451](https://warthogs.atlassian.net/browse/WD-14451), [#14452](https://warthogs.atlassian.net/browse/WD-14452)

