### PR TITLE
feat: Apply design updates to rasp-pi appliance templates and remaining appliance footers

### DIFF
--- a/templates/appliance/adguard/_next-steps.html
+++ b/templates/appliance/adguard/_next-steps.html
@@ -1,40 +1,43 @@
-<section class="p-strip--light">
-  <div class="row u-equal-height">
-    <div class="col-6">
+<section class="p-section--deep">
+  <div class="row--50-50">
+    <hr class="p-rule" />
+    <div class="col">
       <div>
         <h2>
-          Start using your {{ appliance.name }} Ubuntu Appliance
+          Start using your {{ appliance.name }}
+          <br />
+          Ubuntu Appliance
         </h2>
-        <p>
-          Now you can go ahead and set everything up.  It's usually best to wait 5-10 minutes here. Some snaps will need to refresh themselves and the appliance may need to automatically reboot. When you're ready go to:
-        </p>
-        <pre><code>http://&lt;IP-of-your-appliance&gt;:3000</code></pre>
-        <p>
-          in another computers browser. Where you will find the initial configuration wizard.
-        </p>
-        <p>
-          Follow the instructions to start using your new Adguard Home Ubuntu Appliance.
-        </p>
-        <p>
-          On the AdGuard configuration screen, under DNS Server, it will have an error in red: <code>listen udp 0.0.0.0:53: bind: address already in use</code>.  Change the listen interface to <code>Eth0</code>.
-        </p>
-        <p>
-          Once you've finished the AdGuard configuration, you can connect to the admin panel by just going to <code>http://&lt;ip address&gt;</code> (no longer port 3000), and can configure other devices on your network to use that ip address for the DNS server.
-        </p>
-        <p>
-          For more information or more documentation on what to do now, the <a href="https://adguard.com/">AdGuard website</a> is the best place to go next.
-        </p>
+      </div>
     </div>
-  </div>
-  <div class="col-6 u-hide--medium u-hide--small u-align--center u-vertically-center">
-    {{  image(
-      url="https://assets.ubuntu.com/v1/636bd444-adguard-first-screen.png",
-      alt="AdGuard wizard screen",
-      width="600",
-      height="619",
-      hi_def=True,
-      loading="lazy",
-      ) | safe}}
+    <div class="col">
+      <div class="p-section--shallow">
+        <div class="p-image-container is-highlighted">
+          {{ image(url="https://assets.ubuntu.com/v1/60852f18-bottom-adguard.png",
+                    alt="",
+                    width="1800",
+                    height="1200",
+                    hi_def=True,
+                    loading="lazy",
+                    attrs={"class": "p-image-container__image"}) | safe
+          }}
+        </div>
+      </div>
+      <p>
+        Now you can go ahead and set everything up.  It's usually best to wait 5-10 minutes here. Some snaps will need to refresh themselves and the appliance may need to automatically reboot. When you're ready go to:
+      </p>
+      <pre><code>http://&lt;IP-of-your-appliance&gt;:3000</code></pre>
+      <p>in another computers browser. Where you will find the initial configuration wizard.</p>
+      <p>Follow the instructions to start using your new Adguard Home Ubuntu Appliance.</p>
+      <p>
+        On the AdGuard configuration screen, under DNS Server, it will have an error in red: <code>listen udp 0.0.0.0:53: bind: address already in use</code>.  Change the listen interface to <code>Eth0</code>.
+      </p>
+      <p>
+        Once you've finished the AdGuard configuration, you can connect to the admin panel by just going to <code>http://&lt;ip address&gt;</code> (no longer port 3000), and can configure other devices on your network to use that ip address for the DNS server.
+      </p>
+      <p>
+        For more information or more documentation on what to do now, the <a href="https://adguard.com/">AdGuard website</a> is the best place to go next.
+      </p>
     </div>
   </div>
 </section>

--- a/templates/appliance/adguard/_next-steps.html
+++ b/templates/appliance/adguard/_next-steps.html
@@ -2,13 +2,11 @@
   <div class="row--50-50">
     <hr class="p-rule" />
     <div class="col">
-      <div>
-        <h2>
-          Start using your {{ appliance.name }}
-          <br />
-          Ubuntu Appliance
-        </h2>
-      </div>
+      <h2>
+        Start using your AdGuard
+        <br />
+        Ubuntu Appliance
+      </h2>
     </div>
     <div class="col">
       <div class="p-section--shallow">

--- a/templates/appliance/lxd/_next-steps.html
+++ b/templates/appliance/lxd/_next-steps.html
@@ -1,34 +1,45 @@
-<section class="p-strip--light">
-  <div class="row u-equal-height">
-    <div class="col-6">
+<section class="p-section--deep">
+  <div class="row--50-50">
+    <hr class="p-rule" />
+    <div class="col">
+      <h2>
+        Start using your {{ appliance.name }}
+        <br />
+        Ubuntu Appliance
+      </h2>
+    </div>
+    <div class="col">
+      <div class="p-section--shallow">
+        <div class="p-image-container is-highlighted">
+          {{ image(url="https://assets.ubuntu.com/v1/0c7aa5b3-bottom-lxd.png",
+                    alt="",
+                    width="1800",
+                    height="1013",
+                    hi_def=True,
+                    loading="lazy",
+                    attrs={"class": "p-image-container__image"}) | safe
+          }}
+        </div>
+      </div>
       <div>
-        <h2>
-          Start using your {{ appliance.name }} Ubuntu Appliance
-        </h2>
         <p>
           Now you can go ahead and set everything up.  It's usually best to wait 5-10 minutes here. Some snaps will need to refresh themselves and the appliance may need to automatically reboot.
         </p>
-        <p>
-          When you're ready ssh into your appliance as described in step 6 and run:
-        </p>
+        <p>When you're ready ssh into your appliance as described in step 6 and run:</p>
         <pre><code>sudo lxc config set core.trust_password &lt;SOME PASSWORD&gt;</code></pre>
-        <p>
-          Then, on your main system (not the appliance) install the LXD client:
-        </p>
-        <ul>
-          <li>
+        <p>Then, on your main system (not the appliance) install the LXD client:</p>
+        <ul class="p-list--divided">
+          <li class="p-list__item has-bullet">
             <code>snap install lxd</code> on Linux
           </li>
-         <li>
-           <code>brew install lxc</code> on macOS
+          <li class="p-list__item has-bullet">
+            <code>brew install lxc</code> on macOS
           </li>
-          <li>
+          <li class="p-list__item has-bullet">
             <code>choco install lxc</code> on Windows
           </li>
         </ul>
-        <p>
-          And connect to the appliance with:
-        </p>
+        <p>And connect to the appliance with:</p>
         <pre>lxc remote add appliance IP-ADDRESS
 lxc list appliance:</pre>
         <p>
@@ -36,25 +47,13 @@ lxc list appliance:</pre>
         </p>
         <div class="p-notification" id="notification">
           <div class="p-notification__content">
-            <span class="p-notification__title">
-              Note:
-            </span>
+            <span class="p-notification__title">Note:</span>
             <p class="p-notification__message">
               If there is a core update, the appliance will automatically update, then reboot. Typically this isn't an issue but some use cases should take note.
             </p>
           </div>
         </div>
-    </div>
-  </div>
-  <div class="col-6 u-hide--medium u-hide--small u-align--center u-vertically-center">
-    {{  image(
-      url="https://assets.ubuntu.com/v1/d85ef015-image-lxd.svg",
-      alt="LXD illustration",
-      width="400",
-      height="368",
-      hi_def=True,
-      loading="lazy",
-      ) | safe}}
+      </div>
     </div>
   </div>
 </section>

--- a/templates/appliance/lxd/_next-steps.html
+++ b/templates/appliance/lxd/_next-steps.html
@@ -3,7 +3,7 @@
     <hr class="p-rule" />
     <div class="col">
       <h2>
-        Start using your {{ appliance.name }}
+        Start using your LXD
         <br />
         Ubuntu Appliance
       </h2>

--- a/templates/appliance/mosquitto/_next-steps.html
+++ b/templates/appliance/mosquitto/_next-steps.html
@@ -1,5 +1,5 @@
 <section class="p-section--deep">
-  <div class="row--50-50">
+  <div class="row--50-50-on-large">
     <hr class="p-rule" />
     <div class="col">
       <h2>

--- a/templates/appliance/mosquitto/_next-steps.html
+++ b/templates/appliance/mosquitto/_next-steps.html
@@ -1,9 +1,26 @@
-<section class="p-strip--light">
-  <div class="row u-equal-height">
-    <div class="col-8">
+<section class="p-section--deep">
+  <div class="row--50-50">
+    <hr class="p-rule" />
+    <div class="col">
       <h2>
-        Start using your Mosquitto Ubuntu Appliance
+        Start using your Mosquitto
+        <br />
+        Ubuntu Appliance
       </h2>
+    </div>
+    <div class="col">
+      <div class="p-section--shallow">
+        <div class="p-image-container is-highlighted">
+          {{ image(url="https://assets.ubuntu.com/v1/f884efa0-bottom-mosquitto.png",
+                    alt="",
+                    width="1800",
+                    height="1013",
+                    hi_def=True,
+                    loading="lazy",
+                    attrs={"class": "p-image-container__image"}) | safe
+          }}
+        </div>
+      </div>
       <p>
         After installing the Mosquitto image, the Mosquitto broker will be running with the default configuration, listening for connections on port 1883. To test the broker, you can use the <code>mosquitto-pub</code> and <code>mosquitto-sub</code> command-line utilities. This is a basic test example to start using your appliance. If you want more information about Mosquitto and what to do next the best place to go is the <a href="https://mosquitto.org/">Mosquitto website</a>.
       </p>
@@ -22,7 +39,8 @@
       <p>
         The <code>-t snap/example</code> option sets the topic to subscribe and can be provided multiple times. The <code>-v</code> option means to print both the topic of the message as well as its payload. Now to publish a message to the same topic you use mosquitto_pub:
       </p>
-      <pre><code>mosquitto_pub -h localhost -t 'snap/example' -m 'Hello from mosquitto_pub'</code></pre>
+      <pre><code>mosquitto_pub -h localhost -t 'snap/example' -m 'Hello from
+mosquitto_pub'</code></pre>
       <p>
         In this case, the <code>-m</code> option provides the message payload to be published. If everything works as planned, you should see <code>mosquitto_sub</code> print
       </p>
@@ -34,7 +52,8 @@
       <div class="p-notification" id="notification">
         <div class="p-notification__content">
           <span class="p-notification__title">Note:</span>
-          <p class="p-notification__message">The command line treats <code>#</code> as a special character, and <code>SSYS</code> will be expanded as an environment variable if you do not surround them with single quotes.
+          <p class="p-notification__message">
+            The command line treats <code>#</code> as a special character, and <code>SSYS</code> will be expanded as an environment variable if you do not surround them with single quotes.
           </p>
         </div>
       </div>
@@ -45,15 +64,5 @@
         This file contains all of the broker configurations, in a similar manner to the <a href="https://mosquitto.org/man/">man page</a>. To create your own configuration, copy the example file to <code>/var/snap/mosquitto/common/mosquitto.conf</code> and edit according to your needs. Any additional files required by the configuration, such as TLS certificates and keys, must also be placed in <code>/var/snap/mosquitto/common/</code> and have their full path provided in the configuration file.
       </p>
     </div>
-    <div class="col-4 u-hide--medium u-hide--small u-align--center u-vertically-center">
-      {{  image(
-        url="https://assets.ubuntu.com/v1/0fbfab25-mosquitto-text-side.png",
-        alt="",
-        width="400",
-        height="81",
-        hi_def=True,
-        loading="lazy",
-        ) | safe}}
-      </div>
-    </div>
-  </section>
+  </div>
+</section>

--- a/templates/appliance/mosquitto/_next-steps.html
+++ b/templates/appliance/mosquitto/_next-steps.html
@@ -47,7 +47,7 @@ mosquitto_pub'</code></pre>
 
       <pre><code>snap/example Hello from mosquitto_pub</code></pre>
       <p>
-        This is a very simple example but allows testing of the broker operation. Other things you may wish to try are subscribing to wildcard topics that include <code>#</code> or <code></code>, or subscribing to the <code>$SYS/#</code> topic to see the information the broker is publishing about itself.
+        This is a very simple example but allows testing of the broker operation. Other things you may wish to try are subscribing to wildcard topics that include <code>#</code>, or subscribing to the <code>$SYS/#</code> topic to see the information the broker is publishing about itself.
       </p>
       <div class="p-notification" id="notification">
         <div class="p-notification__content">

--- a/templates/appliance/nextcloud/_next-steps.html
+++ b/templates/appliance/nextcloud/_next-steps.html
@@ -23,11 +23,11 @@
       </p>
       <ul class="p-list--divided u-no-margin--bottom">
         <li class="p-list__item has-bullet">
-          On Raspberry Pis and PCs: <a href="http://nextcloud.local">http://nextcloud.local</a>
+          On Raspberry Pis and PCs: {# djlint:off #}<a href="http://nextcloud.local">http://nextcloud.local</a>{# djlint:on #}
 
         </li>
         <li class="p-list__item has-bullet">
-          On a Virtual machine: <code>http://&lt;IP-of-your-appliance&gt;</code>
+          On a Virtual machine: {# djlint:off #}<code>http://&lt;IP-of-your-appliance&gt;</code>{# djlint:on #}
         </li>
 
       </ul>

--- a/templates/appliance/nextcloud/_next-steps.html
+++ b/templates/appliance/nextcloud/_next-steps.html
@@ -3,7 +3,7 @@
     <hr class="p-rule" />
     <div class="col">
       <h2>
-        Start using your {{ appliance.name }}
+        Start using your Nextcloud
         <br />
         Ubuntu Appliance
       </h2>

--- a/templates/appliance/nextcloud/_next-steps.html
+++ b/templates/appliance/nextcloud/_next-steps.html
@@ -1,39 +1,39 @@
-<section class="p-strip--light">
-  <div class="row u-equal-height">
-    <div class="col-6">
-      <div>
-        <h2>
-          Start using your {{ appliance.name }} Ubuntu Appliance
-        </h2>
-        <p>
-          When you start Nextcloud for the first time you make an account and go through some initial configuration. To do so, open a browser and go to:
-        </p>
-        <p>
-          <em>On Raspberry Pis and PCs:</em>
-        </p>
-        <p>
-          <a href="http://nextcloud.local">http://nextcloud.local</a>
-        </p>
-        <p>
-          <em>On a Virtual machine:</em>
-        </p>
-        <p>
-          <code>http://&lt;IP-of-your-appliance&gt;</code>
-        </p>
-        <p>
-          After that, you can start using your new Nextcloud server. For more information and <a href="https://docs.nextcloud.com/server/18/admin_manual/installation/index.html">documentation</a> visit the <a href="https://docs.nextcloud.com/">Nextcloud website</a>.
-       </p>
-      </div>
+<section class="p-section--deep">
+  <div class="row--50-50">
+    <hr class="p-rule" />
+    <div class="col">
+      <h2>
+        Start using your {{ appliance.name }}
+        <br />
+        Ubuntu Appliance
+      </h2>
     </div>
-    <div class="col-6 u-hide--medium u-hide--small u-align--center u-vertically-center">
-      {{  image(
-        url="https://assets.ubuntu.com/v1/4945963f-nextcloud-screenshot.png ",
-        width="600",
-        alt="",
-        height="337",
-        hi_def=True,
-        loading="lazy",
-        ) | safe}}
+    <div class="col">
+      <div class="p-section--shallow">
+        {{ image(url="https://assets.ubuntu.com/v1/4c6ea9cd-bottom-nextcloud.png",
+                alt="",
+                width="1800",
+                height="1013",
+                hi_def=True,
+                loading="lazy") | safe
+        }}
       </div>
+      <p>
+        When you start Nextcloud for the first time you make an account and go through some initial configuration. To do so, open a browser and go to:
+      </p>
+      <ul class="p-list--divided u-no-margin--bottom">
+        <li class="p-list__item has-bullet">
+          On Raspberry Pis and PCs: <a href="http://nextcloud.local">http://nextcloud.local</a>
+
+        </li>
+        <li class="p-list__item has-bullet">
+          On a Virtual machine: <code>http://&lt;IP-of-your-appliance&gt;</code>
+        </li>
+
+      </ul>
+      <p>
+        After that, you can start using your new Nextcloud server. For more information and <a href="https://docs.nextcloud.com/server/18/admin_manual/installation/index.html">documentation</a> visit the <a href="https://docs.nextcloud.com/">Nextcloud website</a>.
+      </p>
     </div>
-  </section>
+  </div>
+</section>

--- a/templates/appliance/openhab/_next-steps.html
+++ b/templates/appliance/openhab/_next-steps.html
@@ -23,7 +23,7 @@
         When you start openHAB for the first time, it only starts the dashboard. So let's have a look at it: open a browser and browse to your openHAB dashboard:
       </p>
       <p>
-        <code>http://&lt;IP-of-your-machine&gt;:8080</code>
+        {# djlint:on #}<code>http://&lt;IP-of-your-machine&gt;:8080</code>{# djlint:off #}
       </p>
       <p>
         Now just follow the instructions on the screen to use your new openHAB Ubuntu Appliance. For more information or more <a href="https://www.openhab.org/docs/">documentation</a>, the <a href="https://www.openhab.org/">openHAB website</a> is the best place to go next.

--- a/templates/appliance/plex/_next-steps.html
+++ b/templates/appliance/plex/_next-steps.html
@@ -1,9 +1,26 @@
-<section class="p-strip--light">
-  <div class="row u-equal-height">
-    <div class="col-6">
+<section class="p-section--deep">
+  <div class="row--50-50">
+    <hr class="p-rule" />
+    <div class="col">
       <h2>
-        Start using your {{ appliance.name }} Ubuntu Appliance
+        Start using your {{ appliance.name }}
+        <br />
+        Ubuntu Appliance
       </h2>
+    </div>
+    <div class="col">
+      <div class="p-section--shallow">
+        <div class="p-image-container is-highlighted">
+          {{ image(url="https://assets.ubuntu.com/v1/fdf9ef8d-bottom-plex.png",
+                    alt="",
+                    width="1800",
+                    height="1200",
+                    hi_def=True,
+                    loading="lazy",
+                    attrs={"class": "p-image-container__image"}) | safe
+          }}
+        </div>
+      </div>
       <p>
         When you start Plex Media Server for the first time you make an account and go through some initial configuration. To do so, open a browser and go to:
       </p>
@@ -11,16 +28,5 @@
       <p>
         Then just follow the instructions on the screen. For more information or more <a href="https://support.plex.tv/articles/">documentation</a>, the <a href="https://www.plex.tv/">Plex Media Server website</a> is the best place to go next.
       </p>
-    </div>
-    <div class="col-6 u-hide--medium u-hide--small u-align--center u-vertically-center">
-      {{  image(
-        url="https://assets.ubuntu.com/v1/5765e231-plex-first-screen.png",
-        alt="Plex welcome screen",
-        width="717",
-        height="480",
-        hi_def=True,
-        loading="lazy",
-        ) | safe}}
-      </div>
     </div>
   </section>

--- a/templates/appliance/plex/_next-steps.html
+++ b/templates/appliance/plex/_next-steps.html
@@ -24,9 +24,12 @@
       <p>
         When you start Plex Media Server for the first time you make an account and go through some initial configuration. To do so, open a browser and go to:
       </p>
+      {# djlint:off #}
       <pre><code>http://&lt;IP-of-your-appliance&gt;:32400/web</code></pre>
+      {# djlint:on #}
       <p>
         Then just follow the instructions on the screen. For more information or more <a href="https://support.plex.tv/articles/">documentation</a>, the <a href="https://www.plex.tv/">Plex Media Server website</a> is the best place to go next.
       </p>
     </div>
-  </section>
+  </div>
+</section>

--- a/templates/appliance/plex/_next-steps.html
+++ b/templates/appliance/plex/_next-steps.html
@@ -3,7 +3,7 @@
     <hr class="p-rule" />
     <div class="col">
       <h2>
-        Start using your {{ appliance.name }}
+        Start using your Plex
         <br />
         Ubuntu Appliance
       </h2>

--- a/templates/appliance/shared/_appliance-os-tabs.html
+++ b/templates/appliance/shared/_appliance-os-tabs.html
@@ -1,0 +1,32 @@
+<nav class="p-tabs">
+  <ul class="p-tabs__list" role="tablist">
+    <li class="p-tabs__item" role="presentation">
+      <a href="#ubuntuos"
+         class="p-tabs__link"
+         id="ubuntuos-tab"
+         role="tab"
+         aria-controls="ubuntuos"
+         aria-selected="true">Ubuntu</a>
+    </li>
+    <li class="p-tabs__item" role="presentation">
+      <a href="#windows"
+         class="p-tabs__link"
+         role="tab"
+         id="windows-tab"
+         aria-controls="windows">Windows</a>
+    </li>
+    <li class="p-tabs__item" role="presentation">
+      <a href="#macos"
+         class="p-tabs__link"
+         role="tab"
+         id="macos-tab"
+         aria-controls="macos">macOS</a>
+    </li>
+  </ul>
+</nav>
+
+<style>
+  .p-tabs__content {
+    scroll-margin-top: 8rem
+  }
+</style>

--- a/templates/appliance/shared/_install_instructions_raspberry-pi.html
+++ b/templates/appliance/shared/_install_instructions_raspberry-pi.html
@@ -1,3 +1,13 @@
-<div class="p-strip is-shallow u-no-padding--top">
-  <p>These steps will flash your {{ appliance.appliance_name }} Ubuntu Appliance to your Raspberry Pi with a {{ os }} machine, and get you logged in.</p>
+<div class="p-section--shallow">
+  <div class="row--50-50-on-large">
+    <hr class="p-rule" />
+    <div class="col">
+      <h3>How to install</h3>
+    </div>
+    <div class="col">
+      <p>
+        <p>These steps will flash your {{ appliance.appliance_name }} Ubuntu Appliance to your Raspberry Pi with a {{ os }} machine, and get you logged in.</p>
+      </p>
+    </div>
+  </div>
 </div>

--- a/templates/appliance/shared/_raspberry-pi.html
+++ b/templates/appliance/shared/_raspberry-pi.html
@@ -61,7 +61,7 @@
            role="tabpanel"
            aria-labelledby="windows-tab">
         {% include "appliance/shared/_what_you_will_need_pi.html" %}
-        {% with  os="Windows" %}
+        {% with os="Windows" %}
           {% include "appliance/shared/_install_instructions_raspberry-pi.html" %}
         {% endwith %}
         <ol class="p-stepped-list--detailed">

--- a/templates/appliance/shared/_raspberry-pi.html
+++ b/templates/appliance/shared/_raspberry-pi.html
@@ -36,35 +36,7 @@
     </div>
 
     <div class="js-tab-container">
-      <nav class="p-tabs">
-        <ul class="p-tabs__list" role="tablist">
-          <li class="p-tabs__item" role="presentation">
-            <a href="#ubuntuos"
-               class="p-tabs__link"
-               id="ubuntuos-tab"
-               role="tab"
-               aria-controls="ubuntuos"
-               aria-selected="true">Ubuntu</a>
-          </li>
-          <li class="p-tabs__item" role="presentation">
-            <a href="#windows"
-               class="p-tabs__link"
-               tabindex="-1"
-               role="tab"
-               id="windows-tab"
-               aria-controls="windows">Windows</a>
-          </li>
-          <li class="p-tabs__item" role="presentation">
-            <a href="#macos"
-               class="p-tabs__link"
-               tabindex="-1"
-               role="tab"
-               id="macos-tab"
-               aria-controls="macos">macOS</a>
-          </li>
-        </ul>
-      </nav>
-
+      {% include "appliance/shared/_appliance-os-tabs.html" %}
       <div id="ubuntuos"
            class="p-tabs__content"
            role="tabpanel"

--- a/templates/appliance/shared/_raspberry-pi.html
+++ b/templates/appliance/shared/_raspberry-pi.html
@@ -1,59 +1,78 @@
-<section class="p-strip--suru-topped" style="overflow: visible;">
-  <div class="row u-vertically-center">
-    <div class="col-8">
-      {% if appliance.iso_url.raspberrypi %}
-      <h1>Install the {{ appliance.appliance_name }} Ubuntu Appliance for Raspberry&nbsp;Pi</h1>
-      <p class="u-no-margin--bottom">
-        <a class="p-button--positive is-inline u-no-margin--left" href="{{ appliance.iso_url.raspberrypi }}">Download the {{ appliance.appliance_name }} image</a>
-      </p>
-      {% include "appliance/shared/_verify-checksums.html" %}
-      {% else %}
-      <h1>Setup your Ubuntu {{ appliance.appliance_name }} appliance for Raspberry Pi</h1>
-      {% endif %}
+<section class="p-section--hero">
+  <div class="row--25-75-on-large">
+    <div class="col">
+      <div class="p-section--shallow p-image-wrapper">
+        {{ image(url="https://assets.ubuntu.com/v1/fd190a31-logo-raspberrypi.png",
+                alt="",
+                width="166",
+                height="45",
+                hi_def=True,
+                loading="auto") | safe
+        }}
+      </div>
     </div>
-    <div class="col-4 u-hide--medium u-hide--small u-align--center">
-      {{
-        image(
-        url="https://assets.ubuntu.com/v1/9f09965f-1+-+Download+and+install+Ubuntu+Server+on+Raspberry+Pi.svg",
-        alt="",
-        height="227",
-        width="350",
-        hi_def=True,
-        loading="auto"
-        ) | safe
-      }}
+    <div class="col">
+      <div class="p-section--shallow">
+        {% if appliance.iso_url.raspberrypi %}
+          <h1>Install the {{ appliance.appliance_name }} Ubuntu Appliance for Raspberry&nbsp;Pi</h1>
+          <div class="p-cta-block">
+            <a class="p-button--positive" href="{{ appliance.iso_url.raspberrypi }}">Download the {{ appliance.appliance_name }} image</a>
+
+            {% include "appliance/shared/_verify-checksums-pc.html" %}
+          </div>
+        {% else %}
+          <h1>Setup your Ubuntu {{ appliance.appliance_name }} appliance for Raspberry Pi</h1>
+        {% endif %}
+      </div>
     </div>
   </div>
 </section>
 
-<hr>
-<section class="p-strip is-bordered">
+<section class="p-section">
   <div class="u-fixed-width">
-    <h2>Installation instructions</h2>
+    <hr class="p-rule" />
+    <div class="p-section--shallow">
+      <h2>Installation instructions</h2>
+    </div>
+
     <div class="js-tab-container">
       <nav class="p-tabs">
         <ul class="p-tabs__list" role="tablist">
           <li class="p-tabs__item" role="presentation">
-            <a href="#ubuntuos" class="p-tabs__link" id="ubuntuos-tab" role="tab" aria-controls="ubuntuos" aria-selected="true">
-              Ubuntu
-            </a>
+            <a href="#ubuntuos"
+               class="p-tabs__link"
+               id="ubuntuos-tab"
+               role="tab"
+               aria-controls="ubuntuos"
+               aria-selected="true">Ubuntu</a>
           </li>
           <li class="p-tabs__item" role="presentation">
-            <a href="#windows" class="p-tabs__link" tabindex="-1" role="tab" id="windows-tab" aria-controls="windows">
-              Windows
-            </a>
+            <a href="#windows"
+               class="p-tabs__link"
+               tabindex="-1"
+               role="tab"
+               id="windows-tab"
+               aria-controls="windows">Windows</a>
           </li>
           <li class="p-tabs__item" role="presentation">
-            <a href="#macos" class="p-tabs__link" tabindex="-1" role="tab" id="macos-tab" aria-controls="macos">
-              macOS
-            </a>
+            <a href="#macos"
+               class="p-tabs__link"
+               tabindex="-1"
+               role="tab"
+               id="macos-tab"
+               aria-controls="macos">macOS</a>
           </li>
         </ul>
       </nav>
 
-      <div id="ubuntuos" class="p-tabs__content" role="tabpanel" aria-labelledby="ubuntuos-tab">
+      <div id="ubuntuos"
+           class="p-tabs__content"
+           role="tabpanel"
+           aria-labelledby="ubuntuos-tab">
         {% include "appliance/shared/_what_you_will_need_pi.html" %}
-        {% with os="Ubuntu" %}{% include "appliance/shared/_install_instructions_raspberry-pi.html" %}{% endwith %}
+        {% with os="Ubuntu" %}
+          {% include "appliance/shared/_install_instructions_raspberry-pi.html" %}
+        {% endwith %}
         <ol class="p-stepped-list--detailed">
           {% include 'appliance/shared/_steps_pi_imager_ubuntu.html' %}
           {% include 'appliance/shared/_steps_pi_prep-sd-card.html' %}
@@ -65,9 +84,14 @@
         </ol>
       </div>
 
-      <div id="windows" class="p-tabs__content" role="tabpanel" aria-labelledby="windows-tab">
+      <div id="windows"
+           class="p-tabs__content"
+           role="tabpanel"
+           aria-labelledby="windows-tab">
         {% include "appliance/shared/_what_you_will_need_pi.html" %}
-        {% with  os="Windows" %}{% include "appliance/shared/_install_instructions_raspberry-pi.html" %}{% endwith %}
+        {% with  os="Windows" %}
+          {% include "appliance/shared/_install_instructions_raspberry-pi.html" %}
+        {% endwith %}
         <ol class="p-stepped-list--detailed">
           {% include 'appliance/shared/_steps_pi_imager_windows.html' %}
           {% include 'appliance/shared/_steps_pi_prep-sd-card.html' %}
@@ -80,9 +104,14 @@
         </ol>
       </div>
 
-      <div id="macos" class="p-tabs__content" role="tabpanel" aria-labelledby="macos-tab">
+      <div id="macos"
+           class="p-tabs__content"
+           role="tabpanel"
+           aria-labelledby="macos-tab">
         {% include "appliance/shared/_what_you_will_need_pi.html" %}
-        {% with os="macOS" %}{% include "appliance/shared/_install_instructions_raspberry-pi.html" %}{% endwith %}
+        {% with os="macOS" %}
+          {% include "appliance/shared/_install_instructions_raspberry-pi.html" %}
+        {% endwith %}
         <ol class="p-stepped-list--detailed">
           {% include 'appliance/shared/_steps_pi_imager_macos.html' %}
           {% include 'appliance/shared/_steps_pi_prep-sd-card.html' %}
@@ -96,5 +125,15 @@
     </div>
   </div>
 </section>
+
+<style>
+  .p-stepped-list--detailed>.p-stepped-list__item:first-child {
+    &::after {
+      display: none;
+    }
+
+    border: 0;
+  }
+</style>
 
 <script src="{{ versioned_static('js/dist/tabotronic.js') }}" defer></script>

--- a/templates/appliance/shared/_steps_pi_imager_ubuntu.html
+++ b/templates/appliance/shared/_steps_pi_imager_ubuntu.html
@@ -4,7 +4,7 @@
   </h4>
   <p class="p-stepped-list__content">
     <a href="https://downloads.raspberrypi.org/imager/imager_1.6_amd64.deb">
-      Download the Imaging Tool for Ubuntu
+      Download the Imaging Tool for Ubuntu&nbsp;&rsaquo;
     </a>
   </p>
 </li>

--- a/templates/appliance/shared/_steps_pi_imager_windows.html
+++ b/templates/appliance/shared/_steps_pi_imager_windows.html
@@ -4,7 +4,7 @@
   </h4>
   <p class="p-stepped-list__content">
     <a href="https://downloads.raspberrypi.org/imager/imager_1.6.exe">
-      Download the Imaging Tool for Windows
+      Download the Imaging Tool for Windows&nbsp;&rsaquo;
     </a>
   </p>
 </li>

--- a/templates/appliance/shared/_steps_pi_prep-sd-card.html
+++ b/templates/appliance/shared/_steps_pi_prep-sd-card.html
@@ -1,42 +1,48 @@
 <li class="p-stepped-list__item">
-  <h4 class="p-stepped-list__title">
-    Prepare the microSD card
-  </h4>
+  <h4 class="p-stepped-list__title">Prepare the microSD card</h4>
   <div class="p-stepped-list__content">
-    <div class="p-notification--caution">
+    <div class="p-notification--caution is-light">
       <div class="p-notification__content">
         <span class="p-notification__title">Warning</span>
         <p class="p-notification__message">This will completely erase the microSD card.</p>
       </div>
     </div>
     <ul class="p-list">
-      <li>Insert the microSD card into your computer
-      </li>
-      <li>Run the imager and click <code>CHOOSE OS</code>
-        <div class="p-strip is-shallow">
-          {{  image(
-            url="https://assets.ubuntu.com/v1/1148ca79-1_.png",
-            alt="CHOOSE OS",
-            width="750",
-            height="505",
-            hi_def=True,
-            loading="lazy"  ) | safe}}
+      <li class="p-list__item">Insert the microSD card into your computer</li>
+      <li class="p-list__item">
+        <p>
+          Run the imager and click <code>CHOOSE OS</code>
+        </p>
+        <div class="p-section--shallow">
+          {{ image(url="https://assets.ubuntu.com/v1/7987f409-screenshot1.png",
+                    alt="",
+                    width="1800",
+                    height="1201",
+                    hi_def=True,
+                    loading="lazy") | safe
+          }}
         </div>
-        </li>
-        <li>Next, choose <code>Use Custom</code>. Select the image you downloaded.
-          <div class="p-strip is-shallow">
-            {{  image(      url="https://assets.ubuntu.com/v1/8f1a170c-raspberry-pi-imager-step2.png",
-            alt="Custom",
-            width="750",
-            height="494",
-            hi_def=True,
-            loading="lazy",       ) | safe}}
-          </div>
-        </li>
-        <li>Select your microSD card and click <code>WRITE</code>.</li>
-      </ul>
-      <p>
-        While it is preparing the disk you can go on to the next step and create your SSH keys for secure access to the appliance.
-      </p>
-    </div>
-  </li>
+      </li>
+      <li class="p-list__item">
+        <p>
+          Next, choose <code>Use Custom</code>. Select the image you downloaded.
+        </p>
+        <div class="p-section--shallow">
+          {{ image(url="https://assets.ubuntu.com/v1/aea8201e-screenshot2.png",
+                    alt="",
+                    width="1800",
+                    height="1201",
+                    hi_def=True,
+                    loading="lazy") | safe
+          }}
+        </div>
+      </li class="p-list__item">
+      <li>
+        Select your microSD card and click <code>WRITE</code>.
+      </li>
+    </ul>
+    <p>
+      While it is preparing the disk you can go on to the next step and create your SSH keys for secure access to the appliance.
+    </p>
+  </div>
+</li>

--- a/templates/appliance/shared/_steps_pi_thats-it.html
+++ b/templates/appliance/shared/_steps_pi_thats-it.html
@@ -1,4 +1,4 @@
-<li class="p-stepped-list__item">
+<li class="p-stepped-list__item u-no-padding--bottom">
   <h4 class="p-stepped-list__title">
     That's it
   </h4>

--- a/templates/appliance/shared/_what_you_will_need_pi.html
+++ b/templates/appliance/shared/_what_you_will_need_pi.html
@@ -5,31 +5,12 @@
   <div class="col">
     <ul class="p-list--divided">
       <li class="p-list__item is-ticked">A microSD card (4GB minimum, 8GB recommended)</li>
-      <li class="p-list__item is-ticked">A Raspberry Pi 
-        {% if appliance.pi is defined and appliance.pi %}
-          {% if appliance.pi.3 %}3{% endif %}
-          {% if appliance.pi.3 and appliance.pi.4 %} &amp; {% endif %}
-          {% if appliance.pi.4 %}4{% endif %}
-        {% else %}3 or 4{% endif %}</li>
+      <li class="p-list__item is-ticked">A Raspberry Pi 3 or 4</li>
       <li class="p-list__item is-ticked">A computer with a microSD card drive</li>
-      <li class="p-list__item is-ticked">A 
-        {% if appliance.pi is defined and appliance.pi %}
-        {% if appliance.pi.3 %}micro-USB power cable{% endif %}
-        {% if appliance.pi.3 and appliance.pi.4 %} ({% endif %}
-        {% if appliance.pi.4 %}USB-C cable for the Pi 4{% endif %}
-        {% if appliance.pi.3 and appliance.pi.4 %}) {% endif %}
-      {% else %}micro-USB power cable (USB-C cable for the Pi 4){% endif %}</li>
+      <li class="p-list__item is-ticked">A micro-USB power cable (USB-C cable for the Pi 4)</li>
       <li class="p-list__item is-ticked">A monitor with an HDMI interface</li>
-      <li class="p-list__item is-ticked">A{% if appliance.pi is defined and appliance.pi %}
-        {% if appliance.pi.3 %}n HDMI cable for the Pi 3{% endif %}
-        {% if appliance.pi.3 and appliance.pi.4 %} and a{% endif %}
-        {% if appliance.pi.4 %} MicroHDMI cable for the Pi 4{% endif %}
-        {% if appliance.pi.3 and appliance.pi.4 %}) {% endif %}
-      {% else %}HDMI cable for the Pi 3 and a MicroHDMI cable for the Pi 4{% endif %}</li>
+      <li class="p-list__item is-ticked">An HDMI cable for the Pi 3 and a MicroHDMI cable for the Pi 4 </li>
       <li class="p-list__item is-ticked">A USB keyboard</li>
-      {% if appliance.extra_requirements is defined and appliance.extra_requirements.raspberrypi %}
-      <li class="p-list__item is-ticked">{{ appliance.extra_requirements.raspberrypi }}</li>
-      {% endif %}
     </ul>
   </div>
 </div>

--- a/templates/appliance/shared/_what_you_will_need_pi.html
+++ b/templates/appliance/shared/_what_you_will_need_pi.html
@@ -1,30 +1,35 @@
-<h4>What you'll need</h4>
-<ul class="p-list is-split">
-  <li class="p-list__item is-ticked">A microSD card (4GB minimum, 8GB recommended)</li>
-  <li class="p-list__item is-ticked">A Raspberry Pi 
-    {% if appliance.pi is defined and appliance.pi %}
-      {% if appliance.pi.3 %}3{% endif %}
-      {% if appliance.pi.3 and appliance.pi.4 %} &amp; {% endif %}
-      {% if appliance.pi.4 %}4{% endif %}
-    {% else %}3 or 4{% endif %}</li>
-  <li class="p-list__item is-ticked">A computer with a microSD card drive</li>
-  <li class="p-list__item is-ticked">A 
-    {% if appliance.pi is defined and appliance.pi %}
-    {% if appliance.pi.3 %}micro-USB power cable{% endif %}
-    {% if appliance.pi.3 and appliance.pi.4 %} ({% endif %}
-    {% if appliance.pi.4 %}USB-C cable for the Pi 4{% endif %}
-    {% if appliance.pi.3 and appliance.pi.4 %}) {% endif %}
-  {% else %}micro-USB power cable (USB-C cable for the Pi 4){% endif %}</li>
-  <li class="p-list__item is-ticked">A monitor with an HDMI interface</li>
-  <li class="p-list__item is-ticked">A{% if appliance.pi is defined and appliance.pi %}
-    {% if appliance.pi.3 %}n HDMI cable for the Pi 3{% endif %}
-    {% if appliance.pi.3 and appliance.pi.4 %} and a{% endif %}
-    {% if appliance.pi.4 %} MicroHDMI cable for the Pi 4{% endif %}
-    {% if appliance.pi.3 and appliance.pi.4 %}) {% endif %}
-  {% else %}HDMI cable for the Pi 3 and a MicroHDMI cable for the Pi 4{% endif %}</li>
-  <li class="p-list__item is-ticked">A USB keyboard</li>
-  {% if appliance.extra_requirements is defined and appliance.extra_requirements.raspberrypi %}
-  <li class="p-list__item is-ticked">{{ appliance.extra_requirements.raspberrypi }}</li>
-  {% endif %}
-</ul>
-<hr>
+<div class="row--50-50-on-large">
+  <div class="col">
+    <h3>What you'll need</h3>
+  </div>
+  <div class="col">
+    <ul class="p-list--divided">
+      <li class="p-list__item is-ticked">A microSD card (4GB minimum, 8GB recommended)</li>
+      <li class="p-list__item is-ticked">A Raspberry Pi 
+        {% if appliance.pi is defined and appliance.pi %}
+          {% if appliance.pi.3 %}3{% endif %}
+          {% if appliance.pi.3 and appliance.pi.4 %} &amp; {% endif %}
+          {% if appliance.pi.4 %}4{% endif %}
+        {% else %}3 or 4{% endif %}</li>
+      <li class="p-list__item is-ticked">A computer with a microSD card drive</li>
+      <li class="p-list__item is-ticked">A 
+        {% if appliance.pi is defined and appliance.pi %}
+        {% if appliance.pi.3 %}micro-USB power cable{% endif %}
+        {% if appliance.pi.3 and appliance.pi.4 %} ({% endif %}
+        {% if appliance.pi.4 %}USB-C cable for the Pi 4{% endif %}
+        {% if appliance.pi.3 and appliance.pi.4 %}) {% endif %}
+      {% else %}micro-USB power cable (USB-C cable for the Pi 4){% endif %}</li>
+      <li class="p-list__item is-ticked">A monitor with an HDMI interface</li>
+      <li class="p-list__item is-ticked">A{% if appliance.pi is defined and appliance.pi %}
+        {% if appliance.pi.3 %}n HDMI cable for the Pi 3{% endif %}
+        {% if appliance.pi.3 and appliance.pi.4 %} and a{% endif %}
+        {% if appliance.pi.4 %} MicroHDMI cable for the Pi 4{% endif %}
+        {% if appliance.pi.3 and appliance.pi.4 %}) {% endif %}
+      {% else %}HDMI cable for the Pi 3 and a MicroHDMI cable for the Pi 4{% endif %}</li>
+      <li class="p-list__item is-ticked">A USB keyboard</li>
+      {% if appliance.extra_requirements is defined and appliance.extra_requirements.raspberrypi %}
+      <li class="p-list__item is-ticked">{{ appliance.extra_requirements.raspberrypi }}</li>
+      {% endif %}
+    </ul>
+  </div>
+</div>


### PR DESCRIPTION
## Done

- Applied redesign for lxd templates as per [mock-up](https://www.figma.com/design/POgmRw4Rpq1hlgaD9DN8mS/ubuntu.com%2Fappliance?node-id=964-10029&m=dev)
- Updated footer designs for remaining footers

## QA

- View the site locally in your web browser at: https://ubuntu-com-14914.demos.haus/appliance/nextcloud/raspberry-pi
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check against mock-up (content itself should not change)
- For the footer templates, please check the following:
  -   https://ubuntu-com-14914.demos.haus/appliance/adguard/raspberry-pi
  - https://ubuntu-com-14914.demos.haus/appliance/openhab/raspberry-pi
  - https://ubuntu-com-14914.demos.haus/appliance/lxd/raspberry-pi
  - https://ubuntu-com-14914.demos.haus/appliance/plex/raspberry-pi
  - https://ubuntu-com-14914.demos.haus/appliance/mosquitto/raspberry-pi

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-16589
