### PR TITLE
chore: Bump discourse version to 5.7.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,8 @@ canonicalwebteam.blog==6.4.1
 canonicalwebteam.search==2.1.1
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.3.1
-canonicalwebteam.discourse==5.7.2
+# canonicalwebteam.discourse==5.7.2
+canonicalwebteam.discourse @ git+https://github.com/canonical/canonicalwebteam.discourse.git@masked-links#egg=canonicalwebteam.discourse
 python-dateutil==2.8.2
 pytz==2022.7.1
 maxminddb-geolite2==2018.703

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,7 @@ canonicalwebteam.blog==6.4.1
 canonicalwebteam.search==2.1.1
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.3.1
-# canonicalwebteam.discourse==5.7.2
-canonicalwebteam.discourse @ git+https://github.com/canonical/canonicalwebteam.discourse.git@masked-links#egg=canonicalwebteam.discourse
+canonicalwebteam.discourse==5.7.3
 python-dateutil==2.8.2
 pytz==2022.7.1
 maxminddb-geolite2==2018.703


### PR DESCRIPTION
## Done

- Bump discourse version to 5.7.3

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
