### PR TITLE
Fix exam naming in your-exams

### DIFF
--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -46,6 +46,7 @@ TIMEZONE_COUNTRIES["Asia/Calcutta"] = "IN"
 EXAM_NAMES = {
     "cue-test": "CUE Linux Beta",
     "cue-linux-essentials": "CUE.01 Linux",
+    "cue-01-linux": "CUE.01 Linux",
 }
 
 RESERVATION_STATES = {


### PR DESCRIPTION
## Done

- Rename _cue-01-linux_ to _CUE.01 Linux_

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Purchase a **CUE.01 Linux** exam
- Go to `credentials/your-exams` page and make sure the exam name shows **CUE.01 Linux**

## Issue / Card

Fixes [WD-13432](https://warthogs.atlassian.net/browse/WD-13432)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-13432]: https://warthogs.atlassian.net/browse/WD-13432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ