### PR TITLE
fix: Prevent form generator from removing request.path form url_rule

### DIFF
--- a/templates/aws/base_aws.html
+++ b/templates/aws/base_aws.html
@@ -4,6 +4,7 @@
   {% block content %}{% endblock %}
 
   <!-- Set default Marketo information for contact form below-->
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/aws" data-form-id="3790" data-lp-id="" data-return-url="https://ubuntu.com/aws/thank-you" data-lp-url="https://ubuntu.com/aws/contact-us">
-  </div>
+  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/form-template" data-form-id="{{ formData.formId }}" data-lp-id="" data-return-url="{{ formData.returnUrl }}" data-lp-url="https://ubuntu.com/aws/contact-us">
+    {% include "/shared/forms/form-template.html" %}
+ </div>
 {% endblock %}

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1249,15 +1249,13 @@ app.add_url_rule("/supermicro", view_func=render_supermicro_blogs)
 def render_form(form):
     @wraps(render_form)
     def wrapper_func():
-        with app.app_context() and app.test_request_context():
-            return flask.render_template(
-                form["templatePath"],
-                fieldsets=form["fieldsets"],
-                formData=form["formData"],
-                isModal=form.get("isModal"),
-                modalId=form.get("modalId"),
-            )
-
+        return flask.render_template(
+            form["templatePath"],
+            fieldsets=form["fieldsets"],
+            formData=form["formData"],
+            isModal=form.get("isModal"),
+            modalId=form.get("modalId"),
+        )
     return wrapper_func
 
 


### PR DESCRIPTION
**Before merge please remove changes in base_aws.html**

## Done

- Removes the line `with app.app_context() and app.test_request_context()`, this shouldn't needed as the function is already passed in the context of the app. This was also causing the `request.path` to get stripped.

## QA

- Open [the demo]()
- Open the form, fill it in and submit it
- Porfit???


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
