### PR TITLE
chore: Use image module on ubuntu home page

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -44,12 +44,14 @@
           </div>
         </div>
         <div class="u-align--center">
-          <img id="test-takeover-image"
-               src="https://assets.ubuntu.com/v1/fb1ea84e-Kernelt%20industries@2x.png"
-               width="508"
-               height="364"
-               loading="lazy"
-               alt="" />
+          {{ image(url="https://assets.ubuntu.com/v1/fb1ea84e-Kernelt%20industries@2x.png",
+                    alt="",
+                    width="2382",
+                    height="1684",
+                    hi_def=True,
+                    loading="lazy",
+                    attrs={"id": "test-takeover-image"}) | safe
+          }}
         </div>
       </div>
     </section>
@@ -74,11 +76,14 @@
           </div>
         </div>
         <div class="col-6 u-vertically-center u-align--center u-hide--medium u-hide--small">
-          <img id="takeover-image"
-               src="https://assets.ubuntu.com/v1/33b5133c-Noble-Numbat-optimised.svg"
-               width="300"
-               alt=""
-               loading="lazy" />
+          {{ image(url="https://assets.ubuntu.com/v1/33b5133c-Noble-Numbat-optimised.svg",
+                    alt="",
+                    width="197",
+                    height="150",
+                    hi_def=True,
+                    loading="lazy",
+                    attrs={"id": "takeover-image"}) | safe
+          }}
         </div>
       </div>
     </section>
@@ -1258,9 +1263,14 @@
       <div class="u-fixed-width">
         <div class="u-vertically-center u-align--center p-image-container--cinematic"
              style="background: rgba(0, 0, 0, 0.15)">
-          <img src="https://assets.ubuntu.com/v1/6d657910-Multi-cloud%20Applications%C2%A0%C2%A0Beyond%20PAAS.png"
-               alt=""
-               loading="lazy" />
+          {{ image(url="https://assets.ubuntu.com/v1/6d657910-Multi-cloud%20Applications%C2%A0%C2%A0Beyond%20PAAS.png",
+                    alt="",
+                    width="2464",
+                    height="1020",
+                    hi_def=True,
+                    attrs={"class": "p-image-container__image"},
+                    loading="lazy") | safe
+          }}
         </div>
         <hr class="p-rule" />
         <div class="p-section--shallow">


### PR DESCRIPTION
## Done

- Replaced img tags with image module

## QA

- View the site locally in your web browser at: https://ubuntu-com-14849.demos.haus/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Verify the replaced images are showing correctly.
