### PR TITLE
chore: Refactor sitemap templates

### DIFF
--- a/static/files/sitemap_tree.xml
+++ b/static/files/sitemap_tree.xml
@@ -1,3816 +1,2523 @@
 <?xml version="1.0" encoding="utf-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">  
-  
-  <url>
-    <loc>https://ubuntu.com/openstack</loc>   
-    <lastmod>2024-12-09T10:41:13+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-  <url>
-    <loc>https://ubuntu.com/openstack/pricing-calculator</loc>
-    <lastmod>2024-09-23T17:09:02+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/openstack/install</loc>
-    <lastmod>2024-09-23T17:09:02+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/openstack/compare</loc>
-    <lastmod>2023-10-25T13:56:33+02:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/openstack/support</loc>
-    <lastmod>2025-01-31T15:46:26+05:30</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/openstack/openstack-cheat-sheet</loc>
-    <lastmod>2023-06-13T11:20:36+02:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/openstack/contact-us</loc>
-    <lastmod>2024-08-15T15:36:45+08:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/openstack/what-is-openstack</loc>
-    <lastmod>2025-01-10T12:37:12+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/openstack/resources</loc>
-    <lastmod>2024-12-20T09:20:49+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/openstack/consulting</loc>
-    <lastmod>2025-02-25T17:12:18+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/openstack/why-openstack</loc>
-    <lastmod>2024-09-09T14:58:27+02:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/openstack/managed</loc>
-    <lastmod>2024-09-23T17:09:02+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/openstack/tutorials</loc>
-    <lastmod>2024-06-27T16:03:44+02:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/openstack/features</loc>
-    <lastmod>2024-11-20T10:45:10+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/openstack/thank-you</loc>
-    <lastmod>2024-07-31T17:40:32+08:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/openstack/newsletter-thank-you</loc>
-    <lastmod>2019-08-23T14:16:45+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  
-  
-  <url>
-    <loc>https://ubuntu.com/403</loc>   
-    <lastmod>2025-02-13T11:02:14+05:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-  
-  <url>
-    <loc>https://ubuntu.com/managed</loc>   
-    <lastmod>2025-01-10T12:37:12+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-  <url>
-    <loc>https://ubuntu.com/managed/contact-us</loc>
-    <lastmod>2024-08-15T15:36:45+08:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/managed/firefighting-support</loc>
-    <lastmod>2024-09-23T17:09:02+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/managed/apps</loc>
-    <lastmod>2025-01-31T15:46:26+05:30</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-      
-  <url>
-    <loc>https://ubuntu.com/managed/apps/kafka</loc>
-    <lastmod>2023-05-17T09:06:03+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-    
-  
-
-  <url>
-    <loc>https://ubuntu.com/managed/thank-you</loc>
-    <lastmod>2021-08-24T15:29:16+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  
-  
-  <url>
-    <loc>https://ubuntu.com/supermicro</loc>   
-    <lastmod>2024-12-09T16:45:38+08:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-  <url>
-    <loc>https://ubuntu.com/supermicro/contact-us</loc>
-    <lastmod>2024-01-12T19:32:28+06:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  
-  
-  <url>
-    <loc>https://ubuntu.com/advantage</loc>   
-    <lastmod>2023-03-17T10:42:07+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-  <url>
-    <loc>https://ubuntu.com/advantage/offers</loc>
-    <lastmod>2022-01-17T15:06:07+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/advantage/subscribe</loc>
-    <lastmod>2024-11-21T10:21:37+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-      
-  <url>
-    <loc>https://ubuntu.com/advantage/subscribe/blender</loc>
-    <lastmod>2023-09-26T12:09:21+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-    
-  
-
-  <url>
-    <loc>https://ubuntu.com/advantage/users</loc>
-    <lastmod>2021-09-20T15:33:31+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/advantage/maintenance</loc>
-    <lastmod>2024-08-16T16:49:20+05:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/advantage/blender</loc>
-    <lastmod>2021-10-20T09:08:34+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  
-  
-  <url>
-    <loc>https://ubuntu.com/internet-of-things</loc>   
-    <lastmod>2025-02-27T13:48:30+05:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-  <url>
-    <loc>https://ubuntu.com/internet-of-things/contact-us</loc>
-    <lastmod>2024-12-13T18:12:48+05:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/internet-of-things/management</loc>
-    <lastmod>2025-02-27T13:48:30+05:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/internet-of-things/nvidia</loc>
-    <lastmod>None</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-      
-  <url>
-    <loc>https://ubuntu.com/internet-of-things/nvidia/contact-us</loc>
-    <lastmod>2025-01-13T15:13:08+08:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-    
-  
-
-  <url>
-    <loc>https://ubuntu.com/internet-of-things/digital-signage</loc>
-    <lastmod>2025-02-27T13:48:30+05:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/internet-of-things/smart-displays</loc>
-    <lastmod>2025-02-27T13:48:30+05:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/internet-of-things/gateways</loc>
-    <lastmod>2025-02-27T13:48:30+05:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/internet-of-things/smart-city</loc>
-    <lastmod>2025-02-27T13:48:30+05:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/internet-of-things/networking</loc>
-    <lastmod>2025-02-27T13:48:30+05:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/internet-of-things/appstore</loc>
-    <lastmod>2025-02-27T13:48:30+05:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/internet-of-things/contact-us-hannover</loc>
-    <lastmod>2023-03-29T10:20:59+02:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/internet-of-things/smart-home</loc>
-    <lastmod>2025-02-27T13:48:30+05:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/internet-of-things/thank-you</loc>
-    <lastmod>2023-03-13T14:30:31+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  
-  
-  <url>
-    <loc>https://ubuntu.com/masters-conference</loc>   
-    <lastmod>2025-02-25T09:50:36+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-  <url>
-    <loc>https://ubuntu.com/masters-conference/contact-us</loc>
-    <lastmod>2021-10-15T10:33:50+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/masters-conference/thank-you</loc>
-    <lastmod>2019-12-06T11:28:40+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  
-  
-  <url>
-    <loc>https://ubuntu.com/core</loc>   
-    <lastmod>2024-09-23T17:09:02+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-  <url>
-    <loc>https://ubuntu.com/core/features</loc>
-    <lastmod>2024-09-23T17:09:02+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-      
-  <url>
-    <loc>https://ubuntu.com/core/features/full-disk-encryption</loc>
-    <lastmod>2024-09-23T17:09:02+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/core/features/recovery</loc>
-    <lastmod>2024-09-23T17:09:02+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/core/features/secure-boot</loc>
-    <lastmod>2024-09-23T17:09:02+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/core/features/ota-updates</loc>
-    <lastmod>2024-09-23T17:09:02+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-    
-  
-
-  <url>
-    <loc>https://ubuntu.com/core/contact-us</loc>
-    <lastmod>2024-07-31T17:39:05+08:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/core/stories</loc>
-    <lastmod>2024-09-23T17:09:02+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/core/services</loc>
-    <lastmod>2024-09-23T17:09:02+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-      
-  <url>
-    <loc>https://ubuntu.com/core/services/contact-us</loc>
-    <lastmod>2022-04-22T14:56:11+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/core/services/_markdown</loc>
-    <lastmod>2022-04-22T14:56:11+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/core/services/thank-you</loc>
-    <lastmod>2024-08-28T21:25:23+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-    
-  
-
-  <url>
-    <loc>https://ubuntu.com/core/thank-you</loc>
-    <lastmod>2024-08-28T21:25:23+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  
-  
-  <url>
-    <loc>https://ubuntu.com/user-research</loc>   
-    <lastmod>2024-09-23T17:09:02+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-  
-  <url>
-    <loc>https://ubuntu.com/pro</loc>   
-    <lastmod>2024-09-23T17:09:02+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-  <url>
-    <loc>https://ubuntu.com/pro/tutorial</loc>
-    <lastmod>2024-12-11T16:36:23+08:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/pro/devices</loc>
-    <lastmod>2024-12-05T17:45:34+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/pro/why-pro</loc>
-    <lastmod>2024-09-23T17:09:02+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/pro/attach</loc>
-    <lastmod>2024-01-10T17:21:04+05:30</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-      
-  <url>
-    <loc>https://ubuntu.com/pro/attach/confirmation</loc>
-    <lastmod>2023-01-13T14:28:32+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-    
-  
-
-  <url>
-    <loc>https://ubuntu.com/pro/distributor</loc>
-    <lastmod>2024-07-29T23:21:52+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-      
-  <url>
-    <loc>https://ubuntu.com/pro/distributor/thank-you</loc>
-    <lastmod>2024-07-22T17:26:21+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-    
-  
-
-  <url>
-    <loc>https://ubuntu.com/pro/activate</loc>
-    <lastmod>2023-08-04T10:26:41+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/pro/thank-you</loc>
-    <lastmod>2024-12-11T16:41:28+08:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  
-  
-  <url>
-    <loc>https://ubuntu.com/appliance</loc>   
-    <lastmod>2024-09-23T17:09:02+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-  <url>
-    <loc>https://ubuntu.com/appliance/mosquitto</loc>
-    <lastmod>None</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-      
-  <url>
-    <loc>https://ubuntu.com/appliance/mosquitto/raspberry-pi</loc>
-    <lastmod>2020-12-17T13:41:36+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/appliance/mosquitto/vm</loc>
-    <lastmod>2020-06-11T14:13:47+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/appliance/mosquitto/raspberry-pi2</loc>
-    <lastmod>2020-12-17T13:41:36+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/appliance/mosquitto/intel-nuc</loc>
-    <lastmod>2020-12-17T13:41:36+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-    
-  
-
-  <url>
-    <loc>https://ubuntu.com/appliance/nextcloud</loc>
-    <lastmod>None</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-      
-  <url>
-    <loc>https://ubuntu.com/appliance/nextcloud/raspberry-pi</loc>
-    <lastmod>2020-06-05T11:44:29+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/appliance/nextcloud/vm</loc>
-    <lastmod>2020-06-11T14:13:47+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/appliance/nextcloud/raspberry-pi2</loc>
-    <lastmod>2020-06-15T19:49:56+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/appliance/nextcloud/intel-nuc</loc>
-    <lastmod>2020-06-11T08:40:26+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-    
-  
-
-  <url>
-    <loc>https://ubuntu.com/appliance/community</loc>
-    <lastmod>2024-09-23T17:09:02+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/appliance/adguard</loc>
-    <lastmod>None</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-      
-  <url>
-    <loc>https://ubuntu.com/appliance/adguard/raspberry-pi</loc>
-    <lastmod>2020-12-17T13:41:36+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/appliance/adguard/vm</loc>
-    <lastmod>2020-06-03T22:18:47+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/appliance/adguard/raspberry-pi2</loc>
-    <lastmod>2020-12-17T13:41:36+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/appliance/adguard/intel-nuc</loc>
-    <lastmod>2020-12-17T13:41:36+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-    
-  
-
-  <url>
-    <loc>https://ubuntu.com/appliance/about</loc>
-    <lastmod>2024-09-23T17:09:02+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/appliance/contact-us</loc>
-    <lastmod>2021-10-15T10:33:50+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/appliance/openhab</loc>
-    <lastmod>None</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-      
-  <url>
-    <loc>https://ubuntu.com/appliance/openhab/raspberry-pi</loc>
-    <lastmod>2020-12-17T13:41:36+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/appliance/openhab/vm</loc>
-    <lastmod>2020-06-03T22:18:47+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/appliance/openhab/raspberry-pi2</loc>
-    <lastmod>2020-12-17T13:41:36+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/appliance/openhab/intel-nuc</loc>
-    <lastmod>2020-12-17T13:41:36+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-    
-  
-
-  <url>
-    <loc>https://ubuntu.com/appliance/lxd</loc>
-    <lastmod>None</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-      
-  <url>
-    <loc>https://ubuntu.com/appliance/lxd/raspberry-pi</loc>
-    <lastmod>2020-12-17T13:41:36+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/appliance/lxd/intel-nuc</loc>
-    <lastmod>2020-12-17T13:41:36+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-    
-  
-
-  <url>
-    <loc>https://ubuntu.com/appliance/vm</loc>
-    <lastmod>2023-03-06T09:04:51+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/appliance/plex</loc>
-    <lastmod>None</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-      
-  <url>
-    <loc>https://ubuntu.com/appliance/plex/raspberry-pi</loc>
-    <lastmod>2020-12-17T13:41:36+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/appliance/plex/vm</loc>
-    <lastmod>2020-06-03T22:18:47+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/appliance/plex/raspberry-pi2</loc>
-    <lastmod>2020-12-17T13:41:36+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/appliance/plex/intel-nuc</loc>
-    <lastmod>2020-12-17T13:41:36+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-    
-  
-
-  <url>
-    <loc>https://ubuntu.com/appliance/tutorials</loc>
-    <lastmod>2022-01-11T15:10:20+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/appliance/hardware</loc>
-    <lastmod>2024-09-23T17:09:02+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/appliance/thank-you</loc>
-    <lastmod>2022-03-17T13:39:32+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/appliance/portfolio</loc>
-    <lastmod>2024-09-23T17:09:02+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  
-  
-  <url>
-    <loc>https://ubuntu.com/security</loc>   
-    <lastmod>2025-02-28T13:05:36+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-  <url>
-    <loc>https://ubuntu.com/security/vex</loc>
-    <lastmod>2025-02-28T13:22:10+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/security/disclosure-policy</loc>
-    <lastmod>2025-02-28T13:13:11+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/security/cis</loc>
-    <lastmod>2025-02-28T13:22:10+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/security/platform-security</loc>
-    <lastmod>2025-02-21T17:55:43+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/security/compliance-automation</loc>
-    <lastmod>2025-02-28T13:22:10+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/security/fips</loc>
-    <lastmod>2025-02-28T13:05:36+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/security/oval</loc>
-    <lastmod>2025-02-28T13:13:11+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/security/esm</loc>
-    <lastmod>2025-02-28T13:22:10+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/security/contact-us</loc>
-    <lastmod>2024-08-15T15:36:45+08:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/security/notices</loc>
-    <lastmod>None</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-      
-  <url>
-    <loc>https://ubuntu.com/security/notices/lsn</loc>
-    <lastmod>2022-03-23T16:18:05+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/security/notices/usn</loc>
-    <lastmod>2024-12-06T11:58:07-05:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-    
-  
-
-  <url>
-    <loc>https://ubuntu.com/security/notices</loc>
-    <lastmod>2024-09-23T17:09:02+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/security/cc</loc>
-    <lastmod>2025-02-28T13:05:36+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/security/fedramp</loc>
-    <lastmod>2025-03-03T15:58:43+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/security/docker-images</loc>
-    <lastmod>2025-02-28T13:13:11+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/security/osv</loc>
-    <lastmod>2025-02-28T13:22:10+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/security/thank-you</loc>
-    <lastmod>2024-08-15T16:05:01+08:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/security/cves</loc>
-    <lastmod>2025-01-10T12:37:12+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-      
-  <url>
-    <loc>https://ubuntu.com/security/cves/about</loc>
-    <lastmod>2024-10-07T17:55:35+02:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/security/cves/cve</loc>
-    <lastmod>2025-02-06T16:07:22+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-    
-  
-
-  <url>
-    <loc>https://ubuntu.com/security/livepatch</loc>
-    <lastmod>2025-02-28T13:22:10+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/security/disa-stig</loc>
-    <lastmod>2025-02-28T13:13:09+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  
-  
-  <url>
-    <loc>https://ubuntu.com/azure</loc>   
-    <lastmod>2025-01-10T12:37:12+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-  <url>
-    <loc>https://ubuntu.com/azure/ebook</loc>
-    <lastmod>2024-09-05T20:47:16+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-      
-  <url>
-    <loc>https://ubuntu.com/azure/ebook/thank-you</loc>
-    <lastmod>2022-03-04T13:44:23+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-    
-  
-
-  <url>
-    <loc>https://ubuntu.com/azure/fips</loc>
-    <lastmod>2025-02-25T12:12:00+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/azure/support</loc>
-    <lastmod>2024-09-05T20:47:16+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/azure/pro</loc>
-    <lastmod>2025-01-10T15:33:09+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/azure/private-offer</loc>
-    <lastmod>2024-09-23T17:09:02+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/azure/sql</loc>
-    <lastmod>2024-09-05T20:47:54+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/azure/contact-us</loc>
-    <lastmod>2021-10-15T10:33:50+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/azure/thank-you</loc>
-    <lastmod>2024-09-05T20:48:12+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/azure/confidential-computing</loc>
-    <lastmod>2025-01-10T12:37:12+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  
-  
-  <url>
-    <loc>https://ubuntu.com/ceph</loc>   
-    <lastmod>2025-01-24T18:22:12+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-  <url>
-    <loc>https://ubuntu.com/ceph/install</loc>
-    <lastmod>2024-12-02T10:45:14+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/ceph/contact-us</loc>
-    <lastmod>2021-10-15T10:33:50+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/ceph/consulting</loc>
-    <lastmod>2024-12-02T10:45:14+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/ceph/what-is-ceph</loc>
-    <lastmod>2024-12-02T10:45:14+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/ceph/managed</loc>
-    <lastmod>2024-12-02T15:35:23+05:30</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/ceph/thank-you</loc>
-    <lastmod>2024-12-02T10:45:14+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  
-  
-  <url>
-    <loc>https://ubuntu.com/workstations-journey-to-ai</loc>   
-    <lastmod>2021-07-21T09:48:39+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-  
-  <url>
-    <loc>https://ubuntu.com/robotics</loc>   
-    <lastmod>2024-09-23T17:09:02+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-  <url>
-    <loc>https://ubuntu.com/robotics/ros-esm</loc>
-    <lastmod>2025-01-10T12:37:12+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/robotics/community</loc>
-    <lastmod>2024-12-03T11:07:54+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/robotics/what-is-ros</loc>
-    <lastmod>2024-07-11T13:17:11+08:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/robotics/thank-you</loc>
-    <lastmod>2021-05-03T11:13:00+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  
-  
-  <url>
-    <loc>https://ubuntu.com/training</loc>   
-    <lastmod>2024-10-11T11:11:59+02:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-  <url>
-    <loc>https://ubuntu.com/training/contact-us</loc>
-    <lastmod>2024-08-15T15:36:45+08:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/training/thank-you</loc>
-    <lastmod>2023-01-16T17:26:33+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  
-  
-  <url>
-    <loc>https://ubuntu.com/security-series</loc>   
-    <lastmod>2024-09-23T17:09:02+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-  <url>
-    <loc>https://ubuntu.com/security-series/thank-you</loc>
-    <lastmod>2020-09-29T16:30:43+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  
-  
-  <url>
-    <loc>https://ubuntu.com/resources</loc>   
-    <lastmod>2024-09-23T17:09:02+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-  
-  <url>
-    <loc>https://ubuntu.com/summit</loc>   
-    <lastmod>2024-10-10T13:50:56+05:30</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-  
-  <url>
-    <loc>https://ubuntu.com/429</loc>   
-    <lastmod>2025-02-13T11:02:14+05:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-  
-  <url>
-    <loc>https://ubuntu.com/takeovers</loc>   
-    <lastmod>2024-07-25T14:51:58+02:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-  
-  <url>
-    <loc>https://ubuntu.com/500</loc>   
-    <lastmod>2025-02-13T11:02:14+05:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-  
-  <url>
-    <loc>https://ubuntu.com/_image-testing</loc>   
-    <lastmod>2020-02-24T16:38:05+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-  
-  <url>
-    <loc>https://ubuntu.com/20-04</loc>   
-    <lastmod>2024-12-20T09:20:49+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-  
-  <url>
-    <loc>https://ubuntu.com/404</loc>   
-    <lastmod>2025-02-13T11:02:14+05:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-  
-  <url>
-    <loc>https://ubuntu.com/hpe</loc>   
-    <lastmod>2024-12-16T16:01:52+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-  
-  <url>
-    <loc>https://ubuntu.com/desktop</loc>   
-    <lastmod>2025-02-14T10:10:16+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-  <url>
-    <loc>https://ubuntu.com/desktop/wsl</loc>
-    <lastmod>2025-02-20T16:25:58+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/desktop/organisations</loc>
-    <lastmod>2025-02-26T23:52:41-05:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/desktop/flavours</loc>
-    <lastmod>2024-10-10T16:57:47+02:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/desktop/developers</loc>
-    <lastmod>2024-09-23T17:09:02+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/desktop/contact-us</loc>
-    <lastmod>2021-10-15T10:33:50+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/desktop/partners</loc>
-    <lastmod>2022-07-29T06:08:19+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/desktop/thank-you</loc>
-    <lastmod>2024-07-31T17:39:04+08:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  
-  
-  <url>
-    <loc>https://ubuntu.com/server</loc>   
-    <lastmod>2024-09-23T17:09:02+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-  <url>
-    <loc>https://ubuntu.com/server/maas</loc>
-    <lastmod>None</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-      
-  <url>
-    <loc>https://ubuntu.com/server/maas/thank-you</loc>
-    <lastmod>2019-08-23T14:16:45+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-    
-  
-
-  <url>
-    <loc>https://ubuntu.com/server/contact-us</loc>
-    <lastmod>2024-08-15T15:36:45+08:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/server/hyperscale</loc>
-    <lastmod>2024-09-23T17:09:02+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/server/thank-you</loc>
-    <lastmod>2024-07-31T17:41:13+08:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  
-  
-  <url>
-    <loc>https://ubuntu.com/about</loc>   
-    <lastmod>2024-08-05T09:17:57+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-  <url>
-    <loc>https://ubuntu.com/about/packages</loc>
-    <lastmod>2022-10-06T14:28:28+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/about/release-cycle</loc>
-    <lastmod>2025-03-04T16:26:02+11:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  
-  
-  <url>
-    <loc>https://ubuntu.com/engage</loc>   
-    <lastmod>2025-02-24T10:42:57+05:30</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-  <url>
-    <loc>https://ubuntu.com/engage/unlisted</loc>
-    <lastmod>None</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-      
-  <url>
-    <loc>https://ubuntu.com/engage/unlisted/at&amp;t-onboarding</loc>
-    <lastmod>2022-09-28T16:16:14+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/engage/unlisted/custom-ubuntu-pro-image-on-azure</loc>
-    <lastmod>2023-01-04T15:57:19+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/engage/unlisted/shell-onboarding</loc>
-    <lastmod>2025-01-10T12:37:12+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-    
-  
-
-  <url>
-    <loc>https://ubuntu.com/engage/es_why-openstack</loc>
-    <lastmod>2024-09-09T14:58:27+02:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/engage/shared</loc>
-    <lastmod>None</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-      
-  <url>
-    <loc>https://ubuntu.com/engage/shared/_ru_thank-you</loc>
-    <lastmod>2024-03-04T16:06:48+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/engage/shared/_de_thank-you</loc>
-    <lastmod>2024-03-04T16:06:48+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/engage/shared/_it_thank-you</loc>
-    <lastmod>2024-03-04T16:06:48+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/engage/shared/_tr_thank-you</loc>
-    <lastmod>2025-02-20T11:54:49+05:30</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/engage/shared/_fr_thank-you</loc>
-    <lastmod>2024-03-04T16:06:48+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/engage/shared/_zh-TW_thank-you</loc>
-    <lastmod>2024-03-04T16:06:48+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/engage/shared/_kr_thank-you</loc>
-    <lastmod>2024-04-10T17:34:49+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/engage/shared/_pt_thank-you</loc>
-    <lastmod>2024-03-04T16:06:48+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/engage/shared/_es_thank-you</loc>
-    <lastmod>2024-03-04T16:06:48+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-    
-  
-
-  <url>
-    <loc>https://ubuntu.com/engage/de_why-openstack</loc>
-    <lastmod>2024-09-09T14:58:27+02:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/engage/fr_why-openstack</loc>
-    <lastmod>2024-09-09T14:58:27+02:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/engage/thank-you</loc>
-    <lastmod>2024-03-22T11:06:49+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  
-  
-  <url>
-    <loc>https://ubuntu.com/real-time</loc>   
-    <lastmod>2024-08-14T16:13:22+02:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-  
-  <url>
-    <loc>https://ubuntu.com/gcp</loc>   
-    <lastmod>2024-12-13T08:53:53+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-  <url>
-    <loc>https://ubuntu.com/gcp/fips</loc>
-    <lastmod>2025-02-06T18:23:19+04:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/gcp/pro</loc>
-    <lastmod>2024-09-20T18:26:36+05:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/gcp/contact-us</loc>
-    <lastmod>2021-10-15T10:33:50+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/gcp/thank-you</loc>
-    <lastmod>2024-09-05T20:48:12+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  
-  
-  <url>
-    <loc>https://ubuntu.com/automotive</loc>   
-    <lastmod>2024-09-23T17:09:02+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-  <url>
-    <loc>https://ubuntu.com/automotive/developers</loc>
-    <lastmod>2025-01-10T12:37:12+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/automotive/resources</loc>
-    <lastmod>2024-10-16T12:02:05+08:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/automotive/buyers-guide</loc>
-    <lastmod>2024-09-23T17:09:02+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  
-  
-  <url>
-    <loc>https://ubuntu.com/hpc</loc>   
-    <lastmod>2024-12-20T09:20:49+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-  <url>
-    <loc>https://ubuntu.com/hpc/contact-us</loc>
-    <lastmod>2022-08-23T09:54:17+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/hpc/use-cases</loc>
-    <lastmod>2025-01-10T12:37:12+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/hpc/thank-you</loc>
-    <lastmod>2022-08-23T09:54:17+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  
-  
-  <url>
-    <loc>https://ubuntu.com/dell</loc>   
-    <lastmod>2024-12-09T16:45:38+08:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-  <url>
-    <loc>https://ubuntu.com/dell/powerflex</loc>
-    <lastmod>2025-01-21T10:08:46+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/dell/contact-us</loc>
-    <lastmod>2021-10-15T10:33:50+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/dell/thank-you</loc>
-    <lastmod>2022-03-17T13:39:32+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  
-  
-  <url>
-    <loc>https://ubuntu.com/blog</loc>   
-    <lastmod>2022-08-30T13:52:58+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-  <url>
-    <loc>https://ubuntu.com/blog/desktop</loc>
-    <lastmod>2024-04-17T11:48:34+02:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/blog/tag</loc>
-    <lastmod>2020-01-10T11:44:45+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/blog/article</loc>
-    <lastmod>2025-01-17T18:10:07+05:30</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/blog/people-and-culture</loc>
-    <lastmod>2022-11-23T14:32:15+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/blog/author</loc>
-    <lastmod>2023-08-11T10:45:23+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/blog/upcoming</loc>
-    <lastmod>2020-01-10T11:44:45+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/blog/internet-of-things</loc>
-    <lastmod>2022-01-11T15:10:20+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/blog/cloud-and-server</loc>
-    <lastmod>2022-01-11T15:10:20+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/blog/archives</loc>
-    <lastmod>2020-01-10T11:44:45+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/blog/topics</loc>
-    <lastmod>None</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-      
-  <url>
-    <loc>https://ubuntu.com/blog/topics/design</loc>
-    <lastmod>2024-04-17T11:48:34+02:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/blog/topics/snapcraft</loc>
-    <lastmod>2024-04-17T11:48:34+02:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/blog/topics/juju</loc>
-    <lastmod>2024-04-17T11:48:34+02:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/blog/topics/maas</loc>
-    <lastmod>2024-04-17T11:48:34+02:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/blog/topics/robotics</loc>
-    <lastmod>2024-04-17T11:48:34+02:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-    
-  
-
-  
-  
-  <url>
-    <loc>https://ubuntu.com/ibm</loc>   
-    <lastmod>2023-06-08T11:21:06+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-  <url>
-    <loc>https://ubuntu.com/ibm/contact-us</loc>
-    <lastmod>2021-10-15T10:33:50+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/ibm/thank-you</loc>
-    <lastmod>2022-03-17T13:39:32+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  
-  
-  <url>
-    <loc>https://ubuntu.com/rfp</loc>   
-    <lastmod>2023-03-29T10:20:59+02:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-  
-  <url>
-    <loc>https://ubuntu.com/telco</loc>   
-    <lastmod>2025-01-08T14:38:19+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-  <url>
-    <loc>https://ubuntu.com/telco/cnf</loc>
-    <lastmod>2025-01-10T12:37:12+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/telco/openran</loc>
-    <lastmod>2024-11-21T10:21:37+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/telco/contact-us</loc>
-    <lastmod>2021-10-15T10:33:50+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/telco/thank-you</loc>
-    <lastmod>2022-03-17T13:39:32+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/telco/vnf</loc>
-    <lastmod>2024-09-23T17:09:02+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  
-  
-  <url>
-    <loc>https://ubuntu.com/industrial</loc>   
-    <lastmod>2024-09-23T17:09:02+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-  
-  <url>
-    <loc>https://ubuntu.com/nvidia</loc>   
-    <lastmod>2024-09-23T17:09:02+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-  
-  <url>
-    <loc>https://ubuntu.com/support</loc>   
-    <lastmod>2025-02-05T18:38:24+08:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-  <url>
-    <loc>https://ubuntu.com/support/community-support</loc>
-    <lastmod>2024-09-03T14:04:34+02:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/support/contact-us</loc>
-    <lastmod>2024-08-15T15:36:45+08:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/support/thank-you</loc>
-    <lastmod>2024-07-31T17:41:13+08:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  
-  
-  <url>
-    <loc>https://ubuntu.com/software-partnerships</loc>   
-    <lastmod>2025-01-08T14:38:19+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-  
-  <url>
-    <loc>https://ubuntu.com/download</loc>   
-    <lastmod>2025-02-14T10:10:16+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-  <url>
-    <loc>https://ubuntu.com/download/alternative-downloads</loc>
-    <lastmod>2024-09-23T17:09:02+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/download/raspberry-pi</loc>
-    <lastmod>2024-10-10T16:57:47+02:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-      
-  <url>
-    <loc>https://ubuntu.com/download/raspberry-pi/thank-you</loc>
-    <lastmod>2024-04-08T09:35:49+05:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-    
-  
-
-  <url>
-    <loc>https://ubuntu.com/download/qualcomm-iot</loc>
-    <lastmod>2025-01-22T14:48:36+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/download/core</loc>
-    <lastmod>2024-09-23T17:09:02+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/download/intel-iei-tank-870</loc>
-    <lastmod>2024-04-08T09:35:49+05:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/download/up-squared-iot-grove-server</loc>
-    <lastmod>2024-04-08T09:35:49+05:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/download/desktop</loc>
-    <lastmod>2024-10-10T21:33:22+05:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-      
-  <url>
-    <loc>https://ubuntu.com/download/desktop/thank-you</loc>
-    <lastmod>2025-02-25T11:34:03+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-    
-  
-
-  <url>
-    <loc>https://ubuntu.com/download/server</loc>
-    <lastmod>None</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-      
-  <url>
-    <loc>https://ubuntu.com/download/server/arm</loc>
-    <lastmod>2024-10-10T22:01:37+05:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/download/server/s390x</loc>
-    <lastmod>2024-09-23T17:09:02+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/download/server/thank-you-s390x</loc>
-    <lastmod>2025-01-10T12:37:12+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/download/server/download</loc>
-    <lastmod>2024-09-27T12:56:59+05:30</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/download/server/power</loc>
-    <lastmod>2024-09-23T17:09:02+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/download/server/manual</loc>
-    <lastmod>2024-10-10T21:33:22+05:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/download/server/thank-you</loc>
-    <lastmod>2024-12-19T12:00:16+08:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-    
-  
-
-  <url>
-    <loc>https://ubuntu.com/download/contact-us</loc>
-    <lastmod>2024-11-25T15:39:28+11:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/download/iot</loc>
-    <lastmod>2024-09-23T17:09:02+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-      
-  <url>
-    <loc>https://ubuntu.com/download/iot/intel-iot</loc>
-    <lastmod>2024-09-23T17:09:02+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-    
-  
-
-  <url>
-    <loc>https://ubuntu.com/download/intel-nuc-desktop</loc>
-    <lastmod>2024-06-12T10:15:40+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/download/amd</loc>
-    <lastmod>2024-12-05T10:13:41+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/download/mediatek-genio</loc>
-    <lastmod>2024-09-23T17:09:02+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-      
-  <url>
-    <loc>https://ubuntu.com/download/mediatek-genio/contact-us</loc>
-    <lastmod>2025-01-10T17:00:30+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-    
-  
-
-  <url>
-    <loc>https://ubuntu.com/download/risc-v</loc>
-    <lastmod>2024-10-10T16:57:47+02:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/download/qualcomm-dragonboard-410c</loc>
-    <lastmod>2024-04-08T09:35:49+05:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/download/cloud</loc>
-    <lastmod>2024-10-03T23:37:48+05:30</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/download/nvidia-jetson</loc>
-    <lastmod>2024-09-23T17:09:02+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/download/intel-nuc</loc>
-    <lastmod>2024-10-10T16:57:12+02:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/download/thank-you</loc>
-    <lastmod>2024-11-25T15:39:28+11:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  
-  
-  <url>
-    <loc>https://ubuntu.com/ai</loc>   
-    <lastmod>2024-09-23T17:09:02+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-  <url>
-    <loc>https://ubuntu.com/ai/mlflow</loc>
-    <lastmod>2024-09-23T17:09:02+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/ai/roadshow</loc>
-    <lastmod>2025-01-10T12:37:12+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/ai/mlops-workshop</loc>
-    <lastmod>2024-12-03T13:01:22+08:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/ai/contact-us</loc>
-    <lastmod>2024-08-15T15:36:45+08:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/ai/data-science</loc>
-    <lastmod>2024-09-23T17:09:02+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/ai/consulting</loc>
-    <lastmod>2025-02-06T15:48:07+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/ai/what-is-kubeflow</loc>
-    <lastmod>2024-11-12T16:38:01+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/ai/mlops</loc>
-    <lastmod>2024-11-12T16:38:01+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/ai/thank-you</loc>
-    <lastmod>2024-08-15T16:05:01+08:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  
-  
-  <url>
-    <loc>https://ubuntu.com/cloud</loc>   
-    <lastmod>2024-09-20T19:36:40+05:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-  <url>
-    <loc>https://ubuntu.com/cloud/hybrid-cloud</loc>
-    <lastmod>2024-09-20T19:38:56+05:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/cloud/public-cloud-survey</loc>
-    <lastmod>2022-03-17T13:39:32+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/cloud/public-cloud</loc>
-    <lastmod>2024-09-06T10:44:02+05:30</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/cloud/cloud-computing</loc>
-    <lastmod>2025-02-19T12:51:23+05:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/cloud/private-cloud</loc>
-    <lastmod>2024-09-20T19:38:56+05:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/cloud/multi-cloud</loc>
-    <lastmod>2024-09-20T19:36:40+05:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  
-  
-  <url>
-    <loc>https://ubuntu.com/410</loc>   
-    <lastmod>2025-02-13T11:02:14+05:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-  
-  <url>
-    <loc>https://ubuntu.com/contact-us</loc>   
-    <lastmod>2024-06-13T11:36:48+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-  <url>
-    <loc>https://ubuntu.com/contact-us/form</loc>
-    <lastmod>2024-08-15T15:36:45+08:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-      
-  <url>
-    <loc>https://ubuntu.com/contact-us/form/thank-you</loc>
-    <lastmod>2024-07-31T18:10:45+08:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-    
-  
-
-  <url>
-    <loc>https://ubuntu.com/contact-us/newsletter-opt-in</loc>
-    <lastmod>2025-02-21T13:38:39+05:30</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  
-  
-  <url>
-    <loc>https://ubuntu.com/subscription-centre</loc>   
-    <lastmod>2024-09-23T17:09:02+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-  
-  <url>
-    <loc>https://ubuntu.com/16-04</loc>   
-    <lastmod>2025-01-10T12:37:12+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-  <url>
-    <loc>https://ubuntu.com/16-04/azure</loc>
-    <lastmod>2024-09-23T17:09:02+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  
-  
-  <url>
-    <loc>https://ubuntu.com/confidential-computing</loc>   
-    <lastmod>2024-09-23T17:09:02+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-  <url>
-    <loc>https://ubuntu.com/confidential-computing/ai</loc>
-    <lastmod>2024-10-08T10:28:16+02:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  
-  
-  <url>
-    <loc>https://ubuntu.com/templates</loc>   
-    
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-  <url>
-    <loc>https://ubuntu.com/templates/_error_login</loc>
-    
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/templates/meganav</loc>
-    
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-      
-  <url>
-    <loc>https://ubuntu.com/templates/meganav/navigation-nojs</loc>
-    
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-    
-  
-
-  <url>
-    <loc>https://ubuntu.com/templates/docs</loc>
-    
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-      
-  <url>
-    <loc>https://ubuntu.com/templates/docs/shared</loc>
-    
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-      
-  <url>
-    <loc>https://ubuntu.com/templates/docs/shared/_docs</loc>
-    
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/templates/docs/shared/_search-results</loc>
-    
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-    
-  
-
-  <url>
-    <loc>https://ubuntu.com/templates/docs/markdown</loc>
-    
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-    
-  
-
-  <url>
-    <loc>https://ubuntu.com/templates/_product</loc>
-    
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/templates/one-column_no_nav</loc>
-    
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/templates/error</loc>
-    
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/templates/one-column</loc>
-    
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  
-  
-  <url>
-    <loc>https://ubuntu.com/tutorials</loc>   
-    <lastmod>2024-04-17T11:48:34+02:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-  <url>
-    <loc>https://ubuntu.com/tutorials/tutorial</loc>
-    <lastmod>2024-09-23T17:09:02+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  
-  
-  <url>
-    <loc>https://ubuntu.com/aws</loc>   
-    <lastmod>2025-01-16T13:16:42+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-  <url>
-    <loc>https://ubuntu.com/aws/outposts</loc>
-    <lastmod>2025-01-16T13:16:42+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/aws/fips</loc>
-    <lastmod>2025-02-14T15:07:37+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/aws/support</loc>
-    <lastmod>2025-01-16T13:16:42+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/aws/pro</loc>
-    <lastmod>2025-01-16T13:16:42+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/aws/contact-us</loc>
-    <lastmod>2024-08-15T15:36:45+08:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/aws/workspaces</loc>
-    <lastmod>2024-11-19T14:06:04+05:30</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/aws/thank-you</loc>
-    <lastmod>2024-09-05T20:48:12+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  
-  
-  <url>
-    <loc>https://ubuntu.com/search</loc>   
-    <lastmod>2024-09-26T07:42:16+02:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-  
-  <url>
-    <loc>https://ubuntu.com/landscape</loc>   
-    <lastmod>2025-02-26T16:04:34+05:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-  <url>
-    <loc>https://ubuntu.com/landscape/compare</loc>
-    <lastmod>2024-12-20T18:09:30+05:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/landscape/managed</loc>
-    <lastmod>2025-02-26T16:04:34+05:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/landscape/features</loc>
-    <lastmod>2025-01-08T13:35:32+05:30</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  
-  
-  <url>
-    <loc>https://ubuntu.com/containers</loc>   
-    <lastmod>2025-02-10T17:37:34+08:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-  <url>
-    <loc>https://ubuntu.com/containers/chiseled</loc>
-    <lastmod>2025-02-27T11:49:36+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-      
-  <url>
-    <loc>https://ubuntu.com/containers/chiseled/dotnet</loc>
-    <lastmod>2025-01-08T14:38:19+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-    
-  
-
-  <url>
-    <loc>https://ubuntu.com/containers/contact-us</loc>
-    <lastmod>2024-08-15T15:36:45+08:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/containers/what-are-containers</loc>
-    <lastmod>2024-09-23T17:09:02+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/containers/thank-you</loc>
-    <lastmod>2020-01-30T16:42:37+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  
-  
-  <url>
-    <loc>https://ubuntu.com/account</loc>   
-    <lastmod>2022-10-06T11:17:09+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-  <url>
-    <loc>https://ubuntu.com/account/status</loc>
-    <lastmod>2023-03-17T10:42:07+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/account/invoices</loc>
-    <lastmod>2023-08-08T12:45:13+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/account/maintenance-check</loc>
-    <lastmod>2023-03-17T11:50:33+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/account/forbidden</loc>
-    <lastmod>2024-07-22T17:26:21+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/account/checkout</loc>
-    <lastmod>2024-11-21T10:21:37+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/account/payment-methods</loc>
-    <lastmod>2022-03-02T17:23:21+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  
-  
-  <url>
-    <loc>https://ubuntu.com/financial-services</loc>   
-    <lastmod>2024-12-20T09:20:49+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-  <url>
-    <loc>https://ubuntu.com/financial-services/contact-us</loc>
-    <lastmod>2024-08-15T15:36:45+08:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/financial-services/resources</loc>
-    <lastmod>2024-09-23T17:09:02+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/financial-services/thank-you</loc>
-    <lastmod>2022-09-28T11:09:13+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  
-  
-  <url>
-    <loc>https://ubuntu.com/kubernetes</loc>   
-    <lastmod>2025-02-26T17:49:49+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-  <url>
-    <loc>https://ubuntu.com/kubernetes/install</loc>
-    <lastmod>2025-02-26T15:23:58+05:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/kubernetes/compare</loc>
-    <lastmod>2025-02-11T10:11:50+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/kubernetes/documentation</loc>
-    <lastmod>2025-02-25T14:10:29+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/kubernetes/what-is-kubernetes</loc>
-    <lastmod>2025-02-11T10:11:50+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/kubernetes/contact-us</loc>
-    <lastmod>2025-02-11T10:11:50+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/kubernetes/resources</loc>
-    <lastmod>2025-02-11T10:11:50+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/kubernetes/charmed-k8s</loc>
-    <lastmod>2025-02-25T09:57:14+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/kubernetes/managed</loc>
-    <lastmod>2025-02-11T10:11:50+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  
-  
-  <url>
-    <loc>https://ubuntu.com/legal</loc>   
-    <lastmod>2023-01-25T15:37:09-05:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-  <url>
-    <loc>https://ubuntu.com/legal/developer-terms-and-conditions</loc>
-    <lastmod>2022-10-12T20:31:44+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-      
-  <url>
-    <loc>https://ubuntu.com/legal/developer-terms-and-conditions/2016-04-06</loc>
-    <lastmod>2022-10-12T20:31:44+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/legal/developer-terms-and-conditions/2018-07-23</loc>
-    <lastmod>2022-10-12T20:31:44+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-    
-  
-
-  <url>
-    <loc>https://ubuntu.com/legal/intellectual-property-policy</loc>
-    <lastmod>2022-03-24T13:55:22+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-      
-  <url>
-    <loc>https://ubuntu.com/legal/intellectual-property-policy/2013-05-14</loc>
-    <lastmod>2022-03-24T13:55:22+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-    
-  
-
-  <url>
-    <loc>https://ubuntu.com/legal/ua-miracle-tc-ja</loc>
-    <lastmod>2022-10-12T20:31:44+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/legal/anbox-cloud-terms-of-service</loc>
-    <lastmod>2022-10-12T20:31:44+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/legal/data-privacy</loc>
-    <lastmod>2025-02-04T10:00:05+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-      
-  <url>
-    <loc>https://ubuntu.com/legal/data-privacy/enquiry</loc>
-    <lastmod>2023-02-08T11:14:56+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/legal/data-privacy/recruitment</loc>
-    <lastmod>2023-07-14T16:38:44+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/legal/data-privacy/2013-03-25</loc>
-    <lastmod>2022-03-02T12:17:36+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/legal/data-privacy/2016-02-08</loc>
-    <lastmod>2022-03-24T13:55:22+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-    
-  
-
-  <url>
-    <loc>https://ubuntu.com/legal/companies</loc>
-    <lastmod>2025-01-27T12:18:20+02:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/legal/ubuntu-pro-description</loc>
-    <lastmod>None</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-      
-  <url>
-    <loc>https://ubuntu.com/legal/ubuntu-pro-description/ros-esm-service-description</loc>
-    <lastmod>2023-05-22T11:54:31+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-    
-  
-
-  <url>
-    <loc>https://ubuntu.com/legal/ubuntu-pro</loc>
-    <lastmod>2024-01-09T11:58:43+06:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-      
-  <url>
-    <loc>https://ubuntu.com/legal/ubuntu-pro/personal</loc>
-    <lastmod>None</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-      
-  <url>
-    <loc>https://ubuntu.com/legal/ubuntu-pro/personal/_markdown</loc>
-    <lastmod>2024-09-24T17:17:49+05:30</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-    
-  
-
-    
-  
-
-  <url>
-    <loc>https://ubuntu.com/legal/terms</loc>
-    <lastmod>2022-10-18T09:18:55+02:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/legal/nvidia-jetson-and-ubuntu</loc>
-    <lastmod>2023-04-17T10:11:46+02:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/legal/livepatch-terms-of-service</loc>
-    <lastmod>2023-07-14T16:38:44+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/legal/ubuntu-pro-assurance</loc>
-    <lastmod>2023-01-25T15:37:09-05:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/legal/ua-miracle-tc</loc>
-    <lastmod>2022-10-12T20:31:44+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/legal/systems-information-notice</loc>
-    <lastmod>2023-07-14T16:38:44+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/legal/jaas-beta-terms-of-service</loc>
-    <lastmod>2022-10-12T20:31:44+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/legal/equal-employment-opportunity-commitment</loc>
-    <lastmod>2022-08-03T13:32:14+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/legal/anbox-cloud-privacy-notice</loc>
-    <lastmod>2023-07-14T16:38:44+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/legal/contributors</loc>
-    <lastmod>2025-02-14T09:06:24+11:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-      
-  <url>
-    <loc>https://ubuntu.com/legal/contributors/agreement</loc>
-    <lastmod>2025-02-07T12:56:29+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/legal/contributors/faq</loc>
-    <lastmod>2025-02-14T09:06:24+11:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/legal/contributors/thank-you</loc>
-    <lastmod>2022-03-24T13:55:22+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-    
-  
-
-  <url>
-    <loc>https://ubuntu.com/legal/confidentiality-agreement</loc>
-    <lastmod>2024-08-06T13:47:37+05:30</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/legal/open-source-licences</loc>
-    <lastmod>2022-09-30T15:57:58+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/legal/terms-of-service</loc>
-    <lastmod>2022-10-12T20:31:44+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/legal/launchpad-terms-of-service</loc>
-    <lastmod>2022-03-24T13:55:22+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/legal/ubuntu-pro-service-terms</loc>
-    <lastmod>None</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-      
-  <url>
-    <loc>https://ubuntu.com/legal/ubuntu-pro-service-terms/2016-05-20</loc>
-    <lastmod>2024-02-14T15:35:33+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/legal/ubuntu-pro-service-terms/2015-06-24</loc>
-    <lastmod>2024-02-14T15:35:33+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/legal/ubuntu-pro-service-terms/2016-06-24</loc>
-    <lastmod>2024-02-14T15:35:33+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/legal/ubuntu-pro-service-terms/ja</loc>
-    <lastmod>2024-02-14T15:35:33+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/legal/ubuntu-pro-service-terms/2015-09-09</loc>
-    <lastmod>2024-02-14T15:35:33+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-    
-  
-
-  <url>
-    <loc>https://ubuntu.com/legal/ua-dell-tc</loc>
-    <lastmod>2022-10-12T20:31:44+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/legal/websites</loc>
-    <lastmod>2024-05-23T16:28:59+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/legal/terms-and-policies</loc>
-    <lastmod>2024-01-04T11:03:15+06:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-      
-  <url>
-    <loc>https://ubuntu.com/legal/terms-and-policies/credentials-terms</loc>
-    <lastmod>2025-01-10T12:37:12+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/legal/terms-and-policies/contact-us</loc>
-    <lastmod>2022-03-17T13:38:37+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/legal/terms-and-policies/snap-store-terms</loc>
-    <lastmod>2022-10-12T20:31:44+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/legal/terms-and-policies/thank-you</loc>
-    <lastmod>2022-03-24T13:55:22+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-    
-  
-
-  <url>
-    <loc>https://ubuntu.com/legal/font-licence</loc>
-    <lastmod>2024-07-23T16:57:00+08:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-      
-  <url>
-    <loc>https://ubuntu.com/legal/font-licence/differences</loc>
-    <lastmod>2019-10-16T15:00:25+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/legal/font-licence/faq</loc>
-    <lastmod>2022-03-24T13:55:22+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-    
-  
-
-  <url>
-    <loc>https://ubuntu.com/legal/online-account-terms</loc>
-    <lastmod>2022-10-12T20:31:44+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/legal/motd</loc>
-    <lastmod>2023-07-12T17:04:57+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/legal/solution-support</loc>
-    <lastmod>2022-03-24T13:55:22+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  
-  
-  <url>
-    <loc>https://ubuntu.com/0_docs</loc>   
-    <lastmod>2021-03-09T13:03:40+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-  <url>
-    <loc>https://ubuntu.com/0_docs/takeovers</loc>
-    <lastmod>2022-01-11T14:01:17+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/0_docs/strips</loc>
-    <lastmod>2024-09-23T17:09:02+03:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/0_docs/engage_pages</loc>
-    <lastmod>2022-03-17T13:39:32+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/0_docs/takeover-archives</loc>
-    <lastmod>2021-03-09T13:03:40+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/0_docs/content_strips</loc>
-    <lastmod>2023-04-19T15:37:22+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  
-  
-  <url>
-    <loc>https://ubuntu.com/certified</loc>   
-    <lastmod>2024-10-10T17:31:18+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-  <url>
-    <loc>https://ubuntu.com/certified/vendors</loc>
-    <lastmod>None</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-      
-  <url>
-    <loc>https://ubuntu.com/certified/vendors/vendor</loc>
-    <lastmod>2024-11-04T14:40:45+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-    
-  
-
-  <url>
-    <loc>https://ubuntu.com/certified/laptops</loc>
-    <lastmod>2025-02-13T11:58:26+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/certified/platforms</loc>
-    <lastmod>None</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-      
-  <url>
-    <loc>https://ubuntu.com/certified/platforms/platform-details</loc>
-    <lastmod>2024-10-17T11:18:30+02:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-    
-  
-
-  <url>
-    <loc>https://ubuntu.com/certified/model-details</loc>
-    <lastmod>2024-10-31T14:40:02+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/certified/devices</loc>
-    <lastmod>2025-02-13T11:58:26+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/certified/hardware-details</loc>
-    <lastmod>None</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-      
-  <url>
-    <loc>https://ubuntu.com/certified/hardware-details/hardware-details</loc>
-    <lastmod>2024-12-16T11:25:56+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-    
-  
-
-  <url>
-    <loc>https://ubuntu.com/certified/why-certify</loc>
-    <lastmod>2025-01-10T12:37:12+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/certified/desktops</loc>
-    <lastmod>2025-02-13T11:58:26+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/certified/servers</loc>
-    <lastmod>2025-02-13T12:31:54+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/certified/components</loc>
-    <lastmod>None</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-      
-  <url>
-    <loc>https://ubuntu.com/certified/components/component-details</loc>
-    <lastmod>2024-11-01T11:24:13+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-    
-  
-
-  <url>
-    <loc>https://ubuntu.com/certified/socs</loc>
-    <lastmod>2025-02-13T11:58:26+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/certified/search-results</loc>
-    <lastmod>2025-02-13T11:58:26+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  
-  
-  <url>
-    <loc>https://ubuntu.com/18-04</loc>   
-    <lastmod>2024-11-21T10:21:37+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-  <url>
-    <loc>https://ubuntu.com/18-04/oci</loc>
-    <lastmod>2024-11-21T10:21:37+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/18-04/azure</loc>
-    <lastmod>2024-11-21T10:21:37+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/18-04/aws</loc>
-    <lastmod>2024-11-21T10:21:37+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/18-04/gcp</loc>
-    <lastmod>2024-11-21T10:21:37+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/18-04/ibm</loc>
-    <lastmod>2024-11-21T10:21:37+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  
-  
-  <url>
-    <loc>https://ubuntu.com/blender</loc>   
-    <lastmod>2022-03-17T13:39:32+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-  <url>
-    <loc>https://ubuntu.com/blender/contact-us</loc>
-    <lastmod>2021-10-15T10:33:50+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/blender/thank-you</loc>
-    <lastmod>2022-03-17T13:39:32+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  
-  
-  <url>
-    <loc>https://ubuntu.com/20years</loc>   
-    <lastmod>2024-10-24T13:37:30+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-  
-  <url>
-    <loc>https://ubuntu.com/pricing</loc>   
-    <lastmod>2024-10-09T13:55:59+02:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-  <url>
-    <loc>https://ubuntu.com/pricing/desktop</loc>
-    <lastmod>2024-10-09T13:55:59+02:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/pricing/devices</loc>
-    <lastmod>2024-10-24T09:10:40+02:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/pricing/pro</loc>
-    <lastmod>2024-11-20T10:45:10+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/pricing/contact-us</loc>
-    <lastmod>2024-10-09T13:55:59+02:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/pricing/consulting</loc>
-    <lastmod>2024-09-30T12:44:34+08:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/pricing/thank-you</loc>
-    <lastmod>2024-10-09T13:55:59+02:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  
-  
-  <url>
-    <loc>https://ubuntu.com/embedded</loc>   
-    <lastmod>2025-02-27T13:49:32+05:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-  
-  <url>
-    <loc>https://ubuntu.com/security-error-500</loc>   
-    <lastmod>2022-03-24T13:55:22+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-  
-  <url>
-    <loc>https://ubuntu.com/kubeconeurope2020</loc>   
-    <lastmod>2023-01-04T15:57:19+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-  
-  <url>
-    <loc>https://ubuntu.com/cpu-compatibility</loc>   
-    <lastmod>2024-08-05T09:17:57+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-  
-  <url>
-    <loc>https://ubuntu.com/thank-you</loc>   
-    <lastmod>2024-04-04T13:27:56+02:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-  
-  <url>
-    <loc>https://ubuntu.com/kernel</loc>   
-    <lastmod>2024-10-11T14:01:32+02:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-  <url>
-    <loc>https://ubuntu.com/kernel/variants</loc>
-    <lastmod>2023-05-12T10:15:41+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/kernel/real-time</loc>
-    <lastmod>None</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-      
-  <url>
-    <loc>https://ubuntu.com/kernel/real-time/contact-us</loc>
-    <lastmod>2024-11-08T09:07:49+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-    
-  
-
-  <url>
-    <loc>https://ubuntu.com/kernel/lifecycle</loc>
-    <lastmod>2024-06-28T14:07:39+02:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  
-  
-  <url>
-    <loc>https://ubuntu.com/gov</loc>   
-    <lastmod>2025-01-10T12:37:12+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-  <url>
-    <loc>https://ubuntu.com/gov/contact-us</loc>
-    <lastmod>2024-08-15T15:36:45+08:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/gov/thank-you</loc>
-    <lastmod>2022-03-17T13:39:32+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  
-  
-  <url>
-    <loc>https://ubuntu.com/400</loc>   
-    <lastmod>2025-02-13T11:02:14+05:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-  
-  <url>
-    <loc>https://ubuntu.com/credentials</loc>   
-    <lastmod>2024-11-15T13:21:04+05:30</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-  <url>
-    <loc>https://ubuntu.com/credentials/redeem_with_captcha</loc>
-    <lastmod>2024-06-26T10:24:25+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/credentials/exam</loc>
-    <lastmod>2024-08-30T14:15:33+05:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/credentials/exit-survey</loc>
-    <lastmod>2024-06-26T10:24:25+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/credentials/schedule-confirm</loc>
-    <lastmod>2024-06-26T10:24:25+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/credentials/self-study</loc>
-    <lastmod>2025-01-10T12:37:12+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/credentials/redeem_with_form</loc>
-    <lastmod>2024-10-18T01:04:17+05:30</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/credentials/schedule</loc>
-    <lastmod>2024-08-16T17:30:17+05:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/credentials/assessments</loc>
-    <lastmod>2024-06-26T10:24:25+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/credentials/shop</loc>
-    <lastmod>2024-10-08T16:44:09+05:30</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-    
-      
-  <url>
-    <loc>https://ubuntu.com/credentials/shop/manage</loc>
-    <lastmod>2024-06-12T18:54:53+05:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/credentials/shop/keys</loc>
-    <lastmod>2024-10-01T17:49:25+05:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/credentials/shop/thank-you</loc>
-    <lastmod>2024-06-26T10:24:25+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/credentials/shop/webhook_responses</loc>
-    <lastmod>2024-06-26T10:24:25+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-    
-  
-
-  <url>
-    <loc>https://ubuntu.com/credentials/redeem</loc>
-    <lastmod>2024-06-26T10:24:25+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/credentials/exam-no-agreement</loc>
-    <lastmod>2024-06-26T10:24:25+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/credentials/syllabus</loc>
-    <lastmod>2024-10-01T17:49:25+05:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/credentials/dashboard</loc>
-    <lastmod>2024-08-06T20:20:13+05:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/credentials/sign-up</loc>
-    <lastmod>2024-12-10T15:46:51+05:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/credentials/beta-activation</loc>
-    <lastmod>2024-06-26T10:24:25+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/credentials/your-exams</loc>
-    <lastmod>2024-10-01T17:49:25+05:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/credentials/faq</loc>
-    <lastmod>2025-01-10T12:37:12+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/credentials/your-badges</loc>
-    <lastmod>2024-06-26T10:24:25+01:00</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  <url>
-    <loc>https://ubuntu.com/credentials/thank-you</loc>
-    <lastmod>2024-11-29T00:25:38+05:30</lastmod>
-    <changefreq>monthly</changefreq>
-  </url>
-  
-
-  
-  
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+<url>
+  <loc>https://ubuntu.com/openstack</loc>
+  <lastmod>2024-12-09T10:41:13+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/openstack/pricing-calculator</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/openstack/install</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/openstack/compare</loc>
+  <lastmod>2023-10-25T13:56:33+02:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/openstack/support</loc>
+  <lastmod>2025-01-31T15:46:26+05:30</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/openstack/openstack-cheat-sheet</loc>
+  <lastmod>2023-06-13T11:20:36+02:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/openstack/contact-us</loc>
+  <lastmod>2024-08-15T15:36:45+08:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/openstack/what-is-openstack</loc>
+  <lastmod>2025-01-10T12:37:12+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/openstack/resources</loc>
+  <lastmod>2024-12-20T09:20:49+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/openstack/consulting</loc>
+  <lastmod>2025-02-25T17:12:18+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/openstack/why-openstack</loc>
+  <lastmod>2024-09-09T14:58:27+02:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/openstack/managed</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/openstack/tutorials</loc>
+  <lastmod>2024-06-27T16:03:44+02:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/openstack/features</loc>
+  <lastmod>2024-11-20T10:45:10+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/openstack/thank-you</loc>
+  <lastmod>2024-07-31T17:40:32+08:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/openstack/newsletter-thank-you</loc>
+  <lastmod>2019-08-23T14:16:45+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/403</loc>
+  <lastmod>2025-02-13T11:02:14+05:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/managed</loc>
+  <lastmod>2025-01-10T12:37:12+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/managed/contact-us</loc>
+  <lastmod>2024-08-15T15:36:45+08:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/managed/firefighting-support</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/managed/apps</loc>
+  <lastmod>2025-01-31T15:46:26+05:30</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/managed/apps/kafka</loc>
+  <lastmod>2023-05-17T09:06:03+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/managed/thank-you</loc>
+  <lastmod>2021-08-24T15:29:16+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/supermicro</loc>
+  <lastmod>2024-12-09T16:45:38+08:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/supermicro/contact-us</loc>
+  <lastmod>2024-01-12T19:32:28+06:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/advantage</loc>
+  <lastmod>2023-03-17T10:42:07+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/advantage/offers</loc>
+  <lastmod>2022-01-17T15:06:07+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/advantage/subscribe</loc>
+  <lastmod>2024-11-21T10:21:37+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/advantage/subscribe/blender</loc>
+  <lastmod>2023-09-26T12:09:21+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/advantage/users</loc>
+  <lastmod>2021-09-20T15:33:31+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/advantage/maintenance</loc>
+  <lastmod>2024-08-16T16:49:20+05:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/advantage/blender</loc>
+  <lastmod>2021-10-20T09:08:34+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/internet-of-things</loc>
+  <lastmod>2025-02-27T13:48:30+05:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/internet-of-things/contact-us</loc>
+  <lastmod>2024-12-13T18:12:48+05:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/internet-of-things/management</loc>
+  <lastmod>2025-02-27T13:48:30+05:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/internet-of-things/nvidia</loc>
+  
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/internet-of-things/nvidia/contact-us</loc>
+  <lastmod>2025-01-13T15:13:08+08:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/internet-of-things/digital-signage</loc>
+  <lastmod>2025-02-27T13:48:30+05:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/internet-of-things/smart-displays</loc>
+  <lastmod>2025-02-27T13:48:30+05:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/internet-of-things/gateways</loc>
+  <lastmod>2025-02-27T13:48:30+05:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/internet-of-things/smart-city</loc>
+  <lastmod>2025-02-27T13:48:30+05:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/internet-of-things/networking</loc>
+  <lastmod>2025-02-27T13:48:30+05:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/internet-of-things/appstore</loc>
+  <lastmod>2025-02-27T13:48:30+05:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/internet-of-things/contact-us-hannover</loc>
+  <lastmod>2023-03-29T10:20:59+02:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/internet-of-things/smart-home</loc>
+  <lastmod>2025-02-27T13:48:30+05:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/internet-of-things/thank-you</loc>
+  <lastmod>2023-03-13T14:30:31+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/masters-conference</loc>
+  <lastmod>2025-02-25T09:50:36+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/masters-conference/contact-us</loc>
+  <lastmod>2021-10-15T10:33:50+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/masters-conference/thank-you</loc>
+  <lastmod>2019-12-06T11:28:40+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/core</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/core/features</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/core/features/full-disk-encryption</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/core/features/recovery</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/core/features/secure-boot</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/core/features/ota-updates</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/core/contact-us</loc>
+  <lastmod>2024-07-31T17:39:05+08:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/core/stories</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/core/services</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/core/services/contact-us</loc>
+  <lastmod>2022-04-22T14:56:11+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/core/services/_markdown</loc>
+  <lastmod>2022-04-22T14:56:11+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/core/services/thank-you</loc>
+  <lastmod>2024-08-28T21:25:23+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/core/thank-you</loc>
+  <lastmod>2024-08-28T21:25:23+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/user-research</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/pro</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/pro/tutorial</loc>
+  <lastmod>2024-12-11T16:36:23+08:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/pro/devices</loc>
+  <lastmod>2024-12-05T17:45:34+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/pro/why-pro</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/pro/attach</loc>
+  <lastmod>2024-01-10T17:21:04+05:30</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/pro/attach/confirmation</loc>
+  <lastmod>2023-01-13T14:28:32+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/pro/distributor</loc>
+  <lastmod>2024-07-29T23:21:52+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/pro/distributor/thank-you</loc>
+  <lastmod>2024-07-22T17:26:21+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/pro/activate</loc>
+  <lastmod>2023-08-04T10:26:41+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/pro/thank-you</loc>
+  <lastmod>2024-12-11T16:41:28+08:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/appliance</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/appliance/mosquitto</loc>
+  
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/appliance/mosquitto/raspberry-pi</loc>
+  <lastmod>2020-12-17T13:41:36+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/appliance/mosquitto/vm</loc>
+  <lastmod>2020-06-11T14:13:47+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/appliance/mosquitto/raspberry-pi2</loc>
+  <lastmod>2020-12-17T13:41:36+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/appliance/mosquitto/intel-nuc</loc>
+  <lastmod>2020-12-17T13:41:36+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/appliance/nextcloud</loc>
+  
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/appliance/nextcloud/raspberry-pi</loc>
+  <lastmod>2020-06-05T11:44:29+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/appliance/nextcloud/vm</loc>
+  <lastmod>2020-06-11T14:13:47+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/appliance/nextcloud/raspberry-pi2</loc>
+  <lastmod>2020-06-15T19:49:56+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/appliance/nextcloud/intel-nuc</loc>
+  <lastmod>2020-06-11T08:40:26+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/appliance/community</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/appliance/adguard</loc>
+  
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/appliance/adguard/raspberry-pi</loc>
+  <lastmod>2020-12-17T13:41:36+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/appliance/adguard/vm</loc>
+  <lastmod>2020-06-03T22:18:47+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/appliance/adguard/raspberry-pi2</loc>
+  <lastmod>2020-12-17T13:41:36+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/appliance/adguard/intel-nuc</loc>
+  <lastmod>2020-12-17T13:41:36+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/appliance/about</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/appliance/contact-us</loc>
+  <lastmod>2021-10-15T10:33:50+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/appliance/openhab</loc>
+  
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/appliance/openhab/raspberry-pi</loc>
+  <lastmod>2020-12-17T13:41:36+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/appliance/openhab/vm</loc>
+  <lastmod>2020-06-03T22:18:47+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/appliance/openhab/raspberry-pi2</loc>
+  <lastmod>2020-12-17T13:41:36+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/appliance/openhab/intel-nuc</loc>
+  <lastmod>2020-12-17T13:41:36+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/appliance/lxd</loc>
+  
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/appliance/lxd/raspberry-pi</loc>
+  <lastmod>2020-12-17T13:41:36+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/appliance/lxd/intel-nuc</loc>
+  <lastmod>2020-12-17T13:41:36+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/appliance/vm</loc>
+  <lastmod>2023-03-06T09:04:51+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/appliance/plex</loc>
+  
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/appliance/plex/raspberry-pi</loc>
+  <lastmod>2020-12-17T13:41:36+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/appliance/plex/vm</loc>
+  <lastmod>2020-06-03T22:18:47+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/appliance/plex/raspberry-pi2</loc>
+  <lastmod>2020-12-17T13:41:36+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/appliance/plex/intel-nuc</loc>
+  <lastmod>2020-12-17T13:41:36+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/appliance/tutorials</loc>
+  <lastmod>2022-01-11T15:10:20+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/appliance/hardware</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/appliance/thank-you</loc>
+  <lastmod>2022-03-17T13:39:32+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/appliance/portfolio</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/security</loc>
+  <lastmod>2025-02-28T13:05:36+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/security/vex</loc>
+  <lastmod>2025-02-28T13:22:10+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/security/disclosure-policy</loc>
+  <lastmod>2025-02-28T13:13:11+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/security/cis</loc>
+  <lastmod>2025-02-28T13:22:10+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/security/platform-security</loc>
+  <lastmod>2025-02-21T17:55:43+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/security/compliance-automation</loc>
+  <lastmod>2025-02-28T13:22:10+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/security/fips</loc>
+  <lastmod>2025-02-28T13:05:36+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/security/oval</loc>
+  <lastmod>2025-02-28T13:13:11+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/security/esm</loc>
+  <lastmod>2025-02-28T13:22:10+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/security/contact-us</loc>
+  <lastmod>2024-08-15T15:36:45+08:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/security/notices</loc>
+  
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/security/notices/lsn</loc>
+  <lastmod>2022-03-23T16:18:05+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/security/notices/usn</loc>
+  <lastmod>2024-12-06T11:58:07-05:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/security/notices</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/security/cc</loc>
+  <lastmod>2025-02-28T13:05:36+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/security/fedramp</loc>
+  <lastmod>2025-03-03T15:58:43+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/security/docker-images</loc>
+  <lastmod>2025-02-28T13:13:11+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/security/osv</loc>
+  <lastmod>2025-02-28T13:22:10+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/security/thank-you</loc>
+  <lastmod>2024-08-15T16:05:01+08:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/security/cves</loc>
+  <lastmod>2025-01-10T12:37:12+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/security/cves/about</loc>
+  <lastmod>2024-10-07T17:55:35+02:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/security/cves/cve</loc>
+  <lastmod>2025-02-06T16:07:22+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/security/livepatch</loc>
+  <lastmod>2025-02-28T13:22:10+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/security/disa-stig</loc>
+  <lastmod>2025-02-28T13:13:09+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/azure</loc>
+  <lastmod>2025-01-10T12:37:12+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/azure/ebook</loc>
+  <lastmod>2024-09-05T20:47:16+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/azure/ebook/thank-you</loc>
+  <lastmod>2022-03-04T13:44:23+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/azure/fips</loc>
+  <lastmod>2025-02-25T12:12:00+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/azure/support</loc>
+  <lastmod>2024-09-05T20:47:16+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/azure/pro</loc>
+  <lastmod>2025-01-10T15:33:09+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/azure/private-offer</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/azure/sql</loc>
+  <lastmod>2024-09-05T20:47:54+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/azure/contact-us</loc>
+  <lastmod>2021-10-15T10:33:50+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/azure/thank-you</loc>
+  <lastmod>2024-09-05T20:48:12+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/azure/confidential-computing</loc>
+  <lastmod>2025-01-10T12:37:12+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/ceph</loc>
+  <lastmod>2025-01-24T18:22:12+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/ceph/install</loc>
+  <lastmod>2024-12-02T10:45:14+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/ceph/contact-us</loc>
+  <lastmod>2021-10-15T10:33:50+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/ceph/consulting</loc>
+  <lastmod>2024-12-02T10:45:14+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/ceph/what-is-ceph</loc>
+  <lastmod>2024-12-02T10:45:14+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/ceph/managed</loc>
+  <lastmod>2024-12-02T15:35:23+05:30</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/ceph/thank-you</loc>
+  <lastmod>2024-12-02T10:45:14+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/workstations-journey-to-ai</loc>
+  <lastmod>2021-07-21T09:48:39+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/robotics</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/robotics/ros-esm</loc>
+  <lastmod>2025-01-10T12:37:12+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/robotics/community</loc>
+  <lastmod>2024-12-03T11:07:54+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/robotics/what-is-ros</loc>
+  <lastmod>2024-07-11T13:17:11+08:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/robotics/thank-you</loc>
+  <lastmod>2021-05-03T11:13:00+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/training</loc>
+  <lastmod>2024-10-11T11:11:59+02:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/training/contact-us</loc>
+  <lastmod>2024-08-15T15:36:45+08:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/training/thank-you</loc>
+  <lastmod>2023-01-16T17:26:33+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/security-series</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/security-series/thank-you</loc>
+  <lastmod>2020-09-29T16:30:43+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/resources</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/summit</loc>
+  <lastmod>2024-10-10T13:50:56+05:30</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/429</loc>
+  <lastmod>2025-02-13T11:02:14+05:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/takeovers</loc>
+  <lastmod>2024-07-25T14:51:58+02:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/500</loc>
+  <lastmod>2025-02-13T11:02:14+05:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/_image-testing</loc>
+  <lastmod>2020-02-24T16:38:05+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/20-04</loc>
+  <lastmod>2024-12-20T09:20:49+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/404</loc>
+  <lastmod>2025-02-13T11:02:14+05:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/hpe</loc>
+  <lastmod>2024-12-16T16:01:52+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/desktop</loc>
+  <lastmod>2025-02-14T10:10:16+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/desktop/wsl</loc>
+  <lastmod>2025-02-20T16:25:58+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/desktop/organisations</loc>
+  <lastmod>2025-02-26T23:52:41-05:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/desktop/flavours</loc>
+  <lastmod>2024-10-10T16:57:47+02:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/desktop/developers</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/desktop/contact-us</loc>
+  <lastmod>2021-10-15T10:33:50+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/desktop/partners</loc>
+  <lastmod>2022-07-29T06:08:19+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/desktop/thank-you</loc>
+  <lastmod>2024-07-31T17:39:04+08:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/server</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/server/maas</loc>
+  
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/server/maas/thank-you</loc>
+  <lastmod>2019-08-23T14:16:45+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/server/contact-us</loc>
+  <lastmod>2024-08-15T15:36:45+08:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/server/hyperscale</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/server/thank-you</loc>
+  <lastmod>2024-07-31T17:41:13+08:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/about</loc>
+  <lastmod>2024-08-05T09:17:57+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/about/packages</loc>
+  <lastmod>2022-10-06T14:28:28+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/about/release-cycle</loc>
+  <lastmod>2025-03-04T16:26:02+11:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/engage</loc>
+  <lastmod>2025-02-24T10:42:57+05:30</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/engage/unlisted</loc>
+  
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/engage/unlisted/at&amp;t-onboarding</loc>
+  <lastmod>2022-09-28T16:16:14+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/engage/unlisted/custom-ubuntu-pro-image-on-azure</loc>
+  <lastmod>2023-01-04T15:57:19+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/engage/unlisted/shell-onboarding</loc>
+  <lastmod>2025-01-10T12:37:12+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/engage/es_why-openstack</loc>
+  <lastmod>2024-09-09T14:58:27+02:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/engage/shared</loc>
+  
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/engage/shared/_ru_thank-you</loc>
+  <lastmod>2024-03-04T16:06:48+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/engage/shared/_de_thank-you</loc>
+  <lastmod>2024-03-04T16:06:48+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/engage/shared/_it_thank-you</loc>
+  <lastmod>2024-03-04T16:06:48+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/engage/shared/_tr_thank-you</loc>
+  <lastmod>2025-02-20T11:54:49+05:30</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/engage/shared/_fr_thank-you</loc>
+  <lastmod>2024-03-04T16:06:48+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/engage/shared/_zh-TW_thank-you</loc>
+  <lastmod>2024-03-04T16:06:48+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/engage/shared/_kr_thank-you</loc>
+  <lastmod>2024-04-10T17:34:49+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/engage/shared/_pt_thank-you</loc>
+  <lastmod>2024-03-04T16:06:48+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/engage/shared/_es_thank-you</loc>
+  <lastmod>2024-03-04T16:06:48+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/engage/de_why-openstack</loc>
+  <lastmod>2024-09-09T14:58:27+02:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/engage/fr_why-openstack</loc>
+  <lastmod>2024-09-09T14:58:27+02:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/engage/thank-you</loc>
+  <lastmod>2024-03-22T11:06:49+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/real-time</loc>
+  <lastmod>2024-08-14T16:13:22+02:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/gcp</loc>
+  <lastmod>2024-12-13T08:53:53+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/gcp/fips</loc>
+  <lastmod>2025-02-06T18:23:19+04:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/gcp/pro</loc>
+  <lastmod>2024-09-20T18:26:36+05:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/gcp/contact-us</loc>
+  <lastmod>2021-10-15T10:33:50+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/gcp/thank-you</loc>
+  <lastmod>2024-09-05T20:48:12+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/automotive</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/automotive/developers</loc>
+  <lastmod>2025-01-10T12:37:12+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/automotive/resources</loc>
+  <lastmod>2024-10-16T12:02:05+08:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/automotive/buyers-guide</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/hpc</loc>
+  <lastmod>2024-12-20T09:20:49+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/hpc/contact-us</loc>
+  <lastmod>2022-08-23T09:54:17+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/hpc/use-cases</loc>
+  <lastmod>2025-01-10T12:37:12+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/hpc/thank-you</loc>
+  <lastmod>2022-08-23T09:54:17+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/dell</loc>
+  <lastmod>2024-12-09T16:45:38+08:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/dell/powerflex</loc>
+  <lastmod>2025-01-21T10:08:46+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/dell/contact-us</loc>
+  <lastmod>2021-10-15T10:33:50+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/dell/thank-you</loc>
+  <lastmod>2022-03-17T13:39:32+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/blog</loc>
+  <lastmod>2022-08-30T13:52:58+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/blog/desktop</loc>
+  <lastmod>2024-04-17T11:48:34+02:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/blog/tag</loc>
+  <lastmod>2020-01-10T11:44:45+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/blog/article</loc>
+  <lastmod>2025-01-17T18:10:07+05:30</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/blog/people-and-culture</loc>
+  <lastmod>2022-11-23T14:32:15+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/blog/author</loc>
+  <lastmod>2023-08-11T10:45:23+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/blog/upcoming</loc>
+  <lastmod>2020-01-10T11:44:45+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/blog/internet-of-things</loc>
+  <lastmod>2022-01-11T15:10:20+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/blog/cloud-and-server</loc>
+  <lastmod>2022-01-11T15:10:20+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/blog/archives</loc>
+  <lastmod>2020-01-10T11:44:45+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/blog/topics</loc>
+  
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/blog/topics/design</loc>
+  <lastmod>2024-04-17T11:48:34+02:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/blog/topics/snapcraft</loc>
+  <lastmod>2024-04-17T11:48:34+02:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/blog/topics/juju</loc>
+  <lastmod>2024-04-17T11:48:34+02:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/blog/topics/maas</loc>
+  <lastmod>2024-04-17T11:48:34+02:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/blog/topics/robotics</loc>
+  <lastmod>2024-04-17T11:48:34+02:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/ibm</loc>
+  <lastmod>2023-06-08T11:21:06+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/ibm/contact-us</loc>
+  <lastmod>2021-10-15T10:33:50+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/ibm/thank-you</loc>
+  <lastmod>2022-03-17T13:39:32+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/rfp</loc>
+  <lastmod>2023-03-29T10:20:59+02:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/telco</loc>
+  <lastmod>2025-01-08T14:38:19+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/telco/cnf</loc>
+  <lastmod>2025-01-10T12:37:12+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/telco/openran</loc>
+  <lastmod>2024-11-21T10:21:37+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/telco/contact-us</loc>
+  <lastmod>2021-10-15T10:33:50+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/telco/thank-you</loc>
+  <lastmod>2022-03-17T13:39:32+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/telco/vnf</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/industrial</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/nvidia</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/support</loc>
+  <lastmod>2025-02-05T18:38:24+08:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/support/community-support</loc>
+  <lastmod>2024-09-03T14:04:34+02:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/support/contact-us</loc>
+  <lastmod>2024-08-15T15:36:45+08:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/support/thank-you</loc>
+  <lastmod>2024-07-31T17:41:13+08:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/software-partnerships</loc>
+  <lastmod>2025-01-08T14:38:19+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/download</loc>
+  <lastmod>2025-02-14T10:10:16+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/download/alternative-downloads</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/download/raspberry-pi</loc>
+  <lastmod>2024-10-10T16:57:47+02:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/download/raspberry-pi/thank-you</loc>
+  <lastmod>2024-04-08T09:35:49+05:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/download/qualcomm-iot</loc>
+  <lastmod>2025-01-22T14:48:36+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/download/core</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/download/intel-iei-tank-870</loc>
+  <lastmod>2024-04-08T09:35:49+05:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/download/up-squared-iot-grove-server</loc>
+  <lastmod>2024-04-08T09:35:49+05:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/download/desktop</loc>
+  <lastmod>2024-10-10T21:33:22+05:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/download/desktop/thank-you</loc>
+  <lastmod>2025-02-25T11:34:03+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/download/server</loc>
+  
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/download/server/arm</loc>
+  <lastmod>2024-10-10T22:01:37+05:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/download/server/s390x</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/download/server/thank-you-s390x</loc>
+  <lastmod>2025-01-10T12:37:12+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/download/server/download</loc>
+  <lastmod>2024-09-27T12:56:59+05:30</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/download/server/power</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/download/server/manual</loc>
+  <lastmod>2024-10-10T21:33:22+05:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/download/server/thank-you</loc>
+  <lastmod>2024-12-19T12:00:16+08:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/download/contact-us</loc>
+  <lastmod>2024-11-25T15:39:28+11:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/download/iot</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/download/iot/intel-iot</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/download/intel-nuc-desktop</loc>
+  <lastmod>2024-06-12T10:15:40+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/download/amd</loc>
+  <lastmod>2024-12-05T10:13:41+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/download/mediatek-genio</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/download/mediatek-genio/contact-us</loc>
+  <lastmod>2025-01-10T17:00:30+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/download/risc-v</loc>
+  <lastmod>2024-10-10T16:57:47+02:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/download/qualcomm-dragonboard-410c</loc>
+  <lastmod>2024-04-08T09:35:49+05:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/download/cloud</loc>
+  <lastmod>2024-10-03T23:37:48+05:30</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/download/nvidia-jetson</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/download/intel-nuc</loc>
+  <lastmod>2024-10-10T16:57:12+02:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/download/thank-you</loc>
+  <lastmod>2024-11-25T15:39:28+11:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/ai</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/ai/mlflow</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/ai/roadshow</loc>
+  <lastmod>2025-01-10T12:37:12+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/ai/mlops-workshop</loc>
+  <lastmod>2024-12-03T13:01:22+08:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/ai/contact-us</loc>
+  <lastmod>2024-08-15T15:36:45+08:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/ai/data-science</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/ai/consulting</loc>
+  <lastmod>2025-02-06T15:48:07+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/ai/what-is-kubeflow</loc>
+  <lastmod>2024-11-12T16:38:01+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/ai/mlops</loc>
+  <lastmod>2024-11-12T16:38:01+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/ai/thank-you</loc>
+  <lastmod>2024-08-15T16:05:01+08:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/cloud</loc>
+  <lastmod>2024-09-20T19:36:40+05:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/cloud/hybrid-cloud</loc>
+  <lastmod>2024-09-20T19:38:56+05:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/cloud/public-cloud-survey</loc>
+  <lastmod>2022-03-17T13:39:32+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/cloud/public-cloud</loc>
+  <lastmod>2024-09-06T10:44:02+05:30</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/cloud/cloud-computing</loc>
+  <lastmod>2025-02-19T12:51:23+05:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/cloud/private-cloud</loc>
+  <lastmod>2024-09-20T19:38:56+05:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/cloud/multi-cloud</loc>
+  <lastmod>2024-09-20T19:36:40+05:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/410</loc>
+  <lastmod>2025-02-13T11:02:14+05:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/contact-us</loc>
+  <lastmod>2024-06-13T11:36:48+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/contact-us/form</loc>
+  <lastmod>2024-08-15T15:36:45+08:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/contact-us/form/thank-you</loc>
+  <lastmod>2024-07-31T18:10:45+08:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/contact-us/newsletter-opt-in</loc>
+  <lastmod>2025-02-21T13:38:39+05:30</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/subscription-centre</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/16-04</loc>
+  <lastmod>2025-01-10T12:37:12+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/16-04/azure</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/confidential-computing</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/confidential-computing/ai</loc>
+  <lastmod>2024-10-08T10:28:16+02:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/templates</loc>
+  
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/templates/_error_login</loc>
+  <lastmod>2022-03-24T13:55:22+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/templates/meganav</loc>
+  
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/templates/meganav/navigation-nojs</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/templates/docs</loc>
+  
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/templates/docs/shared</loc>
+  
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/templates/docs/shared/_docs</loc>
+  <lastmod>2024-11-19T09:10:35+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/templates/docs/shared/_search-results</loc>
+  <lastmod>2022-01-11T15:10:20+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/templates/docs/markdown</loc>
+  <lastmod>2022-04-22T14:56:11+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/templates/_product</loc>
+  <lastmod>2023-01-04T15:57:19+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/templates/one-column_no_nav</loc>
+  <lastmod>2018-01-19T14:05:56+02:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/templates/error</loc>
+  <lastmod>2019-08-28T16:14:22+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/templates/one-column</loc>
+  <lastmod>2017-06-15T18:00:18+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/tutorials</loc>
+  <lastmod>2024-04-17T11:48:34+02:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/tutorials/tutorial</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/aws</loc>
+  <lastmod>2025-01-16T13:16:42+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/aws/outposts</loc>
+  <lastmod>2025-01-16T13:16:42+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/aws/fips</loc>
+  <lastmod>2025-02-14T15:07:37+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/aws/support</loc>
+  <lastmod>2025-01-16T13:16:42+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/aws/pro</loc>
+  <lastmod>2025-01-16T13:16:42+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/aws/contact-us</loc>
+  <lastmod>2024-08-15T15:36:45+08:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/aws/workspaces</loc>
+  <lastmod>2024-11-19T14:06:04+05:30</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/aws/thank-you</loc>
+  <lastmod>2024-09-05T20:48:12+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/search</loc>
+  <lastmod>2024-09-26T07:42:16+02:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/landscape</loc>
+  <lastmod>2025-02-26T16:04:34+05:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/landscape/compare</loc>
+  <lastmod>2024-12-20T18:09:30+05:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/landscape/managed</loc>
+  <lastmod>2025-02-26T16:04:34+05:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/landscape/features</loc>
+  <lastmod>2025-01-08T13:35:32+05:30</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/containers</loc>
+  <lastmod>2025-02-10T17:37:34+08:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/containers/chiseled</loc>
+  <lastmod>2025-02-27T11:49:36+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/containers/chiseled/dotnet</loc>
+  <lastmod>2025-01-08T14:38:19+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/containers/contact-us</loc>
+  <lastmod>2024-08-15T15:36:45+08:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/containers/what-are-containers</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/containers/thank-you</loc>
+  <lastmod>2020-01-30T16:42:37+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/account</loc>
+  <lastmod>2022-10-06T11:17:09+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/account/status</loc>
+  <lastmod>2023-03-17T10:42:07+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/account/invoices</loc>
+  <lastmod>2023-08-08T12:45:13+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/account/maintenance-check</loc>
+  <lastmod>2023-03-17T11:50:33+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/account/forbidden</loc>
+  <lastmod>2024-07-22T17:26:21+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/account/checkout</loc>
+  <lastmod>2024-11-21T10:21:37+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/account/payment-methods</loc>
+  <lastmod>2022-03-02T17:23:21+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/financial-services</loc>
+  <lastmod>2024-12-20T09:20:49+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/financial-services/contact-us</loc>
+  <lastmod>2024-08-15T15:36:45+08:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/financial-services/resources</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/financial-services/thank-you</loc>
+  <lastmod>2022-09-28T11:09:13+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/kubernetes</loc>
+  <lastmod>2025-02-26T17:49:49+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/kubernetes/install</loc>
+  <lastmod>2025-02-26T15:23:58+05:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/kubernetes/compare</loc>
+  <lastmod>2025-02-11T10:11:50+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/kubernetes/documentation</loc>
+  <lastmod>2025-02-25T14:10:29+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/kubernetes/what-is-kubernetes</loc>
+  <lastmod>2025-02-11T10:11:50+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/kubernetes/contact-us</loc>
+  <lastmod>2025-02-11T10:11:50+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/kubernetes/resources</loc>
+  <lastmod>2025-02-11T10:11:50+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/kubernetes/charmed-k8s</loc>
+  <lastmod>2025-02-25T09:57:14+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/kubernetes/managed</loc>
+  <lastmod>2025-02-11T10:11:50+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal</loc>
+  <lastmod>2023-01-25T15:37:09-05:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/developer-terms-and-conditions</loc>
+  <lastmod>2022-10-12T20:31:44+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/developer-terms-and-conditions/2016-04-06</loc>
+  <lastmod>2022-10-12T20:31:44+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/developer-terms-and-conditions/2018-07-23</loc>
+  <lastmod>2022-10-12T20:31:44+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/intellectual-property-policy</loc>
+  <lastmod>2022-03-24T13:55:22+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/intellectual-property-policy/2013-05-14</loc>
+  <lastmod>2022-03-24T13:55:22+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/ua-miracle-tc-ja</loc>
+  <lastmod>2022-10-12T20:31:44+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/anbox-cloud-terms-of-service</loc>
+  <lastmod>2022-10-12T20:31:44+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/data-privacy</loc>
+  <lastmod>2025-02-04T10:00:05+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/data-privacy/enquiry</loc>
+  <lastmod>2023-02-08T11:14:56+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/data-privacy/recruitment</loc>
+  <lastmod>2023-07-14T16:38:44+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/data-privacy/2013-03-25</loc>
+  <lastmod>2022-03-02T12:17:36+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/data-privacy/2016-02-08</loc>
+  <lastmod>2022-03-24T13:55:22+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/companies</loc>
+  <lastmod>2025-01-27T12:18:20+02:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/ubuntu-pro-description</loc>
+  
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/ubuntu-pro-description/ros-esm-service-description</loc>
+  <lastmod>2023-05-22T11:54:31+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/ubuntu-pro</loc>
+  <lastmod>2024-01-09T11:58:43+06:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/ubuntu-pro/personal</loc>
+  
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/ubuntu-pro/personal/_markdown</loc>
+  <lastmod>2024-09-24T17:17:49+05:30</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/terms</loc>
+  <lastmod>2022-10-18T09:18:55+02:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/nvidia-jetson-and-ubuntu</loc>
+  <lastmod>2023-04-17T10:11:46+02:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/livepatch-terms-of-service</loc>
+  <lastmod>2023-07-14T16:38:44+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/ubuntu-pro-assurance</loc>
+  <lastmod>2023-01-25T15:37:09-05:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/ua-miracle-tc</loc>
+  <lastmod>2022-10-12T20:31:44+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/systems-information-notice</loc>
+  <lastmod>2023-07-14T16:38:44+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/jaas-beta-terms-of-service</loc>
+  <lastmod>2022-10-12T20:31:44+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/equal-employment-opportunity-commitment</loc>
+  <lastmod>2022-08-03T13:32:14+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/anbox-cloud-privacy-notice</loc>
+  <lastmod>2023-07-14T16:38:44+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/contributors</loc>
+  <lastmod>2025-02-14T09:06:24+11:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/contributors/agreement</loc>
+  <lastmod>2025-02-07T12:56:29+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/contributors/faq</loc>
+  <lastmod>2025-02-14T09:06:24+11:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/contributors/thank-you</loc>
+  <lastmod>2022-03-24T13:55:22+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/confidentiality-agreement</loc>
+  <lastmod>2024-08-06T13:47:37+05:30</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/open-source-licences</loc>
+  <lastmod>2022-09-30T15:57:58+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/terms-of-service</loc>
+  <lastmod>2022-10-12T20:31:44+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/launchpad-terms-of-service</loc>
+  <lastmod>2022-03-24T13:55:22+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/ubuntu-pro-service-terms</loc>
+  
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/ubuntu-pro-service-terms/2016-05-20</loc>
+  <lastmod>2024-02-14T15:35:33+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/ubuntu-pro-service-terms/2015-06-24</loc>
+  <lastmod>2024-02-14T15:35:33+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/ubuntu-pro-service-terms/2016-06-24</loc>
+  <lastmod>2024-02-14T15:35:33+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/ubuntu-pro-service-terms/ja</loc>
+  <lastmod>2024-02-14T15:35:33+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/ubuntu-pro-service-terms/2015-09-09</loc>
+  <lastmod>2024-02-14T15:35:33+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/ua-dell-tc</loc>
+  <lastmod>2022-10-12T20:31:44+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/websites</loc>
+  <lastmod>2024-05-23T16:28:59+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/terms-and-policies</loc>
+  <lastmod>2024-01-04T11:03:15+06:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/terms-and-policies/credentials-terms</loc>
+  <lastmod>2025-01-10T12:37:12+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/terms-and-policies/contact-us</loc>
+  <lastmod>2022-03-17T13:38:37+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/terms-and-policies/snap-store-terms</loc>
+  <lastmod>2022-10-12T20:31:44+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/terms-and-policies/thank-you</loc>
+  <lastmod>2022-03-24T13:55:22+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/font-licence</loc>
+  <lastmod>2024-07-23T16:57:00+08:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/font-licence/differences</loc>
+  <lastmod>2019-10-16T15:00:25+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/font-licence/faq</loc>
+  <lastmod>2022-03-24T13:55:22+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/online-account-terms</loc>
+  <lastmod>2022-10-12T20:31:44+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/motd</loc>
+  <lastmod>2023-07-12T17:04:57+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/legal/solution-support</loc>
+  <lastmod>2022-03-24T13:55:22+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/0_docs</loc>
+  <lastmod>2021-03-09T13:03:40+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/0_docs/takeovers</loc>
+  <lastmod>2022-01-11T14:01:17+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/0_docs/strips</loc>
+  <lastmod>2024-09-23T17:09:02+03:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/0_docs/engage_pages</loc>
+  <lastmod>2022-03-17T13:39:32+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/0_docs/takeover-archives</loc>
+  <lastmod>2021-03-09T13:03:40+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/0_docs/content_strips</loc>
+  <lastmod>2023-04-19T15:37:22+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/certified</loc>
+  <lastmod>2024-10-10T17:31:18+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/certified/vendors</loc>
+  
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/certified/vendors/vendor</loc>
+  <lastmod>2024-11-04T14:40:45+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/certified/laptops</loc>
+  <lastmod>2025-02-13T11:58:26+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/certified/platforms</loc>
+  
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/certified/platforms/platform-details</loc>
+  <lastmod>2024-10-17T11:18:30+02:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/certified/model-details</loc>
+  <lastmod>2024-10-31T14:40:02+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/certified/devices</loc>
+  <lastmod>2025-02-13T11:58:26+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/certified/hardware-details</loc>
+  
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/certified/hardware-details/hardware-details</loc>
+  <lastmod>2024-12-16T11:25:56+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/certified/why-certify</loc>
+  <lastmod>2025-01-10T12:37:12+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/certified/desktops</loc>
+  <lastmod>2025-02-13T11:58:26+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/certified/servers</loc>
+  <lastmod>2025-02-13T12:31:54+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/certified/components</loc>
+  
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/certified/components/component-details</loc>
+  <lastmod>2024-11-01T11:24:13+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/certified/socs</loc>
+  <lastmod>2025-02-13T11:58:26+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/certified/search-results</loc>
+  <lastmod>2025-02-13T11:58:26+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/18-04</loc>
+  <lastmod>2024-11-21T10:21:37+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/18-04/oci</loc>
+  <lastmod>2024-11-21T10:21:37+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/18-04/azure</loc>
+  <lastmod>2024-11-21T10:21:37+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/18-04/aws</loc>
+  <lastmod>2024-11-21T10:21:37+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/18-04/gcp</loc>
+  <lastmod>2024-11-21T10:21:37+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/18-04/ibm</loc>
+  <lastmod>2024-11-21T10:21:37+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/blender</loc>
+  <lastmod>2022-03-17T13:39:32+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/blender/contact-us</loc>
+  <lastmod>2021-10-15T10:33:50+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/blender/thank-you</loc>
+  <lastmod>2022-03-17T13:39:32+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/20years</loc>
+  <lastmod>2024-10-24T13:37:30+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/pricing</loc>
+  <lastmod>2024-10-09T13:55:59+02:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/pricing/desktop</loc>
+  <lastmod>2024-10-09T13:55:59+02:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/pricing/devices</loc>
+  <lastmod>2024-10-24T09:10:40+02:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/pricing/pro</loc>
+  <lastmod>2024-11-20T10:45:10+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/pricing/contact-us</loc>
+  <lastmod>2024-10-09T13:55:59+02:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/pricing/consulting</loc>
+  <lastmod>2024-09-30T12:44:34+08:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/pricing/thank-you</loc>
+  <lastmod>2024-10-09T13:55:59+02:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/embedded</loc>
+  <lastmod>2025-02-27T13:49:32+05:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/security-error-500</loc>
+  <lastmod>2022-03-24T13:55:22+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/kubeconeurope2020</loc>
+  <lastmod>2023-01-04T15:57:19+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/cpu-compatibility</loc>
+  <lastmod>2024-08-05T09:17:57+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/thank-you</loc>
+  <lastmod>2024-04-04T13:27:56+02:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/kernel</loc>
+  <lastmod>2024-10-11T14:01:32+02:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/kernel/variants</loc>
+  <lastmod>2023-05-12T10:15:41+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/kernel/real-time</loc>
+  
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/kernel/real-time/contact-us</loc>
+  <lastmod>2024-11-08T09:07:49+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/kernel/lifecycle</loc>
+  <lastmod>2024-06-28T14:07:39+02:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/gov</loc>
+  <lastmod>2025-01-10T12:37:12+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/gov/contact-us</loc>
+  <lastmod>2024-08-15T15:36:45+08:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/gov/thank-you</loc>
+  <lastmod>2022-03-17T13:39:32+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/400</loc>
+  <lastmod>2025-02-13T11:02:14+05:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/credentials</loc>
+  <lastmod>2024-11-15T13:21:04+05:30</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/credentials/redeem_with_captcha</loc>
+  <lastmod>2024-06-26T10:24:25+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/credentials/exam</loc>
+  <lastmod>2024-08-30T14:15:33+05:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/credentials/exit-survey</loc>
+  <lastmod>2024-06-26T10:24:25+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/credentials/schedule-confirm</loc>
+  <lastmod>2024-06-26T10:24:25+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/credentials/self-study</loc>
+  <lastmod>2025-01-10T12:37:12+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/credentials/redeem_with_form</loc>
+  <lastmod>2024-10-18T01:04:17+05:30</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/credentials/schedule</loc>
+  <lastmod>2024-08-16T17:30:17+05:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/credentials/assessments</loc>
+  <lastmod>2024-06-26T10:24:25+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/credentials/shop</loc>
+  <lastmod>2024-10-08T16:44:09+05:30</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/credentials/shop/manage</loc>
+  <lastmod>2024-06-12T18:54:53+05:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/credentials/shop/keys</loc>
+  <lastmod>2024-10-01T17:49:25+05:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/credentials/shop/thank-you</loc>
+  <lastmod>2024-06-26T10:24:25+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/credentials/shop/webhook_responses</loc>
+  <lastmod>2024-06-26T10:24:25+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/credentials/redeem</loc>
+  <lastmod>2024-06-26T10:24:25+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/credentials/exam-no-agreement</loc>
+  <lastmod>2024-06-26T10:24:25+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/credentials/syllabus</loc>
+  <lastmod>2024-10-01T17:49:25+05:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/credentials/dashboard</loc>
+  <lastmod>2024-08-06T20:20:13+05:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/credentials/sign-up</loc>
+  <lastmod>2024-12-10T15:46:51+05:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/credentials/beta-activation</loc>
+  <lastmod>2024-06-26T10:24:25+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/credentials/your-exams</loc>
+  <lastmod>2024-10-01T17:49:25+05:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/credentials/faq</loc>
+  <lastmod>2025-01-10T12:37:12+00:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/credentials/your-badges</loc>
+  <lastmod>2024-06-26T10:24:25+01:00</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
+<url>
+  <loc>https://ubuntu.com/credentials/thank-you</loc>
+  <lastmod>2024-11-29T00:25:38+05:30</lastmod>
+  <changefreq>monthly</changefreq>
+</url>
 </urlset>

--- a/templates/sitemap_children.xml
+++ b/templates/sitemap_children.xml
@@ -1,12 +1,11 @@
-{% for child in children %}
-  <url>
-    <loc>{{ base_url }}{{ child["name"] }}</loc>
-    {% if node["last_modified"] != None %}<lastmod>{{ child["last_modified"] }}</lastmod>{% endif %}
-    <changefreq>monthly</changefreq>
-  </url>
-  {% if child["children"]|length > 0 %}
-    {% with children=child["children"]%}
-      {% include "sitemap_children.xml" %}
-    {% endwith %}
-  {% endif %}
-{% endfor %}
+
+<url>
+  <loc>{{ base_url }}{{ node["name"] }}</loc>
+  {% if node["last_modified"] != None %}<lastmod>{{ node["last_modified"] }}</lastmod>{% endif %}
+  <changefreq>monthly</changefreq>
+</url>
+{%- if node["children"]|length > 0 -%}
+  {%- for node in node["children"] %}
+    {%- include "sitemap_children.xml" %}
+  {%- endfor %}
+{%- endif -%}

--- a/templates/sitemap_template.xml
+++ b/templates/sitemap_template.xml
@@ -1,13 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">  
-  {% for node in tree %}
-  <url>
-    <loc>{{ base_url }}{{ node["name"] }}</loc>   
-    {% if node["last_modified"] != None %}<lastmod>{{ node["last_modified"] }}</lastmod>{% endif %}
-    <changefreq>monthly</changefreq>
-  </url>
-  {% if node["children"]|length > 0 %}
-    {% with children=node["children"]%}{% include "sitemap_children.xml"%}{% endwith %}
-  {% endif %}
-  {% endfor %}
+  {%- for node in tree %}
+  {%- include "sitemap_children.xml" %}  
+  {%- endfor %}
 </urlset>


### PR DESCRIPTION
## Done

- Refactor sitemap templates to reduce redundant code
- Update `sitemap_tree.xml` with new template, removing unnecessary new lines

## QA

- Go to `sitemap_tree.xml` file on GH file changes
- See that the file does not have redundant new lines


## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
