### PR TITLE
fix: Add redirect for static case study

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -129,6 +129,7 @@ case-study/esa/?: "https://canonical.com/case-study/esa/"
 case-study/sbi-bits/?: "https://canonical.com/case-study/sbi-bits/"
 case-study/grundium-ubuntu-pro-for-devices/?: "https://canonical.com/case-study/grundium-ubuntu-pro-for-devices/"
 case-study/ubuntu-pro-support-for-games-developer/?: "https://canonical.com/case-study/ubuntu-pro-support-for-games-developer/"
+case-study/lucid-aws-fedramp-compliance-case-study/?: "https://canonical.com/case-study/lucid-aws-fedramp-compliance-case-study/"
 # old certification.ubuntu.com redirects
 certified/desktop/?: "/certified/desktops"
 certified/server/?: "/certified/servers"


### PR DESCRIPTION
## Done

- Add redirect link for static case study

## QA

- Go to https://ubuntu-com-14706.demos.haus/case-study/lucid-aws-fedramp-compliance-case-study/
- See that it redirects to the case study on c.com

## Issue / Card

Fixes 

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
