### PR TITLE
K8s docs update landing page update with link to Canonical Kubernetes

### DIFF
--- a/templates/kubernetes/docs/index.md
+++ b/templates/kubernetes/docs/index.md
@@ -1,15 +1,10 @@
 ---
-wrapper_template: "base-docs.html"
+wrapper_template: "templates/docs/markdown.html"
 markdown_includes:
-  nav: "shared/_side-navigation.md"
+  nav: "kubernetes/docs/shared/_side-navigation.md"
 context:
-  title: "Charmed Kubernetes documentation"
-  description: Documentation for the Canonical Distribution of Kubernetes.
-keywords: homepage
-tags: [getting_started]
-sidebar: k8smain-sidebar
-permalink: index.html
-layout: base_noedit
+  title: "Kubernetes documentation"
+  description: Documentation for Charmed Kubernetes.
 toc: False
 ---
 

--- a/templates/kubernetes/docs/index.md
+++ b/templates/kubernetes/docs/index.md
@@ -1,23 +1,35 @@
 ---
-wrapper_template: "templates/docs/markdown.html"
+wrapper_template: "base-docs.html"
 markdown_includes:
-  nav: "kubernetes/docs/shared/_side-navigation.md"
+  nav: "shared/_side-navigation.md"
 context:
-  title: "Kubernetes documentation"
-  description: Documentation for Charmed Kubernetes.
+  title: "Charmed Kubernetes documentation"
+  description: Documentation for the Canonical Distribution of Kubernetes.
+keywords: homepage
+tags: [getting_started]
+sidebar: k8smain-sidebar
+permalink: index.html
+layout: base_noedit
 toc: False
 ---
 
-Charmed Kubernetes<sup>&reg;</sup>, is pure Kubernetes tested across the widest range of clouds with modern metrics and
- monitoring, brought to you by the people who deliver Ubuntu.
+## Canonical Kubernetes
 
-Google, Microsoft, and many other institutions run Kubernetes on Ubuntu because we focus on the latest container 
-capabilities in modern kernels. That’s why it’s the top choice for enterprise Kubernetes, too.
+We've just announced a 12-year support commitment for Canonical Kubernetes! It offers hassle-free maintenance, single-line installation process, and more control over your upgrade cadence.
 
-[Find out more in the Charmed Kubernetes overview&nbsp;&rsaquo;](/kubernetes/docs/overview)
+[Read the Canonical Kubernetes 12-year LTS announcement >](https://canonical.com/blog/12-year-lts-for-kubernetes)
 
-<img src="https://assets.ubuntu.com/v1/843c77b6-juju-at-a-glace.svg" style="float:right; margin-left: 2rem; border: 0
-" alt="">
+[Go to Canonical Kubernetes documentation >](https://documentation.ubuntu.com/canonical-kubernetes)
+
+---
+
+Charmed Kubernetes<sup>&reg;</sup>, is pure Kubernetes tested across the widest range of clouds with modern metrics and monitoring, brought to you by the people who deliver Ubuntu.
+
+Google, Microsoft, and many other institutions run Kubernetes on Ubuntu because we focus on the latest container capabilities in modern kernels. That’s why it’s the top choice for enterprise Kubernetes, too.
+
+[Find out more in the Charmed Kubernetes overview&nbsp;&rsaquo;](../overview)
+
+<img src="https://assets.ubuntu.com/v1/843c77b6-juju-at-a-glace.svg" style="float:right; margin-left: 2rem; border: 0" alt="">
 
 ## In this documentation
 
@@ -53,3 +65,5 @@ Charmed Kubernetes is a member of the Ubuntu family. It's an open source project
 * [Join the Discourse forum](https://discuss.kubernetes.io/)
 * [Contribute to our documentation](https://github.com/charmed-kubernetes/kubernetes-docs)
 * [Source code and project management](https://github.com/charmed-kubernetes)
+
+


### PR DESCRIPTION
## Done

- Add links to Canonical Kubernetes on the landing page for Charmed Kubernetes

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]
