### PR TITLE
WD-17891 fix(links): Corrected the incorrect links

### DIFF
--- a/templates/landscape/features.html
+++ b/templates/landscape/features.html
@@ -27,7 +27,7 @@
     {%- endif -%}
     {%- if slot == 'cta' -%}
       <a href="/landscape/compare" class="p-button--positive">Get Landscape</a>
-      <a href="/landscape/contact-us" class="p-button js-invoke-modal">Contact us</a>
+      <a href="/contact-us" class="p-button js-invoke-modal">Contact us</a>
     {%- endif -%}
     {%- if slot == 'image' -%}
       <div class="p-image-container--cinematic is-cover">
@@ -282,7 +282,7 @@
         <a href="/landscape/compare"
            class="p-button--positive"
            aria-label="Try Landscape">Get Landscape</a>
-        <a href="/landscape/contact-us" class="js-invoke-modal">Contact us&nbsp;&rsaquo;</a>
+        <a href="/contact-us" class="js-invoke-modal">Contact us&nbsp;&rsaquo;</a>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Done

- Corrected the incorrect links returning 404 for contact us in landscape/features
## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go on [/landscape/features](https://ubuntu-com-14597.demos.haus/landscape/features) and check if the links are working correctly.

## Issue / Card

Fixes # [WD-17891](https://warthogs.atlassian.net/browse/WD-17981)




## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-17891]: https://warthogs.atlassian.net/browse/WD-17891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ