### PR TITLE
Use modal form on iot/management

### DIFF
--- a/templates/internet-of-things/management.html
+++ b/templates/internet-of-things/management.html
@@ -35,7 +35,7 @@
 
     {%- if slot == 'cta' -%}
       <a href="/internet-of-things/contact-us?product=management"
-         class="p-button--positive">Get in touch</a>
+         class="p-button--positive js-invoke-modal">Get in touch</a>
       <a href="/engage/a-practical-guide-to-iot-lifecycle-management">Discover best practices to manage IoT devices&nbsp;&rsaquo;</a>
     {%- endif -%}
 
@@ -94,7 +94,7 @@
           </p>
           <hr class="p-rule--muted" />
           <p>
-            <a href="/internet-of-things/contact-us?product=management">Get in touch to discuss your device management needs&nbsp;&rsaquo;</a>
+            <a href="/internet-of-things/contact-us?product=management" class="js-invoke-modal">Get in touch to discuss your device management needs&nbsp;&rsaquo;</a>
           </p>
         </div>
       </div>
@@ -221,7 +221,7 @@
             We know that everyone’s needs are different. That’s why we have multiple solutions available for you to use to manage your devices.
           </p>
           <hr class="p-rule--muted" />
-          <a href="/internet-of-things/contact-us?product=management">Get in touch to discuss the best solution for you&nbsp;&rsaquo;</a>
+          <a href="/internet-of-things/contact-us?product=management" class="js-invoke-modal">Get in touch to discuss the best solution for you&nbsp;&rsaquo;</a>
         </div>
       {%- endif -%}
 
@@ -484,9 +484,18 @@
         </p>
         <hr class="p-rule--muted" />
         <a href="/internet-of-things/contact-us?product=management"
-           class="p-button--positive">Get in touch</a>
+           class="p-button--positive js-invoke-modal">Get in touch</a>
       </div>
     </div>
   </section>
+
+<!-- Set default Marketo information for contact form below-->
+<div class="u-hide"
+     id="contact-form-container"
+     data-form-location="/shared/forms/interactive/internet-of-things"
+     data-form-id="4296"
+     data-lp-id=""
+     data-return-url="/internet-of-things#success"
+     data-lp-url="https://pages.ubuntu.com/things-contact-us.html"></div>
 
 {% endblock content %}


### PR DESCRIPTION
## Done

- Use modal form on iot/management

## QA

- View the site in your web browser at: https://ubuntu-com-14548.demos.haus/internet-of-things/management
    - Be sure to test on mobile, tablet and desktop screen sizes
- Find the three contact buttons, namely `Get in touch`, `Get in touch to discuss your device management needs ›`, `Get in touch`
- First, with JavaScript enabled, click on the three buttons to see a contact form opening up in a modal.
- Secondly, with JavaScript disabled, click on the three buttons to get redirected to iot/contact-us static page.
- Submit both forms to verify form's successful submission.

## Issue / Card

Fixes #[17586](https://warthogs.atlassian.net/browse/WD-17586)
