### PR TITLE
fix: Fix reported broken links 

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -125,11 +125,7 @@ category/product/(server|ubuntu-server-edition)/?: /server
 category/product/ubuntu-advantage/?: /support
 category/product/ubuntu-light/?: http://lubuntu.net/
 case-study/?: "https://canonical.com/case-study"
-case-study/esa/?: "https://canonical.com/case-study/esa/"
-case-study/sbi-bits/?: "https://canonical.com/case-study/sbi-bits/"
-case-study/grundium-ubuntu-pro-for-devices/?: "https://canonical.com/case-study/grundium-ubuntu-pro-for-devices/"
-case-study/ubuntu-pro-support-for-games-developer/?: "https://canonical.com/case-study/ubuntu-pro-support-for-games-developer/"
-case-study/lucid-aws-fedramp-compliance-case-study/?: "https://canonical.com/case-study/lucid-aws-fedramp-compliance-case-study/"
+case-study/(?P<path>.*)/?: "https://canonical.com/case-study/{path}"
 # old certification.ubuntu.com redirects
 certified/desktop/?: "/certified/desktops"
 certified/server/?: "/certified/servers"

--- a/templates/containers/chiseled/index.html
+++ b/templates/containers/chiseled/index.html
@@ -508,16 +508,14 @@
           <div class="col-4 col-medium-3">
             <ul class="p-list--divided">
               <li class="p-list__item">
-                <a href="https://canonical-rockcraft.readthedocs-hosted.com/en/latest/explanation/chisel/">Using chisel in
-                Rockcraft</a>
+                <a href="https://documentation.ubuntu.com/rockcraft/en/latest/how-to/rocks/chisel-existing-rock.html">Using chisel in Rockcraft</a>
               </li>
               <li class="p-list__item">
                 <a href="https://documentation.ubuntu.com/oci-registries/en/latest/oci-how-to/create-chiseled-ubuntu-image/">Create
                 a chiseled Ubuntu base image for C/C++, Go and Rust applications</a>
               </li>
               <li class="p-list__item">
-                <a href="https://documentation.ubuntu.com/rockcraft/en/latest/how-to/chisel/install-slice/">Install packages
-                slices into a rock</a>
+                <a href="https://documentation.ubuntu.com/rockcraft/en/latest/how-to/chisel/install-slice.html">Install packages slices into a rock</a>
               </li>
             </ul>
           </div>

--- a/templates/kubernetes/charmed-k8s.html
+++ b/templates/kubernetes/charmed-k8s.html
@@ -219,7 +219,7 @@
     </div>
     <div class="row">
       <div class="col-12">
-        <a href="https://technology.amis.nl/platform/kubernetes/charmed-kubernetes-on-kvm-using-maas-and-juju/">Learn more about MAAS&nbsp;&rsaquo;</a>
+        <a href="https://maas.io/">Learn more about MAAS&nbsp;&rsaquo;</a>
       </div>
     </div>
   </section>

--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -622,7 +622,7 @@
             </p>
             <ul class="p-list--divided">
               <li class="p-list__item has-bullet">
-                <a href="https://canonical-rockcraft.readthedocs-hosted.com/en/latest/explanation/rocks/">Rocks</a>, Canonical's new generation of OCI-compliant, container images, built on top of Ubuntu LTS and optimised to run applications
+                <a href="/server/docs/about-rock-images">Rocks</a>, Canonical's new generation of OCI-compliant, container images, built on top of Ubuntu LTS and optimised to run applications
               </li>
               <li class="p-list__item has-bullet">
                 <a href="/engage/chiselled-ubuntu-images-for-containers">Chiselled Ubuntu</a>, Canonical's distroless container images that only fit the strictly required dependencies


### PR DESCRIPTION
## Done

- Fix broken links reported on ["Links on live"](https://github.com/canonical/ubuntu.com/actions/runs/13130367860) 
- Drive-by: Refactor redirect rules for case study

## QA

- Go to https://ubuntu-com-14707.demos.haus/containers/chiseled
  - Scroll to "Using chisel in Rockcraft" and "Install package slices into a rock"
  - Click on the links and see that it redirects to a working doc page
- Go to https://ubuntu-com-14707.demos.haus/support
  - Scroll to "Rocks", click and see that the link works

## Issue / Card

Fixes [WD-18982](https://warthogs.atlassian.net/browse/WD-18982)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-18982]: https://warthogs.atlassian.net/browse/WD-18982?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ