### PR TITLE
Update styles.scss

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1385,7 +1385,7 @@ $color-link-dark: #69c !default;
 
 // XXX: Lyubo: reduce logo section component height globally (to be moved to vanilla)
 .p-logo-section--dense .p-logo-section__logo {
-  height: 6rem;
+  height: 5rem;
 }
 
 .landing-logos {


### PR DESCRIPTION
## Done

Reduced logo section component height from 6rem to 5rem to prevent overlapping of security patches logos on Firefox browser at widescreen resolution with 100% zoom

## QA

-changed using firefox inspect and style editor

## Issue / Card

Fixes security patch section on ubuntu.com/pro having overlapping logos

## Screenshots
ansible logo is most noticeable.

before:
<img width="2002" alt="Screenshot 2025-02-02 at 20 03 55" src="https://github.com/user-attachments/assets/303586e6-9842-4b6a-a0b6-2b5b521951ad" />
<img width="412" alt="Screenshot 2025-02-02 at 20 03 43" src="https://github.com/user-attachments/assets/5e2dc6b0-8da1-4705-a07a-8d356166d669" />

after:
<img width="2008" alt="Screenshot 2025-02-02 at 20 03 01" src="https://github.com/user-attachments/assets/82cf4812-9a1a-49aa-8c09-b8e2667ac32c" />
<img width="418" alt="Screenshot 2025-02-02 at 20 03 23" src="https://github.com/user-attachments/assets/266c16eb-cfe8-4c8d-9b94-6264b8be6add" />



## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
