### PR TITLE
[WD-21032] Ubuntu 25.04 copy update - about/release-cycle

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -143,9 +143,29 @@ export var serverAndDesktopReleases = [
     taskName: "24.10 (Oracular Oriole)",
     status: "INTERIM_RELEASE",
   },
+  {
+    startDate: new Date("2025-04-01T00:00:00"),
+    endDate: new Date("2026-01-05T00:00:00"),
+    taskName: "25.04 (Plucky Puffin)",
+    status: "INTERIM_RELEASE",
+  },
 ];
 
 export var kernelReleases = [
+  {
+    startDate: new Date("2025-04-01T00:00:00"),
+    endDate: new Date("2026-01-01T00:00:00"),
+    taskName: "25.04",
+    taskVersion: "6.14 kernel",
+    status: "INTERIM_RELEASE",
+  },
+  {
+    startDate: new Date("2025-02-01T00:00:00"),
+    endDate: new Date("2025-07-01T00:00:00"),
+    taskName: "24.04.2 LTS (HWE)",
+    taskVersion: "6.11 kernel",
+    status: "INTERIM_RELEASE",
+  },
   {
     startDate: new Date("2024-10-01T00:00:00"),
     endDate: new Date("2025-07-01T00:00:00"),
@@ -1201,6 +1221,7 @@ export var microStackStatus = {
 };
 
 export var desktopServerReleaseNames = [
+  "25.04 (Plucky Puffin)",
   "24.10 (Oracular Oriole)",
   "24.04 LTS (Noble Numbat)",
   "22.04 LTS (Jammy Jellyfish)",
@@ -1211,6 +1232,8 @@ export var desktopServerReleaseNames = [
 ];
 
 export var kernelReleaseNames = [
+  "25.04",
+  "24.04.2 LTS (HWE)",
   "24.10",
   "22.04.5 LTS (HWE)",
   "24.04.1 LTS",
@@ -1230,7 +1253,9 @@ export var kernelReleaseNames = [
 ];
 
 export var kernelVersionNames = [
+  "6.14",
   "6.11",
+  "",
   "6.8",
   "",
   "",

--- a/templates/about/release_cycles/releases-table.html
+++ b/templates/about/release_cycles/releases-table.html
@@ -10,10 +10,14 @@
     </thead>
     <tbody>
         <tr>
+            <td colspan="2">25.04 (Plucky Puffin)</td>
+            <td>Apr 2025</td>
+            <td>Jan 2026</td>
+        </tr>
+        <tr>
             <td colspan="2">24.10 (Oracular Oriole)</td>
             <td>Oct 2024</td>
             <td>Jul 2025</td>
-            <td>&nbsp;</td>
         </tr>
         <tr>
             <td colspan="2"><strong>24.04 LTS (Noble Numbat)</strong></td>

--- a/templates/shared/_kernel-release-diagram.html
+++ b/templates/shared/_kernel-release-diagram.html
@@ -12,14 +12,30 @@
   <tbody>
     <tr>
       <td>
+        <strong>6.14</strong>
+      </td>
+      <td>
+        <strong>25.04</strong>
+      </td>
+      <td>Apr 2025</td>
+      <td>Jan 2026</td>
+    </tr>
+    <tr>
+      <td rowspan="2">
         <strong>6.11</strong>
       </td>
+      <td>
+        <strong>24.04.2 LTS (HWE)</strong>
+      </td>
+      <td>Feb 2025</td>
+      <td>Jul 2025</td>
+    </tr>
+    <tr>
       <td>
         <strong>24.10</strong>
       </td>
       <td>Oct 2024</td>
       <td>Jul 2025</td>
-      <td>&nbsp;</td>
     </tr>
     <tr>
       <td rowspan="3">


### PR DESCRIPTION
## Done

- Add **Ubuntu 25.04 Plucky Puffin** in release graph and table for Ubuntu
- Add **Kernel 6.14** and **6.11 - 24.04.2 LTS (HWE)** in the release graph and table for Ubuntu kernel

## QA

[**Copy doc**](https://docs.google.com/document/d/1-l3B7AoyDoETaL80UhlfEWCVKmMWPdy3zoF5LpsGcYQ/edit?disco=AAABgB1dGHA&tab=t.0)

- Visit: https://ubuntu-com-14942.demos.haus/about/release-cycle
- [x] You should see `25.04 Plucky Puffin` in the release graph and the table
- Click into the **Ubuntu kernel** tab
- [x] You should see `6.14` and `6.11 - 24.04.2 LTS (HWE)` in the release graph and the table

## Issue / Card

Fixes [WD-21032](https://warthogs.atlassian.net/browse/WD-21032)

## Screenshots

### Ubuntu
**Before:**
![image](https://github.com/user-attachments/assets/0ea8f33c-8bed-42e4-83d0-8f8b2f89a95d)

**After:**
![image](https://github.com/user-attachments/assets/837164bf-50a1-4c3d-b279-2cc7ba26049e)

### Ubuntu Kernel
**Before:**
![image](https://github.com/user-attachments/assets/687a1861-f896-4e56-9e13-d0ee1fff66c3)

**After:**
![image](https://github.com/user-attachments/assets/0b599de5-f6e6-445d-aba6-07a1300a8563)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-21032]: https://warthogs.atlassian.net/browse/WD-21032?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ