### PR TITLE
WD-20559 fix: refactor error messaging for exam scheduling

### DIFF
--- a/templates/credentials/schedule.html
+++ b/templates/credentials/schedule.html
@@ -20,7 +20,15 @@ meta_copydoc %}
         <div class="p-notification--negative">
           <div class="p-notification__content">
             <h5 class="p-notification__title">Error</h5>
-            <p class="p-notification__message" id="error-message"></p>
+            <p class="p-notification__message" id="error-message">
+              {% if maintenance_error == 'True' %}
+                Scheduled time should be outside of the maintenance window. Please schedule the exam before 
+                <strong>{{ maintenance_start | date:"SHORT_DATETIME_FORMAT" }}</strong> or after 
+                <strong>{{ maintenance_end | date:"SHORT_DATETIME_FORMAT" }}</strong>.
+              {% elif error %}
+                {{ error }}
+              {% endif %}
+            </p>
           </div>
         </div>
       </div>
@@ -86,11 +94,6 @@ meta_copydoc %}
     const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
     {% endif %}
 
-    const error = "{{ error }}";
-    const maintenance_error = "{{ maintenance_error }}";
-    const maintenance_start = "{{ maintenance_start }}";
-    const maintenance_end = "{{ maintenance_end }}";
-
     const formatDateTime = (dateTime, locale = 'default') => {
       const date = new Date(dateTime);
       const options = {
@@ -107,24 +110,6 @@ meta_copydoc %}
       formattedDate = formattedDate.replace(/am|pm/, match => match.toUpperCase());
       const timeZone = date.toLocaleString(locale, { timeZoneName: 'short' }).split(' ').pop();
       return `${formattedDate} (${timeZone})`;
-    }
-
-    const setError = () => {
-      if (maintenance_error === 'True') {
-        const elem = document.getElementById("error-message");
-        const startFormatted = formatDateTime(maintenance_start, navigator.language);
-        const endFormatted = formatDateTime(maintenance_end, navigator.language);
-        if (elem) {
-          elem.innerHTML = `Scheduled time should be outside of the maintenance window. Please schedule the exam before <strong>${startFormatted}</strong> or after <strong>${endFormatted}</strong>`;
-        }
-      } else if (error) {
-        const elem = document.getElementById("error-message");
-        if (error.includes("user is banned from using CUE")) {
-          elem.innerHTML = "Your account is banned from scheduling CUE exams.";
-        } else {
-          elem.innerHTML = error;
-        }
-      }
     }
 
     const setDateTime = () => {
@@ -153,8 +138,7 @@ meta_copydoc %}
     })
 
     document.addEventListener('DOMContentLoaded', setDateTime);
-    document.addEventListener('DOMContentLoaded', setError);
-</script>
+  </script>
   {# djlint:on #}
 
 {% endblock content %}


### PR DESCRIPTION
## Done

- Refactor how error is rendered. Previously, the logic lived inside the script and now inside Jinja

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Update your `.env.local` and set following three variables
    - CRED_MAINTENANCE=true
    - CRED_MAINTENANCE_START=2024-09-28T11:00:00Z
    - CRED_MAINTENANCE_END=2028-09-28T15:00:00Z
- You should see following banner when visiting `/credentials`


<img width="1712" alt="Screenshot 2025-04-07 at 12 18 32 pm" src="https://github.com/user-attachments/assets/8a83fa7f-ffe6-49c2-af94-6775d435b035" />

## Issue / Card

Fixes [WD-20559](https://warthogs.atlassian.net/browse/WD-20559)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-20559]: https://warthogs.atlassian.net/browse/WD-20559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ