### PR TITLE
Fix summarised status copy for CVEs that affect a single package

### DIFF
--- a/templates/security/cves/_cve-card.html
+++ b/templates/security/cves/_cve-card.html
@@ -50,7 +50,7 @@
         <p>{{ cve.description|truncate(235) }}</p>
       </div>
       <div class="cve-summary col-3 col-medium-2">
-        <p class="p-text--small-caps u-text--muted u-no-margin--top">{{ cve.packages | length }} affected packages</p>
+        <p class="p-text--small-caps u-text--muted u-no-margin--top">{{ cve.packages | length }} affected package{% if cve.packages | length > 1 %}s{% endif %}</p>
         <p class="u-text--muted">
           {% for package in cve.packages %}
             {% if cve.packages | length > 6 %}


### PR DESCRIPTION
## Done

"Affected package" (singular) for CVEs that affect a simple package

[Demo](https://ubuntu-com-14561.demos.haus/security/cves?version=noble&version=jammy&version=focal&version=bionic&version=xenial&version=trusty&version=oracular&offset=10)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Screenshots

Currently:

![Screenshot 2024-12-11 at 16 30 23](https://github.com/user-attachments/assets/df1a39b6-01f2-4154-9095-bdbe5e63c4ad)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
