### PR TITLE
WD-16647 Redesigned internet-of-things/smart-home

### DIFF
--- a/templates/internet-of-things/smart-home.html
+++ b/templates/internet-of-things/smart-home.html
@@ -37,7 +37,7 @@
     {%- if slot == 'image' -%}
       <div class="p-image-container--cinematic is-cover is-highlighted">
         <img class="p-image-container__image"
-             src="https://assets.ubuntu.com/v1/48243070-smart-home-hero.png"
+             src="https://assets.ubuntu.com/v1/736618a0-hero-img.png"
              alt="Smart Home Hero Image" />
       </div>
     {% endif -%}
@@ -97,12 +97,10 @@
         <h2>Universal compatibility</h2>
       </div>
       <div class="col">
-        <div class="p-section--shallow">
-          <div class="p-image-container is-cover is-highlighted">
-            <img class="p-image-container__image"
-                 src="https://assets.ubuntu.com/v1/c8af9315-universal-compatibility.png"
-                 alt="Universal Compatibility Image" />
-          </div>
+        <div class="p-image-container is-cover is-highlighted">
+          <img class="p-image-container__image"
+               src="https://assets.ubuntu.com/v1/c8af9315-universal-compatibility.png"
+               alt="Universal Compatibility Image" />
         </div>
         <h5>Devices that speak a common language</h5>
         Canonical <a href="https://ubuntu.com/blog/canonical-joins-the-connectivity-standards-alliance">recently

--- a/templates/internet-of-things/smart-home.html
+++ b/templates/internet-of-things/smart-home.html
@@ -35,10 +35,15 @@
       <a href="#get-in-touch" class="p-button--positive">Contact us to get started</a>
     {%- endif -%}
     {%- if slot == 'image' -%}
-      <div class="p-image-container--cinematic is-cover is-highlighted">
-        <img class="p-image-container__image"
-             src="https://assets.ubuntu.com/v1/736618a0-hero-img.png"
-             alt="Smart Home Hero Image" />
+      <div class="p-image-container--cinematic is-cover is-highlighted u-hide--small">
+        {{ image(url="https://assets.ubuntu.com/v1/736618a0-hero-img.png",
+                alt="",
+                width="3696",
+                height="1541",
+                hi_def=True,
+                loading="auto|lazy",
+                attrs={"class": "p-image-container__image"}) | safe
+        }}
       </div>
     {% endif -%}
   {% endcall -%}
@@ -46,7 +51,10 @@
   <section class="p-section">
     {%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=false, is_list_full_width_on_tablet=false) -%}
       {%- if slot == 'title' -%}
-        <h2>Why develop with Ubuntu</h2>
+        <div class="fixed-width">
+          <hr class="p-rule u-hide--medium u-hide--large" />
+          <h2>Why develop with Ubuntu</h2>
+        </div>
       {%- endif -%}
 
       {%- if slot == 'list_item_title_1' -%}
@@ -98,13 +106,16 @@
       </div>
       <div class="col">
         <div class="p-image-container is-cover is-highlighted">
-          <img class="p-image-container__image"
-               src="https://assets.ubuntu.com/v1/c8af9315-universal-compatibility.png"
-               alt="Universal Compatibility Image" />
+          {{ image(url="https://assets.ubuntu.com/v1/c8af9315-universal-compatibility.png",
+                    alt="",
+                    width="1800",
+                    height="1015",
+                    hi_def=True,
+                    loading="auto|lazy",
+                    attrs={"class": "p-image-container__image"}) | safe
+          }}
         </div>
-        <h3 class="p-heading--5">
-          Devices that speak a common language
-        </h3 class="p-heading--5">
+        <h3 class="p-heading--5">Devices that speak a common language</h3>
         Canonical <a href="https://ubuntu.com/blog/canonical-joins-the-connectivity-standards-alliance">recently
         announced</a> its membership in the Connectivity Standards Alliance and its upcoming support for the Matter
         standard. <a href="#get-in-touch" class="js-invoke-modal">Sign up</a> to receive smart home and IoT news.
@@ -113,9 +124,11 @@
   </section>
 
   <section class="p-section">
-    <div class="row p-section--shallow">
-      <hr class="p-rule" />
-      <h2>Secure, resilient, low-touch</h2>
+    <div class="u-fixed-width">
+      <div class="p-section--shallow">
+        <hr class="p-rule" />
+        <h2>Secure, resilient, low-touch</h2>
+      </div>
     </div>
     <div class="row">
       <div class="col-start-large-4 col-9">
@@ -123,10 +136,14 @@
           <div class="p-equal-height-row__col">
             <div class="p-equal-height-row__item">
               <div class="p-image-container--3-2-on-small p-image-container--square-on-medium p-image-container--2-3-on-large is-highlighted">
-                <img class="p-image-container__image"
-                     src="https://assets.ubuntu.com/v1/166662b7-reliable-ota-updates.png"
-                     alt=""
-                     width="250" />
+                {{ image(url="https://assets.ubuntu.com/v1/166662b7-reliable-ota-updates.png",
+                                alt="",
+                                width="852",
+                                height="1279",
+                                hi_def=True,
+                                loading="auto|lazy",
+                                attrs={"class": "p-image-container__image"}) | safe
+                }}
               </div>
             </div>
             <div class="p-equal-height-row__item">
@@ -143,10 +160,14 @@
           <div class="p-equal-height-row__col">
             <div class="p-equal-height-row__item">
               <div class="p-image-container--3-2-on-small p-image-container--square-on-medium p-image-container--2-3-on-large is-highlighted">
-                <img class="p-image-container__image"
-                     src="https://assets.ubuntu.com/v1/a6fc8f4d-organize-your-fleet.png"
-                     alt=""
-                     width="250" />
+                {{ image(url="https://assets.ubuntu.com/v1/a6fc8f4d-organize-your-fleet.png",
+                                alt="",
+                                width="852",
+                                height="1279",
+                                hi_def=True,
+                                loading="auto|lazy",
+                                attrs={"class": "p-image-container__image"}) | safe
+                }}
               </div>
             </div>
             <div class="p-equal-height-row__item">
@@ -164,15 +185,19 @@
           <div class="p-equal-height-row__col">
             <div class="p-equal-height-row__item">
               <div class="p-image-container--3-2-on-small p-image-container--square-on-medium p-image-container--2-3-on-large is-highlighted">
-                <img class="p-image-container__image"
-                     src="https://assets.ubuntu.com/v1/79509554-integrate-with-cloud-solutions.png"
-                     alt=""
-                     width="250" />
+                {{ image(url="https://assets.ubuntu.com/v1/79509554-integrate-with-cloud-solutions.png",
+                                alt="",
+                                width="852",
+                                height="1279",
+                                hi_def=True,
+                                loading="auto|lazy",
+                                attrs={"class": "p-image-container__image"}) | safe
+                }}
               </div>
             </div>
             <div class="p-equal-height-row__item">
               <hr class="p-rule--highlight u-hide--medium u-hide--small" />
-              <h3 class="p-heading--5">Fleet management through snap store</h3>
+              <h3 class="p-heading--5">Fleet management through the snap store</h3>
             </div>
             <div class="p-equal-height-row__item">
               <p>
@@ -187,9 +212,11 @@
   </section>
 
   <section class="p-section--deep">
-    <div class="row p-section--shallow">
-      <hr class="p-rule" />
-      <h2>How to develop your open source smart home application</h2>
+    <div class="u-fixed-width">
+      <div class="p-section--shallow">
+        <hr class="p-rule" />
+        <h2>How to develop your open source smart home application</h2>
+      </div>
     </div>
     <div class="row">
       <div class="col-start-large-4 col-9">
@@ -223,15 +250,13 @@
                     comes with the same level of OTA and revision control you have for your own application.
 
                   </p>
-                  {{ image (
-                  url="https://assets.ubuntu.com/v1/2fcfbc3b-snap-store.png",
-                  alt="",
-                  width="636",
-                  height="346",
-                  hi_def=True,
-                  loading="lazy",
-                  attrs={"class": "u-hide--small is-cover is-highlighted"}
-                  ) | safe
+                  {{ image(url="https://assets.ubuntu.com/v1/2fcfbc3b-snap-store.png",
+                                    alt="",
+                                    width="1800",
+                                    height="1014",
+                                    hi_def=True,
+                                    loading="auto|lazy",
+                                    attrs={"class": "u-hide--small is-cover is-highlighted"}) | safe
                   }}
                 </div>
               </div>

--- a/templates/internet-of-things/smart-home.html
+++ b/templates/internet-of-things/smart-home.html
@@ -50,7 +50,7 @@
       {%- endif -%}
 
       {%- if slot == 'list_item_title_1' -%}
-        <h5>Free up resources</h5>
+        <h3 class="p-heading--5">Free up resources</h3>
       {%- endif -%}
 
       {%- if slot == 'list_item_description_1' -%}
@@ -62,7 +62,7 @@
       {%- endif -%}
 
       {%- if slot == 'list_item_title_2' -%}
-        <h5>Start development earlier</h5>
+        <h3 class="p-heading--5">Start development earlier</h3>
       {%- endif -%}
 
       {%- if slot == 'list_item_description_2' -%}
@@ -75,7 +75,7 @@
       {%- endif -%}
 
       {%- if slot == 'list_item_title_3' -%}
-        <h5>Have confidence in your OTAs</h5>
+        <h3 class="p-heading--5">Have confidence in your OTAs</h3>
       {%- endif -%}
 
       {%- if slot == 'list_item_description_3' -%}
@@ -102,7 +102,9 @@
                src="https://assets.ubuntu.com/v1/c8af9315-universal-compatibility.png"
                alt="Universal Compatibility Image" />
         </div>
-        <h5>Devices that speak a common language</h5>
+        <h3 class="p-heading--5">
+          Devices that speak a common language
+        </h3 class="p-heading--5">
         Canonical <a href="https://ubuntu.com/blog/canonical-joins-the-connectivity-standards-alliance">recently
         announced</a> its membership in the Connectivity Standards Alliance and its upcoming support for the Matter
         standard. <a href="#get-in-touch" class="js-invoke-modal">Sign up</a> to receive smart home and IoT news.
@@ -129,7 +131,7 @@
             </div>
             <div class="p-equal-height-row__item">
               <hr class="p-rule--highlight u-hide--medium u-hide--small" />
-              <h5>Data privacy assured</h5>
+              <h3 class="p-heading--5">Data privacy assured</h3>
             </div>
             <div class="p-equal-height-row__item">
               <p>
@@ -149,7 +151,7 @@
             </div>
             <div class="p-equal-height-row__item">
               <hr class="p-rule--highlight u-hide--medium u-hide--small" />
-              <h5>Continuous security updates</h5>
+              <h3 class="p-heading--5">Continuous security updates</h3>
             </div>
             <div class="p-equal-height-row__item">
               <p>
@@ -170,7 +172,7 @@
             </div>
             <div class="p-equal-height-row__item">
               <hr class="p-rule--highlight u-hide--medium u-hide--small" />
-              <h5>Fleet management through snap store</h5>
+              <h3 class="p-heading--5">Fleet management through snap store</h3>
             </div>
             <div class="p-equal-height-row__item">
               <p>

--- a/templates/internet-of-things/smart-home.html
+++ b/templates/internet-of-things/smart-home.html
@@ -10,210 +10,268 @@
   https://docs.google.com/document/d/1zwB-6Flt0Jm7XIxhWUWRJjKC1WCGVmVVNmPHtyOTHuE/edit#
 {% endblock meta_copydoc %}
 
+{% from "_macros/vf_hero.jinja" import vf_hero %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
+{% block body_class %}
+  is-paper
+{% endblock body_class %}
+
 {% block content %}
 
-  <section class="p-strip--suru-topped">
-    <div class="row">
-      <div class="col-6">
-        <h1>Reduce development cost for the open source smart home with Ubuntu</h1>
-        <p class="p-heading--4">Shorter development cycles, effortless maintenance</p>
-
-        <p>
-          Product development for the smart home comes with unique challenges: margins can be thin, and time-to-market is critical. Canonical can provide the support and security maintenance you need so your team can focus on developing world-class products.
-        </p>
-        <p>
-          <a href="#get-in-touch" class="js-invoke-modal p-button--positive">Contact us to get started</a>
-        </p>
+  {% call(slot) vf_hero(
+    title_text='Reduce development costs for the open source smart home with Ubuntu',
+    subtitle_text='Shorter development cycles, effortless maintenance',
+    layout='50/50-full-width-image'
+    ) -%}
+    {%- if slot == 'description' -%}
+      <p>
+        Product development for the smart home comes with unique challenges: margins can be thin, and time-to-market is
+        critical. Canonical can provide the support and security maintenance you need so your team can focus on developing
+        world-class products.
+      </p>
+    {%- endif -%}
+    {%- if slot == 'cta' -%}
+      <a href="#get-in-touch" class="p-button--positive">Contact us to get started</a>
+    {%- endif -%}
+    {%- if slot == 'image' -%}
+      <div class="p-image-container--cinematic is-cover is-highlighted">
+        <img class="p-image-container__image"
+             src="https://assets.ubuntu.com/v1/48243070-smart-home-hero.png"
+             alt="Smart Home Hero Image" />
       </div>
-      <div class="col-6 u-align--center u-vertically-center u-hide--medium u-hide--small">
-        {{ image (
-        url="https://assets.ubuntu.com/v1/32675035-smart-home.png",
-        alt="",
-        width="1810",
-        height="1204",
-        hi_def=True,
-        loading="auto"
-        ) | safe
-        }}
+    {% endif -%}
+  {% endcall -%}
+
+  <section class="p-section">
+    {%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=false, is_list_full_width_on_tablet=false) -%}
+      {%- if slot == 'title' -%}
+        <h2>Why develop with Ubuntu</h2>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_title_1' -%}
+        <h5>Free up resources</h5>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_description_1' -%}
+        <div class="p-section--shallow">
+          <p>
+            Security update issues are a thing of the past with Canonical's support. Let your developers <a href="/engage/embedded-linux-make-or-buy">focus on the application instead of maintenance</a>.
+          </p>
+        </div>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_title_2' -%}
+        <h5>Start development earlier</h5>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_description_2' -%}
+        <div class="p-section--shallow">
+          <p>
+            With existing support for <a href="/certified">dozens of the most popular IoT chips</a>, and board support
+            offered as a service, you can start developing on Ubuntu now, and move to your final hardware when it's ready.
+          </p>
+        </div>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_title_3' -%}
+        <h5>Have confidence in your OTAs</h5>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_description_3' -%}
+        <div class="p-section--shallow">
+          <p>
+            Over-the-air updates always have an element of risk. With <a href="/core">Ubuntu Core</a> you have the assurance
+            that a failed update will never affect your device.
+          </p>
+        </div>
+      {%- endif -%}
+
+    {%- endcall -%}
+  </section>
+
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <h2>Universal compatibility</h2>
+      </div>
+      <div class="col">
+        <div class="p-section--shallow">
+          <div class="p-image-container is-cover is-highlighted">
+            <img class="p-image-container__image"
+                 src="https://assets.ubuntu.com/v1/c8af9315-universal-compatibility.png"
+                 alt="Universal Compatibility Image" />
+          </div>
+        </div>
+        <h5>Devices that speak a common language</h5>
+        Canonical <a href="https://ubuntu.com/blog/canonical-joins-the-connectivity-standards-alliance">recently
+        announced</a> its membership in the Connectivity Standards Alliance and its upcoming support for the Matter
+        standard. <a href="#get-in-touch" class="js-invoke-modal">Sign up</a> to receive smart home and IoT news.
       </div>
     </div>
   </section>
 
-  <section class="p-strip--light">
-    <div class="row">
-      <div class="col-4">
-        <h2 class="p-heading--4">Free up resources</h2>
-        <p>
-          Security update issues are a thing of the past with Canonical's support. Let your developers <a href="/engage/embedded-linux-make-or-buy">focus on the application instead of maintenance</a>.
-        </p>
-      </div>
-      <div class="col-4">
-        <h2 class="p-heading--4">Start development earlier</h2>
-        <p>
-          With existing support for <a href="/certified">dozens of the most popular IoT chips</a>, and board support offered as a service, you can start developing on Ubuntu now, and move to your final hardware when it's ready.
-        </p>
-      </div>
-      <div class="col-4">
-        <h2 class="p-heading--4">Have confidence in your OTAs</h2>
-        <p>
-          Over-the-air updates always have an element of risk. With <a href="/core">Ubuntu Core</a> you have the assurance that a failed update will never affect your device.
-        </p>
-      </div>
-    </div>
-  </section>
-
-  <section class="p-strip">
-    <div class="u-fixed-width">
-      <h2>Universal compatibility</h2>
-    </div>
-    <div class="row">
-      <div class="col-6">
-        <h3>Devices that speak a common language</h3>
-        <p>
-          Canonical <a href="https://ubuntu.com/blog/canonical-joins-the-connectivity-standards-alliance">recently announced</a> its membership in the Connectivity Standards Alliance and its upcoming support for the Matter standard. <a href="#get-in-touch" class="js-invoke-modal">Sign up</a> to receive smart home and IoT news.
-        </p>
-      </div>
-      <div class="col-6 u-hide--medium u-hide--small">
-        {{ image(url="https://assets.ubuntu.com/v1/d988b991-matter_lkup_rgb_night.png",
-                alt="",
-                height="178",
-                width="513",
-                hi_def=True,
-                loading="lazy") | safe
-        }}
-      </div>
-    </div>
-  </section>
-
-  <section class="p-strip--light">
-    <div class="u-fixed-width">
+  <section class="p-section">
+    <div class="row p-section--shallow">
+      <hr class="p-rule" />
       <h2>Secure, resilient, low-touch</h2>
     </div>
     <div class="row">
-      <div class="col-6">
-        <h3>Data privacy assured</h3>
-        <p>
-          Keep customer data safe with Snaps. Applications in Ubuntu Core are fully confined, so security threats in one application can't affect other parts of the system.
-        </p>
-      </div>
-      <div class="col-6 u-align--center u-vertically-center u-hide--small u-hide--medium">
-        {{ image (
-        url="https://assets.ubuntu.com/v1/338124d1-shields-security.svg",
-        alt="",
-        width="263",
-        height="150",
-        hi_def=True,
-        loading="lazy"
-        ) | safe
-        }}
-      </div>
-    </div>
-
-    <div class="u-fixed-width">
-      <hr class="p-rule" />
-    </div>
-
-    <div class="row">
-      <div class="col-6 u-align--center u-vertically-center u-hide--small u-hide--medium">
-        {{ image (
-        url="https://assets.ubuntu.com/v1/a43d61ae-update+control.svg",
-        alt="",
-        width="150",
-        height="150",
-        hi_def=True,
-        loading="lazy"
-        ) | safe
-        }}
-      </div>
-      <div class="col-6">
-        <h3>Continuous security updates</h3>
-        <p>
-          As soon as vulnerabilities become known, security patches are delivered to each device in your fleet. Our Expanded Security Maintenance offering for Ubuntu Core is active for up to ten years. You don't have to worry about CVEs, we keep your security debt at zero.
-        </p>
-      </div>
-    </div>
-
-    <div class="u-fixed-width">
-      <hr class="p-rule" />
-    </div>
-
-    <div class="row">
-      <div class="col-6">
-        <h3>Fleet management through the snap store</h3>
-        <p>
-          Get fine-grained control on OTAs. Roll out delta updates gradually, with the confidence of automatic rollback. Know that each version of each application on every device has been tested together with <a href="/core/docs/reference/assertions/validation-set">validation sets</a>.
-        </p>
-      </div>
-      <div class="col-6 u-align--center u-vertically-center u-hide--small u-hide--medium">
-        {{ image (
-        url="https://assets.ubuntu.com/v1/da83f401-4+-+Register+to+the+snap+store+and+distribute+your+application+to+RasPi+users+everywhere.svg",
-        alt="",
-        width="232",
-        height="150",
-        hi_def=True,
-        loading="lazy"
-        ) | safe
-        }}
+      <div class="col-start-large-4 col-9">
+        <div class="p-equal-height-row">
+          <div class="p-equal-height-row__col">
+            <div class="p-equal-height-row__item">
+              <div class="p-image-container--3-2-on-small p-image-container--square-on-medium p-image-container--2-3-on-large is-highlighted">
+                <img class="p-image-container__image"
+                     src="https://assets.ubuntu.com/v1/166662b7-reliable-ota-updates.png"
+                     alt=""
+                     width="250" />
+              </div>
+            </div>
+            <div class="p-equal-height-row__item">
+              <hr class="p-rule--highlight u-hide--medium u-hide--small" />
+              <h5>Data privacy assured</h5>
+            </div>
+            <div class="p-equal-height-row__item">
+              <p>
+                Keep customer data safe with snaps. Applications in Ubuntu Core are fully confined, so security threats in one
+                application can’t affect other parts of the system.
+              </p>
+            </div>
+          </div>
+          <div class="p-equal-height-row__col">
+            <div class="p-equal-height-row__item">
+              <div class="p-image-container--3-2-on-small p-image-container--square-on-medium p-image-container--2-3-on-large is-highlighted">
+                <img class="p-image-container__image"
+                     src="https://assets.ubuntu.com/v1/a6fc8f4d-organize-your-fleet.png"
+                     alt=""
+                     width="250" />
+              </div>
+            </div>
+            <div class="p-equal-height-row__item">
+              <hr class="p-rule--highlight u-hide--medium u-hide--small" />
+              <h5>Continuous security updates</h5>
+            </div>
+            <div class="p-equal-height-row__item">
+              <p>
+                As soon as vulnerabilities become known, security patches are delivered to each device in your fleet. Our
+                Extended Security Maintenance offering for Ubuntu Core is active for up to ten years. You don’t have to worry
+                about CVEs, we keep your security debt at zero.
+              </p>
+            </div>
+          </div>
+          <div class="p-equal-height-row__col">
+            <div class="p-equal-height-row__item">
+              <div class="p-image-container--3-2-on-small p-image-container--square-on-medium p-image-container--2-3-on-large is-highlighted">
+                <img class="p-image-container__image"
+                     src="https://assets.ubuntu.com/v1/79509554-integrate-with-cloud-solutions.png"
+                     alt=""
+                     width="250" />
+              </div>
+            </div>
+            <div class="p-equal-height-row__item">
+              <hr class="p-rule--highlight u-hide--medium u-hide--small" />
+              <h5>Fleet management through snap store</h5>
+            </div>
+            <div class="p-equal-height-row__item">
+              <p>
+                Get fine-grained control on OTAs. Roll out delta updates gradually, with the confidence of automatic rollback.
+                Know that each version of each application on every device has been tested together with <a href="/core/docs/reference/assertions/validation-set">validation sets</a>.
+              </p>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </section>
 
-  <section class="p-strip">
-    <div class="u-fixed-width">
+  <section class="p-section--deep">
+    <div class="row p-section--shallow">
+      <hr class="p-rule" />
       <h2>How to develop your open source smart home application</h2>
+    </div>
+    <div class="row">
+      <div class="col-start-large-4 col-9">
+        <ol class="p-stepped-list--detailed u-no-margin--bottom">
+          <li class="p-stepped-list__item">
+            <div class="row">
+              <div class="col-3 col-medium-3">
+                <p class="p-stepped-list__title p-heading--5">Get started with any development kit</p>
+              </div>
+              <div class="col-6 col-medium-3">
+                <div class="p-stepped-list__content">
+                  <p>
+                    Ubuntu supports a large <a href="/certified">library of hardware</a> out of the box, and Canonical
+                    provides board support as a service. This means you can start your development before your hardware is
+                    finalised, with the confidence that your application will run smoothly on the final product.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </li>
+          <li class="p-stepped-list__item">
+            <div class="row">
+              <div class="col-3 col-medium-3">
+                <p class="p-stepped-list__title p-heading--5">Find the building blocks of your application in the Snap Store</p>
+              </div>
+              <div class="col-6 col-medium-3">
+                <div class="p-stepped-list__content">
+                  <p>
+                    The <a href="https://snapcraft.io/search?category=devices-and-iot">Snap Store</a> includes a huge
+                    collection of open source projects that can be seamlessly integrated into your application. Each snap
+                    comes with the same level of OTA and revision control you have for your own application.
 
-      <ol class="p-stepped-list--detailed">
-        <li class="p-stepped-list__item">
-          <h3 class="p-stepped-list__title">Get started with any development kit</h3>
+                  </p>
+                  {{ image (
+                  url="https://assets.ubuntu.com/v1/2fcfbc3b-snap-store.png",
+                  alt="",
+                  width="636",
+                  height="346",
+                  hi_def=True,
+                  loading="lazy",
+                  attrs={"class": "u-hide--small is-cover is-highlighted"}
+                  ) | safe
+                  }}
+                </div>
+              </div>
+            </div>
+          </li>
+          <li class="p-stepped-list__item">
+            <div class="row">
+              <div class="col-3 col-medium-3">
+                <p class="p-stepped-list__title p-heading--5">Snap your application or let us do the heavy lifting</p>
+              </div>
+              <div class="col-6 col-medium-3">
+                <div class="p-stepped-list__content">
+                  <p>
+                    <a href="https://snapcraft.io/first-snap">Getting started with Snap</a> is a breeze. Canonical is on
+                    this journey with you, and can give you the assurance that your project won’t hit roadblocks down the
+                    line. When you’re ready to put all the pieces together, we’re here to help.
 
-          <div class="p-stepped-list__content">
-            <p>
-              Ubuntu supports a large <a href="/certified">library of hardware</a> out of the box, and Canonical provides board support as a service. This means you can start your development before your hardware is finalised, with the confidence that your application will run smoothly on the final product.
-            </p>
-          </div>
-        </li>
-
-        <li class="p-stepped-list__item">
-          <h3 class="p-stepped-list__title">Find the building blocks of your application in the Snap Store</h3>
-
-          <div class="p-stepped-list__content">
-            <p>
-              The <a href="https://snapcraft.io/search?category=devices-and-iot">Snap Store</a> includes a huge collection of open source projects that can be seamlessly integrated into your application. Each snap comes with the same level of OTA and revision control you have for your own application.
-            </p>
-
-            {{ image (
-            url="https://assets.ubuntu.com/v1/d22c1230-snap-store-iot-devices.png",
-            alt="",
-            width="636",
-            height="346",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "u-hide--small"}
-            ) | safe
-            }}
-          </div>
-        </li>
-
-        <li class="p-stepped-list__item">
-          <h3 class="p-stepped-list__title">Snap your application or let us do the heavy lifting</h3>
-
-          <div class="p-stepped-list__content">
-            <p>
-              <a href="https://snapcraft.io/first-snap">Getting started with Snap</a> is a breeze. Canonical is on this journey with you, and can give you the assurance that your project won't hit roadblocks down the line. When you're ready to put all the pieces together, we're here to help.
-            </p>
-          </div>
-        </li>
-
-        <li class="p-stepped-list__item">
-          <h3 class="p-stepped-list__title">Port to certified hardware or get support for custom boards</h3>
-
-          <div class="p-stepped-list__content">
-            <p>
-              Once your hardware is ready, it's easy to move your application from the development board to your production hardware. There is a <a href="/certified">library of hardware</a> that comes pre-certified for Ubuntu, and Canonical is here to help with more customised use cases.
-            </p>
-          </div>
-        </li>
-      </ol>
+                  </p>
+                </div>
+              </div>
+            </div>
+          </li>
+          <li class="p-stepped-list__item">
+            <div class="row">
+              <div class="col-3 col-medium-3">
+                <p class="p-stepped-list__title p-heading--5">Port to certified hardware or get support for custom boards</p>
+              </div>
+              <div class="col-6 col-medium-3">
+                <div class="p-stepped-list__content">
+                  <p>
+                    Once your hardware is ready, it’s easy to move your application from the development board to your
+                    production hardware. There is a <a href="/certified">library of hardware</a> that comes pre-certified
+                    for Ubuntu, and Canonical is here to help with more customised use cases.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </li>
+        </ol>
+      </div>
     </div>
   </section>
 

--- a/templates/internet-of-things/smart-home.html
+++ b/templates/internet-of-things/smart-home.html
@@ -32,7 +32,8 @@
       </p>
     {%- endif -%}
     {%- if slot == 'cta' -%}
-      <a href="#get-in-touch" class="p-button--positive">Contact us to get started</a>
+      <a href="/internet-of-things/contact-us"
+         class="p-button--positive js-invoke-modal">Contact us to get started</a>
     {%- endif -%}
     {%- if slot == 'image' -%}
       <div class="p-image-container--cinematic is-cover is-highlighted u-hide--small">
@@ -111,14 +112,14 @@
                     width="1800",
                     height="1015",
                     hi_def=True,
-                    loading="auto|lazy",
+                    loading="lazy",
                     attrs={"class": "p-image-container__image"}) | safe
           }}
         </div>
         <h3 class="p-heading--5">Devices that speak a common language</h3>
-        Canonical <a href="https://ubuntu.com/blog/canonical-joins-the-connectivity-standards-alliance">recently
+        Canonical <a href="/blog/canonical-joins-the-connectivity-standards-alliance">recently
         announced</a> its membership in the Connectivity Standards Alliance and its upcoming support for the Matter
-        standard. <a href="#get-in-touch" class="js-invoke-modal">Sign up</a> to receive smart home and IoT news.
+        standard. <a href="/internet-of-things/contact-us" class="js-invoke-modal">Sign up</a> to receive smart home and IoT news.
       </div>
     </div>
   </section>
@@ -141,7 +142,7 @@
                                 width="852",
                                 height="1279",
                                 hi_def=True,
-                                loading="auto|lazy",
+                                loading="lazy",
                                 attrs={"class": "p-image-container__image"}) | safe
                 }}
               </div>
@@ -165,7 +166,7 @@
                                 width="852",
                                 height="1279",
                                 hi_def=True,
-                                loading="auto|lazy",
+                                loading="lazy",
                                 attrs={"class": "p-image-container__image"}) | safe
                 }}
               </div>
@@ -190,7 +191,7 @@
                                 width="852",
                                 height="1279",
                                 hi_def=True,
-                                loading="auto|lazy",
+                                loading="lazy",
                                 attrs={"class": "p-image-container__image"}) | safe
                 }}
               </div>
@@ -255,7 +256,7 @@
                                     width="1800",
                                     height="1014",
                                     hi_def=True,
-                                    loading="auto|lazy",
+                                    loading="lazy",
                                     attrs={"class": "u-hide--small is-cover is-highlighted"}) | safe
                   }}
                 </div>


### PR DESCRIPTION
## Done

- Redesigned ubuntu.com/internet-of-things/smart-home

## QA
- View the site in your web browser at: https://ubuntu-com-14530.demos.haus/internet-of-things/smart-home
    - Be sure to test on mobile, tablet and desktop screen sizes
- Match the website with Design and Copydoc.
  - [Design](https://www.figma.com/design/1CdIT6TV3ASf55GsnQcwXg/Internet-of-Things?node-id=2001-16452&t=4kUhsH39i1i4UsV9-1)
  - [Copydoc](https://docs.google.com/document/d/1zwB-6Flt0Jm7XIxhWUWRJjKC1WCGVmVVNmPHtyOTHuE)

## Issue / Card

Fixes #[16647](https://warthogs.atlassian.net/browse/WD-16647)
