### PR TITLE
feat: Remove 'Charmed Kubernetes' from the /kubernetes secondary-nav

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -222,8 +222,6 @@ kubernetes:
       path: /kubernetes
     - title: What is Kubernetes
       path: /kubernetes/what-is-kubernetes
-    - title: Charmed Kubernetes
-      path: /kubernetes/charmed-k8s
     - title: Managed
       path: /kubernetes/managed
     - title: Install


### PR DESCRIPTION
## Done

- Remove 'Charmed Kubernetes' from the /kubernetes secondary-nav

## QA

- Go to /kubernetes
- See the is no 'Charmed Kubernetes' in the secondary nav

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-19220
