### PR TITLE
customise credentials thank you page for each sign up form

### DIFF
--- a/templates/credentials/sign-up.html
+++ b/templates/credentials/sign-up.html
@@ -22,7 +22,7 @@
       formid="3801",
       lpId="7140",
       sign_up_open=sign_up_open,
-      returnURL="/credentials/thank-you" %}
+      returnURL="/credentials/thank-you?type=sme" %}
       {% include "shared/_credentials-signup-sme-form.html" %}
     {% endwith %}
   {% endif %}
@@ -31,7 +31,7 @@
       formid="3801",
       lpId="7140",
       sign_up_open=sign_up_open,
-      returnURL="/credentials/thank-you" %}
+      returnURL="/credentials/thank-you?type=tester" %}
       {% include "shared/_credentials-signup-tester-form.html" %}
     {% endwith %}
   {% endif %}

--- a/templates/credentials/thank-you.html
+++ b/templates/credentials/thank-you.html
@@ -17,7 +17,11 @@
         </div>
         <div class="p-section--shallow">
           <p>
+            {% if signup_type == 'sme' %}
+            Once our next exam is ready for community contributions, we’ll review applications and contact candidates with the appropriate profile.
+            {% else %}
             Once our next exam enters the testing phase, we’ll review applications and contact qualified testers with the appropriate profile.
+            {% endif %}
           </p>
         </div>
       </div>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -89,6 +89,7 @@ from webapp.shop.cred.views import (
     cred_shop_webhook_responses,
     cred_shop_keys,
     cred_sign_up,
+    cred_thank_you,
     cred_submit_form,
     cred_syllabus_data,
     cred_your_exams,
@@ -890,6 +891,9 @@ app.add_url_rule("/credentials/self-study", view_func=cred_self_study)
 app.add_url_rule("/credentials/exam-content", view_func=cred_syllabus_data)
 app.add_url_rule(
     "/credentials/sign-up", view_func=cred_sign_up, methods=["GET", "POST"]
+)
+app.add_url_rule(
+    "/credentials/thank-you", view_func=cred_thank_you, methods=["GET"]
 )
 app.add_url_rule(
     "/credentials/schedule",

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -336,9 +336,19 @@ def cred_sign_up(**_):
         return flask.redirect(return_url)
 
     if referrer:
-        return flask.redirect(f"/thank-you?referrer={referrer}")
+        return flask.redirect(
+            f"/thank-you?referrer={referrer}?type={search_type}"
+        )
     else:
-        return flask.redirect("/thank-you")
+        return flask.redirect(f"/thank-you?type={search_type}")
+
+
+@shop_decorator(area="cred", response="html")
+def cred_thank_you(**_):
+    signup_type = flask.request.args.get("type")
+    return flask.render_template(
+        "credentials/thank-you.html", signup_type=signup_type
+    )
 
 
 @shop_decorator(area="cred", permission="user", response="html")


### PR DESCRIPTION
## Done

- Customise the thank you message for tester and sme sign up form

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to `credentials/sign-up?type=sme` and submit the form
    - Make sure that the thank you page shows up with the following message: "Once our next exam is ready for community contributions, we’ll review applications and contact candidates with the appropriate profile."
- Go to `credentials/sign-up?type=tester` and submit the form
    - Make sure that the thank you page shows up with the following message: "Once our next exam enters the testing phase, we’ll review applications and contact qualified testers with the appropriate profile."

## Issue / Card

Fixes [WD-16476](https://warthogs.atlassian.net/browse/WD-16476)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-16476]: https://warthogs.atlassian.net/browse/WD-16476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ