### PR TITLE
fix(links): Fix the link to ROS questions

### DIFF
--- a/templates/robotics/community.html
+++ b/templates/robotics/community.html
@@ -102,7 +102,7 @@
       <div class="col-7">
         <h2>Where to start with ROS?</h2>
         <p>
-          The best place to start is in the <a href="https://discourse.ros.org/">ROS Discourse</a> where thousands of roboticists go to talk. If you have specific questions there's the <a href="https://answers.ros.org/questions/">ROS Answers</a> forum with over 13,000 questions to date. And for more context, you can read the <a href="https://wiki.ros.org/">ROS Wiki</a> or the ROS 2 docs that have been worked on by almost 3,500 people.
+          The best place to start is in the <a href="https://discourse.ros.org/">ROS Discourse</a> where thousands of roboticists go to talk. If you have specific questions there's the <a href="https://robotics.stackexchange.com/">Robotics Stack Exchange</a> with over 13,000 questions to date. And for more context, you can read the <a href="https://wiki.ros.org/">ROS Wiki</a> or the ROS 2 docs that have been worked on by almost 3,500 people.
         </p>
         <p>
           <a class="p-button" href="https://discourse.ros.org/"><span>Get started on ROS Discourse</span></a>


### PR DESCRIPTION
## Done

- Update the answers URL on the ROS website to the Stack Exchange website.
- Updated the [copy doc](https://docs.google.com/document/d/1A3iBoD_AAoerI0VwbByl8fR55ljNOjamHtJlkOuaaeA/edit?tab=t.0) for the page

## QA

- Check the old link doesn't work anymore
- Check the new link works
- Check this aligns with the recommendation on the [ROS discourse](https://discourse.ros.org/c/general/8) header

## Issue / Card

Fixes https://github.com/canonical/ubuntu.com/actions/runs/12134872496