### PR TITLE
security web: add esm-infra-legacy pockets WD-17330 WD-19534

### DIFF
--- a/templates/security/notices/usn.html
+++ b/templates/security/notices/usn.html
@@ -74,6 +74,9 @@
                   {% if package.pocket == "esm-infra" %}
                     Available with <a href="/pro">Ubuntu Pro</a>
                   {% endif %}
+                  {% if package.pocket == "esm-infra-legacy" %}
+                    Available with <a href="/pro">Ubuntu Pro</a>
+                  {% endif %}
                   {% if package.pocket == "esm-apps" %}
                     Available with <a href="/pro">Ubuntu Pro</a>
                   {% endif %}

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -631,8 +631,7 @@ def cve(cve_id):
         },
         "esm-infra-legacy": {
             "text": (
-                "Fix available with Ubuntu Pro with "
-                "Legacy support add-on."
+                "Fix available with Ubuntu Pro with " "Legacy support add-on."
             ),
             "label": "Ubuntu Pro",
             "href": "/pro",

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -497,6 +497,7 @@ def cve(cve_id):
             for status in package["statuses"]:
                 if (
                     status["pocket"] == "esm-infra"
+                    or status["pocket"] == "esm-infra-legacy"
                     or status["pocket"] == "esm-apps"
                 ):
                     cve["expanded_coverage"] = True
@@ -624,6 +625,14 @@ def cve(cve_id):
             "text": (
                 "Fix available with Ubuntu Pro and "
                 "Ubuntu Pro (Infra-only) via ESM Infra."
+            ),
+            "label": "Ubuntu Pro",
+            "href": "/pro",
+        },
+        "esm-infra-legacy": {
+            "text": (
+                "Fix available with Ubuntu Pro with "
+                "Legacy support add-on."
             ),
             "label": "Ubuntu Pro",
             "href": "/pro",


### PR DESCRIPTION
## Done

- we need the "Available with Ubuntu Pro" tag for the pocket "esm-infra-legacy" as we have for "esm-infra";
- esm-infra-legacy pocket already exists in https://github.com/canonical/ubuntu-com-security-api and is being pushed by the security team for a while;
- without this tag there is no indication that an update is placed in a different place and could be mislead our users
- for now, I don't see a need to add this pocket in other places like Entitlements and in the list of products in the ubuntu advantage category, this feels like a commercial discussion which I don't want to drive here in this PR

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check for CVEs and USNs where the pocket "esm-infra-legacy" is present, such as:
    - https://ubuntu.com/security/CVE-2021-4156
    - https://ubuntu.com/security/notices/USN-7273-1 

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-17330
Fixes https://warthogs.atlassian.net/browse/WD-19534

## Screenshots

A test for the CVE webpage with the text added (the text has changed, but the idea remains)
![image](https://github.com/user-attachments/assets/dfe2f94b-e3f7-4349-9387-f48ef3d368f3)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
