### PR TITLE
Prevent undefined values from being sent for the address

### DIFF
--- a/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
@@ -300,9 +300,16 @@ const BuyButton = ({ setError, products, action, coupon }: Props) => {
         localStorage.removeItem(key);
       });
 
-      const address = userInfo
-        ? `${userInfo?.customerInfo?.address?.line1} ${userInfo?.customerInfo?.address?.line2} ${userInfo?.customerInfo?.address?.city} ${userInfo?.customerInfo?.address?.postal_code} ${userInfo?.customerInfo?.address?.state} ${userInfo?.customerInfo?.address?.country}`
-        : `${values?.address} ${values?.postalCode} ${values?.city} ${values?.usState} ${values?.caProvince} ${values?.country}`;
+      const address = [
+        values?.address,
+        values?.postalCode,
+        values?.city,
+        values?.usState,
+        values?.caProvince,
+        values?.country,
+      ]
+        .filter(Boolean)
+        .join(" ");
 
       const getName = () => {
         const name = userInfo?.customerInfo?.name || values?.name;

--- a/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
@@ -334,7 +334,9 @@ const BuyButton = ({ setError, products, action, coupon }: Props) => {
         "company",
         (userInfo?.accountInfo?.name || values?.organisationName) ?? "",
       );
-      formData.append("street", address ?? "");
+      if (address) {
+        formData.append("street", address ?? "");
+      }
       formData.append("Consent_to_Processing__c", "yes");
       formData.append("GCLID__c", sessionData?.gclid || "");
       formData.append("utm_campaign", sessionData?.utm_campaign || "");


### PR DESCRIPTION
## Done
- `userInfo` always exists for both first-time buyers and existing users, so first-time buyers will always get undefined in the address on line 303 if checking `userInfo`
- Get the address from form values always instead of checking `userInfo` and prevent sending `undefined` values

## QA
- Go into the local branch and console.log address and check the values (for both first-time buyers and existing users)

## Issue / Card

Fixes #https://warthogs.atlassian.net/browse/WD-18214
