### PR TITLE
disable cue02 exam in production and add coupon discount

### DIFF
--- a/templates/credentials/shop/index.html
+++ b/templates/credentials/shop/index.html
@@ -135,7 +135,7 @@
   <script>
     window.stripePublishableKey = "{{ get_stripe_publishable_key }}";
     const exams = JSON.parse('{{ exams | tojson }}');
-
+    const isStaging = JSON.parse('{{ is_staging | tojson }}');
     const updateOrderTotal = (examIndex = 0) => {
       if (examIndex > 1) {
         return;
@@ -160,12 +160,16 @@
     const handleSubmit = () => {
       event.preventDefault();
       const index = document.querySelector('input[name="exam-radio"]:checked').value;
+      if (index == 1 && !isStaging) {
+        return;
+      }
       const shopCheckoutData = {
         products: [{
           product: exams[index],
           quantity: 1,
         }, ],
         action: "purchase",
+        coupon: exams[index].coupon || null,
       };
       localStorage.setItem(
         "shop-checkout-data",

--- a/webapp/shop/cred/exams.json
+++ b/webapp/shop/cred/exams.json
@@ -27,6 +27,12 @@
       "value": 10000,
       "currency": "USD"
     },
+    "coupon": {
+      "origin": "Stripe",
+      "IDs": [
+        "SMkl9ZHl"
+      ]
+    },
     "metadata": [
       {
         "key": "description",
@@ -35,6 +41,7 @@
       },
       {
         "originalPrice": "100.00",
+        "discountPrice": "0.00",
         "currency": "$"
       }
     ]

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -1085,6 +1085,9 @@ def cred_submit_form(**_):
 
 @shop_decorator(area="cube", permission="user", response="html")
 def cred_shop(ua_contracts_api, advantage_mapper, **kwargs):
+    is_staging = "staging" in os.getenv(
+        "CONTRACTS_API_URL", "https://contracts.staging.canonical.com/"
+    )
     exam_index = 0
     try:
         exam_index = int(flask.request.args.get("exam_index", 0))
@@ -1103,6 +1106,9 @@ def cred_shop(ua_contracts_api, advantage_mapper, **kwargs):
 
     exams_file = open("webapp/shop/cred/exams.json", "r")
     exams = json.load(exams_file)
+    if not is_staging:
+        old_metadata = exams[1]["metadata"]
+        exams[1]["metadata"] = [old_metadata[0]]
     cue_products = get_cue_products(type="exam").json
     for product in cue_products:
         for exam in exams:
@@ -1122,6 +1128,7 @@ def cred_shop(ua_contracts_api, advantage_mapper, **kwargs):
         "credentials/shop/index.html",
         exams=exams,
         exam_index=exam_index,
+        is_staging=is_staging,
     )
 
 


### PR DESCRIPTION
## Done

- Disable CUE.02 on production
- Add coupon discount for CUE.02 by default on the product

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Make sure CUE.02 is not available on production
- Make sure CUE.02 can be bought at 0 USD (coupon added by default)

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
