### PR TITLE
Implement user_id and pass it in marketo submission

### DIFF
--- a/static/js/src/cookie-policy-with-callback.js
+++ b/static/js/src/cookie-policy-with-callback.js
@@ -1,0 +1,20 @@
+import { v4 as uuidv4 } from "https://jspm.dev/uuid";
+// Set user_id after cookie acceptance
+function setUserId() {
+  const getCookie = (targetCookie) =>
+    document.cookie.match(new RegExp("(^| )" + targetCookie + "=([^;]+)"));
+  const cookieAcceptanceValue = getCookie("_cookies_accepted");
+
+  if (
+    cookieAcceptanceValue?.[2] === "all" ||
+    cookieAcceptanceValue?.[2] === "performance"
+  ) {
+    // Check if user doesn't already have a user_id
+    if (!getCookie("user_id")) {
+      // Generate a universally unique identifier
+      const user_id = uuidv4();
+      document.cookie = "user_id=" + user_id + ";max-age=31536000;";
+    }
+  }
+}
+cpNs.cookiePolicy(setUserId);

--- a/static/js/src/cookie-policy-with-callback.js
+++ b/static/js/src/cookie-policy-with-callback.js
@@ -9,7 +9,7 @@ const getCookie = (targetCookie) =>
   document.cookie.match(new RegExp("(^| )" + targetCookie + "=([^;]+)"));
 let cookieAcceptanceValue = getCookie("_cookies_accepted");
 
-if (cookieAcceptanceValue === null) {
+if (!cookieAcceptanceValue) {
   cpNs.cookiePolicy(setUserId);
 } else {
   setUserId();

--- a/static/js/src/cookie-policy-with-callback.js
+++ b/static/js/src/cookie-policy-with-callback.js
@@ -1,10 +1,21 @@
-import { v4 as uuidv4 } from "https://jspm.dev/uuid";
-// Set user_id after cookie acceptance
-function setUserId() {
-  const getCookie = (targetCookie) =>
-    document.cookie.match(new RegExp("(^| )" + targetCookie + "=([^;]+)"));
-  const cookieAcceptanceValue = getCookie("_cookies_accepted");
+/*
+  Set a unique user_id if the user has accepted cookies.
+  If the user has not set their cookie preference, wait for the cookie policy to run first. 
+*/
 
+import { v4 as uuidv4 } from "https://jspm.dev/uuid";
+
+const getCookie = (targetCookie) =>
+  document.cookie.match(new RegExp("(^| )" + targetCookie + "=([^;]+)"));
+const cookieAcceptanceValue = getCookie("_cookies_accepted");
+
+if (cookieAcceptanceValue === null) {
+  cpNs.cookiePolicy(setUserId);
+} else {
+  setUserId();
+}
+
+function setUserId() {
   if (
     cookieAcceptanceValue?.[2] === "all" ||
     cookieAcceptanceValue?.[2] === "performance"
@@ -14,7 +25,10 @@ function setUserId() {
       // Generate a universally unique identifier
       const user_id = uuidv4();
       document.cookie = "user_id=" + user_id + ";max-age=31536000;";
+
+      dataLayer.push({
+        user_id: user_id,
+      });
     }
   }
 }
-cpNs.cookiePolicy(setUserId);

--- a/static/js/src/cookie-policy-with-callback.js
+++ b/static/js/src/cookie-policy-with-callback.js
@@ -7,7 +7,7 @@ import { v4 as uuidv4 } from "https://jspm.dev/uuid";
 
 const getCookie = (targetCookie) =>
   document.cookie.match(new RegExp("(^| )" + targetCookie + "=([^;]+)"));
-const cookieAcceptanceValue = getCookie("_cookies_accepted");
+let cookieAcceptanceValue = getCookie("_cookies_accepted");
 
 if (cookieAcceptanceValue === null) {
   cpNs.cookiePolicy(setUserId);
@@ -16,6 +16,7 @@ if (cookieAcceptanceValue === null) {
 }
 
 function setUserId() {
+  cookieAcceptanceValue = getCookie("_cookies_accepted");
   if (
     cookieAcceptanceValue?.[2] === "all" ||
     cookieAcceptanceValue?.[2] === "performance"

--- a/templates/templates/_tag_manager.html
+++ b/templates/templates/_tag_manager.html
@@ -21,5 +21,4 @@
         })(window,document,'script','dataLayer','GTM-K92JCQ');</script>
         <!-- End Google Tag Manager -->
 
-        <script>dataLayer.push({'user_id': user_id});</script>
         <style>#rememberMe {display: none;}</style>

--- a/templates/templates/_tag_manager.html
+++ b/templates/templates/_tag_manager.html
@@ -12,7 +12,15 @@
         'pages.ubuntu.com', '/tutorials', 'docs.ubuntu.com']);
         </script>
         <!-- End Google Analytics and Google Optimize -->
-
+        <script>
+            const getCookie = () => document.cookie.match(new RegExp("(^| )" + "user_id" + "=([^;]+)"));
+            let idValue = getCookie()[2];
+            if (idValue) {
+                dataLayer.push({
+                        user_id: idValue,
+                });
+            }
+        </script>
         <!-- Google Tag Manager -->
         <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
         new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],

--- a/templates/templates/_tag_manager.html
+++ b/templates/templates/_tag_manager.html
@@ -21,4 +21,5 @@
         })(window,document,'script','dataLayer','GTM-K92JCQ');</script>
         <!-- End Google Tag Manager -->
 
+        <script>dataLayer.push({'user_id': user_id});</script>
         <style>#rememberMe {display: none;}</style>

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -18,9 +18,7 @@
     {% block content_experiment %}{% endblock %}
     <!-- Cookie policy -->
     <script src="{{ versioned_static('js/dist/cookie-policy.js') }}"></script>
-    <script>
-      cpNs.cookiePolicy();
-    </script>
+    <script type="module" src="{{ versioned_static('js/src/cookie-policy-with-callback.js') }}"></script>
     <script src="https://assets.ubuntu.com/v1/703e23c9-lazysizes+noscript+native-loading.5.1.2.min.js"
             defer></script>
 
@@ -32,23 +30,6 @@
     <link rel="stylesheet" type="text/css" media="print" href="{{ versioned_static("css/print.css") }}" />
     <script>
       performance.mark("Stylesheets finished");
-    </script>
-
-    <!-- Set unique user_id -->
-    <script type="module">     
-      import { v4 as uuidv4 } from 'https://jspm.dev/uuid';
-      
-      const getCookie = (targetCookie) => document.cookie.match(new RegExp('(^| )' + _cookies_accepted + '=([^;]+)'));
-      const cookieAcceptanceValue = getCookie("_cookies_accepted"); 
-
-      if (cookieAcceptanceValue?.[2] === 'all' || cookieAcceptanceValue?.[2] === 'performance') {
-        // check if user doesn't already have a user_id
-        if (!getCookie("user_id")) {
-          // generate a universally unique identifier
-          const user_id = uuidv4();
-          document.cookie = 'user_id=' + user_id + ';max-age=31536000;';
-        } 
-      }
     </script>
 
     <link rel="canonical" href="{% block canonical_url %}{{ request.url }}{% endblock %}" />

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -34,6 +34,23 @@
       performance.mark("Stylesheets finished");
     </script>
 
+    <!-- Set unique user_id -->
+    <script type="module">     
+      import { v4 as uuidv4 } from 'https://jspm.dev/uuid';
+      
+      const getCookie = (targetCookie) => document.cookie.match(new RegExp('(^| )' + _cookies_accepted + '=([^;]+)'));
+      const cookieAcceptanceValue = getCookie("_cookies_accepted"); 
+
+      if (cookieAcceptanceValue?.[2] === 'all' || cookieAcceptanceValue?.[2] === 'performance') {
+        // check if user doesn't already have a user_id
+        if (!getCookie("user_id")) {
+          // generate a universally unique identifier
+          const user_id = uuidv4();
+          document.cookie = 'user_id=' + user_id + ';max-age=31536000;';
+        } 
+      }
+    </script>
+
     <link rel="canonical" href="{% block canonical_url %}{{ request.url }}{% endblock %}" />
 
       <link rel="apple-touch-icon"

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -951,6 +951,10 @@ def marketo_submit():
 
     enrichment_fields = {}
 
+    user_id = flask.request.cookies.get("user_id")
+    if user_id:
+        enrichment_fields["Google_Analytics_User_ID__c"] = user_id
+
     # Enrichment data for global enrichment form (id:4198)
     if "email" in form_fields:
         enrichment_fields = {

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -951,10 +951,6 @@ def marketo_submit():
 
     enrichment_fields = {}
 
-    user_id = flask.request.cookies.get("user_id")
-    if user_id:
-        enrichment_fields["Google_Analytics_User_ID__c"] = user_id
-
     # Enrichment data for global enrichment form (id:4198)
     if "email" in form_fields:
         enrichment_fields = {
@@ -978,6 +974,10 @@ def marketo_submit():
     if "country" in form_fields:
         enrichment_fields["country"] = form_fields["country"]
         form_fields.pop("country")
+
+    user_id = flask.request.cookies.get("user_id")
+    if user_id:
+        enrichment_fields["Google_Analytics_User_ID__c"] = user_id
 
     payload = {
         "formId": form_fields.pop("formid"),


### PR DESCRIPTION
## Done

- Implemented “user_id” feature to send universally unique identifiers to Google Analytics as described [here](https://warthogs.atlassian.net/browse/WD-14908)
- Added functionality to pass value on form submission

## QA

- View the site locally in your web browser at: https://ubuntu-com-14440.demos.haus/ (or any page)
- If you have not set cookie preferences:
  - Before accepting any cookies open dev tools, log `document.cookie` and see that `user_id` does not exist
  - Accept either all or performance cookies and do the same as above, this time ensuring that `user_id` is now present
- Go to any form and fill it out (https://ubuntu-com-14440.demos.haus/ai#get-in-touch for example)
- Go to the enrichment form on maketo: https://engage-sj.marketo.com/?munchkinId=066-EOV-335#/mktform/4198/overview/details -> "Lead enrichment details" -> "People"
- Search for the email you used and the click on the ID link, eg:
![image](https://github.com/user-attachments/assets/cdb7b8b6-e43a-43bc-bd4e-9a92ac55f5a3)
- Click on the "SFDC Custom Fields" tab and see that `Google Analytics User ID` has you user id as a value:
![image](https://github.com/user-attachments/assets/d0aa9923-87e1-4006-ba87-88d8c92879ee)



## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-14942