### PR TITLE
Rebrand /ceph/thank-you page

### DIFF
--- a/templates/ceph/thank-you.html
+++ b/templates/ceph/thank-you.html
@@ -5,26 +5,21 @@
 {% block head_extra %}<meta name="robots" content="noindex" />{% endblock %}
 
 {% block content %}
-<div class="p-strip is-bordered is-deep">
-  <div class="row">
-    <div class="col-7">
-      <h1>Thank you for contacting our team.</h1>
-      <p class="p-heading--4">We will be in touch shortly.</p>
-    </div>
-    <div class="col-5 u-vertically-center u-hide--medium u-hide--small u-align--center">
-      {{
-        image(
-          url="https://assets.ubuntu.com/v1/52d53696-picto-thankyou-midaubergine.svg",
-          alt="",
-          height="200",
-          width="200",
-          loading="auto",
-          hi_def=True
-        ) | safe
-      }}
+  <div class="p-section--hero">
+    <div class="row--50-50">
+      <div class="col">
+        <h1 class="u-no-margin--bottom">Thank you for contacting our team.</h1>
+        <h2>We will be in touch shortly.</h2>
+      </div>
+      <div class="col">
+        <div class="p-image-container is-cover u-hide--small">
+          <img class="p-image-container__image"
+              src="https://assets.ubuntu.com/v1/b0fa63e9-christina-wocintechchat-com-LQ1t-8Ms5PY-unsplash.png"
+              alt="" />
+        </div>
+      </div>
     </div>
   </div>
-</div>
 
 {% include "shared/_thank_you_footer.html" %}
 


### PR DESCRIPTION
## Done

- Rebrand /ceph/thank-you page

## QA

- Go to https://ubuntu-com-14505.demos.haus/ceph/thank-you
- Check that it matches design
- No content change from original
- [Design](https://www.figma.com/design/FoWXkNxxdri9EgSsLdtTrH/24.10-ubuntu.com%2Faws?node-id=120-4373&node-type=canvas&m=dev)

## Issue / Card

Fixes [WD-16353](https://warthogs.atlassian.net/browse/WD-16353)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-16353]: https://warthogs.atlassian.net/browse/WD-16353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ