### PR TITLE
fix: Show where you are in docs navigation

### DIFF
--- a/templates/templates/docs/shared/_docs.html
+++ b/templates/templates/docs/shared/_docs.html
@@ -24,16 +24,12 @@
         {% if expandable %}
           {% if element.children %}
             <button class="p-side-navigation__expand"
-                    aria-expanded="{% if element.is_active or element.has_active_child %}"
-                    "
-                    true
-                    "
-                    {% else %}
-                    "
-                    false
-                    "
-                    {% endif %}
-                    aria-label="show submenu for {{ element.navlink_text }}"></button>
+                    aria-expanded="{% if element.is_active or element.has_active_child %}true{% else %}false{% endif %}" aria-label="
+                    show
+                    submenu
+                    for
+                    {{ element.navlink_text }}
+                    "></button>
           {% endif %}
           {{ create_navigation(element.children, expandable, element.is_active or element.has_active_child) }}
         {% else %}


### PR DESCRIPTION
## Done

- Fix bug where `aria-expanded` was not being applied to side navigation items within docs. Leading to the where you are in the navigation not being clear.

## QA

- Go to https://ubuntu-com-14483.demos.haus/landscape/docs/upgrade-landscape and see that the side-navigation expands to show you the page you are on. For reference you can check out https://ubuntu.com/landscape/docs/upgrade-landscape to see how it currently works (or doesn't work)

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-16358