### PR TITLE
WD-16838 Rebranded /landscape/managed page

### DIFF
--- a/templates/landscape/managed.html
+++ b/templates/landscape/managed.html
@@ -105,7 +105,7 @@
             <div class="p-logo-section__items">
               <div class="p-logo-section__item">
                 {{ image(url="https://assets.ubuntu.com/v1/48b68d11-gcp-logo.png",
-                                alt="GCP Logo",
+                                alt="Google Cloud Platform",
                                 width="98",
                                 height="209",
                                 hi_def=True,
@@ -115,7 +115,7 @@
               </div>
               <div class="p-logo-section__item">
                 {{ image(url="https://assets.ubuntu.com/v1/3ec94c2d-aws-logo.png",
-                                alt="",
+                                alt="Amazon Web Services",
                                 width="101",
                                 height="209",
                                 hi_def=True,
@@ -125,7 +125,7 @@
               </div>
               <div class="p-logo-section__item">
                 {{ image(url="https://assets.ubuntu.com/v1/ae511063-azure-logo.png",
-                                alt="",
+                                alt="Microsoft Azure",
                                 width="79",
                                 height="209",
                                 hi_def=True,
@@ -135,7 +135,7 @@
               </div>
               <div class="p-logo-section__item">
                 {{ image(url="https://assets.ubuntu.com/v1/bd83cd83-opensearch-logo.png",
-                                alt="",
+                                alt="OpenStack",
                                 width="81",
                                 height="209",
                                 hi_def=True,
@@ -145,7 +145,7 @@
               </div>
               <div class="p-logo-section__item">
                 {{ image(url="https://assets.ubuntu.com/v1/7589afda-vmware-logo.png",
-                                alt="",
+                                alt="VMWare",
                                 width="216",
                                 height="209",
                                 hi_def=True,
@@ -234,7 +234,7 @@
           Our Field Engineering team can recommend the number and type of machines your Managed Landscape deployment would need.
         </p>
         <div class="p-cta-block u-sv4">
-          <a href="https://docs.google.com/document/d/1PHiLMYzRfrVt14GtMzSAeIo2xrylzvp3v-oOr_HoUtM/edit?usp=sharing">Get started with a free quote and architecture assessment&nbsp;&rsaquo;</a>
+          <a href="/contact-us" class="js-invoke-modal">Get started with a free quote and architecture assessment&nbsp;&rsaquo;</a>
         </div>
 
         <table aria-label="Managed Landscape Pricing Table">
@@ -250,7 +250,7 @@
               <th>Managed Landscape on public clouds, VMware, OpenStack or LXD</th>
               <td>$3,099</td>
               <td>
-                $6,861<a href="https://docs.google.com/document/d/1fLRWW-Gtslaia2ypSrLJVBxZVHo5FY5Q84o97Gs2-w4/edit#bookmark=id.gjdgxs">*</a>
+                $6,861<a href="https://ubuntu.com/managed/apps">*</a>
               </td>
             </tr>
             <tr>
@@ -274,7 +274,7 @@
         our dashboard may not natively address.
       </h2>
       <div class="p-cta-block">
-        <a href="https://docs.google.com/document/d/1PHiLMYzRfrVt14GtMzSAeIo2xrylzvp3v-oOr_HoUtM/edit?usp=sharing">Contact us about your unique requirements&nbsp;&rsaquo;</a>
+        <a href="/contact-us" class="js-invoke-modal">Contact us about your unique requirements&nbsp;&rsaquo;</a>
       </div>
     </div>
   </section>

--- a/templates/landscape/managed.html
+++ b/templates/landscape/managed.html
@@ -173,14 +173,16 @@
       </div>
     </div>
     <div class="u-fixed-width u-hide--small">
-      {{ image(url="https://assets.ubuntu.com/v1/9423d6a0-bring-own-identity.png",
-            alt="",
-            width="2464",
-            height="1028",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-image-container--full-width is-highlighted"}) | safe
-      }}
+      <div class="p-image-container--full-width is-highlighted">
+        {{ image(url="https://assets.ubuntu.com/v1/9423d6a0-bring-own-identity.png",
+                alt="",
+                width="2464",
+                height="1028",
+                hi_def=True,
+                loading="lazy",
+                attrs={"class": "p-image-container__image"}) | safe
+        }}
+      </div>
     </div>
   </section>
 

--- a/templates/landscape/managed.html
+++ b/templates/landscape/managed.html
@@ -174,15 +174,48 @@
         </div>
       </div>
     </div>
-    <div class="u-fixed-width">
+    <div class="u-fixed-width u-hide--small">
       {{ image(url="https://assets.ubuntu.com/v1/9423d6a0-bring-own-identity.png",
             alt="",
             width="2464",
             height="1028",
             hi_def=True,
             loading="lazy",
-            attrs={"class": "p-image-container--full-width"}) | safe
+            attrs={"class": "p-image-container--full-width is-highlighted"}) | safe
       }}
+    </div>
+  </section>
+
+  <section class="p-section">
+    <hr class="is-fixed-width" />
+    <div class="row--50-50">
+      <div class="col">
+        <h2>
+          Mirror Ubuntu repositories,
+          <br />
+          and distribute software internally
+        </h2>
+      </div>
+      <div class="col">
+        <div class="u-sv3">
+          <p>
+            Landscape simplifies the task of scheduling software updates, and provides a mirroring mechanism to deliver software updates at scale, over your local network (LAN).
+          </p>
+          <p>
+            Organizations developing proprietary software on Ubuntu benefit from Managed Landscape's support for private repositories.
+          </p>
+        </div>
+        <div class="p-image-container is-cover">
+          {{ image(url="https://assets.ubuntu.com/v1/f47e7166-mirror-ubuntu repos.png",
+                    alt="",
+                    width="1200",
+                    height="801",
+                    hi_def=True,
+                    loading="lazy",
+                    attrs={"class": "p-image-container__image"}) | safe
+          }}
+        </div>
+      </div>
     </div>
   </section>
 

--- a/templates/landscape/managed.html
+++ b/templates/landscape/managed.html
@@ -234,7 +234,7 @@
           <p>
             Our Field Engineering team can recommend the number and type of machines your Managed Landscape deployment would need.
           </p>
-          <div class="p-cta-block u-sv4">
+          <div class="p-cta-block">
             <a href="/contact-us" class="js-invoke-modal">Get started with a free quote and architecture assessment&nbsp;&rsaquo;</a>
           </div>
         </div>

--- a/templates/landscape/managed.html
+++ b/templates/landscape/managed.html
@@ -260,6 +260,11 @@
             </tr>
           </tbody>
         </table>
+
+        <hr class="p-rule--muted" />
+        <p class="p-text--small u-text--muted">
+          * *  <i>Review the <a href="/managed/apps?_ga=2.124403338.1493445535.1734514472-498580729.1704275961&_gl=1*19cgxe8*_gcl_au*MzAwNDUwMDU4LjE3MjgzNzYwNzI.">details for managed apps</a>.</i>
+        </p>
       </div>
     </div>
   </section>

--- a/templates/landscape/managed.html
+++ b/templates/landscape/managed.html
@@ -49,7 +49,7 @@
     {% endcall -%}
   </section>
 
-  <section class="p-section--shallow">
+  <section class="p-section">
     <div class="p-section--shallow">
       <div class="u-fixed-width">
         <hr class="p-rule" />
@@ -62,27 +62,25 @@
     </div>
     <div class="row">
       <div class="col-9 col-medium-6 col-start-large-4">
-        <div class="p-section">
-          <div class="row">
-            <div class="col-3 col-medium-2">
-              <hr class="p-rule--highlight" />
-              <p class="p-heading--1 u-sv-2">
-                Up to
-                <br class="u-hide--small" />
-                99.9% uptime
-              </p>
-              <p>Backed by an SLA.</p>
-            </div>
-            <div class="col-3 col-medium-2">
-              <hr class="p-rule--highlight" />
-              <p class="p-heading--1 u-sv-2">24/7 monitoring</p>
-              <p>Active management and break/fix response by Canonical engineers.</p>
-            </div>
-            <div class="col-3 col-medium-2">
-              <hr class="p-rule--highlight" />
-              <p class="p-heading--1 u-sv-2">High availability</p>
-              <p>Fault-tolerant and ready for real-world challenges.</p>
-            </div>
+        <div class="row">
+          <div class="col-3 col-medium-2">
+            <hr class="p-rule--highlight" />
+            <p class="p-heading--1 u-sv-2">
+              Up to
+              <br class="u-hide--small" />
+              99.9% uptime
+            </p>
+            <p>Backed by an SLA.</p>
+          </div>
+          <div class="col-3 col-medium-2">
+            <hr class="p-rule--highlight" />
+            <p class="p-heading--1 u-sv-2">24/7 monitoring</p>
+            <p>Active management and break/fix response by Canonical engineers.</p>
+          </div>
+          <div class="col-3 col-medium-2">
+            <hr class="p-rule--highlight" />
+            <p class="p-heading--1 u-sv-2">High availability</p>
+            <p>Fault-tolerant and ready for real-world challenges.</p>
           </div>
         </div>
       </div>
@@ -90,8 +88,8 @@
   </section>
 
   <section class="p-section">
-    <hr class="is-fixed-width" />
     <div class="row--50-50">
+      <hr class="p-rule" />
       <div class="col">
         <h2>Any-cloud ready</h2>
       </div>
@@ -161,9 +159,9 @@
   </section>
 
   <section class="p-section">
-    <hr class="p-rule is-fixed-width" />
     <div class="p-section--shallow">
       <div class="row--50-50">
+        <hr class="p-rule" />
         <div class="col">
           <h2>Bring your own identity and access management platform</h2>
         </div>
@@ -187,8 +185,8 @@
   </section>
 
   <section class="p-section">
-    <hr class="is-fixed-width" />
     <div class="row--50-50">
+      <hr class="p-rule" />
       <div class="col">
         <h2>
           Mirror Ubuntu repositories,
@@ -220,8 +218,8 @@
   </section>
 
   <section class="p-section">
-    <hr class="p-rule is-fixed-width" />
     <div class="row--50-50">
+      <hr class="p-rule" />
       <div class="col">
         <h2>
           Pricing that is clear
@@ -230,11 +228,13 @@
         </h2>
       </div>
       <div class="col">
-        <p>
-          Our Field Engineering team can recommend the number and type of machines your Managed Landscape deployment would need.
-        </p>
-        <div class="p-cta-block u-sv4">
-          <a href="/contact-us" class="js-invoke-modal">Get started with a free quote and architecture assessment&nbsp;&rsaquo;</a>
+        <div class="p-section--shallow">
+          <p>
+            Our Field Engineering team can recommend the number and type of machines your Managed Landscape deployment would need.
+          </p>
+          <div class="p-cta-block u-sv4">
+            <a href="/contact-us" class="js-invoke-modal">Get started with a free quote and architecture assessment&nbsp;&rsaquo;</a>
+          </div>
         </div>
 
         <table aria-label="Managed Landscape Pricing Table">
@@ -250,7 +250,7 @@
               <th>Managed Landscape on public clouds, VMware, OpenStack or LXD</th>
               <td>$3,099</td>
               <td>
-                $6,861<a href="https://ubuntu.com/managed/apps">*</a>
+                $6,861<a href="/managed/apps">*</a>
               </td>
             </tr>
             <tr>

--- a/templates/landscape/managed.html
+++ b/templates/landscape/managed.html
@@ -1,5 +1,7 @@
 {% extends "landscape/base_landscape.html" %}
 
+{% from "_macros/vf_hero.jinja" import vf_hero %}
+
 {% block title %}Managed Landscape{% endblock %}
 
 {% block meta_description %}
@@ -15,250 +17,234 @@
 {% endblock meta_copydoc %}
 
 {% block content %}
-  <main id="main-content" class="inner-wrapper is-paper">
-    <article>
-      <section class="p-strip is-shallow u-no-padding--bottom">
+
+  <section class="p-section--hero u-no-padding--bottom">
+    {% call(slot) vf_hero(
+      title_text='Managed Landscape',
+      layout='50/50',
+      is_split_on_medium=true
+      ) -%}
+      {%- if slot == 'description' -%}
+        <p class="u-no-padding--top">
+          <b>Software as a service convenience, in an environment you control.</b>
+          <br />
+          Manage machines at scale without worrying about tooling. Let Canonical handle Landscape's installation, patching, scaling and maintenance.
+        </p>
+      {%- endif -%}
+      {%- if slot == 'cta' -%}
+        <a href="/contact-us" class="p-button--positive js-invoke-modal">Contact us</a>
+      {%- endif -%}
+      {%- if slot == 'image' -%}
+        <div class="p-image-container--3-2 is-cover">
+          {{ image(url="https://assets.ubuntu.com/v1/798a1063-hero-img.png",
+                    alt="",
+                    width="1200",
+                    height="752",
+                    hi_def=True,
+                    loading="auto|lazy",
+                    attrs={"class": "p-image-container__image"}) | safe
+          }}
+        </div>
+      {%- endif -%}
+    {% endcall -%}
+  </section>
+
+  <section class="p-section--shallow">
+    <div class="p-section--shallow">
+      <div class="u-fixed-width">
+        <hr class="p-rule" />
+        <h2>
+          We take care of the installation
+          <br class="u-hide--small" />
+          and maintenance
+        </h2>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-9 col-medium-6 col-start-large-4">
         <div class="p-section">
           <div class="row">
             <div class="col-3 col-medium-2">
-              <h1 class="p-muted-heading">Managed Landscape</h1>
-            </div>
-            <div class="col-9 col-medium-4">
-              <h2>
-                <strong>Software as a service convenience,
-                  <br class="u-hide--small" />
-                in an environment you control</strong>
-              </h2>
-              <p>
-                Manage machines at scale without worrying about tooling.
-                <br />
-                Let Canonical handle Landscape's installation, patching, scaling and maintenance.
+              <hr class="p-rule--highlight" />
+              <p class="p-heading--1 u-sv-2">
+                Up to
+                <br class="u-hide--small" />
+                99.9% uptime
               </p>
-              <p>
-                <a class="p-button--positive js-invoke-modal"
-                   href="/landscape/managed#get-in-touch">Contact us</a>
-              </p>
+              <p>Backed by an SLA.</p>
+            </div>
+            <div class="col-3 col-medium-2">
+              <hr class="p-rule--highlight" />
+              <p class="p-heading--1 u-sv-2">24/7 monitoring</p>
+              <p>Active management and break/fix response by Canonical engineers.</p>
+            </div>
+            <div class="col-3 col-medium-2">
+              <hr class="p-rule--highlight" />
+              <p class="p-heading--1 u-sv-2">High availability</p>
+              <p>Fault-tolerant and ready for real-world challenges.</p>
             </div>
           </div>
         </div>
-      </section>
+      </div>
+    </div>
+  </section>
 
-      <section class="p-section">
-        <hr class="is-fixed-width p-rule" />
-        <div class="row">
-          <div class="col-3 col-medium-6">
-            <div class="p-block">
-              <h2 class="p-muted-heading">
-                We take care
-                <br class="u-hide--medium u-hide--small" />
-                of the installation
-                <br class="u-hide--medium u-hide--small" />
-                and maintenance
-              </h2>
-            </div>
-          </div>
-          <div class="col-medium-2 col-3">
-            <p class="p-heading--2">Up to 99.9% uptime</p>
-            <p>Backed by an SLA.</p>
-          </div>
-          <div class="col-medium-2 col-3">
-            <p class="p-heading--2">
-              24/7
-              <br />
-              monitoring
-            </p>
-            <p>Active management and break/fix response by Canonical engineers.</p>
-          </div>
-          <div class="col-medium-2 col-3">
-            <p class="p-heading--2">
-              High
-              <br />
-              availability
-            </p>
-            <p>Fault-tolerant and ready for real-world challenges.</p>
-          </div>
-        </div>
-      </section>
-
-      <section class="p-strip is-deep u-no-padding--top">
-        <hr class="p-rule is-fixed-width" />
-        <div class="row">
-          <div class="col-3 col-medium-2">
-            <div class="p-block">
-              <h2 class="p-muted-heading">Why Managed Landscape</h2>
-            </div>
-          </div>
-          <div class="col-9 col-medium-4">
-            <div class="p-strip u-no-padding--top is-shallow">
-              <h3 class="p-heading--2">Any-cloud ready</h3>
-            </div>
-            <p>
-              Managed Landscape can be deployed in high availability across multiple machines, anywhere. Whether you are running your workloads across multiple clouds or a hybrid cloud with your own infrastructure, Managed Landscape can easily provide a scalable and reliable service to maintain your Ubuntu environment.
-            </p>
-          </div>
-        </div>
-        <div class="p-strip is-shallow u-no-padding--top">
-          <div class="row">
-            <div class="col-small-1 col-2 col-start-large-2 col-medium-1 col-start-medium-2 u-sv-3">
-              {{
-              image (
-              url="https://assets.ubuntu.com/v1/38ac7357-openstack-logo.png",
-              alt="Openstack",
-              width="432",
-              height="432",
-              hi_def=True,
-              loading="lazy"
-              ) | safe
-              }}
-            </div>
-            <div class="col-small-1 col-2 col-medium-1 u-sv-3">
-              {{
-              image (
-              url="https://assets.ubuntu.com/v1/865293a8-microsoft-azure--logo.png",
-              alt="Microsoft Azure",
-              width="288",
-              height="288",
-              hi_def=True,
-              loading="lazy"
-              ) | safe
-              }}
-            </div>
-            <div class="col-small-1 col-2 col-medium-1 u-sv-3">
-              {{
-              image (
-              url="https://assets.ubuntu.com/v1/b2952436-aws-logo.svg",
-              alt="Amazon Web Services",
-              width="158",
-              height="158",
-              hi_def=True,
-              loading="lazy"
-              ) | safe
-              }}
-            </div>
-            <div class="col-small-1 col-2 col-medium-1 u-sv-3">
-              {{ image (
-              url="https://assets.ubuntu.com/v1/8347ea7c-vmware-logo.png",
-              alt="VMWare",
-              width="288",
-              height="289",
-              hi_def=True,
-              loading="lazy"
-              ) | safe
-              }}
-            </div>
-            <div class="col-small-1 col-2 col-medium-1 u-sv-3">
-              {{ image (
-              url="https://assets.ubuntu.com/v1/120a5c4b-google-cloud-stacked-logo.png",
-              alt="Google Cloud Platform",
-              width="432",
-              height="432",
-              hi_def=True,
-              loading="lazy"
-              ) | safe
-              }}
-            </div>
-          </div>
-        </div>
-        <div class="row">
-          <div class="col-9 col-start-large-4 col-medium-4 col-start-medium-3">
-            <div class="p-strip u-no-padding--top">
-              <hr class="is-fixed-width p-rule--muted" />
-              <div class="p-strip u-no-padding--top is-shallow">
-                <h3 class="p-heading--2">
-                  Bring your own
-                  <br class="u-hide--small" />
-                  identity and access management platform
-                </h3>
+  <section class="p-section">
+    <hr class="is-fixed-width" />
+    <div class="row--50-50">
+      <div class="col">
+        <h2>Any-cloud ready</h2>
+      </div>
+      <div class="col">
+        <p>
+          Managed Landscape can be deployed in high availability across multiple machines, anywhere. Whether you are running your workloads across multiple clouds or a hybrid cloud with your own infrastructure, Managed Landscape can easily provide a scalable and reliable service to maintain your Ubuntu environment.
+        </p>
+        <div>
+          <hr class="p-rule--muted" />
+          <div class="p-logo-section--dense">
+            <div class="p-logo-section__items">
+              <div class="p-logo-section__item">
+                {{ image(url="https://assets.ubuntu.com/v1/48b68d11-gcp-logo.png",
+                                alt="GCP Logo",
+                                width="98",
+                                height="209",
+                                hi_def=True,
+                                loading="lazy",
+                                attrs={"class": "p-logo-section__logo"}) | safe
+                }}
               </div>
-              <p>
-                Landscape supports OpenID Connect (OIDC) to authenticate users, and integrates enterprise identity providers like Azure AD, Google, Okta, IBM, and more.
-              </p>
-
-              <div class="is-paper__image--container u-hide--small">
-                {{ image (
-                url="https://assets.ubuntu.com/v1/994c1b4b-Canonical Landscape Illustrations v1.png",
-                alt="",
-                width="8000",
-                height="4500",
-                hi_def=True,
-                loading="lazy"
-                ) | safe
+              <div class="p-logo-section__item">
+                {{ image(url="https://assets.ubuntu.com/v1/3ec94c2d-aws-logo.png",
+                                alt="",
+                                width="101",
+                                height="209",
+                                hi_def=True,
+                                loading="lazy",
+                                attrs={"class": "p-logo-section__logo"}) | safe
+                }}
+              </div>
+              <div class="p-logo-section__item">
+                {{ image(url="https://assets.ubuntu.com/v1/ae511063-azure-logo.png",
+                                alt="",
+                                width="79",
+                                height="209",
+                                hi_def=True,
+                                loading="lazy",
+                                attrs={"class": "p-logo-section__logo"}) | safe
+                }}
+              </div>
+              <div class="p-logo-section__item">
+                {{ image(url="https://assets.ubuntu.com/v1/bd83cd83-opensearch-logo.png",
+                                alt="",
+                                width="81",
+                                height="209",
+                                hi_def=True,
+                                loading="lazy",
+                                attrs={"class": "p-logo-section__logo"}) | safe
+                }}
+              </div>
+              <div class="p-logo-section__item">
+                {{ image(url="https://assets.ubuntu.com/v1/7589afda-vmware-logo.png",
+                                alt="",
+                                width="216",
+                                height="209",
+                                hi_def=True,
+                                loading="lazy",
+                                attrs={"class": "p-logo-section__logo"}) | safe
                 }}
               </div>
             </div>
           </div>
-          <div class="col-9 col-start-large-4 col-medium-4 col-start-medium-3">
-            <div class="p-strip u-no-padding--top">
-              <hr class="is-fixed-width p-rule--muted" />
-              <div class="p-strip u-no-padding--top is-shallow">
-                <h3 class="p-heading--2">
-                  Mirror Ubuntu repositories,
-                  <br class="u-hide--small" />
-                  and distribute software internally
-                </h3>
-              </div>
-              <p>
-                Landscape simplifies the task of scheduling software updates, and provides a mirroring mechanism to deliver software updates at scale, over your local network (LAN).
-              </p>
-              <p>
-                Organisations developing proprietary software on Ubuntu benefit from Managed Landscape's support for private repositories.
-              </p>
-            </div>
-          </div>
-          <div class="col-9 col-start-large-4 col-medium-4 col-start-medium-3">
-            <div class="p-strip u-no-padding--top u-no-padding--bottom">
-              <hr class="is-fixed-width p-rule--muted" />
-              <div class="p-strip u-no-padding--top is-shallow">
-                <h3 class="p-heading--2">Pricing that is clear and transparent</h3>
-              </div>
-              <p>
-                Our Field Engineering team can recommend the number and type of machines your Managed Landscape deployment would need.
-              </p>
-              <p class="u-sv2">
-                <a href="/landscape/managed#get-in-touch">Get started with a free quote and architecture assessment</a>
-              </p>
-
-              <div class="row">
-                <table>
-                  <thead>
-                    <tr>
-                      <th></th>
-                      <th>Per Landscape virtual machine/year</th>
-                      <th>Per Landscape physical machine/year</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr>
-                      <th>Managed Landscape on public clouds, VMware, OpenStack or LXD</th>
-                      <td>$3,099</td>
-                      <td>$6,861</td>
-                    </tr>
-                    <tr>
-                      <th>Managed Landscape on bare metal</th>
-                      <td>N/A</td>
-                      <td>$9,470</td>
-                    </tr>
-                  </tbody>
-                </table>
-              </div>
-            </div>
-          </div>
         </div>
-      </section>
+      </div>
+    </div>
+  </section>
 
-      <section class="p-strip is-white" style="background: white;">
-        <div class="row">
-          <div class="col-9 col-start-large-4 col-medium-4 col-start-medium-3 p-strip">
-            <h2>Got questions?</h2>
-            <p>Landscape's API can bridge any requirements our dashboard may not natively address.</p>
-            <p>
-              <a href="/landscape/managed#get-in-touch">Contact us about your unique requirements</a>
-            </p>
-          </div>
+  <section class="p-section">
+    <hr class="p-rule is-fixed-width" />
+    <div class="p-section--shallow">
+      <div class="row--50-50">
+        <div class="col">
+          <h2>Bring your own identity and access management platform</h2>
         </div>
-      </section>
-    </article>
-  </main>
+        <div class="col">
+          <p>
+            Landscape supports OpenID Connect (OIDC) to authenticate users, and integrates enterprise identity providers like Azure AD, Google, Okta, IBM, and more.
+          </p>
+        </div>
+      </div>
+    </div>
+    <div class="u-fixed-width">
+      {{ image(url="https://assets.ubuntu.com/v1/9423d6a0-bring-own-identity.png",
+            alt="",
+            width="2464",
+            height="1028",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class": "p-image-container--full-width"}) | safe
+      }}
+    </div>
+  </section>
+
+  <section class="p-section">
+    <hr class="p-rule is-fixed-width" />
+    <div class="row--50-50">
+      <div class="col">
+        <h2>
+          Pricing that is clear
+          <br class="u-hide--small" />
+          and transparent
+        </h2>
+      </div>
+      <div class="col">
+        <p>
+          Our Field Engineering team can recommend the number and type of machines your Managed Landscape deployment would need.
+        </p>
+        <div class="p-cta-block u-sv4">
+          <a href="https://docs.google.com/document/d/1PHiLMYzRfrVt14GtMzSAeIo2xrylzvp3v-oOr_HoUtM/edit?usp=sharing">Get started with a free quote and architecture assessment&nbsp;&rsaquo;</a>
+        </div>
+
+        <table aria-label="Managed Landscape Pricing Table">
+          <thead>
+            <tr>
+              <th></th>
+              <th>Per Landscape virtual machine/year</th>
+              <th>Per Landscape physical machine/year</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th>Managed Landscape on public clouds, VMware, OpenStack or LXD</th>
+              <td>$3,099</td>
+              <td>
+                $6,861<a href="https://docs.google.com/document/d/1fLRWW-Gtslaia2ypSrLJVBxZVHo5FY5Q84o97Gs2-w4/edit#bookmark=id.gjdgxs">*</a>
+              </td>
+            </tr>
+            <tr>
+              <th>Managed Landscape on bare metal</th>
+              <td>N/A</td>
+              <td>$9,470</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </section>
+
+  <hr class="p-rule is-fixed-width" />
+
+  <section class="p-strip is-deep">
+    <div class="u-fixed-width">
+      <h2>
+        Got questions? Landscape's API can bridge any requirements
+        <br />
+        our dashboard may not natively address.
+      </h2>
+      <div class="p-cta-block">
+        <a href="https://docs.google.com/document/d/1PHiLMYzRfrVt14GtMzSAeIo2xrylzvp3v-oOr_HoUtM/edit?usp=sharing">Contact us about your unique requirements&nbsp;&rsaquo;</a>
+      </div>
+    </div>
+  </section>
 
   <!-- Set default Marketo information for contact form below-->
   <div class="u-hide"


### PR DESCRIPTION
## Done

- Rebranded page

## QA

- View the site  in your web browser at: https://ubuntu-com-14580.demos.haus/landscape/managed
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check that it matches the following:
   - [Design](https://www.figma.com/design/btsxPLFKGPWDlbQ4rjR4jZ/25.04-Landscape-Rebranding?node-id=4015-2226&t=2riHUPsatn9YCZDu-0)
   - [CopyDoc](https://docs.google.com/document/d/1MycPWcmMveCZxrGtn7ASc0myWNxPzLTciHfQIA6kPZ4/edit?tab=t.0#)

## Issue / Card

Fixes #[WD-16838](https://warthogs.atlassian.net/browse/WD-16838)


[WD-16838]: https://warthogs.atlassian.net/browse/WD-16838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ