### PR TITLE
[WD-20515] copy update: ubuntu.com/automotive

### DIFF
--- a/templates/automotive/index.html
+++ b/templates/automotive/index.html
@@ -59,21 +59,20 @@
       <div class="col-6">
         <div class="u-align--center">
           {{ image(url="https://assets.ubuntu.com/v1/24713d12-tuv_sud_logo.webp",
-          alt="",
-          width="208",
-          height="200",
-          hi_def=True,
-          loading="lazy") | safe
+                    alt="",
+                    width="208",
+                    height="200",
+                    hi_def=True,
+                    loading="auto") | safe
           }}
         </div>
         <div class="u-align--left">
-          Canonical is proud to announce it has achieved the <a
-            href="https://ubuntu.com/blog/canonical-achieves-iso-21434-certification">ISO/SAE 21434 certification</a> for
+          Canonical is proud to announce it has achieved the <a href="/blog/canonical-achieves-iso-21434-certification">ISO/SAE 21434 certification</a> for
           its Security Management
           System.
         </div>
       </div>
-      </div>
+    </div>
     <div class="u-fixed-width">
       <hr class="p-rule" />
     </div>
@@ -101,103 +100,93 @@
       <div class="p-logo-section">
         <div class="p-logo-section__items u-no-margin--bottom">
           <div class="p-logo-section__item">
-          {{ image(url="https://assets.ubuntu.com/v1/0db93697-toyota-logo.png",
-          alt="",
-          width="92",
-          height="157",
-          hi_def=True,
-          loading="auto|lazy"
-          ) | safe
-          }}
+            {{ image(url="https://assets.ubuntu.com/v1/0db93697-toyota-logo.png",
+                        alt="Toyota",
+                        width="92",
+                        height="157",
+                        hi_def=True,
+                        loading="lazy") | safe
+            }}
           </div>
           <div class="p-logo-section__item">
-          {{ image(url="https://assets.ubuntu.com/v1/3840c0cb-vw-logo.png",
-          alt="",
-          width="81",
-          height="157",
-          hi_def=True,
-          loading="auto|lazy"
-          ) | safe
-          }}
+            {{ image(url="https://assets.ubuntu.com/v1/3840c0cb-vw-logo.png",
+                        alt="Volkswagen",
+                        width="81",
+                        height="157",
+                        hi_def=True,
+                        loading="lazy") | safe
+            }}
           </div>
           <div class="p-logo-section__item">
-          {{ image(url="https://assets.ubuntu.com/v1/80aac625-mercedes-benz-group-logo.png",
-          alt="",
-          width="300",
-          height="157",
-          hi_def=True,
-          loading="auto|lazy"
-          ) | safe
-          }}
+            {{ image(url="https://assets.ubuntu.com/v1/80aac625-mercedes-benz-group-logo.png",
+                        alt="Mercede Benz",
+                        width="300",
+                        height="157",
+                        hi_def=True,
+                        loading="auto|lazy") | safe
+            }}
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/f137f937-ford-logo.png",
-            alt="",
-            width="108",
-            height="157",
-            hi_def=True,
-            loading="auto|lazy"
-            ) | safe
+                        alt="",
+                        width="108",
+                        height="157",
+                        hi_def=True,
+                        loading="auto|lazy") | safe
             }}
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/cdfa19b3-general-motors-logo.png",
-            alt="",
-            width="75",
-            height="157",
-            hi_def=True,
-            loading="auto|lazy"
-            ) | safe
+                        alt="",
+                        width="75",
+                        height="157",
+                        hi_def=True,
+                        loading="auto|lazy") | safe
             }}
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/6ec4af64-jaguar-logo.png",
-            alt="",
-            width="201",
-            height="157",
-            hi_def=True,
-            loading="auto|lazy"
-            ) | safe
+                        alt="",
+                        width="201",
+                        height="157",
+                        hi_def=True,
+                        loading="auto|lazy") | safe
             }}
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/d0ebe3ac-land-rover-logo.png",
-            alt="",
-            width="129",
-            height="157",
-            hi_def=True,
-            loading="auto|lazy"
-            ) | safe
+                        alt="",
+                        width="129",
+                        height="157",
+                        hi_def=True,
+                        loading="auto|lazy") | safe
             }}
           </div>
           <div class="p-logo-section__item u-align--center">
             {{ image(url="https://assets.ubuntu.com/v1/be48c6a6-volvo-logo.png",
-            alt="",
-            width="314",
-            height="157",
-            hi_def=True,
-            loading="auto|lazy"
-            ) | safe
+                        alt="",
+                        width="314",
+                        height="157",
+                        hi_def=True,
+                        loading="auto|lazy") | safe
             }}
           </div>
           <div class="p-logo-section__item">
-          {{ image(url="https://assets.ubuntu.com/v1/f9de53ca-kassbohrer-logo.png",
-          alt="",
-          width="281",
-          height="157",
-          hi_def=True,
-          loading="auto|lazy"
-          ) | safe
-          }}
+            {{ image(url="https://assets.ubuntu.com/v1/f9de53ca-kassbohrer-logo.png",
+                        alt="",
+                        width="281",
+                        height="157",
+                        hi_def=True,
+                        loading="auto|lazy") | safe
+            }}
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/e173e24a-zoox-logo.png",
-            alt="",
-            width="156",
-            height="157",
-            hi_def=True,
-            loading="auto|lazy"
-            ) | safe
+                        alt="",
+                        width="156",
+                        height="157",
+                        hi_def=True,
+                        loading="auto|lazy") | safe
             }}
           </div>
         </div>
@@ -392,72 +381,65 @@
         <div class="p-logo-section__items u-no-margin--bottom">
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/466c2690-bosch-logo.png",
-            alt="",
-            width="288",
-            height="288",
-            hi_def=True,
-            loading="auto|lazy"
-            ) | safe
+                        alt="",
+                        width="288",
+                        height="288",
+                        hi_def=True,
+                        loading="auto|lazy") | safe
             }}
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/d72656f6-continetal-logo.png",
-            alt="",
-            width="227",
-            height="157",
-            hi_def=True,
-            loading="auto|lazy"
-            ) | safe
+                        alt="",
+                        width="227",
+                        height="157",
+                        hi_def=True,
+                        loading="auto|lazy") | safe
             }}
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/340bd20c-tomtom-logo 1.png",
-            alt="",
-            width="170",
-            height="157",
-            hi_def=True,
-            loading="auto|lazy"
-            ) | safe
+                        alt="",
+                        width="170",
+                        height="157",
+                        hi_def=True,
+                        loading="auto|lazy") | safe
             }}
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/3fed9e2f-cerence-logo.png",
-            alt="",
-            width="244",
-            height="157",
-            hi_def=True,
-            loading="auto|lazy"
-            ) | safe
+                        alt="",
+                        width="244",
+                        height="157",
+                        hi_def=True,
+                        loading="auto|lazy") | safe
             }}
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/5a229298-nvidia-logo-1.png",
-            alt="",
-            width="204",
-            height="157",
-            hi_def=True,
-            loading="auto|lazy"
-            ) | safe
+                        alt="",
+                        width="204",
+                        height="157",
+                        hi_def=True,
+                        loading="auto|lazy") | safe
             }}
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/dd64c442-elektrobit.png",
-            alt="",
-            width="179",
-            height="157",
-            hi_def=True,
-            loading="auto|lazy"
-            ) | safe
+                        alt="",
+                        width="179",
+                        height="157",
+                        hi_def=True,
+                        loading="auto|lazy") | safe
             }}
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/00c5532e-valeo-logo.png",
-            alt="",
-            width="89",
-            height="157",
-            hi_def=True,
-            loading="auto|lazy"
-            ) | safe
+                        alt="",
+                        width="89",
+                        height="157",
+                        hi_def=True,
+                        loading="auto|lazy") | safe
             }}
           </div>
         </div>
@@ -471,9 +453,7 @@
     </div>
     <div class="row u-equal-height">
       <div class="col-6">
-        <h3 class="p-heading--2">
-          Automated factories, smarter robots
-        </h3>
+        <h3 class="p-heading--2">Automated factories, smarter robots</h3>
         <p>
           We offer a complete portfolio of enablers, so you can drive digital transformation and continuous improvement with app-centric factory automation.
         </p>
@@ -524,42 +504,38 @@
         <div class="p-logo-section__items u-no-margin--bottom">
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/1f9d6318-lyft-logo.png",
-            alt="",
-            width="288",
-            height="288",
-            hi_def=True,
-            loading="auto|lazy"
-            ) | safe
+                        alt="",
+                        width="288",
+                        height="288",
+                        hi_def=True,
+                        loading="auto|lazy") | safe
             }}
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/5eaf9fae-cruise-logo.png",
-            alt="",
-            width="288",
-            height="288",
-            hi_def=True,
-            loading="auto|lazy"
-            ) | safe
+                        alt="",
+                        width="288",
+                        height="288",
+                        hi_def=True,
+                        loading="auto|lazy") | safe
             }}
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/e2608cee-zoox-logo.png",
-            alt="",
-            width="288",
-            height="288",
-            hi_def=True,
-            loading="auto|lazy"
-            ) | safe
+                        alt="",
+                        width="288",
+                        height="288",
+                        hi_def=True,
+                        loading="auto|lazy") | safe
             }}
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/eadcdf0b-outrider-logo.png",
-            alt="",
-            width="288",
-            height="288",
-            hi_def=True,
-            loading="auto|lazy"
-            ) | safe
+                        alt="",
+                        width="288",
+                        height="288",
+                        hi_def=True,
+                        loading="auto|lazy") | safe
             }}
           </div>
         </div>

--- a/templates/automotive/index.html
+++ b/templates/automotive/index.html
@@ -83,7 +83,7 @@
                 height="250",
                 width="429",
                 hi_def=True,
-                loading=lazy,) | safe
+                loading="lazy") | safe
         }}
       </div>
       <div class="col-6">
@@ -105,7 +105,7 @@
                         width="92",
                         height="157",
                         hi_def=True,
-                        loading="lazy") | safe
+                        loading="lazy", attrs={"class": "p-logo-section__logo"}) | safe
             }}
           </div>
           <div class="p-logo-section__item">
@@ -114,7 +114,7 @@
                         width="81",
                         height="157",
                         hi_def=True,
-                        loading="lazy") | safe
+                        loading="lazy", attrs={"class": "p-logo-section__logo"}) | safe
             }}
           </div>
           <div class="p-logo-section__item">
@@ -123,70 +123,77 @@
                         width="300",
                         height="157",
                         hi_def=True,
-                        loading="auto|lazy") | safe
+                        loading="lazy", attrs={"class": "p-logo-section__logo"}) | safe
             }}
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/f137f937-ford-logo.png",
-                        alt="",
+                        alt="Ford",
                         width="108",
                         height="157",
                         hi_def=True,
-                        loading="auto|lazy") | safe
+                        loading="lazy", attrs={"class": "p-logo-section__logo"}) | safe
+
             }}
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/cdfa19b3-general-motors-logo.png",
-                        alt="",
+                        alt="General Motors",
                         width="75",
                         height="157",
                         hi_def=True,
-                        loading="auto|lazy") | safe
+                        loading="lazy", attrs={"class": "p-logo-section__logo"}) | safe
+
             }}
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/6ec4af64-jaguar-logo.png",
-                        alt="",
+                        alt="Jaguar",
                         width="201",
                         height="157",
                         hi_def=True,
-                        loading="auto|lazy") | safe
+                        loading="lazy", attrs={"class": "p-logo-section__logo"}) | safe
+
             }}
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/d0ebe3ac-land-rover-logo.png",
-                        alt="",
+                        alt="Land Rover",
                         width="129",
                         height="157",
                         hi_def=True,
-                        loading="auto|lazy") | safe
+                        loading="lazy", attrs={"class": "p-logo-section__logo"}) | safe
+
             }}
           </div>
           <div class="p-logo-section__item u-align--center">
             {{ image(url="https://assets.ubuntu.com/v1/be48c6a6-volvo-logo.png",
-                        alt="",
+                        alt="Volvo",
                         width="314",
                         height="157",
                         hi_def=True,
-                        loading="auto|lazy") | safe
+                        loading="lazy", attrs={"class": "p-logo-section__logo"}) | safe
+
             }}
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/f9de53ca-kassbohrer-logo.png",
-                        alt="",
+                        alt="Kassbohrer",
                         width="281",
                         height="157",
                         hi_def=True,
-                        loading="auto|lazy") | safe
+                        loading="lazy", attrs={"class": "p-logo-section__logo"}) | safe
+
             }}
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/e173e24a-zoox-logo.png",
-                        alt="",
+                        alt="Zoox",
                         width="156",
                         height="157",
                         hi_def=True,
-                        loading="auto|lazy") | safe
+                        loading="lazy", attrs={"class": "p-logo-section__logo"}) | safe
+
             }}
           </div>
         </div>
@@ -275,41 +282,41 @@
           <div class="p-logo-section__items u-no-margin--bottom">
             <div class="p-logo-section__item">
               {{ image(url="https://assets.ubuntu.com/v1/711be910-arm-logo.png",
-                            alt="",
+                            alt="Arm",
                             width="288",
                             height="288",
                             hi_def=True,
-                            loading="lazy",
-                            attrs={"class": "p-logo-section__logo"}) | safe
+                            loading="lazy", attrs={"class": "p-logo-section__logo"}) | safe
               }}
             </div>
             <div class="p-logo-section__item">
               {{ image(url="https://assets.ubuntu.com/v1/6079d02b-amd-logo.png",
-                            alt="",
+                            alt="Amd",
                             width="288",
                             height="288",
                             hi_def=True,
-                            loading="lazy",
-                            attrs={"class": "p-logo-section__logo"}) | safe
+                            loading="lazy", attrs={"class": "p-logo-section__logo"}) | safe
+
               }}
             </div>
             <div class="p-logo-section__item">
               {{ image(url="https://assets.ubuntu.com/v1/67f81bfe-intel-new-logo.png",
-                            alt="",
+                            alt="Intel",
                             width="288",
                             height="288",
                             hi_def=True,
-                            loading="lazy") | safe
+                            loading="lazy", attrs={"class": "p-logo-section__logo"}) | safe
+
               }}
             </div>
             <div class="p-logo-section__item">
               {{ image(url="https://assets.ubuntu.com/v1/cd765ccc-nvidia-logo.png",
-                            alt="",
+                            alt="Nvdia",
                             width="288",
                             height="288",
                             hi_def=True,
-                            loading="lazy",
-                            attrs={"class": "p-logo-section__logo"}) | safe
+                            loading="lazy", attrs={"class": "p-logo-section__logo"}) | safe
+
               }}
             </div>
           </div>
@@ -341,7 +348,7 @@
                 alt="",
                 height="326",
                 width="326",
-                hi_def=True,) | safe
+                hi_def=True, loading="lazy") | safe
         }}
       </div>
     </div>
@@ -351,7 +358,7 @@
     <div class="row u-vertically-center">
       <div class="col-6 u-hide--medium u-hide--small u-align--center">
         {{ image(url="https://assets.ubuntu.com/v1/fc1abe71-Snapcraft-logo-RGB-2022.png",
-                alt="",
+                alt="Snapcraft",
                 width="407",
                 height="120",
                 hi_def=True,
@@ -380,66 +387,73 @@
       <div class="p-logo-section">
         <div class="p-logo-section__items u-no-margin--bottom">
           <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/466c2690-bosch-logo.png",
-                        alt="",
-                        width="288",
-                        height="288",
+            {{ image(url="https://assets.ubuntu.com/v1/0f18f514-bosch-logo.png",
+                        alt="Bosch",
+                        width="168",
+                        height="157",
                         hi_def=True,
-                        loading="auto|lazy") | safe
+                        loading="lazy", attrs={"class": "p-logo-section__logo"}) | safe
+
             }}
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/d72656f6-continetal-logo.png",
-                        alt="",
+                        alt="Continental",
                         width="227",
                         height="157",
                         hi_def=True,
-                        loading="auto|lazy") | safe
+                        loading="lazy", attrs={"class": "p-logo-section__logo"}) | safe
+
             }}
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/340bd20c-tomtom-logo 1.png",
-                        alt="",
+                        alt="Tomtom",
                         width="170",
                         height="157",
                         hi_def=True,
-                        loading="auto|lazy") | safe
+                        loading="lazy", attrs={"class": "p-logo-section__logo"}) | safe
+
             }}
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/3fed9e2f-cerence-logo.png",
-                        alt="",
+                        alt="Cerence",
                         width="244",
                         height="157",
                         hi_def=True,
-                        loading="auto|lazy") | safe
+                        loading="lazy", attrs={"class": "p-logo-section__logo"}) | safe
+
             }}
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/5a229298-nvidia-logo-1.png",
-                        alt="",
+                        alt="Nvidia",
                         width="204",
                         height="157",
                         hi_def=True,
-                        loading="auto|lazy") | safe
+                        loading="lazy", attrs={"class": "p-logo-section__logo"}) | safe
+
             }}
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/dd64c442-elektrobit.png",
-                        alt="",
+                        alt="Elektrobit",
                         width="179",
                         height="157",
                         hi_def=True,
-                        loading="auto|lazy") | safe
+                        loading="lazy", attrs={"class": "p-logo-section__logo"}) | safe
+
             }}
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/00c5532e-valeo-logo.png",
-                        alt="",
+                        alt="Valeo",
                         width="89",
                         height="157",
                         hi_def=True,
-                        loading="auto|lazy") | safe
+                        loading="lazy", attrs={"class": "p-logo-section__logo"}) | safe
+
             }}
           </div>
         </div>
@@ -468,7 +482,7 @@
                 height="200",
                 width="350",
                 hi_def=True,
-                loading=lazy) | safe
+                loading="lazy") | safe
         }}
       </div>
     </div>
@@ -504,38 +518,42 @@
         <div class="p-logo-section__items u-no-margin--bottom">
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/1f9d6318-lyft-logo.png",
-                        alt="",
+                        alt="Lyft",
                         width="288",
                         height="288",
                         hi_def=True,
-                        loading="auto|lazy") | safe
+                        loading="lazy", attrs={"class": "p-logo-section__logo"}) | safe
+
             }}
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/5eaf9fae-cruise-logo.png",
-                        alt="",
+                        alt="Cruise",
                         width="288",
                         height="288",
                         hi_def=True,
-                        loading="auto|lazy") | safe
+                        loading="lazy", attrs={"class": "p-logo-section__logo"}) | safe
+
             }}
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/e2608cee-zoox-logo.png",
-                        alt="",
+                        alt="Zoox",
                         width="288",
                         height="288",
                         hi_def=True,
-                        loading="auto|lazy") | safe
+                        loading="lazy", attrs={"class": "p-logo-section__logo"}) | safe
+
             }}
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/eadcdf0b-outrider-logo.png",
-                        alt="",
+                        alt="Outrider",
                         width="288",
                         height="288",
                         hi_def=True,
-                        loading="auto|lazy") | safe
+                        loading="lazy", attrs={"class": "p-logo-section__logo"}) | safe
+
             }}
           </div>
         </div>
@@ -569,7 +587,7 @@
                         height="150",
                         hi_def=True,
                         loading="lazy",
-                        attrs={"class": "p-heading-icon__img"},) | safe
+                        attrs={"class": "p-heading-icon__img"}) | safe
             }}
             <h4 class="p-heading-icon__title">Whitepaper</h4>
           </div>
@@ -589,7 +607,7 @@
                         height="72",
                         hi_def=True,
                         loading="lazy",
-                        attrs={"class": "p-heading-icon__img"},) | safe
+                        attrs={"class": "p-heading-icon__img"}) | safe
             }}
             <h4 class="p-heading-icon__title">Videos</h4>
           </div>
@@ -608,7 +626,7 @@
                         height="28",
                         hi_def=True,
                         loading="lazy",
-                        attrs={"class": "p-heading-icon__img"},) | safe
+                        attrs={"class": "p-heading-icon__img"}) | safe
             }}
             <h4 class="p-heading-icon__title">Announcements</h4>
           </div>
@@ -630,7 +648,7 @@
                         height="28",
                         hi_def=True,
                         loading="lazy",
-                        attrs={"class": "p-heading-icon__img"},) | safe
+                        attrs={"class": "p-heading-icon__img"}) | safe
             }}
             <h4 class="p-heading-icon__title">Blogs</h4>
           </div>

--- a/templates/automotive/index.html
+++ b/templates/automotive/index.html
@@ -56,7 +56,7 @@
           <a href="https://www.elektrobit.com/products/ecu/eb-corbos/linux-built-on-ubuntu/free?utm_source=Canonical"><b>Try EB Corbos Linux for free now&nbsp;&rsaquo;</b></a>
         </p>
       </div>
-      <div class="col-6 u-hide--medium u-hide--small">
+      <div class="col-6">
         <div class="u-align--center">
           {{ image(url="https://assets.ubuntu.com/v1/24713d12-tuv_sud_logo.webp",
           alt="",

--- a/templates/automotive/index.html
+++ b/templates/automotive/index.html
@@ -56,14 +56,23 @@
           <a href="https://www.elektrobit.com/products/ecu/eb-corbos/linux-built-on-ubuntu/free?utm_source=Canonical"><b>Try EB Corbos Linux for free now&nbsp;&rsaquo;</b></a>
         </p>
       </div>
-      <div class="col-6 u-hide--medium u-hide--small u-align--center">
-        {{ image(url="https://assets.ubuntu.com/v1/ce518a18-CoF-2022_solid+O.svg",
-                alt="",
-                width="208",
-                height="200",
-                hi_def=True,
-                loading="lazy") | safe
-        }}
+      <div class="col-6 u-hide--medium u-hide--small">
+        <div class="u-align--center">
+          {{ image(url="https://assets.ubuntu.com/v1/24713d12-tuv_sud_logo.webp",
+          alt="",
+          width="208",
+          height="200",
+          hi_def=True,
+          loading="lazy") | safe
+          }}
+        </div>
+        <div class="u-align--left">
+          Canonical is proud to announce it has achieved the <a
+            href="https://ubuntu.com/blog/canonical-achieves-iso-21434-certification">ISO/SAE 21434 certification</a> for
+          its Security Management
+          System.
+        </div>
+      </div>
       </div>
     </div>
     <div class="u-fixed-width">
@@ -93,7 +102,7 @@
       <div class="p-logo-section">
         <div class="p-logo-section__items u-no-margin--bottom">
           <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/85be122c-toyota-logo.png",
+            {{ image(url="https://assets.ubuntu.com/v1/0db93697-toyota-logo.png",
                         alt="Toyota",
                         width="288",
                         height="288",
@@ -103,7 +112,7 @@
             }}
           </div>
           <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/e10b8957-vw-logo.png",
+            {{ image(url="https://assets.ubuntu.com/v1/3840c0cb-vw-logo.png",
                         alt="Volkswagen",
                         width="288",
                         height="288",
@@ -113,7 +122,7 @@
             }}
           </div>
           <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/a3bb7ca4-mercedes-benz-group-logo.png",
+            {{ image(url="https://assets.ubuntu.com/v1/80aac625-mercedes-benz-group-logo.png",
                         alt="",
                         width="288",
                         height="288",
@@ -123,7 +132,7 @@
             }}
           </div>
           <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/4c44ed82-skoda-logo.png",
+            {{ image(url="https://assets.ubuntu.com/v1/f137f937-ford-logo.png",
                         alt="",
                         width="288",
                         height="288",
@@ -133,7 +142,7 @@
             }}
           </div>
           <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/3263fb35-ford-logo.png",
+            {{ image(url="https://assets.ubuntu.com/v1/cdfa19b3-general-motors-logo.png",
                         alt="",
                         width="288",
                         height="288",
@@ -143,7 +152,7 @@
             }}
           </div>
           <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/7ad0aaca-general-motors-logo.png",
+            {{ image(url="https://assets.ubuntu.com/v1/6ec4af64-jaguar-logo.png",
                         alt="",
                         width="288",
                         height="288",
@@ -153,48 +162,8 @@
             }}
           </div>
           <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/ff1a0c71-audi-logo.png",
+            {{ image(url="https://assets.ubuntu.com/v1/d0ebe3ac-land-rover-logo.png",
                         alt="",
-                        width="288",
-                        height="288",
-                        hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-logo-section__logo"}) | safe
-            }}
-          </div>
-          <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/c934c5ab-jaguar-logo.png",
-                        alt="",
-                        width="288",
-                        height="288",
-                        hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-logo-section__logo"}) | safe
-            }}
-          </div>
-          <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/48a12f22-land-rover-logo.png",
-                        alt="",
-                        width="288",
-                        height="288",
-                        hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-logo-section__logo"}) | safe
-            }}
-          </div>
-          <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/0a06b7dc-nio-logo.png",
-                        alt="",
-                        width="288",
-                        height="288",
-                        hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-logo-section__logo"}) | safe
-            }}
-          </div>
-          <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/52e19575-scania-logo.png",
-                        alt="Scania",
                         width="288",
                         height="288",
                         hi_def=True,
@@ -203,7 +172,7 @@
             }}
           </div>
           <div class="p-logo-section__item u-align--center">
-            {{ image(url="https://assets.ubuntu.com/v1/e24027db-volvo-logo.png",
+            {{ image(url="https://assets.ubuntu.com/v1/be48c6a6-volvo-logo.png",
                         alt="",
                         width="288",
                         height="288",
@@ -212,8 +181,19 @@
                         attrs={"class": "p-logo-section__logo"}) | safe
             }}
           </div>
+          
           <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/0334b4ed-man-logo.png",
+            {{ image(url="https://assets.ubuntu.com/v1/f9de53ca-kassbohrer-logo.png",
+                        alt="Scania",
+                        width="288",
+                        height="288",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
+          </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/e173e24a-zoox-logo.png",
                         alt="",
                         width="288",
                         height="288",
@@ -423,7 +403,7 @@
             }}
           </div>
           <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/7e3ec23a-continetal-logo.png",
+            {{ image(url="https://assets.ubuntu.com/v1/d72656f6-continetal-logo.png",
                         alt="",
                         width="288",
                         height="288",
@@ -433,7 +413,7 @@
             }}
           </div>
           <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/bfd6083f-tomtom-logo.png",
+            {{ image(url="https://assets.ubuntu.com/v1/340bd20c-tomtom-logo%201.png",
                         alt="",
                         width="288",
                         height="288",
@@ -443,7 +423,7 @@
             }}
           </div>
           <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/2e652eec-rhode-schwarz-logo.png",
+            {{ image(url="https://assets.ubuntu.com/v1/3fed9e2f-cerence-logo.png",
                         alt="",
                         width="288",
                         height="288",
@@ -453,7 +433,7 @@
             }}
           </div>
           <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/38950ca8-cerence-logo.png",
+            {{ image(url="https://assets.ubuntu.com/v1/5a229298-nvidia-logo-1.png",
                         alt="",
                         width="288",
                         height="288",
@@ -463,7 +443,7 @@
             }}
           </div>
           <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/cd765ccc-nvidia-logo.png",
+            {{ image(url="https://assets.ubuntu.com/v1/dd64c442-elektrobit.png",
                         alt="",
                         width="288",
                         height="288",
@@ -473,17 +453,7 @@
             }}
           </div>
           <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/d01c96ec-Elektrobit%20logo%20288.png",
-                        alt="",
-                        width="288",
-                        height="288",
-                        hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-logo-section__logo"}) | safe
-            }}
-          </div>
-          <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/29213f73-Ibeo%20logo%20288.png",
+            {{ image(url="https://assets.ubuntu.com/v1/00c5532e-valeo-logo.png",
                         alt="",
                         width="288",
                         height="288",

--- a/templates/automotive/index.html
+++ b/templates/automotive/index.html
@@ -123,7 +123,7 @@
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/80aac625-mercedes-benz-group-logo.png",
-                        alt="",
+                        alt="Mercedes-Benz",
                         width="288",
                         height="288",
                         hi_def=True,
@@ -133,7 +133,7 @@
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/f137f937-ford-logo.png",
-                        alt="",
+                        alt="Ford",
                         width="288",
                         height="288",
                         hi_def=True,
@@ -143,7 +143,7 @@
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/cdfa19b3-general-motors-logo.png",
-                        alt="",
+                        alt="General Motors",
                         width="288",
                         height="288",
                         hi_def=True,
@@ -153,7 +153,7 @@
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/6ec4af64-jaguar-logo.png",
-                        alt="",
+                        alt="Jaguar",
                         width="288",
                         height="288",
                         hi_def=True,
@@ -163,7 +163,7 @@
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/d0ebe3ac-land-rover-logo.png",
-                        alt="",
+                        alt="Land Rover",
                         width="288",
                         height="288",
                         hi_def=True,
@@ -173,7 +173,7 @@
           </div>
           <div class="p-logo-section__item u-align--center">
             {{ image(url="https://assets.ubuntu.com/v1/be48c6a6-volvo-logo.png",
-                        alt="",
+                        alt="Volvo",
                         width="288",
                         height="288",
                         hi_def=True,
@@ -184,7 +184,7 @@
           
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/f9de53ca-kassbohrer-logo.png",
-                        alt="Scania",
+                        alt="Kässbohrer",
                         width="288",
                         height="288",
                         hi_def=True,
@@ -194,7 +194,7 @@
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/e173e24a-zoox-logo.png",
-                        alt="",
+                        alt="Zoox",
                         width="288",
                         height="288",
                         hi_def=True,
@@ -394,7 +394,7 @@
         <div class="p-logo-section__items u-no-margin--bottom">
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/466c2690-bosch-logo.png",
-                        alt="",
+                        alt="Bosch",
                         width="288",
                         height="288",
                         hi_def=True,
@@ -404,7 +404,7 @@
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/d72656f6-continetal-logo.png",
-                        alt="",
+                        alt="Continental",
                         width="288",
                         height="288",
                         hi_def=True,
@@ -414,7 +414,7 @@
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/340bd20c-tomtom-logo%201.png",
-                        alt="",
+                        alt="TomTom",
                         width="288",
                         height="288",
                         hi_def=True,
@@ -424,7 +424,7 @@
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/3fed9e2f-cerence-logo.png",
-                        alt="",
+                        alt="Cerence",
                         width="288",
                         height="288",
                         hi_def=True,
@@ -434,7 +434,7 @@
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/5a229298-nvidia-logo-1.png",
-                        alt="",
+                        alt="NVDIA",
                         width="288",
                         height="288",
                         hi_def=True,
@@ -444,7 +444,7 @@
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/dd64c442-elektrobit.png",
-                        alt="",
+                        alt="Elektrobit",
                         width="288",
                         height="288",
                         hi_def=True,
@@ -454,7 +454,7 @@
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/00c5532e-valeo-logo.png",
-                        alt="",
+                        alt="Valeo",
                         width="288",
                         height="288",
                         hi_def=True,
@@ -526,7 +526,7 @@
         <div class="p-logo-section__items u-no-margin--bottom">
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/1f9d6318-lyft-logo.png",
-                        alt="",
+                        alt="Lyft",
                         width="288",
                         height="288",
                         hi_def=True,
@@ -536,7 +536,7 @@
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/5eaf9fae-cruise-logo.png",
-                        alt="",
+                        alt="Cruise",
                         width="288",
                         height="288",
                         hi_def=True,
@@ -546,7 +546,7 @@
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/e2608cee-zoox-logo.png",
-                        alt="",
+                        alt="Zoox",
                         width="288",
                         height="288",
                         hi_def=True,
@@ -556,7 +556,7 @@
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/eadcdf0b-outrider-logo.png",
-                        alt="",
+                        alt="Outrider",
                         width="288",
                         height="288",
                         hi_def=True,

--- a/templates/automotive/index.html
+++ b/templates/automotive/index.html
@@ -74,7 +74,6 @@
         </div>
       </div>
       </div>
-    </div>
     <div class="u-fixed-width">
       <hr class="p-rule" />
     </div>
@@ -102,104 +101,103 @@
       <div class="p-logo-section">
         <div class="p-logo-section__items u-no-margin--bottom">
           <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/0db93697-toyota-logo.png",
-                        alt="Toyota",
-                        width="288",
-                        height="288",
-                        hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-logo-section__logo"}) | safe
-            }}
+          {{ image(url="https://assets.ubuntu.com/v1/0db93697-toyota-logo.png",
+          alt="",
+          width="92",
+          height="157",
+          hi_def=True,
+          loading="auto|lazy"
+          ) | safe
+          }}
           </div>
           <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/3840c0cb-vw-logo.png",
-                        alt="Volkswagen",
-                        width="288",
-                        height="288",
-                        hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-logo-section__logo"}) | safe
-            }}
+          {{ image(url="https://assets.ubuntu.com/v1/3840c0cb-vw-logo.png",
+          alt="",
+          width="81",
+          height="157",
+          hi_def=True,
+          loading="auto|lazy"
+          ) | safe
+          }}
           </div>
           <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/80aac625-mercedes-benz-group-logo.png",
-                        alt="Mercedes-Benz",
-                        width="288",
-                        height="288",
-                        hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-logo-section__logo"}) | safe
-            }}
+          {{ image(url="https://assets.ubuntu.com/v1/80aac625-mercedes-benz-group-logo.png",
+          alt="",
+          width="300",
+          height="157",
+          hi_def=True,
+          loading="auto|lazy"
+          ) | safe
+          }}
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/f137f937-ford-logo.png",
-                        alt="Ford",
-                        width="288",
-                        height="288",
-                        hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-logo-section__logo"}) | safe
+            alt="",
+            width="108",
+            height="157",
+            hi_def=True,
+            loading="auto|lazy"
+            ) | safe
             }}
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/cdfa19b3-general-motors-logo.png",
-                        alt="General Motors",
-                        width="288",
-                        height="288",
-                        hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-logo-section__logo"}) | safe
+            alt="",
+            width="75",
+            height="157",
+            hi_def=True,
+            loading="auto|lazy"
+            ) | safe
             }}
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/6ec4af64-jaguar-logo.png",
-                        alt="Jaguar",
-                        width="288",
-                        height="288",
-                        hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-logo-section__logo"}) | safe
+            alt="",
+            width="201",
+            height="157",
+            hi_def=True,
+            loading="auto|lazy"
+            ) | safe
             }}
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/d0ebe3ac-land-rover-logo.png",
-                        alt="Land Rover",
-                        width="288",
-                        height="288",
-                        hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-logo-section__logo"}) | safe
+            alt="",
+            width="129",
+            height="157",
+            hi_def=True,
+            loading="auto|lazy"
+            ) | safe
             }}
           </div>
           <div class="p-logo-section__item u-align--center">
             {{ image(url="https://assets.ubuntu.com/v1/be48c6a6-volvo-logo.png",
-                        alt="Volvo",
-                        width="288",
-                        height="288",
-                        hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-logo-section__logo"}) | safe
+            alt="",
+            width="314",
+            height="157",
+            hi_def=True,
+            loading="auto|lazy"
+            ) | safe
             }}
           </div>
-          
           <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/f9de53ca-kassbohrer-logo.png",
-                        alt="Kässbohrer",
-                        width="288",
-                        height="288",
-                        hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-logo-section__logo"}) | safe
-            }}
+          {{ image(url="https://assets.ubuntu.com/v1/f9de53ca-kassbohrer-logo.png",
+          alt="",
+          width="281",
+          height="157",
+          hi_def=True,
+          loading="auto|lazy"
+          ) | safe
+          }}
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/e173e24a-zoox-logo.png",
-                        alt="Zoox",
-                        width="288",
-                        height="288",
-                        hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-logo-section__logo"}) | safe
+            alt="",
+            width="156",
+            height="157",
+            hi_def=True,
+            loading="auto|lazy"
+            ) | safe
             }}
           </div>
         </div>
@@ -394,72 +392,72 @@
         <div class="p-logo-section__items u-no-margin--bottom">
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/466c2690-bosch-logo.png",
-                        alt="Bosch",
-                        width="288",
-                        height="288",
-                        hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-logo-section__logo"}) | safe
+            alt="",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="auto|lazy"
+            ) | safe
             }}
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/d72656f6-continetal-logo.png",
-                        alt="Continental",
-                        width="288",
-                        height="288",
-                        hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-logo-section__logo"}) | safe
+            alt="",
+            width="227",
+            height="157",
+            hi_def=True,
+            loading="auto|lazy"
+            ) | safe
             }}
           </div>
           <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/340bd20c-tomtom-logo%201.png",
-                        alt="TomTom",
-                        width="288",
-                        height="288",
-                        hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-logo-section__logo"}) | safe
+            {{ image(url="https://assets.ubuntu.com/v1/340bd20c-tomtom-logo 1.png",
+            alt="",
+            width="170",
+            height="157",
+            hi_def=True,
+            loading="auto|lazy"
+            ) | safe
             }}
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/3fed9e2f-cerence-logo.png",
-                        alt="Cerence",
-                        width="288",
-                        height="288",
-                        hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-logo-section__logo"}) | safe
+            alt="",
+            width="244",
+            height="157",
+            hi_def=True,
+            loading="auto|lazy"
+            ) | safe
             }}
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/5a229298-nvidia-logo-1.png",
-                        alt="NVDIA",
-                        width="288",
-                        height="288",
-                        hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-logo-section__logo"}) | safe
+            alt="",
+            width="204",
+            height="157",
+            hi_def=True,
+            loading="auto|lazy"
+            ) | safe
             }}
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/dd64c442-elektrobit.png",
-                        alt="Elektrobit",
-                        width="288",
-                        height="288",
-                        hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-logo-section__logo"}) | safe
+            alt="",
+            width="179",
+            height="157",
+            hi_def=True,
+            loading="auto|lazy"
+            ) | safe
             }}
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/00c5532e-valeo-logo.png",
-                        alt="Valeo",
-                        width="288",
-                        height="288",
-                        hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-logo-section__logo"}) | safe
+            alt="",
+            width="89",
+            height="157",
+            hi_def=True,
+            loading="auto|lazy"
+            ) | safe
             }}
           </div>
         </div>
@@ -526,42 +524,42 @@
         <div class="p-logo-section__items u-no-margin--bottom">
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/1f9d6318-lyft-logo.png",
-                        alt="Lyft",
-                        width="288",
-                        height="288",
-                        hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-logo-section__logo"}) | safe
+            alt="",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="auto|lazy"
+            ) | safe
             }}
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/5eaf9fae-cruise-logo.png",
-                        alt="Cruise",
-                        width="288",
-                        height="288",
-                        hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-logo-section__logo"}) | safe
+            alt="",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="auto|lazy"
+            ) | safe
             }}
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/e2608cee-zoox-logo.png",
-                        alt="Zoox",
-                        width="288",
-                        height="288",
-                        hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-logo-section__logo"}) | safe
+            alt="",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="auto|lazy"
+            ) | safe
             }}
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/eadcdf0b-outrider-logo.png",
-                        alt="Outrider",
-                        width="288",
-                        height="288",
-                        hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-logo-section__logo"}) | safe
+            alt="",
+            width="288",
+            height="288",
+            hi_def=True,
+            loading="auto|lazy"
+            ) | safe
             }}
           </div>
         </div>


### PR DESCRIPTION
## Done

- Add certification image and link
- Update logo cloud images

[Demo](https://ubuntu-com-14966.demos.haus/automotive)

## QA 

Check out this feature branch
Run the site using the command ./run serve or dotrun
View the site locally in your web browser at: http://0.0.0.0:8001/
Be sure to test on mobile, tablet and desktop screen sizes
[List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes #[WD-20515]

## Screenshots
![Screenshot 2025-04-09 at 6 26 02 PM](https://github.com/user-attachments/assets/5d40aaa0-5466-436b-9bd8-13008a4b1b64)
![Screenshot 2025-04-09 at 6 26 16 PM](https://github.com/user-attachments/assets/d0dd8477-4cea-4338-9d58-685a54175820)



## Help

- Some logo assets should be resized to fit logo cloud. (see screenshots)
- A ticket is apparently already assigned for this.

[WD-20515]: https://warthogs.atlassian.net/browse/WD-20515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ