### PR TITLE
Clarify subscription co-term details in shop checkout

### DIFF
--- a/static/js/src/advantage/subscribe/checkout/components/Summary/Summary.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Summary/Summary.tsx
@@ -330,7 +330,10 @@ function Summary({ products, action, coupon, setError }: Props) {
                 {format(new Date(priceData?.end_of_cycle), DATE_FORMAT)}
               </strong>
             </p>
-            <p>The same date as your existing subscription.</p>
+            <p>
+              This subscription is co-termed with your existing subscription.
+              Both subscriptions will end on the same date.
+            </p>
           </Col>
         ) : (
           <Col size={8}>


### PR DESCRIPTION
## Done

- Update the copy for overlapping terms

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Buy an Ubuntu Pro subscription if you don't have one already
    - Buy another which will cause the two to overlap
        - In the section where the ending date is shown you should see the following text if your subscription overlaps: "This subscription is co-termed with your existing subscription. Both subscriptions will end on the same date."

## Issue / Card

Fixes [WD-17227](https://warthogs.atlassian.net/browse/WD-17227)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-17227]: https://warthogs.atlassian.net/browse/WD-17227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ