### PR TITLE
fix(content): Add two company addresses to the legal section

### DIFF
--- a/templates/legal/companies.html
+++ b/templates/legal/companies.html
@@ -127,6 +127,17 @@
             </td>
           </tr>
           <tr>
+            <td>Canonical Services Spain Limited</td>
+            <td>
+              <ul class="p-list">
+                <li class="p-list__item">2nd Floor, Clarendon House,</li>
+                <li class="p-list__item">Victoria street,</li>
+                <li class="p-list__item">Douglas, IM1 2LN,</li>
+                <li class="p-list__item">Isle of Man</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
             <td>Canonical Canada Ltd</td>
             <td>
               <ul class="p-list">
@@ -159,6 +170,16 @@
                 <li class="p-list__item">Songshan Dist.,</li>
                 <li class="p-list__item">Taipei City 105402,</li>
                 <li class="p-list__item">Taiwan (R.O.C.)</li>
+              </ul>
+            </td>
+          </tr>
+          <tr>
+            <td>Canonical Support Services Ireland Limited, Ireland</td>
+            <td>
+              <ul class="p-list">
+                <li class="p-list__item">29 Earlsfort Terrace,</li>
+                <li class="p-list__item">Dublin 2,</li>
+                <li class="p-list__item">Ireland</li>
               </ul>
             </td>
           </tr>


### PR DESCRIPTION
## Done

- Add Canonical Services Spain Limited and Canonical Support Services Ireland Limited to our public companies page

## QA

- Open the demo
- Go to /legal/companies
- Check the two new companies are there