### PR TITLE
Final fixes

### DIFF
--- a/meganav.yaml
+++ b/meganav.yaml
@@ -823,10 +823,8 @@ download_ubuntu:
           links:
             - title: Upgrade Ubuntu Desktop
               url: /tutorials/upgrading-ubuntu-desktop
-            - title: 24.04 desktop guide
-              url: https://help.ubuntu.com/lts/ubuntu-help/index.html
-            - title: 22.04 desktop guide
-              url: https://help.ubuntu.com/22.04/ubuntu-help/index.html
+            - title: Ubuntu Desktop guide
+              url: https://help.ubuntu.com
             - title: Installation tutorial
               url: /tutorials/install-ubuntu-desktop
             - title: Try before installing

--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -33,7 +33,7 @@
         <div class="p-section">
           <h2>Ubuntu {{ releases.lts.full_version }} LTS</h2>
         </div>
-        <div class="p-image-wrapper u-hide--small u-hide--medium">
+        <div class="p-image-wrapper u-hide--small">
           {{ image(url="https://assets.ubuntu.com/v1/3b5fa561-mascot-numbat@2x.png",
                     alt="Noble Numbat",
                     width="182",
@@ -178,8 +178,7 @@
         <div class="p-section">
           <h2>Ubuntu {{ releases.latest.full_version }}</h2>
         </div>
-        <div class="p-image-wrapper u-hide--small u-hide--medium">
-
+        <div class="p-image-wrapper u-hide--small">
           {{ image(url="https://assets.ubuntu.com/v1/d7d087e4-600x600%20-%20PNG.png",
                     alt="Plucky Puffin",
                     width="200",

--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -72,7 +72,7 @@
     <div class="row--50-50 p-section">
       <div class="col u-image-position">
         <h2>Ubuntu {{ releases.lts.full_version }} LTS</h2>
-        <div class="u-image-position--bottom">
+        <div class="p-image-wrapper u-hide--small">
           {{ image(url="https://assets.ubuntu.com/v1/3b5fa561-mascot-numbat@2x.png",
                     alt="Noble Numbat",
                     width="182",
@@ -111,11 +111,11 @@
     <div class="row--50-50 p-section">
       <div class="col u-image-position">
         <h2>Ubuntu {{ releases.latest.full_version }}</h2>
-        <div class="u-image-position--bottom">
-          {{ image(url="https://assets.ubuntu.com/v1/ce1666ec-pp-master-orange-hex.svg",
+        <div class="p-image-wrapper u-hide--small">
+          {{ image(url="https://assets.ubuntu.com/v1/d7d087e4-600x600%20-%20PNG.png",
                     alt="Plucky Puffin",
-                    width="150",
-                    height="150",
+                    width="180",
+                    height="180",
                     hi_def=True,
                     loading="lazy") | safe
           }}

--- a/templates/download/server/manual.html
+++ b/templates/download/server/manual.html
@@ -66,7 +66,7 @@
         <div class="p-section">
           <h2>Ubuntu {{ releases.lts.full_version }} LTS</h2>
         </div>
-        <div class="p-image-wrapper u-hide--small u-hide--medium">
+        <div class="p-image-wrapper u-hide--small">
           {{ image(url="https://assets.ubuntu.com/v1/3b5fa561-mascot-numbat@2x.png",
                     alt="Noble Numbat",
                     width="182",
@@ -198,9 +198,9 @@
         <div class="p-section">
           <h2>Ubuntu {{ releases.latest.full_version }}</h2>
         </div>
-        <div class="p-image-wrapper u-hide--small u-hide--medium">
+        <div class="p-image-wrapper u-hide--small">
           {{ image(url="https://assets.ubuntu.com/v1/ce1666ec-pp-master-orange-hex.svg",
-                    alt="{{ releases.latest.name }}",
+                    alt="Plucky Puffin",
                     width="182",
                     height="192",
                     hi_def=True,


### PR DESCRIPTION
## Done

- Updated logo wrapping and aligned all to be hidden only on small screens
- Updated the download Ubuntu quick links as per [doc](https://docs.google.com/document/d/1DCNvYHfC7AbOcqflTBaVd571iKAP_PaTfnqTENVEDVw/edit?disco=AAABhxz6ACA)

## QA

- View the site locally in your web browser at: https://ubuntu-com-15005.demos.haus/#download-ubuntu
  - See that desktop guide has been updated as per doc
  -  Go to https://ubuntu-com-15005.demos.haus/download/server, https://ubuntu-com-15005.demos.haus/download/desktop, and https://ubuntu-com-15005.demos.haus/download/raspbery-pi
    - See that all plucky logos are wrapped in the same way and are hidden on small screens 

## Issue / Card

Fixes [review comments](https://github.com/canonical/ubuntu.com/pull/14940#issuecomment-2812216943)
