### PR TITLE
Feat: Percy workflow for baseline build

### DIFF
--- a/.github/workflows/percy-baseline.yaml
+++ b/.github/workflows/percy-baseline.yaml
@@ -1,0 +1,23 @@
+# This workflow updates the Percy baseline on every push to main.
+# This allows pull requests to be compared against baseline test results.
+
+name: Update Percy Baseline
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  snapshot:
+    name: Take Percy snapshots
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout SCM
+        uses: actions/checkout@v4
+
+      - uses: ./.github/actions/percy-snapshot
+        with:
+          branch_name: main
+          commitsh: ${{ github.sha }}
+          percy_token_write: ${{ secrets.PERCY_TOKEN_WRITE }}


### PR DESCRIPTION
## Rationale:
- Percy has a strategy where it compares the snapshots for the pull requests with common base commit in the main branch and for that reason it needs builds for all commits in main and hence the workflow.

## Done
- Workflow to update the percy baseline main branch.
- This is set for auto approval which mean that any build from main branch will be auto approved on Percy platform.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- This would work when the workflow is actually in main branch so I have tested it on my [fork](https://github.com/immortalcodes/ubuntu.com) .
- [Here](https://github.com/immortalcodes/ubuntu.com/actions/runs/14333028965) is the baseline build creation on merging a test PR into main branch of fork.
- See the auto-approved build [here](https://percy.io/bb49709b/web/ubuntu.com-eaf28f99)
## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
