### PR TITLE
copy: replace 'Charmhub' with 'AI & MLOps' in meganav. WD-17137

### DIFF
--- a/meganav.yaml
+++ b/meganav.yaml
@@ -75,9 +75,9 @@ products:
             - title: Kubernetes
               description: Containerised workloads
               url: /kubernetes
-            - title: Charmhub
-              description: Charmed Operators marketplace
-              url: https://charmhub.io/
+            - title: AI & MLOps
+              description: AI and machine learning on Ubuntu
+              url: /ai
             - title: Juju
               description: Orchestration engine for operators
               url: https://juju.is/


### PR DESCRIPTION
Replace 'Charmhub' with 'AI & MLOps' in meganav featured products section.

[Doc](https://docs.google.com/document/d/1DCNvYHfC7AbOcqflTBaVd571iKAP_PaTfnqTENVEDVw/edit?tab=t.0)

## Done

- [List of work items including drive-bys - remember to add the why and what of this work.]

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes [#WD-17137](https://warthogs.atlassian.net/browse/WD-17137)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
