### PR TITLE
WD-16854 Redesign ubuntu.com/summit

### DIFF
--- a/meganav.yaml
+++ b/meganav.yaml
@@ -781,6 +781,10 @@ community:
             - title: Teams
               description: The teams in the project
               url: /community/governance/teams
+            - title: Ubuntu Summit
+              description: Showcasing open source innovation
+              url: /summit
+            
 
       secondary_links:
         - title: Quick links

--- a/navigation.yaml
+++ b/navigation.yaml
@@ -619,6 +619,20 @@ edge-computing:
   children:
     - title: Overview
       path: https://canonical.com/edge-computing
+      
+summit:
+  title: Ubuntu Summit
+  path: /summit
+
+  children:
+    - title: Call for collaboration
+      path: /summit/call-for-collaboration
+    - title: Register
+      path: https://events.canonical.com/event/51/registrations/
+    - title: Timetable
+      path: https://events.canonical.com/event/51/timetable/?layout=room#20241025.detailed
+    - title: Travel
+      path: https://events.canonical.com/event/51/page/335-travelling-to-the-hague
 
 landscape:
   title: Landscape
@@ -649,3 +663,4 @@ confidential-ai:
       path: /confidential-computing
     - title: AI
       path: /confidential-computing/ai
+

--- a/navigation.yaml
+++ b/navigation.yaml
@@ -627,14 +627,14 @@ summit:
   children:
     - title: Overview
       path: /summit
-    - title: Call for collaboration
-      path: /summit/call-for-collaboration
     - title: Register
       path: https://events.canonical.com/event/51/registrations/
     - title: Timetable
       path: https://events.canonical.com/event/51/timetable/?layout=room#20241025.detailed
     - title: Travel
       path: https://events.canonical.com/event/51/page/335-travelling-to-the-hague
+    - title: Call for collaboration
+      path: /summit/call-for-collaboration
 
 landscape:
   title: Landscape

--- a/navigation.yaml
+++ b/navigation.yaml
@@ -619,12 +619,14 @@ edge-computing:
   children:
     - title: Overview
       path: https://canonical.com/edge-computing
-      
+
 summit:
   title: Ubuntu Summit
   path: /summit
 
   children:
+    - title: Overview
+      path: /summit
     - title: Call for collaboration
       path: /summit/call-for-collaboration
     - title: Register

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1790,11 +1790,11 @@ ol.p-stepped-list.no-full-stop
 }
 
 // Zoom effect for images on hover, used on /summit page
-.image-hover__zoom {
+.u-zoom-on-hover {
   transition: transform 1s;
 }
 
-.image-hover__zoom:hover {
+.u-zoom-on-hover:hover {
   transform: scale(1.25);
 }
 

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1795,7 +1795,7 @@ ol.p-stepped-list.no-full-stop
 }
 
 .image-hover__zoom:hover {
-  transform: scale(1.25); 
+  transform: scale(1.25);
 }
 
 // Custom styling for side navigation used as a TOC

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1788,3 +1788,11 @@ ol.p-stepped-list.no-full-stop
   content: counter(p-stepped-list-counter);
   text-align: left;
 }
+
+.image-hover__zoom {
+  transition: transform 1s;
+}
+
+.image-hover__zoom:hover {
+  transform: scale(1.25); 
+}

--- a/templates/summit/_base_summit.html
+++ b/templates/summit/_base_summit.html
@@ -1,6 +1,8 @@
 {% extends "templates/base.html" %}
 
-{% set hide_nav = True %}
+{% block body_class %}
+  is-dark
+{% endblock body_class %}
 
 {% block outer_content %}
 

--- a/templates/summit/index.html
+++ b/templates/summit/index.html
@@ -135,11 +135,11 @@
       <hr class="p-rule--muted" />
       <div class="u-align--right u-sv1">
         <a href="#" id="carousel-previous" class="p-carousel__previous">
-          <i class="p-icon--chevron-left">Previous testimonial</i>
+          <i class="p-icon--chevron-left">Previous image</i>
         </a>
         &nbsp;
         <a href="#" id="carousel-next" class="p-carousel__next">
-          <i class="p-icon--chevron-right">Next testimonial</i>
+          <i class="p-icon--chevron-right">Next image</i>
         </a>
       </div>
       <div class="p-section--shallow">
@@ -344,7 +344,7 @@
                                 width="568",
                                 height="380",
                                 hi_def=True,
-                                attrs={"class": "p-image-container__image image-hover__zoom"},
+                                attrs={"class": "p-image-container__image u-zoom-on-hover"},
                                 loading="lazy") | safe
                 }}
               </div>
@@ -363,7 +363,7 @@
                                 width="568",
                                 height="380",
                                 hi_def=True,
-                                attrs={"class": "p-image-container__image image-hover__zoom"},
+                                attrs={"class": "p-image-container__image u-zoom-on-hover"},
                                 loading="lazy") | safe
                 }}
               </div>
@@ -382,7 +382,7 @@
                                 width="568",
                                 height="380",
                                 hi_def=True,
-                                attrs={"class": "p-image-container__image image-hover__zoom"},
+                                attrs={"class": "p-image-container__image u-zoom-on-hover"},
                                 loading="lazy") | safe
                 }}
               </div>
@@ -401,7 +401,7 @@
                                 width="568",
                                 height="380",
                                 hi_def=True,
-                                attrs={"class": "p-image-container__image image-hover__zoom"},
+                                attrs={"class": "p-image-container__image u-zoom-on-hover"},
                                 loading="lazy") | safe
                 }}
               </div>
@@ -420,7 +420,7 @@
                                 width="568",
                                 height="380",
                                 hi_def=True,
-                                attrs={"class": "p-image-container__image image-hover__zoom"},
+                                attrs={"class": "p-image-container__image u-zoom-on-hover"},
                                 loading="lazy") | safe
                 }}
               </div>
@@ -440,7 +440,7 @@
                                 width="568",
                                 height="380",
                                 hi_def=True,
-                                attrs={"class": "p-image-container__image image-hover__zoom"},
+                                attrs={"class": "p-image-container__image u-zoom-on-hover"},
                                 loading="lazy") | safe
                 }}
               </div>
@@ -460,7 +460,7 @@
                                 width="568",
                                 height="380",
                                 hi_def=True,
-                                attrs={"class": "p-image-container__image image-hover__zoom"},
+                                attrs={"class": "p-image-container__image u-zoom-on-hover"},
                                 loading="lazy") | safe
                 }}
               </div>
@@ -479,7 +479,7 @@
                                 width="568",
                                 height="380",
                                 hi_def=True,
-                                attrs={"class": "p-image-container__image image-hover__zoom"},
+                                attrs={"class": "p-image-container__image u-zoom-on-hover"},
                                 loading="lazy") | safe
                 }}
               </div>
@@ -499,7 +499,7 @@
                                 width="568",
                                 height="380",
                                 hi_def=True,
-                                attrs={"class": "p-image-container__image image-hover__zoom"},
+                                attrs={"class": "p-image-container__image u-zoom-on-hover"},
                                 loading="lazy") | safe
                 }}
               </div>

--- a/templates/summit/index.html
+++ b/templates/summit/index.html
@@ -339,9 +339,9 @@
           <div class="p-equal-height-row__col u-sv2">
             <div class="p-equal-height-row__item">
               <div class="p-image-container u-hide--small" style="overflow: hidden;">
-                {{ image(url="https://assets.ubuntu.com/v1/c415a554-linux.png",
+                {{ image(url="https://assets.ubuntu.com/v1/fed38b56-new-linux.png",
                                 alt="",
-                                width="568",
+                                width="566",
                                 height="380",
                                 hi_def=True,
                                 attrs={"class": "p-image-container__image u-zoom-on-hover"},
@@ -358,9 +358,9 @@
           <div class="p-equal-height-row__col u-sv2">
             <div class="p-equal-height-row__item">
               <div class="p-image-container u-hide--small" style="overflow: hidden;">
-                {{ image(url="https://assets.ubuntu.com/v1/33d83ce0-app-ecosystem.png",
+                {{ image(url="https://assets.ubuntu.com/v1/ec34b48a-new-app-ecosystem.png",
                                 alt="",
-                                width="568",
+                                width="566",
                                 height="380",
                                 hi_def=True,
                                 attrs={"class": "p-image-container__image u-zoom-on-hover"},
@@ -377,9 +377,9 @@
           <div class="p-equal-height-row__col u-sv2">
             <div class="p-equal-height-row__item">
               <div class="p-image-container u-hide--small" style="overflow: hidden;">
-                {{ image(url="https://assets.ubuntu.com/v1/8b61336f-content-design.png",
+                {{ image(url="https://assets.ubuntu.com/v1/8a92eed1-new-content-design.png",
                                 alt="",
-                                width="568",
+                                width="566",
                                 height="380",
                                 hi_def=True,
                                 attrs={"class": "p-image-container__image u-zoom-on-hover"},
@@ -396,9 +396,9 @@
           <div class="p-equal-height-row__col u-sv2">
             <div class="p-equal-height-row__item">
               <div class="p-image-container u-hide--small" style="overflow: hidden;">
-                {{ image(url="https://assets.ubuntu.com/v1/0b5cbabe-community.png",
+                {{ image(url="https://assets.ubuntu.com/v1/c71d8fa6-new-community.png",
                                 alt="",
-                                width="568",
+                                width="566",
                                 height="380",
                                 hi_def=True,
                                 attrs={"class": "p-image-container__image u-zoom-on-hover"},
@@ -415,9 +415,9 @@
           <div class="p-equal-height-row__col u-sv2">
             <div class="p-equal-height-row__item">
               <div class="p-image-container u-hide--small" style="overflow: hidden;">
-                {{ image(url="https://assets.ubuntu.com/v1/f996e117-infrastructure.png",
+                {{ image(url="https://assets.ubuntu.com/v1/359e01a1-new-infrastructure.png",
                                 alt="",
-                                width="568",
+                                width="566",
                                 height="380",
                                 hi_def=True,
                                 attrs={"class": "p-image-container__image u-zoom-on-hover"},
@@ -435,9 +435,9 @@
           <div class="p-equal-height-row__col u-sv2">
             <div class="p-equal-height-row__item">
               <div class="p-image-container u-hide--small" style="overflow: hidden;">
-                {{ image(url="https://assets.ubuntu.com/v1/1e8400fd-devices.png",
+                {{ image(url="https://assets.ubuntu.com/v1/5fba2c50-new-devices.png",
                                 alt="",
-                                width="568",
+                                width="566",
                                 height="380",
                                 hi_def=True,
                                 attrs={"class": "p-image-container__image u-zoom-on-hover"},
@@ -455,9 +455,9 @@
           <div class="p-equal-height-row__col u-sv2">
             <div class="p-equal-height-row__item">
               <div class="p-image-container u-hide--small" style="overflow: hidden;">
-                {{ image(url="https://assets.ubuntu.com/v1/c9ea13cb-data.png",
+                {{ image(url="https://assets.ubuntu.com/v1/70b56649-new-data.png",
                                 alt="",
-                                width="568",
+                                width="566",
                                 height="380",
                                 hi_def=True,
                                 attrs={"class": "p-image-container__image u-zoom-on-hover"},
@@ -474,9 +474,9 @@
           <div class="p-equal-height-row__col u-sv2">
             <div class="p-equal-height-row__item">
               <div class="p-image-container u-hide--small" style="overflow: hidden;">
-                {{ image(url="https://assets.ubuntu.com/v1/8b61336f-content-design.png",
+                {{ image(url="https://assets.ubuntu.com/v1/5c5e4abc-new-gaming.png",
                                 alt="",
-                                width="568",
+                                width="566",
                                 height="380",
                                 hi_def=True,
                                 attrs={"class": "p-image-container__image u-zoom-on-hover"},
@@ -494,9 +494,9 @@
           <div class="p-equal-height-row__col u-sv2">
             <div class="p-equal-height-row__item">
               <div class="p-image-container u-hide--small" style="overflow: hidden;">
-                {{ image(url="https://assets.ubuntu.com/v1/278004ac-security.png",
+                {{ image(url="https://assets.ubuntu.com/v1/e298d421-new-security.png",
                                 alt="",
-                                width="568",
+                                width="566",
                                 height="380",
                                 hi_def=True,
                                 attrs={"class": "p-image-container__image u-zoom-on-hover"},

--- a/templates/summit/index.html
+++ b/templates/summit/index.html
@@ -11,405 +11,551 @@
 {% endblock %}
 
 {% block content %}
+  <section class="p-strip">
+    <div class="u-fixed-width">
+      <h1 class="p-heading--display">Ubuntu Summit 2024</h1>
+      <hr class="p-rule--muted" />
+      <h2 class="p-heading--1">We've got exciting things in the works for 2025.</h2>
+      <p class="p-heading--2">
+        Keep an eye out on this page for future updates.
+        <br />
+        In the meantime, explore what we were up to in 2024.
+      </p>
+    </div>
+  </section>
 
-  <header id="navigation" class="p-navigation is-dark">
-    <div class="p-navigation__row--25-75">
-      <div class="p-navigation__banner">
-        <div class="p-navigation__tagged-logo">
-          <a class="p-navigation__link" href="#">
-            <div class="p-navigation__logo-tag">
-              <img class="p-navigation__logo-icon"
-                   src="https://assets.ubuntu.com/v1/82818827-CoF_white.svg"
-                   alt="" />
-            </div>
-            <span class="p-navigation__logo-title">Ubuntu Summit</span>
-          </a>
+  <section class="p-section">
+    <div class="p-section--shallow">
+      <div class="row--50-50">
+        <hr class="p-rule" />
+        <div class="col">
+          <h2 class="p-heading--1">October 25-27</h2>
+          <h2>The Hague, Netherlands</h2>
         </div>
-        <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
-        <a href="#navigation-closed"
-           class="p-navigation__toggle--close"
-           title="close menu">Close menu</a>
+        <div class="col">
+          <p>
+            The Ubuntu Summit is a showcase for the innovative and the ambitious. We invite all experts, builders, engineers, tinkerers, designers and dreamers to join us for an unforgettable three days.
+          </p>
+        </div>
       </div>
-      <nav class="p-navigation__nav" aria-label="Ubuntu summit navigation">
-        <ul class="p-navigation__items">
-          <li class="p-navigation__item is-selected">
-            <a class="p-navigation__link" href="#">About</a>
-          </li>
-          <li class="p-navigation__item">
-            <a class="p-navigation__link" href="https://events.canonical.com/event/51/registrations/">Register</a>
-          </li>
-        </ul>
-      </nav>
     </div>
-  </header>
+    <div class="u-fixed-width">
+      <div class="p-section--shallow">
+        <div class="u-embedded-media u-no-margin--bottom">
+          <iframe width="560"
+                  height="315"
+                  class="u-embedded-media__element"
+                  src="https://www.youtube.com/embed/aR-yTFtjGtw?si=VdJuwA6Uq4u2kEiV&autoplay=1&mute=1"
+                  title="Ubuntu Summit 2024 Highlights"
+                  frameborder="0"
+                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                  referrerpolicy="strict-origin-when-cross-origin"
+                  allowfullscreen></iframe>
+        </div>
+      </div>
+      <hr class="p-rule--muted" />
+      <div class="u-align--right">
+        <a class="p-heading--2"
+           href="https://youtube.com/playlist?list=PLwFSk464RMxmaZj6wi3e-NLOGtRr4iFF6&feature=shared">Watch talks from last year&nbsp;&rsaquo;</a>
+      </div>
+    </div>
+  </section>
 
-  <div class="p-section--hero">
-    <div class="row">
-      <div class="col-8">
-        <h1 class="p-heading--1 u-no-margin--bottom">Ubuntu Summit 2024</h1>
-        <h2 class="p-heading--2">October 25-27</h2>
-        <h3 class="p-heading--5">The Hague, Netherlands</h3>
-        <p>
-          The Ubuntu Summit is a showcase for the innovative and the ambitious. We invite all experts, builders, engineers, tinkerers, designers and dreamers to join us for an unforgettable three days.
-        </p>
-        <p>
-          <a href="https://events.canonical.com/event/51/registrations/"
-             class="p-button--positive">Join for free</a>
-        </p>
-      </div>
-      <div class="col-4 u-vertically-center">
-        {{ image(url="https://assets.ubuntu.com/v1/048df0ca-Canonical%20Ubuntu%20Summit%20Logo%202024%20with%20text.png",
-                  alt="Ubuntu Summit 2024 Logo",
-                  width="350",
-                  hi_def=True,
-                  loading="auto") | safe
-        }}
-      </div>
-    </div>
-  </div>
   <section class="p-section">
     <div class="row--50-50">
       <hr class="p-rule" />
       <div class="col">
-        <h2>An event for makers</h2>
+        <h2 class="p-heading--1">An event for makers</h2>
+      </div>
+      <div class="col">
+        <div class="p-section--shallow">
+          <div class="p-image-container ">
+            {{ image(url="https://assets.ubuntu.com/v1/56a7db37-event-for-makers.png",
+                        alt="",
+                        width="1200",
+                        height="675",
+                        hi_def=True,
+                        attrs={"class": "p-image-container__image"},
+                        loading="lazy") | safe
+            }}
+          </div>
+        </div>
         <p>
           The Ubuntu Summit is a showcase of open source innovation. Bringing developers, engineers, designers and tinkerers from all over the world to shape the world through open code.
         </p>
-        <p>Unsure if the Summit is for you? Listen to attendees from last year.</p>
-      </div>
-      <div class="col">
-          <iframe width="560"
-                  height="315"
-                  src="https://www.youtube.com/embed/ZOSMTaX5u4c?si=-bSujVqaG8-nzsZf"
-                  title="YouTube video player"
-                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                  referrerpolicy="strict-origin-when-cross-origin"
-                  allowfullscreen>
-          </iframe>
       </div>
     </div>
   </section>
+
+  <section class="p-section">
+    <div class="u-fixed-width">
+      <hr class="p-rule" />
+      <h2 class="p-heading--1">Free to attend and contribute</h2>
+      <p class="p-heading--2">
+        In true open source spirit, the Ubuntu Summit
+        <br />
+        is completely free to attend - both in person and online.
+      </p>
+      <div class="p-section--shallow">
+        <div class="p-image-container">
+          {{ image(url="https://assets.ubuntu.com/v1/e0e28f56-free-to-attend.png",
+                    alt="",
+                    width="2464",
+                    height="1028",
+                    attrs={"class": "p-image-container__image"},
+                    hi_def=True,
+                    loading="lazy") | safe
+          }}
+        </div>
+      </div>
+      <hr class="p-rule--muted" />
+      <div class="u-align--right">
+        <a class="p-heading--2" href="/summit/call-for-collaboration">Find out how you can contribute&nbsp;&rsaquo;</a>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <div class="p-section--shallow">
+      <div class="row--50-50">
+        <hr class="p-rule" />
+        <div class="col">
+          <h2 class="p-heading--1">Featured speakers</h2>
+        </div>
+        <div class="col">
+          <p>
+            The Ubuntu Summit will include a series of talks, workshops, panels and Q&A. We cover a broad range of topics to appeal not only to developers, but anyone involved in open source. You will learn about Linux Desktop, cloud and infrastructure, community, arts, design, and much more.
+          </p>
+        </div>
+      </div>
+    </div>
+    <div class="u-fixed-width">
+      <hr class="p-rule--muted" />
+      <div class="u-align--right u-sv1">
+        <a href="#" id="carousel-previous" class="p-carousel__previous">
+          <i class="p-icon--chevron-left">Previous testimonial</i>
+        </a>
+        &nbsp;
+        <a href="#" id="carousel-next" class="p-carousel__next">
+          <i class="p-icon--chevron-right">Next testimonial</i>
+        </a>
+      </div>
+      <div class="p-section--shallow">
+        <div class="p-carousel">
+          <div id="carousel_target">
+            <div class="p-carousel__cell">
+              <div class="p-image-container">
+                {{ image(url="https://assets.ubuntu.com/v1/33033ff9-new-speaker-img-1.jpg",
+                                alt="",
+                                width="1832",
+                                height="1032",
+                                hi_def=True,
+                                attrs={"class": "p-image-container__image"},
+                                loading="lazy") | safe
+                }}
+              </div>
+            </div>
+            <div class="p-carousel__cell">
+              <div class="p-image-container">
+                {{ image(url="https://assets.ubuntu.com/v1/14328845-new-speaker-img-2.jpg",
+                                alt="",
+                                width="1832",
+                                height="1032",
+                                hi_def=True,
+                                attrs={"class": "p-image-container__image"},
+                                loading="lazy") | safe
+                }}
+              </div>
+            </div>
+            <div class="p-carousel__cell">
+              <div class="p-image-container">
+                {{ image(url="https://assets.ubuntu.com/v1/682b53fb-new-speaker-img-3.jpg",
+                                alt="",
+                                width="1832",
+                                height="1032",
+                                hi_def=True,
+                                attrs={"class": "p-image-container__image"},
+                                loading="lazy") | safe
+                }}
+              </div>
+            </div>
+            <div class="p-carousel__cell">
+              <div class="p-image-container">
+                {{ image(url="https://assets.ubuntu.com/v1/85c9d3a3-new-speaker-img-4.jpg",
+                                alt="",
+                                width="1832",
+                                height="1032",
+                                hi_def=True,
+                                attrs={"class": "p-image-container__image"},
+                                loading="lazy") | safe
+                }}
+              </div>
+            </div>
+            <div class="p-carousel__cell">
+              <div class="p-image-container">
+                {{ image(url="https://assets.ubuntu.com/v1/93c82d4b-new-speaker-img-5.jpg",
+                                alt="",
+                                width="1832",
+                                height="1032",
+                                hi_def=True,
+                                attrs={"class": "p-image-container__image"},
+                                loading="lazy") | safe
+                }}
+              </div>
+            </div>
+            <div class="p-carousel__cell">
+              <div class="p-image-container">
+                {{ image(url="https://assets.ubuntu.com/v1/a9b21cea-new-speaker-img-6.jpg",
+                                alt="",
+                                width="1832",
+                                height="1032",
+                                hi_def=True,
+                                attrs={"class": "p-image-container__image"},
+                                loading="lazy") | safe
+                }}
+              </div>
+            </div>
+            <div class="p-carousel__cell">
+              <div class="p-image-container">
+                {{ image(url="https://assets.ubuntu.com/v1/fd2110b7-new-speaker-img-7.jpg",
+                                alt="",
+                                width="1832",
+                                height="1032",
+                                hi_def=True,
+                                attrs={"class": "p-image-container__image"},
+                                loading="lazy") | safe
+                }}
+              </div>
+            </div>
+            <div class="p-carousel__cell">
+              <div class="p-image-container">
+                {{ image(url="https://assets.ubuntu.com/v1/fbd85e66-new-speaker-img-8.jpg",
+                                alt="",
+                                width="1832",
+                                height="1032",
+                                hi_def=True,
+                                attrs={"class": "p-image-container__image"},
+                                loading="lazy") | safe
+                }}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <hr class="p-rule--highlight" />
+      <p>
+        <a class="p-text--small-caps"
+           href="https://events.canonical.com/event/51/contributions/">View the full list of speakers&nbsp;&rsaquo;</a>
+      </p>
+
+      <ul class="p-list--divided row">
+        <li class="p-list__item col-3 col-medium-3 u-no-padding--top u-no-padding--bottom">
+          <hr class="p-rule--muted u-no-margin--bottom" />
+          <h3 class="p-heading--5 u-no-margin--bottom">
+            <a href="https://events.canonical.com/event/51/contributions/545">Marc Jackels</a>
+          </h3>
+          <p class="u-no-padding--top">Dreamworks</p>
+        </li>
+        <li class="p-list__item col-3 col-medium-3 u-no-padding--top u-no-padding--bottom">
+          <h3 class="p-heading--5 u-no-margin--bottom">
+            <a href="https://events.canonical.com/event/51/contributions/590">David Morin</a>
+          </h3>
+          <p class="u-no-padding--top">Academy Software Foundation</p>
+        </li>
+        <li class="p-list__item col-3 col-medium-3 u-no-padding--top u-no-padding--bottom">
+          <h3 class="p-heading--5 u-no-margin--bottom">
+            <a href="https://events.canonical.com/event/51/contributions/519">Jose Blanquicet</a>
+          </h3>
+          <p class="u-no-padding--top">Microsoft</p>
+        </li>
+        <li class="p-list__item col-3 col-medium-3 u-no-padding--top u-no-padding--bottom">
+          <h3 class="p-heading--5 u-no-margin--bottom">
+            <a href="https://events.canonical.com/event/51/contributions/510">Thomas Crider</a>
+          </h3>
+          <p class="u-no-padding--top">Proton-GE</p>
+        </li>
+        <li class="p-list__item col-3 col-medium-3 u-no-padding--top u-no-padding--bottom">
+          <h3 class="p-heading--5 u-no-margin--bottom">
+            <a href="https://events.canonical.com/event/51/contributions/509">Carl Richell</a>
+          </h3>
+          <p class="u-no-padding--top">System 76</p>
+        </li>
+        <li class="p-list__item col-3 col-medium-3 u-no-padding--top u-no-padding--bottom">
+          <h3 class="p-heading--5 u-no-margin--bottom">
+            <a href="https://events.canonical.com/event/51/contributions/549">Dr. Kevin Ottens</a>
+          </h3>
+          <p class="u-no-padding--top">KDE</p>
+        </li>
+        <li class="p-list__item col-3 col-medium-3 u-no-padding--top u-no-padding--bottom">
+          <h3 class="p-heading--5 u-no-margin--bottom">
+            <a href="https://events.canonical.com/event/51/contributions/540">Dongge Liu</a>
+          </h3>
+          <p class="u-no-padding--top">Google</p>
+        </li>
+        <li class="p-list__item col-3 col-medium-3 u-no-padding--top u-no-padding--bottom">
+          <h3 class="p-heading--5 u-no-margin--bottom">
+            <a href="https://events.canonical.com/event/51/contributions/512">Matthew Hodgson</a>
+          </h3>
+          <p class="u-no-padding--top">Matrix Foundation</p>
+        </li>
+        <li class="p-list__item col-3 col-medium-3 u-no-padding--top u-no-padding--bottom">
+          <h3 class="p-heading--5 u-no-margin--bottom">
+            <a href="https://events.canonical.com/event/51/contributions/544">Erik Holk</a>
+          </h3>
+          <p class="u-no-padding--top">Rust Leadership Council</p>
+        </li>
+        <li class="p-list__item col-3 col-medium-3 u-no-padding--top u-no-padding--bottom">
+          <h3 class="p-heading--5 u-no-margin--bottom">
+            <a href="https://events.canonical.com/event/51/contributions/516">Rakhi Sharma</a>
+          </h3>
+          <p class="u-no-padding--top">Servo Project</p>
+        </li>
+        <li class="p-list__item col-3 col-medium-3 col-start-large-7 u-no-padding--top u-no-padding--bottom">
+          <h3 class="p-heading--5 u-no-margin--bottom">
+            <a href="https://events.canonical.com/event/51/contributions/548">Christian Holsing</a>
+          </h3>
+          <p class="u-no-padding--top">Intel</p>
+        </li>
+        <li class="p-list__item col-3 col-medium-3 u-no-padding--top u-no-padding--bottom">
+          <h3 class="p-heading--5 u-no-margin--bottom">
+            <a href="https://events.canonical.com/event/51/contributions/557">Nirav Patel</a>
+          </h3>
+          <p class="u-no-padding--top">Framework</p>
+        </li>
+      </ul>
+    </div>
+  </section>
+
   <section class="p-section">
     <div class="row">
       <hr class="p-rule" />
-      <h2>Featured speakers</h2>
-      <div class="col-2 p-card">
-        <div class="p-card__content">
-          <div class="p-card__image">
-            {{ image(url="https://events.canonical.com/user/1666/picture-895558193",
-                    alt="Mark Jackels",
-                    width="165",
-                    hi_def=True,
-                    loading="lazy") | safe
-            }}
+      <div class="col-3 col-medium-6">
+        <h2 class="p-heading--1">Topics</h2>
+      </div>
+      <div class="col-9 col-medium-6">
+        <div class="p-equal-height-row">
+          <div class="p-equal-height-row__col">
+            <div class="p-equal-height-row__item">
+              <div class="p-image-container u-hide--small" style="overflow: hidden;">
+                {{ image(url="https://assets.ubuntu.com/v1/c415a554-linux.png",
+                                alt="",
+                                width="568",
+                                height="380",
+                                hi_def=True,
+                                attrs={"class": "p-image-container__image image-hover__zoom"},
+                                loading="lazy") | safe
+                }}
+              </div>
+              <hr class="p-rule--highlight u-hide--medium" />
+            </div>
+            <h3 class="p-heading--5 p-equal-height-row__item">Linux Desktop</h3>
+            <p class="p-equal-height-row__item">
+              Sessions on this track will focus on Linux desktop technologies and applications, desktop environments, Raspberry PI, packaging.
+            </p>
           </div>
-          <a href="https://events.canonical.com/event/51/contributions/545/">
-            <h3 class="p-heading--5">Mark Jackels</h3>
-          </a>
-          <p>Dreamworks</p>
-        </div>
-      </div>
-      <div class="col-2 p-card">
-        <div class="p-card__content">
-          <div class="p-card__image">
-            {{ image(url="https://events.canonical.com/user/3099/picture-1004041007",
-                    alt="David Morin",
-                    width="165",
-                    hi_def=True,
-                    loading="lazy") | safe
-            }}
+          <div class="p-equal-height-row__col">
+            <div class="p-equal-height-row__item">
+              <div class="p-image-container u-hide--small" style="overflow: hidden;">
+                {{ image(url="https://assets.ubuntu.com/v1/33d83ce0-app-ecosystem.png",
+                                alt="",
+                                width="568",
+                                height="380",
+                                hi_def=True,
+                                attrs={"class": "p-image-container__image image-hover__zoom"},
+                                loading="lazy") | safe
+                }}
+              </div>
+              <hr class="p-rule--highlight u-hide--medium" />
+            </div>
+            <h3 class="p-heading--5 p-equal-height-row__item">Application Ecosystem</h3>
+            <p class="p-equal-height-row__item">
+              This track will showcase Open Source applications, programming languages, APIs and tools to build and deploy applications.
+            </p>
           </div>
-          <a href="https://events.canonical.com/event/51/contributions/590/">
-            <h3 class="p-heading--5">David Morin</h3>
-          </a>
-          <p>Academy Software Foundation</p>
-        </div>
-      </div>
-      <div class="col-2 p-card">
-        <div class="p-card__content">
-          <div class="p-card__image">
-            {{ image(url="https://events.canonical.com/user/2990/picture-3687146351",
-                    alt="Jose Blanquicet",
-                    width="165",
-                    hi_def=True,
-                    loading="lazy") | safe
-            }}
+          <div class="p-equal-height-row__col">
+            <div class="p-equal-height-row__item">
+              <div class="p-image-container u-hide--small" style="overflow: hidden;">
+                {{ image(url="https://assets.ubuntu.com/v1/8b61336f-content-design.png",
+                                alt="",
+                                width="568",
+                                height="380",
+                                hi_def=True,
+                                attrs={"class": "p-image-container__image image-hover__zoom"},
+                                loading="lazy") | safe
+                }}
+              </div>
+              <hr class="p-rule--highlight u-hide--medium" />
+            </div>
+            <h3 class="p-heading--5 p-equal-height-row__item">Content and Design</h3>
+            <p class="p-equal-height-row__item">
+              This track will take you on a journey to discover what makes a great user experience on a wide range of products and using different technologies.
+            </p>
           </div>
-          <a href="https://events.canonical.com/event/51/contributions/519/">
-            <h3 class="p-heading--5">Jose Blanquicet</h3>
-          </a>
-          <p>Microsoft</p>
-        </div>
-      </div>
-      <div class="col-2 p-card">
-        <div class="p-card__content">
-          <div class="p-card__image">
-            {{ image(url="https://events.canonical.com/user/2835/picture-4162133408",
-                    alt="Thomas Crider",
-                    width="165",
-                    hi_def=True,
-                    loading="lazy") | safe
-            }}
+          <div class="p-equal-height-row__col">
+            <div class="p-equal-height-row__item">
+              <div class="p-image-container u-hide--small" style="overflow: hidden;">
+                {{ image(url="https://assets.ubuntu.com/v1/0b5cbabe-community.png",
+                                alt="",
+                                width="568",
+                                height="380",
+                                hi_def=True,
+                                attrs={"class": "p-image-container__image image-hover__zoom"},
+                                loading="lazy") | safe
+                }}
+              </div>
+              <hr class="p-rule--highlight u-hide--medium" />
+            </div>
+            <h3 class="p-heading--5 p-equal-height-row__item">Community</h3>
+            <p class="p-equal-height-row__item">
+              This track will focus on community building and management, tools and processes useful to community leaders, and documentation in open source projects.
+            </p>
           </div>
-          <a href="https://events.canonical.com/event/51/contributions/510/">
-            <h3 class="p-heading--5">Thomas Crider</h3>
-          </a>
-          <p>Proton-GE</p>
-        </div>
-      </div>
-      <div class="col-2 p-card">
-        <div class="p-card__content">
-          <div class="p-card__image">
-            {{ image(url="https://events.canonical.com/user/270/picture-1215077797",
-                    alt="Carl Richell",
-                    width="165",
-                    hi_def=True,
-                    loading="lazy") | safe
-            }}
-          </div>
-          <a href="https://events.canonical.com/event/51/contributions/509/">
-            <h3 class="p-heading--5">Carl Richell</h3>
-          </a>
-          <p>System76</p>
-        </div>
-      </div>
-      <div class="col-2 p-card">
-        <div class="p-card__content">
-          <div class="p-card__image">
-            {{ image(url="https://events.canonical.com/user/2933/picture-4115884446",
-                    alt="Dr. Kevin Ottens",
-                    width="165",
-                    hi_def=True,
-                    loading="lazy") | safe
-            }}
-          </div>
-          <a href="https://events.canonical.com/event/51/contributions/549/">
-            <h3 class="p-heading--5">Dr. Kevin Ottens</h3>
-          </a>
-          <p>KDE</p>
-        </div>
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-2 p-card">
-        <div class="p-card__content">
-          <div class="p-card__image">
-            {{ image(url="https://events.canonical.com/user/2994/picture-4096009663",
-                    alt="Dongge Liu",
-                    width="165",
-                    hi_def=True,
-                    loading="lazy") | safe
-            }}
-          </div>
-          <a href="https://events.canonical.com/event/51/contributions/540/">
-            <h3 class="p-heading--5">Dongge Liu</h3>
-          </a>
-          <p>Google</p>
-        </div>
-      </div>
-      <div class="col-2 p-card">
-        <div class="p-card__content">
-          <div class="p-card__image">
-            {{ image(url="https://events.canonical.com/user/2947/picture-4051697592",
-                    alt="Matthew Hodgson",
-                    width="165",
-                    hi_def=True,
-                    loading="lazy") | safe
-            }}
-          </div>
-          <a href="https://events.canonical.com/event/51/contributions/512/">
-            <h3 class="p-heading--5">Matthew Hodgson</h3>
-          </a>
-          <p>Matrix Foundation</p>
-        </div>
-      </div>
-      <div class="col-2 p-card">
-        <div class="p-card__content">
-          <div class="p-card__image">
-            {{ image(url="https://events.canonical.com/user/3019/picture-407386855",
-                    alt="Eric Holk",
-                    width="165",
-                    hi_def=True,
-                    loading="lazy") | safe
-            }}
-          </div>
-          <a href="https://events.canonical.com/event/51/contributions/544/">
-            <h3 class="p-heading--5">Eric Holk</h3>
-          </a>
-          <p>Rust Leadership Council</p>
-        </div>
-      </div>
-      <div class="col-2 p-card">
-        <div class="p-card__content">
-          <div class="p-card__image">
-            {{ image(url="https://events.canonical.com/user/2988/picture-3300584080",
-                    alt="Rakhi Sharma",
-                    width="165",
-                    hi_def=True,
-                    loading="lazy") | safe
-            }}
-          </div>
-          <a href="https://events.canonical.com/event/51/contributions/516/">
-            <h3 class="p-heading--5">Rakhi Sharma</h3>
-          </a>
-          <p>Servo Project</p>
-        </div>
-      </div>
-      <div class="col-2 p-card">
-        <div class="p-card__content">
-          <div class="p-card__image">
-            {{ image(url="https://events.canonical.com/user/1645/picture-12244883",
-                    alt="Christian Holsing",
-                    width="165",
-                    hi_def=True,
-                    loading="lazy") | safe
-            }}
-          </div>
-          <a href="https://events.canonical.com/event/51/contributions/588/">
-            <h3 class="p-heading--5">Christian Holsing</h3>
-          </a>
-          <p>Intel</p>
-        </div>
-      </div>
-      <div class="col-2 p-card">
-        <div class="p-card__content">
-          <div class="p-card__image">
-            {{ image(url="https://events.canonical.com/user/2964/picture-2653677503",
-                    alt="Nirav Patel",
-                    width="165",
-                    hi_def=True,
-                    loading="lazy") | safe
-            }}
-          </div>
-          <a href="https://events.canonical.com/event/51/contributions/557/">
-            <h3 class="p-heading--5">Nirav Patel</h3>
-          </a>
-          <p>Framework</p>
-        </div>
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-12">
-        <a href="https://events.canonical.com/event/51/timetable/?layout=room#20241025.detailed"
-           class="p-button">Full timetable</a>
-      </div>
-    </div>
+          <div class="p-equal-height-row__col">
+            <div class="p-equal-height-row__item">
+              <div class="p-image-container u-hide--small" style="overflow: hidden;">
+                {{ image(url="https://assets.ubuntu.com/v1/f996e117-infrastructure.png",
+                                alt="",
+                                width="568",
+                                height="380",
+                                hi_def=True,
+                                attrs={"class": "p-image-container__image image-hover__zoom"},
+                                loading="lazy") | safe
+                }}
+              </div>
+              <hr class="p-rule--highlight u-hide--medium" />
+            </div>
+            <h3 class="p-heading--5 p-equal-height-row__item">Infrastructure</h3>
+            <p class="p-equal-height-row__item">
+              This track is focused on Linux server, infrastructure and cloud: where and how they can be deployed, and how they are optimized on platforms ranging from raspberryPI to IoT.
 
+            </p>
+          </div>
+          <div class="p-equal-height-row__col">
+            <div class="p-equal-height-row__item">
+              <div class="p-image-container u-hide--small" style="overflow: hidden;">
+                {{ image(url="https://assets.ubuntu.com/v1/1e8400fd-devices.png",
+                                alt="",
+                                width="568",
+                                height="380",
+                                hi_def=True,
+                                attrs={"class": "p-image-container__image image-hover__zoom"},
+                                loading="lazy") | safe
+                }}
+              </div>
+              <hr class="p-rule--highlight u-hide--medium" />
+            </div>
+            <h3 class="p-heading--5 p-equal-height-row__item">Devices</h3>
+            <p class="p-equal-height-row__item">
+              From small smart home devices to robots in space stations, Linux is everywhere. This track celebrates our community work in the robotics and IoT field.
+
+            </p>
+          </div>
+          <div class="p-equal-height-row__col">
+            <div class="p-equal-height-row__item">
+              <div class="p-image-container u-hide--small" style="overflow: hidden;">
+                {{ image(url="https://assets.ubuntu.com/v1/c9ea13cb-data.png",
+                                alt="",
+                                width="568",
+                                height="380",
+                                hi_def=True,
+                                attrs={"class": "p-image-container__image image-hover__zoom"},
+                                loading="lazy") | safe
+                }}
+              </div>
+              <hr class="p-rule--highlight u-hide--medium" />
+            </div>
+            <h3 class="p-heading--5 p-equal-height-row__item">Data, MLOps and AI/ML</h3>
+            <p class="p-equal-height-row__item">
+              This landscape is a dynamic one, with new tools, frameworks and models emerging daily. This track is focused on Data, MLOps and AI/ML and how open source empowers the next technological revolution.
+            </p>
+          </div>
+          <div class="p-equal-height-row__col">
+            <div class="p-equal-height-row__item">
+              <div class="p-image-container u-hide--small" style="overflow: hidden;">
+                {{ image(url="https://assets.ubuntu.com/v1/8b61336f-content-design.png",
+                                alt="",
+                                width="568",
+                                height="380",
+                                hi_def=True,
+                                attrs={"class": "p-image-container__image image-hover__zoom"},
+                                loading="lazy") | safe
+                }}
+              </div>
+              <hr class="p-rule--highlight u-hide--medium" />
+            </div>
+            <h3 class="p-heading--5 p-equal-height-row__item">Gaming</h3>
+            <p class="p-equal-height-row__item">
+              In this track, you'll learn about the people behind the gaming software, creative tools and and APIs that are powering this unstoppable phenomenon.
+
+            </p>
+          </div>
+          <div class="p-equal-height-row__col">
+            <div class="p-equal-height-row__item">
+              <div class="p-image-container u-hide--small" style="overflow: hidden;">
+                {{ image(url="https://assets.ubuntu.com/v1/278004ac-security.png",
+                                alt="",
+                                width="568",
+                                height="380",
+                                hi_def=True,
+                                attrs={"class": "p-image-container__image image-hover__zoom"},
+                                loading="lazy") | safe
+                }}
+              </div>
+              <hr class="p-rule--highlight u-hide--medium" />
+            </div>
+            <h3 class="p-heading--5 p-equal-height-row__item">Security</h3>
+            <p class="p-equal-height-row__item">
+              Security is fundamental to Ubuntu, Canonical, and the open source community. This track will focus on the latest developments and practices to keep users and information secure.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
   </section>
 
-  <section class="p-section--shallow">
-    <div class="row">
-      <hr class="p-rule" />
-      <h2>Community booths</h2>
-      <p>
-        We're introducing a new element to the Ubuntu Summit experience. This year, attendees can visit a number of community focused booths stationed throughout the main venue space.
-      </p>
+  <hr class="is-fixed-width" />
 
-      <div class="p-logo-section has-misaligned-images">
-        <div class="p-logo-section__items">
-          <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/d86e845a-Canonical_logo_2023.svg",
-                    alt="Canonical",
-                    width="104",
-                    hi_def=True,
-                    loading="lazy") | safe
-            }}
-          </div>
-          <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/92c89bba-microsoft-logo.png",
-                    alt="Microsoft",
-                    width="104",
-                    hi_def=True,
-                    loading="lazy") | safe
-            }}
-          </div>
-          <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/df00697d-Thunderbird_2023_icon.png",
-                    alt="Thunderbird",
-                    width="104",
-                    hi_def=True,
-                    loading="lazy") | safe
-            }}
-          </div>
-          <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/647ef6e6-AsahiLinux_logo_darkbg.png",
-                    alt="Asahi Linux",
-                    width="104",
-                    hi_def=True,
-                    loading="lazy") | safe
-            }}
-          </div>
-          <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/7844834d-Intel_logo_2023.svg.png",
-                    alt="Intel",
-                    width="104",
-                    hi_def=True,
-                    loading="lazy") | safe
-            }}
-          </div>
-          <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/669623f8-UBports.png",
-                    alt="UBPorts",
-                    width="104",
-                    hi_def=True,
-                    loading="lazy") | safe
-            }}
-          </div>
-          <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/7b309b98-system76.png",
-                    alt="System76",
-                    width="104",
-                    hi_def=True,
-                    loading="lazy") | safe
-            }}
-          </div>
-          <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/e8c86767-Framework_Computer_logo.png",
-                    alt="Framework",
-                    width="104",
-                    hi_def=True,
-                    loading="lazy") | safe
-            }}
-          </div>
-          <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/c4ad31db-lutris.png",
-                    alt="Lutris",
-                    width="104",
-                    hi_def=True,
-                    loading="lazy") | safe
-            }}
-          </div>
-          <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/7dfd7dbe-Fairphone_logo.svg.png",
-                    alt="Fairphone",
-                    width="104",
-                    hi_def=True,
-                    loading="lazy") | safe
-            }}
-          </div>
-          <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/11e66fc8-Opensearch_Logo.svg",
-                    alt="OpenSearch",
-                    width="104",
-                    hi_def=True,
-                    loading="lazy") | safe
-            }}
-          </div>
-          <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/ab8ba220-snapcrafters.png",
-                    alt="Snapcrafters",
-                    width="104",
-                    hi_def=True,
-                    loading="lazy") | safe
-            }}
-          </div>
-        </div>
-      </div>
+  <section class="p-strip">
+    <div class="u-fixed-width">
+      <p class="p-heading--2">
+        Questions?
+        <br />
+        <a href="mailto:summit@ubuntu.com">Email us</a> or <a href="https://matrix.to/#/#summit:ubuntu.com">join the conversation on Matrix</a>
+      </p>
     </div>
   </section>
 
   {% with title_link="/blog/tag/ubuntu-summit", tag_id="4374" %}
-    {% include "download/shared/_latest-blogs_download.html" %}
+    {% include "/summit/shared/_latest-blogs_summit.html" %}
   {% endwith %}
+
+  <script src="{{ versioned_static('js/dist/flickity.pkgd.min.js') }}"></script>
+
+  <script>
+    initCarousel('#carousel_target', '#carousel-next', '#carousel-previous');
+
+    function initCarousel(carouselSelector, nextSelector, previousSelector) {
+      var nextButton = document.querySelector(nextSelector);
+      var previousButton = document.querySelector(previousSelector);
+      var carousel = new Flickity(carouselSelector, {
+        prevNextButtons: false,
+        wrapAround: true,
+      });
+
+      if (nextButton) {
+        nextButton.addEventListener("click", function(e) {
+          e.preventDefault();
+          carousel.next();
+        });
+      }
+
+      if (previousButton) {
+        previousButton.addEventListener("click", function(e) {
+          e.preventDefault();
+          carousel.previous();
+        });
+      }
+    }
+  </script>
 
 {% endblock content %}

--- a/templates/summit/index.html
+++ b/templates/summit/index.html
@@ -45,7 +45,7 @@
           <iframe width="560"
                   height="315"
                   class="u-embedded-media__element"
-                  src="https://www.youtube.com/embed/aR-yTFtjGtw?si=VdJuwA6Uq4u2kEiV&autoplay=1&mute=1"
+                  src="https://www.youtube.com/embed/aR-yTFtjGtw?si=VdJuwA6Uq4u2kEiV&autoplay=1&mute=1&loop=1&playlist=aR-yTFtjGtw"
                   title="Ubuntu Summit 2024 Highlights"
                   frameborder="0"
                   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
@@ -56,7 +56,9 @@
       <hr class="p-rule--muted" />
       <div class="u-align--right">
         <a class="p-heading--2"
-           href="https://youtube.com/playlist?list=PLwFSk464RMxmaZj6wi3e-NLOGtRr4iFF6&feature=shared">Watch talks from last year&nbsp;&rsaquo;</a>
+           href="https://youtube.com/playlist?list=PLwFSk464RMxmaZj6wi3e-NLOGtRr4iFF6&feature=shared">Watch talks from
+          <br class="u-hide--large u-hide--medium" />
+        last year&nbsp;&rsaquo;</a>
       </div>
     </div>
   </section>
@@ -157,7 +159,7 @@
             </div>
             <div class="p-carousel__cell">
               <div class="p-image-container">
-                {{ image(url="https://assets.ubuntu.com/v1/14328845-new-speaker-img-2.jpg",
+                {{ image(url="https://assets.ubuntu.com/v1/d47edc7a-final_speaker-img-2.jpg",
                                 alt="",
                                 width="1832",
                                 height="1032",
@@ -169,7 +171,7 @@
             </div>
             <div class="p-carousel__cell">
               <div class="p-image-container">
-                {{ image(url="https://assets.ubuntu.com/v1/682b53fb-new-speaker-img-3.jpg",
+                {{ image(url="https://assets.ubuntu.com/v1/f47671b6-final_speaker-img-3.jpg",
                                 alt="",
                                 width="1832",
                                 height="1032",
@@ -181,7 +183,7 @@
             </div>
             <div class="p-carousel__cell">
               <div class="p-image-container">
-                {{ image(url="https://assets.ubuntu.com/v1/85c9d3a3-new-speaker-img-4.jpg",
+                {{ image(url="https://assets.ubuntu.com/v1/98a97756-final_speaker-img-4.jpg",
                                 alt="",
                                 width="1832",
                                 height="1032",
@@ -193,7 +195,7 @@
             </div>
             <div class="p-carousel__cell">
               <div class="p-image-container">
-                {{ image(url="https://assets.ubuntu.com/v1/93c82d4b-new-speaker-img-5.jpg",
+                {{ image(url="https://assets.ubuntu.com/v1/c2044ab9-final_speaker-img-5.jpg",
                                 alt="",
                                 width="1832",
                                 height="1032",
@@ -205,7 +207,7 @@
             </div>
             <div class="p-carousel__cell">
               <div class="p-image-container">
-                {{ image(url="https://assets.ubuntu.com/v1/a9b21cea-new-speaker-img-6.jpg",
+                {{ image(url="https://assets.ubuntu.com/v1/a48d1893-final_speaker-img-6.jpg",
                                 alt="",
                                 width="1832",
                                 height="1032",
@@ -217,7 +219,7 @@
             </div>
             <div class="p-carousel__cell">
               <div class="p-image-container">
-                {{ image(url="https://assets.ubuntu.com/v1/fd2110b7-new-speaker-img-7.jpg",
+                {{ image(url="https://assets.ubuntu.com/v1/46eb60da-final_speaker-img-7.jpg",
                                 alt="",
                                 width="1832",
                                 height="1032",
@@ -229,7 +231,7 @@
             </div>
             <div class="p-carousel__cell">
               <div class="p-image-container">
-                {{ image(url="https://assets.ubuntu.com/v1/fbd85e66-new-speaker-img-8.jpg",
+                {{ image(url="https://assets.ubuntu.com/v1/6a882152-final_speaker-img-8.jpg",
                                 alt="",
                                 width="1832",
                                 height="1032",
@@ -312,7 +314,7 @@
         </li>
         <li class="p-list__item col-3 col-medium-3 col-start-large-7 u-no-padding--top u-no-padding--bottom">
           <h3 class="p-heading--5 u-no-margin--bottom">
-            <a href="https://events.canonical.com/event/51/contributions/548">Christian Holsing</a>
+            <a href=" https://events.canonical.com/event/51/contributions/588">Christian Holsing</a>
           </h3>
           <p class="u-no-padding--top">Intel</p>
         </li>
@@ -334,7 +336,7 @@
       </div>
       <div class="col-9 col-medium-6">
         <div class="p-equal-height-row">
-          <div class="p-equal-height-row__col">
+          <div class="p-equal-height-row__col u-sv2">
             <div class="p-equal-height-row__item">
               <div class="p-image-container u-hide--small" style="overflow: hidden;">
                 {{ image(url="https://assets.ubuntu.com/v1/c415a554-linux.png",
@@ -353,7 +355,7 @@
               Sessions on this track will focus on Linux desktop technologies and applications, desktop environments, Raspberry PI, packaging.
             </p>
           </div>
-          <div class="p-equal-height-row__col">
+          <div class="p-equal-height-row__col u-sv2">
             <div class="p-equal-height-row__item">
               <div class="p-image-container u-hide--small" style="overflow: hidden;">
                 {{ image(url="https://assets.ubuntu.com/v1/33d83ce0-app-ecosystem.png",
@@ -372,7 +374,7 @@
               This track will showcase Open Source applications, programming languages, APIs and tools to build and deploy applications.
             </p>
           </div>
-          <div class="p-equal-height-row__col">
+          <div class="p-equal-height-row__col u-sv2">
             <div class="p-equal-height-row__item">
               <div class="p-image-container u-hide--small" style="overflow: hidden;">
                 {{ image(url="https://assets.ubuntu.com/v1/8b61336f-content-design.png",
@@ -391,7 +393,7 @@
               This track will take you on a journey to discover what makes a great user experience on a wide range of products and using different technologies.
             </p>
           </div>
-          <div class="p-equal-height-row__col">
+          <div class="p-equal-height-row__col u-sv2">
             <div class="p-equal-height-row__item">
               <div class="p-image-container u-hide--small" style="overflow: hidden;">
                 {{ image(url="https://assets.ubuntu.com/v1/0b5cbabe-community.png",
@@ -410,7 +412,7 @@
               This track will focus on community building and management, tools and processes useful to community leaders, and documentation in open source projects.
             </p>
           </div>
-          <div class="p-equal-height-row__col">
+          <div class="p-equal-height-row__col u-sv2">
             <div class="p-equal-height-row__item">
               <div class="p-image-container u-hide--small" style="overflow: hidden;">
                 {{ image(url="https://assets.ubuntu.com/v1/f996e117-infrastructure.png",
@@ -430,7 +432,7 @@
 
             </p>
           </div>
-          <div class="p-equal-height-row__col">
+          <div class="p-equal-height-row__col u-sv2">
             <div class="p-equal-height-row__item">
               <div class="p-image-container u-hide--small" style="overflow: hidden;">
                 {{ image(url="https://assets.ubuntu.com/v1/1e8400fd-devices.png",
@@ -450,7 +452,7 @@
 
             </p>
           </div>
-          <div class="p-equal-height-row__col">
+          <div class="p-equal-height-row__col u-sv2">
             <div class="p-equal-height-row__item">
               <div class="p-image-container u-hide--small" style="overflow: hidden;">
                 {{ image(url="https://assets.ubuntu.com/v1/c9ea13cb-data.png",
@@ -469,7 +471,7 @@
               This landscape is a dynamic one, with new tools, frameworks and models emerging daily. This track is focused on Data, MLOps and AI/ML and how open source empowers the next technological revolution.
             </p>
           </div>
-          <div class="p-equal-height-row__col">
+          <div class="p-equal-height-row__col u-sv2">
             <div class="p-equal-height-row__item">
               <div class="p-image-container u-hide--small" style="overflow: hidden;">
                 {{ image(url="https://assets.ubuntu.com/v1/8b61336f-content-design.png",
@@ -489,7 +491,7 @@
 
             </p>
           </div>
-          <div class="p-equal-height-row__col">
+          <div class="p-equal-height-row__col u-sv2">
             <div class="p-equal-height-row__item">
               <div class="p-image-container u-hide--small" style="overflow: hidden;">
                 {{ image(url="https://assets.ubuntu.com/v1/278004ac-security.png",
@@ -540,6 +542,9 @@
       var carousel = new Flickity(carouselSelector, {
         prevNextButtons: false,
         wrapAround: true,
+        pageDots: false,
+        autoPlay: true,
+        pauseAutoPlayOnHover: true
       });
 
       if (nextButton) {

--- a/templates/summit/shared/_latest-blogs_summit.html
+++ b/templates/summit/shared/_latest-blogs_summit.html
@@ -14,7 +14,7 @@
   <template id="ubuntu-summit-template">
     <div class="col-3 col-medium-2 u-equal-height-items">
       <div class="u-crop--16-9">
-        <div class="article-image p-image-wrapper"></div>
+        <div class="article-image p-image-wrapper" aria-hidden></div>
       </div>
       <h3 class="p-heading--5">
         <a class="article-link article-title"></a>

--- a/templates/summit/shared/_latest-blogs_summit.html
+++ b/templates/summit/shared/_latest-blogs_summit.html
@@ -1,0 +1,46 @@
+<section class="p-section--deep">
+  <div class="u-fixed-width">
+    <hr class="p-rule" />
+    <div class="p-section--shallow">
+      <h2>
+        <a href="{{ title_link }}">Latest from&nbsp;our&nbsp;blog&nbsp;&rsaquo;</a>
+      </h2>
+    </div>
+    <div class="p-section--shallow">
+      <div class="row" id="ubuntu-summit-latest"></div>
+    </div>
+  </div>
+
+  <template id="ubuntu-summit-template">
+    <div class="col-3 col-medium-2 u-equal-height-items">
+      <div class="u-crop--16-9">
+        <div class="article-image p-image-wrapper"></div>
+      </div>
+      <h3 class="p-heading--5">
+        <a class="article-link article-title"></a>
+      </h3>
+      <p class="article-excerpt"></p>
+    </div>
+  </template>
+</section>
+
+<script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
+{# djlint:off #}
+  <script>  
+    canonicalLatestNews.fetchLatestNews(
+      {
+        articlesContainerSelector: "#ubuntu-summit-latest",
+        articleTemplateSelector: "#ubuntu-summit-template",
+        excerptLength: 200,
+        {% if group_id %}
+          groupId: {{ group_id }},
+        {% endif %}
+        {% if tag_id %}
+          tagId: {{ tag_id }},
+        {% endif %}
+        linkImage: true,
+        limit: 4
+      }
+    )
+</script>
+{# djlint:on #}


### PR DESCRIPTION
## Done

- Redesigned ubuntu.com/summit page.
- Added custom animations according to framer [demo](https://adaptable-luxury-619824-34344745f.framer.app/).
- Added common blog section.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [Demo](https://ubuntu-com-14872.demos.haus/summit)
- [CopyDoc](https://docs.google.com/document/d/1lj-xPVQjWqo2J_eZ-3ldKhJHj6RQ0Cwmk_Mr4QA4UTY/edit)
- [Figma](https://www.figma.com/design/jnBr57W2MnYiCg8QYxC8el?node-id=3283%3A7064&type=design&fuid=1375015922030380968)
- Check if the carousel is working fine and images in topic gets magnified on hover.

## Issue / Card
[WD-16854](https://warthogs.atlassian.net/browse/WD-16854)

## Linked PR
PR for canonical meganav 

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-16854]: https://warthogs.atlassian.net/browse/WD-16854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ