### PR TITLE
fix: form inputs should fill width

### DIFF
--- a/templates/shared/forms/interactive/automotive.html
+++ b/templates/shared/forms/interactive/automotive.html
@@ -6,7 +6,7 @@
     </header>
     <div class="js-pagination js-pagination--1">
       <div class="row u-no-padding">
-        <div class="col-6">
+        <div class="col-12">
           <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
             <div class="u-sv2">
               <h3 class="p-heading--4">What can we help you with?</h3>

--- a/templates/shared/forms/interactive/automotive.html
+++ b/templates/shared/forms/interactive/automotive.html
@@ -28,7 +28,7 @@
               </li>
               <li class="p-list__item">
                 <label for="phone">Phone number:</label>
-                <input id="phone" name="phone" maxlength="255" type="tel">
+                <input id="phone" name="phone" maxlength="255" type="tel" />
               </li>
               <li class="p-list__item">
                 <label class="p-checkbox">


### PR DESCRIPTION
## Done

- Fixed half-width automotive form

## QA

- Open the demo at https://ubuntu-com-14648.demos.haus/automotive and click `Contact Canonical`
- The inputs should fill the width

## Issue / Card

Fixes [WD-18102](https://warthogs.atlassian.net/browse/WD-18102)

## Screenshots

![image](https://github.com/user-attachments/assets/40c87a2f-20c8-4d73-ac77-b101a4b0db43)
![image](https://github.com/user-attachments/assets/0ab82302-62b1-492a-8515-9b6dfa5d270f)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-18102]: https://warthogs.atlassian.net/browse/WD-18102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ