### PR TITLE
Rebrand /ceph/managed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ WORKDIR /srv
 ADD . .
 RUN rm -rf package.json yarn.lock babel.config.js webpack.config.js
 COPY --from=build-js /srv/static/js static/js
+COPY --from=build-js /srv/node_modules/vanilla-framework/templates node_modules/vanilla-framework/templates
 COPY --from=build-css /srv/static/css static/css
 ADD http://launchpad.net/ubuntu/+cdmirrors-rss etc/ubuntu-mirrors-rss.xml
 

--- a/package.json
+++ b/package.json
@@ -115,12 +115,12 @@
     "react-google-recaptcha": "3.1.0",
     "react-router-dom": "^6.24.1",
     "react-useportal": "1.0.19",
-    "sass": "1.45.2",
+    "sass": "1.79.0",
     "smartquotes": "2.3.2",
     "typescript": "5.5.4",
     "url-polyfill": "1.1.12",
     "url-search-params-polyfill": "8.2.5",
-    "vanilla-framework": "4.16.0",
+    "vanilla-framework": "4.18.0",
     "yup": "1.4.0"
   },
   "resolutions": {

--- a/templates/ceph/managed.html
+++ b/templates/ceph/managed.html
@@ -1,155 +1,290 @@
 {% extends "ceph/base_ceph.html" %}
 
+{% from "_macros/vf_hero.jinja" import vf_hero %}
+
 {% block title %}Managed Ceph | Ceph{% endblock %}
 
-{% block meta_description %}Canonical is the leading managed ceph provider, we build, support and manage ceph clusters in any location. {% endblock meta_description %}
+{% block meta_description %}
+  Canonical is the leading managed ceph provider, we build, support and manage ceph clusters in any location.
+{% endblock meta_description %}
 
-{% block meta_copydoc %}https://docs.google.com/document/d/1Ff3TDYBsukagu85dNZuK0FDdPRSjXEwS6Tv6JphXUvY{% endblock meta_copydoc %}
+{% block meta_copydoc %}
+  https://docs.google.com/document/d/1Ff3TDYBsukagu85dNZuK0FDdPRSjXEwS6Tv6JphXUvY
+{% endblock meta_copydoc %}
 
 {% block content %}
-<section class="p-strip--suru-bottomed">
-  <div class="row u-equal-height u-vertically-center">
-    <div class="col-7">
-      <h1>Fully managed Ceph</h1>
+  {% call(slot) vf_hero(
+    title_text='Fully managed Ceph',
+    layout='50/50',
+    is_split_on_medium=true
+    ) -%}
+    {%- if slot == 'description' -%}
       <p>Reduce operational complexity by allowing Canonical's experts to operate and maintain your Ceph cluster.</p>
-      <ul class="p-list">
-				<li class="p-list__item is-ticked">Fully managed on your servers, in your own data center, or in a co-location facility</li>
-				<li class="p-list__item is-ticked">Built using a proven reference architecture</li>
-				<li class="p-list__item is-ticked">Customise the cluster architecture based on your needs</li>
-				<li class="p-list__item is-ticked">Integrated with your infrastructure, on-prem, hybrid, or public cloud</li>
-				<li class="p-list__item is-ticked">Existing workload analysis and migration services</li>
-				<li class="p-list__item is-ticked">Enterprise SLA for all protocols</li>
-				<li class="p-list__item is-ticked">Your team retains access to all machines at all times</li>
-				<li class="p-list__item is-ticked">Modern monitoring and log management</li>
-				<li class="p-list__item is-ticked">We will hand over the keys when you are ready</li>
-			</ul>
-			<p>Focus on your business applications, while Canonical takes care of your storage needs.</p>
-      <a href="/ceph/contact-us" class="p-button--positive js-invoke-modal" >Get in touch</a>
+      <p>Focus on your business applications, while Canonical takes care of your storage needs.</p>
+    {%- endif -%}
+    {%- if slot == 'cta' -%}
+      <a href="/ceph/contact-us" class="p-button--positive">Get in touch</a>
+    {%- endif -%}
+    {%- if slot == 'image' -%}
+      <div class="p-image-container--3-2 is-highlighted is-cover">
+        {{ image (
+        url="https://assets.ubuntu.com/v1/045c9e3a-fully-managed-ceph.png",
+        alt="",
+        width="1800",
+        height="1128",
+        hi_def=True,
+        loading="lazy",
+        attrs={"class": "p-image-container__image"}) | safe
+        }}
+      </div>
+    {%- endif -%}
+  {% endcall -%}
+
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <h2>
+          Why choose
+          <br class="u-hide-small" />
+          Canonical's Managed Ceph?
+        </h2>
+      </div>
+      <div class="col">
+        <ul class="p-list--divided">
+          <li class="p-list__item is-ticked">
+            Fully managed on your servers, in your own data center, or in a co-location facility
+          </li>
+
+          <li class="p-list__item is-ticked">Built using a proven reference architecture</li>
+
+          <li class="p-list__item is-ticked">Customise the cluster architecture based on your needs</li>
+
+          <li class="p-list__item is-ticked">Integrated with your infrastructure, on-prem, hybrid, or public cloud</li>
+
+          <li class="p-list__item is-ticked">Existing workload analysis and migration services</li>
+
+          <li class="p-list__item is-ticked">Enterprise SLA for all protocols</li>
+
+          <li class="p-list__item is-ticked">Your team retains access to all machines at all times</li>
+
+          <li class="p-list__item is-ticked">Modern monitoring and log management</li>
+
+          <li class="p-list__item is-ticked">We will hand over the keys when you are ready</li>
+        </ul>
+      </div>
     </div>
-    <div class="col-5 u-hide--medium u-hide--small u-align--center">
-			{{ image (
-				url="https://assets.ubuntu.com/v1/4fb05534-canonical-ceph-dark.svg",
-				alt="Ceph",
-				width="318",
-				height="65",
-				hi_def=True,
-				loading="auto"
-				) | safe
-			}}
+  </section>
+
+  <section class="p-section">
+    <div class="u-fixed-width">
+
+      <hr class="p-rule" />
+      <h2>Build, operate, transfer and support</h2>
     </div>
-  </div>
-</section>
-<section class="p-strip strip-light">
-  <div class="u-fixed-width">
-    <h2>Build, operate, transfer and support</h2>
-    <p class="u-sv3">Deploy a fully managed Ceph cluster in a few weeks with these simple steps.</p>
-  </div>
-  <div class="u-fixed-width">
-    <ol class="p-stepped-list">
-      <li class="p-stepped-list__item">
-        <div class="row u-equal-height">
-          <div class="col-6">
-            <h3 class="p-stepped-list__title"> Design </h3>
-						<p>Our experts work with your team to <a href="/ceph/consulting">design a Ceph cluster</a> suited to your needs. We guide you through hardware and configuration decisions, to ensure that the resulting cluster is tailored to meet your performance, capacity, security and integration requirements.</p>
+    <div class="row">
+      <div class="col-6 col-start-large-7">
+        <p>Deploy a fully managed Ceph cluster in a few weeks with these simple steps.</p>
+      </div>
+      <div class="col-9 col-start-large-4">
+        <ol class="p-stepped-list--detailed">
+          <li class="p-stepped-list__item">
+            <div class="row">
+              <div class="col-3 col-medium-3">
+                <h3 class="p-stepped-list__title p-heading--5">Design</h3>
+              </div>
+              <div class="col-6 col-medium-3">
+                <p class="p-stepped-list__content">
+                  Our experts work with your team to <a href="ceph/consulting">design a Ceph cluster</a> suited to your needs. We guide you through hardware and configuration decisions, to ensure that the resulting cluster is tailored to meet your performance, capacity, security and integration requirements.
+                </p>
+              </div>
+            </div>
+          </li>
+
+          <hr class="p-rule--muted u-hide--large" />
+
+          <li class="p-stepped-list__item">
+            <div class="row">
+              <div class="col-3 col-medium-3">
+                <h3 class="p-stepped-list__title p-heading--5">Model</h3>
+              </div>
+              <div class="col-6 col-medium-3">
+                <p class="p-stepped-list__content">
+                  On completion of the design, all decisions are translated into a reusable model. This model allows for reuse across multiple environments, and guarantees repeatable deployments and integrations with infrastructure-as-code (IaC) and continuous integration and continuous delivery (CI/CD) systems.
+                </p>
+              </div>
+            </div>
+          </li>
+
+          <hr class="p-rule--muted u-hide--large" />
+
+          <li class="p-stepped-list__item">
+            <div class="row">
+              <div class="col-3 col-medium-3">
+                <h3 class="p-stepped-list__title p-heading--5">Deploy</h3>
+              </div>
+              <div class="col-6 col-medium-3">
+                <p class="p-stepped-list__content">
+                  Our experts will deploy the Ceph cluster in any location, that could be your own on-premise data center, or a co-location facility. Once your hardware is stood up, we test it end-to-end, ensuring all components are functional, and the networking is correctly configured. Then we build the cluster, validate it, and finally benchmark it's performance before your data is onboarded.
+                </p>
+              </div>
+            </div>
+          </li>
+
+          <hr class="p-rule--muted u-hide--large" />
+
+          <li class="p-stepped-list__item">
+            <div class="row">
+              <div class="col-3 col-medium-3">
+                <h3 class="p-stepped-list__title p-heading--5">Operate</h3>
+              </div>
+              <div class="col-6 col-medium-3">
+                <p class="p-stepped-list__content">
+                  The Ceph cluster is fully managed 24x7 by our team of experts. We provide monitoring, incident and problem resolution and take care of day-to-day maintenance tasks, including Ceph upgrades, and our <a href="/advantage">24x7 commercial support</a> includes security updates, and bug fixes.
+                </p>
+              </div>
+            </div>
+          </li>
+
+          <hr class="p-rule--muted u-hide--large" />
+
+          <li class="p-stepped-list__item">
+            <div class="row">
+              <div class="col-3 col-medium-3">
+                <h3 class="p-stepped-list__title p-heading--5">Transfer</h3>
+              </div>
+              <div class="col-6 col-medium-3">
+                <p class="p-stepped-list__content">
+                  Optionally, on your request, we will transfer control of your Ceph cluster back to your organization, we can provide <a href="/training">training</a> to ensure your team will be able to operate the Ceph cluster and perform a formal handover process. We continue to provide commercial support to make sure that you continue to receive security updates, bug fixes and help as required.
+                </p>
+              </div>
+            </div>
+          </li>
+        </ol>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col p-section">
+        <h2>Companies using Ceph</h2>
+      </div>
+      <div class="col p-section">
+        <p>
+          There are multiple users of Ceph across a broad range of industries, from academia to telecommunications and cloud service providers. Ceph is particularly favoured for its flexibility, scalability, and robustness.
+        </p>
+      </div>
+
+      <hr class="p-rule--muted" />
+
+      <p class="p-heading--5">Notable CEPH USERS</p>
+      <div class="p-logo-section--dense">
+        <div class="p-logo-section__items">
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/57c722c5-cern-logo.png",
+                        alt="CERN",
+                        width="239",
+                        height="313",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
           </div>
-          <div class="col-6 u-vertically-center u-hide--medium u-hide--small u-align--center">
-						{{ image (
-							url="https://assets.ubuntu.com/v1/f5d56df2-OpenStack-consulting+design.svg",
-							alt="Ceph managed design",
-							width="134",
-							height="86",
-							hi_def=True,
-							loading="lazy",
-							) | safe
-						}}
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/60fd1f45-deutsche-telekom.png",
+                        alt="Deutsche Telekom",
+                        width="313",
+                        height="313",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/1e543d4d-Bloomberg-Logo.png",
+                        alt="Bloomberg",
+                        width="313",
+                        height="313",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/c3382d32-cisco-logo.png",
+                        alt="Cisco",
+                        width="189",
+                        height="313",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/6ec58036-dreamhost-logo.png",
+                        alt="Dreamhost",
+                        width="433",
+                        height="313",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/39eef9bb-digitalocean-logo.png",
+                        alt="DigitalOcean",
+                        width="463",
+                        height="313",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
           </div>
         </div>
-      </li>
-      <li class="p-stepped-list__item">
-        <div class="row u-equal-height">
-          <div class="col-6">
-            <h3 class="p-stepped-list__title"> Model </h3>
-						<p>On completion of the design, all decisions are translated into a reusable model. This model allows for reuse across multiple environments, and guarantees repeatable deployments and integrations with infrastructure-as-code (IaC) and continuous integration and continuous delivery (CI/CD) systems.</p>
-          </div>
-          <div class="col-6 u-vertically-center u-hide--medium u-hide--small u-align--center">
-						{{ image (
-							url="https://assets.ubuntu.com/v1/46439b10-2.+model_AW.svg",
-							alt="Ceph managed model",
-							width="134",
-							height="88",
-							hi_def=True,
-							loading="lazy",
-							) | safe
-						}}
-          </div>
-        </div>
-      </li>
-      <li class="p-stepped-list__item">
-        <div class="row u-equal-height">
-          <div class="col-6">
-            <h3 class="p-stepped-list__title"> Deploy </h3>
-						<p>Our experts will deploy the Ceph cluster in any location, that could be your own on-premise data center, or a co-location facility. Once your hardware is stood up, we test it end-to-end, ensuring all components are functional, and the networking is correctly configured.  Then we build the cluster, validate it, and finally benchmark it's performance before your data is onboarded. </p>
-          </div>
-          <div class="col-6 u-vertically-center u-hide--medium u-hide--small u-align--center">
-						{{ image (
-							url="https://assets.ubuntu.com/v1/0cfe6c2d-build.svg",
-							alt="Ceph managed deploy",
-							width="134",
-							height="88",
-							hi_def=True,
-							loading="lazy",
-							) | safe
-						}}
-          </div>
-        </div>
-      </li>
-      <li class="p-stepped-list__item">
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section--deep">
+    <div class="row">
+      <hr class="p-rule" />
+      <div class="col-6">
+        <h2>Learn more about Ceph</h2>
+      </div>
+      <div class="col-6 col-medium-6">
         <div class="row">
-          <div class="col-6">
-            <h3 class="p-stepped-list__title"> Operate </h3>
-						<p>The Ceph cluster is fully managed 24x7 by our team of experts. We provide monitoring, incident and problem resolution and take care of day-to-day maintenance tasks, including Ceph upgrades, and our <a href="/pro">24x7 commercial support</a> includes security updates, and bug fixes.</p>
+          <div class="col-2 col-medium-3">
+            <h3 class="p-heading--5">Webinar</h3>
           </div>
-          <div class="col-6 u-vertically-center u-hide--medium u-hide--small u-align--center">
-						{{ image (
-							url="https://assets.ubuntu.com/v1/e9d3cf66-We+support+your+operations.svg",
-							alt="Ceph managed operate",
-							width="134",
-							height="134",
-							hi_def=True,
-							loading="lazy",
-							) | safe
-						}}
+          <div class="col-4 col-medium-3">
+            <p>
+              <a href="https://www.brighttalk.com/webcast/6793/520582">Ceph for Enterprise</a>
+            </p>
           </div>
         </div>
-			</li>
-			<li class="p-stepped-list__item">
+        <hr class="p-rule--muted" />
         <div class="row">
-          <div class="col-6">
-            <h3 class="p-stepped-list__title">
-							Transfer
-						</h3>
-						<p>Optionally, on your request, we will transfer control of your Ceph cluster back to your organization, we can provide <a href="/training">training</a> to ensure your team will be able to operate the Ceph cluster and perform a formal handover process. We continue to provide commercial support to make sure that you continue to receive security updates, bug fixes and help as required.</p>
+          <div class="col-2 col-medium-3">
+            <h3 class="p-heading--5">Case study</h3>
           </div>
-          <div class="col-6 u-vertically-center u-hide--medium u-hide--small u-align--center">
-						{{ image (
-							url="https://assets.ubuntu.com/v1/2131b805-We+transfer+control.svg",
-							alt="Ceph managed transfer",
-							width="134",
-							height="134",
-							hi_def=True,
-							loading="lazy",
-							) | safe
-						}}
+          <div class="col-4 col-medium-3">
+            <p>
+              <a href="https://ubuntu.com/engage/yahoo-japan-case-study">
+                How Yahoo! Japan built their IaaS storage using Ceph on Ubuntu&nbsp;&rsaquo;
+              </a>
+            </p>
+            <hr class="p-rule--muted" />
+            <p>
+              <a href="https://ubuntu.com/engage/wellcome-sanger-case-study">
+                Genomic research centre turns to Ceph for growing storage needs&nbsp;&rsaquo;
+              </a>
+            </p>
           </div>
         </div>
-      </li>
-    </ol>
-  </div>
-</section>
-<section class="p-strip--light">
-	{% include "ceph/shared/_ceph-users.html" %}
-</section>
-<section class="p-strip is-deep is-bordered">
-	{% include "shared/_resources_ceph.html"%}
-</section>
+      </div>
+    </div>
+  </section>
+
 {% endblock content %}

--- a/templates/ceph/managed.html
+++ b/templates/ceph/managed.html
@@ -252,13 +252,13 @@
           </div>
           <div class="col-4 col-medium-3">
             <p>
-              <a href="https://ubuntu.com/engage/yahoo-japan-case-study">
+              <a href="/engage/yahoo-japan-case-study">
                 How Yahoo! Japan built their IaaS storage using Ceph on Ubuntu
               </a>
             </p>
             <hr class="p-rule--muted" />
             <p>
-              <a href="https://ubuntu.com/engage/wellcome-sanger-case-study">
+              <a href="/engage/wellcome-sanger-case-study">
                 Genomic research centre turns to Ceph for growing storage needs
               </a>
             </p>

--- a/templates/ceph/managed.html
+++ b/templates/ceph/managed.html
@@ -5,7 +5,7 @@
 {% block title %}Managed Ceph | Ceph{% endblock %}
 
 {% block meta_description %}
-  Canonical is the leading managed ceph provider, we build, support and manage ceph clusters in any location.
+  Canonical is the leading managed Ceph provider, we build, support and manage Ceph clusters in any location.
 {% endblock meta_description %}
 
 {% block meta_copydoc %}
@@ -23,10 +23,10 @@
       <p>Focus on your business applications, while Canonical takes care of your storage needs.</p>
     {%- endif -%}
     {%- if slot == 'cta' -%}
-      <a href="/ceph/contact-us" class="p-button--positive">Get in touch</a>
+      <a href="/ceph/contact-us" class="p-button--positive js-invoke-modal">Get in touch</a>
     {%- endif -%}
     {%- if slot == 'image' -%}
-      <div class="p-image-container--3-2 is-highlighted is-cover">
+      <div class="p-image-container--3-2 is-highlighted is-cover u-hide--small">
         {{ image (
         url="https://assets.ubuntu.com/v1/045c9e3a-fully-managed-ceph.png",
         alt="",
@@ -58,7 +58,7 @@
 
           <li class="p-list__item is-ticked">Built using a proven reference architecture</li>
 
-          <li class="p-list__item is-ticked">Customise the cluster architecture based on your needs</li>
+          <li class="p-list__item is-ticked">Customize the cluster architecture based on your needs</li>
 
           <li class="p-list__item is-ticked">Integrated with your infrastructure, on-prem, hybrid, or public cloud</li>
 
@@ -78,7 +78,6 @@
 
   <section class="p-section">
     <div class="u-fixed-width">
-
       <hr class="p-rule" />
       <h2>Build, operate, transfer and support</h2>
     </div>
@@ -86,81 +85,63 @@
       <div class="col-6 col-start-large-7">
         <p>Deploy a fully managed Ceph cluster in a few weeks with these simple steps.</p>
       </div>
-      <div class="col-9 col-start-large-4">
-        <ol class="p-stepped-list--detailed">
-          <li class="p-stepped-list__item">
-            <div class="row">
-              <div class="col-3 col-medium-3">
-                <h3 class="p-stepped-list__title p-heading--5">Design</h3>
-              </div>
-              <div class="col-6 col-medium-3">
-                <p class="p-stepped-list__content">
-                  Our experts work with your team to <a href="ceph/consulting">design a Ceph cluster</a> suited to your needs. We guide you through hardware and configuration decisions, to ensure that the resulting cluster is tailored to meet your performance, capacity, security and integration requirements.
-                </p>
-              </div>
-            </div>
-          </li>
+      <div class="col-9 col-medium-6 col-start-large-4">
+        <hr class="p-rule--muted" />
+        <div class="row p-section--shallow">
+          <div class="col-3 col-medium-3">
+            <h3 class="p-heading--5">1. Design</h3>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              Our experts work with your team to <a href="ceph/consulting">design a Ceph cluster</a> suited to your needs. We guide you through hardware and configuration decisions, to ensure that the resulting cluster is tailored to meet your performance, capacity, security and integration requirements.
+            </p>
+          </div>
+        </div>
+        <hr class="p-rule--muted" />
+        <div class="row p-section--shallow">
+          <div class="col-3 col-medium-3">
+            <h3 class="p-heading--5">2. Model</h3>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              On completion of the design, all decisions are translated into a reusable model. This model allows for reuse across multiple environments, and guarantees repeatable deployments and integrations with infrastructure-as-code (IaC) and continuous integration and continuous delivery (CI/CD) systems.
+            </p>
 
-          <hr class="p-rule--muted u-hide--large" />
-
-          <li class="p-stepped-list__item">
-            <div class="row">
-              <div class="col-3 col-medium-3">
-                <h3 class="p-stepped-list__title p-heading--5">Model</h3>
-              </div>
-              <div class="col-6 col-medium-3">
-                <p class="p-stepped-list__content">
-                  On completion of the design, all decisions are translated into a reusable model. This model allows for reuse across multiple environments, and guarantees repeatable deployments and integrations with infrastructure-as-code (IaC) and continuous integration and continuous delivery (CI/CD) systems.
-                </p>
-              </div>
-            </div>
-          </li>
-
-          <hr class="p-rule--muted u-hide--large" />
-
-          <li class="p-stepped-list__item">
-            <div class="row">
-              <div class="col-3 col-medium-3">
-                <h3 class="p-stepped-list__title p-heading--5">Deploy</h3>
-              </div>
-              <div class="col-6 col-medium-3">
-                <p class="p-stepped-list__content">
-                  Our experts will deploy the Ceph cluster in any location, that could be your own on-premise data center, or a co-location facility. Once your hardware is stood up, we test it end-to-end, ensuring all components are functional, and the networking is correctly configured. Then we build the cluster, validate it, and finally benchmark it's performance before your data is onboarded.
-                </p>
-              </div>
-            </div>
-          </li>
-
-          <hr class="p-rule--muted u-hide--large" />
-
-          <li class="p-stepped-list__item">
-            <div class="row">
-              <div class="col-3 col-medium-3">
-                <h3 class="p-stepped-list__title p-heading--5">Operate</h3>
-              </div>
-              <div class="col-6 col-medium-3">
-                <p class="p-stepped-list__content">
-                  The Ceph cluster is fully managed 24x7 by our team of experts. We provide monitoring, incident and problem resolution and take care of day-to-day maintenance tasks, including Ceph upgrades, and our <a href="/advantage">24x7 commercial support</a> includes security updates, and bug fixes.
-                </p>
-              </div>
-            </div>
-          </li>
-
-          <hr class="p-rule--muted u-hide--large" />
-
-          <li class="p-stepped-list__item">
-            <div class="row">
-              <div class="col-3 col-medium-3">
-                <h3 class="p-stepped-list__title p-heading--5">Transfer</h3>
-              </div>
-              <div class="col-6 col-medium-3">
-                <p class="p-stepped-list__content">
-                  Optionally, on your request, we will transfer control of your Ceph cluster back to your organization, we can provide <a href="/training">training</a> to ensure your team will be able to operate the Ceph cluster and perform a formal handover process. We continue to provide commercial support to make sure that you continue to receive security updates, bug fixes and help as required.
-                </p>
-              </div>
-            </div>
-          </li>
-        </ol>
+          </div>
+        </div>
+        <hr class="p-rule--muted" />
+        <div class="row p-section--shallow">
+          <div class="col-3 col-medium-3">
+            <h3 class="p-heading--5">3. Deploy</h3>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              Our experts will deploy the Ceph cluster in any location, that could be your own on-premise data center, or a co-location facility. Once your hardware is stood up, we test it end-to-end, ensuring all components are functional, and the networking is correctly configured. Then we build the cluster, validate it, and finally benchmark it's performance before your data is onboarded.
+            </p>
+          </div>
+        </div>
+        <hr class="p-rule--muted" />
+        <div class="row p-section--shallow">
+          <div class="col-3 col-medium-3">
+            <h3 class="p-heading--5">4. Operate</h3>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              The Ceph cluster is fully managed 24x7 by our team of experts. We provide monitoring, incident and problem resolution and take care of day-to-day maintenance tasks, including Ceph upgrades, and our <a href="/advantage">24x7 commercial support</a> includes security updates, and bug fixes.
+            </p>
+          </div>
+        </div>
+        <hr class="p-rule--muted" />
+        <div class="row p-section--shallow">
+          <div class="col-3 col-medium-3">
+            <h3 class="p-heading--5">5. Transfer</h3>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p>
+              Optionally, on your request, we will transfer control of your Ceph cluster back to your organization, we can provide <a href="/training">training</a> to ensure your team will be able to operate the Ceph cluster and perform a formal handover process. We continue to provide commercial support to make sure that you continue to receive security updates, bug fixes and help as required.
+            </p>
+          </div>
+        </div>
       </div>
     </div>
   </section>
@@ -168,18 +149,18 @@
   <section class="p-section">
     <div class="row--50-50">
       <hr class="p-rule" />
-      <div class="col p-section">
+      <div class="col p-section--shallow">
         <h2>Companies using Ceph</h2>
       </div>
-      <div class="col p-section">
+      <div class="col p-section--shallow">
         <p>
-          There are multiple users of Ceph across a broad range of industries, from academia to telecommunications and cloud service providers. Ceph is particularly favoured for its flexibility, scalability, and robustness.
+          There are multiple users of Ceph across a broad range of industries, from academia to telecommunications and cloud service providers. Ceph is particularly favored for its flexibility, scalability, and robustness.
         </p>
       </div>
 
       <hr class="p-rule--muted" />
 
-      <p class="p-heading--5">Notable CEPH USERS</p>
+      <p class="p-text--small-caps">Notable Ceph Users</p>
       <div class="p-logo-section--dense">
         <div class="p-logo-section__items">
           <div class="p-logo-section__item">
@@ -272,13 +253,13 @@
           <div class="col-4 col-medium-3">
             <p>
               <a href="https://ubuntu.com/engage/yahoo-japan-case-study">
-                How Yahoo! Japan built their IaaS storage using Ceph on Ubuntu&nbsp;&rsaquo;
+                How Yahoo! Japan built their IaaS storage using Ceph on Ubuntu
               </a>
             </p>
             <hr class="p-rule--muted" />
             <p>
               <a href="https://ubuntu.com/engage/wellcome-sanger-case-study">
-                Genomic research centre turns to Ceph for growing storage needs&nbsp;&rsaquo;
+                Genomic research centre turns to Ceph for growing storage needs
               </a>
             </p>
           </div>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -9,6 +9,7 @@ import math
 import flask
 import requests
 import talisker.requests
+from jinja2 import ChoiceLoader, FileSystemLoader
 from canonicalwebteam.blog import BlogAPI, BlogViews, build_blueprint
 from canonicalwebteam.discourse import (
     DiscourseAPI,
@@ -178,6 +179,16 @@ app = FlaskBase(
     template_500="500.html",
     static_folder="../static",
 )
+
+# ChoiceLoader attempts loading templates from each path in successive order
+loader = ChoiceLoader(
+    [
+        FileSystemLoader("templates"),
+        FileSystemLoader("node_modules/vanilla-framework/templates"),
+    ]
+)
+
+app.jinja_loader = loader
 
 sentry = app.extensions["sentry"]
 session = talisker.requests.get_session()

--- a/yarn.lock
+++ b/yarn.lock
@@ -2904,6 +2904,13 @@ cheerio@^1.0.0-rc.3:
   optionalDependencies:
     fsevents "~2.3.2"
 
+chokidar@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-4.0.1.tgz#4a6dff66798fb0f72a94f616abbd7e1a19f31d41"
+  integrity sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==
+  dependencies:
+    readdirp "^4.0.1"
+
 ci-info@^3.2.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.9.0.tgz#4279a62028a7b1f262f3473fc9605f5e218c59b4"
@@ -6358,6 +6365,11 @@ read-cache@^1.0.0:
   dependencies:
     pify "^2.3.0"
 
+readdirp@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-4.0.2.tgz#388fccb8b75665da3abffe2d8f8ed59fe74c230a"
+  integrity sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==
+
 readdirp@~3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
@@ -6601,12 +6613,12 @@ safe-regex-test@^1.0.3:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-sass@1.45.2:
-  version "1.45.2"
-  resolved "https://registry.npmjs.org/sass/-/sass-1.45.2.tgz"
-  integrity sha512-cKfs+F9AMPAFlbbTXNsbGvg3y58nV0mXA3E94jqaySKcC8Kq3/8983zVKQ0TLMUrHw7hF9Tnd3Bz9z5Xgtrl9g==
+sass@1.79.0:
+  version "1.79.0"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.79.0.tgz#4a58442b6c094ac57a0805519bff6133d70590c9"
+  integrity sha512-9Q1xXsm9XT54yYkmQAoH3vCMEIavwWWQGJ3cZ0WJAgecR4edDDTdtiPyEeFDNWO/hLCy3qZKvwjK4ulPR5Yzow==
   dependencies:
-    chokidar ">=3.0.0 <4.0.0"
+    chokidar "^4.0.0"
     immutable "^4.0.0"
     source-map-js ">=0.6.2 <2.0.0"
 
@@ -7394,10 +7406,10 @@ v8-to-istanbul@^9.0.1:
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^2.0.0"
 
-vanilla-framework@4.16.0:
-  version "4.16.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.16.0.tgz#54e7a51e073de043d45a7bac37ffaa4f4351ac4a"
-  integrity sha512-LrxZLiNOm0cTpG++1X4MMy2efg8Xhc08JUAwNAybeSQ5FaaBGiAodbV1Fx3QvJxlaPFQqsjOdT6uZDwuOD7YJg==
+vanilla-framework@4.18.0:
+  version "4.18.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.18.0.tgz#69c0a9aac824dc10f569e901a9281d4fb0da4c17"
+  integrity sha512-lVfRUHWbY/iCWEMxkYLNjCG43NnYF2+EHAKcabsDK5kYy/B+7R/8i7gnJpARL3hybqPvsPf3hHQIfFDd7MzVRQ==
 
 vanilla-framework@4.9.0:
   version "4.9.0"


### PR DESCRIPTION
## Done

- Rebranded /ceph/managed.
- Added support for Vanilla Macros.
- Bumped versions for Vanilla and SCSS.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- The Vanilla and SCSS version has been updated in this PR, please look for abnormalities/irregularities across the site.
- [Copydoc](https://docs.google.com/document/d/1Ff3TDYBsukagu85dNZuK0FDdPRSjXEwS6Tv6JphXUvY/edit?tab=t.0)
- [Design](https://www.figma.com/design/ulUyOFdQ7CNy0whuJ4S2FM/Ceph-Bubble?node-id=21-6589&node-type=instance&m=dev)
- [Demo](https://ubuntu-com-14470.demos.haus/ceph/managed)  

## Issue / Card

Fixes # [WD-16351](https://warthogs.atlassian.net/browse/WD-16351)



[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-16351]: https://warthogs.atlassian.net/browse/WD-16351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ