### PR TITLE
feat: Add new resource type filter on /engage overview

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -365,6 +365,7 @@ def build_engage_index(engage_docs):
             "Webinar",
             "Whitepaper",
             "Form",
+            "Event",
         ]
         tags_list = engage_docs.get_engage_pages_tags()
         total_pages = math.ceil(current_total / limit)


### PR DESCRIPTION
## Done

- Add new "Event" resource type

## QA

- View the site locally in your web browser at: https://ubuntu-com-14833.demos.haus/engage
- See that "Event" appears as an option under the resource type filter and see that it filters as expected

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-20034
