### PR TITLE
WD-17582 Redirect to success notification instead of thank-you page.

### DIFF
--- a/templates/internet-of-things/contact-us.html
+++ b/templates/internet-of-things/contact-us.html
@@ -11,7 +11,7 @@
   intro_text="If you are thinking about building a digital signage product on Ubuntu, please fill in your details below and a member of our team will get in touch.",
   formid="1422",
   lpId="2166",
-  returnURL="/internet-of-things/thank-you?product=smart-displays" %}
+  returnURL="/internet-of-things#success" %}
   {% include "shared/_client-contact-us-form.html" %}
 {% endwith %}
 
@@ -21,7 +21,7 @@
   intro_text="If you would like to know more about Ubuntu for edge gateways, please fill in your details below and a member of our team will get in touch.",
   formid="1663",
   lpId="3143",
-  returnURL="/internet-of-things/thank-you?product=gateways" %}
+  returnURL="/internet-of-things#success" %}
   {% include "shared/_client-contact-us-form.html" %}
 {% endwith %}
 
@@ -31,7 +31,7 @@
   intro_text="If you would like to know more about Ubuntu for Robotics, please fill in your details below and a member of our team will get in touch.",
   formid="1650",
   lpId="2838",
-  returnURL="/internet-of-things/thank-you?product=robotics" %}
+  returnURL="/internet-of-things#success" %}
   {% include "shared/_client-contact-us-form.html" %}
 {% endwith %}
 
@@ -41,7 +41,7 @@
   intro_text="Enhance your software distribution with a custom, dedicated app store. Fill in your details below and a member of our team will be in touch.",
   formid="2639",
   lpId="5811",
-  returnURL="/internet-of-things/thank-you?product=appstore" %}
+  returnURL="/internet-of-things#success" %}
   {% include "shared/_client-contact-us-form.html" %}
 {% endwith %}
 
@@ -51,7 +51,7 @@
   intro_text="We would love to hear what you want to create, and be your partner in innovation.",
   formid="2639",
   lpId="5811",
-  returnURL="/internet-of-things/thank-you?product=automotive" %}
+  returnURL="/internet-of-things#success" %}
   {% include "shared/_client-contact-us-form.html" %}
 {% endwith %}
 
@@ -61,7 +61,7 @@
   intro_text="If you would like to know more about Ubuntu for networking, please fill in your details below and a member of our team will get in touch.",
   formid="3484",
   lpId="",
-  returnURL="/internet-of-things/thank-you?product=networking" %}
+  returnURL="/internet-of-things#success" %}
   {% include "shared/_client-contact-us-form.html" %}
 {% endwith %}
 
@@ -71,7 +71,7 @@
   intro_text="If you would like to learn more about our enterprise device management features, please fill in the form below and a member of our team will be in touch.",
   formid="4296",
   lpId="",
-  returnURL="/internet-of-things/thank-you?product=management" %}
+  returnURL="/internet-of-things#success" %}
   {% include "shared/_client-contact-us-form.html" %}
 {% endwith %}
 
@@ -81,7 +81,7 @@
   intro_text="If you are thinking about using Ubuntu Core to power your Internet of Things devices, please fill in your details below and a member of our team will get in touch.",
   formid="1266",
   lpId="2551",
-  returnURL="/internet-of-things/thank-you?product=iot",
+  returnURL="/internet-of-things#success",
   side1="shared/forms/_desktop_help.html",
   side2="shared/forms/_desktop_ua-shop.html" %}
   {% include "shared/_client-contact-us-form.html" %}

--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -641,7 +641,7 @@
        data-form-location="/shared/forms/interactive/internet-of-things"
        data-form-id="1266"
        data-lp-id="2551"
-       data-return-url="https://ubuntu.com/internet-of-things/thank-you?product=iot"
+       data-return-url="/internet-of-things#success"
        data-lp-url="https://pages.ubuntu.com/things-contact-us.html"></div>
 
 {% endblock content %}

--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -628,7 +628,7 @@
           Whether you are a startup bringing your concept to market or already  have large fleets of devices deployed in the field, we have the expertise and infrastructure to launch and support you.
         </p>
         <div class="p-cta-block">
-          <a href="/internet-of-things#get-in-touch"
+          <a href="/internet-of-things/contact-us"
              class="js-invoke-modal p-button--positive">Contact our team</a>
         </div>
       </div>


### PR DESCRIPTION
## Done

- Changed form redirect url so that the user is redirected to /internet-of-things#contact-form-success instead of /internet-of-things/thank-you page.

## QA

- View the site in your web browser at: https://ubuntu-com-14545.demos.haus/internet-of-things/
- Make sure you keep javascript enabled.
- Scroll down to the Contact Our Team button and click on it. This should open up the contact form in a modal.
- Fill out the form and submit. You should be redirected to u.com/internet-of-things#success and see the notification on top of page.
- Now disable javascript (from the dev tools)
- Scroll down to the Contact Our Team button and click on it. This should take you to the static contact-us page.
- Fill out the form and submit. ou should be redirected to u.com/internet-of-things#success and see the notification on top of page.


## Issue / Card

Fixes #[17582](https://warthogs.atlassian.net/browse/WD-17582)
