### PR TITLE
fix: Fix form generator bugs and use template on /aws bubble

### DIFF
--- a/static/files/forms-data.json
+++ b/static/files/forms-data.json
@@ -2,6 +2,7 @@
   "forms": {
     "/aws": {
       "templatePath": "/aws/index.html",
+      "childrenPaths": ["/aws/pro", "/aws/support", "/aws/outposts"],
       "isModal": true,
       "modalId": "contact-modal",
       "formData": {

--- a/static/files/forms-data.json
+++ b/static/files/forms-data.json
@@ -28,6 +28,7 @@
         {
           "title": "If you use Ubuntu, which version(s) are you using?",
           "id": "ubuntu-versions",
+          "inputType": "checkbox-visibility",
           "fields": [
             {
               "fieldTitle": "LTS within standard support",
@@ -115,6 +116,7 @@
           "title": "What kind of device are you using?",
           "id": "kind-of-device",
           "isRequired": true,
+          "inputType": "checkbox",
           "fields": [
             {
               "type": "checkbox",
@@ -152,6 +154,7 @@
           "title": "How many devices?",
           "id": "how-many-machines",
           "inputName": "how-many-machines-do-you-have",
+          "inputType": "radio",
           "isRequired": true,
           "fields": [
             {
@@ -543,6 +546,7 @@
           "title": "What kind of device are you using?",
           "id": "kind-of-device",
           "isRequired": true,
+          "inputType": "checkbox",
           "fields": [
             {
               "type": "checkbox",

--- a/static/files/forms-data.json
+++ b/static/files/forms-data.json
@@ -5,140 +5,22 @@
       "isModal": true,
       "modalId": "contact-modal",
       "formData": {
-        "title": "Test form",
-        "introText": "Intro text",
-        "formId": "1266",
+        "title": "Canonical - the \"Ubuntu on AWS\" experts",
+        "introText": "Already running Ubuntu on AWS, or planning a migration to the public cloud? Canonical has the expertise to assist you in your project, whether it involves compliance, application architecture, optimisation or streamlining operations at scale. Share some details about your project with us and let's get started.",
+        "formId": "3790",
         "returnUrl": "/aws#contact-form-success",
         "product": ""
       },
       "fieldsets": [
         {
-          "title": "About your company",
-          "id": "about-company",
+          "title": "Tell us about your project",
+          "id": "about-your-project",
           "noCommentsFromLead": true,
-          "fields": [
-            {
-              "type": "text",
-              "id": "company",
-              "label": "Company name",
-              "isRequired": true
-            },
-            {
-              "type": "text",
-              "id": "job-title",
-              "label": "Job title",
-              "isRequired": true
-            }
-          ]
-        },
-        {
-          "title": "What would you like to talk to us about?",
-          "id": "comments",
-          "isRequired": true,
           "fields": [
             {
               "type": "long-text",
-              "id": "comments"
-            }
-          ]
-        },
-        {
-          "title": "How many devices?",
-          "id": "how-many-machines",
-          "inputName": "how-many-machines-do-you-have",
-          "isRequired": true,
-          "fields": [
-            {
-              "type": "radio",
-              "id": "less-5-machines",
-              "value": "less than 5",
-              "label": "< 5 machines"
-            },
-            {
-              "type": "radio",
-              "id": "5-to-15-machines",
-              "value": "5 to 15 machines",
-              "label": "5 - 15 machines"
-            },
-            {
-              "type": "radio",
-              "id": "15-to-50-machines",
-              "value": "15 to 50 machines",
-              "label": "15 - 50 machines"
-            },
-            {
-              "type": "radio",
-              "id": "50-to-100-machines",
-              "value": "50 to 100 machines",
-              "label": "50 - 100 machines"
-            },
-            {
-              "type": "radio",
-              "id": "greater-than-100",
-              "value": "greater than 100",
-              "label": "> 100 machines"
-            }
-          ]
-        },
-        {
-          "title": "How should we get in touch?",
-          "id": "about-you",
-          "noCommentsFromLead": true,
-          "fields": [
-            {
-              "type": "text",
-              "id": "firstName",
-              "label": "First name",
-              "isRequired": true
-            },
-            {
-              "type": "text",
-              "id": "lastName",
-              "label": "Last name",
-              "isRequired": true
-            },
-            {
-              "type": "email",
-              "id": "email",
-              "label": "Email address",
-              "isRequired": true
-            },
-            {
-              "type": "country",
-              "id": "",
-              "label": "",
-              "isRequired": true
-            },
-            {
-              "type": "tel",
-              "id": "phone",
-              "label": "Mobile/cell phone number"
-            }
-          ]
-        },
-        {
-          "title": "Which platform do you use?",
-          "id": "platform-select",
-          "fields": [
-            {
-              "type": "select",
-              "id": "platform",
-              "label": "Select your platform",
-              "isRequired": true,
-              "options": [
-                {
-                  "value": "raspberry-pi",
-                  "label": "Raspberry Pi"
-                },
-                {
-                  "value": "pc",
-                  "label": "PC"
-                },
-                {
-                  "value": "intel-nuc",
-                  "label": "Intel NUC"
-                }
-              ]
+              "id": "about-your-project",
+              "label": "Abour your project"
             }
           ]
         },
@@ -264,6 +146,206 @@
               "label": "IoT/Edge device"
             }
           ]
+        },
+        {
+          "title": "How many devices?",
+          "id": "how-many-machines",
+          "inputName": "how-many-machines-do-you-have",
+          "isRequired": true,
+          "fields": [
+            {
+              "type": "radio",
+              "id": "less-5-machines",
+              "value": "less than 5",
+              "label": "< 5 machines"
+            },
+            {
+              "type": "radio",
+              "id": "5-to-15-machines",
+              "value": "5 to 15 machines",
+              "label": "5 - 15 machines"
+            },
+            {
+              "type": "radio",
+              "id": "15-to-50-machines",
+              "value": "15 to 50 machines",
+              "label": "15 - 50 machines"
+            },
+            {
+              "type": "radio",
+              "id": "50-to-100-machines",
+              "value": "50 to 100 machines",
+              "label": "50 - 100 machines"
+            },
+            {
+              "type": "radio",
+              "id": "greater-than-100",
+              "value": "greater than 100",
+              "label": "> 100 machines"
+            }
+          ]
+        },
+        {
+          "title": "How do you consume open source?",
+          "id": "how-do-you-consume-open-source",
+          "fields": [
+            {
+              "type": "checkbox",
+              "id": "ubuntu-repositories",
+              "value": "Ubuntu repositories",
+              "label": "Ubuntu repositories"
+            },
+            {
+              "type": "checkbox",
+              "id": "github-upstream",
+              "value": "GitHub/Upstream",
+              "label": "GitHub/Upstream"
+            },
+            {
+              "type": "checkbox",
+              "id": "internally-approved-repository",
+              "value": "Internally approved repository",
+              "label": "Internally approved repository"
+            },
+            {
+              "type": "checkbox",
+              "id": "i-dont-know",
+              "value": "I don't know",
+              "label": "I don't know"
+            }
+          ]
+        },
+        {
+          "title": "Do you have specific compliance or hardening requirements?",
+          "id": "hardening-requirements",
+          "fields": [
+            {
+              "type": "checkbox",
+              "id": "pci",
+              "value": "PCI-DSS",
+              "label": "PCI-DSS"
+            },
+            {
+              "type": "checkbox",
+              "id": "hipaa",
+              "value": "HIPAA",
+              "label": "HIPAA"
+            },
+            {
+              "type": "checkbox",
+              "id": "fisma",
+              "value": "FISMA",
+              "label": "FISMA"
+            },
+            {
+              "type": "checkbox",
+              "id": "fips-140",
+              "value": "FIPS 140",
+              "label": "FIPS 140"
+            },
+            {
+              "type": "checkbox",
+              "id": "ncsc",
+              "value": "NCSC",
+              "label": "NCSC"
+            },
+            {
+              "type": "checkbox",
+              "id": "disa-stig",
+              "value": "DISA-STIG",
+              "label": "DISA-STIG"
+            },
+            {
+              "type": "checkbox",
+              "id": "fedramp",
+              "value": "FedRAMP",
+              "label": "FedRAMP"
+            },
+            {
+              "type": "checkbox",
+              "id": "cis-benchmark",
+              "value": "CIS Benchmark",
+              "label": "CIS Benchmark"
+            }
+          ]
+        },
+        {
+          "title": "Who is responsible for tracking, testing and applying CVE patches in a timely manner?",
+          "id": "responsible-for-tracking",
+          "fields": [
+            {
+              "type": "checkbox",
+              "id": "individual-developers",
+              "value": "Individual developers",
+              "label": "Individual developers"
+            },
+            {
+              "type": "checkbox",
+              "id": "project-team",
+              "value": "The project team",
+              "label": "The project team"
+            },
+            {
+              "type": "checkbox",
+              "id": "third-party-vendor",
+              "value": "Third-party vendor",
+              "label": "Third-party vendor"
+            },
+            {
+              "type": "checkbox",
+              "id": "i-dont-know",
+              "value": "I don't know",
+              "label": "I don't know"
+            }
+          ]
+        },
+        {
+          "title": "What advice are you looking for?",
+          "id": "advice",
+          "noCommentsFromLead": true,
+          "fields": [
+            {
+              "type": "long-text",
+              "id": "advice",
+              "label": "Tell us about your challenges and your goals"
+            }
+          ]
+        },
+        {
+          "title": "How should we get in touch?",
+          "id": "about-you",
+          "noCommentsFromLead": true,
+          "fields": [
+            {
+              "type": "text",
+              "id": "firstName",
+              "label": "First name",
+              "isRequired": true
+            },
+            {
+              "type": "text",
+              "id": "lastName",
+              "label": "Last name",
+              "isRequired": true
+            },
+            {
+              "type": "email",
+              "id": "email",
+              "label": "Email address",
+              "isRequired": true
+            },
+            {
+              "type": "country",
+              "id": "",
+              "label": "",
+              "isRequired": true
+            },
+            {
+              "type": "tel",
+              "id": "phone",
+              "label": "Mobile/cell phone number"
+            }
+          ]
         }
       ]
     },
@@ -372,6 +454,7 @@
         {
           "title": "If you use Ubuntu, which version(s) are you using?",
           "id": "ubuntu-versions",
+          "inputType": "checkbox-visibility",
           "fields": [
             {
               "fieldTitle": "LTS within standard support",

--- a/static/js/src/dynamic-forms.js
+++ b/static/js/src/dynamic-forms.js
@@ -502,8 +502,10 @@ import { prepareInputFields } from "./prepare-form-inputs.js";
 
       // Sets up dial code dropdown options aka. intlTelInput.js
       // and pre fills the country field
-      // This gets triggered when the modal is opened
-      prepareInputFields(phoneNumberInput, countryInput);
+      // Prepares input fields for opened modal if it has not been initialised
+      if (!modalAlreadyExists) {
+        prepareInputFields(phoneNumberInput, countryInput);
+      }
 
       // Set preferredLanguage hidden input
       function setpreferredLanguage() {

--- a/templates/aws/base_aws.html
+++ b/templates/aws/base_aws.html
@@ -3,15 +3,4 @@
 {% block outer_content %}
   {% block content %}{% endblock %}
 
-  <!-- Set default Marketo information for contact form below-->
-  <div class="u-hide" 
-       id="contact-form-container" 
-       data-form-location="/shared/forms/form-template" 
-       data-form-id="3790" 
-       data-lp-id="{{ formData.formId }}" 
-       data-return-url="{{ formData.returnUrl }}"
-       data-lp-url="https://ubuntu.com/aws/contact-us"
-  >
-       {% include "/shared/forms/form-template.html" %}
-  </div>
 {% endblock %}

--- a/templates/aws/base_aws.html
+++ b/templates/aws/base_aws.html
@@ -4,6 +4,14 @@
   {% block content %}{% endblock %}
 
   <!-- Set default Marketo information for contact form below-->
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/aws" data-form-id="3790" data-lp-id="" data-return-url="https://ubuntu.com/aws/thank-you" data-lp-url="https://ubuntu.com/aws/contact-us">
+  <div class="u-hide" 
+       id="contact-form-container" 
+       data-form-location="/shared/forms/form-template" 
+       data-form-id="3790" 
+       data-lp-id="{{ formData.formId }}" 
+       data-return-url="{{ formData.returnUrl }}"
+       data-lp-url="https://ubuntu.com/aws/contact-us"
+  >
+       {% include "/shared/forms/form-template.html" %}
   </div>
 {% endblock %}

--- a/templates/aws/index.html
+++ b/templates/aws/index.html
@@ -290,8 +290,8 @@
       </div>
     </div>
   </section>
-  
-    <!-- Set default Marketo information for contact form below-->
+
+  <!-- Set default Marketo information for contact form below-->
   <div class="u-hide" 
     id="contact-form-container" 
     data-form-location="/shared/forms/form-template" 

--- a/templates/aws/index.html
+++ b/templates/aws/index.html
@@ -295,8 +295,8 @@
   <div class="u-hide" 
     id="contact-form-container" 
     data-form-location="/shared/forms/form-template" 
-    data-form-id="3790" 
-    data-lp-id="{{ formData.formId }}" 
+    data-form-id="{{ formData.formId }}" 
+    data-lp-id="" 
     data-return-url="{{ formData.returnUrl }}"
     data-lp-url="https://ubuntu.com/aws/contact-us"
   >

--- a/templates/aws/index.html
+++ b/templates/aws/index.html
@@ -290,5 +290,17 @@
       </div>
     </div>
   </section>
+  
+    <!-- Set default Marketo information for contact form below-->
+  <div class="u-hide" 
+    id="contact-form-container" 
+    data-form-location="/shared/forms/form-template" 
+    data-form-id="3790" 
+    data-lp-id="{{ formData.formId }}" 
+    data-return-url="{{ formData.returnUrl }}"
+    data-lp-url="https://ubuntu.com/aws/contact-us"
+  >
+    {% include "/shared/forms/form-template.html" %}
+  </div>
 
 {% endblock content %}

--- a/templates/aws/outposts.html
+++ b/templates/aws/outposts.html
@@ -378,8 +378,8 @@
   <div class="u-hide" 
       id="contact-form-container" 
       data-form-location="/shared/forms/form-template" 
-      data-form-id="3790" 
-      data-lp-id="{{ formData.formId }}" 
+      data-form-id="{{ formData.formId }}" 
+      data-lp-id="" 
       data-return-url="{{ formData.returnUrl }}"
       data-lp-url="https://ubuntu.com/aws/contact-us"
     >

--- a/templates/aws/outposts.html
+++ b/templates/aws/outposts.html
@@ -374,4 +374,16 @@
     </div>
   </section>
 
+  <!-- Set default Marketo information for contact form below-->
+  <div class="u-hide" 
+      id="contact-form-container" 
+      data-form-location="/shared/forms/form-template" 
+      data-form-id="3790" 
+      data-lp-id="{{ formData.formId }}" 
+      data-return-url="{{ formData.returnUrl }}"
+      data-lp-url="https://ubuntu.com/aws/contact-us"
+    >
+    {% include "/shared/forms/form-template.html" %}
+  </div>
+
 {% endblock content %}

--- a/templates/aws/pro.html
+++ b/templates/aws/pro.html
@@ -525,4 +525,16 @@
 
   {% include "/aws/shared/_get_pro.html" %}
 
+  <!-- Set default Marketo information for contact form below-->
+  <div class="u-hide" 
+      id="contact-form-container" 
+      data-form-location="/shared/forms/form-template" 
+      data-form-id="3790" 
+      data-lp-id="{{ formData.formId }}" 
+      data-return-url="{{ formData.returnUrl }}"
+      data-lp-url="https://ubuntu.com/aws/contact-us"
+    >
+    {% include "/shared/forms/form-template.html" %}
+  </div>
+
 {% endblock content %}

--- a/templates/aws/pro.html
+++ b/templates/aws/pro.html
@@ -529,8 +529,8 @@
   <div class="u-hide" 
       id="contact-form-container" 
       data-form-location="/shared/forms/form-template" 
-      data-form-id="3790" 
-      data-lp-id="{{ formData.formId }}" 
+      data-form-id="{{ formData.formId }}" 
+      data-lp-id=""
       data-return-url="{{ formData.returnUrl }}"
       data-lp-url="https://ubuntu.com/aws/contact-us"
     >

--- a/templates/aws/support.html
+++ b/templates/aws/support.html
@@ -155,4 +155,17 @@
     </div>
   </section>
 
+  <!-- Set default Marketo information for contact form below-->
+  <div class="u-hide" 
+      id="contact-form-container" 
+      data-form-location="/shared/forms/form-template" 
+      data-form-id="3790" 
+      data-lp-id="{{ formData.formId }}" 
+      data-return-url="{{ formData.returnUrl }}"
+      data-lp-url="https://ubuntu.com/aws/contact-us"
+    >
+    {% include "/shared/forms/form-template.html" %}
+  </div>
+
+
 {% endblock content %}

--- a/templates/aws/support.html
+++ b/templates/aws/support.html
@@ -159,8 +159,8 @@
   <div class="u-hide" 
       id="contact-form-container" 
       data-form-location="/shared/forms/form-template" 
-      data-form-id="3790" 
-      data-lp-id="{{ formData.formId }}" 
+      data-form-id="{{ formData.formId }}" 
+      data-lp-id=""
       data-return-url="{{ formData.returnUrl }}"
       data-lp-url="https://ubuntu.com/aws/contact-us"
     >

--- a/templates/aws/support.html
+++ b/templates/aws/support.html
@@ -167,5 +167,4 @@
     {% include "/shared/forms/form-template.html" %}
   </div>
 
-
 {% endblock content %}

--- a/templates/shared/forms/form-fields.html
+++ b/templates/shared/forms/form-fields.html
@@ -139,7 +139,7 @@
                        aria-hidden="true"
                        aria-label="hidden field"
                        name="returnURL"
-                       value={% if path %}"{{ path }}/#contact-form-success{% else %}{{ formData.returnUrl }}{% endif %}" />
+                       value={% if path %}"{{ path }}/#contact-form-success"{% else %}{{ formData.returnUrl }}{% endif %} />
                 <input type="hidden"
                        aria-hidden="true"
                        aria-label="hidden field"

--- a/templates/shared/forms/form-fields.html
+++ b/templates/shared/forms/form-fields.html
@@ -5,73 +5,71 @@
         id="mktoForm_{{ formData.formId }}">
     {% for fieldset in fieldsets %}
       <div class="p-section">
-        <hr class="is-fixed-width" />
-        <fieldset class="p-fieldset-section {% if fieldset.id=='ubuntu-versions' %} js-toggle-checkbox-visibility {% elif fieldset.isRequired and fieldset.fields[0].type=='checkbox' %} js-required-checkbox {% endif %}" id="{{ fieldset.id }}" aria-labelledby="{{ fieldset.id }}">
-        <div class="row--50-50 {% if not fieldset.noCommentsFromLead %}js-formfield{% endif %}">
-          <div class="col">
-            <legend class="p-heading--2 js-formfield-title {% if fieldset.isRequired %}is-required{% endif %}"
-                    id="{{ fieldset.id }}-legend">{{ fieldset.title }}</legend>
-          </div>
-          <div class="col">
-            <ul class="p-list">
-              {% for field in fieldset.fields %}
-                {% if field.type == "country" %}
-                  {% include "shared/forms/_country.html" %}
-                {% else %}
-                  <li class="p-list__item">
-                    {% if field.type == "text" or field.type == "tel" or field.type == "email" %}
-                      <label {% if field.isRequired %}class="is-required"{% endif %}
-                             for="{{ field.id }}">
-                        {{ field.label
-                        }}:
-                      </label>
-                      <input {% if field.isRequired %}required{% endif %}
-                             id="{{ field.id }}"
-                             name="{{ field.id }}"
-                             maxlength="255"
-                             type="{{ field.type }}"
-                             {% if field.type=="email" %}pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"{% endif %} />
-                    {% elif field.type == "long-text" %}
-                      <textarea {% if fieldset.isRequired %}required{% endif %}
-                                id="{{field.id}}"
-                                rows="5"
-                                maxlength="2000"></textarea>
-                    {% elif field.type == "radio" %}
-                      <label class="p-radio">
-                        <input {% if fieldset.isRequired %}required{% endif %}
-                               class="p-radio__input"
-                               type="radio"
-                               aria-labelledby="{{ field.id }}"
-                               name="{{ fieldset.inputName }}"
-                               value="{{ field.value }}" />
-                        <span class="p-radio__label" id="{{ field.id }}">{{ field.label }}</span>
-                      </label>
-                    {% elif field.type == "checkbox" %}
-                      <label class="p-checkbox">
-                        <input class="p-checkbox__input js-checkbox-visibility"
-                               type="checkbox"
-                               aria-labelledby="{{ field.label }}"
-                               value="{{ field.value }}" />
-                        <span class="p-checkbox__label" id="{{ field.id }}">{{ field.label }}</span>
-                      </label>
-                    {% elif field.fieldTitle is defined and field.fieldTitle|length > 0 %}
-                      <div class="p-section--shallow">
-                        <strong>{{ field.fieldTitle }}</strong>
-                        {% for option in field.options %}
-                          <label class="p-checkbox">
-                            <input {% if field.fieldTitle=="Other" %} class="p-checkbox__input js-checkbox-visibility__other" {%
-                              else %} class="p-checkbox__input js-checkbox-visibility" {% endif %} type="checkbox"
-                              aria-labelledby="{{ option.label }}" value="{{ option.value }}" />
+        <hr class="p-rule is-fixed-width" />
+        <fieldset class="p-fieldset-section {% if fieldset.inputType=='checkbox-visibility' %} js-toggle-checkbox-visibility {% elif fieldset.isRequired and fieldset.inputType =='checkbox' %} js-required-checkbox {% elif fieldset.inputType == 'radio' %} js-remove-radio-names{% endif %}"
+                  id="{{ fieldset.id }}"
+                  aria-labelledby="{{ fieldset.id }}">
+          <div class="row--50-50 {% if not fieldset.noCommentsFromLead %}js-formfield{% endif %}">
+            <div class="col">
+              <legend class="p-heading--4 js-formfield-title {% if fieldset.isRequired %}is-required{% endif %}"
+                      id="{{ fieldset.id }}-legend">{{ fieldset.title }}</legend>
+            </div>
+            <div class="col">
+              <ul class="p-list">
+                {% for field in fieldset.fields %}
+                  {% if field.type == "country" %}
+                    {% include "shared/forms/_country.html" %}
+                  {% else %}
+                    <li class="p-list__item">
+                      {% if field.type == "text" or field.type == "tel" or field.type == "email" %}
+                        <label {% if field.isRequired %}class="is-required"{% endif %}
+                               for="{{ field.id }}">{{ field.label }}:</label>
+                        <input {% if field.isRequired %}required{% endif %}
+                               id="{{ field.id }}"
+                               name="{{ field.id }}"
+                               maxlength="255"
+                               type="{{ field.type }}"
+                               {% if field.type=="email" %}pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"{% endif %} />
+                      {% elif field.type == "long-text" %}
+                        <textarea {% if fieldset.isRequired %}required{% endif %}
+                                  id="{{field.id}}"
+                                  rows="5"
+                                  maxlength="2000"
+                                  {% if field.placeholder %}placeholder="{{ field.placeholder }}"{% endif %}></textarea>
+                      {% elif field.type == "radio" %}
+                        <label class="p-radio">
+                          <input {% if fieldset.isRequired %}required{% endif %}
+                                 class="p-radio__input"
+                                 type="radio"
+                                 aria-labelledby="{{ field.id }}"
+                                 name="{{ fieldset.inputName }}"
+                                 value="{{ field.value }}" />
+                          <span class="p-radio__label" id="{{ field.id }}">{{ field.label }}</span>
+                        </label>
+                      {% elif field.type == "checkbox" %}
+                        <label class="p-checkbox">
+                          <input class="p-checkbox__input js-checkbox-visibility"
+                                 type="checkbox"
+                                 aria-labelledby="{{ field.label }}"
+                                 value="{{ field.value }}" />
+                          <span class="p-checkbox__label" id="{{ field.id }}">{{ field.label }}</span>
+                        </label>
+                      {% elif field.fieldTitle is defined and field.fieldTitle|length > 0 %}
+                        <div class="p-section--shallow">
+                          <strong>{{ field.fieldTitle }}</strong>
+                          {% for option in field.options %}
+                            <label class="p-checkbox">
+                              <input class="p-checkbox__input js-checkbox-visibility {% if field.fieldTitle=="Other" %}__other{% endif %}"
+                                     type="checkbox"
+                                     aria-labelledby="{{ option.label }}"
+                                     value="{{ option.value }}" />
                               <span class="p-checkbox__label" id="{{ option.id }}">{{ option.label }}</span>
                             </label>
                           {% endfor %}
                         </div>
                       {% elif field.type == "select" %}
                         <label {% if fieldset.isRequired %}class="is-required"{% endif %}
-                               for="{{ field.id }}">
-                          {{ field.label
-                          }}:
-                        </label>
+                               for="{{ field.id }}">{{ field.label }}:</label>
                         <select id="{{ field.id }}" {% if field.isRequired %}required{% endif %}>
                           {% for option in field.options %}<option value="{{ option.value }}">{{ option.label }}</option>{% endfor %}
                         </select>

--- a/templates/shared/forms/form-fields.html
+++ b/templates/shared/forms/form-fields.html
@@ -6,7 +6,7 @@
     {% for fieldset in fieldsets %}
       <div class="p-section">
         <hr class="p-rule is-fixed-width" />
-        <fieldset class="p-fieldset-section {% if fieldset.inputType=='checkbox-visibility' %} js-toggle-checkbox-visibility {% elif fieldset.isRequired and fieldset.inputType =='checkbox' %} js-required-checkbox {% elif fieldset.inputType == 'radio' %} js-remove-radio-names{% endif %}"
+        <fieldset class="p-fieldset-section{% if fieldset.inputType == 'checkbox-visibility' %} js-toggle-checkbox-visibility{% elif fieldset.isRequired and fieldset.inputType == 'checkbox' %} js-required-checkbox{% elif fieldset.inputType == 'radio' %} js-remove-radio-names{% endif %}"
                   id="{{ fieldset.id }}"
                   aria-labelledby="{{ fieldset.id }}">
           <div class="row--50-50 {% if not fieldset.noCommentsFromLead %}js-formfield{% endif %}">
@@ -59,7 +59,7 @@
                           <strong>{{ field.fieldTitle }}</strong>
                           {% for option in field.options %}
                             <label class="p-checkbox">
-                              <input class="p-checkbox__input js-checkbox-visibility {% if field.fieldTitle=="Other" %}__other{% endif %}"
+                              <input class="p-checkbox__input js-checkbox-visibility{% if field.fieldTitle=="Other" %}__other{% endif %}"
                                      type="checkbox"
                                      aria-labelledby="{{ option.label }}"
                                      value="{{ option.value }}" />
@@ -139,7 +139,7 @@
                        aria-hidden="true"
                        aria-label="hidden field"
                        name="returnURL"
-                       value="{{ formData.returnURL }}" />
+                       value={% if path %}"{{ path }}/#contact-form-success{% else %}{{ formData.returnUrl }}{% endif %}" />
                 <input type="hidden"
                        aria-hidden="true"
                        aria-label="hidden field"

--- a/templates/shared/forms/form-template.html
+++ b/templates/shared/forms/form-template.html
@@ -15,10 +15,16 @@
           <h3>{{ formData.title }}</h3>
         </div>
       </header>
-      <div class="p-section u-fixed-width">
-        <hr />
-        {{ formData.introText }}
-      </div>
+      {% if formData.introText %}
+        <div class="p-section u-sv-3">
+          <hr class="p-rule is-fixed-width" />
+          <div class="row">
+            <div class="col">
+              {{ formData.introText }}
+            </div>
+          </div>
+        </div>
+      {% endif %}
       {% include "/shared/forms/form-fields.html" %}
     </div>
   </div>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1281,7 +1281,7 @@ def render_form(form, template_path, child=False):
                     fieldsets=form["fieldsets"],
                     formData=form["formData"],
                     isModal=form.get("isModal"),
-                    modalId=form.get("modalId")
+                    modalId=form.get("modalId"),
                 )
         except jinja2.exceptions.TemplateNotFound:
             flask.abort(
@@ -1301,12 +1301,16 @@ def set_form_rules():
                     for child_path in form["childrenPaths"]:
                         app.add_url_rule(
                             child_path,
-                            view_func=render_form(form, child_path, child=True),
+                            view_func=render_form(
+                                form, child_path, child=True
+                            ),
                             endpoint=child_path,
                         )
                 app.add_url_rule(
                     path,
-                    view_func=render_form(form, form["templatePath"].split(".")[0]),
+                    view_func=render_form(
+                        form, form["templatePath"].split(".")[0]
+                    ),
                     endpoint=path,
                 )
             except AssertionError:

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1262,12 +1262,12 @@ def render_supermicro_blogs():
 app.add_url_rule("/supermicro", view_func=render_supermicro_blogs)
 
 
-def render_form(form):
+def render_form(form, template_path):
     @wraps(render_form)
     def wrapper_func():
         try:
             return flask.render_template(
-                form["templatePath"],
+                template_path,
                 fieldsets=form["fieldsets"],
                 formData=form["formData"],
                 isModal=form.get("isModal"),
@@ -1287,8 +1287,13 @@ def set_form_rules():
         data = json.load(forms_json)
         for path, form in data["forms"].items():
             try:
+                if "childrenPaths" in form:
+                    for child_path in form["childrenPaths"]:
+                        app.add_url_rule(
+                            child_path, view_func=render_form(form, child_path + '.html'), endpoint=child_path
+                        )
                 app.add_url_rule(
-                    path, view_func=render_form(form), endpoint=path
+                    path, view_func=render_form(form, form["templatePath"]), endpoint=path
                 )
             except AssertionError:
                 app.logger.error(

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1297,4 +1297,4 @@ def set_form_rules():
 
 
 # Disabling for now, the forms in form-data.json are for testing purposes
-# set_form_rules()
+set_form_rules()

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1262,17 +1262,27 @@ def render_supermicro_blogs():
 app.add_url_rule("/supermicro", view_func=render_supermicro_blogs)
 
 
-def render_form(form, template_path):
+def render_form(form, template_path, child=False):
     @wraps(render_form)
     def wrapper_func():
         try:
-            return flask.render_template(
-                template_path,
-                fieldsets=form["fieldsets"],
-                formData=form["formData"],
-                isModal=form.get("isModal"),
-                modalId=form.get("modalId"),
-            )
+            if child:
+                return flask.render_template(
+                    template_path + ".html",
+                    fieldsets=form["fieldsets"],
+                    formData=form["formData"],
+                    isModal=form.get("isModal"),
+                    modalId=form.get("modalId"),
+                    path=template_path,
+                )
+            else:
+                return flask.render_template(
+                    template_path + ".html",
+                    fieldsets=form["fieldsets"],
+                    formData=form["formData"],
+                    isModal=form.get("isModal"),
+                    modalId=form.get("modalId")
+                )
         except jinja2.exceptions.TemplateNotFound:
             flask.abort(
                 404, description=f"Template {form['templatePath']} not found."
@@ -1291,12 +1301,12 @@ def set_form_rules():
                     for child_path in form["childrenPaths"]:
                         app.add_url_rule(
                             child_path,
-                            view_func=render_form(form, child_path + ".html"),
+                            view_func=render_form(form, child_path, child=True),
                             endpoint=child_path,
                         )
                 app.add_url_rule(
                     path,
-                    view_func=render_form(form, form["templatePath"]),
+                    view_func=render_form(form, form["templatePath"].split(".")[0]),
                     endpoint=path,
                 )
             except AssertionError:

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1290,10 +1290,14 @@ def set_form_rules():
                 if "childrenPaths" in form:
                     for child_path in form["childrenPaths"]:
                         app.add_url_rule(
-                            child_path, view_func=render_form(form, child_path + '.html'), endpoint=child_path
+                            child_path,
+                            view_func=render_form(form, child_path + ".html"),
+                            endpoint=child_path,
                         )
                 app.add_url_rule(
-                    path, view_func=render_form(form, form["templatePath"]), endpoint=path
+                    path,
+                    view_func=render_form(form, form["templatePath"]),
+                    endpoint=path,
                 )
             except AssertionError:
                 app.logger.error(


### PR DESCRIPTION
## Done

- Use form template for modals in the `/aws` bubble
- Added `childrenPaths` entry on `forms-data.json`, this allows children pages to use the same form template
  - e.g /aws modal is used in /aws/outposts, /aws/pro, /aws/support
  - **Note: update forms documentation when this is merged**
- Add inputType to forms-data: radio, checkbox, checkbox-visibility
  - The inputType is read in form-fields.html and adds javascript classes where appropriate
- Added placeholder to long text input
- Run djlint on form-fields.html
- Fixed duplicated intlTelInput for forms

## QA

- Go to https://ubuntu-com-14575.demos.haus/aws, click on CTA button and see that modal pops up
- Fill up form and submit, check payload and that the submission goes through Marketo successfully
- Repeat for 
  - https://ubuntu-com-14575.demos.haus/aws/outposts
  - https://ubuntu-com-14575.demos.haus/aws/pro
  - https://ubuntu-com-14575.demos.haus/aws/support

## Issue / Card

Fixes [WD-17719](https://warthogs.atlassian.net/browse/WD-17719)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-17719]: https://warthogs.atlassian.net/browse/WD-17719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ