### PR TITLE
Route security API requests to single service

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -368,23 +368,17 @@ production:
         - name: SENTRY_DSN
           value: https://0293bb7fc3104e56bafd2422e155790c@sentry.is.canonical.com//13
 
-    - paths: [/security/notices\.json]
-      service_name: ubuntu-com-security-api-notices
-
-    - paths: [/security/notices/.*\.json]
-      service_name: ubuntu-com-security-api-notices-detail
-
-    - paths: [/security/updates/.*]
-      service_name: ubuntu-com-security-api-updates
-
     - paths:
         [
+          /security/notices\.json,
+          /security/notices/.*\.json,
           /security/cves\.json,
           /security/cves/.*\.json,
           /security/releases\.json,
           /security/releases/.*\.json,
           /security/api/.*,
           /security/page/.*\.json,
+          /security/updates/.*
         ]
       service_name: ubuntu-com-security-api
 

--- a/templates/security/notices/usn.html
+++ b/templates/security/notices/usn.html
@@ -59,14 +59,14 @@
           {% for package_name, package in notice.release_packages[version].items() %}
             <li class="p-list__item">
               {% if package.source_link %}
-                <a href="{{package.source_link}}">{{ package.name }}</a>
+                <a href="{{ package.source_link }}">{{ package.name }}</a>
               {% else %}
                 {{ package.name }}
               {% endif %}
               -
               {% if package.version_link %}
-                <a href="{{package.version_link}}">{{ package.version }}</a>
-              {% else%}
+                <a href="{{ package.version_link }}">{{ package.version }}</a>
+              {% else %}
                 {{ package.version }}
               {% endif %}
               <div>
@@ -115,7 +115,7 @@
       <ul class="p-list">
         {% for notice in notice.related_notices %}
           <li class="p-list__item">
-            <a href="/security/notices/{{ notice.id }}">{{ notice.id }}</a>: {{ notice.packages }}
+            <a href="/security/notices/{{ notice }}">{{ notice }}</a>
           </li>
         {% endfor %}
       </ul>


### PR DESCRIPTION
## Done

- Route security API requests to single service
- The new API only returns related_notices as a lis of IDs, so we updated the template of the notice detail page

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Check `/notices/USN-7135-1.json` to make sure links to related notices still work