### PR TITLE
chore: Update linkchecker to report 404 errors only

### DIFF
--- a/.github/workflows/live-links.yaml
+++ b/.github/workflows/live-links.yaml
@@ -3,6 +3,9 @@ name: Links on live
 on:
   schedule:
     - cron: "20 7 * * *"
+  pull_request:
+    branches:
+      - main
 
 jobs:
   check-links:
@@ -49,11 +52,12 @@ jobs:
           [output]
           status=0
           warnings=0
+          ignoreerrors=
+            ^http?s://.* ^.*(471|500|503|504|400)
           EOF
 
-      - name: Run linkchecker
-        run: |
-          linkchecker https://ubuntu.com
+      - name: Run linkchecker for 404 errors only
+        run: linkchecker --no-warning https://ubuntu.com
 
       - name: Send message on failure
         if: failure()


### PR DESCRIPTION
## Done

- Updated `live-links.yaml` cron job to ignore warnings and errors 471, 500, 503, 504, 400
- Tried to use negative matching to ignore non-404 files but it did not work as expected, it could be due to how `linkchecker` searches for matches [here](https://github.com/linkchecker/linkchecker/blob/master/linkcheck/checker/urlbase.py)

## QA

- Go to `live-links` action [here](https://github.com/canonical/ubuntu.com/actions/runs/13966763934/job/39098831580?pr=14722)
- Check that it does not report any failing links
- Go to [today's cron job](https://github.com/canonical/ubuntu.com/actions/runs/13964030095/job/39090439112), see that it reports 471
- Compare it with this PR's `live-links` action and see that the 471 error is not reported

## Issue / Card

Fixes [WD-19063](https://warthogs.atlassian.net/browse/WD-19063)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-19063]: https://warthogs.atlassian.net/browse/WD-19063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ