### PR TITLE
Rebrand embedding/faqs page

### DIFF
--- a/templates/embedding/faqs.html
+++ b/templates/embedding/faqs.html
@@ -1,72 +1,112 @@
 {% extends "embedded/base_embedded.html" %}
 
-{% block title %}Ubuntu is the new standard for embedded Linux{% endblock %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
-{% block meta_description %}Embedded Linux development is easy and secure on Ubuntu. Choose an enterprise app store or use the global Snap Store for reliable IoT package management. Start your embedded Linux project today. Get Ubuntu on your board with hardware certification and enablement.{% endblock meta_description %}
+{% block title %}FAQs - IPRights Policy - January 2024{% endblock %}
 
-{% block meta_image %}https://assets.ubuntu.com/v1/c75046c4-Smart+City.svg{% endblock meta_image %}
+{% block meta_description %}
+  Embedded Linux development is easy and secure on Ubuntu. Choose an enterprise app store or use the global Snap Store for reliable IoT package management. Start your embedded Linux project today. Get Ubuntu on your board with hardware certification and enablement.
+{% endblock meta_description %}
 
-{% block meta_copydoc %}https://docs.google.com/document/d/1xWrM0D4LkWdJh9EiAUuXgbYKqh15BnNcQpXqTlZCuYA/edit?tab=t.0{% endblock meta_copydoc %}
+{% block meta_image %}
+  https://assets.ubuntu.com/v1/c75046c4-Smart+City.svg
+{% endblock meta_image %}
 
-{% block body_class %}is-paper{% endblock body_class %}
+{% block meta_copydoc %}
+  https://docs.google.com/document/d/1xWrM0D4LkWdJh9EiAUuXgbYKqh15BnNcQpXqTlZCuYA/edit?tab=t.0
+{% endblock meta_copydoc %}
+
+{% block body_class %}
+  is-paper
+{% endblock body_class %}
 
 {% block content %}
+  <section class="p-section--deep">
+    {%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=false, is_list_full_width_on_tablet=true) -%}
+      {%- if slot == 'title' -%}
+        <h2>FAQs</h2>
+      {%- endif -%}
 
-<section class="p-strip is-shallow u-no-padding--bottom">
-  <div class="row--50-50 p-section">
-    <div class="col">
-      <h1>FAQS</h1>
-    </div>
-    <div class="col">
-      <p>As per the <a href="https://ubuntu.com/legal/intellectual-property-policy">IPRights Policy</a>, Canonical owns and manages certain intellectual property rights in Ubuntu and other associated intellectual property (Canonical IP) and licenses the use of these rights to enterprises, individuals and members of the Ubuntu community in accordance with the IPRights Policy.</p>
-      <p>Our policy exists to ensure that when you receive something that claims to be Ubuntu, you can trust that it will work to the same standard, regardless of where you got it from. And people everywhere tell us they appreciate that - when they get Ubuntu on a cloud or as a VM, it works, and they can trust it.</p>
-    </div>
-  </div>
-  <hr class="is-fixed-width p-rule" />
-  <div class="row--50-50 p-section--shallow">
-    <div class="col">
-      <h2 class="p-heading--5">Q. Can I publish a cloud VM image based on Ubuntu?</h2>
-    </div>
-    <div class="col">
-      <p>A. Yes, on AWS, Azure, Google, IBM, Oracle, and the others where we have a contract.</p>
-    </div>
-  </div>
-  <hr class="is-fixed-width p-rule" />
-  <div class="row--50-50 p-section--shallow">
-    <div class="col">
-      <h2 class="p-heading--5">Q. Can I install Ubuntu in my company for internal company use only for free?</h2>
-    </div>
-    <div class="col">
-      <p>A. Yes, you get free security updates on the "main" OS and packages for 5 years, you might want to consider an Ubuntu Pro subscription for wider and longer duration security coverage, or Support subscription for phone and email support.</p>
-    </div>
-  </div>
-  <hr class="is-fixed-width p-rule" />
-  <div class="row--50-50 p-section--shallow">
-    <div class="col">
-      <h2 class="p-heading--5">Q. Can I redistribute Ubuntu?</h2>
-    </div>
-    <div class="col">
-      <p>A. Yes, you can mirror our installation images and archives as long as those are mirrored exactly and without modifications.</p>
-    </div>
-  </div>
-  <hr class="is-fixed-width p-rule" />
-  <div class="row--50-50 p-section--shallow">
-    <div class="col">
-      <h2 class="p-heading--5">Q. Can I preinstall Ubuntu on hardware that I sell?</h2>
-    </div>
-    <div class="col">
-      <p>A. You can include unmodified Ubuntu installation media "in the box" [see redistribution above] but you cannot preinstall Ubuntu and ship the resulting hardware without an agreement with Canonical; we have agreements for both certified and uncertified hardware preinstallation.</p>
-    </div>
-  </div>
-  <hr class="is-fixed-width p-rule" />
-  <div class="row--50-50 p-section--deep">
-    <div class="col">
-      <h2 class="p-heading--5">Q. What is a modification?</h2>
-    </div>
-    <div class="col">
-      <p>A. There are many examples of what might be a modification to Ubuntu, including modifying or replacing the kernel, removing or adding packages, theme changes and pre-installation. Ubuntu is available to download in the form of an ISO installation image with DEB files. If a customer was to distribute the unmodified ISO installation image in the same format on a CD or server, this would be unmodified Ubuntu.</p>
-    </div>
-  </div>
-</section>
+      {%- if slot == 'description' -%}
+        <div class="p-section--shallow">
+          <p>
+            As per the <a href="/legal/intellectual-property-policy">IPRights Policy</a>, Canonical owns and manages certain intellectual property rights in Ubuntu and other associated intellectual property (Canonical IP) and licenses the use of these rights to enterprises, individuals and members of the Ubuntu community in accordance with the IPRights Policy.
+          </p>
+          <p>
+            Our policy exists to ensure that when you receive something that claims to be Ubuntu, you can trust that it will work to the same standard, regardless of where you got it from. And people everywhere tell us they appreciate that - when they get Ubuntu on a cloud or as a VM, it works, and they can trust it.
+          </p>
+        </div>
+      {%- endif -%}
 
+      {%- if slot == 'list_item_title_1' -%}
+        <h3 class="p-heading--5 faq-question">Can I publish a cloud VM image based on Ubuntu?</h3>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_description_1' -%}
+        <p class="faq-answer">Yes, on AWS, Azure, Google, IBM, Oracle, and the others where we have a contract.</p>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_title_2' -%}
+        <h3 class="p-heading--5 faq-question">Can I install Ubuntu in my company for internal company use only for free?</h3>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_description_2' -%}
+        <p class="faq-answer">
+          Yes, you can mirror our installation images and archives as long as those are mirrored exactly and without modifications.
+        </p>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_title_3' -%}
+        <h3 class="p-heading--5 faq-question">Can I redistribute Ubuntu?</h3>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_description_3' -%}
+        <p class="faq-answer">
+          Yes, you can mirror our installation images and archives as long as those are mirrored exactly and without modifications.
+        </p>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_title_4' -%}
+        <h3 class="p-heading--5 faq-question">Can I preinstall Ubuntu on hardware that I sell?</h3>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_description_4' -%}
+        <p class="faq-answer">
+          You can include unmodified Ubuntu installation media "in the box" [see redistribution above] but you cannot preinstall Ubuntu and ship the resulting hardware without an agreement with Canonical; we have agreements for both certified and uncertified hardware preinstallation.
+        </p>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_title_5' -%}
+        <h3 class="p-heading--5 faq-question">What is a modification?</h3>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_description_5' -%}
+        <p class="faq-answer">
+          There are many examples of what might be a modification to Ubuntu, including modifying or replacing the kernel, removing or adding packages, theme changes and pre-installation. Ubuntu is available to download in the form of an ISO installation image with DEB files. If a customer was to distribute the unmodified ISO installation image in the same format on a CD or server, this would be unmodified Ubuntu.
+        </p>
+      {%- endif -%}
+    {%- endcall -%}
+  </section>
+
+  <style>
+    .faq-question,
+    .faq-answer {
+      position: relative;
+      padding-left: 2rem;
+    }
+
+    .faq-question::before,
+    .faq-answer::before {
+      position: absolute;
+      left: 0;
+    }
+
+    .faq-question::before {
+      content: "Q.";
+    }
+
+    .faq-answer::before {
+      content: "A.";
+    }
+  </style>
 {% endblock content %}

--- a/templates/embedding/faqs.html
+++ b/templates/embedding/faqs.html
@@ -24,13 +24,13 @@
   <section class="p-section--deep">
     {%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=false, is_list_full_width_on_tablet=true) -%}
       {%- if slot == 'title' -%}
-        <div style="padding-top: 24px;">
-          <h2>FAQs</h2>
-        </div>
+        <div class="p-section--shallow"></div>
+        <h2>FAQs</h2>
       {%- endif -%}
 
       {%- if slot == 'description' -%}
-        <div class="p-section--shallow" style="padding-top: 24px;">
+        <div class="p-section--shallow u-hide--small u-hide--medium"></div>
+        <div class="p-section--shallow">
           <p>
             As per the <a href="/legal/intellectual-property-policy">IPRights Policy</a>, Canonical owns and manages certain intellectual property rights in Ubuntu and other associated intellectual property (Canonical IP) and licenses the use of these rights to enterprises, individuals and members of the Ubuntu community in accordance with the IPRights Policy.
           </p>

--- a/templates/embedding/faqs.html
+++ b/templates/embedding/faqs.html
@@ -24,11 +24,13 @@
   <section class="p-section--deep">
     {%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=false, is_list_full_width_on_tablet=true) -%}
       {%- if slot == 'title' -%}
-        <h2>FAQs</h2>
+        <div style="padding-top: 24px;">
+          <h2>FAQs</h2>
+        </div>
       {%- endif -%}
 
       {%- if slot == 'description' -%}
-        <div class="p-section--shallow">
+        <div class="p-section--shallow" style="padding-top: 24px;">
           <p>
             As per the <a href="/legal/intellectual-property-policy">IPRights Policy</a>, Canonical owns and manages certain intellectual property rights in Ubuntu and other associated intellectual property (Canonical IP) and licenses the use of these rights to enterprises, individuals and members of the Ubuntu community in accordance with the IPRights Policy.
           </p>
@@ -52,7 +54,7 @@
 
       {%- if slot == 'list_item_description_2' -%}
         <p class="faq-answer">
-          Yes, you can mirror our installation images and archives as long as those are mirrored exactly and without modifications.
+          Yes, you get free security updates on the "main" OS and packages for 5 years, you might want to consider an Ubuntu Pro subscription for wider and longer duration security coverage, or Support subscription for phone and email support.
         </p>
       {%- endif -%}
 


### PR DESCRIPTION
## Done

- Rebranded /embedding/faqs page.

## QA

- Open this [demo](https://ubuntu-com-14626.demos.haus/embedding/faqs) in your web browser.
   - Make sure to test on mobile, tablet and desktop.
- Make sure the page matches the [Figma design](https://www.figma.com/design/10NU0NGNkXEHrdhWGXW7xg/25.04-Embedding-Rebranding?node-id=11-766&t=uAlXm46LIvlk1bPb-1) and [Copydoc](https://docs.google.com/document/d/1xWrM0D4LkWdJh9EiAUuXgbYKqh15BnNcQpXqTlZCuYA/edit?tab=t.0)

## Issue / Card

Fixes #[WD-16602](https://warthogs.atlassian.net/browse/WD-16602)

[WD-16602]: https://warthogs.atlassian.net/browse/WD-16602?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ