### PR TITLE
[WD-16659] enable AB tests for takeovers on the landing page

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -1133,7 +1133,7 @@
 
       const getCookie = () => document.cookie.match(new RegExp('(^| )' + "control_or_variant" + '=([^;]+)'));
       // Switch for turning takeover switching on and off on demand
-      const takeoverSwitch = false;
+      const takeoverSwitch = true;
       if (!takeoverSwitch) document.cookie = 'control_or_variant=;';
       else {
         // check if user doesn't already have a group


### PR DESCRIPTION
## Done

- Turned on the switch that will enable A/B tests for two different layouts of takeovers that were implemented before in the scope of this epic: https://warthogs.atlassian.net/browse/WD-11543

## QA

- Navigate to the landing page at https://ubuntu-com-14467.demos.haus/
- Remember the layout of the takeover shown on the top of the page
- Check the value of the `control_or_variant` cookie in dev console
   - if it's `control`, change it to `variant`
   - if it's `variant`, change it to `control`
   - This change happens automatically in the background by splitting users into two groups so that each group only sees their version of the takeover layout. But for testing purpose you need to change it manually.
- Refresh the page
- Check that the layout of the takeover has changed

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-16659

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
