### PR TITLE
/about/release-cycle copy update

### DIFF
--- a/templates/about/release_cycles/releases-table.html
+++ b/templates/about/release_cycles/releases-table.html
@@ -10,7 +10,7 @@
     </thead>
     <tbody>
         <tr>
-            <td colspan="2">24.10 LTS (Oracular Oriole)</td>
+            <td colspan="2">24.10 (Oracular Oriole)</td>
             <td>Oct 2024</td>
             <td>Jul 2025</td>
             <td>&nbsp;</td>


### PR DESCRIPTION
## Done

- Removed "LTS" from "24.10 (Oracular Oriole)"

## QA

- View the site locally in your web browser at: https://ubuntu-com-14417.demos.haus/about/release-cycle
- See that the typo has been fixed 

## Issue / Card

Fixes https://github.com/canonical/ubuntu.com/issues/14416
