### PR TITLE
WD-17783  smart-home modal form - removed pagination + conversion to single page

### DIFF
--- a/templates/shared/forms/interactive/smart-home.html
+++ b/templates/shared/forms/interactive/smart-home.html
@@ -1,169 +1,333 @@
 <div class="p-modal" id="contact-modal">
-  <div class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
-    <header class="p-modal__header" style="display: block; border-bottom: 0;">
-      <button class="p-modal__close" aria-label="Close active modal" style="margin-left: -1rem">Close</button>
-      <h2 class="p-modal__title u-sv1" id="modal-title">Let's get your device to market faster</h2>
+  <div class="p-modal__dialog is-wide-modal"
+       role="dialog"
+       aria-labelledby="modal-title"
+       aria-describedby="modal-description">
+    <header class="p-modal__header" style="border-bottom: 0;">
+      <button class="p-modal__close"
+              aria-label="Close active modal"
+              style="margin-left: -1rem">Close</button>
     </header>
-    <div class="js-pagination js-pagination--1">
-      <p id="modal-description" class="u-no-max-width">Canonical partners with silicon companies, board manufacturers and ODMs to help you bring smart devices to market faster. Tell us about your project so we can bring the right team to the conversation.</p>
 
-      <div class="js-formfield">
-        <h3 class="p-heading--5">Are you interested in custom Hardware Enablement and Certification?</h3>
-        <div class="row u-no-padding">
-          <div class="col-4 u-sv3">
-            <label class="p-radio">
-              <input class="p-radio__input" type="radio" aria-labelledby="hardware-enablement-yes" name="hardware-enablement" value="Yes">
-              <span class="p-radio__label" id="hardware-enablement-yes">Yes</span>
+    <div class="p-section">
+      <div class="row--50-50">
+        <div class="col">
+          <h1 id="modal-title">Let's get your device to market faster!</h1>
+        </div>
+        <div class="col-5">
+          <p id="modal-description">
+            Canonical partners with silicon companies, board manufacturers and ODMs to help you bring smart devices to market faster. Tell us about your project so we can bring the right team to the conversation.
+          </p>
+        </div>
+      </div>
+    </div>
+    <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%">
+      <div class="p-section">
+        <hr class="p-rule is-fixed-width" />
+        <div class="row--50-50 js-formfield">
+          <div class="col">
+            <label class="p-heading--4 js-formfield-title is-required">
+              Are you interested in custom
+              <br />
+              Hardware Enablement and Certification?
             </label>
           </div>
-          <div class="col-5 u-sv3">
+          <div class="col">
             <label class="p-radio">
-              <input class="p-radio__input" type="radio" aria-labelledby="hardware-enablement-no" name="hardware-enablement" value="No">
+              <input class="p-radio__input"
+                     type="radio"
+                     aria-labelledby="hardware-enablement-yes"
+                     name="hardware-enablement"
+                     value="Yes" />
+              <span class="p-radio__label" id="hardware-enablement-yes">Yes</span>
+            </label>
+            <label class="p-radio">
+              <input class="p-radio__input"
+                     type="radio"
+                     aria-labelledby="hardware-enablement-no"
+                     name="hardware-enablement"
+                     value="No" />
               <span class="p-radio__label" id="hardware-enablement-no">No</span>
             </label>
           </div>
         </div>
       </div>
 
-      <div class="js-formfield">
-        <h3 class="p-heading--5">Do you want to learn more about Brand Store and our management solution to deploy software?</h3>
-        <div class="row u-no-padding">
-          <div class="col-4 u-sv3">
-            <label class="p-radio">
-              <input class="p-radio__input" type="radio" aria-labelledby="brand-store-learn-more-yes" name="brand-store-learn-more" value="Yes">
-              <span class="p-radio__label" id="brand-store-learn-more-yes">Yes</span>
+      <div class="p-section">
+        <hr class="p-rule is-fixed-width" />
+        <div class="row--50-50 js-formfield">
+          <div class="col">
+            <label class="p-heading--4 js-formfield-title is-required">
+              Do you want to learn more about Brand Store
+              <br />
+              and our management solution to deploy software?
             </label>
           </div>
-          <div class="col-5 u-sv3">
+          <div class="col">
             <label class="p-radio">
-              <input class="p-radio__input" type="radio" aria-labelledby="brand-store-learn-more-no" name="brand-store-learn-more" value="No">
+              <input class="p-radio__input"
+                     type="radio"
+                     aria-labelledby="brand-store-learn-more-yes"
+                     name="brand-store-learn-more"
+                     value="Yes" />
+              <span class="p-radio__label" id="brand-store-learn-more-yes">Yes</span>
+            </label>
+            <label class="p-radio">
+              <input class="p-radio__input"
+                     type="radio"
+                     aria-labelledby="brand-store-learn-more-no"
+                     name="brand-store-learn-more"
+                     value="No" />
               <span class="p-radio__label" id="brand-store-learn-more-no">No</span>
             </label>
           </div>
         </div>
       </div>
 
-      <div class="js-formfield">
-        <h3 class="p-heading--5">Do you need support getting to market?</h3>
-        <div class="row u-no-padding">
-          <div class="col-4 u-sv3">
+      <div class="p-section">
+        <hr class="p-rule is-fixed-width" />
+        <div class="row--50-50 js-formfield">
+          <div class="col">
+            <label class="p-heading--4 js-formfield-title is-required">Do you need support getting to market?</label>
+          </div>
+          <div class="col">
             <label class="p-radio">
-              <input class="p-radio__input" type="radio" aria-labelledby="get-to-market-support-yes" name="get-to-market-support" value="Yes">
+              <input class="p-radio__input"
+                     type="radio"
+                     aria-labelledby="get-to-market-support-yes"
+                     name="get-to-market-support"
+                     value="Yes" />
               <span class="p-radio__label" id="get-to-market-support-yes">Yes</span>
             </label>
-          </div>
-          <div class="col-5 u-sv3">
             <label class="p-radio">
-              <input class="p-radio__input" type="radio" aria-labelledby="get-to-market-support-no" name="get-to-market-support" value="No">
+              <input class="p-radio__input"
+                     type="radio"
+                     aria-labelledby="get-to-market-support-no"
+                     name="get-to-market-support"
+                     value="No" />
               <span class="p-radio__label" id="get-to-market-support-no">No</span>
             </label>
           </div>
         </div>
       </div>
 
-      <div class="u-sv3 js-formfield">
-        <h3 class="p-heading--5">What can we help you with?</h3>
-        <textarea id="open-question" name="open-question" aria-label="What can we help you with?" placeholder="What types of devices are you considering bringing to market?" rows="3"></textarea>
-      </div>
-
-      <div class="pagination">
-        <a class="p-button--positive pagination__link--next" href="">Next</a>
-      </div>
-    </div>
-
-    <div class="js-pagination js-pagination--2 u-hide">
-      <h3 class="p-heading--5">How should we get in touch?</h3>
-      <div class="row u-no-padding">
-        <div class="col-6">
-          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
-            <ul class="p-list">
-              <li class="p-list__item">
-                <label for="firstName">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
-              </li>
-              <li class="p-list__item">
-                <label for="lastName">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
-              </li>
-              <li class="p-list__item">
-                <label for="email">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
-              </li>
-              <li class="p-list__item">
-                <label for="phone">Mobile/cell phone number:</label>
-                <input id="phone" name="phone" maxlength="255" type="tel" required="required" />
-              </li>
-              <li class="p-list__item">
-                <label class="p-checkbox">
-                  <input class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
-                  <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
-                </label>
-              </li>
-              <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
-              {# These are honey pot fields to catch bots #}
-              <li class="u-off-screen">
-                <label class="website" for="website">Website:</label>
-                <input name="website" type="text" class="website" autocomplete="off" value="" id="website" tabindex="-1" />
-              </li>
-              <li class="u-off-screen">
-                <label class="name" for="name">Name:</label>
-                <input name="name" type="text" class="name" autocomplete="off" value="" id="name" tabindex="-1" />
-              </li>
-              {# End of honey pots #}
-            </ul>
-
-            <div class="u-hide">
-              <h3>Your comments</h3>
-              <ul class="p-list">
-                <li class="p-list__item">
-                  <label for="Comments_from_lead__c">What would you like to talk to us about?</label>
-                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
-                </li>
-              </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Facebook_Click_ID__c" id="Facebook_Click_ID__c" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" id="preferredLanguage" name="preferredLanguage" maxlength="255" value="" />
-            </div>
-
-            <div class="pagination">
-              <a class="pagination__link--previous p-button" href="">Previous</a>
-              <button type="submit" class="pagination__link--next p-button--positive" aria-label="Submit">Let's discuss</button>
-            </div>
-          </form>
+      <div class="p-section">
+        <hr class="p-rule is-fixed-width" />
+        <div class="row--50-50 js-formfield">
+          <div class="col">
+            <label for="about-project" class="p-heading--4 js-formfield-title">Anything else you would like to tell us?</label>
+          </div>
+          <div class="col">
+            <textarea id="open-question"
+                      name="open-question"
+                      aria-label="What can we help you with?"
+                      placeholder="What types of devices are you considering bringing to market?"
+                      rows="5"></textarea>
+          </div>
         </div>
       </div>
-    </div>
 
-    <div class="js-pagination js-pagination--3 u-hide">
+      <div class="p-section">
+        <hr class="p-rule is-fixed-width" />
+        <fieldset class="p-fieldset-section js-formfield"
+                  id="about-you"
+                  aria-labelledby="about-you-legend">
+          <div class="row--50-50">
+            <div class="col">
+              <legend class="p-heading--4" id="about-you-legend">How should we get in touch?</legend>
+            </div>
+            <div class="col">
+              <ul class="p-list">
+                <li class="p-list__item">
+                  <label class="is-required" for="firstName">First name:</label>
+                  <input required id="firstName" name="firstName" maxlength="255" type="text" />
+                </li>
+                <li class="p-list__item">
+                  <label class="is-required" for="lastName">Last name:</label>
+                  <input required id="lastName" name="lastName" maxlength="255" type="text" />
+                </li>
+                <li class="p-list__item">
+                  <label for="company">Company:</label>
+                  <input id="company" name="company" maxlength="255" type="text" />
+                </li>
+                <li class="p-list__item">
+                  <label for="title">Job title:</label>
+                  <input id="title" name="title" maxlength="255" type="text" />
+                </li>
+                <li class="p-list__item">
+                  <label class="is-required" for="email">Email address:</label>
+                  <input required
+                         id="email"
+                         name="email"
+                         maxlength="255"
+                         type="email"
+                         pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
+                </li>
+                <li class="p-list__item">
+                  <label class="is-required" for="phone">Mobile/cell phone number:</label>
+                  <input required id="phone" name="phone" maxlength="255" type="tel" />
+                </li>
+                <!-- country -->
+                {% include "shared/forms/_country.html" %}
+              </ul>
+              <ul class="p-list">
+                <li class="p-list__item">
+                  <label class="p-checkbox">
+                    <input class="p-checkbox__input"
+                           value="yes"
+                           checked
+                           aria-labelledby="canonicalUpdatesOptIn"
+                           name="canonicalUpdatesOptIn"
+                           type="checkbox" />
+                    <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
+                  </label>
+                </li>
+                <li class="p-list__item u-sv3">
+                  By submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.
+                </li>
+                {# These are honey pot fields to catch bots #}
+                <li class="u-off-screen">
+                  <label class="website" for="website">Website:</label>
+                  <input name="website"
+                         type="text"
+                         class="website"
+                         autocomplete="off"
+                         value=""
+                         id="website"
+                         tabindex="-1" />
+                </li>
+                <li class="u-off-screen">
+                  <label class="name" for="name">Name:</label>
+                  <input name="name"
+                         type="text"
+                         class="name"
+                         autocomplete="off"
+                         value=""
+                         id="name"
+                         tabindex="-1" />
+                </li>
+                {# End of honey pots #}
+                <li class="p-list__item">
+                  <button type="submit" class="p-button--positive js-submit-button">Submit</button>
+                </li>
+              </ul>
+              <div class="u-off-screen">
+                <label for="Comments_from_lead__c">
+                  <h3 class="p-heading--4">Your comments</h3>
+                  <textarea id="Comments_from_lead__c"
+                            name="Comments_from_lead__c"
+                            rows="5"
+                            maxlength="2000"></textarea>
+                </label>
+              </div>
+              <input type="hidden"
+                     aria-hidden="true"
+                     aria-label="hidden field"
+                     name="formid"
+                     value="%% formid %%" />
+              <input type="hidden"
+                     aria-hidden="true"
+                     aria-label="hidden field"
+                     name="returnURL"
+                     value="%% returnURL %%" />
+              <input type="hidden"
+                     aria-hidden="true"
+                     aria-label="hidden field"
+                     name="Consent_to_Processing__c"
+                     value="yes" />
+              <input type="hidden"
+                     aria-hidden="true"
+                     aria-label="hidden field"
+                     name="utm_campaign"
+                     id="utm_campaign"
+                     value="" />
+              <input type="hidden"
+                     aria-hidden="true"
+                     aria-label="hidden field"
+                     name="utm_medium"
+                     id="utm_medium"
+                     value="" />
+              <input type="hidden"
+                     aria-hidden="true"
+                     aria-label="hidden field"
+                     name="utm_source"
+                     id="utm_source"
+                     value="" />
+              <input type="hidden"
+                     aria-hidden="true"
+                     aria-label="hidden field"
+                     name="utm_content"
+                     id="utm_content"
+                     value="" />
+              <input type="hidden"
+                     aria-hidden="true"
+                     aria-label="hidden field"
+                     name="utm_term"
+                     id="utm_term"
+                     value="" />
+              <input type="hidden"
+                     aria-hidden="true"
+                     aria-label="hidden field"
+                     name="GCLID__c"
+                     id="GCLID__c"
+                     value="" />
+              <input type="hidden"
+                     aria-hidden="true"
+                     aria-label="hidden field"
+                     name="Facebook_Click_ID__c"
+                     id="Facebook_Click_ID__c"
+                     value="" />
+              <input type="hidden"
+                     aria-hidden="true"
+                     aria-label="hidden field"
+                     id="preferredLanguage"
+                     name="preferredLanguage"
+                     maxlength="255"
+                     value="" />
+              <input type="hidden"
+                     aria-hidden="true"
+                     aria-label="hidden field"
+                     name="productContext"
+                     id="product-context"
+                     value="{{ product }}" />
+            </div>
+          </div>
+        </fieldset>
+      </div>
+    </form>
+
+    <div class="u-hide">
       <div class="row u-no-padding">
         <div class="u-equal-height">
           <div class="col-7">
-            <h3 class="p-heading--2">Thank you for enquiring about embedded Ubuntu</h3>
+            <h3 class="p-heading--4">Thank you for enquiring about embedded Ubuntu</h3>
             <p class="p-heading--4">A member of our team will be in touch within one working day.</p>
           </div>
           <div class="col-5 u-vertically-center u-hide--medium u-hide--small u-align--center">
-            {{
-              image(
-              url="https://assets.ubuntu.com/v1/cbae9a60-thank_you_orange_cmyk.svg",
-              alt="smile",
-              width="200",
-              height="200",
-              hi_def=True,
-              loading="auto",
-              ) | safe
+            {{ image(url="https://assets.ubuntu.com/v1/cbae9a60-thank_you_orange_cmyk.svg",
+                        alt="smile",
+                        width="200",
+                        height="200",
+                        hi_def=True,
+                        loading="auto",) | safe
             }}
           </div>
         </div>
       </div>
       <a class="js-close p-button" href="">Close</a>
     </div>
+
   </div>
 </div>
+
+<script>
+  document.querySelector('form').addEventListener('submit', function(event) {
+    dataLayer.push({
+      'event': 'GAEvent',
+      'eventCategory': 'Form',
+      'eventAction': 'iot contact-us',
+      'eventLabel': '{{ product }}',
+      'eventValue': undefined
+    });
+  });
+</script>


### PR DESCRIPTION
## Done

- Removed pagination
- Conversion to single page
- Cleanup

## QA

- Check the old modal here first: https://ubuntu.com/internet-of-things/smart-home#get-in-touch
- Check the new modal at: https://ubuntu-com-14571.demos.haus/internet-of-things/smart-home#get-in-touch
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check that modal form is a single page without pagination.
- Submit the form to make sure it's working.

## Issue / Card

Fixes #[WD-17783](https://warthogs.atlassian.net/browse/WD-17783)

[WD-17783]: https://warthogs.atlassian.net/browse/WD-17783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ