### PR TITLE
Update text on Pro pricing page

### DIFF
--- a/templates/pricing/pro.html
+++ b/templates/pricing/pro.html
@@ -104,11 +104,17 @@
           </ul>
         </aside>
       </div>
+    </div>
+    <div class="row">
+      <hr class="p-rule" />
+      <div class="col-2 col-medium-6">
+        <h3 class="p-heading--5">Ubuntu Pro for enterprises</h3>
+      </div>
       <div class="col-10 col-medium-6 col-start-large-3">
         <table aria-label="Ubuntu Pro Pricing">
           <thead>
             <tr>
-              <th style="width: 40%;" role="presentation">&nbsp;</th>
+              <th style="width: 40%;" role="presentation"></th>
               <th scope="col">
                 Self-Support
                 <br />


### PR DESCRIPTION
## Done

- Add small text update to the /pricing/pro page

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- visit https://ubuntu-com-14893.demos.haus/pricing/pro
- make sure the text exists from the ticket below

## Issue / Card

Fixes #https://warthogs.atlassian.net/browse/WD-20376

## Screenshots

![image](https://github.com/user-attachments/assets/a4417e1f-2392-44c1-86a9-b7a2429403b6)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
