### PR TITLE
WD-19462 Added turkish language support for engage forms

### DIFF
--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -1,181 +1,167 @@
 {% set hide_nav = False %}
-
 {% extends "engage/base_engage.html" %}
 
 {% block title %}Ubuntu case studies, whitepapers and webinars{% endblock %}
 
 {% block meta_description %}Resources from across Ubuntu and Canonical combined into a single portal{% endblock %}
 
-{% block meta_copydoc %}
-  https://docs.google.com/spreadsheets/d/1UdExqv3PMnejaCISed340IehIhUmpKL-0AK5kumFk2M/edit#gid=0
-{% endblock meta_copydoc %}
+{% block meta_copydoc %}https://docs.google.com/spreadsheets/d/1UdExqv3PMnejaCISed340IehIhUmpKL-0AK5kumFk2M/edit#gid=0{% endblock meta_copydoc %}
 
 {% block head_extra %}
-  {% if preview != None %}<meta name="robots" content="noindex" />{% endif %}
+  {% if preview != None %}
+    <meta name="robots" content="noindex" />
+  {% endif %}
 {% endblock %}
 
 {% block content %}
-  <section class="p-strip--suru-blog-header is-dark">
-    <div class="row">
-      <div class="col-6">
-        <h1>Engage pages</h1>
-        <p>Ubuntu case studies, whitepapers and webinars.</p>
+<section class="p-strip--suru-blog-header is-dark">
+  <div class="row">
+    <div class="col-6">
+      <h1>Engage pages</h1>
+      <p>Ubuntu case studies, whitepapers and webinars.</p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-shallow">
+  <form action="/">
+  <div class="row">
+    <div class="col-3">
+      <div class="p-form__group">
+        <label for="language-selector">Select language:</label>
+        <select name="language-selector" class="js-language-selector u-no-margin--bottom">
+          <option value="all">All languages</option>
+          <option value="zh-TW">Chinese (Traditional)</option>
+          <option value="de">Deutsch</option>
+          <option value="en">English</option>
+          <option value="es">Espa&ntilde;ol</option>
+          <option value="fr">Fran&ccedil;ais</option>
+          <option value="it">Italiano</option>
+          <option value="kr">Korean</option>
+          <option value="pt">Portugu&ecirc;s</option>
+          <option value="ru">Русс&#1082;&#1080;&#1081;</option>
+          <option value="tr">T&uuml;rk&ccedil;e</option>
+        </select>
       </div>
     </div>
-  </section>
-
-  <section class="p-strip is-shallow">
-    <form action="/">
-      <div class="row">
-        <div class="col-3">
-          <div class="p-form__group">
-            <label for="language-selector">Select language:</label>
-            <select name="language-selector"
-                    class="js-language-selector u-no-margin--bottom">
-              <option value="all">All languages</option>
-              <option value="zh-TW">Chinese (Traditional)</option>
-              <option value="de">Deutsch</option>
-              <option value="en">English</option>
-              <option value="es">Espa&ntilde;ol</option>
-              <option value="fr">Fran&ccedil;ais</option>
-              <option value="it">Italiano</option>
-              <option value="kr">Korean</option>
-              <option value="pt">Portugu&ecirc;s</option>
-              <option value="ru">Русс&#1082;&#1080;&#1081;</option>
-              <option value="tr">T&uuml;rk&ccedil;e</option>
-            </select>
-          </div>
-        </div>
-        {% if resource_types %}
-          <div class="col-3">
-            <div class="p-form__group">
-              <label for="resource-selector">Select resource type:</label>
-              <select name="resource-selector"
-                      class="js-resource-selector u-no-margin--bottom">
-                <option value="all">All resource types</option>
-                {% for type in resource_types %}<option value="{{ type | lower }}">{{ type }}</option>{% endfor %}
-              </select>
-            </div>
-          </div>
-        {% endif %}
-        {% if tags %}
-          <div class="col-3">
-            <div class="p-form__group">
-              <label for="tag-selector">Select tag:</label>
-              <select name="tag-selector" class="js-tag-selector u-no-margin--bottom">
-                <option value="all">All tags</option>
-                {% for tag in tags %}
-                  <option {% if tag == "" %}disabled{% endif %} value="{{ tag }}">
-                    {% if tag == "" %}
-                      -
-                    {% else %}
-                      {{ tag }}
-                    {% endif %}
-                  </option>
-                {% endfor %}
-              </select>
-            </div>
-          </div>
-        {% endif %}
-        <div class="col-3"
-             style="display: flex;
-                    align-items: flex-end;
-                    justify-content: flex-end">
-          <div class="u-hide u-show--small">
-            <br />
-            <br />
-          </div>
-          <button class="js-apply-filters p-button--positive u-no-margin--bottom">Apply filters</button>
-          <button class="js-clear-filters u-no-margin--bottom"
-                  onclick="clearFilters()"
-                  type="reset"
-                  disabled>Clear filters</button>
-        </div>
+    {% if resource_types %}
+    <div class="col-3">
+      <div class="p-form__group">
+        <label for="resource-selector">Select resource type:</label>
+        <select name="resource-selector" class="js-resource-selector u-no-margin--bottom">
+          <option value="all">All resource types</option>
+          {% for type in resource_types %}
+            <option value="{{ type | lower }}">{{ type }}</option>
+          {% endfor %}
+        </select>
       </div>
-    </form>
-  </section>
-
-  <section class="p-strip is-shallow" id="posts-list">
-    {% if metadata | length > 0 %}
-      <div class="row u-equal-height">
-        {% for item in metadata %}
-          {% with
-            title=item.topic_name,
-            title_link=item.path,
-            description=item.subtitle,
-            type=item.type,
-            preview=preview,
-            active=item.active,
-            tags=item.tags
-            %}
-            {% include "engage/_article-card.html" %}
-          {% endwith %}
-        {% endfor %}
-      </div>
-      <section class="p-strip is-shallow">
-        {% with %}
-          {% set total_pages = total_pages %}
-          {% set current_page = current_page %}
-          {% include "shared/_pagination.html" %}
-        {% endwith %}
-      </section>
-    {% else %}
-      <div class="u-fixed-width">
-        <h3>No results &mdash; why not try widening your search?</h3>
-        <p>You can do this by clearing and selecting new filters.</p>
-      </div>
+    </div>
     {% endif %}
+    {% if tags %}
+    <div class="col-3">
+      <div class="p-form__group">
+        <label for="tag-selector">Select tag:</label>
+        <select name="tag-selector" class="js-tag-selector u-no-margin--bottom">
+          <option value="all">All tags</option>
+          {% for tag in tags %}
+            <option {% if tag == "" %}disabled{% endif %} value="{{ tag }}">{% if tag == "" %}-{% else %}{{ tag }}{% endif %}</option>
+          {% endfor %}
+        </select>
+      </div>
+    </div>
+    {% endif %}
+    <div class="col-3" style="display: flex; align-items: flex-end; justify-content: flex-end;">
+      <div class="u-hide u-show--small" >
+        <br /><br />
+      </div>
+      <button class="js-apply-filters p-button--positive u-no-margin--bottom">Apply filters</button>
+      <button class="js-clear-filters u-no-margin--bottom" onclick="clearFilters()" type="reset" disabled>Clear filters</button>
+    </div>
+  </div>
+  </form>
+</section>
+
+<section class="p-strip is-shallow" id="posts-list">
+  {% if metadata | length > 0 %}
+  <div class="row u-equal-height">
+    {% for item in metadata %}
+      {% with
+        title=item.topic_name,
+        title_link=item.path,
+        description=item.subtitle,
+        type=item.type,
+        preview=preview,
+        active=item.active,
+        tags=item.tags
+      %}
+      {% include "engage/_article-card.html" %}
+      {% endwith %}
+    {% endfor %}
+  </div>
+  <section class="p-strip is-shallow">
+    {% with %}
+      {% set total_pages = total_pages %}
+      {% set current_page = current_page %}
+      {% include "shared/_pagination.html" %}
+    {% endwith %}
   </section>
-  <script>
-    function clearFilters() {
-      const clearFiltersButton = document.querySelector(".js-clear-filters");
-      window.location.assign("/engage");
+  {% else %}
+  <div class="u-fixed-width">
+    <h3>No results &mdash; why not try widening your search?</h3>
+    <p>You can do this by clearing and selecting new filters.</p>
+  </div>
+  {% endif %}
+</section>
+<script>
+function clearFilters() {
+  const clearFiltersButton = document.querySelector(".js-clear-filters");
+  window.location.assign("/engage");
+}
+(function() {
+  const languageSelector = document.querySelector(".js-language-selector");
+  const resourceSelector = document.querySelector(".js-resource-selector");
+  const tagSelector = document.querySelector(".js-tag-selector");
+
+  const applyFiltersButton = document.querySelector(".js-apply-filters");
+  const clearFiltersButton = document.querySelector(".js-clear-filters");
+  const urlObj = new URL(window.location);
+
+  if (urlObj.search !== "") {
+    clearFiltersButton.removeAttribute("disabled");
+  }
+
+  function setFiltersDropdown(key, selector) {
+    if (!selector) {
+      return;
     }
-    (function() {
-      const languageSelector = document.querySelector(".js-language-selector");
-      const resourceSelector = document.querySelector(".js-resource-selector");
-      const tagSelector = document.querySelector(".js-tag-selector");
+    if (urlObj.searchParams.has(key)) {
+      selector.value = urlObj.searchParams.get(key);
+    }
+  }
 
-      const applyFiltersButton = document.querySelector(".js-apply-filters");
-      const clearFiltersButton = document.querySelector(".js-clear-filters");
-      const urlObj = new URL(window.location);
+  setFiltersDropdown("language", languageSelector);
+  setFiltersDropdown("resource", resourceSelector);
+  setFiltersDropdown("tag", tagSelector);  
 
-      if (urlObj.search !== "") {
-        clearFiltersButton.removeAttribute("disabled");
-      }
+  function setFilters(key, selector) {
+    if (selector.value != "all") {
+      urlObj.searchParams.set(key, selector.value);
+    } else {
+      urlObj.searchParams.delete(key);
+    }
+  }
 
-      function setFiltersDropdown(key, selector) {
-        if (!selector) {
-          return;
-        }
-        if (urlObj.searchParams.has(key)) {
-          selector.value = urlObj.searchParams.get(key);
-        }
-      }
+  function applyFilters(event) {
+    event.preventDefault();
 
-      setFiltersDropdown("language", languageSelector);
-      setFiltersDropdown("resource", resourceSelector);
-      setFiltersDropdown("tag", tagSelector);
+    setFilters("language", languageSelector);
+    setFilters("resource", resourceSelector);
+    setFilters("tag", tagSelector);
 
-      function setFilters(key, selector) {
-        if (selector.value != "all") {
-          urlObj.searchParams.set(key, selector.value);
-        } else {
-          urlObj.searchParams.delete(key);
-        }
-      }
-
-      function applyFilters(event) {
-        event.preventDefault();
-
-        setFilters("language", languageSelector);
-        setFilters("resource", resourceSelector);
-        setFilters("tag", tagSelector);
-
-        urlObj.searchParams.delete("page");
-        window.location = urlObj.href;
-      }
-      applyFiltersButton.addEventListener("click", applyFilters);
-    })()
-  </script>
+    urlObj.searchParams.delete("page");
+    window.location = urlObj.href;
+}
+  applyFiltersButton.addEventListener("click", applyFilters);
+})()
+</script>
 {% endblock content %}

--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -1,173 +1,183 @@
 {% set hide_nav = False %}
+
 {% extends "engage/base_engage.html" %}
 
 {% block title %}Ubuntu case studies, whitepapers and webinars{% endblock %}
 
 {% block meta_description %}Resources from across Ubuntu and Canonical combined into a single portal{% endblock %}
 
-{% block meta_copydoc %}https://docs.google.com/spreadsheets/d/1UdExqv3PMnejaCISed340IehIhUmpKL-0AK5kumFk2M/edit#gid=0{% endblock meta_copydoc %}
+{% block meta_copydoc %}
+  https://docs.google.com/spreadsheets/d/1UdExqv3PMnejaCISed340IehIhUmpKL-0AK5kumFk2M/edit#gid=0
+{% endblock meta_copydoc %}
 
 {% block head_extra %}
-  {% if preview != None %}
-    <meta name="robots" content="noindex" />
-  {% endif %}
+  {% if preview != None %}<meta name="robots" content="noindex" />{% endif %}
 {% endblock %}
 
 {% block content %}
-<section class="p-strip--suru-blog-header is-dark">
-  <div class="row">
-    <div class="col-6">
-      <h1>Engage pages</h1>
-      <p>Ubuntu case studies, whitepapers and webinars.</p>
-    </div>
-  </div>
-</section>
-
-<section class="p-strip is-shallow">
-  <form action="/">
-  <div class="row">
-    <div class="col-3">
-      <div class="p-form__group">
-        <label for="language-selector">Select language:</label>
-        <select name="language-selector" id="language-selector" class="u-no-margin--bottom">
-          <option value="all">All languages</option>
-          <option value="zh-TW">Chinese (Traditional)</option>
-          <option value="de">Deutsch</option>
-          <option value="en">English</option>
-          <option value="es">Espa&ntilde;ol</option>
-          <option value="fr">Fran&ccedil;ais</option>
-          <option value="it">Italiano</option>
-          <option value="kr">Korean</option>
-          <option value="pt">Portugu&ecirc;s</option>
-          <option value="ru">Русс&#1082;&#1080;&#1081;</option>
-        </select>
+  <section class="p-strip--suru-blog-header is-dark">
+    <div class="row">
+      <div class="col-6">
+        <h1>Engage pages</h1>
+        <p>Ubuntu case studies, whitepapers and webinars.</p>
       </div>
     </div>
-    {% if resource_types %}
-    <div class="col-3">
-      <div class="p-form__group">
-        <label for="resource-selector">Select resource type:</label>
-        <select name="resource-selector" id="resource-selector" class="u-no-margin--bottom">
-          <option value="all">All resource types</option>
-          {% for type in resource_types %}
-            <option value="{{ type | lower }}">{{ type }}</option>
-          {% endfor %}
-        </select>
-      </div>
-    </div>
-    {% endif %}
-    {% if tags %}
-    <div class="col-3">
-      <div class="p-form__group">
-        <label for="tag-selector">Select tag:</label>
-        <select name="tag-selector" id="tag-selector" class="u-no-margin--bottom">
-          <option value="all">All tags</option>
-          {% for tag in tags %}
-            <option value="{{ tag }}">{{ tag }}</option>
-          {% endfor %}
-        </select>
-      </div>
-    </div>
-    {% endif %}
-    <div class="col-3" style="display: flex; align-items: flex-end; justify-content: flex-end;">
-      <div class="u-hide u-show--small" >
-        <br /><br />
-      </div>
-      <button id="clear-filters" class="u-no-margin--bottom" onclick="clearFilters()" type="reset" disabled>Clear filters</button>
-    </div>
-  </div>
-  </form>
-</section>
-
-<section class="p-strip is-shallow" id="posts-list">
-  {% if metadata | length > 0 %}
-  <div class="row u-equal-height">
-    {% for item in metadata %}
-      {% with
-        title=item.topic_name,
-        title_link=item.path,
-        description=item.subtitle,
-        type=item.type,
-        preview=preview,
-        active=item.active,
-        tags=item.tags
-      %}
-      {% include "engage/_article-card.html" %}
-      {% endwith %}
-    {% endfor %}
-  </div>
-  <section class="p-strip is-shallow">
-    {% with %}
-      {% set total_pages = total_pages %}
-      {% set current_page = current_page %}
-      {% include "shared/_pagination.html" %}
-    {% endwith %}
   </section>
-  {% else %}
-  <div class="u-fixed-width">
-    <h3>No results &mdash; why not try widening your search?</h3>
-    <p>You can do this by clearing and selecting new filters.</p>
-  </div>
-  {% endif %}
-</section>
-<script>
-function clearFilters() {
-  const clearFiltersButton = document.getElementById("clear-filters");
-  window.location.assign("/engage");
-}
-(function() {
-  const languageSelector = document.getElementById("language-selector");
-  const resourceSelector = document.getElementById("resource-selector");
-  const tagSelector = document.getElementById("tag-selector");
-  const clearFiltersButton = document.getElementById("clear-filters");
-  const urlObj = new URL(window.location);
 
-  if (urlObj.search !== "") {
-    clearFiltersButton.removeAttribute("disabled");
-  }
+  <section class="p-strip is-shallow">
+    <form action="/">
+      <div class="row">
+        <div class="col-3">
+          <div class="p-form__group">
+            <label for="language-selector">Select language:</label>
+            <select name="language-selector"
+                    id="language-selector"
+                    class="u-no-margin--bottom">
+              <option value="all">All languages</option>
+              <option value="zh-TW">Chinese (Traditional)</option>
+              <option value="de">Deutsch</option>
+              <option value="en">English</option>
+              <option value="es">Espa&ntilde;ol</option>
+              <option value="fr">Fran&ccedil;ais</option>
+              <option value="it">Italiano</option>
+              <option value="kr">Korean</option>
+              <option value="pt">Portugu&ecirc;s</option>
+              <option value="ru">Русс&#1082;&#1080;&#1081;</option>
+              <option value="tr">T&uuml;rk&ccedil;e</option>
+            </select>
+          </div>
+        </div>
+        {% if resource_types %}
+          <div class="col-3">
+            <div class="p-form__group">
+              <label for="resource-selector">Select resource type:</label>
+              <select name="resource-selector"
+                      id="resource-selector"
+                      class="u-no-margin--bottom">
+                <option value="all">All resource types</option>
+                {% for type in resource_types %}<option value="{{ type | lower }}">{{ type }}</option>{% endfor %}
+              </select>
+            </div>
+          </div>
+        {% endif %}
+        {% if tags %}
+          <div class="col-3">
+            <div class="p-form__group">
+              <label for="tag-selector">Select tag:</label>
+              <select name="tag-selector" id="tag-selector" class="u-no-margin--bottom">
+                <option value="all">All tags</option>
+                {% for tag in tags %}<option value="{{ tag }}">{{ tag }}</option>{% endfor %}
+              </select>
+            </div>
+          </div>
+        {% endif %}
+        <div class="col-3"
+             style="display: flex;
+                    align-items: flex-end;
+                    justify-content: flex-end">
+          <div class="u-hide u-show--small">
+            <br />
+            <br />
+          </div>
+          <button id="clear-filters"
+                  class="u-no-margin--bottom"
+                  onclick="clearFilters()"
+                  type="reset"
+                  disabled>Clear filters</button>
+        </div>
+      </div>
+    </form>
+  </section>
 
-  // Disable other fields if a filter is already applied
-  const searchParams = new URLSearchParams(urlObj.search);
-  for (const [key, value] of searchParams) {
-    if (key === "language") {
-      resourceSelector.setAttribute("disabled", true);
-      tagSelector.setAttribute("disabled", true);
-    } else if (key === "resource") {
-      languageSelector.setAttribute("disabled", true);
-      tagSelector.setAttribute("disabled", true);
-    } else if (key === "tag") {
-      languageSelector.setAttribute("disabled", true);
-      resourceSelector.setAttribute("disabled", true);
+  <section class="p-strip is-shallow" id="posts-list">
+    {% if metadata | length > 0 %}
+      <div class="row u-equal-height">
+        {% for item in metadata %}
+          {% with
+            title=item.topic_name,
+            title_link=item.path,
+            description=item.subtitle,
+            type=item.type,
+            preview=preview,
+            active=item.active,
+            tags=item.tags
+            %}
+            {% include "engage/_article-card.html" %}
+          {% endwith %}
+        {% endfor %}
+      </div>
+      <section class="p-strip is-shallow">
+        {% with %}
+          {% set total_pages = total_pages %}
+          {% set current_page = current_page %}
+          {% include "shared/_pagination.html" %}
+        {% endwith %}
+      </section>
+    {% else %}
+      <div class="u-fixed-width">
+        <h3>No results &mdash; why not try widening your search?</h3>
+        <p>You can do this by clearing and selecting new filters.</p>
+      </div>
+    {% endif %}
+  </section>
+  <script>
+    function clearFilters() {
+      const clearFiltersButton = document.getElementById("clear-filters");
+      window.location.assign("/engage");
     }
-  } 
+    (function() {
+      const languageSelector = document.getElementById("language-selector");
+      const resourceSelector = document.getElementById("resource-selector");
+      const tagSelector = document.getElementById("tag-selector");
+      const clearFiltersButton = document.getElementById("clear-filters");
+      const urlObj = new URL(window.location);
 
-  function handleFilter(key, el, url) {
-    if (!el) {
-      return;
-    }
-
-    if (url.searchParams.has(key)) {
-      el.value = url.searchParams.get(key);
-    }
-
-    el.addEventListener("change", function(e) {
-      const value = e.target.value;
-      const selectFields = document.querySelectorAll("select:checked")
-
-      // Reset filters, data explorer query can't search multiple fields
-      // at the same time
-      url.search = "";
-
-      if (value !== "all") {
-        url.searchParams.append(key, value);
+      if (urlObj.search !== "") {
+        clearFiltersButton.removeAttribute("disabled");
       }
-      window.location = url;
-    });
-  }
 
-  handleFilter("language", languageSelector, urlObj);
-  handleFilter("resource", resourceSelector, urlObj);
-  handleFilter("tag", tagSelector, urlObj);
-})()
-</script>
+      // Disable other fields if a filter is already applied
+      const searchParams = new URLSearchParams(urlObj.search);
+      for (const [key, value] of searchParams) {
+        if (key === "language") {
+          resourceSelector.setAttribute("disabled", true);
+          tagSelector.setAttribute("disabled", true);
+        } else if (key === "resource") {
+          languageSelector.setAttribute("disabled", true);
+          tagSelector.setAttribute("disabled", true);
+        } else if (key === "tag") {
+          languageSelector.setAttribute("disabled", true);
+          resourceSelector.setAttribute("disabled", true);
+        }
+      }
+
+      function handleFilter(key, el, url) {
+        if (!el) {
+          return;
+        }
+
+        if (url.searchParams.has(key)) {
+          el.value = url.searchParams.get(key);
+        }
+
+        el.addEventListener("change", function(e) {
+          const value = e.target.value;
+          const selectFields = document.querySelectorAll("select:checked")
+
+          // Reset filters, data explorer query can't search multiple fields
+          // at the same time
+          url.search = "";
+
+          if (value !== "all") {
+            url.searchParams.append(key, value);
+          }
+          window.location = url;
+        });
+      }
+
+      handleFilter("language", languageSelector, urlObj);
+      handleFilter("resource", resourceSelector, urlObj);
+      handleFilter("tag", tagSelector, urlObj);
+    })()
+  </script>
 {% endblock content %}

--- a/templates/engage/index.html
+++ b/templates/engage/index.html
@@ -31,8 +31,7 @@
           <div class="p-form__group">
             <label for="language-selector">Select language:</label>
             <select name="language-selector"
-                    id="language-selector"
-                    class="u-no-margin--bottom">
+                    class="js-language-selector u-no-margin--bottom">
               <option value="all">All languages</option>
               <option value="zh-TW">Chinese (Traditional)</option>
               <option value="de">Deutsch</option>
@@ -52,8 +51,7 @@
             <div class="p-form__group">
               <label for="resource-selector">Select resource type:</label>
               <select name="resource-selector"
-                      id="resource-selector"
-                      class="u-no-margin--bottom">
+                      class="js-resource-selector u-no-margin--bottom">
                 <option value="all">All resource types</option>
                 {% for type in resource_types %}<option value="{{ type | lower }}">{{ type }}</option>{% endfor %}
               </select>
@@ -64,9 +62,17 @@
           <div class="col-3">
             <div class="p-form__group">
               <label for="tag-selector">Select tag:</label>
-              <select name="tag-selector" id="tag-selector" class="u-no-margin--bottom">
+              <select name="tag-selector" class="js-tag-selector u-no-margin--bottom">
                 <option value="all">All tags</option>
-                {% for tag in tags %}<option value="{{ tag }}">{{ tag }}</option>{% endfor %}
+                {% for tag in tags %}
+                  <option {% if tag == "" %}disabled{% endif %} value="{{ tag }}">
+                    {% if tag == "" %}
+                      -
+                    {% else %}
+                      {{ tag }}
+                    {% endif %}
+                  </option>
+                {% endfor %}
               </select>
             </div>
           </div>
@@ -79,8 +85,8 @@
             <br />
             <br />
           </div>
-          <button id="clear-filters"
-                  class="u-no-margin--bottom"
+          <button class="js-apply-filters p-button--positive u-no-margin--bottom">Apply filters</button>
+          <button class="js-clear-filters u-no-margin--bottom"
                   onclick="clearFilters()"
                   type="reset"
                   disabled>Clear filters</button>
@@ -122,62 +128,54 @@
   </section>
   <script>
     function clearFilters() {
-      const clearFiltersButton = document.getElementById("clear-filters");
+      const clearFiltersButton = document.querySelector(".js-clear-filters");
       window.location.assign("/engage");
     }
     (function() {
-      const languageSelector = document.getElementById("language-selector");
-      const resourceSelector = document.getElementById("resource-selector");
-      const tagSelector = document.getElementById("tag-selector");
-      const clearFiltersButton = document.getElementById("clear-filters");
+      const languageSelector = document.querySelector(".js-language-selector");
+      const resourceSelector = document.querySelector(".js-resource-selector");
+      const tagSelector = document.querySelector(".js-tag-selector");
+
+      const applyFiltersButton = document.querySelector(".js-apply-filters");
+      const clearFiltersButton = document.querySelector(".js-clear-filters");
       const urlObj = new URL(window.location);
 
       if (urlObj.search !== "") {
         clearFiltersButton.removeAttribute("disabled");
       }
 
-      // Disable other fields if a filter is already applied
-      const searchParams = new URLSearchParams(urlObj.search);
-      for (const [key, value] of searchParams) {
-        if (key === "language") {
-          resourceSelector.setAttribute("disabled", true);
-          tagSelector.setAttribute("disabled", true);
-        } else if (key === "resource") {
-          languageSelector.setAttribute("disabled", true);
-          tagSelector.setAttribute("disabled", true);
-        } else if (key === "tag") {
-          languageSelector.setAttribute("disabled", true);
-          resourceSelector.setAttribute("disabled", true);
-        }
-      }
-
-      function handleFilter(key, el, url) {
-        if (!el) {
+      function setFiltersDropdown(key, selector) {
+        if (!selector) {
           return;
         }
-
-        if (url.searchParams.has(key)) {
-          el.value = url.searchParams.get(key);
+        if (urlObj.searchParams.has(key)) {
+          selector.value = urlObj.searchParams.get(key);
         }
-
-        el.addEventListener("change", function(e) {
-          const value = e.target.value;
-          const selectFields = document.querySelectorAll("select:checked")
-
-          // Reset filters, data explorer query can't search multiple fields
-          // at the same time
-          url.search = "";
-
-          if (value !== "all") {
-            url.searchParams.append(key, value);
-          }
-          window.location = url;
-        });
       }
 
-      handleFilter("language", languageSelector, urlObj);
-      handleFilter("resource", resourceSelector, urlObj);
-      handleFilter("tag", tagSelector, urlObj);
+      setFiltersDropdown("language", languageSelector);
+      setFiltersDropdown("resource", resourceSelector);
+      setFiltersDropdown("tag", tagSelector);
+
+      function setFilters(key, selector) {
+        if (selector.value != "all") {
+          urlObj.searchParams.set(key, selector.value);
+        } else {
+          urlObj.searchParams.delete(key);
+        }
+      }
+
+      function applyFilters(event) {
+        event.preventDefault();
+
+        setFilters("language", languageSelector);
+        setFilters("resource", resourceSelector);
+        setFilters("tag", tagSelector);
+
+        urlObj.searchParams.delete("page");
+        window.location = urlObj.href;
+      }
+      applyFiltersButton.addEventListener("click", applyFilters);
     })()
   </script>
 {% endblock content %}

--- a/templates/engage/shared/_tr_engage_form.html
+++ b/templates/engage/shared/_tr_engage_form.html
@@ -1,0 +1,167 @@
+<!-- MARKETO FORM -->
+<form action="/marketo/submit" method="post" id="mktoForm_{{ id }}">
+  <fieldset class="u-no-padding--top" style="border-bottom-width: 1px;">
+    <legend class="u-off-screen">İletişim bilgileri</legend>
+    <ul class="p-list">
+      <li>
+        <label for="firstName">İlk adı:</label>
+        <input required
+               id="firstName"
+               name="firstName"
+               maxlength="255"
+               type="text"
+               value="" />
+      </li>
+      <li>
+        <label for="lastName">Soy isim:</label>
+        <input required id="lastName" name="lastName" maxlength="255" type="text" />
+      </li>
+      <li>
+        <label for="email">İş e-postası:</label>
+        <input required
+               id="email"
+               name="email"
+               maxlength="255"
+               type="email"
+               pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"
+               value="" />
+      </li>
+      <li>
+        <label for="company">Firma Adı:</label>
+        <input required id="company" name="company" maxlength="255" type="text" />
+      </li>
+      <li>
+        <label for="jobTitle">İş unvanı:</label>
+        <input required id="jobTitle" name="title" maxlength="255" type="text" />
+      </li>
+      <li>
+        <label for="phone">Cep telefonu numarası:</label>
+        <input required id="phone" name="phone" maxlength="255" type="tel" />
+      </li>
+      {% set country = "Ülke" %}
+      {% include "shared/forms/_country.html" %}
+      <li>
+        <label class="p-checkbox">
+          <input class="p-checkbox__input"
+                 name="canonicalUpdatesOptIn"
+                 aria-labelledby="canonicalUpdatesOptIn"
+                 value="yes"
+                 type="checkbox" />
+          <span class="p-checkbox__label" id="canonicalUpdatesOptIn">Canonical'ın ürünleri ve hizmetleri hakkında bilgi almayı kabul ediyorum.</span>
+        </label>
+      </li>
+      {# These are honey pot fields to catch bots #}
+      <li class="u-off-screen">
+        <label class="website" for="website">Web sitesi:</label>
+        <input name="website"
+               type="text"
+               class="website"
+               autocomplete="off"
+               value=""
+               id="website"
+               tabindex="-1" />
+      </li>
+      <li class="u-off-screen">
+        <label class="name" for="name">İsim:</label>
+        <input name="name"
+               type="text"
+               class="name"
+               autocomplete="off"
+               value=""
+               id="name"
+               tabindex="-1" />
+      </li>
+      {# End of honey pots #}
+      <li>
+        <input name="Consent_to_Processing__c"
+               aria-label="Consent"
+               value="Yes"
+               type="hidden" />
+      </li>
+      {% if "partner_permission" in metadata %}
+        <li>
+          <label class="p-checkbox">
+            <input class="p-checkbox__input"
+                   name="Partner_Marketing_Opt_in__c"
+                   aria-label="Partner Permission"
+                   value="true"
+                   type="checkbox" />
+            <span class="p-checkbox__label" id="Partner_Marketing_Opt_in__c">
+              Zaman zaman, Canonical veya tanımlanan yardımcı sunucu(lar) ilginizi çekebilecek etkinlikler ve diğer haberler veya ürün güncellemeleri hakkında bilgi sağlamak için e-posta yoluyla sizinle iletişime geçmek isteyebilir. Bu amaçlar için Canonical veya tanımlanan yardımcı sunucu(lar) tarafından sizinle iletişime geçilmesinden memnunsanız lütfen onay kutusunu seçin. Canonical'ın kişisel verilerinizi işlemesiyle ilgili daha fazla bilgi<a href="/legal/data-privacy/newsletter">Canonical'ın gizlilik bildiriminde</a> bulunabilir . Onay vermeyi seçerseniz, herhangi bir Canonical e-postasının alt kısmındaki "abonelikten çık"a tıklayarak istediğiniz zaman onayınızı geri çekebilirsiniz. Canonical'ın <a href="/legal/data-privacy">veri gizliliği politikasına</a> bakın.
+            </span>
+          </label>
+        </li>
+      {% endif %}
+      <li>
+        <p>
+          <a href="/legal/data-privacy/contact">Bu formu göndererek Canonical'ın Gizlilik Bildirimi</a> ve <a href="/legal/data-privacy">Gizlilik Politikası'nı</a> okuduğumu ve kabul ettiğimi onaylıyorum.
+        </p>
+      </li>
+      <li>
+        <button type="submit"
+                class="u-no-margin--bottom {% if cta_class %}{{ cta_class }}{% endif %}">
+          {% if cta %}
+            {{ cta }}
+          {% else %}
+            Teknik incelemeyi indirin
+          {% endif %}
+        </button>
+        <input name="formid" aria-label="formid" value="{{ id }}" type="hidden" />
+        <input type="hidden"
+               name="returnURL"
+               aria-label="returnURL"
+               value="{{ returnURL }}" />
+        <input type="hidden"
+               aria-hidden="true"
+               aria-label="hidden field"
+               name="utm_campaign"
+               id="utm_campaign"
+               value="{{ utm_campaign }}" />
+        <input type="hidden"
+               aria-hidden="true"
+               aria-label="hidden field"
+               name="utm_medium"
+               id="utm_medium"
+               value="{{ utm_medium }}" />
+        <input type="hidden"
+               aria-hidden="true"
+               aria-label="hidden field"
+               name="utm_source"
+               id="utm_source"
+               value="{{ utm_source }}" />
+        <input type="hidden"
+               aria-hidden="true"
+               aria-label="hidden field"
+               name="utm_content"
+               id="utm_content"
+               value="{{ utm_content }}" />
+        <input type="hidden"
+               aria-hidden="true"
+               aria-label="hidden field"
+               name="utm_term"
+               id="utm_term"
+               value="{{ utm_term }}" />
+        <input type="hidden"
+               aria-hidden="true"
+               aria-label="hidden field"
+               name="GCLID__c"
+               id="GCLID__c"
+               value="" />
+        <input type="hidden"
+               aria-hidden="true"
+               aria-label="hidden field"
+               name="Facebook_Click_ID__c"
+               id="Facebook_Click_ID__c"
+               value="" />
+        <input type="hidden"
+               aria-hidden="true"
+               aria-label="hidden field"
+               id="preferredLanguage"
+               name="preferredLanguage"
+               maxlength="255"
+               value="" />
+      </li>
+    </ul>
+  </fieldset>
+</form>
+<!-- /MARKETO FORM -->

--- a/templates/engage/shared/_tr_engage_form.html
+++ b/templates/engage/shared/_tr_engage_form.html
@@ -31,7 +31,7 @@
         <input required id="company" name="company" maxlength="255" type="text" />
       </li>
       <li>
-        <label for="jobTitle">İş unvanı:</label>
+        <label for="jobTitle">İş ünvanı:</label>
         <input required id="jobTitle" name="title" maxlength="255" type="text" />
       </li>
       <li>

--- a/templates/engage/shared/_tr_thank-you.html
+++ b/templates/engage/shared/_tr_thank-you.html
@@ -1,0 +1,76 @@
+{% extends "engage/base_engage.html" %}
+
+{% block title %}{{ resource_name }} İndir{% endblock %}
+
+{% block head_extra %}<meta name="robots" content="noindex" />{% endblock %}
+
+{% block content %}
+  <section class="p-strip p-engage-banner--grad">
+    <div class="u-fixed-width navigation-logo-engage">
+      <a href="/">
+        {{ image(url="https://assets.ubuntu.com/v1/f263d9c4-logo-ubuntu-white.svg",
+                alt="Ubuntu",
+                width="143",
+                height="32",
+                hi_def=True,
+                loading="auto",) | safe
+        }}
+      </a>
+    </div>
+    <div class="row">
+      <div class="col-8">
+        <h1>Teşekkürler</h1>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-strip">
+    <div class="u-fixed-width">
+      {% if form_details and "access_to_content" in metadata and metadata.access_to_content == "true" %}
+
+        <h3>Bir kopyasını {{ resource_name }} e-posta adresinize gönderdik: {{ form_details.email }}</h3>
+        <p>
+          <a class="p-button--positive" href="{{ request_url }}">Önceki sayfaya dön</a>
+          <a class="p-button" href="/contact-us">Bize Ulaşın</a>
+        </p>
+        <p>E-postayı almadınız mı? Spam klasörünüzü kontrol edin ve doğru e-posta adresini kullandığınızdan emin olun.</p>
+
+      {% else %}
+        {% if "thank_you_text" in metadata %}
+          <p>{{ metadata["thank_you_text"] }}</p>
+        {% else %}
+          <p>{{ resource_name }} şimdi indirilmeye hazır.</p>
+        {% endif %}
+        {% if "contact_form_only" not in metadata and metadata.contact_form_only != "true" or ("access_to_content" in metadata and metadata.access_to_content == "true") %}
+          {% if metadata.resource_url and metadata.resource_url != "" %}
+            <p>
+              <a class="p-button--positive" href="{{ resource_url }}">İndir</a>
+            </p>
+          {% endif %}
+        {% endif %}
+      {% endif %}
+    </div>
+  </section>
+
+  {% if related | length > 0 %}
+    <section class="p-strip--light">
+      <div class="row">
+        <div class="col-8">
+          <h2 class="p-heading--3">İlgilenebileceğiniz diğer içerikler &hellip;</h2>
+        </div>
+      </div>
+      <div class="row p-divider">
+        {% for page in related[0:3] %}
+          <div class="col-4 p-divider__block">
+            <!-- ÜÇ EK CTA -->
+            <h4>{{ page["topic_name"] }}</h4>
+            <p>{{ page["subtitle"] }}</p>
+            <p>
+              <a href="{{ page['path'] }}">Daha fazla gör&nbsp;&rsaquo;</a>
+            </p>
+          </div>
+        {% endfor %}
+      </div>
+    </section>
+  {% endif %}
+{% endblock content %}


### PR DESCRIPTION
## Done

- Added Turkish language filter.
- Added turkish engage form template and thank-you template.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check the demo [here](https://ubuntu-com-14766.demos.haus/engage/ubuntu-security-in-turkish) and see if the form renders in Turkish, also try out turkish filter on engage [homepage](https://ubuntu-com-14766.demos.haus/engage/) 

## Issue / Card

Fixes # [WD19462](https://warthogs.atlassian.net/browse/WD-19462)



## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
