### PR TITLE
WD-21453: update banned error message while scheduling

### DIFF
--- a/templates/credentials/schedule.html
+++ b/templates/credentials/schedule.html
@@ -25,6 +25,8 @@ meta_copydoc %}
                 Scheduled time should be outside of the maintenance window. Please schedule the exam before 
                 <strong>{{ maintenance_start }}</strong> or after 
                 <strong>{{ maintenance_end }}</strong>.
+              {% elif is_banned %}
+                {{ error }} See our <a href="/credentials/faq">FAQ</a> and <a href="/legal/terms-and-policies/credentials-terms">Terms of Service</a> for details.
               {% elif error %}
                 {{ error }}
               {% endif %}

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -392,6 +392,10 @@ def cred_schedule(
         scheduled_time = datetime.strptime(
             f"{data['date']}T{data['time']}", "%Y-%m-%dT%H:%M"
         )
+        cue_banned_error = "user is banned from using CUE"
+        formatted_cue_banned_error = (
+            "User is banned from Canonical credentialing exams."
+        )
         starts_at = tz_info.localize(scheduled_time)
         contract_item_id = flask.request.args.get("contractItemID", "")
         first_name, last_name = get_user_first_last_name()
@@ -505,10 +509,15 @@ def cred_schedule(
                     }
                 )
                 error = error.response.json()["message"]
+                is_banned = False
+                if cue_banned_error in error:
+                    error = formatted_cue_banned_error
+                    is_banned = True
                 return flask.render_template(
                     "/credentials/schedule.html",
                     error=error,
                     time_delay=time_delay,
+                    is_banned=is_banned,
                 )
         else:
             try:
@@ -531,10 +540,15 @@ def cred_schedule(
                     }
                 )
                 error = error.response.json()["message"]
+                is_banned = False
+                if cue_banned_error in error:
+                    error = formatted_cue_banned_error
+                    is_banned = True
                 return flask.render_template(
                     "/credentials/schedule.html",
                     error=error,
                     time_delay=time_delay,
+                    is_banned=is_banned,
                 )
 
             if response and "reservation" not in response:


### PR DESCRIPTION
## Done

- Update error message while scheduling exam for banned users

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Ban a user and try scheduling exam
    - You should see following error message: "User is banned from Canonical credentialing exams. See our [FAQ](http://localhost:8001/credentials/faq) and [Terms of Service](http://localhost:8001/legal/terms-and-policies/credentials-terms) for details."

## Issue / Card

Fixes [WD-21453](https://warthogs.atlassian.net/browse/WD-21453)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-21453]: https://warthogs.atlassian.net/browse/WD-21453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ