### PR TITLE
fix: users blocked from accessing exams

### DIFF
--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -138,6 +138,7 @@ CSP = {
         "cdn.livechat-static.com",
         "*.cloudfront.net",
         "app3.trueability.com",
+        "app.trueability.com",
     ],
     "style-src": [
         "*.cloudfront.net",


### PR DESCRIPTION
## Done

- add "app.trueability.com" to whitelist for frame sources which are allowed to embed

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Buy and take an exam, it should work fine

## Issue / Card

Fixes [WD-19189](https://warthogs.atlassian.net/browse/WD-19189)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-19189]: https://warthogs.atlassian.net/browse/WD-19189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ