### PR TITLE
WD-16658 - copy: replace references to 'OCI'

### DIFF
--- a/templates/security/oval.html
+++ b/templates/security/oval.html
@@ -42,7 +42,7 @@
         Ubuntu OVAL uses the OVAL vulnerability and patch definitions to enable auditing for Common Vulnerabilities and Exposures (CVEs) and to determine whether a particular patch, via an Ubuntu Security Notice (USN), is appropriate for the local system.
       </p>
       <p>
-        Ubuntu OVAL also allows for any third-party Security Content Automation Protocol (SCAP) compliant tools to accurately scan an Ubuntu system or an official Ubuntu OCI image for vulnerabilities.
+        Ubuntu OVAL also allows for any third-party Security Content Automation Protocol (SCAP) compliant tools to accurately scan an Ubuntu system or an official Ubuntu cloud image for vulnerabilities.
       </p>
       <a class="p-button" href="/security/notices">See the Ubuntu Security Notices</a>
     </div>
@@ -99,7 +99,7 @@
           </li>
           <li class="p-stepped-list__item">
             <h3 class="p-stepped-list__title">
-              Scanning an OCI Image
+              Scanning an Official Cloud Image
             </h3>
             <div class="p-stepped-list__content">
               <p>


### PR DESCRIPTION
## Done

- Update copy to remove references to "OCI".

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/oval
    - Be sure to test on mobile, tablet and desktop screen sizes
- Visit https://ubuntu-com-14472.demos.haus/security/oval
- Check that the references to "OCI" have been replaced.

## Issue / Card

https://warthogs.atlassian.net/browse/WD-16658


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
