### PR TITLE
fix(ci): Update broken links to weekly

### DIFF
--- a/.github/workflows/blog-links.yaml
+++ b/.github/workflows/blog-links.yaml
@@ -2,7 +2,7 @@ name: Blog Links
 
 on:
   schedule:
-    - cron: "20 7 * * *"
+    - cron: "20 7 * * 1"
 
 jobs:
   check-links:


### PR DESCRIPTION
## Done

- Update the blog check which reports in the Marketing channel to weekly instead of daily.

## QA

- Check the cron change is correct
