### PR TITLE
Update release notes for Charmed Kubernetes 1.32+ck1

### DIFF
--- a/templates/kubernetes/charmed-k8s/docs/1.28/release-notes.md
+++ b/templates/kubernetes/charmed-k8s/docs/1.28/release-notes.md
@@ -13,6 +13,14 @@ layout: [base, ubuntu-com]
 toc: False
 ---
 
+# 1.28+ck3
+
+### Mar 31, 2025 - `charmed-kubernetes --channel 1.28/stable`
+
+## Notable Fixes
+
+### Kubernetes Worker Charm
+* [LP#2104056](https://bugs.launchpad.net/bugs/2104056) Update ingress-nginx to 1.11.5 resolving CVE-2025-1974
 
 ## 1.28+ck2 Bugfix release
 

--- a/templates/kubernetes/charmed-k8s/docs/1.29/release-notes.md
+++ b/templates/kubernetes/charmed-k8s/docs/1.29/release-notes.md
@@ -13,6 +13,33 @@ layout: [base, ubuntu-com]
 toc: false
 ---
 
+# 1.29+ck5
+
+### Mar 31, 2025 - `charmed-kubernetes --channel 1.29/stable`
+
+## Notable Fixes
+
+### Kubernetes Worker Charm
+* [LP#2104056](https://bugs.launchpad.net/bugs/2104056) Update ingress-nginx to 1.11.5 resolving CVE-2025-1974
+
+# 1.29+ck4
+
+### Jul 31, 2024 - `charmed-kubernetes --channel 1.29/stable`
+
+## Notable Fixes
+
+### Ceph-CSI Charm
+
+* [LP#2073297](https://bugs.launchpad.net/bugs/2073297)
+  Provides charm configuration options for each of the storage-class parameters
+  * `cephfs-storage-class-parameters`
+  * `ceph-xfs-storage-class-parameters`
+  * `ceph-ext4-storage-class-parameters`
+  
+  Provides a charm action which aids in remove storage-classes if they prevent
+    the charm from creating with the existing storage-class parameters.
+  * `delete-storage-class`
+
 # 1.29+ck3
 
 ### Jun 14, 2024 - `charmed-kubernetes --channel 1.29/stable`

--- a/templates/kubernetes/charmed-k8s/docs/1.30/release-notes.md
+++ b/templates/kubernetes/charmed-k8s/docs/1.30/release-notes.md
@@ -17,6 +17,15 @@ toc: false
 
 ---
 
+# 1.30+ck2
+
+### Mar 31, 2025 - `charmed-kubernetes --channel 1.30/stable`
+
+## Notable Fixes
+
+### Kubernetes Worker Charm
+* [LP#2104056](https://bugs.launchpad.net/bugs/2104056) Update ingress-nginx to 1.11.5 resolving CVE-2025-1974
+
 # 1.30
 
 ### July 11, 2024 - `charmed-kubernetes --channel 1.30/stable`

--- a/templates/kubernetes/charmed-k8s/docs/1.31/release-notes.md
+++ b/templates/kubernetes/charmed-k8s/docs/1.31/release-notes.md
@@ -17,6 +17,15 @@ toc: False
 
 ---
 
+# 1.31+ck2
+
+### Mar 31, 2025 - `charmed-kubernetes --channel 1.31/stable`
+
+## Notable Fixes
+
+### Kubernetes Worker Charm
+* [LP#2104056](https://bugs.launchpad.net/bugs/2104056) Update ingress-nginx to 1.11.5 resolving CVE-2025-1974
+
 # 1.31+ck1
 
 ### Dec 16, 2024 - `charmed-kubernetes --channel 1.31/stable`

--- a/templates/kubernetes/charmed-k8s/docs/1.32/release-notes.md
+++ b/templates/kubernetes/charmed-k8s/docs/1.32/release-notes.md
@@ -16,6 +16,15 @@ layout:
   - ubuntu-com
 toc: False
 ---
+# 1.32+ck1
+
+### Mar 28, 2025 - `charmed-kubernetes --channel 1.32/stable`
+
+## Notable Fixes
+
+### Kubernetes Worker Charm
+* [LP#2104056](https://bugs.launchpad.net/bugs/2104056) Update ingress-nginx to 1.11.5 resolving CVE-2025-1974
+
 # 1.32
 
 ### February 24, 2025 - `charmed-kubernetes --channel 1.32/stable`

--- a/templates/kubernetes/charmed-k8s/docs/1.32/release-notes.md
+++ b/templates/kubernetes/charmed-k8s/docs/1.32/release-notes.md
@@ -16,6 +16,7 @@ layout:
   - ubuntu-com
 toc: False
 ---
+
 # 1.32+ck1
 
 ### Mar 28, 2025 - `charmed-kubernetes --channel 1.32/stable`

--- a/templates/kubernetes/charmed-k8s/docs/release-notes.md
+++ b/templates/kubernetes/charmed-k8s/docs/release-notes.md
@@ -12,6 +12,15 @@ permalink: release-notes.html
 layout: [base, ubuntu-com]
 toc: False
 ---
+# 1.32+ck1
+
+### Mar 28, 2025 - `charmed-kubernetes --channel 1.32/stable`
+
+## Notable Fixes
+
+### Kubernetes Worker Charm
+* [LP#2104056](https://bugs.launchpad.net/bugs/2104056) Update ingress-nginx to 1.11.5 resolving CVE-2025-1974
+
 # 1.32
 
 ### February 24, 2025 - `charmed-kubernetes --channel 1.32/stable`

--- a/templates/kubernetes/charmed-k8s/docs/release-notes.md
+++ b/templates/kubernetes/charmed-k8s/docs/release-notes.md
@@ -12,9 +12,16 @@ permalink: release-notes.html
 layout: [base, ubuntu-com]
 toc: False
 ---
+
 # 1.32+ck1
 
 ### Mar 28, 2025 - `charmed-kubernetes --channel 1.32/stable`
+
+### Backports on Mar 31, 2025
+* **1.31+ck2** - `charmed-kubernetes --channel 1.31/stable`
+* **1.30+ck2** - `charmed-kubernetes --channel 1.30/stable`
+* **1.29+ck5** - `charmed-kubernetes --channel 1.29/stable`
+* **1.28+ck3** - `charmed-kubernetes --channel 1.28/stable`
 
 ## Notable Fixes
 


### PR DESCRIPTION
## Done

Updating release  notes for charmed-kubernetes 1.32+ck1

* the same release notes for 1.31, 1.30, 1.29, and 1.28

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes # [LP#2104056](https://bugs.launchpad.net/bugs/2104056)

## Screenshots

[If relevant, please include a screenshot.]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
