### PR TITLE
update exam results table in dashboard

### DIFF
--- a/static/js/src/advantage/credentials/dashboard/components/ExamResults/ExamResults.tsx
+++ b/static/js/src/advantage/credentials/dashboard/components/ExamResults/ExamResults.tsx
@@ -103,6 +103,11 @@ const ExamResults = () => {
           ),
       },
       {
+        Header: "First Name",
+        accessor: "user.first_name",
+        sortType: "basic",
+      },
+      {
         Header: "User Email",
         accessor: "user_email",
         sortType: "basic",
@@ -295,6 +300,8 @@ const ExamResults = () => {
       {flatData && flatData?.length > 0 && (
         <>
           <ModularTable
+            initialSortColumn="completed_at"
+            initialSortDirection="descending"
             data={currentRows}
             columns={columns}
             sortable


### PR DESCRIPTION
## Done

- Show first name in the exam results table
- Sort completed at column by descending order by default

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to `credentials/dashboard/exams/results`
    - Confirm that there is a column with header **FIRST NAME**
    - Confirm that the column **COMPLETED AT** is sorted by descending order by default

## Issue / Card

Fixes [WD-17588](https://warthogs.atlassian.net/browse/WD-17588)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-17588]: https://warthogs.atlassian.net/browse/WD-17588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ