### PR TITLE
Wd 20463 migrate app 3 trueablity com to app trueability com

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -720,6 +720,7 @@ staging:
       app_name: ubuntu.com-credentials
       image: prod-comms.ps5.docker-registry.canonical.com/ubuntu.com
       replicas: 3
+      useProxy: False
       memoryLimit: 512Mi
       env:
         - name: HTTPS_PROXY

--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -722,6 +722,10 @@ staging:
       replicas: 3
       memoryLimit: 512Mi
       env:
+        - name: HTTPS_PROXY
+          value: http://squid.ps6.internal:3128
+        - name: HTTP_PROXY
+          value: http://squid.ps6.internal:3128
         - name: SEARCH_API_KEY
           secretKeyRef:
             key: google-custom-search-key
@@ -1027,6 +1031,10 @@ staging:
 
 demo:
   env:
+    - name: HTTP_PROXY:
+      value: http://squid.ps6.internal:3128
+    - name: HTTPS_PROXY:
+      value: http://squid.ps6.internal:3128
     - name: CREDENTIALS_CONFIDENTIALITY_ENABLED
       value: false
 

--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -1030,6 +1030,7 @@ staging:
     }
 
 demo:
+  useProxy: False
   env:
     - name: HTTP_PROXY
       value: http://squid.ps6.internal:3128

--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -1140,7 +1140,7 @@ demo:
       value: pk_test_yndN9H0GcJffPe0W58Nm64cM00riYG4N46
 
     - name: TRUEABILITY_URL
-      value: https://app.trueability.com
+      value: https://app3.trueability.com
 
     - name: TRUEABILITY_API_KEY
       secretKeyRef:

--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -1031,7 +1031,6 @@ staging:
     }
 
 demo:
-  useProxy: False
   env:
     - name: HTTP_PROXY
       value: http://squid.ps6.internal:3128

--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -1031,9 +1031,9 @@ staging:
 
 demo:
   env:
-    - name: HTTP_PROXY:
+    - name: HTTP_PROXY
       value: http://squid.ps6.internal:3128
-    - name: HTTPS_PROXY:
+    - name: HTTPS_PROXY
       value: http://squid.ps6.internal:3128
     - name: CREDENTIALS_CONFIDENTIALITY_ENABLED
       value: false

--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -1033,8 +1033,10 @@ demo:
   env:
     - name: HTTP_PROXY
       value: http://squid.ps6.internal:3128
+
     - name: HTTPS_PROXY
       value: http://squid.ps6.internal:3128
+    
     - name: CREDENTIALS_CONFIDENTIALITY_ENABLED
       value: false
 

--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -725,8 +725,13 @@ staging:
       env:
         - name: HTTPS_PROXY
           value: http://squid.ps6.internal:3128
+        
         - name: HTTP_PROXY
           value: http://squid.ps6.internal:3128
+
+        - name: NO_PROXY
+          value: "10.24.0.132,10.24.0.23,.internal,ubuntu.com,.ubuntu.com,snapcraft.io,.snapcraft.io,jujucharms.com,.jujucharms.com,maas.io,.maas.io,conjure-up.io,.conjure-up.io,netplan.io,.netplan.io,canonical.com,.canonical.com,launchpad.net,.launchpad.net,linuxcontainers.org,.linuxcontainers.org,cloud-init.io,.cloud-init.io,vanillaframework.io,.vanillaframework.io,anbox-cloud.io,.anbox-cloud.io,juju.is,.juju.is,dqlite.io,.dqlite.io,charmhub.io,.charmhub.io,canonical.design,.canonical.design"
+        
         - name: SEARCH_API_KEY
           secretKeyRef:
             key: google-custom-search-key
@@ -1038,6 +1043,9 @@ demo:
 
     - name: HTTPS_PROXY
       value: http://squid.ps6.internal:3128
+
+    - name: NO_PROXY
+      value: "10.24.0.132,10.24.0.23,.internal,ubuntu.com,.ubuntu.com,snapcraft.io,.snapcraft.io,jujucharms.com,.jujucharms.com,maas.io,.maas.io,conjure-up.io,.conjure-up.io,netplan.io,.netplan.io,canonical.com,.canonical.com,launchpad.net,.launchpad.net,linuxcontainers.org,.linuxcontainers.org,cloud-init.io,.cloud-init.io,vanillaframework.io,.vanillaframework.io,anbox-cloud.io,.anbox-cloud.io,juju.is,.juju.is,dqlite.io,.dqlite.io,charmhub.io,.charmhub.io,canonical.design,.canonical.design"
     
     - name: CREDENTIALS_CONFIDENTIALITY_ENABLED
       value: false

--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -720,7 +720,7 @@ staging:
       app_name: ubuntu.com-credentials
       image: prod-comms.ps5.docker-registry.canonical.com/ubuntu.com
       replicas: 3
-      useProxy: False
+      useProxy: false
       memoryLimit: 512Mi
       env:
         - name: HTTPS_PROXY
@@ -1031,6 +1031,7 @@ staging:
     }
 
 demo:
+  useProxy: false
   env:
     - name: HTTP_PROXY
       value: http://squid.ps6.internal:3128
@@ -1139,7 +1140,7 @@ demo:
       value: pk_test_yndN9H0GcJffPe0W58Nm64cM00riYG4N46
 
     - name: TRUEABILITY_URL
-      value: https://app3.trueability.com
+      value: https://app.trueability.com
 
     - name: TRUEABILITY_API_KEY
       secretKeyRef:

--- a/webapp/shop/api/trueability/api.py
+++ b/webapp/shop/api/trueability/api.py
@@ -1,3 +1,4 @@
+import os
 from typing import List
 from urllib.parse import urlencode
 from requests import Session
@@ -26,6 +27,17 @@ class TrueAbilityAPI:
     ):
         uri = f"{self.base_url}{path}"
         headers["X-API-KEY"] = f"{self.api_key}"
+        headers["Cache-Control"]= "no-cache, no-store, must-revalidate"
+        headers["Pragma"]= "no-cache"
+        headers["Expires"]= "0"
+
+        if os.getenv("DEVEL", "true")=="true":
+            proxies = None
+        else:
+            proxies = {
+                'http': 'http://squid.ps6.internal:3128/',
+                'https': 'http://squid.ps6.internal:3128/',
+            }
 
         response = self.session.request(
             method,
@@ -34,6 +46,8 @@ class TrueAbilityAPI:
             data=data,
             json=json,
             allow_redirects=allow_redirects,
+            proxies=proxies,
+            # verify=False,
         )
         if retry and response.status_code == 401:
             response = self.make_request(
@@ -43,6 +57,8 @@ class TrueAbilityAPI:
                 data=data,
                 json=json,
                 retry=False,
+                proxies=proxies,
+                # verify=False,
             )
 
         return response

--- a/webapp/shop/api/trueability/api.py
+++ b/webapp/shop/api/trueability/api.py
@@ -1,4 +1,3 @@
-import os
 from typing import List
 from urllib.parse import urlencode
 from requests import Session

--- a/webapp/shop/api/trueability/api.py
+++ b/webapp/shop/api/trueability/api.py
@@ -27,17 +27,6 @@ class TrueAbilityAPI:
     ):
         uri = f"{self.base_url}{path}"
         headers["X-API-KEY"] = f"{self.api_key}"
-        headers["Cache-Control"]= "no-cache, no-store, must-revalidate"
-        headers["Pragma"]= "no-cache"
-        headers["Expires"]= "0"
-
-        if os.getenv("DEVEL", "true")=="true":
-            proxies = None
-        else:
-            proxies = {
-                'http': 'http://squid.ps6.internal:3128/',
-                'https': 'http://squid.ps6.internal:3128/',
-            }
 
         response = self.session.request(
             method,
@@ -46,8 +35,6 @@ class TrueAbilityAPI:
             data=data,
             json=json,
             allow_redirects=allow_redirects,
-            proxies=proxies,
-            # verify=False,
         )
         if retry and response.status_code == 401:
             response = self.make_request(
@@ -57,8 +44,6 @@ class TrueAbilityAPI:
                 data=data,
                 json=json,
                 retry=False,
-                proxies=proxies,
-                # verify=False,
             )
 
         return response


### PR DESCRIPTION
## Done

- Add HTTP_PROXY and HTTPS_PROXY for /credentials

## QA

- Visit [/credentials/your-exams](https://ubuntu-com-14875.demos.haus/credentials/your-exams)
- Page should load
- This means the proxy is correctly overwritten to the ps6 squid proxy  
----
USERS WITH ACCESS TO THE DEMO K8S
- `kubectl get pods`
- check the pod with the name ubuntu-com-demos-14875 
- kubectl describe pod <pod_name>
- should have the HTTP_PROXY and HTTPS_PROXY set to `http://squid.ps6.internal:3128` 

*** Cannot test the staging changes without merging or running konf locally***

## Issue / Card

Fixes [#WD-20463](https://warthogs.atlassian.net/browse/WD-20463)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
