### PR TITLE
Added livechat origins to csp

### DIFF
--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -8,7 +8,9 @@ from webapp.context import (
     date_has_passed,
     descending_years,
     format_date,
+    format_to_id,
     get_json_feed,
+    get_meganav,
     get_navigation,
     modify_query,
     month_name,
@@ -16,9 +18,7 @@ from webapp.context import (
     releases,
     schedule_banner,
     sort_by_key_and_ordered_list,
-    get_meganav,
     split_list,
-    format_to_id,
 )
 from webapp.login import empty_session, user_info
 from webapp.security.api import SecurityAPIError
@@ -72,12 +72,16 @@ CSP = {
         "jspm.dev",
         "cdn.livechatinc.com",
         "api.livechatinc.com",
+        "secure.livechatinc.com"
         # This is necessary for Google Tag Manager to function properly.
         "'unsafe-inline'",
     ],
     "font-src": [
         "'self'",
         "assets.ubuntu.com",
+        "cdn.livechatinc.com",
+        "secure.livechatinc.com",
+        "fonts.google.com",
     ],
     "script-src": [
         "'self'",
@@ -107,6 +111,13 @@ CSP = {
         "conversions-config.reddit.com",
         "px.ads.linkedin.com",
         "ws.zoominfo.com",
+        "api.livechatinc.com",
+        "cdn.livechatinc.com",
+        "secure.livechatinc.com",
+        "youtube.com",
+        "google.com",
+        "fonts.google.com",
+        "api.text.com",
     ],
     "frame-src": [
         "'self'",
@@ -126,6 +137,17 @@ CSP = {
     "media-src": [
         "'self'",
         "res.cloudinary.com",
+        "cdn.livechatinc.com",
+        "secure.livechatinc.com",
+        "cdn.livechat-static.com",
+    ],
+    "child-src": [
+        "api.livechatinc.com",
+        "cdn.livechatinc.com",
+        "secure.livechatinc.com",
+        "youtube.com",
+        "google.com",
+        "fonts.google.com",
     ],
 }
 
@@ -317,9 +339,7 @@ def init_handlers(app, sentry):
 
         response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
         response.headers["Cross-Origin-Embedder-Policy"] = "unsafe-none"
-        response.headers["Cross-Origin-Opener-Policy"] = (
-            "same-origin-allow-popups"
-        )
+        response.headers["Cross-Origin-Opener-Policy"] = "same-origin-allow-popups"
         response.headers["Cross-Origin-Resource-Policy"] = "cross-origin"
         response.headers["X-Permitted-Cross-Domain-Policies"] = "none"
         return response

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -339,7 +339,9 @@ def init_handlers(app, sentry):
 
         response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
         response.headers["Cross-Origin-Embedder-Policy"] = "unsafe-none"
-        response.headers["Cross-Origin-Opener-Policy"] = "same-origin-allow-popups"
+        response.headers["Cross-Origin-Opener-Policy"] = (
+            "same-origin-allow-popups"
+        )
         response.headers["Cross-Origin-Resource-Policy"] = "cross-origin"
         response.headers["X-Permitted-Cross-Domain-Policies"] = "none"
         return response


### PR DESCRIPTION
## Done

- Added livechat origins to the content security policy as per https://www.livechat.com/help/use-livechat-with-content-security-policy/#cspv21

## QA

- Open the demo at /server and confirm that there are no console errors

# Fixes

Livechat CSP rules.

## Screenshots
![image](https://github.com/user-attachments/assets/ddd8d2b2-da33-4c79-821a-eeb76d42a228)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
