### PR TITLE
fix: update qualcomm links

### DIFF
--- a/templates/download/qualcomm-iot/tabs/rb3-gen2-lite-tab.html
+++ b/templates/download/qualcomm-iot/tabs/rb3-gen2-lite-tab.html
@@ -48,7 +48,7 @@
           Get started with Ubuntu Server 22.04 for <a href="https://www.qualcomm.com/products/internet-of-things/industrial/industrial-automation/qcs5430">QCS5430</a>
         </li>
         <li class="p-list__item">
-          Ubuntu Server 22.04 for QCS5430 <a href="https://docs.qualcomm.com/bundle/publicresource/topics/80-82645-1/build-on-ubuntu-host.html?product=1601111740057201#download-the-ubuntu-os-image-and-boot-firmware">image installation instructions</a>
+          Ubuntu Server 22.04 for QCS5430 <a href="https://docs.qualcomm.com/bundle/publicresource/topics/80-82645-1/Integrate_and_flash_software_2.html?product=1601111740057201">image installation instructions</a>
         </li>
         <li class="p-list__item">
           Ubuntu Server 22.04 for QCS5430 <a href="https://people.canonical.com/~platform/images/qualcomm-iot/rb3-22.04/rb3-server-22.04-x08/Ubuntu%2022.04%20for%20Qualcomm%C2%AE%20RB3%20Gen%202%20Vision%20Development%20Kit%20Release%20Notes.pdf">release notes</a>

--- a/templates/download/qualcomm-iot/tabs/rb3-gen2-tab.html
+++ b/templates/download/qualcomm-iot/tabs/rb3-gen2-tab.html
@@ -50,7 +50,7 @@
           Get started with Ubuntu Server 22.04 for <a href="https://www.qualcomm.com/products/internet-of-things/industrial/building-enterprise/qcs6490#overview">QCS6490</a>
         </li>
         <li class="p-list__item">
-          Ubuntu Server 22.04 for QCS6490 <a href="https://docs.qualcomm.com/bundle/publicresource/topics/80-82645-1/build-on-ubuntu-host.html?product=1601111740057201#download-the-ubuntu-os-image-and-boot-firmware">image installation instructions</a>
+          Ubuntu Server 22.04 for QCS6490 <a href="https://docs.qualcomm.com/bundle/publicresource/topics/80-82645-1/Integrate_and_flash_software_2.html?product=1601111740057201">image installation instructions</a>
         </li>
         <li class="p-list__item">
           Ubuntu Server 22.04 for QCS6490 <a href="https://people.canonical.com/~platform/images/qualcomm-iot/rb3-22.04/rb3-server-22.04-x08/Ubuntu%2022.04%20for%20Qualcomm%C2%AE%20RB3%20Gen%202%20Vision%20Development%20Kit%20Release%20Notes.pdf">release notes</a>


### PR DESCRIPTION
## Done

- [List of work items including drive-bys - remember to add the why and what of this work.]
- Update urls as per this [ticket](https://warthogs.atlassian.net/browse/WD-20460)
## QA
- go to `/download/qualcomm-iot`
- links for "image installation instructions" are updated for both tabs as per copy update
## Issue / Card

Fixes [WD-20460](https://warthogs.atlassian.net/browse/WD-20460)



[WD-20460]: https://warthogs.atlassian.net/browse/WD-20460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ