### PR TITLE
add compression of js/css assets

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,4 @@ bleach==6.0.0
 numpy==1.24.4
 python-slugify==8.0.1
 djlint==1.34.1
+flask-squeeze==3.1.0

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -37,17 +37,19 @@
             </div>
             <hr class="p-rule--muted" />
             <p>
-              <a id="test-takeover-primary-url" href="/download" class="p-button--positive">Download now</a>
+              <a id="test-takeover-primary-url"
+                 href="/download"
+                 class="p-button--positive">Download now</a>
             </p>
+          </div>
         </div>
-      </div>
         <div class="u-align--center">
           <img id="test-takeover-image"
-              src="https://assets.ubuntu.com/v1/fb1ea84e-Kernelt%20industries@2x.png"
-              width="508"
-              height="364"
-              loading="lazy"
-              alt="" />
+               src="https://assets.ubuntu.com/v1/fb1ea84e-Kernelt%20industries@2x.png"
+               width="508"
+               height="364"
+               loading="lazy"
+               alt="" />
         </div>
       </div>
     </section>
@@ -66,12 +68,17 @@
           <div id="takeover-ctas">
             <p>
               <a id="takeover-primary-url" href="/download" class="p-button--positive">Download for free</a>
-              <a id="takeover-secondary-url" href="/blog/ubuntu-desktop-24-04-noble-numbat-deep-dive">Read the deep dive&nbsp;&rsaquo;</a>
+              <a id="takeover-secondary-url"
+                 href="/blog/ubuntu-desktop-24-04-noble-numbat-deep-dive">Read the deep dive&nbsp;&rsaquo;</a>
             </p>
           </div>
         </div>
         <div class="col-6 u-vertically-center u-align--center u-hide--medium u-hide--small">
-          <img id="takeover-image" src="https://assets.ubuntu.com/v1/d9fc87f3-Numbat.svg" width="300" alt="" loading="lazy" />
+          <img id="takeover-image"
+               src="https://assets.ubuntu.com/v1/d9fc87f3-Numbat.svg"
+               width="300"
+               alt=""
+               loading="lazy" />
         </div>
       </div>
     </section>
@@ -386,16 +393,19 @@
               <div class="p-logo-section__item">
                 <img src="https://assets.ubuntu.com/v1/86ee4118-uber-logo.png"
                      alt="Uber"
+                     loading="lazy"
                      class="p-logo-section__logo" />
               </div>
               <div class="p-logo-section__item">
                 <img src="https://assets.ubuntu.com/v1/d1a04730-spotify-logo.png"
                      alt="Spotify"
+                     loading="lazy"
                      class="p-logo-section__logo" />
               </div>
               <div class="p-logo-section__item">
                 <img src="https://assets.ubuntu.com/v1/ce3090ee-bnp-paribas-logo.png"
                      alt="BNP"
+                     loading="lazy"
                      class="p-logo-section__logo" />
               </div>
             </div>
@@ -477,26 +487,31 @@
                 <div class="p-logo-section__item">
                   <img src="https://assets.ubuntu.com/v1/b0292231-aws-logo.png"
                        alt="AWS"
+                       loading="lazy"
                        class="p-logo-section__logo" />
                 </div>
                 <div class="p-logo-section__item">
                   <img src="https://assets.ubuntu.com/v1/8e354832-is-dark=true.png"
                        alt="GCP"
+                       loading="lazy"
                        class="p-logo-section__logo" />
                 </div>
                 <div class="p-logo-section__item">
                   <img src="https://assets.ubuntu.com/v1/9e14fd33-microsoft-azure-logo.png"
                        alt="Microsoft Azure"
+                       loading="lazy"
                        class="p-logo-section__logo" />
                 </div>
                 <div class="p-logo-section__item">
                   <img src="https://assets.ubuntu.com/v1/6f7d29aa-liberty-global-logo.png"
                        alt="Liberty Global"
+                       loading="lazy"
                        class="p-logo-section__logo" />
                 </div>
                 <div class="p-logo-section__item">
                   <img src="https://assets.ubuntu.com/v1/0f0a0c1d-aci-logo.png"
                        alt="ACI"
+                       loading="lazy"
                        class="p-logo-section__logo" />
                 </div>
               </div>
@@ -571,31 +586,37 @@
               <div class="p-logo-section__item">
                 <img src="https://assets.ubuntu.com/v1/aabc2a34-bestbuy-logo.png"
                      alt="Best Buy"
+                     loading="lazy"
                      class="p-logo-section__logo" />
               </div>
               <div class="p-logo-section__item">
                 <img src="https://assets.ubuntu.com/v1/83e8dd19-bt-logo.png"
                      alt="BT"
+                     loading="lazy"
                      class="p-logo-section__logo" />
               </div>
               <div class="p-logo-section__item">
                 <img src="https://assets.ubuntu.com/v1/8b939be3-deutsche-telekom.png"
                      alt="Deutsche Telekom"
+                     loading="lazy"
                      class="p-logo-section__logo" />
               </div>
               <div class="p-logo-section__item">
                 <img src="https://assets.ubuntu.com/v1/b6d5d92b-rabobank-logo.png"
                      alt="Rabobank"
+                     loading="lazy"
                      class="p-logo-section__logo" />
               </div>
               <div class="p-logo-section__item">
                 <img src="https://assets.ubuntu.com/v1/2c5c1540-Bloomberg-Logo.png"
                      alt="Bloomberg"
+                     loading="lazy"
                      class="p-logo-section__logo" />
               </div>
               <div class="p-logo-section__item">
                 <img src="https://assets.ubuntu.com/v1/99a69f52-ATT-Logo.png"
                      alt="AT&T"
+                     loading="lazy"
                      class="p-logo-section__logo" />
               </div>
             </div>
@@ -687,26 +708,31 @@
                 <div class="p-logo-section__item">
                   <img src="https://assets.ubuntu.com/v1/86b50f30-intel-new-logo.png"
                        class="p-logo-section__logo"
+                       loading="lazy"
                        alt="Intel" />
                 </div>
                 <div class="p-logo-section__item">
                   <img src="https://assets.ubuntu.com/v1/1af15900-rexroth-logo.png"
                        class="p-logo-section__logo"
+                       loading="lazy"
                        alt="Rexroth" />
                 </div>
                 <div class="p-logo-section__item">
                   <img src="https://assets.ubuntu.com/v1/0d5fc741-arm-logo.png"
                        class="p-logo-section__logo"
+                       loading="lazy"
                        alt="ARM" />
                 </div>
                 <div class="p-logo-section__item">
                   <img src="https://assets.ubuntu.com/v1/703330cd-dell-technologies-logo-white.png"
                        class="p-logo-section__logo"
+                       loading="lazy"
                        alt="Dell" />
                 </div>
                 <div class="p-logo-section__item">
                   <img src="https://assets.ubuntu.com/v1/d689e3b6-advantech-logo.png"
                        class="p-logo-section__logo"
+                       loading="lazy"
                        alt="Advantech" />
                 </div>
               </div>
@@ -750,7 +776,9 @@
     <section class="p-section ">
       <div class="u-fixed-width ">
         <div class="u-align--center u-vertically-center u-no-padding--bottom p-image-container--cinematic">
-          <img src="https://assets.ubuntu.com/v1/bb296524-Dell%20pcs.jpg" alt="" loading="lazy"/>
+          <img src="https://assets.ubuntu.com/v1/bb296524-Dell%20pcs.jpg"
+               alt=""
+               loading="lazy" />
         </div>
         <hr class="p-rule" />
         <div class="p-section--shallow">
@@ -766,31 +794,37 @@
               <div class="p-logo-section__item">
                 <img src="https://assets.ubuntu.com/v1/3e3e698b-nvidia-logo.png"
                      alt="NVIDIA"
+                     loading="lazy"
                      class="p-logo-section__logo" />
               </div>
               <div class="p-logo-section__item">
                 <img src="https://assets.ubuntu.com/v1/86b50f30-intel-new-logo.png"
                      alt="Intel"
+                     loading="lazy"
                      class="p-logo-section__logo" />
               </div>
               <div class="p-logo-section__item">
                 <img src="https://assets.ubuntu.com/v1/cc247653-amd-logo.png"
                      alt="AMD"
+                     loading="lazy"
                      class="p-logo-section__logo" />
               </div>
               <div class="p-logo-section__item">
                 <img src="https://assets.ubuntu.com/v1/af7e6fff-hp-logo.png"
                      alt="HP"
+                     loading="lazy"
                      class="p-logo-section__logo" />
               </div>
               <div class="p-logo-section__item">
                 <img src="https://assets.ubuntu.com/v1/703330cd-dell-technologies-logo-white.png"
-                       class="p-logo-section__logo"
-                       alt="Dell" />
+                     class="p-logo-section__logo"
+                     loading="lazy"
+                     alt="Dell" />
               </div>
               <div class="p-logo-section__item">
                 <img src="https://assets.ubuntu.com/v1/dc74391e-lenovo-logo.png"
                      alt="Lenovo"
+                     loading="lazy"
                      class="p-logo-section__logo" />
               </div>
             </div>
@@ -857,7 +891,7 @@
       <div class="u-fixed-width">
         <div class="p-image-container--cinematic">
           <img src="https://assets.ubuntu.com/v1/39667d98-Open%20source%20security.jpg"
-              loading="lazy"
+               loading="lazy"
                alt="" />
         </div>
         <hr class="p-rule" />
@@ -873,31 +907,37 @@
               <div class="p-logo-section__item">
                 <img src="https://assets.ubuntu.com/v1/d34aeb87-verizon-logo.png"
                      alt="Verizon"
+                     loading="lazy"
                      class="p-logo-section__logo" />
               </div>
               <div class="p-logo-section__item">
                 <img src="https://assets.ubuntu.com/v1/874b530e-telefonica-logo.png"
                      alt="Telefonica"
+                     loading="lazy"
                      class="p-logo-section__logo" />
               </div>
               <div class="p-logo-section__item">
                 <img src="https://assets.ubuntu.com/v1/fe4dad9a-tele2-logo.png"
                      alt="Tele2"
+                     loading="lazy"
                      class="p-logo-section__logo" />
               </div>
               <div class="p-logo-section__item">
                 <img src="https://assets.ubuntu.com/v1/06faa04e-telecom-italia-logo.png"
                      alt="Telecom Italia"
+                     loading="lazy"
                      class="p-logo-section__logo" />
               </div>
               <div class="p-logo-section__item">
                 <img src="https://assets.ubuntu.com/v1/54f03cb5-nec-logo.png"
                      alt="NEC"
+                     loading="lazy"
                      class="p-logo-section__logo" />
               </div>
               <div class="p-logo-section__item">
                 <img src="https://assets.ubuntu.com/v1/5bcba2d8-barclays-logo.png"
                      alt="Barclays"
+                     loading="lazy"
                      class="p-logo-section__logo" />
               </div>
             </div>
@@ -978,31 +1018,37 @@
               <div class="p-logo-section__item">
                 <img src="https://assets.ubuntu.com/v1/938bc6df-ABB-logo.png"
                      alt="ABB"
+                     loading="lazy"
                      class="p-logo-section__logo" />
               </div>
               <div class="p-logo-section__item">
                 <img src="https://assets.ubuntu.com/v1/24808373-pal-robotics-logo.png"
                      alt="Pal Robotics"
+                     loading="lazy"
                      class="p-logo-section__logo" />
               </div>
               <div class="p-logo-section__item">
                 <img src="https://assets.ubuntu.com/v1/8825054e-Kuka-logo.png"
                      alt="Kuka"
+                     loading="lazy"
                      class="p-logo-section__logo" />
               </div>
               <div class="p-logo-section__item">
                 <img src="https://assets.ubuntu.com/v1/213d7454-apollo-logo.png"
                      alt="Apollo"
+                     loading="lazy"
                      class="p-logo-section__logo" />
               </div>
               <div class="p-logo-section__item">
                 <img src="https://assets.ubuntu.com/v1/feb30dca-bosch-logo.png"
                      alt="Bosch"
+                     loading="lazy"
                      class="p-logo-section__logo" />
               </div>
               <div class="p-logo-section__item">
                 <img src="https://assets.ubuntu.com/v1/fbbc29ef-bmw-logo.png"
                      alt="BMW"
+                     loading="lazy"
                      class="p-logo-section__logo" />
               </div>
             </div>
@@ -1057,8 +1103,7 @@
              style="background: rgba(0, 0, 0, 0.15)">
           <img src="https://assets.ubuntu.com/v1/6d657910-Multi-cloud%20Applications%C2%A0%C2%A0Beyond%20PAAS.png"
                alt=""
-               loading="lazy"
-               />
+               loading="lazy" />
         </div>
         <hr class="p-rule" />
         <div class="p-section--shallow">
@@ -1071,21 +1116,25 @@
               <div class="p-logo-section__item">
                 <img src="https://assets.ubuntu.com/v1/70b63088-Panasonic_logo.png"
                      alt="Panasonic"
+                     loading="lazy"
                      class="p-logo-section__logo" />
               </div>
               <div class="p-logo-section__item">
                 <img src="https://assets.ubuntu.com/v1/9eff2c35-scania-logo.png"
                      alt="Scania"
+                     loading="lazy"
                      class="p-logo-section__logo" />
               </div>
               <div class="p-logo-section__item">
                 <img src="https://assets.ubuntu.com/v1/84772462-sbi-bits-logo.png"
                      alt="SBI BTS"
+                     loading="lazy"
                      class="p-logo-section__logo" />
               </div>
               <div class="p-logo-section__item">
                 <img src="https://assets.ubuntu.com/v1/e31ed5d5-swissquote-logo.png"
                      alt="Swissquote"
+                     loading="lazy"
                      class="p-logo-section__logo" />
               </div>
             </div>

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -24,7 +24,7 @@
 
     <script src="{{ versioned_static('js/src/navigation.js') }}" defer></script>
     <script src="{{ versioned_static('js/dist/main.js') }}" defer></script>
-    <script src="{{ versioned_static('js/src/infer-preferred-language.js')}}"></script>
+    <script src="{{ versioned_static('js/src/infer-preferred-language.js')}}" defer></script>
 
     <link rel="stylesheet" type="text/css" media="screen" href="{{ versioned_static("css/styles.css") }}" />
     <link rel="stylesheet" type="text/css" media="print" href="{{ versioned_static("css/print.css") }}" />

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -12,6 +12,7 @@ import requests
 import talisker.requests
 from jinja2 import ChoiceLoader, FileSystemLoader
 from pathlib import Path
+from flask_squeeze import Squeeze
 
 from canonicalwebteam.blog import BlogAPI, BlogViews, build_blueprint
 from canonicalwebteam.discourse import (
@@ -183,6 +184,10 @@ app = FlaskBase(
     template_500="500.html",
     static_folder="../static",
 )
+
+# Compress JS and CSS
+squeeze = Squeeze()
+squeeze.init_app(app)
 
 # ChoiceLoader attempts loading templates from each path in successive order
 loader = ChoiceLoader(


### PR DESCRIPTION
## Done

- add `Flask-Squeeze` package to compress js and css
- defer one of the JS files that is not needed immediately
- lazy load all images on the home page that are not visible initially

## QA

- Compare JS and CSS files sizes of the demo instance and production and check that it has significantly decreased.