### PR TITLE
mention recaptcha cookies in data privacy page

### DIFF
--- a/templates/legal/data-privacy/index.html
+++ b/templates/legal/data-privacy/index.html
@@ -301,6 +301,15 @@
               <p><a href="https://vwo.com/privacy-policy/">Visual Website Optimizer’s privacy policy</a></p>
             </td>
           </tr>
+          <tr>
+            <td>Google reCAPTCHA</td>
+            <td><code>__Secure-1PSIDCC</code>, <code>__Secure-3PSIDCC</code>, <code>SIDCC</code></td>
+            <td>
+              <p><a href="https://www.google.com/recaptcha/about/">Google reCAPTCHA</a> tracks various website interaction signals to identify bot sessions and provides us protection against spam and abuse.</p>
+              <p><a href="https://policies.google.com/privacy">Google Privacy Policy</a></p>
+              <p><a href="https://policies.google.com/terms">Google Terms of Service</a></p>
+            </td>
+          </tr>
         </tbody>
       </table>
 


### PR DESCRIPTION
## Done

- Mentioned recaptcha cookies in the data privacy page
Copy doc: https://docs.google.com/document/d/1AlOE2_-BqZNP4hiiuf8kZney8g1zvqAlDYl2u3X6m6I/edit?tab=t.0

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://localhost:8001/legal/data-privacy
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

WD-17842

## Screenshots

![image](https://github.com/user-attachments/assets/a3311a03-8408-48d3-9c65-398776b1bcc2)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
