### PR TITLE
pro: edit billing details from invoices page

### DIFF
--- a/build.js
+++ b/build.js
@@ -15,6 +15,7 @@ let entries = {
   appliance: "./static/js/src/appliance.js",
   costCalculator: "./static/js/src/openstack/react/app.jsx",
   "ua-payment-methods": "./static/js/src/ua-payment-methods.js",
+  "account-billing": "./static/js/src/account-billing.js",
   "sticky-nav": "./static/js/src/sticky-nav.js",
   chassisAnimation: "./static/js/src/chassis-animation.js",
   cve: "./static/js/src/cve/cve.js",

--- a/static/js/src/account-billing.js
+++ b/static/js/src/account-billing.js
@@ -1,0 +1,196 @@
+import {
+  getCustomerInfo,
+  postCustomerInfoToStripeAccount,
+} from "./advantage/api/contracts.js";
+import { countries } from "./advantage/countries-and-states.js";
+
+const accountId = window.accountId;
+
+// This partially replicates the functionality of the modal.js file.
+// We do it so we can control when the modal opens in a predicatable way,
+// i.e. after the fetch the data and populate the content.
+function Modal({ modalSelector }) {
+  let currentDialog = null;
+  let lastFocus = null;
+  let ignoreFocusChanges = false;
+  let focusAfterClose = null;
+  const modal = document.getElementById(modalSelector);
+
+  function trapFocus(e) {
+    if (ignoreFocusChanges) return;
+    if (currentDialog.contains(e.target)) {
+      lastFocus = e.target;
+    } else {
+      focusFirstDescendant(currentDialog);
+      if (lastFocus == document.activeElement) {
+        focusLastDescendant(currentDialog);
+      }
+      lastFocus = document.activeElement;
+    }
+  }
+
+  function attemptFocus(child) {
+    if (child.focus) {
+      ignoreFocusChanges = true;
+      child.focus();
+      ignoreFocusChanges = false;
+      return document.activeElement === child;
+    }
+    return false;
+  }
+
+  function focusFirstDescendant(element) {
+    for (let i = 0; i < element.childNodes.length; i++) {
+      let child = element.childNodes[i];
+      if (attemptFocus(child) || focusFirstDescendant(child)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function focusLastDescendant(element) {
+    for (let i = element.childNodes.length - 1; i >= 0; i--) {
+      let child = element.childNodes[i];
+      if (attemptFocus(child) || focusLastDescendant(child)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function toggleModal(sourceEl, open) {
+    if (open) {
+      currentDialog = modal;
+      modal.style.display = "flex";
+      focusFirstDescendant(modal);
+      focusAfterClose = sourceEl;
+      document.addEventListener("focus", trapFocus, true);
+    } else {
+      modal.style.display = "none";
+      if (focusAfterClose && focusAfterClose.focus) {
+        focusAfterClose.focus();
+      }
+      document.removeEventListener("focus", trapFocus, true);
+      currentDialog = null;
+    }
+  }
+
+  function open(sourceEl) {
+    toggleModal(sourceEl, true);
+  }
+
+  function close() {
+    toggleModal(false, false);
+  }
+
+  document.addEventListener("click", (e) => {
+    const inDialog = e.target.closest(".p-modal__dialog");
+    const isToggle = e.target.matches("[aria-controls]");
+    if ((isToggle && inDialog) || (!inDialog && !isToggle)) {
+      close();
+    }
+  });
+
+  document.addEventListener("keydown", (e) => {
+    if (e.code === "Escape") close();
+  });
+
+  return { open, close };
+}
+
+function ErrorNotification() {
+  const errorContainer = document.querySelector("#error-container");
+
+  return {
+    display: (message) => {
+      errorContainer.querySelector(".p-notification__message").textContent =
+        message;
+      errorContainer.classList.remove("u-hide");
+    },
+    clear: () => {
+      errorContainer.classList.add("u-hide");
+    },
+  };
+}
+
+const editBillingModal = Modal({
+  modalSelector: "edit-billing-modal",
+});
+const errorNotification = ErrorNotification();
+
+const editBillingDetailsBtn = document.querySelector("#edit-billing-btn");
+editBillingDetailsBtn.addEventListener("click", async (e) => {
+  try {
+    const payload = await getCustomerInfo(accountId);
+    const customerInfo = payload.data.customerInfo;
+    populateForm(customerInfo);
+    editBillingModal.open(e.target);
+  } catch (error) {
+    errorNotification.display();
+  }
+
+  async function populateForm(data) {
+    const form = document.querySelector("#edit-billing-form");
+    const foundCountry = countries.find(
+      (c) => c.value === data.address.country,
+    );
+    const country = form.querySelector("#country");
+    country.textContent = foundCountry.label ?? "";
+    form.elements["vat"].value = data.taxID.value ?? "";
+    form.elements["name"].value = data.name ?? "";
+    form.elements["address"].value = data.address.line1 ?? "";
+    form.elements["city"].value = data.address.city ?? "";
+    form.elements["postal-code"].value = data.address.postal_code ?? "";
+    form.elements["country-code"].value = data.address.country ?? "";
+    form.elements["payment-method-id"].value =
+      data.defaultPaymentMethod.id ?? "";
+  }
+});
+
+const saveBtn = document.getElementById("save-modal-btn");
+saveBtn.addEventListener("click", async (e) => {
+  try {
+    const form = document.querySelector("#edit-billing-form");
+    const formData = new FormData(form);
+    const data = await updateBillingDetails(formData);
+    if (data.errors) {
+      errorNotification.display(
+        "The details provided are not valid. Please check and try again.",
+      );
+    } else {
+      errorNotification.clear();
+    }
+  } catch (error) {
+    errorNotification.display();
+  } finally {
+    editBillingModal.close();
+  }
+
+  async function updateBillingDetails(formData) {
+    const vatNumber = formData.get("vat");
+    const name = formData.get("name");
+    const address = formData.get("address");
+    const city = formData.get("city");
+    const postalCode = formData.get("postal-code");
+    const country = formData.get("country-code");
+    const paymentMethodID = formData.get("payment-method-id");
+
+    const data = await postCustomerInfoToStripeAccount({
+      paymentMethodID: paymentMethodID,
+      accountID: accountId,
+      address: {
+        line1: address,
+        city: city,
+        postal_code: postalCode,
+        country: country,
+      },
+      name: name,
+      taxID: {
+        value: vatNumber,
+      },
+    });
+
+    return data;
+  }
+});

--- a/static/js/src/account-billing.js
+++ b/static/js/src/account-billing.js
@@ -129,7 +129,7 @@ function createModal({ modalSelector, triggerButton }) {
       // Unless it is hidden
       if (group.classList.contains("u-hide")) continue;
       const errorMessage = el.nextElementSibling;
-      
+
       const isEmpty = el.value.trim() === "";
       if (isEmpty) {
         isValid = false;

--- a/static/js/src/account-billing.js
+++ b/static/js/src/account-billing.js
@@ -120,13 +120,9 @@ function createModal({ modalSelector, triggerButton }) {
   function validateForm() {
     let isValid = true;
 
-    // Do not allow empty values
-    for (const el of form.elements) {
-      const group = el.closest(".p-form__group");
-      // Unless it is hidden
-      if (group.classList.contains("u-hide")) continue;
-      const errorMessage = el.nextElementSibling;
-
+    const requiredFields = ["name", "address", "city", "postal-code"];
+    for (const field of requiredFields) {
+      const el = form.elements[field];
       const isEmpty = el.value.trim() === "";
       if (isEmpty) {
         isValid = false;

--- a/static/js/src/account-billing.js
+++ b/static/js/src/account-billing.js
@@ -104,8 +104,10 @@ function ErrorNotification() {
 
   return {
     display: (message) => {
+      if (message) {
       errorContainer.querySelector(".p-notification__message").textContent =
         message;
+      };
       errorContainer.classList.remove("u-hide");
     },
     clear: () => {

--- a/static/sass/_pattern_invoices.scss
+++ b/static/sass/_pattern_invoices.scss
@@ -1,0 +1,7 @@
+@mixin ubuntu-p-invoices {
+  #edit-billing-modal > [role="dialog"] {
+    @media only screen and (min-width: $breakpoint-large) {
+      min-width: 38rem;
+    }
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -81,6 +81,7 @@ $color-shadow: rgba(0, 0, 0, 0.5) !default;
 @import "pattern_heading-icon";
 @import "pattern_icons";
 @import "pattern_inline-list-midline";
+@import "pattern_invoices";
 @import "pattern_lightbox";
 @import "pattern_lists";
 @import "pattern_matrix";
@@ -136,6 +137,7 @@ $color-shadow: rgba(0, 0, 0, 0.5) !default;
 @include ubuntu-p-grid;
 @include ubuntu-p-heading-icon;
 @include ubuntu-p-inline-list-midline;
+@include ubuntu-p-invoices;
 @include ubuntu-p-attention-icon;
 @include ubuntu-p-lightbox;
 @include ubuntu-p-lists;
@@ -775,6 +777,10 @@ td.p-accordion {
 
   @media (max-width: $breakpoint-small) {
     height: auto;
+  }
+
+  @media only screen and (min-width: $breakpoint-large) {
+    min-width: 38rem;
   }
 }
 

--- a/templates/account/invoices/_edit_billing_form.html
+++ b/templates/account/invoices/_edit_billing_form.html
@@ -9,7 +9,7 @@
       </div>
     </div>
   </div>
-  <div class="p-form__group p-form-validation row u-no-padding--left u-no-padding--right">
+  <div class="p-form__group p-form-validation row u-no-padding--left u-no-padding--right u-hide">
     <div class="col-4">
       <label for="vat" class="p-form__label">VAT number</label>
     </div>
@@ -17,7 +17,6 @@
       <div class="p-form__control">
         <input class="p-form-validation__input" type="text" id="vat" name="vat" />
         <p id="vat-error" class="p-form-validation__message u-hide">This field is required.</p>
-        <p id="vat-invalid-error" class="p-form-validation__message u-hide">The VAT number entered is invalid: check the number<br class="u-hide--medium u-hide--small"/> and try again</p>
       </div>
     </div>
   </div>

--- a/templates/account/invoices/_edit_billing_form.html
+++ b/templates/account/invoices/_edit_billing_form.html
@@ -1,0 +1,66 @@
+<form id="edit-billing-form" class="p-form p-form--stacked">
+  <div class="p-form__group row u-no-padding--left u-no-padding--right">
+    <div class="col-4">
+      <label for="country" class="p-form__label">Country/Region</label>
+    </div>
+    <div class="col-8">
+      <div class="p-form__control">
+        <strong id="country"></strong>
+      </div>
+    </div>
+  </div>
+  <div class="p-form__group row u-no-padding--left u-no-padding--right">
+    <div class="col-4">
+      <label for="vat" class="p-form__label">VAT number</label>
+    </div>
+    <div class="col-8">
+      <div class="p-form__control">
+        <input type="text" id="vat" name="vat" />
+      </div>
+    </div>
+  </div>
+  <hr class="p-rule" />
+  <div class="p-form__group row u-no-padding--left u-no-padding--right">
+    <div class="col-4">
+      <label for="name" class="p-form__label">Name</label>
+    </div>
+    <div class="col-8">
+      <div class="p-form__control">
+        <input type="text" id="name" name="name" />
+      </div>
+    </div>
+  </div>
+  <div class="p-form__group row u-no-padding--left u-no-padding--right">
+    <div class="col-4">
+      <label for="address" class="p-form__label">Address</label>
+    </div>
+    <div class="col-8">
+      <div class="p-form__control">
+        <input type="text" id="address" name="address" />
+      </div>
+    </div>
+  </div>
+  <div class="p-form__group row u-no-padding--left u-no-padding--right">
+    <div class="col-4">
+      <label for="city" class="p-form__label">City</label>
+    </div>
+    <div class="col-8">
+      <div class="p-form__control">
+        <input type="text" id="city" name="city" />
+      </div>
+    </div>
+  </div>
+  <div class="p-form__group row u-no-padding--left u-no-padding--right">
+    <div class="col-4">
+      <label for="postal-code" class="p-form__label">Postal code</label>
+    </div>
+    <div class="col-8">
+      <div class="p-form__control">
+        <input type="text" id="postal-code" name="postal-code" />
+      </div>
+    </div>
+  </div>
+  {# Fields that we need to call the API, but are not shown to the user #}
+  <input type="text" id="payment-method-id" name="payment-method-id" hidden />
+  <input type="text" id="country-code" name="country-code" hidden />
+</form>

--- a/templates/account/invoices/_edit_billing_form.html
+++ b/templates/account/invoices/_edit_billing_form.html
@@ -9,13 +9,15 @@
       </div>
     </div>
   </div>
-  <div class="p-form__group row u-no-padding--left u-no-padding--right">
+  <div class="p-form__group p-form-validation row u-no-padding--left u-no-padding--right">
     <div class="col-4">
       <label for="vat" class="p-form__label">VAT number</label>
     </div>
     <div class="col-8">
       <div class="p-form__control">
-        <input type="text" id="vat" name="vat" />
+        <input class="p-form-validation__input" type="text" id="vat" name="vat" />
+        <p id="vat-error" class="p-form-validation__message u-hide">This field is required.</p>
+        <p id="vat-invalid-error" class="p-form-validation__message u-hide">The VAT number entered is invalid: check the number<br class="u-hide--medium u-hide--small"/> and try again</p>
       </div>
     </div>
   </div>
@@ -26,7 +28,8 @@
     </div>
     <div class="col-8">
       <div class="p-form__control">
-        <input type="text" id="name" name="name" />
+        <input class="p-form-validation__input" type="text" id="name" name="name" />
+        <p id="name-error" class="p-form-validation__message u-hide">This field is required.</p>
       </div>
     </div>
   </div>
@@ -36,31 +39,31 @@
     </div>
     <div class="col-8">
       <div class="p-form__control">
-        <input type="text" id="address" name="address" />
+        <input class="p-form-validation__input" type="text" id="address" name="address" />
+        <p id="address-error" class="p-form-validation__message u-hide">This field is required.</p>
       </div>
     </div>
   </div>
-  <div class="p-form__group row u-no-padding--left u-no-padding--right">
+  <div class="p-form__group p-form-validation row u-no-padding--left u-no-padding--right">
     <div class="col-4">
       <label for="city" class="p-form__label">City</label>
     </div>
     <div class="col-8">
       <div class="p-form__control">
-        <input type="text" id="city" name="city" />
+        <input class="p-form-validation__input" type="text" id="city" name="city" />
+        <p id="city-error" class="p-form-validation__message u-hide">This field is required.</p>
       </div>
     </div>
   </div>
-  <div class="p-form__group row u-no-padding--left u-no-padding--right">
+  <div class="p-form__group p-form-validation row u-no-padding--left u-no-padding--right">
     <div class="col-4">
       <label for="postal-code" class="p-form__label">Postal code</label>
     </div>
     <div class="col-8">
       <div class="p-form__control">
-        <input type="text" id="postal-code" name="postal-code" />
+        <input class="p-form-validation__input" type="text" id="postal-code" name="postal-code" />
+        <p id="city-error" class="p-form-validation__message u-hide">This field is required.</p>
       </div>
     </div>
   </div>
-  {# Fields that we need to call the API, but are not shown to the user #}
-  <input type="text" id="payment-method-id" name="payment-method-id" hidden />
-  <input type="text" id="country-code" name="country-code" hidden />
 </form>

--- a/templates/account/invoices/_edit_billing_modal.html
+++ b/templates/account/invoices/_edit_billing_modal.html
@@ -1,0 +1,21 @@
+<div style="display: none;" class="p-modal" id="edit-billing-modal">
+  <section style="min-width: 38rem"
+           class="p-modal__dialog"
+           role="dialog"
+           aria-modal="true"
+           aria-labelledby="modal-title">
+    <header class="p-modal__header">
+      <h2 class="p-modal__title" id="modal-title">Edit billing details</h2>
+      <button class="p-modal__close"
+              aria-label="Close active modal"
+              aria-controls="modal">Close</button>
+    </header>
+    {% include 'account/invoices/_edit_billing_form.html' %}
+    <footer class="p-modal__footer">
+      <button id="cancel-modal-btn"
+              class="u-no-margin--bottom"
+              aria-controls="modal">Cancel</button>
+      <button id="save-modal-btn" class="p-button--positive u-no-margin--bottom">Save</button>
+    </footer>
+  </section>
+</div>

--- a/templates/account/invoices/_edit_billing_modal.html
+++ b/templates/account/invoices/_edit_billing_modal.html
@@ -1,6 +1,5 @@
 <div style="display: none;" class="p-modal" id="edit-billing-modal">
-  <section style="min-width: 38rem"
-           class="p-modal__dialog"
+  <section class="p-modal__dialog"
            role="dialog"
            aria-modal="true"
            aria-labelledby="modal-title">
@@ -11,6 +10,12 @@
               aria-controls="modal">Close</button>
     </header>
     {% include 'account/invoices/_edit_billing_form.html' %}
+    <div id="error-container" class="p-notification--negative u-hide">
+      <div class="p-notification__content">
+        <h5 class="p-notification__title">Error saving your details</h5>
+        <p class="p-notification__message">Please try again later. If the issue persists, contact Canonical sales.</p>
+      </div>
+    </div>
     <footer class="p-modal__footer">
       <button id="cancel-modal-btn"
               class="u-no-margin--bottom"

--- a/templates/account/invoices/index.html
+++ b/templates/account/invoices/index.html
@@ -10,9 +10,18 @@
 {% block content %}
 
 <section class="p-strip--suru-topped p-strip-account-page">
-  <div class="row">
-    <div class="col-12">
-      <h1>Invoices</h1>
+  <div class="u-fixed-width">
+    <div id="error-container" class="p-notification--negative u-hide">
+      <div class="p-notification__content">
+        <h5 class="p-notification__title">Error</h5>
+        <p class="p-notification__message">There was an error, please try again later. Contact Contact <a href='/contact-us'>Canonical sales</a> if the problem persists.</p>
+      </div>
+    </div>
+    <div style="display: flex; justify-content: space-between; align-items: baseline;">
+      <h1>Billing</h1>
+      <button id="edit-billing-btn" class="p-button" aria-controls="modal">
+        Edit billing details
+      </button>
     </div>
   </div>
   <div class="row">
@@ -95,7 +104,7 @@
     </div>
   </div>
 </section>
-
+{% include "account/invoices/_edit_billing_modal.html" %}
 
 <script>
   const prices = document.querySelectorAll('.js-format-price');
@@ -119,5 +128,9 @@
     window.location.replace(href);
   })
 </script>
+<script>
+  window.accountId = "{{ account_id }}";
+</script>
+<script src="{{ versioned_static('js/dist/account-billing.js') }}"></script>
 
 {% endblock content %}

--- a/templates/account/invoices/index.html
+++ b/templates/account/invoices/index.html
@@ -11,12 +11,6 @@
 
 <section class="p-strip--suru-topped p-strip-account-page">
   <div class="u-fixed-width">
-    <div id="error-container" class="p-notification--negative u-hide">
-      <div class="p-notification__content">
-        <h5 class="p-notification__title">Error</h5>
-        <p class="p-notification__message">There was an error, please try again later. Contact Contact <a href='/contact-us'>Canonical sales</a> if the problem persists.</p>
-      </div>
-    </div>
     <div style="display: flex; justify-content: space-between; align-items: baseline;">
       <h1>Billing</h1>
       <button id="edit-billing-btn" class="p-button" aria-controls="modal">

--- a/webapp/shop/schemas.py
+++ b/webapp/shop/schemas.py
@@ -146,7 +146,7 @@ post_payment_methods = {
 }
 
 post_customer_info = {
-    "payment_method_id": String(required=True),
+    "payment_method_id": String(),
     "account_id": String(required=True),
     "name": String(),
     "tax_id": Nested(TaxIdSchema, allow_none=True),

--- a/webapp/shop/views.py
+++ b/webapp/shop/views.py
@@ -111,6 +111,7 @@ def invoices_view(advantage_mapper: AdvantageMapper, **kwargs):
 
     return flask.render_template(
         "account/invoices/index.html",
+        account_id=account.id,
         invoices=payments[start_page:end_page],
         marketplace=marketplace,
         total_pages=(len(payments) // per_page) + 1,


### PR DESCRIPTION
## Done

- `/account/invoices`: let users update their billing details (customer info)

See [design](https://www.figma.com/design/GXrVXEGISyJVJbGk4V7PoD/25.04-Pro-Dashboard-Updates?node-id=501-6579&m=dev)

## QA

- Go to `account/invoices`
- Click `Edit billing details`
- Modify the form
- Click save
- [x] Check that the data is updated if you click the button again

---
- [x] Leave one or more fields empty
- Click save
- [x] Check that an error is shown below the empty field(s) and the data is not saved

---

- [x] Write an invalid VAT
- [x] Check that an error is shown below the VAT field and the data is not saved

---

- [x] If the country you used for purchasing doesn't require a VAT, no VAT field should show up.

---

Check that the overall behaviour looks alright (the modal behaves as it should, etc.)

## Issue

https://warthogs.atlassian.net/browse/WD-20699
