### PR TITLE
fix incorrect data being shown for free Pro on subscribe

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -661,7 +661,7 @@ staging:
       value: pk_test_yndN9H0GcJffPe0W58Nm64cM00riYG4N46
 
     - name: TRUEABILITY_URL
-      value: https://app3.trueability.com
+      value: https://app.trueability.com
 
     - name: TRUEABILITY_API_KEY
       secretKeyRef:
@@ -797,7 +797,7 @@ staging:
             name: confidentiality-webhook
 
         - name: TRUEABILITY_URL
-          value: https://app3.trueability.com
+          value: https://app.trueability.com
 
         - name: TRUEABILITY_API_KEY
           secretKeyRef:
@@ -1128,7 +1128,7 @@ demo:
       value: pk_test_yndN9H0GcJffPe0W58Nm64cM00riYG4N46
 
     - name: TRUEABILITY_URL
-      value: https://app3.trueability.com
+      value: https://app.trueability.com
 
     - name: TRUEABILITY_API_KEY
       secretKeyRef:

--- a/static/js/src/advantage/subscribe/react/components/ProductSummary/ProductSummary.tsx
+++ b/static/js/src/advantage/subscribe/react/components/ProductSummary/ProductSummary.tsx
@@ -138,7 +138,9 @@ const ProductSummary = () => {
           <Col size={12}>
             <p>
               {productUser == ProductUsers.myself ? 5 : quantity} subscription
-              {+quantity > 1 || productUser == ProductUsers.myself ? "s" : ""}{" "}
+              {+quantity > 1 || productUser == ProductUsers.myself
+                ? "s"
+                : ""}{" "}
               for
             </p>
           </Col>

--- a/static/js/src/advantage/subscribe/react/components/ProductSummary/ProductSummary.tsx
+++ b/static/js/src/advantage/subscribe/react/components/ProductSummary/ProductSummary.tsx
@@ -137,7 +137,9 @@ const ProductSummary = () => {
         <Row className="u-sv3">
           <Col size={12}>
             <p>
-              {quantity} subscription{+quantity > 1 ? "s" : ""} for
+              {productUser == ProductUsers.myself ? 5 : quantity} subscription
+              {+quantity > 1 || productUser == ProductUsers.myself ? "s" : ""}{" "}
+              for
             </p>
           </Col>
           <Col size={12}>
@@ -175,9 +177,12 @@ const ProductSummary = () => {
           </Col>
           <Col size={1} small={2}>
             <p className="p-heading--2">
-              {currencyFormatter.format(
-                ((product?.price.value ?? 0) / 100) * (Number(quantity) ?? 0),
-              )}
+              {productUser == ProductUsers.myself
+                ? "Free"
+                : currencyFormatter.format(
+                    ((product?.price.value ?? 0) / 100) *
+                      (Number(quantity) ?? 0),
+                  )}
             </p>
             {productUser === ProductUsers.myself ? (
               <a


### PR DESCRIPTION
## Done

- Fixed wrong data being shown for free Pro subscriptions on shop

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile
*Fix only for mobile*
- Visit [/pro/subscribe](https://ubuntu-com-14860.demos.haus/pro/subscribe)
- Select myself as the user in the first section
- It should show the price as free and quantity as 5

## Issue / Card

Fixes [#WD-20369](https://warthogs.atlassian.net/browse/WD-20369)

## Screenshots
Old:
![image](https://github.com/user-attachments/assets/5c4dafd8-c2ea-4577-b175-3f439236b401)

New:
![image](https://github.com/user-attachments/assets/5cc6adc9-00d0-4138-b287-98b4fce3a2f6)
## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
