### PR TITLE
fix: Adjust spacing above footer headings

### DIFF
--- a/templates/templates/footer.html
+++ b/templates/templates/footer.html
@@ -57,7 +57,7 @@
       {% endwith %}
     <!-- The following 3 sections are custom and cannot be pulled from nav.yaml -->
     <div class="row">
-      <hr class="p-rule--muted" />
+      <hr class="p-rule--muted u-no-margin--bottom" />
       <div class="col-3 col-medium-2">
         <h2 class="p-heading--5">
           Solutions
@@ -91,7 +91,7 @@
     </div>
     
     <div class="row">
-      <hr class="p-rule--muted" />
+      <hr class="p-rule--muted u-no-margin--bottom" />
       <div class="col-3 col-medium-2">
         <h2 class="p-heading--5">
           Sectors


### PR DESCRIPTION
## Done

- Adds ` u-no-margin--bottom` to the `hr`'s above the 'Section' and 'Solutions' headings in the footer

## QA

- Open https://ubuntu-com-14905.demos.haus/
- Scroll down to the footer
- See the'Section' and 'Solutions' headings in the footer have the save spacing above as all the other headings


## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-19400

## Screenshots

![image](https://github.com/user-attachments/assets/2b2212f5-e297-49aa-a1d2-37926d176acf)
