### PR TITLE
fix: Init cookie-policy even if cookies have been set already

### DIFF
--- a/static/js/src/cookie-policy-with-callback.js
+++ b/static/js/src/cookie-policy-with-callback.js
@@ -13,6 +13,7 @@ if (!cookieAcceptanceValue) {
   cpNs.cookiePolicy(setUserId);
 } else {
   setUserId();
+  cpNs.cookiePolicy();
 }
 
 function setUserId() {


### PR DESCRIPTION
## Done

- fix: Init cookie-policy even if cookies have been set already

## QA

- Open [the demo](https://ubuntu-com-14497.demos.haus/)
- Accept your preferred cookie-policy setttings
- Refresh the page and scroll to the very bottom
- Click 'Manage your tracker settings'
- The cookie-policy modal should open and you will be able to change your preferences
- Make sure to check with different combinations of cookie-policy preferences and check they are being stored

*it is a known bug that the cookie is not update until the page is refreshed. There is an issue to fix it [here](https://warthogs.atlassian.net/browse/WD-17163)*

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-16366
