### PR TITLE
Download AMD: add 24.04 LTS

### DIFF
--- a/static/js/src/tabbed-content.js
+++ b/static/js/src/tabbed-content.js
@@ -150,17 +150,15 @@
 
       attachEvents(tabs, persistURLHash);
 
-      const isInsideCurrentContainer =
-        null !==
-        tabContainer.querySelector(".p-tabs__link[href='" + currentHash + "']");
-
-      if (persistURLHash && currentHash && isInsideCurrentContainer) {
-        const activeTab = document.querySelector(
+      if (persistURLHash && currentHash) {
+        const activeTabLink = document.querySelector(
           ".p-tabs__link[href='" + currentHash + "']",
         );
-
-        if (activeTab) {
-          setActiveTab(activeTab, tabs);
+        const activeTabButton = document.querySelector(
+          ".p-tabs__item[id='" + currentHash.replace("#", "") + "']",
+        );
+        if (activeTabLink || activeTabButton) {
+          setActiveTab(activeTabLink || activeTabButton, tabs);
         }
 
         return;

--- a/templates/download/amd/_wiki_notification.html
+++ b/templates/download/amd/_wiki_notification.html
@@ -1,4 +1,4 @@
-<div class="p-notification--information is-borderless no-margin-bottom">
+<div class="p-notification--information is-borderless u-no-margin-bottom">
   <div class="p-notification__content">
     <p class="p-notification__message">
       Please check the

--- a/templates/download/amd/_wiki_notification.html
+++ b/templates/download/amd/_wiki_notification.html
@@ -1,4 +1,4 @@
-<div class="p-notification--information is-borderless u-no-margin-bottom">
+<div class="p-notification--information is-borderless u-no-margin--bottom">
   <div class="p-notification__content">
     <p class="p-notification__message">
       Please check the

--- a/templates/download/amd/_wiki_notification.html
+++ b/templates/download/amd/_wiki_notification.html
@@ -1,0 +1,13 @@
+<div class="p-notification--information is-borderless no-margin-bottom">
+  <div class="p-notification__content">
+    <p class="p-notification__message">
+      Please check the
+      <a href="https://xilinx-wiki.atlassian.net/wiki/spaces/A/pages/1641152513">AMD Kria&trade; Wiki</a>
+      for the platform's latest boot firmware, technical documentation,
+      and the <a href="https://xilinx-wiki.atlassian.net/wiki/spaces/A/pages/1413611532/Canonical+Ubuntu">
+      Ubuntu for AMD-Xilinx Devices Wiki
+    </a>
+    for known issues and limitations.
+  </p>
+</div>
+</div>

--- a/templates/download/amd/index.html
+++ b/templates/download/amd/index.html
@@ -60,6 +60,7 @@
           </div>
           <ul class="js-tabbed-content p-tabs--vertical is-black u-hide--small"
               role="tablist"
+              data-maintain-hash="true"
               aria-label="AMD boards">
             <li>
               <button class="p-tabs__item"

--- a/templates/download/amd/index.html
+++ b/templates/download/amd/index.html
@@ -64,14 +64,14 @@
               aria-label="AMD boards">
             <li>
               <button class="p-tabs__item"
-                      id="kira-k24-vision"
+                      id="kira-k24"
                       role="tab"
                       aria-selected="true"
                       aria-controls="kira-k24-vision-tab">Kria&trade; K24 SOMs</button>
             </li>
             <li>
               <button class="p-tabs__item"
-                      id="kria-kv260-kr260"
+                      id="kria-k26"
                       role="tab"
                       aria-selected="false"
                       aria-controls="kria-kv260-kr260-tab">Kria&trade; K26 SOMs</button>

--- a/templates/download/amd/tab-1.html
+++ b/templates/download/amd/tab-1.html
@@ -12,40 +12,34 @@
       </h2>
     </div>
     <div class="col-6 amd-container u-align--center col-medium-4">
-      {{
-        image(
-          url="https://assets.ubuntu.com/v1/08a98740-AMD%20KD240.png",
-          alt="AMD Kria KR260 circuit board",
-          width="312",
-          height="250",
-          hi_def=True,
-          loading="lazy",
-        ) | safe
+      {{ image(url="https://assets.ubuntu.com/v1/08a98740-AMD%20KD240.png",
+            alt="AMD Kria KR260 circuit board",
+            width="312",
+            height="250",
+            hi_def=True,
+            loading="lazy",) | safe
       }}
     </div>
   </div>
   <hr class="p-rule" />
   <div class="row p-strip u-no-padding--top">
     <div class="col-3 col-medium-2">
-      <h3>Ubuntu Server 22.04 LTS</h3>
+      <h3>Ubuntu Server 24.04 LTS</h3>
     </div>
     <div class="col-6 col-medium-3">
-      <p>The version of Ubuntu with up to 10 years of long term support, until April 2032.</p>
+      <p>The version of optimised Ubuntu Server 24.04 is beta for now, the certified version is coming soon.</p>
       <p>Works on:</p>
       <ul class="p-list">
         <li class="p-list__item is-ticked">AMD Kria&trade; KD240 Drives Starter Kit</li>
       </ul>
       <hr class="p-rule" />
-      <div class="p-notification--information is-borderless u-no-margin--bottom">
-        <div class="p-notification__content">
-          <p class="p-notification__message">
-            Please check the <a href="https://xilinx-wiki.atlassian.net/wiki/spaces/A/pages/1641152513">AMD Kria&trade; Wiki</a> for the platform's latest boot firmware, technical documentation, and the <a href="https://xilinx-wiki.atlassian.net/wiki/spaces/A/pages/1413611532/Canonical+Ubuntu">Ubuntu for AMD-Xilinx Devices Wiki</a> for known issues and limitations.
-          </p>
-        </div>
-      </div>
+      {% include "download/amd/_wiki_notification.html" %}
       <p>
         <a class="p-button--positive"
-           href="https://people.canonical.com/~platform/images/xilinx/kria24-ubuntu-22.04/iot-limerick-kria-classic-server-2204-classic-22.04-kd05-20240223-170.img.xz">Download 22.04 LTS</a>
+           href="https://people.canonical.com/~platform/images/xilinx/kria-ubuntu-24.04/iot-limerick-kria-classic-server-2404-classic-24.04-x05-20241114.img.xz">Download 24.04 LTS</a>
+      </p>
+      <p>
+        <a href="https://www.amd.com/KD240-Start">Kria&trade; KD240 Getting Started Guide for Ubuntu 24.04</a>
       </p>
     </div>
   </div>
@@ -53,6 +47,59 @@
   {% include "download/amd/_working_commercial_section.html" %}
 
   {% include "download/amd/_ubuntu_pro_section.html" %}
+  <hr class="p-rule" />
+  <div class="row p-strip u-no-padding--top">
+    <div class="col-3">
+      <h3 class="p-heading--5 u-no-padding--top">
+        <strong>AMD Ubuntu Software Development Kit</strong>
+      </h3>
+    </div>
+    <div class="col-6">
+      <p>Ubuntu developers targeting Kria&trade; KR260 and KV260 platform may also want to download the following files:</p>
+
+      <table class="col-6">
+        <thead>
+          <tr>
+            <th>Image name</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <a href="https://people.canonical.com/~platform/images/xilinx/kria-ubuntu-24.04/iot-limerick-kria-classic-server-2404-classic-24.04-x05-20241114-sysroot.tar.xz">
+                iot-limerick-kria-classic-server-2404-classic-24.04-x05-20241114-sysroot.tar.xz
+              </a>
+            </td>
+            <td>Sysroot for cross-compilation</td>
+          </tr>
+          <tr>
+            <td>
+              <a href="https://people.canonical.com/~platform/images/xilinx/kria-ubuntu-24.04/iot-limerick-kria-classic-server-2404-classic-24.04-x05-20241114-rootfs.tar.gz">
+                iot-limerick-kria-classic-server-2404-classic-24.04-x05-20241114-rootfs.tar.gz
+              </a>
+            </td>
+            <td>Raw Root filesystem</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <hr class="p-rule" />
+  <div class="row p-strip u-no-padding--top">
+    <div class="col-3 col-medium-2">
+      <h3>Ubuntu Server 22.04 LTS</h3>
+    </div>
+    <div class="col-6 col-medium-3">
+      The version of Ubuntu with up to 10 years of long term support, until April 2032.
+      <p>Works on:</p>
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">AMD Kria&trade; KD240 Drives Starter Kit</li>
+      </ul>
+      {% include "download/amd/_wiki_notification.html" %}
+    </div>
+  </div>
 
   <hr class="p-rule" />
   <div class="row p-strip u-no-padding--top">

--- a/templates/download/amd/tab-1.html
+++ b/templates/download/amd/tab-1.html
@@ -24,19 +24,28 @@
   <hr class="p-rule" />
   <div class="row p-strip u-no-padding--top">
     <div class="col-3 col-medium-2">
-      <h3>Ubuntu Server 24.04 LTS</h3>
+      <h3>Ubuntu Server 24.04</h3>
     </div>
     <div class="col-6 col-medium-3">
-      <p>The version of optimised Ubuntu Server 24.04 is beta for now, the certified version is coming soon.</p>
+      <p>The optimised Ubuntu Server 24.04 is beta for now, the certified version is coming soon.</p>
       <p>Works on:</p>
       <ul class="p-list">
         <li class="p-list__item is-ticked">AMD Kria&trade; KD240 Drives Starter Kit</li>
+        <li class="p-list__item is-ticked">AMD Kria&trade; KR260 Robotics Starter Kit</li>
+        <li class="p-list__item is-ticked">AMD Kria&trade; KV260 Vision AI Starter Kit</li>
       </ul>
       <hr class="p-rule" />
+      <div class="p-notification--information is-borderless u-no-margin--bottom">
+        <div class="p-notification__content">
+          <p class="p-notification__message">
+            This Ubuntu version is working on K26 SOMs as well.
+          </p>
+        </div>
+      </div>      
       {% include "download/amd/_wiki_notification.html" %}
       <p>
         <a class="p-button--positive"
-           href="https://people.canonical.com/~platform/images/xilinx/kria-ubuntu-24.04/iot-limerick-kria-classic-server-2404-classic-24.04-x05-20241114.img.xz">Download 24.04 LTS</a>
+           href="https://people.canonical.com/~platform/images/xilinx/kria-ubuntu-24.04/iot-limerick-kria-classic-server-2404-classic-24.04-x05-20241114.img.xz">Download 24.04</a>
       </p>
       <p>
         <a href="https://www.amd.com/KD240-Start">Kria&trade; KD240 Getting Started Guide for Ubuntu 24.04</a>
@@ -55,7 +64,7 @@
       </h3>
     </div>
     <div class="col-6">
-      <p>Ubuntu developers targeting Kria&trade; KR260 and KV260 platform may also want to download the following files:</p>
+      <p>Ubuntu developers targeting Kria&trade; KD240 platform may also want to download the following files:</p>
 
       <table class="col-6">
         <thead>
@@ -98,6 +107,10 @@
         <li class="p-list__item is-ticked">AMD Kria&trade; KD240 Drives Starter Kit</li>
       </ul>
       {% include "download/amd/_wiki_notification.html" %}
+      <p>
+        <a class="p-button--positive"
+           href="https://people.canonical.com/~platform/images/xilinx/kria-ubuntu-22.04/iot-limerick-kria-classic-desktop-2204-20240304-165.img.xz">Download 22.04 LTS</a>
+      </p>
     </div>
   </div>
 

--- a/templates/download/amd/tab-2.html
+++ b/templates/download/amd/tab-2.html
@@ -29,20 +29,28 @@
   <hr class="p-rule" />
   <div class="row p-strip u-no-padding--top">
     <div class="col-3 col-medium-2">
-      <h3>Ubuntu Desktop 24.04 LTS</h3>
+      <h3>Ubuntu Server 24.04</h3>
     </div>
     <div class="col-6 col-medium-3">
-      <p>The version of optimised Ubuntu Server 24.04 is beta for now, the certified version is coming soon.</p>
+      <p>The optimised Ubuntu Server 24.04 is beta for now, the certified version is coming soon.</p>
       <p>Works on:</p>
       <ul class="p-list">
-        <li class="p-list__item is-ticked">KR260 Robotics Starter Kit</li>
-        <li class="p-list__item is-ticked">KV260 Vision AI Starter Kit</li>
+        <li class="p-list__item is-ticked">AMD Kria&trade; KR260 Robotics Starter Kit</li>
+        <li class="p-list__item is-ticked">AMD Kria&trade; KV260 Vision AI Starter Kit</li>
+        <li class="p-list__item is-ticked">AMD Kria&trade; KD240 Drives Starter Kit</li>
       </ul>
       <hr class="p-rule" />
+      <div class="p-notification--information is-borderless u-no-margin--bottom">
+        <div class="p-notification__content">
+          <p class="p-notification__message">
+            This Ubuntu version is working on K24 SOMs as well.
+          </p>
+        </div>
+      </div>   
       {% include "download/amd/_wiki_notification.html" %}
       <p>
         <a class="p-button--positive"
-           href="https://people.canonical.com/~platform/images/xilinx/kria-ubuntu-24.04/iot-limerick-kria-classic-server-2404-classic-24.04-x05-20241114.img.xz">Download 24.04 LTS</a>
+           href="https://people.canonical.com/~platform/images/xilinx/kria-ubuntu-24.04/iot-limerick-kria-classic-server-2404-classic-24.04-x05-20241114.img.xz">Download 24.04</a>
       </p>
       <p>
         <a href="https://www.amd.com/KR260-Start">Kria&trade; KR260 Getting Started Guide for Ubuntu 24.04</a>

--- a/templates/download/amd/tab-2.html
+++ b/templates/download/amd/tab-2.html
@@ -6,7 +6,7 @@
   <div class="row p-strip is-shallow u-no-padding--top">
     <div class="col-3 col-medium-2">
       <h2 class="u-hide--small">
-        Kria&trade;K26 SOMs
+        Kria&trade; K26 SOMs
         <br class="u-hide--medium" />
         (KR260/
         <br class="u-hide--medium" />
@@ -17,7 +17,7 @@
       {{
       image (
       url="https://assets.ubuntu.com/v1/0f377de2-AMD_KR260_KV260-removebg-preview.png",
-      alt="AMD Kria&trade;KR260 circuit board",
+      alt="AMD Kria&trade; KR260 circuit board",
       width="1200",
       height="628",
       hi_def=True,
@@ -29,32 +29,26 @@
   <hr class="p-rule" />
   <div class="row p-strip u-no-padding--top">
     <div class="col-3 col-medium-2">
-      <h3>Ubuntu Desktop 22.04 LTS</h3>
+      <h3>Ubuntu Desktop 24.04 LTS</h3>
     </div>
     <div class="col-6 col-medium-3">
-      <p>The version of Ubuntu with up to 10 years of long term support, until April 2032.</p>
+      <p>The version of optimised Ubuntu Server 24.04 is beta for now, the certified version is coming soon.</p>
       <p>Works on:</p>
       <ul class="p-list">
         <li class="p-list__item is-ticked">KR260 Robotics Starter Kit</li>
         <li class="p-list__item is-ticked">KV260 Vision AI Starter Kit</li>
       </ul>
       <hr class="p-rule" />
-      <div class="p-notification--information is-borderless u-no-margin--bottom">
-        <div class="p-notification__content">
-          <p class="p-notification__message">
-            Please check the <a href="https://xilinx-wiki.atlassian.net/wiki/spaces/A/pages/1641152513">AMD Kria&trade; Wiki</a> for the platform's latest boot firmware, technical documentation, and the <a href="https://xilinx-wiki.atlassian.net/wiki/spaces/A/pages/1413611532/Canonical+Ubuntu">Ubuntu for AMD-Xilinx Devices Wiki</a> for known issues and limitations.
-          </p>
-        </div>
-      </div>
+      {% include "download/amd/_wiki_notification.html" %}
       <p>
         <a class="p-button--positive"
-           href="https://people.canonical.com/~platform/images/xilinx/kria-ubuntu-22.04/iot-limerick-kria-classic-desktop-2204-20240304-165.img.xz">Download 22.04 LTS</a>
+           href="https://people.canonical.com/~platform/images/xilinx/kria-ubuntu-24.04/iot-limerick-kria-classic-server-2404-classic-24.04-x05-20241114.img.xz">Download 24.04 LTS</a>
       </p>
       <p>
-        <a href="https://www.xilinx.com/kr260-start">Kria&trade; KR260 Getting Started Guide for Ubuntu 22.04</a>
+        <a href="https://www.amd.com/KR260-Start">Kria&trade; KR260 Getting Started Guide for Ubuntu 24.04</a>
       </p>
       <p>
-        <a href="https://www.xilinx.com/kv260-start">Kria&trade; KV260 Getting Started Guide for Ubuntu 22.04</a>
+        <a href="https://www.amd.com/KV260-Start">Kria&trade; KV260 Getting Started Guide for Ubuntu 24.04</a>
       </p>
     </div>
   </div>
@@ -71,7 +65,74 @@
       </h3>
     </div>
     <div class="col-6">
-      <p>Ubuntu developers targeting Kria&trade;KR260 and KV260 platform may also want to download the following files:</p>
+      <p>Ubuntu developers targeting Kria&trade; KR260 and KV260 platform may also want to download the following files:</p>
+      <table class="amd-table"
+             aria-label="AMD Ubuntu Software Development Kit table">
+        <thead>
+          <tr>
+            <th>Image name</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <a href="https://people.canonical.com/~platform/images/xilinx/kria-ubuntu-24.04/iot-limerick-kria-classic-server-2404-classic-24.04-x05-20241114-sysroot.tar.xz">
+                iot-limerick-kria-classic-server-2404-classic-24.04-x05-20241114-sysroot.tar.xz
+              </a>
+            </td>
+            <td>Sysroot for cross-compilation</td>
+          </tr>
+          <tr>
+            <td>
+              <a href="https://people.canonical.com/~platform/images/xilinx/kria-ubuntu-24.04/iot-limerick-kria-classic-server-2404-classic-24.04-x05-20241114-rootfs.tar.gz">
+                iot-limerick-kria-classic-server-2404-classic-24.04-x05-20241114-rootfs.tar.gz
+              </a>
+            </td>
+            <td>Raw Root filesystem</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <hr class="p-rule" />
+  <div class="row p-strip u-no-padding--top">
+    <div class="col-3 col-medium-2">
+      <h3>Ubuntu Desktop 22.04 LTS</h3>
+    </div>
+    <div class="col-6 col-medium-3">
+      The version of Ubuntu with up to 10 years of long term support, until April 2032.
+      <p>Works on:</p>
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">KR260 Robotics Starter Kit</li>
+        <li class="p-list__item is-ticked">KV260 Vision AI Starter Kit</li>
+      </ul>
+      {% include "download/amd/_wiki_notification.html" %}
+      <p>
+        <a class="p-button--positive"
+           href="https://people.canonical.com/~platform/images/xilinx/kria-ubuntu-22.04/iot-limerick-kria-classic-desktop-2204-20240304-165.img.xz">
+          Download 22.04 LTS
+        </a>
+      </p>
+      <p>
+        <a href="https://www.xilinx.com/kr260-start">Kria&trade; KR260 Getting Started Guide for Ubuntu 22.04</a>
+      </p>
+      <p>
+        <a href="https://www.xilinx.com/kv260-start">Kria&trade; KV260 Getting Started Guide for Ubuntu 22.04</a>
+      </p>
+    </div>
+  </div>
+
+  <hr class="p-rule" />
+  <div class="row p-strip u-no-padding--top">
+    <div class="col-3">
+      <h3 class="p-heading--5 u-no-padding--top">
+        <strong>AMD Ubuntu Software Development Kit</strong>
+      </h3>
+    </div>
+    <div class="col-6">
+      <p>Ubuntu developers targeting Kria&trade; KR260 and KV260 platform may also want to download the following files:</p>
       <table class="amd-table"
              aria-label="AMD Ubuntu Software Development Kit table">
         <thead>
@@ -136,7 +197,7 @@
       </h3>
     </div>
     <div class="col-6">
-      <p>Ubuntu developers targeting Kria&trade;KV260 platform may also want to download the following files:</p>
+      <p>Ubuntu developers targeting Kria&trade; KV260 platform may also want to download the following files:</p>
       <table class="amd-table"
              aria-label="AMD Ubuntu Software Development Kit table">
         <thead>
@@ -194,7 +255,7 @@
     <div class="col-6 amd-container u-align--center col-medium-4">
       {{ image (
       url="https://assets.ubuntu.com/v1/08fdc6b3-xilinx-board.png",
-      alt="AMD Kria&trade;KR260 circuit board",
+      alt="AMD Kria&trade; KR260 circuit board",
       width="478",
       height="382",
       hi_def=True,
@@ -204,8 +265,8 @@
     </div>
   </div>
 
-<hr class="p-rule" />  
-<div class="row p-strip is-shallow u-no-padding--top">
+  <hr class="p-rule" />
+  <div class="row p-strip is-shallow u-no-padding--top">
     <div class="col-3 col-medium-2">
       <h3>Ubuntu Core 22 (Developer Preview)</h3>
     </div>


### PR DESCRIPTION
## Done

[Copy docs update](https://docs.google.com/document/d/1cxQnEErs8FZ3dZ_IhlfcaJ03gE_vrMJfRC-5me9IDd4/edit?tab=t.0) to include Ubuntu 24.04 LTS.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: https://ubuntu-com-14507.demos.haus/download/amd
    - Be sure to test on mobile, tablet and desktop screen sizes
- Make sure that the new changes to the [copy docs](https://docs.google.com/document/d/1cxQnEErs8FZ3dZ_IhlfcaJ03gE_vrMJfRC-5me9IDd4/edit?tab=t.0) are applied

## Issue / Card

Fixes WD-17126

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
