### PR TITLE
fix: blank page when opening anchors

### DIFF
--- a/static/js/src/tutorial.js
+++ b/static/js/src/tutorial.js
@@ -26,6 +26,36 @@ function setActiveLink(navigationItems, hash) {
   });
 }
 
+function scrollToRegularAnchor() {
+  /**
+   * As a result of navigation being tightly coupled to css, anchors for
+   * regular links are not working as expected. This function is a workaround.
+   */
+  console.log("scrollToRegularAnchor");
+  const match = window.location.hash.match(/^#(.*)$/);
+  const digitMatch = window.location.hash.match(/^#(\d+).*$/);
+  if (match && !digitMatch) {
+    // Get the section id from the anchor link
+    const header = document.querySelectorAll(
+      `a[href='${window.location.hash}']`,
+    )[0];
+    if (header) {
+      const sectionId = header.parentNode.parentNode.parentNode.id;
+
+      const reloadSection = new Promise((resolve) => {
+        window.location.hash = sectionId;
+        resolve();
+      });
+      reloadSection.then(() => {
+        header.scrollIntoView({ behavior: "smooth", block: "center" });
+      });
+    } else {
+      // Go to the default section
+      window.location.href = window.location.href.split("#")[0];
+    }
+  }
+}
+
 const navigationItems = document.querySelectorAll(".l-tutorial__nav-item");
 const toggleButton = document.querySelector(".l-tutorial__nav-toggle");
 
@@ -43,6 +73,7 @@ navigationItems.forEach((item) => {
 window.addEventListener("hashchange", (e) => {
   e.preventDefault();
   setActiveLink(navigationItems, window.location.hash);
+  scrollToRegularAnchor();
 });
 
 const sectionIds = [];
@@ -65,14 +96,7 @@ if (!window.location.hash) {
   }
 } else {
   // Redirect #0, #1 etc. to the correct section
-  const match = window.location.hash.match(/^#(\d+)$/);
-
-  if (match) {
-    const index = parseInt(match[1]);
-    const sectionId = sectionIds[index];
-    window.location.hash = "#" + sectionId;
-    window.location.reload();
-  }
+  scrollToRegularAnchor();
 }
 
 const tutorialFeedbackOptions = document.querySelector(

--- a/static/js/src/tutorial.js
+++ b/static/js/src/tutorial.js
@@ -31,7 +31,6 @@ function scrollToRegularAnchor() {
    * As a result of navigation being tightly coupled to css, anchors for
    * regular links are not working as expected. This function is a workaround.
    */
-  console.log("scrollToRegularAnchor");
   const match = window.location.hash.match(/^#(.*)$/);
   const digitMatch = window.location.hash.match(/^#(\d+).*$/);
   if (match && !digitMatch) {


### PR DESCRIPTION
## Done

- Find and scroll to header anchors in the page, instead of displaying a blank page

## QA

- Open the demo at [/tutorials/install-ubuntu-desktop#1-overview](https://ubuntu-com-14658.demos.haus/tutorials/install-ubuntu-desktop#1-overview)
- Click on any header with an anchor
- The page should scroll to, and center this header instead of a blank page
- Try other anchors, e.g https://ubuntu-com-14658.demos.haus/tutorials/install-ubuntu-desktop#manual-partitioning

## Issue / Card

- [WD-18201](https://warthogs.atlassian.net/browse/WD-18201)
- https://github.com/canonical/ubuntu.com/issues/14634

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-18201]: https://warthogs.atlassian.net/browse/WD-18201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ