### PR TITLE
copy update: links to marketplace listings

### DIFF
--- a/templates/20-04/aws.html
+++ b/templates/20-04/aws.html
@@ -76,7 +76,7 @@
             <ul class="p-list--divided">
               <li class="p-list__item has-bullet"><a href="/server/docs/upgrade-introduction">Upgrade directly from Ubuntu 20.04 LTS</a></li>
               <li class="p-list__item has-bullet">
-                <a href="https://aws.amazon.com/marketplace/pp/prodview-dxdx74ozlxsl2">Launch a new instance of Ubuntu 22.04 LTS on AWS</a>
+                <a href="https://aws.amazon.com/marketplace/pp/prodview-f2if34z3a4e3i">Launch a new instance of Ubuntu 22.04 LTS on AWS</a>
               </li>
             </ul>
             <hr class="p-rule--muted" />
@@ -85,10 +85,10 @@
             <ul class="p-list--divided">
               <li class="p-list__item has-bullet"><a href="/server/docs/upgrade-introduction">Upgrade to Ubuntu 22.04 LTS first and then upgrade to 24.04 LTS</a></li>
               <li class="p-list__item has-bullet">
-                <a href="https://aws.amazon.com/marketplace/pp/prodview-kbkyvwyqubv2g">Launch a new instance of Ubuntu 24.04 LTS on AWS</a>
+                <a href="https://aws.amazon.com/marketplace/pp/prodview-s4zvkzmlirbga">Launch a new instance of Ubuntu 24.04 LTS on AWS</a>
               </li>
               <li class="p-list__item has-bullet">
-                <a href="#get-in-touch">Contact us to purchase annual subscription tokens</a>
+                <a href="/aws#get-in-touch">Contact us to purchase annual subscription tokens</a>
               </li>
             </ul>
           </div>
@@ -107,7 +107,7 @@
                 <a href="https://aws.amazon.com/marketplace/pp/prodview-ngmnrama2krsg">Fresh installation of Ubuntu Pro 20.04</a>
               </li>
               <li class="p-list__item has-bullet">
-                <a href="#get-in-touch">Contact us to purchase annual subscription tokens</a>
+                <a href="/aws#get-in-touch">Contact us to purchase annual subscription tokens</a>
               </li>
             </ul>
 


### PR DESCRIPTION
## Done

- Updated marketplace listings on https://ubuntu.com/20-04/aws according to the [copy doc](https://docs.google.com/document/d/15Zmi9XqCoo00UU4DOIzhSPENVdGsdAt6nTBpZTeKa3g/edit?tab=t.0)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Alternatively, view the [demo](https://ubuntu-com-14961.demos.haus/)
- Navigate to `/20-04/aws`
- Check the following links to point to expected pages (PFA screenshot)
     - `Contact us to purchase annual subscription tokens` should work (2 places)
     - `Launch a new instance of Ubuntu 22.04 LTS on AWS` should not point to Pro version
     - `Launch a new instance of Ubuntu 24.04 LTS on AWS` should not point to Pro version
## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-21339

## Screenshots

<img width="1352" alt="Screenshot 2025-04-09 at 2 50 36 PM" src="https://github.com/user-attachments/assets/772522cb-c86c-4edd-807c-7a8162c876be" />

