### PR TITLE
WD-19441 exclude non-english language tags from blogs

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1237,6 +1237,7 @@ def render_blogs():
         api=BlogAPI(
             session=session, thumbnail_width=555, thumbnail_height=311
         ),
+        excluded_tags=[3184, 3265, 3408, 3960, 4491, 3599],
         tag_ids=[4307],
         per_page=3,
         blog_title="HPE blogs",
@@ -1259,6 +1260,7 @@ def render_public_cloud_blogs():
         api=BlogAPI(
             session=session, thumbnail_width=1000, thumbnail_height=700
         ),
+        excluded_tags=[3184, 3265, 3408, 3960, 4491, 3599],
         tag_ids=[1205, 1350, 1748, 4191, 4478, 4540, 4387],
         per_page=3,
         blog_title="Public-cloud blogs",
@@ -1280,6 +1282,7 @@ def render_supermicro_blogs():
             session=session, thumbnail_width=555, thumbnail_height=311
         ),
         tag_ids=[2247],
+        excluded_tags=[3184, 3265, 3408, 3960, 4491, 3599],
         per_page=3,
         blog_title="Supermicro blogs",
     )


### PR DESCRIPTION
## Done

- Excluded non-english language tags from blogs
## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [Demo](https://ubuntu-com-14761.demos.haus/cloud/public-cloud)
- Check that we only see english blogs on page such as [/cloud/public-cloud](https://ubuntu-com-14761.demos.haus/cloud/public-cloud) ,  [/hpe](https://ubuntu-com-14761.demos.haus/hpe), [/supermicro](https://ubuntu-com-14761.demos.haus/supermicro)

## Issue / Card

Fixes # [WD-19441](https://warthogs.atlassian.net/browse/WD-19441)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-19441]: https://warthogs.atlassian.net/browse/WD-19441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ