### PR TITLE
make changes for 3 hour exam provisioning on prod

### DIFF
--- a/templates/credentials/faq.html
+++ b/templates/credentials/faq.html
@@ -119,7 +119,7 @@
         </p>
         <h3>Am I able to schedule the exam in advance?</h3>
         <p>
-          Yes. Once purchased, exams can be scheduled up to one year in the future. <i>[Note that preview releases, including CUE.01 Linux 24.04 exam version, are only available for 30 days after purchase.] </i> Exam bookings require a minimum of 60 minutes notice before taking your exam to allow for the environment to be provisioned and checked.
+          Yes. Once purchased, exams can be scheduled up to one year in the future. Exam bookings require a minimum of 3 hours notice before taking your exam to allow for the environment to be provisioned and checked.
         </p>
         <h3>Can I reschedule if the time slot I chose doesn’t work for me?</h3>
         <p>
@@ -164,12 +164,12 @@
         </p>
         <h3>What are the technical requirements of our environment?</h3>
         <p>
-          <i>[NOTE: There is a known issue with keyboards and Firefox in the CUE.01 Linux 24.04 preview release at this time, which will be resolved in the CUE.01 Linux 24.10 exam release. We recommend using Chrome-based browsers at this time.]</i>
+          <i>[NOTE: There is a known issue with keyboards and Firefox in the CUE.01 Linux 24.04 preview release at this time, which will be resolved in the CUE.01 Linux 24.10 exam release. We recommend using Chrome-based browsers at this time. ]</i>
         </p>
         <p>
           The exam is conducted via web browser, and any operating system capable of running a modern browser is acceptable.
         </p>
-        <h3>What are the exam’s Linux distributions and desktop environments?</h3>
+        <h3>What are the exam's Linux distributions and desktop environments?</h3>
         <p>
           Once the environment is loaded, it will appear to be a default installation of Ubuntu 22.04 LTS (Jammy Jellyfish) with a GNOME Desktop, Terminal, and other relevant tools. All other nodes in the exam environment are running Ubuntu Server 22.04 LTS.
         </p>

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -256,8 +256,8 @@ def cred_schedule(
     is_staging = "staging" in os.getenv(
         "CONTRACTS_API_URL", "https://contracts.staging.canonical.com/"
     )
-    time_delta = 0.5 if is_staging else 1
-    time_delay = "30 minutes" if is_staging else "1 hour"
+    time_delta = 0.5 if is_staging else 3
+    time_delay = "30 minutes" if is_staging else "3 hours"
 
     if flask.request.method == "POST":
         data = flask.request.form


### PR DESCRIPTION
## Done

- Changed scheduling delay from 1 hour to 3 hours on prod
- Changes to FAQ to reflect the same

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to /credentials/faq
- Verify changes to time and Firefox note are included.
*Have to test the scheduling locally*
- Change CONTRACTS_API_URL to prod
- Go to /credentials/your-exams
- Try to schedule an exam
- Should restrict scheduling before 3 hours 

## Issue / Card

Fixes [WD-15681](https://warthogs.atlassian.net/browse/WD-15681)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
