### PR TITLE
Client IP not being forwarded during magic attach

### DIFF
--- a/webapp/shop/api/ua_contracts/advantage_mapper.py
+++ b/webapp/shop/api/ua_contracts/advantage_mapper.py
@@ -282,7 +282,7 @@ class AdvantageMapper:
     def activate_magic_attach(
         self, user_code: str, contract_id: str, client_ip: int
     ):
-        headers = {} if client_ip else {"X-Forwarded-For": client_ip}
+        headers = {"X-Forwarded-For": client_ip} if client_ip else {}
         return self.ua_contracts_api.post_magic_attach(
             request_body={"userCode": user_code, "contractID": contract_id},
             headers=headers,


### PR DESCRIPTION
## Done

- client IP not being forwarded to UA contracts backend

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Client IP should be forwarded to the backend. 
- Visit /pro/attach
- Verify by spamming the endpoint and checking if it rejects responses

## Issue / Card

Fixes [#https://warthogs.atlassian.net/browse/WD-17439](https://warthogs.atlassian.net/browse/WD-17439)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
