### PR TITLE
fix: Swap frame and core images

### DIFF
--- a/templates/internet-of-things/smart-displays.html
+++ b/templates/internet-of-things/smart-displays.html
@@ -216,10 +216,10 @@
           <div class="row--25-75">
             <hr class="p-rule--muted" />
             <div class="col u-hide--small">
-              {{ image(url="https://assets.ubuntu.com/v1/d68b3378-ubuntu-frame-final.png",
+              {{ image(url="https://assets.ubuntu.com/v1/9d527111-ubuntu-core-final.png",
                             alt="",
                             width="852",
-                            height="172",
+                            height="166",
                             hi_def=True,
                             loading="lazy") | safe
               }}
@@ -245,10 +245,10 @@
           <div class="row--25-75">
             <hr class="p-rule--muted" />
             <div class="col u-hide--small">
-              {{ image(url="https://assets.ubuntu.com/v1/9d527111-ubuntu-core-final.png",
+              {{ image(url="https://assets.ubuntu.com/v1/d68b3378-ubuntu-frame-final.png",
                             alt="",
                             width="852",
-                            height="166",
+                            height="172",
                             hi_def=True,
                             loading="lazy") | safe
               }}


### PR DESCRIPTION
## Done

- Swap Ubuntu Frame and Core images

## QA

- Go to /internet-of-things/smart-displays
- Scroll down to "Get started now with Ubuntu Core and Frame"
- See that the images for Ubuntu Core and Frame are in the correct section

## Issue / Card

Fixes [WD-20418](https://warthogs.atlassian.net/browse/WD-20418) and #14864 

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-20418]: https://warthogs.atlassian.net/browse/WD-20418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ