### PR TITLE
/kernel copy update

### DIFF
--- a/templates/kernel/index.html
+++ b/templates/kernel/index.html
@@ -106,7 +106,7 @@
     <div class="u-fixed-width">
       <h2 id="kernel-security">Kernel security</h2>
       <p>
-        The Canonical Kernel Team's primary focus is the careful maintenance of kernels and their variants for regular delivery via the <a href="https://wiki.ubuntu.com/StableReleaseUpdates">Ubuntu SRU process</a> and the Canonical <a href="/security/livepatch">livepatch service</a>. This includes rigorous management of all Linux kernel Common Vulnerabilities and Exposures (CVE) lists (with a focus on patching  all <a href="https://people.canonical.com/~ubuntu-security/priority.html">high and critical</a> CVEs) review and application of all relevant patches for all critical and serious kernel defects in the mailing lists and then rigorously testing newly updated kernels end-to-end each SRU cycle.
+        The Canonical Kernel Team's primary focus is the careful maintenance of kernels and their variants for regular delivery via the <a href="https://wiki.ubuntu.com/StableReleaseUpdates">Ubuntu SRU process</a> and the Canonical <a href="/security/livepatch">livepatch service</a>. This includes rigorous management of all Linux kernel Common Vulnerabilities and Exposures (CVE) lists (with a focus on patching  all <a href="/security/cves/about#priority">high and critical</a> CVEs) review and application of all relevant patches for all critical and serious kernel defects in the mailing lists and then rigorously testing newly updated kernels end-to-end each SRU cycle.
       </p>
     </div>
   </section>


### PR DESCRIPTION
## Done

- Updated link https://people.canonical.com/~ubuntu-security/priority.html -> https://ubuntu.com/security/cves/about#priority as per linked ticket (I searched the codebase and this seems to be the only instance)

## QA

- View the site locally in your web browser at: https://ubuntu-com-14415.demos.haus/kernel
- Scroll to the "Kernel security" section and see that the "high and critical" link routes correctly 

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-2706
