### PR TITLE
[WD-15094] fix: onhover not working on tablet/mobile meganav

### DIFF
--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -153,6 +153,10 @@ $meganav-height: 3rem;
               text-decoration: none;
             }
           }
+
+          &:hover {
+            background-color: $colors--dark-theme--background-hover;
+          }
         }
       }
 


### PR DESCRIPTION
## Done

- Fixed onhover

## QA

- Open this [demo](https://ubuntu-com-14686.demos.haus/) on tablet or mobile screen size
- Open the meganav by clicking the 'menu'
- Navigation to the bottom layer of any navigation item. ex. 'Products' > 'Featured'.
- Hover your mouse over the dropdown items
- Verify hover effect is applied

## Issue / Card

Fixes #[WD-15094](https://warthogs.atlassian.net/browse/WD-15094)


[WD-15094]: https://warthogs.atlassian.net/browse/WD-15094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ