### PR TITLE
fix: update link

### DIFF
--- a/templates/containers/chiseled/index.html
+++ b/templates/containers/chiseled/index.html
@@ -515,7 +515,7 @@
                 a chiseled Ubuntu base image for C/C++, Go and Rust applications</a>
               </li>
               <li class="p-list__item">
-                <a href="https://documentation.ubuntu.com/rockcraft/en/latest/how-to/chisel/install-slice.html">Install packages slices into a rock</a>
+                <a href="https://documentation.ubuntu.com/rockcraft/en/latest/how-to/chisel/install-slice/">Install packages slices into a rock</a>
               </li>
             </ul>
           </div>


### PR DESCRIPTION
## Done

- Removed html suffix from docs link

## QA

- Open the [demo](https://ubuntu-com-14803.demos.haus/containers/chiseled) and scroll to the documentation section.
- Click `Install packages slices into a rock`

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
