### PR TITLE
feat: Add names and email as default active contact fields

### DIFF
--- a/templates/aws/form-data.json
+++ b/templates/aws/form-data.json
@@ -325,24 +325,6 @@
           "noCommentsFromLead": true,
           "fields": [
             {
-              "type": "text",
-              "id": "firstName",
-              "label": "First name",
-              "isRequired": true
-            },
-            {
-              "type": "text",
-              "id": "lastName",
-              "label": "Last name",
-              "isRequired": true
-            },
-            {
-              "type": "email",
-              "id": "email",
-              "label": "Email address",
-              "isRequired": true
-            },
-            {
               "type": "country",
               "label": "Country",
               "isRequired": true

--- a/templates/kubernetes/form-data.json
+++ b/templates/kubernetes/form-data.json
@@ -39,24 +39,6 @@
             "noCommentsFromLead": true,
             "fields": [
               {
-                "type": "text",
-                "id": "firstName",
-                "label": "First name",
-                "isRequired": true
-              },
-              {
-                "type": "text",
-                "id": "lastName",
-                "label": "Last name",
-                "isRequired": true
-              },
-              {
-                "type": "email",
-                "id": "email",
-                "label": "Work email",
-                "isRequired": true
-              },
-              {
                 "type": "tel",
                 "id": "phone",
                 "label": "Phone number",

--- a/templates/shared/forms/form-fields.html
+++ b/templates/shared/forms/form-fields.html
@@ -29,6 +29,31 @@
             </div>
             <div class="col">
               <ul class="p-list">
+                {% if fieldset_id == "about-you" %}
+                  <label class="is-required"
+                          for="firstName">First name:</label>
+                  <input required
+                          id="firstName"
+                          name="firstName"
+                          maxlength="255"
+                          type="text" />                              
+                  <label class="is-required"
+                          for="lastName">Last name:</label>
+                  <input required
+                          id="lastName"
+                          name="lastName"
+                          maxlength="255"
+                          type="text" />
+                  <label class="is-required"
+                            for="email">Email:</label>
+                  <input required
+                          id="email"
+                          name="email"
+                          maxlength="255"
+                          type="email"
+                          pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"/>
+                {% endif %}
+                
                 {% for field in fieldset.fields %}
 
                   {% if field.id %}


### PR DESCRIPTION
## Done

- Add first name, last name and email as default active contact fields on form generator
- Remove duplicated contact fields on affected forms

## QA

- Go to /aws#get-in-touch and /k8s#get-in-touch
- See that first name, last name and email are present
- Submit form, check payload and see that it goes through Marketo successfully

## Issue / Card

Fixes [WD-19672](https://warthogs.atlassian.net/browse/WD-19672)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-19672]: https://warthogs.atlassian.net/browse/WD-19672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ