### PR TITLE
WD-19019 - fix: add checksums to verify desktop download

### DIFF
--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -66,7 +66,10 @@
                   now</a>.
                 {% endif %}
                 <br />
-                You can <a href="/tutorials/tutorial-how-to-verify-ubuntu">verify your download</a>, or <a href="/tutorials/install-ubuntu-desktop">get help installing</a>.
+                {% with version=version, system="desktop", architecture=architecture %}
+                  {% include "download/shared/_verify-checksums.html" %}
+                {% endwith %}
+
               </p>
             {% else %}
               <h1>Thank you for your contribution</h1>


### PR DESCRIPTION
## Done

- Reintroduced the verification widget for checking desktop downloads

## QA

- Open the demo
- Download the desktop iso
- Click "verify download"
- See that is now displayed how to verify the download

## Issue / Card

Fixes https://github.com/canonical/ubuntu.com/issues/14711
Fixes https://warthogs.atlassian.net/browse/WD-19019

