### PR TITLE
fix template errors

### DIFF
--- a/templates/credentials/schedule.html
+++ b/templates/credentials/schedule.html
@@ -23,8 +23,8 @@ meta_copydoc %}
             <p class="p-notification__message" id="error-message">
               {% if maintenance_error == 'True' %}
                 Scheduled time should be outside of the maintenance window. Please schedule the exam before 
-                <strong>{{ maintenance_start | date:"SHORT_DATETIME_FORMAT" }}</strong> or after 
-                <strong>{{ maintenance_end | date:"SHORT_DATETIME_FORMAT" }}</strong>.
+                <strong>{{ maintenance_start }}</strong> or after 
+                <strong>{{ maintenance_end }}</strong>.
               {% elif error %}
                 {{ error }}
               {% endif %}


### PR DESCRIPTION
## Done

- Fixed jinja errors in scheduling template

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- visit /credentials/your-exams
- Try to schedule an exam
- Should work

## Issue / Card

Fixes [#WD-21397](https://warthogs.atlassian.net/browse/WD-21397)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
