### PR TITLE
Rebrand /iot/smart-displays

### DIFF
--- a/templates/internet-of-things/smart-displays.html
+++ b/templates/internet-of-things/smart-displays.html
@@ -76,7 +76,7 @@
             </div>
             <div class="p-equal-height-row__item">
               <hr class="p-rule--highlight u-hide--medium u-hide--small" />
-              <h5 class="p-heading--5">Secure</h5>
+              <h3 class="p-heading--5">Secure</h3>
             </div>
             <p class="p-equal-height-row__item">
               Keep sensitive information secure with an industrial proven OS. Enjoy an OS with built-in security and comprehensive features, such as strict application confinement,
@@ -99,7 +99,7 @@
             </div>
             <div class="p-equal-height-row__item">
               <hr class="p-rule--highlight u-hide--medium u-hide--small" />
-              <h5 class="p-heading--5">Reliable</h5>
+              <h3 class="p-heading--5">Reliable</h3>
             </div>
             <p class="p-equal-height-row__item">
               With more than 15 years of industrial experience, Ubuntu is one of the most mature graphical servers available today for embedded devices.
@@ -123,7 +123,7 @@
             </div>
             <div class="p-equal-height-row__item">
               <hr class="p-rule--highlight u-hide--medium u-hide--small" />
-              <h5 class="p-heading--5">Simple</h5>
+              <h3 class="p-heading--5">Simple</h3>
             </div>
             <p class="p-equal-height-row__item">
               Preferred by developers, Ubuntu’s flexibility allows you to do more with less. Together with tools for deployment, provisioning,
@@ -217,11 +217,11 @@
             <hr class="p-rule--muted" />
             <div class="col u-hide--small">
               {{ image(url="https://assets.ubuntu.com/v1/d68b3378-ubuntu-frame-final.png",
-                        alt="",
-                        width="852",
-                        height="172",
-                        hi_def=True,
-                        loading="lazy") | safe
+                            alt="",
+                            width="852",
+                            height="172",
+                            hi_def=True,
+                            loading="lazy") | safe
               }}
             </div>
             <div class="col">
@@ -246,11 +246,11 @@
             <hr class="p-rule--muted" />
             <div class="col u-hide--small">
               {{ image(url="https://assets.ubuntu.com/v1/9d527111-ubuntu-core-final.png",
-                        alt="",
-                        width="852",
-                        height="166",
-                        hi_def=True,
-                        loading="lazy") | safe
+                            alt="",
+                            width="852",
+                            height="166",
+                            hi_def=True,
+                            loading="lazy") | safe
               }}
             </div>
             <div class="col">
@@ -342,65 +342,63 @@
     </div>
     <div class="row">
       <div class="col-start-large-7 col-6">
-        <div class="row--50-50">
-          <div class="p-equal-height-row p-equal-height-row-50-50">
-            <div class="p-equal-height-row__col">
-              <div class="p-equal-height-row__item">
-                <div class="p-media-container u-darker-background">
-                  {{ image(url="https://assets.ubuntu.com/v1/18c95711-screenly-updated.png",
-                                    alt="",
-                                    width="852",
-                                    height="1278",
-                                    hi_def=True,
-                                    loading="lazy",
-                                    attrs={"class": "p-image-container__image"}) | safe
-                  }}
-                </div>
-                <hr class="p-rule--highlight" />
-                <h3 class="p-heading--5">Screenly</h3>
+        <div class="p-equal-height-row p-equal-height-row-50-50">
+          <div class="p-equal-height-row__col">
+            <div class="p-equal-height-row__item">
+              <div class="p-media-container u-darker-background">
+                {{ image(url="https://assets.ubuntu.com/v1/18c95711-screenly-updated.png",
+                                alt="",
+                                width="852",
+                                height="1278",
+                                hi_def=True,
+                                loading="lazy",
+                                attrs={"class": "p-image-container__image"}) | safe
+                }}
               </div>
-              <div class="p-equal-height-row__item">
-                <p>
-                  Screenly provides the hardware and software you need to manage digital signs at scale. Update and schedule content, monitor screen health, and show content from your existing tech stack.
-                </p>
-              </div>
-              <div class="p-equal-height-row__item">
-                <hr class="is-muted" />
-                <p>
-                  <a href="https://www.screenly.io/">Learn more about Screenly&nbsp;&rsaquo;</a>
-                </p>
-                <hr class="is-muted" />
-                <p>
-                  <a href="/engage/screenly-empowers-security-conscious-enterprises">Read about the case study&nbsp;&rsaquo;</a>
-                </p>
-              </div>
+              <hr class="p-rule--highlight" />
+              <h3 class="p-heading--5">Screenly</h3>
             </div>
-            <div class="p-equal-height-row__col">
-              <div class="p-equal-height-row__item">
-                <div class="p-media-container u-darker-background">
-                  {{ image(url="https://assets.ubuntu.com/v1/0ed335b9-broadsign-updated.png",
-                                    alt="",
-                                    width="852",
-                                    height="1278",
-                                    hi_def=True,
-                                    loading="lazy",
-                                    attrs={"class": "p-image-container__image"}) | safe
-                  }}
-                </div>
-                <hr class="p-rule--highlight" />
-                <h3 class="p-heading--5">Broadsign</h3>
+            <div class="p-equal-height-row__item">
+              <p>
+                Screenly provides the hardware and software you need to manage digital signs at scale. Update and schedule content, monitor screen health, and show content from your existing tech stack.
+              </p>
+            </div>
+            <div class="p-equal-height-row__item">
+              <hr class="is-muted" />
+              <p>
+                <a href="https://www.screenly.io/">Learn more about Screenly&nbsp;&rsaquo;</a>
+              </p>
+              <hr class="is-muted" />
+              <p>
+                <a href="/engage/screenly-empowers-security-conscious-enterprises">Read about the case study&nbsp;&rsaquo;</a>
+              </p>
+            </div>
+          </div>
+          <div class="p-equal-height-row__col">
+            <div class="p-equal-height-row__item">
+              <div class="p-media-container u-darker-background">
+                {{ image(url="https://assets.ubuntu.com/v1/0ed335b9-broadsign-updated.png",
+                                alt="",
+                                width="852",
+                                height="1278",
+                                hi_def=True,
+                                loading="lazy",
+                                attrs={"class": "p-image-container__image"}) | safe
+                }}
               </div>
-              <div class="p-equal-height-row__item">
-                <p>
-                  An end-to-end software solution built on Ubuntu Core for media owners and buyers to plan, manage and deliver smart displays of any kind.
-                </p>
-              </div>
-              <div class="p-equal-height-row__item">
-                <hr class="is-muted" />
-                <p>
-                  <a href="https://broadsign.com/">Learn more about Broadsign&nbsp;&rsaquo;</a>
-                </p>
-              </div>
+              <hr class="p-rule--highlight" />
+              <h3 class="p-heading--5">Broadsign</h3>
+            </div>
+            <div class="p-equal-height-row__item">
+              <p>
+                An end-to-end software solution built on Ubuntu Core for media owners and buyers to plan, manage and deliver smart displays of any kind.
+              </p>
+            </div>
+            <div class="p-equal-height-row__item">
+              <hr class="is-muted" />
+              <p>
+                <a href="https://broadsign.com/">Learn more about Broadsign&nbsp;&rsaquo;</a>
+              </p>
             </div>
           </div>
         </div>

--- a/templates/internet-of-things/smart-displays.html
+++ b/templates/internet-of-things/smart-displays.html
@@ -7,377 +7,537 @@
 {% endblock meta_description %}
 
 {% block meta_copydoc %}
-  https://docs.google.com/document/d/1fFvBl-ZZvKDFV6OMv7O4kudQKtyxfvSU60rfVdKluAQ/edit
+  https://docs.google.com/document/d/1fFvBl-ZZvKDFV6OMv7O4kudQKtyxfvSU60rfVdKluAQ/edit?tab=t.0
 {% endblock meta_copydoc %}
+
+{% block body_class %}is-paper{% endblock %}
+
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
 {% block content %}
 
-  <section class="p-strip--image is-dark is-deep u-no-padding--top u-no-padding--bottom"
-           style="background-image: url(https://assets.ubuntu.com/v1/bc06a585-GettyImages-1397987876.jpg);
-                  background-position: right bottom;
-                  background-size: 50vw auto;
-                  background-position: 100% 55%">
-    <div class="p-strip--suru-half-and-half-reversed">
-
-      <div class="row u-equal-height u-vertically-center">
-        <div class="col-6">
+  <section class="p-section--hero">
+    <div class="row--50-50">
+      <div class="col">
+        <div class="p-section--shallow">
           <h1>
             Digital signage and kiosk
-            <br class="u-hide--large" />
+            <br class="u-hide--small u-hide--medium" />
             with Ubuntu
           </h1>
-          <p class="p-heading--4">
-            The easy, secure, and reliable way of building open source digital signage software for your business.
-          </p>
+        </div>
+      </div>
+      <div class="col">
+        <div class="p-section--shallow">
+          <p>The easy, secure, and reliable way of building open source digital signage software for your business.</p>
+        </div>
+        <div class="p-cta-block">
+          <a href="/internet-of-things/contact-us"
+             class="p-button--positive js-invoke-modal">Contact us to learn more</a>
           <p>
-            <a href="/internet-of-things/smart-displays#get-in-touch"
-               class="p-button--positive">Contact us to learn more</a>
-          </p>
-          <p>
-            <a href="/engage/Embedding_IoT_GUI_with_Ubuntu_Frame"
-               class="p-link--inverted">Develop GUIs for IoT with our guide&nbsp;&rsaquo;</a>
+            <a href="/engage/Embedding_IoT_GUI_with_Ubuntu_Frame">Develop GUIs for IoT with our guide&nbsp;&rsaquo;</a>
           </p>
         </div>
       </div>
     </div>
   </section>
 
-  <section class="p-strip is-shallow">
-    {% include "shared/_18-04-eol-banner.html" %}
-  </section>
-
-  <section class="p-strip is-shallow">
-    <div class="u-fixed-width">
-      <h2 class="u-sv3">Open source software for smart displays</h2>
-      <p class="p-heading--4">
-        Building a smart display solution? Ubuntu Core and Ubuntu Frame is all you need. Entirely open source and long term supported by Canonical.
-      </p>
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <h2>
+          Open source software
+          <br class="u-hide--small u-hide--medium" />
+          for smart displays
+        </h2>
+      </div>
+      <div class="col">
+        <p>
+          Building a smart display solution? Ubuntu Core and Ubuntu Frame is all you need. Entirely open source and long term supported by Canonical.
+        </p>
+      </div>
     </div>
     <div class="row">
-      <div class="col-4">
-        <h3 class="p-heading--4">Secure</h3>
-        <p>
-          Keep sensitive information secure with an industrial proven OS. Enjoy an OS with built-in security and comprehensive features, such as applications strict confinement, full disk encryption, secure boot, plus 10 years of security maintenance that matches the lifetime of your device.
-        </p>
-      </div>
-      <div class="col-4">
-        <h3 class="p-heading--4">Reliable</h3>
-        <p>
-          With more than 15 years of industrial experience, Ubuntu is one of the most mature graphical servers available today for embedded devices.
-        </p>
-        <p>
-          It has been used in kiosk, IoT, and digital signage solutions,
-          including smart mirrors, health kiosks, and industrial panels.
-        </p>
-      </div>
-      <div class="col-4">
-        <h3 class="p-heading--4">Simple</h3>
-        <p>
-          Preferred by developers, Ubuntu's flexibility allows you to do more. Together with tools for deployment, provisioning, and over the air updates, you can get your smart display up and running in a matter of seconds. Simple integration so you can focus on business value.
-        </p>
+      <div class="col-start-large-4 col-9 col-medium-6">
+        <div class="p-equal-height-row u-no-padding--bottom p-section--shallow">
+          <div class="p-equal-height-row__col">
+            <div class="p-equal-height-row__item">
+              <div class="p-media-container u-darker-background u-hide--small u-hide--medium">
+                {{ image(url="https://assets.ubuntu.com/v1/54ae2ac8-secure.png",
+                                alt="",
+                                width="852",
+                                height="1279",
+                                hi_def=True,
+                                loading="lazy") | safe
+                }}
+              </div>
+              <div class="p-equal-height-row__item">
+                <hr class="p-rule--highlight u-hide--medium u-hide--small" />
+                <h3 class="p-heading--5">Secure</h3>
+              </div>
+            </div>
+            <p class="p-equal-height-row__item">
+              Keep sensitive information secure with an industrial proven OS. Enjoy an OS with built-in security and comprehensive features, such as strict application confinement,
+              full disk encryption, secure boot, plus 10 years of security maintenance that matches the lifetime of your device.
+            </p>
+          </div>
+          <div class="p-equal-height-row__col">
+            <div class="p-equal-height-row__item">
+              <div class="p-media-container u-darker-background u-hide--small u-hide--medium">
+                {{ image(url="https://assets.ubuntu.com/v1/d0b6c883-reliable.png",
+                                alt="",
+                                width="852",
+                                height="1279",
+                                hi_def=True,
+                                loading="lazy") | safe
+                }}
+              </div>
+              <div class="p-equal-height-row__item">
+                <hr class="p-rule--highlight u-hide--medium u-hide--small" />
+                <h3 class="p-heading--5">Reliable</h3>
+              </div>
+            </div>
+            <p class="p-equal-height-row__item">
+              With more than 15 years of industrial experience, Ubuntu is one of the most mature graphical servers available today for embedded devices.
+              <br />
+              It has been used in kiosk, IoT, and digital signage solutions, including smart mirrors, health kiosks, and industrial panels.
+            </p>
+          </div>
+          <div class="p-equal-height-row__col">
+            <div class="p-equal-height-row__item">
+              <div class="p-media-container u-darker-background u-hide--small u-hide--medium">
+                {{ image(url="https://assets.ubuntu.com/v1/5c259427-simple.png",
+                                alt="",
+                                width="852",
+                                height="1279",
+                                hi_def=True,
+                                loading="lazy") | safe
+                }}
+              </div>
+              <div class="p-equal-height-row__item">
+                <hr class="p-rule--highlight u-hide--medium u-hide--small" />
+                <h3 class="p-heading--5">Simple</h3>
+              </div>
+            </div>
+            <p class="p-equal-height-row__item">
+              Preferred by developers, Ubuntu’s flexibility allows you to do more with less. Together with tools for deployment, provisioning,
+              and over the air updates, you can get your smart display up and running in a matter of seconds, so you can focus on business value.
+            </p>
+          </div>
+
+        </div>
       </div>
     </div>
   </section>
 
-  <section class="p-strip--light">
-    <div class="u-fixed-width">
-      <h2>Unlock the best smart displays experience</h2>
-      <p class="p-heading--4">
-        Enable a seamless and secure graphic experience powered by Canonical's open source technologies.
-      </p>
-      <p>
-        Give your screens the uptime and robustness they need, while simplifying the integration of your graphic application. From security to fleet management, with Ubuntu you can unlock:
-      </p>
-      <ul class="p-list">
-        <li class="p-list__item is-ticked">
-          <strong>Faster innovation</strong>: wide peripheral support, Wi-Fi, 3G/4G, NFC, Bluetooth, software-defined radio, deep learning, audio, and camera support (including RealSense)
-        </li>
-        <li class="p-list__item is-ticked">
-          <strong>Streamline development</strong>: simplify the build of graphical outputs with services that bundle communication protocols, input protocols, and security policies into a single kit
-        </li>
-        <li class="p-list__item is-ticked">
-          <strong>Security</strong>: in-built security features, such as strict confinement, secure boot, and disk encryption, with up to ten years of security maintenance
-        </li>
-        <li class="p-list__item is-ticked">
-          <strong>Updated infrastructure</strong>: leverage a reliable software management infrastructure, with over-the-air low bandwidth updates, with automatic failure recovery
-        </li>
-        <li class="p-list__item is-ticked">
-          <strong>Remote maintenance</strong>: no need for on-site personnel with management tools to deploy, monitor and manage your Ubuntu devices
-        </li>
-      </ul>
-      <p>
-        <a href="/internet-of-things/smart-displays#get-in-touch"
-           class="p-button--positive">Reach out to hear more</a>
-      </p>
-    </div>
+  <section class="p-section">
+    {%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=false, is_list_full_width_on_tablet=true) -%}
+      {%- if slot == 'title' -%}
+        <h2>
+          Unlock the best
+          <br class="u-hide--small u-hide--medium" />
+          smart display experience
+        </h2>
+      {%- endif -%}
+
+      {%- if slot == 'description' -%}
+        <p class="p-heading--5 u-no-margin--bottom">
+          Enable seamless and secure graphical experiences powered by Canonical’s open source technologies.
+        </p>
+        <p>
+          Give your screens the uptime and robustness they need, while simplifying the integration of your graphical application. From security to fleet management, with Ubuntu you can unlock:
+        </p>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_title_1' -%}
+        <h5>Faster innovation</h5>
+      {%- endif -%}
+      {%- if slot == 'list_item_description_1' -%}
+        <p>
+          With wide peripheral support. Including: Wi-Fi, 3G/4G, NFC, Bluetooth, software-defined radio, deep learning, audio, and camera support (including RealSense).
+        </p>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_title_2' -%}
+        <h5>Streamlined development</h5>
+      {%- endif -%}
+      {%- if slot == 'list_item_description_2' -%}
+        <p>
+          Simplify the building of graphical outputs with services that bundle communication protocols, input protocols, and security policies into a single kit. Easily customizable with a few lines of code.
+        </p>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_title_3' -%}
+        <h5>Security</h5>
+      {%- endif -%}
+      {%- if slot == 'list_item_description_3' -%}
+        <p>
+          In-built security features, such as strict confinement, secure boot, and disk encryption, with up to ten years of security maintenance.
+        </p>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_title_4' -%}
+        <h5>Updated infrastructure</h5>
+      {%- endif -%}
+      {%- if slot == 'list_item_description_4' -%}
+        <p>
+          Leverage a reliable software management infrastructure, with over-the-air, low bandwidth updates, with automatic failure recovery.
+        </p>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_title_5' -%}
+        <h5>Remote maintenance</h5>
+      {%- endif -%}
+      {%- if slot == 'list_item_description_5' -%}
+        <p>No need for on-site personnel with management tools to deploy, monitor, and manage your Ubuntu devices.</p>
+      {%- endif -%}
+
+      {%- if slot == 'cta' -%}
+        <a href="/internet-of-things/contact-us"
+           class="p-button js-invoke-modal">Reach out to hear more</a>
+      {%- endif -%}
+
+    {%- endcall -%}
   </section>
 
-  <section class="p-strip">
-    <div class="row u-sv3">
-      <div class="col-12">
-        <h2>Get started now with Ubuntu Core and Frame</h2>
-      </div>
+  <section class="p-section">
+    <div class="p-section--shallow u-fixed-width">
+      <hr class="p-rule" />
+      <h2>Get started now with Ubuntu Core and Frame</h2>
     </div>
-
     <div class="row">
-      <div class="p-card col-6">
-        <div class="u-sv1">
-          {{ image(url="https://assets.ubuntu.com/v1/8498283b-Ubuntu+Core-logo-RGB-2022.png",
-                    alt="Ubuntu core",
-                    width="156",
-                    height="36",
-                    hi_def=True,
-                    loading="lazy",
-                    attrs={"class": "p-card__thumbnail"}) | safe
-          }}
-        </div>
-        <p class="p-heading--4">An operating system designed for the edge</p>
-        <div class="p-card__content">
-          <p>
-            With a small footprint and serious power, <a href="/core">Ubuntu Core</a> reduces hardware costs while still running 4k video. As a low-cost, open source solution, it builds from its heritage on servers to bring a secure and stable platform, designed for 24/7 availability, and resistant to screen takeovers and other attacks.
-          </p>
-          <p>
-            Ubuntu Core brings all the security features and device management solutions you need to deploy, provision, and maintain your device.
-          </p>
-        </div>
-        <p>
-          <a href="/core">Learn more about Ubuntu Core&nbsp;&rsaquo;</a>
-        </p>
-      </div>
-      <div class="p-card col-6">
-        <div class="u-sv1">
-          {{ image(url="https://assets.ubuntu.com/v1/cac4e35c-Ubuntu+Frame-logo-RGB-2022.png",
-                    alt="Ubuntu frame",
-                    width="172",
-                    height="36",
-                    hi_def=True,
-                    loading="lazy",
-                    attrs={"class": "p-card__thumbnail"}) | safe
-          }}
-        </div>
-        <p class="p-heading--4">A fullscreen shell for embedded displays</p>
-        <div class="p-card__content">
-          <p>
-            <a href="https://mir-server.io/ubuntu-frame/">Ubuntu Frame</a> unlocks a kiosk mode that helps you create a dedicated and locked-down user experience. Your graphic application will instantly run on full screen with all input modalities without needing to deal with the specific hardware.
-          </p>
-          <p>
-            Ubuntu Frame supports a range of applications built with GTK, Qt, Flutter, Electron. and SDL2. It also has a solution for applications based on HTML5 and Java.
-          </p>
-          <p>
-            <a href="https://mir-server.io/ubuntu-frame/">Learn more about Ubuntu Frame&nbsp;&rsaquo;</a>
-          </p>
-        </div>
-      </div>
-    </div>
-  </section>
-
-  <section class="p-strip--light">
-    <div class="row">
-      <h2 class="u-sv2">Learn more about smart displays on Ubuntu</h2>
-    </div>
-    <div class="row p-divider">
-      <div class="col-4 p-divider__block">
-        <div class="p-heading-icon--muted">
-          <div class="p-heading-icon__header">
-            {{ image(url="https://assets.ubuntu.com/v1/b061c401-White+paper.svg",
-                        alt="whitepaper",
-                        width="171",
-                        height="150",
-                        hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},) | safe
-            }}
-            <h4 class="p-heading-icon__title">Tutorial</h4>
+      <div class="col-start-large-4 col-9 col-medium-6">
+        <div class="p-section--shallow">
+          <div class="row--25-75">
+            <hr class="p-rule--muted" />
+            <div class="col">
+              {{ image(url="https://assets.ubuntu.com/v1/6136e1f9-ubuntu-core.png",
+                            alt="",
+                            width="852",
+                            height="628",
+                            hi_def=True,
+                            loading="auto") | safe
+              }}
+            </div>
+            <div class="col">
+              <div class="p-section--shallow">
+                <p>
+                  With a small footprint and serious power, <a href="/core">Ubuntu Core</a> reduces hardware costs while still being able to run 4k video.
+                  As a low-cost, open source solution, it builds on top of its server heritage to bring a secure and stable platform, designed for 24/7 availability,
+                  and resistant to screen takeovers and other attacks.
+                </p>
+                <p>
+                  Ubuntu Core brings all the security features and device management solutions you need to deploy, provision, and maintain your device.
+                </p>
+              </div>
+              <div class="p-cta-block">
+                <a href="/core">Learn more about Ubuntu Core&nbsp;&rsaquo;</a>
+              </div>
+            </div>
           </div>
         </div>
-        <h3 class="p-heading--4">
-          <a href="https://ubuntu.com/engage/Embedding_IoT_GUI_with_Ubuntu_Frame">Develop GUIs for IoT with Ubuntu Frame&nbsp;&rsaquo;</a>
-        </h3>
-      </div>
-      <div class="col-4 p-divider__block">
-        <div class="p-heading-icon--muted">
-          <div class="p-heading-icon__header">
-            {{ image(url="https://assets.ubuntu.com/v1/3769b4a7-webinar-icon.svg",
-                        alt="",
-                        width="88",
-                        height="72",
-                        hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},) | safe
-            }}
-            <h4 class="p-heading-icon__title">Webinars</h4>
+        <div class="p-section--shallow">
+          <div class="row--25-75">
+            <hr class="p-rule--muted" />
+            <div class="col">
+              {{ image(url="https://assets.ubuntu.com/v1/708e9d0c-ubuntu-frame.png",
+                            alt="",
+                            width="852",
+                            height="628",
+                            hi_def=True,
+                            loading="lazy") | safe
+              }}
+            </div>
+            <div class="col">
+              <div class="p-section--shallow">
+                <p>
+                  <a href="https://mir-server.io/ubuntu-frame/">Ubuntu Frame</a> unlocks a kiosk mode that helps you create a dedicated and locked-down user experience.
+                  Your graphical application will instantly run inon full screen with all input modalities seamlessly on all hardware.
+                </p>
+                <p>
+                  Ubuntu Frame supports a range of applications built with Flutter, Electron, Qt, GTK and SDL2. It also has a solution for applications based on HTML5 and Java.
+                </p>
+              </div>
+              <div class="p-cta-block">
+                <a href="https://mir-server.io/ubuntu-frame/">Learn more about Ubuntu Frame&nbsp;&rsaquo;</a>
+              </div>
+            </div>
           </div>
         </div>
-        <h3 class="p-heading--4">
-          <a href="https://ubuntu.com/engage/Embedded-Apps-With-Ubuntu-Edge">Discover the power of embedding graphic applications for the edge&nbsp;&rsaquo;</a>
-        </h3>
-      </div>
-      <div class="col-4 p-divider__block">
-        <div class="p-heading-icon--muted">
-          <div class="p-heading-icon__header">
-            {{ image(url="https://assets.ubuntu.com/v1/f6d6f78b-Case+study.svg",
-                        alt="",
-                        width="32",
-                        height="32",
-                        hi_def=True,
-                        attrs={"class": "p-heading-icon__img p-heading-icon__img--small"},) | safe
-            }}
-            <h4 class="p-heading-icon__title">Case study</h4>
-          </div>
-        </div>
-        <h3 class="p-heading--4">
-          <a href="https://ubuntu.com/engage/pudo-case-study">Pudo brings convenience and sustainability to last-mile logistics with smart lockers software&nbsp;&rsaquo;</a>
-        </h3>
       </div>
     </div>
   </section>
 
-  <section class="p-strip is-bordered">
+  <section class="p-section">
     <div class="row">
-      <div class="col-8">
+      <hr class="p-rule" />
+      <div class="col-6">
+        <h2>
+          Learn more about
+          <br class="u-hide--medium u-hide--small" />
+          smart displays on Ubuntu
+        </h2>
+      </div>
+      <div class="col-6 col-medium-6">
+        <div class="row">
+          <div class="col-2 col-medium-3">
+            <h3 class="p-heading--5">Tutorial</h3>
+          </div>
+          <div class="col-4 col-medium-3">
+            <p>
+              <a href="/engage/Embedding_IoT_GUI_with_Ubuntu_Frame">Develop GUIs for IoT with Ubuntu Frame&nbsp;&rsaquo;</a>
+            </p>
+          </div>
+        </div>
+        <hr class="p-rule--muted" />
+        <div class="row">
+          <div class="col-2 col-medium-3">
+            <h3 class="p-heading--5">Webinar</h3>
+          </div>
+          <div class="col-4 col-medium-3">
+            <p>
+              <a href="/engage/Embedded-Apps-With-Ubuntu-Edge">
+                Discover the power of embedding
+                <br class="u-hide--small u-hide--medium" />
+                graphic applications for the edge&nbsp;&rsaquo;
+              </a>
+            </p>
+          </div>
+        </div>
+        <hr class="p-rule--muted" />
+        <div class="row">
+          <div class="col-2 col-medium-3">
+            <h3 class="p-heading--5">Case study</h3>
+          </div>
+          <div class="col-4 col-medium-3">
+            <p>
+              <a href="/engage/pudo-case-study">
+                Pudo brings convenience and sustainability
+                <br class="u-hide--small u-hide--medium" />
+                to last-mile logistics with smart lockers software&nbsp;&rsaquo;
+              </a>
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
         <h2>Partners</h2>
+      </div>
+      <div class="col">
         <p>
           Get in touch with one of our partners to help you build your Digital Signage or Kiosk solution using Ubuntu as the foundation of your technology stack.
         </p>
       </div>
     </div>
-    <div class="row u-equal-height">
-      <div class="col-4 p-card">
-        <header class="no-border u-align--center u-vertically-center u-hide--small"
-                style="min-height: 7rem">
-          <a href="https://www.screenly.io/">
-            {{ image(url="https://assets.ubuntu.com/v1/be292257-Dark%20Logo.svg",
-                        alt="Screenly",
-                        width="200",
-                        height="46",
-                        hi_def=True,
-                        loading="lazy") | safe
-            }}
-          </a>
-        </header>
-        <hr class="p-rule--muted u-hide--small" />
-        <h3 class="p-card__title">Screenly</h3>
-        <p class="p-card__content">
-          Screenly provides the hardware and software you need to manage digital signs at scale. Update and schedule content, monitor screen health, and show content from your existing tech stack.
-        </p>
-        <a href="https://www.screenly.io/">Learn more about Screenly&nbsp;&rsaquo;</a>
-        <a href="/engage/screenly-empowers-security-conscious-enterprises">Read about the case study&nbsp;&rsaquo;</a>
-      </div>
-      <div class="col-4 p-card">
-        <header class="no-border u-align--center u-vertically-center u-hide--small"
-                style="min-height: 7rem">
-          <a href="https://broadsign.com/">
-            {{ image(url="https://assets.ubuntu.com/v1/56fec042-Broadsign_Logotype_rgb.svg",
-                        alt="Broadsign",
-                        height="76",
-                        width="250",
-                        hi_def=True,
-                        loading="lazy") | safe
-            }}
-          </a>
-        </header>
-        <hr class="p-rule--muted u-hide--small" />
-        <h3 class="p-card__title">Broadsign</h3>
-        <p class="p-card__content">
-          An end-to-end software solution built on Ubuntu Core for media owners and buyers to plan, manage and deliver smart displays of any kind..
-        </p>
-        <a href="https://broadsign.com/">Learn more about Broadsign&nbsp;&rsaquo;</a>
-      </div>
-    </div>
-  </section>
-
-  <section class="p-strip">
     <div class="row">
-      <div class="col-8">
-        <h2>Ready for all boards, frameworks, and applications</h2>
-        <p>Minimise your costs and time to market: Ubuntu Core is compatible with the most popular boards and silicon.</p>
-        <p>
-          Check the <a href="/certified/iot">full list of Ubuntu certified hardware</a> and find the right one for your application.
-        </p>
-      </div>
-    </div>
-    <div class="row u-equal-height">
-      <div class="col-4 p-card u-align--center">
-        <div class="p-card__content">
-          <h3 class="u-sv3 u-vertically-center">Raspberry Pi</h3>
-          <a href="/download/raspberry-pi-core"
-             class="u-hide--small u-hide--medium">
-            {{ image(url="https://assets.ubuntu.com/v1/a999bb5f-Raspberry+Pi+4.png",
-                        alt="",
-                        width="470",
-                        height="300",
-                        hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-card__image"}) | safe
-            }}
-          </a>
+      <div class="col-start-large-7 col-6 col-medium-3">
+        <div class="row--50-50">
+          <div class="p-equal-height-row p-equal-height-row-50-50">
+            <div class="p-equal-height-row__col">
+              <div class="p-equal-height-row__item">
+                <div class="p-media-container u-darker-background u-hide--small u-hide--medium">
+                  {{ image(url="https://assets.ubuntu.com/v1/54e5c4ec-screenly.png",
+                                    alt="",
+                                    width="852",
+                                    height="1278",
+                                    hi_def=True,
+                                    loading="lazy",
+                                    attrs={"class": "p-image-container__image"}) | safe
+                  }}
+                </div>
+              </div>
+              <div class="p-equal-height-row__item">
+                <hr class="p-rule--highlight u-hide--medium u-hide--small" />
+                <h3 class="p-heading--5">Screenly</h3>
+              </div>
+              <div class="p-equal-height-row__item">
+                <p>
+                  Screenly provides the hardware and software you need to manage digital signs at scale. Update and schedule content, monitor screen health, and show content from your existing tech stack.
+                </p>
+              </div>
+              <div class="p-equal-height-row__item">
+                <hr class="is-muted" />
+                <p>
+                  <a href="https://www.screenly.io/">Learn more about Screenly&nbsp;&rsaquo;</a>
+                </p>
+                <hr class="is-muted" />
+                <p>
+                  <a href="/engage/screenly-empowers-security-conscious-enterprises">Read about the case study&nbsp;&rsaquo;</a>
+                </p>
+              </div>
+            </div>
+            <div class="p-equal-height-row__col">
+              <div class="p-equal-height-row__item">
+                <div class="p-media-container u-darker-background u-hide--small u-hide--medium">
+                  {{ image(url="https://assets.ubuntu.com/v1/07e49a5d-broadsign.png",
+                                    alt="",
+                                    width="852",
+                                    height="1278",
+                                    hi_def=True,
+                                    loading="lazy",
+                                    attrs={"class": "p-image-container__image"}) | safe
+                  }}
+                </div>
+              </div>
+              <div class="p-equal-height-row__item">
+                <hr class="p-rule--highlight u-hide--medium u-hide--small" />
+                <h3 class="p-heading--5">Broadsign</h3>
+              </div>
+              <div class="p-equal-height-row__item">
+                <p>
+                  An end-to-end software solution built on Ubuntu Core for media owners and buyers to plan, manage and deliver smart displays of any kind.
+                </p>
+              </div>
+              <div class="p-equal-height-row__item">
+                <hr class="is-muted" />
+                <p>
+                  <a href="https://broadsign.com/">Learn more about Broadsign&nbsp;&rsaquo;</a>
+                </p>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
-      <div class="col-4 p-card u-align--center">
-        <div class="p-card__content">
-          <h3 class="u-sv3 u-vertically-center">Intel NUC</h3>
-          <a href="/download/iot/intel-iotg" class="u-hide--small u-hide--medium">
-            {{ image(url="https://assets.ubuntu.com/v1/09356811-intel-nuc-chip.png",
-                        alt="",
-                        width="1089",
-                        height="838",
-                        hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-card__image"}) | safe
-            }}
-          </a>
-        </div>
-      </div>
-      <div class="col-4 p-card u-align--center">
-        <div class="p-card__content">
-          <h3 class="u-sv3 u-vertically-center">Dragonboard</h3>
-          <a href="/download/qualcomm-dragonboard-410c"
-             class="u-hide--small u-hide--medium">
-            {{ image(url="https://assets.ubuntu.com/v1/a64b7ee2-dragonboard.png",
-                        alt="",
-                        width="2394",
-                        height="1476",
-                        hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-card__image"}) | safe
-            }}
-          </a>
-        </div>
-      </div>
-    </div>
-    <div class="u-fixed-width">
-      <p>
-        <a href="https://discourse.ubuntu.com/t/where-does-ubuntu-frame-work/23193">More information about Ubuntu Frame graphic support&nbsp;&rsaquo;</a>
-      </p>
     </div>
   </section>
 
-  <section class="p-strip--light">
-    <div class="row u-equal-height">
-      <div class="col-4 u-align--left u-hide--small u-hide--medium">
-        {{ image(url="https://assets.ubuntu.com/v1/c4b290c8-Contact+us.svg",
-                alt="",
-                width="280",
-                height="280",
-                hi_def=True,) | safe
-        }}
-      </div>
-      <div class="col-8 u-vertically-center">
-        <div>
-          <h2>Kickstart your Digital Signage solution</h2>
-          <p>Get in touch and see how we can get your device to market for you.</p>
+  <section class="p-section">
+    <div class="p-section--shallow">
+      <div class="row--50-50">
+        <hr class="p-rule" />
+        <div class="col">
+          <h2>Ready for all boards, frameworks, and applications</h2>
+        </div>
+        <div class="col">
+          <p>Minimize your costs and time to market: Ubuntu Core is compatible with the most popular boards and silicon.</p>
           <p>
-            <a class="p-button--positive js-invoke-modal"
-               href="/internet-of-things/smart-displays#get-in-touch"
-               onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Digital Signage Page - Build your own', 'eventLabel' : 'Get in touch', 'eventValue' : undefined });">Get in touch</a>
+            Check the <a href="/certified/devices">full list of Ubuntu certified hardware</a> and find the right one for your application.
           </p>
         </div>
       </div>
     </div>
+    <div class="row">
+      <div class="col-start-large-4 col-9 col-medium-6">
+        <div class="p-section--shallow">
+          <div class="p-equal-height-row u-no-padding--bottom">
+            <div class="p-equal-height-row__col">
+              <div class="p-equal-height-row__item">
+                <div class="p-media-container u-darker-background u-hide--small u-hide--medium">
+                  <a href="/download/raspberry-pi-core">
+                    {{ image(url="https://assets.ubuntu.com/v1/4f5d5967-raspberry-pi.png",
+                                        alt="",
+                                        width="852",
+                                        height="1278",
+                                        hi_def=True,
+                                        loading="lazy") | safe
+                    }}
+                  </a>
+                </div>
+                <div class="p-equal-height-row__item">
+                  <hr class="p-rule--highlight u-hide--medium u-hide--small" />
+                  <h3 class="p-heading--5">Raspberry Pi</h3>
+                </div>
+              </div>
+            </div>
+            <div class="p-equal-height-row__col">
+              <div class="p-equal-height-row__item">
+                <div class="p-media-container u-darker-background u-hide--small u-hide--medium">
+                  <a href="/download/iot/intel-iotg">
+                    {{ image(url="https://assets.ubuntu.com/v1/d8721aa0-intel-nuc-no-white-bg.png",
+                                        alt="",
+                                        width="852",
+                                        height="1278",
+                                        hi_def=True,
+                                        loading="lazy") | safe
+                    }}
+                  </a>
+                </div>
+                <div class="p-equal-height-row__item">
+                  <hr class="p-rule--highlight u-hide--medium u-hide--small" />
+                  <h3 class="p-heading--5">Intel NUC</h3>
+                </div>
+              </div>
+            </div>
+            <div class="p-equal-height-row__col">
+              <div class="p-equal-height-row__item">
+                <div class="p-media-container u-darker-background u-hide--small u-hide--medium">
+                  <a href="/download/qualcomm-dragonboard-410c">
+                    {{ image(url="https://assets.ubuntu.com/v1/88e5fa17-dragonboard.png",
+                                        alt="",
+                                        width="852",
+                                        height="1278",
+                                        hi_def=True,
+                                        loading="lazy") | safe
+                    }}
+                  </a>
+                </div>
+                <div class="p-equal-height-row__item">
+                  <hr class="p-rule--highlight u-hide--medium u-hide--small" />
+                  <h3 class="p-heading--5">Dragonboard</h3>
+                </div>
+              </div>
+            </div>
+
+          </div>
+        </div>
+      </div>
+      <hr class="p-rule--muted" />
+      <div class="col-start-large-7 col-6 col-medium-3">
+        <p>
+          <a href="">More information about Ubuntu Frame graphics support&nbsp;&rsaquo;</a>
+        </p>
+      </div>
+    </div>
   </section>
 
-  {% with first_item="_iot_developers", second_item="_iot_newsletter_signup", third_item="_iot_further_reading" %}
-    {% include "shared/contextual_footers/_contextual_footer.html" %}
+  <hr class="p-rule is-fixed-width" />
+  <div class="p-strip is-deep">
+    <div class="row u-vertically-center">
+      <div class="col-10">
+        <h2>Learn how we can get your device to market for you</h2>
+        <p class="p-heading--2">
+          <a href="/internet-of-things/contact-us">Get in touch&nbsp;&rsaquo;</a>
+        </p>
+      </div>
+    </div>
+  </div>
+
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <h2>Try Ubuntu Core</h2>
+      </div>
+      <div class="col">
+        <p>
+          Want to learn more about developing with Ubuntu Core? Learn how to build or port apps for the next generation of Ubuntu.
+        </p>
+        <div class="p-cta-block">
+          <a href="/core" class="p-button">Try Ubuntu Core</a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <h2>Sign up for our IoT newsletter</h2>
+      </div>
+      <div class="col">{% include "shared/contextual_footers/_iot_newsletter_signup.html" %}</div>
+    </div>
+  </section>
+
+  {% with title_link="/blog/internet-of-things", groupId="1666" %}
+    {% include "internet-of-things/shared/_latest-news-iot.html" %}
   {% endwith %}
 
   <!-- Set default Marketo information for contact form below-->
@@ -389,4 +549,4 @@
        data-return-url="https://ubuntu.com/internet-of-things/thank-you?product=smart-displays"
        data-lp-url="https://pages.ubuntu.com/things-contact-us.html"></div>
 
-{% endblock content %}
+{% endblock %}

--- a/templates/internet-of-things/smart-displays.html
+++ b/templates/internet-of-things/smart-displays.html
@@ -60,43 +60,46 @@
     </div>
     <div class="row">
       <div class="col-start-large-4 col-9 col-medium-6">
-        <div class="p-equal-height-row u-no-padding--bottom p-section--shallow">
+        <div class="p-equal-height-row--wrap">
           <div class="p-equal-height-row__col">
             <div class="p-equal-height-row__item">
-              <div class="p-media-container u-darker-background">
+              <div class="p-image-container--3-2-on-small p-image-container--square-on-medium p-image-container--2-3-on-large is-highlighted">
                 {{ image(url="https://assets.ubuntu.com/v1/54ae2ac8-secure.png",
                                 alt="",
                                 width="852",
                                 height="1279",
                                 hi_def=True,
-                                loading="lazy") | safe
+                                loading="lazy",
+                                attrs={"class":"p-image-container__image"}) | safe
                 }}
               </div>
-              <div class="p-equal-height-row__item">
-                <hr class="p-rule--highlight" />
-                <h3 class="p-heading--5">Secure</h3>
-              </div>
+            </div>
+            <div class="p-equal-height-row__item">
+              <hr class="p-rule--highlight u-hide--medium u-hide--small" />
+              <h5 class="p-heading--5">Secure</h5>
             </div>
             <p class="p-equal-height-row__item">
               Keep sensitive information secure with an industrial proven OS. Enjoy an OS with built-in security and comprehensive features, such as strict application confinement,
               full disk encryption, secure boot, plus 10 years of security maintenance that matches the lifetime of your device.
             </p>
           </div>
+
           <div class="p-equal-height-row__col">
             <div class="p-equal-height-row__item">
-              <div class="p-media-container u-darker-background">
+              <div class="p-image-container--3-2-on-small p-image-container--square-on-medium p-image-container--2-3-on-large is-highlighted">
                 {{ image(url="https://assets.ubuntu.com/v1/d0b6c883-reliable.png",
                                 alt="",
                                 width="852",
                                 height="1279",
                                 hi_def=True,
-                                loading="lazy") | safe
+                                loading="lazy",
+                                attrs={"class": "p-image-container__image"}) | safe
                 }}
               </div>
-              <div class="p-equal-height-row__item">
-                <hr class="p-rule--highlight" />
-                <h3 class="p-heading--5">Reliable</h3>
-              </div>
+            </div>
+            <div class="p-equal-height-row__item">
+              <hr class="p-rule--highlight u-hide--medium u-hide--small" />
+              <h5 class="p-heading--5">Reliable</h5>
             </div>
             <p class="p-equal-height-row__item">
               With more than 15 years of industrial experience, Ubuntu is one of the most mature graphical servers available today for embedded devices.
@@ -104,28 +107,29 @@
               It has been used in kiosk, IoT, and digital signage solutions, including smart mirrors, health kiosks, and industrial panels.
             </p>
           </div>
+
           <div class="p-equal-height-row__col">
             <div class="p-equal-height-row__item">
-              <div class="p-media-container u-darker-background">
+              <div class="p-image-container--3-2-on-small p-image-container--square-on-medium p-image-container--2-3-on-large is-highlighted">
                 {{ image(url="https://assets.ubuntu.com/v1/5c259427-simple.png",
                                 alt="",
                                 width="852",
                                 height="1279",
                                 hi_def=True,
-                                loading="lazy") | safe
+                                loading="lazy",
+                                attrs={"class": "p-image-container__image"}) | safe
                 }}
               </div>
-              <div class="p-equal-height-row__item">
-                <hr class="p-rule--highlight" />
-                <h3 class="p-heading--5">Simple</h3>
-              </div>
+            </div>
+            <div class="p-equal-height-row__item">
+              <hr class="p-rule--highlight u-hide--medium u-hide--small" />
+              <h5 class="p-heading--5">Simple</h5>
             </div>
             <p class="p-equal-height-row__item">
               Preferred by developers, Ubuntu’s flexibility allows you to do more with less. Together with tools for deployment, provisioning,
               and over the air updates, you can get your smart display up and running in a matter of seconds, so you can focus on business value.
             </p>
           </div>
-
         </div>
       </div>
     </div>
@@ -213,11 +217,11 @@
             <hr class="p-rule--muted" />
             <div class="col">
               {{ image(url="https://assets.ubuntu.com/v1/65e92caf-ubuntu-core-updated.png",
-                        alt="",
-                        width="501",
-                        height="165",
-                        hi_def=True,
-                        loading="lazy") | safe
+                            alt="",
+                            width="501",
+                            height="165",
+                            hi_def=True,
+                            loading="lazy") | safe
               }}
             </div>
             <div class="col">
@@ -242,11 +246,11 @@
             <hr class="p-rule--muted" />
             <div class="col">
               {{ image(url="https://assets.ubuntu.com/v1/733f4c53-ubuntu-frame-updated.png",
-                        alt="",
-                        width="570",
-                        height="171",
-                        hi_def=True,
-                        loading="lazy") | safe
+                            alt="",
+                            width="570",
+                            height="171",
+                            hi_def=True,
+                            loading="lazy") | safe
               }}
             </div>
             <div class="col">
@@ -344,12 +348,12 @@
               <div class="p-equal-height-row__item">
                 <div class="p-media-container u-darker-background">
                   {{ image(url="https://assets.ubuntu.com/v1/18c95711-screenly-updated.png",
-                            alt="",
-                            width="852",
-                            height="1278",
-                            hi_def=True,
-                            loading="lazy",
-                            attrs={"class": "p-image-container__image"}) | safe
+                                    alt="",
+                                    width="852",
+                                    height="1278",
+                                    hi_def=True,
+                                    loading="lazy",
+                                    attrs={"class": "p-image-container__image"}) | safe
                   }}
                 </div>
                 <hr class="p-rule--highlight" />
@@ -375,12 +379,12 @@
               <div class="p-equal-height-row__item">
                 <div class="p-media-container u-darker-background">
                   {{ image(url="https://assets.ubuntu.com/v1/0ed335b9-broadsign-updated.png",
-                            alt="",
-                            width="852",
-                            height="1278",
-                            hi_def=True,
-                            loading="lazy",
-                            attrs={"class": "p-image-container__image"}) | safe
+                                    alt="",
+                                    width="852",
+                                    height="1278",
+                                    hi_def=True,
+                                    loading="lazy",
+                                    attrs={"class": "p-image-container__image"}) | safe
                   }}
                 </div>
                 <hr class="p-rule--highlight" />
@@ -420,72 +424,76 @@
       </div>
     </div>
     <div class="row">
-      <div class="col-start-large-4 col-9 col-medium-6">
+      <div class="col-start-large-4 col-9">
         <div class="p-section--shallow">
-          <div class="p-equal-height-row u-no-padding--bottom">
+          <div class="p-equal-height-row--wrap">
             <div class="p-equal-height-row__col">
               <div class="p-equal-height-row__item">
-                <div class="p-media-container u-darker-background">
+                <div class="p-image-container--3-2-on-small p-image-container--square-on-medium p-image-container--2-3-on-large is-highlighted">
                   <a href="/download/raspberry-pi-core">
                     {{ image(url="https://assets.ubuntu.com/v1/4f5d5967-raspberry-pi.png",
                                         alt="",
                                         width="852",
                                         height="1278",
                                         hi_def=True,
-                                        loading="lazy") | safe
+                                        loading="lazy",
+                                        attrs={"class":"p-image-container__image"}) | safe
                     }}
                   </a>
                 </div>
-                <div class="p-equal-height-row__item">
-                  <hr class="p-rule--highlight" />
-                  <h3 class="p-heading--5">Raspberry Pi</h3>
-                </div>
+              </div>
+              <div class="p-equal-height-row__item">
+                <hr class="p-rule--highlight u-hide--medium u-hide--small" />
+                <h5 class="p-heading--5">Raspberry Pi</h5>
               </div>
             </div>
+
             <div class="p-equal-height-row__col">
               <div class="p-equal-height-row__item">
-                <div class="p-media-container u-darker-background">
+                <div class="p-image-container--3-2-on-small p-image-container--square-on-medium p-image-container--2-3-on-large is-highlighted">
                   <a href="/download/iot/intel-iotg">
                     {{ image(url="https://assets.ubuntu.com/v1/d8721aa0-intel-nuc-no-white-bg.png",
                                         alt="",
                                         width="852",
                                         height="1278",
                                         hi_def=True,
-                                        loading="lazy") | safe
+                                        loading="lazy",
+                                        attrs={"class": "p-image-container__image"}) | safe
                     }}
                   </a>
                 </div>
-                <div class="p-equal-height-row__item">
-                  <hr class="p-rule--highlight" />
-                  <h3 class="p-heading--5">Intel NUC</h3>
-                </div>
+              </div>
+              <div class="p-equal-height-row__item">
+                <hr class="p-rule--highlight u-hide--medium u-hide--small" />
+                <h5 class="p-heading--5">Intel NUC</h5>
               </div>
             </div>
+
             <div class="p-equal-height-row__col">
               <div class="p-equal-height-row__item">
-                <div class="p-media-container u-darker-background">
+                <div class="p-image-container--3-2-on-small p-image-container--square-on-medium p-image-container--2-3-on-large is-highlighted">
                   <a href="/download/qualcomm-dragonboard-410c">
                     {{ image(url="https://assets.ubuntu.com/v1/88e5fa17-dragonboard.png",
                                         alt="",
                                         width="852",
                                         height="1278",
                                         hi_def=True,
-                                        loading="lazy") | safe
+                                        loading="lazy",
+                                        attrs={"class": "p-image-container__image"}) | safe
                     }}
                   </a>
                 </div>
-                <div class="p-equal-height-row__item">
-                  <hr class="p-rule--highlight" />
-                  <h3 class="p-heading--5">Dragonboard</h3>
-                </div>
+              </div>
+              <div class="p-equal-height-row__item">
+                <hr class="p-rule--highlight u-hide--medium u-hide--small" />
+                <h5 class="p-heading--5">Dragonboard</h5>
               </div>
             </div>
-
           </div>
         </div>
       </div>
       <hr class="p-rule--muted" />
-      <div class="col-start-large-7 col-6 col-medium-3">
+      <div class="col-start-large-7 col-6">
         <p>
           <a href="https://discourse.ubuntu.com/t/where-does-ubuntu-frame-work/23193">More information about Ubuntu Frame graphics support&nbsp;&rsaquo;</a>
         </p>

--- a/templates/internet-of-things/smart-displays.html
+++ b/templates/internet-of-things/smart-displays.html
@@ -73,7 +73,7 @@
                 }}
               </div>
               <div class="p-equal-height-row__item">
-                <hr class="p-rule--highlight u-hide--medium u-hide--small" />
+                <hr class="p-rule--highlight" />
                 <h3 class="p-heading--5">Secure</h3>
               </div>
             </div>
@@ -84,7 +84,7 @@
           </div>
           <div class="p-equal-height-row__col">
             <div class="p-equal-height-row__item">
-              <div class="p-media-container u-darker-background u-hide--small u-hide--medium">
+              <div class="p-media-container u-darker-background">
                 {{ image(url="https://assets.ubuntu.com/v1/d0b6c883-reliable.png",
                                 alt="",
                                 width="852",
@@ -94,7 +94,7 @@
                 }}
               </div>
               <div class="p-equal-height-row__item">
-                <hr class="p-rule--highlight u-hide--medium u-hide--small" />
+                <hr class="p-rule--highlight" />
                 <h3 class="p-heading--5">Reliable</h3>
               </div>
             </div>
@@ -106,7 +106,7 @@
           </div>
           <div class="p-equal-height-row__col">
             <div class="p-equal-height-row__item">
-              <div class="p-media-container u-darker-background u-hide--small u-hide--medium">
+              <div class="p-media-container u-darker-background">
                 {{ image(url="https://assets.ubuntu.com/v1/5c259427-simple.png",
                                 alt="",
                                 width="852",
@@ -116,7 +116,7 @@
                 }}
               </div>
               <div class="p-equal-height-row__item">
-                <hr class="p-rule--highlight u-hide--medium u-hide--small" />
+                <hr class="p-rule--highlight" />
                 <h3 class="p-heading--5">Simple</h3>
               </div>
             </div>
@@ -151,16 +151,16 @@
       {%- endif -%}
 
       {%- if slot == 'list_item_title_1' -%}
-        <h5>Faster innovation</h5>
+        <h3 class="p-heading--5">Faster innovation</h3>
       {%- endif -%}
       {%- if slot == 'list_item_description_1' -%}
         <p>
-          With wide peripheral support. Including: Wi-Fi, 3G/4G, NFC, Bluetooth, software-defined radio, deep learning, audio, and camera support (including RealSense).
+          With wide peripheral support. Including: Wi-Fi, 3G/4G, NFC, Bluetooth, software-defined radio, deep learning hardware, audio, and camera support (including RealSense).
         </p>
       {%- endif -%}
 
       {%- if slot == 'list_item_title_2' -%}
-        <h5>Streamlined development</h5>
+        <h3 class="p-heading--5">Streamlined development</h3>
       {%- endif -%}
       {%- if slot == 'list_item_description_2' -%}
         <p>
@@ -169,7 +169,7 @@
       {%- endif -%}
 
       {%- if slot == 'list_item_title_3' -%}
-        <h5>Security</h5>
+        <h3 class="p-heading--5">Security</h3>
       {%- endif -%}
       {%- if slot == 'list_item_description_3' -%}
         <p>
@@ -187,7 +187,7 @@
       {%- endif -%}
 
       {%- if slot == 'list_item_title_5' -%}
-        <h5>Remote maintenance</h5>
+        <h3 class="p-heading--5">Remote maintenance</h3>
       {%- endif -%}
       {%- if slot == 'list_item_description_5' -%}
         <p>No need for on-site personnel with management tools to deploy, monitor, and manage your Ubuntu devices.</p>
@@ -253,7 +253,7 @@
               <div class="p-section--shallow">
                 <p>
                   <a href="https://mir-server.io/ubuntu-frame/">Ubuntu Frame</a> unlocks a kiosk mode that helps you create a dedicated and locked-down user experience.
-                  Your graphical application will instantly run inon full screen with all input modalities seamlessly on all hardware.
+                  Your graphical application will instantly run in full screen with all input modalities seamlessly on all hardware.
                 </p>
                 <p>
                   Ubuntu Frame supports a range of applications built with Flutter, Electron, Qt, GTK and SDL2. It also has a solution for applications based on HTML5 and Java.
@@ -337,12 +337,12 @@
       </div>
     </div>
     <div class="row">
-      <div class="col-start-large-7 col-6 col-medium-3">
+      <div class="col-start-large-7 col-6">
         <div class="row--50-50">
           <div class="p-equal-height-row p-equal-height-row-50-50">
             <div class="p-equal-height-row__col">
               <div class="p-equal-height-row__item">
-                <div class="p-media-container u-darker-background u-hide--small u-hide--medium">
+                <div class="p-media-container u-darker-background">
                   {{ image(url="https://assets.ubuntu.com/v1/18c95711-screenly-updated.png",
                             alt="",
                             width="852",
@@ -352,9 +352,7 @@
                             attrs={"class": "p-image-container__image"}) | safe
                   }}
                 </div>
-              </div>
-              <div class="p-equal-height-row__item">
-                <hr class="p-rule--highlight u-hide--medium u-hide--small" />
+                <hr class="p-rule--highlight" />
                 <h3 class="p-heading--5">Screenly</h3>
               </div>
               <div class="p-equal-height-row__item">
@@ -375,7 +373,7 @@
             </div>
             <div class="p-equal-height-row__col">
               <div class="p-equal-height-row__item">
-                <div class="p-media-container u-darker-background u-hide--small u-hide--medium">
+                <div class="p-media-container u-darker-background">
                   {{ image(url="https://assets.ubuntu.com/v1/0ed335b9-broadsign-updated.png",
                             alt="",
                             width="852",
@@ -385,9 +383,7 @@
                             attrs={"class": "p-image-container__image"}) | safe
                   }}
                 </div>
-              </div>
-              <div class="p-equal-height-row__item">
-                <hr class="p-rule--highlight u-hide--medium u-hide--small" />
+                <hr class="p-rule--highlight" />
                 <h3 class="p-heading--5">Broadsign</h3>
               </div>
               <div class="p-equal-height-row__item">
@@ -491,7 +487,7 @@
       <hr class="p-rule--muted" />
       <div class="col-start-large-7 col-6 col-medium-3">
         <p>
-          <a href="">More information about Ubuntu Frame graphics support&nbsp;&rsaquo;</a>
+          <a href="https://discourse.ubuntu.com/t/where-does-ubuntu-frame-work/23193">More information about Ubuntu Frame graphics support&nbsp;&rsaquo;</a>
         </p>
       </div>
     </div>
@@ -503,7 +499,7 @@
       <div class="col-10">
         <h2>Learn how we can get your device to market for you</h2>
         <p class="p-heading--2">
-          <a href="/internet-of-things/contact-us">Get in touch&nbsp;&rsaquo;</a>
+          <a href="/internet-of-things/contact-us" class="js-invoke-modal">Get in touch&nbsp;&rsaquo;</a>
         </p>
       </div>
     </div>

--- a/templates/internet-of-things/smart-displays.html
+++ b/templates/internet-of-things/smart-displays.html
@@ -63,7 +63,7 @@
         <div class="p-equal-height-row u-no-padding--bottom p-section--shallow">
           <div class="p-equal-height-row__col">
             <div class="p-equal-height-row__item">
-              <div class="p-media-container u-darker-background u-hide--small u-hide--medium">
+              <div class="p-media-container u-darker-background">
                 {{ image(url="https://assets.ubuntu.com/v1/54ae2ac8-secure.png",
                                 alt="",
                                 width="852",
@@ -212,12 +212,12 @@
           <div class="row--25-75">
             <hr class="p-rule--muted" />
             <div class="col">
-              {{ image(url="https://assets.ubuntu.com/v1/6136e1f9-ubuntu-core.png",
-                            alt="",
-                            width="852",
-                            height="628",
-                            hi_def=True,
-                            loading="auto") | safe
+              {{ image(url="https://assets.ubuntu.com/v1/65e92caf-ubuntu-core-updated.png",
+                        alt="",
+                        width="501",
+                        height="165",
+                        hi_def=True,
+                        loading="lazy") | safe
               }}
             </div>
             <div class="col">
@@ -241,12 +241,12 @@
           <div class="row--25-75">
             <hr class="p-rule--muted" />
             <div class="col">
-              {{ image(url="https://assets.ubuntu.com/v1/708e9d0c-ubuntu-frame.png",
-                            alt="",
-                            width="852",
-                            height="628",
-                            hi_def=True,
-                            loading="lazy") | safe
+              {{ image(url="https://assets.ubuntu.com/v1/733f4c53-ubuntu-frame-updated.png",
+                        alt="",
+                        width="570",
+                        height="171",
+                        hi_def=True,
+                        loading="lazy") | safe
               }}
             </div>
             <div class="col">
@@ -343,13 +343,13 @@
             <div class="p-equal-height-row__col">
               <div class="p-equal-height-row__item">
                 <div class="p-media-container u-darker-background u-hide--small u-hide--medium">
-                  {{ image(url="https://assets.ubuntu.com/v1/54e5c4ec-screenly.png",
-                                    alt="",
-                                    width="852",
-                                    height="1278",
-                                    hi_def=True,
-                                    loading="lazy",
-                                    attrs={"class": "p-image-container__image"}) | safe
+                  {{ image(url="https://assets.ubuntu.com/v1/18c95711-screenly-updated.png",
+                            alt="",
+                            width="852",
+                            height="1278",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"class": "p-image-container__image"}) | safe
                   }}
                 </div>
               </div>
@@ -376,13 +376,13 @@
             <div class="p-equal-height-row__col">
               <div class="p-equal-height-row__item">
                 <div class="p-media-container u-darker-background u-hide--small u-hide--medium">
-                  {{ image(url="https://assets.ubuntu.com/v1/07e49a5d-broadsign.png",
-                                    alt="",
-                                    width="852",
-                                    height="1278",
-                                    hi_def=True,
-                                    loading="lazy",
-                                    attrs={"class": "p-image-container__image"}) | safe
+                  {{ image(url="https://assets.ubuntu.com/v1/0ed335b9-broadsign-updated.png",
+                            alt="",
+                            width="852",
+                            height="1278",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"class": "p-image-container__image"}) | safe
                   }}
                 </div>
               </div>
@@ -429,7 +429,7 @@
           <div class="p-equal-height-row u-no-padding--bottom">
             <div class="p-equal-height-row__col">
               <div class="p-equal-height-row__item">
-                <div class="p-media-container u-darker-background u-hide--small u-hide--medium">
+                <div class="p-media-container u-darker-background">
                   <a href="/download/raspberry-pi-core">
                     {{ image(url="https://assets.ubuntu.com/v1/4f5d5967-raspberry-pi.png",
                                         alt="",
@@ -441,14 +441,14 @@
                   </a>
                 </div>
                 <div class="p-equal-height-row__item">
-                  <hr class="p-rule--highlight u-hide--medium u-hide--small" />
+                  <hr class="p-rule--highlight" />
                   <h3 class="p-heading--5">Raspberry Pi</h3>
                 </div>
               </div>
             </div>
             <div class="p-equal-height-row__col">
               <div class="p-equal-height-row__item">
-                <div class="p-media-container u-darker-background u-hide--small u-hide--medium">
+                <div class="p-media-container u-darker-background">
                   <a href="/download/iot/intel-iotg">
                     {{ image(url="https://assets.ubuntu.com/v1/d8721aa0-intel-nuc-no-white-bg.png",
                                         alt="",
@@ -460,14 +460,14 @@
                   </a>
                 </div>
                 <div class="p-equal-height-row__item">
-                  <hr class="p-rule--highlight u-hide--medium u-hide--small" />
+                  <hr class="p-rule--highlight" />
                   <h3 class="p-heading--5">Intel NUC</h3>
                 </div>
               </div>
             </div>
             <div class="p-equal-height-row__col">
               <div class="p-equal-height-row__item">
-                <div class="p-media-container u-darker-background u-hide--small u-hide--medium">
+                <div class="p-media-container u-darker-background">
                   <a href="/download/qualcomm-dragonboard-410c">
                     {{ image(url="https://assets.ubuntu.com/v1/88e5fa17-dragonboard.png",
                                         alt="",
@@ -479,7 +479,7 @@
                   </a>
                 </div>
                 <div class="p-equal-height-row__item">
-                  <hr class="p-rule--highlight u-hide--medium u-hide--small" />
+                  <hr class="p-rule--highlight" />
                   <h3 class="p-heading--5">Dragonboard</h3>
                 </div>
               </div>

--- a/templates/internet-of-things/smart-displays.html
+++ b/templates/internet-of-things/smart-displays.html
@@ -215,13 +215,13 @@
         <div class="p-section--shallow">
           <div class="row--25-75">
             <hr class="p-rule--muted" />
-            <div class="col">
-              {{ image(url="https://assets.ubuntu.com/v1/65e92caf-ubuntu-core-updated.png",
-                            alt="",
-                            width="501",
-                            height="165",
-                            hi_def=True,
-                            loading="lazy") | safe
+            <div class="col u-hide--small">
+              {{ image(url="https://assets.ubuntu.com/v1/d68b3378-ubuntu-frame-final.png",
+                        alt="",
+                        width="852",
+                        height="172",
+                        hi_def=True,
+                        loading="lazy") | safe
               }}
             </div>
             <div class="col">
@@ -244,13 +244,13 @@
         <div class="p-section--shallow">
           <div class="row--25-75">
             <hr class="p-rule--muted" />
-            <div class="col">
-              {{ image(url="https://assets.ubuntu.com/v1/733f4c53-ubuntu-frame-updated.png",
-                            alt="",
-                            width="570",
-                            height="171",
-                            hi_def=True,
-                            loading="lazy") | safe
+            <div class="col u-hide--small">
+              {{ image(url="https://assets.ubuntu.com/v1/9d527111-ubuntu-core-final.png",
+                        alt="",
+                        width="852",
+                        height="166",
+                        hi_def=True,
+                        loading="lazy") | safe
               }}
             </div>
             <div class="col">


### PR DESCRIPTION
## Done

- Apply rebranding on /internet-of-things/smart-displays
- No changes to content, only design

## QA

- Go to https://ubuntu-com-14538.demos.haus/internet-of-things/smart-displays
- Check that design matches [Figma](https://www.figma.com/design/1CdIT6TV3ASf55GsnQcwXg/Internet-of-Things?node-id=2001-15688&node-type=frame&m=dev)
- No changes to design

## Issue / Card

Fixes [WD-16639](https://warthogs.atlassian.net/browse/WD-16639)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-16639]: https://warthogs.atlassian.net/browse/WD-16639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ