### PR TITLE
Fixes #14426

### DIFF
--- a/templates/desktop/index.html
+++ b/templates/desktop/index.html
@@ -354,7 +354,7 @@
     </div>
   </section>
 
-  <section>
+  <section class="p-section">
     <div class="row--50-50 p-section">
       <hr class="p-rule" />
       <div class="col">
@@ -462,7 +462,7 @@
     </div>
   </section>
 
-  <section>
+  <section class="p-section">
     <div class="row--50-50 p-section--shallow">
       <hr class="p-rule" />
       <div class="col">


### PR DESCRIPTION
## Done

Have added the class p-section to both the sections for adding the required padding-bottom of 4rem.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #14426 

## Screenshots
<img width="1177" alt="Screenshot 2024-10-17 at 6 59 16 PM" src="https://github.com/user-attachments/assets/39b4d253-c87f-4528-b36c-b9d137c52656">
<img width="1167" alt="Screenshot 2024-10-17 at 6 59 25 PM" src="https://github.com/user-attachments/assets/ac41b767-2b09-4b35-8522-6805bc68f20c">


[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
