### PR TITLE
feat: Add 'aria-controls' attribute to the button element for generated forms

### DIFF
--- a/static/js/src/dynamic-forms.js
+++ b/static/js/src/dynamic-forms.js
@@ -14,8 +14,12 @@ import { prepareInputFields } from "./prepare-form-inputs.js";
     const formContainer = document.getElementById("contact-form-container");
     const contactButtons = document.querySelectorAll(".js-invoke-modal");
     let returnData = window.location.pathname + "#success";
-    const contactModalSelector = "contact-modal";
     const modalAlreadyExists = document.querySelector(".js-modal-ready");
+    // If the modal contains the class "js-modal-ready", it means we are using the form generator
+    // And each form will have a unique ID
+    let contactModalSelector = modalAlreadyExists
+      ? modalAlreadyExists.id
+      : "contact-modal";
 
     contactButtons.forEach(function (contactButton) {
       contactButton.addEventListener("click", function (e) {
@@ -352,7 +356,7 @@ import { prepareInputFields } from "./prepare-form-inputs.js";
 
       // Concatinate the options selected into a string
       function createMessage(submit) {
-        const contactModal = document.getElementById("contact-modal");
+        const contactModal = document.getElementById(contactModalSelector);
         let message = "";
         if (contactModal) {
           const formFields = contactModal.querySelectorAll(".js-formfield");

--- a/static/sass/_pattern_contact-modal.scss
+++ b/static/sass/_pattern_contact-modal.scss
@@ -1,5 +1,6 @@
 @mixin ubuntu-p-contact-modal {
-  #contact-modal {
+  #contact-modal,
+  .p-modal--generated {
     &.p-modal {
       align-items: start;
       position: fixed;

--- a/static/sass/_pattern_contact-modal.scss
+++ b/static/sass/_pattern_contact-modal.scss
@@ -1,62 +1,58 @@
-@mixin ubuntu-p-contact-modal {
-  .p-modal--generated.p-modal,
-  #contact-modal.p-modal {
-    align-items: start;
-    position: fixed;
-    z-index: 100;
-  }
+@mixin ubuntu-p-contact-modal { 
+  .p-modal--generated,
+  #contact-modal {
+    &.p-modal {
+      align-items: start;
+      position: fixed;
+      z-index: 100;
 
-  .p-modal--generated.p-modal .p-modal__dialog,
-  #contact-modal.p-modal .p-modal__dialog {
-    margin-bottom: 0;
+      .p-modal__dialog {
+        margin-bottom: 0;
 
-    @media (min-width: $breakpoint-medium + 100px) {
-      max-width: $breakpoint-medium;
-      min-width: $breakpoint-medium;
-    }
-  }
-
-  .p-modal--generated.p-modal .p-modal__header,
-  #contact-modal.p-modal .p-modal__header {
-    border-bottom: 1px solid $color-mid-light;
-    margin-bottom: $spv--medium;
-  }
-
-  .p-modal--generated.p-modal .p-modal__header::after,
-  #contact-modal.p-modal .p-modal__header::after {
-    display: none;
-  }
-
-  .p-modal--generated.p-modal .p-modal__title,
-  #contact-modal.p-modal .p-modal__title {
-    margin-bottom: $spv--small;
-  }
-
-  .p-modal--generated.p-modal.thank-you .p-modal__title,
-  #contact-modal.p-modal.thank-you .p-modal__title {
-    opacity: 0;
-  }
-
-  .p-modal--generated.p-modal.thank-you .p-modal__header,
-  #contact-modal.p-modal.thank-you .p-modal__header {
-    border-bottom: 0;
-  }
-
-  .p-modal--generated.p-modal.thank-you .p-modal__header::after,
-  #contact-modal.p-modal.thank-you .p-modal__header::after {
-    display: none;
-  }
-
-  @media only screen and (min-width: $breakpoint-medium) {
-    .p-modal--generated.p-modal,
-    #contact-modal.p-modal {
-      .u-align {
-        padding-bottom: 70px;
+        @media (min-width: $breakpoint-medium + 100px) {
+          max-width: $breakpoint-medium;
+          min-width: $breakpoint-medium;
+        }
       }
 
-      .pagination__link--next,
-      .pagination__link--previous {
-        margin-bottom: 0;
+      .p-modal__header {
+        border-bottom: 1px solid $color-mid-light;
+        margin-bottom: $spv--medium;
+
+        &::after {
+          // Remove the bottom border from the title.
+          display: none;
+        }
+      }
+
+      .p-modal__title {
+        margin-bottom: $spv--small;
+      }
+
+      &.thank-you {
+        .p-modal__title { /* stylelint-disable-line no-descending-specificity */
+          opacity: 0;
+        }
+
+        .p-modal__header { /* stylelint-disable-line no-descending-specificity */
+          border-bottom: 0;
+
+          &::after { /* stylelint-disable-line no-descending-specificity */
+            // Remove the bottom border from the title.
+            display: none;
+          }
+        }
+      }
+
+      @media only screen and (min-width: $breakpoint-medium) {
+        .u-align {
+          padding-bottom: 70px;
+        }
+
+        .pagination__link--next,
+        .pagination__link--previous {
+          margin-bottom: 0;
+        }
       }
     }
   }

--- a/static/sass/_pattern_contact-modal.scss
+++ b/static/sass/_pattern_contact-modal.scss
@@ -1,58 +1,62 @@
 @mixin ubuntu-p-contact-modal {
-  #contact-modal,
-  .p-modal--generated {
-    &.p-modal {
-      align-items: start;
-      position: fixed;
-      z-index: 100;
+  .p-modal--generated.p-modal,
+  #contact-modal.p-modal {
+    align-items: start;
+    position: fixed;
+    z-index: 100;
+  }
 
-      .p-modal__dialog {
+  .p-modal--generated.p-modal .p-modal__dialog,
+  #contact-modal.p-modal .p-modal__dialog {
+    margin-bottom: 0;
+
+    @media (min-width: $breakpoint-medium + 100px) {
+      max-width: $breakpoint-medium;
+      min-width: $breakpoint-medium;
+    }
+  }
+
+  .p-modal--generated.p-modal .p-modal__header,
+  #contact-modal.p-modal .p-modal__header {
+    border-bottom: 1px solid $color-mid-light;
+    margin-bottom: $spv--medium;
+  }
+
+  .p-modal--generated.p-modal .p-modal__header::after,
+  #contact-modal.p-modal .p-modal__header::after {
+    display: none;
+  }
+
+  .p-modal--generated.p-modal .p-modal__title,
+  #contact-modal.p-modal .p-modal__title {
+    margin-bottom: $spv--small;
+  }
+
+  .p-modal--generated.p-modal.thank-you .p-modal__title,
+  #contact-modal.p-modal.thank-you .p-modal__title {
+    opacity: 0;
+  }
+
+  .p-modal--generated.p-modal.thank-you .p-modal__header,
+  #contact-modal.p-modal.thank-you .p-modal__header {
+    border-bottom: 0;
+  }
+
+  .p-modal--generated.p-modal.thank-you .p-modal__header::after,
+  #contact-modal.p-modal.thank-you .p-modal__header::after {
+    display: none;
+  }
+
+  @media only screen and (min-width: $breakpoint-medium) {
+    .p-modal--generated.p-modal,
+    #contact-modal.p-modal {
+      .u-align {
+        padding-bottom: 70px;
+      }
+
+      .pagination__link--next,
+      .pagination__link--previous {
         margin-bottom: 0;
-
-        @media (min-width: $breakpoint-medium + 100px) {
-          max-width: $breakpoint-medium;
-          min-width: $breakpoint-medium;
-        }
-      }
-
-      .p-modal__header {
-        border-bottom: 1px solid $color-mid-light;
-        margin-bottom: $spv--medium;
-
-        &::after {
-          // Remove the bottom border from the title.
-          display: none;
-        }
-      }
-
-      .p-modal__title {
-        margin-bottom: $spv--small;
-      }
-
-      &.thank-you {
-        .p-modal__title {
-          opacity: 0;
-        }
-
-        .p-modal__header {
-          border-bottom: 0;
-
-          &::after {
-            // Remove the bottom border from the title.
-            display: none;
-          }
-        }
-      }
-
-      @media only screen and (min-width: $breakpoint-medium) {
-        .u-align {
-          padding-bottom: 70px;
-        }
-
-        .pagination__link--next,
-        .pagination__link--previous {
-          margin-bottom: 0;
-        }
       }
     }
   }

--- a/static/sass/_pattern_contact-modal.scss
+++ b/static/sass/_pattern_contact-modal.scss
@@ -1,4 +1,4 @@
-@mixin ubuntu-p-contact-modal { 
+@mixin ubuntu-p-contact-modal {
   .p-modal--generated,
   #contact-modal {
     &.p-modal {
@@ -30,14 +30,17 @@
       }
 
       &.thank-you {
-        .p-modal__title { /* stylelint-disable-line no-descending-specificity */
+        /* stylelint-disable-next-line no-descending-specificity */
+        .p-modal__title {
           opacity: 0;
         }
 
-        .p-modal__header { /* stylelint-disable-line no-descending-specificity */
+        /* stylelint-disable-next-line no-descending-specificity */
+        .p-modal__header {
           border-bottom: 0;
 
-          &::after { /* stylelint-disable-line no-descending-specificity */
+          /* stylelint-disable-next-line no-descending-specificity */
+          &::after {
             // Remove the bottom border from the title.
             display: none;
           }

--- a/templates/16-04/azure.html
+++ b/templates/16-04/azure.html
@@ -25,7 +25,7 @@
           </a>
         </p>
         <p>
-          <a class="js-invoke-modal" shref="/azure/contact-us">
+          <a class="js-invoke-modal" href="/azure/contact-us">
             Contact us to add  ESM to existing Ubuntu 16.04 virtual machines&nbsp;&rsaquo;
           </a>
         </p>

--- a/templates/aws/form-data.json
+++ b/templates/aws/form-data.json
@@ -4,7 +4,7 @@
       "templatePath": "/aws/index.html",
       "childrenPaths": ["/aws/pro", "/aws/support", "/aws/outposts"],
       "isModal": true,
-      "modalId": "contact-modal",
+      "modalId": "aws-modal",
       "formData": {
         "title": "Canonical - the \"Ubuntu on AWS\" experts",
         "introText": "Already running Ubuntu on AWS, or planning a migration to the public cloud? Canonical has the expertise to assist you in your project, whether it involves compliance, application architecture, optimisation or streamlining operations at scale. Share some details about your project with us and let's get started.",

--- a/templates/aws/index.html
+++ b/templates/aws/index.html
@@ -32,7 +32,7 @@
           <p>Today, Ubuntu powers billions of mission-critical workloads.</p>
         </div>
         <hr class="is-muted" />
-        <a href="/aws/contact-us" class="p-button--positive js-invoke-modal">Talk to us about Ubuntu on AWS</a>
+        <a href="/aws/contact-us" class="p-button--positive js-invoke-modal" aria-controls="aws-modal">Talk to us about Ubuntu on AWS</a>
       </div>
       <div class="col">
         <div class="p-image-container--3-2 is-highlighted">
@@ -285,7 +285,7 @@
         <hr class="is-muted" />
         <p>
           <a href="/aws/contact-us"
-             class="p-button--positive js-invoke-modal u-no-margin--bottom">Talk to us about Ubuntu on AWS</a>
+             class="p-button--positive js-invoke-modal u-no-margin--bottom" aria-controls="aws-modal">Talk to us about Ubuntu on AWS</a>
         </p>
       </div>
     </div>

--- a/templates/aws/outposts.html
+++ b/templates/aws/outposts.html
@@ -27,7 +27,7 @@
           <p>Security, compliance and support available for all enterprise scenarios.</p>
         </div>
         <hr class="is-muted" />
-        <a href="/aws/contact-us" class="p-button--positive js-invoke-modal">Talk to us about Ubuntu on AWS Outposts</a>
+        <a href="/aws/contact-us" class="p-button--positive js-invoke-modal" aria-controls="aws-modal">Talk to us about Ubuntu on AWS Outposts</a>
       </div>
       <div class="col u-hide--small">
         <div class="p-image-container--16-9 is-highlighted">

--- a/templates/aws/pro.html
+++ b/templates/aws/pro.html
@@ -116,7 +116,7 @@
                 </div>
               </li>
             </ul>
-            <a href="/aws/contact-us" class="js-invoke-modal">Contact us to discuss Ubuntu Pro with
+            <a href="/aws/contact-us" class="js-invoke-modal" aria-controls="aws-modal">Contact us to discuss Ubuntu Pro with
             support&nbsp;&rsaquo;</a>
           </div>
         </div>

--- a/templates/aws/support.html
+++ b/templates/aws/support.html
@@ -21,7 +21,7 @@
           </p>
           <hr class="is-muted" />
           <p>
-            <a href="/contact-us" class="p-button--positive js-invoke-modal">Contact us</a>
+            <a href="/contact-us" class="p-button--positive js-invoke-modal" aria-controls="aws-modal">Contact us</a>
           </p>
         </div>
         <div class="col p-image-container is-highlighted u-hide--small">

--- a/templates/embedded/form-data.json
+++ b/templates/embedded/form-data.json
@@ -3,7 +3,7 @@
     "/embedded": {
       "templatePath": "/embedded/index.html",
       "isModal": true,
-      "modalId": "contact-modal",
+      "modalId": "embedded-modal",
       "formData": {
         "title": "Let's get your device to market faster!",
         "introText": "Canonical partners with silicon companies, board manufacturers and ODMs to help you bring smart devices to market faster. Tell us about your project so we can bring the right team to the conversation.",

--- a/templates/embedded/index.html
+++ b/templates/embedded/index.html
@@ -156,7 +156,8 @@
 
       {%- if slot == 'cta' -%}
         <a class="p-button--positive js-invoke-modal"
-           href="/internet-of-things/contact-us">Get in touch</a>
+           href="/internet-of-things/contact-us"
+           aria-controls="embedded-modal">Get in touch</a>
       {%- endif -%}
     {%- endcall -%}
   </section>
@@ -804,7 +805,9 @@
           <li class="p-list__item is-ticked">Supported by Canonical</li>
         </ul>
         <div class="p-cta-block">
-          <a class="p-button js-invoke-modal" href="/core/contact-us">Get in touch about certification</a>
+          <a class="p-button js-invoke-modal"
+             href="/core/contact-us"
+             aria-controls="embedded-modal">Get in touch about certification</a>
         </div>
       {%- endif -%}
 
@@ -1020,7 +1023,8 @@
 
       {%- if slot == 'cta' -%}
         <a href="/internet-of-things/contact-us"
-           class="p-button--positive js-invoke-modal">Contact us</a>
+           class="p-button--positive js-invoke-modal"
+           aria-controls="embedded-modal">Contact us</a>
       {%- endif -%}
     {%- endcall -%}
   </section>

--- a/templates/internet-of-things/appstore.html
+++ b/templates/internet-of-things/appstore.html
@@ -29,7 +29,8 @@
     {%- endif -%}
     {%- if slot == "cta" -%}
       <a href="/internet-of-things/contact-us?product=appstore"
-         class="p-button--positive js-invoke-modal">Contact us</a>
+         class="p-button--positive js-invoke-modal"
+         aria-controls="iot-modal">Contact us</a>
       <a href="https://assets.ubuntu.com/v1/d6d1d3fc-IoT+App+Store+Datasheet+v3.pdf"
          class="p-button">Read the datasheet</a>
     {%- endif -%}
@@ -142,7 +143,8 @@
         <div class="p-cta-block">
           <p style="margin-right: 1rem">Ready to find out more?</p>
           <a href="/internet-of-things/contact-us?product=appstore"
-             class="p-button--positive js-invoke-modal">Get in touch</a>
+             class="p-button--positive js-invoke-modal"
+             aria-controls="iot-modal">Get in touch</a>
         </div>
       </div>
     </div>
@@ -467,6 +469,7 @@
         <div class="p-cta-block">
           <a class="p-button--positive js-invoke-modal"
              href="/internet-of-things#get-in-touch"
+             aria-controls="iot-modal"
              onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact us' });">Contact our team</a>
         </div>
       </div>
@@ -489,6 +492,6 @@
     {% include "internet-of-things/shared/_latest-news-iot.html" %}
   {% endwith %}
 
-  {{ load_form("/internet-of-things", 2639) | safe }}
+  {{ load_form('/internet-of-things', 2639) | safe }}
 
 {% endblock content %}

--- a/templates/internet-of-things/digital-signage.html
+++ b/templates/internet-of-things/digital-signage.html
@@ -178,6 +178,7 @@
         <p>
           <a class="p-button js-invoke-modal"
              href="/internet-of-things/contact-us?product=smart-displays"
+             aria-controls="iot-modal"
              onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Digital Signage Page - Partners and players', 'eventLabel' : 'Get in touch', 'eventValue' : undefined });">Get in touch</a>
         </p>
       </div>
@@ -357,6 +358,7 @@
           <p>
             <a class="p-button--positive js-invoke-modal"
                href="/internet-of-things/contact-us?product=smart-displays"
+               aria-controls="iot-modal"
                onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Digital Signage Page - Build your own', 'eventLabel' : 'Get in touch', 'eventValue' : undefined });">Get in touch</a>
           </p>
         </div>

--- a/templates/internet-of-things/form-data.json
+++ b/templates/internet-of-things/form-data.json
@@ -11,7 +11,7 @@
         "/internet-of-things/smart-displays"
       ],
       "isModal": true,
-      "modalId": "contact-modal",
+      "modalId": "iot-modal",
       "formData": {
         "title": "Let's get your project to market faster!",
         "introText": "Canonical partners with silicon companies, board manufacturers and ODMs to help the industry bring smart device and software capabilities to market faster. Tell us about your project so we can bring the right Canonical team members to the conversation to help you.",

--- a/templates/internet-of-things/gateways.html
+++ b/templates/internet-of-things/gateways.html
@@ -524,7 +524,8 @@
           <p>Our team will help you build secure and flexible gateways for the industrial edge.</p>
           <div class="p-cta-block">
             <a class="p-button--positive js-invoke-modal"
-               href="/internet-of-things/contact-us?product=gateways">Get in touch</a>
+               href="/internet-of-things/contact-us?product=gateways"
+               aria-controls="iot-modal">Get in touch</a>
           </div>
         </div>
       </div>

--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -630,7 +630,8 @@
         </p>
         <div class="p-cta-block">
           <a href="/internet-of-things/contact-us"
-             class="js-invoke-modal p-button--positive">Contact our team</a>
+             class="js-invoke-modal p-button--positive"
+             aria-controls="iot-modal">Contact our team</a>
         </div>
       </div>
     </div>

--- a/templates/internet-of-things/management.html
+++ b/templates/internet-of-things/management.html
@@ -35,7 +35,8 @@
 
     {%- if slot == 'cta' -%}
       <a href="/internet-of-things/contact-us?product=management"
-         class="p-button--positive js-invoke-modal">Get in touch</a>
+         class="p-button--positive js-invoke-modal"
+         aria-controls="iot-modal">Get in touch</a>
       <a href="/engage/a-practical-guide-to-iot-lifecycle-management">Discover best practices to manage IoT devices&nbsp;&rsaquo;</a>
     {%- endif -%}
 
@@ -95,7 +96,8 @@
           <hr class="p-rule--muted" />
           <p>
             <a href="/internet-of-things/contact-us?product=management"
-               class="js-invoke-modal">Get in touch to discuss your device management needs&nbsp;&rsaquo;</a>
+               class="js-invoke-modal"
+               aria-controls="iot-modal">Get in touch to discuss your device management needs&nbsp;&rsaquo;</a>
           </p>
         </div>
       </div>
@@ -223,7 +225,8 @@
           </p>
           <hr class="p-rule--muted" />
           <a href="/internet-of-things/contact-us?product=management"
-             class="js-invoke-modal">Get in touch to discuss the best solution for you&nbsp;&rsaquo;</a>
+             class="js-invoke-modal"
+             aria-controls="iot-modal">Get in touch to discuss the best solution for you&nbsp;&rsaquo;</a>
         </div>
       {%- endif -%}
 
@@ -486,7 +489,8 @@
         </p>
         <hr class="p-rule--muted" />
         <a href="/internet-of-things/contact-us?product=management"
-           class="p-button--positive js-invoke-modal">Get in touch</a>
+           class="p-button--positive js-invoke-modal"
+           aria-controls="iot-modal">Get in touch</a>
       </div>
     </div>
   </section>

--- a/templates/internet-of-things/networking.html
+++ b/templates/internet-of-things/networking.html
@@ -22,6 +22,7 @@
 
         <p>
           <a class="p-button--positive js-invoke-modal"
+             aria-controls="iot-modal"
              href="/internet-of-things/contact-us?product=networking"
              onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Internal Link', 'eventAction' : 'Contact us', 'eventLabel' : 'Networking - Top CTA' });">Tell us more about your project</a>
         </p>
@@ -223,7 +224,8 @@
 
         <p>
           <a href="/internet-of-things/contact-us?product=networking"
-             class="p-button--positive js-invoke-modal">Get in touch</a>
+             class="p-button--positive js-invoke-modal"
+             aria-controls="iot-modal">Get in touch</a>
         </p>
       </div>
 

--- a/templates/internet-of-things/smart-city/form-data.json
+++ b/templates/internet-of-things/smart-city/form-data.json
@@ -3,7 +3,7 @@
     "/internet-of-things/smart-city": {
       "templatePath": "/internet-of-things/smart-city/index.html",
       "isModal": true,
-      "modalId": "contact-modal",
+      "modalId": "iot-smart-city-modal",
       "formData": {
         "title": "Pave the way to an open source future",
         "introText": "Canonical partners with silicon companies, board manufacturers and ODMs to help the industry bring smart device and software capabilities to market faster. Tell us about your project so we can bring the right Canonical team members to the conversation to help you.",

--- a/templates/internet-of-things/smart-city/index.html
+++ b/templates/internet-of-things/smart-city/index.html
@@ -30,7 +30,8 @@
     {%- if slot == 'cta' -%}
       <a href="/internet-of-things/contact-us"
          aria-label="Contact us for smart city solutions"
-         class="p-button--positive js-invoke-modal">Contact Canonical</a>
+         class="p-button--positive js-invoke-modal"
+         aria-controls="iot-smart-city-modal">Contact Canonical</a>
     {%- endif -%}
     {%- if slot == 'image' -%}
       <div class="p-image-container--cinematic is-cover is-highlighted">
@@ -536,7 +537,8 @@
         <div class="p-cta-block">
           <a href="/internet-of-things/contact-us"
              aria-label="Contact us for smart city solutions"
-             class="p-button--positive js-invoke-modal">Get in touch</a>
+             class="p-button--positive js-invoke-modal"
+             aria-controls="iot-smart-city-modal">Get in touch</a>
         </div>
       </div>
     </div>

--- a/templates/internet-of-things/smart-displays.html
+++ b/templates/internet-of-things/smart-displays.html
@@ -33,7 +33,8 @@
         </div>
         <div class="p-cta-block">
           <a href="/internet-of-things/contact-us"
-             class="p-button--positive js-invoke-modal">Contact us to learn more</a>
+             class="p-button--positive js-invoke-modal"
+             aria-controls="iot-modal">Contact us to learn more</a>
           <p>
             <a href="/engage/Embedding_IoT_GUI_with_Ubuntu_Frame">Develop GUIs for IoT with our guide&nbsp;&rsaquo;</a>
           </p>
@@ -199,7 +200,8 @@
 
       {%- if slot == 'cta' -%}
         <a href="/internet-of-things/contact-us"
-           class="p-button js-invoke-modal">Reach out to hear more</a>
+           class="p-button js-invoke-modal"
+           aria-controls="iot-modal">Reach out to hear more</a>
       {%- endif -%}
 
     {%- endcall -%}
@@ -505,7 +507,9 @@
       <div class="col-10">
         <h2>Learn how we can get your device to market for you</h2>
         <p class="p-heading--2">
-          <a href="/internet-of-things/contact-us" class="js-invoke-modal">Get in touch&nbsp;&rsaquo;</a>
+          <a href="/internet-of-things/contact-us"
+             class="js-invoke-modal"
+             aria-controls="iot-modal">Get in touch&nbsp;&rsaquo;</a>
         </p>
       </div>
     </div>

--- a/templates/internet-of-things/smart-home/form-data.json
+++ b/templates/internet-of-things/smart-home/form-data.json
@@ -3,7 +3,7 @@
     "/internet-of-things/smart-home": {
       "templatePath": "/internet-of-things/smart-home/index.html",
       "isModal": true,
-      "modalId": "contact-modal",
+      "modalId": "iot-smart-home-modal",
       "formData": {
         "title": "Let's get your device to market faster!",
         "introText": "Canonical partners with silicon companies, board manufacturers and ODMs to help you bring smart devices to market faster. Tell us about your project so we can bring the right team to the conversation.",

--- a/templates/internet-of-things/smart-home/index.html
+++ b/templates/internet-of-things/smart-home/index.html
@@ -33,7 +33,8 @@
     {%- endif -%}
     {%- if slot == 'cta' -%}
       <a href="/internet-of-things/contact-us"
-         class="p-button--positive js-invoke-modal">Contact us to get started</a>
+         class="p-button--positive js-invoke-modal"
+         aria-controls="iot-smart-home-modal">Contact us to get started</a>
     {%- endif -%}
     {%- if slot == 'image' -%}
       <div class="p-image-container--cinematic is-cover is-highlighted u-hide--small">
@@ -119,7 +120,9 @@
         <h3 class="p-heading--5">Devices that speak a common language</h3>
         Canonical <a href="/blog/canonical-joins-the-connectivity-standards-alliance">recently
         announced</a> its membership in the Connectivity Standards Alliance and its upcoming support for the Matter
-        standard. <a href="/internet-of-things/contact-us" class="js-invoke-modal">Sign up</a> to receive smart home and IoT news.
+        standard. <a href="/internet-of-things/contact-us"
+    class="js-invoke-modal"
+    aria-controls="iot-smart-home-modal">Sign up</a> to receive smart home and IoT news.
       </div>
     </div>
   </section>

--- a/templates/kubernetes/charmed-k8s.html
+++ b/templates/kubernetes/charmed-k8s.html
@@ -40,7 +40,8 @@
     {%- endif -%}
     {%- if slot == "cta" -%}
       <a class="p-button--positive js-invoke-modal"
-         href="/kubernetes/contact-us?product=kubernetes-features">Get in touch</a>
+         href="/kubernetes/contact-us?product=kubernetes-features"
+         aria-controls="kubernetes-modal">Get in touch</a>
     {%- endif -%}
     {%- if slot == "image" -%}
       <div class="u-embedded-media">
@@ -337,7 +338,7 @@
         </p>
         <div class="p-cta-block">
           <a href="/kubernetes/contact-us"
-             class="p-button--positive js-invoke-modal">Contact us</a>
+             class="p-button--positive js-invoke-modal" aria-controls="kubernetes-modal">Contact us</a>
         </div>
       </div>
     </div>

--- a/templates/kubernetes/compare.html
+++ b/templates/kubernetes/compare.html
@@ -35,7 +35,8 @@
         </p>
         <div class="p-cta-block">
           <a class="p-button--positive js-invoke-modal"
-             href="/kubernetes/contact-us">Get in touch</a>
+             href="/kubernetes/contact-us"
+             aria-controls="kubernetes-modal">Get in touch</a>
           <a href="/engage/enterprise-kubernetes-comparison">Learn more in the Kubernetes comparison whitepaper&nbsp;&rsaquo;</a>
         </div>
       </div>
@@ -504,7 +505,8 @@
         </ul>
         <div class="p-cta-block">
           <a href="/kubernetes/contact-us"
-             class="p-button--positive js-invoke-modal">Contact us</a>
+             class="p-button--positive js-invoke-modal"
+             aria-controls="kubernetes-modal">Contact us</a>
         </div>
       </div>
     </div>

--- a/templates/kubernetes/documentation.html
+++ b/templates/kubernetes/documentation.html
@@ -30,7 +30,8 @@
         </div>
         <div class="p-cta-block">
           <a href="/kubernetes/contact-us"
-             class="js-invoke-modal p-button--positive">Get in touch</a>
+             class="js-invoke-modal p-button--positive"
+             aria-controls="kubernetes-modal">Get in touch</a>
         </div>
       </div>
     </div>
@@ -154,7 +155,9 @@
   <section class="p-strip is-deep">
     <div class="u-fixed-width">
       <h2 class="u-no-margin--bottom u-sv1">Get your K8s questions answered today</h2>
-      <a href="/kubernetes/contact-us" class="js-invoke-modal p-heading--2">Contact us</a>
+      <a href="/kubernetes/contact-us"
+         class="js-invoke-modal p-heading--2"
+         aria-controls="kubernetes-modal">Contact us</a>
     </div>
   </section>
   {{ load_form("/kubernetes") | safe }}

--- a/templates/kubernetes/form-data.json
+++ b/templates/kubernetes/form-data.json
@@ -59,7 +59,7 @@
                 "type": "text",
                 "id": "title",
                 "label": "Job title",
-                "isRequired": false
+                "isRequired": true
               }
             ]
           }

--- a/templates/kubernetes/form-data.json
+++ b/templates/kubernetes/form-data.json
@@ -12,7 +12,7 @@
           "/kubernetes/documentation"
         ],
         "isModal": true,
-        "modalId": "contact-modal",
+        "modalId": "kubernetes-modal",
         "formData": {
           "title": "Talk to our Kubernetes experts",
           "formId": "3897",

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -29,7 +29,8 @@
     {%- endif -%}
     {%- if slot == 'cta' -%}
       <a href="/kubernetes/contact-us"
-         class="js-invoke-modal p-button--positive">Get in touch</a>
+         class="js-invoke-modal p-button--positive"
+         aria-controls="kubernetes-modal">Get in touch</a>
       <a href="/kubernetes/install">Try Canonical Kubernetes today&nbsp;&rsaquo;</a>
     {%- endif -%}
     {%- if slot == 'image' -%}
@@ -203,7 +204,9 @@
       <hr class="p-rule--muted" />
       <div class="col-start-large-7 col-6">
         <p>
-          <a class="p-button js-invoke-modal" href="/kubernetes/contact-us">Talk to us to learn more</a>
+          <a class="p-button js-invoke-modal"
+             href="/kubernetes/contact-us"
+             aria-controls="kubernetes-modal">Talk to us to learn more</a>
         </p>
       </div>
     </div>
@@ -469,7 +472,9 @@
           <p>Canonical Kubernetes consulting and cluster deployment services</p>
           <div class="p-cta-block">
             <p>
-              <a class="js-invoke-modal" href="/kubernetes/contact-us">Get in touch to learn more&nbsp;&rsaquo;</a>
+              <a class="js-invoke-modal"
+                 href="/kubernetes/contact-us"
+                 aria-controls="kubernetes-modal">Get in touch to learn more&nbsp;&rsaquo;</a>
             </p>
           </div>
         </div>
@@ -753,7 +758,9 @@
   <section class="p-strip is-deep">
     <div class="u-fixed-width">
       <h2>Get your K8s questions answered today</h2>
-      <a class="p-heading--2 js-invoke-modal" href="/kubernetes/contact-us">Contact us</a>
+      <a class="p-heading--2 js-invoke-modal"
+         href="/kubernetes/contact-us"
+         aria-controls="kubernetes-modal">Contact us</a>
     </div>
   </section>
 

--- a/templates/kubernetes/install.html
+++ b/templates/kubernetes/install.html
@@ -252,7 +252,9 @@
       <h2>
         For more information, <a href="/kubernetes/documentation" aria-label="Check out the docs">read the docs</a>
         <br />
-        Or <a href="/kubernetes/contact-us" class="js-invoke-modal">contact us</a> to let our experts help you take the next step
+        Or <a href="/kubernetes/contact-us"
+    class="js-invoke-modal"
+    aria-controls="kubernetes-modal">contact us</a> to let our experts help you take the next step
       </h2>
     </div>
   </section>

--- a/templates/kubernetes/managed.html
+++ b/templates/kubernetes/managed.html
@@ -30,7 +30,8 @@
     {%- endif -%}
     {%- if slot == 'cta' -%}
       <a href="/kubernetes/contact-us?product=kubernetes-managed"
-         class="js-invoke-modal p-button--positive">Talk to an expert</a>
+         class="js-invoke-modal p-button--positive"
+         aria-controls="kubernetes-modal">Talk to an expert</a>
     {%- endif -%}
     {%- if slot == 'image' -%}
       <div class="p-image-container--cinematic is-cover">
@@ -174,7 +175,8 @@
         </ul>
         <div class="p-cta-block">
           <a href="/kubernetes/contact-us?product=kubernetes-managed"
-             class="js-invoke-modal p-button">Let us manage your K8s</a>
+             class="js-invoke-modal p-button"
+             aria-controls="kubernetes-modal">Let us manage your K8s</a>
           <a href="/engage/managed-services-overcoming-cio-challenges-2021">Managed IT services - read the whitepaper&nbsp;&rsaquo;</a>
         </div>
       </div>
@@ -444,7 +446,8 @@
     <div class="u-fixed-width">
       <p class="p-heading--2">
         <a href="/kubernetes/contact-us?product=kubernetes-managed"
-           class="js-invoke-modal">Talk to us about managing your Kubernetes cluster&nbsp;&rsaquo;</a>
+           class="js-invoke-modal"
+           aria-controls="kubernetes-modal">Talk to us about managing your Kubernetes cluster&nbsp;&rsaquo;</a>
       </p>
     </div>
   </section>

--- a/templates/kubernetes/resources.html
+++ b/templates/kubernetes/resources.html
@@ -32,7 +32,8 @@
         </p>
         <div class="p-cta-block">
           <a href="/kubernetes/contact-us"
-             class="p-button--positive js-invoke-modal">Get in touch</a>
+             class="p-button--positive js-invoke-modal"
+             aria-controls="kubernetes-modal">Get in touch</a>
         </div>
       </div>
     </div>

--- a/templates/kubernetes/what-is-kubernetes.html
+++ b/templates/kubernetes/what-is-kubernetes.html
@@ -36,7 +36,8 @@
     {%- endif -%}
     {%- if slot == "cta" -%}
       <a class="p-button--positive js-invoke-modal"
-         href="/kubernetes/contact-us?product=kubernetes-features">Get in touch</a>
+         href="/kubernetes/contact-us?product=kubernetes-features"
+         aria-controls="kubernetes-modal">Get in touch</a>
       <a href="https://documentation.ubuntu.com/canonical-kubernetes">Try Canonical Kubernetes today&nbsp;&rsaquo;</a>
     {%- endif -%}
     {%- if slot == "image" -%}
@@ -405,7 +406,9 @@
         </div>
         <div class="p-cta-block">
           <a href="/kubernetes/resources" class="p-button">Find more resources</a>
-          <a href="/kubernetes/contact-us" class="js-invoke-modal">Contact us to get your K8s questions answered today&nbsp;&rsaquo;</a>
+          <a href="/kubernetes/contact-us"
+             class="js-invoke-modal"
+             aria-controls="kubernetes-modal">Contact us to get your K8s questions answered today&nbsp;&rsaquo;</a>
         </div>
       </div>
     </div>
@@ -730,7 +733,8 @@
         <p>Let our Kubernetes experts help you take the next step.</p>
         <div class="p-cta-block">
           <a href="/kubernetes/contact-us"
-             class="p-button--positive js-invoke-modal">Contact us</a>
+             class="p-button--positive js-invoke-modal"
+             aria-controls="kubernetes-modal">Contact us</a>
         </div>
       </div>
     </div>

--- a/templates/landscape/form-data.json
+++ b/templates/landscape/form-data.json
@@ -4,7 +4,7 @@
       "templatePath": "/landscape/index.html",
       "childrenPaths": ["/landscape/features", "/landscape/compare"],
       "isModal": true,
-      "modalId": "contact-modal",
+      "modalId": "landscape-modal",
       "formData": {
         "title": "Talk to our Landscape team",
         "introText": "If you want to learn more about Landscape or our professional services options, meet with us and discuss your needs with one of our advisors.",

--- a/templates/landscape/index.html
+++ b/templates/landscape/index.html
@@ -36,7 +36,7 @@
     {%- endif -%}
     {%- if slot == 'cta' -%}
       <a href="/landscape/pricing" class="p-button--positive">Get Landscape</a>
-      <a href="/contact-us" class="p-button js-invoke-modal">Contact us</a>
+      <a href="/contact-us" class="p-button js-invoke-modal" aria-controls="landscape-modal">Contact us</a>
     {%- endif -%}
     {%- if slot == 'image' -%}
       <div class="p-image-container--cinematic is-cover">

--- a/templates/landscape/managed/form-data.json
+++ b/templates/landscape/managed/form-data.json
@@ -4,7 +4,7 @@
       "templatePath": "/landscape/managed/index.html",
       "childrenPaths": [],
       "isModal": true,
-      "modalId": "contact-modal",
+      "modalId": "landscape-managed-modal",
       "formData": {
         "title": "Talk to our Landscape team",
         "introText": "Discuss your needs with an advisor",

--- a/templates/landscape/managed/index.html
+++ b/templates/landscape/managed/index.html
@@ -32,7 +32,9 @@
         </p>
       {%- endif -%}
       {%- if slot == 'cta' -%}
-        <a href="/contact-us" class="p-button--positive js-invoke-modal">Contact us</a>
+        <a href="/contact-us"
+           class="p-button--positive js-invoke-modal"
+           aria-controls="landscape-managed-modal">Contact us</a>
       {%- endif -%}
       {%- if slot == 'image' -%}
         <div class="p-image-container--3-2 is-cover">
@@ -235,7 +237,9 @@
             Our Field Engineering team can recommend the number and type of machines your Managed Landscape deployment would need.
           </p>
           <div class="p-cta-block">
-            <a href="/contact-us" class="js-invoke-modal">Get started with a free quote and architecture assessment&nbsp;&rsaquo;</a>
+            <a href="/contact-us"
+               class="js-invoke-modal"
+               aria-controls="landscape-managed-modal">Get started with a free quote and architecture assessment&nbsp;&rsaquo;</a>
           </div>
         </div>
 
@@ -281,7 +285,9 @@
         our dashboard may not natively address.
       </h2>
       <div class="p-cta-block">
-        <a href="/contact-us" class="js-invoke-modal">Contact us about your unique requirements&nbsp;&rsaquo;</a>
+        <a href="/contact-us"
+           class="js-invoke-modal"
+           aria-controls="landscape-managed-modal">Contact us about your unique requirements&nbsp;&rsaquo;</a>
       </div>
     </div>
   </section>

--- a/templates/security/fips.html
+++ b/templates/security/fips.html
@@ -30,7 +30,8 @@
     {%- endif -%}
     {%- if slot == 'cta' -%}
       <a href="/security/contact-us"
-         class="p-button--positive js-invoke-modal">Contact us</a>
+         class="p-button--positive js-invoke-modal"
+         aria-controls="security-modal">Contact us</a>
       <a href="/pro" class="p-button">Get Ubuntu Pro</a>
     {%- endif -%}
     {%- if slot == 'image' -%}
@@ -83,7 +84,9 @@
     {%- endif -%}
 
     {%- if slot == 'cta' -%}
-      <a class="p-button js-invoke-modal" href="/security/contact-us">Contact us</a>
+      <a class="p-button js-invoke-modal"
+         href="/security/contact-us"
+         aria-controls="security-modal">Contact us</a>
       <a href="/security/certifications/docs/fips">Read more about FIPS&nbsp;&rsaquo;</a>
     {%- endif -%}
   {%- endcall -%}
@@ -143,7 +146,9 @@
           Learn about the US government security standards and the common challenges faced by organizations in their implementation. See how the Ubuntu Security Guide can transform systems compliance in a few minutes. Get to know how Ubuntu is a secure platform for government agencies and complying organizations to build, operate and innovate with open source applications and technologies.
         </p>
         <div class="p-cta-block">
-          <a class="p-button js-invoke-modal" href="/security/contact-us">Contact us</a>
+          <a class="p-button js-invoke-modal"
+             href="/security/contact-us"
+             aria-controls="security-modal">Contact us</a>
           <a href="https://www.brighttalk.com/webcast/6793/591276">Watch the <span class="u-off-screen">How Ubuntu enables your compliance with FedRAMP, FISMA, FIPS, and DISA-STIG</span> webinar&nbsp;&rsaquo;</a>
         </div>
       </div>

--- a/templates/security/form-data.json
+++ b/templates/security/form-data.json
@@ -327,13 +327,13 @@
                 "type": "text",
                 "id": "company",
                 "label": "Company",
-                "isRequired": false
+                "isRequired": true
               },
               {
                 "type": "text",
                 "id": "jobTitle",
                 "label": "Job title",
-                "isRequired": false
+                "isRequired": true
               },
               {
                 "type": "tel",

--- a/templates/security/form-data.json
+++ b/templates/security/form-data.json
@@ -6,7 +6,7 @@
           "/security/fips"
         ],
         "isModal": true,
-        "modalId": "contact-modal",
+        "modalId": "security-modal",
         "formData": {
           "title": "The Ubuntu experts",
           "introText": "Canonical certifies, secures and enables enterprise open source on Ubuntu. Tell us about your project so we bring the right team to the conversation.",

--- a/templates/security/index.html
+++ b/templates/security/index.html
@@ -29,7 +29,7 @@
     {%- endif -%}
     {%- if slot == 'cta' -%}
       <a class="p-button--positive js-invoke-modal"
-         href="/security/contact-us">Contact us</a>
+         href="/security/contact-us" aria-controls="security-modal">Contact us</a>
       <a href="/engage/ubuntu-cybersecurity-webinar"
          onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'External Link', 'eventAction' : 'Watch the Ubuntu security webinar', 'eventLabel' : 'Watch the Ubuntu security webinar', 'eventValue' : undefined });">Watch the Ubuntu cybersecurity webinar&nbsp;&rsaquo;</a>
     {%- endif -%}
@@ -52,7 +52,7 @@
       <div class="p-notification--information is-light">
         <div class="p-notification__content">
           <div class="p-notification__message">
-            Need information about the CRA? Canonical is committed to delivering Cyber Resilience Act (CRA) compliant Ubuntu. To learn more, <a href="https://canonical.com/solutions/open-source-security/cyber-resilience-act">visit our dedicated webpage</a> on the CRA and its requirements, or <a href="/security/contact-us" class="js-invoke-modal">contact our sales team</a>.
+            Need information about the CRA? Canonical is committed to delivering Cyber Resilience Act (CRA) compliant Ubuntu. To learn more, <a href="https://canonical.com/solutions/open-source-security/cyber-resilience-act">visit our dedicated webpage</a> on the CRA and its requirements, or <a href="/security/contact-us" class="js-invoke-modal" aria-controls="security-modal">contact our sales team</a>.
           </div>
         </div>
       </div>
@@ -164,7 +164,7 @@
           Learn about cybersecurity and zero trust as well as the common challenges faced in the implementation of cybersecurity programs, including challenges in vulnerability management, secure configuration of software and defenses against malware. See how Canonical and Ubuntu can help manage these challenges and lay the software foundation of a successful cybersecurity program.
         </p>
         <div class="p-cta-block">
-          <a class="p-button js-invoke-modal" href="/security/contact-us">Contact us</a>
+          <a class="p-button js-invoke-modal" href="/security/contact-us" aria-controls="security-modal">Contact us</a>
           <a href="https://www.brighttalk.com/webcast/6793/516333?">Watch the <span class="u-off-screen">Cybersecurity & Compliance with Ubuntu</span> webinar&nbsp;&rsaquo;</a>
         </div>
       </div>
@@ -592,7 +592,7 @@
         </ul>
         <div class="p-cta-block">
           <a href="/pro" class="p-button--positive">Purchase Ubuntu Pro</a>
-          <a href="/support/contact-us" class="js-invoke-modal">Contact us about Ubuntu Pro&nbsp;&rsaquo;</a>
+          <a href="/support/contact-us" class="js-invoke-modal" aria-controls="security-modal">Contact us about Ubuntu Pro&nbsp;&rsaquo;</a>
         </div>
       </div>
     </div>
@@ -604,7 +604,7 @@
     <div class="u-fixed-width">
       <h2 class="u-no-margin--bottom">Find a security solution that best suits the needs of your organization.</h2>
       <p>
-        <a href="/support/contact-us" class="js-invoke-modal p-heading--2">Talk to a member of our team&nbsp;&rsaquo;</a>
+        <a href="/support/contact-us" class="js-invoke-modal p-heading--2" aria-controls="security-modal">Talk to a member of our team&nbsp;&rsaquo;</a>
       </p>
     </div>
   </section>

--- a/templates/shared/forms/form-template.html
+++ b/templates/shared/forms/form-template.html
@@ -8,7 +8,7 @@
        data-lp-id=""
        data-return-url="{{ formData.returnUrl }}"
        data-lp-url="{{ formData.lpUrl }}">
-    <div class="p-modal js-modal-ready" id="{{ modalId }}">
+    <div class="p-modal p-modal--generated js-modal-ready" id="{{ modalId }}">
       <div class="p-modal__dialog is-wide-modal"
            role="dialog"
            aria-labelledby="modal-title"


### PR DESCRIPTION
## Done

- Add 'aria-controls' attribute to the button element for generated forms. This is one part of a phased approach to aligning how our forms open. The rest shall be done as we migrate the forms to use the form generator

## QA

- These are the pages that saw the update:
 /aws
/aws/pro
/aws/support
/aws/outposts
/download/renesas
/embedded
/internet-of-things/smart-home
/internet-of-things/smart-city
/internet-of-things/smart-displays
/internet-of-things/networking
/internet-of-things/management
/internet-of-things/gateways
/internet-of-things/digital-signage
/internet-of-things/appstore
/internet-of-things
/kubernetes/documentation
/kubernetes/what-is-kubernetes
/kubernetes/charmed-k8s/index
/kubernetes/compare
/kubernetes/resources
/kubernetes/managed
/kubernetes/install
/kubernetes
/landscape/managed
/landscape/compare
/landscape/features
/landscape
/security

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-21410
