### PR TITLE
WD-18199-change-get-ubuntu-to-download-ubuntu-in-the-top-navigation-on-ubuntu-com

### DIFF
--- a/templates/templates/_navigation.html
+++ b/templates/templates/_navigation.html
@@ -82,7 +82,7 @@
                href="/navigation#get-ubuntu-navigation"
                aria-controls="#get-ubuntu-content"
                tabindex="0"
-               onfocus="fetchDropdown('/templates/meganav/get-ubuntu', 'get-ubuntu');">Get Ubuntu</a>
+               onfocus="fetchDropdown('/templates/meganav/get-ubuntu', 'get-ubuntu');">Download Ubuntu</a>
           </li>
           <li class="p-navigation__item--dropdown-toggle global-nav-mobile global-nav"
               role="menuitem"

--- a/templates/templates/meganav/_section-heading.html
+++ b/templates/templates/meganav/_section-heading.html
@@ -7,5 +7,5 @@
 {% elif section == "community" %}
   <h2 class="p-heading--1 u-no-padding--left" id="community-navigation">Community</h2>
 {% elif section == "get_ubuntu" %}
-  <h2 class="p-heading--1 u-no-padding--left" id="get-ubuntu-navigation">Get Ubuntu</h2>
+  <h2 class="p-heading--1 u-no-padding--left" id="get-ubuntu-navigation">Download Ubuntu</h2>
 {% endif %}


### PR DESCRIPTION
## Done

- Changed Get Ubuntu to Download Ubuntu on the nav

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- The nav item should say Download Ubuntu instead of Get Ubuntu

## Issue / Card

Fixes [#WD-18199](https://warthogs.atlassian.net/browse/WD-18199)

## Screenshots

![image](https://github.com/user-attachments/assets/b12f2dc2-493f-4b34-a19c-3c55450381d8)



## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
