### PR TITLE
fix: Set scrset for takeover images and switch to auto loading

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -49,7 +49,7 @@
                     width="2382",
                     height="1684",
                     hi_def=True,
-                    loading="lazy",
+                    loading="auto",
                     attrs={"id": "test-takeover-image"}) | safe
           }}
         </div>
@@ -81,7 +81,7 @@
                     width="197",
                     height="150",
                     hi_def=True,
-                    loading="lazy",
+                    loading="auto",
                     attrs={"id": "takeover-image"}) | safe
           }}
         </div>
@@ -1559,6 +1559,8 @@
         subtitle.textContent = selectedTakeover.subtitle;
 
         image.src = selectedTakeover.image;
+        image.srcset = selectedTakeover.image;
+
         image.onload = function() {
           // Remove animation delay
           if (takeoverAnimation) {


### PR DESCRIPTION
## Done

- Set `srcset` for takeover image
- Switched to auto loading for takeover images

## QA

- View the site locally in your web browser at: https://ubuntu-com-14930.demos.haus/
    - Be sure to test on mobile, tablet and desktop screen sizes
- See that the correct takeover image is shown

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
