### PR TITLE
feat: update links on /download/amd

### DIFF
--- a/templates/download/amd/tab-1.html
+++ b/templates/download/amd/tab-1.html
@@ -41,14 +41,14 @@
             This Ubuntu version is working on K26 SOMs as well.
           </p>
         </div>
-      </div>      
+      </div>
       {% include "download/amd/_wiki_notification.html" %}
       <p>
         <a class="p-button--positive"
            href="https://people.canonical.com/~platform/images/xilinx/kria-ubuntu-24.04/iot-limerick-kria-classic-server-2404-classic-24.04-x05-20241114.img.xz">Download 24.04</a>
       </p>
       <p>
-        <a href="https://www.amd.com/KD240-Start">Kria&trade; KD240 Getting Started Guide for Ubuntu 24.04</a>
+        <a href="https://xilinx.github.io/kria-apps-docs/kd240/linux_boot.html">Kria&trade; KD240 Getting Started Guide for Ubuntu</a>
       </p>
     </div>
   </div>

--- a/templates/download/amd/tab-2.html
+++ b/templates/download/amd/tab-2.html
@@ -46,17 +46,17 @@
             This Ubuntu version is working on K24 SOMs as well.
           </p>
         </div>
-      </div>   
+      </div>
       {% include "download/amd/_wiki_notification.html" %}
       <p>
         <a class="p-button--positive"
            href="https://people.canonical.com/~platform/images/xilinx/kria-ubuntu-24.04/iot-limerick-kria-classic-server-2404-classic-24.04-x05-20241114.img.xz">Download 24.04</a>
       </p>
       <p>
-        <a href="https://www.amd.com/KR260-Start">Kria&trade; KR260 Getting Started Guide for Ubuntu 24.04</a>
+        <a href="https://xilinx.github.io/kria-apps-docs/kr260/linux_boot.html">Kria&trade; KR260 Getting Started Guide for Ubuntu</a>
       </p>
       <p>
-        <a href="https://www.amd.com/KV260-Start">Kria&trade; KV260 Getting Started Guide for Ubuntu 24.04</a>
+        <a href="https://xilinx.github.io/kria-apps-docs/kv260/linux_boot.html">Kria&trade; KV260 Getting Started Guide for Ubuntu</a>
       </p>
     </div>
   </div>
@@ -124,10 +124,10 @@
         </a>
       </p>
       <p>
-        <a href="https://www.xilinx.com/kr260-start">Kria&trade; KR260 Getting Started Guide for Ubuntu 22.04</a>
+        <a href="https://xilinx.github.io/kria-apps-docs/kr260/linux_boot.html">Kria&trade; KR260 Getting Started Guide for Ubuntu</a>
       </p>
       <p>
-        <a href="https://www.xilinx.com/kv260-start">Kria&trade; KV260 Getting Started Guide for Ubuntu 22.04</a>
+        <a href="https://xilinx.github.io/kria-apps-docs/kv260/linux_boot.html">Kria&trade; KV260 Getting Started Guide for Ubuntu</a>
       </p>
     </div>
   </div>


### PR DESCRIPTION
## Done

- update links on /download/amd
https://docs.google.com/document/d/1cxQnEErs8FZ3dZ_IhlfcaJ03gE_vrMJfRC-5me9IDd4/edit?tab=t.0

## QA

- Go to [/download/amd](https://ubuntu-com-14563.demos.haus/download/amd)
- Check that the links have changed as per the copy doc updates.

## Issue / Card

https://warthogs.atlassian.net/browse/WD-17707


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
