### PR TITLE
Update partner logos on /pro/devices

### DIFF
--- a/templates/certified/shared/_partners.html
+++ b/templates/certified/shared/_partners.html
@@ -140,7 +140,7 @@
     }}
   </div>
   <div class="col-small-1 col-medium-1 col-1">
-    {{ image(url="https://assets.ubuntu.com/v1/1d02aa46-aaeon-logo.png",
+    {{ image(url="https://assets.ubuntu.com/v1/b53b5c6b-aaeon-new-logo.png",
         alt="Aaeon",
         attrs={"class":"p-logo-section__logo"},
         width="280",

--- a/templates/pro/devices.html
+++ b/templates/pro/devices.html
@@ -373,10 +373,10 @@ meta_copydoc %}
             <div class="col-3">
               <div style="padding-top:1rem;">
                 {{ image (
-                url="https://assets.ubuntu.com/v1/e6e3feeb-AAEON-logo.png",
+                url="https://assets.ubuntu.com/v1/9c8bfd51-Aaeon-Logo.png",
                 alt="AAEON logo",
-                width="276",
-                height="72",
+                width="138",
+                height="36",
                 hi_def=True,
                 loading="lazy"
                 ) | safe
@@ -408,8 +408,8 @@ meta_copydoc %}
                 {{ image (
                 url="https://assets.ubuntu.com/v1/4ed674b0-advantech-logo.png",
                 alt="advantech logo",
-                width="353",
-                height="72",
+                width="176",
+                height="36",
                 hi_def=True,
                 loading="lazy"
                 ) | safe
@@ -438,8 +438,8 @@ meta_copydoc %}
                 {{ image (
                 url="https://assets.ubuntu.com/v1/8b7059c4-DFI-logo.png",
                 alt="DFI logo",
-                width="147",
-                height="72",
+                width="73",
+                height="36",
                 hi_def=True,
                 loading="lazy"
                 ) | safe
@@ -471,8 +471,8 @@ meta_copydoc %}
                 {{ image (
                 url="https://assets.ubuntu.com/v1/0ed224e1-adlink-logo.png",
                 alt="adlink logo",
-                width="331",
-                height="72",
+                width="165",
+                height="36",
                 hi_def=True,
                 loading="lazy"
                 ) | safe


### PR DESCRIPTION
## Done

- Updated Aaeon logo with the new one according to the [copy doc](https://docs.google.com/document/d/1i_3nPkSpCQJ4jfOwN380sdfuTxaiDuDIgDfk01wVPqo/edit?tab=t.0)

## QA

- Check out this feature branch
- Run the site using the command `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001
- Alternatively, view the [demo](https://ubuntu-com-14913.demos.haus)
- Check the following pages to verify the updated logo
   - /pro/devices
   - /certified 
   - /certified/why-certify 

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-20639

## Screenshots

Before:

<img width="711" alt="Screenshot 2025-03-27 at 9 34 08 AM" src="https://github.com/user-attachments/assets/11b406fb-7c98-430f-9040-015f2f5005d4" />
<img width="430" alt="Screenshot 2025-03-27 at 9 35 01 AM" src="https://github.com/user-attachments/assets/01377fd4-581e-47ec-9a66-aa570f9e3cbd" />

After:

<img width="919" alt="Screenshot 2025-03-26 at 8 59 51 PM" src="https://github.com/user-attachments/assets/5626da6d-486e-44b4-aea7-7ea3717ed577" />
<img width="457" alt="Screenshot 2025-03-26 at 8 58 59 PM" src="https://github.com/user-attachments/assets/e2dd4157-cf10-4ef9-98a9-ac6480409d38" />
