### PR TITLE
upgrade to flask-base 2.1.0 that does the assets comression

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-canonicalwebteam.flask-base==2.0.0
+canonicalwebteam.flask-base==2.1.0
 canonicalwebteam.http==1.0.4
 canonicalwebteam.blog==6.4.4
 canonicalwebteam.search==2.1.1
@@ -32,4 +32,3 @@ bleach==6.0.0
 numpy==1.24.4
 python-slugify==8.0.1
 djlint==1.34.1
-flask-squeeze==3.1.0

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -12,7 +12,6 @@ import requests
 import talisker.requests
 from jinja2 import ChoiceLoader, FileSystemLoader
 from pathlib import Path
-from flask_squeeze import Squeeze
 
 from canonicalwebteam.blog import BlogAPI, BlogViews, build_blueprint
 from canonicalwebteam.discourse import (
@@ -184,10 +183,6 @@ app = FlaskBase(
     template_500="500.html",
     static_folder="../static",
 )
-
-# Compress JS and CSS
-squeeze = Squeeze()
-squeeze.init_app(app)
 
 # ChoiceLoader attempts loading templates from each path in successive order
 loader = ChoiceLoader(


### PR DESCRIPTION
## Done

- This is the next step after [this PR](https://github.com/canonical/ubuntu.com/pull/14672), doing the assets compression on the flask-base level.

## QA

- Check that the resources on the demo and production are the same. You can do that by using Network tab of the dev console. For example, compare the sizes of `styles.css` on the demo and on production, and check that it didn't become bigger.
