### PR TITLE
fix: Update chip buttons to anchor tags

### DIFF
--- a/templates/dell/index.html
+++ b/templates/dell/index.html
@@ -330,18 +330,15 @@
         <div>
           <h2>
             <a href="https://canonical.com/blog/canonical-and-dell-emc-provide-certified-production-ready-kubernetes-solution">Dell XPS 13 Plus Developer Edition
-              <br class="u-hide--medium u-hide--small" />
-            now certified with Ubuntu 22.04 LTS</a>
+              <br class="u-hide--medium u-hide--small" />now certified with Ubuntu 22.04 LTS</a>
           </h2>
           <p>
-            <button class="p-chip--information"
-                    onclick="location.href='/blog/tag/dell-xps'">
+            <a class="p-chip--information" href="/blog/tag/dell-xps">
               <span class="p-chip__value">Dell XPS</span>
-            </button>
-            <button class="p-chip--information"
-                    onclick="location.href='/blog/tag/ubuntu-desktop'">
+            </a>
+            <a class="p-chip--information" href="/blog/tag/ubuntu-desktop">
               <span class="p-chip__value">Ubuntu Desktop</span>
-            </button>
+            </a>
           </p>
         </div>
         <hr class="p-rule--muted u-fixed-width" style="margin-top: 4rem" />
@@ -352,14 +349,12 @@
             a proven solution</a>
           </h2>
           <p>
-            <button onclick="location.href='/blog/dell-emc-poweredge-and-canonical-charmed-ceph'"
-                    class="p-chip--information">
+            <a href="/blog/dell-emc-poweredge-and-canonical-charmed-ceph" class="p-chip--information">
               <span class="p-chip__value">Ceph</span>
-            </button>
-            <button onclick="location.href='/blog/tag/storage'"
-                    class="p-chip--information">
+            </a>
+            <a href="/blog/tag/storage" class="p-chip--information">
               <span class="p-chip__value">Storage</span>
-            </button>
+            </a>
           </p>
         </div>
         <hr class="p-rule--muted u-fixed-width" style="margin-top: 4rem" />
@@ -370,14 +365,13 @@
             production-ready Kubernetes solution</a>
           </h2>
           <p>
-            <button onclick="location.href='https://canonical.com/blog/canonical-and-dell-emc-provide-certified-production-ready-kubernetes-solution'"
-                    class="p-chip--information">
+            <a href="https://canonical.com/blog/canonical-and-dell-emc-provide-certified-production-ready-kubernetes-solution" class="p-chip--information">
               <span class="p-chip__value">Charmed Kubernetes</span>
-            </button>
-            <button onclick="location.href='https://canonical.com/blog/tag/kubernetes'"
+            </a>
+            <a href="https://canonical.com/blog/tag/kubernetes"
                     class="p-chip--information">
               <span class="p-chip__value">Kubernetes</span>
-            </button>
+            </a>
           </p>
         </div>
       </div>

--- a/templates/hpe/index.html
+++ b/templates/hpe/index.html
@@ -505,19 +505,19 @@
               </h2>
               <p>
                 {% if 4307 in article.tags %}
-                  <button class="p-chip--information" onclick="location.href='/blog/tag/hpe'">
+                  <a class="p-chip--information" href="/blog/tag/hpe">
                     <span class="p-chip__value">HPE</span>
-                  </button>
+                  </a>
                 {% endif %}
                 {% if 1419 in article.tags %}
-                  <button class="p-chip--information" onclick="location.href='/blog/tag/event'">
+                  <a class="p-chip--information" href="/blog/tag/event">
                     <span class="p-chip__value">Event</span>
-                  </button>
+                  </a>
                 {% endif %}
                 {% if 1377 in article.tags %}
-                  <button class="p-chip--information" onclick="location.href='/blog/tag/telco'">
+                  <a class="p-chip--information" href="/blog/tag/telco">
                     <span class="p-chip__value">Telco</span>
-                  </button>
+                  </a>
                 {% endif %}
               </p>
             </div>

--- a/templates/supermicro/index.html
+++ b/templates/supermicro/index.html
@@ -306,10 +306,9 @@
               <p>
                 <a href="/blog/{{ article.slug }}">{{ article.title.rendered | safe }}</a>
               </p>
-              <button class="p-chip--information"
-                      onclick="location.href='/blog/tag/supermicro'">
+              <a class="p-chip--information" href="/blog/tag/supermicro">
                 <span class="p-chip__value">Supermicro</span>
-              </button>
+              </a>
             </div>
             {% if loop.index < 3 %}<hr class="p-rule" />{% endif %}
           {% endif %}


### PR DESCRIPTION
## Done

- Update chip buttons to anchor tags for a11y

## QA

- Go to https://ubuntu-com-14551.demos.haus/dell, https://ubuntu-com-14551.demos.haus/hpe, https://ubuntu-com-14551.demos.haus/supermicro
- Scroll to find chip tags
- Click on them and check that they redirect as expected

## Issue / Card

Fixes [WD-17631](https://warthogs.atlassian.net/browse/WD-17631) and https://github.com/canonical/ubuntu.com/issues/12660

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-17631]: https://warthogs.atlassian.net/browse/WD-17631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ