### PR TITLE
chore: Bump vanilla version

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "url-polyfill": "1.1.12",
     "url-search-params-polyfill": "8.2.5",
     "use-query-params": "^2.2.1",
-    "vanilla-framework": "4.20.3",
+    "vanilla-framework": "4.21.1",
     "yup": "1.4.0"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7418,10 +7418,10 @@ v8-to-istanbul@^9.0.1:
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^2.0.0"
 
-vanilla-framework@4.20.3:
-  version "4.20.3"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.20.3.tgz#a306e80f32f5c6b6f107c02e64cc642c6eb32148"
-  integrity sha512-8nE8BxHRckdjo8VYW0jVLK9JMz1XAoTZcKGweg0jM8cV+/D313pPyomEeODAD1qq66yf/W0RfHTXv/wp0AaYfQ==
+vanilla-framework@4.21.1:
+  version "4.21.1"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.21.1.tgz#6a011d49cc028784d091d8745882a9343e9845ab"
+  integrity sha512-kf1l41iv9H4xhJrrpJC3TOF4SBiXJvtZsUFP20g8GVv6d4wgV4vAClD4zCF6sUEnGhxZ13kO/P9nK++DvWzdvQ==
 
 vanilla-framework@4.9.0:
   version "4.9.0"


### PR DESCRIPTION
## Done

- Bump vanilla version to 4.21.1

## QA

- View the site locally in your web browser at: https://ubuntu-com-14835.demos.haus/
- This version shouldn't introduce any breaking changes, but click through a couple pages to double check nothing looks broken 

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-19622
