### PR TITLE
Fix key redemption

### DIFF
--- a/templates/credentials/redeem_with_form.html
+++ b/templates/credentials/redeem_with_form.html
@@ -20,7 +20,9 @@
     <div class="row">
       <form class="p-form p-form--stacked col-4 col-medium-3"
             action="/credentials/redeem"
-            method="POST">
+            method="POST"
+            onSubmit="document.getElementById('activate-button').disabled=true;"
+            >
         <div class="p-form__group col">
           <div class="col-3">
             <label for="activation-key">Key</label>
@@ -47,7 +49,7 @@
         <div class="p-form__group row">
           <div class="col-3"></div>
           <div class="col-3">
-            <button class="p-button--positive" type="submit" name="submit">Activate</button>
+            <button class="p-button--positive" type="submit" name="submit" id="activate-button" ondblclick="disableButton()">Activate</button>
           </div>
         </div>
       </form>
@@ -55,6 +57,10 @@
   </div>
 
   <script>
+    function disableButton(event) {
+      document.getElementById("activate-button").disable = true;
+    }
+    
     function debounce(func, delay) {
       // A timer variable to track the delay period
       let timer;

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -1059,8 +1059,9 @@ def cred_redeem_code(ua_contracts_api, advantage_mapper, **kwargs):
             return flask.redirect(
                 f"/credentials/schedule?contractItemID={contract_id}"
             )
-        message = "Your exam has been activated."
-        +"To schedule your exam, click the Your Exams button."
+        message = """Your exam has been activated.
+        To schedule your exam, click the Your Exams button."""
+        
         return flask.render_template(
             "/credentials/redeem.html",
             notification_class="positive",


### PR DESCRIPTION
## Done

- Fix keys getting key already activated on redemption

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to /credentials/redeem
- Redeem a key
- Should redeem without problems

## Issue / Card

Fixes [#WD-15795](https://warthogs.atlassian.net/browse/WD-15795)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
