### PR TITLE
[WD-8780]  fix: docs link scroll margin for same page links

### DIFF
--- a/templates/templates/docs/shared/_docs.html
+++ b/templates/templates/docs/shared/_docs.html
@@ -24,12 +24,8 @@
         {% if expandable %}
           {% if element.children %}
             <button class="p-side-navigation__expand"
-                    aria-expanded="{% if element.is_active or element.has_active_child %}true{% else %}false{% endif %}" aria-label="
-                    show
-                    submenu
-                    for
-                    {{ element.navlink_text }}
-                    "></button>
+                    aria-expanded="{% if element.is_active or element.has_active_child %}true{% else %}false{% endif %}"
+                    aria-label=" show submenu for {{ element.navlink_text }} "></button>
           {% endif %}
           {{ create_navigation(element.children, expandable, element.is_active or element.has_active_child) }}
         {% else %}
@@ -223,4 +219,18 @@
       }
     }
   </script>
+
+  <!-- These styles take care of the issue where the same page links for h2, h3 are cut-off from the top upon click and auto-scroll -->
+  <style>
+    h2,
+    h3 {
+      &[id] {
+        scroll-margin: 2.05rem;
+      }
+
+      & a.p-link--anchor-heading {
+        scroll-margin: 4rem;
+      }
+    }
+  </style>
 {% endblock %}


### PR DESCRIPTION
## Done

- Added scroll-margin to h2 and h3

## QA

- View the site in your web browser at: 
   - https://ubuntu-com-14836.demos.haus/landscape/docs/install-landscape-client
   - https://ubuntu-com-14836.demos.haus/landscape/docs/install-fips-hardened-landscape-server
- Click on different headers on both pages and verify the text is scrolled into view properly

## Issue / Card

Fixes #[WD-8780](https://warthogs.atlassian.net/browse/WD-8780)


[WD-8780]: https://warthogs.atlassian.net/browse/WD-8780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ