### PR TITLE
[WD-17303] Updating the "Free Trial Available" badge on Pro store page

### DIFF
--- a/static/js/src/advantage/subscribe/react/components/ProductSummary/ProductSummary.tsx
+++ b/static/js/src/advantage/subscribe/react/components/ProductSummary/ProductSummary.tsx
@@ -121,9 +121,7 @@ const ProductSummary = () => {
           >
             {product?.canBeTrialled && productUser !== ProductUsers.myself ? (
               <StatusLabel appearance="positive">
-                <a href="/engage/Ubuntu-Pro-1-month-trial">
-                  Free trial available
-                </a>
+                Free trial on checkout
               </StatusLabel>
             ) : null}
             <PaymentButton />
@@ -206,9 +204,7 @@ const ProductSummary = () => {
           {product?.canBeTrialled && productUser !== ProductUsers.myself ? (
             <Col size={12}>
               <StatusLabel appearance="positive">
-                <a href="/engage/Ubuntu-Pro-1-month-trial">
-                  Free trial available
-                </a>
+                Free trial on checkout
               </StatusLabel>
             </Col>
           ) : null}


### PR DESCRIPTION
## Done

- Remove `Free trial available` hyperlink. 
- Change copy to `Free trial on checkout`.

## QA

- Go to https://ubuntu-com-14516.demos.haus/pro/subscribe
- Verify that the hyperlink is removed and the copy is updated

## Issue / Card

Fixes [WD-17303](https://warthogs.atlassian.net/browse/WD-17303)

## Screenshots

#### Before:
![image](https://github.com/user-attachments/assets/56016127-34b8-4982-a513-3e8076832e49)

#### After:
![image](https://github.com/user-attachments/assets/5709eb91-e828-4932-8462-690a279956e9)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-17303]: https://warthogs.atlassian.net/browse/WD-17303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ