### PR TITLE
fix the sidebar logo for cred dashboard

### DIFF
--- a/static/js/src/advantage/credentials/dashboard/components/Sidebar/Sidebar.tsx
+++ b/static/js/src/advantage/credentials/dashboard/components/Sidebar/Sidebar.tsx
@@ -4,6 +4,30 @@ import { setupAppLayoutExamples } from "./utils";
 import { useQuery } from "@tanstack/react-query";
 import { getSystemStatuses } from "../../api/queryFns";
 
+const HeadingImage = () => (
+  <a
+    href="/credentials"
+    target="_blank"
+    className="p-link--soft"
+    style={{
+      display: "flex",
+      alignItems: "center",
+      gap: "0.5rem",
+      margin: "1rem 0rem",
+      cursor: "pointer",
+    }}
+  >
+    <img
+      src="https://assets.ubuntu.com/v1/82818827-CoF_white.svg"
+      width={20}
+      height={"auto"}
+    />
+    <p className="p-heading--5" style={{ padding: "0rem", margin: "0rem" }}>
+      Credentials
+    </p>
+  </a>
+);
+
 const Sidebar = () => {
   const location = useLocation();
   const {
@@ -65,37 +89,12 @@ const Sidebar = () => {
     return status;
   }, [statuses]);
 
-  const handleClickDashboard = () => {
-    window.open("/credentials", "_blank");
-  };
-
   return (
     <>
       <div className="l-navigation-bar">
         <div className="p-panel is-dark">
           <div className="p-panel__header">
-            <div
-              onClick={handleClickDashboard}
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: "0.5rem",
-                margin: "1rem 0rem",
-                cursor: "pointer",
-              }}
-            >
-              <img
-                src="https://assets.ubuntu.com/v1/82818827-CoF_white.svg"
-                width={20}
-                height={"auto"}
-              />
-              <p
-                className="p-heading--5"
-                style={{ padding: "0rem", margin: "0rem" }}
-              >
-                Credentials
-              </p>
-            </div>
+            <HeadingImage />
             <div className="p-panel__controls">
               <span className="p-panel__toggle js-menu-toggle">Menu</span>
             </div>
@@ -107,28 +106,7 @@ const Sidebar = () => {
         <div className="l-navigation__drawer">
           <div className="p-panel is-dark">
             <div className="p-panel__header is-sticky">
-              <div
-                onClick={handleClickDashboard}
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  gap: "1.2rem",
-                  margin: "1rem 0rem",
-                  cursor: "pointer",
-                }}
-              >
-                <img
-                  src="https://assets.ubuntu.com/v1/82818827-CoF_white.svg"
-                  width={20}
-                  height={"auto"}
-                />
-                <p
-                  className="p-heading--5"
-                  style={{ padding: "0rem", margin: "0rem" }}
-                >
-                  Credentials
-                </p>
-              </div>
+              <HeadingImage />
               <div className="p-panel__controls u-hide--large">
                 <button className="p-button--base is-dark has-icon u-no-margin u-hide--medium js-menu-close">
                   <i className="is-light p-icon--close"></i>


### PR DESCRIPTION
## Done

- Fix the sidebar logo on smaller screens

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Make sure the logo is clickable on smaller screens and is the same logo which you see on larger screens

## Issue / Card

Fixes [WD-16076](https://warthogs.atlassian.net/browse/WD-16076)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-16076]: https://warthogs.atlassian.net/browse/WD-16076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ