### PR TITLE
feat: Rebrand /kubernetes index page

### DIFF
--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -534,6 +534,7 @@
                 <div style="display:inline-flex;">
                   <span class="p-heading--5">Discoverer</span>
                   <label class="p-switch"
+                         aria-label="Toggle between Kubernetes Discoverer and Discoverer Plus plans"
                          style="display: inline-block;
                                 padding-left: 32px;
                                 padding-right: 32px">

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -51,7 +51,11 @@
       <hr class="p-rule" />
       <div class="col">
         <div class="p-section--shallow">
-          <h2>Why choose Canonical Kubernetes Platform?</h2>
+          <h2>
+            Why choose
+            <br />
+            Canonical Kubernetes Platform?
+          </h2>
         </div>
       </div>
       <div class="col">
@@ -219,7 +223,11 @@
       <hr class="p-rule" />
       <div class="col">
         <div class="p-section--shallow u-hide--large">
-          <h2>Public cloud Kubernetes powered by Ubuntu</h2>
+          <h2>
+            Public cloud Kubernetes
+            <br />
+            powered by Ubuntu
+          </h2>
         </div>
         <div class="p-image-container u-hide--small u-hide--medium">
           {{ image(url="https://assets.ubuntu.com/v1/5a2779e1-public%20cloud.png",
@@ -234,7 +242,11 @@
       </div>
       <div class="col">
         <div class="p-section--shallow u-hide--medium u-hide--small">
-          <h2>Public cloud Kubernetes powered by Ubuntu</h2>
+          <h2>
+            Public cloud Kubernetes
+            <br />
+            powered by Ubuntu
+          </h2>
         </div>
         <p>Cloud-tailored experience, optimized kernels, unlimited options</p>
         <hr class="p-rule--muted u-no-margin--bottom" />
@@ -257,52 +269,52 @@
           <div class="p-logo-section__items">
             <div class="p-logo-section__item">
               {{ image(url="https://assets.ubuntu.com/v1/15f4f759-aws-logo.png",
-                        alt="AWS",
-                        width="151",
-                        height="312",
-                        hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-logo-section__logo"},) | safe
+                            alt="AWS",
+                            width="151",
+                            height="312",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"class": "p-logo-section__logo"},) | safe
               }}
             </div>
             <div class="p-logo-section__item">
               {{ image(url="https://assets.ubuntu.com/v1/f1ec4ff5-microsoft-azure-logo [DEPRECATED] .png",
-                        alt="Microsoft Azure",
-                        width="272",
-                        height="312",
-                        hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-logo-section__logo"},) | safe
+                            alt="Microsoft Azure",
+                            width="272",
+                            height="312",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"class": "p-logo-section__logo"},) | safe
               }}
             </div>
             <div class="p-logo-section__item">
               {{ image(url="https://assets.ubuntu.com/v1/6c959a61-google-cloud-stacked-logo [DEPRECATED] .png",
-                        alt="Google Cloud",
-                        width="189",
-                        height="312",
-                        hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-logo-section__logo"},) | safe
+                            alt="Google Cloud",
+                            width="189",
+                            height="312",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"class": "p-logo-section__logo"},) | safe
               }}
             </div>
             <div class="p-logo-section__item">
               {{ image(url="https://assets.ubuntu.com/v1/4a30e5f7-ibm-cloud-logo.png",
-                        alt="IBM Cloud",
-                        width="437",
-                        height="312",
-                        hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-logo-section__logo"},) | safe
+                            alt="IBM Cloud",
+                            width="437",
+                            height="312",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"class": "p-logo-section__logo"},) | safe
               }}
             </div>
             <div class="p-logo-section__item">
               {{ image(url="https://assets.ubuntu.com/v1/dbab531e-oracle-cloud-logo.png",
-                        alt="Oracle Cloud",
-                        width="387",
-                        height="312",
-                        hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-logo-section__logo"},) | safe
+                            alt="Oracle Cloud",
+                            width="387",
+                            height="312",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"class": "p-logo-section__logo"},) | safe
               }}
             </div>
           </div>
@@ -316,7 +328,11 @@
       <hr class="p-rule" />
       <div class="col">
         <div class="p-section--shallow">
-          <h2>Integrated cluster management platforms</h2>
+          <h2>
+            Integrated
+            <br />
+            cluster management platforms
+          </h2>
         </div>
         <div class="u-hide--medium u-hide--small">
           <p>Remove the toil of Kubernetes cluster management</p>
@@ -510,7 +526,9 @@
               <div class="col">
                 <div class="p-section--shallow">
                   <h3 class="js-discoverer-text">Kubernetes Discoverer</h3>
-                  <p class="u-text--muted js-discoverer-description">Three-day training and 2-week deployment of reference K8s architecture, including:</p>
+                  <p class="u-text--muted js-discoverer-description">
+                    Three-day training and 2-week deployment of reference K8s architecture, including:
+                  </p>
                 </div>
                 <p>
                   <span class="p-heading--5">Discoverer</span>

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -1,657 +1,638 @@
 {% extends "kubernetes/base_kubernetes.html" %}
 
-{% block title %}Enterprise Kubernetes for multi-cloud operations{% endblock %}
+{% block title %}Secure, enterprise-grade Kubernetes for multi-cloud operations{% endblock %}
 
 {% block meta_description %}
-  Canonical Kubernetes enterprise solutions build up from Ubuntu OS to hybrid multi-cloud container orchestration clouds, edge and IoT, managed Kubernetes and enterprise support packages.
+  Canonical’s securely designed enterprise-grade Kubernetes builds up from Ubuntu OS to hybrid multi-cloud container orchestration clouds, edge and IoT, managed Kubernetes and enterprise support packages.
 {% endblock meta_description %}
 
 {% block meta_copydoc %}
   https://docs.google.com/document/d/1b018GoKMF3abEFJlUkfAEK2JEhXWICKF4V0dGdTvgJs/edit
 {% endblock meta_copydoc %}
 
+{% from "_macros/vf_hero.jinja" import vf_hero %}
+{% from "_macros/vf_quote-wrapper.jinja" import vf_quote_wrapper %}
+
 {% block body_class %}is-paper{% endblock body_class %}
 
 {% block content %}
-
-<section class="p-strip is-shallow u-no-padding--bottom">
-  <div class="row--50-50 p-section">
-    <div class="col">
-      <h1>Enterprise-grade<br /> Kubernetes</h1>
-    </div>
-    <div class="col">
-      <h2>Kubernetes that comes with 12 years of Long Term Support</h2>
-      <p>Focus on applications and innovation rather than infrastructure. With Canonical Kubernetes, you get hassle-free maintenance, a single-line installation process, and choice to orchestrate your workloads as you prefer.</p>
-      <div class="p-strip is-shallow" style="display: flex; align-items: flex-start; gap: 2rem;">
-        {{ image (
-          url="https://assets.ubuntu.com/v1/62b09bad-certified-kubernetes-color.svg",
-          alt="Certified Kubernetes",
-          width="96",
-          height="128",
-          hi_def=True,
-          loading="lazy",
-          ) | safe
-        }}
-        {{ image (
-          url="https://assets.ubuntu.com/v1/48ee616b-kubernetes-kcsp-color.svg",
-          alt="Certified Kubernetes Service Provider",
-          width="131",
-          height="128",
-          hi_def=True,
-          loading="lazy",
-          ) | safe
-        }}
-      </div>
-      <hr />
-      <a class="p-button--positive js-invoke-modal" href="/kubernetes/contact-us">Get in touch</a>
+  {% call(slot) vf_hero(
+    title_text='Enterprise-grade Kubernetes <br class="u-hide--small u-hide--medium" />for multi-cloud operations',
+    layout='50/50-full-width-image'
+    ) -%}
+    {%- if slot == 'description' -%}
+      <p>
+        Secure your Kubernetes deployments long term and focus on applications, not infrastructure. With Canonical Kubernetes, you get hassle-free installation and maintenance, and peace of mind for your containerized workloads.
+      </p>
+    {%- endif -%}
+    {%- if slot == 'cta' -%}
+      <a href="/kubernetes/contact-us" class="js-invoke-modal p-button--positive">Get in touch</a>
       <a href="/kubernetes/install">Try Canonical Kubernetes today&nbsp;&rsaquo;</a>
-    </div>
-  </div>
-</section>
+    {%- endif -%}
+    {%- if slot == 'image' -%}
+      <div class="p-image-container--cinematic is-cover">
+        {{ image(url="https://assets.ubuntu.com/v1/7d724c59-hero.png",
+                alt="",
+                width="3696",
+                height="1540",
+                hi_def=True,
+                loading="auto",
+                attrs={"class": "p-image-container__image"}) | safe
+        }}
+      </div>
+    {% endif -%}
+  {% endcall -%}
 
-<section class="p-section">
-  <div class="row--50-50">
-    <hr class="p-rule" />
-    <div class="col">
-      <h2 class="p-text--small-caps p-section--shallow">Public cloud Kubernetes<br /> powered by Ubuntu</h2>
-      <p class="p-heading--2">Cloud-tailored experience, optimised kernels, unlimited options</p>
-    </div>
-    <div class="col">
-      <div class="row">
-        <div class="col-3">
-          <ul class="p-list--divided">
-            <li class="p-list__item" style="margin-top: .25rem;">
-              {{ image (
-                url="https://assets.ubuntu.com/v1/d6bb76c7-aws%20logo.png",
-                alt="AWS",
-                width="41",
-                height="24",
-                hi_def=True,
-                loading="auto"
-                ) | safe
-              }}
-            </li>
-            <li class="p-list__item">
-              {{ 
-                image (
-                url="https://assets.ubuntu.com/v1/5f2a687f-ms%20azure%20logo.png",
-                alt="Microsoft Azure",
-                width="85",
-                height="24",
-                hi_def=True,
-                loading="auto"
-                ) | safe
-              }}
-            </li>
-            <li class="p-list__item">
-              {{ 
-                image (
-                url="https://assets.ubuntu.com/v1/de136903-googlecloud%20logo.png",
-                alt="Google Cloud",
-                width="154",
-                height="24",
-                hi_def=True,
-                loading="auto"
-                ) | safe
-              }}
-            </li>
-            <li class="p-list__item">
-              {{ 
-                image (
-                url="https://assets.ubuntu.com/v1/43adb0a3-ibm%20cloud%20logo.png",
-                alt="IBM Cloud",
-                width="104",
-                height="24",
-                hi_def=True,
-                loading="auto"
-                ) | safe
-              }}
-            </li>
-            <li class="p-list__item">
-              {{ 
-                image (
-                url="https://assets.ubuntu.com/v1/94f00081-oracle%20logo.png",
-                alt="Oracle",
-                width="99",
-                height="13",
-                hi_def=True,
-                loading="auto"
-                ) | safe
-              }}
-            </li>
-          </ul>
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <div class="p-section--shallow">
+          <h2>Why choose Canonical Kubernetes Platform?</h2>
         </div>
-        <div class="col-3">
-          <p>Ubuntu is the host OS for the world's most popular cloud-hosted Kubernetes. Our distributions are optimised for performance, boot speed, and drivers on all major public clouds. They provide out-of-the-box cloud integration with the option of enterprise-grade commercial support.</p>
-          <p>Ubuntu Pro provides deeper integrations with cloud services, in-cloud Ubuntu package mirrors for high bandwidth and local updates and gives you full control over kernel security patching with <a href="/security/livepatch">Livepatch</a>.</p>
-          <hr />
-          <a href="/public-cloud">Learn more about Ubuntu on public clouds&nbsp;&rsaquo;</a>
+      </div>
+      <div class="col">
+        <ul class="p-list--divided">
+          <li class="p-list__item is-ticked">12-year security maintenance and support gives you control over your upgrades schedule.</li>
+          <li class="p-list__item is-ticked">Easy to use with built-in, best-of-breed open source components for networking, local storage, DNS, load-balancer, metrics server, gateway, and ingress.</li>
+          <li class="p-list__item is-ticked">Zero ops from Day 0 to Day 2 - add and manage nodes in small Kubernetes clusters with minimal effort.</li>
+          <li class="p-list__item is-ticked">Automated cluster operations for easier large scale maintenance with <a href="https://juju.is">Juju</a>.</li>
+          <li class="p-list__item is-ticked">The same security-maintained Kubernetes that scales from your laptop to the cloud and the data centre.</li>
+          <li class="p-list__item is-ticked">CNCF conformant.</li>
+        </ul>
+        <div class="p-cta-block">
+          <a class="p-button" href="/pro/subscribe">Purchase support with Ubuntu Pro</a>
         </div>
       </div>
     </div>
-  </div>
-</section>
+  </section>
 
-<section class="p-section">
-  <div class="row--25-75">
-    <hr class="p-rule" />
-    <div class="col">
-      <h2 class="p-text--small-caps">Canonical Kubernetes<br /> distributions</h2>
+  <section class="p-section">
+    <hr class="p-rule--highlight is-fixed-width" />
+    <div class="u-fixed-width">
+      <h2 class="p-text--small-caps">What our clients say</h2>
     </div>
-    <div class="col">
-      <div class="row">
-        <div class="col-3 p-image-wrapper">
-          <h3 class="u-no-padding--top">
-            {{ 
-              image (
-              url="https://assets.ubuntu.com/v1/0e7e4a7a-k8s%20logo.png",
-              alt="Canonical Kubernetes",
-              width="230",
-              height="34",
-              hi_def=True,
-              loading="lazy"
-              ) | safe
-            }}
-          </h3>
+    {% call(slot) vf_quote_wrapper(
+      quote_size="small",
+      quote_text="Kubernetes is both fast-moving and hard, so supporting it ourselves was not a viable option. The thought of having to support it would be daunting. To keep it supported and up to date, it’s better to have experts who do this every day involved and manage it for us.",
+      citation_source_name_text="Michael Hawkshaw",
+      citation_source_title_text="Mission Operations Infrastructure IT Service Manager",
+      citation_source_organisation_text="European Space Operations Centre",
+      is_shallow=true
+      ) -%}
+
+      {%- if slot == 'signpost_image' -%}
+        {{ image(url="https://assets.ubuntu.com/v1/d2f13d46-logo-esa-wide.png",
+                  alt="",
+                  width="852",
+                  height="189",
+                  hi_def=True,
+                  loading="lazy") | safe
+        }}
+      {%- endif -%}
+
+    {% endcall -%}
+
+    {% call(slot) vf_quote_wrapper(
+      quote_size="small",
+      quote_text="We were looking for a Kubernetes distribution that is close to the upstream Kubernetes project and offers enterprise support. Canonical support is very qualified, effective and well structured.",
+      citation_source_name_text="Patric Lichtsteiner",
+      citation_source_title_text="Linux Senior System Engineer",
+      citation_source_organisation_text="ZHAW",
+      is_shallow=true
+      ) -%}
+
+      {%- if slot == 'signpost_image' -%}
+        {{ image(url="https://assets.ubuntu.com/v1/ecc63b0c-logo-zhaw-wide.png",
+                  alt="",
+                  width="852",
+                  height="222",
+                  hi_def=True,
+                  loading="lazy") | safe
+        }}
+      {%- endif -%}
+
+    {% endcall -%}
+  </section>
+
+  <section class="p-section">
+    <hr class="p-rule is-fixed-width" />
+    <div class="p-section--shallow u-fixed-width">
+      <h2>Supporting Kubernetes since 2015</h2>
+    </div>
+    <div class="p-section--shallow">
+      <div class="row--50-50">
+        <div class="col">
+          <h3>Canonical Kubernetes</h3>
+          <p>Secure and automate your Kubernetes infrastructure with a trusted provider. Build on the experience we gained since 2015.  Our new Kubernetes distribution offers hassle-free maintenance, single-line installation process, and more control over your upgrade cadence. It’s secure by default and comes with a 12-year support commitment  offered with an Ubuntu Pro subscription.</p>
+
         </div>
-        <div class="col-6">
-          <p>Canonical Kubernetes, currently in beta, provides 12 years of security maintenance and enterprise support on any infrastructure.</p>
-          <ul class="p-list--divided">
-            <li class="p-list__item is-ticked">Easy to use with built-in capabilities: networking, local storage, DNS, metrics server, gateway and ingress </li>
-            <li class="p-list__item is-ticked">Zero ops from Day 0 to Day 2 - add and manage nodes in small Kubernetes clusters with minimal effort</li>
-            <li class="p-list__item is-ticked">Automated cluster operations for easier large scale maintenance with <a href="https://juju.is">Juju</a></li>
-            <li class="p-list__item is-ticked">12 year Long Term Support commitment  that lets you decide when it is time to upgrade your infrastructure</li>
-            <li class="p-list__item is-ticked">The same Kubernetes that scales from your laptop to the cloud and the data centre</li>
-            <li class="p-list__item is-ticked">CNCF conformant</li>
-          </ul>
-          <hr />
+        <div class="col">
+          <div class="p-image-container">
+            {{ image(url="https://assets.ubuntu.com/v1/6dffa7f1-kubernetes-platform-updated.png",
+                      alt="",
+                      width="1800",
+                      height="1013",
+                      hi_def=True,
+                      attrs={"class": "p-image-container__image"},
+                      loading="lazy") | safe
+            }}
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="p-section--shallow">
+      <div class="row">
+        <hr class="p-rule--muted" />
+        <div class="col-3">
+          <h3>Other distributions</h3>
+        </div>
+        <div class="col-9">
+          <div class="row">
+            <div class="col-3">
+              <h5>MicroK8s</h5>
+            </div>
+            <div class="col-6">
+              <p>Lightweight, low-touch Kubernetes for cloud, edge and IoT. It brings all Kubernetes services and the most popular addons in a single package, and requires minimal ops for easy clustering, self-healing HA and simpler upgrades. Secure by default and CNCF conformant.</p>
+              <hr class="p-rule--muted" />
+              <p>
+                <a href="https://microk8s.io/">Learn more about MicroK8s&nbsp;&rsaquo;</a>
+              </p>
+            </div>
+          </div>
+          <hr class="p-rule--muted" />
+          <div class="row">
+            <div class="col-3">
+              <h5>Charmed Kubernetes</h5>
+            </div>
+            <div class="col-6">
+              <p>Composable, operator-based Kubernetes for the enterprise, with full life-cycle management for host and in-cluster with <a href="https://juju.is/">Juju</a>. It provides carrier-grade and hardware acceleration features, and support for third-party components and services. It gives you fully customizable deployments, with pluggable CNI, CSI, CRI and monitoring components. Secure by default and CNCF conformant.</p>
+              <hr class="p-rule--muted" />
+              <p>
+                <a href="/kubernetes/charmed-k8s">Learn more about Charmed Kubernetes&nbsp;&rsaquo;</a>
+              </p>
+            </div>
+          </div>
+          <hr class="p-rule--muted" />
+          <div class="row">
+            <div class="col-3">
+              <h5>Kubernetes clusters with Kubeadm</h5>
+            </div>
+            <div class="col-6">
+              <p>Canonical provides commercial support for Kubernetes clusters deployed using kubeadm.</p>            
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <hr class="p-rule--muted" />
+      <div class="col-start-large-7 col-6">
+        <p>
+          <a class="p-button js-invoke-modal" href="/kubernetes/contact-us">Talk to us to learn more</a>
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="row--50-50-on-large">
+      <hr class="p-rule" />
+      <div class="col">
+        <div class="p-section--shallow u-hide--large">
+          <h2>Public cloud Kubernetes powered by Ubuntu</h2>
+        </div>
+        <div class="p-image-container u-hide--small u-hide--medium">
+          {{ image(url="https://assets.ubuntu.com/v1/5a2779e1-public cloud.png",
+                    alt="",
+                    width="1800",
+                    height="2701",
+                    hi_def=True,
+                    loading="lazy",
+                    attrs={"class": "p-image-container__image"}) | safe
+          }}
+        </div>
+      </div>
+      <div class="col">
+        <div class="p-section--shallow u-hide--medium u-hide--small">
+          <h2>Public cloud Kubernetes powered by Ubuntu</h2>
+        </div>
+        <p>
+          Cloud-tailored experience, optimized kernels, unlimited options
+        </p>
+        <hr class="p-rule--muted u-no-margin--bottom" />
+        <ul class="p-list--divided">
+          <li class="p-list__item is-ticked">Ubuntu is the host OS for the world’s most popular cloud-hosted Kubernetes</li>
+          <li class="p-list__item is-ticked">Optimized for performance, boot speed, and drivers on all major public clouds.</li>
+          <li class="p-list__item is-ticked">Out-of-the-box cloud integration with the option of enterprise-grade commercial support</li>
+          <li class="p-list__item is-ticked">Ubuntu Pro provides deeper integrations with cloud services</li>
+          <li class="p-list__item is-ticked">In-cloud Ubuntu package mirrors for high bandwidth and local updates</li>
+          <li class="p-list__item is-ticked">Full control over kernel security patching with Canonical Livepatch</li>
+        </ul>
+        <div class="p-cta-block">
           <p>
-            <a class="p-button" href="https://documentation.ubuntu.com/canonical-kubernetes">Try Canonical Kubernetes today</a>
-            <a href="">Read the announcement&nbsp;&rsaquo;</a>
+            <a href="/public-cloud">Learn more about Ubuntu on public clouds&nbsp;&rsaquo;</a>
           </p>
         </div>
+        <div class="p-logo-section has-misaligned-images">
+          <div class="p-logo-section__items">
+            <div class="p-logo-section__item">
+              {{ image(url="https://assets.ubuntu.com/v1/15f4f759-aws-logo.png",
+                        alt="",
+                        width="151",
+                        height="312",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"},) | safe
+              }}
+            </div>
+            <div class="p-logo-section__item">
+              {{ image(url="https://assets.ubuntu.com/v1/f1ec4ff5-microsoft-azure-logo [DEPRECATED] .png",
+                        alt="",
+                        width="272",
+                        height="312",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"},) | safe
+              }}
+            </div>
+            <div class="p-logo-section__item">
+
+              {{ image(url="https://assets.ubuntu.com/v1/6c959a61-google-cloud-stacked-logo [DEPRECATED] .png",
+                        alt="",
+                        width="189",
+                        height="312",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"},) | safe
+              }}
+            </div>
+            <div class="p-logo-section__item">
+              {{ image(url="https://assets.ubuntu.com/v1/4a30e5f7-ibm-cloud-logo.png",
+                        alt="",
+                        width="437",
+                        height="312",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"},) | safe
+              }}
+            </div>
+            <div class="p-logo-section__item">
+              {{ image(url="https://assets.ubuntu.com/v1/dbab531e-oracle-cloud-logo.png",
+                        alt="",
+                        width="387",
+                        height="312",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"},) | safe
+              }}
+            </div>
+          </div>
+        </div>
       </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="row--50-50-on-large">
       <hr class="p-rule" />
-      <div class="row">
-        <div class="col-3 p-image-wrapper">
-          <h3 class="u-no-padding--top"><a href="https://microk8s.io/">
-            {{ 
-              image (
-              url="https://assets.ubuntu.com/v1/2db04010-microk8s%20logo.png",
-              alt="MicroK8s",
-              width="230",
-              height="35",
-              hi_def=True,
-              loading="lazy"
-              ) | safe
-            }}
-          </a></h3>
+      <div class="col">
+        <div class="p-section--shallow">
+          <h2>Integrated cluster management platforms</h2>
         </div>
-        <div class="col-6">
-          <p>Low-touch Kubernetes for cloud, edge and IoT</p>
+        <div class="u-hide--medium u-hide--small">
+          <p>Remove the toil of Kubernetes cluster management</p>
+          <hr class="p-rule--muted u-no-margin--bottom" />
           <ul class="p-list--divided">
-            <li class="p-list__item is-ticked">All Kubernetes services and the most popular addons in a single package</li>
-            <li class="p-list__item is-ticked">Minimal ops for easy clustering, self-healing HA and simpler upgrades</li>
-            <li class="p-list__item is-ticked">Lightweight K8s for resource-constrained environments</li>
-            <li class="p-list__item is-ticked">Secure by default with strict confinement</li>
-            <li class="p-list__item is-ticked">Compatible with Linux, Windows and macOS</li>
-            <li class="p-list__item is-ticked">12 years of long term support as of second generation of MicroK8s</li>
-            <li class="p-list__item is-ticked">CNCF conformant</li>
+            <li class="p-list__item is-ticked">No need to yaml and cli, we integrate with the most popular GUIs</li>
+            <li class="p-list__item is-ticked">Single pane of glass for your Kubernetes and container estate</li>
+            <li class="p-list__item is-ticked">Unified multi-cluster management and real-time monitoring</li>
+            <li class="p-list__item is-ticked">Policy-based management, governance, security and compliance</li>
+            <li class="p-list__item is-ticked">GitOps at scale for application management and configuration</li>
+            <li class="p-list__item is-ticked">Flexibility across environments from public cloud to edge</li>
           </ul>
-          <hr />
-          <p>
-            <a class="p-button" href="https://microk8s.io/">Try MicroK8s today</a>
-            <a href="https://microk8s.io/resources">Learn more about MicroK8s&nbsp;&rsaquo;</a>
-          </p>
+          <div class="p-logo-section--dense">
+            <div class="p-logo-section__items">
+              <div class="p-logo-section__item">
+                {{ image(url="https://assets.ubuntu.com/v1/58440b6b-rancher-logo.png",
+                          alt="Rancher",
+                          width="107",
+                          height="96",
+                          hi_def=True,
+                          loading="lazy",
+                          attrs={"class": "p-logo-section__logo"}) | safe
+                }}
+              </div>
+              <div class="p-logo-section__item">
+                {{ image(url="https://assets.ubuntu.com/v1/eb826d4d-portainer-io-logo.png",
+                          alt="Portainer.io",
+                          width="144",
+                          height="96",
+                          hi_def=True,
+                          loading="lazy",
+                          attrs={"class": "p-logo-section__logo"}) | safe
+                }}
+              </div>
+              <div class="p-logo-section__item">
+                {{ image(url="https://assets.ubuntu.com/v1/d0e0b382-spectro-cloud-logo.png",
+                          alt="Spectro Cloud",
+                          width="72",
+                          height="96",
+                          hi_def=True,
+                          loading="lazy",
+                          attrs={"class": "p-logo-section__logo"}) | safe
+                }}
+              </div>
+              <div class="p-logo-section__item">
+                {{ image(url="https://assets.ubuntu.com/v1/9ffbe97e-azure-arc-logo.png",
+                          alt="Azure arc",
+                          width="42",
+                          height="96",
+                          hi_def=True,
+                          loading="lazy",
+                          attrs={"class": "p-logo-section__logo"}) | safe
+                }}
+              </div>
+            </div>
+          </div>
         </div>
       </div>
+      <div class="col">
+        <div class="u-hide--large">
+          <p>Remove the toil of Kubernetes cluster management</p>
+          <hr class="p-rule--muted u-no-margin--bottom" />
+          <ul class="p-list--divided">
+            <li class="p-list__item is-ticked">No need to yaml and cli, we integrate with the most popular GUIs</li>
+            <li class="p-list__item is-ticked">Single pane of glass for your Kubernetes and container estate</li>
+            <li class="p-list__item is-ticked">Unified multi-cluster management and real-time monitoring</li>
+            <li class="p-list__item is-ticked">Policy-based management, governance, security and compliance</li>
+            <li class="p-list__item is-ticked">GitOps at scale for application management and configuration</li>
+            <li class="p-list__item is-ticked">Flexibility across environments from public cloud to edge</li>
+          </ul>
+          <div class="p-logo-section--dense">
+            <div class="p-logo-section__items">
+              <div class="p-logo-section__item">
+                {{ image(url="https://assets.ubuntu.com/v1/58440b6b-rancher-logo.png",
+                          alt="Rancher",
+                          width="107",
+                          height="96",
+                          hi_def=True,
+                          loading="lazy",
+                          attrs={"class": "p-logo-section__logo"}) | safe
+                }}
+              </div>
+              <div class="p-logo-section__item">
+                {{ image(url="https://assets.ubuntu.com/v1/eb826d4d-portainer-io-logo.png",
+                          alt="Portainer.io",
+                          width="144",
+                          height="96",
+                          hi_def=True,
+                          loading="lazy",
+                          attrs={"class": "p-logo-section__logo"}) | safe
+                }}
+              </div>
+              <div class="p-logo-section__item">
+                {{ image(url="https://assets.ubuntu.com/v1/d0e0b382-spectro-cloud-logo.png",
+                          alt="Spectro Cloud",
+                          width="72",
+                          height="96",
+                          hi_def=True,
+                          loading="lazy",
+                          attrs={"class": "p-logo-section__logo"}) | safe
+                }}
+              </div>
+              <div class="p-logo-section__item">
+                {{ image(url="https://assets.ubuntu.com/v1/9ffbe97e-azure-arc-logo.png",
+                          alt="Azure arc",
+                          width="42",
+                          height="96",
+                          hi_def=True,
+                          loading="lazy",
+                          attrs={"class": "p-logo-section__logo"}) | safe
+                }}
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="p-image-container u-hide--medium u-hide--small">
+          {{ image(url="https://assets.ubuntu.com/v1/9bcc23aa-on%20openstack.png",
+                    alt="",
+                    width="1800",
+                    height="2701",
+                    hi_def=True,
+                    loading="lazy",
+                    attrs={"class": "p-image-container__image"}) | safe
+          }}
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <hr class="p-rule is-fixed-width" />
+    <div class="p-section--shallow">
+      <div class="row--50-50">
+        <div class="col">
+          <h2>Bootstrap <br class="u-hide--medium u-hide--small" />your Kubernetes journey</h2>
+        </div>
+        <div class="col">
+          <p>Canonical Kubernetes consulting and cluster deployment services</p>
+          <div class="p-cta-block">
+            <p><a class="js-invoke-modal" href="/kubernetes/contact-us">Get in touch to learn more&nbsp;&rsaquo;</a></p>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="p-section--shallow">
+      <div class="row--50-50">
+        <div class="col">
+          Cards here
+        </div>
+        <div class="col">
+          Cards here
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <hr class="p-rule is-fixed-width" />
+    <div class="p-section--shallow">
+      <div class="row--50-50">
+        <div class="col">
+          <h2>Fully-managed Kubernetes</h2>
+        </div>
+        <div class="col">
+          <p>Cost-effective Kubernetes-as-a-service on public and private clouds </p>
+          <hr class="p-rule--muted u-no-margin--bottom" />
+          <ul class="p-list--divided">
+            <li class="p-list__item is-ticked">Predictable economics, full-stack monitoring and clear responsibilities</li>
+            <li class="p-list__item is-ticked">Tailor-made Kubernetes deployments to address your use-cases</li>
+            <li class="p-list__item is-ticked">24/7 active management by our team of experts</li>
+            <li class="p-list__item is-ticked">99.9% uptime SLA means you get time back to focus on your business</li>
+            <li class="p-list__item is-ticked">Experiencing traffic peaks? On-request scaling is part of the deal</li>
+            <li class="p-list__item is-ticked">Upgrade fast to the latest stable Kubernetes the SAAS way</li>
+            <li class="p-list__item is-ticked">Data and security compliance certified by industry standards</li>
+            <li class="p-list__item is-ticked">Get back the keys to your Kubernetes as soon as you feel ready</li>
+          </ul>
+          <div class="p-cta-block">
+            <p><a href="/kubernetes/managed">More on Managed Kubernetes&nbsp;&rsaquo;</a></p>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="p-image-container--cinematic u-fixed-width">
+      {{ image(url="https://assets.ubuntu.com/v1/e8cb6c61-fully-managed.png",
+                alt="",
+                width="3696",
+                height="1541",
+                hi_def=True,
+                loading="lazy",
+                attrs={"class":"p-image-container__image"}) | safe
+      }}
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="u-fixed-width">
       <hr class="p-rule" />
-      <div class="row">
-        <div class="col-3 p-image-wrapper">
-          <h3 class="u-no-padding--top"><a href="/kubernetes/charmed-k8s">
-            {{ 
-              image (
-              url="https://assets.ubuntu.com/v1/c5161bf1-charmedk8s%20logo.png",
-              alt="Charmed Kubernetes",
-              width="230",
-              height="34",
-              hi_def=True,
-              loading="lazy"
-              ) | safe
-            }}
-          </a></h3>
-        </div>
-        <div class="col-6">
-          <p>Composable, operator-based Kubernetes for the enterprise</p>
-          <ul class="p-list--divided">
-            <li class="p-list__item is-ticked">Model-driven Kubernetes for fully customisable deployments</li>
-            <li class="p-list__item is-ticked">Pluggable CNI, CSI, CRI and monitoring components</li>
-            <li class="p-list__item is-ticked">Carrier-grade and hardware acceleration features</li>
-            <li class="p-list__item is-ticked">Support for third-party components and services</li>
-            <li class="p-list__item is-ticked">Full life cycle management for host and in-cluster with <a href="https://juju.is/">Juju</a></li>
-            <li class="p-list__item is-ticked">12 years of long term support as of second generation of Charmed Kubernetes</li>
-            <li class="p-list__item is-ticked">CNCF conformant</li>
-          </ul>
-          <hr />
-          <p>
-            <a class="p-button" href="/kubernetes/install#multi-node">Install Charmed Kubernetes</a>
-            <a href="/kubernetes/features">Learn more about Charmed Kubernetes&nbsp;&rsaquo;</a>
-          </p>
-        </div>
-      </div>
+      <h2 class="p-text--small-caps">Fully-supported Kubernetes clouds</h2>
     </div>
-  </div>
-</section>
-
-<section class="p-section">
-  <div class="u-fixed-width">
-    <hr class="p-rule" />
-    <h2 class="p-text--small-caps">Fully-supported Kubernetes clouds</h2>
-  </div>
-  <div class="u-fixed-width">
-    <div class="p-logo-section">
-      <div class="p-logo-section__items">
-        <div class="p-logo-section__item">
-          {{ 
-            image (
-            url="https://assets.ubuntu.com/v1/3948d6dd-openstack-logo.png",
-            alt="OpenStack",
-            width="182",
-            height="138",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-logo-section__logo"}
-            ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{ 
-            image (
-            url="https://assets.ubuntu.com/v1/4452b734-vmware-logo.png",
-            alt="VMWare",
-            width="140",
-            height="135",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-logo-section__logo"}
-            ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{ 
-            image (
-            url="https://assets.ubuntu.com/v1/d987ba27-Rackspace%20logo.png",
-            alt="Rackspace",
-            width="155",
-            height="135",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-logo-section__logo"}
-            ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{ 
-            image (
-            url="https://assets.ubuntu.com/v1/05285685-equinix-logo.png",
-            alt="Equinix",
-            width="113",
-            height="135",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-logo-section__logo"}
-            ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{ 
-            image (
-            url="https://assets.ubuntu.com/v1/dae49585-joyent-logo.png",
-            alt="Joyent",
-            width="105",
-            height="135",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-logo-section__logo"}
-            ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{ 
-            image (
-            url="https://assets.ubuntu.com/v1/b526fd14-cloud-sigma-logo.png",
-            alt="CloudSigma",
-            width="141",
-            height="135",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-logo-section__logo"}
-            ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{ 
-            image (
-            url="https://assets.ubuntu.com/v1/4ec1a195-maas-logo.png",
-            alt="Canonical MAAS",
-            width="87",
-            height="135",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-logo-section__logo"}
-            ) | safe
-          }}
-        </div>
-        <div class="p-logo-section__item">
-          {{ 
-            image (
-            url="https://assets.ubuntu.com/v1/cd584004-lxd-logo.png",
-            alt="Canonical LXD",
-            width="66",
-            height="135",
-            hi_def=True,
-            loading="lazy",
-            attrs={"class": "p-logo-section__logo"}
-            ) | safe
-          }}
-        </div>
-      </div>
-    </div>
-  </div>
-</section>
-
-<section class="p-section">
-  <div class="row--50-50">
-    <hr class="p-rule" />
-    <div class="col">
-      <h2 class="p-text--small-caps p-section--shallow">Fully-managed Kubernetes</h2>
-      <p class="p-heading--2">Cost-effective<br />Kubernetes-as-a-service<br /> on public and private clouds</p>
-    </div>
-    <div class="col">
-      <div class="p-section--shallow">
-        <div class="p-image__background--3-2 u-vertically-center u-align--center">
-          {{
-            image(
-            url="https://assets.ubuntu.com/v1/91154a9f-Managed+Kubernetes.svg",
-            alt="Managed Kubernetes",
-            width="284",
-            height="200",
-            hi_def=True,
-            loading="lazy",
-            ) | safe
-          }}
-        </div>
-      </div>
-      <hr class="is-muted" />
-      <ul class="p-list--divided p-section--shallow">
-        <li class="p-list__item is-ticked">Predictable economics, full-stack monitoring and clear responsibilities</li>
-        <li class="p-list__item is-ticked">Tailor-made Kubernetes deployments to address your use-cases</li>
-        <li class="p-list__item is-ticked">24/7 active management by our team of experts</li>
-        <li class="p-list__item is-ticked">99.9% uptime SLA means you get time back to focus on your business</li>
-        <li class="p-list__item is-ticked">Experiencing traffic peaks? On-request scaling is part of the deal</li>
-        <li class="p-list__item is-ticked">Upgrade fast to the latest stable Kubernetes the SAAS way</li>
-        <li class="p-list__item is-ticked">Data and security compliance certified by industry standards</li>
-        <li class="p-list__item is-ticked">Get back the keys to your Kubernetes as soon as you feel ready</li>
-      </ul>
-      <hr />
-      <a href="/kubernetes/managed">More on Managed Kubernetes&nbsp;&rsaquo;</a>
-    </div>
-  </div>
-</section>
-
-<section class="p-section">
-  <div class="row--25-75">
-    <hr class="p-rule" />
-    <div class="col">
-      <h2 class="p-text--small-caps">Kubernetes resources</h2>
-    </div>
-    <div class="col">
-      <div class="row p-section--shallow">
-        <div class="col-3">
-          <h3 class="p-heading--5">Case study</h3>
-        </div>
-        <div class="col-6">
-          <p><a href="/engage/atresmedia-charmed-kubernetes-case-study">Atresmedia dominates Spain's OTT media market with Charmed Kubernetes</a></p>
-        </div>
-      </div>
-      <hr class="p-rule" />
-      <div class="row p-section--shallow">
-        <div class="col-3">
-          <h3 class="p-heading--5">Whitepapers</h3>
-        </div>
-        <div class="col-6">
-          <ul class="p-list--divided">
-            <li class="p-list__item"><a href="/engage/kubernetes-deployment-enterprise-whitepaper">Five strategies to accelerate Kubernetes deployment in the enterprise</a></li>
-            <li class="p-list__item"><a href="/engage/bare-metal-kubernetes">How to run workloads on bare metal Kubernetes with MAAS</a></li>
-          </ul>
-        </div>
-      </div>
-    </div>
-  </div>
-</section>
-
-<section class="p-section">
-  <div class="row--50-50">
-    <hr class="p-rule" />
-    <div class="col">
-      <h2 class="p-text--small-caps p-section--shallow">Integrated cluster management platforms</h2>
-      <p class="p-heading--2">Remove the toil of Kubernetes cluster management </p>
-      <div class="p-logo-section--dense p-strip is-shallow">
+    <div class="u-fixed-width">
+      <div class="p-logo-section">
         <div class="p-logo-section__items">
           <div class="p-logo-section__item">
-            {{ 
-              image (
-              url="https://assets.ubuntu.com/v1/58440b6b-rancher-logo.png",
-              alt="Rancher",
-              width="107",
-              height="96",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-logo-section__logo"}
-              ) | safe
+            {{ image(url="https://assets.ubuntu.com/v1/3948d6dd-openstack-logo.png",
+                      alt="OpenStack",
+                      width="182",
+                      height="138",
+                      hi_def=True,
+                      loading="lazy",
+                      attrs={"class": "p-logo-section__logo"}) | safe
             }}
           </div>
           <div class="p-logo-section__item">
-            {{ 
-              image (
-              url="https://assets.ubuntu.com/v1/eb826d4d-portainer-io-logo.png",
-              alt="Portainer.io",
-              width="144",
-              height="96",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-logo-section__logo"}
-              ) | safe
+            {{ image(url="https://assets.ubuntu.com/v1/4452b734-vmware-logo.png",
+                      alt="VMWare",
+                      width="140",
+                      height="135",
+                      hi_def=True,
+                      loading="lazy",
+                      attrs={"class": "p-logo-section__logo"}) | safe
             }}
           </div>
           <div class="p-logo-section__item">
-            {{ 
-              image (
-              url="https://assets.ubuntu.com/v1/d0e0b382-spectro-cloud-logo.png",
-              alt="Spectro Cloud",
-              width="72",
-              height="96",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-logo-section__logo"}
-              ) | safe
+            {{ image(url="https://assets.ubuntu.com/v1/d987ba27-Rackspace%20logo.png",
+                      alt="Rackspace",
+                      width="155",
+                      height="135",
+                      hi_def=True,
+                      loading="lazy",
+                      attrs={"class": "p-logo-section__logo"}) | safe
             }}
           </div>
           <div class="p-logo-section__item">
-            {{ 
-              image (
-              url="https://assets.ubuntu.com/v1/9ffbe97e-azure-arc-logo.png",
-              alt="Azure arc",
-              width="42",
-              height="96",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-logo-section__logo"}
-              ) | safe
+            {{ image(url="https://assets.ubuntu.com/v1/05285685-equinix-logo.png",
+                      alt="Equinix",
+                      width="113",
+                      height="135",
+                      hi_def=True,
+                      loading="lazy",
+                      attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/dae49585-joyent-logo.png",
+                      alt="Joyent",
+                      width="105",
+                      height="135",
+                      hi_def=True,
+                      loading="lazy",
+                      attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/b526fd14-cloud-sigma-logo.png",
+                      alt="CloudSigma",
+                      width="141",
+                      height="135",
+                      hi_def=True,
+                      loading="lazy",
+                      attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/4ec1a195-maas-logo.png",
+                      alt="Canonical MAAS",
+                      width="87",
+                      height="135",
+                      hi_def=True,
+                      loading="lazy",
+                      attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/cd584004-lxd-logo.png",
+                      alt="Canonical LXD",
+                      width="66",
+                      height="135",
+                      hi_def=True,
+                      loading="lazy",
+                      attrs={"class": "p-logo-section__logo"}) | safe
             }}
           </div>
         </div>
       </div>
     </div>
-    <div class="col">
-      <ul class="p-list--divided">
-        <li class="p-list__item is-ticked">No need to yaml and cli, we integrate with the most popular GUIs</li>
-        <li class="p-list__item is-ticked">Single pane of glass for your Kubernetes and container estate</li>
-        <li class="p-list__item is-ticked">Unified multi-cluster management and real-time monitoring</li>
-        <li class="p-list__item is-ticked">Policy-based management, governance, security and compliance</li>
-        <li class="p-list__item is-ticked">GitOps at scale for application management and configuration</li>
-        <li class="p-list__item is-ticked">Flexibility across environments from public cloud to edge</li>
-      </ul>
-      <hr />
-      <a href="/kubernetes/features">Check out all the features&nbsp;&rsaquo;</a>
-    </div>
-  </div>
-</section>
+  </section>
 
-<div class="p-section">
-  <div class="row--50-50">
-    <hr class="p-rule" />
-    <div class="col">
-      <h2 class="p-text--small-caps p-section--shallow">Full stack K8s services</h2>
-      <p class="p-heading--2">Transform your business and safeguard your infrastructure</p>
-    </div>
-    <div class="col">
-      <p class="p-heading--5">Long-term Enterprise Support</p>
-      <p>Canonical Kubernetes is supported  through <a href="/pricing/infra">Ubuntu Pro</a>.</p>
-      <hr class="is-muted" />
-      <ul class="p-list--divided">
-        <li class="p-list__item is-ticked">Long term supported versions of Canonical Kubernetes will bring 12 years of security updates, including built in capabilities, like networking or local storage.</li>
-        <li class="p-list__item is-ticked">24/7 enterprise-grade support for K8s, OS and applications, from public cloud to the edge.</li>
-      </ul>
-      <hr />
-      <p><a href="/pro">Get Ubuntu Pro&nbsp;&rsaquo;</a></p>
-    </div>
-  </div>
-</div>
-
-<section class="p-section">
-  <div class="u-fixed-width p-section--shallow">
-    <hr class="p-rule is-fixed-width" />
-    <p class="p-text--small-caps p-section--shallow">Bootstrap your Kubernetes journey</p>
-    <h2>Canonical Kubernetes consulting and cluster&nbsp;deployment&nbsp;services</h2>
-  </div>
-  <div class="row">
-    <div class="col-start-large-4 col-9 col-start-medium-2 col-medium-5">
+  <section class="p-section">
+    <div class="row--50-50">
       <hr class="p-rule" />
-      <div class="row p-section--shallow">
-        <div class="col-3 col-medium-2">
-          <h3 class="p-heading--5 u-no-margin--bottom">Kubernetes Explorer</h3>
-          <p class="u-text--muted">Training & onboarding package</p>
-        </div>
-        <div class="col-6 col-medium-3">
-          <p>Three-day Kubernetes training to ramp up your team's skills, including:</p>
+      <div class="col">
+        <h2>
+          Learn more
+          <br class="u-hide--small u-hide--medium" />
+          about Canonical Kubernetes
+        </h2>
+      </div>
+      <div class="col">
+        <div class="p-section--shallow">
           <ul class="p-list--divided">
-            <li class="p-list__item is-ticked">Kubernetes fundamentals</li>
-            <li class="p-list__item is-ticked">Container development basics</li>
-            <li class="p-list__item is-ticked">MicroK8s enablement</li>
-            <li class="p-list__item is-ticked">Charmed Kubernetes enablement</li>
-            <li class="p-list__item is-ticked">Monitoring and logging</li>
-            <li class="p-list__item is-ticked">Kubernetes lifecycle management</li>
-            <li class="p-list__item is-ticked">Security essentials</li>
+            <li class="p-list__item u-no-padding--bottom">
+              <p>
+                <a href="https://ubuntu.com/case-study/esa">The European Space Agency modernized its infrastructure with Canonical Kubernetes</a>
+              </p>
+              <p>Find out why ESA chose Canonical to implement a new, dynamic platform for efficient, automated, and fast deployment of systems across their missions.</p>
+            </li>
+            <li class="p-list__item u-no-padding--bottom">
+              <p>
+                <a href="/kubernetes/managed">Optimize your ML workloads on Kubernetes</a>
+              </p>
+              <p>Leverage your existing computing power to accelerate model training in order to move your ML projects to production.</p>
+            </li>
+            <li class="p-list__item u-no-padding--bottom">
+              <p>
+                <a href="/engage/bare-metal-kubernetes">How to run workloads on bare metal Kubernetes with MAAS</a>
+              </p>
+              <p>Understand bare metal Kubernetes and how it compares to virtual machines.</p>
+            </li>
           </ul>
         </div>
-      </div>
-      <hr class="p-rule" />
-      <div class="row p-section--shallow">
-        <div class="col-3 col-medium-2">
-          <h3 class="p-heading--5 u-no-margin--bottom">Kubernetes Discoverer</h3>
-          <p class="u-text--muted">Reference architecture design & deployment</p>
-        </div>
-        <div class="col-6 col-medium-3">
-          <p>Three-day training & 2-week deployment of reference K8s architecture, including:</p>
-          <ul class="p-list--divided">
-            <li class="p-list__item is-ticked">High Availability</li>
-            <li class="p-list__item is-ticked"><a href="/public-cloud">Public clouds</a>, VMware, <a href="/openstack">OpenStack</a></li>
-            <li class="p-list__item is-ticked">Storage & SDN basic options</li>
-            <li class="p-list__item is-ticked">Logging, monitoring, alerting</li>
-            <li class="p-list__item is-ticked">Kubernetes lifecycle management</li>
-            <li class="p-list__item is-ticked">Security essentials</li>
-            <li class="p-list__item is-ticked">Supported or Fully Managed</li>
-          </ul>
+        <div class="p-cta-block">
+          <a href="/kubernetes/resources" class="p-button">Find more resources</a>
         </div>
       </div>
-      <hr class="p-rule" />
-      <div class="row p-section--shallow">
-        <div class="col-3 col-medium-2">
-          <h3 class="p-heading--5 u-no-margin--bottom">Kubernetes Discoverer Plus</h3>
-          <p class="u-text--muted">Custom architecture design & deployment</p>
-        </div>
-        <div class="col-6 col-medium-3">
-          <p>Three-week custom architecture deployment project and knowledge transfer, including:</p>
-          <ul class="p-list--divided">
-            <li class="p-list__item is-ticked">High Availability</li>
-            <li class="p-list__item is-ticked"><a href="/public-cloud">Public clouds</a>, VMware, <a href="/openstack">OpenStack</a>, <a href="https://maas.io/">Bare metal</a></li>
-            <li class="p-list__item is-ticked">Storage & SDN extensive options</li>
-            <li class="p-list__item is-ticked">Third-party integrations</li>
-            <li class="p-list__item is-ticked">GPU Acceleration</li>
-            <li class="p-list__item is-ticked">Private registry options</li>
-            <li class="p-list__item is-ticked">Logging, monitoring, alerting</li>
-            <li class="p-list__item is-ticked">Kubernetes lifecycle management</li>
-            <li class="p-list__item is-ticked">Security essentials</li>
-            <li class="p-list__item is-ticked">Supported or Fully Managed</li>
-          </ul>
-        </div>
-      </div>
-      <hr class="p-rule" />
-      <p><a href="/pricing/consulting#kubernetes">Canonical Kubernetes services pricing&nbsp;&rsaquo;</a></p>
     </div>
-  </div>
-</section>
+  </section>
 
-<section class="p-section">
-  <div class="row--50-50">
-    <hr class="p-rule" />
-    <div class="col">
-      <h2 class="p-section--shallow">Kubernetes clusters with Kubeadm</h2>
-      <p class="p-section--shallow">Canonical provides commercial support for Kubernetes clusters deployed using kubeadm.</p>
-      <a class="p-button--positive js-invoke-modal" href="/kubernetes/contact-us">Get support for kubeadm</a>
+  <hr class="p-rule is-fixed-width" />
+  <section class="p-strip is-deep">
+    <div class="u-fixed-width">
+      <h2>Get your K8s questions answered today</h2>
+      <a class="p-heading--2 js-invoke-modal" href="/kubernetes/contact-us">Contact us</a>.
     </div>
-    <div class="col">
-      <div class="p-image-wrapper">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/3919da99-kubeadm-stacked-color 1.png",
-          alt="Kubeadm",
-          width="84",
-          hi_def=True,
-          loading="lazy"
-          ) | safe
-        }}
-    </div>
-    </div>
-  </div>
-</section>
-
-<section class="p-section--deep">
-  <div class="row--50-50">
-    <hr class="p-rule" />
-    <div class="col">
-      <h2 class="p-section--shallow">Train for the future</h2>
-    </div>
-    <div class="col">
-      <p>Train your sysadmins and DevOps engineers to become Kubernetes, OpenStack or Ubuntu Server experts. Canonical runs training programmes to suit all environments and all levels of experience.</p>
-      <p>Get the most out of your investment.</p>
-      <hr />
-      <a href="/training">Learn more about training&nbsp;&rsaquo;</a>
-    </div>
-  </div>
-</section>
-
-<div class="u-fixed-width">
-  <hr />
-</div>
-
-<section class="p-strip is-deep">
-  <div class="u-fixed-width">
-    <h2>Get your K8s questions answered today</h2>
-    <a class="p-heading--2 js-invoke-modal" href="/kubernetes/contact-us">Contact us</a>.
-  </div>
-</section>
+  </section>
 
 <!-- Set default Marketo information for contact form below-->
 <div class="u-hide" 

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -265,7 +265,7 @@
             <a href="/public-cloud">Learn more about Ubuntu on public clouds&nbsp;&rsaquo;</a>
           </p>
         </div>
-        <div class="p-logo-section has-misaligned-images">
+        <div class="p-logo-section--dense">
           <div class="p-logo-section__items">
             <div class="p-logo-section__item">
               {{ image(url="https://assets.ubuntu.com/v1/15f4f759-aws-logo.png",
@@ -274,29 +274,30 @@
                             height="312",
                             hi_def=True,
                             loading="lazy",
-                            attrs={"class": "p-logo-section__logo"},) | safe
+                            attrs={"class": "p-logo-section__logo"}) | safe
               }}
             </div>
             <div class="p-logo-section__item">
-              {{ image(url="https://assets.ubuntu.com/v1/f1ec4ff5-microsoft-azure-logo [DEPRECATED] .png",
+              {{ image(url="https://assets.ubuntu.com/v1/f1ec4ff5-microsoft-azure-logo%20[DEPRECATED]%20.png",
                             alt="Microsoft Azure",
                             width="272",
                             height="312",
                             hi_def=True,
                             loading="lazy",
-                            attrs={"class": "p-logo-section__logo"},) | safe
+                            attrs={"class": "p-logo-section__logo"}) | safe
               }}
             </div>
             <div class="p-logo-section__item">
-              {{ image(url="https://assets.ubuntu.com/v1/6c959a61-google-cloud-stacked-logo [DEPRECATED] .png",
+              {{ image(url="https://assets.ubuntu.com/v1/c09079b4-google-cloud-logo-horizontal.png",
                             alt="Google Cloud",
-                            width="189",
-                            height="312",
+                            width="382",
+                            height="313",
                             hi_def=True,
                             loading="lazy",
-                            attrs={"class": "p-logo-section__logo"},) | safe
+                            attrs={"class": "p-logo-section__logo"}) | safe
               }}
             </div>
+            <br class="u-hide--small u-hide--medium" />
             <div class="p-logo-section__item">
               {{ image(url="https://assets.ubuntu.com/v1/4a30e5f7-ibm-cloud-logo.png",
                             alt="IBM Cloud",
@@ -304,7 +305,7 @@
                             height="312",
                             hi_def=True,
                             loading="lazy",
-                            attrs={"class": "p-logo-section__logo"},) | safe
+                            attrs={"class": "p-logo-section__logo"}) | safe
               }}
             </div>
             <div class="p-logo-section__item">
@@ -314,7 +315,7 @@
                             height="312",
                             hi_def=True,
                             loading="lazy",
-                            attrs={"class": "p-logo-section__logo"},) | safe
+                            attrs={"class": "p-logo-section__logo"}) | safe
               }}
             </div>
           </div>

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -446,11 +446,88 @@
     <div class="p-section--shallow">
       <div class="row--50-50">
         <div class="col">
-          Cards here
+          <hr class="p-rule--highlight u-no-margin--bottom" />
+          <div class="p-card--overlay u-no-padding--top"
+               style="padding: 1.5rem;
+                      height: 95%;
+                      overflow: hidden">
+            <div class="row p-section--shallow">
+              <div class="col">
+                <h3>Kubernetes Explorer</h3>
+                <p class="u-text--muted">The low cost solution for maximum scalability.</p>
+              </div>
+            </div>              
+            <hr class="p-rule--muted u-no-margin--bottom" />
+            <div class="row">
+              <div class="col-2">
+                <h5 class="p-text--small-caps">What's included</h5>
+              </div>
+              <div class="col-4">
+                <ul class="p-list--divided">
+                  <li class="p-list__item is-ticked">Kubernetes fundamentals</li>
+                  <li class="p-list__item is-ticked">Container development basics</li>
+                  <li class="p-list__item is-ticked">MicroK8s enablement</li>
+                  <li class="p-list__item is-ticked">Charmed Kubernetes enablement</li>
+                  <li class="p-list__item is-ticked">Monitoring and logging</li>
+                  <li class="p-list__item is-ticked">Kubernetes lifecycle management</li>
+                  <li class="p-list__item is-ticked">Security essentials</li>
+                </ul>
+              </div>
+            </div>
+          </div>
         </div>
         <div class="col">
-          Cards here
+          <hr class="p-rule--highlight u-no-margin--bottom" />
+          <div class="p-card--overlay u-no-padding--top"
+               style="padding: 1.5rem;
+                      height: 95%;
+                      overflow: hidden">
+            <div class="row">
+              <div class="col">
+                <div class="p-section--shallow">
+                  <h3 id="discoverer-text">Kubernetes Discoverer</h3>
+                  <p class="u-text--muted">Three-day training and 2-week deployment of reference K8s architecture, including:</p>
+                </div>
+                <p>
+                  <span class="p-heading--5">Discoverer</span>
+                  <label class="p-switch" style="display: inline-block; padding-left: 32px; padding-right: 32px;">
+                    <input type="checkbox" class="p-switch__input" role="switch" id="discoverer-switch" />
+                    <span class="p-switch__slider"></span>
+                  </label>
+                  <span class="p-heading--5">Discoverer Plus</span>
+                </p>
+              </div>
+            </div>              
+            <hr class="p-rule--muted u-no-margin--bottom" />
+            <div class="row">
+              <div class="col-2">
+                <h5 class="p-text--small-caps">What's included</h5>
+              </div>
+              <div class="col-4">
+                <ul class="p-list--divided">
+                  <li class="p-list__item is-ticked">High Availability</li>
+                  <li class="p-list__item is-ticked" id="discoverer-item">
+                    <a href="/public-cloud">Public clouds</a>, VMware, <a href="/openstack">OpenStack</a>
+                  </li>
+                  <li class="p-list__item is-ticked u-hide" id="discoverer-pro-item">
+                    <a href="/public-cloud">Public clouds</a>, VMware, <a href="/openstack">OpenStack</a>, <a href="/bare-metal">Bare Metal</a>
+                  </li>
+                  <li class="p-list__item is-ticked" id="discoverer-item">Storage and SDN basic options</li>
+                  <li class="p-list__item is-ticked u-hide" id="discoverer-pro-item">Storage and SDN extensive options</li>
+                  <li class="p-list__item is-ticked">Logging, monitoring, alerting</li>
+                  <li class="p-list__item is-ticked">Kubernetes lifecycle management</li>
+                  <li class="p-list__item is-ticked">Security essentials</li>
+                  <li class="p-list__item is-ticked">Supported or Fully Managed</li>
+
+                  <li class="p-list__item is-crossed u-text--muted" id="discoverer-muted-item">Third-party integrations</li>
+                  <li class="p-list__item is-crossed u-text--muted" id="discoverer-muted-item">GPU Acceleration</li>
+                  <li class="p-list__item is-crossed u-text--muted" id="discoverer-muted-item">Private registry options</li>
+                </ul>
+              </div>
+            </div>
+          </div>
         </div>
+        
       </div>
     </div>
   </section>
@@ -642,5 +719,44 @@
      data-lp-id="6274" 
      data-return-url="/kubernetes#contact-form-success" 
      data-lp-url="https://pages.ubuntu.com/things-contact-us.html"></div>
+
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    const switchElement = document.getElementById('discoverer-switch');
+    const discovererText = document.getElementById('discoverer-text');
+    const discovererProItems = document.querySelectorAll('#discoverer-pro-item');
+    const discovererItems = document.querySelectorAll('#discoverer-item');
+    const discovererMutedItems = document.querySelectorAll('#discoverer-muted-item');
+  
+    switchElement.addEventListener('change', function() {
+      if (switchElement.checked) {
+        discovererMutedItems.forEach(item => {
+          item.classList.remove('is-crossed', 'u-text--muted');
+          item.classList.add('is-ticked');
+          discovererText.textContent = 'Kubernetes Discoverer Plus';
+        });
+        discovererItems.forEach(item => {
+          item.classList.add('u-hide');
+        });
+        discovererProItems.forEach(item => {
+          item.classList.remove('u-hide');
+        });
+
+      } else {
+        discovererMutedItems.forEach(item => {
+          item.classList.remove('is-ticked');
+          item.classList.add('is-crossed', 'u-text--muted');
+          discovererText.textContent = 'Kubernetes Discoverer';
+        });
+        discovererItems.forEach(item => {
+          item.classList.remove('u-hide');
+        });
+        discovererProItems.forEach(item => {
+          item.classList.add('u-hide');
+        });
+      }
+    });
+  });
+</script>
 
 {% endblock content %}

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -3,7 +3,7 @@
 {% block title %}Secure, enterprise-grade Kubernetes for multi-cloud operations{% endblock %}
 
 {% block meta_description %}
-  Canonical’s securely designed enterprise-grade Kubernetes builds up from Ubuntu OS to hybrid multi-cloud container orchestration clouds, edge and IoT, managed Kubernetes and enterprise support packages.
+  Canonical's securely designed enterprise-grade Kubernetes builds up from Ubuntu OS to hybrid multi-cloud container orchestration clouds, edge and IoT, managed Kubernetes and enterprise support packages.
 {% endblock meta_description %}
 
 {% block meta_copydoc %}
@@ -13,7 +13,9 @@
 {% from "_macros/vf_hero.jinja" import vf_hero %}
 {% from "_macros/vf_quote-wrapper.jinja" import vf_quote_wrapper %}
 
-{% block body_class %}is-paper{% endblock body_class %}
+{% block body_class %}
+  is-paper
+{% endblock body_class %}
 
 {% block content %}
   {% call(slot) vf_hero(
@@ -26,7 +28,8 @@
       </p>
     {%- endif -%}
     {%- if slot == 'cta' -%}
-      <a href="/kubernetes/contact-us" class="js-invoke-modal p-button--positive">Get in touch</a>
+      <a href="/kubernetes/contact-us"
+         class="js-invoke-modal p-button--positive">Get in touch</a>
       <a href="/kubernetes/install">Try Canonical Kubernetes today&nbsp;&rsaquo;</a>
     {%- endif -%}
     {%- if slot == 'image' -%}
@@ -53,12 +56,22 @@
       </div>
       <div class="col">
         <ul class="p-list--divided">
-          <li class="p-list__item is-ticked">12-year security maintenance and support gives you control over your upgrades schedule.</li>
-          <li class="p-list__item is-ticked">Easy to use with built-in, best-of-breed open source components for networking, local storage, DNS, load-balancer, metrics server, gateway, and ingress.</li>
-          <li class="p-list__item is-ticked">Zero ops from Day 0 to Day 2 - add and manage nodes in small Kubernetes clusters with minimal effort.</li>
-          <li class="p-list__item is-ticked">Automated cluster operations for easier large scale maintenance with <a href="https://juju.is">Juju</a>.</li>
-          <li class="p-list__item is-ticked">The same security-maintained Kubernetes that scales from your laptop to the cloud and the data centre.</li>
-          <li class="p-list__item is-ticked">CNCF conformant.</li>
+          <li class="p-list__item is-ticked">
+            12-year security maintenance and support gives you control over your upgrades schedule
+          </li>
+          <li class="p-list__item is-ticked">
+            Easy to use with built-in, best-of-breed open source components for networking, local storage, DNS, load-balancer, metrics server, gateway, and ingress
+          </li>
+          <li class="p-list__item is-ticked">
+            Zero ops from Day 0 to Day 2 - add and manage nodes in small Kubernetes clusters with minimal effort
+          </li>
+          <li class="p-list__item is-ticked">
+            Automated cluster operations for easier large scale maintenance with <a href="https://juju.is">Juju</a>
+          </li>
+          <li class="p-list__item is-ticked">
+            The same security-maintained Kubernetes that scales from your laptop to the cloud and the data centre
+          </li>
+          <li class="p-list__item is-ticked">CNCF conformant</li>
         </ul>
         <div class="p-cta-block">
           <a class="p-button" href="/pro/subscribe">Purchase support with Ubuntu Pro</a>
@@ -74,7 +87,7 @@
     </div>
     {% call(slot) vf_quote_wrapper(
       quote_size="small",
-      quote_text="Kubernetes is both fast-moving and hard, so supporting it ourselves was not a viable option. The thought of having to support it would be daunting. To keep it supported and up to date, it’s better to have experts who do this every day involved and manage it for us.",
+      quote_text="Kubernetes is both fast-moving and hard, so supporting it ourselves was not a viable option. The thought of having to support it would be daunting. To keep it supported and up to date, it's better to have experts who do this every day involved and manage it for us.",
       citation_source_name_text="Michael Hawkshaw",
       citation_source_title_text="Mission Operations Infrastructure IT Service Manager",
       citation_source_organisation_text="European Space Operations Centre",
@@ -83,11 +96,11 @@
 
       {%- if slot == 'signpost_image' -%}
         {{ image(url="https://assets.ubuntu.com/v1/d2f13d46-logo-esa-wide.png",
-                  alt="",
-                  width="852",
-                  height="189",
-                  hi_def=True,
-                  loading="lazy") | safe
+                alt="",
+                width="852",
+                height="189",
+                hi_def=True,
+                loading="lazy") | safe
         }}
       {%- endif -%}
 
@@ -104,11 +117,11 @@
 
       {%- if slot == 'signpost_image' -%}
         {{ image(url="https://assets.ubuntu.com/v1/ecc63b0c-logo-zhaw-wide.png",
-                  alt="",
-                  width="852",
-                  height="222",
-                  hi_def=True,
-                  loading="lazy") | safe
+                alt="",
+                width="852",
+                height="222",
+                hi_def=True,
+                loading="lazy") | safe
         }}
       {%- endif -%}
 
@@ -124,18 +137,20 @@
       <div class="row--50-50">
         <div class="col">
           <h3>Canonical Kubernetes</h3>
-          <p>Secure and automate your Kubernetes infrastructure with a trusted provider. Build on the experience we gained since 2015.  Our new Kubernetes distribution offers hassle-free maintenance, single-line installation process, and more control over your upgrade cadence. It’s secure by default and comes with a 12-year support commitment  offered with an Ubuntu Pro subscription.</p>
+          <p>
+            Secure and automate your Kubernetes infrastructure with a trusted provider. Build on the experience we gained since 2015.  Our new Kubernetes distribution offers hassle-free maintenance, single-line installation process, and more control over your upgrade cadence. It's secure by default and comes with a 12-year support commitment  offered with an Ubuntu Pro subscription.
+          </p>
 
         </div>
         <div class="col">
           <div class="p-image-container">
             {{ image(url="https://assets.ubuntu.com/v1/6dffa7f1-kubernetes-platform-updated.png",
-                      alt="",
-                      width="1800",
-                      height="1013",
-                      hi_def=True,
-                      attrs={"class": "p-image-container__image"},
-                      loading="lazy") | safe
+                        alt="",
+                        width="1800",
+                        height="1013",
+                        hi_def=True,
+                        attrs={"class": "p-image-container__image"},
+                        loading="lazy") | safe
             }}
           </div>
         </div>
@@ -150,10 +165,12 @@
         <div class="col-9">
           <div class="row">
             <div class="col-3">
-              <h5>MicroK8s</h5>
+              <h4 class="p-heading--5">MicroK8s</h4>
             </div>
             <div class="col-6">
-              <p>Lightweight, low-touch Kubernetes for cloud, edge and IoT. It brings all Kubernetes services and the most popular addons in a single package, and requires minimal ops for easy clustering, self-healing HA and simpler upgrades. Secure by default and CNCF conformant.</p>
+              <p>
+                Lightweight, low-touch Kubernetes for cloud, edge and IoT. It brings all Kubernetes services and the most popular addons in a single package, and requires minimal ops for easy clustering, self-healing HA and simpler upgrades. Secure by default and CNCF conformant.
+              </p>
               <hr class="p-rule--muted" />
               <p>
                 <a href="https://microk8s.io/">Learn more about MicroK8s&nbsp;&rsaquo;</a>
@@ -163,10 +180,12 @@
           <hr class="p-rule--muted" />
           <div class="row">
             <div class="col-3">
-              <h5>Charmed Kubernetes</h5>
+              <h4 class="p-heading--5">Charmed Kubernetes</h4>
             </div>
             <div class="col-6">
-              <p>Composable, operator-based Kubernetes for the enterprise, with full life-cycle management for host and in-cluster with <a href="https://juju.is/">Juju</a>. It provides carrier-grade and hardware acceleration features, and support for third-party components and services. It gives you fully customizable deployments, with pluggable CNI, CSI, CRI and monitoring components. Secure by default and CNCF conformant.</p>
+              <p>
+                Composable, operator-based Kubernetes for the enterprise, with full life-cycle management for host and in-cluster with <a href="https://juju.is/">Juju</a>. It provides carrier-grade and hardware acceleration features, and support for third-party components and services. It gives you fully customizable deployments, with pluggable CNI, CSI, CRI and monitoring components. Secure by default and CNCF conformant.
+              </p>
               <hr class="p-rule--muted" />
               <p>
                 <a href="/kubernetes/charmed-k8s">Learn more about Charmed Kubernetes&nbsp;&rsaquo;</a>
@@ -176,10 +195,10 @@
           <hr class="p-rule--muted" />
           <div class="row">
             <div class="col-3">
-              <h5>Kubernetes clusters with Kubeadm</h5>
+              <h4 class="p-heading--5">Kubernetes clusters with Kubeadm</h4>
             </div>
             <div class="col-6">
-              <p>Canonical provides commercial support for Kubernetes clusters deployed using kubeadm.</p>            
+              <p>Canonical provides commercial support for Kubernetes clusters deployed using kubeadm.</p>
             </div>
           </div>
         </div>
@@ -203,7 +222,7 @@
           <h2>Public cloud Kubernetes powered by Ubuntu</h2>
         </div>
         <div class="p-image-container u-hide--small u-hide--medium">
-          {{ image(url="https://assets.ubuntu.com/v1/5a2779e1-public cloud.png",
+          {{ image(url="https://assets.ubuntu.com/v1/5a2779e1-public%20cloud.png",
                     alt="",
                     width="1800",
                     height="2701",
@@ -217,14 +236,14 @@
         <div class="p-section--shallow u-hide--medium u-hide--small">
           <h2>Public cloud Kubernetes powered by Ubuntu</h2>
         </div>
-        <p>
-          Cloud-tailored experience, optimized kernels, unlimited options
-        </p>
+        <p>Cloud-tailored experience, optimized kernels, unlimited options</p>
         <hr class="p-rule--muted u-no-margin--bottom" />
         <ul class="p-list--divided">
-          <li class="p-list__item is-ticked">Ubuntu is the host OS for the world’s most popular cloud-hosted Kubernetes</li>
-          <li class="p-list__item is-ticked">Optimized for performance, boot speed, and drivers on all major public clouds.</li>
-          <li class="p-list__item is-ticked">Out-of-the-box cloud integration with the option of enterprise-grade commercial support</li>
+          <li class="p-list__item is-ticked">Ubuntu is the host OS for the world's most popular cloud-hosted Kubernetes</li>
+          <li class="p-list__item is-ticked">Optimized for performance, boot speed, and drivers on all major public clouds</li>
+          <li class="p-list__item is-ticked">
+            Out-of-the-box cloud integration with the option of enterprise-grade commercial support
+          </li>
           <li class="p-list__item is-ticked">Ubuntu Pro provides deeper integrations with cloud services</li>
           <li class="p-list__item is-ticked">In-cloud Ubuntu package mirrors for high bandwidth and local updates</li>
           <li class="p-list__item is-ticked">Full control over kernel security patching with Canonical Livepatch</li>
@@ -238,7 +257,7 @@
           <div class="p-logo-section__items">
             <div class="p-logo-section__item">
               {{ image(url="https://assets.ubuntu.com/v1/15f4f759-aws-logo.png",
-                        alt="",
+                        alt="AWS",
                         width="151",
                         height="312",
                         hi_def=True,
@@ -248,7 +267,7 @@
             </div>
             <div class="p-logo-section__item">
               {{ image(url="https://assets.ubuntu.com/v1/f1ec4ff5-microsoft-azure-logo [DEPRECATED] .png",
-                        alt="",
+                        alt="Microsoft Azure",
                         width="272",
                         height="312",
                         hi_def=True,
@@ -257,9 +276,8 @@
               }}
             </div>
             <div class="p-logo-section__item">
-
               {{ image(url="https://assets.ubuntu.com/v1/6c959a61-google-cloud-stacked-logo [DEPRECATED] .png",
-                        alt="",
+                        alt="Google Cloud",
                         width="189",
                         height="312",
                         hi_def=True,
@@ -269,7 +287,7 @@
             </div>
             <div class="p-logo-section__item">
               {{ image(url="https://assets.ubuntu.com/v1/4a30e5f7-ibm-cloud-logo.png",
-                        alt="",
+                        alt="IBM Cloud",
                         width="437",
                         height="312",
                         hi_def=True,
@@ -279,7 +297,7 @@
             </div>
             <div class="p-logo-section__item">
               {{ image(url="https://assets.ubuntu.com/v1/dbab531e-oracle-cloud-logo.png",
-                        alt="",
+                        alt="Oracle Cloud",
                         width="387",
                         height="312",
                         hi_def=True,
@@ -315,42 +333,42 @@
             <div class="p-logo-section__items">
               <div class="p-logo-section__item">
                 {{ image(url="https://assets.ubuntu.com/v1/58440b6b-rancher-logo.png",
-                          alt="Rancher",
-                          width="107",
-                          height="96",
-                          hi_def=True,
-                          loading="lazy",
-                          attrs={"class": "p-logo-section__logo"}) | safe
+                                alt="Rancher",
+                                width="107",
+                                height="96",
+                                hi_def=True,
+                                loading="lazy",
+                                attrs={"class": "p-logo-section__logo"}) | safe
                 }}
               </div>
               <div class="p-logo-section__item">
                 {{ image(url="https://assets.ubuntu.com/v1/eb826d4d-portainer-io-logo.png",
-                          alt="Portainer.io",
-                          width="144",
-                          height="96",
-                          hi_def=True,
-                          loading="lazy",
-                          attrs={"class": "p-logo-section__logo"}) | safe
+                                alt="Portainer.io",
+                                width="144",
+                                height="96",
+                                hi_def=True,
+                                loading="lazy",
+                                attrs={"class": "p-logo-section__logo"}) | safe
                 }}
               </div>
               <div class="p-logo-section__item">
                 {{ image(url="https://assets.ubuntu.com/v1/d0e0b382-spectro-cloud-logo.png",
-                          alt="Spectro Cloud",
-                          width="72",
-                          height="96",
-                          hi_def=True,
-                          loading="lazy",
-                          attrs={"class": "p-logo-section__logo"}) | safe
+                                alt="Spectro Cloud",
+                                width="72",
+                                height="96",
+                                hi_def=True,
+                                loading="lazy",
+                                attrs={"class": "p-logo-section__logo"}) | safe
                 }}
               </div>
               <div class="p-logo-section__item">
                 {{ image(url="https://assets.ubuntu.com/v1/9ffbe97e-azure-arc-logo.png",
-                          alt="Azure arc",
-                          width="42",
-                          height="96",
-                          hi_def=True,
-                          loading="lazy",
-                          attrs={"class": "p-logo-section__logo"}) | safe
+                                alt="Azure arc",
+                                width="42",
+                                height="96",
+                                hi_def=True,
+                                loading="lazy",
+                                attrs={"class": "p-logo-section__logo"}) | safe
                 }}
               </div>
             </div>
@@ -373,42 +391,42 @@
             <div class="p-logo-section__items">
               <div class="p-logo-section__item">
                 {{ image(url="https://assets.ubuntu.com/v1/58440b6b-rancher-logo.png",
-                          alt="Rancher",
-                          width="107",
-                          height="96",
-                          hi_def=True,
-                          loading="lazy",
-                          attrs={"class": "p-logo-section__logo"}) | safe
+                                alt="Rancher",
+                                width="107",
+                                height="96",
+                                hi_def=True,
+                                loading="lazy",
+                                attrs={"class": "p-logo-section__logo"}) | safe
                 }}
               </div>
               <div class="p-logo-section__item">
                 {{ image(url="https://assets.ubuntu.com/v1/eb826d4d-portainer-io-logo.png",
-                          alt="Portainer.io",
-                          width="144",
-                          height="96",
-                          hi_def=True,
-                          loading="lazy",
-                          attrs={"class": "p-logo-section__logo"}) | safe
+                                alt="Portainer.io",
+                                width="144",
+                                height="96",
+                                hi_def=True,
+                                loading="lazy",
+                                attrs={"class": "p-logo-section__logo"}) | safe
                 }}
               </div>
               <div class="p-logo-section__item">
                 {{ image(url="https://assets.ubuntu.com/v1/d0e0b382-spectro-cloud-logo.png",
-                          alt="Spectro Cloud",
-                          width="72",
-                          height="96",
-                          hi_def=True,
-                          loading="lazy",
-                          attrs={"class": "p-logo-section__logo"}) | safe
+                                alt="Spectro Cloud",
+                                width="72",
+                                height="96",
+                                hi_def=True,
+                                loading="lazy",
+                                attrs={"class": "p-logo-section__logo"}) | safe
                 }}
               </div>
               <div class="p-logo-section__item">
                 {{ image(url="https://assets.ubuntu.com/v1/9ffbe97e-azure-arc-logo.png",
-                          alt="Azure arc",
-                          width="42",
-                          height="96",
-                          hi_def=True,
-                          loading="lazy",
-                          attrs={"class": "p-logo-section__logo"}) | safe
+                                alt="Azure arc",
+                                width="42",
+                                height="96",
+                                hi_def=True,
+                                loading="lazy",
+                                attrs={"class": "p-logo-section__logo"}) | safe
                 }}
               </div>
             </div>
@@ -433,12 +451,18 @@
     <div class="p-section--shallow">
       <div class="row--50-50">
         <div class="col">
-          <h2>Bootstrap <br class="u-hide--medium u-hide--small" />your Kubernetes journey</h2>
+          <h2>
+            Bootstrap
+            <br class="u-hide--medium u-hide--small" />
+            your Kubernetes journey
+          </h2>
         </div>
         <div class="col">
           <p>Canonical Kubernetes consulting and cluster deployment services</p>
           <div class="p-cta-block">
-            <p><a class="js-invoke-modal" href="/kubernetes/contact-us">Get in touch to learn more&nbsp;&rsaquo;</a></p>
+            <p>
+              <a class="js-invoke-modal" href="/kubernetes/contact-us">Get in touch to learn more&nbsp;&rsaquo;</a>
+            </p>
           </div>
         </div>
       </div>
@@ -454,13 +478,13 @@
             <div class="row p-section--shallow">
               <div class="col">
                 <h3>Kubernetes Explorer</h3>
-                <p class="u-text--muted">The low cost solution for maximum scalability.</p>
+                <p class="u-text--muted">Three-day Kubernetes training to ramp up your team's skills, including:</p>
               </div>
-            </div>              
+            </div>
             <hr class="p-rule--muted u-no-margin--bottom" />
             <div class="row">
               <div class="col-2">
-                <h5 class="p-text--small-caps">What's included</h5>
+                <h4 class="p-text--small-caps">What's included</h4>
               </div>
               <div class="col-4">
                 <ul class="p-list--divided">
@@ -485,49 +509,54 @@
             <div class="row">
               <div class="col">
                 <div class="p-section--shallow">
-                  <h3 id="discoverer-text">Kubernetes Discoverer</h3>
-                  <p class="u-text--muted">Three-day training and 2-week deployment of reference K8s architecture, including:</p>
+                  <h3 class="js-discoverer-text">Kubernetes Discoverer</h3>
+                  <p class="u-text--muted js-discoverer-description">Three-day training and 2-week deployment of reference K8s architecture, including:</p>
                 </div>
                 <p>
                   <span class="p-heading--5">Discoverer</span>
-                  <label class="p-switch" style="display: inline-block; padding-left: 32px; padding-right: 32px;">
-                    <input type="checkbox" class="p-switch__input" role="switch" id="discoverer-switch" />
+                  <label class="p-switch"
+                         style="display: inline-block;
+                                padding-left: 32px;
+                                padding-right: 32px">
+                    <input type="checkbox"
+                           class="p-switch__input js-discoverer-switch"
+                           role="switch" />
                     <span class="p-switch__slider"></span>
                   </label>
                   <span class="p-heading--5">Discoverer Plus</span>
                 </p>
               </div>
-            </div>              
+            </div>
             <hr class="p-rule--muted u-no-margin--bottom" />
             <div class="row">
               <div class="col-2">
-                <h5 class="p-text--small-caps">What's included</h5>
+                <h4 class="p-text--small-caps">What's included</h4>
               </div>
               <div class="col-4">
                 <ul class="p-list--divided">
                   <li class="p-list__item is-ticked">High Availability</li>
-                  <li class="p-list__item is-ticked" id="discoverer-item">
+                  <li class="p-list__item is-ticked js-discoverer-item">
                     <a href="/public-cloud">Public clouds</a>, VMware, <a href="/openstack">OpenStack</a>
                   </li>
-                  <li class="p-list__item is-ticked u-hide" id="discoverer-pro-item">
-                    <a href="/public-cloud">Public clouds</a>, VMware, <a href="/openstack">OpenStack</a>, <a href="/bare-metal">Bare Metal</a>
+                  <li class="p-list__item is-ticked u-hide js-discoverer-pro-item">
+                    <a href="/public-cloud">Public clouds</a>, VMware, <a href="/openstack">OpenStack</a>, <a href="https://maas.io/">Bare Metal</a>
                   </li>
-                  <li class="p-list__item is-ticked" id="discoverer-item">Storage and SDN basic options</li>
-                  <li class="p-list__item is-ticked u-hide" id="discoverer-pro-item">Storage and SDN extensive options</li>
+                  <li class="p-list__item is-ticked js-discoverer-item">Storage and SDN basic options</li>
+                  <li class="p-list__item is-ticked u-hide discoverer-pro-item">Storage and SDN extensive options</li>
                   <li class="p-list__item is-ticked">Logging, monitoring, alerting</li>
                   <li class="p-list__item is-ticked">Kubernetes lifecycle management</li>
                   <li class="p-list__item is-ticked">Security essentials</li>
                   <li class="p-list__item is-ticked">Supported or Fully Managed</li>
 
-                  <li class="p-list__item is-crossed u-text--muted" id="discoverer-muted-item">Third-party integrations</li>
-                  <li class="p-list__item is-crossed u-text--muted" id="discoverer-muted-item">GPU Acceleration</li>
-                  <li class="p-list__item is-crossed u-text--muted" id="discoverer-muted-item">Private registry options</li>
+                  <li class="p-list__item is-crossed u-text--muted js-discoverer-muted-item">Third-party integrations</li>
+                  <li class="p-list__item is-crossed u-text--muted js-discoverer-muted-item">GPU Acceleration</li>
+                  <li class="p-list__item is-crossed u-text--muted js-discoverer-muted-item">Private registry options</li>
                 </ul>
               </div>
             </div>
           </div>
         </div>
-        
+
       </div>
     </div>
   </section>
@@ -540,7 +569,7 @@
           <h2>Fully-managed Kubernetes</h2>
         </div>
         <div class="col">
-          <p>Cost-effective Kubernetes-as-a-service on public and private clouds </p>
+          <p>Cost-effective Kubernetes-as-a-service on public and private clouds</p>
           <hr class="p-rule--muted u-no-margin--bottom" />
           <ul class="p-list--divided">
             <li class="p-list__item is-ticked">Predictable economics, full-stack monitoring and clear responsibilities</li>
@@ -553,19 +582,21 @@
             <li class="p-list__item is-ticked">Get back the keys to your Kubernetes as soon as you feel ready</li>
           </ul>
           <div class="p-cta-block">
-            <p><a href="/kubernetes/managed">More on Managed Kubernetes&nbsp;&rsaquo;</a></p>
+            <p>
+              <a href="/kubernetes/managed">More on Managed Kubernetes&nbsp;&rsaquo;</a>
+            </p>
           </div>
         </div>
       </div>
     </div>
     <div class="p-image-container--cinematic u-fixed-width">
       {{ image(url="https://assets.ubuntu.com/v1/e8cb6c61-fully-managed.png",
-                alt="",
-                width="3696",
-                height="1541",
-                hi_def=True,
-                loading="lazy",
-                attrs={"class":"p-image-container__image"}) | safe
+            alt="",
+            width="3696",
+            height="1541",
+            hi_def=True,
+            loading="lazy",
+            attrs={"class":"p-image-container__image"}) | safe
       }}
     </div>
   </section>
@@ -580,82 +611,82 @@
         <div class="p-logo-section__items">
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/3948d6dd-openstack-logo.png",
-                      alt="OpenStack",
-                      width="182",
-                      height="138",
-                      hi_def=True,
-                      loading="lazy",
-                      attrs={"class": "p-logo-section__logo"}) | safe
+                        alt="OpenStack",
+                        width="182",
+                        height="138",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
             }}
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/4452b734-vmware-logo.png",
-                      alt="VMWare",
-                      width="140",
-                      height="135",
-                      hi_def=True,
-                      loading="lazy",
-                      attrs={"class": "p-logo-section__logo"}) | safe
+                        alt="VMWare",
+                        width="140",
+                        height="135",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
             }}
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/d987ba27-Rackspace%20logo.png",
-                      alt="Rackspace",
-                      width="155",
-                      height="135",
-                      hi_def=True,
-                      loading="lazy",
-                      attrs={"class": "p-logo-section__logo"}) | safe
+                        alt="Rackspace",
+                        width="155",
+                        height="135",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
             }}
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/05285685-equinix-logo.png",
-                      alt="Equinix",
-                      width="113",
-                      height="135",
-                      hi_def=True,
-                      loading="lazy",
-                      attrs={"class": "p-logo-section__logo"}) | safe
+                        alt="Equinix",
+                        width="113",
+                        height="135",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
             }}
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/dae49585-joyent-logo.png",
-                      alt="Joyent",
-                      width="105",
-                      height="135",
-                      hi_def=True,
-                      loading="lazy",
-                      attrs={"class": "p-logo-section__logo"}) | safe
+                        alt="Joyent",
+                        width="105",
+                        height="135",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
             }}
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/b526fd14-cloud-sigma-logo.png",
-                      alt="CloudSigma",
-                      width="141",
-                      height="135",
-                      hi_def=True,
-                      loading="lazy",
-                      attrs={"class": "p-logo-section__logo"}) | safe
+                        alt="CloudSigma",
+                        width="141",
+                        height="135",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
             }}
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/4ec1a195-maas-logo.png",
-                      alt="Canonical MAAS",
-                      width="87",
-                      height="135",
-                      hi_def=True,
-                      loading="lazy",
-                      attrs={"class": "p-logo-section__logo"}) | safe
+                        alt="Canonical MAAS",
+                        width="87",
+                        height="135",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
             }}
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/cd584004-lxd-logo.png",
-                      alt="Canonical LXD",
-                      width="66",
-                      height="135",
-                      hi_def=True,
-                      loading="lazy",
-                      attrs={"class": "p-logo-section__logo"}) | safe
+                        alt="Canonical LXD",
+                        width="66",
+                        height="135",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
             }}
           </div>
         </div>
@@ -680,13 +711,17 @@
               <p>
                 <a href="https://ubuntu.com/case-study/esa">The European Space Agency modernized its infrastructure with Canonical Kubernetes</a>
               </p>
-              <p>Find out why ESA chose Canonical to implement a new, dynamic platform for efficient, automated, and fast deployment of systems across their missions.</p>
+              <p>
+                Find out why ESA chose Canonical to implement a new, dynamic platform for efficient, automated, and fast deployment of systems across their missions.
+              </p>
             </li>
             <li class="p-list__item u-no-padding--bottom">
               <p>
-                <a href="/kubernetes/managed">Optimize your ML workloads on Kubernetes</a>
+                <a href="/engage/optimise-ml-workloads-on-kubernetes">Optimize your ML workloads on Kubernetes</a>
               </p>
-              <p>Leverage your existing computing power to accelerate model training in order to move your ML projects to production.</p>
+              <p>
+                Leverage your existing computing power to accelerate model training in order to move your ML projects to production.
+              </p>
             </li>
             <li class="p-list__item u-no-padding--bottom">
               <p>
@@ -707,56 +742,58 @@
   <section class="p-strip is-deep">
     <div class="u-fixed-width">
       <h2>Get your K8s questions answered today</h2>
-      <a class="p-heading--2 js-invoke-modal" href="/kubernetes/contact-us">Contact us</a>.
+      <a class="p-heading--2 js-invoke-modal" href="/kubernetes/contact-us">Contact us</a>
     </div>
   </section>
 
-<!-- Set default Marketo information for contact form below-->
-<div class="u-hide" 
-     id="contact-form-container" 
-     data-form-location="/shared/forms/interactive/kubernetes" 
-     data-form-id="3230" 
-     data-lp-id="6274" 
-     data-return-url="/kubernetes#contact-form-success" 
-     data-lp-url="https://pages.ubuntu.com/things-contact-us.html"></div>
+  <!-- Set default Marketo information for contact form below-->
+  <div class="u-hide"
+       id="contact-form-container"
+       data-form-location="/shared/forms/interactive/kubernetes"
+       data-form-id="3230"
+       data-lp-id="6274"
+       data-return-url="/kubernetes#contact-form-success"
+       data-lp-url="https://pages.ubuntu.com/things-contact-us.html"></div>
 
-<script>
-  document.addEventListener('DOMContentLoaded', function() {
-    const switchElement = document.getElementById('discoverer-switch');
-    const discovererText = document.getElementById('discoverer-text');
-    const discovererProItems = document.querySelectorAll('#discoverer-pro-item');
-    const discovererItems = document.querySelectorAll('#discoverer-item');
-    const discovererMutedItems = document.querySelectorAll('#discoverer-muted-item');
-  
-    switchElement.addEventListener('change', function() {
-      if (switchElement.checked) {
-        discovererMutedItems.forEach(item => {
-          item.classList.remove('is-crossed', 'u-text--muted');
-          item.classList.add('is-ticked');
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      const switchElement = document.querySelector('.js-discoverer-switch');
+      const discovererText = document.querySelector('.js-discoverer-text');
+      const discovererDescription = document.querySelector('.js-discoverer-description');
+      const discovererProItems = document.querySelectorAll('.js-discoverer-pro-item');
+      const discovererItems = document.querySelectorAll('.js-discoverer-item');
+      const discovererMutedItems = document.querySelectorAll('.js-discoverer-muted-item');
+
+      switchElement.addEventListener('change', function() {
+        if (switchElement.checked) {
+          discovererMutedItems.forEach(item => {
+            item.classList.remove('is-crossed', 'u-text--muted');
+            item.classList.add('is-ticked');
+          });
+          discovererItems.forEach(item => {
+            item.classList.add('u-hide');
+          });
+          discovererProItems.forEach(item => {
+            item.classList.remove('u-hide');
+          });
           discovererText.textContent = 'Kubernetes Discoverer Plus';
-        });
-        discovererItems.forEach(item => {
-          item.classList.add('u-hide');
-        });
-        discovererProItems.forEach(item => {
-          item.classList.remove('u-hide');
-        });
-
-      } else {
-        discovererMutedItems.forEach(item => {
-          item.classList.remove('is-ticked');
-          item.classList.add('is-crossed', 'u-text--muted');
+          discovererDescription.textContent = 'Three-week custom architecture deployment project and knowledge transfer, including:';
+        } else {
+          discovererMutedItems.forEach(item => {
+            item.classList.remove('is-ticked');
+            item.classList.add('is-crossed', 'u-text--muted');
+          });
+          discovererItems.forEach(item => {
+            item.classList.remove('u-hide');
+          });
+          discovererProItems.forEach(item => {
+            item.classList.add('u-hide');
+          });
           discovererText.textContent = 'Kubernetes Discoverer';
-        });
-        discovererItems.forEach(item => {
-          item.classList.remove('u-hide');
-        });
-        discovererProItems.forEach(item => {
-          item.classList.add('u-hide');
-        });
-      }
+          discovererDescription.textContent = 'Three-day training and 2-week deployment of reference K8s architecture, including:';
+        }
+      });
     });
-  });
-</script>
+  </script>
 
 {% endblock content %}

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -531,7 +531,7 @@
                     Three-day training and 2-week deployment of reference K8s architecture, including:
                   </p>
                 </div>
-                <p>
+                <div style="display:inline-flex;">
                   <span class="p-heading--5">Discoverer</span>
                   <label class="p-switch"
                          style="display: inline-block;
@@ -543,7 +543,7 @@
                     <span class="p-switch__slider"></span>
                   </label>
                   <span class="p-heading--5">Discoverer Plus</span>
-                </p>
+                </div>
               </div>
             </div>
             <hr class="p-rule--muted u-no-margin--bottom" />


### PR DESCRIPTION
## Done

- Apply rebranding for /kubernetes landing page

## QA

- Go to https://ubuntu-com-14683.demos.haus/kubernetes
- Check against [copy doc](https://docs.google.com/document/d/1b018GoKMF3abEFJlUkfAEK2JEhXWICKF4V0dGdTvgJs/edit?tab=t.0) and [Figma](https://www.figma.com/design/l4wd5ry1KQ6fHbrWptvQbE/24.04-Kubernetes-bubble?node-id=0-1&p=f&m=dev)
- Toggle the switch in "Kubernetes Discoverer" and check that it updates card details as expected

## Issue / Card

Fixes [WD-12944](https://warthogs.atlassian.net/browse/WD-12944)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-12944]: https://warthogs.atlassian.net/browse/WD-12944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ