### PR TITLE
Disable multiple fields filtering on engage pages

### DIFF
--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -126,6 +126,21 @@ function clearFilters() {
     clearFiltersButton.removeAttribute("disabled");
   }
 
+  // Disable other fields if a filter is already applied
+  const searchParams = new URLSearchParams(urlObj.search);
+  for (const [key, value] of searchParams) {
+    if (key === "language") {
+      resourceSelector.setAttribute("disabled", true);
+      tagSelector.setAttribute("disabled", true);
+    } else if (key === "resource") {
+      languageSelector.setAttribute("disabled", true);
+      tagSelector.setAttribute("disabled", true);
+    } else if (key === "tag") {
+      languageSelector.setAttribute("disabled", true);
+      resourceSelector.setAttribute("disabled", true);
+    }
+  } 
+
   function handleFilter(key, el, url) {
     if (!el) {
       return;


### PR DESCRIPTION
## Done

- When one filter is applied, disable the other field options
- The [data query explorer](https://github.com/canonical/ubuntu.com/blob/3aa78f2090452cde1fd01ca65394f0658b3bad07/templates/engage/index.html#L142) on Discourse is limited to one field filtering at the moment, and the frontend does not reflect that which may confuse users.

## QA

- Go to https://ubuntu-com-14444.demos.haus/engage
- Select a filter, check that the other selections are disabled
- Clear filters, and see that all filters are enabled again

## Issue / Card

Fixes [WD-15843](https://warthogs.atlassian.net/browse/WD-15843)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-15843]: https://warthogs.atlassian.net/browse/WD-15843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ