### PR TITLE
WD-17971-add-a-the-on-the-form-text-at-download-server-thank-you

### DIFF
--- a/templates/download/shared/_server_weekly_news.html
+++ b/templates/download/shared/_server_weekly_news.html
@@ -64,7 +64,7 @@
                    aria-labelledby="canonicalUpdatesOptIn"
                    name="canonicalUpdatesOptIn"
                    type="checkbox" />
-            <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I would like to receive news from Ubuntu newsletter and occasional updates from Canonical by email.</span>
+            <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I would like to receive news from the Ubuntu newsletter and occasional updates from Canonical by email.</span>
           </label>
 
           <p>


### PR DESCRIPTION
## Done

- Add "the" to the form field in the server weekly newsletter form  

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- visit /download/server/thank-you
- Click on "Download the CLI cheatsheet" button 
- Check if the form has a checkbox that says "I would like to receive news from the Ubuntu newsletter and occasional updates from Canonical by email"
- Copy Link: https://docs.google.com/document/d/1bC2b3bVylJFTuGpIcFzCph7GDp89_c4ixQRhEZiGUeE/

## Issue / Card

Fixes [#WD-17971](https://warthogs.atlassian.net/browse/WD-17971)

## Screenshots

![image](https://github.com/user-attachments/assets/6dec09e8-f528-4645-9ae2-77f7ec232d83)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
