### PR TITLE
fix: Update broken link for chiseled docs

### DIFF
--- a/templates/containers/chiseled/index.html
+++ b/templates/containers/chiseled/index.html
@@ -511,7 +511,7 @@
                 <a href="https://documentation.ubuntu.com/rockcraft/en/latest/how-to/rocks/chisel-existing-rock/">Using chisel in Rockcraft</a>
               </li>
               <li class="p-list__item">
-                <a href="https://documentation.ubuntu.com/oci-registries/en/latest/oci-how-to/create-chiseled-ubuntu-image/">Create
+                <a href="https://canonical-public-cloud.readthedocs-hosted.com/en/latest/oci/oci-how-to/create-chiselled-ubuntu-image.html">Create
                 a chiseled Ubuntu base image for C/C++, Go and Rust applications</a>
               </li>
               <li class="p-list__item">


### PR DESCRIPTION
## Done

- Update broken link for chiseled docs

## QA

- Go to /containers/chiseled
- Scroll down to "Create a chiseled Ubuntu base image for C/C++..."
- Click on link, see that it redirects to the docs and not 404

## Issue / Card

Fixes [broken link report](https://github.com/canonical/ubuntu.com/actions/runs/13941081506/job/39017886532)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
