### PR TITLE
adjust referenced technologies for ubuntu server ARM

### DIFF
--- a/templates/download/server/arm.html
+++ b/templates/download/server/arm.html
@@ -101,9 +101,9 @@
         <li class="p-list__item is-ticked">
           Application container technology based on Docker and Kubernetes, including FAN-based networking.
         </li>
-        <li class="p-list__item is-ticked">SQL and NoSQL databases including CouchDB, MySQL, PostgreSQL, Redis and SQLite.</li>
+        <li class="p-list__item is-ticked">SQL and NoSQL databases including MySQL, PostgreSQL, Valkey and SQLite.</li>
         <li class="p-list__item is-ticked">
-          A wide collection of web technologies, from HTTP servers to frameworks including Apache, Django, memcached, Nginx, WordPress and Varnish.
+          A wide collection of web technologies, from HTTP servers to frameworks including Apache, Nginx, Django, memcached and Varnish.
         </li>
       </ul>
     </div>


### PR DESCRIPTION
## Done

- adjusted referenced technologies for ubuntu server ARM

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- access `/download/server/arm` and verify everything looks in order

## Issue / Card

https://warthogs.atlassian.net/browse/WD-20897

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
