### PR TITLE
fix: Update chiseled doc link

### DIFF
--- a/templates/containers/chiseled/index.html
+++ b/templates/containers/chiseled/index.html
@@ -337,7 +337,7 @@
     <hr class="p-rule" />
     <div class="p-strip is-deep">
       <p class="p-heading--2">
-        <a href="https://documentation.ubuntu.com/oci-registries/en/latest/oci-how-to/create-chiseled-ubuntu-image/">Get
+        <a href="https://documentation.ubuntu.com/chisel/en/latest/tutorial/getting-started/">Get
         started now and ship with chiseled Ubuntu in minutes&nbsp;&rsaquo;</a>
       </p>
     </div>


### PR DESCRIPTION
## Done

- Update chiseled doc link with working link
- Broken link reported here https://github.com/canonical/ubuntu.com/actions/runs/13917651784/job/38943545779

## QA

- Go to /containers/chiseled
- Scroll down to "Get started now and ship with chiseled Ubuntu"
- Click on it, see that it redirects to [docs](https://documentation.ubuntu.com/chisel/en/latest/tutorial/getting-started/?_ga=2.248922628.2004906391.1742270386-1966056870.1729153128&_gl=1*tyk574*_gcl_au*MTE2NzUzMTQ3Ni4xNzM3MzU5MDc0) successfully

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
