### PR TITLE
add app.trueability.com to frame-src

### DIFF
--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -136,6 +136,7 @@ CSP = {
         "secure.livechatinc.com",
         "cdn.livechat-static.com",
         "*.cloudfront.net",
+        "app3.trueability.com",
     ],
     "style-src": [
         "*.cloudfront.net",


### PR DESCRIPTION
## Done

- Add `app.trueability.com` to `frame-src`

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Make sure that an exam starts and loads without any issues

## Issue / Card

Fixes [WD-18320](https://warthogs.atlassian.net/browse/WD-18320)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-18320]: https://warthogs.atlassian.net/browse/WD-18320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ