### PR TITLE
WD-20631 Typo correction

### DIFF
--- a/templates/aws/support.html
+++ b/templates/aws/support.html
@@ -143,7 +143,7 @@
             </tr>
             <tr>
               <th>
-                Canonical-backed 24x7 Support with enterprise grade SLA, with possibilities to integrate into existing Azure support workflows
+                Canonical-backed 24x7 Support with enterprise grade SLA, with possibilities to integrate into existing AWS support workflows
               </th>
               <td>No</td>
               <td>No</td>


### PR DESCRIPTION
## Done

- Corrected typo ; "Azure" to "AWS"

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [Demo](https://ubuntu-com-14923.demos.haus/aws/support)

## Issue / Card
#14907 
Fixes # [WD-20631](https://warthogs.atlassian.net/browse/WD-20631)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-20631]: https://warthogs.atlassian.net/browse/WD-20631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ