### PR TITLE
[WD-14950] Made company and job title fields mandatory on ubuntu contact forms

### DIFF
--- a/templates/automotive/buyers-guide/_form.html
+++ b/templates/automotive/buyers-guide/_form.html
@@ -28,15 +28,15 @@
       <form action="/marketo/submit" method="post" id="mktoForm_5356">
           <ul class="p-list">
             <li class="p-list__item">
-              <label for="firstName">First name:</label>
+              <label class="is-required" for="firstName">First name:</label>
               <input required id="firstName" name="firstName" maxlength="255" type="text" />
             </li>
             <li class="p-list__item">
-              <label for="lastName">Last name:</label>
+              <label class="is-required" for="lastName">Last name:</label>
               <input required id="lastName" name="lastName" maxlength="255" type="text" />
             </li>
             <li class="p-list__item">
-              <label for="email">Email:</label>
+              <label class="is-required" for="email">Email:</label>
               <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
             </li>
            <li class="p-list__item">
@@ -48,7 +48,7 @@
               <input required id="title" name="title" maxlength="255" type="text" />
             </li>
             <li class="p-list__item u-sv3">
-              <label for="phone">Mobile/cell phone number:</label>
+              <label class="is-required" for="phone">Mobile/cell phone number:</label>
               <input required id="phone" name="phone" maxlength="255" type="tel" />
             </li>
             <li class="p-list__item">

--- a/templates/automotive/buyers-guide/_form.html
+++ b/templates/automotive/buyers-guide/_form.html
@@ -40,11 +40,11 @@
               <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
             </li>
            <li class="p-list__item">
-              <label for="company">Company:</label>
+              <label class="is-required" for="company">Company:</label>
               <input required id="company" name="company" maxlength="255" type="text" />
             </li>
            <li class="p-list__item">
-              <label for="title">Job title:</label>
+              <label class="is-required" for="title">Job title:</label>
               <input required id="title" name="title" maxlength="255" type="text" />
             </li>
             <li class="p-list__item u-sv3">

--- a/templates/contact-us/newsletter-opt-in.html
+++ b/templates/contact-us/newsletter-opt-in.html
@@ -24,7 +24,7 @@
               method="post"
               id="mktoForm_4960"
               class="modal-form">
-          <label for="email">Email:</label>
+          <label class="is-required" for="email">Email:</label>
           <input required
                  id="email"
                  name="email"

--- a/templates/download/mediatek-genio/contact-us.html
+++ b/templates/download/mediatek-genio/contact-us.html
@@ -50,11 +50,11 @@
                 <input required id="lastName" name="lastName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="company">Company:</label>
+                <label class="is-required" for="company">Company:</label>
                 <input required id="company" name="company" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="title">Title:</label>
+                <label class="is-required" for="title">Job Title:</label>
                 <input required id="title" name="title" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">

--- a/templates/download/mediatek-genio/contact-us.html
+++ b/templates/download/mediatek-genio/contact-us.html
@@ -42,11 +42,11 @@
             <h2 class="p-heading--3">About you</h2>
             <ul class="p-list">
               <li class="p-list__item">
-                <label for="firstName">First name:</label>
+                <label class="is-required" for="firstName">First name:</label>
                 <input required id="firstName" name="firstName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="lastName">Last name:</label>
+                <label class="is-required" for="lastName">Last name:</label>
                 <input required id="lastName" name="lastName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
@@ -58,7 +58,7 @@
                 <input required id="title" name="title" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="email">Email:</label>
+                <label class="is-required" for="email">Email:</label>
                 <input required
                        id="email"
                        name="email"
@@ -67,7 +67,7 @@
                        pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
               </li>
               <li class="p-list__item">
-                <label for="phone">Mobile/cell phone number:</label>
+                <label class="is-required" for="phone">Mobile/cell phone number:</label>
                 <input required id="phone" name="phone" maxlength="255" type="tel" />
               </li>
             </ul>

--- a/templates/download/shared/_get-ebook-security.html
+++ b/templates/download/shared/_get-ebook-security.html
@@ -43,7 +43,7 @@
               <input required  id="lastName" name="lastName" maxlength="255" type="text">
             </li>
             <li class="p-list__item">
-              <label for="company">Company Name:</label>
+              <label class="is-required" for="company">Company Name:</label>
               <input required  id="company" name="company" maxlength="255" type="text">
             </li>
             <li class="p-list__item">

--- a/templates/download/shared/_get-ebook-security.html
+++ b/templates/download/shared/_get-ebook-security.html
@@ -47,6 +47,10 @@
               <input required  id="company" name="company" maxlength="255" type="text">
             </li>
             <li class="p-list__item">
+              <label class="is-required" for="title">Job Title:</label>
+              <input required id="title" name="title" maxlength="255" type="text" />
+            </li>
+            <li class="p-list__item">
               <label for="email">Work email address:</label>
               <input required  id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$">
             </li>

--- a/templates/download/shared/_get-ebook-security.html
+++ b/templates/download/shared/_get-ebook-security.html
@@ -35,11 +35,11 @@
           <legend class="u-off-screen">Contact information</legend>
           <ul class="p-list">
             <li class="p-list__item">
-              <label for="firstName">First name:</label>
+              <label class="is-required" for="firstName">First name:</label>
               <input required  id="firstName" name="firstName" maxlength="255" type="text" >
             </li>
             <li class="p-list__item">
-              <label for="lastName">Last name:</label>
+              <label class="is-required" for="lastName">Last name:</label>
               <input required  id="lastName" name="lastName" maxlength="255" type="text">
             </li>
             <li class="p-list__item">
@@ -51,11 +51,11 @@
               <input required id="title" name="title" maxlength="255" type="text" />
             </li>
             <li class="p-list__item">
-              <label for="email">Work email address:</label>
+              <label class="is-required" for="email">Work email address:</label>
               <input required  id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$">
             </li>
             <li class="p-list__item">
-              <label for="phone">Mobile/cell phone number:</label>
+              <label class="is-required" for="phone">Mobile/cell phone number:</label>
               <input required  id="phone" name="phone" maxlength="255" type="tel">
             </li>
             {% include "shared/forms/_country.html" %}

--- a/templates/download/shared/_get_ebook_maas.html
+++ b/templates/download/shared/_get_ebook_maas.html
@@ -53,7 +53,7 @@
             </li>
 
             <li class="p-list__item">
-              <label for="title">Job title:</label>
+              <label class="is-required" for="title">Job title:</label>
               <input required id="title" name="title" maxlength="255" type="text" />
             </li>
 

--- a/templates/download/shared/_server_weekly_news.html
+++ b/templates/download/shared/_server_weekly_news.html
@@ -18,9 +18,9 @@
             <input required  id="firstName" name="firstName" maxlength="255" type="text" />
             <label for="lastName">Last name:</label>
             <input required  id="lastName" name="lastName" maxlength="255" type="text" />
-            <label for="company">Company name:</label>
+            <label class="is-required" for="company">Company name:</label>
             <input required  id="company" name="company" maxlength="255" type="text" />
-            <label for="title">Job title:</label>
+            <label class="is-required" for="title">Job title:</label>
             <input required  id="title" name="title" maxlength="255" type="text" />
             <label for="email">Work email:</label>
             <input required

--- a/templates/download/shared/_server_weekly_news.html
+++ b/templates/download/shared/_server_weekly_news.html
@@ -14,22 +14,22 @@
                 onclick="toggleModal()">Close</button>
         <form action="/marketo/submit" method="post" id="mktoForm_3485">
           <div class="p-section--shallow">
-            <label for="firstName">First name:</label>
+            <label class="is-required" for="firstName">First name:</label>
             <input required  id="firstName" name="firstName" maxlength="255" type="text" />
-            <label for="lastName">Last name:</label>
+            <label class="is-required" for="lastName">Last name:</label>
             <input required  id="lastName" name="lastName" maxlength="255" type="text" />
             <label class="is-required" for="company">Company name:</label>
             <input required  id="company" name="company" maxlength="255" type="text" />
             <label class="is-required" for="title">Job title:</label>
             <input required  id="title" name="title" maxlength="255" type="text" />
-            <label for="email">Work email:</label>
+            <label class="is-required" for="email">Work email:</label>
             <input required
                    id="email"
                    name="email"
                    maxlength="255"
                    type="email"
                    pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
-            <label for="phone">Mobile/cell phone number:</label>
+            <label class="is-required" for="phone">Mobile/cell phone number:</label>
             <input required
                    id="phone"
                    name="phone"

--- a/templates/engage/shared/_de_engage_form.html
+++ b/templates/engage/shared/_de_engage_form.html
@@ -4,15 +4,15 @@
     <legend class="u-off-screen">Kontaktinformationen</legend>
     <ul class="p-list u-no-margin--bottom">
       <li>
-        <label for="firstName">Vorname:</label>
+        <label class="is-required" for="firstName">Vorname:</label>
         <input required id="firstName" name="firstName" maxlength="255" type="text" aria-label="First Name" />
       </li>
       <li>
-        <label for="lastName">Nachname:</label>
+        <label class="is-required" for="lastName">Nachname:</label>
         <input required id="lastName" name="lastName" maxlength="255" type="text" aria-label="Last Name" />
       </li>
       <li>
-        <label for="email">Email beruflich:</label>
+        <label class="is-required" for="email">Email beruflich:</label>
         <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" aria-label="Email" />
       </li>
       <li>
@@ -24,7 +24,7 @@
         <input required id="title" name="title" maxlength="255" type="text" aria-label="Job Title" />
       </li>
       <li>
-        <label for="phone">Handynummer:</label>
+        <label class="is-required" for="phone">Handynummer:</label>
         <input required id="phone" name="phone" maxlength="255" type="tel" aria-label="Phone Number" />
       </li>
       <li>

--- a/templates/engage/shared/_de_engage_form.html
+++ b/templates/engage/shared/_de_engage_form.html
@@ -16,11 +16,11 @@
         <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" aria-label="Email" />
       </li>
       <li>
-        <label for="company">Name des Unternehmens:</label>
+        <label class="is-required" for="company">Name des Unternehmens:</label>
         <input required id="company" name="company" maxlength="255" type="text" aria-label="Company Name" />
       </li>
       <li>
-        <label for="title">Tätigkeitsbezeichnung:</label>
+        <label class="is-required" for="jobTitle">Tätigkeitsbezeichnung:</label>
         <input required id="title" name="title" maxlength="255" type="text" aria-label="Job Title" />
       </li>
       <li>

--- a/templates/engage/shared/_de_engage_form.html
+++ b/templates/engage/shared/_de_engage_form.html
@@ -20,7 +20,7 @@
         <input required id="company" name="company" maxlength="255" type="text" aria-label="Company Name" />
       </li>
       <li>
-        <label class="is-required" for="jobTitle">Tätigkeitsbezeichnung:</label>
+        <label class="is-required" for="title">Tätigkeitsbezeichnung:</label>
         <input required id="title" name="title" maxlength="255" type="text" aria-label="Job Title" />
       </li>
       <li>

--- a/templates/engage/shared/_en_engage_form.html
+++ b/templates/engage/shared/_en_engage_form.html
@@ -4,15 +4,15 @@
     <legend class="u-off-screen">Contact information</legend>
     <ul class="p-list">
       <li>
-        <label for="firstName">First name:</label>
+        <label class="is-required" for="firstName">First name:</label>
         <input required id="firstName" name="firstName" maxlength="255" type="text" value="" />
       </li>
       <li>
-        <label for="lastName">Last name:</label>
+        <label class="is-required" for="lastName">Last name:</label>
         <input required id="lastName" name="lastName" maxlength="255" type="text" />
       </li>
       <li>
-        <label for="email">Work email:</label>
+        <label class="is-required" for="email">Work email:</label>
         <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" value="" />
       </li>
       <li>
@@ -24,7 +24,7 @@
         <input required id="title" name="title" maxlength="255" type="text" />
       </li>
       <li>
-        <label for="phone">Mobile/cell phone number:</label>
+        <label class="is-required" for="phone">Mobile/cell phone number:</label>
         <input required id="phone" name="phone" maxlength="255" type="tel" />
       </li>
 

--- a/templates/engage/shared/_en_engage_form.html
+++ b/templates/engage/shared/_en_engage_form.html
@@ -16,12 +16,12 @@
         <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" value="" />
       </li>
       <li>
-        <label for="company">Company name:</label>
+        <label class="is-required" for="company">Company name:</label>
         <input required id="company" name="company" maxlength="255" type="text" />
       </li>
       <li>
-        <label for="jobTitle">Job title:</label>
-        <input required id="jobTitle" name="title" maxlength="255" type="text" />
+        <label class="is-required" for="title">Job title:</label>
+        <input required id="title" name="title" maxlength="255" type="text" />
       </li>
       <li>
         <label for="phone">Mobile/cell phone number:</label>

--- a/templates/engage/shared/_es_engage_form.html
+++ b/templates/engage/shared/_es_engage_form.html
@@ -4,17 +4,17 @@
     <legend class="u-off-screen">Información del contacto</legend>
     <ul class="p-list">
       <li>
-        <label for="firstName">Nombre:</label>
+        <label class="is-required" for="firstName">Nombre:</label>
         <input required id="firstName" name="firstName" maxlength="255" type="text"
           aria-label="Nombre" />
       </li>
       <li>
-        <label for="lastName">Apellido:</label>
+        <label class="is-required" for="lastName">Apellido:</label>
         <input required id="lastName" name="lastName" maxlength="255" type="text"
           aria-label="Apellido" />
       </li>
       <li>
-        <label for="email">E-mail de trabajo:</label>
+        <label class="is-required" for="email">E-mail de trabajo:</label>
         <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"
           aria-label="E-mail de trabajo" />
       </li>
@@ -28,7 +28,7 @@
         <input required id="title" name="title" maxlength="255" type="text" aria-label="Título del puesto de trabajo" />
       </li>
       <li>
-        <label for="phone">Número del teléfono móvil/celular:</label>
+        <label class="is-required" for="phone">Número del teléfono móvil/celular:</label>
         <input required id="phone" name="phone" maxlength="255" type="tel"
           aria-label="Número de teléfono" />
       </li>

--- a/templates/engage/shared/_es_engage_form.html
+++ b/templates/engage/shared/_es_engage_form.html
@@ -19,12 +19,12 @@
           aria-label="E-mail de trabajo" />
       </li>
       <li>
-        <label for="company">Nombre de la compañía:</label>
+        <label class="is-required" for="company">Nombre de la compañía:</label>
         <input required id="company" name="company" maxlength="255" type="text"
           aria-label="Nombre de la compañía" />
       </li>
       <li>
-        <label for="title">Título del puesto de trabajo:</label>
+        <label class="is-required" for="jobTitle">Título del puesto de trabajo:</label>
         <input required id="title" name="title" maxlength="255" type="text" aria-label="Título del puesto de trabajo" />
       </li>
       <li>

--- a/templates/engage/shared/_es_engage_form.html
+++ b/templates/engage/shared/_es_engage_form.html
@@ -24,7 +24,7 @@
           aria-label="Nombre de la compañía" />
       </li>
       <li>
-        <label class="is-required" for="jobTitle">Título del puesto de trabajo:</label>
+        <label class="is-required" for="title">Título del puesto de trabajo:</label>
         <input required id="title" name="title" maxlength="255" type="text" aria-label="Título del puesto de trabajo" />
       </li>
       <li>

--- a/templates/engage/shared/_fr_engage_form.html
+++ b/templates/engage/shared/_fr_engage_form.html
@@ -24,7 +24,7 @@
         <input required id="company" name="company" maxlength="255" type="text"/>
       </li>
       <li class="p-list__item">
-        <label class="is-required" for="jobTitle">Votre fonction ou poste:</label>
+        <label class="is-required" for="title">Votre fonction ou poste:</label>
         <input required id="title" name="title" maxlength="255" type="text"/>
       </li>
       <li class="p-list__item">

--- a/templates/engage/shared/_fr_engage_form.html
+++ b/templates/engage/shared/_fr_engage_form.html
@@ -4,19 +4,19 @@
     <h2 class="p-heading--3">Prenons contact</h2>
     <ul class="p-list u-no-margin--bottom">
       <li class="p-list__item">
-        <label for="firstName">Prénom :</label>
+        <label class="is-required" for="firstName">Prénom :</label>
         <input required id="firstName" name="firstName" maxlength="255" type="text"/>
       </li>
       <li class="p-list__item">
-        <label for="lastName">Nom :</label>
+        <label class="is-required" for="lastName">Nom :</label>
         <input required id="lastName" name="lastName" maxlength="255" type="text"/>
       </li>
       <li class="p-list__item">
-        <label for="email">Adresse électronique professionnelle :</label>
+        <label class="is-required" for="email">Adresse électronique professionnelle :</label>
         <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
       </li>
       <li class="p-list__item">
-        <label for="phone">N° de téléphone portable:</label>
+        <label class="is-required" for="phone">N° de téléphone portable:</label>
         <input required id="phone" name="phone" maxlength="255" type="tel" />
       </li>
       <li class="p-list__item">

--- a/templates/engage/shared/_fr_engage_form.html
+++ b/templates/engage/shared/_fr_engage_form.html
@@ -20,11 +20,11 @@
         <input required id="phone" name="phone" maxlength="255" type="tel" />
       </li>
       <li class="p-list__item">
-        <label for="company">Société :</label>
+        <label class="is-required" for="company">Société :</label>
         <input required id="company" name="company" maxlength="255" type="text"/>
       </li>
       <li class="p-list__item">
-        <label for="title">Votre fonction ou poste:</label>
+        <label class="is-required" for="jobTitle">Votre fonction ou poste:</label>
         <input required id="title" name="title" maxlength="255" type="text"/>
       </li>
       <li class="p-list__item">

--- a/templates/engage/shared/_it_engage_form.html
+++ b/templates/engage/shared/_it_engage_form.html
@@ -24,7 +24,7 @@
           aria-label="Nome società" />
       </li>
       <li>
-        <label class="is-required" for="jobTitle">Titolo lavorativo:</label>
+        <label class="is-required" for="title">Titolo lavorativo:</label>
         <input required id="title" name="title" maxlength="255" type="text" aria-label="Titolo lavorativo" />
       </li>
       <li>

--- a/templates/engage/shared/_it_engage_form.html
+++ b/templates/engage/shared/_it_engage_form.html
@@ -19,12 +19,12 @@
           aria-label="E-mail lavorativa" />
       </li>
       <li>
-        <label for="company">Nome società:</label>
+        <label class="is-required" for="company">Nome società:</label>
         <input required id="company" name="company" maxlength="255" type="text"
           aria-label="Nome società" />
       </li>
       <li>
-        <label for="title">Titolo lavorativo:</label>
+        <label class="is-required" for="jobTitle">Titolo lavorativo:</label>
         <input required id="title" name="title" maxlength="255" type="text" aria-label="Titolo lavorativo" />
       </li>
       <li>

--- a/templates/engage/shared/_it_engage_form.html
+++ b/templates/engage/shared/_it_engage_form.html
@@ -4,17 +4,17 @@
     <legend class="u-off-screen">Informazioni sui contatti</legend>
     <ul class="p-list">
       <li>
-        <label for="firstName">Nome:</label>
+        <label class="is-required" for="firstName">Nome:</label>
         <input required id="firstName" name="firstName" maxlength="255" type="text"
           aria-label="Nome" />
       </li>
       <li>
-        <label for="lastName">Cognome:</label>
+        <label class="is-required" for="lastName">Cognome:</label>
         <input required id="lastName" name="lastName" maxlength="255" type="text"
           aria-label="Cognome" />
       </li>
       <li>
-        <label for="email">E-mail lavorativa:</label>
+        <label class="is-required" for="email">E-mail lavorativa:</label>
         <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"
           aria-label="E-mail lavorativa" />
       </li>
@@ -28,7 +28,7 @@
         <input required id="title" name="title" maxlength="255" type="text" aria-label="Titolo lavorativo" />
       </li>
       <li>
-        <label for="phone">Numero di telefono:</label>
+        <label class="is-required" for="phone">Numero di telefono:</label>
         <input required id="phone" name="phone" maxlength="255" type="tel"
           aria-label="Numero di telefono" />
       </li>

--- a/templates/engage/shared/_kr_engage_form.html
+++ b/templates/engage/shared/_kr_engage_form.html
@@ -4,15 +4,15 @@
     <legend class="u-off-screen">연락처 정보</legend>
     <ul class="p-list">
       <li>
-        <label for="firstName">이름:</label>
+        <label class="is-required" for="firstName">이름:</label>
         <input required id="firstName" name="firstName" maxlength="255" type="text" value="" />
       </li>
       <li>
-        <label for="lastName">성:</label>
+        <label class="is-required" for="lastName">성:</label>
         <input required id="lastName" name="lastName" maxlength="255" type="text" />
       </li>
       <li>
-        <label for="email">직장 이메일:</label>
+        <label class="is-required" for="email">직장 이메일:</label>
         <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" value="" />
       </li>
       <li>
@@ -24,7 +24,7 @@
         <input required id="title" name="title" maxlength="255" type="text" />
       </li>
       <li>
-        <label for="phone">휴대폰 번호:</label>
+        <label class="is-required" for="phone">휴대폰 번호:</label>
         <input required id="phone" name="phone" maxlength="255" type="tel" />
       </li>
       <li>

--- a/templates/engage/shared/_kr_engage_form.html
+++ b/templates/engage/shared/_kr_engage_form.html
@@ -16,12 +16,12 @@
         <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" value="" />
       </li>
       <li>
-        <label for="company">회사 이름:</label>
+        <label class="is-required" for="company">회사 이름:</label>
         <input required id="company" name="company" maxlength="255" type="text" />
       </li>
       <li>
-        <label for="jobTitle">직위:</label>
-        <input required id="jobTitle" name="title" maxlength="255" type="text" />
+        <label class="is-required" for="jobTitle">직위:</label>
+        <input required id="title" name="title" maxlength="255" type="text" />
       </li>
       <li>
         <label for="phone">휴대폰 번호:</label>

--- a/templates/engage/shared/_kr_engage_form.html
+++ b/templates/engage/shared/_kr_engage_form.html
@@ -20,7 +20,7 @@
         <input required id="company" name="company" maxlength="255" type="text" />
       </li>
       <li>
-        <label class="is-required" for="jobTitle">직위:</label>
+        <label class="is-required" for="title">직위:</label>
         <input required id="title" name="title" maxlength="255" type="text" />
       </li>
       <li>

--- a/templates/engage/shared/_pt_engage_form.html
+++ b/templates/engage/shared/_pt_engage_form.html
@@ -4,17 +4,17 @@
     <legend class="u-off-screen">Informações de contato</legend>
     <ul class="p-list">
       <li>
-        <label for="firstName">Primeiro Nome:</label>
+        <label class="is-required" for="firstName">Primeiro Nome:</label>
         <input required id="firstName" name="firstName" maxlength="255" type="text"
           aria-label="First Name" />
       </li>
       <li>
-        <label for="lastName">Último Nome:</label>
+        <label class="is-required" for="lastName">Último Nome:</label>
         <input required id="lastName" name="lastName" maxlength="255" type="text"
           aria-label="Last Name" />
       </li>
       <li>
-        <label for="email">Email do trabalho:</label>
+        <label class="is-required" for="email">Email do trabalho:</label>
         <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"
           aria-label="Email" />
       </li>
@@ -28,7 +28,7 @@
         <input required id="title" name="title" maxlength="255" type="text" aria-label="Job Title" />
       </li>
       <li>
-        <label for="phone">Telemóvel:</label>
+        <label class="is-required" for="phone">Telemóvel:</label>
         <input required id="phone" name="phone" maxlength="255" type="tel"
           aria-label="Phone Number" />
       </li>

--- a/templates/engage/shared/_pt_engage_form.html
+++ b/templates/engage/shared/_pt_engage_form.html
@@ -19,12 +19,12 @@
           aria-label="Email" />
       </li>
       <li>
-        <label for="company">Nome da Empresa:</label>
+        <label class="is-required" for="company">Nome da Empresa:</label>
         <input required id="company" name="company" maxlength="255" type="text"
           aria-label="Company Name" />
       </li>
       <li>
-        <label for="title">Titulo do trabalho:</label>
+        <label class="is-required" for="jobTitle">Titulo do trabalho:</label>
         <input required id="title" name="title" maxlength="255" type="text" aria-label="Job Title" />
       </li>
       <li>

--- a/templates/engage/shared/_pt_engage_form.html
+++ b/templates/engage/shared/_pt_engage_form.html
@@ -24,7 +24,7 @@
           aria-label="Company Name" />
       </li>
       <li>
-        <label class="is-required" for="jobTitle">Titulo do trabalho:</label>
+        <label class="is-required" for="title">Titulo do trabalho:</label>
         <input required id="title" name="title" maxlength="255" type="text" aria-label="Job Title" />
       </li>
       <li>

--- a/templates/engage/shared/_ru_engage_form.html
+++ b/templates/engage/shared/_ru_engage_form.html
@@ -4,15 +4,15 @@
         <legend class="u-off-screen">Контактная информация</legend>
         <ul class="p-list">
         <li>
-            <label for="firstName">Имя:</label>
+            <label class="is-required" for="firstName">Имя:</label>
             <input required id="firstName" name="firstName" maxlength="255" type="text" />
         </li>
         <li>
-            <label for="lastName">Фамилия:</label>
+            <label class="is-required" for="lastName">Фамилия:</label>
             <input required id="lastName" name="lastName" maxlength="255" type="text" />
         </li>
         <li>
-            <label for="email">Рабочая электронная почта:</label>
+            <label class="is-required" for="email">Рабочая электронная почта:</label>
             <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
         </li>
         <li>
@@ -24,7 +24,7 @@
             <input required id="title" name="title" maxlength="255" type="text" />
         </li>
         <li>
-            <label for="phone">Номер телефона:</label>
+            <label class="is-required" for="phone">Номер телефона:</label>
             <input required id="phone" name="phone" maxlength="255" type="tel" />
         </li>
         <li>

--- a/templates/engage/shared/_ru_engage_form.html
+++ b/templates/engage/shared/_ru_engage_form.html
@@ -16,12 +16,12 @@
             <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
         </li>
         <li>
-            <label for="company">Компания:</label>
+            <label class="is-required" for="company">Компания:</label>
             <input required id="company" name="company" maxlength="255" type="text" />
         </li>
         <li>
-            <label for="jobTitle">Должность:</label>
-            <input required id="jobTitle" name="title" maxlength="255" type="text" />
+            <label class="is-required" for="jobTitle">Должность:</label>
+            <input required id="title" name="title" maxlength="255" type="text" />
         </li>
         <li>
             <label for="phone">Номер телефона:</label>

--- a/templates/engage/shared/_ru_engage_form.html
+++ b/templates/engage/shared/_ru_engage_form.html
@@ -20,7 +20,7 @@
             <input required id="company" name="company" maxlength="255" type="text" />
         </li>
         <li>
-            <label class="is-required" for="jobTitle">Должность:</label>
+            <label class="is-required" for="title">Должность:</label>
             <input required id="title" name="title" maxlength="255" type="text" />
         </li>
         <li>

--- a/templates/engage/shared/_tr_engage_form.html
+++ b/templates/engage/shared/_tr_engage_form.html
@@ -4,7 +4,7 @@
     <legend class="u-off-screen">İletişim bilgileri</legend>
     <ul class="p-list">
       <li>
-        <label for="firstName">İlk adı:</label>
+        <label class="is-required" for="firstName">İlk adı:</label>
         <input required
                id="firstName"
                name="firstName"
@@ -13,11 +13,11 @@
                value="" />
       </li>
       <li>
-        <label for="lastName">Soy isim:</label>
+        <label class="is-required" for="lastName">Soy isim:</label>
         <input required id="lastName" name="lastName" maxlength="255" type="text" />
       </li>
       <li>
-        <label for="email">İş e-postası:</label>
+        <label class="is-required" for="email">İş e-postası:</label>
         <input required
                id="email"
                name="email"
@@ -35,7 +35,7 @@
         <input required id="title" name="title" maxlength="255" type="text" />
       </li>
       <li>
-        <label for="phone">Cep telefonu numarası:</label>
+        <label class="is-required" for="phone">Cep telefonu numarası:</label>
         <input required id="phone" name="phone" maxlength="255" type="tel" />
       </li>
       {% set country = "Ülke" %}

--- a/templates/engage/shared/_tr_engage_form.html
+++ b/templates/engage/shared/_tr_engage_form.html
@@ -27,12 +27,12 @@
                value="" />
       </li>
       <li>
-        <label for="company">Firma Adı:</label>
+        <label class="is-required" for="company">Firma Adı:</label>
         <input required id="company" name="company" maxlength="255" type="text" />
       </li>
       <li>
-        <label for="jobTitle">İş ünvanı:</label>
-        <input required id="jobTitle" name="title" maxlength="255" type="text" />
+        <label class="is-required" for="jobTitle">İş ünvanı:</label>
+        <input required id="title" name="title" maxlength="255" type="text" />
       </li>
       <li>
         <label for="phone">Cep telefonu numarası:</label>

--- a/templates/engage/shared/_tr_engage_form.html
+++ b/templates/engage/shared/_tr_engage_form.html
@@ -31,7 +31,7 @@
         <input required id="company" name="company" maxlength="255" type="text" />
       </li>
       <li>
-        <label class="is-required" for="jobTitle">İş ünvanı:</label>
+        <label class="is-required" for="title">İş ünvanı:</label>
         <input required id="title" name="title" maxlength="255" type="text" />
       </li>
       <li>

--- a/templates/engage/shared/_zh-TW_engage_form.html
+++ b/templates/engage/shared/_zh-TW_engage_form.html
@@ -16,12 +16,12 @@
         <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" value="" />
       </li>
       <li>
-        <label for="company">Company name:</label>
+        <label class="is-required" for="company">Company name:</label>
         <input required id="company" name="company" maxlength="255" type="text" />
       </li>
       <li>
-        <label for="jobTitle">Job title:</label>
-        <input required id="jobTitle" name="title" maxlength="255" type="text" />
+        <label class="is-required" for="title">Job title:</label>
+        <input required id="title" name="title" maxlength="255" type="text" />
       </li>
       <li>
         <label for="phone">Mobile/cell phone number:</label>

--- a/templates/engage/shared/_zh-TW_engage_form.html
+++ b/templates/engage/shared/_zh-TW_engage_form.html
@@ -4,15 +4,15 @@
     <legend class="u-off-screen">Contact information</legend>
     <ul class="p-list">
       <li>
-        <label for="firstName">First name:</label>
+        <label class="is-required" for="firstName">First name:</label>
         <input required id="firstName" name="firstName" maxlength="255" type="text" value="" />
       </li>
       <li>
-        <label for="lastName">Last name:</label>
+        <label class="is-required" for="lastName">Last name:</label>
         <input required id="lastName" name="lastName" maxlength="255" type="text" />
       </li>
       <li>
-        <label for="email">Work email:</label>
+        <label class="is-required" for="email">Work email:</label>
         <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" value="" />
       </li>
       <li>
@@ -24,7 +24,7 @@
         <input required id="title" name="title" maxlength="255" type="text" />
       </li>
       <li>
-        <label for="phone">Mobile/cell phone number:</label>
+        <label class="is-required" for="phone">Mobile/cell phone number:</label>
         <input required id="phone" name="phone" maxlength="255" type="tel" />
       </li>
       <li>

--- a/templates/hpc/_hpc-contact-us-form.html
+++ b/templates/hpc/_hpc-contact-us-form.html
@@ -38,8 +38,8 @@
           <h3>About your role</h3>
           <ul class="p-list">
             <li class="p-list__item">
-              <label for="jobTitle">Job title:</label>
-              <input required id="jobTitle" name="title" maxlength="255" type="text" />
+              <label class="is-required" for="title">Job title:</label>
+              <input required id="title" name="title" maxlength="255" type="text" />
             </li>
           </ul>
         </fieldset>
@@ -47,12 +47,12 @@
           <h3>About your company</h3>
           <ul class="p-list">
             <li class="p-list__item">
-              <label for="company">Company name:</label>
+              <label class="is-required" for="company">Company name:</label>
               <input required id="company" name="company" maxlength="255" type="text" />
             </li>
             <li class="p-list__item">
               <label for="industry">Industry:</label>
-              <input id="industry" name="title" maxlength="255" type="text" />
+              <input required id="title" name="title" maxlength="255" type="text" />
             </li>
           </ul>
         </fieldset>

--- a/templates/hpc/_hpc-contact-us-form.html
+++ b/templates/hpc/_hpc-contact-us-form.html
@@ -10,15 +10,15 @@
           <h3>About you</h3>
           <ul class="p-list">
             <li class="p-list__item">
-              <label for="firstName">First name:</label>
+              <label class="is-required" for="firstName">First name:</label>
               <input required id="firstName" name="firstName" maxlength="255" type="text" />
             </li>
             <li class="p-list__item">
-              <label for="lastName">Last name:</label>
+              <label class="is-required" for="lastName">Last name:</label>
               <input required id="lastName" name="lastName" maxlength="255" type="text" />
             </li>
             <li class="p-list__item">
-              <label for="email">Email address:</label>
+              <label class="is-required" for="email">Email address:</label>
               <input required
                      id="email"
                      name="email"

--- a/templates/hpc/_hpc-contact-us-form.html
+++ b/templates/hpc/_hpc-contact-us-form.html
@@ -52,7 +52,7 @@
             </li>
             <li class="p-list__item">
               <label for="industry">Industry:</label>
-              <input required id="title" name="title" maxlength="255" type="text" />
+              <input required id="industry" name="title" maxlength="255" type="text" />
             </li>
           </ul>
         </fieldset>

--- a/templates/internet-of-things/contact-us-hannover.html
+++ b/templates/internet-of-things/contact-us-hannover.html
@@ -77,7 +77,7 @@
               <input required id="lastName" name="lastName" maxlength="255" type="text" />
             </li>
             <li class="p-list__item">
-              <label for="company">Company:</label>
+              <label class="is-required" for="company">Company:</label>
               <input required id="company" name="company" maxlength="255" type="text" />
             </li>
             <li class="p-list__item">

--- a/templates/internet-of-things/contact-us-hannover.html
+++ b/templates/internet-of-things/contact-us-hannover.html
@@ -81,6 +81,10 @@
               <input required id="company" name="company" maxlength="255" type="text" />
             </li>
             <li class="p-list__item">
+              <label class="is-required" for="title">Job Title:</label>
+              <input required id="title" name="title" maxlength="255" type="text" />
+            </li>
+            <li class="p-list__item">
               <label for="email">Email:</label>
               <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
             </li>

--- a/templates/internet-of-things/contact-us-hannover.html
+++ b/templates/internet-of-things/contact-us-hannover.html
@@ -69,11 +69,11 @@
           <h3>About you</h3>
           <ul class="p-list">
             <li class="p-list__item">
-              <label for="firstName">First name:</label>
+              <label class="is-required" for="firstName">First name:</label>
               <input required id="firstName" name="firstName" maxlength="255" type="text" />
             </li>
             <li class="p-list__item">
-              <label for="lastName">Last name:</label>
+              <label class="is-required" for="lastName">Last name:</label>
               <input required id="lastName" name="lastName" maxlength="255" type="text" />
             </li>
             <li class="p-list__item">
@@ -85,11 +85,11 @@
               <input required id="title" name="title" maxlength="255" type="text" />
             </li>
             <li class="p-list__item">
-              <label for="email">Email:</label>
+              <label class="is-required" for="email">Email:</label>
               <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
             </li>
             <li class="p-list__item">
-              <label for="phone">Mobile/cell phone number:</label>
+              <label class="is-required" for="phone">Mobile/cell phone number:</label>
               <input required id="phone" name="phone" maxlength="255" type="tel" />
             </li>
           </ul>

--- a/templates/kernel/real-time/contact-us.html
+++ b/templates/kernel/real-time/contact-us.html
@@ -613,12 +613,12 @@
                   <input required id="lastName" name="lastName" maxlength="255" type="text" />
                 </li>
                 <li class="p-list__item">
-                  <label for="company">Company:</label>
-                  <input id="company" name="company" maxlength="255" type="text" />
+                  <label class="is-required" for="company">Company:</label>
+                  <input required id="company" name="company" maxlength="255" type="text" />
                 </li>
                 <li class="p-list__item">
-                  <label for="title">Job title:</label>
-                  <input id="title" name="title" maxlength="255" type="text" />
+                  <label class="is-required" for="title">Job title:</label>
+                  <input required id="title" name="title" maxlength="255" type="text" />
                 </li>
                 <li class="p-list__item">
                   <label class="is-required" for="email">Email address:</label>

--- a/templates/rfp/index.html
+++ b/templates/rfp/index.html
@@ -30,38 +30,38 @@
     </div>
     <div class="col-6">
       <!-- MARKETO FORM -->
-      <form action="/marketo/submit" method="post" id="mktoForm_3285">
+      <form action="/marketo/submit" method="post" id="mktoForm_3285" />
         <fieldset>
           <ul class="p-list">
 
             <li class="p-list__item">
-              <label for="firstName">First name:</label>
-              <input required="" id="firstName" name="firstName" maxlength="255" type="text">
+              <label class="is-required" for="firstName">First name:</label>
+              <input required id="firstName" name="firstName" maxlength="255" type="text" />
             </li>
 
             <li class="p-list__item">
-              <label for="lastName">Last name:</label>
-              <input required="" id="lastName" name="lastName" maxlength="255" type="text">
+              <label class="is-required" for="lastName">Last name:</label>
+              <input required id="lastName" name="lastName" maxlength="255" type="text" />
             </li>
 
             <li class="p-list__item">
-              <label for="company">Company:</label>
-              <input required="" id="company" name="company" maxlength="255" type="text">
+              <label class="is-required" for="company">Company:</label>
+              <input required id="company" name="company" maxlength="255" type="text" />
             </li>
 
             <li class="p-list__item">
-              <label for="email">Email:</label>
-              <input required="" id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$">
+              <label class="is-required" for="email">Email:</label>
+              <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
             </li>
 
             <li class="p-list__item">
-              <label for="title">Title:</label>
-              <input required="" id="title" name="title" maxlength="255" type="text">
+              <label class="is-required" for="title">Job title:</label>
+              <input required id="title" name="title" maxlength="255" type="text" />
             </li>
 
             <li class="p-list__item">
-              <label for="phone">Mobile/cell phone number:</label>
-              <input required="" id="phone" name="phone" maxlength="255" type="tel">
+              <label class="is-required" for="phone">Mobile/cell phone number:</label>
+              <input required id="phone" name="phone" maxlength="255" type="tel" />
             </li>
 
             <li  class="p-list__item">
@@ -71,7 +71,7 @@
 
 
             <li class="p-list__item">
-              <label for="Comments_from_lead__c">Your message:</label>
+              <label class="is-required" for="Comments_from_lead__c">Your message:</label>
               <textarea required id="Comments_from_lead__c" name="Comments_from_lead__c" rows="4" maxlength="2000"></textarea>
             </li>
 

--- a/templates/shared/_blender-contact-us-form.html
+++ b/templates/shared/_blender-contact-us-form.html
@@ -18,23 +18,27 @@
           <p>How should we get in touch?</p>
           <ul class="p-list">
             <li class="p-list__item">
-              <label for="firstName">First name:</label>
+              <label class="is-required" for="firstName">First name:</label>
               <input required id="firstName" name="firstName" maxlength="255" type="text"/>
             </li>
             <li class="p-list__item">
-              <label for="lastName">Last name:</label>
+              <label class="is-required" for="lastName">Last name:</label>
               <input required id="lastName" name="lastName" maxlength="255" type="text"/>
             </li>
             <li class="p-list__item">
-              <label for="companyName">Company name:</label>
+              <label class="is-required" for="companyName">Company name:</label>
               <input required id="companyName" name="company" maxlength="255" type="text"/>
             </li>
             <li class="p-list__item">
-              <label for="email">Email address:</label>
+              <label class="is-required" for="title">Job Title:</label>
+              <input required id="title" name="title" maxlength="255" type="text" />
+            </li>
+            <li class="p-list__item">
+              <label class="is-required" for="email">Email address:</label>
               <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
             </li>
             <li class="p-list__item">
-              <label for="phone">Mobile/cell phone number:</label>
+              <label class="is-required" for="phone">Mobile/cell phone number:</label>
               <input required id="phone" name="phone" maxlength="255" type="tel" />
             </li>
           </ul>

--- a/templates/shared/_client-contact-us-form.html
+++ b/templates/shared/_client-contact-us-form.html
@@ -27,7 +27,7 @@
                 <input required id="company" name="company" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label class="is-required" for="job-title">Job title:</label>
+                <label class="is-required" for="title">Job title:</label>
                 <input required id="title" name="title" maxlength="255" type="text" />
               </li>
             </ul>

--- a/templates/shared/_client-contact-us-form.html
+++ b/templates/shared/_client-contact-us-form.html
@@ -28,7 +28,7 @@
               </li>
               <li class="p-list__item">
                 <label class="is-required" for="job-title">Job title:</label>
-                <input required id="job-title" name="title" maxlength="255" type="text" />
+                <input required id="title" name="title" maxlength="255" type="text" />
               </li>
             </ul>
           </div>

--- a/templates/shared/_default-contact-us-form.html
+++ b/templates/shared/_default-contact-us-form.html
@@ -428,12 +428,12 @@
                 <input required id="lastName" name="lastName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="company">Company:</label>
-                <input id="company" name="company" maxlength="255" type="text" />
+                <label class="is-required" for="company">Company:</label>
+                <input required id="company" name="company" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="title">Job title:</label>
-                <input id="title" name="title" maxlength="255" type="text" />
+                <label class="is-required" for="title">Job title:</label>
+                <input required id="title" name="title" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
                 <label class="is-required" for="email">Email address:</label>

--- a/templates/shared/_download-newsletter.html
+++ b/templates/shared/_download-newsletter.html
@@ -7,7 +7,7 @@
       method="post"
       id="mktoForm_5883"
       onsubmit="stringifyCustomFields(); ga('send', 'Newsletter', 'Signup', '{{ ga_event_title }} newsletter signup');">
-  <label for="email">Email*:</label>
+  <label class="is-required" for="email">Email:</label>
   <input required
          id="email"
          name="email"

--- a/templates/shared/_openstack_contact_us.html
+++ b/templates/shared/_openstack_contact_us.html
@@ -354,7 +354,7 @@
               </li>
               <li class="p-list__item">
                 <label for="job-title">Job title:</label>
-                <input id="job-title" name="title" maxlength="255" type="text" />
+                <input required id="title" name="title" maxlength="255" type="text" />
               </li>
               {% include "shared/forms/_industry.html" %}
               {% include "shared/forms/_country.html" %}

--- a/templates/shared/_pro-contact-us-form.html
+++ b/templates/shared/_pro-contact-us-form.html
@@ -443,12 +443,12 @@
                 <input required id="lastName" name="lastName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="company">Company:</label>
-                <input id="company" name="company" maxlength="255" type="text" />
+                <label class="is-required" for="company">Company:</label>
+                <input required id="company" name="company" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="title">Job title:</label>
-                <input id="title" name="title" maxlength="255" type="text" />
+                <label class="is-required" for="title">Job title:</label>
+                <input required id="title" name="title" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
                 <label class="is-required" for="email">Email address:</label>

--- a/templates/shared/_telco-contact-us.html
+++ b/templates/shared/_telco-contact-us.html
@@ -164,20 +164,20 @@
               <div class="col-6">
                 <ul class="p-list">
                   <li class="p-list__item">
-                    <label for="FirstName">First name:</label>
-                    <input required id="FirstName" name="firstName" maxlength="255" type="text" required="required" />
+                    <label class="is-required" for="firstName">First name:</label>
+                    <input required id="firstName" name="firstName" maxlength="255" type="text" />
                   </li>
                   <li class="p-list__item">
-                    <label for="LastName">Last name:</label>
-                    <input required id="LastName" name="lastName" maxlength="255" type="text" required="required" />
+                    <label class="is-required" for="lastName">Last name:</label>
+                    <input required id="lastName" name="lastName" maxlength="255" type="text" />
                   </li>
                   <li class="p-list__item">
-                    <label for="Email">Email:</label>
-                    <input required id="Email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
+                    <label class="is-required" for="email">Email:</label>
+                    <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
                   </li>
                   <li class="p-list__item">
-                    <label for="Phone">Mobile/cell phone number:</label>
-                    <input required id="Phone" name="phone" maxlength="255" type="tel" required="required" />
+                    <label class="is-required" for="phone">Mobile/cell phone number:</label>
+                    <input required id="phone" name="phone" maxlength="255" type="tel" />
                   </li>
                   {# These are honey pot fields to catch bots #}
                   <li class="u-off-screen">

--- a/templates/shared/contextual_footers/_download_iot_iotg_newsletter.html
+++ b/templates/shared/contextual_footers/_download_iot_iotg_newsletter.html
@@ -4,7 +4,7 @@
     <h3>Sign up to receive information about product updates</h3>
     <ul class="p-list u-clearfix">
       <li class="p-list__item">
-        <label for="email">Your email:</label>
+        <label class="is-required" for="email">Your email:</label>
         <input id="email" name="email" maxlength="255" type="email"  aria-required="true" required />
       </li>
       <li class="p-list__item">

--- a/templates/shared/forms/_desktop-security.html
+++ b/templates/shared/forms/_desktop-security.html
@@ -10,7 +10,7 @@
       <input required  id="lastName" name="lastName" maxlength="255" type="text">
     </li>
     <li class="p-list__item">
-      <label for="company">Company Name:</label>
+      <label class="is-required" for="company">Company Name:</label>
       <input required  id="company" name="company" maxlength="255" type="text">
     </li>
     <li class="p-list__item">

--- a/templates/shared/forms/_desktop-security.html
+++ b/templates/shared/forms/_desktop-security.html
@@ -2,11 +2,11 @@
   <legend class="u-off-screen">Contact information</legend>
   <ul class="p-list">
     <li class="p-list__item">
-      <label for="firstName">First name:</label>
+      <label class="is-required" for="firstName">First name:</label>
       <input required  id="firstName" name="firstName" maxlength="255" type="text" >
     </li>
     <li class="p-list__item">
-      <label for="lastName">Last name:</label>
+      <label class="is-required" for="lastName">Last name:</label>
       <input required  id="lastName" name="lastName" maxlength="255" type="text">
     </li>
     <li class="p-list__item">
@@ -18,11 +18,11 @@
       <input required id="title" name="title" maxlength="255" type="text" />
     </li>
     <li class="p-list__item">
-      <label for="email">Work email address:</label>
+      <label class="is-required" for="email">Work email address:</label>
       <input required  id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$">
     </li>
     <li class="p-list__item">
-      <label for="phone">Mobile/cell phone number:</label>
+      <label class="is-required" for="phone">Mobile/cell phone number:</label>
       <input required  id="phone" name="phone" maxlength="255" type="tel">
     </li>
     {% include "shared/forms/_country.html" %}

--- a/templates/shared/forms/_desktop-security.html
+++ b/templates/shared/forms/_desktop-security.html
@@ -14,6 +14,10 @@
       <input required  id="company" name="company" maxlength="255" type="text">
     </li>
     <li class="p-list__item">
+      <label class="is-required" for="title">Job Title:</label>
+      <input required id="title" name="title" maxlength="255" type="text" />
+    </li>
+    <li class="p-list__item">
       <label for="email">Work email address:</label>
       <input required  id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$">
     </li>

--- a/templates/shared/forms/interactive/advantage-beta.html
+++ b/templates/shared/forms/interactive/advantage-beta.html
@@ -14,21 +14,21 @@
           <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
             <ul class="p-list">
               <li class="p-list__item">
-                <label for="firstName">First name:</label>
+                <label class="is-required" for="firstName">First name:</label>
                 {% if user_info %}
                   {% set first_name = user_info.fullname.split(' ')[0] %}
                   {% set last_name = user_info.fullname | replace(first_name + " ", "") %}
                   <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" value="{{ first_name }}" />
                 {% else %}
-                  <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
+                  <input required id="firstName" name="firstName" maxlength="255" type="text" />
                 {% endif %}
               </li>
               <li class="p-list__item">
-                <label for="lastName">Last name:</label>
+                <label class="is-required" for="lastName">Last name:</label>
                 {% if user_info %}
                   <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" value="{{ last_name }}" />
                 {% else %}
-                  <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
+                  <input required id="lastName" name="lastName" maxlength="255" type="text" />
                 {% endif %}
               </li>
               <li class="p-list__item">
@@ -36,7 +36,7 @@
                 {% if user_info %}
                   <input required id="email_disabled" name="email_disabled" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" value="{{ user_info.email }}" disabled/>
                 {% else %}
-                  <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
+                  <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
                 {% endif %}
               </li>
               <li class="p-list__item">

--- a/templates/shared/forms/interactive/ai-data-science.html
+++ b/templates/shared/forms/interactive/ai-data-science.html
@@ -77,10 +77,10 @@
               {% with raw = "true" %}
                 {% include "shared/forms/_country.html" %}
               {% endwith %}
-              <label for="company">Company:</label>
-              <input id="company" name="company" maxlength="255" type="text" />
-              <label for="company">Job Title:</label>
-              <input id="title" name="title" maxlength="255" type="text" />
+              <label class="is-required" for="company">Company:</label>
+              <input required id="company" name="company" maxlength="255" type="text" />
+              <label class="is-required" for="title">Job Title:</label>
+              <input required id="title" name="title" maxlength="255" type="text" />
             </div>
             <div class="p-section--shallow">
               <label class="p-checkbox">

--- a/templates/shared/forms/interactive/ai.html
+++ b/templates/shared/forms/interactive/ai.html
@@ -91,7 +91,7 @@
               <label class="is-required" for="company">Company:</label>
               <input required id="company" name="company" maxlength="255" type="text" />
 
-              <label class="is-required" for="company">Title:</label>
+              <label class="is-required" for="title">Title:</label>
               <input required id="title" name="title" maxlength="255" type="text" />
 
               <label for="email">Email:</label>

--- a/templates/shared/forms/interactive/ai.html
+++ b/templates/shared/forms/interactive/ai.html
@@ -88,10 +88,10 @@
               <label for="lastName">Last name:</label>
               <input required id="lastName" name="lastName" maxlength="255" type="text" />
 
-              <label for="company">Company:</label>
+              <label class="is-required" for="company">Company:</label>
               <input required id="company" name="company" maxlength="255" type="text" />
 
-              <label for="company">Title:</label>
+              <label class="is-required" for="company">Title:</label>
               <input required id="title" name="title" maxlength="255" type="text" />
 
               <label for="email">Email:</label>

--- a/templates/shared/forms/interactive/ai.html
+++ b/templates/shared/forms/interactive/ai.html
@@ -82,10 +82,10 @@
             <div class="row">
               <hr class="p-rule" />
               <p class="p-heading--5">Add your information</p>
-              <label for="firstName">First name:</label>
+              <label class="is-required" for="firstName">First name:</label>
               <input required id="firstName" name="firstName" maxlength="255" type="text" />
 
-              <label for="lastName">Last name:</label>
+              <label class="is-required" for="lastName">Last name:</label>
               <input required id="lastName" name="lastName" maxlength="255" type="text" />
 
               <label class="is-required" for="company">Company:</label>
@@ -94,7 +94,7 @@
               <label class="is-required" for="title">Title:</label>
               <input required id="title" name="title" maxlength="255" type="text" />
 
-              <label for="email">Email:</label>
+              <label class="is-required" for="email">Email:</label>
               <input required
                      id="email"
                      name="email"
@@ -102,7 +102,7 @@
                      type="email"
                      pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
 
-              <label for="phone">Phone number:</label>
+              <label class="is-required" for="phone">Phone number:</label>
               <input required id="phone" name="phone" maxlength="255" type="tel" />
 
               <label for="country">Country:</label>

--- a/templates/shared/forms/interactive/appliance.html
+++ b/templates/shared/forms/interactive/appliance.html
@@ -245,7 +245,7 @@
                 class="modal-form">
             <ul class="p-list">
               <li class="p-list__item">
-                <label for="firstName">First name:</label>
+                <label class="is-required" for="firstName">First name:</label>
                 <input required
                        id="firstName"
                        name="firstName"
@@ -254,7 +254,7 @@
                        required="required" />
               </li>
               <li class="p-list__item">
-                <label for="lastName">Last name:</label>
+                <label class="is-required" for="lastName">Last name:</label>
                 <input required
                        id="lastName"
                        name="lastName"
@@ -263,7 +263,7 @@
                        required="required" />
               </li>
               <li class="p-list__item">
-                <label for="email">Work email:</label>
+                <label class="is-required" for="email">Work email:</label>
                 <input required
                        id="email"
                        name="email"

--- a/templates/shared/forms/interactive/automotive-newsletter-opt-in.html
+++ b/templates/shared/forms/interactive/automotive-newsletter-opt-in.html
@@ -10,8 +10,8 @@
           <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
             <ul class="p-list">
               <li class="p-list__item js-formfield">
-                <label for="email">Email address:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
+                <label class="is-required" for="email">Email address:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
               </li>
               <li class="p-list__item">In submitting this form, I confirm that I have read and agree to Canonical's <a href="/legal/terms-and-policies/privacy-policy"> Privacy Policy</a></li>
               {# These are honey pot fields to catch bots #}

--- a/templates/shared/forms/interactive/automotive.html
+++ b/templates/shared/forms/interactive/automotive.html
@@ -15,15 +15,15 @@
             <h3 class="p-heading--4">How should we get in touch?</h3>
             <ul class="p-list">
               <li class="p-list__item">
-                <label for="firstName">First name:</label>
+                <label class="is-required" for="firstName">First name:</label>
                 <input required id="firstName" name="firstName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="lastName">Last name:</label>
+                <label class="is-required" for="lastName">Last name:</label>
                 <input required id="lastName" name="lastName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="email">Email address:</label>
+                <label class="is-required" for="email">Email address:</label>
                 <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
               </li>
               <li class="p-list__item">

--- a/templates/shared/forms/interactive/aws.html
+++ b/templates/shared/forms/interactive/aws.html
@@ -436,12 +436,12 @@
                     <input required id="lastName" name="lastName" maxlength="255" type="text" />
                   </li>
                   <li class="p-list__item">
-                    <label for="company">Company:</label>
-                    <input id="company" name="company" maxlength="255" type="text" />
+                    <label class="is-required" for="company">Company:</label>
+                    <input required id="company" name="company" maxlength="255" type="text" />
                   </li>
                   <li class="p-list__item">
-                    <label for="title">Job title:</label>
-                    <input id="title" name="title" maxlength="255" type="text" />
+                    <label class="is-required" for="title">Job title:</label>
+                    <input required id="title" name="title" maxlength="255" type="text" />
                   </li>
                   <li class="p-list__item">
                     <label class="is-required" for="email">Email address:</label>

--- a/templates/shared/forms/interactive/azure-1604.html
+++ b/templates/shared/forms/interactive/azure-1604.html
@@ -208,15 +208,15 @@
           <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
             <ul class="p-list">
               <li class="p-list__item">
-                <label for="firstName">First name:</label>
+                <label class="is-required" for="firstName">First name:</label>
                 <input required id="firstName" name="firstName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="lastName">Last name:</label>
+                <label class="is-required" for="lastName">Last name:</label>
                 <input required id="lastName" name="lastName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="email">Work email:</label>
+                <label class="is-required" for="email">Work email:</label>
                 <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
               </li>
               <li class="p-list__item">

--- a/templates/shared/forms/interactive/azure.html
+++ b/templates/shared/forms/interactive/azure.html
@@ -203,20 +203,20 @@
           <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
             <ul class="p-list">
               <li class="p-list__item">
-                <label for="firstName">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
+                <label class="is-required" for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="lastName">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
+                <label class="is-required" for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="email">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
+                <label class="is-required" for="email">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
               </li>
               <li class="p-list__item">
-                <label for="phone">Mobile/cell phone number:</label>
-                <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
+                <label class="is-required" for="phone">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" />
               </li>
               <li class="p-list__item">
                 <label class="p-checkbox">

--- a/templates/shared/forms/interactive/bootstack.html
+++ b/templates/shared/forms/interactive/bootstack.html
@@ -573,20 +573,20 @@
           <div class="col-6">
             <ul class="p-list">
               <li class="p-list__item">
-                <label for="firstName">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
+                <label class="is-required" for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="lastName">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
+                <label class="is-required" for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="email">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
+                <label class="is-required" for="email">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
               </li>
               <li class="p-list__item">
-                <label for="phone">Mobile/cell phone number:</label>
-                <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
+                <label class="is-required" for="phone">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" />
               </li>
               <li class="p-list__item">
                 <label class="p-checkbox">

--- a/templates/shared/forms/interactive/confidential-computing.html
+++ b/templates/shared/forms/interactive/confidential-computing.html
@@ -23,9 +23,8 @@
                 <input required id="customerName" name="name" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="email">Email:</label>
-                <input class="is-required"
-                       required
+                <label class="is-required" for="email">Email:</label>
+                <input required
                        id="email"
                        name="email"
                        maxlength="255"

--- a/templates/shared/forms/interactive/containers-chiseled-dotnet.html
+++ b/templates/shared/forms/interactive/containers-chiseled-dotnet.html
@@ -15,16 +15,16 @@
             <h3 class="p-heading--5">How should we get in touch?</h3>
             <ul class="p-list">
               <li class="p-list__item">
-                <label for="firstName">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
+                <label class="is-required" for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="lastName">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
+                <label class="is-required" for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="email">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
+                <label class="is-required" for="email">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
               </li>
               <li class="p-list__item">
                 <label class="is-required" for="company">Company Name:</label>
@@ -35,8 +35,8 @@
                 <input required id="title" name="title" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="phone">Phone number:</label>
-                <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
+                <label class="is-required" for="phone">Phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" />
               </li>
               <!-- country -->
               {% include "shared/forms/_country.html" %}

--- a/templates/shared/forms/interactive/containers-chiseled-dotnet.html
+++ b/templates/shared/forms/interactive/containers-chiseled-dotnet.html
@@ -31,6 +31,10 @@
                 <input required  id="company" name="company" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
+                <label class="is-required" for="title">Job Title:</label>
+                <input required id="title" name="title" maxlength="255" type="text" />
+              </li>
+              <li class="p-list__item">
                 <label for="phone">Phone number:</label>
                 <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
               </li>

--- a/templates/shared/forms/interactive/containers-chiseled-dotnet.html
+++ b/templates/shared/forms/interactive/containers-chiseled-dotnet.html
@@ -27,7 +27,7 @@
                 <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
               </li>
               <li class="p-list__item">
-                <label for="company">Company Name:</label>
+                <label class="is-required" for="company">Company Name:</label>
                 <input required  id="company" name="company" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">

--- a/templates/shared/forms/interactive/containers.html
+++ b/templates/shared/forms/interactive/containers.html
@@ -43,12 +43,12 @@
                     <input required id="lastName" name="lastName" maxlength="255" type="text" />
                   </li>
                   <li class="p-list__item">
-                    <label for="company">Company:</label>
-                    <input id="company" name="company" maxlength="255" type="text" />
+                    <label class="is-required" for="company">Company:</label>
+                    <input required id="company" name="company" maxlength="255" type="text" />
                   </li>
                   <li class="p-list__item">
-                    <label for="title">Job title:</label>
-                    <input id="title" name="title" maxlength="255" type="text" />
+                    <label class="is-required" for="title">Job title:</label>
+                    <input required id="title" name="title" maxlength="255" type="text" />
                   </li>
                   <li class="p-list__item">
                     <label class="is-required" for="email">Email address:</label>

--- a/templates/shared/forms/interactive/embedded.html
+++ b/templates/shared/forms/interactive/embedded.html
@@ -394,12 +394,12 @@
                   <input required id="lastName" name="lastName" maxlength="255" type="text" />
                 </li>
                 <li class="p-list__item">
-                  <label for="company">Company:</label>
-                  <input id="company" name="company" maxlength="255" type="text" />
+                  <label class="is-required" for="company">Company:</label>
+                  <input required id="company" name="company" maxlength="255" type="text" />
                 </li>
                 <li class="p-list__item">
-                  <label for="title">Job title:</label>
-                  <input id="title" name="title" maxlength="255" type="text" />
+                  <label class="is-required" for="title">Job title:</label>
+                  <input required id="title" name="title" maxlength="255" type="text" />
                 </li>
                 <li class="p-list__item">
                   <label class="is-required" for="email">Email address:</label>

--- a/templates/shared/forms/interactive/esm.html
+++ b/templates/shared/forms/interactive/esm.html
@@ -425,12 +425,12 @@
                     <input required id="lastName" name="lastName" maxlength="255" type="text" />
                   </li>
                   <li class="p-list__item">
-                    <label for="company">Company:</label>
-                    <input id="company" name="company" maxlength="255" type="text" />
+                    <label class="is-required" for="company">Company:</label>
+                    <input required id="company" name="company" maxlength="255" type="text" />
                   </li>
                   <li class="p-list__item">
-                    <label for="title">Job title:</label>
-                    <input id="title" name="title" maxlength="255" type="text" />
+                    <label class="is-required" for="title">Job title:</label>
+                    <input required id="title" name="title" maxlength="255" type="text" />
                   </li>
                   <li class="p-list__item">
                     <label class="is-required" for="email">Email address:</label>

--- a/templates/shared/forms/interactive/financial.html
+++ b/templates/shared/forms/interactive/financial.html
@@ -163,15 +163,15 @@
           <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
             <ul class="p-list">
               <li class="p-list__item">
-                <label for="firstName">First name:</label>
+                <label class="is-required" for="firstName">First name:</label>
                 <input required id="firstName" name="firstName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="lastName">Last name:</label>
+                <label class="is-required" for="lastName">Last name:</label>
                 <input required id="lastName" name="lastName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="email">Work email:</label>
+                <label class="is-required" for="email">Work email:</label>
                 <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
               </li>
               <li class="p-list__item">

--- a/templates/shared/forms/interactive/gcp.html
+++ b/templates/shared/forms/interactive/gcp.html
@@ -203,20 +203,20 @@
           <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
             <ul class="p-list">
               <li class="p-list__item">
-                <label for="firstName">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
+                <label class="is-required" for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="lastName">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
+                <label class="is-required" for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="email">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
+                <label class="is-required" for="email">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
               </li>
               <li class="p-list__item">
-                <label for="phone">Phone number:</label>
-                <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
+                <label class="is-required" for="phone">Phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" />
               </li>
               <li class="p-list__item">
                 <label class="p-checkbox">

--- a/templates/shared/forms/interactive/general.html
+++ b/templates/shared/forms/interactive/general.html
@@ -434,12 +434,12 @@
                     <input required id="lastName" name="lastName" maxlength="255" type="text" />
                   </li>
                   <li class="p-list__item">
-                    <label for="company">Company:</label>
-                    <input id="company" name="company" maxlength="255" type="text" />
+                    <label class="is-required" for="company">Company:</label>
+                    <input required id="company" name="company" maxlength="255" type="text" />
                   </li>
                   <li class="p-list__item">
-                    <label for="title">Job title:</label>
-                    <input id="title" name="title" maxlength="255" type="text" />
+                    <label class="is-required" for="title">Job title:</label>
+                    <input required id="title" name="title" maxlength="255" type="text" />
                   </li>
                   <li class="p-list__item">
                     <label class="is-required" for="email">Email address:</label>

--- a/templates/shared/forms/interactive/gov.html
+++ b/templates/shared/forms/interactive/gov.html
@@ -334,20 +334,20 @@
           <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
             <ul class="p-list">
               <li class="p-list__item">
-                <label for="firstName">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
+                <label class="is-required" for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="lastName">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
+                <label class="is-required" for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="email">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
+                <label class="is-required" for="email">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
               </li>
               <li class="p-list__item">
-                <label for="phone">Work phone:</label>
-                <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
+                <label class="is-required" for="phone">Work phone:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" />
               </li>
               <li class="p-list__item">
                 <label class="p-checkbox">

--- a/templates/shared/forms/interactive/hpc.html
+++ b/templates/shared/forms/interactive/hpc.html
@@ -432,7 +432,7 @@
                 class="modal-form">
             <ul class="p-list">
               <li class="p-list__item">
-                <label for="firstName">First name:</label>
+                <label class="is-required" for="firstName">First name:</label>
                 <input required
                        id="firstName"
                        name="firstName"
@@ -441,7 +441,7 @@
                        required="required" />
               </li>
               <li class="p-list__item">
-                <label for="lastName">Last name:</label>
+                <label class="is-required" for="lastName">Last name:</label>
                 <input required
                        id="lastName"
                        name="lastName"
@@ -450,7 +450,7 @@
                        required="required" />
               </li>
               <li class="p-list__item">
-                <label for="email">Work email:</label>
+                <label class="is-required" for="email">Work email:</label>
                 <input required
                        id="email"
                        name="email"

--- a/templates/shared/forms/interactive/hpe.html
+++ b/templates/shared/forms/interactive/hpe.html
@@ -33,12 +33,12 @@
           <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form p-form p-form--stacked">
             <ul class="p-list">
               <li class="p-list__item">
-                <label for="firstName">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
+                <label class="is-required" for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="lastName">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
+                <label class="is-required" for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
                 <label class="is-required" for="company">Company name:</label>
@@ -49,8 +49,8 @@
                 <input required id="title" name="title" maxlength="255" type="text">
               </li>
               <li class="p-list__item">
-                <label for="email">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
+                <label class="is-required" for="email">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
               </li>
               <li class="p-list__item" style="margin-bottom: 1.23rem;">
                 <label for="phone">Mobile/cell phone number:</label>

--- a/templates/shared/forms/interactive/hpe.html
+++ b/templates/shared/forms/interactive/hpe.html
@@ -41,11 +41,11 @@
                 <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
               </li>
               <li class="p-list__item">
-                <label for="Company">Company name:</label>
+                <label class="is-required" for="company">Company name:</label>
                 <input id="Company" name="Company" maxlength="255" type="text" required="required"/>
               </li>
               <li class="p-list__item">
-                <label for="title">Job title:</label>
+                <label class="is-required" for="title">Job title:</label>
                 <input required id="title" name="title" maxlength="255" type="text">
               </li>
               <li class="p-list__item">

--- a/templates/shared/forms/interactive/intel-iot.html
+++ b/templates/shared/forms/interactive/intel-iot.html
@@ -252,7 +252,7 @@
                    required="required" />
           </li>
           <li class="p-list__item">
-            <label for="company">Company:</label>
+            <label class="is-required" for="company">Company:</label>
             <input required
                    id="company"
                    name="company"
@@ -261,7 +261,7 @@
                    required="required" />
           </li>
           <li class="p-list__item">
-            <label for="title">Job title:</label>
+            <label class="is-required" for="title">Job title:</label>
             <input required id="title" name="title" maxlength="255" type="text" />
           </li>
           <li class="p-list__item">

--- a/templates/shared/forms/interactive/intel-iot.html
+++ b/templates/shared/forms/interactive/intel-iot.html
@@ -234,7 +234,7 @@
 
         <ul class="p-list">
           <li class="p-list__item">
-            <label for="firstName">First name:</label>
+            <label class="is-required" for="firstName">First name:</label>
             <input required
                    id="firstName"
                    name="firstName"
@@ -243,7 +243,7 @@
                    required="required" />
           </li>
           <li class="p-list__item">
-            <label for="lastName">Last name:</label>
+            <label class="is-required" for="lastName">Last name:</label>
             <input required
                    id="lastName"
                    name="lastName"
@@ -265,7 +265,7 @@
             <input required id="title" name="title" maxlength="255" type="text" />
           </li>
           <li class="p-list__item">
-            <label for="email">Email:</label>
+            <label class="is-required" for="email">Email:</label>
             <input required
                    id="email"
                    name="email"
@@ -275,7 +275,7 @@
                    required="required" />
           </li>
           <li class="p-list__item">
-            <label for="phone">Mobile/cell phone number:</label>
+            <label class="is-required" for="phone">Mobile/cell phone number:</label>
             <input required
                    id="phone"
                    name="phone"

--- a/templates/shared/forms/interactive/internet-of-things.html
+++ b/templates/shared/forms/interactive/internet-of-things.html
@@ -127,12 +127,12 @@
                     <input required id="lastName" name="lastName" maxlength="255" type="text" />
                   </li>
                   <li class="p-list__item">
-                    <label for="company">Company:</label>
-                    <input id="company" name="company" maxlength="255" type="text" />
+                    <label class="is-required" for="company">Company:</label>
+                    <input required id="company" name="company" maxlength="255" type="text" />
                   </li>
                   <li class="p-list__item">
-                    <label for="title">Job title:</label>
-                    <input id="title" name="title" maxlength="255" type="text" />
+                    <label class="is-required" for="title">Job title:</label>
+                    <input required id="title" name="title" maxlength="255" type="text" />
                   </li>
                   <li class="p-list__item">
                     <label class="is-required" for="email">Email address:</label>

--- a/templates/shared/forms/interactive/kafka.html
+++ b/templates/shared/forms/interactive/kafka.html
@@ -25,11 +25,11 @@
                 <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
               </li>
               <li class="p-list__item">
-                <label for="company">Company name:</label>
+                <label class="is-required" for="company">Company name:</label>
                 <input required id="company" name="company" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="title">Job title:</label>
+                <label class="is-required" for="title">Job title:</label>
                 <input required id="title" name="title" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">

--- a/templates/shared/forms/interactive/kafka.html
+++ b/templates/shared/forms/interactive/kafka.html
@@ -17,12 +17,12 @@
             <h3 class="p-heading--5">How should we get in touch?</h3>
             <ul class="p-list">
               <li class="p-list__item">
-                <label for="firstName">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
+                <label class="is-required" for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="lastName">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
+                <label class="is-required" for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
                 <label class="is-required" for="company">Company name:</label>
@@ -33,12 +33,12 @@
                 <input required id="title" name="title" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="email">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
+                <label class="is-required" for="email">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
               </li>
               <li class="p-list__item">
-                <label for="phone">Mobile/cell phone number:</label>
-                <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
+                <label class="is-required" for="phone">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" />
               </li>
               <li class="p-list__item">
                 <label class="p-checkbox">

--- a/templates/shared/forms/interactive/kubeflow.html
+++ b/templates/shared/forms/interactive/kubeflow.html
@@ -237,20 +237,20 @@
           <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form marketo-form">
             <ul class="p-list">
               <li class="p-list__item">
-                <label for="firstName">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
+                <label class="is-required" for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="lastName">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
+                <label class="is-required" for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="email" >Work email:</label>
-                <input id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
+                <label class="is-required" for="email" >Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
               </li>
               <li class="p-list__item">
-                <label for="phone">Mobile/cell phone number:</label>
-                <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
+                <label class="is-required" for="phone">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" />
               </li>
               <li class="p-list__item">
                 <label class="p-checkbox">

--- a/templates/shared/forms/interactive/kubernetes.html
+++ b/templates/shared/forms/interactive/kubernetes.html
@@ -52,7 +52,7 @@
                 <input required id="title" name="title" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="email">Work email:</label>
+                <label class="is-required" for="email">Work email:</label>
                 <input required
                        id="email"
                        name="email"

--- a/templates/shared/forms/interactive/kubernetes.html
+++ b/templates/shared/forms/interactive/kubernetes.html
@@ -44,11 +44,11 @@
                        required="required" />
               </li>
               <li class="p-list__item">
-                <label for="company">Company name:</label>
+                <label class="is-required" for="company">Company name:</label>
                 <input required id="company" name="company" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="title">Job title:</label>
+                <label class="is-required" for="title">Job title:</label>
                 <input required id="title" name="title" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">

--- a/templates/shared/forms/interactive/landscape-managed.html
+++ b/templates/shared/forms/interactive/landscape-managed.html
@@ -12,19 +12,19 @@
               <form action="/marketo/submit" onsubmit="contactPreference()" method="post" id="mktoForm_%% formid %%" class="modal-form" id="landscape-form">
                 <ul class="p-list">
                   <li class="p-list__item">
-                    <label for="firstName">First name:</label>
+                    <label class="is-required" for="firstName">First name:</label>
                     <input required id="firstName" name="firstName" maxlength="255" type="text"/>
                   </li>
                   <li class="p-list__item">
-                    <label for="lastName">Last name:</label>
+                    <label class="is-required" for="lastName">Last name:</label>
                     <input required id="lastName" name="lastName" maxlength="255" type="text"/>
                   </li>
                   <li class="p-list__item">
-                    <label for="email">Work email:</label>
+                    <label class="is-required" for="email">Work email:</label>
                     <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"/>
                   </li>
                   <li class="p-list__item u-sv3">
-                    <label for="phone">Phone number:</label>
+                    <label class="is-required" for="phone">Phone number:</label>
                     <input required id="phone" name="phone" maxlength="255" type="tel" />
                   </li>
                   <li class="p-list__item">

--- a/templates/shared/forms/interactive/landscape-pricing-saas.html
+++ b/templates/shared/forms/interactive/landscape-pricing-saas.html
@@ -33,6 +33,10 @@
                 <input required id="company" name="company" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
+                <label class="is-required" for="title">Job Title:</label>
+                <input required id="title" name="title" maxlength="255" type="text" />
+              </li>
+              <li class="p-list__item">
                 <label for="email">Work email:</label>
                 <input required
                        id="email"

--- a/templates/shared/forms/interactive/landscape-pricing-saas.html
+++ b/templates/shared/forms/interactive/landscape-pricing-saas.html
@@ -29,8 +29,8 @@
                 <input required id="lastName" name="lastName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="company">Company:</label>
-                <input id="company" name="company" maxlength="255" type="text" />
+                <label class="is-required" for="company">Company:</label>
+                <input required id="company" name="company" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
                 <label for="email">Work email:</label>

--- a/templates/shared/forms/interactive/landscape-pricing-saas.html
+++ b/templates/shared/forms/interactive/landscape-pricing-saas.html
@@ -21,11 +21,11 @@
                 id="landscape-form">
             <ul class="p-list">
               <li class="p-list__item">
-                <label for="firstName">First name:</label>
+                <label class="is-required" for="firstName">First name:</label>
                 <input required id="firstName" name="firstName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="lastName">Last name:</label>
+                <label class="is-required" for="lastName">Last name:</label>
                 <input required id="lastName" name="lastName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
@@ -37,7 +37,7 @@
                 <input required id="title" name="title" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="email">Work email:</label>
+                <label class="is-required" for="email">Work email:</label>
                 <input required
                        id="email"
                        name="email"

--- a/templates/shared/forms/interactive/landscape.html
+++ b/templates/shared/forms/interactive/landscape.html
@@ -434,12 +434,12 @@
                     <input required id="lastName" name="lastName" maxlength="255" type="text" />
                   </li>
                   <li class="p-list__item">
-                    <label for="company">Company:</label>
-                    <input id="company" name="company" maxlength="255" type="text" />
+                    <label class="is-required" for="company">Company:</label>
+                    <input required id="company" name="company" maxlength="255" type="text" />
                   </li>
                   <li class="p-list__item">
-                    <label for="title">Job title:</label>
-                    <input id="title" name="title" maxlength="255" type="text" />
+                    <label class="is-required" for="title">Job title:</label>
+                    <input required id="title" name="title" maxlength="255" type="text" />
                   </li>
                   <li class="p-list__item">
                     <label class="is-required" for="email">Email address:</label>

--- a/templates/shared/forms/interactive/managed-apps-contact-us.html
+++ b/templates/shared/forms/interactive/managed-apps-contact-us.html
@@ -12,28 +12,28 @@
           <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
             <ul class="p-list">
               <li class="p-list__item">
-                <label for="firstName">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
+                <label class="is-required" for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="lastName">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
+                <label class="is-required" for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" />
               </li>
               <li>
                 <label class="is-required" for="title">Job title:</label>
-                <input required id="title" name="title" maxlength="255" type="text" required="required">
+                <input required id="title" name="title" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
                 <label class="is-required" for="company">Company name:</label>
-                <input id="Company" name="Company" maxlength="255" type="text" required="required"/>
+                <input required id="Company" name="Company" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="email">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
+                <label class="is-required" for="email">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
               </li>
               <li class="p-list__item">
-                <label for="phone">Mobile/cell phone number:</label>
-                <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
+                <label class="is-required" for="phone">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" />
               </li>
 
               {% include "shared/forms/_country.html" %}

--- a/templates/shared/forms/interactive/managed-apps-contact-us.html
+++ b/templates/shared/forms/interactive/managed-apps-contact-us.html
@@ -20,11 +20,11 @@
                 <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
               </li>
               <li>
-                <label for="title">Job title:</label>
+                <label class="is-required" for="title">Job title:</label>
                 <input required id="title" name="title" maxlength="255" type="text" required="required">
               </li>
               <li class="p-list__item">
-                <label for="Company">Company name:</label>
+                <label class="is-required" for="company">Company name:</label>
                 <input id="Company" name="Company" maxlength="255" type="text" required="required"/>
               </li>
               <li class="p-list__item">

--- a/templates/shared/forms/interactive/managed-apps.html
+++ b/templates/shared/forms/interactive/managed-apps.html
@@ -277,11 +277,11 @@
                 <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
               </li>
               <li class="p-list__item">
-                <label for="title">Job title:</label>
+                <label class="is-required" for="title">Job title:</label>
                 <input required id="title" name="title" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="company">Company:</label>
+                <label class="is-required" for="company">Company:</label>
                 <input required id="company" name="company" maxlength="255" type="text"/>
               </li>
               <li class="p-list__item">

--- a/templates/shared/forms/interactive/managed-apps.html
+++ b/templates/shared/forms/interactive/managed-apps.html
@@ -269,12 +269,12 @@
           <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
             <ul class="p-list">
               <li class="p-list__item">
-                <label for="firstName">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
+                <label class="is-required" for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="lastName">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
+                <label class="is-required" for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
                 <label class="is-required" for="title">Job title:</label>
@@ -285,12 +285,12 @@
                 <input required id="company" name="company" maxlength="255" type="text"/>
               </li>
               <li class="p-list__item">
-                <label for="email">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
+                <label class="is-required" for="email">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
               </li>
               <li class="p-list__item">
-                <label for="phone">Mobile/cell phone number:</label>
-                <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
+                <label class="is-required" for="phone">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" />
               </li>
 
               {% include "shared/forms/_country.html" %}

--- a/templates/shared/forms/interactive/managed-cassandra.html
+++ b/templates/shared/forms/interactive/managed-cassandra.html
@@ -394,15 +394,15 @@
           <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
             <ul class="p-list">
               <li class="p-list__item">
-                <label for="firstName">First name:</label>
+                <label class="is-required" for="firstName">First name:</label>
                 <input required id="firstName" name="firstName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="lastName">Last name:</label>
+                <label class="is-required" for="lastName">Last name:</label>
                 <input required id="lastName" name="lastName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="email">Work email:</label>
+                <label class="is-required" for="email">Work email:</label>
                 <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"/>
               </li>
               <li class="p-list__item">

--- a/templates/shared/forms/interactive/managed-kafka.html
+++ b/templates/shared/forms/interactive/managed-kafka.html
@@ -308,15 +308,15 @@
           <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
             <ul class="p-list">
               <li class="p-list__item">
-                <label for="firstName">First name:</label>
+                <label class="is-required" for="firstName">First name:</label>
                 <input required id="firstName" name="firstName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="lastName">Last name:</label>
+                <label class="is-required" for="lastName">Last name:</label>
                 <input required id="lastName" name="lastName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="email">Work email:</label>
+                <label class="is-required" for="email">Work email:</label>
                 <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
               </li>
               <li class="p-list__item">

--- a/templates/shared/forms/interactive/managed-kubernetes.html
+++ b/templates/shared/forms/interactive/managed-kubernetes.html
@@ -15,12 +15,12 @@
           <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
             <ul class="p-list">
               <li class="p-list__item">
-                <label for="firstName">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
+                <label class="is-required" for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="lastName">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
+                <label class="is-required" for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
                 <label class="is-required" for="company">Company name:</label>
@@ -31,12 +31,12 @@
                 <input required id="title" name="title" maxlength="255" type="text">
               </li>
               <li class="p-list__item">
-                <label for="email">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
+                <label class="is-required" for="email">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
               </li>
               <li class="p-list__item">
-                <label for="phone">Mobile/cell phone number:</label>
-                <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
+                <label class="is-required" for="phone">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" />
               </li>
               <li class="p-list__item">
                 <label class="p-checkbox">

--- a/templates/shared/forms/interactive/managed-kubernetes.html
+++ b/templates/shared/forms/interactive/managed-kubernetes.html
@@ -23,11 +23,11 @@
                 <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
               </li>
               <li class="p-list__item">
-                <label for="company">Company name:</label>
+                <label class="is-required" for="company">Company name:</label>
                 <input required id="company" name="company" maxlength="255" type="text">
               </li>
               <li class="p-list__item">
-                <label for="title">Job title:</label>
+                <label class="is-required" for="title">Job title:</label>
                 <input required id="title" name="title" maxlength="255" type="text">
               </li>
               <li class="p-list__item">

--- a/templates/shared/forms/interactive/managed-services.html
+++ b/templates/shared/forms/interactive/managed-services.html
@@ -65,7 +65,7 @@
                 class="modal-form">
             <ul class="p-list">
               <li class="p-list__item">
-                <label for="firstName">First name:</label>
+                <label class="is-required" for="firstName">First name:</label>
                 <input required
                        id="firstName"
                        name="firstName"
@@ -74,7 +74,7 @@
                        required="required" />
               </li>
               <li class="p-list__item">
-                <label for="lastName">Last name:</label>
+                <label class="is-required" for="lastName">Last name:</label>
                 <input required
                        id="lastName"
                        name="lastName"
@@ -83,7 +83,7 @@
                        required="required" />
               </li>
               <li class="p-list__item">
-                <label for="email">Work email:</label>
+                <label class="is-required" for="email">Work email:</label>
                 <input required
                        id="email"
                        name="email"
@@ -93,7 +93,7 @@
                        required="required" />
               </li>
               <li class="p-list__item">
-                <label for="phone">Mobile/cell phone number:</label>
+                <label class="is-required" for="phone">Mobile/cell phone number:</label>
                 <input required
                        id="phone"
                        name="phone"

--- a/templates/shared/forms/interactive/masters-conference.html
+++ b/templates/shared/forms/interactive/masters-conference.html
@@ -12,12 +12,12 @@
           <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
             <ul class="p-list">
               <li class="p-list__item">
-                <label for="email">Email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
+                <label class="is-required" for="email">Email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
               </li>
               <li class="p-list__item">
-                <label for="phone">Mobile/cell phone number:</label>
-                <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
+                <label class="is-required" for="phone">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" />
               </li>
               <li class="p-list__item">In submitting this form, I confirm that I have read and agree to <a href="/legal/data-privacy/contact">Canonical's Privacy Notice</a> and <a href="/legal/data-privacy">Privacy Policy</a>.</li>
               {# These are honey pot fields to catch bots #}

--- a/templates/shared/forms/interactive/newsletter-opt-in.html
+++ b/templates/shared/forms/interactive/newsletter-opt-in.html
@@ -20,7 +20,7 @@
                 class="modal-form">
             <ul class="p-list">
               <li class="p-list__item">
-                <label for="email">Email:</label>
+                <label class="is-required" for="email">Email:</label>
                 <input required
                        id="email"
                        name="email"

--- a/templates/shared/forms/interactive/nvidia-jetson.html
+++ b/templates/shared/forms/interactive/nvidia-jetson.html
@@ -77,7 +77,7 @@
               <label class="is-required" for="company">Company:</label>
               <input required id="company" name="company" maxlength="255" type="text" />
 
-              <label class="is-required" for="company">Job title:</label>
+              <label class="is-required" for="title">Job title:</label>
               <input required id="title" name="title" maxlength="255" type="text" />
 
               <label class="is-required" for="email">Email:</label>

--- a/templates/shared/forms/interactive/nvidia.html
+++ b/templates/shared/forms/interactive/nvidia.html
@@ -278,20 +278,20 @@
             <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
               <ul class="p-list">
                 <li class="p-list__item">
-                  <label for="firstName">First name:</label>
-                  <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
+                  <label class="is-required" for="firstName">First name:</label>
+                  <input required id="firstName" name="firstName" maxlength="255" type="text" />
                 </li>
                 <li class="p-list__item">
-                  <label for="lastName">Last name:</label>
-                  <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
+                  <label class="is-required" for="lastName">Last name:</label>
+                  <input required id="lastName" name="lastName" maxlength="255" type="text" />
                 </li>
                 <li class="p-list__item">
-                  <label for="email">Work email:</label>
-                  <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
+                  <label class="is-required" for="email">Work email:</label>
+                  <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
                 </li>
                 <li class="p-list__item">
-                  <label for="phone">Mobile/cell phone number:</label>
-                  <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
+                  <label class="is-required" for="phone">Mobile/cell phone number:</label>
+                  <input required id="phone" name="phone" maxlength="255" type="tel" />
                 </li>
                 <li class="p-list__item">
                   <label class="p-checkbox">

--- a/templates/shared/forms/interactive/openstack-cost-calculator.html
+++ b/templates/shared/forms/interactive/openstack-cost-calculator.html
@@ -12,12 +12,12 @@
           <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
             <ul class="p-list">
               <li class="p-list__item">
-                <label for="firstName">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
+                <label class="is-required" for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="lastName">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
+                <label class="is-required" for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
                 <label class="is-required" for="company">Company name:</label>
@@ -28,12 +28,12 @@
                 <input required id="title" name="title" maxlength="255" type="text" required="required" />
               </li>
               <li class="p-list__item">
-                <label for="email">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
+                <label class="is-required" for="email">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
               </li>
               <li class="p-list__item">
-                <label for="phone">Mobile/cell phone number:</label>
-                <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
+                <label class="is-required" for="phone">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" />
               </li>
               <li class="p-list__item u-sv2">
                 <label class="p-checkbox">

--- a/templates/shared/forms/interactive/openstack-cost-calculator.html
+++ b/templates/shared/forms/interactive/openstack-cost-calculator.html
@@ -20,11 +20,11 @@
                 <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
               </li>
               <li class="p-list__item">
-                <label for="company">Company name:</label>
+                <label class="is-required" for="company">Company name:</label>
                 <input required id="company" name="company" maxlength="255" type="text" required="required" />
               </li>
               <li class="p-list__item">
-                <label for="jobTitle">Job title:</label>
+                <label class="is-required" for="title">Job title:</label>
                 <input required id="jobTitle" name="title" maxlength="255" type="text" required="required" />
               </li>
               <li class="p-list__item">

--- a/templates/shared/forms/interactive/openstack-cost-calculator.html
+++ b/templates/shared/forms/interactive/openstack-cost-calculator.html
@@ -25,7 +25,7 @@
               </li>
               <li class="p-list__item">
                 <label class="is-required" for="title">Job title:</label>
-                <input required id="jobTitle" name="title" maxlength="255" type="text" required="required" />
+                <input required id="title" name="title" maxlength="255" type="text" required="required" />
               </li>
               <li class="p-list__item">
                 <label for="email">Work email:</label>

--- a/templates/shared/forms/interactive/openstack.html
+++ b/templates/shared/forms/interactive/openstack.html
@@ -550,20 +550,20 @@
           <div class="col-6">
             <ul class="p-list">
               <li class="p-list__item">
-                <label for="firstName">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
+                <label class="is-required" for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="lastName">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
+                <label class="is-required" for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="email">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
+                <label class="is-required" for="email">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
               </li>
               <li class="p-list__item">
-                <label for="phone">Mobile/cell phone number:</label>
-                <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
+                <label class="is-required" for="phone">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" />
               </li>
               <li class="p-list__item">
                 <label class="p-checkbox">

--- a/templates/shared/forms/interactive/osm-contact-us.html
+++ b/templates/shared/forms/interactive/osm-contact-us.html
@@ -239,20 +239,20 @@
           <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
             <ul class="p-list">
               <li class="p-list__item">
-                <label for="firstName">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
+                <label class="is-required" for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="lastName">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
+                <label class="is-required" for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="email">Email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
+                <label class="is-required" for="email">Email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
               </li>
               <li class="p-list__item">
-                <label for="phone">Mobile/cell phone number:</label>
-                <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
+                <label class="is-required" for="phone">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" />
               </li>
               <li class="p-list__item">
                 <label class="p-checkbox">

--- a/templates/shared/forms/interactive/partner-dell.html
+++ b/templates/shared/forms/interactive/partner-dell.html
@@ -321,20 +321,20 @@
           <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
             <ul class="p-list">
               <li class="p-list__item">
-                <label for="firstName">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
+                <label class="is-required" for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="lastName">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
+                <label class="is-required" for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="email">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
+                <label class="is-required" for="email">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
               </li>
               <li class="p-list__item">
-                <label for="phone">Mobile/cell phone number:</label>
-                <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
+                <label class="is-required" for="phone">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" />
               </li>
               <li class="p-list__item">
                 <label class="p-checkbox">

--- a/templates/shared/forms/interactive/pricing-infra.html
+++ b/templates/shared/forms/interactive/pricing-infra.html
@@ -436,12 +436,12 @@
                     <input required id="lastName" name="lastName" maxlength="255" type="text" />
                   </li>
                   <li class="p-list__item">
-                    <label for="company">Company:</label>
-                    <input id="company" name="company" maxlength="255" type="text" />
+                    <label class="is-required" for="company">Company:</label>
+                    <input required id="company" name="company" maxlength="255" type="text" />
                   </li>
                   <li class="p-list__item">
-                    <label for="title">Job title:</label>
-                    <input id="title" name="title" maxlength="255" type="text" />
+                    <label class="is-required" for="title">Job title:</label>
+                    <input required id="title" name="title" maxlength="255" type="text" />
                   </li>
                   <li class="p-list__item">
                     <label class="is-required" for="email">Email address:</label>

--- a/templates/shared/forms/interactive/pro-devices.html
+++ b/templates/shared/forms/interactive/pro-devices.html
@@ -85,6 +85,10 @@
                 <label class="is-required" for="title">Job title:</label>
                 <input required id="title" name="title" maxlength="255" type="text" />
               </li>
+              <li class="p-list__item">
+                <label class="is-required" for="company">Company:</label>
+                <input required id="company" name="company" maxlength="255" type="text" />
+              </li>
               <li class="p-list__item u-sv3">
                 <label for="phone">Mobile/cell phone number:</label>
                 <input required

--- a/templates/shared/forms/interactive/pro-devices.html
+++ b/templates/shared/forms/interactive/pro-devices.html
@@ -20,7 +20,7 @@
                 class="modal-form">
             <ul class="p-list">
               <li class="p-list__item">
-                <label for="firstName">First name:</label>
+                <label class="is-required" for="firstName">First name:</label>
                 {% if user_info %}
                   {% set first_name = user_info.fullname.split(' ')[0] %}
                   {% set last_name = user_info.fullname | replace(first_name + " ", "") %}
@@ -41,7 +41,7 @@
                 {% endif %}
               </li>
               <li class="p-list__item">
-                <label for="lastName">Last name:</label>
+                <label class="is-required" for="lastName">Last name:</label>
                 {% if user_info %}
                   <input required
                          id="lastName"
@@ -90,7 +90,7 @@
                 <input required id="company" name="company" maxlength="255" type="text" />
               </li>
               <li class="p-list__item u-sv3">
-                <label for="phone">Mobile/cell phone number:</label>
+                <label class="is-required" for="phone">Mobile/cell phone number:</label>
                 <input required
                        id="phone"
                        name="phone"

--- a/templates/shared/forms/interactive/pro-devices.html
+++ b/templates/shared/forms/interactive/pro-devices.html
@@ -82,7 +82,7 @@
                 {% endif %}
               </li>
               <li class="p-list__item">
-                <label for="title">Job title:</label>
+                <label class="is-required" for="title">Job title:</label>
                 <input required id="title" name="title" maxlength="255" type="text" />
               </li>
               <li class="p-list__item u-sv3">

--- a/templates/shared/forms/interactive/risc-v.html
+++ b/templates/shared/forms/interactive/risc-v.html
@@ -138,7 +138,7 @@
                 <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
               </li>
               <li class="p-list__item">
-                <label for="company">Company:</label>
+                <label class="is-required" for="company">Company:</label>
                 <input required id="company" name="company" maxlength="255" type="text" required="required" />
               </li>
               <li class="p-list__item">

--- a/templates/shared/forms/interactive/risc-v.html
+++ b/templates/shared/forms/interactive/risc-v.html
@@ -142,6 +142,10 @@
                 <input required id="company" name="company" maxlength="255" type="text" required="required" />
               </li>
               <li class="p-list__item">
+                <label class="is-required" for="title">Job Title:</label>
+                <input required id="title" name="title" maxlength="255" type="text" />
+              </li>
+              <li class="p-list__item">
                 <label for="email">Email:</label>
                 <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
               </li>

--- a/templates/shared/forms/interactive/risc-v.html
+++ b/templates/shared/forms/interactive/risc-v.html
@@ -130,12 +130,12 @@
           <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
             <ul class="p-list">
               <li class="p-list__item">
-                <label for="firstName">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
+                <label class="is-required" for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="lastName">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
+                <label class="is-required" for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
                 <label class="is-required" for="company">Company:</label>
@@ -146,12 +146,12 @@
                 <input required id="title" name="title" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="email">Email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
+                <label class="is-required" for="email">Email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
               </li>
               <li class="p-list__item">
-                <label for="phone">Mobile/cell phone number:</label>
-                <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
+                <label class="is-required" for="phone">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" />
               </li>
               <li class="p-list__item">
                 <label class="p-checkbox">

--- a/templates/shared/forms/interactive/robotics.html
+++ b/templates/shared/forms/interactive/robotics.html
@@ -302,20 +302,20 @@
           <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
             <ul class="p-list">
               <li class="p-list__item">
-                <label for="firstName">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
+                <label class="is-required" for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="lastName">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
+                <label class="is-required" for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="email">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
+                <label class="is-required" for="email">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
               </li>
               <li class="p-list__item">
-                <label for="phone">Mobile/cell phone number:</label>
-                <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
+                <label class="is-required" for="phone">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" />
               </li>
               <li class="p-list__item">
                 <label class="p-checkbox">

--- a/templates/shared/forms/interactive/robotics_ros.html
+++ b/templates/shared/forms/interactive/robotics_ros.html
@@ -154,11 +154,11 @@
                 <input required id="lastName" name="lastName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="company">Company:</label>
+                <label class="is-required" for="company">Company:</label>
                 <input required id="company" name="company" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="title">Job title:</label>
+                <label class="is-required" for="title">Job title:</label>
                 <input required id="title" name="title" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">

--- a/templates/shared/forms/interactive/robotics_ros.html
+++ b/templates/shared/forms/interactive/robotics_ros.html
@@ -146,11 +146,11 @@
                 class="modal-form">
             <ul class="p-list">
               <li class="p-list__item">
-                <label for="firstName">First name:</label>
+                <label class="is-required" for="firstName">First name:</label>
                 <input required id="firstName" name="firstName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="lastName">Last name:</label>
+                <label class="is-required" for="lastName">Last name:</label>
                 <input required id="lastName" name="lastName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
@@ -162,7 +162,7 @@
                 <input required id="title" name="title" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="email">Email address:</label>
+                <label class="is-required" for="email">Email address:</label>
                 <input required
                        id="email"
                        name="email"

--- a/templates/shared/forms/interactive/security-fips.html
+++ b/templates/shared/forms/interactive/security-fips.html
@@ -89,20 +89,20 @@
 					<form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
 						<ul class="p-list">
 							<li class="p-list__item">
-								<label for="firstName">First name:</label>
-								<input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
+								<label class="is-required" for="firstName">First name:</label>
+								<input required id="firstName" name="firstName" maxlength="255" type="text" />
 							</li>
 							<li class="p-list__item">
-								<label for="lastName">Last name:</label>
-								<input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
+								<label class="is-required" for="lastName">Last name:</label>
+								<input required id="lastName" name="lastName" maxlength="255" type="text" />
 							</li>
 							<li class="p-list__item">
-								<label for="email">Work email:</label>
-								<input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
+								<label class="is-required" for="email">Work email:</label>
+								<input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
 							</li>
 							<li class="p-list__item">
-								<label for="phone">Mobile/cell phone number:</label>
-								<input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
+								<label class="is-required" for="phone">Mobile/cell phone number:</label>
+								<input required id="phone" name="phone" maxlength="255" type="tel" />
 							</li>
 							<li class="p-list__item">
 								<label class="p-checkbox">

--- a/templates/shared/forms/interactive/smart-start.html
+++ b/templates/shared/forms/interactive/smart-start.html
@@ -320,7 +320,7 @@
                 <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
               </li>
               <li class="p-list__item">
-                <label for="company">Company:</label>
+                <label class="is-required" for="company">Company:</label>
                 <input required id="company" name="company" maxlength="255" type="text" required="required" />
               </li>
               <li class="p-list__item">

--- a/templates/shared/forms/interactive/smart-start.html
+++ b/templates/shared/forms/interactive/smart-start.html
@@ -324,6 +324,10 @@
                 <input required id="company" name="company" maxlength="255" type="text" required="required" />
               </li>
               <li class="p-list__item">
+                <label class="is-required" for="title">Job Title:</label>
+                <input required id="title" name="title" maxlength="255" type="text" />
+              </li>
+              <li class="p-list__item">
                 <label for="email">Work email:</label>
                 <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
               </li>

--- a/templates/shared/forms/interactive/smart-start.html
+++ b/templates/shared/forms/interactive/smart-start.html
@@ -312,12 +312,12 @@
           <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
             <ul class="p-list">
               <li class="p-list__item">
-                <label for="firstName">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
+                <label class="is-required" for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="lastName">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
+                <label class="is-required" for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
                 <label class="is-required" for="company">Company:</label>
@@ -328,12 +328,12 @@
                 <input required id="title" name="title" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="email">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
+                <label class="is-required" for="email">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
               </li>
               <li class="p-list__item">
-                <label for="phone">Mobile/cell phone number:</label>
-                <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
+                <label class="is-required" for="phone">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" />
               </li>
               <li class="p-list__item">
                 <label class="p-checkbox">

--- a/templates/shared/forms/interactive/spark.html
+++ b/templates/shared/forms/interactive/spark.html
@@ -23,11 +23,11 @@
                 <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
               </li>
               <li class="p-list__item">
-                <label for="company">Company name:</label>
+                <label class="is-required" for="company">Company name:</label>
                 <input required id="company" name="company" maxlength="255" type="text">
               </li>
               <li class="p-list__item">
-                <label for="title">Job title:</label>
+                <label class="is-required" for="title">Job title:</label>
                 <input required id="title" name="title" maxlength="255" type="text">
               </li>
               <li class="p-list__item">

--- a/templates/shared/forms/interactive/spark.html
+++ b/templates/shared/forms/interactive/spark.html
@@ -15,12 +15,12 @@
             <h3 class="p-heading--5">How should we get in touch?</h3>
             <ul class="p-list">
               <li class="p-list__item">
-                <label for="firstName">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
+                <label class="is-required" for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="lastName">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
+                <label class="is-required" for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
                 <label class="is-required" for="company">Company name:</label>
@@ -31,12 +31,12 @@
                 <input required id="title" name="title" maxlength="255" type="text">
               </li>
               <li class="p-list__item">
-                <label for="email">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
+                <label class="is-required" for="email">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
               </li>
               <li class="p-list__item">
-                <label for="phone">Mobile/cell phone number:</label>
-                <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
+                <label class="is-required" for="phone">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" />
               </li>
               <li class="p-list__item">
                 <label class="p-checkbox">

--- a/templates/shared/forms/interactive/storage.html
+++ b/templates/shared/forms/interactive/storage.html
@@ -434,12 +434,12 @@
                     <input required id="lastName" name="lastName" maxlength="255" type="text" />
                   </li>
                   <li class="p-list__item">
-                    <label for="company">Company:</label>
-                    <input id="company" name="company" maxlength="255" type="text" />
+                    <label class="is-required" for="company">Company:</label>
+                    <input required id="company" name="company" maxlength="255" type="text" />
                   </li>
                   <li class="p-list__item">
-                    <label for="title">Job title:</label>
-                    <input id="title" name="title" maxlength="255" type="text" />
+                    <label class="is-required" for="title">Job title:</label>
+                    <input required id="title" name="title" maxlength="255" type="text" />
                   </li>
                   <li class="p-list__item">
                     <label class="is-required" for="email">Email address:</label>

--- a/templates/shared/forms/interactive/supermicro.html
+++ b/templates/shared/forms/interactive/supermicro.html
@@ -12,15 +12,15 @@
           <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
             <ul class="p-list">
               <li class="p-list__item">
-                <label for="firstName">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
+                <label class="is-required" for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="lastName">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
+                <label class="is-required" for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="email">Email:</label>
+                <label class="is-required" for="email">Email:</label>
                 <input required id="email" name="email" maxlength="255" type="email"
                   pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
               </li>

--- a/templates/shared/forms/interactive/supermicro.html
+++ b/templates/shared/forms/interactive/supermicro.html
@@ -29,11 +29,11 @@
                 <input id="phone" name="phone" maxlength="255" type="tel" />
               </li>
               <li class="p-list__item">
-                <label for="company">Company:</label>
+                <label class="is-required" for="company">Company:</label>
                 <input required id="company" name="company" maxlength="255" type="text">
               </li>
               <li class="p-list__item">
-                <label for="title">Job title:</label>
+                <label class="is-required" for="title">Job title:</label>
                 <input required id="title" name="title" maxlength="255" type="text">
               </li>
 

--- a/templates/shared/forms/interactive/support-openstack.html
+++ b/templates/shared/forms/interactive/support-openstack.html
@@ -569,7 +569,7 @@
       >
       <ul class="p-list">
         <li class="p-list__item">
-          <label for="firstName">First name:</label>
+          <label class="is-required" for="firstName">First name:</label>
           <input
           required
           id="firstName"
@@ -580,7 +580,7 @@
           />
         </li>
         <li class="p-list__item">
-          <label for="lastName">Last name:</label>
+          <label class="is-required" for="lastName">Last name:</label>
           <input
           required
           id="lastName"
@@ -591,7 +591,7 @@
           />
         </li>
         <li class="p-list__item">
-          <label for="email">Work email:</label>
+          <label class="is-required" for="email">Work email:</label>
           <input
           required
           id="email"
@@ -602,8 +602,8 @@
           />
         </li>
         <li class="p-list__item">
-          <label for="phone">Mobile/cell phone number:</label>
-          <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
+          <label class="is-required" for="phone">Mobile/cell phone number:</label>
+          <input required id="phone" name="phone" maxlength="255" type="tel" />
         </li>
         <li class="p-list__item">
           <label class="p-checkbox">

--- a/templates/shared/forms/interactive/support.html
+++ b/templates/shared/forms/interactive/support.html
@@ -302,20 +302,20 @@
           <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
             <ul class="p-list">
               <li class="p-list__item">
-                <label for="firstName">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
+                <label class="is-required" for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="lastName">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
+                <label class="is-required" for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="email">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
+                <label class="is-required" for="email">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
               </li>
               <li class="p-list__item">
-                <label for="phone">Mobile/cell phone number:</label>
-                <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
+                <label class="is-required" for="phone">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" />
               </li>
               <li class="p-list__item">
                 <label class="p-checkbox">

--- a/templates/shared/forms/interactive/telco-networks.html
+++ b/templates/shared/forms/interactive/telco-networks.html
@@ -159,20 +159,20 @@
           <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
             <ul class="p-list">
               <li class="p-list__item">
-                <label for="firstName">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
+                <label class="is-required" for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="lastName">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
+                <label class="is-required" for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="email">Email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
+                <label class="is-required" for="email">Email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
               </li>
               <li class="p-list__item">
-                <label for="phone">Mobile/cell phone number:</label>
-                <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
+                <label class="is-required" for="phone">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" />
               </li>
               <li class="p-list__item">
                 <label class="p-checkbox">

--- a/templates/shared/forms/interactive/telco.html
+++ b/templates/shared/forms/interactive/telco.html
@@ -452,20 +452,20 @@
           <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
             <ul class="p-list">
               <li class="p-list__item">
-                <label for="firstName">First name:</label>
+                <label class="is-required" for="firstName">First name:</label>
                 <input required id="firstName" name="firstName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="lastName">Last name:</label>
+                <label class="is-required" for="lastName">Last name:</label>
                 <input required id="lastName" name="lastName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="email">Work email:</label>
+                <label class="is-required" for="email">Work email:</label>
                 <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
               </li>
               <li class="p-list__item">
-                <label for="phone">Mobile/cell phone number:</label>
-                <input required="" id="phone" name="phone" maxlength="255" type="tel">
+                <label class="is-required" for="phone">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel">
               </li>
               <li class="p-list__item">
                 <label class="p-checkbox">

--- a/templates/shared/forms/interactive/wsl.html
+++ b/templates/shared/forms/interactive/wsl.html
@@ -128,6 +128,10 @@
                 <input required id="company" name="company" maxlength="255" type="text" required="required" />
               </li>
               <li class="p-list__item">
+                <label class="is-required" for="title">Job Title:</label>
+                <input required id="title" name="title" maxlength="255" type="text" />
+              </li>
+              <li class="p-list__item">
                 <label for="email">Work email:</label>
                 <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
               </li>

--- a/templates/shared/forms/interactive/wsl.html
+++ b/templates/shared/forms/interactive/wsl.html
@@ -116,12 +116,12 @@
           <form action="/marketo/submit" method="post" id="mktoForm_%% formid %%" class="modal-form">
             <ul class="p-list">
               <li class="p-list__item">
-                <label for="firstName">First name:</label>
-                <input required id="firstName" name="firstName" maxlength="255" type="text" required="required" />
+                <label class="is-required" for="firstName">First name:</label>
+                <input required id="firstName" name="firstName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="lastName">Last name:</label>
-                <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
+                <label class="is-required" for="lastName">Last name:</label>
+                <input required id="lastName" name="lastName" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
                 <label class="is-required" for="company">Company:</label>
@@ -132,12 +132,12 @@
                 <input required id="title" name="title" maxlength="255" type="text" />
               </li>
               <li class="p-list__item">
-                <label for="email">Work email:</label>
-                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" required="required" />
+                <label class="is-required" for="email">Work email:</label>
+                <input required id="email" name="email" maxlength="255" type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" />
               </li>
               <li class="p-list__item">
-                <label for="phone">Mobile/cell phone number:</label>
-                <input required id="phone" name="phone" maxlength="255" type="tel" required="required" />
+                <label class="is-required" for="phone">Mobile/cell phone number:</label>
+                <input required id="phone" name="phone" maxlength="255" type="tel" />
               </li>
               <li class="p-list__item">
                 <label class="p-checkbox">

--- a/templates/shared/forms/interactive/wsl.html
+++ b/templates/shared/forms/interactive/wsl.html
@@ -124,7 +124,7 @@
                 <input required id="lastName" name="lastName" maxlength="255" type="text" required="required" />
               </li>
               <li class="p-list__item">
-                <label for="company">Company:</label>
+                <label class="is-required" for="company">Company:</label>
                 <input required id="company" name="company" maxlength="255" type="text" required="required" />
               </li>
               <li class="p-list__item">


### PR DESCRIPTION
## Done

- Company and Job title fields are now mandatory
- Added missing company/job title fields
- cleaned up some labels and input ids to be consistent across all forms.
- [drive by]: added the missing "is-required" class to labels for all the personal information inputs with required attribute in contact forms

## QA

- View the site in your web browser at: https://ubuntu-com-14950.demos.haus/
- Open a few forms mentioned in this [document](https://docs.google.com/spreadsheets/d/1e99_3tUZjldtO1fd9-cmaYac9h4ASCAg0Fpcvfz1ugY/edit?gid=1400082#gid=1400082) and verify that the company and job title fields are mandatory.


Bonus points: try to submit a few forms to make sure they work.

## Issue / Card

Fixes #[WD-19541](https://warthogs.atlassian.net/browse/WD-19541)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-19541]: https://warthogs.atlassian.net/browse/WD-19541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ