### PR TITLE
WD-17171 Tooltip for ubuntu pro button has a typo

### DIFF
--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -630,8 +630,8 @@ def cve(cve_id):
         },
         "esm-apps": {
             "text": (
-                "Fix available with Ubuntu Pro via ESM Apps."
-                "A fix from the community might become publicly available"
+                "Fix available with Ubuntu Pro via ESM Apps. "
+                "A fix from the community might become publicly available "
                 "in the future."
             ),
             "label": "Ubuntu Pro",


### PR DESCRIPTION
## Done

- Fixed spacing typo

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to demo down at the /ubuntupro to see the tooltip and correction [demo](https://ubuntu-com-14502.demos.haus/security/CVE-2024-48990)

## Issue / Card

Fixes #14499 

## Screenshots

The issue is here
![image](https://github.com/user-attachments/assets/4008c189-c9ef-45f8-932f-f6e992cedb6d)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
