### PR TITLE
Commented the pagination for CVEs

### DIFF
--- a/static/sass/_pattern_cve.scss
+++ b/static/sass/_pattern_cve.scss
@@ -101,7 +101,6 @@
     .p-form__control {
       max-width: fit-content;
       min-width: 0;
-      padding-right: 1rem;
     }
   }
 

--- a/templates/security/cves/_pagination.html
+++ b/templates/security/cves/_pagination.html
@@ -121,10 +121,11 @@
                 id="limit-set">
           <option value="10">10</option>
           <option value="20">20</option>
-          <option value="40">40</option>
+          <!-- Currently we get errors for any values greater than 20 -->
+          <!-- <option value="40">40</option>
           <option value="60">60</option>
           <option value="80">80</option>
-          <option value="100">100</option>
+          <option value="100">100</option> -->
         </select>
       </div>
     </div>


### PR DESCRIPTION
## Done

- Commented out the options to get more than 20 notices on a single page since that is not supported by api yet.

## Info
- We will check if it possible to get 20+ results on singel page and update it accordingly.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Please visit demo(https://ubuntu-com-14747.demos.haus/security/cves?q=) and see at the bottom for "Results per page" and it should show only 2 options for 10 and 20.

## Issue / Card

Fixes  # [WD- 19371](https://warthogs.atlassian.net/issues/WD-19371)
#14746 

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
