### PR TITLE
fix wrong path on retry for Trueability API

### DIFF
--- a/webapp/shop/api/trueability/api.py
+++ b/webapp/shop/api/trueability/api.py
@@ -38,7 +38,7 @@ class TrueAbilityAPI:
         if retry and response.status_code == 401:
             response = self.make_request(
                 method,
-                uri,
+                path,
                 headers=headers,
                 data=data,
                 json=json,


### PR DESCRIPTION
## Done

- The trueability api tries to fetch the wrong endpoint on retry. This PR fixes that.

## QA

** Blocking trueabillity to force retries **
- run the following command or add this to your local /etc/hosts file `127.0.0.1 app.trueability.com localhost` at the end of the block `127.0.0.1 localhost`
    - This will redirect all the calls to localhost 80 which should not have any app running on it.
    - ** Remember to remove this at the end of the QA or you'll be left with a very broken hostfile **
- Another way on ubuntu is to use `ufw` which is a wrapper for `iptables`
    - Run `sudo ufw deny out to 66.151.49.1 port 80`
    - Run `sudo ufw deny in from 66.151.49.1 port 80`
    - Remember to run allow rules on both to remove them

** Run the app and try to go to pages which call app.trueability.com **
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/credentials/your-exams
- View the terminal logs from dotrun
- Should see that the retries are going to the correct URL

## Issue / Card

Fixes [#WD-20630](https://warthogs.atlassian.net/browse/WD-20630)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
