### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-canonicalwebteam.flask-base==2.1.0
+canonicalwebteam.flask-base==2.4.0
 canonicalwebteam.http==1.0.4
 canonicalwebteam.blog==6.4.4
 canonicalwebteam.search==2.1.1


### PR DESCRIPTION
## Done
- Updated to `flask-base 2.4.0` which brings:
  - Increased werkzeug version limit, allowing flask 2.3.3
  - Added support for extension based content-encoding

## QA

- Open the [demo](https://ubuntu-com-14924.demos.haus/), and confirm that pages are loading as expected
- View the site locally in your web browser
    - Be sure to test on mobile, tablet and desktop screen sizes
## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
