### PR TITLE
fix(/contact-us/newsletter-opt-in): Add appropriate returnURL

### DIFF
--- a/templates/contact-us/newsletter-opt-in.html
+++ b/templates/contact-us/newsletter-opt-in.html
@@ -3,6 +3,7 @@
 {% block title %}Newsletter signup{% endblock %}
 
 {% block meta_copydoc %}
+https://docs.google.com/document/d/12BqHqrbgCwYEllFeR9yTd07cWojwz22Ao6dteHV98tI/edit?tab=t.0
 {% endblock meta_copydoc %}
 
 {% block content %}
@@ -79,7 +80,7 @@
                aria-hidden="true"
                aria-label="hidden field"
                name="returnURL"
-               value="%% returnURL %%" />
+               value="/contact-us/newsletter-opt-in#newsletter-signup" />
         <input type="hidden"
                aria-hidden="true"
                aria-label="hidden field"


### PR DESCRIPTION
## Done

- Add appropriate returnURL to /contact-us/newsletter-opt-in so it doesn't fail

## QA

- Go to https://ubuntu-com-14749.demos.haus/contact-us/newsletter-opt-in
- Fill in the form and submit
- See it succeeds and redirects back the the sign-up page

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-19388