### PR TITLE
Add redirects for static case studies

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -124,7 +124,11 @@ category/product/landscape/?: /landscape
 category/product/(server|ubuntu-server-edition)/?: /server
 category/product/ubuntu-advantage/?: /support
 category/product/ubuntu-light/?: http://lubuntu.net/
-case-study: "https://canonical.com/case-study"
+case-study/?: "https://canonical.com/case-study"
+case-study/esa/?: "https://canonical.com/case-study/esa/"
+case-study/sbi-bits/?: "https://canonical.com/case-study/sbi-bits/"
+case-study/grundium-ubuntu-pro-for-devices/?: "https://canonical.com/case-study/grundium-ubuntu-pro-for-devices/"
+case-study/ubuntu-pro-support-for-games-developer/?: "https://canonical.com/case-study/ubuntu-pro-support-for-games-developer/"
 # old certification.ubuntu.com redirects
 certified/desktop/?: "/certified/desktops"
 certified/server/?: "/certified/servers"


### PR DESCRIPTION
## Done

- Add redirect rules for static case studies that have been migrated from u.com to c.com

## QA

- Go to https://ubuntu-com-14704.demos.haus/case-study/esa
- See that it redirects to the case study on c.com
- Repeat for 
  - https://ubuntu-com-14704.demos.haus/case-study/sbi-bits
  - https://ubuntu-com-14704.demos.haus/case-study/grundium-ubuntu-pro-for-devices
  - https://ubuntu-com-14704.demos.haus/case-study/ubuntu-pro-support-for-games-developer

## Issue / Card

Fixes [WD-18974](https://warthogs.atlassian.net/browse/WD-18974)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-18974]: https://warthogs.atlassian.net/browse/WD-18974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ