### PR TITLE
Change CTA color to positive (green)

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -106,7 +106,7 @@
             </p>
           </div>
           <p>
-            <a class="p-button p-button--positive" href="/pro">Get Ubuntu Pro</a>
+            <a class="p-button--positive" href="/pro">Get Ubuntu Pro</a>
           </p>
         </div>
         <div class="col-3 col-medium-2">

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -106,7 +106,7 @@
             </p>
           </div>
           <p>
-            <a class="p-button is-dark" href="/pro">Get Ubuntu Pro</a>
+            <a class="p-button p-button--positive" href="/pro">Get Ubuntu Pro</a>
           </p>
         </div>
         <div class="col-3 col-medium-2">


### PR DESCRIPTION
## Done

- Changed CTA color on the Pro section on the u.c homepage to green (positive)

## QA

- Visit https://ubuntu-com-14491.demos.haus/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Make sure the CTA color is green.

## Issue / Card

Fixes [WD-17037](https://warthogs.atlassian.net/browse/WD-17037)

## Screenshots
Before
![Before](https://github.com/user-attachments/assets/4fd11647-3bd6-4996-b156-7ece751d5535)
After
![After](https://github.com/user-attachments/assets/b7b8c189-89e3-4f47-a899-df76b97386c0)


[WD-17037]: https://warthogs.atlassian.net/browse/WD-17037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ