### PR TITLE
feat: update remaining vm and rasp-2 appliance templates

### DIFF
--- a/templates/appliance/_base-appliance.html
+++ b/templates/appliance/_base-appliance.html
@@ -10,4 +10,17 @@
   {% block content %}{% endblock %}
   <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/_appliance" data-form-id="3231" data-lp-id="6279" data-return-url="https://ubuntu.com/appliance#contact-form-success" data-lp-url="https://pages.ubuntu.com/things-contact-us.html"></div>
   <script src="{{ versioned_static('js/dist/appliance.js') }}" defer></script>
+
+  <style>
+    .p-stepped-list--detailed ol li {
+      margin-bottom: 1rem;
+    }
+  
+    .p-stepped-list--detailed > .p-stepped-list__item:first-child {
+      &::after {
+        display: none;
+      }
+      border: 0;
+    }
+  </style>
 {% endblock %}

--- a/templates/appliance/shared/_install_instructions_vm_macos.html
+++ b/templates/appliance/shared/_install_instructions_vm_macos.html
@@ -1,6 +1,12 @@
-<h4>What you'll need</h4>
-<ul class="p-list is-split">
-  <li class="p-list__item is-ticked">
-    A Mac running macOS and <a href="https://www.oracle.com/technetwork/server-storage/virtualbox/downloads/index.html">VirtualBox</a>. To use Multipass on macOS <a href="https://multipass.run/docs/using-virtualbox-in-multipass-macos">this is required</a>.
-  </li>
-</ul>
+<div class="row--50-50-on-large">
+  <div class="col">
+    <h3>What you'll need</h3>
+  </div>
+  <div class="col">
+    <ul class="p-list--divided">
+      <li class="p-list__item is-ticked">
+        A Mac running macOS and <a href="https://www.oracle.com/technetwork/server-storage/virtualbox/downloads/index.html">VirtualBox</a>. To use Multipass on macOS <a href="https://multipass.run/docs/using-virtualbox-in-multipass-macos">this is required</a>.
+      </li>
+    </ul>
+  </div>
+</div>

--- a/templates/appliance/shared/_install_instructions_vm_ubuntu.html
+++ b/templates/appliance/shared/_install_instructions_vm_ubuntu.html
@@ -1,4 +1,10 @@
-<h4>What you'll need</h4>
-<ul class="p-list is-split">
-  <li class="p-list__item is-ticked">A PC running Ubuntu 18.04 LTS or later</li>
-</ul>
+<div class="row--50-50-on-large">
+  <div class="col">
+    <h3>What you'll need</h3>
+  </div>
+  <div class="col">
+    <ul class="p-list--divided">
+      <li class="p-list__item is-ticked">A PC running Ubuntu 18.04 LTS or later</li>
+    </ul>
+  </div>
+</div>

--- a/templates/appliance/shared/_install_instructions_vm_windows.html
+++ b/templates/appliance/shared/_install_instructions_vm_windows.html
@@ -1,6 +1,12 @@
-<h4>What you'll need</h4>
-<ul class="p-list is-split">
-  <li class="p-list__item is-ticked">
-    A PC running Windows 10 Pro/Enterprise/Education Update 1803 or later, or any version of Windows with <a href="https://www.oracle.com/technetwork/server-storage/virtualbox/downloads/index.html">VirtualBox</a>.
-  </li>
-</ul>
+<div class="row--50-50-on-large">
+  <div class="col">
+    <h3>What you'll need</h3>
+  </div>
+  <div class="col">
+    <ul class="p-list--divided">
+      <li class="p-list__item is-ticked">
+        A PC running Windows 10 Pro/Enterprise/Education Update 1803 or later, or any version of Windows with <a href="https://www.oracle.com/technetwork/server-storage/virtualbox/downloads/index.html">VirtualBox</a>.
+      </li>
+    </ul>
+  </div>
+</div>

--- a/templates/appliance/shared/_intel-nuc.html
+++ b/templates/appliance/shared/_intel-nuc.html
@@ -22,7 +22,7 @@
           <div class="p-cta-block">
             <a class="p-button--positive is-inline u-no-margin--left"
                href="{{ appliance.iso_url.pc }}">Download the {{ appliance.appliance_name }} image</a>
-            {% include "appliance/shared/_verify-checksums-pc.html" %}
+            {% include "appliance/shared/_verify-checksums.html" %}
           </div>
         {% else %}
           <h1>Setup your Ubuntu {{ appliance.name }} appliance for an Intel NUC</h1>
@@ -40,32 +40,7 @@
     </div>
 
     <div class="js-tab-container">
-      <nav class="p-tabs">
-        <ul class="p-tabs__list js-tabbed-content" role="tablist" aria-label="Intel NUC installation instructions" data-maintain-hash="true">
-          <li class="p-tabs__item" role="presentation">
-            <a href="#ubuntuos"
-               class="p-tabs__link"
-               id="ubuntuos-tab"
-               role="tab"
-               aria-controls="ubuntuos"
-               aria-selected="true">Ubuntu</a>
-          </li>
-          <li class="p-tabs__item" role="presentation">
-            <a href="#windows"
-               class="p-tabs__link"
-               role="tab"
-               id="windows-tab"
-               aria-controls="windows">Windows</a>
-          </li>
-          <li class="p-tabs__item" role="presentation">
-            <a href="#macos"
-               class="p-tabs__link"
-               role="tab"
-               id="macos-tab"
-               aria-controls="macos">macOS</a>
-          </li>
-        </ul>
-      </nav>
+      {% include "appliance/shared/_appliance-os-tabs.html" %}
 
       <section id="ubuntuos"
                class="p-tabs__content"
@@ -133,17 +108,4 @@
   </div>
 </section>
 
-<style>
-  .p-stepped-list--detailed ol li {
-    margin-bottom: 1rem;
-  }
-
-  .p-stepped-list--detailed > .p-stepped-list__item:first-child {
-    &::after {
-      display: none;
-    }
-    border: 0;
-  }
-</style>
-
-<script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
+<script src="{{ versioned_static('js/dist/tabotronic.js') }}" defer></script>

--- a/templates/appliance/shared/_raspberry-pi2.html
+++ b/templates/appliance/shared/_raspberry-pi2.html
@@ -1,93 +1,103 @@
-<section class="p-strip--suru-topped" style="overflow: visible;">
-  <div class="row u-vertically-center">
-    <div class="col-8">
-      {% if appliance.iso_url.pi2 %}
-      <h1>Install the {{ appliance.appliance_name }} Ubuntu Appliance for Raspberry Pi 2</h1>
-      <p class="u-no-margin--bottom">
-        <a class="p-button--positive is-inline u-no-margin--left" href="{{ appliance.iso_url.pi2 }}">Download the {{ appliance.appliance_name }} image</a>
-      </p>
-      {% include "appliance/shared/_verify-checksums.html" %}
-      {% else %}
-      <h1>Setup your Ubuntu {{ appliance.appliance_name }} appliance for Raspberry Pi 2</h1>
-      {% endif %}
+<section class="p-section--hero">
+  <div class="row--25-75-on-large">
+    <div class="col">
+      <div class="p-section--shallow p-image-wrapper">
+        {{ image(url="https://assets.ubuntu.com/v1/fd190a31-logo-raspberrypi.png",
+                alt="",
+                width="166",
+                height="45",
+                hi_def=True,
+                loading="auto") | safe
+        }}
+      </div>
     </div>
-    <div class="col-4 u-hide--medium u-hide--small u-align--center">
-      {{
-        image(
-          url="https://assets.ubuntu.com/v1/fb8a736f-Pi2.jpg?w=225",
-          alt="",
-          height="143",
-          width="225",
-          hi_def=True,
-          loading="auto"
-        ) | safe
-      }}
+    <div class="col">
+      <div class="p-section--shallow">
+        {% if appliance.iso_url.pi2 %}
+          <h1>
+            Install the {{ appliance.appliance_name }} Ubuntu Appliance
+            <br />
+            for Raspberry Pi 2
+          </h1>
+          <div class="p-cta-block">
+            <a class="p-button--positive" href="{{ appliance.iso_url.pi2 }}">Download the {{ appliance.appliance_name }} image</a>
+            {% include "appliance/shared/_verify-checksums.html" %}
+
+          </div>
+        {% else %}
+          <h1>Setup your Ubuntu {{ appliance.appliance_name }} appliance for Raspberry Pi 2</h1>
+        {% endif %}
+      </div>
     </div>
   </div>
 </section>
 
-<hr>
-<section class="p-strip is-bordered">
+<section class="p-section">
   <div class="u-fixed-width">
-    <h2>Installation instructions</h2>
+    <hr class="p-rule" />
+    <div class="p-section--shallow">
+      <h2>Installation instructions</h2>
+    </div>
     <div class="js-tab-container">
-      <nav class="p-tabs">
-        <ul class="p-tabs__list" role="tablist">
-          <li class="p-tabs__item" role="presentation">
-            <a href="#ubuntuos" class="p-tabs__link" id="ubuntuos-tab" role="tab" aria-controls="ubuntuos" aria-selected="true">
-              Ubuntu
-            </a>
-          </li>
-          <li class="p-tabs__item" role="presentation">
-            <a href="#windows" class="p-tabs__link" tabindex="-1" role="tab" id="windows-tab" aria-controls="windows">
-              Windows
-            </a>
-          </li>
-          <li class="p-tabs__item" role="presentation">
-            <a href="#macos" class="p-tabs__link" tabindex="-1" role="tab" id="macos-tab" aria-controls="macos">
-              macOS
-            </a>
-          </li>
-        </ul>
-      </nav>
-
-      <div id="ubuntuos" class="p-tabs__content" role="tabpanel" aria-labelledby="ubuntuos-tab">
+      {% include "appliance/shared/_appliance-os-tabs.html" %}
+      <div id="ubuntuos"
+           class="p-tabs__content"
+           role="tabpanel"
+           aria-labelledby="ubuntuos-tab">
         {% include "appliance/shared/_what_you_will_need_pi2.html" %}
-        {% with os="Ubuntu" %}{% include "appliance/shared/_install_instructions_raspberry-pi.html" %}{% endwith %}
+        {% with os="Ubuntu" %}
+          {% include "appliance/shared/_install_instructions_raspberry-pi.html" %}
+        {% endwith %}
         <ol class="p-stepped-list--detailed">
           {% include 'appliance/shared/_steps_pi_imager_ubuntu.html' %}
           {% include 'appliance/shared/_steps_pi_prep-sd-card.html' %}
           {% include 'appliance/shared/_steps_ssh-keys_ubuntu.html' %}
           {% include 'appliance/shared/_steps_sso.html' %}
-          {% with command='cat' %}{% include 'appliance/shared/_steps_pi_boot-raspberry-pi.html' %}{% endwith %}
+          {% with command='cat' %}
+            {% include 'appliance/shared/_steps_pi_boot-raspberry-pi.html' %}
+          {% endwith %}
           {% include 'appliance/shared/_steps_pi_ssh-in.html' %}
           {% include 'appliance/shared/_steps_pi_thats-it.html' %}
         </ol>
       </div>
 
-      <div id="windows" class="p-tabs__content" role="tabpanel" aria-labelledby="windows-tab">
+      <div id="windows"
+           class="p-tabs__content"
+           role="tabpanel"
+           aria-labelledby="windows-tab">
         {% include "appliance/shared/_what_you_will_need_pi2.html" %}
-        {% with  os="Windows" %}{% include "appliance/shared/_install_instructions_raspberry-pi.html" %}{% endwith %}
+        {% with os="Windows" %}
+          {% include "appliance/shared/_install_instructions_raspberry-pi.html" %}
+        {% endwith %}
         <ol class="p-stepped-list--detailed">
           {% include 'appliance/shared/_steps_pi_imager_windows.html' %}
           {% include 'appliance/shared/_steps_pi_prep-sd-card.html' %}
           {% include 'appliance/shared/_steps_ssh-keys_windows.html' %}
           {% include 'appliance/shared/_steps_sso.html' %}
-          {% with command='type' %}{% include 'appliance/shared/_steps_pi_boot-raspberry-pi.html' %}{% endwith %}
+          {% with command='type' %}
+            {% include 'appliance/shared/_steps_pi_boot-raspberry-pi.html' %}
+          {% endwith %}
           {% include 'appliance/shared/_steps_pi_ssh-in.html' %}
           {% include 'appliance/shared/_steps_pi_thats-it.html' %}
         </ol>
       </div>
 
-      <div id="macos" class="p-tabs__content" role="tabpanel" aria-labelledby="macos-tab">
+      <div id="macos"
+           class="p-tabs__content"
+           role="tabpanel"
+           aria-labelledby="macos-tab">
         {% include "appliance/shared/_what_you_will_need_pi2.html" %}
-        {% with os="macOS" %}{% include "appliance/shared/_install_instructions_raspberry-pi.html" %}{% endwith %}
+        {% with os="macOS" %}
+          {% include "appliance/shared/_install_instructions_raspberry-pi.html" %}
+        {% endwith %}
         <ol class="p-stepped-list--detailed">
           {% include 'appliance/shared/_steps_pi_imager_macos.html' %}
           {% include 'appliance/shared/_steps_pi_prep-sd-card.html' %}
           {% include 'appliance/shared/_steps_ssh-keys_macos.html' %}
           {% include 'appliance/shared/_steps_sso.html' %}
-          {% with command='cat' %}{% include 'appliance/shared/_steps_pi_boot-raspberry-pi.html' %}{% endwith %}
+          {% with command='cat' %}
+            {% include 'appliance/shared/_steps_pi_boot-raspberry-pi.html' %}
+          {% endwith %}
           {% include 'appliance/shared/_steps_pi_ssh-in.html' %}
           {% include 'appliance/shared/_steps_pi_thats-it.html' %}
         </ol>

--- a/templates/appliance/shared/_steps-multipass-find-ip-macos.html
+++ b/templates/appliance/shared/_steps-multipass-find-ip-macos.html
@@ -1,12 +1,9 @@
 <li class="p-stepped-list__item">
-  <h4 class="p-stepped-list__title">
-    Find your appliance
-  </h4>
+  <h4 class="p-stepped-list__title">Find your appliance</h4>
   <div class="p-stepped-list__content">
-    <p>
-      To use VirtualBox's port forwarding run:
-    </p>
-    <pre><code>sudo VBoxManage controlvm "&lt;instance name&gt;" --natpf1 "{{ appliance.alias }},tcp,,{{ appliance.port }},,{{ appliance.port }}"</code></pre>
+    <p>To use VirtualBox's port forwarding run:</p>
+    <pre><code>sudo VBoxManage controlvm "&lt;instance name&gt;" --natpf1
+"{{ appliance.alias }},tcp,,{{ appliance.port }},,{{ appliance.port }}"</code></pre>
     <p>
       You can find more information about what this command means in the <a href="https://multipass.run/docs/using-virtualbox-in-multipass-macos#port-forwarding">Multipass documentation</a>.
     </p>

--- a/templates/appliance/shared/_steps-multipass-find-ip-windows.html
+++ b/templates/appliance/shared/_steps-multipass-find-ip-windows.html
@@ -1,24 +1,16 @@
 <li class="p-stepped-list__item">
-  <h4 class="p-stepped-list__title">
-    Find and connect to your appliance
-  </h4>
-    <div class="p-stepped-list__content">
-      <h5>
-        Hyper-V instructions
-      </h5>
-      <p>
-        On Hyper-V, find your virtual appliance IP address:
-      </p>
-      <pre><code>multipass list</code></pre>
-      <h5>
-        VirtualBox instructions
-      </h5>
-      <p>
-        On VirtualBox, forward the appliance port to the outside world with this command in an Administrator PowerShell:
-      </p>
-      <pre><code>env:USERPROFILE\Downloads\PSTools\PsExec.exe -s $env:VBOX_MSI_INSTALL_PATH\VBoxManage.exe controlvm "&lt;instance name&gt;" --natpf1 "{{ appliance.alias }},tcp,,{{ appliance.port}},,{{ appliance.port}}"</code></pre>
-      <p>
-        For more information about this command see the <a href="https://multipass.run/docs/using-virtualbox-in-multipass-windows#port-forwarding">Multipass documentation</a>.
-      </p>
-    </div>
+  <h4 class="p-stepped-list__title">Find and connect to your appliance</h4>
+  <div class="p-stepped-list__content">
+    <h5>Hyper-V instructions</h5>
+    <p>On Hyper-V, find your virtual appliance IP address:</p>
+    <pre><code>multipass list</code></pre>
+    <h5>VirtualBox instructions</h5>
+    <p>On VirtualBox, forward the appliance port to the outside world with this command in an Administrator PowerShell:</p>
+    <pre><code>env:USERPROFILE\Downloads\PSTools\PsExec.exe -s
+$env:VBOX_MSI_INSTALL_PATH\VBoxManage.exe controlvm "&lt;instance 
+name&gt;" --natpf1 "{{ appliance.alias }},tcp,,{{ appliance.port}},,{{ appliance.port}}"</code></pre>
+    <p>
+      For more information about this command see the <a href="https://multipass.run/docs/using-virtualbox-in-multipass-windows#port-forwarding">Multipass documentation</a>.
+    </p>
+  </div>
 </li>

--- a/templates/appliance/shared/_steps_multipass_macos.html
+++ b/templates/appliance/shared/_steps_multipass_macos.html
@@ -1,7 +1,5 @@
 <li class="p-stepped-list__item">
-  <h4 class="p-stepped-list__title">
-    Install Multipass
-  </h4>
+  <h4 class="p-stepped-list__title">Install Multipass</h4>
   <div class="p-stepped-list__content">
     <ol>
       <li>
@@ -10,24 +8,17 @@
         </p>
       </li>
       <li>
-        <p>
-          Activate the downloaded installer in an account with Administrator privileges.
-        </p>
-        {{
-          image (
-          url="https://assets.ubuntu.com/v1/ac6f638d-multipass-macos-install-screen.png",
-          alt="",
-          width="658",
-          height="475",
-          hi_def=True,
-          loading="lazy",
-          ) | safe
+        <p>Activate the downloaded installer in an account with Administrator privileges.</p>
+        {{ image(url="https://assets.ubuntu.com/v1/e16fba1a-vm-macos.png",
+                alt="",
+                width="1656",
+                height="1196",
+                hi_def=True,
+                loading="lazy") | safe
         }}
       </li>
       <li>
-        <p>
-          To start Multipass with VirtualBox use this Terminal app command:
-        </p>
+        <p>To start Multipass with VirtualBox use this Terminal app command:</p>
         <pre><code>sudo multipass set local.driver=virtualbox</code></pre>
       </li>
     </ol>

--- a/templates/appliance/shared/_steps_pi_imager_macos.html
+++ b/templates/appliance/shared/_steps_pi_imager_macos.html
@@ -4,7 +4,7 @@
   </h4>
   <p class="p-stepped-list__content">
     <a href="https://downloads.raspberrypi.org/imager/imager_1.6.dmg">
-      Download the Imaging Tool for macOS
+      Download the Imaging Tool for macOS&nbsp;&rsaquo;
     </a>
   </p>
 </li>

--- a/templates/appliance/shared/_steps_vm_intro.html
+++ b/templates/appliance/shared/_steps_vm_intro.html
@@ -1,3 +1,13 @@
-<div class="p-strip is-shallow u-no-padding--top">
-  <p>We will walk you through the steps of setting up your {{ appliance.appliance_name }} Ubuntu Appliance in a vm with Multipass and get logged in.</p>
+<div class="p-section--shallow">
+  <div class="row--50-50-on-large">
+    <hr class="p-rule" />
+    <div class="col">
+      <h3>How to install</h3>
+    </div>
+    <div class="col">
+      <p>
+        We will walk you through the steps of setting up your {{ appliance.appliance_name }} Ubuntu Appliance in a vm with Multipass and get logged in.
+      </p>
+    </div>
+  </div>
 </div>

--- a/templates/appliance/shared/_steps_vm_thats-it.html
+++ b/templates/appliance/shared/_steps_vm_thats-it.html
@@ -1,11 +1,9 @@
-<li class="p-stepped-list__item">
-  <h4 class="p-stepped-list__title">
-    That's it
-  </h4>
+<li class="p-stepped-list__item u-no-padding--bottom">
+  <h4 class="p-stepped-list__title">That's it</h4>
   <div class="p-stepped-list__content">
     <p>
       Your appliance is now running in a virtual machine. Start and stop it with <code>multipass start &lt;name&gt;</code> and <code>multipass stop &lt;name&gt;</code>. To access the command-line:
-      </p>
+    </p>
     <pre><code>multipass shell {{ appliance.alias }}</code></pre>
   </div>
 </li>

--- a/templates/appliance/shared/_verify-checksums.html
+++ b/templates/appliance/shared/_verify-checksums.html
@@ -1,14 +1,34 @@
-<p>
-<span class="p-contextual-menu--left">
-    <a href="#" class="p-contextual-menu__toggle" data-trigger="click" aria-controls="menu-4" aria-expanded="false" aria-haspopup="true"><i class="p-icon--information"></i>&nbsp;&nbsp;&nbsp;Verify your download</a>
-    <span class="p-contextual-menu__dropdown" id="menu-4" aria-hidden="true" aria-label="Verification instructions:" style="width: 600px; max-width: 70vw; padding: 1rem; z-index: 10;">
-      <span class="p-contextual-menu__group">
+<p class="js-checksum-tooltip">
+  <span class="p-contextual-menu--left">
+    <a href="#" class="p-contextual-menu__toggle js-checksum-toggle" data-trigger="click" aria-controls="menu-4" aria-expanded="false" aria-haspopup="true"><i class="p-icon--information"></i>&nbsp;&nbsp;&nbsp;How to verify your download</a>
+    <span class="p-contextual-menu__dropdown js-checksum-dropdown" id="menu-4" aria-hidden="true" aria-label="Verification instructions:" style="width: 600px; max-width: 70vw; padding: 1rem; z-index: 10;">
+      <span  class="p-contextual-menu__group">
         <small>Run this command in your terminal in the directory the iso was downloaded to verify the SHA256 checksum:</small><br />
-        <code style="display: block; margin-top: 1rem;">echo "{{ appliance.checksum.raspberrypi }}" | shasum -a 256 --check</code><br />
+        <code style="display: block; margin-top: 1rem;">echo {% if "raspberry-pi" in request.path %} "{{ appliance.checksum.raspberrypi }}" {% else %} "{{ appliance.checksum.pc }}" {% endif %} | shasum -a 256 --check</code><br />
         <small>You should get the following output:</small><br />
-        <code style="display: block; margin-top: 1rem;">{{ appliance.iso_url.raspberrypi }}: OK</code><br />
+        <code style="display: block; margin-top: 1rem;">{% if "raspberry-pi" in request.path %} {{ appliance.iso_url.raspberrypi }} {% else %} {{ appliance.iso_url.pc }} {% endif %}: OK</code><br />
         <small>Or follow this tutorial to learn <a href="/tutorials/tutorial-how-to-verify-ubuntu">how to verify downloads</a></small>
       </span>
     </span>
   </span>
 </p>
+
+<script>
+  // Closes dropdown when click is registered outside of the tooltip
+  function toggleChecksumDropdown() {
+    const toggleControl = document.querySelector(".js-checksum-toggle");
+    const dropdown = document.querySelector(".js-checksum-dropdown");
+    const tooltip = document.querySelector(".js-checksum-tooltip");
+  
+    if (tooltip) {
+      document.addEventListener("click", (e) => {
+        if (!tooltip.contains(e.target)) {
+          toggleControl.setAttribute("aria-expanded", false)
+          dropdown.setAttribute("aria-hidden", true)
+        }
+      });
+    }
+  }
+
+toggleChecksumDropdown()
+</script>

--- a/templates/appliance/shared/_vm.html
+++ b/templates/appliance/shared/_vm.html
@@ -1,51 +1,29 @@
-<section class="p-strip--suru-topped" style="overflow: visible;">
-  <div class="row u-equal-height">
-    <div class="col-8">
-      <h1>Setup the {{ appliance.appliance_name }} Ubuntu Appliance in a virtual machine</h1>
-    </div>
-    <div class="col-4 u-hide-small u-vertically-center u-align--center">
-      {{
-        image(
-        url="https://assets.ubuntu.com/v1/ea34f006-Multipass+logomark_rgb.svg",
-        alt="",
-        width="180",
-        height="180",
-        hi_def=True,
-        loading="auto",
-        ) | safe
-      }}
-    </div>
+<section class="p-section--hero">
+  <div class="u-fixed-width">
+    <h1>
+      Setup the {{ appliance.appliance_name }} Ubuntu Appliance
+      <br />
+      in a virtual machine
+    </h1>
   </div>
 </section>
 
-<hr>
-<section class="p-strip is-bordered">
+<section class="p-section">
   <div class="u-fixed-width">
-    <h2>Installation instructions</h2>
-    <div class="js-tab-container">
-      <nav class="p-tabs">
-        <ul class="p-tabs__list" role="tablist">
-          <li class="p-tabs__item" role="presentation">
-            <a href="#ubuntuos" class="p-tabs__link" id="ubuntuos-tab" role="tab" aria-controls="ubuntuos" aria-selected="true">
-              Ubuntu
-            </a>
-          </li>
-          <li class="p-tabs__item" role="presentation">
-            <a href="#windows" class="p-tabs__link" tabindex="-1" role="tab" id="windows-tab" aria-controls="windows">
-              Windows
-            </a>
-          </li>
-          <li class="p-tabs__item" role="presentation">
-            <a href="#macos" class="p-tabs__link" tabindex="-1" role="tab" id="macos-tab" aria-controls="macos">
-              macOS
-            </a>
-          </li>
-        </ul>
-      </nav>
+    <hr class="p-rule" />
+    <div class="p-section--shallow">
+      <h2>Installation instructions</h2>
+    </div>
 
-      <div id="ubuntuos" class="p-tabs__content" role="tabpanel" aria-labelledby="ubuntuos-tab">
-        {% include "appliance/shared/_steps_vm_intro.html" %}
+    <div class="js-tab-container">
+      {% include "appliance/shared/_appliance-os-tabs.html" %}
+
+      <div id="ubuntuos"
+           class="p-tabs__content"
+           role="tabpanel"
+           aria-labelledby="ubuntuos-tab">
         {% include "appliance/shared/_install_instructions_vm_ubuntu.html" %}
+        {% include "appliance/shared/_steps_vm_intro.html" %}
         <ol class="p-stepped-list--detailed">
           {% include "appliance/shared/_steps_multipass_ubuntu.html" %}
           {% include "appliance/shared/_steps-multipass-launch.html" %}
@@ -54,9 +32,12 @@
         </ol>
       </div>
 
-      <div id="windows" class="p-tabs__content" role="tabpanel" aria-labelledby="windows-tab">
-        {% include "appliance/shared/_steps_vm_intro.html" %}
+      <div id="windows"
+           class="p-tabs__content"
+           role="tabpanel"
+           aria-labelledby="windows-tab">
         {% include "appliance/shared/_install_instructions_vm_windows.html" %}
+        {% include "appliance/shared/_steps_vm_intro.html" %}
         <ol class="p-stepped-list--detailed">
           {% include "appliance/shared/_steps_multipass_windows.html" %}
           {% include "appliance/shared/_steps-multipass-launch.html" %}
@@ -65,9 +46,12 @@
         </ol>
       </div>
 
-      <div id="macos" class="p-tabs__content" role="tabpanel" aria-labelledby="macos-tab">
-        {% include "appliance/shared/_steps_vm_intro.html" %}
+      <div id="macos"
+           class="p-tabs__content"
+           role="tabpanel"
+           aria-labelledby="macos-tab">
         {% include "appliance/shared/_install_instructions_vm_macos.html" %}
+        {% include "appliance/shared/_steps_vm_intro.html" %}
         <ol class="p-stepped-list--detailed">
           {% include "appliance/shared/_steps_multipass_macos.html" %}
           {% include "appliance/shared/_steps-multipass-launch.html" %}

--- a/templates/appliance/shared/_what_you_will_need_pi2.html
+++ b/templates/appliance/shared/_what_you_will_need_pi2.html
@@ -1,11 +1,16 @@
-<h4>What you'll need</h4>
-<ul class="p-list is-split">
-  <li class="p-list__item is-ticked">A microSD card (4GB minimum, 8GB recommended)</li>
-  <li class="p-list__item is-ticked">A Raspberry Pi 2</li>
-  <li class="p-list__item is-ticked">A computer with a microSD card drive</li>
-  <li class="p-list__item is-ticked">A micro-USB power cable</li>
-  <li class="p-list__item is-ticked">A monitor with an HDMI interface</li>
-  <li class="p-list__item is-ticked">An HDMI cable</li>
-  <li class="p-list__item is-ticked">A USB keyboard</li>
-</ul>
-<hr>
+<div class="row--50-50-on-large">
+  <div class="col">
+    <h3>What you'll need</h3>
+  </div>
+  <div class="col">
+    <ul class="p-list--divided">
+      <li class="p-list__item is-ticked">A microSD card (4GB minimum, 8GB recommended)</li>
+      <li class="p-list__item is-ticked">A Raspberry Pi 2</li>
+      <li class="p-list__item is-ticked">A computer with a microSD card drive</li>
+      <li class="p-list__item is-ticked">A micro-USB power cable</li>
+      <li class="p-list__item is-ticked">A monitor with an HDMI interface</li>
+      <li class="p-list__item is-ticked">An HDMI cable</li>
+      <li class="p-list__item is-ticked">A USB keyboard</li>
+    </ul>
+  </div>
+</div>


### PR DESCRIPTION
## Done

- Applied design updates to remaining appliance templates as per [mock-up](https://www.figma.com/design/POgmRw4Rpq1hlgaD9DN8mS/ubuntu.com%2Fappliance?node-id=964-10972&m=dev)

## QA

- View the site locally in your web browser at: 
  - https://ubuntu-com-14917.demos.haus/appliance/plex/raspberry-pi2
  - https://ubuntu-com-14917.demos.haus/appliance/plex/vm
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check against design. There should be no content changes

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-16589
