### PR TITLE
Fix typo in expiry notification

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/ExpiryNotification/ExpiryNotification.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/ExpiryNotification/ExpiryNotification.test.tsx
@@ -196,7 +196,7 @@ describe("ExpiryNotification", () => {
       "Your subscription is about to expire.",
     );
     expect(wrapper.find(Notification).prop("children")).toBe(
-      "Click on Renew subscription to to ensure service continuity.",
+      "Click on Renew subscription to ensure service continuity.",
     );
   });
   it("is expiring shows not legacy message if not actionable", () => {
@@ -241,7 +241,7 @@ describe("ExpiryNotification", () => {
       "Your subscription has expired.",
     );
     expect(wrapper.find(Notification).prop("children")).toBe(
-      "Click on Renew subscription to to ensure service continuity.",
+      "Click on Renew subscription to ensure service continuity.",
     );
   });
 
@@ -287,7 +287,7 @@ describe("ExpiryNotification", () => {
       "Your subscription has expired.",
     );
     expect(wrapper.find(Notification).prop("children")).toBe(
-      "Click on Renew subscription to to ensure service continuity.",
+      "Click on Renew subscription to ensure service continuity.",
     );
   });
 

--- a/static/js/src/advantage/react/components/Subscriptions/ExpiryNotification/ExpiryNotification.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/ExpiryNotification/ExpiryNotification.tsx
@@ -57,7 +57,7 @@ const MESSAGES: Messages = {
       message: {
         default: "Check the subscription errors below for more information.",
         [UserSubscriptionType.Legacy]:
-          "Click on Renew subscription to to ensure service continuity.",
+          "Click on Renew subscription to ensure service continuity.",
         [UserSubscriptionType.Monthly]:
           "Enable auto-renewals via the renewal settings menu to ensure service continuity.",
         [UserSubscriptionType.Yearly]:
@@ -82,7 +82,7 @@ const MESSAGES: Messages = {
       message: {
         default: "Check the subscription errors below for more information.",
         [UserSubscriptionType.Legacy]:
-          "Click on Renew subscription to to ensure service continuity.",
+          "Click on Renew subscription to ensure service continuity.",
         [UserSubscriptionType.Monthly]: (
           <>
             If you don&apos;t renew it, it will disappear from your dashboard in
@@ -116,7 +116,7 @@ const MESSAGES: Messages = {
       message: {
         default: "Check the subscription errors below for more information.",
         [UserSubscriptionType.Legacy]:
-          "Click on Renew subscription to to ensure service continuity.",
+          "Click on Renew subscription to ensure service continuity.",
         [UserSubscriptionType.Monthly]: (
           <>
             If you don&apos;t renew it, it will disappear from your dashboard in


### PR DESCRIPTION
## Done
- Fix typo in expiry notification
Remove one "to" from "Click on Renew subscription **to to** ensure service continuity."

## Issue / Card

Fixes #https://warthogs.atlassian.net/browse/WD-16915

