### PR TITLE
copy update: [WD-20930] add copy for canonical ceph release cycle tab

### DIFF
--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -353,7 +353,7 @@ For more information on previous and current releases, please see the <a href="h
     <div class="p-strip is-shallow">
       <div class="u-fixed-width">
         <h2>Canonical Ceph release cycle</h2>
-        <p>For the Ceph release cycle and supported versions, refer to the <a href="https://ubuntu.com/ceph/docs/supported-ceph-versions">product documentation</a>.
+        <p>For the Ceph release cycle and supported versions, refer to the <a href="/ceph/docs/supported-ceph-versions">product documentation</a>.
         </p>
       </div>
     </div>

--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -68,6 +68,13 @@
                  role="tab"
                  aria-controls="canonical-kubernetes-release-cycle">Kubernetes</a>
             </li>
+            <li class="p-tabs__item" role="presentation">
+              <a href="#canonical-ceph-release-cycle"
+                 class="p-tabs__link"
+                 id="canonical-ceph-release-cycle-tab"
+                 role="tab"
+                 aria-controls="canonical-ceph-release-cycle">Ceph</a>
+            </li>
           </ul>
         </nav>
       </div>
@@ -334,6 +341,19 @@ For more information on previous and current releases, please see the <a href="h
       <div class="u-fixed-width">
         <p>
           For more information on previous and current releases, please see the <a href="/kubernetes/charmed-k8s/docs/release-notes">Charmed Kubernetes release notes</a> or the <a href="https://microk8s.io/docs/release-notes">MicroK8s release notes.</a>
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-tabs__content"
+           id="canonical-ceph-release-cycle"
+           role="tabpanel"
+           aria-labelledby="canonical-ceph-release-cycle-tab">
+    <div class="p-strip is-shallow">
+      <div class="u-fixed-width">
+        <h2>Canonical Ceph release cycle</h2>
+        <p>For the Ceph release cycle and supported versions, refer to the <a href="https://ubuntu.com/ceph/docs/supported-ceph-versions">product documentation</a>.
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Done

- Update https://ubuntu.com/about/release-cycle#openstack-release-cycle
- A Ceph tab was added with the appropriate copies

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- View update via http://0.0.0.0:8001/about/release-cycle#canonical-ceph-release-cycle

## Issue / Card
[Copy doc](https://docs.google.com/document/d/1-l3B7AoyDoETaL80UhlfEWCVKmMWPdy3zoF5LpsGcYQ/edit?usp=sharing)
[Jira ticket](https://warthogs.atlassian.net/browse/WD-20930?linkSource=email)

Fixes #

## Screenshots

View [screenshot](https://drive.google.com/file/d/1DS3jDu-f1Y3ytPf8ekoDYxlUJiV43W1Y/view?usp=sharing)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
