### PR TITLE
[WD-18697] feat: Add "other" option with textarea for radio and checkbox inputs in form generator on u.com

### DIFF
--- a/static/js/src/dynamic-forms.js
+++ b/static/js/src/dynamic-forms.js
@@ -422,6 +422,20 @@ import { prepareInputFields } from "./prepare-form-inputs.js";
             });
           }
 
+          const checkboxFieldsets = document.querySelectorAll(
+            ".js-remove-checkbox-names",
+          );
+          if (checkboxFieldsets.length > 0) {
+            checkboxFieldsets.forEach((checkboxFieldset) => {
+              const checkboxInputs = checkboxFieldset.querySelectorAll(
+                "input[type='checkbox']",
+              );
+              checkboxInputs.forEach((checkboxInput) => {
+                checkboxInput.removeAttribute("name");
+              });
+            });
+          }
+
           return message;
         }
       }

--- a/static/js/src/dynamic-forms.js
+++ b/static/js/src/dynamic-forms.js
@@ -399,7 +399,10 @@ import { prepareInputFields } from "./prepare-form-inputs.js";
                 case "text":
                 case "number":
                 case "textarea":
-                  if (input.value !== "") {
+                  if (
+                    input.value !== "" &&
+                    !input.classList.contains("js-other-input")
+                  ) {
                     message += input.value + comma + " ";
                   }
                   break;

--- a/static/js/src/prepare-form-inputs.js
+++ b/static/js/src/prepare-form-inputs.js
@@ -158,6 +158,7 @@ function setupOtherInputs() {
               if (input.checked) {
                 textarea.classList.remove("u-hide");
               } else {
+                textarea.value = "";
                 textarea.classList.add("u-hide");
               }
             }

--- a/static/js/src/prepare-form-inputs.js
+++ b/static/js/src/prepare-form-inputs.js
@@ -61,9 +61,16 @@ export function setupIntlTelInput(countryCode, phoneInput) {
  */
 function addInputValidation(phoneInput) {
   const mobileInput = document.querySelector(".iti");
-  mobileInput.parentNode.classList.add("p-form-validation");
-  phoneInput.classList.add("p-form-validation__input");
+  const parentNode = mobileInput.parentNode;
+  parentNode.classList.add("p-form-validation");
 
+  // remove rogue li item from intlTelInput library
+  setTimeout(() => {
+    const listItems = parentNode.querySelectorAll("li");
+    listItems[listItems.length - 1]?.remove();
+  }, 2000);
+
+  phoneInput.classList.add("p-form-validation__input");
   const errorElement = createErrorMessage();
   phoneInput.addEventListener("blur", () =>
     validateInput(phoneInput, errorElement),

--- a/static/js/src/prepare-form-inputs.js
+++ b/static/js/src/prepare-form-inputs.js
@@ -134,6 +134,43 @@ if (phoneNumberInput || countryInput) {
   prepareInputFields(phoneNumberInput, countryInput);
 }
 
+/**
+ * Initializes 'other' inputs. Where selecting the input triggers a textarea to appear.
+ */
+function setupOtherInputs() {
+  const otherTextarea = document.querySelectorAll(".js-other-input");
+  otherTextarea.forEach((textarea) => {
+    const triggerInputEle = document.querySelector(
+      `#${textarea.dataset.inputId}`,
+    );
+    document
+      .querySelectorAll(`[name=${triggerInputEle.name}]`)
+      .forEach((input) => {
+        input.onclick = () => {
+          if (input.type === "radio") {
+            if (input == triggerInputEle) {
+              textarea.classList.remove("u-hide");
+            } else {
+              textarea.classList.add("u-hide");
+            }
+          } else if (input.type === "checkbox") {
+            if (input === triggerInputEle) {
+              if (input.checked) {
+                textarea.classList.remove("u-hide");
+              } else {
+                textarea.classList.add("u-hide");
+              }
+            }
+          }
+        };
+      });
+    textarea.addEventListener("input", () => {
+      triggerInputEle.value = textarea.value;
+    });
+  });
+}
+setupOtherInputs();
+
 export default {
   prepareInputFields,
   setupIntlTelInput,

--- a/templates/aws/form-data.json
+++ b/templates/aws/form-data.json
@@ -2,11 +2,7 @@
   "form": {
     "/aws": {
       "templatePath": "/aws/index.html",
-      "childrenPaths": [
-        "/aws/pro",
-        "/aws/support",
-        "/aws/outposts"
-      ],
+      "childrenPaths": ["/aws/pro", "/aws/support", "/aws/outposts"],
       "isModal": true,
       "modalId": "contact-modal",
       "formData": {
@@ -197,6 +193,7 @@
         {
           "title": "How do you consume open source?",
           "id": "how-do-you-consume-open-source",
+          "inputType": "checkbox",
           "fields": [
             {
               "type": "checkbox",
@@ -227,6 +224,7 @@
         {
           "title": "Do you have specific compliance or hardening requirements?",
           "id": "hardening-requirements",
+          "inputType": "checkbox",
           "fields": [
             {
               "type": "checkbox",
@@ -281,6 +279,7 @@
         {
           "title": "Who is responsible for tracking, testing and applying CVE patches in a timely manner?",
           "id": "responsible-for-tracking",
+          "inputType": "checkbox",
           "fields": [
             {
               "type": "checkbox",

--- a/templates/shared/forms/form-fields.html
+++ b/templates/shared/forms/form-fields.html
@@ -19,7 +19,7 @@
 
       <div class="p-section">
         <hr class="p-rule is-fixed-width" />
-        <fieldset class="p-fieldset-section{% if fieldset.inputType == 'checkbox-visibility' %} js-toggle-checkbox-visibility{% elif fieldset.isRequired and fieldset.inputType == 'checkbox' %} js-required-checkbox{% elif fieldset.inputType == 'radio' %} js-remove-radio-names{% endif %}"
+        <fieldset class="p-fieldset-section{% if fieldset.inputType == 'checkbox-visibility' %} js-toggle-checkbox-visibility{% elif fieldset.isRequired and fieldset.inputType == 'checkbox' %} js-required-checkbox{% elif fieldset.inputType == 'radio' %} js-remove-radio-names{% endif %} {% if fieldset.inputType == 'checkbox' or fieldset.inputType == 'checkbox-visibility' %}js-remove-checkbox-names{% endif %}"
                   id="{{ fieldset.id }}"
                   aria-labelledby="{{ fieldset.id }}">
           <div class="row--50-50 {% if not fieldset.noCommentsFromLead %}js-formfield{% endif %}">
@@ -72,19 +72,33 @@
                           <input {% if fieldset.isRequired %}required{% endif %}
                                  class="p-radio__input"
                                  type="radio"
+                                 id="{{ field.id }}"
+                                 name="{{ fieldset_inputName }}"
                                  aria-labelledby="{{ field.id }}"
                                  name="{{ fieldset.inputName }}"
                                  value="{{ field.value }}" />
-                          <span class="p-radio__label" id="{{ field.id }}">{{ field.label }}</span>
+                          <span class="p-radio__label">{{ field.label }}</span>
                         </label>
+                        {% if field.hasTextarea %}
+                          <textarea class="js-other-input u-hide"
+                                    data-input-id="{{ field_id }}"
+                                    id="{{ field_id }}-textarea"></textarea>
+                        {% endif %}
                       {% elif field.type == "checkbox" %}
                         <label class="p-checkbox">
                           <input class="p-checkbox__input js-checkbox-visibility"
                                  type="checkbox"
+                                 id="{{ field.id }}"
+                                 name="{{ fieldset_inputName }}"
                                  aria-labelledby="{{ field.label }}"
                                  value="{{ field.value }}" />
-                          <span class="p-checkbox__label" id="{{ field.id }}">{{ field.label }}</span>
+                          <span class="p-checkbox__label">{{ field.label }}</span>
                         </label>
+                        {% if field.hasTextarea %}
+                          <textarea class="js-other-input u-hide"
+                                    data-input-id="{{ field_id }}"
+                                    id="{{ field_id }}-textarea"></textarea>
+                        {% endif %}
                       {% elif field.fieldTitle is defined and field.fieldTitle|length > 0 %}
                         <div class="p-section--shallow">
                           <strong>{{ field.fieldTitle }}</strong>

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -3,6 +3,7 @@ from typing import List
 
 import flask
 from canonicalwebteam import image_template
+from slugify import slugify
 
 from webapp.context import (
     current_year,
@@ -376,3 +377,7 @@ def init_handlers(app, sentry):
     app.add_template_filter(date_has_passed)
 
     app.add_template_filter(sort_by_key_and_ordered_list)
+
+    @app.template_filter()
+    def slug(text):
+        return slugify(text)


### PR DESCRIPTION
## Done

- Add support for "other" option with textarea using js.
- Remove names from checkboxes for fieldSets named "checkbox" or "checkbox-visibility"
- Drive by: updated form on /aws to include missing inputType for checkbox fieldsets.
- Drive by: added a missing filter named "slug"

## QA

- Open this [demo/iot/smart-city#get-in-touch](https://ubuntu-com-14689.demos.haus/internet-of-things/smart-city#get-in-touch) in your browser.
- Verify the form opens up.
- Fill in the form and make sure to select any/all checkboxes/ radios with "Other" option.
- Submit the form to make sure it works.
- Monitor the payload from devtools to make sure the names are stripped from checkboxes.
- Verify form submission in Marketo if possible and have access.

Also do the same as above for [demo/embedded#get-in-touch](https://ubuntu-com-14689.demos.haus/embedded#get-in-touch)

## Issue / Card

Fixes #[WD-18697](https://warthogs.atlassian.net/browse/WD-18697)


[WD-18697]: https://warthogs.atlassian.net/browse/WD-18697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ