### PR TITLE
prevent duplicate submissions for cred sign-up

### DIFF
--- a/templates/credentials/sign-up.html
+++ b/templates/credentials/sign-up.html
@@ -9,6 +9,15 @@
 {% endblock meta_copydoc %}
 
 {% block content %}
+  <script>
+    function getSubmitButton() {
+      return document.getElementById('formSubmitButton');
+    }
+
+    function disableSubmit() {
+      getSubmitButton().disabled = true;
+    }
+  </script>
   {% if error %}
     <div class="p-notification--negative">
       <div class="p-notification__content">

--- a/templates/shared/_credentials-signup-sme-form.html
+++ b/templates/shared/_credentials-signup-sme-form.html
@@ -795,6 +795,7 @@
   }
 
   function getCustomFields() {
+    disableSubmit();
     const nativeLanguage = document.getElementById("NativeLanguage");
     const jobTitle = document.getElementById("JobTitle");
 
@@ -845,7 +846,6 @@
       "ApplicationType": "Exam SME",
       "Country": country.value
     }
-    console.log(data);
 
     const textarea = document.getElementById("Comments_from_lead__c");
     textarea.value = JSON.stringify(data);

--- a/templates/shared/_credentials-signup-tester-form.html
+++ b/templates/shared/_credentials-signup-tester-form.html
@@ -768,6 +768,7 @@
   }
 
   function getCustomFields() {
+    disableSubmit();
     // disable submit button when form is submitted to stop duplicates
     document.getElementById("formSubmitButton").setAttribute("disabled", "true");
 
@@ -816,8 +817,6 @@
       "ApplicationType": "Exam Tester",
       "Country": country.value
     }
-
-    console.log(data);
 
     const textarea = document.getElementById("Comments_from_lead__c");
     textarea.value = JSON.stringify(data);


### PR DESCRIPTION
## Done

- Disables the submit button when the form gets submitted to prevent multiple clicks on the submit button

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to `credentials/sign-up?type=tester`
    - Fill out the form and submit it
        - The submit button should be disabled
    - Hit submit button without filling out all the required fields
        - Submit button should not get disabled and window should scroll to the first required element
- Repeat the above process for `credentials/sign-up?type=sme`

## Issue / Card

Fixes [WD-17571](https://warthogs.atlassian.net/browse/WD-17571)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-17571]: https://warthogs.atlassian.net/browse/WD-17571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ