### PR TITLE
[WD-15818] Email address rejected when trying to add users via the Pro dashboard

### DIFF
--- a/static/js/src/advantage/users/utils.ts
+++ b/static/js/src/advantage/users/utils.ts
@@ -41,6 +41,6 @@ export const validateRequired = (value: string): string | undefined =>
 
 export const validateEmail = (value: string): string | undefined =>
   validateRequired(value) ||
-  !/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i.test(value)
+  !/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i.test(value)
     ? "Must be a valid email."
     : undefined;


### PR DESCRIPTION
## Done

- Remove upper limit in email validation for `/pro/users`

## QA

- Go to [/pro/users](https://ubuntu-com-14414.demos.haus/pro/users)
- Try adding a new user with the email `test@long-domain.global`
- The user should be successfully added

## Issue / Card

Fixes [WD-15818](https://warthogs.atlassian.net/browse/WD-15818)

## Screenshots

Before:
![image](https://github.com/user-attachments/assets/a5a44426-1d04-42d4-b3de-a45ebfb94f0a)

After:
![image](https://github.com/user-attachments/assets/1b304a67-d775-46b4-a1a8-7380a6c56c52)



## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-15818]: https://warthogs.atlassian.net/browse/WD-15818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ