### PR TITLE
/training copy update

### DIFF
--- a/templates/training/index.html
+++ b/templates/training/index.html
@@ -39,6 +39,55 @@
       </div>
     </section>
 
+    <section class="p-strip is-bordered">
+      <div class="row">
+        <div class="col-7">
+          <h2>MongoDB</h2>
+        </div>
+      </div>
+      <div itemscope itemtype="https://schema.org/Product">
+        <div class="u-fixed-width">
+          <hr class="p-rule" />
+          <h3 itemprop="name">Deployment and Operations training</h3>
+        </div>
+        <div class="row p-divider">
+          <div class="col-7 p-divider__block">
+            <p itemprop="description">
+              A three-day hands-on course for up to 15 people that focuses on MongoDB. The aim of this training is to educate users on MongoDB, practice deployment, perform operations and optimisations as well as troubleshooting.            </p>
+            <p>
+              <a href="https://assets.ubuntu.com/v1/5dcac162-Charmed%20MongoDB%20Training_Public%20Module.pdf">Read the course outline (PDF)&nbsp;&rsaquo;</a>
+            </p>
+          </div>
+          <div class="col-5 p-divider__block">
+            <dl class="p-inline-definition-list">
+              <dt class="p-inline-definition-list__title">Duration</dt>
+              <dd class="p-inline-definition-list__item">
+                3 days
+              </dd>
+              <dt class="p-inline-definition-list__title">Cost</dt>
+              <dd class="p-inline-definition-list__item"
+                  itemprop="offers"
+                  itemscope
+                  itemtype="https://schema.org/Offer">
+                USD <span itemprop="priceCurrency" content="USD">$</span><span itemprop="price" content="23500">23,500</span> up to 15 attendees, remote delivery
+              </dd>
+              <dt class="p-inline-definition-list__title">Location</dt>
+              <dd class="p-inline-definition-list__item">
+                Remote or your premises at extra cost
+              </dd>
+              <dt class="p-inline-definition-list__title">Availability</dt>
+              <dd class="p-inline-definition-list__item">
+                Private groups only
+              </dd>
+            </dl>
+            <p>
+              <a href="/contact-us">Contact us to book yours&nbsp;&rsaquo;</a>
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+
     <section class="p-strip--light is-bordered">
       <div class="row">
         <div class="col-7">


### PR DESCRIPTION
## Done

- Add a new Mongo DB section to `/training`

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/ (or open demo)
- Go to http://0.0.0.0:8001/training
- Check that the new Mongo DB section is there and it matches the [copy doc](https://docs.google.com/document/d/1gyxy75qXC5Ta08o6Vnm13yK6aeN4qOnsETB2gZ4e0ZY/edit?tab=t.0)

## Issue / Card

https://warthogs.atlassian.net/browse/WD-15792