### PR TITLE
fix(a11y): Refactor the HTML validator issues on the base templates

### DIFF
--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -12,7 +12,7 @@
 
 {% block head_extra %}<meta name="robots" content="noindex" />{% endblock %}
 
-{% block content_experiment %}
+{% block head_extra %}
   <style>
     .async-hide {
       opacity: 0 !important

--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -10,9 +10,8 @@
   is-paper
 {% endblock body_class %}
 
-{% block head_extra %}<meta name="robots" content="noindex" />{% endblock %}
-
 {% block head_extra %}
+  <meta name="robots" content="noindex" />
   <style>
     .async-hide {
       opacity: 0 !important

--- a/templates/templates/_getfeedback.html
+++ b/templates/templates/_getfeedback.html
@@ -1,5 +1,5 @@
 <!-- begin usabilla live embed code -->
-<script type="text/javascript">
+<script>
   window.lightningjs || function(n) {
     var e = "lightningjs";
 

--- a/templates/templates/_navigation.html
+++ b/templates/templates/_navigation.html
@@ -80,7 +80,7 @@
               onmouseenter="fetchDropdown('/templates/meganav/download-ubuntu', 'download-ubuntu', event); this.onmouseenter = null;">
             <a class="p-navigation__link"
                href="/navigation#download-ubuntu-navigation"
-               aria-controls="#download-ubuntu-content"
+               aria-controls="download-ubuntu-content"
                tabindex="0"
                onfocus="fetchDropdown('/templates/meganav/download-ubuntu', 'download-ubuntu');">Download Ubuntu</a>
           </li>
@@ -103,7 +103,7 @@
                     class="p-search-box__input u-hide "
                     name="search"
                     placeholder="Search our sites"
-                    aria-label="Search our sites" 
+                    aria-label="Search our sites"
                     value=""/>
             <!-- end of honeypot search input -->
             <input type="search"
@@ -157,7 +157,7 @@
             {% endif %}
           {% endif %}
         </div>
-        
+
         <nav class="p-navigation__nav"
              aria-label="{{ breadcrumbs.section.title | replace(' ', '&nbsp;') | safe }} navigation">
           {% if breadcrumbs.children %}

--- a/templates/templates/_notifications.html
+++ b/templates/templates/_notifications.html
@@ -44,7 +44,7 @@
   <div class="p-notification--positive u-no-margin--bottom">
     <div class="p-notification__content">
       <p class="p-notification__message">
-        Your preferences have been successfully updated. <a href="#" alt="Close notification" onclick="location.href = document.referrer; return false;"><i class="p-notification__close">Close</i></a>
+        Your preferences have been successfully updated. <a href="#" onclick="location.href = document.referrer; return false;"><i class="p-notification__close">Close notification</i></a>
       </p>
     </div>
   </div>

--- a/templates/templates/_tag_manager.html
+++ b/templates/templates/_tag_manager.html
@@ -1,34 +1,34 @@
-        <!-- Google Analytics and Google Optimize -->
-        <script>(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-        ga('create', 'UA-1018242-59', 'auto', {'allowLinker': true});
-        ga('require', 'GTM-N2MDH37');
-        ga('require', 'linker');
-        ga('linker:autoLink', ['conjure-up.io', 'login.ubuntu.com', 'www.ubuntu.com',
-        'ubuntu.com', 'insights.ubuntu.com', 'developer.ubuntu.com', 'cn.ubuntu.com',
-        'design.ubuntu.com', 'maas.io', 'canonical.com', 'landscape.canonical.com',
-        'pages.ubuntu.com', '/tutorials', 'docs.ubuntu.com']);
-        </script>
-        <!-- End Google Analytics and Google Optimize -->
-        <script>
-            const userIDCookie = document.cookie.match(new RegExp("(^| )" + "user_id" + "=([^;]+)"));
-            if (userIDCookie !== null) {
-                let idValue = userIDCookie[2];
-                if (idValue) {
-                    dataLayer.push({
-                            user_id: idValue,
-                    });
-                }
+<!-- Google Analytics and Google Optimize -->
+    <script>(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+    ga('create', 'UA-1018242-59', 'auto', {'allowLinker': true});
+    ga('require', 'GTM-N2MDH37');
+    ga('require', 'linker');
+    ga('linker:autoLink', ['conjure-up.io', 'login.ubuntu.com', 'www.ubuntu.com',
+    'ubuntu.com', 'insights.ubuntu.com', 'developer.ubuntu.com', 'cn.ubuntu.com',
+    'design.ubuntu.com', 'maas.io', 'canonical.com', 'landscape.canonical.com',
+    'pages.ubuntu.com', '/tutorials', 'docs.ubuntu.com']);
+    </script>
+    <!-- End Google Analytics and Google Optimize -->
+    <script>
+        const userIDCookie = document.cookie.match(new RegExp("(^| )" + "user_id" + "=([^;]+)"));
+        if (userIDCookie !== null) {
+            let idValue = userIDCookie[2];
+            if (idValue) {
+                dataLayer.push({
+                        user_id: idValue,
+                });
             }
-        </script>
-        <!-- Google Tag Manager -->
-        <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-        '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-        })(window,document,'script','dataLayer','GTM-K92JCQ');</script>
-        <!-- End Google Tag Manager -->
+        }
+    </script>
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-K92JCQ');</script>
+    <!-- End Google Tag Manager -->
 
-        <style>#rememberMe {display: none;}</style>
+    <style>#rememberMe {display: none;}</style>

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -8,7 +8,7 @@
     <meta name="keywords" content="index, follow">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% block title %}{% endblock %} | Ubuntu</title>
-    <link rel="preconnect" href="https://res.cloudinary.com">
+    <link rel="preconnect" href="https://res.cloudinary.com" />
     <script src="{{ versioned_static('js/dist/cookie-policy.js') }}"></script>
     <script src="{{ versioned_static('js/src/cookie-policy-with-callback.js') }}" type="module"></script>
     <script src="https://assets.ubuntu.com/v1/703e23c9-lazysizes+noscript+native-loading.5.1.2.min.js" defer></script>
@@ -16,69 +16,69 @@
     <script src="{{ versioned_static('js/dist/main.js') }}" defer></script>
     <script src="{{ versioned_static('js/src/infer-preferred-language.js')}}" defer></script>
 
-    <link rel="stylesheet" type="text/css" media="screen" href="{{ versioned_static("css/styles.css") }}">
-    <link rel="stylesheet" type="text/css" media="print" href="{{ versioned_static("css/print.css") }}">
+    <link rel="stylesheet" type="text/css" media="screen" href="{{ versioned_static("css/styles.css") }}" />
+    <link rel="stylesheet" type="text/css" media="print" href="{{ versioned_static("css/print.css") }}" />
     <script>
       performance.mark("Stylesheets finished");
     </script>
 
-    <link rel="canonical" href="{% block canonical_url %}{{ request.url }}{% endblock %}">
+    <link rel="canonical" href="{% block canonical_url %}{{ request.url }}{% endblock %}" />
 
     <link rel="apple-touch-icon"
           sizes="180x180"
-          href="https://assets.ubuntu.com/v1/f38b9c7e-COF%20apple-touch-icon.png">
+          href="https://assets.ubuntu.com/v1/f38b9c7e-COF%20apple-touch-icon.png" />
     <link rel="icon"
           type="image/png"
           sizes="32x32"
-          href="https://assets.ubuntu.com/v1/be7e4cc6-COF-favicon-32x32.png">
+          href="https://assets.ubuntu.com/v1/be7e4cc6-COF-favicon-32x32.png" />
     <link rel="icon"
           type="image/png"
           sizes="16x16"
-          href="https://assets.ubuntu.com/v1/16c27f81-COF%20favicon-16x16.png">
-    <link rel="manifest" href="{{ versioned_static("files/site.webmanifest") }}">
+          href="https://assets.ubuntu.com/v1/16c27f81-COF%20favicon-16x16.png" />
+    <link rel="manifest" href="{{ versioned_static("files/site.webmanifest") }}" />
     <!-- Serving favicon for search engines locally -->
-    <link rel="icon" type="image/png" sizes="48x48" href="{{ versioned_static("favicons/COF-favicon-48x48.png") }}">
+    <link rel="icon" type="image/png" sizes="48x48" href="{{ versioned_static("favicons/COF-favicon-48x48.png") }}" />
     {%- block head_extra %}{% endblock %}
     <link rel="preload"
           as="font"
           type="font/woff2"
           href="https://assets.ubuntu.com/v1/f1ea362b-Ubuntu%5Bwdth,wght%5D-latin-v0.896a.woff2"
-          crossorigin>
+          crossorigin />
     <link rel="preload"
           as="font"
           type="font/woff2"
           href="https://assets.ubuntu.com/v1/90b59210-Ubuntu-Italic%5Bwdth,wght%5D-latin-v0.896a.woff2"
-          crossorigin>
+          crossorigin />
     <link rel="preload"
           as="font"
           type="font/woff2"
           href="https://assets.ubuntu.com/v1/d5fc1819-UbuntuMono%5Bwght%5D-latin-v0.869.woff2"
-          crossorigin>
+          crossorigin />
     <link rel="preload"
           as="font"
           type="font/woff2"
           href="https://assets.ubuntu.com/v1/77cd6650-Ubuntu%5Bwdth,wght%5D-cyrillic-extended-v0.896a.woff2"
-          crossorigin>
+          crossorigin />
     <link rel="preload"
           as="font"
           type="font/woff2"
           href="https://assets.ubuntu.com/v1/2702fce5-Ubuntu%5Bwdth,wght%5D-cyrillic-v0.896a.woff2"
-          crossorigin>
+          crossorigin />
     <link rel="preload"
           as="font"
           type="font/woff2"
           href="https://assets.ubuntu.com/v1/5c108b7d-Ubuntu%5Bwdth,wght%5D-greek-extended-v0.896a.woff2"
-          crossorigin>
+          crossorigin />
     <link rel="preload"
           as="font"
           type="font/woff2"
           href="https://assets.ubuntu.com/v1/0a14c405-Ubuntu%5Bwdth,wght%5D-greek-v0.896a.woff2"
-          crossorigin>
+          crossorigin />
     <link rel="preload"
           as="font"
           type="font/woff2"
           href="https://assets.ubuntu.com/v1/19f68eeb-Ubuntu%5Bwdth,wght%5D-latin-extended-v0.896a.woff2"
-          crossorigin>
+          crossorigin />
 
     <meta name="description" content="{% block meta_description %}Ubuntu is an open source software operating system that runs from the desktop, to the cloud, to all your internet connected things.{% endblock %}">
     <meta name="facebook-domain-verification"

--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -1,208 +1,158 @@
 <!DOCTYPE html>
 
-<html prefix="og: http://ogp.me/ns#" class=" 
-  {% block extra_html_class %}{% endblock %}" 
+<html prefix="og: http://ogp.me/ns#" class="
+  {% block extra_html_class %}{% endblock %}"
   lang="{% block meta_lang %}en{% endblock %}" dir="ltr">
   <head>
-    <meta charset="UTF-8" />
-    <meta name="keywords" content="index, follow" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-
-    <title>
-
-      {% block title %}{% endblock %}
-    | Ubuntu</title>
-
-    <link rel="preconnect" href="https://res.cloudinary.com" />
-
-    {% block content_experiment %}{% endblock %}
-    <!-- Cookie policy -->
+    <meta charset="UTF-8">
+    <meta name="keywords" content="index, follow">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% block title %}{% endblock %} | Ubuntu</title>
+    <link rel="preconnect" href="https://res.cloudinary.com">
     <script src="{{ versioned_static('js/dist/cookie-policy.js') }}"></script>
-    <script type="module" src="{{ versioned_static('js/src/cookie-policy-with-callback.js') }}"></script>
-    <script src="https://assets.ubuntu.com/v1/703e23c9-lazysizes+noscript+native-loading.5.1.2.min.js"
-            defer></script>
-
+    <script src="{{ versioned_static('js/src/cookie-policy-with-callback.js') }}" type="module"></script>
+    <script src="https://assets.ubuntu.com/v1/703e23c9-lazysizes+noscript+native-loading.5.1.2.min.js" defer></script>
     <script src="{{ versioned_static('js/src/navigation.js') }}" defer></script>
     <script src="{{ versioned_static('js/dist/main.js') }}" defer></script>
     <script src="{{ versioned_static('js/src/infer-preferred-language.js')}}" defer></script>
 
-    <link rel="stylesheet" type="text/css" media="screen" href="{{ versioned_static("css/styles.css") }}" />
-    <link rel="stylesheet" type="text/css" media="print" href="{{ versioned_static("css/print.css") }}" />
+    <link rel="stylesheet" type="text/css" media="screen" href="{{ versioned_static("css/styles.css") }}">
+    <link rel="stylesheet" type="text/css" media="print" href="{{ versioned_static("css/print.css") }}">
     <script>
       performance.mark("Stylesheets finished");
     </script>
 
-    <link rel="canonical" href="{% block canonical_url %}{{ request.url }}{% endblock %}" />
+    <link rel="canonical" href="{% block canonical_url %}{{ request.url }}{% endblock %}">
 
-      <link rel="apple-touch-icon"
-            sizes="180x180"
-            href="https://assets.ubuntu.com/v1/f38b9c7e-COF%20apple-touch-icon.png" />
-      <link rel="icon"
-            type="image/png"
-            sizes="32x32"
-            href="https://assets.ubuntu.com/v1/be7e4cc6-COF-favicon-32x32.png" />
-      <link rel="icon"
-            type="image/png"
-            sizes="16x16"
-            href="https://assets.ubuntu.com/v1/16c27f81-COF%20favicon-16x16.png" />
-      <link rel="manifest" href="{{ versioned_static("files/site.webmanifest") }}" />
-      <!-- Serving favicon for search engines locally -->
-      <link rel="icon" type="image/png" sizes="48x48" href="{{ versioned_static("favicons/COF-favicon-48x48.png") }}" />
+    <link rel="apple-touch-icon"
+          sizes="180x180"
+          href="https://assets.ubuntu.com/v1/f38b9c7e-COF%20apple-touch-icon.png">
+    <link rel="icon"
+          type="image/png"
+          sizes="32x32"
+          href="https://assets.ubuntu.com/v1/be7e4cc6-COF-favicon-32x32.png">
+    <link rel="icon"
+          type="image/png"
+          sizes="16x16"
+          href="https://assets.ubuntu.com/v1/16c27f81-COF%20favicon-16x16.png">
+    <link rel="manifest" href="{{ versioned_static("files/site.webmanifest") }}">
+    <!-- Serving favicon for search engines locally -->
+    <link rel="icon" type="image/png" sizes="48x48" href="{{ versioned_static("favicons/COF-favicon-48x48.png") }}">
+    {%- block head_extra %}{% endblock %}
+    <link rel="preload"
+          as="font"
+          type="font/woff2"
+          href="https://assets.ubuntu.com/v1/f1ea362b-Ubuntu%5Bwdth,wght%5D-latin-v0.896a.woff2"
+          crossorigin>
+    <link rel="preload"
+          as="font"
+          type="font/woff2"
+          href="https://assets.ubuntu.com/v1/90b59210-Ubuntu-Italic%5Bwdth,wght%5D-latin-v0.896a.woff2"
+          crossorigin>
+    <link rel="preload"
+          as="font"
+          type="font/woff2"
+          href="https://assets.ubuntu.com/v1/d5fc1819-UbuntuMono%5Bwght%5D-latin-v0.869.woff2"
+          crossorigin>
+    <link rel="preload"
+          as="font"
+          type="font/woff2"
+          href="https://assets.ubuntu.com/v1/77cd6650-Ubuntu%5Bwdth,wght%5D-cyrillic-extended-v0.896a.woff2"
+          crossorigin>
+    <link rel="preload"
+          as="font"
+          type="font/woff2"
+          href="https://assets.ubuntu.com/v1/2702fce5-Ubuntu%5Bwdth,wght%5D-cyrillic-v0.896a.woff2"
+          crossorigin>
+    <link rel="preload"
+          as="font"
+          type="font/woff2"
+          href="https://assets.ubuntu.com/v1/5c108b7d-Ubuntu%5Bwdth,wght%5D-greek-extended-v0.896a.woff2"
+          crossorigin>
+    <link rel="preload"
+          as="font"
+          type="font/woff2"
+          href="https://assets.ubuntu.com/v1/0a14c405-Ubuntu%5Bwdth,wght%5D-greek-v0.896a.woff2"
+          crossorigin>
+    <link rel="preload"
+          as="font"
+          type="font/woff2"
+          href="https://assets.ubuntu.com/v1/19f68eeb-Ubuntu%5Bwdth,wght%5D-latin-extended-v0.896a.woff2"
+          crossorigin>
 
-      {% block
-        head_extra %}
-      {% endblock %}
+    <meta name="description" content="{% block meta_description %}Ubuntu is an open source software operating system that runs from the desktop, to the cloud, to all your internet connected things.{% endblock %}">
+    <meta name="facebook-domain-verification"
+          content="zxp9j79g1gy2xenbu9ll964pttk5hu">
+    <meta name="twitter:account_id" content="4503599627481511">
+    <meta name="twitter:site" content="@ubuntu">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="{{ request.url }}">
+    <meta property="og:site_name" content="Ubuntu">
+    <meta name="copydoc" content="{% block meta_copydoc %}https://drive.google.com/drive/folders/0B4s80tIYQW4BMjNiMGFmNzQtNDkxZC00YmQ0LWJiZWUtNTk2YThlY2MzZmJh{% endblock %}">
+    <meta name="google-site-verification"
+          content="ddh2iq7ZuKf1LpkL_gtM_T7DkKDVD7ibq6Ceue4a_3M">
 
-      <link rel="preload"
-            as="font"
-            type="font/woff2"
-            href="https://assets.ubuntu.com/v1/f1ea362b-Ubuntu%5Bwdth,wght%5D-latin-v0.896a.woff2"
-            crossorigin />
-      <link rel="preload"
-            as="font"
-            type="font/woff2"
-            href="https://assets.ubuntu.com/v1/90b59210-Ubuntu-Italic%5Bwdth,wght%5D-latin-v0.896a.woff2"
-            crossorigin />
-      <link rel="preload"
-            as="font"
-            type="font/woff2"
-            href="https://assets.ubuntu.com/v1/d5fc1819-UbuntuMono%5Bwght%5D-latin-v0.869.woff2"
-            crossorigin />
-      <link rel="preconnect"
-            as="font"
-            type="font/woff2"
-            href="https://assets.ubuntu.com/v1/77cd6650-Ubuntu%5Bwdth,wght%5D-cyrillic-extended-v0.896a.woff2"
-            crossorigin />
-      <link rel="preconnect"
-            as="font"
-            type="font/woff2"
-            href="https://assets.ubuntu.com/v1/2702fce5-Ubuntu%5Bwdth,wght%5D-cyrillic-v0.896a.woff2"
-            crossorigin />
-      <link rel="preconnect"
-            as="font"
-            type="font/woff2"
-            href="https://assets.ubuntu.com/v1/5c108b7d-Ubuntu%5Bwdth,wght%5D-greek-extended-v0.896a.woff2"
-            crossorigin />
-      <link rel="preconnect"
-            as="font"
-            type="font/woff2"
-            href="https://assets.ubuntu.com/v1/0a14c405-Ubuntu%5Bwdth,wght%5D-greek-v0.896a.woff2"
-            crossorigin />
-      <link rel="preconnect"
-            as="font"
-            type="font/woff2"
-            href="https://assets.ubuntu.com/v1/19f68eeb-Ubuntu%5Bwdth,wght%5D-latin-extended-v0.896a.woff2"
-            crossorigin />
+    {% if self.title() %}
+    <meta name="twitter:title" content="{{ self.title() }} | Ubuntu">
+    <meta property="og:title" content="{{ self.title() }} | Ubuntu">
+    {% endif %}
 
-      <meta name="description" content=" 
-        {% block meta_description %}Ubuntu is an open source software operating system that runs from the desktop, to the cloud, to all your internet connected things.{% endblock %}" />
+    {% if self.meta_description() %}
+    <meta name="twitter:description" content="{{ self.meta_description() }}">
+    <meta property="og:description" content="{{ self.meta_description() }}">
+    {% endif %}
+    {# Define the required meta_image block #}
+    <!-- Meta image: {% block meta_image %}{% endblock %} -->
+    {%- if self.meta_image() %}
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:image"
+          content="{% if 'http' not in self.meta_image() %}https://assets.ubuntu.com/v1/{% endif %}{{ self.meta_image() }}">
+    <meta property="og:image"
+          content="{% if 'http' not in self.meta_image() %}https://assets.ubuntu.com/v1/{% endif %}{{ self.meta_image() }}">
+    {% endif %}
+    {% block extra_metatags %}{% endblock %}
+    {%- include "templates/_tag_manager.html" %}
+  </head>
 
-        <meta name="facebook-domain-verification"
-              content="zxp9j79g1gy2xenbu9ll964pttk5hu" />
-        <meta name="twitter:account_id" content="4503599627481511" />
-        <meta name="twitter:site" content="@ubuntu" />
-        <meta property="og:type" content="website" />
-        <meta property="og:url" content="{{ request.url }}" />
-        <meta property="og:site_name" content="Ubuntu" />
-        <meta name="copydoc" content=" 
-          {% block meta_copydoc %}https://drive.google.com/drive/folders/0B4s80tIYQW4BMjNiMGFmNzQtNDkxZC00YmQ0LWJiZWUtNTk2YThlY2MzZmJh{% endblock %}" />
-          <meta name="google-site-verification"
-                content="ddh2iq7ZuKf1LpkL_gtM_T7DkKDVD7ibq6Ceue4a_3M" />
+  <body class="{% block body_class %}{% endblock %}">
+    <!-- google tag manager -->
+    <noscript>
+      <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K92JCQ"
+              height="0"
+              width="0"
+              style="display: none;
+                      visibility: hidden"
+              title="Google Tag Manager"></iframe>
+    </noscript>
+    <!-- end google tag manager -->
 
-          {% if self.title() %}
-            <meta name="twitter:title" content="{{ self.title() }} | Ubuntu" />
-            <meta property="og:title" content="{{ self.title() }} | Ubuntu" />
-          {% endif %}
+    {% include "templates/_getfeedback.html" %}
+    {% include "templates/_notifications.html" %}
 
-          {% if self.meta_description() %}
-            <meta name="twitter:description" content="{{ self.meta_description() }}" />
-            <meta property="og:description" content="{{ self.meta_description() }}" />
-          {% endif %}
-          {# Define the required meta_image block #}
-          <!-- Meta image: {% block meta_image %}{% endblock %} -->
-          {% if self.meta_image() %}
-            <meta name="twitter:card" content="summary_large_image" />
-            <meta name="twitter:image"
-                  content="{% if 'http' not in self.meta_image() %}https://assets.ubuntu.com/v1/{% endif %}{{ self.meta_image() }}" />
-            <meta property="og:image"
-                  content="{% if 'http' not in self.meta_image() %}https://assets.ubuntu.com/v1/{% endif %}{{ self.meta_image() }}" />
-          {% endif %}
+    {% if not(hide_nav == True) %}
+      {% include "templates/_navigation.html" %}
+    {% endif %}
 
-          {% block extra_metatags %}{% endblock %}
+    <div class="wrapper u-no-margin--top">
+      <main id="main-content" class="inner-wrapper">
+        {% block content_head %}{% endblock %}
+        {% block content_container %}
+          {% block outer_content %}{% endblock outer_content %}
+        {% endblock content_container %}
+      </main>
+    </div>
 
-          {% include
-          "templates/_tag_manager.html" %}
-
-        </head>
-
-        <body class=" 
-          {% block body_class %}{% endblock %}">
-          <!-- google tag manager -->
-          <noscript>
-            <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K92JCQ"
-                    height="0"
-                    width="0"
-                    style="display: none;
-                           visibility: hidden"
-                    title="Google Tag Manager"></iframe>
-          </noscript>
-          <!-- end google tag manager -->
-
-          <noscript>
-            <style>
-              body {
-                transform: translateY(0) !important;
-              }
-            </style>
-          </noscript>
-          {% include "templates/_getfeedback.html" %}
-          {% include "templates/_notifications.html" %}
-
-          {% if not(hide_nav == True) %}
-
-            {% include "templates/_navigation.html" %}
-            {%
-            endif %}
-
-            <div class="wrapper u-no-margin--top">
-              
-              <main id="main-content" class="inner-wrapper">
-                
-                
-                {% block content_head %}{% endblock %}
-                
-                {% block content_container %}
-
-                  {%
-                  block outer_content %}
-                {% endblock outer_content %}
-
-              {% endblock
-              content_container %}
-            </main>
-            <!-- /.inner-wrapper -->
-          </div>
-          <!-- /.wrapper -->
-
-          <!-- footer content goes here -->
-          {% if not(hide_footer == True) %}
-            {% if small_footer %}
-
-              {% include "templates/small-footer.html" %}
-
-            {% else %}
-              {% include "templates/footer.html" %}
-
-              {% if "/whitepapers" not in
-                request.path %}
-
-              {% endif %}
-
-              {% block footer_extra %}{% endblock %}
-
-            {% endif
-            %}
-          {% endif %}
-          
-        </body>
-      </html>
+    <!-- footer content goes here -->
+    {% if not(hide_footer == True) %}
+      {% if small_footer %}
+        {% include "templates/small-footer.html" %}
+      {% else %}
+        {% include "templates/footer.html" %}
+        {% if "/whitepapers" not in
+          request.path %}
+        {% endif %}
+        {% block footer_extra %}{% endblock %}
+      {% endif %}
+    {% endif %}
+  </body>
+</html>


### PR DESCRIPTION
## Done

- Fixed several HTML validation errors across the base templates. _Left the `Info: Trailing slash on void elements` warnings as I believe that is our coding standards, based on linting_
- Removed some unnecessary piece

## QA

- Copy the source code of the demo homepage into https://validator.w3.org/nu/#textarea
-  See there are ~120 issues
- Do the same for production and see its ~160 issues
