### PR TITLE
chore: Add git diff-filter

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -107,7 +107,7 @@ jobs:
         id: changed-files
         run: |
           TARGET_SHA=$(git rev-parse $GITHUB_BASE_REF)
-          CHANGED_FILES=$(git diff --name-only $TARGET_SHA $GITHUB_SHA -- 'templates/**.html' | tr '\n' ' ')
+          CHANGED_FILES=$(git diff --diff-filter=ACMR --name-only $TARGET_SHA $GITHUB_SHA -- 'templates/**.html' | tr '\n' ' ')
           echo "CHANGED_FILES=$CHANGED_FILES" >> $GITHUB_ENV
 
       - name: Lint jinja


### PR DESCRIPTION
## Done

- Add git `--diff-filter` to track ACMR actions 
  - **A**dded, **C**reated, **M**odified, **R**enamed
- Allows`lint-jinja` action to run on these ACMR tracked files only

## QA

- See that `lint-jinja` action passes
- Previously throwing an error due to renamed file not being tracked correctly

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
