### PR TITLE
Specify selected medium CVEs on esm page

### DIFF
--- a/templates/security/esm.html
+++ b/templates/security/esm.html
@@ -28,7 +28,7 @@
         </div>
         <div class="col-6">
           <p>Security maintenance for the entire collection of software packages shipped with Ubuntu.</p>
-          <p>ESM enables continuous vulnerability management for critical, high and medium CVEs.</p>
+          <p>ESM enables continuous vulnerability management for critical, high and selected medium CVEs.</p>
           <a href="/security/esm#get-in-touch"
              class="p-button--positive js-invoke-modal">Contact us</a>
         </div>


### PR DESCRIPTION
## Done

- Coverage for esm includes only selected medium CVEs, rather than all. The current phrasing is misleading and implies medium coverage is consistent with High/Critical CVEs. This update brings the esm page into consistency with other references to CVE coverage ( including on this same page)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
