### PR TITLE
fix: update footer to span full width

### DIFF
--- a/templates/templates/small-footer.html
+++ b/templates/templates/small-footer.html
@@ -1,9 +1,7 @@
 <div class="p-footer p-strip">
   <div class="u-fixed-width">
     <div class="p-footer--secondary row">
-      <div class="col-7">
-        {% include "templates/_footer-copyright-and-legal.html" %}
-      </div>
+      {% include "templates/_footer-copyright-and-legal.html" %}
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Done
- Update footer to span full width

## QA

- Go to a tutorial page, e.g https://ubuntu-com-14557.demos.haus/tutorials/build-your-cloudformation-templates-with-the-latest-ubuntu-ami#1-overview
- Scroll down to footer
- Check that footer spans throughout the page

## Issue / Card

Fixes [WD-17657](https://warthogs.atlassian.net/browse/WD-17657)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-17657]: https://warthogs.atlassian.net/browse/WD-17657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ