### PR TITLE
copy: add "Stay secure and supported" banner to tag templates. WD-20921

### DIFF
--- a/templates/blog/tag.html
+++ b/templates/blog/tag.html
@@ -10,6 +10,25 @@
         <div id="rtp-banner" class="rtp-banner"></div>
       </div>
     </div>
+    {% if tag.slug in ["20-04-lts", "20-04", "18-04-lts", "18-04", "16-04"] %}
+      <div class="u-fixed-width p-strip is-shallow u-no-padding--bottom">
+        <div class="p-notification--information u-no-margin--bottom">
+          <div class="p-notification__content">
+            <h5 class="p-notification__title">Stay secure and supported with Ubuntu Pro.</h5>
+            <p class="p-notification__message">
+              {% if tag.slug in ["20-04-lts", "20-04"] %}
+                Enjoy 5 extra years of peace of mind with enhanced security, compliance, and rebootless patching until 2030.
+              {% elif tag.slug in ["18-04-lts", "18-04"] %}
+                Enjoy 5 extra years of peace of mind with enhanced security, compliance, and rebootless patching until 2028.
+              {% else %}
+                Enjoy 5 extra years of peace of mind with enhanced security, compliance, and rebootless patching until 2026.
+              {% endif %}
+              <a href="/pro">Subscribe to Ubuntu Pro now!</a>
+            </p>
+          </div>
+        </div>
+      </div>
+    {% endif %}
   </div>
 
   <section class="p-strip is-shallow" id="posts-list">


### PR DESCRIPTION
Add a "Stay secure and supported with Ubuntu Pro" banner to 20-04-*, 18-04-* and 16-04-* tag templates.

## Done

- [List of work items including drive-bys - remember to add the why and what of this work.]

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes [#WD-20921](https://warthogs.atlassian.net/browse/WD-20921)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
