### PR TITLE
feat: update ubuntu server cli cheatsheet

### DIFF
--- a/templates/download/server/thank-you.html
+++ b/templates/download/server/thank-you.html
@@ -48,7 +48,7 @@
         </div>
         <button class="p-button--positive" onclick="toggleModal()">Download the CLI cheat sheet</button>
         <div class="p-section--shallow p-image-wrapper">
-          {{ image(url="https://assets.ubuntu.com/v1/639c1f12-server-cli-cheatsheet.png",
+          {{ image(url="https://assets.ubuntu.com/v1/5809ba46-(Updated)%20Ubuntu%20Server%20CLI%20cheat%20sheet%2002.07.2024%20update.pdf",
                     alt="CLI cheat sheet",
                     width="1200",
                     height="849",

--- a/templates/download/shared/_server_weekly_news.html
+++ b/templates/download/shared/_server_weekly_news.html
@@ -125,7 +125,7 @@
                  value="" />
           <input type="hidden"
                  name="returnURL"
-                 value="https://assets.ubuntu.com/v1/3bd0daaf-Ubuntu%20Server%20CLI%20cheat%20sheet%202024%20v6.pdf" />
+                 value="https://assets.ubuntu.com/v1/5809ba46-(Updated)%20Ubuntu%20Server%20CLI%20cheat%20sheet%2002.07.2024%20update.pdf" />
         </form>
 
       </div>


### PR DESCRIPTION
## Done

- Updated link for cli cheatsheet

## QA

- View the site locally in your web browser at: https://ubuntu-com-14973.demos.haus/server/download
- Download a new iso, and on the thank you page, click the cli cheatsheet link and fill out the form. It should download [this](https://assets.ubuntu.com/v1/5809ba46-(Updated)%20Ubuntu%20Server%20CLI%20cheat%20sheet%2002.07.2024%20update.pdf) file.
    - Be sure to test on mobile, tablet and desktop screen sizes


## Issue / Card

Fixes [WD-16269](https://warthogs.atlassian.net/browse/WD-16269)

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-16269]: https://warthogs.atlassian.net/browse/WD-16269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ