### PR TITLE
feat: Add a 'deprecated' warning notification to /landscape/docs

### DIFF
--- a/templates/landscape/docs/document.html
+++ b/templates/landscape/docs/document.html
@@ -40,16 +40,18 @@
       secondaryNav.after(notification);
 
       // If linking to an anchor tag, scroll it into view
-      if (window.scrollY > 0) {
-        window.scrollBy(0, -notificationContainer.offsetHeight);
-      }
+      window.addEventListener('load', function() {
+        if (window.scrollY > 0) {
+          const offset = -notificationContainer.offsetHeight;
+          window.scrollBy(0, offset);
+        }
+      });
 
       notificationContainer.querySelector(".js-notification-close").addEventListener("click", function(e) {
         e.preventDefault();
         notificationContainer.style.display = "none";
         sessionStorage.setItem("notificationClosed", "true");
       });
-      
     }
   });
 </script>

--- a/templates/landscape/docs/document.html
+++ b/templates/landscape/docs/document.html
@@ -5,6 +5,42 @@
   siteSearch="https://ubuntu.com/landscape/docs",
   placeholder="Search on Landscape Docs",
   navigation=navigation
-%}
+  %}
   {% include "templates/docs/shared/_docs.html" %}
 {% endwith %}
+
+<template id="notification-template">
+  <div class="u-fixed-width"
+       style="position: sticky;
+              top: 4rem;
+              z-index: 11;
+              padding-top: 1rem">
+    <div class="p-notification--caution u-no-margin--bottom js-notification-type">
+      <div class="p-notification__content">
+        <h5 class="p-notification__title js-notification-title">Important</h5>
+        <p class="p-notification__message js-notification-message">
+          We have a new documentation website
+          <link />
+          ! You're viewing an old version of the documentation. Please use the new documentation site for the most up-to-date content. This site will redirect to our new documentation in June 2025.
+          <a href="#" class="js-notification-close"><i class="p-notification__close">Close notification</i></a>
+        </p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+  document.addEventListener("DOMContentLoaded", function() {
+    const template = document.querySelector("#notification-template");
+    const notification = template.content.cloneNode(true);
+    const notificationContainer = notification.children[0];
+
+    const secondaryNav = document.querySelector("#secondary-navigation");
+    secondaryNav.after(notification);
+
+    notificationContainer.querySelector(".js-notification-close").addEventListener("click", function(e) {
+      e.preventDefault();
+      notificationContainer.style.display = "none";
+    });
+  });
+</script>

--- a/templates/landscape/docs/document.html
+++ b/templates/landscape/docs/document.html
@@ -19,7 +19,7 @@
       <div class="p-notification__content">
         <h5 class="p-notification__title js-notification-title">You're viewing an outdated version of our documentation.</h5>
         <p class="p-notification__message js-notification-message">
-          This version will be archived in June 2025. Please use the new documentation site <a href="https://documentation.ubuntu.com/landscape">https://documentation.ubuntu.com/landscape</a> for the most up-to-date content.
+          This version will be archived in June 2025. Please use the <a href="https://documentation.ubuntu.com/landscape">new documentation site</a> for the most up-to-date content.
           <a href="#" class="js-notification-close"><i class="p-notification__close">Close notification</i></a>
         </p>
       </div>

--- a/templates/landscape/docs/document.html
+++ b/templates/landscape/docs/document.html
@@ -29,16 +29,22 @@
 
 <script>
   document.addEventListener("DOMContentLoaded", function() {
-    const template = document.querySelector("#notification-template");
-    const notification = template.content.cloneNode(true);
-    const notificationContainer = notification.children[0];
+    // Check if the user previously closed the notification
+    if (sessionStorage.getItem("notificationClosed") !== "true") {
+      const template = document.querySelector("#notification-template");
+      const notification = template.content.cloneNode(true);
+      const notificationContainer = notification.children[0];
 
-    const secondaryNav = document.querySelector("#secondary-navigation");
-    secondaryNav.after(notification);
+      // Place the notification between the navigation and content
+      const secondaryNav = document.querySelector("#secondary-navigation");
+      secondaryNav.after(notification);
 
-    notificationContainer.querySelector(".js-notification-close").addEventListener("click", function(e) {
-      e.preventDefault();
-      notificationContainer.style.display = "none";
-    });
+      notificationContainer.querySelector(".js-notification-close").addEventListener("click", function(e) {
+        e.preventDefault();
+        notificationContainer.style.display = "none";
+        sessionStorage.setItem("notificationClosed", "true");
+      });
+      
+    }
   });
 </script>

--- a/templates/landscape/docs/document.html
+++ b/templates/landscape/docs/document.html
@@ -17,9 +17,9 @@
               padding-top: 1rem">
     <div class="p-notification--caution u-no-margin--bottom js-notification-type">
       <div class="p-notification__content">
-        <h5 class="p-notification__title js-notification-title">Important</h5>
+        <h5 class="p-notification__title js-notification-title">You're viewing an outdated version of our documentation.</h5>
         <p class="p-notification__message js-notification-message">
-          We have a new documentation website <a href="https://documentation.ubuntu.com/landscape">https://documentation.ubuntu.com/landscape</a>. You're viewing an old version of the documentation. Please use the new documentation site for the most up-to-date content. This site will redirect to our new documentation in June 2025.
+          This version will be archived in June 2025. Please use the new documentation site <a href="https://documentation.ubuntu.com/landscape">https://documentation.ubuntu.com/landscape</a> for the most up-to-date content.
           <a href="#" class="js-notification-close"><i class="p-notification__close">Close notification</i></a>
         </p>
       </div>
@@ -38,6 +38,11 @@
       // Place the notification between the navigation and content
       const secondaryNav = document.querySelector("#secondary-navigation");
       secondaryNav.after(notification);
+
+      // If linking to an anchor tag, scroll it into view
+      if (window.scrollY > 0) {
+        window.scrollBy(0, -notificationContainer.offsetHeight);
+      }
 
       notificationContainer.querySelector(".js-notification-close").addEventListener("click", function(e) {
         e.preventDefault();

--- a/templates/landscape/docs/document.html
+++ b/templates/landscape/docs/document.html
@@ -19,9 +19,7 @@
       <div class="p-notification__content">
         <h5 class="p-notification__title js-notification-title">Important</h5>
         <p class="p-notification__message js-notification-message">
-          We have a new documentation website
-          <link />
-          ! You're viewing an old version of the documentation. Please use the new documentation site for the most up-to-date content. This site will redirect to our new documentation in June 2025.
+          We have a new documentation website <a href="https://documentation.ubuntu.com/landscape">https://documentation.ubuntu.com/landscape</a>. You're viewing an old version of the documentation. Please use the new documentation site for the most up-to-date content. This site will redirect to our new documentation in June 2025.
           <a href="#" class="js-notification-close"><i class="p-notification__close">Close notification</i></a>
         </p>
       </div>


### PR DESCRIPTION


## Done

- Add a 'deprecated' warning notification to /landscape/docs based on the specification in the [jira ticket](https://warthogs.atlassian.net/browse/WD-18358). **Note** - I used this approach as the fix is only until June, when the entirety of `/landscape/docs` will be decommissioned 

## QA

- Go to any `/landscape/docs` page, ex. https://ubuntu-com-14936.demos.haus/landscape/docs
- See there is a notification with the text from the Jira ticket, eg.
"Important: We have a new documentation website <link>! You’re viewing an old version of the documentation. Please use the new documentation site for the most up-to-date content. This site will redirect to our new documentation in June 2025."
- See it is sticky when you scroll and closes when you click the 'x'.
- See it is on all `/landscape/docs` pages, ex. https://ubuntu-com-14936.demos.haus/landscape/docs/upgrade-landscape-to-24

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-18358
