### PR TITLE
fix: Include 'country' field on forms where it was missing

### DIFF
--- a/templates/kubernetes/form-data.json
+++ b/templates/kubernetes/form-data.json
@@ -45,6 +45,11 @@
                 "isRequired": true
               },
               {
+                "type": "country",
+                "label": "Country",
+                "isRequired": false
+              },
+              {
                 "type": "text",
                 "id": "company",
                 "label": "Company",

--- a/templates/shared/_default-contact-us-form.html
+++ b/templates/shared/_default-contact-us-form.html
@@ -448,6 +448,9 @@
                 <label for="phone">Mobile/cell phone number:</label>
                 <input id="phone" name="phone" maxlength="255" type="tel" />
               </li>
+
+              {% include "shared/forms/_country.html" %}
+              
             </ul>
             <ul class="p-list">
               <li class="p-list__item">

--- a/templates/shared/forms/interactive/ai.html
+++ b/templates/shared/forms/interactive/ai.html
@@ -1,23 +1,44 @@
 <div class="p-modal" id="contact-modal">
-  <div class="p-modal__dialog is-paper" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
+  <div class="p-modal__dialog is-paper"
+       role="dialog"
+       aria-labelledby="modal-title"
+       aria-describedby="modal-description">
     <div class="js-pagination js-pagination--1">
       <div class="row--50-50 p-strip is-shallow">
         <div class="col">
           <h2 class="p-heading--1" id="modal-title">Open source AI: a scalable path to production</h2>
-          <p>Looking to scale your MLOPs infrastructure or need consulting services to kick start your AI journey? Our experts are here to help you.</p>
+          <p>
+            Looking to scale your MLOPs infrastructure or need consulting services to kick start your AI journey? Our experts are here to help you.
+          </p>
         </div>
         <div class="col">
           <button class="p-modal__close" aria-label="Close active modal">Close</button>
-          <form action="/marketo/submit" onsubmit="stringifyCustomFields()" method="post" id="mktoForm_%% formid %%" class="modal-form">
+          <form action="/marketo/submit"
+                onsubmit="stringifyCustomFields()"
+                method="post"
+                id="mktoForm_%% formid %%"
+                class="modal-form">
             <div class="js-formfield">
               <div class="p-section--shallow">
                 <p class="p-heading--5">Do you already have any AI projects rolled out in your enterprise?</p>
                 <label class="p-radio">
-                  <input type="radio" value="Yes" class="p-radio__input" id="aiProjectsYes" name="aiProjects" aria-labelledby="aiProjectsYes" required />
+                  <input type="radio"
+                         value="Yes"
+                         class="p-radio__input"
+                         id="aiProjectsYes"
+                         name="aiProjects"
+                         aria-labelledby="aiProjectsYes"
+                         required />
                   <span class="p-radio__label" id="aiProjectsYes">Yes</span>
                 </label>
                 <label class="p-radio">
-                  <input type="radio" value="No" class="p-radio__input" id="aiProjectsNo" name="aiProjects" aria-labelledby="aiProjectsNo" required />
+                  <input type="radio"
+                         value="No"
+                         class="p-radio__input"
+                         id="aiProjectsNo"
+                         name="aiProjects"
+                         aria-labelledby="aiProjectsNo"
+                         required />
                   <span class="p-radio__label" id="aiProjectsNo">No</span>
                 </label>
               </div>
@@ -27,15 +48,21 @@
                 <hr class="p-rule" />
                 <p class="p-heading--5">What are you interested in from our AI offering?</p>
                 <label class="p-checkbox js-checkbox">
-                  <input type="checkbox" aria-labelledby="canonicalMlopsSolution" class="p-checkbox__input" />
+                  <input type="checkbox"
+                         aria-labelledby="canonicalMlopsSolution"
+                         class="p-checkbox__input" />
                   <span class="p-checkbox__label" id="canonicalMlopsSolution">Canonical MLOps solution</span>
                 </label>
                 <label class="p-checkbox js-checkbox">
-                  <input type="checkbox" aria-labelledby="aiConsultingServices" class="p-checkbox__input" />
+                  <input type="checkbox"
+                         aria-labelledby="aiConsultingServices"
+                         class="p-checkbox__input" />
                   <span class="p-checkbox__label" id="aiConsultingServices">AI consultancy services</span>
                 </label>
                 <label class="p-checkbox js-checkbox">
-                  <input type="checkbox" aria-labelledby="mlopsWorkshop" class="p-checkbox__input" />
+                  <input type="checkbox"
+                         aria-labelledby="mlopsWorkshop"
+                         class="p-checkbox__input" />
                   <span class="p-checkbox__label" id="mlopsWorkshop">MLOps Workshop</span>
                 </label>
                 <label class="p-checkbox js-checkbox">
@@ -56,40 +83,68 @@
               <hr class="p-rule" />
               <p class="p-heading--5">Add your information</p>
               <label for="firstName">First name:</label>
-              <input required id="firstName" name="firstName" maxlength="255" type="text"/>
+              <input required id="firstName" name="firstName" maxlength="255" type="text" />
 
               <label for="lastName">Last name:</label>
-              <input required id="lastName" name="lastName" maxlength="255" type="text"/>
+              <input required id="lastName" name="lastName" maxlength="255" type="text" />
 
               <label for="company">Company:</label>
-              <input required id="company" name="company" maxlength="255" type="text"/>
+              <input required id="company" name="company" maxlength="255" type="text" />
 
               <label for="company">Title:</label>
-              <input required id="title" name="title" maxlength="255" type="text"/>
+              <input required id="title" name="title" maxlength="255" type="text" />
 
               <label for="email">Email:</label>
-              <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"/>
+              <input required
+                     id="email"
+                     name="email"
+                     maxlength="255"
+                     type="email"
+                     pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
 
               <label for="phone">Phone number:</label>
               <input required id="phone" name="phone" maxlength="255" type="tel" />
 
+              <label for="country">Country:</label>
+              {% with raw="true" %}
+                {% include "shared/forms/_country.html" %}
+              {% endwith %}
+
             </div>
             <div class="p-section--shallow">
               <label class="p-checkbox">
-                <input class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                <input class="p-checkbox__input"
+                       value="yes"
+                       aria-labelledby="canonicalUpdatesOptIn"
+                       name="canonicalUpdatesOptIn"
+                       type="checkbox" />
                 <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
               </label>
 
-              <p>By submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</p>
+              <p>
+                By submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.
+              </p>
               {# These are honey pot fields to catch bots #}
               <ul class="p-list u-off-screen">
                 <li class="u-off-screen">
                   <label class="website" for="website">Website:</label>
-                  <input name="website" type="text" class="website" autocomplete="off" value="" id="website" tabindex="-1" />
+                  <input name="website"
+                         type="text"
+                         class="website"
+                         autocomplete="off"
+                         value=""
+                         id="website"
+                         tabindex="-1" />
                 </li>
                 <li class="u-off-screen">
                   <label class="name" for="name">Name:</label>
-                  <input name="name" type="text" class="name" autocomplete="off" value="" id="name" tabindex="-1" />
+                  <input name="name"
+                         type="text"
+                         class="name"
+                         autocomplete="off"
+                         value=""
+                         id="name"
+                         tabindex="-1" />
                 </li>
               </ul>
               {# End of honey pots #}
@@ -100,27 +155,85 @@
               <ul class="p-list">
                 <li class="p-list__item">
                   <label for="Comments_from_lead__c">What would you like to talk to us about?</label>
-                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
+                  <textarea id="Comments_from_lead__c"
+                            name="Comments_from_lead__c"
+                            rows="5"
+                            maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Facebook_Click_ID__c" id="Facebook_Click_ID__c" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" id="preferredLanguage" name="preferredLanguage" maxlength="255" value="" />
+              <input type="hidden"
+                     aria-hidden="true"
+                     aria-label="hidden field"
+                     name="returnURL"
+                     value="%% returnURL %%" />
+              <input type="hidden"
+                     aria-hidden="true"
+                     aria-label="hidden field"
+                     name="formid"
+                     value="%% formid %%" />
+              <input type="hidden"
+                     aria-hidden="true"
+                     aria-label="hidden field"
+                     name="Consent_to_Processing__c"
+                     value="yes" />
+              <input type="hidden"
+                     aria-hidden="true"
+                     aria-label="hidden field"
+                     name="utm_campaign"
+                     id="utm_campaign"
+                     value="" />
+              <input type="hidden"
+                     aria-hidden="true"
+                     aria-label="hidden field"
+                     name="utm_medium"
+                     id="utm_medium"
+                     value="" />
+              <input type="hidden"
+                     aria-hidden="true"
+                     aria-label="hidden field"
+                     name="utm_source"
+                     id="utm_source"
+                     value="" />
+              <input type="hidden"
+                     aria-hidden="true"
+                     aria-label="hidden field"
+                     name="utm_content"
+                     id="utm_content"
+                     value="" />
+              <input type="hidden"
+                     aria-hidden="true"
+                     aria-label="hidden field"
+                     name="utm_term"
+                     id="utm_term"
+                     value="" />
+              <input type="hidden"
+                     aria-hidden="true"
+                     aria-label="hidden field"
+                     name="GCLID__c"
+                     id="GCLID__c"
+                     value="" />
+              <input type="hidden"
+                     aria-hidden="true"
+                     aria-label="hidden field"
+                     name="Facebook_Click_ID__c"
+                     id="Facebook_Click_ID__c"
+                     value="" />
+              <input type="hidden"
+                     aria-hidden="true"
+                     aria-label="hidden field"
+                     id="preferredLanguage"
+                     name="preferredLanguage"
+                     maxlength="255"
+                     value="" />
             </div>
 
             <div class="pagination p-section--shallow">
               <hr class="p-rule" />
-              <button type="submit" class="pagination__link--next p-button--positive" aria-label="Submit">Submit form</button>
+              <button type="submit"
+                      class="pagination__link--next p-button--positive"
+                      aria-label="Submit">Submit form</button>
             </div>
-          </form>           
+          </form>
         </div>
       </div>
     </div>

--- a/templates/shared/forms/interactive/managed-services.html
+++ b/templates/shared/forms/interactive/managed-services.html
@@ -1,139 +1,234 @@
 <div class="p-modal" id="contact-modal">
-  <div class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description" >
+  <div class="p-modal__dialog"
+       role="dialog"
+       aria-labelledby="modal-title"
+       aria-describedby="modal-description">
     <header class="p-modal__header" style="display: block; border-bottom: 0">
-      <button class="p-modal__close" aria-label="Close active modal" style="margin-left: -1rem" > Close </button>
-      <h2 class="p-modal__title u-sv1" id="modal-title"> You innovate, we operate! </h2>
+      <button class="p-modal__close"
+              aria-label="Close active modal"
+              style="margin-left: -1rem">Close</button>
+      <h2 class="p-modal__title u-sv1" id="modal-title">You innovate, we operate!</h2>
     </header>
-    <div class="js-pagination js-pagination--1">
-      <div class="js-formfield">
-        <h3 class="p-heading--5">What services can we help with?</h3>
-        <div class="row u-no-padding u-equal-height">
-          <div class="col-12 u-sv3">
-            <label class="p-checkbox">
-              <input class="p-checkbox__input" type="checkbox" aria-labelledby="service-openstack" />
-              <span class="p-checkbox__label" id="service-openstack">Openstack</span>
-            </label>
-            <label class="p-checkbox">
-              <input class="p-checkbox__input" type="checkbox" aria-labelledby="service-kubernetes" />
-              <span class="p-checkbox__label" id="service-kubernetes">Kubernetes</span>
-            </label>
-            <label class="p-checkbox">
-              <input class="p-checkbox__input" type="checkbox" aria-labelledby="service-ceph" />
-              <span class="p-checkbox__label" id="service-ceph">Ceph</span>
-            </label>
-            <label class="p-checkbox">
-              <input class="p-checkbox__input" type="checkbox" aria-labelledby="service-database-apps" />
-              <span class="p-checkbox__label" id="service-database-apps">Database and Applications</span>
-            </label>
-            <label class="p-checkbox">
-              <input class="p-checkbox__input" type="checkbox" aria-labelledby="service-observability" />
-              <span class="p-checkbox__label" id="service-observability">Observability</span>
-            </label>
-          </div>
-        </div>
-      </div>
-      <div class="row u-no-padding js-formfield">
-        <h3 class="p-heading--5">Tell us more</h3>
-        <textarea
-          id="apps-using-other-info"
-          aria-label="Tell us more"
-          rows="3"
-          placeholder="What are you currently working on? What does your current infrastructure and services look like? Anything extra you’d like to communicate about your needs or interests?"
-        ></textarea>
-      </div>
-      <div class="row u-no-padding">
-        <div class="pagination">
-          <a class="p-button--positive pagination__link--next" href="">Next</a>
+    <div class="js-formfield">
+      <h3 class="p-heading--5">What services can we help with?</h3>
+      <div class="row u-no-padding u-equal-height">
+        <div class="col-8 u-sv3">
+          <label class="p-checkbox">
+            <input class="p-checkbox__input"
+                   type="checkbox"
+                   aria-labelledby="service-openstack" />
+            <span class="p-checkbox__label" id="service-openstack">Openstack</span>
+          </label>
+          <label class="p-checkbox">
+            <input class="p-checkbox__input"
+                   type="checkbox"
+                   aria-labelledby="service-kubernetes" />
+            <span class="p-checkbox__label" id="service-kubernetes">Kubernetes</span>
+          </label>
+          <label class="p-checkbox">
+            <input class="p-checkbox__input"
+                   type="checkbox"
+                   aria-labelledby="service-ceph" />
+            <span class="p-checkbox__label" id="service-ceph">Ceph</span>
+          </label>
+          <label class="p-checkbox">
+            <input class="p-checkbox__input"
+                   type="checkbox"
+                   aria-labelledby="service-database-apps" />
+            <span class="p-checkbox__label" id="service-database-apps">Database and Applications</span>
+          </label>
+          <label class="p-checkbox">
+            <input class="p-checkbox__input"
+                   type="checkbox"
+                   aria-labelledby="service-observability" />
+            <span class="p-checkbox__label" id="service-observability">Observability</span>
+          </label>
         </div>
       </div>
     </div>
-    <div class="js-pagination js-pagination--2 u-hide">
-      <div class="js-formfield js-choice-limit" data-choice-limit="4">
-        <h3 class="p-heading--5">How should we get in touch?</h3>
-        <div class="row u-no-padding">
-          <div class="col-6">
-            <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form" >
+    <div class="row u-no-padding js-formfield">
+      <div class="col-8">
+        <h3 class="p-heading--5">Tell us more</h3>
+        <textarea id="apps-using-other-info"
+                  aria-label="Tell us more"
+                  rows="3"
+                  placeholder="What are you currently working on? What does your current infrastructure and services look like? Anything extra you’d like to communicate about your needs or interests?"></textarea>
+      </div>
+    </div>
+    <div class="js-formfield js-choice-limit" data-choice-limit="4">
+      <h3 class="p-heading--5">How should we get in touch?</h3>
+      <div class="row u-no-padding">
+        <div class="col-8">
+          <form action="/marketo/submit"
+                method="post"
+                id="mktoForm_%% formid %%"
+                class="modal-form">
+            <ul class="p-list">
+              <li class="p-list__item">
+                <label for="firstName">First name:</label>
+                <input required
+                       id="firstName"
+                       name="firstName"
+                       maxlength="255"
+                       type="text"
+                       required="required" />
+              </li>
+              <li class="p-list__item">
+                <label for="lastName">Last name:</label>
+                <input required
+                       id="lastName"
+                       name="lastName"
+                       maxlength="255"
+                       type="text"
+                       required="required" />
+              </li>
+              <li class="p-list__item">
+                <label for="email">Work email:</label>
+                <input required
+                       id="email"
+                       name="email"
+                       maxlength="255"
+                       type="email"
+                       pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"
+                       required="required" />
+              </li>
+              <li class="p-list__item">
+                <label for="phone">Mobile/cell phone number:</label>
+                <input required
+                       id="phone"
+                       name="phone"
+                       maxlength="255"
+                       type="tel"
+                       required="required" />
+              </li>
+
+              {% include "shared/forms/_country.html" %}
+
+              <li class="p-list__item">
+                <label class="p-checkbox">
+                  <input class="p-checkbox__input"
+                         value="yes"
+                         aria-labelledby="canonicalUpdatesOptIn"
+                         name="canonicalUpdatesOptIn"
+                         type="checkbox" />
+                  <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
+                </label>
+              </li>
+              <li class="p-list__item">
+                In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.
+              </li>
+              {# These are honey pot fields to catch bots #}
+              <li class="u-off-screen">
+                <label class="website" for="website">Website:</label>
+                <input name="website"
+                       type="text"
+                       class="website"
+                       autocomplete="off"
+                       value=""
+                       id="website"
+                       tabindex="-1" />
+              </li>
+              <li class="u-off-screen">
+                <label class="name" for="name">Name:</label>
+                <input name="name"
+                       type="text"
+                       class="name"
+                       autocomplete="off"
+                       value=""
+                       id="name"
+                       tabindex="-1" />
+              </li>
+              {# End of honey pots #}
+            </ul>
+
+            <div class="u-hide">
+              <h3>Your comments</h3>
               <ul class="p-list">
                 <li class="p-list__item">
-                  <label for="firstName">First name:</label>
-                  <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
+                  <label for="Comments_from_lead__c">What would you like to talk to us about?</label>
+                  <textarea id="Comments_from_lead__c"
+                            name="Comments_from_lead__c"
+                            rows="5"
+                            maxlength="2000"></textarea>
                 </li>
-                <li class="p-list__item">
-                  <label for="lastName">Last name:</label>
-                  <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
-                </li>
-                <li class="p-list__item">
-                  <label for="email">Work email:</label>
-                  <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
-                </li>
-                <li class="p-list__item">
-                  <label for="phone">Mobile/cell phone number:</label >
-                  <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
-                </li>
-                <li class="p-list__item">
-                  <label class="p-checkbox">
-                    <input class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
-                    <span class="p-checkbox__label" id="canonicalUpdatesOptIn" >I agree to receive information about Canonical's products and services.</span>
-                  </label>
-                </li>
-                <li class="p-list__item">
-                  In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact" >Canonical's Privacy Notice</a > and <a href="/legal/data-privacy">Privacy Policy</a>.
-                </li>
-                {# These are honey pot fields to catch bots #}
-                <li class="u-off-screen">
-                  <label class="website" for="website">Website:</label>
-                  <input name="website" type="text" class="website" autocomplete="off" value="" id="website" tabindex="-1" />
-                </li>
-                <li class="u-off-screen">
-                  <label class="name" for="name">Name:</label>
-                  <input name="name" type="text" class="name" autocomplete="off" value="" id="name" tabindex="-1" />
-                </li>
-                {# End of honey pots #}
               </ul>
-
-              <div class="u-hide">
-                <h3>Your comments</h3>
-                <ul class="p-list">
-                  <li class="p-list__item">
-                    <label for="Comments_from_lead__c">What would you like to talk to us about?</label >
-                    <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000" ></textarea>
-                  </li>
-                </ul>
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %% " />
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Facebook_Click_ID__c" id="Facebook_Click_ID__c" value="" />
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" id="preferredLanguage" name="preferredLanguage" maxlength="255" value="" />
-                <input type="hidden" aria-hidden="true" aria-label="hidden field" name="productContext" id="product-context" value="{{ product }}" />
-              </div>
-              <div class="pagination">
-                <a class="pagination__link--previous p-button" href="" >Previous</a >
-                <button type="submit" class="pagination__link--next p-button--positive" aria-label="Submit" > Let's discuss </button>
-              </div>
-            </form>
-          </div>
+              <input type="hidden"
+                     aria-hidden="true"
+                     aria-label="hidden field"
+                     name="returnURL"
+                     value="%% returnURL %%" />
+              <input type="hidden"
+                     aria-hidden="true"
+                     aria-label="hidden field"
+                     name="formid"
+                     value="%% formid %% " />
+              <input type="hidden"
+                     aria-hidden="true"
+                     aria-label="hidden field"
+                     name="Consent_to_Processing__c"
+                     value="yes" />
+              <input type="hidden"
+                     aria-hidden="true"
+                     aria-label="hidden field"
+                     name="utm_campaign"
+                     id="utm_campaign"
+                     value="" />
+              <input type="hidden"
+                     aria-hidden="true"
+                     aria-label="hidden field"
+                     name="utm_medium"
+                     id="utm_medium"
+                     value="" />
+              <input type="hidden"
+                     aria-hidden="true"
+                     aria-label="hidden field"
+                     name="utm_source"
+                     id="utm_source"
+                     value="" />
+              <input type="hidden"
+                     aria-hidden="true"
+                     aria-label="hidden field"
+                     name="utm_content"
+                     id="utm_content"
+                     value="" />
+              <input type="hidden"
+                     aria-hidden="true"
+                     aria-label="hidden field"
+                     name="utm_term"
+                     id="utm_term"
+                     value="" />
+              <input type="hidden"
+                     aria-hidden="true"
+                     aria-label="hidden field"
+                     name="GCLID__c"
+                     id="GCLID__c"
+                     value="" />
+              <input type="hidden"
+                     aria-hidden="true"
+                     aria-label="hidden field"
+                     name="Facebook_Click_ID__c"
+                     id="Facebook_Click_ID__c"
+                     value="" />
+              <input type="hidden"
+                     aria-hidden="true"
+                     aria-label="hidden field"
+                     id="preferredLanguage"
+                     name="preferredLanguage"
+                     maxlength="255"
+                     value="" />
+              <input type="hidden"
+                     aria-hidden="true"
+                     aria-label="hidden field"
+                     name="productContext"
+                     id="product-context"
+                     value="{{ product }}" />
+            </div>
+            <button type="submit"
+                    class="pagination__link--next p-button--positive"
+                    aria-label="Submit">Let's discuss</button>
+          </form>
         </div>
       </div>
-    </div>
-    <div class="js-pagination js-pagination--3 u-hide">
-      <div class="row u-no-padding">
-        <div class="u-equal-height">
-          <div class="col-7">
-            <h3 class="p-heading--2"> Thank you for enquiring about managed IT services </h3>
-            <p class="p-heading--4"> A member of our team will be in touch within one working day. </p>
-          </div>
-          <div class="col-5 u-vertically-center u-hide--medium u-hide--small u-align--center">
-            <img src="https://assets.ubuntu.com/v1/cbae9a60-thank_you_orange_cmyk.svg" alt="smile" width="200" height="200" loading="auto">
-          </div>
-        </div>
-      </div>
-      <a class="js-close p-button" href="">Close</a>
     </div>
   </div>
 </div>

--- a/templates/shared/forms/interactive/robotics_ros.html
+++ b/templates/shared/forms/interactive/robotics_ros.html
@@ -1,24 +1,38 @@
 <div class="p-modal" id="contact-modal">
-  <div class="p-modal__dialog" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description">
+  <div class="p-modal__dialog"
+       role="dialog"
+       aria-labelledby="modal-title"
+       aria-describedby="modal-description">
     <header class="p-modal__header" style="display: block; border-bottom: 0;">
-      <button class="p-modal__close" aria-label="Close active modal" style="margin-left: -1rem">Close</button>
+      <button class="p-modal__close"
+              aria-label="Close active modal"
+              style="margin-left: -1rem">Close</button>
       <h2 class="p-modal__title u-sv1" id="modal-title">Let's get your robot rolling</h2>
     </header>
     <div class="js-pagination js-pagination--1">
-      <p id="modal-description" class="u-no-max-width u-no-margin--bottom">Tell us about your project so we can bring the right team to the conversation. If the form  doesn't address your questions, please press next and submit your inquiry in the  text area.</p>
-
+      <p id="modal-description" class="u-no-max-width u-no-margin--bottom">
+        Tell us about your project so we can bring the right team to the conversation. If the form  doesn't address your questions, please press next and submit your inquiry in the  text area.
+      </p>
       <div class="js-formfield">
         <h3 class="p-heading--5">Are you interested in learning more about ROS ESM and our enterprise support for ROS?</h3>
         <div class="row u-no-padding">
           <div class="col-2 u-sv3">
             <label class="p-radio">
-              <input class="p-radio__input" type="radio" aria-labelledby="enterprise-support-for-ROS-yes" name="enterprise-support-for-ROS" value="Yes">
+              <input class="p-radio__input"
+                     type="radio"
+                     aria-labelledby="enterprise-support-for-ROS-yes"
+                     name="enterprise-support-for-ROS"
+                     value="Yes" />
               <span class="p-radio__label" id="enterprise-support-for-ROS-yes">Yes</span>
             </label>
           </div>
           <div class="col-2 u-sv3">
             <label class="p-radio">
-              <input class="p-radio__input" type="radio" aria-labelledby="enterprise-support-for-ROS-no" name="enterprise-support-for-ROS" value="No">
+              <input class="p-radio__input"
+                     type="radio"
+                     aria-labelledby="enterprise-support-for-ROS-no"
+                     name="enterprise-support-for-ROS"
+                     value="No" />
               <span class="p-radio__label" id="enterprise-support-for-ROS-no">No</span>
             </label>
           </div>
@@ -30,13 +44,21 @@
         <div class="row u-no-padding">
           <div class="col-2 u-sv3">
             <label class="p-radio">
-              <input class="p-radio__input" type="radio" aria-labelledby="Hardware-Enablement-and-Certification-yes" name="Hardware-Enablement-and-Certification" value="Yes">
+              <input class="p-radio__input"
+                     type="radio"
+                     aria-labelledby="Hardware-Enablement-and-Certification-yes"
+                     name="Hardware-Enablement-and-Certification"
+                     value="Yes" />
               <span class="p-radio__label" id="Hardware-Enablement-and-Certification-yes">Yes</span>
             </label>
           </div>
           <div class="col-2 u-sv3">
             <label class="p-radio">
-              <input class="p-radio__input" type="radio" aria-labelledby="Hardware-Enablement-and-Certification-no" name="Hardware-Enablement-and-Certification" value="No">
+              <input class="p-radio__input"
+                     type="radio"
+                     aria-labelledby="Hardware-Enablement-and-Certification-no"
+                     name="Hardware-Enablement-and-Certification"
+                     value="No" />
               <span class="p-radio__label" id="Hardware-Enablement-and-Certification-no">No</span>
             </label>
           </div>
@@ -44,18 +66,30 @@
       </div>
 
       <div class="js-formfield">
-        <h3 class="p-heading--5">Do you want to learn more about Brand Store and our management solution to deploy software?</h3>
+        <h3 class="p-heading--5">
+          Do you want to learn more about Brand Store and our management solution to deploy software?
+        </h3>
         <div class="row u-no-padding">
           <div class="col-2 u-sv3">
             <label class="p-radio">
-              <input class="p-radio__input" type="radio" aria-labelledby="Brand-Store-and-our-management-solution-yes" name="Brand-Store-and-our-management-solution" value="Yes">
-              <span class="p-radio__label" id="Brand-Store-and-our-management-solution-yes">Yes</span>
+              <input class="p-radio__input"
+                     type="radio"
+                     aria-labelledby="Brand-Store-and-our-management-solution-yes"
+                     name="Brand-Store-and-our-management-solution"
+                     value="Yes" />
+              <span class="p-radio__label"
+                    id="Brand-Store-and-our-management-solution-yes">Yes</span>
             </label>
           </div>
           <div class="col-2 u-sv3">
             <label class="p-radio">
-              <input class="p-radio__input" type="radio" aria-labelledby="Brand-Store-and-our-management-solution-no" name="Brand-Store-and-our-management-solution" value="No">
-              <span class="p-radio__label" id="Brand-Store-and-our-management-solution-no">No</span>
+              <input class="p-radio__input"
+                     type="radio"
+                     aria-labelledby="Brand-Store-and-our-management-solution-no"
+                     name="Brand-Store-and-our-management-solution"
+                     value="No" />
+              <span class="p-radio__label"
+                    id="Brand-Store-and-our-management-solution-no">No</span>
             </label>
           </div>
         </div>
@@ -66,13 +100,21 @@
         <div class="row u-no-padding">
           <div class="col-2 u-sv3">
             <label class="p-radio">
-              <input class="p-radio__input" type="radio" aria-labelledby="support-getting-to-market-yes" name="support-getting-to-market" value="Yes">
+              <input class="p-radio__input"
+                     type="radio"
+                     aria-labelledby="support-getting-to-market-yes"
+                     name="support-getting-to-market"
+                     value="Yes" />
               <span class="p-radio__label" id="support-getting-to-market-yes">Yes</span>
             </label>
           </div>
           <div class="col-2 u-sv3">
             <label class="p-radio">
-              <input class="p-radio__input" type="radio" aria-labelledby="support-getting-to-market-no" name="support-getting-to-market" value="No">
+              <input class="p-radio__input"
+                     type="radio"
+                     aria-labelledby="support-getting-to-market-no"
+                     name="support-getting-to-market"
+                     value="No" />
               <span class="p-radio__label" id="support-getting-to-market-no">No</span>
             </label>
           </div>
@@ -81,7 +123,11 @@
 
       <div class="u-sv3 js-formfield">
         <label class="p-heading--5" for="open-question">What can we help you with?</label>
-        <textarea id="open-question" name="open-question" aria-label="What can we help you with?" placeholder="What type of robotics project or product are you working on? Manufacturing? Industrial automation? " rows="3"></textarea>
+        <textarea id="open-question"
+                  name="open-question"
+                  aria-label="What can we help you with?"
+                  placeholder="What type of robotics project or product are you working on? Manufacturing? Industrial automation? "
+                  rows="3"></textarea>
       </div>
 
       <div class="pagination">
@@ -94,7 +140,10 @@
       <h3 class="p-heading--5">How should we get in touch?</h3>
       <div class="row u-no-padding">
         <div class="col-6">
-          <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
+          <form action="/marketo/submit"
+                method="post"
+                id="mktoForm_%% formid %%"
+                class="modal-form">
             <ul class="p-list">
               <li class="p-list__item">
                 <label for="firstName">First name:</label>
@@ -114,27 +163,53 @@
               </li>
               <li class="p-list__item">
                 <label for="email">Email address:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
+                <input required
+                       id="email"
+                       name="email"
+                       maxlength="255"
+                       type="email"
+                       pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
               </li>
               <li class="p-list__item">
                 <label for="phone">Phone number:</label>
-                <input id="phone" name="phone" maxlength="255" type="tel">
+                <input id="phone" name="phone" maxlength="255" type="tel" />
               </li>
+
+              {% include "shared/forms/_country.html" %}
+              
               <li class="p-list__item">
                 <label class="p-checkbox">
-                  <input class="p-checkbox__input" value="yes" aria-labelledby="canonicalUpdatesOptIn" name="canonicalUpdatesOptIn" type="checkbox" />
+                  <input class="p-checkbox__input"
+                         value="yes"
+                         aria-labelledby="canonicalUpdatesOptIn"
+                         name="canonicalUpdatesOptIn"
+                         type="checkbox" />
                   <span class="p-checkbox__label" id="canonicalUpdatesOptIn">I agree to receive information about Canonical's products and services.</span>
                 </label>
               </li>
-              <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
+              <li class="p-list__item">
+                In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.
+              </li>
               {# These are honey pot fields to catch bots #}
               <li class="u-off-screen">
                 <label class="website" for="website">Website:</label>
-                <input name="website" type="text" class="website" autocomplete="off" value="" id="website" tabindex="-1" />
+                <input name="website"
+                       type="text"
+                       class="website"
+                       autocomplete="off"
+                       value=""
+                       id="website"
+                       tabindex="-1" />
               </li>
               <li class="u-off-screen">
                 <label class="name" for="name">Name:</label>
-                <input name="name" type="text" class="name" autocomplete="off" value="" id="name" tabindex="-1" />
+                <input name="name"
+                       type="text"
+                       class="name"
+                       autocomplete="off"
+                       value=""
+                       id="name"
+                       tabindex="-1" />
               </li>
               {# End of honey pots #}
             </ul>
@@ -144,25 +219,83 @@
               <ul class="p-list">
                 <li class="p-list__item">
                   <label for="Comments_from_lead__c">What would you like to talk to us about?</label>
-                  <textarea id="Comments_from_lead__c" name="Comments_from_lead__c" rows="5" maxlength="2000"></textarea>
+                  <textarea id="Comments_from_lead__c"
+                            name="Comments_from_lead__c"
+                            rows="5"
+                            maxlength="2000"></textarea>
                 </li>
               </ul>
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="returnURL" value="%% returnURL %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="formid" value="%% formid %%" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Consent_to_Processing__c" value="yes" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Facebook_Click_ID__c" id="Facebook_Click_ID__c" value="" />
-              <input type="hidden" aria-hidden="true" aria-label="hidden field" id="preferredLanguage" name="preferredLanguage" maxlength="255" value="" />
+              <input type="hidden"
+                     aria-hidden="true"
+                     aria-label="hidden field"
+                     name="returnURL"
+                     value="%% returnURL %%" />
+              <input type="hidden"
+                     aria-hidden="true"
+                     aria-label="hidden field"
+                     name="formid"
+                     value="%% formid %%" />
+              <input type="hidden"
+                     aria-hidden="true"
+                     aria-label="hidden field"
+                     name="Consent_to_Processing__c"
+                     value="yes" />
+              <input type="hidden"
+                     aria-hidden="true"
+                     aria-label="hidden field"
+                     name="utm_campaign"
+                     id="utm_campaign"
+                     value="" />
+              <input type="hidden"
+                     aria-hidden="true"
+                     aria-label="hidden field"
+                     name="utm_medium"
+                     id="utm_medium"
+                     value="" />
+              <input type="hidden"
+                     aria-hidden="true"
+                     aria-label="hidden field"
+                     name="utm_source"
+                     id="utm_source"
+                     value="" />
+              <input type="hidden"
+                     aria-hidden="true"
+                     aria-label="hidden field"
+                     name="utm_content"
+                     id="utm_content"
+                     value="" />
+              <input type="hidden"
+                     aria-hidden="true"
+                     aria-label="hidden field"
+                     name="utm_term"
+                     id="utm_term"
+                     value="" />
+              <input type="hidden"
+                     aria-hidden="true"
+                     aria-label="hidden field"
+                     name="GCLID__c"
+                     id="GCLID__c"
+                     value="" />
+              <input type="hidden"
+                     aria-hidden="true"
+                     aria-label="hidden field"
+                     name="Facebook_Click_ID__c"
+                     id="Facebook_Click_ID__c"
+                     value="" />
+              <input type="hidden"
+                     aria-hidden="true"
+                     aria-label="hidden field"
+                     id="preferredLanguage"
+                     name="preferredLanguage"
+                     maxlength="255"
+                     value="" />
             </div>
 
             <div class="pagination">
               <a class="pagination__link--previous p-button" href="">Previous</a>
-              <button type="submit" class="pagination__link--next p-button--positive" aria-label="Submit">Let's discuss</button>
+              <button type="submit"
+                      class="pagination__link--next p-button--positive"
+                      aria-label="Submit">Let's discuss</button>
             </div>
           </form>
         </div>
@@ -177,7 +310,11 @@
             <p class="p-heading--4">A member of our team will be in touch within one working day.</p>
           </div>
           <div class="col-5 u-vertically-center u-hide--medium u-hide--small u-align--center">
-            <img src="https://assets.ubuntu.com/v1/cbae9a60-thank_you_orange_cmyk.svg" alt="smile" width="200" height="200" loading="auto">
+            <img src="https://assets.ubuntu.com/v1/cbae9a60-thank_you_orange_cmyk.svg"
+                 alt="smile"
+                 width="200"
+                 height="200"
+                 loading="auto" />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Done

Adds the 'country' field to the following forms:
https://ubuntu-com-14928.demos.haus/robotics/ros-esm#get-in-touch
https://ubuntu-com-14928.demos.haus/kubernetes/install#get-in-touch
https://ubuntu-com-14928.demos.haus/ai#get-in-touch
https://ubuntu-com-14928.demos.haus/openstack/contact-us
https://ubuntu-com-14928.demos.haus/landscape/compare#get-in-touch
https://ubuntu-com-14928.demos.haus/blog/cloud-instance-initialisation-with-cloud-init
http://ubuntu-com-14928.demos.haus/managed#get-in-touch
https://ubuntu-com-14928.demos.haus/openstack/contact-us
https://ubuntu-com-14928.demos.haus/training/contact-us?product=openstack-training-onsite

## QA

- Open the above forms and ensure they have the 'country' input with appropriate `name` attribute

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-20914
