### PR TITLE
fix: update broken Ubuntu Pro discourse links

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -317,7 +317,7 @@ support:
     - title: Pricing
       path: /pricing/pro
     - title: Discourse
-      path: https://discourse.ubuntu.com/c/ubuntu-pro
+      path: https://discourse.ubuntu.com/c/project/ubuntu-pro/116/
 
 pro:
   title: Ubuntu Pro
@@ -335,7 +335,7 @@ pro:
     - title: Docs
       path: https://documentation.ubuntu.com/pro
     - title: Discourse
-      path: https://discourse.ubuntu.com/c/ubuntu-pro
+      path: https://discourse.ubuntu.com/c/project/ubuntu-pro/116/
 
 Distributor:
   title: Ubuntu Pro Distributor

--- a/templates/pro/thank-you.html
+++ b/templates/pro/thank-you.html
@@ -11,7 +11,7 @@
       <div class="col-7">
         <p class="p-heading--4">Your request has been received. We will be in touch with you as soon as possible.</p>
 
-        <p>Questions? <a href="https://discourse.ubuntu.com/c/ubuntu-pro/">Visit our Discourse channel</a>.</p>
+        <p>Questions? <a href="https://discourse.ubuntu.com/c/project/ubuntu-pro/116/">Visit our Discourse channel</a>.</p>
       </div>
     </div>
   </div>

--- a/templates/pro/thank-you.html
+++ b/templates/pro/thank-you.html
@@ -3,7 +3,7 @@
 {% block title %}Thank you{% endblock %}
 {% block canonical_url %}https://ubuntu.com/pro{% endblock %}
 {% block meta_copydoc %}https://docs.google.com/document/d/1cVWrayrMBp8-GF1nP-V1M88WSB09KMkJqbyN0aWlHC4/edit{% endblock meta_copydoc %}
-{% block head_extra%}<meta name="robots" content="noindex" />{% endblock %}
+{% block head_extra %}<meta name="robots" content="noindex" />{% endblock %}
 
 {% block content %}
   <div class="p-strip is-bordered is-deep">

--- a/templates/pro/tutorial.html
+++ b/templates/pro/tutorial.html
@@ -460,7 +460,7 @@ Subscription: Ubuntu Pro - free personal subscription</pre>
       <h3 class="p-heading--5">Next steps:</h3>
 
       <p>
-        Still hungry to learn more about Ubuntu Pro? <a href="/contact-us/form?product=pro">Talk to the Canonical team</a> or head on over to <a href="https://discourse.ubuntu.com/c/ubuntu-pro/">Ubuntu Pro Discourse</a>.
+        Still hungry to learn more about Ubuntu Pro? <a href="/contact-us/form?product=pro">Talk to the Canonical team</a> or head on over to <a href="https://discourse.ubuntu.com/c/project/ubuntu-pro/116/">Ubuntu Pro Discourse</a>.
       </p>
     </div>
   </div>

--- a/templates/shared/forms/interactive/advantage-beta.html
+++ b/templates/shared/forms/interactive/advantage-beta.html
@@ -97,7 +97,7 @@
         <div class="col-7">
           <h3 class="p-heading--2">Thank you</h3>
           <p>Your request has been received. We will be in touch with you as soon as possible. </p>
-          <p>Questions? Visit our <a href="https://discourse.ubuntu.com/c/ubuntu-pro/">discourse channel</a></p>
+          <p>Questions? Visit our <a href="https://discourse.ubuntu.com/c/project/ubuntu-pro/116/">discourse channel</a></p>
         </div>
         <div class="col-5 u-vertically-center u-hide--medium u-hide--small u-align--center">
           {{

--- a/templates/shared/forms/interactive/advantage-beta.html
+++ b/templates/shared/forms/interactive/advantage-beta.html
@@ -2,7 +2,7 @@
   <div class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
     <header class="p-modal__header" style="display: block; border-bottom: 0;">
       <button class="p-modal__close js-close" aria-label="Close active modal" style="margin-left: -1rem">Close</button>
-      <h2 class="p-modal__title  u-sv1" id="modal-title">Ubuntu Pro<br><span class="u-text--muted">Free trial for Ubuntu Advantage for Infrastructure customers</span></h2>
+      <h2 class="p-modal__title  u-sv1" id="modal-title">Ubuntu Pro<br /><span class="u-text--muted">Free trial for Ubuntu Advantage for Infrastructure customers</span></h2>
     </header>
 
     <div class="js-pagination js-pagination--1">
@@ -41,7 +41,7 @@
               </li>
               <li class="p-list__item">
                 <label class="p-checkbox">
-                  <input class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
+                  <input class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
                   <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
                 </label>
               </li>
@@ -79,7 +79,7 @@
               <input type="hidden" aria-hidden="true" aria-label="hidden field" id="preferredLanguage" name="preferredLanguage" maxlength="255" value="" />
               <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
               {% if user_info %}
-                <input type="hidden" id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" value="{{ user_info.email }}" />
+                <input type="hidden" id="email" name="email" maxlength="255" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" value="{{ user_info.email }}" />
               {% endif %}
             </div>
 

--- a/templates/shared/forms/interactive/pro-devices.html
+++ b/templates/shared/forms/interactive/pro-devices.html
@@ -230,7 +230,7 @@
           <h3 class="p-heading--2">Thank you</h3>
           <p>Your request has been received. We will be in touch with you as soon as possible.</p>
           <p>
-            Questions? Visit our <a href="https://discourse.ubuntu.com/c/ubuntu-pro/">discourse channel</a>
+            Questions? Visit our <a href="https://discourse.ubuntu.com/c/project/ubuntu-pro/116">discourse channel</a>
           </p>
         </div>
         <div class="col-5 u-vertically-center u-hide--medium u-hide--small u-align--center">


### PR DESCRIPTION
## Done

- Reported by failing links on live check https://github.com/canonical/ubuntu.com/actions/runs/12271620104/job/34238813073
- Updated all occurrences of https://discourse.ubuntu.com/c/ubuntu-pro to https://discourse.ubuntu.com/c/project/ubuntu-pro/116

## QA

- Go to https://ubuntu-com-14558.demos.haus/
- Check that affected pages link to the Discourse forum
- Check that the nav on https://ubuntu-com-14558.demos.haus/pro links to the Discourse forum

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
