### PR TITLE
WD-20901 - Update Pro logo on `desktop/organisations`

### DIFF
--- a/templates/desktop/organisations.html
+++ b/templates/desktop/organisations.html
@@ -47,10 +47,10 @@
     <div class="row--25-75 p-section--shallow">
       <hr class="p-rule" />
       <div class="col u-hide--medium u-hide--small">
-        {{ image(url="https://assets.ubuntu.com/v1/5cdf69d6-Ubuntu+Pro.svg",
-                alt="",
-                width="225",
-                height="58",
+        {{ image(url="https://assets.ubuntu.com/v1/5853afcd-Digital-No-Canonical-Light-Theme-Canonical Ubuntu Pro logo.png",
+                alt="Ubuntu Pro logo",
+                width="1194",
+                height="337",
                 hi_def=True,
                 loading="lazy") | safe
         }}

--- a/templates/desktop/organisations.html
+++ b/templates/desktop/organisations.html
@@ -47,7 +47,7 @@
     <div class="row--25-75 p-section--shallow">
       <hr class="p-rule" />
       <div class="col u-hide--medium u-hide--small">
-        {{ image(url="https://assets.ubuntu.com/v1/5853afcd-Digital-No-Canonical-Light-Theme-Canonical Ubuntu Pro logo.png",
+        {{ image(url="https://assets.ubuntu.com/v1/5853afcd-Digital-No-Canonical-Light-Theme-Canonical%20Ubuntu%20Pro%20logo.png",
                 alt="Ubuntu Pro logo",
                 width="225",
                 height="64",

--- a/templates/desktop/organisations.html
+++ b/templates/desktop/organisations.html
@@ -49,8 +49,8 @@
       <div class="col u-hide--medium u-hide--small">
         {{ image(url="https://assets.ubuntu.com/v1/5853afcd-Digital-No-Canonical-Light-Theme-Canonical Ubuntu Pro logo.png",
                 alt="Ubuntu Pro logo",
-                width="1194",
-                height="337",
+                width="225",
+                height="64",
                 hi_def=True,
                 loading="lazy") | safe
         }}


### PR DESCRIPTION
## Done

Updates the Ubuntu Pro logo on [desktop/organisations](https://ubuntu.com/desktop/organisations) to be higher quality, per [copydoc](https://docs.google.com/document/d/1RuxCA6GYh9UriNv26HCZP9UHo4b4_9fYaaMtGQuH_xc/edit?tab=t.0)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Open [`desktop/organisations`](https://ubuntu-com-14922.demos.haus/desktop/organisations) and verify that the Ubuntu pro logo has been updated

## Issue / Card

Fixes [WD-20901](https://warthogs.atlassian.net/browse/WD-20901)

## Screenshots

Before
<img width="532" alt="Screenshot 2025-03-31 at 15 14 49" src="https://github.com/user-attachments/assets/f848bfc0-6a8f-45db-b8fc-1f27604c1dee" />

After
<img width="532" alt="Screenshot 2025-03-31 at 15 14 52" src="https://github.com/user-attachments/assets/23e294b3-3837-43e5-b78d-284d09cf3f27" />


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-20901]: https://warthogs.atlassian.net/browse/WD-20901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ