### PR TITLE
Implement a specific cache policy for vulnerabilities & use latest discourse module branch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ canonicalwebteam.blog==6.4.4
 canonicalwebteam.search==2.1.1
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.5.0
-canonicalwebteam.discourse @ git+https://github.com/canonical/canonicalwebteam.discourse.git@refs/pull/207/head
+canonicalwebteam.discourse==6.1.0
 python-dateutil==2.8.2
 pytz==2022.7.1
 maxminddb-geolite2==2018.703

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ canonicalwebteam.blog==6.4.4
 canonicalwebteam.search==2.1.1
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.5.0
-canonicalwebteam.discourse==6.0.0
+canonicalwebteam.discourse @ git+https://github.com/canonical/canonicalwebteam.discourse.git@refs/pull/207/head
 python-dateutil==2.8.2
 pytz==2022.7.1
 maxminddb-geolite2==2018.703

--- a/templates/security/vulnerabilities/vulnerability-detailed.html
+++ b/templates/security/vulnerabilities/vulnerability-detailed.html
@@ -1,8 +1,8 @@
 {% extends "security/base_security.html" %}
 
-{% block title %}Vulnerability Knowledge Base | document.title{% endblock %}
+{% block title %}Vulnerability Knowledge Base | {{ document.title }}{% endblock %}
 
-{% block meta_description %}{{ document.sections[0].title }}{% endblock %}
+{% block meta_description %}{{ document.sections[0].title if document.sections|length > 0 else document.title }}{% endblock %}
 
 {% block body_class %}
   is-paper
@@ -13,77 +13,109 @@
   {% set breadcrumbs = [{"name": "Vulnerability knowledge base", "href": "/security/vulnerabilities"}, {"name": "View all", "href": "/security/vulnerabilities/view-all"}, {"name": document.title}] %}
   {% include '/shared/_breadcrumbs.html' %}
 
-  <div class="p-section--hero">
-    <div class="row--25-75">
-      <div class="col">
-        <div class="p-section">
-          <div class="p-section--shallow">
-            <h1>{{ document.title }}</h1>
-            <p class="p-heading--3 section-heading" id="description">{{ document.sections[0].title }}</p>
-            <div class="row">
-              <div class="col-2 col-medium-2 col-small-2">
-                <p class="u-no-margin--bottom u-sv1">Published</p>
+  {% if document.sections|length > 0 %}
+    <div class="p-section--hero">
+      <div class="row--25-75">
+        <div class="col">
+          <div class="p-section">
+            <div class="p-section--shallow">
+              <h1>{{ document.title }}</h1>
+              <p class="p-heading--3 section-heading" id="description">{{ document.sections[0].title }}</p>
+              <div class="row">
+                <div class="col-2 col-medium-2 col-small-2">
+                  <p class="u-no-margin--bottom u-sv1">Published</p>
+                </div>
+                <div class="col-2 col-medium-2 col-small-2">
+                  <p class="u-no-margin--bottom u-sv1">{{ format_date(metadata.published) }}</p>
+                </div>
               </div>
-              <div class="col-2 col-medium-2 col-small-2">
-                <p class="u-no-margin--bottom u-sv1">{{ format_date(metadata.published) }}</p>
+              <div class="row">
+                <div class="col-2 col-medium-2 col-small-2">Updated</div>
+                <div class="col-2 col-medium-2 col-small-2">{{ document.updated }}</div>
               </div>
             </div>
-            <div class="row">
-              <div class="col-2 col-medium-2 col-small-2">Updated</div>
-              <div class="col-2 col-medium-2 col-small-2">{{ document.updated }}</div>
-            </div>
+            <hr class="p-rule" />
           </div>
-          <hr class="p-rule" />
+        </div>
+      </div>
+      <div class="row">
+        {% if document.sections|length > 1 %}
+          <button class="p-toggle--sticky js-drawer-toggle"
+                  aria-controls="drawer"
+                  href="#"
+                  aria-expanded="false">Open side navigation</button>
+          <div class="col-3">
+            <nav class="p-side-navigation--raw-html is-single-page js-dynamic-toc"
+                 id="drawer">
+              <div class="p-side-navigation__overlay js-drawer-toggle"
+                   aria-controls="drawer"></div>
+              <div class="p-side-navigation__drawer"
+                   aria-label="documentation side navigation">
+                <div class="p-side-navigation__drawer-header">
+                  <button href="#"
+                          class="p-side-navigation__toggle--in-drawer js-drawer-toggle"
+                          aria-controls="drawer"
+                          aria-expanded="false">Close side navigation</button>
+                </div>
+                <ul>
+                  {% for section in document.sections %}
+                    <li class="p-side-navigation__item">
+                      {% if loop.first %}
+                        <a class="highlight-link is-active" href="#description">Description</a>
+                      {% else %}
+                        <a class="highlight-link" href="#{{ format_to_id(section.title) }}">{{ section.title }}</a>
+                      {% endif %}
+                    </li>
+                  {% endfor %}
+                </ul>
+              </div>
+            </nav>
+          </div>
+        {% endif %}
+        <div class="col-9 col-start-large-4">
+          {% for section in document.sections %}
+            <div class="p-section--shallow vulnerabilities-content">
+              {% if not loop.first %}
+                <hr class="p-rule" />
+                <h2 class="p-heading--3 section-heading"
+                    id="{{ format_to_id(section.title) }}">{{ section.title }}</h2>
+              {% endif %}
+              <div id="main-content" style="overflow-wrap: break-word;">{{ section.content | safe }}</div>
+            </div>
+          {% endfor %}
         </div>
       </div>
     </div>
-    <div class="row">
-      {% if document.sections|length > 1 %}
-        <button class="p-toggle--sticky js-drawer-toggle"
-                aria-controls="drawer"
-                href="#"
-                aria-expanded="false">Open side navigation</button>
-        <div class="col-3">
-          <nav class="p-side-navigation--raw-html is-single-page js-dynamic-toc"
-               id="drawer">
-            <div class="p-side-navigation__overlay js-drawer-toggle"
-                 aria-controls="drawer"></div>
-            <div class="p-side-navigation__drawer"
-                 aria-label="documentation side navigation">
-              <div class="p-side-navigation__drawer-header">
-                <button href="#"
-                        class="p-side-navigation__toggle--in-drawer js-drawer-toggle"
-                        aria-controls="drawer"
-                        aria-expanded="false">Close side navigation</button>
+  {% else %}
+    <div class="p-section--hero">
+      <div class="row--25-75">
+        <div class="col">
+          <div class="p-section">
+            <div class="p-section--shallow">
+              <h1>{{ document.title }}</h1>
+              <div class="row">
+                <div class="col-2 col-medium-2 col-small-2">
+                  <p class="u-no-margin--bottom u-sv1">Published</p>
+                </div>
+                <div class="col-2 col-medium-2 col-small-2">
+                  <p class="u-no-margin--bottom u-sv1">{{ format_date(metadata.published) }}</p>
+                </div>
               </div>
-              <ul>
-                {% for section in document.sections %}
-                  <li class="p-side-navigation__item">
-                    {% if loop.first %}
-                      <a class="highlight-link is-active" href="#description">Description</a>
-                    {% else %}
-                      <a class="highlight-link" href="#{{ format_to_id(section.title) }}">{{ section.title }}</a>
-                    {% endif %}
-                  </li>
-                {% endfor %}
-              </ul>
+              <div class="row">
+                <div class="col-2 col-medium-2 col-small-2">Updated</div>
+                <div class="col-2 col-medium-2 col-small-2">{{ document.updated }}</div>
+              </div>
             </div>
-          </nav>
-        </div>
-      {% endif %}
-      <div class="col-9">
-        {% for section in document.sections %}
-          <div class="p-section--shallow vulnerabilities-content">
-            {% if not loop.first %}
-              <hr class="p-rule" />
-              <h2 class="p-heading--3 section-heading"
-                  id="{{ format_to_id(section.title) }}">{{ section.title }}</h2>
-            {% endif %}
-            <div id="main-content" style="overflow-wrap: break-word;">{{ section.content | safe }}</div>
+            <hr class="p-rule" />
           </div>
-        {% endfor %}
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-9 col-start-large-4">
+          <div id="main-content" style="overflow-wrap: break-word;">{{ document.body_html | safe }}</div>
+        </div>
       </div>
     </div>
-  </div>
+  {% endif %}
   <script src="{{ versioned_static('js/dist/dynamic-toc.js') }}" defer></script>
 {% endblock content %}

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -1231,17 +1231,20 @@ def build_vulnerabilities_list(security_vulnerabilities, path=None):
                     v for v in vulnerabilities if v["year"] in top_years
                 ]
 
-            response = flask.render_template(
+            response = flask.make_response(
+                flask.render_template(
                 template_path,
                 topics=topics,
                 vulnerabilities=vulnerabilities,
+                )
             )
-            response.cache_control.max_age = "300"
+            response.headers["Cache-Control"] = "max-age=900, stale-while-revalidate=1200, stale-if-error=3600"
             return response
         except HTTPError as e:
             flask.current_app.extensions["sentry"].captureException(
                 f"Error fetching vulnerabilities: {e}"
             )
+            return flask.Response("Internal Server Error", status=500)
 
     return vulnerabilities_list
 
@@ -1261,16 +1264,19 @@ def build_vulnerabilities(security_vulnerabilities):
                     document_metadata = item
                     break
 
-            response = flask.render_template(
+            response = flask.make_response(
+                flask.render_template(
                 "security/vulnerabilities/vulnerability-detailed.html",
                 metadata=document_metadata,
                 document=document,
+                )
             )
-            response.cache_control.max_age = "300"
+            response.headers["Cache-Control"] = "max-age=900, stale-while-revalidate=1200, stale-if-error=3600"
             return response
         except HTTPError as e:
             flask.current_app.extensions["sentry"].captureException(
                 f"Error fetching vulnerabilities: {e}"
             )
+            return flask.Response("Internal Server Error", status=500)
 
     return vulnerability

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -1231,11 +1231,13 @@ def build_vulnerabilities_list(security_vulnerabilities, path=None):
                     v for v in vulnerabilities if v["year"] in top_years
                 ]
 
-            return flask.render_template(
+            response = flask.render_template(
                 template_path,
                 topics=topics,
                 vulnerabilities=vulnerabilities,
             )
+            response.cache_control.max_age = "300"
+            return response
         except HTTPError as e:
             flask.current_app.extensions["sentry"].captureException(
                 f"Error fetching vulnerabilities: {e}"
@@ -1259,11 +1261,13 @@ def build_vulnerabilities(security_vulnerabilities):
                     document_metadata = item
                     break
 
-            return flask.render_template(
+            response = flask.render_template(
                 "security/vulnerabilities/vulnerability-detailed.html",
                 metadata=document_metadata,
                 document=document,
             )
+            response.cache_control.max_age = "300"
+            return response
         except HTTPError as e:
             flask.current_app.extensions["sentry"].captureException(
                 f"Error fetching vulnerabilities: {e}"

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -1233,12 +1233,14 @@ def build_vulnerabilities_list(security_vulnerabilities, path=None):
 
             response = flask.make_response(
                 flask.render_template(
-                template_path,
-                topics=topics,
-                vulnerabilities=vulnerabilities,
+                    template_path,
+                    topics=topics,
+                    vulnerabilities=vulnerabilities,
                 )
             )
-            response.headers["Cache-Control"] = "max-age=900, stale-while-revalidate=1200, stale-if-error=3600"
+            response.headers["Cache-Control"] = (
+                "max-age=900, stale-while-revalidate=900, stale-if-error=3600"
+            )
             return response
         except HTTPError as e:
             flask.current_app.extensions["sentry"].captureException(
@@ -1266,12 +1268,14 @@ def build_vulnerabilities(security_vulnerabilities):
 
             response = flask.make_response(
                 flask.render_template(
-                "security/vulnerabilities/vulnerability-detailed.html",
-                metadata=document_metadata,
-                document=document,
+                    "security/vulnerabilities/vulnerability-detailed.html",
+                    metadata=document_metadata,
+                    document=document,
                 )
             )
-            response.headers["Cache-Control"] = "max-age=900, stale-while-revalidate=1200, stale-if-error=3600"
+            response.headers["Cache-Control"] = (
+                "max-age=900, stale-while-revalidate=900, stale-if-error=3600"
+            )
             return response
         except HTTPError as e:
             flask.current_app.extensions["sentry"].captureException(


### PR DESCRIPTION
## Done

- Updates the cache on vulnerability pages to `max-age=900, stale-while-revalidate=1200, stale-if-error=3600`
- Adds a fallback to the vulerability_detailed.html in case the proper format has not been used
- Use the latest version of discourse module (still a [pr](https://github.com/canonical/canonicalwebteam.discourse/pull/207))

## QA

- Open [the demo](https://ubuntu-com-14789.demos.haus/security/vulnerabilities)
- Go to any specific vulnerability
- Make an update to it [in discourse](https://discourse.ubuntu.com/c/project/security-vulnerabilities/308)
- _without_ refreshing, re-visit the page the see if the update is visible within  the caching parameters above

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-19706
