### PR TITLE
chore: Use git diff to get changed files

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -99,20 +99,21 @@ jobs:
         run: |
           python3 -m pip install --upgrade pip
           sudo pip3 install djlint
+      
+      - name: Test GH events
+        id: test-gh-events
+        run: more $GITHUB_EVENT_PATH
 
       - name: Get changed HTML files in the templates folder
         id: changed-files
-        uses: tj-actions/changed-files@v43
-        with:
-          files: templates/**/*.html
+        run: |
+          CHANGED_FILES=$(git diff --name-only ${{ github.base.sha }} ${{ github.after }})
 
       - name: Lint jinja
-        if: steps.changed-files.outputs.any_changed == 'true'
-        env:
-          CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+        if: env.CHANGED_FILE != ''
         run: |
           echo "The following files have changed: $CHANGED_FILES"
-          djlint $CHANGED_FILES --lint --profile="jinja"
+          djlint $CHANGED_FILES --lint --profile="jinja"            
 
   validate-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -91,6 +91,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install node dependencies
         run: yarn install --immutable
@@ -99,21 +101,19 @@ jobs:
         run: |
           python3 -m pip install --upgrade pip
           sudo pip3 install djlint
-      
-      - name: Test GH events
-        id: test-gh-events
-        run: more $GITHUB_EVENT_PATH
 
       - name: Get changed HTML files in the templates folder
         id: changed-files
         run: |
-          CHANGED_FILES=$(git diff --name-only ${{ github.base.sha }} ${{ github.after }})
+          TARGET_SHA=$(git rev-parse origin/$GITHUB_BASE_REF)
+          CHANGED_FILES=$(git diff --name-only $TARGET_SHA $GITHUB_SHA -- 'templates/**.html' | tr '\n' ' ')
+          echo "CHANGED_FILES=$CHANGED_FILES" >> $GITHUB_ENV
 
       - name: Lint jinja
-        if: env.CHANGED_FILE != ''
+        if: env.CHANGED_FILES != ''
         run: |
           echo "The following files have changed: $CHANGED_FILES"
-          djlint $CHANGED_FILES --lint --profile="jinja"            
+          djlint $CHANGED_FILES --lint --profile="jinja"
 
   validate-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Note: revert changed HTML files before merging

## Done

- Replace `tj-actions/changed-files` with `git diff` actions to track changed files in a PR
- Introduced minor changes to template files for `git diff` to track changes

## QA

- Go to GH actions (either from the checks below or [this link](https://github.com/canonical/ubuntu.com/actions/runs/13941058447/job/39017825278))
- Go to `lint-jinja` action and expand it
- See that it displays the changed files as expected

## Issue / Card

Fixes [WD-20401](https://warthogs.atlassian.net/browse/WD-20401)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-20401]: https://warthogs.atlassian.net/browse/WD-20401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ