### PR TITLE
Rate limit marketo endpoint

### DIFF
--- a/webapp/decorators.py
+++ b/webapp/decorators.py
@@ -1,8 +1,12 @@
 # Core packages
 import functools
+import json
+from datetime import datetime, timedelta
+from typing import Callable
 
 # Third party packages
 import flask
+
 from webapp.login import user_info
 
 
@@ -20,3 +24,49 @@ def login_required(func):
         return func(*args, **kwargs)
 
     return is_user_logged_in
+
+
+def rate_limit_with_backoff(func: Callable):
+    """
+    Decorator to rate limit function calls based on the users' session.
+    The rate limit restricts users to:
+    - 1 request every 2 seconds
+    - 2 request every 4 seconds
+    - 3 request every 8 seconds
+    """
+    rate_limit_attempt_map = {
+        1: timedelta(seconds=2),
+        2: timedelta(seconds=4),
+        3: timedelta(seconds=8),
+    }
+    ATTEMPT_LIMIT = 3
+
+    @functools.wraps(func)
+    def rate_limited(*args, **kwargs):
+        # Get the initial request timestamp, or update the session with the
+        # timestamp from the most recent successful request
+        if initial_request := json.loads(flask.session.get(func.__name__)):
+            # Get the current limit
+            current_limit = rate_limit_attempt_map.get(initial_request["attempts"])
+
+            time_since_last_request = datetime.now() - datetime.fromtimestamp(
+                initial_request["timestamp"]
+            )
+            # Abort if the time is too early for this number of attempts
+            if time_since_last_request.total_seconds() < current_limit.total_seconds():
+                # Increment the number of attempts. 3 is a hard upper limit.
+                if initial_request["attempts"] < ATTEMPT_LIMIT:
+                    initial_request["attempts"] += 1
+                    flask.session[func.__name__] = json.dumps(
+                        initial_request["attempts"]
+                    )
+
+                return flask.abort(429)
+
+        # Set values for a successful request
+        flask.session[func.__name__] = json.dumps(
+            {"timestamp": datetime.now().timestamp(), "attempts": 1}
+        )
+        return func(*args, **kwargs)
+
+    return rate_limited

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -1,35 +1,35 @@
 # Standard library
 import datetime
 import html
+import json
 import math
 import os
 import re
-import json
+from urllib.parse import quote
 
 # Packages
 import dateutil
 import feedparser
 import flask
+import jinja2
 import talisker.requests
 import yaml
-import jinja2
-from ubuntu_release_info.data import Data
+from bs4 import BeautifulSoup
+from canonicalwebteam.discourse import (
+    DiscourseAPI,
+    DocParser,
+    Docs,
+)
+from canonicalwebteam.search.models import get_search_results
+from canonicalwebteam.search.views import NoAPIKeyError
 from geolite2 import geolite2
 from requests import Session
 from requests.exceptions import HTTPError
-from urllib.parse import quote
-
-from canonicalwebteam.search.models import get_search_results
-from canonicalwebteam.search.views import NoAPIKeyError
-from bs4 import BeautifulSoup
+from ubuntu_release_info.data import Data
 from werkzeug.exceptions import BadRequest
-from canonicalwebteam.discourse import (
-    DiscourseAPI,
-    Docs,
-    DocParser,
-)
 
 # Local
+from webapp.decorators import rate_limit_with_backoff
 from webapp.login import user_info
 from webapp.marketo import MarketoAPI
 
@@ -898,7 +898,7 @@ def shorten_acquisition_url(acquisition_url):
         return new_acquisition_url
     return acquisition_url
 
-
+@rate_limit_with_backoff
 def marketo_submit():
     form_fields = {}
     for key in flask.request.form:


### PR DESCRIPTION
## Done

- Added rate limiting to the marketo endpoint

## QA

- Fill out a marketo form and submit twice in intervals of 2s, 4s and 8s. The request should return a 429 error. 
- Wait for another 8s and make another request, This one should pass through.

## Issue / Card

Fixes [WD-15861](https://warthogs.atlassian.net/browse/WD-15861?atlOrigin=eyJpIjoiODM1NzgwNmM3NzczNGYyZGEzYTZlMWUyNmE3NjU2MDMiLCJwIjoiaiJ9)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
