### PR TITLE
[WD-19307] fix typo, update datasheet url

### DIFF
--- a/templates/robotics/ros-esm.html
+++ b/templates/robotics/ros-esm.html
@@ -40,7 +40,7 @@ from "_macros/vf_quote-wrapper.jinja" import vf_quote_wrapper %}
     {%- if slot == 'cta' -%}
       <a href="/robotics#get-in-touch"
          class="js-invoke-modal p-button--positive">Get in touch</a>
-      <a href="https://pages.ubuntu.com/rs/066-EOV-335/images/ROS%20datasheet%202023.pdf">Read the datasheet&nbsp;&rsaquo;</a>
+      <a href="https://assets.ubuntu.com/v1/4dedff79-ROS%20ESM%20datasheet.pdf">Read the datasheet&nbsp;&rsaquo;</a>
     {%- endif -%}
     {%- if slot == 'image' -%}
       <div class="p-image-container--cinematic is-cover">
@@ -354,7 +354,7 @@ from "_macros/vf_quote-wrapper.jinja" import vf_quote_wrapper %}
           With ROS ESM, you can count on backports for critical security
           updates, common vulnerabilities and exposures (CVE) fixes and bug
           fixes for ROS and the Ubuntu base OS. Our security experts follow a
-          standardizsed process to identify vulnerabilities and create and test
+          standardized process to identify vulnerabilities and create and test
           security patches.
         </p>
         <p>


### PR DESCRIPTION
## Done

- updated datasheet url
- fixed typo (standardizsed -> standardized)

## QA

- goto https://ubuntu-com-14932.demos.haus/robotics/ros-esm
- check datasheet (should have updated design compared to https://ubuntu.com/robotics/ros-esm)
- check typo (ctrl+f standardizsed)

## Issue / Card

WD-19307

