### PR TITLE
[WD-19941] Exclude new(static) case-studies from engage page

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ canonicalwebteam.blog==6.4.4
 canonicalwebteam.search==2.1.1
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.5.0
-canonicalwebteam.discourse==5.8.1
+canonicalwebteam.discourse==6.1.1
 python-dateutil==2.8.2
 pytz==2022.7.1
 maxminddb-geolite2==2018.703

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -356,7 +356,7 @@ def build_engage_index(engage_docs):
                 count,
                 active_count,
                 current_total,
-            ) = engage_docs.get_index(limit, offset)
+            ) = engage_docs.get_index(limit, offset, key="is_static", value=None)
 
         # Fixed so that engage page authors don't create random resource types
         resource_types = [

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -356,7 +356,9 @@ def build_engage_index(engage_docs):
                 count,
                 active_count,
                 current_total,
-            ) = engage_docs.get_index(limit, offset, key="is_static", value=None)
+            ) = engage_docs.get_index(
+                limit, offset, key="is_static", value=None
+            )
 
         # Fixed so that engage page authors don't create random resource types
         resource_types = [


### PR DESCRIPTION
## Done

- Added a field called "is_static" on the new case-studies at canonical.com/case-study
- Passed this field as a separate param


## QA

- View the site  in your web browser at: https://ubuntu-com-14848.demos.haus/engage
- Verify the engage pages are loading normally
- Make sure they don't include the static case-studies (case-studies that are hosted statically at canonical.com)

## Issue / Card

Fixes #[WD-19941](https://warthogs.atlassian.net/browse/WD-19941)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-19941]: https://warthogs.atlassian.net/browse/WD-19941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ