### PR TITLE
feat: Add multiple filters functionality on engage pages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ canonicalwebteam.blog==6.4.4
 canonicalwebteam.search==2.1.1
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.5.0
-canonicalwebteam.discourse==5.7.3
+-e ../discourse
 python-dateutil==2.8.2
 pytz==2022.7.1
 maxminddb-geolite2==2018.703

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ canonicalwebteam.blog==6.4.4
 canonicalwebteam.search==2.1.1
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.5.0
--e ../discourse
+canonicalwebteam.discourse==5.8.1
 python-dateutil==2.8.2
 pytz==2022.7.1
 maxminddb-geolite2==2018.703

--- a/templates/engage/_article-card.html
+++ b/templates/engage/_article-card.html
@@ -1,16 +1,20 @@
 <article class="col-4 blog-p-card--post">
   <header class="blog-p-card__header{% if 'whitepaper' in type %}--internet-of-things{% elif 'webinar' in type %}--desktop{% elif 'case study' in type %}--cloud-and-server{% endif %}">
     <h5 class="p-muted-heading u-no-margin--bottom">
-      {{type}}
+      {% if type %}
+        {{ type }}
+      {% else %}
+        Post
+      {% endif %}
     </h5>
   </header>
   <div class="blog-p-card__content">
     <h4>
-      <a href="{% if active == 'false' and preview != None %}{{title_link}}?preview{% else %}{{title_link}}{% endif %}">{{title | safe}}</a>
+      <a href="{% if active == 'false' and preview != None %}{{ title_link }}?preview{% else %}{{ title_link }}{% endif %}">{{ title | safe }}</a>
     </h4>
-    <p class="u-no-padding--bottom u-hide--small">{{description | safe}}</p>
+    <p class="u-no-padding--bottom u-hide--small">{{ description | safe }}</p>
   </div>
   <footer class="blog-p-card__footer">
-    {{tags}}
+    {{ tags }}
   </footer>
 </article>

--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -143,10 +143,6 @@ function clearFilters() {
   setFiltersDropdown("tag", tagSelector);  
 
   function setFilters(key, selector) {
-    //if (urlObj.searchParams.has(key)) {
-    //  selector.value = urlObj.searchParams.get(key);
-    //}
-    
     if (selector.value != "all") {
       urlObj.searchParams.set(key, selector.value);
     } else {
@@ -161,6 +157,7 @@ function clearFilters() {
     setFilters("resource", resourceSelector);
     setFilters("tag", tagSelector);
 
+    urlObj.searchParams.delete("page");
     window.location = urlObj.href;
 }
   applyFiltersButton.addEventListener("click", applyFilters);

--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -126,21 +126,6 @@ function clearFilters() {
     clearFiltersButton.removeAttribute("disabled");
   }
 
-  // Disable other fields if a filter is already applied
-  const searchParams = new URLSearchParams(urlObj.search);
-  for (const [key, value] of searchParams) {
-    if (key === "language") {
-      resourceSelector.setAttribute("disabled", true);
-      tagSelector.setAttribute("disabled", true);
-    } else if (key === "resource") {
-      languageSelector.setAttribute("disabled", true);
-      tagSelector.setAttribute("disabled", true);
-    } else if (key === "tag") {
-      languageSelector.setAttribute("disabled", true);
-      resourceSelector.setAttribute("disabled", true);
-    }
-  } 
-
   function handleFilter(key, el, url) {
     if (!el) {
       return;
@@ -152,14 +137,11 @@ function clearFilters() {
 
     el.addEventListener("change", function(e) {
       const value = e.target.value;
-      const selectFields = document.querySelectorAll("select:checked")
-
-      // Reset filters, data explorer query can't search multiple fields
-      // at the same time
-      url.search = "";
 
       if (value !== "all") {
-        url.searchParams.append(key, value);
+        url.searchParams.set(key, value);
+      } else {
+        url.searchParams.delete(key);
       }
       window.location = url;
     });

--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -29,7 +29,7 @@
     <div class="col-3">
       <div class="p-form__group">
         <label for="language-selector">Select language:</label>
-        <select name="language-selector" id="language-selector" class="u-no-margin--bottom">
+        <select name="language-selector" class="js-language-selector u-no-margin--bottom">
           <option value="all">All languages</option>
           <option value="zh-TW">Chinese (Traditional)</option>
           <option value="de">Deutsch</option>
@@ -47,7 +47,7 @@
     <div class="col-3">
       <div class="p-form__group">
         <label for="resource-selector">Select resource type:</label>
-        <select name="resource-selector" id="resource-selector" class="u-no-margin--bottom">
+        <select name="resource-selector" class="js-resource-selector u-no-margin--bottom">
           <option value="all">All resource types</option>
           {% for type in resource_types %}
             <option value="{{ type | lower }}">{{ type }}</option>
@@ -60,10 +60,10 @@
     <div class="col-3">
       <div class="p-form__group">
         <label for="tag-selector">Select tag:</label>
-        <select name="tag-selector" id="tag-selector" class="u-no-margin--bottom">
+        <select name="tag-selector" class="js-tag-selector u-no-margin--bottom">
           <option value="all">All tags</option>
           {% for tag in tags %}
-            <option value="{{ tag }}">{{ tag }}</option>
+            <option {% if tag == "" %}disabled{% endif %} value="{{ tag }}">{% if tag == "" %}-{% else %}{{ tag }}{% endif %}</option>
           {% endfor %}
         </select>
       </div>
@@ -73,8 +73,8 @@
       <div class="u-hide u-show--small" >
         <br /><br />
       </div>
-      <button id="apply-filters" class="p-button--positive u-no-margin--bottom" onclick="applyFilters()">Apply filters</button>
-      <button id="clear-filters" class="u-no-margin--bottom" onclick="clearFilters()" type="reset" disabled>Clear filters</button>
+      <button class="js-apply-filters p-button--positive u-no-margin--bottom">Apply filters</button>
+      <button class="js-clear-filters u-no-margin--bottom" onclick="clearFilters()" type="reset" disabled>Clear filters</button>
     </div>
   </div>
   </form>
@@ -113,16 +113,16 @@
 </section>
 <script>
 function clearFilters() {
-  const clearFiltersButton = document.getElementById("clear-filters");
+  const clearFiltersButton = document.querySelector(".js-clear-filters");
   window.location.assign("/engage");
 }
 (function() {
-  const languageSelector = document.getElementById("language-selector");
-  const resourceSelector = document.getElementById("resource-selector");
-  const tagSelector = document.getElementById("tag-selector");
+  const languageSelector = document.querySelector(".js-language-selector");
+  const resourceSelector = document.querySelector(".js-resource-selector");
+  const tagSelector = document.querySelector(".js-tag-selector");
 
-  const applyFiltersButton = document.getElementById("apply-filters");
-  const clearFiltersButton = document.getElementById("clear-filters");
+  const applyFiltersButton = document.querySelector(".js-apply-filters");
+  const clearFiltersButton = document.querySelector(".js-clear-filters");
   const urlObj = new URL(window.location);
 
   if (urlObj.search !== "") {

--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -73,6 +73,7 @@
       <div class="u-hide u-show--small" >
         <br /><br />
       </div>
+      <button id="apply-filters" class="p-button--positive u-no-margin--bottom" onclick="applyFilters()">Apply filters</button>
       <button id="clear-filters" class="u-no-margin--bottom" onclick="clearFilters()" type="reset" disabled>Clear filters</button>
     </div>
   </div>
@@ -119,6 +120,8 @@ function clearFilters() {
   const languageSelector = document.getElementById("language-selector");
   const resourceSelector = document.getElementById("resource-selector");
   const tagSelector = document.getElementById("tag-selector");
+
+  const applyFiltersButton = document.getElementById("apply-filters");
   const clearFiltersButton = document.getElementById("clear-filters");
   const urlObj = new URL(window.location);
 
@@ -126,30 +129,41 @@ function clearFilters() {
     clearFiltersButton.removeAttribute("disabled");
   }
 
-  function handleFilter(key, el, url) {
-    if (!el) {
+  function setFiltersDropdown(key, selector) {
+    if (!selector) {
       return;
     }
-
-    if (url.searchParams.has(key)) {
-      el.value = url.searchParams.get(key);
+    if (urlObj.searchParams.has(key)) {
+      selector.value = urlObj.searchParams.get(key);
     }
-
-    el.addEventListener("change", function(e) {
-      const value = e.target.value;
-
-      if (value !== "all") {
-        url.searchParams.set(key, value);
-      } else {
-        url.searchParams.delete(key);
-      }
-      window.location = url;
-    });
   }
 
-  handleFilter("language", languageSelector, urlObj);
-  handleFilter("resource", resourceSelector, urlObj);
-  handleFilter("tag", tagSelector, urlObj);
+  setFiltersDropdown("language", languageSelector);
+  setFiltersDropdown("resource", resourceSelector);
+  setFiltersDropdown("tag", tagSelector);  
+
+  function setFilters(key, selector) {
+    //if (urlObj.searchParams.has(key)) {
+    //  selector.value = urlObj.searchParams.get(key);
+    //}
+    
+    if (selector.value != "all") {
+      urlObj.searchParams.set(key, selector.value);
+    } else {
+      urlObj.searchParams.delete(key);
+    }
+  }
+
+  function applyFilters(event) {
+    event.preventDefault();
+
+    setFilters("language", languageSelector);
+    setFilters("resource", resourceSelector);
+    setFilters("tag", tagSelector);
+
+    window.location = urlObj.href;
+}
+  applyFiltersButton.addEventListener("click", applyFilters);
 })()
 </script>
 {% endblock content %}

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -334,30 +334,21 @@ def build_engage_index(engage_docs):
         tag = flask.request.args.get("tag", default=None, type=str)
         limit = 20  # adjust as needed
         offset = (page - 1) * limit
-        if resource:
+
+        if tag or resource or language:
             (
                 metadata,
                 count,
                 active_count,
                 current_total,
             ) = engage_docs.get_index(
-                limit, offset, key="type", value=resource
-            )
-        elif tag:
-            (
-                metadata,
-                count,
-                active_count,
-                current_total,
-            ) = engage_docs.get_index(limit, offset, key="tag", value=tag)
-        elif language:
-            (
-                metadata,
-                count,
-                active_count,
-                current_total,
-            ) = engage_docs.get_index(
-                limit, offset, key="language", value=language
+                limit,
+                offset,
+                tag_value=tag,
+                key="type",
+                value=resource,
+                second_key="language",
+                second_value=language,
             )
         else:
             (

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -332,7 +332,7 @@ def build_engage_index(engage_docs):
         language = flask.request.args.get("language", default=None, type=str)
         resource = flask.request.args.get("resource", default=None, type=str)
         tag = flask.request.args.get("tag", default=None, type=str)
-        limit = 20  # adjust as needed
+        limit = 21  # adjust as needed
         offset = (page - 1) * limit
 
         if tag or resource or language:


### PR DESCRIPTION
## Done

- Add multiple filters functionality on engage page index
- Users can now search up to three filters simultaneously. Previously this was set at one

## QA

- Go to https://ubuntu-com-14740.demos.haus/engage
- Select one filter from the dropdown
- See that page loads, select another filter. 
- Repeat and see that page loads according to selected filters.

## Issue / Card

Fixes [WD-16129](https://warthogs.atlassian.net/browse/WD-16129)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-16129]: https://warthogs.atlassian.net/browse/WD-16129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ