### PR TITLE
fix: Add line wrapping to references links

### DIFF
--- a/static/sass/_pattern_cve.scss
+++ b/static/sass/_pattern_cve.scss
@@ -246,4 +246,19 @@
   .section-heading {
     scroll-margin-top: 3.5rem;
   }
+
+  .u-break-wrap {
+    overflow-wrap: break-word;
+  }
+
+  @media screen and (width < $breakpoint-x-large) {
+    .u-cve-table-horizontal-scroll {
+      overflow-x: hidden;
+      .u-cve-table-horizontal-scroll__table {
+        display: block;
+        overflow-x: auto;
+        white-space: nowrap;
+      }
+    }
+  }
 }

--- a/templates/security/cves/cve.html
+++ b/templates/security/cves/cve.html
@@ -522,7 +522,7 @@
 
           {% if other_references %}
             <h3>Other references</h3>
-            <ul class="p-list">
+            <ul class="p-list" style="overflow-wrap: break-word;">
               {% for reference in other_references %}
                 <li class="p-list__item">
                   <a href="{{ reference }}">{{ reference }}</a>

--- a/templates/security/cves/cve.html
+++ b/templates/security/cves/cve.html
@@ -243,8 +243,8 @@
             </div>
           </div>
           {% if cve.status == 'active' and only_upstream == False %}
-            <div class="row p-section--shallow u-table-horizontal-scroll">
-              <table class="cve-table u-table-horizontal-scroll__table">
+            <div class="row p-section--shallow u-cve-table-horizontal-scroll">
+              <table class="cve-table u-cve-table-horizontal-scroll__table">
                 <thead>
                   <tr>
                     <th style="width: 12rem;">Package</th>
@@ -344,7 +344,7 @@
                       <a href="https://launchpad.net/~{{ note.author }}">{{ note.author }}</a>
                     </h3>
                   {% endif %}
-                  <p>{{ note.note }}</p>
+                  <p class="u-break-wrap">{{ note.note }}</p>
                 {% endfor %}
               </div>
             </div>
@@ -522,7 +522,7 @@
 
           {% if other_references %}
             <h3>Other references</h3>
-            <ul class="p-list" style="overflow-wrap: break-word;">
+            <ul class="p-list u-break-wrap">
               {% for reference in other_references %}
                 <li class="p-list__item">
                   <a href="{{ reference }}">{{ reference }}</a>


### PR DESCRIPTION
## Done

- Added line wrapping for "Other references" links 

## QA

- View the site locally in your web browser at: https://ubuntu-com-14720.demos.haus/security/CVE-2024-12084
    - Be sure to test on mobile, tablet and desktop screen sizes
- See that this is not happening:
![image](https://github.com/user-attachments/assets/597cd23d-afa4-4873-bb72-20667a3c5d0d)


## Issue / Card

Reported on [MM](https://chat.canonical.com/canonical/pl/aid9zr8uw7ro9faf4qj5zgcabh)