### PR TITLE
[WD-17261] switch off the A/B for takeovers

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -1138,7 +1138,7 @@
 
       const getCookie = () => document.cookie.match(new RegExp('(^| )' + "control_or_variant" + '=([^;]+)'));
       // Switch for turning takeover switching on and off on demand
-      const takeoverSwitch = true;
+      const takeoverSwitch = false;
       if (!takeoverSwitch) document.cookie = 'control_or_variant=;';
       else {
         // check if user doesn't already have a group


### PR DESCRIPTION
## Done

- Turn off the switch that is used for showing different layouts for takeovers on the home page.

## QA

- Open the demo link at https://ubuntu-com-14506.demos.haus/
- Make sure that the layout of the takeover is correct
- Open cookies from the dev console
- Change the value of "control_or_variant" cookie to "variant" (if it's not that already)
- Refresh the page and check if the takeover layout has not changed

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-17261

## Screenshots

The layout that is expected to see:
![Screenshot From 2024-11-26 11-56-56](https://github.com/user-attachments/assets/534ccab5-27c4-4597-8289-c383502bc1bf)

Alternative layout that should not render anymore:
![Screenshot From 2024-11-26 11-57-24](https://github.com/user-attachments/assets/6abf4dbb-3208-433f-819e-c40e3b0e20f2)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
