### PR TITLE
fix: Update chiselled link

### DIFF
--- a/templates/containers/index.html
+++ b/templates/containers/index.html
@@ -112,7 +112,7 @@
               Canonical's variation of “distroless” containers. Chiseled Ubuntu containers take size optimisation to a new level. Developers can keep building with Ubuntu and rely on Chisel to extract an ultra-small, bitwise identical image tailored for production. No more worries about library incompatibilities, just seamless development to deployment.
             </p>
             <p>
-              <a href="/blog/combining-distroless-and-ubuntu-chiseled-containers">Learn about Chiseled Ubuntu&nbsp;&rsaquo;</a>
+              <a href="/blog/combining-distroless-and-ubuntu-chiselled-containers">Learn about Chiselled Ubuntu&nbsp;&rsaquo;</a>
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Done

- Update the “[Learn about Chiselled Ubuntu](https://ubuntu.com/blog/combining-distroless-and-ubuntu-chiselled-containers)” link as specified in the [copy doc](https://docs.google.com/document/d/1OtyfNeA--EJgpgvDzqcbJ8jqa6d9H5H9xyxHNxcKXvc/edit?tab=t.0)

## QA

- Go to https://ubuntu-com-14729.demos.haus/containers
- Click on "Learn about Chiselled Ubuntu" and see that it redirects to the blog

## Issue / Card

Fixes [WD-19154](https://warthogs.atlassian.net/browse/WD-19154)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-19154]: https://warthogs.atlassian.net/browse/WD-19154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ