### PR TITLE
Fix typo: 'Ubuntu Ppro' to 'Ubuntu Pro"

### DIFF
--- a/templates/security/docker-images.html
+++ b/templates/security/docker-images.html
@@ -127,7 +127,7 @@
           Getting started with .NET on Ubuntu is straightforward and efficient with Canonical-maintained ultra-small container images.
         </p>
         <p>
-          Developers now have production-grade container images to ship their .NET apps on Ubuntu. Predictable release cadence aligned with Ubuntu LTS and .NET LTS releases guarantees security and stability, long-term. Security patches and support are available to Ubuntu Ppro customers, including on the Microsoft Azure platform.
+          Developers now have production-grade container images to ship their .NET apps on Ubuntu. Predictable release cadence aligned with Ubuntu LTS and .NET LTS releases guarantees security and stability, long-term. Security patches and support are available to Ubuntu Pro customers, including on the Microsoft Azure platform.
         </p>
         <div class="p-cta-block">
           <a href="/blog/install-dotnet-on-ubuntu">Read about .NET support on Ubuntu&nbsp;&rsaquo;</a>


### PR DESCRIPTION
Fixed a small typo I found in the section called "Building .NET apps on Ubuntu LTS"
It said "Ubuntu Ppro Customers" instead of "Ubuntu Pro Customers"


