### PR TITLE
Update compliance-automation.html link

### DIFF
--- a/templates/security/compliance-automation.html
+++ b/templates/security/compliance-automation.html
@@ -55,7 +55,7 @@
         <p>
           The default configuration of Ubuntu balances usability and security. However, systems carrying dedicated workloads can be further hardened to reduce their attack surface. Canonical provides the Ubuntu Security Guide to automatically harden systems to DISA STIG and CIS benchmarks profiles, and generate audit reports. Available with <a href="/pro">Ubuntu Pro on-premise</a> or ready-built on <a href="/public-cloud">public clouds</a>.
         </p>
-        <a class="p-button" href="https://wiki.ubuntu.com/Security/Features">See our compliance profiles</a>
+        <a class="p-button" href="/security/compliance-automation#compliance-profiles">See our compliance profiles</a>
       </div>
       <div class="col-4 p-divider__block">
         <h3>Fix security vulnerabilities across the estate</h3>


### PR DESCRIPTION
## Done

- Updated the link according to copydoc

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [Copydoc](https://docs.google.com/document/d/13RcVvHBAoywfk3o5Dy-16F3KrMytL9-2v6wWbW444Ko/edit?disco=AAABV8SLRr4)
- Go to [demo](https://ubuntu-com-14512.demos.haus/security/compliance-automation)

## Issue / Card

Fixes #14309 

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
