### PR TITLE
add a basic rate limiter to magic attach

### DIFF
--- a/webapp/decorators.py
+++ b/webapp/decorators.py
@@ -1,9 +1,15 @@
 # Core packages
 import functools
+from collections import defaultdict, deque
+import time
 
 # Third party packages
 import flask
 from webapp.login import user_info
+
+rate_limits = defaultdict(deque)
+RATE_LIMIT = 5  # Max requests
+TIME_WINDOW = 60  # Time window in seconds (e.g., 60 seconds)
 
 
 def login_required(func):
@@ -20,3 +26,27 @@ def login_required(func):
         return func(*args, **kwargs)
 
     return is_user_logged_in
+
+
+def rate_limiter(func):
+    def wrapper(*args, **kwargs):
+        if not user_info(flask.session):
+            return flask.redirect("/login?next=" + flask.request.path)
+
+        current_time = time.time()
+        user = user_info(flask.session)
+        rate_limits[user["email"]] = [
+            timestamp
+            for timestamp in rate_limits[user["email"]]
+            if current_time - timestamp < TIME_WINDOW
+        ]
+
+        if len(rate_limits[user["email"]]) >= RATE_LIMIT:
+            return (
+                flask.jsonify({"error": "Rate limit exceeded, try again later."}),
+                429,
+            )
+        rate_limits[user["email"]].append(current_time)
+        return func(*args, **kwargs)
+
+    return wrapper

--- a/webapp/shop/advantage/views.py
+++ b/webapp/shop/advantage/views.py
@@ -3,6 +3,7 @@ import json
 from typing import List
 
 import flask
+from webapp.decorators import rate_limiter
 from webargs.fields import String
 
 from webapp.login import user_info
@@ -716,6 +717,7 @@ def blender_shop_view(advantage_mapper, **kwargs):
 
 
 @shop_decorator(area="advantage", permission="user", response="html")
+@rate_limiter
 def activate_magic_attach(advantage_mapper, **kwargs):
     client_ip = flask.request.headers.get(
         "X-Real-IP", flask.request.remote_addr


### PR DESCRIPTION
## Done

- Add 

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to /pro/attach
- Set the limit to something like 1 in 1500
    - Try to submit more times than the limit
    - Should get a limited response as below
- Let the time limit pass
    - Should be able to submit again

## Issue / Card

Fixes #

## Screenshots

![image](https://github.com/user-attachments/assets/f17ba517-cfe0-4aaf-b3d2-16d86561a2a0)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
