### PR TITLE
fix: Handle hitting '/download/server/thank-you' without a defined version

### DIFF
--- a/templates/download/desktop/thank-you.html
+++ b/templates/download/desktop/thank-you.html
@@ -71,8 +71,8 @@
 
               </p>
             {% else %}
-              <h1>Thank you for your contribution</h1>
-              <p>It will help further the open source development of Ubuntu.</p>
+              <h1>You have not selected an image to download</h1>
+              <p>Please <a href="/download/desktop">select an image</a> to download.</p>
             {% endif %}
           </div>
           <div class="col">

--- a/templates/download/raspberry-pi/thank-you.html
+++ b/templates/download/raspberry-pi/thank-you.html
@@ -2,11 +2,17 @@
 
 {% block title %}Thank you for downloading Ubuntu Server for Raspberry Pi{% endblock %}
 
-{% block meta_image %}https://assets.ubuntu.com/v1/f60f86c4-Embedded+social+media+banner+.jpg{% endblock meta_image %}
+{% block meta_image %}
+  https://assets.ubuntu.com/v1/f60f86c4-Embedded+social+media+banner+.jpg
+{% endblock meta_image %}
 
-{% block meta_description %}Ubuntu is an open-source operating system for cross platform development, there's no better place to get started than with Ubuntu on a Raspberry Pi.{% endblock meta_description %}
+{% block meta_description %}
+  Ubuntu is an open-source operating system for cross platform development, there's no better place to get started than with Ubuntu on a Raspberry Pi.
+{% endblock meta_description %}
 
-{% block meta_copydoc %}https://docs.google.com/document/d/1RXsLbMB-LJVwiG0gAi0HgVEJvZ9_GIU3ESLJ6KmBb54{% endblock meta_copydoc %}
+{% block meta_copydoc %}
+  https://docs.google.com/document/d/1RXsLbMB-LJVwiG0gAi0HgVEJvZ9_GIU3ESLJ6KmBb54
+{% endblock meta_copydoc %}
 
 {% block head_extra %}<meta name="robots" content="noindex" />{% endblock %}
 
@@ -14,142 +20,160 @@
 
 {% block content %}
 
-{% if version %}
-  <meta http-equiv="refresh" content="3;url={% if version==releases.latest.core_version %}https://cdimage.ubuntu.com/ubuntu-core/{{ version }}/stable/current/ubuntu-{{ architecture }}.img.xz{% else %}https://cdimage.ubuntu.com/releases/{{ version }}/release/ubuntu-{{ version }}-preinstalled-{{ architecture }}.img.xz{% endif %}">
-{% endif %}
+  {% if version %}
+    <meta http-equiv="refresh"
+          content="3;url={% if version==releases.latest.core_version %}https://cdimage.ubuntu.com/ubuntu-core/{{ version }}/stable/current/ubuntu-{{ architecture }}.img.xz{% else %}https://cdimage.ubuntu.com/releases/{{ version }}/release/ubuntu-{{ version }}-preinstalled-{{ architecture }}.img.xz{% endif %}" />
+  {% endif %}
 
-<section class="p-strip is-shallow u-no-padding--bottom">
-  <div class="row--50-50">
-    <div class="col">
-      {% if version %}
-        <h1>Thank you for downloading<br class="u-hide--small" />
-        Ubuntu {% if version==releases.latest.core_version %}Core {% endif %}{{ version }}<br />
-        for Raspberry Pi</h1>
-        <p>Your download should start automatically. If it doesn't, 
-          <a href="{% if version==releases.latest.core_version %}https://cdimage.ubuntu.com/ubuntu-core/{{ version }}/stable/current/ubuntu-{{ architecture }}.img.xz{% else %}https://cdimage.ubuntu.com/releases/{{ version }}/release/ubuntu-{{ version }}-preinstalled-{{ architecture }}.img.xz{% endif %}">download now</a>.<br />
-        {% with version=version, system=architecture, architecture=architecture %}
-          {% include "download/shared/_verify-checksums.html" %}
-        {% endwith %}
-        </p>
-      {% else %}
-        <h1>Thank you</h1>
-        <p>However, you have not selected an image to download.<br />Go to the <a href="/download/raspberry-pi">download page</a> to select an image.</p>
-      {% endif %}
-    </div>
-    <div class="col">
-      {% with returnUrl="/download/raspberry-pi", ga_event_title="Raspberry Pi download" %}
-        {% include 'shared/_download-newsletter.html' %}
-      {% endwith %}
-    </div>
-  </div>
-</section>
-
-<section class="p-section">
-  <hr class="p-rule is-fixed-width" />
-  <div class="row--50-50 p-section--shallow">
-    <div class="col">
-      <h2>Installation instructions</h2>
-    </div>
-    <div class="col">
-      <p>The simplest way to install Ubuntu is to use the <a href="https://www.raspberrypi.com/software/">Raspberry Pi Imager</a> which enables you to select an Ubuntu image during installation. Follow our tutorials below to learn how.</p>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-12 col-medium-6 col-start-large-4">
-      <hr class="p-rule is-fixed-width" />
-      <div class="row">
-        {% if version == releases.latest.core_version %}
-        <div class="col-4 col-medium-2">
-          <h3 class="p-heading--5">
-            <a href="/core/docs/uc20/install-raspberry-pi">Installing Ubuntu Core 20 on a Raspberry Pi</a>
-          </h3>
-          <p>A complete guide to installing Ubuntu Core on a Raspberry Pi 4 (4GB or 8GB).</p>
-        </div>
+  <section class="p-strip is-shallow u-no-padding--bottom">
+    <div class="row--50-50">
+      <div class="col">
+        {% if version %}
+          <h1>
+            Thank you for downloading
+            <br class="u-hide--small" />
+            Ubuntu
+            {% if version==releases.latest.core_version %}Core{% endif %}
+            {{ version }}
+            <br />
+            for Raspberry Pi
+          </h1>
+          <p>
+            Your download should start automatically. If it doesn't,
+            <a href="{% if version==releases.latest.core_version %}https://cdimage.ubuntu.com/ubuntu-core/{{ version }}/stable/current/ubuntu-{{ architecture }}.img.xz{% else %}https://cdimage.ubuntu.com/releases/{{ version }}/release/ubuntu-{{ version }}-preinstalled-{{ architecture }}.img.xz{% endif %}">download now</a>.
+            <br />
+            {% with version=version, system=architecture, architecture=architecture %}
+              {% include "download/shared/_verify-checksums.html" %}
+            {% endwith %}
+          </p>
         {% else %}
-        <div class="col-4 col-medium-2">
-          <h3 class="p-heading--5">
-            <a href="/tutorials/how-to-install-ubuntu-desktop-on-raspberry-pi-4">How to install Ubuntu Desktop on Raspberry Pi 4</a>
-          </h3>
-          <p>A complete guide to installing Ubuntu Desktop on a Raspberry Pi 4 (2GB or above).</p>
-        </div>
+          <h1>You have not selected an image to download</h1>
+          <p>
+            Please <a href="/download/raspberry-pi">select an image</a> to download.
+          </p>
         {% endif %}
-        <div class="col-4 col-medium-2">
-          <h3 class="p-heading--5">
-            <a href="/tutorials/how-to-install-ubuntu-on-your-raspberry-pi">How to install Ubuntu Server on your Raspberry Pi</a>
-          </h3>
-          <p>A complete guide to installing Ubuntu Server on your Raspberry Pi 4, 3 or 2 in a couple minutes. In a headless setup or with a screen and with a Wi-Fi or ethernet connection.</p>
+      </div>
+      <div class="col">
+        {% with returnUrl="/download/raspberry-pi", ga_event_title="Raspberry Pi download" %}
+          {% include 'shared/_download-newsletter.html' %}
+        {% endwith %}
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <hr class="p-rule is-fixed-width" />
+    <div class="row--50-50 p-section--shallow">
+      <div class="col">
+        <h2>Installation instructions</h2>
+      </div>
+      <div class="col">
+        <p>
+          The simplest way to install Ubuntu is to use the <a href="https://www.raspberrypi.com/software/">Raspberry Pi Imager</a> which enables you to select an Ubuntu image during installation. Follow our tutorials below to learn how.
+        </p>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-12 col-medium-6 col-start-large-4">
+        <hr class="p-rule is-fixed-width" />
+        <div class="row">
+          {% if version == releases.latest.core_version %}
+            <div class="col-4 col-medium-2">
+              <h3 class="p-heading--5">
+                <a href="/core/docs/uc20/install-raspberry-pi">Installing Ubuntu Core 20 on a Raspberry Pi</a>
+              </h3>
+              <p>A complete guide to installing Ubuntu Core on a Raspberry Pi 4 (4GB or 8GB).</p>
+            </div>
+          {% else %}
+            <div class="col-4 col-medium-2">
+              <h3 class="p-heading--5">
+                <a href="/tutorials/how-to-install-ubuntu-desktop-on-raspberry-pi-4">How to install Ubuntu Desktop on Raspberry Pi 4</a>
+              </h3>
+              <p>A complete guide to installing Ubuntu Desktop on a Raspberry Pi 4 (2GB or above).</p>
+            </div>
+          {% endif %}
+          <div class="col-4 col-medium-2">
+            <h3 class="p-heading--5">
+              <a href="/tutorials/how-to-install-ubuntu-on-your-raspberry-pi">How to install Ubuntu Server on your Raspberry Pi</a>
+            </h3>
+            <p>
+              A complete guide to installing Ubuntu Server on your Raspberry Pi 4, 3 or 2 in a couple minutes. In a headless setup or with a screen and with a Wi-Fi or ethernet connection.
+            </p>
+          </div>
+          <div class="col-4 col-medium-2">
+            <h3 class="p-heading--5">
+              <a href="/download/raspberry-pi-core">Install Ubuntu Core on a Raspberry Pi</a>
+            </h3>
+            <p>
+              Walk through the steps of flashing Ubuntu Core on a Raspberry Pi 4, 3, 2 or CM4. At the end of this process, you will have a board ready for production or testing snaps.
+            </p>
+          </div>
         </div>
-        <div class="col-4 col-medium-2">
-          <h3 class="p-heading--5">
-            <a href="/download/raspberry-pi-core">Install Ubuntu Core on a Raspberry Pi</a>
-          </h3>
-          <p>Walk through the steps of flashing Ubuntu Core on a Raspberry Pi 4, 3, 2 or CM4. At the end of this process, you will have a board ready for production or testing snaps.</p>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <hr class="p-rule is-fixed-width" />
+    <div class="row">
+      <div class="col-6">
+        <h2>Make something great today</h2>
+      </div>
+      <div class="col-6">
+        <ul class="p-list--divided">
+          <li class="p-list__item">
+            <a href="/blog/linux-gaming-tutorial-raspberry-pi-minecraft-server-on-ubuntu-desktop">Raspberry Pi Tutorial: Host a Minecraft server on Ubuntu Desktop</a>
+          </li>
+          <li class="p-list__item">
+            <a href="/blog/common-sense-using-the-raspberry-pi-sense-hat-on-ubuntu-impish-indri">Common Sense &mdash; using the Raspberry Pi Sense HAT on Ubuntu Impish Indri</a>
+          </li>
+          <li class="p-list__item">
+            <a href="/blog/homelab-clusters-lxd-micro-cloud-on-raspberry-pi">Homelab clusters: LXD micro cloud on Raspberry Pi</a>
+          </li>
+          <li class="p-list__item">
+            <a href="https://maas.io/tutorials/build-your-own-bare-metal-cloud-using-a-raspberry-pi-cluster-with-maas#1-overview">Build your own bare metal cloud using a Raspberry Pi cluster with MAAS</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section--deep">
+    <div class="row">
+      <hr class="p-rule" />
+      <div class="col-3 col-medium-6">
+        <div class="p-section--shallow">
+          <h2 class="p-text--small-caps">
+            <a href="/blog/tag/raspberry-pi">Latest from&nbsp;our&nbsp;blog&nbsp;&rsaquo;</a>
+          </h2>
         </div>
       </div>
-    </div>
-  </div>
-</section>
-
-<section class="p-section">
-  <hr class="p-rule is-fixed-width" />
-  <div class="row">
-    <div class="col-6">
-      <h2>Make something great today</h2>
-    </div>
-    <div class="col-6">
-      <ul class="p-list--divided">
-        <li class="p-list__item">
-          <a href="/blog/linux-gaming-tutorial-raspberry-pi-minecraft-server-on-ubuntu-desktop">Raspberry Pi Tutorial: Host a Minecraft server on Ubuntu Desktop</a>
-        </li>
-        <li class="p-list__item">
-          <a href="/blog/common-sense-using-the-raspberry-pi-sense-hat-on-ubuntu-impish-indri">Common Sense &mdash; using the Raspberry Pi Sense HAT on Ubuntu Impish Indri</a>
-        </li>
-        <li class="p-list__item">
-          <a href="/blog/homelab-clusters-lxd-micro-cloud-on-raspberry-pi">Homelab clusters: LXD micro cloud on Raspberry Pi</a>
-        </li>
-        <li class="p-list__item">
-          <a href="https://maas.io/tutorials/build-your-own-bare-metal-cloud-using-a-raspberry-pi-cluster-with-maas#1-overview">Build your own bare metal cloud using a Raspberry Pi cluster with MAAS</a>
-        </li>
-      </ul>
-    </div>
-  </div>
-</section>
-
-<section class="p-section--deep">
-  <div class="row">
-    <hr class="p-rule"/>
-    <div class="col-3 col-medium-6">
-      <div class="p-section--shallow">
-        <h2 class="p-text--small-caps"><a href="/blog/tag/raspberry-pi">Latest from&nbsp;our&nbsp;blog&nbsp;&rsaquo;</a></h2>
+      <div class="col-9 col-medium-6">
+        <div class="row p-section--shallow" id="blog-latest"></div>
       </div>
     </div>
-    <div class="col-9 col-medium-6">
-      <div class="row p-section--shallow" id="blog-latest">
+
+    <template style="display:none" id="blog-template">
+      <div class="col-3 col-medium-2">
+        <div class="article-image u-blog-thumbnails p-image-wrapper"></div>
+        <h3 class="p-heading--5">
+          <a class="article-link article-title"></a>
+        </h3>
+        <p class="article-excerpt"></p>
       </div>
-    </div>
-  </div>
+    </template>
+  </section>
 
-  <template style="display:none" id="blog-template">
-    <div class="col-3 col-medium-2">
-      <div class="article-image u-blog-thumbnails p-image-wrapper"></div>
-      <h3 class="p-heading--5"><a class="article-link article-title"></a></h3>
-      <p class="article-excerpt"></p>
-    </div>
-  </template>
-</section>
-
-<script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
-<script>
-  canonicalLatestNews.fetchLatestNews(
-    {
+  <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
+  <script>
+    canonicalLatestNews.fetchLatestNews({
       articlesContainerSelector: "#blog-latest",
       articleTemplateSelector: "#blog-template",
       excerptLength: 200,
       tagId: 1672,
       limit: 3,
       linkImage: true,
-    }
-  )
-</script>
+    })
+  </script>
 
 {% endblock %}

--- a/templates/download/server/thank-you.html
+++ b/templates/download/server/thank-you.html
@@ -32,11 +32,9 @@
             {% endwith %}
           </p>
         {% else %}
-          <h1>Thank you</h1>
+          <h1>You have not selected an image to download</h1>
           <p>
-            However, you have not selected an image to download.
-            <br />
-            Go to the <a href="/download/server">download page</a> to select an image.
+            Please <a href="/download/server">select an image</a> to download.
           </p>
         {% endif %}
       </div>

--- a/templates/download/server/thank-you.html
+++ b/templates/download/server/thank-you.html
@@ -21,15 +21,24 @@
   <section class="p-strip is-shallow u-no-padding--bottom">
     <div class="row--50-50">
       <div class="col">
-        <h1>Thank you for downloading Ubuntu Server {{ version }}{{ " LTS" if lts }}</h1>
-        <p>
-          Your download should start in the background. If it doesn't,
-          <a href="https://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-live-server-amd64.iso">download&nbsp;now</a>.
-          <br />
-          {% with version=version, system="live-server", architecture="amd64" %}
-            {% include "download/shared/_verify-checksums.html" %}
-          {% endwith %}
-        </p>
+        {% if version %}
+          <h1>Thank you for downloading Ubuntu Server {{ version }}{{ " LTS" if lts }}</h1>
+          <p>
+            Your download should start in the background. If it doesn't,
+            <a href="https://releases.ubuntu.com/{{ version }}/ubuntu-{{ version }}-live-server-amd64.iso">download&nbsp;now</a>.
+            <br />
+            {% with version=version, system="live-server", architecture="amd64" %}
+              {% include "download/shared/_verify-checksums.html" %}
+            {% endwith %}
+          </p>
+        {% else %}
+          <h1>Thank you</h1>
+          <p>
+            However, you have not selected an image to download.
+            <br />
+            Go to the <a href="/download/server">download page</a> to select an image.
+          </p>
+        {% endif %}
       </div>
       <div class="col">
         {% include 'download/shared/_server_weekly_news.html' %}
@@ -39,17 +48,16 @@
             Learn how to use the command line efficiently and get started with DevOps &mdash; from basic file management to LXD virtualization and Ubuntu Pro.
           </p>
         </div>
-        <button class="p-button--positive"
-           onclick="toggleModal()">Download the CLI cheat sheet</button>
-           <div class="p-section--shallow p-image-wrapper">
-            {{ image(url="https://assets.ubuntu.com/v1/639c1f12-server-cli-cheatsheet.png",
-                      alt="CLI cheat sheet",
-                      width="1200",
-                      height="849",
-                      hi_def=True,
-                      loading="auto") | safe
-            }}
-          </div>
+        <button class="p-button--positive" onclick="toggleModal()">Download the CLI cheat sheet</button>
+        <div class="p-section--shallow p-image-wrapper">
+          {{ image(url="https://assets.ubuntu.com/v1/639c1f12-server-cli-cheatsheet.png",
+                    alt="CLI cheat sheet",
+                    width="1200",
+                    height="849",
+                    hi_def=True,
+                    loading="auto") | safe
+          }}
+        </div>
       </div>
     </div>
   </section>
@@ -237,10 +245,11 @@
 
   <script defer>
     var version = '{{ version }}';
+    if (version) {
+      var GAlabel = version + '-server-amd64';
+      var imagePath = version + '/ubuntu-' + version + '-live-server-amd64.iso';
 
-    var GAlabel = version + '-server-amd64';
-    var imagePath = version + '/ubuntu-' + version + '-live-server-amd64.iso';
-
-    window.initImageDownload(imagePath, GAlabel);
+      window.initImageDownload(imagePath, GAlabel);
+    }
   </script>
 {% endblock footer_extra %}


### PR DESCRIPTION
## Done

- If there is no version in the query params do not attempt to download anything and provided a link to the download page

## QA

- Go to https://ubuntu-com-14902.demos.haus/download/server/thank-you
- See that no download attempts to start/no redirect is made
- See that in the place of the normal 'if the download doesn't start..' text, it states 'you have not selected an image to download.' and offers a link back to [the download page](https://ubuntu-com-14902.demos.haus/download/server)
- Go to [the download page](https://ubuntu-com-14902.demos.haus/download/server) and attempt to download a version of ubuntu server
- see it functions as normal 

- repeat with:
https://ubuntu-com-14902.demos.haus/download/server/thank-you
https://ubuntu-com-14902.demos.haus/download/raspberry-pi/thank-you

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-16046


## Screenshots

![image](https://github.com/user-attachments/assets/7e153425-b237-4df1-a70f-19bed643ce3a)

