### PR TITLE
WD-21345: usn.html: add FIPS and Realtime pockets

### DIFF
--- a/templates/security/notices/usn.html
+++ b/templates/security/notices/usn.html
@@ -71,13 +71,7 @@
               {% endif %}
               <div>
                 <small>
-                  {% if package.pocket == "esm-infra" %}
-                    Available with <a href="/pro">Ubuntu Pro</a>
-                  {% endif %}
-                  {% if package.pocket == "esm-infra-legacy" %}
-                    Available with <a href="/pro">Ubuntu Pro</a>
-                  {% endif %}
-                  {% if package.pocket == "esm-apps" %}
+                  {% if package.pocket in ["esm-infra", "esm-infra-legacy", "esm-apps", "realtime", "fips", "fips-updates"] %}
                     Available with <a href="/pro">Ubuntu Pro</a>
                   {% endif %}
                 </small>


### PR DESCRIPTION
## Done

- we want to add "Available with Ubuntu Pro" message for the pockets 'fips', 'fips-updates' and 'realtime'.
- those are known pockets in https://github.com/canonical/ubuntu-com-security-api and started to get published recently.
- an example: https://ubuntu.com/security/notices/USN-7408-3
- the CVE website already show the relevant information, example: https://ubuntu.com/security/CVE-2024-26928 (look for linux-aws-fips)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check if USN with FIPS or Realtime contain "Available with Ubuntu Pro", examples of such cases:
    - https://ubuntu.com/security/notices/USN-7383-2 (Real-time)
    - https://ubuntu.com/security/notices/USN-7387-2 (FIPS)
    - https://ubuntu.com/security/notices/USN-7387-3 (Real-time)
    - https://ubuntu.com/security/notices/USN-7393-1 (FIPS)
 - Also make sure ESM cases are still showing, examples:
    - https://ubuntu.com/security/notices/USN-7404-1 
    - https://ubuntu.com/security/notices/USN-7405-1 
 - And finally, that regular USNs are still not showing, examples:
    - https://ubuntu.com/security/notices/USN-7419-1 (mixed releses, ESM and regular)
    - https://ubuntu.com/security/notices/USN-7402-4

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-21345

## Screenshots

Local execution, example after the patch applied, USN-7408-3
![image](https://github.com/user-attachments/assets/dba6ebd6-8098-43c5-8eb8-a974bb860905)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
