### PR TITLE
add more options to Pro contact form

### DIFF
--- a/templates/shared/_pro-contact-us-form.html
+++ b/templates/shared/_pro-contact-us-form.html
@@ -340,6 +340,27 @@
                      value="CIS Benchmark" />
               <span class="p-checkbox__label" id="cis-benchmark">CIS Benchmark</span>
             </label>
+            <label class="p-checkbox">
+              <input type="checkbox"
+                     aria-labelledby="cmms"
+                     class="p-checkbox__input"
+                     value="CMMS" />
+              <span class="p-checkbox__label" id="cmms">CMMS</span>
+            </label>
+            <label class="p-checkbox">
+              <input type="checkbox"
+                     aria-labelledby="nis2"
+                     class="p-checkbox__input"
+                     value="NIS2" />
+              <span class="p-checkbox__label" id="nis2">NIS2</span>
+            </label>
+            <label class="p-checkbox">
+              <input type="checkbox"
+                     aria-labelledby="cyber-essentials"
+                     class="p-checkbox__input"
+                     value="Cyber Essentials" />
+              <span class="p-checkbox__label" id="cyber-essentials">Cyber Essentials</span>
+            </label>
           </div>
         </div>
       </fieldset>


### PR DESCRIPTION
## Done

- Add CMMC, NIS2 and Cyber Essentials to Pro contact form

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- go to /contact-us/form?product=pro
- Scroll down to the section titled "Do you have specific compliance or hardening requirements?" 
- The new options should appear there
- Fill in the form
- Verify the submission on marketo for form 1257
- Copy doc link: https://docs.google.com/document/d/1X1Qx5cimbU7D_xQKnm3se9gRDFcRDEaX5fkGR42b3yU/edit?tab=t.0

## Issue / Card

Fixes [#WD-17096](https://warthogs.atlassian.net/browse/WD-17096)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
