### PR TITLE
feat: remove kubeadm section

### DIFF
--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -196,15 +196,6 @@
               </p>
             </div>
           </div>
-          <hr class="p-rule--muted" />
-          <div class="row">
-            <div class="col-3">
-              <h4 class="p-heading--5">Kubernetes clusters with Kubeadm</h4>
-            </div>
-            <div class="col-6">
-              <p>Canonical provides commercial support for Kubernetes clusters deployed using kubeadm.</p>
-            </div>
-          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Done

- Removed section as per [copydoc](https://docs.google.com/document/d/1b018GoKMF3abEFJlUkfAEK2JEhXWICKF4V0dGdTvgJs/edit?tab=t.0)

## QA

- Open demo at /kubernetes and scroll to `Other distributions`. 
- Check [copydoc](https://docs.google.com/document/d/1b018GoKMF3abEFJlUkfAEK2JEhXWICKF4V0dGdTvgJs/edit?tab=t.0) to confirm changes (the kubeadm section is removed).

## Issue / Card

Fixes #
[WD-19497](https://warthogs.atlassian.net/browse/WD-19497)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
