### PR TITLE
style: Add highlight bar below images

### DIFF
--- a/templates/pricing/devices.html
+++ b/templates/pricing/devices.html
@@ -257,6 +257,7 @@
                             attrs={"class": "p-image-container__image"}) | safe
               }}
             </div>
+            <hr class="p-rule--highlight u-hide--small" />
             <h4 class="p-heading--5">Full disk encryption</h4>
             <p>
               Enable full disk encryption with hardware key management and optional key escrow. Choice of cyphers and hardware acceleration for minimal performance impact. Essential for devices with personal information in regulated industries.
@@ -273,6 +274,7 @@
                             attrs={"class": "p-image-container__image"}) | safe
               }}
             </div>
+            <hr class="p-rule--highlight u-hide--small" />
             <h4 class="p-heading--5">Secure boot</h4>
             <p>
               Enable secure boot, ensuring that the device will only run its certified workload. Hardware key management devices such as the TPM are used to validate each stage of the boot process, for enhanced assurance of the integrity of the running OS.


### PR DESCRIPTION
## Done

- Adds a `<hr>` below the images in the section 'Add-ons to board enablement services' as per @mattea-turic's request

## QA

- Open the [demo](https://ubuntu-com-14446.demos.haus/pricing/devices)
- Check the bar is visible only on large and medium screens
