### PR TITLE
copy-update: ubuntu.com/download/server/s390x

### DIFF
--- a/templates/download/server/s390x.html
+++ b/templates/download/server/s390x.html
@@ -26,10 +26,17 @@
           </h1>
         </div>
         <p>
-          IBM Z and LinuxONE systems leverage open technology solutions to meet the demands of the new application economy. They combine the best of open source to offer IBM's enterprise customers unprecedented performance, flexibility, security and resiliency. Ubuntu Server LTS are released every two years in April and can now be downloaded by all IBM Z and LinuxONE system customers.
+          IBM Z and LinuxONE systems leverage open technology solutions to meet the demands of the new application economy. They combine the best of open source to offer IBM's enterprise customers unprecedented performance, flexibility, security and resiliency. Ubuntu Server LTS releases are published every two years in April and can now be downloaded by all IBM Z and LinuxONE system customers.
         </p>
         <p>
-          Starting with 20.04 LTS the minimal requirement is z13s/z13, respectively LinuxONE Rockhopper/Emperor. zBC12/zEC12 are only supported up to Ubuntu 18.04 LTS.
+          Minimum requirements:
+          <ul>
+            <li>Starting with 24.04 LTS, the minimum requirement is z14s/z14 for LinuxONE Rockhopper II/Emperor II, respectively.</li>
+            <li>For 20.04 LTS, the minimum requirement is z13s/z13, for LinuxONE Rockhopper/Emperor, respectively.</li>
+          </ul>
+        </p>
+        <p>
+          zBC12/zEC12 was only supported up to Ubuntu Server 18.04 LTS.
         </p>
         <p>
           Ubuntu Server for IBM Z and LinuxONE is priced at $19,500 per drawer per year, covering unlimited usage of Ubuntu within that drawer, Ubuntu Pro + Support (24/7) and regular security and reliability fixes from Canonical.


### PR DESCRIPTION
## Done

Ubuntu 25.04 Copy Updates for ubuntu.com/download/server/s390x 

:exclamation:  to go live when ISO is up on Apr 17, 2025

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://localhost:8001/download/server/s390x
    - Be sure to test on mobile, tablet and desktop screen sizes
- compare the copy update from: https://docs.google.com/document/d/1d85IfqqxZYYZ0orj5lBhqLWLGpLYWRLdvs75lYsplGs/edit?tab=t.0

## Issue / Card

Fixes #

https://warthogs.atlassian.net/browse/WD-20899#icft=WD-20899

## Screenshots

![image](https://github.com/user-attachments/assets/83e67b67-b443-4ce5-b6c6-8115fb1abd52)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
