### PR TITLE
Update Qualcomm image installation instructions

### DIFF
--- a/templates/download/qualcomm-iot.html
+++ b/templates/download/qualcomm-iot.html
@@ -105,7 +105,7 @@
               </p>
               <hr class="p-rule--muted" />
               <p>
-                Ubuntu Server 22.04 for QCS6490 <a href="https://docs.qualcomm.com/bundle/resource/topics/80-82645-1/getting-started-with-qualcomm-rb3-gen-2-development-kit_1.html?product=1601111740057201#sub$download-images-and-boot-firmware_1_3">image installation instructions</a>
+                Ubuntu Server 22.04 for QCS6490 <a href="https://docs.qualcomm.com/bundle/publicresource/topics/80-82645-1/getting-started-with-qualcomm-rb3-gen-2-development-kit_1.html?product=1601111740057201">image installation instructions</a>
               </p>
               <hr class="p-rule--muted" />
               <p>


### PR DESCRIPTION
## Done

Update the link to the image installation instructions on the Qualcomm IOT downloads page.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/downloads/qualcomm-iot
- Check the link to `Image installation instructions` links to the correct place