### PR TITLE
Fix: update deprecated link to SRU documentation

### DIFF
--- a/templates/certified/index.html
+++ b/templates/certified/index.html
@@ -410,7 +410,7 @@
           for up to 12 years
         </h2>
         <p>
-          Roughly every 3 weeks, Ubuntu releases <a href="https://wiki.ubuntu.com/StableReleaseUpdates">Stable Release Updates</a>, ensuring a secure and reliable experience. These updates are carefully tested by the Hardware Certification team to make sure that systems work well with Ubuntu.
+          Roughly every 3 weeks, Ubuntu releases <a href="https://documentation.ubuntu.com/sru/">Stable Release Updates</a>, ensuring a secure and reliable experience. These updates are carefully tested by the Hardware Certification team to make sure that systems work well with Ubuntu.
         </p>
         <p>
           <a href="/about/release-cycle">Learn more about Ubuntu release lifecycle</a>


### PR DESCRIPTION
## Done

- Updated the link href to the StableReleaseUpdates documentation. The wiki site has been deprecated and replaced by a collection on ubuntu.com. 

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes [CDOC-204](https://warthogs.atlassian.net/browse/CDOC-204)

## Screenshots

No change

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[CDOC-204]: https://warthogs.atlassian.net/browse/CDOC-204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ