### PR TITLE
Wd-16440 Restrict channel users from editing billing information

### DIFF
--- a/static/js/src/advantage/distributor/components/DistributorBuyButton/DistributorBuyButton.test.tsx
+++ b/static/js/src/advantage/distributor/components/DistributorBuyButton/DistributorBuyButton.test.tsx
@@ -12,7 +12,7 @@ import {
   FormContext,
   defaultValues,
 } from "advantage/distributor/utils/FormContext";
-import { distributorProduct } from "advantage/subscribe/checkout/utils/test/Mocks";
+import { DistributorProduct } from "advantage/subscribe/checkout/utils/test/Mocks";
 import { ChannelOfferFactory } from "advantage/offers/tests/factories/channelOffers";
 import { UserSubscriptionMarketplace } from "advantage/api/enum";
 
@@ -27,7 +27,7 @@ const mockSubscription: SubscriptionItem = {
 const mockContextValue = {
   ...defaultValues,
   subscriptionList: [mockSubscription] as SubscriptionItem[],
-  products: [distributorProduct] as ChannelProduct[],
+  products: [DistributorProduct] as ChannelProduct[],
   offer: ChannelOfferFactory.build({ id: "offer-id-1" }),
 };
 

--- a/static/js/src/advantage/distributor/components/DistributorShopForm/AddSubscriptions/SubscriptionCard.tsx/SubscriptionCard.test.tsx
+++ b/static/js/src/advantage/distributor/components/DistributorShopForm/AddSubscriptions/SubscriptionCard.tsx/SubscriptionCard.test.tsx
@@ -11,7 +11,7 @@ import {
   FormContext,
   defaultValues,
 } from "advantage/distributor/utils/FormContext";
-import { distributorProduct } from "advantage/subscribe/checkout/utils/test/Mocks";
+import { DistributorProduct } from "advantage/subscribe/checkout/utils/test/Mocks";
 
 const mockSubscription: SubscriptionItem = {
   id: "mocked-id-1",
@@ -25,7 +25,7 @@ const mockContextValue = {
   ...defaultValues,
   subscriptionList: [mockSubscription] as SubscriptionItem[],
   setSubscriptionList: jest.fn(),
-  products: [distributorProduct] as ChannelProduct[],
+  products: [DistributorProduct] as ChannelProduct[],
   duration: 1,
 };
 

--- a/static/js/src/advantage/subscribe/checkout/components/Taxes/Taxes.test.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Taxes/Taxes.test.tsx
@@ -2,9 +2,11 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Formik } from "formik";
 import { Elements } from "@stripe/react-stripe-js";
 import { loadStripe } from "@stripe/stripe-js";
-import { fireEvent, render, screen } from "@testing-library/react";
-import { UAProduct } from "../../utils/test/Mocks";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { DistributorProduct, UAProduct } from "../../utils/test/Mocks";
 import Taxes from "./Taxes";
+import userEvent from "@testing-library/user-event";
+import { UserSubscriptionMarketplace } from "advantage/api/enum";
 
 describe("TaxesTests", () => {
   let queryClient: QueryClient;
@@ -12,6 +14,10 @@ describe("TaxesTests", () => {
 
   beforeEach(async () => {
     queryClient = new QueryClient();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
   it("renders country select correctly", () => {
@@ -211,5 +217,97 @@ describe("TaxesTests", () => {
     fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
     expect(screen.getByTestId("country")).toHaveTextContent("United Kingdom");
     expect(screen.getByTestId("vat-number")).toHaveTextContent("GB123123123");
+  });
+
+  it("Edit should be available for pro users", async () => {
+    global.window = Object.create(window);
+    Object.defineProperty(window, "accountId", { value: "ABCDEF" });
+
+    const initialValues = {
+      country: "GB",
+      VATNumber: "GB123123123",
+      marketPlace: "canonical-ua",
+    };
+
+    const products = [
+      {
+        product: UAProduct,
+        quantity: 1,
+      },
+    ];
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Formik initialValues={initialValues} onSubmit={jest.fn()}>
+          <Elements stripe={stripePromise}>
+            <Taxes products={products} setError={jest.fn()} />
+          </Elements>
+        </Formik>
+      </QueryClientProvider>,
+    );
+
+    expect(screen.queryByRole("button", { name: "Edit" })).toBeInTheDocument();
+    userEvent.click(screen.getByRole("button", { name: "Edit" }));
+    await waitFor(() => {
+      expect(screen.getByTestId("select-country")).toBeInTheDocument();
+      expect(screen.getByTestId("field-vat-number")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+    });
+  });
+
+  it("Edit button should not be displayed for channel users", () => {
+    global.window = Object.create(window);
+    Object.defineProperty(window, "accountId", { value: "ABCDEF" });
+    const initialValues = {
+      country: "GB",
+      VATNumber: "GB123123123",
+      marketPlace: UserSubscriptionMarketplace.CanonicalProChannel,
+    };
+    const products = [
+      {
+        product: DistributorProduct,
+        quantity: 1,
+      },
+    ];
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Formik initialValues={initialValues} onSubmit={jest.fn()}>
+          <Elements stripe={stripePromise}>
+            <Taxes products={products} setError={jest.fn()} />
+          </Elements>
+        </Formik>
+      </QueryClientProvider>,
+    );
+
+    expect(screen.queryByTestId("tax-edit-button")).toBeInTheDocument();
+  });
+
+  it("New channel users should be able to add their tax info", async () => {
+    global.window = Object.create(window);
+    Object.defineProperty(window, "accountId", { value: "ABCDEF" });
+
+    const initialValues = {
+      country: "",
+      VATNumber: "",
+      marketPlace: UserSubscriptionMarketplace.CanonicalProChannel,
+    };
+
+    const products = [
+      {
+        product: DistributorProduct,
+        quantity: 1,
+      },
+    ];
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Formik initialValues={initialValues} onSubmit={jest.fn()}>
+          <Elements stripe={stripePromise}>
+            <Taxes products={products} setError={jest.fn()} />
+          </Elements>
+        </Formik>
+      </QueryClientProvider>,
+    );
+
+    expect(screen.queryByTestId("tax-edit-button")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
   });
 });

--- a/static/js/src/advantage/subscribe/checkout/components/Taxes/Taxes.test.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Taxes/Taxes.test.tsx
@@ -2,7 +2,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Formik } from "formik";
 import { Elements } from "@stripe/react-stripe-js";
 import { loadStripe } from "@stripe/stripe-js";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { DistributorProduct, UAProduct } from "../../utils/test/Mocks";
 import Taxes from "./Taxes";
 import userEvent from "@testing-library/user-event";
@@ -59,12 +59,11 @@ describe("TaxesTests", () => {
     );
 
     expect(screen.getByTestId("select-country")).toBeInTheDocument();
-    fireEvent.change(screen.getByTestId("select-country"), {
-      target: { value: "JP" },
-    });
+    userEvent.selectOptions(screen.getByTestId("select-country"), "JP");
+    expect(screen.queryByText("VAT number:")).not.toBeInTheDocument();
   });
 
-  it("When VAT country is selected, VAT Number input displays", () => {
+  it("When VAT country is selected, VAT Number input displays", async () => {
     const products = [
       {
         product: UAProduct,
@@ -82,14 +81,11 @@ describe("TaxesTests", () => {
     );
 
     expect(screen.getByTestId("select-country")).toBeInTheDocument();
-    fireEvent.change(screen.getByTestId("select-country"), {
-      target: { value: "FR" },
-    });
-
-    expect(screen.getByText("VAT number:")).toBeInTheDocument();
+    await userEvent.selectOptions(screen.getByTestId("select-country"), "FR");
+    expect(screen.queryByText("VAT number:")).toBeInTheDocument();
   });
 
-  it("When USA is selected, State select displays", () => {
+  it("When USA is selected, State select displays", async () => {
     const products = [
       {
         product: UAProduct,
@@ -105,13 +101,10 @@ describe("TaxesTests", () => {
         </Formik>
       </QueryClientProvider>,
     );
-    fireEvent.change(getByTestId("select-country"), {
-      target: { value: "US" },
-    });
+    await userEvent.selectOptions(getByTestId("select-country"), "US");
     expect(screen.getByText("State:")).toBeInTheDocument();
-    fireEvent.change(getByTestId("select-state"), {
-      target: { value: "Texas" },
-    });
+    await userEvent.selectOptions(getByTestId("select-state"), "Texas");
+    expect(screen.queryByText("VAT number:")).not.toBeInTheDocument();
   });
 
   it("sets status right if country is stored", () => {
@@ -160,7 +153,7 @@ describe("TaxesTests", () => {
     expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
   });
 
-  it("cancel button resets tax step values", () => {
+  it("cancel button resets tax step values", async () => {
     global.window = Object.create(window);
     Object.defineProperty(window, "accountId", { value: "ABCDEF" });
 
@@ -184,37 +177,27 @@ describe("TaxesTests", () => {
         </Formik>
       </QueryClientProvider>,
     );
-
-    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
-    fireEvent.change(screen.getByTestId("select-country"), {
-      target: { value: "FR" },
-    });
-    fireEvent.change(screen.getByTestId("field-vat-number"), {
-      target: { value: "FR123123123" },
-    });
-    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    await userEvent.click(screen.getByRole("button", { name: "Edit" }));
+    await userEvent.selectOptions(screen.getByTestId("select-country"), "FR");
+    await userEvent.type(screen.getByTestId("field-vat-number"), "FR123123123");
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
     expect(screen.getByTestId("country")).toHaveTextContent("United Kingdom");
     expect(screen.getByTestId("vat-number")).toHaveTextContent("GB123123123");
 
-    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
-    fireEvent.change(screen.getByTestId("select-country"), {
-      target: { value: "US" },
-    });
-    fireEvent.change(screen.getByTestId("select-state"), {
-      target: { value: "AL" },
-    });
-    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    await userEvent.click(screen.getByRole("button", { name: "Edit" }));
+    await userEvent.selectOptions(screen.getByTestId("select-country"), "US");
+    await userEvent.selectOptions(screen.getByTestId("select-state"), "AL");
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
     expect(screen.getByTestId("country")).toHaveTextContent("United Kingdom");
     expect(screen.getByTestId("vat-number")).toHaveTextContent("GB123123123");
 
-    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
-    fireEvent.change(screen.getByTestId("select-country"), {
-      target: { value: "CA" },
-    });
-    fireEvent.change(screen.getByTestId("select-ca-province"), {
-      target: { value: "AL" },
-    });
-    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    await userEvent.click(screen.getByRole("button", { name: "Edit" }));
+    await userEvent.selectOptions(screen.getByTestId("select-country"), "CA");
+    await userEvent.selectOptions(
+      screen.getByTestId("select-ca-province"),
+      "AB",
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
     expect(screen.getByTestId("country")).toHaveTextContent("United Kingdom");
     expect(screen.getByTestId("vat-number")).toHaveTextContent("GB123123123");
   });
@@ -246,12 +229,12 @@ describe("TaxesTests", () => {
     );
 
     expect(screen.queryByRole("button", { name: "Edit" })).toBeInTheDocument();
-    userEvent.click(screen.getByRole("button", { name: "Edit" }));
-    await waitFor(() => {
-      expect(screen.getByTestId("select-country")).toBeInTheDocument();
-      expect(screen.getByTestId("field-vat-number")).toBeInTheDocument();
-      expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
-    });
+    await userEvent.click(screen.getByRole("button", { name: "Edit" }));
+
+    const countryField = await screen.findByTestId("select-country");
+    expect(countryField).toBeInTheDocument();
+    expect(screen.getByTestId("field-vat-number")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
   });
 
   it("Edit button should not be displayed for channel users", () => {

--- a/static/js/src/advantage/subscribe/checkout/components/Taxes/Taxes.test.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Taxes/Taxes.test.tsx
@@ -112,7 +112,7 @@ describe("TaxesTests", () => {
     global.window = Object.create(window);
     Object.defineProperty(window, "accountId", { value: "ABCDEF" });
 
-    const intialValues = {
+    const initialValues = {
       country: "GB",
     };
     const products = [
@@ -123,7 +123,7 @@ describe("TaxesTests", () => {
     ];
     render(
       <QueryClientProvider client={queryClient}>
-        <Formik initialValues={intialValues} onSubmit={jest.fn()}>
+        <Formik initialValues={initialValues} onSubmit={jest.fn()}>
           <Elements stripe={stripePromise}>
             <Taxes products={products} setError={jest.fn()} />
           </Elements>
@@ -158,7 +158,7 @@ describe("TaxesTests", () => {
     global.window = Object.create(window);
     Object.defineProperty(window, "accountId", { value: "ABCDEF" });
 
-    const intialValues = {
+    const initialValues = {
       country: "GB",
       VATNumber: "GB123123123",
     };
@@ -171,7 +171,7 @@ describe("TaxesTests", () => {
     ];
     render(
       <QueryClientProvider client={queryClient}>
-        <Formik initialValues={intialValues} onSubmit={jest.fn()}>
+        <Formik initialValues={initialValues} onSubmit={jest.fn()}>
           <Elements stripe={stripePromise}>
             <Taxes products={products} setError={jest.fn()} />
           </Elements>

--- a/static/js/src/advantage/subscribe/checkout/components/Taxes/Taxes.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Taxes/Taxes.tsx
@@ -18,6 +18,7 @@ import {
 import { getLabel } from "advantage/subscribe/react/utils/utils";
 import postCustomerTaxInfo from "../../hooks/postCustomerTaxInfo";
 import { CheckoutProducts, FormValues } from "../../utils/types";
+import { UserSubscriptionMarketplace } from "advantage/api/enum";
 
 type TaxesProps = {
   products: CheckoutProducts[];
@@ -34,8 +35,15 @@ const Taxes = ({ products, setError }: TaxesProps) => {
     setFieldTouched,
     setErrors: setFormikErrors,
   } = useFormikContext<FormValues>();
-  const [isEditing, setIsEditing] = useState(!initialValues.country);
   const queryClient = useQueryClient();
+  const isNewUser = !window.accountId || !initialValues.country;
+  const isChannelUser =
+    values.marketplace === UserSubscriptionMarketplace.CanonicalProChannel;
+  const [isEditing, setIsEditing] = useState(isNewUser || !isChannelUser);
+  const postCustomerTaxInfoMutation = postCustomerTaxInfo();
+  const hasZeroPriceValue = products.some(
+    (item) => item.product.price.value === 0,
+  );
 
   useEffect(() => {
     if (errors.VATNumber) {
@@ -53,10 +61,6 @@ const Taxes = ({ products, setError }: TaxesProps) => {
     }
   }, [initialValues]);
 
-  const postCustomerTaxInfoMutation = postCustomerTaxInfo();
-  const hasZeroPriceValue = products.some(
-    (item) => item.product.price.value === 0,
-  );
   const onSaveClick = () => {
     setIsEditing(false);
     setFieldTouched("isTaxSaved", false);
@@ -290,43 +294,53 @@ const Taxes = ({ products, setError }: TaxesProps) => {
             error={touched?.isTaxSaved && errors?.isTaxSaved}
           />
         </Col>
-        <hr />
-        <div
-          className="u-align--right"
-          style={{ marginTop: "calc(.5rem - 1.5px)" }}
-        >
-          {isEditing ? (
-            <>
-              {window.accountId && !!initialValues.country ? (
+        {(!isChannelUser || isNewUser) && (
+          <>
+            <hr />
+            <div
+              className="u-align--right"
+              style={{ marginTop: "calc(.5rem - 1.5px)" }}
+            >
+              {isEditing ? (
+                <>
+                  {window.accountId && !!initialValues.country && (
+                    // if both exist, show cancel button, or only show save button
+                    <ActionButton
+                      onClick={() => {
+                        setFieldValue("country", initialValues.country);
+                        setFieldValue("usState", initialValues.usState);
+                        setFieldValue("caProvince", initialValues.caProvince);
+                        setFieldValue("VATNumber", initialValues.VATNumber);
+                        setIsEditing(false);
+                        setFieldValue("isTaxSaved", true);
+                        setFieldTouched("isTaxSaved", false);
+                      }}
+                    >
+                      Cancel
+                    </ActionButton>
+                  )}
+                  <ActionButton
+                    onClick={onSaveClick}
+                    disabled={
+                      !values.country ||
+                      (values.country === "US" && !values.usState) ||
+                      (values.country === "CA" && !values.caProvince)
+                    }
+                  >
+                    Save
+                  </ActionButton>
+                </>
+              ) : (
                 <ActionButton
-                  onClick={() => {
-                    setFieldValue("country", initialValues.country);
-                    setFieldValue("usState", initialValues.usState);
-                    setFieldValue("caProvince", initialValues.caProvince);
-                    setFieldValue("VATNumber", initialValues.VATNumber);
-                    setIsEditing(false);
-                    setFieldValue("isTaxSaved", true);
-                    setFieldTouched("isTaxSaved", false);
-                  }}
+                  onClick={onEditClick}
+                  data-testid="tax-edit-button"
                 >
-                  Cancel
+                  Edit
                 </ActionButton>
-              ) : null}
-              <ActionButton
-                onClick={onSaveClick}
-                disabled={
-                  !values.country ||
-                  (values.country === "US" && !values.usState) ||
-                  (values.country === "CA" && !values.caProvince)
-                }
-              >
-                Save
-              </ActionButton>
-            </>
-          ) : (
-            <ActionButton onClick={onEditClick}>Edit</ActionButton>
-          )}
-        </div>
+              )}
+            </div>
+          </>
+        )}
       </Row>
     </>
   );

--- a/static/js/src/advantage/subscribe/checkout/components/UserInfoForm/UserInfoForm.test.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/UserInfoForm/UserInfoForm.test.tsx
@@ -17,7 +17,7 @@ describe("UserInfoFormTests", () => {
     global.window = Object.create(window);
     Object.defineProperty(window, "accountId", { value: "ABCDEF" });
 
-    const intialValues = {
+    const initialValues = {
       name: "Joe",
       organisationName: "Canonical",
       buyingFor: "organisation",
@@ -36,7 +36,7 @@ describe("UserInfoFormTests", () => {
 
     render(
       <QueryClientProvider client={queryClient}>
-        <Formik initialValues={intialValues} onSubmit={jest.fn()}>
+        <Formik initialValues={initialValues} onSubmit={jest.fn()}>
           <Elements stripe={stripePromise}>
             <UserInfoForm setError={jest.fn()} />
           </Elements>

--- a/static/js/src/advantage/subscribe/checkout/components/UserInfoForm/UserInfoForm.test.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/UserInfoForm/UserInfoForm.test.tsx
@@ -4,6 +4,7 @@ import { Elements } from "@stripe/react-stripe-js";
 import { loadStripe } from "@stripe/stripe-js";
 import { fireEvent, render, screen } from "@testing-library/react";
 import UserInfoForm from "./UserInfoForm";
+import { UserSubscriptionMarketplace } from "advantage/api/enum";
 
 describe("UserInfoFormTests", () => {
   let queryClient: QueryClient;
@@ -74,5 +75,101 @@ describe("UserInfoFormTests", () => {
     expect(screen.getByTestId("customer-postal-code")).toHaveTextContent(
       "AB12 3CD",
     );
+  });
+
+  it("Channel user should be able to edit only card number", () => {
+    global.window = Object.create(window);
+    Object.defineProperty(window, "accountId", { value: "ABCDEF" });
+
+    const initialValues = {
+      name: "Min",
+      marketplace: UserSubscriptionMarketplace.CanonicalProChannel,
+      buyingFor: "organisation",
+      organisationName: "Canonical",
+      address: "ABC Street",
+      city: "DEF City",
+      postalCode: "AB12 3CD",
+      defaultPaymentMethod: {
+        brand: "visa",
+        country: "US",
+        expMonth: 4,
+        expYear: 2024,
+        id: "pm_ABCDEF",
+        last4: "4242",
+      },
+    };
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Formik initialValues={initialValues} onSubmit={jest.fn()}>
+          <Elements stripe={stripePromise}>
+            <UserInfoForm setError={jest.fn()} />
+          </Elements>
+        </Formik>
+      </QueryClientProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+    fireEvent.change(screen.getByTestId("field-card-number"), {
+      target: { value: "1234 5678 1234 5678" },
+    });
+
+    expect(screen.getByTestId("customer-name")).toHaveTextContent("Min");
+    expect(screen.getByTestId("organisation-name")).toHaveTextContent(
+      "Canonical",
+    );
+    expect(screen.getByTestId("customer-address")).toHaveTextContent(
+      "ABC Street",
+    );
+    expect(screen.getByTestId("customer-city")).toHaveTextContent("DEF City");
+    expect(screen.getByTestId("customer-postal-code")).toHaveTextContent(
+      "AB12 3CD",
+    );
+  });
+
+  it("New channel users should be able to add their user info", () => {
+    global.window = Object.create(window);
+    Object.defineProperty(window, "accountId", { value: "ABCDEF" });
+
+    const initialValues = {
+      name: "Min",
+      marketplace: UserSubscriptionMarketplace.CanonicalProChannel,
+      buyingFor: "organisation",
+      organisationName: "",
+      address: "",
+      city: "",
+      postalCode: "",
+      defaultPaymentMethod: null,
+    };
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Formik initialValues={initialValues} onSubmit={jest.fn()}>
+          <Elements stripe={stripePromise}>
+            <UserInfoForm setError={jest.fn()} />
+          </Elements>
+        </Formik>
+      </QueryClientProvider>,
+    );
+    expect(
+      screen.queryByRole("button", { name: "Edit" }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("customer-name")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("organisation-name")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("customer-address")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("customer-city")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("customer-postal-code"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("user-info-save-button"),
+    ).not.toBeInTheDocument();
+
+    expect(screen.getByTestId("field-card-number")).toBeInTheDocument();
+    expect(screen.getByTestId("field-customer-name")).toBeInTheDocument();
+    expect(screen.getByTestId("field-org-name")).toBeInTheDocument();
+    expect(screen.getByTestId("field-address")).toBeInTheDocument();
+    expect(screen.getByTestId("field-city")).toBeInTheDocument();
+    expect(screen.getByTestId("field-post-code")).toBeInTheDocument();
   });
 });

--- a/static/js/src/advantage/subscribe/checkout/components/UserInfoForm/UserInfoForm.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/UserInfoForm/UserInfoForm.tsx
@@ -15,6 +15,7 @@ import registerPaymentMethod from "../../hooks/postCustomerInfo";
 import { FormValues } from "../../utils/types";
 import FormRow from "../FormRow";
 import PaymentMethodSummary from "./PaymentMethodSummary";
+import { UserSubscriptionMarketplace } from "advantage/api/enum";
 
 type Error = {
   type: "validation_error";
@@ -38,13 +39,14 @@ const UserInfoForm = ({ setError }: Props) => {
   } = useFormikContext<FormValues>();
   const queryClient = useQueryClient();
   const paymentMethodMutation = registerPaymentMethod();
-  const [isEditing, setIsEditing] = useState(
-    !window.accountId || !initialValues.defaultPaymentMethod,
-  );
+  const isNewUser = !window.accountId || !initialValues.defaultPaymentMethod;
+  const [isEditing, setIsEditing] = useState(isNewUser);
   const [isButtonDisabled, setIsButtonDisabled] = useState(false);
   const [cardFieldHasFocus, setCardFieldFocus] = useState(false);
   const [cardFieldError, setCardFieldError] = useState<Error | null>(null);
   const [showCardValidation, setShowCardValidation] = useState<boolean>(false);
+  const isChannelUser =
+    values.marketplace === UserSubscriptionMarketplace.CanonicalProChannel;
 
   const toggleEditing = () => {
     if (isEditing) {
@@ -144,10 +146,9 @@ const UserInfoForm = ({ setError }: Props) => {
     return errorMessage;
   };
 
-  const displayMode = (
+  const UserInfoSummary = () => (
     <>
-      <PaymentMethodSummary />
-      {values.buyingFor === "organisation" ? (
+      {values.buyingFor === "organisation" && (
         <>
           <Row>
             <Col size={4}>
@@ -163,7 +164,7 @@ const UserInfoForm = ({ setError }: Props) => {
           </Row>
           <hr />
         </>
-      ) : null}
+      )}
       <Row>
         <Col size={4}>
           <p>Your name:</p>
@@ -209,6 +210,13 @@ const UserInfoForm = ({ setError }: Props) => {
           </p>
         </Col>
       </Row>
+    </>
+  );
+
+  const displayMode = (
+    <>
+      <PaymentMethodSummary />
+      <UserInfoSummary />
     </>
   );
 
@@ -280,103 +288,116 @@ const UserInfoForm = ({ setError }: Props) => {
           }}
           required
           error={touched?.isCardValid && errors?.isCardValid}
+          data-testid="field-card-number"
         />
       </FormRow>
-      <Field
-        data-testid="field-customer-name"
-        as={Input}
-        type="text"
-        id="name"
-        name="name"
-        label="Name:"
-        stacked
-        validate={validateRequired}
-        error={touched?.name && errors?.name}
-      />
-      <FormRow label="I’m buying for:">
-        <div className="u-sv3 p-form p-form--inline" role="group">
-          <Field name="buyingFor">
-            {({ field }: any) => (
-              <>
-                <RadioInput
-                  {...field}
-                  id="myself"
-                  value="myself"
-                  checked={field.value === "myself"}
-                  onChange={() => setFieldValue("buyingFor", "myself")}
-                  label="Myself"
-                  disabled={window.accountId && initialValues.organisationName}
-                />
-                <RadioInput
-                  {...field}
-                  id="organisation"
-                  value="organisation"
-                  checked={field.value === "organisation"}
-                  onChange={() => setFieldValue("buyingFor", "organisation")}
-                  label="An organisation"
-                  disabled={window.accountId && initialValues.organisationName}
-                />
-              </>
-            )}
-          </Field>
-        </div>
-      </FormRow>
-      {initialValues.buyingFor === "myself" &&
-      window.accountId &&
-      initialValues.organisationName ? null : (
-        <Field
-          data-testid="field-org-name"
-          as={Input}
-          type="text"
-          id="organisationName"
-          name="organisationName"
-          disabled={
-            values.buyingFor === "myself" ||
-            (window.accountId && initialValues.organisationName)
-          }
-          label="Organisation:"
-          stacked
-          validate={validateOrganisationName}
-          error={
-            values.buyingFor === "organisation" &&
-            touched?.organisationName &&
-            errors?.organisationName
-          }
-        />
+      {isChannelUser && !isNewUser ? (
+        <UserInfoSummary />
+      ) : (
+        <>
+          <Field
+            data-testid="field-customer-name"
+            as={Input}
+            type="text"
+            id="name"
+            name="name"
+            label="Name:"
+            stacked
+            validate={validateRequired}
+            error={touched?.name && errors?.name}
+          />
+          <FormRow label="I'm buying for:">
+            <div className="u-sv3 p-form p-form--inline" role="group">
+              <Field name="buyingFor">
+                {({ field }: any) => (
+                  <>
+                    <RadioInput
+                      {...field}
+                      id="myself"
+                      value="myself"
+                      checked={field.value === "myself"}
+                      onChange={() => setFieldValue("buyingFor", "myself")}
+                      label="Myself"
+                      disabled={
+                        window.accountId && initialValues.organisationName
+                      }
+                    />
+                    <RadioInput
+                      {...field}
+                      id="organisation"
+                      value="organisation"
+                      checked={field.value === "organisation"}
+                      onChange={() =>
+                        setFieldValue("buyingFor", "organisation")
+                      }
+                      label="An organisation"
+                      disabled={
+                        window.accountId && initialValues.organisationName
+                      }
+                    />
+                  </>
+                )}
+              </Field>
+            </div>
+          </FormRow>
+          {initialValues.buyingFor === "myself" &&
+          window.accountId &&
+          initialValues.organisationName ? null : (
+            <Field
+              data-testid="field-org-name"
+              as={Input}
+              type="text"
+              id="organisationName"
+              name="organisationName"
+              disabled={
+                values.buyingFor === "myself" ||
+                (window.accountId && initialValues.organisationName)
+              }
+              label="Organisation:"
+              stacked
+              validate={validateOrganisationName}
+              error={
+                values.buyingFor === "organisation" &&
+                touched?.organisationName &&
+                errors?.organisationName
+              }
+            />
+          )}
+          <Field
+            data-testid="field-address"
+            as={Input}
+            type="text"
+            id="address"
+            name="address"
+            label="Address:"
+            stacked
+            validate={validateRequired}
+            error={touched?.address && errors?.address}
+          />
+          <Field
+            data-testid="field-city"
+            as={Input}
+            type="text"
+            id="city"
+            name="city"
+            label="City:"
+            stacked
+            validate={validateRequired}
+            error={touched?.city && errors?.city}
+          />
+          <Field
+            data-testid="field-post-code"
+            as={Input}
+            type="text"
+            id="postalCode"
+            name="postalCode"
+            label="Postal code:"
+            stacked
+            validate={validateRequired}
+            error={touched?.postalCode && errors?.postalCode}
+          />
+        </>
       )}
-      <Field
-        data-testid="field-address"
-        as={Input}
-        type="text"
-        id="address"
-        name="address"
-        label="Address:"
-        stacked
-        validate={validateRequired}
-        error={touched?.address && errors?.address}
-      />
-      <Field
-        data-testid="field-city"
-        as={Input}
-        type="text"
-        id="city"
-        name="city"
-        label="City:"
-        stacked
-        validate={validateRequired}
-        error={touched?.city && errors?.city}
-      />
-      <Field
-        data-testid="field-post-code"
-        as={Input}
-        type="text"
-        id="postalCode"
-        name="postalCode"
-        label="Postal code:"
-        stacked
-        validate={validateRequired}
-        error={touched?.postalCode && errors?.postalCode}
-      />
     </>
   );
 

--- a/static/js/src/advantage/subscribe/checkout/components/UserInfoForm/UserInfoForm.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/UserInfoForm/UserInfoForm.tsx
@@ -404,7 +404,7 @@ const UserInfoForm = ({ setError }: Props) => {
   return (
     <Row>
       {isEditing ? editMode : displayMode}
-      {window.accountId && initialValues.defaultPaymentMethod ? (
+      {window.accountId && initialValues.defaultPaymentMethod && (
         <>
           <Col size={4}></Col>
           <Col size={8}>
@@ -428,7 +428,7 @@ const UserInfoForm = ({ setError }: Props) => {
             className="u-align--right"
             style={{ marginTop: "calc(.5rem - 1.5px)" }}
           >
-            {isEditing ? (
+            {isEditing && (
               <ActionButton
                 onClick={() => {
                   setFieldValue("buyingFor", initialValues.buyingFor);
@@ -447,17 +447,18 @@ const UserInfoForm = ({ setError }: Props) => {
               >
                 Cancel
               </ActionButton>
-            ) : null}
+            )}
             <ActionButton
               onClick={toggleEditing}
               loading={isSubmitting}
               disabled={isButtonDisabled}
+              data-testid="user-info-save-button"
             >
               {isEditing ? "Save" : "Edit"}
             </ActionButton>
           </div>
         </>
-      ) : null}
+      )}
     </Row>
   );
 };

--- a/static/js/src/advantage/subscribe/checkout/utils/test/Mocks.ts
+++ b/static/js/src/advantage/subscribe/checkout/utils/test/Mocks.ts
@@ -152,7 +152,7 @@ export const BlenderProduct: Product = {
   canBeTrialled: false,
 };
 
-export const distributorProduct: ChannelProduct = {
+export const DistributorProduct: ChannelProduct = {
   id: "uai-essential-desktop-1y-channel-eur-v2",
   longId: "lANXjQ-H8fzvf_Ea8bIK1KW7Wi2W0VHnV0ZUsrEGbUiQ",
   name: "uai-essential-desktop-1y-channel-eur-v2",


### PR DESCRIPTION
## Done

-  Restrict channel users from editing billing information

## QA steps
**Pro shop & Credential users** 
1. Log in as Pro user (normal user)
2. Select products from the pro shop (/pro/subscribe)
3. Click the checkout button to land on the checkout page
4. On the check out page
- [x] If new user who hasn't made any purchases before: the Tax section and User Information section inputs will be displayed and allow users to edit the fields.
<img width="445" alt="image" src="https://github.com/user-attachments/assets/753202ab-2863-4a69-ad26-5ad6e5a351b0">

- [x] If the existing user who has made a purchase before, the Tax section and User Information section are in display mode. but they can still edit their fields by clicking the edit button. When in edit mode, all fields are available for editing.
<img width="394" alt="image" src="https://github.com/user-attachments/assets/16b9545a-26c9-49fd-b888-0f0cbbeba9ed">

7. Edit the information or save the information, and check the purchase is working properly.

**Distributor users**
1. Log in as a channel user (distributor user)
2. Go to /pro/distributor
3. Click the checkout button to land on the checkout page.
4.  On the check out page
- [x] New user: it works the same as for Pro Shop users
- [x] For existing users: the Tax section is restricted for editing, and only the card number is editable in the User Information section.
<img width="486" alt="image" src="https://github.com/user-attachments/assets/3d6304fc-403e-4b1d-9d4e-d8e7389923ae">

7. Edit the information or save the information, and check the purchase is working properly.

## Issue / Card

Fixes #https://warthogs.atlassian.net/browse/WD-16449
