### PR TITLE
Swap image arrangement

### DIFF
--- a/templates/containers/what-are-containers.html
+++ b/templates/containers/what-are-containers.html
@@ -163,7 +163,7 @@
     <div class="u-fixed-width">
       <div class="p-media-container p-strip is-shallow u-darker-background col-3 u-align--center u-vertically-center">
         <img width="834"
-             src="https://assets.ubuntu.com/v1/2e35a691-diagram%201.png"
+             src="https://assets.ubuntu.com/v1/a09a1433-diagram%202.png"
              alt=""
              loading="lazy" />
       </div>
@@ -185,7 +185,7 @@
     <div class="u-fixed-width">
       <div class="p-media-container p-strip is-shallow u-darker-background col-3 u-align--center u-vertically-center">
         <img width="834"
-             src="https://assets.ubuntu.com/v1/a09a1433-diagram%202.png"
+             src="https://assets.ubuntu.com/v1/2e35a691-diagram%201.png"
              alt=""
              loading="lazy" />
       </div>


### PR DESCRIPTION
## Done
There is a section that explains: "Containers vs. virtual machines" and another for "Docker vs. LXD" but the corresponding diagrams appear to be swapped. This update switches the diagrams to align their their correct section. 

## Screenshots

Original image placement:
![image](https://github.com/user-attachments/assets/ecf7057d-a1a3-496c-a061-11b13a7480a6)

Images places with corresponding headings: 
![image](https://github.com/user-attachments/assets/970edeef-5ddc-4ee2-b493-d8d4ae2593a8)
