### PR TITLE
fix: Update AI datasheet link

### DIFF
--- a/templates/ai/index.html
+++ b/templates/ai/index.html
@@ -567,7 +567,7 @@
             </div>
             <hr class="p-rule" />
             <p>
-              <a href="https://pages.ubuntu.com/rs/066-EOV-335/images/Charmed Kubeflow%20-%20Digital.pdf">Get the AI consulting datasheet&nbsp;&rsaquo;</a>
+              <a href="https://assets.ubuntu.com/v1/429359fe-MLOps%20advisory%20DS%2029.11.22.pdf">Get the AI consulting datasheet&nbsp;&rsaquo;</a>
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Done

- Update `Get the AI consulting datasheet` to match copydoc

## QA

- Go to https://ubuntu-com-14885.demos.haus/ai
- Go to `Get the AI consulting datasheet` link and see that it links to the same URL provided in copy doc

## Issue / Card

Fixes [WD-20437](https://warthogs.atlassian.net/browse/WD-20437)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-20437]: https://warthogs.atlassian.net/browse/WD-20437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ