### PR TITLE
WD-21452: add env variable to marketo

### DIFF
--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -163,6 +163,10 @@ def cred_sign_up(**_):
     if client_ip and ":" not in client_ip:
         visitor_data["leadClientIpAddress"] = client_ip
 
+    is_staging = "staging" in os.getenv(
+        "CONTRACTS_API_URL", "https://contracts.staging.canonical.com/"
+    )
+    form_fields["enviornment"] = "staging" if is_staging else "production"
     payload = {
         "formId": form_fields.pop("formid"),
         "input": [


### PR DESCRIPTION
## Done

- Add environment variable to Marketo

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes

## Issue / Card

Fixes [WD-21452](https://warthogs.atlassian.net/browse/WD-21452)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-21452]: https://warthogs.atlassian.net/browse/WD-21452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ