### PR TITLE
chore: update link in nvidia-jetson

### DIFF
--- a/templates/download/nvidia-jetson/tab-2-jetson-orin-nano.html
+++ b/templates/download/nvidia-jetson/tab-2-jetson-orin-nano.html
@@ -54,7 +54,7 @@
       <div class="p-notification--information is-borderless">
         <div class="p-notification__content">
           <p class="p-notification__message">
-            The Ubuntu images are tested on the <a href="https://developer.nvidia.com/embedded/jetson-developer-kits">Jetson Orin Nano Developer Kit</a>
+            The Ubuntu images are tested on the <a href="https://developer.nvidia.com/embedded/jetson-developer-kits">Jetson Orin Nano Super Developer Kit</a>
           </p>
         </div>
       </div>

--- a/templates/download/nvidia-jetson/tab-3-jetson-orin-nx.html
+++ b/templates/download/nvidia-jetson/tab-3-jetson-orin-nx.html
@@ -62,7 +62,7 @@
       <div class="p-notification--information is-borderless">
         <div class="p-notification__content">
           <p class="p-notification__message">
-            The Ubuntu images are tested on the <a href="https://developer.nvidia.com/embedded/jetson-developer-kits">Jetson Orin Nano Developer Kit</a> with a NX module
+            The Ubuntu images are tested on the <a href="https://developer.nvidia.com/embedded/jetson-developer-kits">Jetson Orin Nano Super Developer Kit</a> with a NX module
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Done

Updated link

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to /download/nvidia-jetson
- Check tabs 2 & 3

## Issue / Card

Fixes #[WD-17752](https://warthogs.atlassian.net/browse/WD-17752)




[WD-17752]: https://warthogs.atlassian.net/browse/WD-17752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ