### PR TITLE
Corrected Link on Ubuntu Support

### DIFF
--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -625,7 +625,7 @@
                 <a href="https://canonical-rockcraft.readthedocs-hosted.com/en/latest/explanation/rocks/">Rocks</a>, Canonical's new generation of OCI-compliant, container images, built on top of Ubuntu LTS and optimised to run applications
               </li>
               <li class="p-list__item has-bullet">
-                <a href="https://ubuntu.com/engage/chiseled-ubuntu-images-for-containers">Chiseled Ubuntu</a>, Canonical's distroless container images that only fit the strictly required dependencies
+                <a href="https://ubuntu.com/engage/chiselled-ubuntu-images-for-containers">Chiselled Ubuntu</a>, Canonical's distroless container images that only fit the strictly required dependencies
               </li>
             </ul>
           </div>


### PR DESCRIPTION
## Done

- Corrected link

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check if link works properly
- [Copydoc](https://docs.google.com/document/d/1AU2dwTXpQk2UuEvSuAqRKrbPWYb-LR0ZGvWu6xw95I8/edit?tab=t.0#)
- [Demo](https://ubuntu-com-14628.demos.haus/support)




## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
