### PR TITLE
feat: Add preview image to /20years

### DIFF
--- a/templates/20years/index.html
+++ b/templates/20years/index.html
@@ -10,6 +10,8 @@
   https://docs.google.com/document/d/1vlENASSxNJdnK5tRuNYEZGVbh_qrVN0lhon8SOYo6A0/edit
 {% endblock meta_copydoc %}
 
+{% block meta_image %}https://assets.ubuntu.com/v1/41824d95-Ubuntu-20-Years-Social-Share.png{% endblock %}
+
 {% block body_class %}
   is-paper
 {% endblock body_class %}
@@ -42,7 +44,13 @@
       <div class="col">
         <div class="p-section">
           <div class="u-embedded-media">
-            <iframe class="u-embedded-media__element" src="https://www.youtube.com/embed/otDFa83aQqc?si=8y8lnjqkepR4iXoE" title="Ubuntu Community | 20 years of Ubuntu" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+            <iframe class="u-embedded-media__element"
+                    src="https://www.youtube.com/embed/otDFa83aQqc?si=8y8lnjqkepR4iXoE"
+                    title="Ubuntu Community | 20 years of Ubuntu"
+                    frameborder="0"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                    referrerpolicy="strict-origin-when-cross-origin"
+                    allowfullscreen></iframe>
           </div>
         </div>
       </div>
@@ -69,7 +77,11 @@
         <hr class="p-rule--muted" />
         <div class="row">
           <div class="col-1 col-medium-1 u-hide--small">
-            <img src="https://assets.ubuntu.com/v1/db939bdb-Frame%203611.png" alt="Warty warthog logo" width="57" height="40" style="margin-top:0.65rem" />
+            <img src="https://assets.ubuntu.com/v1/db939bdb-Frame%203611.png"
+                 alt="Warty warthog logo"
+                 width="57"
+                 height="40"
+                 style="margin-top:0.65rem" />
           </div>
           <div class="col-2 col-medium-2 col-small-2 u-align--right">
             <div class="p-tube-line">
@@ -203,7 +215,11 @@
         </div>
         <div class="row">
           <div class="col-1 col-medium-1 u-hide--small">
-            <img src="https://assets.ubuntu.com/v1/e1af7468-wubi.png" alt="Wubi logo" width="57" height="40" style="margin-top:0.65rem" />
+            <img src="https://assets.ubuntu.com/v1/e1af7468-wubi.png"
+                 alt="Wubi logo"
+                 width="57"
+                 height="40"
+                 style="margin-top:0.65rem" />
           </div>
           <div class="col-2 col-medium-2 col-small-2 col-start-large-2 col-start-medium-2 u-align--right">
             <div class="p-tube-line">
@@ -256,7 +272,11 @@
         <hr class="p-rule--muted" />
         <div class="row">
           <div class="col-1 col-medium-1 u-hide--small">
-            <img src="https://assets.ubuntu.com/v1/86744995-pangolin.png" alt="Precise Pangolin logo" width="57" height="40" style="margin-top:0.65rem" />
+            <img src="https://assets.ubuntu.com/v1/86744995-pangolin.png"
+                 alt="Precise Pangolin logo"
+                 width="57"
+                 height="40"
+                 style="margin-top:0.65rem" />
           </div>
           <div class="col-2 col-medium-2 col-small-2 u-align--right">
             <div class="p-tube-line">
@@ -293,7 +313,11 @@
         <hr class="p-rule--muted" />
         <div class="row">
           <div class="col-1 col-medium-1 u-hide--small">
-            <img src="https://assets.ubuntu.com/v1/f9b5d5f2-unicorn.png" alt="Utopic Unicorn logo" width="57" height="40" style="margin-top:0.65rem" />
+            <img src="https://assets.ubuntu.com/v1/f9b5d5f2-unicorn.png"
+                 alt="Utopic Unicorn logo"
+                 width="57"
+                 height="40"
+                 style="margin-top:0.65rem" />
           </div>
           <div class="col-2 col-medium-2 col-small-2 u-align--right">
             <div class="p-tube-line">
@@ -313,7 +337,11 @@
         <hr class="p-rule--muted" />
         <div class="row">
           <div class="col-1 col-medium-1 u-hide--small">
-            <img src="https://assets.ubuntu.com/v1/714c5293-ubuntu-mate-circle-icon.png" alt="Ubuntu Mate logo" width="40" height="40" style="margin-top:0.65rem" />
+            <img src="https://assets.ubuntu.com/v1/714c5293-ubuntu-mate-circle-icon.png"
+                 alt="Ubuntu Mate logo"
+                 width="40"
+                 height="40"
+                 style="margin-top:0.65rem" />
           </div>
           <div class="col-2 col-medium-2 col-small-2 u-align--right">
             <div class="p-tube-line">
@@ -333,7 +361,11 @@
         <hr class="p-rule--muted" />
         <div class="row">
           <div class="col-1 col-medium-1 u-hide--small">
-            <img src="https://assets.ubuntu.com/v1/3a434514-ubuntu-core.png" alt="Old Circle of friends logo" width="40" height="40" style="margin-top:0.65rem" />
+            <img src="https://assets.ubuntu.com/v1/3a434514-ubuntu-core.png"
+                 alt="Old Circle of friends logo"
+                 width="40"
+                 height="40"
+                 style="margin-top:0.65rem" />
           </div>
           <div class="col-2 col-medium-2 col-small-2 u-align--right">
             <div class="p-tube-line">
@@ -352,7 +384,11 @@
         </div>
         <div class="row">
           <div class="col-1 col-medium-1 u-hide--small">
-            <img src="https://assets.ubuntu.com/v1/f2b0a195-snapcraft.png" alt="Snap store logo" width="57" height="40" style="margin-top:0.65rem" />
+            <img src="https://assets.ubuntu.com/v1/f2b0a195-snapcraft.png"
+                 alt="Snap store logo"
+                 width="57"
+                 height="40"
+                 style="margin-top:0.65rem" />
           </div>
           <div class="col-2 col-medium-2 col-small-2 u-align--right">
             <div class="p-tube-line">
@@ -406,7 +442,11 @@
         <hr class="p-rule--muted" />
         <div class="row">
           <div class="col-1 col-medium-1 u-hide--small">
-            <img src="https://assets.ubuntu.com/v1/1edfdad3-CoF%20larger.png" alt="Circle of Friends tag" width="57" height="61" style="margin-top:0.65rem" />
+            <img src="https://assets.ubuntu.com/v1/1edfdad3-CoF%20larger.png"
+                 alt="Circle of Friends tag"
+                 width="57"
+                 height="61"
+                 style="margin-top:0.65rem" />
           </div>
           <div class="col-2 col-medium-2 col-small-2 u-align--right">
             <div class="p-tube-line">
@@ -443,7 +483,11 @@
         <hr class="p-rule--muted" />
         <div class="row">
           <div class="col-1 col-medium-1 u-hide--small">
-            <img src="https://assets.ubuntu.com/v1/8d056333-numbat.png" alt="Noble Numbat logo" width="57" height="40" style="margin-top:0.65rem" />
+            <img src="https://assets.ubuntu.com/v1/8d056333-numbat.png"
+                 alt="Noble Numbat logo"
+                 width="57"
+                 height="40"
+                 style="margin-top:0.65rem" />
           </div>
           <div class="col-2 col-medium-2 col-small-2 u-align--right">
             <div class="p-tube-line">
@@ -480,7 +524,9 @@
           <div class="col-2 col-medium-2 col-small-2 col-start-large-2 col-start-medium-2 u-align--right">
             <div class="p-tube-line--image">
               <div class="p-tube-line__circle"></div>
-              <img class="p-tube-line__image" src="https://assets.ubuntu.com/v1/a73ced17-bday-cake-no-bg.png" alt="Birthday cake emoji" />
+              <img class="p-tube-line__image"
+                   src="https://assets.ubuntu.com/v1/a73ced17-bday-cake-no-bg.png"
+                   alt="Birthday cake emoji" />
             </div>
           </div>
           <div class="col-6 col-medium-3 col-small-2">
@@ -584,7 +630,9 @@
         <div class="p-card--social-media">
           <div class="p-heading-icon">
             <div class="p-heading-icon__header">
-              <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/9a62ef78-@shaakunthala.png" alt="" />
+              <img class="p-heading-icon__img"
+                   src="https://assets.ubuntu.com/v1/9a62ef78-@shaakunthala.png"
+                   alt="" />
               <p class="p-heading-icon__title">
                 <strong><small>Tweet by @shaakunthala</small></strong>
               </p>
@@ -597,14 +645,12 @@
             I want to thank you for sending bulk quantities for £0, even outside Europe at a time when we had no fast Internet. I learned Linux thanks to <a href="https://x.com/hashtag/Ubuntu?src=hashtag_click">&#35;Ubuntu</a>.
           </p>
           <div class="p-section--shallow">
-            {{ image (
-              url="https://assets.ubuntu.com/v1/eb725025-post 6.png",
-              alt="",
-              width="1512",
-              height="852",
-              hi_def=True,
-              loading="lazy"
-              ) | safe
+            {{ image(url="https://assets.ubuntu.com/v1/eb725025-post 6.png",
+                        alt="",
+                        width="1512",
+                        height="852",
+                        hi_def=True,
+                        loading="lazy") | safe
             }}
           </div>
           <hr class="p-rule--muted" />
@@ -653,21 +699,17 @@
               </p>
             </div>
           </div>
-          <p>
-            Can't believe it's been 20 years, Ubuntu.
-          </p>
+          <p>Can't believe it's been 20 years, Ubuntu.</p>
           <p>
             Ubuntu was my first introduction to Linux and open source software. That's probably a common story as Ubuntu is considered one of the most user friendly distributions.
           </p>
           <div class="p-section--shallow">
-            {{ image (
-              url="https://assets.ubuntu.com/v1/9fa66990-240401.jpeg",
-              alt="",
-              width="300",
-              height="168",
-              hi_def=True,
-              loading="lazy"
-              ) | safe
+            {{ image(url="https://assets.ubuntu.com/v1/9fa66990-240401.jpeg",
+                        alt="",
+                        width="300",
+                        height="168",
+                        hi_def=True,
+                        loading="lazy") | safe
             }}
           </div>
           <hr class="p-rule--muted" />
@@ -697,20 +739,20 @@
             I was feeling a bit nostalgic today and decided to install Ubuntu Warty Warthog 4.10. What a walk down memory lane! I still can't believe &#35;Ubuntu turns 20 this year.
           </p>
           <div class="p-section--shallow">
-            {{ image (
-              url="https://assets.ubuntu.com/v1/d7fff746-ken%20vandine%20post.png",
-              alt="",
-              width="2145",
-              height="1207",
-              hi_def=True,
-              loading="lazy"
-              ) | safe
+            {{ image(url="https://assets.ubuntu.com/v1/d7fff746-ken%20vandine%20post.png",
+                        alt="",
+                        width="2145",
+                        height="1207",
+                        hi_def=True,
+                        loading="lazy") | safe
             }}
           </div>
           <hr class="p-rule--muted" />
           <div class="p-heading-icon--small">
             <div class="p-heading-icon__header">
-              <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/965ec1de-LinkedIn%20Logo%20-%20Updated%202.png" alt="LinkedIn logo" />
+              <img class="p-heading-icon__img"
+                   src="https://assets.ubuntu.com/v1/965ec1de-LinkedIn%20Logo%20-%20Updated%202.png"
+                   alt="LinkedIn logo" />
               <p class="p-heading-icon__title">
                 <a href="https://www.linkedin.com/posts/kenvandine_ubuntu-activity-7177007812047183872-Wz-9">See post&nbsp;&rsaquo;</a>
               </p>
@@ -722,19 +764,27 @@
         <div class="p-card--social-media">
           <div class="p-heading-icon">
             <div class="p-heading-icon__header">
-              <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/5bbc95e4-Jono.jpeg" alt="Jono Bacon portrait" />
+              <img class="p-heading-icon__img"
+                   src="https://assets.ubuntu.com/v1/5bbc95e4-Jono.jpeg"
+                   alt="Jono Bacon portrait" />
               <p class="p-heading-icon__title">
                 <strong><small>LinkedIn post by Jono Bacon</small></strong>
               </p>
             </div>
           </div>
           <p>Wow, 20 years ago Canonical sprung into life...and it completely changed my own life.</p>
-          <p>While I didn't join in 2004, I came along a few years later...Canonical captured the interest of the early British open source community with @ubuntu .</p>
-          <p>At the time I was a journalist, writing for Linux Format, Linux Magazine, Linux User & Developer and others, I was building a community in the UK called Linux UK...and I spent my days helping companies move to open source at OpenAdvantage (a small government-funded consultancy.)</p>
+          <p>
+            While I didn't join in 2004, I came along a few years later...Canonical captured the interest of the early British open source community with @ubuntu .
+          </p>
+          <p>
+            At the time I was a journalist, writing for Linux Format, Linux Magazine, Linux User & Developer and others, I was building a community in the UK called Linux UK...and I spent my days helping companies move to open source at OpenAdvantage (a small government-funded consultancy.)
+          </p>
           <hr class="p-rule--muted" />
           <div class="p-heading-icon--small">
             <div class="p-heading-icon__header">
-              <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/965ec1de-LinkedIn%20Logo%20-%20Updated%202.png" alt="LinkedIn logo" />
+              <img class="p-heading-icon__img"
+                   src="https://assets.ubuntu.com/v1/965ec1de-LinkedIn%20Logo%20-%20Updated%202.png"
+                   alt="LinkedIn logo" />
               <p class="p-heading-icon__title">
                 <a href="https://www.linkedin.com/pulse/holy-smokes-20-years-canonical-ubuntu-jono-bacon-el1dc/?trackingId=U6%2BX7%2Fa9anAAFVzgEfG7UQ%3D%3D">See post&nbsp;&rsaquo;</a>
               </p>
@@ -744,7 +794,9 @@
         <div class="p-card--social-media">
           <div class="p-heading-icon">
             <div class="p-heading-icon__header">
-              <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/883761af-brandon%20lichtenwalner.jpeg" alt="Brandon Lichtenwalner portrait" />
+              <img class="p-heading-icon__img"
+                   src="https://assets.ubuntu.com/v1/883761af-brandon%20lichtenwalner.jpeg"
+                   alt="Brandon Lichtenwalner portrait" />
               <p class="p-heading-icon__title">
                 <strong><small>LinkedIn post by Brandon Lichtenwalner</small></strong>
               </p>
@@ -753,24 +805,22 @@
           <p>
             Can you believe Ubuntu has been around for 20 years!? I remember it changing the game when it first released, and it has been one of my go to distributions (for desktop and later server) ever since, even when it's not my daily driver.
           </p>
-          <p>
-            Releases that stick out for me: 6.06 | 12.04 | 20.04
-          </p>
+          <p>Releases that stick out for me: 6.06 | 12.04 | 20.04</p>
           <div class="p-section--shallow">
-            {{ image (
-              url="https://assets.ubuntu.com/v1/ecab51bd-ubuntu 20 years.jpeg",
-              alt="",
-              width="480",
-              height="480",
-              hi_def=True,
-              loading="lazy"
-              ) | safe
+            {{ image(url="https://assets.ubuntu.com/v1/ecab51bd-ubuntu 20 years.jpeg",
+                        alt="",
+                        width="480",
+                        height="480",
+                        hi_def=True,
+                        loading="lazy") | safe
             }}
           </div>
           <hr class="p-rule--muted" />
           <div class="p-heading-icon--small">
             <div class="p-heading-icon__header">
-              <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/965ec1de-LinkedIn%20Logo%20-%20Updated%202.png" alt="LinkedIn logo" />
+              <img class="p-heading-icon__img"
+                   src="https://assets.ubuntu.com/v1/965ec1de-LinkedIn%20Logo%20-%20Updated%202.png"
+                   alt="LinkedIn logo" />
               <p class="p-heading-icon__title">
                 <a href="https://www.linkedin.com/posts/brandonlichtenwalner_ubuntults-opensource-activity-7190780387613122560-3WVe?utm_source=share&utm_medium=member_desktop">See post&nbsp;&rsaquo;</a>
               </p>
@@ -780,7 +830,9 @@
         <div class="p-card--social-media">
           <div class="p-heading-icon">
             <div class="p-heading-icon__header">
-              <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/3aa35ae4-@nebojsa%20tomic.png" alt="" />
+              <img class="p-heading-icon__img"
+                   src="https://assets.ubuntu.com/v1/3aa35ae4-@nebojsa%20tomic.png"
+                   alt="" />
               <p class="p-heading-icon__title">
                 <strong><small>LinkedIn post by
                 Nebojsa Tomic</small></strong>
@@ -794,20 +846,20 @@
             Today, I am still using Ubuntu as my daily driver (with a little distribution browsing over the years ), and every day I get more and more satisfaction from it - look and feel, functionality and community support are something that no other free Operating System provides. Congratulations on the 24.04 version to Ubuntu and <a href="https://uk.linkedin.com/company/canonical?trk=public_post-text">Canonical</a>
           </p>
           <div class="p-section--shallow">
-            {{ image (
-              url="https://assets.ubuntu.com/v1/22ccf0a5-post%205.png",
-              alt="",
-              width="1512",
-              height="851",
-              hi_def=True,
-              loading="lazy"
-              ) | safe
+            {{ image(url="https://assets.ubuntu.com/v1/22ccf0a5-post%205.png",
+                        alt="",
+                        width="1512",
+                        height="851",
+                        hi_def=True,
+                        loading="lazy") | safe
             }}
           </div>
           <hr class="p-rule--muted" />
           <div class="p-heading-icon--small">
             <div class="p-heading-icon__header">
-              <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/965ec1de-LinkedIn%20Logo%20-%20Updated%202.png" alt="LinkedIn logo" />
+              <img class="p-heading-icon__img"
+                   src="https://assets.ubuntu.com/v1/965ec1de-LinkedIn%20Logo%20-%20Updated%202.png"
+                   alt="LinkedIn logo" />
               <p class="p-heading-icon__title">
                 <a href="https://www.linkedin.com/posts/nebojsatomic_almost-20-years-ago-when-very-few-people-activity-7189918964301381632-bzSd">See post&nbsp;&rsaquo;</a>
               </p>
@@ -825,23 +877,25 @@
             </div>
           </div>
           <p>
-            20 years of Ubuntu: Canonical celebrates with upcoming 24.10 - and it's outstanding as usual <br/> &#35;Linux &#35;Ubuntu &#35;Desktop &#35;Canonical
+            20 years of Ubuntu: Canonical celebrates with upcoming 24.10 - and it's outstanding as usual
+            <br />
+            &#35;Linux &#35;Ubuntu &#35;Desktop &#35;Canonical
           </p>
           <div class="p-section--shallow">
-            {{ image (
-              url="https://assets.ubuntu.com/v1/8fd3c50e-2410.jpeg",
-              alt="",
-              width="768",
-              height="479",
-              hi_def=True,
-              loading="lazy"
-              ) | safe
+            {{ image(url="https://assets.ubuntu.com/v1/8fd3c50e-2410.jpeg",
+                        alt="",
+                        width="768",
+                        height="479",
+                        hi_def=True,
+                        loading="lazy") | safe
             }}
           </div>
           <hr class="p-rule--muted" />
           <div class="p-heading-icon--small">
             <div class="p-heading-icon__header">
-              <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/965ec1de-LinkedIn%20Logo%20-%20Updated%202.png" alt="LinkedIn logo" />
+              <img class="p-heading-icon__img"
+                   src="https://assets.ubuntu.com/v1/965ec1de-LinkedIn%20Logo%20-%20Updated%202.png"
+                   alt="LinkedIn logo" />
               <p class="p-heading-icon__title">
                 <a href="https://www.linkedin.com/posts/jokar_linux-ubuntu-desktop-activity-7246555578204909569-pZXR/?utm_source=share&utm_medium=member_desktop">See post&nbsp;&rsaquo;</a>
               </p>
@@ -859,9 +913,7 @@
               </p>
             </div>
           </div>
-          <p>
-            When I was in my early teens my friend Nate gave me an Ubuntu Linux install disc. 
-          </p>
+          <p>When I was in my early teens my friend Nate gave me an Ubuntu Linux install disc.</p>
           <p>
             I dual booted that bad boy alongside windows xp on the family Desktop. It didn't have drivers for our modem preinstalled so I had to build them from source, manually grabbing one dependency at a time.
           </p>
@@ -889,20 +941,20 @@
             Found this old photo of Ubuntu 6.06 LTS (or 6.10? Can't remember) CD-ROM. The image is very blurry because I took it on an old feature phone. I started using Ubuntu around version 5.x and it was really exciting for me to receive the CD-ROM via air mail. It's amazing that I've been in the Linux world for more than 20 years already!
           </p>
           <div class="p-section--shallow">
-            {{ image (
-              url="https://assets.ubuntu.com/v1/4732b314-post9.jpeg",
-              alt="",
-              width="400",
-              height="300",
-              hi_def=True,
-              loading="lazy"
-              ) | safe
+            {{ image(url="https://assets.ubuntu.com/v1/4732b314-post9.jpeg",
+                        alt="",
+                        width="400",
+                        height="300",
+                        hi_def=True,
+                        loading="lazy") | safe
             }}
           </div>
           <hr class="p-rule--muted" />
           <div class="p-heading-icon--small">
             <div class="p-heading-icon__header">
-              <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/965ec1de-LinkedIn%20Logo%20-%20Updated%202.png" alt="LinkedIn logo" />
+              <img class="p-heading-icon__img"
+                   src="https://assets.ubuntu.com/v1/965ec1de-LinkedIn%20Logo%20-%20Updated%202.png"
+                   alt="LinkedIn logo" />
               <p class="p-heading-icon__title">
                 <a href="https://www.linkedin.com/posts/shinglyu_found-this-old-photo-of-ubuntu-606-lts-activity-7206958851890315265-wjZ4?utm_source=share&utm_medium=member_desktop">See post&nbsp;&rsaquo;</a>
               </p>
@@ -912,7 +964,9 @@
         <div class="p-card--social-media">
           <div class="p-heading-icon">
             <div class="p-heading-icon__header">
-              <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/523f779c-Shannon%20smith.jpeg" alt="Shannon Smith portrait" />
+              <img class="p-heading-icon__img"
+                   src="https://assets.ubuntu.com/v1/523f779c-Shannon%20smith.jpeg"
+                   alt="Shannon Smith portrait" />
               <p class="p-heading-icon__title">
                 <strong><small>LinkedIn post by Shannon Smith</small></strong>
               </p>
@@ -922,7 +976,9 @@
           <hr class="p-rule--muted" />
           <div class="p-heading-icon--small">
             <div class="p-heading-icon__header">
-              <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/965ec1de-LinkedIn%20Logo%20-%20Updated%202.png" alt="LinkedIn logo" />
+              <img class="p-heading-icon__img"
+                   src="https://assets.ubuntu.com/v1/965ec1de-LinkedIn%20Logo%20-%20Updated%202.png"
+                   alt="LinkedIn logo" />
               <p class="p-heading-icon__title">
                 <a href="https://www.linkedin.com/posts/shannonandriansmith_ubuntults-opensource-activity-7191994640412151808-KUQW?utm_source=share&utm_medium=member_desktop">See post&nbsp;&rsaquo;</a>
               </p>
@@ -1010,36 +1066,30 @@
                 </p>
                 <div class="row">
                   <div class="col-3 col-medium-2">
-                    {{ image (
-                      url="https://assets.ubuntu.com/v1/c9715935-wallpaper1.jpeg",
-                      alt="",
-                      width="800",
-                      height="450",
-                      hi_def=True,
-                      loading="lazy"
-                      ) | safe
+                    {{ image(url="https://assets.ubuntu.com/v1/c9715935-wallpaper1.jpeg",
+                                        alt="",
+                                        width="800",
+                                        height="450",
+                                        hi_def=True,
+                                        loading="lazy") | safe
                     }}
                   </div>
                   <div class="col-3 col-medium-2">
-                    {{ image (
-                      url="https://assets.ubuntu.com/v1/7e8803dc-wallpaper2.jpeg",
-                      alt="",
-                      width="960",
-                      height="540",
-                      hi_def=True,
-                      loading="lazy"
-                      ) | safe
+                    {{ image(url="https://assets.ubuntu.com/v1/7e8803dc-wallpaper2.jpeg",
+                                        alt="",
+                                        width="960",
+                                        height="540",
+                                        hi_def=True,
+                                        loading="lazy") | safe
                     }}
                   </div>
                   <div class="col-3 col-medium-2">
-                    {{ image (
-                      url="https://assets.ubuntu.com/v1/54bfdd54-wallpaper3.jpeg",
-                      alt="",
-                      width="960",
-                      height="568",
-                      hi_def=True,
-                      loading="lazy"
-                      ) | safe
+                    {{ image(url="https://assets.ubuntu.com/v1/54bfdd54-wallpaper3.jpeg",
+                                        alt="",
+                                        width="960",
+                                        height="568",
+                                        hi_def=True,
+                                        loading="lazy") | safe
                     }}
                   </div>
                 </div>
@@ -1053,36 +1103,30 @@
                 </p>
                 <div class="row">
                   <div class="col-3 col-medium-2">
-                    {{ image (
-                      url="https://assets.ubuntu.com/v1/ead7f0b0-Noble%20Numbat%20Wallpaper%201.png",
-                      alt="",
-                      width="1073",
-                      height="604",
-                      hi_def=True,
-                      loading="lazy"
-                      ) | safe
+                    {{ image(url="https://assets.ubuntu.com/v1/ead7f0b0-Noble%20Numbat%20Wallpaper%201.png",
+                                        alt="",
+                                        width="1073",
+                                        height="604",
+                                        hi_def=True,
+                                        loading="lazy") | safe
                     }}
                   </div>
                   <div class="col-3 col-medium-2">
-                    {{ image (
-                      url="https://assets.ubuntu.com/v1/2c284276-Noble%20Numbat%20Wallpaper%202.png",
-                      alt="",
-                      width="1073",
-                      height="604",
-                      hi_def=True,
-                      loading="lazy"
-                      ) | safe
+                    {{ image(url="https://assets.ubuntu.com/v1/2c284276-Noble%20Numbat%20Wallpaper%202.png",
+                                        alt="",
+                                        width="1073",
+                                        height="604",
+                                        hi_def=True,
+                                        loading="lazy") | safe
                     }}
                   </div>
                   <div class="col-3 col-medium-2">
-                    {{ image (
-                      url="https://assets.ubuntu.com/v1/eba5f89b-Noble%20Numbat%20Wallpaper%203.png",
-                      alt="",
-                      width="1073",
-                      height="604",
-                      hi_def=True,
-                      loading="lazy"
-                      ) | safe
+                    {{ image(url="https://assets.ubuntu.com/v1/eba5f89b-Noble%20Numbat%20Wallpaper%203.png",
+                                        alt="",
+                                        width="1073",
+                                        height="604",
+                                        hi_def=True,
+                                        loading="lazy") | safe
                     }}
                   </div>
                 </div>
@@ -1096,36 +1140,30 @@
                 </p>
                 <div class="row">
                   <div class="col-3 col-medium-2">
-                    {{ image (
-                      url="https://assets.ubuntu.com/v1/eb31ad15-Lunar%20Lobster%20Wallpaper%201.png",
-                      alt="",
-                      width="1073",
-                      height="604",
-                      hi_def=True,
-                      loading="lazy"
-                      ) | safe
+                    {{ image(url="https://assets.ubuntu.com/v1/eb31ad15-Lunar%20Lobster%20Wallpaper%201.png",
+                                        alt="",
+                                        width="1073",
+                                        height="604",
+                                        hi_def=True,
+                                        loading="lazy") | safe
                     }}
                   </div>
                   <div class="col-3 col-medium-2">
-                    {{ image (
-                      url="https://assets.ubuntu.com/v1/011b12df-Lunar%20Lobster%20Wallpaper%202.png",
-                      alt="",
-                      width="1073",
-                      height="604",
-                      hi_def=True,
-                      loading="lazy"
-                      ) | safe
+                    {{ image(url="https://assets.ubuntu.com/v1/011b12df-Lunar%20Lobster%20Wallpaper%202.png",
+                                        alt="",
+                                        width="1073",
+                                        height="604",
+                                        hi_def=True,
+                                        loading="lazy") | safe
                     }}
                   </div>
                   <div class="col-3 col-medium-2">
-                    {{ image (
-                      url="https://assets.ubuntu.com/v1/b2acb801-Lunar%20Lobster%20Wallpaper%203.png",
-                      alt="",
-                      width="1073",
-                      height="604",
-                      hi_def=True,
-                      loading="lazy"
-                      ) | safe
+                    {{ image(url="https://assets.ubuntu.com/v1/b2acb801-Lunar%20Lobster%20Wallpaper%203.png",
+                                        alt="",
+                                        width="1073",
+                                        height="604",
+                                        hi_def=True,
+                                        loading="lazy") | safe
                     }}
                   </div>
                 </div>
@@ -1139,36 +1177,30 @@
                 </p>
                 <div class="row">
                   <div class="col-3 col-medium-2">
-                    {{ image (
-                      url="https://assets.ubuntu.com/v1/a024ba19-Jammy%20Jellyfish%20Wallpaper%201.png",
-                      alt="",
-                      width="1073",
-                      height="604",
-                      hi_def=True,
-                      loading="lazy"
-                      ) | safe
+                    {{ image(url="https://assets.ubuntu.com/v1/a024ba19-Jammy%20Jellyfish%20Wallpaper%201.png",
+                                        alt="",
+                                        width="1073",
+                                        height="604",
+                                        hi_def=True,
+                                        loading="lazy") | safe
                     }}
                   </div>
                   <div class="col-3 col-medium-2">
-                    {{ image (
-                      url="https://assets.ubuntu.com/v1/992f8bdf-Jammy%20Jellyfish%20Wallpaper%202.png",
-                      alt="",
-                      width="1073",
-                      height="604",
-                      hi_def=True,
-                      loading="lazy"
-                      ) | safe
+                    {{ image(url="https://assets.ubuntu.com/v1/992f8bdf-Jammy%20Jellyfish%20Wallpaper%202.png",
+                                        alt="",
+                                        width="1073",
+                                        height="604",
+                                        hi_def=True,
+                                        loading="lazy") | safe
                     }}
                   </div>
                   <div class="col-3 col-medium-2">
-                    {{ image (
-                      url="https://assets.ubuntu.com/v1/f74566f0-Jammy%20Jellyfish%20Wallpaper%203.png",
-                      alt="",
-                      width="1073",
-                      height="604",
-                      hi_def=True,
-                      loading="lazy"
-                      ) | safe
+                    {{ image(url="https://assets.ubuntu.com/v1/f74566f0-Jammy%20Jellyfish%20Wallpaper%203.png",
+                                        alt="",
+                                        width="1073",
+                                        height="604",
+                                        hi_def=True,
+                                        loading="lazy") | safe
                     }}
                   </div>
                 </div>
@@ -1192,7 +1224,7 @@
           What is it about Ubuntu that our partners value? Our partners have helped us take Ubuntu across industries, and from desktops to automotive devices.
         </p>
         <p>
-          We invited our partners to send their recorded anniversary wishes to celebrate 20 years of Ubuntu. We've put them together in a blog that charts the history of our partnerships. 
+          We invited our partners to send their recorded anniversary wishes to celebrate 20 years of Ubuntu. We've put them together in a blog that charts the history of our partnerships.
         </p>
         <p>
           <a href="/blog/20-years-of-partnership">Check out the blog&nbsp;&rsaquo;</a>
@@ -1236,7 +1268,11 @@
     <div class="p-section">
       <div class="row--25-75">
         <div class="col u-hide--small">
-          <img src="https://assets.ubuntu.com/v1/48056c37-DFI-Logo.png" alt="DFI logo" width="126" height="50" style="margin-top:1rem" />
+          <img src="https://assets.ubuntu.com/v1/48056c37-DFI-Logo.png"
+               alt="DFI logo"
+               width="126"
+               height="50"
+               style="margin-top:1rem" />
         </div>
         <div class="col">
           <hr class="p-rule--muted" />
@@ -1259,7 +1295,11 @@
     <div class="p-section">
       <div class="row--25-75">
         <div class="col u-hide--small">
-          <img src="https://assets.ubuntu.com/v1/8a9c6ca4-Advantech%20Logo.png" alt="Advantech logo" width="126" height="50" style="margin-top:1rem" />
+          <img src="https://assets.ubuntu.com/v1/8a9c6ca4-Advantech%20Logo.png"
+               alt="Advantech logo"
+               width="126"
+               height="50"
+               style="margin-top:1rem" />
         </div>
         <div class="col">
           <hr class="p-rule--muted" />
@@ -1282,7 +1322,11 @@
     <div class="p-section">
       <div class="row--25-75">
         <div class="col u-hide--small">
-          <img src="https://assets.ubuntu.com/v1/3afe5e82-ADLINK%20Logo.png" alt="Adlink logo" width="126" height="50" style="margin-top:1rem" />
+          <img src="https://assets.ubuntu.com/v1/3afe5e82-ADLINK%20Logo.png"
+               alt="Adlink logo"
+               width="126"
+               height="50"
+               style="margin-top:1rem" />
         </div>
         <div class="col">
           <hr class="p-rule--muted" />
@@ -1305,7 +1349,11 @@
     <div class="p-section">
       <div class="row--25-75">
         <div class="col u-hide--small">
-          <img src="https://assets.ubuntu.com/v1/ff6f1197-ASRock%20Logo.png" alt="ASRock logo" width="126" height="50" style="margin-top:1rem" />
+          <img src="https://assets.ubuntu.com/v1/ff6f1197-ASRock%20Logo.png"
+               alt="ASRock logo"
+               width="126"
+               height="50"
+               style="margin-top:1rem" />
         </div>
         <div class="col">
           <hr class="p-rule--muted" />
@@ -1328,7 +1376,11 @@
     <div class="p-section">
       <div class="row--25-75">
         <div class="col u-hide--small">
-          <img src="https://assets.ubuntu.com/v1/b645dd23-ASUS%20IoT%20Logo.png" alt="Asus IOT logo" width="126" height="50" style="margin-top:1rem" />
+          <img src="https://assets.ubuntu.com/v1/b645dd23-ASUS%20IoT%20Logo.png"
+               alt="Asus IOT logo"
+               width="126"
+               height="50"
+               style="margin-top:1rem" />
         </div>
         <div class="col">
           <hr class="p-rule--muted" />
@@ -1351,7 +1403,11 @@
     <div class="p-section">
       <div class="row--25-75">
         <div class="col u-hide--small">
-          <img src="https://assets.ubuntu.com/v1/021e8610-A24%20Logo.png" alt="A24 logo" width="126" height="50" style="margin-top:1rem" />
+          <img src="https://assets.ubuntu.com/v1/021e8610-A24%20Logo.png"
+               alt="A24 logo"
+               width="126"
+               height="50"
+               style="margin-top:1rem" />
         </div>
         <div class="col">
           <hr class="p-rule--muted" />
@@ -1374,7 +1430,11 @@
     <div class="p-section">
       <div class="row--25-75">
         <div class="col u-hide--small">
-          <img src="https://assets.ubuntu.com/v1/55a19d67-Nvidia%20Logo.png" alt="NVidia logo" width="126" height="50" style="margin-top:1rem" />
+          <img src="https://assets.ubuntu.com/v1/55a19d67-Nvidia%20Logo.png"
+               alt="NVidia logo"
+               width="126"
+               height="50"
+               style="margin-top:1rem" />
         </div>
         <div class="col">
           <hr class="p-rule--muted" />
@@ -1397,7 +1457,11 @@
     <div class="p-section">
       <div class="row--25-75">
         <div class="col u-hide--small">
-          <img src="https://assets.ubuntu.com/v1/62f81bcb-arm%20Logo.png" alt="ARM logo" width="126" height="50" style="margin-top:1rem" />
+          <img src="https://assets.ubuntu.com/v1/62f81bcb-arm%20Logo.png"
+               alt="ARM logo"
+               width="126"
+               height="50"
+               style="margin-top:1rem" />
         </div>
         <div class="col">
           <hr class="p-rule--muted" />
@@ -1420,7 +1484,11 @@
     <div class="p-section">
       <div class="row--25-75">
         <div class="col u-hide--small">
-          <img src="https://assets.ubuntu.com/v1/b93ffef5-Dell%20Technologies%20Logo.png" alt="Dell logo" width="126" height="50" style="margin-top:1rem" />
+          <img src="https://assets.ubuntu.com/v1/b93ffef5-Dell%20Technologies%20Logo.png"
+               alt="Dell logo"
+               width="126"
+               height="50"
+               style="margin-top:1rem" />
         </div>
         <div class="col">
           <hr class="p-rule--muted" />
@@ -1443,7 +1511,11 @@
     <div class="p-section">
       <div class="row--25-75">
         <div class="col u-hide--small">
-          <img src="https://assets.ubuntu.com/v1/0600e0fa-Hewlett%20Packard%20Enterprise%20Logo.png" alt="HP Enterprise logo" width="126" height="50" style="margin-top:1rem" />
+          <img src="https://assets.ubuntu.com/v1/0600e0fa-Hewlett%20Packard%20Enterprise%20Logo.png"
+               alt="HP Enterprise logo"
+               width="126"
+               height="50"
+               style="margin-top:1rem" />
         </div>
         <div class="col">
           <hr class="p-rule--muted" />
@@ -1466,15 +1538,13 @@
     <div class="p-section">
       <div class="row--25-75">
         <div class="col u-hide--small">
-          {{ image (
-            url="https://assets.ubuntu.com/v1/04197778-logo-ibm.png",
-            alt="",
-            width="88",
-            height="70",
-            hi_def=True,
-            loading="lazy",
-            attrs={"style": "margin-top:1rem"}
-            ) | safe
+          {{ image(url="https://assets.ubuntu.com/v1/04197778-logo-ibm.png",
+                    alt="",
+                    width="88",
+                    height="70",
+                    hi_def=True,
+                    loading="lazy",
+                    attrs={"style": "margin-top:1rem"}) | safe
           }}
         </div>
         <div class="col">
@@ -1489,8 +1559,7 @@
               <p class="u-no-margin--bottom">
                 <strong>Matt Whitbourne</strong>
               </p>
-              <p class="u-text--muted">Director - Product Management - OS & Virtualization, IBM Z & IBM LinuxONE systems
-              </p>
+              <p class="u-text--muted">Director - Product Management - OS & Virtualization, IBM Z & IBM LinuxONE systems</p>
             </div>
           </div>
         </div>
@@ -1500,15 +1569,13 @@
       <div class="row--25-75">
         <div class="col u-hide--small">
 
-          {{ image (
-            url="https://assets.ubuntu.com/v1/a1cffb7a-ampere_computing_logo.svg",
-            alt="",
-            width="119",
-            height="63",
-            hi_def=True,
-            loading="lazy",
-            attrs={"style": "margin-top:1rem"}
-            ) | safe
+          {{ image(url="https://assets.ubuntu.com/v1/a1cffb7a-ampere_computing_logo.svg",
+                    alt="",
+                    width="119",
+                    height="63",
+                    hi_def=True,
+                    loading="lazy",
+                    attrs={"style": "margin-top:1rem"}) | safe
           }}
         </div>
         <div class="col">
@@ -1523,9 +1590,7 @@
               <p class="u-no-margin--bottom">
                 <strong>Sean Varley</strong>
               </p>
-              <p class="u-text--muted">
-                Chief Evangelist, VP of Business Development, Ampere Computing
-              </p>
+              <p class="u-text--muted">Chief Evangelist, VP of Business Development, Ampere Computing</p>
             </div>
           </div>
         </div>
@@ -1609,7 +1674,13 @@
     </div>
   </section>
 
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/newsletter-opt-in" data-form-id="4960" data-lp-id="" data-return-url="/20years#newsletter-signup" data-lp-url=""></div>
+  <div class="u-hide"
+       id="contact-form-container"
+       data-form-location="/shared/forms/interactive/newsletter-opt-in"
+       data-form-id="4960"
+       data-lp-id=""
+       data-return-url="/20years#newsletter-signup"
+       data-lp-url=""></div>
   <script src="{{ versioned_static('js/third-party/typer.js') }}" defer></script>
 
 {% endblock content %}


### PR DESCRIPTION
## Done

-  Add [this preview image](https://assets.ubuntu.com/v1/41824d95-Ubuntu-20-Years-Social-Share.png) to /20years

## QA

- https://ubuntu-com-14906.demos.haus/20years
- Inspect the page, go to the 'Elements's' tab
- Use crt+f to find `og:image`
- See that is match the images mentioned above

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-14918
