### PR TITLE
ui: add Lazy loading for images>1MB

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -46,6 +46,7 @@
               src="https://assets.ubuntu.com/v1/fb1ea84e-Kernelt%20industries@2x.png"
               width="508"
               height="364"
+              loading="lazy"
               alt="" />
         </div>
       </div>
@@ -70,7 +71,7 @@
           </div>
         </div>
         <div class="col-6 u-vertically-center u-align--center u-hide--medium u-hide--small">
-          <img id="takeover-image" src="https://assets.ubuntu.com/v1/d9fc87f3-Numbat.svg" width="300" alt="" />
+          <img id="takeover-image" src="https://assets.ubuntu.com/v1/d9fc87f3-Numbat.svg" width="300" alt="" loading="lazy" />
         </div>
       </div>
     </section>
@@ -749,7 +750,7 @@
     <section class="p-section ">
       <div class="u-fixed-width ">
         <div class="u-align--center u-vertically-center u-no-padding--bottom p-image-container--cinematic">
-          <img src="https://assets.ubuntu.com/v1/bb296524-Dell%20pcs.jpg" alt="" />
+          <img src="https://assets.ubuntu.com/v1/bb296524-Dell%20pcs.jpg" alt="" loading="lazy"/>
         </div>
         <hr class="p-rule" />
         <div class="p-section--shallow">
@@ -856,6 +857,7 @@
       <div class="u-fixed-width">
         <div class="p-image-container--cinematic">
           <img src="https://assets.ubuntu.com/v1/39667d98-Open%20source%20security.jpg"
+              loading="lazy"
                alt="" />
         </div>
         <hr class="p-rule" />
@@ -962,6 +964,7 @@
       <div class="u-fixed-width">
         <div class="p-image-container--cinematic">
           <img src="https://assets.ubuntu.com/v1/465d1258-Smart%20robots%20of%20all%20shapes%20and%20sizes.jpg"
+               loading="lazy"
                alt="" />
         </div>
         <hr class="p-rule" />
@@ -1053,7 +1056,9 @@
         <div class="u-vertically-center u-align--center p-image-container--cinematic"
              style="background: rgba(0, 0, 0, 0.15)">
           <img src="https://assets.ubuntu.com/v1/6d657910-Multi-cloud%20Applications%C2%A0%C2%A0Beyond%20PAAS.png"
-               alt="" />
+               alt=""
+               loading="lazy" 
+               />
         </div>
         <hr class="p-rule" />
         <div class="p-section--shallow">


### PR DESCRIPTION
inital loading of hompage was loading around 9MB of resources.
By lazy loading images we can reduce the intial loading by 5-6 MB.

## Done

- [List of work items including drive-bys - remember to add the why and what of this work.]

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Partially Fixes: #14443

## Screenshots

[If relevant, please include a screenshot.]
before
<img width="1280" alt="image" src="https://github.com/user-attachments/assets/e2157f60-0d28-497a-aaca-014826c07136">
after
<img width="1280" alt="image" src="https://github.com/user-attachments/assets/f9bd31df-77dd-453d-9448-917898bdf2ce">


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
