### PR TITLE
chore: Remove stale link from sitemap index

### DIFF
--- a/templates/sitemap_index.xml
+++ b/templates/sitemap_index.xml
@@ -10,9 +10,6 @@
     <loc>https://ubuntu.com/engage/sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://ubuntu.com/server/docs/sitemap.xml</loc>
-  </sitemap>
-  <sitemap>
     <loc>https://ubuntu.com/ceph/docs/sitemap.xml</loc>
   </sitemap>
   <sitemap>


### PR DESCRIPTION
## Done

- Removed link from sitemap index, was missed in [this pr](https://github.com/canonical/ubuntu.com/pull/14823)

## QA

- View the site locally in your web browser at: https://ubuntu-com-14829.demos.haus/sitemap.xml and see that `https://ubuntu.com/server/docs/sitemap.xml` is not listed

## Issue / Card

Fixes [link checker](https://github.com/canonical/ubuntu.com/actions/runs/13693409020)