### PR TITLE
copy: add Azure banner to multiple pages. WD-16533

### DIFF
--- a/templates/ai/mlops.html
+++ b/templates/ai/mlops.html
@@ -20,6 +20,7 @@
     <div class="p-section--deep">
       <div class="row">
         <div class="col-start-large-4 col-9">
+          {% include "shared/_azure-banner.html" %}
           <div class="p-section--shallow">
             <h1 class="u-no-padding--bottom">
               Deliver AI at scale
@@ -103,7 +104,7 @@
           </p>
         </div>
         <div class="p-section--shallow">
-          <hr />
+          <hr class="p-rule--muted" />
           <a class="p-button--positive"
              href="https://charmed-kubeflow.io/docs/get-started-with-charmed-kubeflow">Get started with Charmed Kubeflow</a>
         </div>
@@ -138,7 +139,7 @@
           </p>
         </div>
         <div class="p-section--shallow">
-          <hr class="p-rule" />
+          <hr class="p-rule--muted" />
           <div class="p-section--shallow">
             <h3 class="p-heading--2">Managed MLOps</h3>
           </div>
@@ -150,7 +151,7 @@
           </p>
         </div>
         <div class="p-section--shallow">
-          <hr class="p-rule" />
+          <hr class="p-rule--muted" />
           <div class="p-section--shallow">
             <h3 class="p-heading--2">Open source MLOps in the public cloud</h3>
           </div>
@@ -162,7 +163,7 @@
           </p>
         </div>
         <div class="p-section--shallow">
-          <hr class="p-rule" />
+          <hr class="p-rule--muted" />
           <div class="p-section--shallow">
             <h3 class="p-heading--2">
               Get your team up-to-date
@@ -200,7 +201,7 @@
             <p>One of our customers migrated from a legacy platform to Canonical MLOps and reduced their operational costs.</p>
           </div>
         </div>
-        <hr class="p-rule" />
+        <hr class="p-rule--muted" />
         <div class="row p-section--shallow">
           <div class="col-3">
             <p>
@@ -211,7 +212,7 @@
             <p>Learn to take models to production using open source MLOps platforms.</p>
           </div>
         </div>
-        <hr class="p-rule" />
+        <hr class="p-rule--muted" />
         <div class="row p-section--shallow">
           <div class="col-3">
             <p>
@@ -224,7 +225,7 @@
             <p>Find out how to streamline operations and scale AI initiatives using open source MLOps platforms on NVIDIA DGX.</p>
           </div>
         </div>
-        <hr class="p-rule" />
+        <hr class="p-rule--muted" />
         <div class="row p-section--shallow">
           <div class="col-3">
             <p>
@@ -235,7 +236,7 @@
             <p>Run open source MLOps on AWS to remove compute power constraints and start your AI project quickly.</p>
           </div>
         </div>
-        <hr class="p-rule" />
+        <hr class="p-rule--muted" />
         <div class="row p-section--shallow">
           <div class="col-3">
             <p>

--- a/templates/ai/what-is-kubeflow.html
+++ b/templates/ai/what-is-kubeflow.html
@@ -7,6 +7,11 @@
 {% block body_class %}is-paper{% endblock body_class %}
 {% block content %}
 
+<div class="p-strip is-shallow u-no-padding--bottom">
+  <div class="u-fixed-width">
+    {% include "shared/_azure-banner.html" %}
+  </div>
+</div>
 <section class="p-strip is-shallow u-no-padding--bottom">
   <div class="p-section">
     <div class="row--25-75">
@@ -35,7 +40,7 @@
         </div>
         </div>
 
-        <hr class="p-rule" />
+        <hr class="p-rule--muted" />
         <a class="p-button--positive" href="https://charmed-kubeflow.io/docs/install">Try out Charmed Kubeflow</a>
         <a class="p-button" href="/engage/mlops-toolkit">Read our MLOps toolkit</a>
       </div>
@@ -126,7 +131,7 @@
           </div>
         </div>
       </div>
-      <hr class="p-rule u-hide--small u-hide--medium" />
+      <hr class="p-rule--muted u-hide--small u-hide--medium" />
       <div class="row p-section--shallow">
         <div class="col-3 col-medium-2">
           <h3 class="p-heading--5">Kubeflow dashboard</h3>
@@ -147,7 +152,7 @@
         </div>
       </div>
 
-      <hr class="p-rule u-hide--small" />
+      <hr class="p-rule--muted u-hide--small" />
       <div class="row">
         <div class="col-3 col-medium-2 p-section--shallow">
           <h3 class="p-heading--5">Kubeflow Pipelines</h3>
@@ -163,7 +168,7 @@
           <p>Kubeflow includes <a href="https://www.kubeflow.org/docs/components/katib/">Katib</a> for hyperparameter tuning. Katib runs pipelines with different hyperparameters (e.g. learning rate, # of hidden layers) optimising for the best ML model.</p>
         </div>
       </div>
-      <hr class="p-rule u-hide--small" />
+      <hr class="p-rule--muted u-hide--small" />
       <div class="row">
         <div class="col-3 col-medium-2">
           <h3 class="p-heading--5">KServe for inference serving</h3>
@@ -191,7 +196,7 @@
     <div class="col">
       <p>Enterprise-ready Charmed Kubeflow, the fully supported MLOps platform for any cloud, is validate and certified on high-end AI hardware, such as NVIDIA DGX.</p>
       <p class="p-section--shallow">A complete solution for sophisticated data science labs. Upgrades and security updates - all supported in the free, open source distribution.</p>
-      <hr class="p-rule" />
+      <hr class="p-rule--muted" />
       <a class="p-button--positive" href="/engage/run-ai-at-scale">Get the whitepaper</a>
     </div>
   </div>
@@ -206,7 +211,7 @@
     <div class="col p-section--shallow">
       <p>Bringing AI solutions to market can involve many steps: data pre-processing, training, model deployment or inference serving at scale... The list of tasks is complex and keeping them in a set of notebooks or scripts is hard to maintain, share and collaborate on, leading to inefficient processes.</p>
       <p class="p-section--shallow"><a href="https://papers.nips.cc/paper/5656-hidden-technical-debt-in-machine-learning-systems.pdf">Google describes</a> that only about 20% of the effort and code required to bring AI systems to production is the development of ML code, while the remaining is operations. Standardizing ops in your ML workflows can hence greatly decrease time-to-market and costs for your AI solutions.</p>
-      <hr class="p-rule" />
+      <hr class="p-rule--muted" />
       <a href="/blog/what-is-mlops">Read more about MLOps</a>
     </div>
     <div class="u-align--center u-hide--small p-image-wrapper">
@@ -225,7 +230,7 @@
       <p>Thousands of companies have chosen Kubeflow for their AI/ML stack.</p>
       <p>From research institutions like CERN, to transport and logistics companies - Uber, Lyft, GoJek - to financial and media industries with Spotify, Bloomberg, Shopify and PayPal.</p>
       <p class="p-section--shallow">Forward-looking enterprises are using Kubeflow to empower their data scientists.</p>
-      <hr class="p-rule" />
+      <hr class="p-rule--muted" />
       <a href="/engage/ai-ml-casestudy-tasmania/">Read our case study with the University of Tasmania</a>
     </div>
     <div class="row--25-75">

--- a/templates/azure/index.html
+++ b/templates/azure/index.html
@@ -15,6 +15,11 @@
 {% endblock body_class %}
 
 {% block content %}
+  <div class="p-strip is-shallow u-no-padding--bottom">
+    <div class="u-fixed-width">
+      {% include "shared/_azure-banner.html" %}
+    </div>
+  </div>
   <section class="p-section--hero">
     <div class="row--50-50">
       <div class="col">

--- a/templates/shared/_azure-banner.html
+++ b/templates/shared/_azure-banner.html
@@ -1,0 +1,12 @@
+<div id="notification" class="p-notification">
+  <div class="p-notification__content">
+    <h5 class="p-notification__title">
+      Apply to join our preview for Managed Kubeflow on Azure!
+    </h5>
+    <p class="p-notification__message">
+      <a href="https://krzty8pox19.typeform.com/to/UdYZJulp" target="_blank" rel="noopener noreferrer">
+        Learn more and sign up.
+      </a>
+    </p>
+  </div>
+</div>


### PR DESCRIPTION
## Done

Updated a series of pages to have a small banner that invites people to sign up for Managed Kubeflow on Azure.
[Doc 1](https://docs.google.com/document/d/1m-96RlGkbzFa1KaGAxYFpY0ztIlsTuViCjXSAlErQlg/edit?tab=t.0#heading=h.m90kfgudav7e), [doc 2](https://docs.google.com/document/d/18AMX_-3zjBNUNGr0X5QtjKhsUzAc2k8VM1-opZEGh4k/edit?tab=t.0), [doc 3](https://docs.google.com/document/d/1GUlSATrqZmGrsk4DhP9W0s-gcOuFxpdKVgx7YE4g780/edit?tab=t.0#)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Make sure to test on mobile, tablet and desktop screen sizes

## Issue / Card

Fixes [#WD-16533](https://warthogs.atlassian.net/browse/WD-16533)

## Screenshots

<img width="1686" alt="image" src="https://github.com/user-attachments/assets/0820dd26-c008-4a88-a648-d0a80d7d6f80">

<img width="1634" alt="image" src="https://github.com/user-attachments/assets/6606b40b-43d0-4e78-84f0-fb105b8c80d8">

<img width="1646" alt="image" src="https://github.com/user-attachments/assets/6f8ac0bf-71de-42b0-a058-249ae123cd0c">

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
