### PR TITLE
bug: Fix issue where 'is-loading' class was not removed from loaded takeovers

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -1266,7 +1266,6 @@
         xhr.send();
         fetchUserCountry.open("GET", "/user-country.json", true);
         fetchUserCountry.send();
-        takeoverAnimation.className += " is-loading";
       }
 
       function showTakeover(takeovers, index) {
@@ -1319,6 +1318,7 @@
 
         image.src = selectedTakeover.image;
         image.onload = function() {
+          console.log("image loaded")
           // Remove animation delay
           if (takeoverAnimation) {
             takeoverAnimation.className = takeoverAnimation.className.replace(" is-loading", "");

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -1318,7 +1318,6 @@
 
         image.src = selectedTakeover.image;
         image.onload = function() {
-          console.log("image loaded")
           // Remove animation delay
           if (takeoverAnimation) {
             takeoverAnimation.className = takeoverAnimation.className.replace(" is-loading", "");


### PR DESCRIPTION
## Done

- Removes a line of code that was assigning 'is-loading' after the rest of the code had executed leading to a visual bug

## QA

- Open [the demo](https://ubuntu-com-14566.demos.haus/)
- See that the takeover shows on _all_ screen sizes

## Issue / Card

Fixes [Bug reported here](https://chat.canonical.com/canonical/pl/d3c7sde8b38xbq6oa6jzrbjjdo)
