### PR TITLE
fix(/embedding/faqs): Update meta_copydoc link

### DIFF
--- a/templates/embedding/faqs.html
+++ b/templates/embedding/faqs.html
@@ -6,7 +6,7 @@
 
 {% block meta_image %}https://assets.ubuntu.com/v1/c75046c4-Smart+City.svg{% endblock meta_image %}
 
-{% block meta_copydoc %}https://docs.google.com/document/d/15Tz87YRg4SnX4DWGOSl2TDTHLSStJoma879xHnF0nuo/edit{% endblock meta_copydoc %}
+{% block meta_copydoc %}https://docs.google.com/document/d/1xWrM0D4LkWdJh9EiAUuXgbYKqh15BnNcQpXqTlZCuYA/edit?tab=t.0{% endblock meta_copydoc %}
 
 {% block body_class %}is-paper{% endblock body_class %}
 


### PR DESCRIPTION
## Done

- Updates the meta copydoc to the correct link https://docs.google.com/document/d/1xWrM0D4LkWdJh9EiAUuXgbYKqh15BnNcQpXqTlZCuYA/edit?tab=t.0

## QA

- Check the link in the meta_copydoc block matches the one above/ the one mention by Sophie in [her comment](https://chat.canonical.com/canonical/pl/sg9r6bqf43gi58pfzoi75bf3ww)
