### PR TITLE
Restrict channel users from editing billing details

### DIFF
--- a/static/js/src/advantage/distributor/components/DistributorBuyButton/DistributorBuyButton.test.tsx
+++ b/static/js/src/advantage/distributor/components/DistributorBuyButton/DistributorBuyButton.test.tsx
@@ -12,7 +12,7 @@ import {
   FormContext,
   defaultValues,
 } from "advantage/distributor/utils/FormContext";
-import { distributorProduct } from "advantage/subscribe/checkout/utils/test/Mocks";
+import { DistributorProduct } from "advantage/subscribe/checkout/utils/test/Mocks";
 import { ChannelOfferFactory } from "advantage/offers/tests/factories/channelOffers";
 import { UserSubscriptionMarketplace } from "advantage/api/enum";
 
@@ -27,7 +27,7 @@ const mockSubscription: SubscriptionItem = {
 const mockContextValue = {
   ...defaultValues,
   subscriptionList: [mockSubscription] as SubscriptionItem[],
-  products: [distributorProduct] as ChannelProduct[],
+  products: [DistributorProduct] as ChannelProduct[],
   offer: ChannelOfferFactory.build({ id: "offer-id-1" }),
 };
 

--- a/static/js/src/advantage/distributor/components/DistributorShopForm/AddSubscriptions/SubscriptionCard.tsx/SubscriptionCard.test.tsx
+++ b/static/js/src/advantage/distributor/components/DistributorShopForm/AddSubscriptions/SubscriptionCard.tsx/SubscriptionCard.test.tsx
@@ -11,7 +11,7 @@ import {
   FormContext,
   defaultValues,
 } from "advantage/distributor/utils/FormContext";
-import { distributorProduct } from "advantage/subscribe/checkout/utils/test/Mocks";
+import { DistributorProduct } from "advantage/subscribe/checkout/utils/test/Mocks";
 
 const mockSubscription: SubscriptionItem = {
   id: "mocked-id-1",
@@ -25,7 +25,7 @@ const mockContextValue = {
   ...defaultValues,
   subscriptionList: [mockSubscription] as SubscriptionItem[],
   setSubscriptionList: jest.fn(),
-  products: [distributorProduct] as ChannelProduct[],
+  products: [DistributorProduct] as ChannelProduct[],
   duration: 1,
 };
 

--- a/static/js/src/advantage/subscribe/checkout/components/Taxes/Taxes.test.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Taxes/Taxes.test.tsx
@@ -3,7 +3,7 @@ import { Formik } from "formik";
 import { Elements } from "@stripe/react-stripe-js";
 import { loadStripe } from "@stripe/stripe-js";
 import { fireEvent, render, screen } from "@testing-library/react";
-import { UAProduct } from "../../utils/test/Mocks";
+import { DistributorProduct, UAProduct } from "../../utils/test/Mocks";
 import Taxes from "./Taxes";
 
 describe("TaxesTests", () => {
@@ -112,7 +112,7 @@ describe("TaxesTests", () => {
     global.window = Object.create(window);
     Object.defineProperty(window, "accountId", { value: "ABCDEF" });
 
-    const intialValues = {
+    const initialValues = {
       country: "GB",
     };
     const products = [
@@ -123,7 +123,7 @@ describe("TaxesTests", () => {
     ];
     render(
       <QueryClientProvider client={queryClient}>
-        <Formik initialValues={intialValues} onSubmit={jest.fn()}>
+        <Formik initialValues={initialValues} onSubmit={jest.fn()}>
           <Elements stripe={stripePromise}>
             <Taxes products={products} setError={jest.fn()} />
           </Elements>
@@ -158,7 +158,7 @@ describe("TaxesTests", () => {
     global.window = Object.create(window);
     Object.defineProperty(window, "accountId", { value: "ABCDEF" });
 
-    const intialValues = {
+    const initialValues = {
       country: "GB",
       VATNumber: "GB123123123",
     };
@@ -171,7 +171,7 @@ describe("TaxesTests", () => {
     ];
     render(
       <QueryClientProvider client={queryClient}>
-        <Formik initialValues={intialValues} onSubmit={jest.fn()}>
+        <Formik initialValues={initialValues} onSubmit={jest.fn()}>
           <Elements stripe={stripePromise}>
             <Taxes products={products} setError={jest.fn()} />
           </Elements>
@@ -211,5 +211,63 @@ describe("TaxesTests", () => {
     fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
     expect(screen.getByTestId("country")).toHaveTextContent("United Kingdom");
     expect(screen.getByTestId("vat-number")).toHaveTextContent("GB123123123");
+  });
+
+  it("Edit button should be displayed for pro users", () => {
+    global.window = Object.create(window);
+    Object.defineProperty(window, "accountId", { value: "ABCDEF" });
+
+    const initialValues = {
+      country: "GB",
+      VATNumber: "GB123123123",
+      marketPlace: "canonical-ua",
+    };
+
+    const products = [
+      {
+        product: UAProduct,
+        quantity: 1,
+      },
+    ];
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Formik initialValues={initialValues} onSubmit={jest.fn()}>
+          <Elements stripe={stripePromise}>
+            <Taxes products={products} setError={jest.fn()} />
+          </Elements>
+        </Formik>
+      </QueryClientProvider>,
+    );
+
+    expect(screen.queryByRole("button", { name: "Edit" })).toBeInTheDocument();
+  });
+
+  it("Edit button should not be displayed for channel users", () => {
+    global.window = Object.create(window);
+    Object.defineProperty(window, "accountId", { value: "ABCDEF" });
+
+    const initialValues = {
+      country: "GB",
+      VATNumber: "GB123123123",
+      marketPlace: "canonical-pro-channel",
+    };
+
+    const products = [
+      {
+        product: DistributorProduct,
+        quantity: 1,
+      },
+    ];
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Formik initialValues={initialValues} onSubmit={jest.fn()}>
+          <Elements stripe={stripePromise}>
+            <Taxes products={products} setError={jest.fn()} />
+          </Elements>
+        </Formik>
+      </QueryClientProvider>,
+    );
+
+    expect(screen.queryByTestId("tax-edit-button")).not.toBeInTheDocument();
   });
 });

--- a/static/js/src/advantage/subscribe/checkout/components/UserInfoForm/UserInfoForm.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/UserInfoForm/UserInfoForm.tsx
@@ -15,6 +15,7 @@ import registerPaymentMethod from "../../hooks/postCustomerInfo";
 import { FormValues } from "../../utils/types";
 import FormRow from "../FormRow";
 import PaymentMethodSummary from "./PaymentMethodSummary";
+import { UserSubscriptionMarketplace } from "advantage/api/enum";
 
 type Error = {
   type: "validation_error";
@@ -45,6 +46,8 @@ const UserInfoForm = ({ setError }: Props) => {
   const [cardFieldHasFocus, setCardFieldFocus] = useState(false);
   const [cardFieldError, setCardFieldError] = useState<Error | null>(null);
   const [showCardValidation, setShowCardValidation] = useState<boolean>(false);
+  const isChannelUser =
+    values.marketplace === UserSubscriptionMarketplace.CanonicalProChannel;
 
   const toggleEditing = () => {
     if (isEditing) {
@@ -87,7 +90,9 @@ const UserInfoForm = ({ setError }: Props) => {
       {
         onSuccess: () => {
           queryClient.invalidateQueries({ queryKey: ["customerInfo"] });
-          queryClient.invalidateQueries({ queryKey: ["preview"] });
+          queryClient.invalidateQueries({
+            queryKey: ["preview"],
+          });
           setIsButtonDisabled(false);
           setIsEditing(false);
         },
@@ -144,10 +149,9 @@ const UserInfoForm = ({ setError }: Props) => {
     return errorMessage;
   };
 
-  const displayMode = (
+  const UserInfoSummary = () => (
     <>
-      <PaymentMethodSummary />
-      {values.buyingFor === "organisation" ? (
+      {values.buyingFor === "organisation" && (
         <>
           <Row>
             <Col size={4}>
@@ -163,7 +167,7 @@ const UserInfoForm = ({ setError }: Props) => {
           </Row>
           <hr />
         </>
-      ) : null}
+      )}
       <Row>
         <Col size={4}>
           <p>Your name:</p>
@@ -209,6 +213,13 @@ const UserInfoForm = ({ setError }: Props) => {
           </p>
         </Col>
       </Row>
+    </>
+  );
+
+  const displayMode = (
+    <>
+      <PaymentMethodSummary />
+      <UserInfoSummary />
     </>
   );
 
@@ -280,103 +291,116 @@ const UserInfoForm = ({ setError }: Props) => {
           }}
           required
           error={touched?.isCardValid && errors?.isCardValid}
+          data-testid="field-card-number"
         />
       </FormRow>
-      <Field
-        data-testid="field-customer-name"
-        as={Input}
-        type="text"
-        id="name"
-        name="name"
-        label="Name:"
-        stacked
-        validate={validateRequired}
-        error={touched?.name && errors?.name}
-      />
-      <FormRow label="I’m buying for:">
-        <div className="u-sv3 p-form p-form--inline" role="group">
-          <Field name="buyingFor">
-            {({ field }: any) => (
-              <>
-                <RadioInput
-                  {...field}
-                  id="myself"
-                  value="myself"
-                  checked={field.value === "myself"}
-                  onChange={() => setFieldValue("buyingFor", "myself")}
-                  label="Myself"
-                  disabled={window.accountId && initialValues.organisationName}
-                />
-                <RadioInput
-                  {...field}
-                  id="organisation"
-                  value="organisation"
-                  checked={field.value === "organisation"}
-                  onChange={() => setFieldValue("buyingFor", "organisation")}
-                  label="An organisation"
-                  disabled={window.accountId && initialValues.organisationName}
-                />
-              </>
-            )}
-          </Field>
-        </div>
-      </FormRow>
-      {initialValues.buyingFor === "myself" &&
-      window.accountId &&
-      initialValues.organisationName ? null : (
-        <Field
-          data-testid="field-org-name"
-          as={Input}
-          type="text"
-          id="organisationName"
-          name="organisationName"
-          disabled={
-            values.buyingFor === "myself" ||
-            (window.accountId && initialValues.organisationName)
-          }
-          label="Organisation:"
-          stacked
-          validate={validateOrganisationName}
-          error={
-            values.buyingFor === "organisation" &&
-            touched?.organisationName &&
-            errors?.organisationName
-          }
-        />
+      {isChannelUser ? (
+        <UserInfoSummary />
+      ) : (
+        <>
+          <Field
+            data-testid="field-customer-name"
+            as={Input}
+            type="text"
+            id="name"
+            name="name"
+            label="Name:"
+            stacked
+            validate={validateRequired}
+            error={touched?.name && errors?.name}
+          />
+          <FormRow label="I'm buying for:">
+            <div className="u-sv3 p-form p-form--inline" role="group">
+              <Field name="buyingFor">
+                {({ field }: any) => (
+                  <>
+                    <RadioInput
+                      {...field}
+                      id="myself"
+                      value="myself"
+                      checked={field.value === "myself"}
+                      onChange={() => setFieldValue("buyingFor", "myself")}
+                      label="Myself"
+                      disabled={
+                        window.accountId && initialValues.organisationName
+                      }
+                    />
+                    <RadioInput
+                      {...field}
+                      id="organisation"
+                      value="organisation"
+                      checked={field.value === "organisation"}
+                      onChange={() =>
+                        setFieldValue("buyingFor", "organisation")
+                      }
+                      label="An organisation"
+                      disabled={
+                        window.accountId && initialValues.organisationName
+                      }
+                    />
+                  </>
+                )}
+              </Field>
+            </div>
+          </FormRow>
+          {initialValues.buyingFor === "myself" &&
+          window.accountId &&
+          initialValues.organisationName ? null : (
+            <Field
+              data-testid="field-org-name"
+              as={Input}
+              type="text"
+              id="organisationName"
+              name="organisationName"
+              disabled={
+                values.buyingFor === "myself" ||
+                (window.accountId && initialValues.organisationName)
+              }
+              label="Organisation:"
+              stacked
+              validate={validateOrganisationName}
+              error={
+                values.buyingFor === "organisation" &&
+                touched?.organisationName &&
+                errors?.organisationName
+              }
+            />
+          )}
+          <Field
+            data-testid="field-address"
+            as={Input}
+            type="text"
+            id="address"
+            name="address"
+            label="Address:"
+            stacked
+            validate={validateRequired}
+            error={touched?.address && errors?.address}
+          />
+          <Field
+            data-testid="field-city"
+            as={Input}
+            type="text"
+            id="city"
+            name="city"
+            label="City:"
+            stacked
+            validate={validateRequired}
+            error={touched?.city && errors?.city}
+          />
+          <Field
+            data-testid="field-post-code"
+            as={Input}
+            type="text"
+            id="postalCode"
+            name="postalCode"
+            label="Postal code:"
+            stacked
+            validate={validateRequired}
+            error={touched?.postalCode && errors?.postalCode}
+          />
+        </>
       )}
-      <Field
-        data-testid="field-address"
-        as={Input}
-        type="text"
-        id="address"
-        name="address"
-        label="Address:"
-        stacked
-        validate={validateRequired}
-        error={touched?.address && errors?.address}
-      />
-      <Field
-        data-testid="field-city"
-        as={Input}
-        type="text"
-        id="city"
-        name="city"
-        label="City:"
-        stacked
-        validate={validateRequired}
-        error={touched?.city && errors?.city}
-      />
-      <Field
-        data-testid="field-post-code"
-        as={Input}
-        type="text"
-        id="postalCode"
-        name="postalCode"
-        label="Postal code:"
-        stacked
-        validate={validateRequired}
-        error={touched?.postalCode && errors?.postalCode}
-      />
     </>
   );
 

--- a/static/js/src/advantage/subscribe/checkout/utils/test/Mocks.ts
+++ b/static/js/src/advantage/subscribe/checkout/utils/test/Mocks.ts
@@ -152,7 +152,7 @@ export const BlenderProduct: Product = {
   canBeTrialled: false,
 };
 
-export const distributorProduct: ChannelProduct = {
+export const DistributorProduct: ChannelProduct = {
   id: "uai-essential-desktop-1y-channel-eur-v2",
   longId: "lANXjQ-H8fzvf_Ea8bIK1KW7Wi2W0VHnV0ZUsrEGbUiQ",
   name: "uai-essential-desktop-1y-channel-eur-v2",


### PR DESCRIPTION
## Done

- Restrict distributor store users from editing billing details

## QA

- Check out this feature branch or go to the demo link
- Go to /pro/distributor, /pro/subscribe and /credentials
- Purchase an item for each shop
- Distributor users should not be able to edit their tax and billing address info (Only card number)
- Pro/credential users should be able to edit as before.

## Issue / Card

Fixes #https://warthogs.atlassian.net/browse/WD-16449

## Screenshots
before
![image](https://github.com/user-attachments/assets/250705c9-5043-4467-adf4-e16cbfb8b370)

after
![image](https://github.com/user-attachments/assets/28f5bcf5-1afa-4936-b584-a4dc2a97184d)

before
![image](https://github.com/user-attachments/assets/d65f32d5-6dae-4641-a8e6-5f71ec12540e)

after
![image](https://github.com/user-attachments/assets/3c839b31-0bf9-4d7b-b36a-648c65ff3c86)

