### PR TITLE
[WD-19716] fix: replace broken link

### DIFF
--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -378,7 +378,7 @@
       <div class="col">
         <p class="p-heading--5">From public clouds to data centres to devices</p>
         <p>
-          Ubuntu is the most popular guest operating system on public clouds, the foundation for private cloud implementation and the platform of choice of developers according to the <a href="https://recruit-c7ff.kxcdn.com/recruit/wp-content/uploads/2020/05/he-developer-survey-2020.pdf">2020 HackerEarth Developer Survey</a>.
+          Ubuntu is the most popular guest operating system on public clouds, the foundation for private cloud implementation and the platform of choice of developers according to the <a href="https://www.hackerearth.com/recruit/developer-survey">2020 HackerEarth Developer Survey</a>.
         </p>
         <hr class="p-rule--muted" />
         <a href="/engage/from-vmware-to-open-source">Watch a webinar - “From VMware to Open Source”&nbsp;&rsaquo;</a>


### PR DESCRIPTION
## Done

- Fixed a broken link

## QA

- View the site  in your web browser at: https://ubuntu-com-14853.demos.haus/server
- Scroll down to the section named "Infrastructure and applications foundation"
- Click on the "[2020 HackerEarth Developer Survey](https://www.hackerearth.com/recruit/developer-survey)" link
- It should take you to hackerearth.com correctly.

## Issue / Card

Fixes #[WD-19716](https://warthogs.atlassian.net/browse/WD-19716)


[WD-19716]: https://warthogs.atlassian.net/browse/WD-19716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ