### PR TITLE
fix: /iot/smart-home form payload submission

### DIFF
--- a/templates/shared/forms/interactive/smart-city.html
+++ b/templates/shared/forms/interactive/smart-city.html
@@ -33,144 +33,120 @@
             <label class="p-checkbox">
               <input type="checkbox"
                      aria-labelledby="topic-energy"
-                     name="smart-city-topic"
                      value="Energy"
                      class="p-checkbox__input" />
               <span class="p-checkbox__label"
                     id="topic-energy"
-                    name="smart-city-topic"
                     value="Energy">Energy</span>
             </label>
 
             <label class="p-checkbox">
               <input type="checkbox"
                      aria-labelledby="topic-government-services"
-                     name="smart-city-topic"
                      value="Government services"
                      class="p-checkbox__input" />
               <span class="p-checkbox__label"
                     id="topic-government-services"
-                    name="smart-city-topic"
                     value="Government services">Government services</span>
             </label>
 
             <label class="p-checkbox">
               <input type="checkbox"
                      aria-labelledby="topic-infrastructure"
-                     name="smart-city-topic"
                      value="Infrasructure"
                      class="p-checkbox__input" />
               <span class="p-checkbox__label"
                     id="topic-infrastructure"
-                    name="smart-city-topic"
                     value="Infrasructure">Infrastructure</span>
             </label>
 
             <label class="p-checkbox">
               <input type="checkbox"
                      aria-labelledby="topic-smart-homes"
-                     name="smart-city-topic"
                      value="Smart Homes"
                      class="p-checkbox__input" />
               <span class="p-checkbox__label"
                     id="topic-smart-homes"
-                    name="smart-city-topic"
                     value="Smart Homes">Smart Homes</span>
             </label>
 
             <label class="p-checkbox">
               <input type="checkbox"
                      aria-labelledby="topic-environment"
-                     name="smart-city-topic"
                      value="Environment"
                      class="p-checkbox__input" />
               <span class="p-checkbox__label"
                     id="topic-environment"
-                    name="smart-city-topic"
                     value="Environment">Environment</span>
             </label>
 
             <label class="p-checkbox">
               <input type="checkbox"
                      aria-labelledby="topic-healthcare"
-                     name="smart-city-topic"
                      value="Energy"
                      class="p-checkbox__input" />
               <span class="p-checkbox__label"
                     id="topic-healthcare"
-                    name="smart-city-topic"
                     value="Energy">Healthcare</span>
             </label>
 
             <label class="p-checkbox">
               <input type="checkbox"
                      aria-labelledby="topic-retail-commerce"
-                     name="smart-city-topic"
                      value="Retail and commerce"
                      class="p-checkbox__input" />
               <span class="p-checkbox__label"
                     id="topic-retail-commerce"
-                    name="smart-city-topic"
                     value="Retail and commerce">Retail and Commerce</span>
             </label>
 
             <label class="p-checkbox">
               <input type="checkbox"
                      aria-labelledby="topic-telecommunications"
-                     name="smart-city-topic"
                      value="Telecommunications"
                      class="p-checkbox__input" />
               <span class="p-checkbox__label"
                     id="topic-telecommunications"
-                    name="smart-city-topic"
                     value="Telecommunications">Telecommunications</span>
             </label>
 
             <label class="p-checkbox">
               <input type="checkbox"
                      aria-labelledby="topic-finance"
-                     name="smart-city-topic"
                      value="Finance"
                      class="p-checkbox__input" />
               <span class="p-checkbox__label"
                     id="topic-finance"
-                    name="smart-city-topic"
                     value="Finance">Finance</span>
             </label>
 
             <label class="p-checkbox">
               <input type="checkbox"
                      aria-labelledby="topic-information-technology"
-                     name="smart-city-topic"
                      value="Information Technology"
                      class="p-checkbox__input" />
               <span class="p-checkbox__label"
                     id="topic-information-technology"
-                    name="smart-city-topic"
                     value="Information Technology">Information Technology</span>
             </label>
 
             <label class="p-checkbox">
               <input type="checkbox"
                      aria-labelledby="topic-robotics-drones"
-                     name="smart-city-topic"
                      value="Robotics and drones"
                      class="p-checkbox__input" />
               <span class="p-checkbox__label"
                     id="topic-robotics-drones"
-                    name="smart-city-topic"
                     value="Robotics and drones">Robotics and drones</span>
             </label>
 
             <label class="p-checkbox">
               <input type="checkbox"
                      aria-labelledby="topic-transport-mobility"
-                     name="smart-city-topic"
                      value="Robotics and drones"
                      class="p-checkbox__input" />
               <span class="p-checkbox__label"
                     id="topic-transport-mobility"
-                    name="smart-city-topic"
                     value="Robotics and drones">Trasport and mobility</span>
             </label>
             <div class="js-other-container">
@@ -194,7 +170,7 @@
 
       <div class="p-section">
         <hr class="p-rule is-fixed-width" />
-        <fieldset class="p-fieldset-section js-formfield"
+        <fieldset class="p-fieldset-section"
                   id="about-you"
                   aria-labelledby="about-you-legend">
           <div class="row--50-50">

--- a/templates/shared/forms/interactive/smart-city.html
+++ b/templates/shared/forms/interactive/smart-city.html
@@ -160,7 +160,7 @@
                      id="priority-workloads-other-specified"
                      class="js-other-container__input"
                      placeholder="Please specify"
-                     style="opacity: 0;
+                     style="display: none;
                             margin-top: .25rem"
                      aria-label="Other architecture" />
             </div>


### PR DESCRIPTION
## Done

- Remove "name" attributed from checkbox input
- Show and hide "Other" checkbox text input when selected 

## QA

- Go to https://ubuntu-com-14785.demos.haus/iot/smart-city#get-in-touch
- Select "Other" checkbox, see that text input shows up on select
- Fill up form, submit and see that it goes through Marketo successfully

## Issue / Card

Fixes [WD-19633](https://warthogs.atlassian.net/browse/WD-19633)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-19633]: https://warthogs.atlassian.net/browse/WD-19633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ