### PR TITLE
Add custom download URL for NVIDIA Jetson platforms

### DIFF
--- a/webapp/certified/helpers.py
+++ b/webapp/certified/helpers.py
@@ -8,6 +8,7 @@ def get_download_url(model_details):
     platform_category = model_details.get("category", "").lower()
     architecture = model_details.get("architecture", "").lower()
     make = model_details.get("make", "").lower()
+    configuration_name = model_details.get("model", "").lower()
 
     if model_details.get("level") == "Enabled":
         # Enabled systems use oem images without download links.
@@ -15,6 +16,9 @@ def get_download_url(model_details):
 
     if platform_category in ["desktop", "laptop"]:
         return "https://ubuntu.com/download/desktop"
+
+    if make == "nvidia" and "jetson" in configuration_name:
+        return "https://ubuntu.com/download/nvidia-jetson"
 
     if "core" in platform_category:
         if make == "xilinx":


### PR DESCRIPTION
## Done

This change adds a special condition in the `get_download_url` to check whether the platform in question is NVIDIA Jetson. If this is the case, it returns https://ubuntu.com/download/nvidia-jetson

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes [C3-1048](https://warthogs.atlassian.net/browse/C3-1048)

## Screenshots

It changes where the "Download" button on the following three configuration points to. Previously it was pointing to: "https://ubuntu.com/download/core" while now it is "https://ubuntu.com/download/nvidia-jetson"
* https://ubuntu.com/certified/202406-34151
* https://ubuntu.com/certified/202407-34213
* https://ubuntu.com/certified/202406-34152

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[C3-1048]: https://warthogs.atlassian.net/browse/C3-1048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ