### PR TITLE
feat: update openstack release cycle tab

### DIFF
--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -120,7 +120,7 @@
         <h2>Maintenance and security updates</h2>
 
         <p>
-          The debs in Ubuntu are categorised by whether they are considered part of the base system ('main' and 'restricted' are in the base and 'universe' and 'multiverse' are not) and whether they are open source ('main' and 'universe' are, 'restricted' and 'multiverse' are not).
+          The debs in Ubuntu are categorized by whether they are considered part of the base system ('main' and 'restricted' are in the base and 'universe' and 'multiverse' are not) and whether they are open source ('main' and 'universe' are, 'restricted' and 'multiverse' are not).
         </p>
 
         <table style="margin-top: 1rem;">
@@ -195,7 +195,7 @@
         </p>
 
         <p>
-          The heart of Ubuntu is a collection of 'deb' packages which are tested and integrated so that they work well as a set. Debs are optimised for highly structured dependency management, enabling you to combine debs very richly while ensuring that the necessary software dependencies for each deb (themselves delivered as debs) are installed on your machine.
+          The heart of Ubuntu is a collection of 'deb' packages which are tested and integrated so that they work well as a set. Debs are optimized for highly structured dependency management, enabling you to combine debs very richly while ensuring that the necessary software dependencies for each deb (themselves delivered as debs) are installed on your machine.
         </p>
 
         <p>
@@ -207,7 +207,7 @@
         </p>
 
         <p>
-          A snap can be strictly confined, which means that it operates in a secure box with only predefined points of access to the rest of the system. For third-party applications, this means that you will have a very high level of confidence that the app can only see appropriate data that you have provided to it. Snaps can also be 'classic' which means that they behave more like debs, and can see everything on your system. You should make sure you have a high level of confidence in the publisher of any classic snap you install since a compromise or bad faith behaviour in that code is not confined to the app itself.
+          A snap can be strictly confined, which means that it operates in a secure box with only predefined points of access to the rest of the system. For third-party applications, this means that you will have a very high level of confidence that the app can only see appropriate data that you have provided to it. Snaps can also be 'classic' which means that they behave more like debs, and can see everything on your system. You should make sure you have a high level of confidence in the publisher of any classic snap you install since a compromise or bad faith behavior in that code is not confined to the app itself.
         </p>
 
         <p>

--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -270,51 +270,7 @@
     <div class="p-strip is-shallow">
       <div class="u-fixed-width">
         <h2>OpenStack release cycle</h2>
-
-        <p>
-          The <a href="/openstack">OpenStack</a> release cadence follows the Ubuntu release cadence. This means that new versions of OpenStack are released twice a year: in April and in October. Those are shipped with new versions of Ubuntu as packages in the <a href="https://packages.ubuntu.com/">Ubuntu Archive</a>.
-        </p>
-
-        <p>
-          However, since Canonical recommends using only LTS versions of Ubuntu in production environments, this limits available OpenStack versions to one by default. Therefore, Canonical maintains an additional archive &ndash; <a href="https://wiki.ubuntu.com/OpenStack/CloudArchive">Ubuntu Cloud Archive</a> &ndash; to provide access to newer versions of OpenStack on Ubuntu LTS.
-        </p>
-
-        <p>
-          As a result, OpenStack versions that are shipped on Ubuntu LTS by default (aka OpenStack LTS versions) benefit from Canonical's commitment around the Ubuntu Archive, including 5 years of standard security maintenance and <a href="/security/esm">Expanded Security Maintenance (ESM)</a> available to <a href="/pro">Ubuntu Pro and Ubuntu Pro (Infra-only) customers</a>. In turn, OpenStack versions which are shipped on Ubuntu LTS through the Ubuntu Cloud Archive are maintained by Canonical for 18 months only, except for some versions that are maintained for 36 months under Ubuntu Pro and Ubuntu Pro (Infra-only).
-        </p>
-      </div>
-      <div class="u-fixed-width">
-        <h3>Charmed OpenStack</h3>
-
-        <p>
-          OpenStack clouds deployed through <a href="/openstack/consulting">Private Cloud Build</a> or validated through <a href="/openstack/consulting">Cloud Validation</a> consulting engagement (aka Charmed OpenStack clouds) can also benefit from <a href="/legal/ubuntu-pro-description#uprosd-full-openstack-support">Full OpenStack support</a> under <a href="/support">Ubuntu Pro &plus; Support and Ubuntu Pro (Infra-only) &plus; Support</a>. Full OpenStack support is provided for all OpenStack versions available in the Ubuntu Archive and Ubuntu Cloud Archive during their lifespan under standard security maintenance (9, 18, 36 or 60 months depending on the version).
-        </p>
-
-        <p>Charmed OpenStack support lifecycle on Ubuntu can be represented in this way:</p>
-
-        {% include "/about/release_cycles/openstack-eol.html" %}
-
-        <p>
-          For more information on supported versions, see <a href="/openstack/docs/supported-versions">Charmed OpenStack documentation</a>.
-        </p>
-      </div>
-      <div class="u-fixed-width">
-        <h3>MicroStack</h3>
-
-        <p>
-          OpenStack clouds deployed with <a href="https://microstack.run">MicroStack</a> can also benefit from <a href="/legal/ubuntu-pro-description#uprosd-full-openstack-support">Full OpenStack support</a> under <a href="/support">Ubuntu Pro &plus; Support and Ubuntu Pro (Infra-only) &plus; Support</a>. Since MicroStack does not use OpenStack packages directly, but rather uses snaps and open container initiative (OCI) images, its support lifecycle is different from Charmed OpenStack.
-        </p>
-
-        <p>
-          The first supported version of OpenStack in MicroStack is Antelope. It will be supported until April 2026. Every LTS version of OpenStack will benefit from 10 years of support moving forward. Every second, non LTS version of OpenStack will benefit from 3 years of support moving forward. Only every second version of OpenStack will be supported moving forward. Users will be able to securely upgrade between supported versions of OpenStack using the Skip Level Upgrade Release Process (SLURP) mechanism for 2 years after the next LTS version release.
-        </p>
-
-        <p>MicroStack support lifecycle on Ubuntu can be represented this way:</p>
-
-        {% include "/about/release_cycles/microstack-eol.html" %}
-
-        <p>
-          For more information on supported versions, see <a href="https://microstack.run/docs">MicroStack documentation</a>.
+        <p>For OpenStack release cycle and supported versions refer to the <a href="https://canonical-openstack.readthedocs-hosted.com/en/latest/reference/release-cycle-and-supported-versions/">product documentation</a>.
         </p>
       </div>
     </div>
@@ -350,9 +306,8 @@
           The Canonical Kubernetes support lifecycle can be represented this way:
         </p>
 
-        
         {% include "/about/release_cycles/k8s-lts.html" %}
-      
+
         <p>
 For more information on previous and current releases, please see the <a href="https://documentation.ubuntu.com/canonical-kubernetes/latest/releases/">Canonical Kubernetes</a> release notes.
         </p>


### PR DESCRIPTION
## Done

- Replace the OpenStack release cycle tab with shorter paragraph and link.
- Update to US English.

https://docs.google.com/document/d/1-l3B7AoyDoETaL80UhlfEWCVKmMWPdy3zoF5LpsGcYQ/edit?tab=t.0

## QA

- Go to [/about/release-cycle#openstack-release-cycle](https://ubuntu-com-14817.demos.haus/about/release-cycle#openstack-release-cycle).
- Under OpenStack tab at the bottom check that the content has a short paragraph (see the copy doc) and link to a Read The Docs page.

## Issue / Card

https://warthogs.atlassian.net/browse/WD-19544

## Screenshots

<img width="1510" alt="Screenshot 2025-03-04 at 1 17 08 pm" src="https://github.com/user-attachments/assets/a438c60a-1de2-4058-bd62-c8dd09587f64" />

