### PR TITLE
feat: Update requirements to import pypi package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ canonicalwebteam.search==2.1.1
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.5.0
 canonicalwebteam.discourse==5.8.1
+canonicalwebteam.sitemaps-parser===1.0.1
 python-dateutil==2.8.2
 pytz==2022.7.1
 maxminddb-geolite2==2018.703
@@ -33,4 +34,3 @@ numpy==1.24.4
 python-slugify==8.0.1
 djlint==1.34.1
 pycountry==24.6.1
--e ../parser

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -24,7 +24,7 @@ from canonicalwebteam.discourse import (
     Tutorials,
 )
 from canonicalwebteam.flask_base.app import FlaskBase
-from canonicalwebteam.parser import scan_directory
+from canonicalwebteam.sitemaps_parser import scan_directory
 from canonicalwebteam.search import build_search_view
 from canonicalwebteam.templatefinder import TemplateFinder
 


### PR DESCRIPTION
## Done

- Published sitemaps-repo on test PyPi - [package here](https://test.pypi.org/project/canonicalwebteam.sitemaps-parser/1.0.0/)
- Update `requirements.txt` to use the package
- Note: The package is currently on test pypi. It will be migrated outside of test before this feature branch is merged

## QA

- Check that [ubuntu-com-14827.demos.haus](https://ubuntu-com-14827.demos.haus/) loads
- Go to https://ubuntu-com-14827.demos.haus/sitemaps_parser
- See that it shows JSON field of directory tree

## Issue / Card

Fixes [WD-19979](https://warthogs.atlassian.net/browse/WD-19979)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-19979]: https://warthogs.atlassian.net/browse/WD-19979?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ