### PR TITLE
copy update: [WD-20895] update download/server page

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -5,10 +5,10 @@ latest:
   full_version: "25.04"
   desktop_version: "25.04"
   core_version: "24"
-  release_date: "October 2024"
+  release_date: "April 2025"
   eol: "January 2026"
   past_eol_date: false
-  release_notes_url: "https://discourse.ubuntu.com/t/oracular-oriole-release-notes/44878"
+  release_notes_url: "https://discourse.ubuntu.com/t/plucky-puffin-release-notes"
   iso_download_size: "5.3GB"
   server_iso_size: "2.0GB"
   raspi_desktop_iso_size: "2.7GB"

--- a/templates/download/server/manual.html
+++ b/templates/download/server/manual.html
@@ -163,6 +163,10 @@
             <li class="p-list__item is-ticked">5 GB of free hard drive space</li>
             <li class="p-list__item is-ticked">Either a USB port or a DVD drive for the installer media</li>
           </ul>
+          <hr class="p-rule" />
+          <p>
+            <a href="https://documentation.ubuntu.com/server/reference/installation/system-requirements/">Detailed system requirements&nbsp;&rsaquo;</a>
+          </p>
         </div>
 
         <div class="p-tabs__content p-section"
@@ -195,8 +199,8 @@
           <h2>Ubuntu {{ releases.latest.full_version }}</h2>
         </div>
         <div class="p-image-wrapper u-hide--small u-hide--medium">
-          {{ image(url="https://assets.ubuntu.com/v1/0749ce0e-Orange%20O_no%20background-resized.png",
-                    alt="Oracular Oriole",
+          {{ image(url="https://assets.ubuntu.com/v1/ce1666ec-pp-master-orange-hex.svg",
+                    alt="{{ releases.latest.name }}",
                     width="182",
                     height="192",
                     hi_def=True,
@@ -206,7 +210,7 @@
       </div>
       <div class="col">
         <div class="p-section--shallow">
-          <p>The latest version of Ubuntu Server, including nine months of security and maintenance updates until July 2025.</p>
+          <p>The latest version of Ubuntu Server, including nine months of security and maintenance updates until {{ releases.latest.eol }}.</p>
           <hr />
           <p class="u-responsive-realign">
             <a class="p-button--positive"
@@ -259,20 +263,20 @@
              role="tabpanel"
              aria-labelledby="release-notes-tab-latest">
           <ul class="p-list--divided">
-            <li class="p-list__item is-ticked">Linux 6.11 kernel</li>
-            <li class="p-list__item is-ticked">Addition of kdump-tools for automatic kernel crash dumps</li>
-            <li class="p-list__item is-ticked">Inclusion of Valkey, a high performance key/value data store.</li>
-            <li class="p-list__item is-ticked">
-              Toolchain updates now include versioned Rust packages and TCK certified OpenJDK 21 and 17
-            </li>
+            <li class="p-list__item is-ticked">Linux 6.14 kernel</li>
+            <li class="p-list__item is-ticked">Updates to new Database versions including MySQL 8.4 and Postgresql 17</li>
+            <li class="p-list__item is-ticked">Updated Virtualization stack based on QEMU 9.2 and libvirt 11.0</li>
+            <li class="p-list__item is-ticked">Chrony as NTP client using the secure NTS by default</li>
           </ul>
           <hr class="p-rule" />
           <ul class="u-responsive-realign p-inline-list">
             <li class="p-inline-list__item">
-              <a href="/blog/canonical-releases-ubuntu-24-10-oracular-oriole" aria-label="24.10 Press Release">Press release&nbsp;&rsaquo;</a>
+              <a href="/blog/canonical-releases-ubuntu-25-04-plucky-puffin"
+                 aria-label="{{ releases.latest.short_version }} Press Release">Press release&nbsp;&rsaquo;</a>
             </li>
             <li class="p-inline-list__item">
-              <a href="{{ releases.latest.release_notes_url }}" aria-label="{{ releases.latest.short_version }} release notes">Release notes&nbsp;&rsaquo;</a>
+              <a href="{{ releases.latest.release_notes_url }}"
+                 aria-label="{{ releases.latest.short_version }} release notes">Release notes&nbsp;&rsaquo;</a>
             </li>
           </ul>
         </div>
@@ -287,6 +291,10 @@
             <li class="p-list__item is-ticked">2.5 GB of free hard drive space</li>
             <li class="p-list__item is-ticked">Either a USB port or a DVD drive for the installer media</li>
           </ul>
+          <hr class="p-rule" />
+          <p>
+            <a href="https://documentation.ubuntu.com/server/reference/installation/system-requirements/">Detailed system requirements&nbsp;&rsaquo;</a>
+          </p>
         </div>
 
         <div class="p-tabs__content p-section"


### PR DESCRIPTION
## Done

- Updates to the ubuntu.com/download/server page.

## QA
Navigate to /download/server in the demo server. Check that the copy doc matches the page
[Copy doc](https://docs.google.com/document/d/1Qob4Ni_y1ffIdSWqaw2xH0dxiHZQmkRGP5nuoBhIfyM/edit)
[Demo server](https://ubuntu-com-14925.demos.haus/download/server)

## Fixes
[Jira ticket](https://warthogs.atlassian.net/browse/WD-20895)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
