### PR TITLE
feat: Apply rebranding for /security/oval

### DIFF
--- a/templates/security/docker-images.html
+++ b/templates/security/docker-images.html
@@ -184,10 +184,9 @@
           Both. Some LTS Docker Images have a free five year maintenance period, based on the underlying Ubuntu LTS free standard security maintenance period. After five years, these LTS images will get five more years of security patches through the Expanded Security Maintenance (ESM) program. The ESM program is available with our Ubuntu Pro subscriptions. Some images don&apos;t get the free five initial LTS years,
           but still are eligible for the 10-year ESM program. On each image&apos;s documentation, the support dates and LTS/ESM logos indicate the current support status for every version. As with Ubuntu interim releases, ongoing development images are released regularly and receive free security updates while they are the current version.
         </p>
-        <hr class="p-rule--muted" />
-        <p>
+        <div class="p-cta-block">
           <a href="https://canonical.com/blog/canonical-publishes-lts-docker-image-portfolio-on-docker-hub">Read more&nbsp;&rsaquo;</a>
-        </p>
+        </div>
       {%- endif -%}
 
       {%- if slot == 'list_item_title_4' -%}
@@ -197,10 +196,9 @@
         <p>
           ESM Images are security-maintained for the full ten year period of their underlying Ubuntu LTS release. Some applications will have versions on multiple Ubuntu LTS versions. In each case, the image is maintained for the full life of the underlying Ubuntu LTS.
         </p>
-        <hr class="p-rule--muted" />
-        <p>
+        <div class="p-cta-block">
           <a href="https://canonical.com/blog/canonical-publishes-lts-docker-image-portfolio-on-docker-hub">Read more&nbsp;&rsaquo;</a>
-        </p>
+        </div>
       {%- endif -%}
 
       {%- if slot == 'list_item_title_5' -%}
@@ -210,10 +208,9 @@
         <p>
           Yes. Our hardened images are optimised for the developer experience, layering, and minimality. Each image is engineered to be clean, without layering artefacts, making it an ideal foundation for enterprise continuous integration and golden images. If you are an ISV, Canonical can offer embedded terms for redistribution and specific support.
         </p>
-        <hr class="p-rule--muted" />
-        <p>
+        <div class="p-cta-block">
           <a href="/security/contact-us?product=docker" class="js-invoke-modal">Get in touch&nbsp;&rsaquo;</a>
-        </p>
+        </div>
       {%- endif -%}
 
       {%- if slot == 'list_item_title_6' -%}

--- a/templates/security/oval.html
+++ b/templates/security/oval.html
@@ -1,265 +1,226 @@
 {% extends "security/base_security.html" %}
 
+{% from "_macros/vf_hero.jinja" import vf_hero %}
+
 {% block title %}Ubuntu Oval | Security{% endblock %}
 
-{% block meta_description %}Parameters and methods for consuming Ubuntu OVAL data. OVAL is used by the Ubuntu Security Team for CVE tracking and management.{% endblock %}
+{% block meta_description %}
+  Parameters and methods for consuming Ubuntu OVAL data. OVAL is used by the Ubuntu Security Team for CVE tracking and management.
+{% endblock %}
 
-{% block meta_copydoc %}https://docs.google.com/document/d/1hBG6NIfBIrixIV753fsOiEymmeuFIF-KOhiDkV68PRY/edit{% endblock meta_copydoc %}
+{% block meta_copydoc %}
+  https://docs.google.com/document/d/1hBG6NIfBIrixIV753fsOiEymmeuFIF-KOhiDkV68PRY/edit
+{% endblock meta_copydoc %}
 
 {% block content %}
-<section class="p-strip--suru-bottomed">
-  <div class="row u-equal-height">
-    <div class="col-7 u-vertically-center">
-      <h1>
-        Ubuntu OVAL data
-      </h1>
+
+  {% call(slot) vf_hero(
+    title_text='Ubuntu OVAL data',
+    layout='25/75'
+    ) -%}
+    {%- if slot == 'description' -%}
       <p>
         Canonical's Security Team produces Ubuntu OVAL, a structured, machine-readable dataset for all <a href="/about/release-cycle">supported Ubuntu releases</a>.  It can be used to evaluate and manage security risks related to any existing Ubuntu components. It is based on the Open Vulnerability and Assessment Language (OVAL).
       </p>
-    </div>
-    <div class="col-5 u-align--center u-vertically-center u-hide--medium u-hide--small">
-      {{
-        image(
-        url="https://assets.ubuntu.com/v1/eb653b8e-oval_logo.png",
-        alt="",
-        width="250",
-        height="164",
-        hi_def=True,
-        loading="auto",
-        ) | safe
-      }}
-    </div>
-  </div>
-</section>
-
-<section class="p-strip--light">
-  <div class="row u-vertically-center">
-    <div class="col-7">
-      <h2 id="how-we-use-oval">
-        How we use Ubuntu OVAL
-      </h2>
-      <p>
-        Ubuntu OVAL uses the OVAL vulnerability and patch definitions to enable auditing for Common Vulnerabilities and Exposures (CVEs) and to determine whether a particular patch, via an Ubuntu Security Notice (USN), is appropriate for the local system.
-      </p>
-      <p>
-        Ubuntu OVAL also allows for any third-party Security Content Automation Protocol (SCAP) compliant tools to accurately scan an Ubuntu system or an official Ubuntu cloud image for vulnerabilities.
-      </p>
-      <a class="p-button" href="/security/notices">See the Ubuntu Security Notices</a>
-    </div>
-    <div class="col-5 u-hide--medium u-hide--small u-align--center">
-      {{
-        image(
-        url="https://assets.ubuntu.com/v1/f880a3bd-Enterprise+support.svg",
-        alt="",
-        width="200",
-        height="200",
-        hi_def=True,
-        loading="lazy",
-        ) | safe
-      }}
-    </div>
-  </div>
-</section>
-
-<section class="p-strip is-deep" id="instructions">
-  <div class="u-fixed-width">
-    <h2 id="using-oval-data">
-      Using Ubuntu's OVAL data
-    </h2>
-  </div>
-  <div class="row">
-    <div class="col-8">
-      <ol class="p-stepped-list">
-        <li class="p-stepped-list__item">
-          <h3 class="p-stepped-list__title">
-            Using OpenSCAP
-          </h3>
-          <div class="p-stepped-list__content">
-            <p>
-              Download the compressed XML:
-            </p>
-            <pre><code>wget https://security-metadata.canonical.com/oval/com.ubuntu.$(lsb_release -cs).usn.oval.xml.bz2</code></pre>
-            <p>
-              Uncompress the data:
-            </p>
-            <pre><code>bunzip2 com.ubuntu.$(lsb_release -cs).usn.oval.xml.bz2</code></pre>
-            <p>
-              Use OpenSCAP to evaluate the OVAL and generate an html report:
-            </p>
-            <pre><code>oscap oval eval --report report.html com.ubuntu.$(lsb_release -cs).usn.oval.xml</code></pre>
-            <p>
-              The output is generated in the file report.html, open it using your browser:
-            </p>
-            <pre><code>xdg-open report.html</code></pre>
-            <p>
-              File naming convention:
-            </p>
-            <pre><code>com.ubuntu.&lt;example release name&gt;.usn.oval.xml.bz2</code></pre>
-            </div>
-          </li>
-          <li class="p-stepped-list__item">
-            <h3 class="p-stepped-list__title">
-              Scanning an Official Cloud Image
-            </h3>
-            <div class="p-stepped-list__content">
-              <p>
-                To scan an <a href="https://cloud-images.ubuntu.com">Ubuntu Official Cloud Image</a> for known vulnerabilities, the manifest file and xml data can be used together. Unlike above where we were able to use the <code>lsb_release</code> command, you will need to manually enter the URL for the OVAL data.
-              </p>
-              <p>
-                <i class="p-icon--information">Note:</i> In the example below we are using focal/20.04, you would replace 'focal' with the version you are inspecting.
-              </p>
-              <pre><code>wget https://security-metadata.canonical.com/oval/oci.com.ubuntu.focal.usn.oval.xml.bz2
-bunzip2 oci.com.ubuntu.focal.usn.oval.xml.bz2</code></pre>
-                <p>
-                  Download the manifest file for the image
-                </p>
-                <pre><code>wget -O manifest https://cloud-images.ubuntu.com/releases/focal/release/ubuntu-20.04-server-cloudimg-amd64-root.manifest</code></pre>
-                <p>
-                  Use OpenSCAP to evaluate the OVAL and generate an html report
-                </p>
-                <pre><code>oscap oval eval --report report.html oci.com.ubuntu.focal.usn.oval.xml</code></pre>
-                <p>
-                  The output is generated in the file <code>report.html</code>, open it using your browser
-                </p>
-                <pre><code>xdg-open report.html</code></pre>
-                <p>
-                  File naming convention:
-                </p>
-                <pre><code>oci.com.ubuntu.&lt;example release name&gt;.usn.oval.xml.bz2</code></pre>
-              </div>
-            </li>
-          </ol>
-        </div>
-        <div class="col-4 u-hide--small">
-          {{
-            image(
-            url="https://assets.ubuntu.com/v1/2670bd16-OpenScap-logo.svg",
+    {%- endif -%}
+    {%- if slot =='signpost_image' -%}
+      {{ image(url="https://assets.ubuntu.com/v1/aeb508c5-oval-logo.png",
             alt="",
-            width="210",
-            height="46",
+            width="852",
+            height="333",
             hi_def=True,
-            loading="lazy",
-            ) | safe
-          }}
-        </div>
+            loading="auto") | safe
+      }}
+    {%- endif -%}
+    {%- if slot == 'image' -%}
+      <div class="p-image-container--cinematic is-cover">
+        {{ image(url="https://assets.ubuntu.com/v1/7761320f-hero.png",
+                alt="",
+                width="2464",
+                height="1027",
+                hi_def=True,
+                loading="auto",
+                attrs={"class": "p-image-container__image"}) | safe
+        }}
       </div>
-    </section>
+    {% endif -%}
+  {% endcall -%}
 
-    <section class="p-strip--light">
-      <div class="row">
-        <div class="col-7">
-          <h2 id="oval-data-parameters">
-            Ubuntu OVAL data parameters
-          </h2>
-          <table>
-            <thead>
-              <tr>
-                <th scope="col" style="width: 33%;">
-                  Parameter
-                </th>
-                <th scope="col">
-                  Description
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>
-                  CVE_ID
-                </td>
-                <td>
-                  CVE number as reported by MITRE
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  USN
-                </td>
-                <td>
-                  Corresponding Ubuntu Security Notice
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  Description
-                </td>
-                <td>
-                  A short description of the security risk addressed
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  Severity
-                </td>
-                <td>
-                  CVE or USN severity as defined by the Ubuntu Security team
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  Affected Platform
-                </td>
-                <td>
-                  Affected Ubuntu release(s), incl ESM
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  Title
-                </td>
-                <td>
-                  CVE number, affected Ubuntu release(s), and Severity
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  Public date
-                </td>
-                <td>
-                  The date on which a CVE was publicly announced
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  Public date of USN
-                </td>
-                <td>
-                  The date on which a USN was published
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  Reference
-                </td>
-                <td>
-                  Links to more information about the issue
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  BugReport
-                </td>
-                <td>
-                  Link to bugreport about the issue
-                </td>
-              </tr>
-            </tbody>
-          </table>
+  <section class="p-section">
+    <div class="row--50-50">
+      <hr class="p-rule" />
+      <div class="col">
+        <h2 id="how-we-use-oval">How we use Ubuntu OVAL</h2>
+      </div>
+      <div class="col">
+        <p>
+          Ubuntu OVAL uses the OVAL vulnerability and patch definitions to enable auditing for Common Vulnerabilities and Exposures (CVEs) and to determine whether a particular patch, via an Ubuntu Security Notice (USN), is appropriate for the local system.
+        </p>
+        <p>
+          Ubuntu OVAL also allows for any third-party Security Content Automation Protocol (SCAP) compliant tools to accurately scan an Ubuntu system or an official Ubuntu cloud image for vulnerabilities.
+        </p>
+        <div class="p-cta-block">
           <p>
-            <small>
-              <i class="p-icon--information">Note:</i> The above parameters are included in the OVAL xml file, but not all are shown in the resulting generated OpenSCAP report.
-            </small>
+            <a class="p-button" href="/security/notices">See the Ubuntu Security Notices</a>
           </p>
         </div>
       </div>
-    </section>
+    </div>
+  </section>
 
-    <section class="p-strip">
-      <div class="row">
-        <div class="col-7">
-          <h2 id="how-oval-works">
-            How Ubuntu OVAL data works
-          </h2>
+  <section class="p-section">
+    <div class="u-fixed-width">
+      <hr class="p-rule" />
+      <div class="p-section--shallow">
+        <h2 id="using-oval-data">Using Ubuntu's OVAL data</h2>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-9 col-start-large-4">
+        <hr class="p-rule--muted" />
+      </div>
+    </div>
+    <ol class="p-stepped-list">
+      <li class="p-stepped-list__item">
+        <div class="row">
+          <div class="col-3 col-start-large-4">
+            <h3 class="p-heading--5 p-stepped-list__title">Using OpenSCAP</h3>
+          </div>
+          <div class="col-6 p-stepped-list__content">
+            <p>Download the compressed XML:</p>
+            <pre><code>wget https://security-metadata.canonical.com/oval/com.ubuntu.$(lsb_release -cs).usn.oval.xml.bz2</code></pre>
+            <hr class="p-rule--muted" />
+            <p>Uncompress the data:</p>
+            <pre><code>bunzip2 com.ubuntu.$(lsb_release -cs).usn.oval.xml.bz2</code></pre>
+            <hr class="p-rule--muted" />
+            <p>Use OpenSCAP to evaluate the OVAL and generate an html report:</p>
+            <pre><code>oscap oval eval --report report.html com.ubuntu.$(lsb_release -cs).usn.oval.xml</code></pre>
+            <hr class="p-rule--muted" />
+            <p>
+              The output is generated in the file <code>report.html</code>, open it using your browser:
+            </p>
+            <pre><code>xdg-open report.html</code></pre>
+            <hr class="p-rule--muted" />
+            <p>File naming convention:</p>
+            <pre><code>com.ubuntu.&lt;example release name&gt;.usn.oval.xml.bz2</code></pre>
+          </div>
+        </div>
+      </li>
+      <li class="p-stepped-list__item">
+        <div class="row">
+          <div class="col-9 col-start-large-4">
+            <hr class="p-rule--muted" />
+          </div>
+        </div>
+        <div class="row">
+          <div class="col-3 col-start-large-4">
+            <h3 class="p-heading--5 p-stepped-list__title">Scanning an Official Cloud Image</h3>
+          </div>
+          <div class="col-6 p-stepped-list__content">
+            <p>
+              To scan an <a href="https://cloud-images.ubuntu.com">Ubuntu Official Cloud Image</a> for known vulnerabilities, the manifest file and xml data can be used together. Unlike above where we were able to use the <code>lsb_release</code> command, you will need to manually enter the URL for the OVAL data.
+            </p>
+            <p>In the example below we are using focal/20.04, you would replace 'focal' with the version you are inspecting.</p>
+            <pre><code>wget https://security-metadata.canonical.com/oval/oci.com.ubuntu.focal.usn.oval.xml.bz2<br />bunzip2 oci.com.ubuntu.focal.usn.oval.xml.bz2</code></pre>
+            <hr class="p-rule--muted" />
+            <p>Download the manifest file for the image</p>
+            <pre><code>wget -O manifest https://cloud-images.ubuntu.com/releases/focal/release/ubuntu-20.04-server-cloudimg-amd64-root.manifest</code></pre>
+            <hr class="p-rule--muted" />
+            <p>Use OpenSCAP to evaluate the OVAL and generate an html report</p>
+            <pre><code>oscap oval eval --report report.html oci.com.ubuntu.focal.usn.oval.xml</code></pre>
+            <hr class="p-rule--muted" />
+            <p>
+              The output is generated in the file <code>report.html</code>, open it using your browser
+            </p>
+            <pre><code>xdg-open report.html</code></pre>
+            <hr class="p-rule--muted" />
+            <p>File naming convention:</p>
+            <pre><code>oci.com.ubuntu.&lt;example release name&gt;.usn.oval.xml.bz2</code></pre>
+          </div>
+        </div>
+      </li>
+    </ol>
+  </section>
+
+  <section class="p-section">
+    <div class="u-fixed-width">
+      <hr class="p-rule" />
+      <div class="p-section--shallow">
+        <h2 id="oval-data-parameters">Ubuntu OVAL data parameters</h2>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-9 col-start-large-4">
+        <table>
+          <thead>
+            <tr>
+              <th scope="col" style="width: 33%;">Parameter</th>
+              <th scope="col">Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>CVE_ID</td>
+              <td>CVE number as reported by MITRE</td>
+            </tr>
+            <tr>
+              <td>USN</td>
+              <td>Corresponding Ubuntu Security Notice</td>
+            </tr>
+            <tr>
+              <td>Description</td>
+              <td>A short description of the security risk addressed</td>
+            </tr>
+            <tr>
+              <td>Severity</td>
+              <td>CVE or USN severity as defined by the Ubuntu Security team</td>
+            </tr>
+            <tr>
+              <td>Affected Platform</td>
+              <td>Affected Ubuntu release(s), incl ESM</td>
+            </tr>
+            <tr>
+              <td>Title</td>
+              <td>CVE number, affected Ubuntu release(s), and Severity</td>
+            </tr>
+            <tr>
+              <td>Public date</td>
+              <td>The date on which a CVE was publicly announced</td>
+            </tr>
+            <tr>
+              <td>Public date of USN</td>
+              <td>The date on which a USN was published</td>
+            </tr>
+            <tr>
+              <td>Reference</td>
+              <td>Links to more information about the issue</td>
+            </tr>
+            <tr>
+              <td>BugReport</td>
+              <td>Link to bugreport about the issue</td>
+            </tr>
+            <tr>
+              <td class="u-no-padding--top"></td>
+              <td class="u-no-padding--top">
+                <small class="u-text--muted"><i>
+                  Note: The above parameters are included in the OVAL xml file, but not all are shown in the resulting generated OpenSCAP report.
+                </i></small>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section--deep">
+    <div class="p-section--shallow">
+      <div class="row--50-50">
+        <hr class="p-rule" />
+        <div class="col">
+          <h2 id="how-oval-works">How Ubuntu OVAL data works</h2>
+        </div>
+        <div class="col">
           <p>
             As software vulnerabilities are discovered, they are assigned CVE identifiers by MITRE and other organizations. Canonical triages these CVEs to determine whether the vulnerabilities affect software distributed within Ubuntu. The results of this triage are then used to generate the CVE OVAL. The CVE OVAL can be used to assess the local system for vulnerabilities.
           </p>
@@ -268,19 +229,19 @@ bunzip2 oci.com.ubuntu.focal.usn.oval.xml.bz2</code></pre>
           </p>
         </div>
       </div>
-      <div class="u-fixed-width">
-        {{
-          image(
-          url="https://assets.ubuntu.com/v1/ce2c3422-how-OVAL-data-works-diagram.svg",
-          alt="",
-          width="682",
-          height="290",
-          hi_def=True,
-          loading="lazy",
-
-          ) | safe
+    </div>
+    <div class="u-fixed-width">
+      <div class="p-image-container--cinematic is-cover">
+        {{ image(url="https://assets.ubuntu.com/v1/7761320f-hero.png",
+                alt="",
+                width="2464",
+                height="1027",
+                hi_def=True,
+                loading="lazy",
+                attrs={"class": "p-image-container__image"}) | safe
         }}
       </div>
-    </section>
+    </div>
+  </section>
 
-    {% endblock content %}
+{% endblock content %}

--- a/templates/security/oval.html
+++ b/templates/security/oval.html
@@ -29,7 +29,8 @@
             width="852",
             height="333",
             hi_def=True,
-            loading="auto") | safe
+            loading="auto",
+            attrs={"class": "u-hide--small u-hide--medium"}) | safe
       }}
     {%- endif -%}
     {%- if slot == 'image' -%}

--- a/templates/security/oval.html
+++ b/templates/security/oval.html
@@ -24,13 +24,13 @@
       </p>
     {%- endif -%}
     {%- if slot =='signpost_image' -%}
-      {{ image(url="https://assets.ubuntu.com/v1/aeb508c5-oval-logo.png",
-            alt="",
-            width="852",
-            height="333",
-            hi_def=True,
-            loading="auto",
-            attrs={"class": "u-hide--small u-hide--medium"}) | safe
+        {{ image(url="https://assets.ubuntu.com/v1/97cb005e-oval-logo.png",
+                alt="",
+                width="858",
+                height="333",
+                hi_def=True,
+                loading="auto",
+                attrs={"class": "u-hide--small u-hide--medium"}) | safe
       }}
     {%- endif -%}
     {%- if slot == 'image' -%}
@@ -60,10 +60,8 @@
         <p>
           Ubuntu OVAL also allows for any third-party Security Content Automation Protocol (SCAP) compliant tools to accurately scan an Ubuntu system or an official Ubuntu cloud image for vulnerabilities.
         </p>
-        <div class="p-cta-block">
-          <p>
-            <a class="p-button" href="/security/notices">See the Ubuntu Security Notices</a>
-          </p>
+        <div class="p-cta-block">          
+          <a class="p-button" href="/security/notices">See the Ubuntu Security Notices</a>
         </div>
       </div>
     </div>
@@ -115,7 +113,7 @@
         </div>
         <div class="row">
           <div class="col-3 col-start-large-4">
-            <h3 class="p-heading--5 p-stepped-list__title">Scanning an Official Cloud Image</h3>
+            <h3 class="p-heading--5 p-stepped-list__title">Scanning an <br class="u-hide--medium u-hide--small" />Official Cloud Image</h3>
           </div>
           <div class="col-6 p-stepped-list__content">
             <p>
@@ -201,8 +199,8 @@
               <td>Link to bugreport about the issue</td>
             </tr>
             <tr>
-              <td class="u-no-padding--top"></td>
-              <td class="u-no-padding--top">
+              <td></td>
+              <td>
                 <small class="u-text--muted"><i>
                   Note: The above parameters are included in the OVAL xml file, but not all are shown in the resulting generated OpenSCAP report.
                 </i></small>
@@ -232,14 +230,14 @@
       </div>
     </div>
     <div class="u-fixed-width">
-      <div class="p-image-container--cinematic is-cover">
-        {{ image(url="https://assets.ubuntu.com/v1/7761320f-hero.png",
-                alt="",
-                width="2464",
-                height="1027",
-                hi_def=True,
-                loading="lazy",
-                attrs={"class": "p-image-container__image"}) | safe
+      <div class="p-image-container--cinematic is-highlighted">
+        {{ image(url="https://assets.ubuntu.com/v1/4745474d-how-ubuntu-oval.png",
+                    alt="",
+                    width="3696",
+                    height="1541",
+                    hi_def=True,
+                    loading="lazy",
+                    attrs={"class": "p-image-container__image"}) | safe
         }}
       </div>
     </div>

--- a/templates/security/oval.html
+++ b/templates/security/oval.html
@@ -25,7 +25,7 @@
     {%- endif -%}
     {%- if slot =='signpost_image' -%}
         {{ image(url="https://assets.ubuntu.com/v1/97cb005e-oval-logo.png",
-                alt="",
+                alt="Oval logo",
                 width="858",
                 height="333",
                 hi_def=True,


### PR DESCRIPTION
## Done

- Rebrand /security/oval based on [Design](https://www.figma.com/design/pc4AcZqcXvWJqrm4t1x1y6/ubuntu.com%2Fsecurity?node-id=722-22966&m=dev), no changes in copy doc
- Drive-by: Update /security/docker-images to use `p-cta-block` classes where necessary
- Note: Waiting for chart placeholder from design

## QA

- Go to https://ubuntu-com-14734.demos.haus/security/oval
- Check that design matches Figma

## Issue / Card

Fixes [WD-12041](https://warthogs.atlassian.net/browse/WD-12041)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-12041]: https://warthogs.atlassian.net/browse/WD-12041?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ