### PR TITLE
fix(spelling): update BE->AE in meganav [WD-18260]

### DIFF
--- a/meganav.yaml
+++ b/meganav.yaml
@@ -73,7 +73,7 @@ products:
               description: Stay patched and defer reboots
               url: /security/livepatch
             - title: Kubernetes
-              description: Containerised workloads
+              description: Containerized workloads
               url: /kubernetes
             - title: AI & MLOps
               description: AI and machine learning on Ubuntu
@@ -112,7 +112,7 @@ products:
               url: /desktop/wsl
             - title: Multipass
               description: VMs for Windows, macOS & Linux
-              url: https://multipass.run/
+              url: https://canonical.com/multipass
       secondary_links:
         - title: Quick links
           links:
@@ -148,7 +148,7 @@ products:
               description: Open source storage
               url: /ceph
             - title: Anbox Cloud
-              description: Virtualised Android on demand
+              description: Virtualized Android on demand
               url: https://anbox-cloud.io/
             - title: Juju
               description: Orchestrator engine for operators
@@ -171,7 +171,7 @@ products:
               url: https://maas.io/docs
             - title: MicroStack installation
               url: https://microstack.run/docs/single-node
-            - title: Data Centre Networking blog
+            - title: Data Center Networking blog
               url: /blog/data-centre-networking-what-is-sdn
             - title: OpenStack pricing
               url: /openstack/pricing-calculator
@@ -199,12 +199,12 @@ products:
               description: Virtual desktops on AWS
               url: /aws/workspaces
 
-    - title: Virtualisation
+    - title: Virtualization
       primary_links:
         - links:
             - title: Multipass
               description: VMs for Windows, macOS & Linux
-              url: https://multipass.run/
+              url: https://canonical.com/multipass
             - title: LXD
               description: Linux containers and VMs
               url: https://canonical.com/lxd
@@ -215,11 +215,11 @@ products:
       secondary_links:
         - title: Quick links
           links:
-            - title: What is virtualisation?
+            - title: What is virtualization?
               url: https://snapcraft.io/blog/what-is-virtualisation-the-basics
             - title: Multipass documentation
-              url: https://multipass.run/docs
-            - title: Virtualisation docs in the server guide
+              url: https://canonical.com/multipass/docs
+            - title: Virtualization docs in the server guide
               url: /server/docs/virtualization-multipass
             - title: What is WSL?
               url: https://wiki.ubuntu.com/WSL
@@ -280,7 +280,7 @@ products:
       primary_links:
         - links:
             - title: Kubernetes
-              description: Containerised workloads
+              description: Containerized workloads
               url: /kubernetes
             - title: MicroK8s
               description: Simplest way to get Kubernetes
@@ -366,7 +366,7 @@ products:
               description: Certified for Ubuntu
               url: /certified?q=&limit=20&category=Laptop&category=Desktop
             - title: Servers
-              description: Hardware for data centres
+              description: Hardware for data centers
               url: /certified/servers
             - title: IoT devices
               description: Stable and secure devices
@@ -433,7 +433,7 @@ products:
               url: /blog/a-cisos-comprehensive-breakdown-of-the-cyber-resilience-act
             - title: Deploying AI at the edge with open source
               url: /engage/guide-to-deploying-ai-at-the-edge
-            - title: Landscape for IoT device Management
+            - title: Landscape for IoT device management
               url: /engage/iot-management-landscape
             - title: "Embedded Linux: Yocto or Ubuntu Core"
               url: /engage/embedded-linux-yocto-ubuntu-core-whitepaper
@@ -446,7 +446,7 @@ products:
       primary_links:
         - links:
             - title: Snaps
-              description: Containerised applications for Linux
+              description: Containerized applications for Linux
               url: https://snapcraft.io/about
             - title: Snapcraft
               description: Build and publish your snaps
@@ -509,10 +509,7 @@ use_case:
         - title: Managed IT services
           description: Fully managed open source solutions
           url: /managed
-        - title: Observability
-          description: Monitoring tools
-          url: /observability
-        - title: Private cloud and data centre
+        - title: Private cloud and data center
           description: OpenStack implementation
           url: /openstack/consulting
         - title: Public cloud
@@ -693,7 +690,7 @@ community:
           links:
             - title: "Forum: New to Ubuntu"
               url: https://ubuntuforums.org/forumdisplay.php?f=125
-            - title: "Forum: Ubuntu Official Flavours Support"
+            - title: "Forum: Ubuntu Official Flavors Support"
               url: https://ubuntuforums.org/forumdisplay.php?f=327
             - title: "Forum: Ubuntu, Linux and OS Chat"
               url: https://ubuntuforums.org/forumdisplay.php?f=434
@@ -703,7 +700,7 @@ community:
     - title: Contribute to Ubuntu
       primary_links:
         - links:
-            - title: Translate and localise
+            - title: Translate and localize
               description: Translate into your language
               url: /community/contribute/translation-localisation
             - title: QA and testing
@@ -811,7 +808,7 @@ get_ubuntu:
               url: /desktop
               secondary_cta_title: Download Ubuntu Desktop
               secondary_cta_url: /download/desktop
-            - title: Ubuntu flavours
+            - title: Ubuntu flavors
               description: Variations of Ubuntu OS
               url: /download/flavours
             - title: Ubuntu-ready PC and laptops
@@ -853,7 +850,7 @@ get_ubuntu:
               url: /cloud/public-cloud
             - title: Multipass
               description: VMs for Windows, macOS & Linux
-              url: https://multipass.run/
+              url: https://canonical.com/multipass
       secondary_links:
         - title: Quick links
           links:
@@ -961,11 +958,11 @@ get_ubuntu:
               url: /cloud/public-cloud
             - title: Minimal Ubuntu for containers
               url: /blog/minimal-ubuntu-released
-            - title: Customise cloud instances
+            - title: Customize cloud instances
               url: https://cloud-init.io/
             - title: Model driven operations
               url: /model-driven-operations
-            - title: Juju for standardised operations
+            - title: Juju for standardized operations
               url: https://jaas.ai/
             - title: Charmed Kubernetes
               url: /kubernetes
@@ -984,7 +981,7 @@ get_ubuntu:
               url: /desktop/wsl
             - title: Multipass
               description: Ubuntu VMs for Windows and macOS
-              url: https://multipass.run/
+              url: https://canonical.com/multipass
       secondary_links:
         - title: Quick links
           links:

--- a/yarn.lock
+++ b/yarn.lock
@@ -7406,10 +7406,10 @@ v8-to-istanbul@^9.0.1:
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^2.0.0"
 
-vanilla-framework@4.18.4:
-  version "4.18.4"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.18.4.tgz#8f740cd369d9a61d1cc3c34d3119660db4030e4a"
-  integrity sha512-g5jotlb6ENcK1+9hF3QsP5y8hGIXkgEdwjnDGTMEJ3vmtmwSJNa3KWp0QaFBE59nIZq71VGxTbYh+GI+9dzlLQ==
+vanilla-framework@4.18.5:
+  version "4.18.5"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.18.5.tgz#038e3bbeaeca49ae6cf6a074e0ed83901818eae6"
+  integrity sha512-UuYI6se/IV/u9YfzYPIs2FNJapgi9ld7F3s9IbjeR0yCvfH1HCjfZdDPD23tkQDBHiT6wNT6wugXDqFnunVJfQ==
 
 vanilla-framework@4.9.0:
   version "4.9.0"


### PR DESCRIPTION
## Done

- Updated spelling in meganav (BE -> AE) - see [copy doc](https://docs.google.com/document/d/1DCNvYHfC7AbOcqflTBaVd571iKAP_PaTfnqTENVEDVw/edit?tab=t.0)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Open this: [demo page](https://ubuntu-com-14657.demos.haus/)
- Open the meganav
- Check that the changes in the [copy doc](https://docs.google.com/document/d/1DCNvYHfC7AbOcqflTBaVd571iKAP_PaTfnqTENVEDVw/edit?tab=t.0) are implemented

## Issue / Card

Fixes [WD-18260](https://warthogs.atlassian.net/browse/WD-18260)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-18260]: https://warthogs.atlassian.net/browse/WD-18260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ