### PR TITLE
fix: update documentation links in `/kubernetes/install`

### DIFF
--- a/templates/kubernetes/install.html
+++ b/templates/kubernetes/install.html
@@ -28,7 +28,7 @@
       </p>
     {%- endif -%}
     {%- if slot == 'cta' -%}
-      <a href="/kubernetes/charmed-k8s/docs" class="p-button--positive">Read the docs</a>
+      <a href="/kubernetes/documentation" class="p-button--positive">Read the docs</a>
       <a href="/pro/subscribe">Purchase support with Ubuntu Pro&nbsp;&rsaquo;</a>
     {%- endif -%}
     {%- if slot == 'image' -%}
@@ -250,7 +250,7 @@
   <section class="p-strip is-deep">
     <div class="u-fixed-width">
       <h2>
-        For more information, <a href="/kubernetes/charmed-k8s/docs" aria-label="Check out the docs">read the docs</a>
+        For more information, <a href="/kubernetes/documentation" aria-label="Check out the docs">read the docs</a>
         <br />
         Or <a href="/kubernetes/contact-us" class="js-invoke-modal">contact us</a> to let our experts help you take the next step
       </h2>


### PR DESCRIPTION
## Done

- Change doc links in two instances

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Click Read the docs green button
- Click For more information, [read the docs](http://localhost:8001/kubernetes/documentation)
- It should take you to /kubernetes/documentation

## Issue / Card

Fixes [WD-19221](https://warthogs.atlassian.net/browse/WD-19221)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-19221]: https://warthogs.atlassian.net/browse/WD-19221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ