### PR TITLE
[WD-20814] COPYDOC: Update security/disa-stig

### DIFF
--- a/templates/security/disa-stig.html
+++ b/templates/security/disa-stig.html
@@ -36,13 +36,13 @@
     {%- endif -%}
     {%- if slot == 'description' -%}
       <p>
-        Security Technical Implementation Guides (STIG) are developed by the Defense Information System Agency (DISA) for the U.S. Department of Defense (DoD). <a href="/cloud/public-cloud">Ubuntu Pro on public cloud</a> and <a href="/advantage">Ubuntu Pro (Infra)</a> have the necessary <a href="/security/fips">certifications</a> and controls to comply with DISA-STIG guidelines on Linux.
+        Security Technical Implementation Guides (STIG) are developed by the Defense Information System Agency (DISA) for the U.S. Department of Defense (DoD). <a href="/pro">Ubuntu Pro</a> has the necessary <a href="/security/fips">certifications</a> and controls to comply with DISA-STIG guidelines on Linux, available on-premise or on public cloud.
       </p>
     {%- endif -%}
     {%- if slot == 'cta' -%}
       <a href="/security/contact-us"
          class="p-button--positive js-invoke-modal">Contact us</a>
-      <a href="/advantage">Get Ubuntu Pro (Infra)&nbsp;&rsaquo;</a>
+      <a href="/pro">Get Ubuntu Pro&nbsp;&rsaquo;</a>
     {%- endif -%}
     {%- if slot == 'image' -%}
       <div class="p-image-container--cinematic is-cover">


### PR DESCRIPTION
## Done

- Updated Ubuntu.com/security/dis-stig

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Navigate to ubuntu.com/security/disa-stig and verify that the correct copydoc updates have been made according to the google doc.

## Issue / Card

Fixes #
Fixes - Copy Doc: https://docs.google.com/document/d/1zJwZzc-cERj9YKNXFtmrXwynJptyT7-D3qCNzBctRfo/edit?tab=t.0
Jira - https://warthogs.atlassian.net/browse/WD-20814

## Screenshots
N/A

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
