### PR TITLE
Add header ID to /security/oval

### DIFF
--- a/templates/security/oval.html
+++ b/templates/security/oval.html
@@ -35,7 +35,7 @@
 <section class="p-strip--light">
   <div class="row u-vertically-center">
     <div class="col-7">
-      <h2>
+      <h2 id="how-we-use-oval">
         How we use Ubuntu OVAL
       </h2>
       <p>
@@ -63,7 +63,7 @@
 
 <section class="p-strip is-deep" id="instructions">
   <div class="u-fixed-width">
-    <h2>
+    <h2 id="using-oval-data">
       Using Ubuntu's OVAL data
     </h2>
   </div>
@@ -148,7 +148,7 @@ bunzip2 oci.com.ubuntu.focal.usn.oval.xml.bz2</code></pre>
     <section class="p-strip--light">
       <div class="row">
         <div class="col-7">
-          <h2>
+          <h2 id="oval-data-parameters">
             Ubuntu OVAL data parameters
           </h2>
           <table>
@@ -257,7 +257,7 @@ bunzip2 oci.com.ubuntu.focal.usn.oval.xml.bz2</code></pre>
     <section class="p-strip">
       <div class="row">
         <div class="col-7">
-          <h2>
+          <h2 id="how-oval-works">
             How Ubuntu OVAL data works
           </h2>
           <p>


### PR DESCRIPTION
## Done

- Added ID to headers as requested

## QA

- Go to https://ubuntu-com-14712.demos.haus/security/oval#how-we-use-oval
- See that the page scrolls to the respective header section
- Repeat with the other ID hashes

## Issue / Card

Fixes #12487 and [WD-18981](https://warthogs.atlassian.net/browse/WD-18981)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-18981]: https://warthogs.atlassian.net/browse/WD-18981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ