### PR TITLE
Add markdown support for certification notes and escape raw-html content

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,3 +34,5 @@ numpy==1.24.4
 python-slugify==8.0.1
 djlint==1.34.1
 pycountry==24.6.1
+markdown==3.7
+markupsafe==2.1.5

--- a/templates/certified/model-details.html
+++ b/templates/certified/model-details.html
@@ -102,9 +102,7 @@
               </p>
             {% endif %}
 
-            {% for note in release.notes %}
-              {{ note.comment | convert_markdown_to_html | safe }}
-            {% endfor %}
+            {% for note in release.notes %}{{ note.comment | convert_markdown_to_html | safe }}{% endfor %}
 
             <div class="p-section--shallow">
               <table aria-label="Software" style="margin-top:1.4rem">

--- a/templates/certified/model-details.html
+++ b/templates/certified/model-details.html
@@ -103,9 +103,7 @@
             {% endif %}
 
             {% for note in release.notes %}
-              <p>
-                {{ note.comment | replace('\n', '<br />') | safe }}
-              </p>
+              {{ note.comment | convert_markdown_to_html | safe }}
             {% endfor %}
 
             <div class="p-section--shallow">

--- a/tests/cassettes/TestCertification.test_note_rendering.yaml
+++ b/tests/cassettes/TestCertification.test_note_rendering.yaml
@@ -1,0 +1,116 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.2
+    method: GET
+    uri: https://certification.canonical.com/api/v2/certified-configuration-details/?format=json&canonical_id=202301-31183&pagination=limitoffset
+  response:
+    body:
+      string: '{"count":3,"next":null,"previous":null,"results":[{"id":15981,"canonical_id":"202301-31183","architecture":"amd64","bios":"Lenovo:
+        ESE124F-3.13 (UEFI)","hardware_website":"https://lenovopress.lenovo.com/lp1601-thinksystem-sr650-v3-server","category":"Server","kernel_version":"5.15.0-117-generic","notes":[{"title":"test
+        note","comment":"# Heading 1\r\n## Heading 2\r\n**Bold text**\r\n*Italic text*\r\n[Link
+        text](https://example.com)\r\n\r\n* List item 1\r\n* List item 2\r\n\r\n<script>alert(''XSS
+        attack'');</script>\r\n<div class=\"dangerous\">\r\n<h1>Custom HTML</h1>\r\n</div>\r\n<img
+        src=\"javascript:alert(''XSS'')\" />"}],"make":"Lenovo","model":"ThinkSystem
+        SR650 V3 (SPR)","platform_name":"ThinkSystem SR650 V3","platform_id":"13487","processor":[{"name":"Intel(R)
+        Xeon(R) Platinum 8490H","make":"Intel Corp.","bus":"dmi","identifier":"dmi:Intel(R)Xeon(R)Platinum8490H","subsystem":"","subproduct_name":"","vendor_id":4103,"subvendor_id":"","category":"PROCESSOR"},{"name":"Intel(R)
+        Xeon(R) Platinum 8490H","make":"Intel Corp.","bus":"dmi","identifier":"dmi:Intel(R)Xeon(R)Platinum8490H","subsystem":"","subproduct_name":"","vendor_id":4103,"subvendor_id":"","category":"PROCESSOR"}],"network":[{"name":"NetXtreme
+        BCM5719 Gigabit Ethernet PCIe","make":"Broadcom Corp.","bus":"pci","identifier":"14e4:1657","subsystem":"17aa:4104","subproduct_name":"","vendor_id":5843,"subvendor_id":3654,"category":"NETWORK"},{"name":"NetXtreme
+        BCM5719 Gigabit Ethernet PCIe","make":"Broadcom Corp.","bus":"pci","identifier":"14e4:1657","subsystem":"17aa:4104","subproduct_name":"","vendor_id":5843,"subvendor_id":3654,"category":"NETWORK"},{"name":"NetXtreme
+        BCM5719 Gigabit Ethernet PCIe","make":"Broadcom Corp.","bus":"pci","identifier":"14e4:1657","subsystem":"17aa:4104","subproduct_name":"","vendor_id":5843,"subvendor_id":3654,"category":"NETWORK"},{"name":"NetXtreme
+        BCM5719 Gigabit Ethernet PCIe","make":"Broadcom Corp.","bus":"pci","identifier":"14e4:1657","subsystem":"17aa:4104","subproduct_name":"","vendor_id":5843,"subvendor_id":3654,"category":"NETWORK"}],"video":[{"name":"ASPEED
+        Graphics Family","make":"ASPEED Technology, Inc.","bus":"pci","identifier":"1a03:2000","subsystem":"1a03:2000","subproduct_name":"","vendor_id":1736,"subvendor_id":1736,"category":"VIDEO"}],"wireless":[],"certified_release":"24.04
+        LTS","level":"Certified","name":"2408-15981","form_factor":"Server","platform_certified_configuration_count":2},{"id":15552,"canonical_id":"202301-31183","architecture":"amd64","bios":"Lenovo:
+        ESE124B-3.11 (UEFI)","hardware_website":"https://lenovopress.lenovo.com/lp1601-thinksystem-sr650-v3-server","category":"Server","kernel_version":"6.8.0-11-generic","notes":[],"make":"Lenovo","model":"ThinkSystem
+        SR650 V3 (SPR)","platform_name":"ThinkSystem SR650 V3","platform_id":"13487","processor":[{"name":"Intel(R)
+        Xeon(R) Platinum 8490H","make":"Intel Corp.","bus":"dmi","identifier":"dmi:Intel(R)Xeon(R)Platinum8490H","subsystem":"","subproduct_name":"","vendor_id":4103,"subvendor_id":"","category":"PROCESSOR"},{"name":"Intel(R)
+        Xeon(R) Platinum 8490H","make":"Intel Corp.","bus":"dmi","identifier":"dmi:Intel(R)Xeon(R)Platinum8490H","subsystem":"","subproduct_name":"","vendor_id":4103,"subvendor_id":"","category":"PROCESSOR"}],"network":[{"name":"NetXtreme
+        BCM5719 Gigabit Ethernet PCIe","make":"Broadcom Corp.","bus":"pci","identifier":"14e4:1657","subsystem":"17aa:4104","subproduct_name":"","vendor_id":5843,"subvendor_id":3654,"category":"NETWORK"},{"name":"NetXtreme
+        BCM5719 Gigabit Ethernet PCIe","make":"Broadcom Corp.","bus":"pci","identifier":"14e4:1657","subsystem":"17aa:4104","subproduct_name":"","vendor_id":5843,"subvendor_id":3654,"category":"NETWORK"},{"name":"NetXtreme
+        BCM5719 Gigabit Ethernet PCIe","make":"Broadcom Corp.","bus":"pci","identifier":"14e4:1657","subsystem":"17aa:4104","subproduct_name":"","vendor_id":5843,"subvendor_id":3654,"category":"NETWORK"},{"name":"NetXtreme
+        BCM5719 Gigabit Ethernet PCIe","make":"Broadcom Corp.","bus":"pci","identifier":"14e4:1657","subsystem":"17aa:4104","subproduct_name":"","vendor_id":5843,"subvendor_id":3654,"category":"NETWORK"}],"video":[{"name":"ASPEED
+        Graphics Family","make":"ASPEED Technology, Inc.","bus":"pci","identifier":"1a03:2000","subsystem":"1a03:2000","subproduct_name":"","vendor_id":1736,"subvendor_id":1736,"category":"VIDEO"}],"wireless":[],"certified_release":"20.04
+        LTS","level":"Certified","name":"2404-15552","form_factor":"Server","platform_certified_configuration_count":2},{"id":14130,"canonical_id":"202301-31183","architecture":"amd64","bios":"Lenovo:
+        ESE109N-1.10 (UEFI)","hardware_website":"https://lenovopress.lenovo.com/lp1601-thinksystem-sr650-v3-server","category":"Server","kernel_version":"5.15.0-58-generic","notes":[],"make":"Lenovo","model":"ThinkSystem
+        SR650 V3 (SPR)","platform_name":"ThinkSystem SR650 V3","platform_id":"13487","processor":[{"name":"Intel(R)
+        Xeon(R) Platinum 8490H","make":"Intel Corp.","bus":"dmi","identifier":"dmi:Intel(R)Xeon(R)Platinum8490H","subsystem":"","subproduct_name":"","vendor_id":4103,"subvendor_id":"","category":"PROCESSOR"},{"name":"Intel(R)
+        Xeon(R) Platinum 8490H","make":"Intel Corp.","bus":"dmi","identifier":"dmi:Intel(R)Xeon(R)Platinum8490H","subsystem":"","subproduct_name":"","vendor_id":4103,"subvendor_id":"","category":"PROCESSOR"}],"network":[{"name":"NetXtreme
+        BCM5719 Gigabit Ethernet PCIe","make":"Broadcom Corp.","bus":"pci","identifier":"14e4:1657","subsystem":"17aa:4104","subproduct_name":"","vendor_id":5843,"subvendor_id":3654,"category":"NETWORK"},{"name":"NetXtreme
+        BCM5719 Gigabit Ethernet PCIe","make":"Broadcom Corp.","bus":"pci","identifier":"14e4:1657","subsystem":"17aa:4104","subproduct_name":"","vendor_id":5843,"subvendor_id":3654,"category":"NETWORK"},{"name":"NetXtreme
+        BCM5719 Gigabit Ethernet PCIe","make":"Broadcom Corp.","bus":"pci","identifier":"14e4:1657","subsystem":"17aa:4104","subproduct_name":"","vendor_id":5843,"subvendor_id":3654,"category":"NETWORK"},{"name":"NetXtreme
+        BCM5719 Gigabit Ethernet PCIe","make":"Broadcom Corp.","bus":"pci","identifier":"14e4:1657","subsystem":"17aa:4104","subproduct_name":"","vendor_id":5843,"subvendor_id":3654,"category":"NETWORK"}],"video":[{"name":"ASPEED
+        Graphics Family","make":"ASPEED Technology, Inc.","bus":"pci","identifier":"1a03:2000","subsystem":"1a03:2000","subproduct_name":"","vendor_id":1736,"subvendor_id":1736,"category":"VIDEO"}],"wireless":[],"certified_release":"22.04
+        LTS","level":"Certified","name":"2302-14130","form_factor":"Server","platform_certified_configuration_count":2}]}'
+    headers:
+      Allow:
+      - GET, HEAD, OPTIONS
+      Content-Length:
+      - '6554'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 20 Mar 2025 13:22:58 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.9.5
+      Vary:
+      - Accept, Cookie
+      X-QueryInspect-Duplicate-SQL-Queries:
+      - '0'
+      X-QueryInspect-Num-SQL-Queries:
+      - '13'
+      X-QueryInspect-Total-Request-Time:
+      - 57 ms
+      X-QueryInspect-Total-SQL-Time:
+      - 19 ms
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.2
+    method: GET
+    uri: https://certification.canonical.com/api/v2/component-summaries/?format=json&canonical_id=202301-31183&pagination=limitoffset
+  response:
+    body:
+      string: '{"count":0,"next":null,"previous":null,"results":[]}'
+    headers:
+      Allow:
+      - GET, HEAD, OPTIONS
+      Content-Length:
+      - '52'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 20 Mar 2025 13:22:58 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.9.5
+      Vary:
+      - Accept, Cookie
+      X-QueryInspect-Duplicate-SQL-Queries:
+      - '0'
+      X-QueryInspect-Num-SQL-Queries:
+      - '1'
+      X-QueryInspect-Total-Request-Time:
+      - 4 ms
+      X-QueryInspect-Total-SQL-Time:
+      - 2 ms
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_certification.py
+++ b/tests/test_certification.py
@@ -1,11 +1,8 @@
-from textwrap import dedent
-
 # Packages
 from vcr_unittest import VCRTestCase
 
 # Local
 from webapp.app import app
-from webapp.certified.helpers import convert_markdown_to_html
 
 
 class TestCertification(VCRTestCase):

--- a/tests/test_certification.py
+++ b/tests/test_certification.py
@@ -1,8 +1,11 @@
+from textwrap import dedent
+
 # Packages
 from vcr_unittest import VCRTestCase
 
 # Local
 from webapp.app import app
+from webapp.certified.helpers import convert_markdown_to_html
 
 
 class TestCertification(VCRTestCase):
@@ -58,3 +61,36 @@ class TestCertification(VCRTestCase):
         # so please change it also in the certified-search-results.js
         self.assertIn("release_filters", response.json.keys())
         self.assertIn("vendor_filters", response.json.keys())
+
+    def test_note_rendering(self):
+        """
+        Test that basic markdown elements are rendered correctly.
+        Raw HTML should be escaped
+        """
+        response = self.client.get("/certified/202301-31183")
+        # self.assertEqual(response.status_code, 200)
+        content = response.data.decode("utf-8")
+
+        # Check for headings
+        self.assertIn("<h1>Heading 1</h1>", content)
+        self.assertIn("<h2>Heading 2</h2>", content)
+
+        # Check for formatting
+        self.assertIn("<strong>Bold text</strong>", content)
+        self.assertIn("<em>Italic text</em>", content)
+
+        # Check for links
+        self.assertIn('<a href="https://example.com">Link text</a>', content)
+
+        # Check for lists
+        self.assertIn("<li>List item 1</li>", content)
+        self.assertIn("<li>List item 2</li>", content)
+
+        # HTML should be escaped and not interpreted
+        self.assertNotIn("<script>alert('XSS attack');</script>", content)
+        self.assertNotIn('<div class="dangerous">', content)
+        self.assertNotIn("<img src=\"javascript:alert('XSS')\" />", content)
+
+        self.assertIn("&lt;script&gt;", content)
+        self.assertIn("&lt;div class=&quot;dangerous&quot;&gt;", content)
+        self.assertIn("&lt;img src=", content)

--- a/tests/test_certification.py
+++ b/tests/test_certification.py
@@ -65,7 +65,6 @@ class TestCertification(VCRTestCase):
         Raw HTML should be escaped
         """
         response = self.client.get("/certified/202301-31183")
-        # self.assertEqual(response.status_code, 200)
         content = response.data.decode("utf-8")
 
         # Check for headings

--- a/webapp/certified/helpers.py
+++ b/webapp/certified/helpers.py
@@ -1,3 +1,9 @@
+import html
+import bleach
+import markdown
+from markupsafe import Markup
+
+
 def get_download_url(model_details):
     """
     Return the appropriate ubuntu models.com/download url for the model
@@ -41,6 +47,57 @@ def get_download_url(model_details):
         return f"https://ubuntu.com/download/server/{arch}"
 
     return "https://ubuntu.com/download"
+
+
+def convert_markdown_to_html(text):
+    """
+    Convert markdown to HTML while ensuring security by sanitizing
+    the output.  Only pure Markdown is allowed, raw HTML is escaped
+    and displayed as code.  Tables and images are not supported.
+    """
+    if not text:
+        return ""
+
+    escaped_text = html.escape(text)
+
+    html_content = markdown.markdown(
+        escaped_text,
+        extensions=[
+            "markdown.extensions.fenced_code",
+            "markdown.extensions.nl2br",
+        ],
+    )
+
+    allowed_tags = [
+        "p",
+        "h1",
+        "h2",
+        "h3",
+        "h4",
+        "h5",
+        "h6",
+        "hr",
+        "br",
+        "ul",
+        "ol",
+        "li",
+        "blockquote",
+        "pre",
+        "code",
+        "em",
+        "strong",
+        "a",
+    ]
+    allowed_attrs = {
+        "a": ["href", "title"],
+        "code": ["class"],
+        "pre": ["class"],
+    }
+
+    clean_html = bleach.clean(
+        html_content, tags=allowed_tags, attributes=allowed_attrs, strip=True
+    )
+    return Markup(clean_html)
 
 
 def _get_clean_in_filter(filter_in):

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -31,6 +31,7 @@ from webapp.shop.api.ua_contracts.api import (
     UnauthorizedErrorView,
 )
 from webapp.shop.flaskparser import UAContractsValidationError
+from webapp.certified.helpers import convert_markdown_to_html
 
 CSP = {
     "default-src": ["'self'"],
@@ -377,6 +378,8 @@ def init_handlers(app, sentry):
     app.add_template_filter(date_has_passed)
 
     app.add_template_filter(sort_by_key_and_ordered_list)
+
+    app.add_template_filter(convert_markdown_to_html)
 
     @app.template_filter()
     def slug(text):


### PR DESCRIPTION
## Done

**NOTE: This PR resolves a security issue found on the website.**

The hardware certification team introduces Markdown support in certificate notes (initially in https://github.com/canonical/hexr/pull/575). The same support is introduced here.
While working on this PR, I noticed that if a note contains raw HTML code the current production code on the `ubuntu.com` website renders it, even if it's a script. For example, if a note contains `<script>alert("Hello!")</script>`, an alert will appear:

![image](https://github.com/user-attachments/assets/2070eb2a-bbcd-4e82-93e3-410d38c6a812)

This security issue is fixed in this PR, and raw HTML code gets escaped (see screenshots for more)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to the detail page for a certified configuration (URL like `/certified/202301-31183`) that has notes with markdown code
- Check that it's rendered correctly. 

The hardware certification team can also create a test note with raw HTML text (for example on staging) and verify that it's not rendered.

## Issue / Card

Fixes [C3-969](https://warthogs.atlassian.net/browse/C3-969)

## Screenshots

Original note markdown text:

```markdown
This is my `note` with **bold text** and *italic text*
[Link text](https://example.com)

* List item 1
* List item 2

<script>alert('XSS attack');</script>
<div class="dangerous">
<h1>Custom HTML</h1>
</div>
<img src="javascript:alert('XSS')" />
```

![image](https://github.com/user-attachments/assets/33b7ae5b-e8a0-43e0-996d-f15f9d8cc960)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[C3-969]: https://warthogs.atlassian.net/browse/C3-969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ