### PR TITLE
copy-update: update the phrasing used for the "adopting secure enterprise linux desktop" link

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -186,7 +186,7 @@
           <p>That's why Ubuntu supports the fastest, biggest and most successful digital operations.</p>
           <hr class="p-rule--muted" />
           <p class="u-no-margin--bottom">
-            <a href="/engage/adopting-secure-enterprise-linux-desktop">Download our guide to secure enterprise Linux&nbsp;&rsaquo;</a>
+            <a href="/engage/adopting-secure-enterprise-linux-desktop">Download our guide to adopting Linux securely in your enterprise&nbsp;&rsaquo;</a>
           </p>
           <p>
             <a href="/ai">Build your AI models on Ubuntu&nbsp;&rsaquo;</a>


### PR DESCRIPTION
## Done

- Update the phrasing used for a link as requested in this [copy doc](https://docs.google.com/document/d/1ySJxQbqVdeH4Tra0zwBm2Tn0s56kFGnEF7d8xDRTxwU/edit?tab=t.0)

## QA
Check that the phrasing of the link has been updated as requested in the copy doc.

Open [demo](https://ubuntu-com-14730.demos.haus/) and scroll to the "Energise your engineers" section. The first link in that section should now be changed to "Download our guide to adopting Linux securely in your enterprise"

## Issue / Card
https://warthogs.atlassian.net/browse/WD-19133