### PR TITLE
Rebrand /ceph/consulting

### DIFF
--- a/templates/ceph/consulting.html
+++ b/templates/ceph/consulting.html
@@ -2,320 +2,358 @@
 
 {% block title %}Ceph Consulting - Ceph Cluster Design and Delivery{% endblock %}
 
-{% block meta_description %}Canonical is a global leader in Ceph consulting, and provides design and implementation packages at fixed prices.{% endblock %}
+{% block meta_description %}
+  Canonical is a global leader in Ceph consulting, and provides design and implementation packages at fixed prices.
+{% endblock %}
 
-{% block meta_copydoc %}https://docs.google.com/document/d/1LK8mut0O30Zk60mmbgCPFiQ2COR-BUnJnbASMMdyycU/edit#{% endblock meta_copydoc %}
+{% block meta_copydoc %}
+  https://docs.google.com/document/d/1LK8mut0O30Zk60mmbgCPFiQ2COR-BUnJnbASMMdyycU/edit#
+{% endblock meta_copydoc %}
 
 {% block content %}
-<section class="p-section--hero">
-	<div class="row--50-50">
-		<div class="col p-section--shallow">
-			<div class="p-section--shallow">
-				<h1>Ceph solution design and delivery</h1>
-			</div>
-			<div class="p-section--shallow">
-				<p>
-					Fixed-price Ceph implementation, with consulting packages tailored to your needs.
-					Right size your Ceph solution for performance, capacity and budget with help from our team of experts.
-				</p>
-			</div>
-			<hr class="is-muted" />
-			<a href="/ceph/contact-us" class="p-button--positive js-invoke-modal">Get in touch</a>
-		</div>
-		<div class="col">
-			<div class="p-image-container--3-2 is-highlighted">
-				{{ image(url="https://assets.ubuntu.com/v1/4f840180-cephadm.png",
-									alt="",
-									width="852",
-									height="1278",
-									hi_def=True,
-									loading="auto",
-									attrs={"class": "p-image-container__image"}) | safe
-				}}
-			</div>
-		</div>
-	</div>
-</section>
+  <section class="p-section--hero">
+    <div class="row--50-50">
+      <div class="col p-section--shallow">
+        <div class="p-section--shallow">
+          <h1>Ceph solution design and delivery</h1>
+        </div>
+        <div class="p-section--shallow">
+          <p>
+            Fixed-price Ceph implementation, with consulting packages tailored to your needs.
+            Right size your Ceph solution for performance, capacity and budget with help from our team of experts.
+          </p>
+        </div>
+        <hr class="is-muted" />
+        <a href="/ceph/contact-us" class="p-button--positive js-invoke-modal">Get in touch</a>
+      </div>
+      <div class="col">
+        <div class="p-image-container--3-2 is-highlighted">
+          {{ image(url="https://assets.ubuntu.com/v1/4f840180-cephadm.png",
+                    alt="",
+                    width="852",
+                    height="1278",
+                    hi_def=True,
+                    loading="auto",
+                    attrs={"class": "p-image-container__image"}) | safe
+          }}
+        </div>
+      </div>
+    </div>
+  </section>
 
-<section class="p-section">
-	<div class="row--50-50">
-		<hr class="p-rule" />
-		<div class="col">
-			<div class="p-section--shallow">
-				<h2>Ceph implementation challenges</h2>
-			</div>
-		</div>
-		<div class="col">
-			<div class="p-section--shallow">
-				<p>Designing an optimised storage solution for any use case requires expert level knowledge, and many years of experience. </p>
-				<p>Common questions that arise during design and build:</p>
-				<ul class="p-list--divided">
-					<li class="p-list__item is-ticked">Which deployment tooling should I use?</li>
-					<li class="p-list__item is-ticked">Which version of Ceph should I install?</li>
-					<li class="p-list__item is-ticked">What CPUs, Memory, Disks, NICs should I buy?</li>
-					<li class="p-list__item is-ticked">How do I configure my network?</li>
-					<li class="p-list__item is-ticked">Which workloads are suitable for Ceph?</li>
-					<li class="p-list__item is-ticked">Can I use Ceph for traditional workloads too?</li>
-					<li class="p-list__item is-ticked">How can I secure my cluster?</li>
-					<li class="p-list__item is-ticked">How can I prepare for Disaster Recovery?</li>
-				</ul>
-				<p>Canonical's Ceph consultants can help guide you through these and many other questions related to deploying a cost-effective and fit for purpose Ceph storage system for a fixed price.</p>
-				<hr class="p-rule--muted" />
-				<p><a href="/ceph/what-is-ceph">Learn more about Ceph&nbsp;&rsaquo;</a></p>
-			</div>
-		</div>
-	</div>
-</section>
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <div class="p-section--shallow">
+          <h2>Ceph implementation challenges</h2>
+        </div>
+      </div>
+      <div class="col">
+        <div class="p-section--shallow">
+          <p>
+            Designing an optimised storage solution for any use case requires expert level knowledge, and many years of experience.
+          </p>
+          <p>Common questions that arise during design and build:</p>
+          <ul class="p-list--divided">
+            <li class="p-list__item is-ticked">Which deployment tooling should I use?</li>
+            <li class="p-list__item is-ticked">Which version of Ceph should I install?</li>
+            <li class="p-list__item is-ticked">What CPUs, Memory, Disks, NICs should I buy?</li>
+            <li class="p-list__item is-ticked">How do I configure my network?</li>
+            <li class="p-list__item is-ticked">Which workloads are suitable for Ceph?</li>
+            <li class="p-list__item is-ticked">Can I use Ceph for traditional workloads too?</li>
+            <li class="p-list__item is-ticked">How can I secure my cluster?</li>
+            <li class="p-list__item is-ticked">How can I prepare for Disaster Recovery?</li>
+          </ul>
+          <p>
+            Canonical's Ceph consultants can help guide you through these and many other questions related to deploying a cost-effective and fit for purpose Ceph storage system for a fixed price.
+          </p>
+          <hr class="p-rule--muted" />
+          <p>
+            <a href="/ceph/what-is-ceph">Learn more about Ceph&nbsp;&rsaquo;</a>
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
 
-<section class="p-section">
-	<div class="p-section--shallow">
-		<div class="row--50-50">
-			<hr class="p-rule" />
-			<div class="col">
-				<h2>What consulting services are available?</h2>
-			</div>
-			<div class="col">
-				<p>
-					Canonical offers two Ceph cluster consulting packages, Ceph Cluster Build (CCB), and Ceph Cluster Build Plus (CCB Plus). 
-					CCB is a basic package to get your Ceph cluster up and running in a simplified configuration, and CCB Plus offers more consulting 
-					time to evaluate your needs and customise the deployment architecture as required.
-				</p>
-			</div>
-		</div>
-	</div>
-	<div class="row">
-		<div class="col-9 col-start-large-4">
-			<div class="p-block">
-				<hr class="p-rule--muted" />
-				<div class="row">
-					<div class="col-3 col-medium-3 col-small-2">
-						<h3 class="p-heading--5">Fixed-Prices</h3>
-					</div>
-					<div class="col-6 col-medium-3">
-						<p>
-							Both packages are provided as fixed price services, therefore all project costs are transparent and predictable.
-						</p>
-					</div>
-				</div>
-			</div>
-		</div>
-	</div>
-	<div class="row">
-		<div class="col-9 col-start-large-4">
-			<div class="p-block">
-				<hr class="p-rule--muted" />
-				<div class="row">
-					<div class="col-3 col-medium-3 col-small-2">
-						<h3 class="p-heading--5">Workshops</h3>
-					</div>
-					<div class="col-6 col-medium-3">
-						<p>
-							Both packages include a workshop for team introductions, requirements gathering and architecture discussion and design. The workshop for CCB is provided remotely, and CCB Plus is provided on-site.
-						</p>
-					</div>
-				</div>
-			</div>
-		</div>
-	</div>
-	<div class="row">
-		<div class="col-9 col-start-large-4">
-			<div class="p-block">
-				<hr class="p-rule--muted" />
-				<div class="row">
-					<div class="col-3 col-medium-3 col-small-2">
-						<h3 class="p-heading--5">Workload assessment</h3>
-					</div>
-					<div class="col-6 col-medium-3">
-						<p>
-							During the workshop, our consultant will assess your existing infrastructure (be it on-prem, hybrid, or public cloud based), to ensure that the architecture design meets the needs of your applications.
-						</p>
-					</div>
-				</div>
-			</div>
-		</div>
-	</div>
-	<div class="row">
-		<div class="col-9 col-start-large-4">
-			<div class="p-block">
-				<hr class="p-rule--muted" />
-				<div class="row">
-					<div class="col-3 col-medium-3 col-small-2">
-						<h3 class="p-heading--5">Cluster design</h3>
-					</div>
-					<div class="col-6 col-medium-3">
-						<p>
-							Working jointly with your team, we design the Ceph cluster to meet your requirements. Providing guidance around hardware and configuration options.
-						</p>
-					</div>
-				</div>
-			</div>
-		</div>
-	</div>
-	<div class="row">
-		<div class="col-9 col-start-large-4">
-			<div class="p-block">
-				<hr class="p-rule--muted" />
-				<div class="row">
-					<div class="col-3 col-medium-3 col-small-2">
-						<h3 class="p-heading--5">Cluster delivery</h3>
-					</div>
-					<div class="col-6 col-medium-3">
-						<p>
-							Once your hardware is stood up, we test it end-to-end, ensuring all components are functional, and the networking is correctly configured. Then we build the cluster, validate it, and finally benchmark it's performance before your data is onboarded.
-						</p>
-					</div>
-				</div>
-			</div>
-		</div>
-	</div>
-	<div class="row">
-		<div class="col-9 col-start-large-4">
-			<div class="p-block">
-				<hr class="p-rule--muted" />
-				<div class="row">
-					<div class="col-3 col-medium-3 col-small-2">
-						<h3 class="p-heading--5">Workloads migration</h3>
-					</div>
-					<div class="col-6 col-medium-3">
-						<p>
-							Optionally, we can assist with data migrations from other storage systems. We partner with market-leading companies that can assist with minimally disruptive migrations.
-						</p>
-					</div>
-				</div>
-			</div>
-		</div>
-	</div>
-	<div class="row">
-		<div class="col-9 col-start-large-4">
-			<div class="p-block">
-				<hr class="p-rule--muted" />
-				<div class="row">
-					<div class="col-3 col-medium-3 col-small-2">
-						<h3 class="p-heading--5">Repeatable artifacts</h3>
-					</div>
-					<div class="col-6 col-medium-3">
-						<p>
-							On conclusion of the engagement we provide a detailed deployment guide that enables repeatable re-deployments of your cluster, and perform a formal handover process to your team, or to our <a href="/ceph/managed">Managed Service</a> team.
-						</p>
-					</div>
-				</div>
-			</div>
-		</div>
-	</div>
-	<div class="row">
-		<div class="col-9 col-start-large-4">
-			<div class="p-block">
-				<hr class="p-rule--muted" />
-				<div class="row">
-					<div class="col-3 col-medium-3 col-small-2">
-						<h3 class="p-heading--5">Day-2 automation</h3>
-					</div>
-					<div class="col-6 col-medium-3">
-						<p>
-							Charmed Ceph provides automation around common tasks, such as cluster scaling, integration and Ceph upgrades.
-						</p>
-					</div>
-				</div>
-			</div>
-		</div>
-	</div>
-	<div class="row">
-		<div class="col-9 col-start-large-4">
-			<div class="p-block">
-				<hr class="p-rule--muted" />
-				<div class="row">
-					<div class="col-3 col-medium-3 col-small-2">
-						<h3 class="p-heading--5">Optional training</h3>
-					</div>
-					<div class="col-6 col-medium-3">
-						<p>
-							If required we can deliver Ceph <a href="/training">training courses</a> to your team to familiarise them with Charmed Ceph.
-						</p>
-					</div>
-				</div>
-			</div>
-		</div>
-	</div>
-</section>
+  <section class="p-section">
+    <div class="p-section--shallow">
+      <div class="row--50-50">
+        <hr class="p-rule" />
+        <div class="col">
+          <h2>What consulting services are available?</h2>
+        </div>
+        <div class="col">
+          <p>
+            Canonical offers two Ceph cluster consulting packages, Ceph Cluster Build (CCB), and Ceph Cluster Build Plus (CCB Plus).
+            CCB is a basic package to get your Ceph cluster up and running in a simplified configuration, and CCB Plus offers more consulting
+            time to evaluate your needs and customise the deployment architecture as required.
+          </p>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-9 col-start-large-4">
+        <div class="p-block">
+          <hr class="p-rule--muted" />
+          <div class="row">
+            <div class="col-3 col-medium-3 col-small-2">
+              <h3 class="p-heading--5">Fixed-Prices</h3>
+            </div>
+            <div class="col-6 col-medium-3">
+              <p>Both packages are provided as fixed price services, therefore all project costs are transparent and predictable.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-9 col-start-large-4">
+        <div class="p-block">
+          <hr class="p-rule--muted" />
+          <div class="row">
+            <div class="col-3 col-medium-3 col-small-2">
+              <h3 class="p-heading--5">Workshops</h3>
+            </div>
+            <div class="col-6 col-medium-3">
+              <p>
+                Both packages include a workshop for team introductions, requirements gathering and architecture discussion and design. The workshop for CCB is provided remotely, and CCB Plus is provided on-site.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-9 col-start-large-4">
+        <div class="p-block">
+          <hr class="p-rule--muted" />
+          <div class="row">
+            <div class="col-3 col-medium-3 col-small-2">
+              <h3 class="p-heading--5">Workload assessment</h3>
+            </div>
+            <div class="col-6 col-medium-3">
+              <p>
+                During the workshop, our consultant will assess your existing infrastructure (be it on-prem, hybrid, or public cloud based), to ensure that the architecture design meets the needs of your applications.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-9 col-start-large-4">
+        <div class="p-block">
+          <hr class="p-rule--muted" />
+          <div class="row">
+            <div class="col-3 col-medium-3 col-small-2">
+              <h3 class="p-heading--5">Cluster design</h3>
+            </div>
+            <div class="col-6 col-medium-3">
+              <p>
+                Working jointly with your team, we design the Ceph cluster to meet your requirements. Providing guidance around hardware and configuration options.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-9 col-start-large-4">
+        <div class="p-block">
+          <hr class="p-rule--muted" />
+          <div class="row">
+            <div class="col-3 col-medium-3 col-small-2">
+              <h3 class="p-heading--5">Cluster delivery</h3>
+            </div>
+            <div class="col-6 col-medium-3">
+              <p>
+                Once your hardware is stood up, we test it end-to-end, ensuring all components are functional, and the networking is correctly configured. Then we build the cluster, validate it, and finally benchmark it's performance before your data is onboarded.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-9 col-start-large-4">
+        <div class="p-block">
+          <hr class="p-rule--muted" />
+          <div class="row">
+            <div class="col-3 col-medium-3 col-small-2">
+              <h3 class="p-heading--5">Workloads migration</h3>
+            </div>
+            <div class="col-6 col-medium-3">
+              <p>
+                Optionally, we can assist with data migrations from other storage systems. We partner with market-leading companies that can assist with minimally disruptive migrations.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-9 col-start-large-4">
+        <div class="p-block">
+          <hr class="p-rule--muted" />
+          <div class="row">
+            <div class="col-3 col-medium-3 col-small-2">
+              <h3 class="p-heading--5">Repeatable artifacts</h3>
+            </div>
+            <div class="col-6 col-medium-3">
+              <p>
+                On conclusion of the engagement we provide a detailed deployment guide that enables repeatable re-deployments of your cluster, and perform a formal handover process to your team, or to our <a href="/ceph/managed">Managed Service</a> team.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-9 col-start-large-4">
+        <div class="p-block">
+          <hr class="p-rule--muted" />
+          <div class="row">
+            <div class="col-3 col-medium-3 col-small-2">
+              <h3 class="p-heading--5">Day-2 automation</h3>
+            </div>
+            <div class="col-6 col-medium-3">
+              <p>Charmed Ceph provides automation around common tasks, such as cluster scaling, integration and Ceph upgrades.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-9 col-start-large-4">
+        <div class="p-block">
+          <hr class="p-rule--muted" />
+          <div class="row">
+            <div class="col-3 col-medium-3 col-small-2">
+              <h3 class="p-heading--5">Optional training</h3>
+            </div>
+            <div class="col-6 col-medium-3">
+              <p>
+                If required we can deliver Ceph <a href="/training">training courses</a> to your team to familiarise them with Charmed Ceph.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
 
-<section class="p-section">
-	<div class="row--50-50 p-section--shallow">
-		<hr class="p-rule--muted" />
-		<div class="col">
-			<h2>Choose the right Ubuntu for you</h2>
-		</div>
-		<div class="col">
-			<p>
-				Select between the standard Ubuntu Server and the Pro edition, which includes expanded security, compliance and GCP integration:
-			</p>
-		</div>
-	</div>    
+  <section class="p-section">
+    <div class="u-fixed-width p-section--shallow">
+      <hr class="p-rule--muted" />
+      <div class="col">
+        <h2>Getting started with Ceph on Ubuntu</h2>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-6">
+        <hr class="p-rule--highlight u-no-margin--bottom" />
+        <div class="p-card--overlay u-no-padding--top" style="padding: 1.5rem;">
+          <div class="row p-section--shallow">
+            <div class="col-4 col-medium-3 col-small-2">
+              <h3 class="u-no-margin--bottom">Ceph Cluster Build</h3>
+              <p class="u-text--muted">
+                Design and deployment of an Object only Ceph cluster based on Canonical’s reference architecture.
+              </p>
+            </div>
+            <div class="col-2 col-medium-3 col-small-2">
+              <p class="p-heading--3 u-align-text--right u-no-margin--bottom">$25,000</p>
+              <p class="u-text--muted u-align-text--right">Fixed price</p>
+            </div>
+          </div>
+          <div class="p-section--shallow">
+            <div class="row">
+              <div class="col-2">
+                <p class="p-text--small-caps">
+                  What's included: <sup><a href="#os-footnote">*</a></sup>
+                </p>
+              </div>
+              <div class="col-4">
+                <ul class="p-list--divided p-section--shallow">
+                  <li class="p-list__item is-ticked">RADOS Gateway (RGW) Object storage interface (S3 compatible)</li>
+                  <li class="p-list__item is-ticked">Hardware guidance and sizing</li>
+                  <li class="p-list__item is-ticked">Hardware and Network Reference Architecture</li>
+                  <li class="p-list__item is-ticked">Containerised control plane</li>
+                  <li class="p-list__item is-ticked">Observability stack</li>
+                  <li class="p-list__item is-ticked">High availability</li>
+                </ul>
+                <hr class="p-rule--muted u-no-margin--bottom" />
+                <p class="u-text--muted">
+                  Cluster capacity up to 650TB RAW<sup><a href="#os-footnote-2">**</a></sup>
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
 
-	<div class="row--50-50">
-		<div class="col">
-			<hr class="p-rule--highlight u-no-margin--bottom" />
-			<div class="p-card--overlay u-no-padding--top" style="height: 95%; overflow: hidden;">
-				<div class="row p-section--shallow">
-					<h3>Ubuntu LTS</h3>
-					<p class="p-heading--4">Free to use</p>
-				</div>
-				<hr class="p-rule--muted" />
-				<ul class="p-list--divided p-section--shallow">
-					<li class="p-list__item is-ticked">GCP-optimised kernel and userspace components built from the latest releases</li>
-					<li class="p-list__item is-ticked">Broad set of open source application components available for development</li>
-					<li class="p-list__item is-ticked">Security patches for the kernel and key infrastructure components</li>
-					<li class="p-list__item is-ticked">Updates mirrored and images published in all GCP regions worldwide</li>
-					<li class="p-list__item is-ticked">5-year lifetime</li>
-				</ul>
-				<hr class="p-rule--muted" />
-				<p>
-					<a href="https://console.cloud.google.com/compute/instancesAdd?imageId=4629240575064276470&imageProjectId=ubuntu-os-cloud"
-							class="p-button u-no-margin--bottom">Launch Ubuntu Server 24.04 LTS</a>
-				</p>
-			</div>
-		</div>
+      <div class="col-6">
+        <hr class="p-rule--highlight u-no-margin--bottom" />
+        <div class="p-card--overlay u-no-padding--top" style="padding: 1.5rem;">
+          <div class="row p-section--shallow">
+            <div class="col-4 col-medium-3 col-small-2">
+              <h3 class="u-no-margin--bottom">Ceph Cluster Build Plus</h3>
+              <p class="u-text--muted">
+                Design and deployment of a multi-protocol Ceph cluster, based on a custom architecture tuned to your needs.
+              </p>
+            </div>
+            <div class="col-2 col-medium-3 col-small-2">
+              <p class="p-heading--3 u-align-text--right u-no-margin--bottom">$50,000</p>
+              <p class="u-text--muted u-align-text--right">Fixed price</p>
+            </div>
+          </div>
+          <div class="p-section--shallow">
+            <div class="row">
+              <div class="col-2">
+                <p class="p-text--small-caps">
+                  What's included: <sup><a href="#os-footnote">*</a></sup>
+                </p>
+              </div>
+              <div class="col-4">
+                <ul class="p-list--divided p-section--shallow">
+                  <li class="p-list__item is-ticked">RBD Block interface</li>
+                  <li class="p-list__item is-ticked">CephFS file storage interfance</li>
+                  <li class="p-list__item is-ticked">Custom scale-out architecture</li>
+                  <li class="p-list__item is-ticked">Capacity planning</li>
+                  <li class="p-list__item is-ticked">Storage-oriented networking</li>
+                  <li class="p-list__item is-ticked">Transparent caching</li>
+                  <li class="p-list__item is-ticked">Multiple storage pools</li>
+                  <li class="p-list__item is-ticked">Data encryption at rest, with integrated Key Management</li>
+                  <li class="p-list__item is-ticked">Security hardening and compliance</li>
+                </ul>
+                <hr class="p-rule--muted u-no-margin--bottom" />
+                <p class="u-text--muted">
+                  Cluster capacity up to 3.6PB RAW<sup><a href="#os-footnote-2">**</a></sup>
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
 
-		<div class="col">
-			<hr class="p-rule--highlight u-no-margin--bottom" />
-			<div class="p-card--overlay u-no-padding--top" style="height: 95%; overflow: hidden;">
-				<div class="row p-section--shallow">
-					<h3>Ubuntu Pro for Google Cloud</h3>
-					<p class="p-heading--4">3-4.5% of an average instance cost</p>
-				</div>
-				<hr class="p-rule--muted" />
-				<ul class="p-list--divided p-section--shallow">
-					<li class="p-list__item is-ticked">Includes all Ubuntu optimisations and updates of the free version</li>
-					<li class="p-list__item is-ticked">
-						Expanded security covering 28,000 additional application components delivered with Ubuntu
-					</li>
-					<li class="p-list__item is-ticked">Kernel live patching for instant security and longer uptimes</li>
-					<li class="p-list__item is-ticked">FIPS 140-2 and CC-EAL certified components</li>
-					<li class="p-list__item is-ticked">Integration with GCP security and compliance features</li>
-					<li class="p-list__item is-ticked">10-year lifetime</li>
-				</ul>
-				<hr class="p-rule--muted" />
-				<ul class="p-inline-list u-responsive-realign u-no-margin--bottom">
-					<li class="p-inline-list__item">
-						<a href="https://console.cloud.google.com/compute/instancesAdd?imageId=960077196939492817&imageProjectId=ubuntu-os-pro-cloud"
-							 class="p-button--positive u-no-margin--bottom">Launch Ubuntu Pro 24.04 LTS</a>
-					</li>
-					<li class="p-inline-list__item">
-						<p>
-							<a href="/gcp/pro">More about Ubuntu Pro for Google Cloud&nbsp;&rsaquo;</a>
-						</p>
-					</li>
-				</ul>
-			</div>
-		</div>
-	</div>
-</section>
+    </div>
+    <div class="u-fixed-width">
+      <hr class="p-rule--muted" />
+      <p class="u-text--muted">
+        <i id="os-footnote">* Additional features, functionality and integrations are available via add-ons</i>
+        <br />
+        <i id="os-footnote-2">** Higher capacity clusters available via add&ndash;ons</i>
+      </p>
+    </div>
 
+  </section>
 
+  <section class="p-section">
+    {% include "ceph/shared/_ceph-users.html" %}
+  </section>
 
-<section class="p-strip--light">
-	{% include "ceph/shared/_ceph-users.html" %}
-</section>
-<section class="p-strip is-deep is-bordered">
-{% include "shared/_resources_ceph.html"%}
-</section>
+  <section class="p-section--deep">
+    {% include "shared/_resources_ceph.html" %}
+  </section>
 {% endblock content %}

--- a/templates/ceph/consulting.html
+++ b/templates/ceph/consulting.html
@@ -7,116 +7,310 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/1LK8mut0O30Zk60mmbgCPFiQ2COR-BUnJnbASMMdyycU/edit#{% endblock meta_copydoc %}
 
 {% block content %}
-<section class="p-strip--suru-bottomed">
-  <div class="row u-equal-height">
-	<div class="col-8">
-	  <h1> Ceph solution design and delivery </h1>
-	  <p> Fixed-price Ceph implementation, with consulting packages tailored to your needs. </p>
-	  <p> Right size your Ceph solution for performance, capacity and budget with help from our team of experts. </p>
-	  <p><a href="/ceph/contact-us" class="p-button--positive js-invoke-modal" >Get in touch</a></p>
-	</div>
-  </div>
-</section>
-<section class="p-strip">
-  <div class="row">
-		<div class="col-7">
-			<h2>Ceph implementation challenges</h2>
-			<p>Designing an optimised storage solution for any use case requires expert level knowledge, and many years of experience. </p>
-			<p>Common questions that arise during design and build:</p>
-			<ul class="p-list">
-				<li class="p-list__item is-ticked"> Which deployment tooling should I use? </li>
-				<li class="p-list__item is-ticked">Which version of Ceph should I install? </li>
-				<li class="p-list__item is-ticked">What CPUs, Memory, Disks, NICs should I buy?</li>
-				<li class="p-list__item is-ticked">How do I configure my network?</li>
-				<li class="p-list__item is-ticked">Which workloads are suitable for Ceph?</li>
-				<li class="p-list__item is-ticked">Can I use Ceph for traditional workloads too?</li>
-				<li class="p-list__item is-ticked">How can I secure my cluster?</li>
-				<li class="p-list__item is-ticked">How can I prepare for Disaster Recovery?</li>
-			</ul>
-			<p> Canonical's Ceph consultants can help guide you through these and many other questions related to deploying a cost-effective and fit for purpose Ceph storage system for a fixed price. </p>
-			<p><a href="/ceph/what-is-ceph">Learn more about Ceph&nbsp;&rsaquo;</a></p>
+<section class="p-section--hero">
+	<div class="row--50-50">
+		<div class="col p-section--shallow">
+			<div class="p-section--shallow">
+				<h1>Ceph solution design and delivery</h1>
+			</div>
+			<div class="p-section--shallow">
+				<p>
+					Fixed-price Ceph implementation, with consulting packages tailored to your needs.
+					Right size your Ceph solution for performance, capacity and budget with help from our team of experts.
+				</p>
+			</div>
+			<hr class="is-muted" />
+			<a href="/ceph/contact-us" class="p-button--positive js-invoke-modal">Get in touch</a>
 		</div>
-		<div class="col-5 u-align--center u-vertically-center u-hide--medium u-hide--small">
-      {{ image (
-        url="https://assets.ubuntu.com/v1/c7cc4e28-ubuntu-advantage-circular.svg",
-        alt="",
-        width="278",
-        height="300",
-        hi_def=True,
-        loading="lazy"
-        ) | safe
-      }}
+		<div class="col">
+			<div class="p-image-container--3-2 is-highlighted">
+				{{ image(url="https://assets.ubuntu.com/v1/4f840180-cephadm.png",
+									alt="",
+									width="852",
+									height="1278",
+									hi_def=True,
+									loading="auto",
+									attrs={"class": "p-image-container__image"}) | safe
+				}}
+			</div>
 		</div>
-  </div>
-</section>
-<section class="p-strip--light">
-	<div class="u-fixed-width">
-		<h2>What consulting services are available?</h2>
-		<p>Canonical offers two Ceph cluster consulting packages, Ceph Cluster Build (CCB), and Ceph Cluster Build Plus (CCB Plus). CCB is a basic package to get your Ceph cluster up and running in a simplified configuration, and CCB Plus offers more consulting time to evaluate your needs and customise the deployment architecture as required. </p>
-		<ul class="p-matrix">
-			<li class="p-matrix__item">
-				<div class="p-matrix__content">
-				<h3 class="p-matrix__title">Fixed-Prices</h3>
-				<p class="p-matrix__desc">Both packages are provided as fixed price services, therefore all project costs are transparent and predictable.</p>
-				</div>
-			</li>
-			<li class="p-matrix__item">
-				<div class="p-matrix__content">
-				<h3 class="p-matrix__title">Workshops</h3>
-				<p class="p-matrix__desc">Both packages include a workshop for team introductions, requirements gathering and architecture discussion and design. The workshop for CCB is provided remotely, and CCB Plus is provided on-site.</p>
-				</div>
-			</li>
-			<li class="p-matrix__item">
-				<div class="p-matrix__content">
-				<h3 class="p-matrix__title">Workload assessment</h3>
-				<p class="p-matrix__desc">During the workshop, our consultant will assess your existing infrastructure (be it on-prem, hybrid, or public cloud based), to ensure that the architecture design meets the needs of your applications.</p>
-				</div>
-			</li>
-			<li class="p-matrix__item">
-				<div class="p-matrix__content">
-				<h3 class="p-matrix__title">Cluster design</h3>
-				<p class="p-matrix__desc">Working jointly with your team, we design the Ceph cluster to meet your requirements. Providing guidance around hardware and configuration options.</p>
-				</div>
-			</li>
-			<li class="p-matrix__item">
-				<div class="p-matrix__content">
-				<h3 class="p-matrix__title">Cluster delivery</h3>
-				<p class="p-matrix__desc">Once your hardware is stood up, we test it end-to-end, ensuring all components are functional, and the networking is correctly configured. Then we build the cluster, validate it, and finally benchmark it's performance before your data is onboarded.</p>
-				</div>
-			</li>
-			<li class="p-matrix__item">
-				<div class="p-matrix__content">
-				<h3 class="p-matrix__title">Workloads migration</h3>
-				<p class="p-matrix__desc">Optionally, we can assist with data migrations from other storage systems. We partner with market-leading companies that can assist with minimally disruptive migrations.</p>
-				</div>
-			</li>
-			<li class="p-matrix__item">
-				<div class="p-matrix__content">
-				<h3 class="p-matrix__title">Repeatable artifacts</h3>
-				<p class="p-matrix__desc">On conclusion of the engagement we provide a detailed deployment guide that enables repeatable re-deployments of your cluster, and perform a formal handover process to your team, or to our <a href="/ceph/managed">Managed Service</a> team.</p>
-				</div>
-			</li>
-			<li class="p-matrix__item">
-				<div class="p-matrix__content">
-				<h3 class="p-matrix__title">Day-2 automation</h3>
-				<p class="p-matrix__desc">Charmed Ceph provides automation around common tasks, such as cluster scaling, integration and Ceph upgrades.</p>
-				</div>
-			</li>
-			<li class="p-matrix__item">
-				<div class="p-matrix__content">
-				<h3 class="p-matrix__title">Optional training</h3>
-				<p class="p-matrix__desc">If required we can deliver Ceph <a href="/training">training courses</a> to your team to familiarise them with Charmed Ceph.</p>
-				</div>
-			</li>
-		</ul>
-  </div>
-</section>
-<section class="p-strip">
-	<div class="u-fixed-width">
-		<h2>Ceph Cluster Build pricing</h2>
 	</div>
-		{% include "shared/pricing/_ceph-cluster-build-pricing.html" %}
 </section>
+
+<section class="p-section">
+	<div class="row--50-50">
+		<hr class="p-rule" />
+		<div class="col">
+			<div class="p-section--shallow">
+				<h2>Ceph implementation challenges</h2>
+			</div>
+		</div>
+		<div class="col">
+			<div class="p-section--shallow">
+				<p>Designing an optimised storage solution for any use case requires expert level knowledge, and many years of experience. </p>
+				<p>Common questions that arise during design and build:</p>
+				<ul class="p-list--divided">
+					<li class="p-list__item is-ticked">Which deployment tooling should I use?</li>
+					<li class="p-list__item is-ticked">Which version of Ceph should I install?</li>
+					<li class="p-list__item is-ticked">What CPUs, Memory, Disks, NICs should I buy?</li>
+					<li class="p-list__item is-ticked">How do I configure my network?</li>
+					<li class="p-list__item is-ticked">Which workloads are suitable for Ceph?</li>
+					<li class="p-list__item is-ticked">Can I use Ceph for traditional workloads too?</li>
+					<li class="p-list__item is-ticked">How can I secure my cluster?</li>
+					<li class="p-list__item is-ticked">How can I prepare for Disaster Recovery?</li>
+				</ul>
+				<p>Canonical's Ceph consultants can help guide you through these and many other questions related to deploying a cost-effective and fit for purpose Ceph storage system for a fixed price.</p>
+				<hr class="p-rule--muted" />
+				<p><a href="/ceph/what-is-ceph">Learn more about Ceph&nbsp;&rsaquo;</a></p>
+			</div>
+		</div>
+	</div>
+</section>
+
+<section class="p-section">
+	<div class="p-section--shallow">
+		<div class="row--50-50">
+			<hr class="p-rule" />
+			<div class="col">
+				<h2>What consulting services are available?</h2>
+			</div>
+			<div class="col">
+				<p>
+					Canonical offers two Ceph cluster consulting packages, Ceph Cluster Build (CCB), and Ceph Cluster Build Plus (CCB Plus). 
+					CCB is a basic package to get your Ceph cluster up and running in a simplified configuration, and CCB Plus offers more consulting 
+					time to evaluate your needs and customise the deployment architecture as required.
+				</p>
+			</div>
+		</div>
+	</div>
+	<div class="row">
+		<div class="col-9 col-start-large-4">
+			<div class="p-block">
+				<hr class="p-rule--muted" />
+				<div class="row">
+					<div class="col-3 col-medium-3 col-small-2">
+						<h3 class="p-heading--5">Fixed-Prices</h3>
+					</div>
+					<div class="col-6 col-medium-3">
+						<p>
+							Both packages are provided as fixed price services, therefore all project costs are transparent and predictable.
+						</p>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+	<div class="row">
+		<div class="col-9 col-start-large-4">
+			<div class="p-block">
+				<hr class="p-rule--muted" />
+				<div class="row">
+					<div class="col-3 col-medium-3 col-small-2">
+						<h3 class="p-heading--5">Workshops</h3>
+					</div>
+					<div class="col-6 col-medium-3">
+						<p>
+							Both packages include a workshop for team introductions, requirements gathering and architecture discussion and design. The workshop for CCB is provided remotely, and CCB Plus is provided on-site.
+						</p>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+	<div class="row">
+		<div class="col-9 col-start-large-4">
+			<div class="p-block">
+				<hr class="p-rule--muted" />
+				<div class="row">
+					<div class="col-3 col-medium-3 col-small-2">
+						<h3 class="p-heading--5">Workload assessment</h3>
+					</div>
+					<div class="col-6 col-medium-3">
+						<p>
+							During the workshop, our consultant will assess your existing infrastructure (be it on-prem, hybrid, or public cloud based), to ensure that the architecture design meets the needs of your applications.
+						</p>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+	<div class="row">
+		<div class="col-9 col-start-large-4">
+			<div class="p-block">
+				<hr class="p-rule--muted" />
+				<div class="row">
+					<div class="col-3 col-medium-3 col-small-2">
+						<h3 class="p-heading--5">Cluster design</h3>
+					</div>
+					<div class="col-6 col-medium-3">
+						<p>
+							Working jointly with your team, we design the Ceph cluster to meet your requirements. Providing guidance around hardware and configuration options.
+						</p>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+	<div class="row">
+		<div class="col-9 col-start-large-4">
+			<div class="p-block">
+				<hr class="p-rule--muted" />
+				<div class="row">
+					<div class="col-3 col-medium-3 col-small-2">
+						<h3 class="p-heading--5">Cluster delivery</h3>
+					</div>
+					<div class="col-6 col-medium-3">
+						<p>
+							Once your hardware is stood up, we test it end-to-end, ensuring all components are functional, and the networking is correctly configured. Then we build the cluster, validate it, and finally benchmark it's performance before your data is onboarded.
+						</p>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+	<div class="row">
+		<div class="col-9 col-start-large-4">
+			<div class="p-block">
+				<hr class="p-rule--muted" />
+				<div class="row">
+					<div class="col-3 col-medium-3 col-small-2">
+						<h3 class="p-heading--5">Workloads migration</h3>
+					</div>
+					<div class="col-6 col-medium-3">
+						<p>
+							Optionally, we can assist with data migrations from other storage systems. We partner with market-leading companies that can assist with minimally disruptive migrations.
+						</p>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+	<div class="row">
+		<div class="col-9 col-start-large-4">
+			<div class="p-block">
+				<hr class="p-rule--muted" />
+				<div class="row">
+					<div class="col-3 col-medium-3 col-small-2">
+						<h3 class="p-heading--5">Repeatable artifacts</h3>
+					</div>
+					<div class="col-6 col-medium-3">
+						<p>
+							On conclusion of the engagement we provide a detailed deployment guide that enables repeatable re-deployments of your cluster, and perform a formal handover process to your team, or to our <a href="/ceph/managed">Managed Service</a> team.
+						</p>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+	<div class="row">
+		<div class="col-9 col-start-large-4">
+			<div class="p-block">
+				<hr class="p-rule--muted" />
+				<div class="row">
+					<div class="col-3 col-medium-3 col-small-2">
+						<h3 class="p-heading--5">Day-2 automation</h3>
+					</div>
+					<div class="col-6 col-medium-3">
+						<p>
+							Charmed Ceph provides automation around common tasks, such as cluster scaling, integration and Ceph upgrades.
+						</p>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+	<div class="row">
+		<div class="col-9 col-start-large-4">
+			<div class="p-block">
+				<hr class="p-rule--muted" />
+				<div class="row">
+					<div class="col-3 col-medium-3 col-small-2">
+						<h3 class="p-heading--5">Optional training</h3>
+					</div>
+					<div class="col-6 col-medium-3">
+						<p>
+							If required we can deliver Ceph <a href="/training">training courses</a> to your team to familiarise them with Charmed Ceph.
+						</p>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</section>
+
+<section class="p-section">
+	<div class="row--50-50 p-section--shallow">
+		<hr class="p-rule--muted" />
+		<div class="col">
+			<h2>Choose the right Ubuntu for you</h2>
+		</div>
+		<div class="col">
+			<p>
+				Select between the standard Ubuntu Server and the Pro edition, which includes expanded security, compliance and GCP integration:
+			</p>
+		</div>
+	</div>    
+
+	<div class="row--50-50">
+		<div class="col">
+			<hr class="p-rule--highlight u-no-margin--bottom" />
+			<div class="p-card--overlay u-no-padding--top" style="height: 95%; overflow: hidden;">
+				<div class="row p-section--shallow">
+					<h3>Ubuntu LTS</h3>
+					<p class="p-heading--4">Free to use</p>
+				</div>
+				<hr class="p-rule--muted" />
+				<ul class="p-list--divided p-section--shallow">
+					<li class="p-list__item is-ticked">GCP-optimised kernel and userspace components built from the latest releases</li>
+					<li class="p-list__item is-ticked">Broad set of open source application components available for development</li>
+					<li class="p-list__item is-ticked">Security patches for the kernel and key infrastructure components</li>
+					<li class="p-list__item is-ticked">Updates mirrored and images published in all GCP regions worldwide</li>
+					<li class="p-list__item is-ticked">5-year lifetime</li>
+				</ul>
+				<hr class="p-rule--muted" />
+				<p>
+					<a href="https://console.cloud.google.com/compute/instancesAdd?imageId=4629240575064276470&imageProjectId=ubuntu-os-cloud"
+							class="p-button u-no-margin--bottom">Launch Ubuntu Server 24.04 LTS</a>
+				</p>
+			</div>
+		</div>
+
+		<div class="col">
+			<hr class="p-rule--highlight u-no-margin--bottom" />
+			<div class="p-card--overlay u-no-padding--top" style="height: 95%; overflow: hidden;">
+				<div class="row p-section--shallow">
+					<h3>Ubuntu Pro for Google Cloud</h3>
+					<p class="p-heading--4">3-4.5% of an average instance cost</p>
+				</div>
+				<hr class="p-rule--muted" />
+				<ul class="p-list--divided p-section--shallow">
+					<li class="p-list__item is-ticked">Includes all Ubuntu optimisations and updates of the free version</li>
+					<li class="p-list__item is-ticked">
+						Expanded security covering 28,000 additional application components delivered with Ubuntu
+					</li>
+					<li class="p-list__item is-ticked">Kernel live patching for instant security and longer uptimes</li>
+					<li class="p-list__item is-ticked">FIPS 140-2 and CC-EAL certified components</li>
+					<li class="p-list__item is-ticked">Integration with GCP security and compliance features</li>
+					<li class="p-list__item is-ticked">10-year lifetime</li>
+				</ul>
+				<hr class="p-rule--muted" />
+				<ul class="p-inline-list u-responsive-realign u-no-margin--bottom">
+					<li class="p-inline-list__item">
+						<a href="https://console.cloud.google.com/compute/instancesAdd?imageId=960077196939492817&imageProjectId=ubuntu-os-pro-cloud"
+							 class="p-button--positive u-no-margin--bottom">Launch Ubuntu Pro 24.04 LTS</a>
+					</li>
+					<li class="p-inline-list__item">
+						<p>
+							<a href="/gcp/pro">More about Ubuntu Pro for Google Cloud&nbsp;&rsaquo;</a>
+						</p>
+					</li>
+				</ul>
+			</div>
+		</div>
+	</div>
+</section>
+
+
 
 <section class="p-strip--light">
 	{% include "ceph/shared/_ceph-users.html" %}

--- a/templates/ceph/consulting.html
+++ b/templates/ceph/consulting.html
@@ -1,5 +1,7 @@
 {% extends "ceph/base_ceph.html" %}
 
+{% from "_macros/vf_hero.jinja" import vf_hero %}
+
 {% block title %}Ceph Consulting - Ceph Cluster Design and Delivery{% endblock %}
 
 {% block meta_description %}
@@ -11,43 +13,39 @@
 {% endblock meta_copydoc %}
 
 {% block content %}
-  <section class="p-section--hero">
-    <div class="row--50-50">
-      <div class="col p-section--shallow">
-        <div class="p-section--shallow">
-          <h1>Ceph solution design and delivery</h1>
-        </div>
-        <div class="p-section--shallow">
-          <p>
-            Fixed-price Ceph implementation, with consulting packages tailored to your needs.
-            Right size your Ceph solution for performance, capacity and budget with help from our team of experts.
-          </p>
-        </div>
-        <hr class="is-muted" />
-        <a href="/ceph/contact-us" class="p-button--positive js-invoke-modal">Get in touch</a>
-      </div>
-      <div class="col">
-        <div class="p-image-container--3-2 is-highlighted">
-          {{ image(url="https://assets.ubuntu.com/v1/4f840180-cephadm.png",
-                    alt="",
-                    width="852",
-                    height="1278",
-                    hi_def=True,
-                    loading="auto",
-                    attrs={"class": "p-image-container__image"}) | safe
-          }}
-        </div>
-      </div>
-    </div>
-  </section>
+	{% call(slot) vf_hero(
+		title_text='Ceph solution design and delivery',
+		layout='50/50',
+		is_split_on_medium=true
+		) -%}
+		{%- if slot == 'description' -%}
+			<p>
+				Fixed-price Ceph implementation, with consulting packages tailored to your needs.
+				Right size your Ceph solution for performance, capacity and budget with help from our team of experts.
+			</p>
+		{%- endif -%}
+		{%- if slot == 'cta' -%}
+			<a href="/ceph/contact-us" class="p-button--positive js-invoke-modal">Get in touch</a>
+		{%- endif -%}
+		{%- if slot == 'image' -%}
+			<div class="p-image-container--3-2 is-highlighted u-hide--small">
+				{{ image(url="https://assets.ubuntu.com/v1/4f840180-cephadm.png",
+									alt="",
+									width="852",
+									height="1278",
+									hi_def=True,
+									loading="auto",
+									attrs={"class": "p-image-container__image"}) | safe
+				}}
+			</div>
+		{%- endif -%}
+	{% endcall -%}
 
   <section class="p-section">
     <div class="row--50-50">
       <hr class="p-rule" />
       <div class="col">
-        <div class="p-section--shallow">
-          <h2>Ceph implementation challenges</h2>
-        </div>
+				<h2>Ceph implementation challenges</h2>
       </div>
       <div class="col">
         <div class="p-section--shallow">
@@ -95,7 +93,7 @@
     </div>
     <div class="row">
       <div class="col-9 col-start-large-4">
-        <div class="p-block">
+        <div class="p-section--shallow">
           <hr class="p-rule--muted" />
           <div class="row">
             <div class="col-3 col-medium-3 col-small-2">
@@ -110,7 +108,7 @@
     </div>
     <div class="row">
       <div class="col-9 col-start-large-4">
-        <div class="p-block">
+        <div class="p-section--shallow">
           <hr class="p-rule--muted" />
           <div class="row">
             <div class="col-3 col-medium-3 col-small-2">
@@ -127,7 +125,7 @@
     </div>
     <div class="row">
       <div class="col-9 col-start-large-4">
-        <div class="p-block">
+        <div class="p-section--shallow">
           <hr class="p-rule--muted" />
           <div class="row">
             <div class="col-3 col-medium-3 col-small-2">
@@ -144,7 +142,7 @@
     </div>
     <div class="row">
       <div class="col-9 col-start-large-4">
-        <div class="p-block">
+        <div class="p-section--shallow">
           <hr class="p-rule--muted" />
           <div class="row">
             <div class="col-3 col-medium-3 col-small-2">
@@ -161,7 +159,7 @@
     </div>
     <div class="row">
       <div class="col-9 col-start-large-4">
-        <div class="p-block">
+        <div class="p-section--shallow">
           <hr class="p-rule--muted" />
           <div class="row">
             <div class="col-3 col-medium-3 col-small-2">
@@ -178,7 +176,7 @@
     </div>
     <div class="row">
       <div class="col-9 col-start-large-4">
-        <div class="p-block">
+        <div class="p-section--shallow">
           <hr class="p-rule--muted" />
           <div class="row">
             <div class="col-3 col-medium-3 col-small-2">
@@ -195,7 +193,7 @@
     </div>
     <div class="row">
       <div class="col-9 col-start-large-4">
-        <div class="p-block">
+        <div class="p-section--shallow">
           <hr class="p-rule--muted" />
           <div class="row">
             <div class="col-3 col-medium-3 col-small-2">
@@ -212,7 +210,7 @@
     </div>
     <div class="row">
       <div class="col-9 col-start-large-4">
-        <div class="p-block">
+        <div class="p-section--shallow">
           <hr class="p-rule--muted" />
           <div class="row">
             <div class="col-3 col-medium-3 col-small-2">
@@ -227,7 +225,7 @@
     </div>
     <div class="row">
       <div class="col-9 col-start-large-4">
-        <div class="p-block">
+        <div class="p-section--shallow">
           <hr class="p-rule--muted" />
           <div class="row">
             <div class="col-3 col-medium-3 col-small-2">
@@ -247,9 +245,7 @@
   <section class="p-section">
     <div class="u-fixed-width p-section--shallow">
       <hr class="p-rule--muted" />
-      <div class="col">
-        <h2>Getting started with Ceph on Ubuntu</h2>
-      </div>
+			<h2>Getting started with Ceph on Ubuntu</h2>
     </div>
     <div class="row">
       <div class="col-6">
@@ -316,6 +312,9 @@
                 </p>
               </div>
               <div class="col-4">
+								<p>
+									<strong>Everything in Ceph Cluster Build, plus:</strong>
+								</p>
                 <ul class="p-list--divided p-section--shallow">
                   <li class="p-list__item is-ticked">RBD Block interface</li>
                   <li class="p-list__item is-ticked">CephFS file storage interfance</li>

--- a/templates/ceph/consulting.html
+++ b/templates/ceph/consulting.html
@@ -29,14 +29,14 @@
 		{%- endif -%}
 		{%- if slot == 'image' -%}
 			<div class="p-image-container--3-2 is-highlighted u-hide--small">
-				{{ image(url="https://assets.ubuntu.com/v1/4f840180-cephadm.png",
-									alt="",
-									width="852",
-									height="1278",
-									hi_def=True,
-									loading="auto",
-									attrs={"class": "p-image-container__image"}) | safe
-				}}
+        {{ image(url="https://assets.ubuntu.com/v1/f2c25341-ceph-solution-design-and-delivery.png",
+                  alt="",
+                  width="1800",
+                  height="1128",
+                  hi_def=True,
+                  loading="auto",
+                  attrs={"class": "p-image-container__image"}) | safe
+        }}
 			</div>
 		{%- endif -%}
 	{% endcall -%}
@@ -53,7 +53,7 @@
             Designing an optimised storage solution for any use case requires expert level knowledge, and many years of experience.
           </p>
           <p>Common questions that arise during design and build:</p>
-          <ul class="p-list--divided">
+          <ul class="p-list--divided u-no-margin--bottom">
             <li class="p-list__item is-ticked">Which deployment tooling should I use?</li>
             <li class="p-list__item is-ticked">Which version of Ceph should I install?</li>
             <li class="p-list__item is-ticked">What CPUs, Memory, Disks, NICs should I buy?</li>

--- a/templates/ceph/shared/_ceph-users.html
+++ b/templates/ceph/shared/_ceph-users.html
@@ -1,85 +1,77 @@
-<div class="row">
-  <div class="col-8">
+<div class="row--50-50">
+  <hr class="p-rule" />
+  <div class="col p-section">
     <h2>Companies using Ceph</h2>
-    <p>There are multiple users of Ceph across a broad range of industries, from academia to telecommunications and cloud service providers. Ceph is particularly favoured for its flexibility, scalability, and robustness.</p>
   </div>
-</div>
-<div class="u-fixed-width">
-  <p class="p-muted-heading">
-    Notable Ceph users
-  </p>
-  <div class="p-logo-section">
+  <div class="col p-section">
+    <p>
+      There are multiple users of Ceph across a broad range of industries, from academia to telecommunications and cloud service providers. Ceph is particularly favoured for its flexibility, scalability, and robustness.
+    </p>
+  </div>
+
+  <hr class="p-rule--muted" />
+
+  <p class="p-heading--5">Notable CEPH USERS</p>
+  <div class="p-logo-section--dense">
     <div class="p-logo-section__items">
-      <div class="p-logo-section__item u-align--center">
-        {{ image (
-          url="https://assets.ubuntu.com/v1/0194b789-cern-logo.png",
-          alt="CERN",
-          width="288",
-          height="288",
-          hi_def=True,
-          loading="auto",
-          attrs={"class": "p-logo-section__logo"}
-          ) | safe
+      <div class="p-logo-section__item">
+        {{ image(url="https://assets.ubuntu.com/v1/57c722c5-cern-logo.png",
+                alt="CERN",
+                width="239",
+                height="313",
+                hi_def=True,
+                loading="lazy",
+                attrs={"class": "p-logo-section__logo"}) | safe
         }}
       </div>
       <div class="p-logo-section__item">
-        {{ image (
-          url="https://assets.ubuntu.com/v1/c6e197c4-deutsche-telekom-logo.png",
-          alt="Deutsche Telecom",
-          width="288",
-          height="288",
-          hi_def=True,
-          loading="auto",
-          attrs={"class": "p-logo-section__logo"}
-          ) | safe
+        {{ image(url="https://assets.ubuntu.com/v1/60fd1f45-deutsche-telekom.png",
+                alt="Deutsche Telekom",
+                width="313",
+                height="313",
+                hi_def=True,
+                loading="lazy",
+                attrs={"class": "p-logo-section__logo"}) | safe
         }}
       </div>
       <div class="p-logo-section__item">
-        {{ image (
-          url="https://assets.ubuntu.com/v1/b1e3d2d2-bloomberg-logo.png",
-          alt="Bloomberg",
-          width="288",
-          height="288",
-          hi_def=True,
-          loading="auto",
-          attrs={"class": "p-logo-section__logo"}
-          ) | safe
+        {{ image(url="https://assets.ubuntu.com/v1/1e543d4d-Bloomberg-Logo.png",
+                alt="Bloomberg",
+                width="313",
+                height="313",
+                hi_def=True,
+                loading="lazy",
+                attrs={"class": "p-logo-section__logo"}) | safe
         }}
       </div>
       <div class="p-logo-section__item">
-        {{ image (
-          url="https://assets.ubuntu.com/v1/7eebe11c-cisco-logo.png",
-          alt="Cisco",
-          width="288",
-          height="288",
-          hi_def=True,
-          loading="auto",
-          attrs={"class": "p-logo-section__logo"}
-          ) | safe
+        {{ image(url="https://assets.ubuntu.com/v1/c3382d32-cisco-logo.png",
+                alt="Cisco",
+                width="189",
+                height="313",
+                hi_def=True,
+                loading="lazy",
+                attrs={"class": "p-logo-section__logo"}) | safe
         }}
       </div>
       <div class="p-logo-section__item">
-        {{ image (
-          url="https://assets.ubuntu.com/v1/5845c684-dreamhost-logo.png",
-          alt="DreamHost",
-          width="288",
-          height="288",
-          hi_def=True,
-          loading="auto",
-          attrs={"class": "p-logo-section__logo"}
-          ) | safe
+        {{ image(url="https://assets.ubuntu.com/v1/6ec58036-dreamhost-logo.png",
+                alt="Dreamhost",
+                width="433",
+                height="313",
+                hi_def=True,
+                loading="lazy",
+                attrs={"class": "p-logo-section__logo"}) | safe
         }}
       </div>
-      <div class="p-logo-section__item u-align--center">
-        {{ image (
-          url="https://assets.ubuntu.com/v1/92a04d46-digital-ocean-logo.png",
-          alt="Digital Ocean",
-          width="288",
-          height="288",
-          hi_def=True,
-          loading="auto",
-          attrs={"class": "p-logo-section__logo"}
-          ) | safe
+      <div class="p-logo-section__item">
+        {{ image(url="https://assets.ubuntu.com/v1/39eef9bb-digitalocean-logo.png",
+                alt="DigitalOcean",
+                width="463",
+                height="313",
+                hi_def=True,
+                loading="lazy",
+                attrs={"class": "p-logo-section__logo"}) | safe
         }}
       </div>
     </div>

--- a/templates/ceph/shared/_ceph-users.html
+++ b/templates/ceph/shared/_ceph-users.html
@@ -1,17 +1,21 @@
-<div class="row--50-50">
+<div class="u-fixed-width">
   <hr class="p-rule" />
-  <div class="col p-section">
-    <h2>Companies using Ceph</h2>
-  </div>
-  <div class="col p-section">
-    <p>
-      There are multiple users of Ceph across a broad range of industries, from academia to telecommunications and cloud service providers. Ceph is particularly favoured for its flexibility, scalability, and robustness.
-    </p>
+  <div class="p-section--shallow">
+    <div class="row--50-50">    
+      <div class="col">
+        <h2>Companies using Ceph</h2>
+      </div>
+      <div class="col">
+        <p>
+          There are multiple users of Ceph across a broad range of industries, from academia to telecommunications and cloud service providers. Ceph is particularly favoured for its flexibility, scalability, and robustness.
+        </p>
+      </div>
+    </div>
   </div>
 
   <hr class="p-rule--muted" />
 
-  <p class="p-heading--5">Notable CEPH USERS</p>
+  <p class="p-heading--5 p-text--small-caps">Notable Ceph Users</p>
   <div class="p-logo-section--dense">
     <div class="p-logo-section__items">
       <div class="p-logo-section__item">

--- a/templates/shared/_resources_ceph.html
+++ b/templates/shared/_resources_ceph.html
@@ -4,37 +4,33 @@
     <h2>Learn more about Ceph</h2>
   </div>
   <div class="col-6 col-medium-6">
-    <div class="p-section--shallow">
-      <div class="row">
-        <div class="col-2 col-medium-3">
-          <h3 class="p-heading--5">Webinar</h3>
-        </div>
-        <div class="col-4 col-medium-3">
-          <p>
-            <a href="https://www.brighttalk.com/webcast/6793/520582">Ceph for Enterprise</a>
-          </p>
-        </div>
+    <div class="row">
+      <div class="col-2 col-medium-3">
+        <h3 class="p-heading--5">Webinar</h3>
+      </div>
+      <div class="col-4 col-medium-3">
+        <p>
+          <a href="https://www.brighttalk.com/webcast/6793/520582">Ceph for Enterprise</a>
+        </p>
       </div>
     </div>
     <hr class="p-rule--muted" />
-    <div class="p-section--shallow">
-      <div class="row">
-        <div class="col-2 col-medium-3">
-          <h3 class="p-heading--5">Case study</h3>
-        </div>
-        <div class="col-4 col-medium-3">
-          <p>
-            <a href="https://ubuntu.com/engage/yahoo-japan-case-study">
-              How Yahoo! Japan built their IaaS storage using Ceph on Ubuntu
-            </a>
-          </p>
-          <hr class="p-rule--muted" />
-          <p>
-            <a href="https://ubuntu.com/engage/wellcome-sanger-case-study">
-              Genomic research centre turns to Ceph for growing storage needs
-            </a>
-          </p>
-        </div>
+    <div class="row">
+      <div class="col-2 col-medium-3">
+        <h3 class="p-heading--5">Case study</h3>
+      </div>
+      <div class="col-4 col-medium-3">
+        <p>
+          <a href="https://ubuntu.com/engage/yahoo-japan-case-study">
+            How Yahoo! Japan built their IaaS storage using Ceph on Ubuntu
+          </a>
+        </p>
+        <hr class="p-rule--muted" />
+        <p>
+          <a href="https://ubuntu.com/engage/wellcome-sanger-case-study">
+            Genomic research centre turns to Ceph for growing storage needs
+          </a>
+        </p>
       </div>
     </div>
   </div>

--- a/templates/shared/_resources_ceph.html
+++ b/templates/shared/_resources_ceph.html
@@ -1,68 +1,41 @@
-<div class="u-fixed-width">
-  <h3>Learn more about Ceph</h3>
-  <div class="row p-divider u-no-padding--left u-no-padding--right">
-    <div class="col-4 p-divider__block">
-      <div class="p-heading-icon--muted">
-        <div class="p-heading-icon__header">
-          {{
-            image(
-            url="https://assets.ubuntu.com/v1/6e184942-Webinar.svg",
-            alt="",
-            width="32",
-            height="28",
-            hi_def=True,
-            loading="auto",
-            attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
-            ) | safe
-          }}
-          <h4 class="p-heading-icon__title">Webinar</h4>
+<div class="row">
+  <hr class="p-rule" />
+  <div class="col-6">
+    <h2>Learn more about Ceph</h2>
+  </div>
+  <div class="col-6 col-medium-6">
+    <div class="p-section--shallow">
+      <div class="row">
+        <div class="col-2 col-medium-3">
+          <h3 class="p-heading--5">Webinar</h3>
+        </div>
+        <div class="col-4 col-medium-3">
+          <p>
+            <a href="https://www.brighttalk.com/webcast/6793/520582">Ceph for Enterprise</a>
+          </p>
         </div>
       </div>
-      <h3 class="p-heading--4">
-        <a href="https://www.brighttalk.com/webcast/6793/520582">Ceph for Enterprise</a>
-      </h3>
     </div>
-    <div class="col-4 p-divider__block">
-      <div class="p-heading-icon--muted">
-        <div class="p-heading-icon__header">
-          {{
-              image(
-              url="https://assets.ubuntu.com/v1/5edefef9-Datasheet.svg",
-              alt="",
-              width="32",
-              height="28",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
-              ) | safe
-            }}
-            <h4 class="p-heading-icon__title">Whitepaper</h4>
+    <hr class="p-rule--muted" />
+    <div class="p-section--shallow">
+      <div class="row">
+        <div class="col-2 col-medium-3">
+          <h3 class="p-heading--5">Case study</h3>
+        </div>
+        <div class="col-4 col-medium-3">
+          <p>
+            <a href="https://ubuntu.com/engage/yahoo-japan-case-study">
+              How Yahoo! Japan built their IaaS storage using Ceph on Ubuntu
+            </a>
+          </p>
+          <hr class="p-rule--muted" />
+          <p>
+            <a href="https://ubuntu.com/engage/wellcome-sanger-case-study">
+              Genomic research centre turns to Ceph for growing storage needs
+            </a>
+          </p>
         </div>
       </div>
-      <h3 class="p-heading--4">
-        <a href="/engage/introduction-to-cloud-native-storage">Introduction to cloud-native storage</a>
-      </h3>
-    </div>
-    <div class="col-4 p-divider__block">
-      <div class="p-heading-icon--muted">
-        <div class="p-heading-icon__header">
-          {{
-              image(
-              url="https://assets.ubuntu.com/v1/5edefef9-Datasheet.svg",
-              alt="",
-              width="32",
-              height="28",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},
-              ) | safe
-            }}
-            <h4 class="p-heading-icon__title">Whitepaper</h4>
-        </div>
-      </div>
-      <h3 class="p-heading--4">
-        <a href="/engage/optimize-cloud-storage-costs">Cloud storage cost optimisation</a>
-      </h3>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Done

- Rebrand /ceph/consulting
- Update shared sections in Ceph bubble for **resources** and **users**

## QA

- Go to https://ubuntu-com-14473.demos.haus/ceph/consulting
- Compare with [design](https://www.figma.com/design/ulUyOFdQ7CNy0whuJ4S2FM/Ceph-Bubble?node-id=13-3904&node-type=instance&m=dev)
- There are no content changes, only redesign

## Issue / Card

Fixes [WD-16345](https://warthogs.atlassian.net/browse/WD-16345)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-16345]: https://warthogs.atlassian.net/browse/WD-16345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ