### PR TITLE
Update Ubuntu release chart 

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -43,12 +43,12 @@ export var serverAndDesktopReleases = [
   },
   {
     startDate: new Date("2018-04-01T00:00:00"),
-    endDate: new Date("2023-04-02T00:00:00"),
+    endDate: new Date("2023-05-02T00:00:00"),
     taskName: "18.04 LTS (Bionic Beaver)",
     status: "HARDWARE_AND_MAINTENANCE_UPDATES",
   },
   {
-    startDate: new Date("2023-04-02T00:00:00"),
+    startDate: new Date("2023-05-02T00:00:00"),
     endDate: new Date("2028-04-01T00:00:00"),
     taskName: "18.04 LTS (Bionic Beaver)",
     status: "ESM",
@@ -67,12 +67,12 @@ export var serverAndDesktopReleases = [
   },
   {
     startDate: new Date("2020-04-01T00:00:00"),
-    endDate: new Date("2025-04-02T00:00:00"),
+    endDate: new Date("2025-05-02T00:00:00"),
     taskName: "20.04 LTS (Focal Fossa)",
     status: "HARDWARE_AND_MAINTENANCE_UPDATES",
   },
   {
-    startDate: new Date("2025-04-02T00:00:00"),
+    startDate: new Date("2025-05-02T00:00:00"),
     endDate: new Date("2030-04-02T00:00:00"),
     taskName: "20.04 LTS (Focal Fossa)",
     status: "ESM",

--- a/templates/about/release_cycles/releases-table.html
+++ b/templates/about/release_cycles/releases-table.html
@@ -32,14 +32,14 @@
         <tr>
             <td colspan="2"><strong>20.04 LTS (Focal Fossa)</strong></td>
             <td>Apr 2020</td>
-            <td>Apr 2025</td>
+            <td>May 2025</td>
             <td>Apr 2030</td>
             <td>Apr 2032</td>
         </tr>
         <tr>
             <td colspan="2"><strong>18.04 LTS (Bionic Beaver)</strong></td>
             <td>Apr 2018</td>
-            <td>Apr 2023</td>
+            <td>May 2023</td>
             <td>Apr 2028</td>
             <td>Apr 2030</td>
         </tr>


### PR DESCRIPTION
## Done

- Updated "end of support" dates for 18.04 and 20.04 as per [sheet](https://docs.google.com/spreadsheets/d/1KIuOAa620yseE0uhIl67u2SlS0bWlPI_d98bvYM2Yl8/edit?disco=AAABeA61apo) 

## QA

- View the site locally in your web browser at: https://ubuntu-com-14738.demos.haus/about/release-cycle#ubuntu
- See that the chart and table have been updated 

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-19280

## Screenshots

![image](https://github.com/user-attachments/assets/934eaa34-2d3d-4630-ade4-bbffc17bd757)
