### PR TITLE
fix: Fix payload attributes on /iot/nvidia/contact-us and /download/mediatek-genio/contact-us

### DIFF
--- a/templates/download/mediatek-genio/contact-us.html
+++ b/templates/download/mediatek-genio/contact-us.html
@@ -1,20 +1,26 @@
 {% extends "download/_base_download.html" %}
 
 {% block title %}Contact us{% endblock %}
-{% block meta_copydoc %}https://docs.google.com/document/d/1WnWVmVuqd1G_BCA060K1LozS2xYFCDli90sGc1SU7ug/edit#{% endblock meta_copydoc %}
+
+{% block meta_copydoc %}
+  https://docs.google.com/document/d/1WnWVmVuqd1G_BCA060K1LozS2xYFCDli90sGc1SU7ug/edit#
+{% endblock meta_copydoc %}
 
 {% block content %}
 
-
-<section class="p-strip--light u-no-padding--bottom">
-  <div class="row">
-    <div class="col-8">
-      <h1>Interested in optimised Ubuntu on MediaTek's Genio SoC?</h1>
-      <p>By partnering to enable Ubuntu on the Genio, MediaTek and Canonical will allow developers, innovators and the embedded community to take advantage of this power-efficient, high-performance Genio SoC. The collaboration ensures developers and enterprises can create reliable and secure devices, benefiting from up to 10 years of enterprise-grade Ubuntu support, security updates, and anywhere, anytime connectivity. Devices built on the MediaTek Genio and Ubuntu enjoy reliable and efficient over-the-air updates, enabling the next generation of secure, open and extensible IoT devices.</p>
-      <p><strong>Tell us about your project so we can bring the right Canonical team members to the conversation to help you.</strong></p>
-    </div>
-    <div class="col-4 u-vertically-center u-hide--small u-hide--medium">
-      {{ image (
+  <section class="p-strip--light u-no-padding--bottom">
+    <div class="row">
+      <div class="col-8">
+        <h1>Interested in optimised Ubuntu on MediaTek's Genio SoC?</h1>
+        <p>
+          By partnering to enable Ubuntu on the Genio, MediaTek and Canonical will allow developers, innovators and the embedded community to take advantage of this power-efficient, high-performance Genio SoC. The collaboration ensures developers and enterprises can create reliable and secure devices, benefiting from up to 10 years of enterprise-grade Ubuntu support, security updates, and anywhere, anytime connectivity. Devices built on the MediaTek Genio and Ubuntu enjoy reliable and efficient over-the-air updates, enabling the next generation of secure, open and extensible IoT devices.
+        </p>
+        <p>
+          <strong>Tell us about your project so we can bring the right Canonical team members to the conversation to help you.</strong>
+        </p>
+      </div>
+      <div class="col-4 u-vertically-center u-hide--small u-hide--medium">
+        {{ image (
         url="https://assets.ubuntu.com/v1/0ebb345c-MediaTek_logo.svg",
         alt="",
         width="1024",
@@ -22,136 +28,263 @@
         hi_def=True,
         loading="auto"
         ) | safe
-      }}
+        }}
+      </div>
     </div>
-  </div>
-</section>
+  </section>
 
-<section class="p-strip">
-  <div class="row">
-    <div class="col-8">
-      <form action="/marketo/submit" method="post" id="mktoForm_4644">
-        <fieldset class="u-no-margin--bottom">
-          <legend class="u-off-screen">About you</legend>
-          <h2 class="p-heading--3">About you</h2>
-          <ul class="p-list">
-            <li class="p-list__item">
-              <label for="firstName">First name:</label>
-              <input required id="firstName" name="firstName" maxlength="255" type="text" />
-            </li>
-            <li class="p-list__item">
-              <label for="lastName">Last name:</label>
-              <input required id="lastName" name="lastName" maxlength="255" type="text" />
-            </li>
-           <li class="p-list__item">
-              <label for="company">Company:</label>
-              <input required id="company" name="company" maxlength="255" type="text" />
-            </li>
-           <li class="p-list__item">
-              <label for="title">Title:</label>
-              <input required id="title" name="title" maxlength="255" type="text" />
-            </li>
-            <li class="p-list__item">
-              <label for="email">Email:</label>
-              <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
-            </li>
-            <li class="p-list__item">
-              <label for="phone">Mobile/cell phone number:</label>
-              <input required id="phone" name="phone" maxlength="255" type="tel" />
-            </li>
-          </ul>
+  <section class="p-strip">
+    <div class="row">
+      <div class="col-8">
+        <form action="/marketo/submit" method="post" id="mktoForm_4644">
+          <fieldset class="u-no-margin--bottom">
+            <legend class="u-off-screen">About you</legend>
+            <h2 class="p-heading--3">About you</h2>
+            <ul class="p-list">
+              <li class="p-list__item">
+                <label for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" />
+              </li>
+              <li class="p-list__item">
+                <label for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" />
+              </li>
+              <li class="p-list__item">
+                <label for="company">Company:</label>
+                <input required id="company" name="company" maxlength="255" type="text" />
+              </li>
+              <li class="p-list__item">
+                <label for="title">Title:</label>
+                <input required id="title" name="title" maxlength="255" type="text" />
+              </li>
+              <li class="p-list__item">
+                <label for="email">Email:</label>
+                <input required
+                       id="email"
+                       name="email"
+                       maxlength="255"
+                       type="email"
+                       pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
+              </li>
+              <li class="p-list__item">
+                <label for="phone">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" />
+              </li>
+            </ul>
 
-
-          <div class="js-formfield">
             <h2 class="p-heading--3">About your company</h2>
-            <p class="u-no-margin--bottom">Tell us about your project so we can bring the right Canonical team members to the conversation to help you.</p>
-            <h3 class="p-heading--4">Your company is:</h3>
-            <label class="p-radio">
-              <input class="p-radio__input" type="radio" aria-labelledby="your-company-is-ODM-OEM" name="your-company-is" value="an ODM/OEM">
-              <span class="p-radio__label" id="your-company-is-ODM-OEM">an ODM/OEM</span>
-            </label>
-            <label class="p-radio u-sv3">
-              <input class="p-radio__input" type="radio" aria-labelledby="your-company-is-end-customer" name="your-company-is" value="an end customer">
-              <span class="p-radio__label" id="your-company-is-end-customer">an end customer</span>
-            </label>
-            <h3 class="p-heading--4">Do you have a commercial project?</h3>
-            <label class="p-radio">
-              <input class="p-radio__input" type="radio" aria-labelledby="commercial-project-yes" name="commercial-project" value="Yes">
-              <span class="p-radio__label" id="commercial-project-yes">Yes</span>
-            </label>
-            <label class="p-radio">
-              <input class="p-radio__input" type="radio" aria-labelledby="commercial-project-no" name="commercial-project" value="No">
-              <span class="p-radio__label" id="commercial-project-no">No</span>
-            </label>
-            <label class="p-radio">
-              <input class="p-radio__input" type="radio" aria-labelledby="commercial-project-not-applicable" name="commercial-project" value="Not applicable">
-              <span class="p-radio__label" id="commercial-project-not-applicable">Not applicable</span>
-            </label>
-            <h3 class="p-heading--4">When do you need to ship?</h3>
-            <label class="p-radio">
-              <input class="p-radio__input" type="radio" aria-labelledby="when-do-you-ship-next-3-months" name="when-do-you-ship" value="Next 3 months">
-              <span class="p-radio__label" id="when-do-you-ship-next-3-months">Next 3 months</span>
-            </label>
-            <label class="p-radio">
-              <input class="p-radio__input" type="radio" aria-labelledby="when-do-you-ship-next-3-6-months" name="when-do-you-ship" value="Next 3-6 months">
-              <span class="p-radio__label" id="when-do-you-ship-next-3-6-months">Next 3-6 months</span>
-            </label>
-            <label class="p-radio">
-              <input class="p-radio__input" type="radio" aria-labelledby="when-do-you-ship-next-6-12-months" name="when-do-you-ship" value="Next 6-12 months">
-              <span class="p-radio__label" id="when-do-you-ship-next-6-12-months">Next 6-12 months</span>
-            </label>
-            <label class="p-radio u-sv3">
-              <input class="p-radio__input" type="radio" aria-labelledby="when-do-you-ship-no-timeline" name="when-do-you-ship" value="No timeline - just researching">
-              <span class="p-radio__label" id="when-do-you-ship-no-timeline">No timeline - just researching</span>
-            </label>
-            <label for="tell-us-about-your-project"><h3 class="p-heading--4">Tell us more about your project</h3></label>
-            <textarea id="tell-us-about-your-project" name="tell-us-about-your-project" rows="5" maxlength="2000"></textarea>
-          </div>
-
-          <ul class="p-list">
-            <li class="p-list__item">
-              <label class="p-checkbox">
-                <input class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
-                <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
+            <p class="u-no-margin--bottom">
+              Tell us about your project so we can bring the right Canonical team members to the conversation to help you.
+            </p>
+            <div class="js-formfield js-remove-radio-names">
+              <h3 class="p-heading--4 js-formfield-title">Your company is:</h3>
+              <label class="p-radio">
+                <input class="p-radio__input"
+                       type="radio"
+                       aria-labelledby="your-company-is-ODM-OEM"
+                       name="your-company-is"
+                       value="an ODM/OEM" />
+                <span class="p-radio__label" id="your-company-is-ODM-OEM">an ODM/OEM</span>
               </label>
-            </li>
-            <li class="p-list__item u-sv3">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
-            {# These are honey pot fields to catch bots #}
-            <li class="u-off-screen">
-              <label class="website" for="website">Website:</label>
-              <input name="website" type="text" class="website" autocomplete="off" value="" id="website" tabindex="-1" />
-            </li>
-            <li class="u-off-screen">
-              <label class="name" for="name">Name:</label>
-              <input name="name" type="text" class="name" autocomplete="off" value="" id="name" tabindex="-1" />
-            </li>
-            {# End of honey pots #}
-            <li class="p-list__item">
-              <button type="submit" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Form', 'eventAction' : 'download contact-us', 'eventLabel' : 'MediaTek', 'eventValue' : undefined });">Submit</button>
-            </li>
-          </ul>
-          <div class="u-off-screen">
-            <label for="Comments_from_lead__c">
-              <h3 class="p-heading--4">Your comments</h3>
-              <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
-            </label>
-          </div>
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="4644" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="/download/thank-you" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Facebook_Click_ID__c" id="Facebook_Click_ID__c" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" id="preferredLanguage" name="preferredLanguage" maxlength="255" value="" />
-        </fieldset>
-      </form>
-    </div>
-  </div>
-</section>
+              <label class="p-radio u-sv3">
+                <input class="p-radio__input"
+                       type="radio"
+                       aria-labelledby="your-company-is-end-customer"
+                       name="your-company-is"
+                       value="an end customer" />
+                <span class="p-radio__label" id="your-company-is-end-customer">an end customer</span>
+              </label>
+            </div>
+            <div class="js-formfield js-remove-radio-names">
+              <h3 class="p-heading--4 js-formfield-title">Do you have a commercial project?</h3>
+              <label class="p-radio">
+                <input class="p-radio__input"
+                       type="radio"
+                       aria-labelledby="commercial-project-yes"
+                       name="commercial-project"
+                       value="Yes" />
+                <span class="p-radio__label" id="commercial-project-yes">Yes</span>
+              </label>
+              <label class="p-radio">
+                <input class="p-radio__input"
+                       type="radio"
+                       aria-labelledby="commercial-project-no"
+                       name="commercial-project"
+                       value="No" />
+                <span class="p-radio__label" id="commercial-project-no">No</span>
+              </label>
+              <label class="p-radio">
+                <input class="p-radio__input"
+                       type="radio"
+                       aria-labelledby="commercial-project-not-applicable"
+                       name="commercial-project"
+                       value="Not applicable" />
+                <span class="p-radio__label" id="commercial-project-not-applicable">Not applicable</span>
+              </label>
+            </div>
+            <div class="js-formfield js-remove-radio-names">
+              <h3 class="p-heading--4 js-formfield-title">When do you need to ship?</h3>
+              <label class="p-radio">
+                <input class="p-radio__input"
+                       type="radio"
+                       aria-labelledby="when-do-you-ship-next-3-months"
+                       name="when-do-you-ship"
+                       value="Next 3 months" />
+                <span class="p-radio__label" id="when-do-you-ship-next-3-months">Next 3 months</span>
+              </label>
+              <label class="p-radio">
+                <input class="p-radio__input"
+                       type="radio"
+                       aria-labelledby="when-do-you-ship-next-3-6-months"
+                       name="when-do-you-ship"
+                       value="Next 3-6 months" />
+                <span class="p-radio__label" id="when-do-you-ship-next-3-6-months">Next 3-6 months</span>
+              </label>
+              <label class="p-radio">
+                <input class="p-radio__input"
+                       type="radio"
+                       aria-labelledby="when-do-you-ship-next-6-12-months"
+                       name="when-do-you-ship"
+                       value="Next 6-12 months" />
+                <span class="p-radio__label" id="when-do-you-ship-next-6-12-months">Next 6-12 months</span>
+              </label>
+              <label class="p-radio u-sv3">
+                <input class="p-radio__input"
+                       type="radio"
+                       aria-labelledby="when-do-you-ship-no-timeline"
+                       name="when-do-you-ship"
+                       value="No timeline - just researching" />
+                <span class="p-radio__label" id="when-do-you-ship-no-timeline">No timeline - just researching</span>
+              </label>
+            </div>
+            <div class="js-formfield">
+              <label for="tell-us-about-your-project">
+                <h3 class="p-heading--4 js-formfield-title">Tell us more about your project</h3>
+              </label>
+              <textarea id="tell-us-about-your-project" rows="5" maxlength="2000"></textarea>
+            </div>
 
+            <ul class="p-list">
+              <li class="p-list__item">
+                <label class="p-checkbox">
+                  <input class="p-checkbox__input"
+                         value="yes"
+                         aria-labelledby="canonicalUpdatesOptIn"
+                         name="canonicalUpdatesOptIn"
+                         type="checkbox" />
+                  <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
+                </label>
+              </li>
+              <li class="p-list__item u-sv3">
+                In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.
+              </li>
+              {# These are honey pot fields to catch bots #}
+              <li class="u-off-screen">
+                <label class="website" for="website">Website:</label>
+                <input name="website"
+                       type="text"
+                       class="website"
+                       autocomplete="off"
+                       value=""
+                       id="website"
+                       tabindex="-1" />
+              </li>
+              <li class="u-off-screen">
+                <label class="name" for="name">Name:</label>
+                <input name="name"
+                       type="text"
+                       class="name"
+                       autocomplete="off"
+                       value=""
+                       id="name"
+                       tabindex="-1" />
+              </li>
+              {# End of honey pots #}
+              <li class="p-list__item">
+                <button type="submit"
+                        class="p-button--positive"
+                        onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Form', 'eventAction' : 'download contact-us', 'eventLabel' : 'MediaTek', 'eventValue' : undefined });">
+                  Submit
+                </button>
+              </li>
+            </ul>
+            <div class="u-off-screen">
+              <label for="Comments_from_lead__c">
+                <h3 class="p-heading--4">Your comments</h3>
+                <textarea id="Comments_from_lead__c"
+                          name="Comments_from_lead__c"
+                          rows="5"
+                          maxlength="2000"></textarea>
+              </label>
+            </div>
+            <input type="hidden"
+                   aria-hidden="true"
+                   aria-label="hidden field"
+                   name="formid"
+                   value="4644" />
+            <input type="hidden"
+                   aria-hidden="true"
+                   aria-label="hidden field"
+                   name="returnURL"
+                   value="/download/thank-you" />
+            <input type="hidden"
+                   aria-hidden="true"
+                   aria-label="hidden field"
+                   name="Consent_to_Processing__c"
+                   value="yes" />
+            <input type="hidden"
+                   aria-hidden="true"
+                   aria-label="hidden field"
+                   name="utm_campaign"
+                   id="utm_campaign"
+                   value="" />
+            <input type="hidden"
+                   aria-hidden="true"
+                   aria-label="hidden field"
+                   name="utm_medium"
+                   id="utm_medium"
+                   value="" />
+            <input type="hidden"
+                   aria-hidden="true"
+                   aria-label="hidden field"
+                   name="utm_source"
+                   id="utm_source"
+                   value="" />
+            <input type="hidden"
+                   aria-hidden="true"
+                   aria-label="hidden field"
+                   name="utm_content"
+                   id="utm_content"
+                   value="" />
+            <input type="hidden"
+                   aria-hidden="true"
+                   aria-label="hidden field"
+                   name="utm_term"
+                   id="utm_term"
+                   value="" />
+            <input type="hidden"
+                   aria-hidden="true"
+                   aria-label="hidden field"
+                   name="GCLID__c"
+                   id="GCLID__c"
+                   value="" />
+            <input type="hidden"
+                   aria-hidden="true"
+                   aria-label="hidden field"
+                   name="Facebook_Click_ID__c"
+                   id="Facebook_Click_ID__c"
+                   value="" />
+            <input type="hidden"
+                   aria-hidden="true"
+                   aria-label="hidden field"
+                   id="preferredLanguage"
+                   name="preferredLanguage"
+                   maxlength="255"
+                   value="" />
+          </fieldset>
+        </form>
+      </div>
+    </div>
+  </section>
 
 {% endblock %}

--- a/templates/internet-of-things/nvidia/contact-us.html
+++ b/templates/internet-of-things/nvidia/contact-us.html
@@ -1,22 +1,28 @@
 {% extends "internet-of-things/base_things.html" %}
 
 {% block title %}Contact us | Optimised Ubuntu on NVIDIA Orin platforms{% endblock %}
-{% block meta_copydoc %}https://docs.google.com/document/d/1znVFFLSyTmDwCplvloGAlEI3p_dpGH8v82hbYzVfz0o/edit#{% endblock meta_copydoc %}
+
+{% block meta_copydoc %}
+  https://docs.google.com/document/d/1znVFFLSyTmDwCplvloGAlEI3p_dpGH8v82hbYzVfz0o/edit#
+{% endblock meta_copydoc %}
 
 {% block content %}
 
-
-<section class="p-strip--light">
-  <div class="row">
-    <div class="col-8">
-      <h1>Interested in optimised Ubuntu on NVIDIA platforms?</h1>
-      <p>Canonical announced plans to certify Ubuntu to run on NVIDIA platforms powered by the Orin architecture. Ubuntu will run on the full range of NVIDIA IoT platforms, bringing Ubuntu to the automotive industry with the NVIDIA DRIVE&reg; platform, to industrial applications with the NVIDIA IGX Orin&trade; platform, as well as to advanced embedded systems with NVIDIA Jetson Orin&trade;  system-on-modules. The optimised kernel and images will combine software features from NVIDIA with unparalleled security, reliability, and support for regulated enterprise deployments.</p>
-      <p>With this collaboration, optimised Ubuntu and Ubuntu Core images will be available for commercial-grade IoT deployments for a wide range of popular silicon platforms across a variety of vendors, establishing a de facto standard across enterprise IoT &ndash; from software- defined vehicles and industry 4.0 to retail and robotics.</p>
-      <p>Fill out the form to receive the latest update from us!</p>
-    </div>
-    <div class="col-4 u-vertically-center u-hide--small u-hide--medium">
-      {{
-				image (
+  <section class="p-strip--light">
+    <div class="row">
+      <div class="col-8">
+        <h1>Interested in optimised Ubuntu on NVIDIA platforms?</h1>
+        <p>
+          Canonical announced plans to certify Ubuntu to run on NVIDIA platforms powered by the Orin architecture. Ubuntu will run on the full range of NVIDIA IoT platforms, bringing Ubuntu to the automotive industry with the NVIDIA DRIVE&reg; platform, to industrial applications with the NVIDIA IGX Orin&trade; platform, as well as to advanced embedded systems with NVIDIA Jetson Orin&trade;  system-on-modules. The optimised kernel and images will combine software features from NVIDIA with unparalleled security, reliability, and support for regulated enterprise deployments.
+        </p>
+        <p>
+          With this collaboration, optimised Ubuntu and Ubuntu Core images will be available for commercial-grade IoT deployments for a wide range of popular silicon platforms across a variety of vendors, establishing a de facto standard across enterprise IoT &ndash; from software- defined vehicles and industry 4.0 to retail and robotics.
+        </p>
+        <p>Fill out the form to receive the latest update from us!</p>
+      </div>
+      <div class="col-4 u-vertically-center u-hide--small u-hide--medium">
+        {{
+        image (
         url="https://assets.ubuntu.com/v1/cb6924a9-Nvidia_image_logo.svg",
         alt="",
         width="351",
@@ -24,129 +30,242 @@
         hi_def=True,
         loading="auto"
         ) | safe
-      }}
+        }}
+      </div>
     </div>
-  </div>
-</section>
+  </section>
 
-<section class="p-strip">
-  <div class="row">
-    <div class="col-8">
-      <form action="/marketo/submit" method="post" id="mktoForm_4953">
-        <fieldset class="u-no-margin--bottom">
-          <div class="js-formfield">
-            <div role="group" aria-labelledby="which-nvidia-orin-platforms">
-              <h2 class="p-heading--5" id="which-nvidia-orin-platforms">Which NVIDIA platforms are you interested in?</h2>
-              <label class="p-checkbox">
-                <input class="p-checkbox__input" type="checkbox" aria-labelledby="drive-orin" name="which-nvidia-orin-platforms" value="DRIVE Orin">
-                <span class="p-checkbox__label" id="drive-orin">Xavier</span>
-              </label>
-              <label class="p-checkbox">
-                <input class="p-checkbox__input" type="checkbox" aria-labelledby="drive-orin" name="which-nvidia-orin-platforms" value="DRIVE Orin">
-                <span class="p-checkbox__label" id="drive-orin">DRIVE Orin</span>
-              </label>
-              <label class="p-checkbox">
-                <input class="p-checkbox__input" type="checkbox" aria-labelledby="igx-orin" name="which-nvidia-orin-platforms" value="IGX Orin">
-                <span class="p-checkbox__label" id="igx-orin">IGX Orin</span>
-              </label>
-              <label class="p-checkbox">
-                <input class="p-checkbox__input" type="checkbox" aria-labelledby="jetson-agx-orin" name="which-nvidia-orin-platforms" value="Jetson AGX Orin">
-                <span class="p-checkbox__label" id="jetson-agx-orin">Jetson AGX Orin</span>
-              </label>
-              <label class="p-checkbox">
-                <input class="p-checkbox__input" type="checkbox" aria-labelledby="jetson-orin-nx" name="which-nvidia-orin-platforms" value="Jetson Orin NX">
-                <span class="p-checkbox__label" id="jetson-orin-nx">Jetson Orin NX</span>
-              </label>
-              <label class="p-checkbox">
-                <input class="p-checkbox__input" type="checkbox" aria-labelledby="jetson-orin-nano" name="which-nvidia-orin-platforms" value="Jetson Orin Nano">
-                <span class="p-checkbox__label" id="jetson-orin-nano">Jetson Orin Nano</span>
-              </label>
+  <section class="p-strip">
+    <div class="row">
+      <div class="col-8">
+        <form action="/marketo/submit" method="post" id="mktoForm_4953">
+          <fieldset class="u-no-margin--bottom">
+            <div class="js-formfield">
+              <div role="group" aria-labelledby="which-nvidia-orin-platforms">
+                <h2 class="p-heading--5" id="which-nvidia-orin-platforms">Which NVIDIA platforms are you interested in?</h2>
+                <label class="p-checkbox">
+                  <input class="p-checkbox__input"
+                         type="checkbox"
+                         aria-labelledby="drive-orin"
+                         name="which-nvidia-orin-platforms"
+                         value="DRIVE Orin" />
+                  <span class="p-checkbox__label" id="drive-orin">Xavier</span>
+                </label>
+                <label class="p-checkbox">
+                  <input class="p-checkbox__input"
+                         type="checkbox"
+                         aria-labelledby="drive-orin"
+                         name="which-nvidia-orin-platforms"
+                         value="DRIVE Orin" />
+                  <span class="p-checkbox__label" id="drive-orin">DRIVE Orin</span>
+                </label>
+                <label class="p-checkbox">
+                  <input class="p-checkbox__input"
+                         type="checkbox"
+                         aria-labelledby="igx-orin"
+                         name="which-nvidia-orin-platforms"
+                         value="IGX Orin" />
+                  <span class="p-checkbox__label" id="igx-orin">IGX Orin</span>
+                </label>
+                <label class="p-checkbox">
+                  <input class="p-checkbox__input"
+                         type="checkbox"
+                         aria-labelledby="jetson-agx-orin"
+                         name="which-nvidia-orin-platforms"
+                         value="Jetson AGX Orin" />
+                  <span class="p-checkbox__label" id="jetson-agx-orin">Jetson AGX Orin</span>
+                </label>
+                <label class="p-checkbox">
+                  <input class="p-checkbox__input"
+                         type="checkbox"
+                         aria-labelledby="jetson-orin-nx"
+                         name="which-nvidia-orin-platforms"
+                         value="Jetson Orin NX" />
+                  <span class="p-checkbox__label" id="jetson-orin-nx">Jetson Orin NX</span>
+                </label>
+                <label class="p-checkbox">
+                  <input class="p-checkbox__input"
+                         type="checkbox"
+                         aria-labelledby="jetson-orin-nano"
+                         name="which-nvidia-orin-platforms"
+                         value="Jetson Orin Nano" />
+                  <span class="p-checkbox__label" id="jetson-orin-nano">Jetson Orin Nano</span>
+                </label>
+              </div>
             </div>
-          </div>
-          <div class="js-formfield">
-            <label for="tell-us-about-your-project"><h3 class="p-heading--5">Tell us more about your project</h3></label>
-            <textarea id="tell-us-about-your-project" name="tell-us-about-your-project" rows="4" maxlength="2000"></textarea>
-          </div>
-        </fieldset>
+            <div class="js-formfield">
+              <label for="tell-us-about-your-project">
+                <h3 class="p-heading--5">Tell us more about your project</h3>
+              </label>
+              <textarea id="tell-us-about-your-project"
+                        name="tell-us-about-your-project"
+                        rows="4"
+                        maxlength="2000"></textarea>
+            </div>
+          </fieldset>
 
-        <fieldset class="u-no-margin--bottom">
-          <div role="group" aria-labelledby="please-leave-your-contact-details">
-            <h2 class="p-heading--5" id="please-leave-your-contact-details">Please leave your contact details so that we can inform you once the optimised Ubuntu images are available to download and install on your Tegra SoCs.</h2>
+          <fieldset class="u-no-margin--bottom">
+            <div role="group" aria-labelledby="please-leave-your-contact-details">
+              <h2 class="p-heading--5" id="please-leave-your-contact-details">
+                Please leave your contact details so that we can inform you once the optimised Ubuntu images are available to download and install on your Tegra SoCs.
+              </h2>
+              <ul class="p-list">
+                <li class="p-list__item">
+                  <label class="is-required" for="firstName">First name:</label>
+                  <input required id="firstName" name="firstName" maxlength="255" type="text" />
+                </li>
+                <li class="p-list__item">
+                  <label class="is-required" for="lastName">Last name:</label>
+                  <input required id="lastName" name="lastName" maxlength="255" type="text" />
+                </li>
+                <li class="p-list__item">
+                  <label class="is-required" for="company">Company:</label>
+                  <input required id="company" name="company" maxlength="255" type="text" />
+                </li>
+                <li class="p-list__item">
+                  <label class="is-required" for="title">Job title:</label>
+                  <input required id="title" name="title" maxlength="255" type="text" />
+                </li>
+                <li class="p-list__item">
+                  <label class="is-required" for="email">Email:</label>
+                  <input required
+                         id="email"
+                         name="email"
+                         maxlength="255"
+                         type="email"
+                         pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
+                </li>
+                <li class="p-list__item">
+                  <label class="is-required" for="phone">Mobile/cell phone number:</label>
+                  <input required id="phone" name="phone" maxlength="255" type="tel" />
+                </li>
+              </ul>
+            </div>
+          </fieldset>
+
+          <fieldset>
+            <legend class="u-off-screen">Privacy policy and form submission</legend>
             <ul class="p-list">
               <li class="p-list__item">
-                <label class="is-required" for="firstName">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" />
+                <label class="p-checkbox is-required">
+                  <input class="p-checkbox__input"
+                         value="yes"
+                         aria-labelledby="canonicalUpdatesOptIn"
+                         name="canonicalUpdatesOptIn"
+                         type="checkbox" />
+                  <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
+                </label>
               </li>
+              <li class="p-list__item u-sv3">
+                In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.
+              </li>
+              {# These are honey pot fields to catch bots #}
+              <li class="u-off-screen">
+                <label class="website" for="website">Website:</label>
+                <input name="website"
+                       type="text"
+                       class="website"
+                       autocomplete="off"
+                       value=""
+                       id="website"
+                       tabindex="-1" />
+              </li>
+              <li class="u-off-screen">
+                <label class="name" for="name">Name:</label>
+                <input name="name"
+                       type="text"
+                       class="name"
+                       autocomplete="off"
+                       value=""
+                       id="name"
+                       tabindex="-1" />
+              </li>
+              {# End of honey pots #}
               <li class="p-list__item">
-                <label class="is-required" for="lastName">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" />
-              </li>
-            <li class="p-list__item">
-                <label class="is-required" for="company">Company:</label>
-                <input required id="company" name="company" maxlength="255" type="text" />
-              </li>
-            <li class="p-list__item">
-                <label class="is-required" for="title">Job title:</label>
-                <input required id="title" name="title" maxlength="255" type="text" />
-              </li>
-              <li class="p-list__item">
-                <label class="is-required" for="email">Email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
-              </li>
-              <li class="p-list__item">
-                <label class="is-required" for="phone">Mobile/cell phone number:</label>
-                <input required id="phone" name="phone" maxlength="255" type="tel" />
+                <button type="submit"
+                        class="p-button--positive"
+                        onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Form', 'eventAction' : 'download contact-us', 'eventLabel' : 'NVIDIA', 'eventValue' : undefined });">
+                  Let's discuss
+                </button>
               </li>
             </ul>
-          </div>
-        </fieldset>
-
-        <fieldset>
-          <legend class="u-off-screen">Privacy policy and form submission</legend>
-          <ul class="p-list">
-            <li class="p-list__item">
-              <label class="p-checkbox is-required">
-                <input class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox">
-                <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
+            <div class="u-off-screen">
+              <label for="Comments_from_lead__c">
+                <h3 class="p-heading--4">Your comments</h3>
+                <textarea id="Comments_from_lead__c"
+                          name="Comments_from_lead__c"
+                          rows="5"
+                          maxlength="2000"></textarea>
               </label>
-            </li>
-            <li class="p-list__item u-sv3">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
-            {# These are honey pot fields to catch bots #}
-            <li class="u-off-screen">
-              <label class="website" for="website">Website:</label>
-              <input name="website" type="text" class="website" autocomplete="off" value="" id="website" tabindex="-1" />
-            </li>
-            <li class="u-off-screen">
-              <label class="name" for="name">Name:</label>
-              <input name="name" type="text" class="name" autocomplete="off" value="" id="name" tabindex="-1" />
-            </li>
-            {# End of honey pots #}
-            <li class="p-list__item">
-              <button type="submit" class="p-button--positive" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Form', 'eventAction' : 'download contact-us', 'eventLabel' : 'NVIDIA', 'eventValue' : undefined });">Let's discuss</button>
-            </li>
-          </ul>
-          <div class="u-off-screen">
-            <label for="Comments_from_lead__c">
-              <h3 class="p-heading--4">Your comments</h3>
-              <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
-            </label>
-          </div>
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="4953" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="/internet-of-things/thank-you?product=nvidia" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Facebook_Click_ID__c" id="Facebook_Click_ID__c" value="" />
-          <input type="hidden" aria-hidden="true" aria-label="hidden field" id="preferredLanguage" name="preferredLanguage" maxlength="255" value="" />
-        </fieldset>
-      </form>
+            </div>
+            <input type="hidden"
+                   aria-hidden="true"
+                   aria-label="hidden field"
+                   name="formid"
+                   value="4953" />
+            <input type="hidden"
+                   aria-hidden="true"
+                   aria-label="hidden field"
+                   name="returnURL"
+                   value="/internet-of-things/thank-you?product=nvidia" />
+            <input type="hidden"
+                   aria-hidden="true"
+                   aria-label="hidden field"
+                   name="Consent_to_Processing__c"
+                   value="yes" />
+            <input type="hidden"
+                   aria-hidden="true"
+                   aria-label="hidden field"
+                   name="utm_campaign"
+                   id="utm_campaign"
+                   value="" />
+            <input type="hidden"
+                   aria-hidden="true"
+                   aria-label="hidden field"
+                   name="utm_medium"
+                   id="utm_medium"
+                   value="" />
+            <input type="hidden"
+                   aria-hidden="true"
+                   aria-label="hidden field"
+                   name="utm_source"
+                   id="utm_source"
+                   value="" />
+            <input type="hidden"
+                   aria-hidden="true"
+                   aria-label="hidden field"
+                   name="utm_content"
+                   id="utm_content"
+                   value="" />
+            <input type="hidden"
+                   aria-hidden="true"
+                   aria-label="hidden field"
+                   name="utm_term"
+                   id="utm_term"
+                   value="" />
+            <input type="hidden"
+                   aria-hidden="true"
+                   aria-label="hidden field"
+                   name="GCLID__c"
+                   id="GCLID__c"
+                   value="" />
+            <input type="hidden"
+                   aria-hidden="true"
+                   aria-label="hidden field"
+                   name="Facebook_Click_ID__c"
+                   id="Facebook_Click_ID__c"
+                   value="" />
+            <input type="hidden"
+                   aria-hidden="true"
+                   aria-label="hidden field"
+                   id="preferredLanguage"
+                   name="preferredLanguage"
+                   maxlength="255"
+                   value="" />
+          </fieldset>
+        </form>
+      </div>
     </div>
-  </div>
-</section>
-
+  </section>
 
 {% endblock %}

--- a/templates/internet-of-things/nvidia/contact-us.html
+++ b/templates/internet-of-things/nvidia/contact-us.html
@@ -62,6 +62,8 @@
                 <span class="p-checkbox__label" id="jetson-orin-nano">Jetson Orin Nano</span>
               </label>
             </div>
+          </div>
+          <div class="js-formfield">
             <label for="tell-us-about-your-project"><h3 class="p-heading--5">Tell us more about your project</h3></label>
             <textarea id="tell-us-about-your-project" name="tell-us-about-your-project" rows="4" maxlength="2000"></textarea>
           </div>

--- a/templates/internet-of-things/nvidia/contact-us.html
+++ b/templates/internet-of-things/nvidia/contact-us.html
@@ -21,15 +21,12 @@
         <p>Fill out the form to receive the latest update from us!</p>
       </div>
       <div class="col-4 u-vertically-center u-hide--small u-hide--medium">
-        {{
-        image (
-        url="https://assets.ubuntu.com/v1/cb6924a9-Nvidia_image_logo.svg",
-        alt="",
-        width="351",
-        height="259",
-        hi_def=True,
-        loading="auto"
-        ) | safe
+        {{ image(url="https://assets.ubuntu.com/v1/cb6924a9-Nvidia_image_logo.svg",
+                  alt="",
+                  width="351",
+                  height="259",
+                  hi_def=True,
+                  loading="auto") | safe
         }}
       </div>
     </div>
@@ -47,7 +44,6 @@
                   <input class="p-checkbox__input"
                          type="checkbox"
                          aria-labelledby="drive-orin"
-                         name="which-nvidia-orin-platforms"
                          value="DRIVE Orin" />
                   <span class="p-checkbox__label" id="drive-orin">Xavier</span>
                 </label>
@@ -55,7 +51,6 @@
                   <input class="p-checkbox__input"
                          type="checkbox"
                          aria-labelledby="drive-orin"
-                         name="which-nvidia-orin-platforms"
                          value="DRIVE Orin" />
                   <span class="p-checkbox__label" id="drive-orin">DRIVE Orin</span>
                 </label>
@@ -63,7 +58,6 @@
                   <input class="p-checkbox__input"
                          type="checkbox"
                          aria-labelledby="igx-orin"
-                         name="which-nvidia-orin-platforms"
                          value="IGX Orin" />
                   <span class="p-checkbox__label" id="igx-orin">IGX Orin</span>
                 </label>
@@ -71,7 +65,6 @@
                   <input class="p-checkbox__input"
                          type="checkbox"
                          aria-labelledby="jetson-agx-orin"
-                         name="which-nvidia-orin-platforms"
                          value="Jetson AGX Orin" />
                   <span class="p-checkbox__label" id="jetson-agx-orin">Jetson AGX Orin</span>
                 </label>
@@ -79,7 +72,6 @@
                   <input class="p-checkbox__input"
                          type="checkbox"
                          aria-labelledby="jetson-orin-nx"
-                         name="which-nvidia-orin-platforms"
                          value="Jetson Orin NX" />
                   <span class="p-checkbox__label" id="jetson-orin-nx">Jetson Orin NX</span>
                 </label>
@@ -87,21 +79,17 @@
                   <input class="p-checkbox__input"
                          type="checkbox"
                          aria-labelledby="jetson-orin-nano"
-                         name="which-nvidia-orin-platforms"
                          value="Jetson Orin Nano" />
                   <span class="p-checkbox__label" id="jetson-orin-nano">Jetson Orin Nano</span>
                 </label>
               </div>
             </div>
-            <div class="js-formfield">
-              <label for="tell-us-about-your-project">
-                <h3 class="p-heading--5">Tell us more about your project</h3>
-              </label>
-              <textarea id="tell-us-about-your-project"
-                        name="tell-us-about-your-project"
-                        rows="4"
-                        maxlength="2000"></textarea>
-            </div>
+            <label for="tell-us-about-your-project">
+              <h3 class="p-heading--5">Tell us more about your project</h3>
+            </label>
+            <textarea id="tell-us-about-your-project"
+                      rows="4"
+                      maxlength="2000"></textarea>
           </fieldset>
 
           <fieldset class="u-no-margin--bottom">

--- a/templates/internet-of-things/nvidia/contact-us.html
+++ b/templates/internet-of-things/nvidia/contact-us.html
@@ -43,8 +43,8 @@
                 <label class="p-checkbox">
                   <input class="p-checkbox__input"
                          type="checkbox"
-                         aria-labelledby="drive-orin"
-                         value="DRIVE Orin" />
+                         aria-labelledby="xavier"
+                         value="Xavier" />
                   <span class="p-checkbox__label" id="drive-orin">Xavier</span>
                 </label>
                 <label class="p-checkbox">

--- a/templates/internet-of-things/nvidia/contact-us.html
+++ b/templates/internet-of-things/nvidia/contact-us.html
@@ -39,7 +39,7 @@
           <fieldset class="u-no-margin--bottom">
             <div class="js-formfield">
               <div role="group" aria-labelledby="which-nvidia-orin-platforms">
-                <h2 class="p-heading--5" id="which-nvidia-orin-platforms">Which NVIDIA platforms are you interested in?</h2>
+                <h2 class="p-heading--5 js-formfield-title" id="which-nvidia-orin-platforms">Which NVIDIA platforms are you interested in?</h2>
                 <label class="p-checkbox">
                   <input class="p-checkbox__input"
                          type="checkbox"
@@ -84,12 +84,14 @@
                 </label>
               </div>
             </div>
-            <label for="tell-us-about-your-project">
-              <h3 class="p-heading--5">Tell us more about your project</h3>
-            </label>
-            <textarea id="tell-us-about-your-project"
-                      rows="4"
-                      maxlength="2000"></textarea>
+            <div class="js-formfield">
+              <label for="tell-us-about-your-project">
+                <h3 class="p-heading--5 js-formfield-title">Tell us more about your project</h3>
+              </label>
+              <textarea id="tell-us-about-your-project"
+                        rows="4"
+                        maxlength="2000"></textarea>
+            </div>
           </fieldset>
 
           <fieldset class="u-no-margin--bottom">


### PR DESCRIPTION
## Done

- Remove `name` attributes on "Which Nvidia platforms..." and "Tell us more about your project" to exclude them in the payload on /iot/nvidia/contact-us
- Add `js-formfield` and `js-remove-radio-names` to fieldsets on /download/mediatek-genio/contact-us
- Run djlint on both files

## QA

- Go to https://ubuntu-com-14641.demos.haus/internet-of-things/nvidia/contact-us
- Submit form
- Check that `Comments_from_lead__c` in payload concatenated results for NVIDIA platform and About Project
- Repeat for https://ubuntu-com-14641.demos.haus/download/mediatek-genio/contact-us

## Issue / Card

Fixes [WD-18062](https://warthogs.atlassian.net/browse/WD-18062) and [WD-17008](https://warthogs.atlassian.net/browse/WD-17008)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-18062]: https://warthogs.atlassian.net/browse/WD-18062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[WD-17008]: https://warthogs.atlassian.net/browse/WD-17008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ