### PR TITLE
WD-20581 fix: contextual footer further reading section

### DIFF
--- a/templates/legal/_base_legal_markdown.html
+++ b/templates/legal/_base_legal_markdown.html
@@ -8,7 +8,7 @@
 {% block outer_content %}
 
   {% block content %}
-    <div class="p-strip is-deep">
+    <div class="p-strip is-deep u-no-margin--bottom">
     {% if update_date %}
       <div class="row">
         <div class="col-6">
@@ -26,7 +26,7 @@
         </div>
       </div>
     {% endif %}
-      <div class="row" id="service-description">
+      <div class="row">
         <div class="col-8 l-legal-pages">
           {{ content | safe }}
           <div class="p-top">

--- a/templates/shared/contextual_footers/_further_reading.html
+++ b/templates/shared/contextual_footers/_further_reading.html
@@ -19,20 +19,11 @@
     articlesContainerSelector: "#latest-articles",
     articleTemplateSelector: "#article-template",
     limit: "{{ limit }}",
-    {
-      %
-      if tagId %
-    }
+    {% if tagId %}
     tagId: "{{ tagId }}",
-    {
-      % endif %
-    } {
-      %
-      if groupId %
-    }
+    {% endif %}
+    {% if groupId %}
     groupId: "{{ groupId }}",
-    {
-      % endif %
-    }
+    {% endif %}
   })
 </script>


### PR DESCRIPTION
## Done

- Fix the broken formatting of the contextual footer further reading section
- Remove the space between legal content and the contextual footer

## QA

1. Open the demo
2. Go to the legal pages 
3. See the contextual footer loads the further reading content