### PR TITLE
Fix radio modal bug for dynamic forms

### DIFF
--- a/static/js/src/dynamic-forms.js
+++ b/static/js/src/dynamic-forms.js
@@ -410,12 +410,14 @@ import { prepareInputFields } from "./prepare-form-inputs.js";
 
           const howManyMachinesFieldset =
             document.getElementById("how-many-machines");
-          const machinesInputs = howManyMachinesFieldset?.querySelectorAll(
-            "input[name='how-many-machines-do-you-have']",
-          );
-          machinesInputs.forEach((input) => {
-            input.removeAttribute("name");
-          });
+          if (howManyMachinesFieldset) {
+            const machinesInputs = howManyMachinesFieldset.querySelectorAll(
+              "input[name='how-many-machines-do-you-have']",
+            );
+            machinesInputs.forEach((input) => {
+              input.removeAttribute("name");
+            });
+          }
 
           return message;
         }

--- a/static/js/src/dynamic-forms.js
+++ b/static/js/src/dynamic-forms.js
@@ -408,14 +408,13 @@ import { prepareInputFields } from "./prepare-form-inputs.js";
             message += "\r\n\r\n";
           });
 
-          const howManyMachinesFieldset =
-            document.getElementById("how-many-machines");
-          if (howManyMachinesFieldset) {
-            const machinesInputs = howManyMachinesFieldset.querySelectorAll(
-              "input[name='how-many-machines-do-you-have']",
-            );
-            machinesInputs.forEach((input) => {
-              input.removeAttribute("name");
+          const radioFieldsets = document.querySelectorAll(".js-remove-radio-names");
+          if (radioFieldsets) {
+            radioFieldsets.forEach((radioFieldset) => {
+              const radioInputs = radioFieldset.querySelectorAll("input[type='radio']");
+              radioInputs.forEach((radioInput) => {
+                radioInput.removeAttribute("name");
+              });
             });
           }
 

--- a/static/js/src/dynamic-forms.js
+++ b/static/js/src/dynamic-forms.js
@@ -408,10 +408,14 @@ import { prepareInputFields } from "./prepare-form-inputs.js";
             message += "\r\n\r\n";
           });
 
-          const radioFieldsets = document.querySelectorAll(".js-remove-radio-names");
+          const radioFieldsets = document.querySelectorAll(
+            ".js-remove-radio-names",
+          );
           if (radioFieldsets) {
             radioFieldsets.forEach((radioFieldset) => {
-              const radioInputs = radioFieldset.querySelectorAll("input[type='radio']");
+              const radioInputs = radioFieldset.querySelectorAll(
+                "input[type='radio']",
+              );
               radioInputs.forEach((radioInput) => {
                 radioInput.removeAttribute("name");
               });

--- a/templates/kernel/real-time/contact-us.html
+++ b/templates/kernel/real-time/contact-us.html
@@ -363,7 +363,7 @@
 
       <div class="p-section">
         <hr class="p-rule is-fixed-width" />
-        <fieldset class="p-fieldset-section js-formfield"
+        <fieldset class="p-fieldset-section js-formfield js-remove-radio-names"
                   aria-labelledby="how-many-machines-legend"
                   aria-required="true"
                   id="how-many-machines">

--- a/templates/shared/_client-contact-us-form.html
+++ b/templates/shared/_client-contact-us-form.html
@@ -38,7 +38,7 @@
 
     <div class="p-section">
       <hr class="p-rule is-fixed-width" />
-      <fieldset class="p-fieldset-section js-formfield"
+      <fieldset class="p-fieldset-section js-formfield js-remove-radio-names"
                 aria-labelledby="how-many-machines-legend"
                 aria-required="true"
                 id="how-many-machines">

--- a/templates/shared/_default-contact-us-form.html
+++ b/templates/shared/_default-contact-us-form.html
@@ -172,7 +172,7 @@
     </div>
     <div class="p-section">
       <hr class="p-rule is-fixed-width" />
-      <fieldset class="p-fieldset-section js-formfield"
+      <fieldset class="p-fieldset-section js-formfield js-remove-radio-names"
                 aria-labelledby="how-many-machines-legend"
                 aria-required="true"
                 id="how-many-machines">

--- a/templates/shared/_pro-contact-us-form.html
+++ b/templates/shared/_pro-contact-us-form.html
@@ -172,7 +172,7 @@
     </div>
     <div class="p-section">
       <hr class="p-rule is-fixed-width" />
-      <fieldset class="p-fieldset-section js-formfield"
+      <fieldset class="p-fieldset-section js-formfield js-remove-radio-names"
                 aria-labelledby="how-many-machines-legend"
                 aria-required="true"
                 id="how-many-machines">

--- a/templates/shared/forms/interactive/aws.html
+++ b/templates/shared/forms/interactive/aws.html
@@ -188,7 +188,7 @@
         </div>
         <div class="p-section">
           <hr class="p-rule is-fixed-width" />
-          <fieldset class="p-fieldset-section js-formfield"
+          <fieldset class="p-fieldset-section js-formfield js-remove-radio-names"
                     aria-labelledby="how-many-machines-legend"
                     aria-required="true"
                     id="how-many-machines">

--- a/templates/shared/forms/interactive/esm.html
+++ b/templates/shared/forms/interactive/esm.html
@@ -177,7 +177,7 @@
         </div>
         <div class="p-section">
           <hr class="p-rule is-fixed-width" />
-          <fieldset class="p-fieldset-section js-formfield"
+          <fieldset class="p-fieldset-section js-formfield js-remove-radio-names"
                     aria-labelledby="how-many-machines-legend"
                     aria-required="true"
                     id="how-many-machines">

--- a/templates/shared/forms/interactive/general.html
+++ b/templates/shared/forms/interactive/general.html
@@ -186,7 +186,7 @@
         </div>
         <div class="p-section">
           <hr class="p-rule is-fixed-width" />
-          <fieldset class="p-fieldset-section js-formfield"
+          <fieldset class="p-fieldset-section js-formfield js-remove-radio-names"
                     aria-labelledby="how-many-machines-legend"
                     aria-required="true"
                     id="how-many-machines">

--- a/templates/shared/forms/interactive/landscape.html
+++ b/templates/shared/forms/interactive/landscape.html
@@ -186,7 +186,7 @@
         </div>
         <div class="p-section">
           <hr class="p-rule is-fixed-width" />
-          <fieldset class="p-fieldset-section js-formfield"
+          <fieldset class="p-fieldset-section js-formfield js-remove-radio-names"
                     aria-labelledby="how-many-machines-legend"
                     aria-required="true"
                     id="how-many-machines">

--- a/templates/shared/forms/interactive/pricing-infra.html
+++ b/templates/shared/forms/interactive/pricing-infra.html
@@ -188,7 +188,7 @@
         </div>
         <div class="p-section">
           <hr class="p-rule is-fixed-width" />
-          <fieldset class="p-fieldset-section js-formfield"
+          <fieldset class="p-fieldset-section js-formfield js-remove-radio-names"
                     aria-labelledby="how-many-machines-legend"
                     aria-required="true"
                     id="how-many-machines">

--- a/templates/shared/forms/interactive/storage.html
+++ b/templates/shared/forms/interactive/storage.html
@@ -186,7 +186,7 @@
         </div>
         <div class="p-section">
           <hr class="p-rule is-fixed-width" />
-          <fieldset class="p-fieldset-section js-formfield"
+          <fieldset class="p-fieldset-section js-formfield js-remove-radio-names"
                     aria-labelledby="how-many-machines-legend"
                     aria-required="true"
                     id="how-many-machines">


### PR DESCRIPTION
## Done

- Add check for machinesInput
- Fixes the javascript error that was previously looping through an empty instance

## QA
To test for modal:
- Go to https://ubuntu-com-14465.demos.haus/case-study/esa or any page with a dynamic form modal
- Scroll down and click on "Contact Us", modal should pop up
- Close the modal and see that it behaves as expected

To test that radio attributes are removed correctly:
- Go to https://ubuntu-com-14465.demos.haus/aws#get-in-touch or any of the affected pages (see file diff)
- Fill up the form and submit
- Check that payload includes radio "How many machines..." as intended

## Issue / Card

Fixes [WD-16656](https://warthogs.atlassian.net/browse/WD-16656)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-16656]: https://warthogs.atlassian.net/browse/WD-16656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ