### PR TITLE
Fixed phone modal for country code

### DIFF
--- a/static/js/src/dynamic-forms.js
+++ b/static/js/src/dynamic-forms.js
@@ -500,6 +500,11 @@ import { prepareInputFields } from "./prepare-form-inputs.js";
 
       setCheckboxLimit();
 
+      // Sets up dial code dropdown options aka. intlTelInput.js
+      // and pre fills the country field
+      // This gets triggered when the modal is opened
+      prepareInputFields(phoneNumberInput, countryInput);
+
       // Set preferredLanguage hidden input
       function setpreferredLanguage() {
         const preferredLanguage = getPrimaryParentLanguage();


### PR DESCRIPTION
## Done

- Country code now gets displayed beside phone number in modal forms

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- visit #getintouch forms and check if you could see the extensions for country.
    eg. https://ubuntu-com-14517.demos.haus/kubernetes#get-in-touch

## Issue / Card

Fixes #14509 

## Screenshots

Previous
![image](https://github.com/user-attachments/assets/766feb0d-500b-4a6b-a298-5506e460603c)

Now
![image](https://github.com/user-attachments/assets/8a00af9b-05cd-4ad4-99d1-7fa7ddbffc79)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
