### PR TITLE
WD-21501: migrate cred views to use cue-contracts

### DIFF
--- a/static/js/src/navigation.js
+++ b/static/js/src/navigation.js
@@ -781,8 +781,9 @@ if (accountContainer) {
   fetch("/account.json")
     .then((response) => response.json())
     .then((data) => {
+      const isCue = window.location.pathname.startsWith("/credentials");
       if (data.account === null) {
-        accountContainer.innerHTML = `<a href="/login" class="p-navigation__link" style="padding-right: 1rem;" tabindex="0" onclick="event.stopPropagation()">Sign in</a>`;
+        accountContainer.innerHTML = `<a href="${isCue ? "/login?login_for=cue" : "/login"}" class="p-navigation__link" style="padding-right: 1rem;" tabindex="0" onclick="event.stopPropagation()">Sign in</a>`;
       } else {
         window.accountJSONRes = data.account;
         accountContainer.innerHTML = `<button href="#" class="p-navigation__link is-signed-in" aria-controls="canonical-login-content-mobile" aria-expanded="false" aria-haspopup="true">Account</button>
@@ -799,7 +800,7 @@ if (accountContainer) {
             </li>
             <li class="p-navigation__dropdown-item"><a class="p-link--inverted" href="/pro/dashboard" onclick="event.stopPropagation()">Ubuntu Pro dashboard</a></li>
             <li class="p-navigation__dropdown-item">
-              <a class="p-link--inverted" href="/account/invoices" onclick="event.stopPropagation()">Invoices & Payments</a>
+              <a class="p-link--inverted" href="${isCue ? "/credentials/invoices" : "/account/invoices"}" onclick="event.stopPropagation()">Invoices & Payments</a>
             </li>
             <li class="p-navigation__dropdown-item">
               <a class="p-link--inverted" href="https://login.ubuntu.com/" onclick="event.stopPropagation()">Account settings</a>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -129,6 +129,7 @@ from webapp.shop.views import (
     get_purchase_account_status,
     get_shop_status_page,
     invoices_view,
+    cred_invoices_view,
     maintenance_check,
     payment_methods_view,
     post_anonymised_customer_info,
@@ -978,6 +979,7 @@ app.add_url_rule(
     view_func=cred_schedule,
     methods=["GET", "POST"],
 )
+app.add_url_rule("/credentials/invoices", view_func=cred_invoices_view)
 app.add_url_rule("/credentials/your-exams", view_func=cred_your_exams)
 app.add_url_rule("/credentials/cancel-exam", view_func=cred_cancel_exam)
 app.add_url_rule("/credentials/assessments", view_func=cred_assessments)

--- a/webapp/shop/api/cue_contracts/advantage_mapper.py
+++ b/webapp/shop/api/cue_contracts/advantage_mapper.py
@@ -1,0 +1,289 @@
+from typing import Dict, List, Optional, Union
+
+from webapp.shop.api.cue_contracts.api import CUEContractsAPI
+from webapp.shop.api.cue_contracts.builders import build_user_subscriptions
+from webapp.shop.api.cue_contracts.models import (
+    Invoice,
+    Listing,
+    Offer,
+    Purchase,
+    UserSubscription,
+)
+from webapp.shop.api.cue_contracts.parsers import (
+    parse_contract,
+    parse_contracts,
+    parse_offers,
+    parse_product_listing,
+    parse_product_listings,
+    parse_channel_product_listings,
+    parse_subscriptions,
+    parse_users,
+)
+from webapp.shop.api.cue_contracts.primitives import (
+    Account,
+    AnnotatedContractItem,
+    Contract,
+    Subscription,
+    User,
+)
+from webapp.shop.api.cue_contracts.schema import (
+    AccountSchema,
+    AnnotatedContractItemsSchema,
+    EnsurePurchaseAccountSchema,
+    InvoiceSchema,
+    PurchaseSchema,
+)
+
+
+class CUEAdvantageMapper:
+    def __init__(self, ua_contrats_api: CUEContractsAPI):
+        self.cue_contracts_api = ua_contrats_api
+
+    def get_accounts(self, email: str = None) -> List[Account]:
+        response = self.cue_contracts_api.get_accounts(email)
+
+        return AccountSchema(many=True).load(response.get("accounts", []))
+
+    def get_account_contracts(
+        self,
+        account_id: str,
+        product_tags: str = "ua,classic,pro,blender",
+        include_active_machines: bool = False,
+    ) -> List[Contract]:
+        response = self.cue_contracts_api.get_account_contracts(
+            account_id, product_tags, include_active_machines
+        )
+        contracts = response.get("contracts", [])
+
+        return parse_contracts(contracts)
+
+    def get_all_account_contracts(self, account_id: str) -> List[Contract]:
+        response = self.cue_contracts_api.get_all_account_contracts(account_id)
+        contracts = response.get("contracts", [])
+
+        return parse_contracts(contracts)
+
+    def get_activation_key_contracts(self, account_id: str) -> List[Contract]:
+        response = self.cue_contracts_api.get_activation_key_contracts(
+            account_id
+        )
+        contracts = response.get("contracts", [])
+
+        return parse_contracts(contracts)
+
+    def get_contract(self, contract_id: str) -> Contract:
+        contract = self.cue_contracts_api.get_contract(contract_id)
+
+        return parse_contract(contract)
+
+    def get_account_offers(self, account_id: str) -> List[Offer]:
+        offers = self.cue_contracts_api.get_account_offers(account_id)
+
+        return parse_offers(offers)
+
+    def get_account_users(self, account_id: str) -> List[User]:
+        response = self.cue_contracts_api.get_account_users(account_id)
+        users = [user.get("userInfo") for user in response.get("users")]
+
+        return parse_users(users)
+
+    def get_contract_token(self, contract_id: str) -> Optional[str]:
+        response = self.cue_contracts_api.get_contract_token(contract_id)
+
+        return response.get("contractToken")
+
+    def get_product_listings(
+        self, marketplace: str, filters=None
+    ) -> Dict[str, Listing]:
+        url_filters = ""
+        if filters:
+            filters = "&".join(
+                "{}={}".format(key, value) for key, value in filters.items()
+            )
+            url_filters = f"?{filters}"
+
+        response = self.cue_contracts_api.get_product_listings(
+            marketplace, url_filters
+        )
+
+        if marketplace == "canonical-pro-channel":
+            return parse_channel_product_listings(
+                response.get("productListings", []),
+                response.get("products", []),
+            )
+        else:
+            return parse_product_listings(
+                response.get("productListings", []),
+                response.get("products", []),
+            )
+
+    def get_purchase_account(self, marketplace: str = "") -> Account:
+        response = self.cue_contracts_api.get_purchase_account(marketplace)
+
+        return AccountSchema().load(response)
+
+    def get_account_subscriptions(
+        self, account_id: str, marketplace: str, filters=None
+    ) -> List[Subscription]:
+        url_filters = ""
+        if filters:
+            filters = "&".join(
+                "{}={}".format(key, value) for key, value in filters.items()
+            )
+            url_filters = f"?{filters}"
+
+        response = self.cue_contracts_api.get_account_subscriptions(
+            account_id, marketplace, url_filters
+        )
+
+        subscriptions = response.get("subscriptions", [])
+
+        return parse_subscriptions(raw_subscriptions=subscriptions)
+
+    def get_account_purchases(
+        self, account_id: str, filters=None
+    ) -> List[Purchase]:
+        url_filters = ""
+        if filters:
+            filters = "&".join(
+                "{}={}".format(key, value) for key, value in filters.items()
+            )
+            url_filters = f"?{filters}"
+
+        response = self.cue_contracts_api.get_account_purchases(
+            account_id, url_filters
+        )
+
+        response = response.get("purchases", [])
+        if not response:
+            return []
+
+        listings = {
+            listing["id"]: parse_product_listing(listing)
+            for listing in response.get("productListings", [])
+        }
+
+        purchases = PurchaseSchema(many=True).load(
+            response.get("purchases", [])
+        )
+
+        for purchase in purchases:
+            for item in purchase.items:
+                item.listing = listings.get(item.listing_id)
+
+        purchases.sort(key=lambda purchase: purchase.created_at, reverse=True)
+
+        return purchases
+
+    def get_purchase(self, purchase_id) -> Purchase:
+        response = self.cue_contracts_api.get_purchase(purchase_id)
+
+        return PurchaseSchema().load(response)
+
+    def purchase_from_marketplace(
+        self, marketplace: str, purchase_request: dict, preview=True
+    ) -> Union[Invoice, Purchase]:
+        if preview:
+            invoice = self.cue_contracts_api.preview_purchase_from_marketplace(
+                marketplace=marketplace, purchase_request=purchase_request
+            )
+
+            return InvoiceSchema().load(invoice)
+
+        purchase = self.cue_contracts_api.purchase_from_marketplace(
+            marketplace=marketplace, purchase_request=purchase_request
+        )
+
+        return PurchaseSchema().load(purchase)
+
+    def ensure_purchase_account(
+        self,
+        marketplace: str = "",
+        email: str = "",
+        account_name: str = "",
+        captcha_value: str = "",
+    ) -> dict:
+        response = self.cue_contracts_api.ensure_purchase_account(
+            marketplace=marketplace,
+            email=email,
+            account_name=account_name,
+            captcha_value=captcha_value,
+        )
+
+        return EnsurePurchaseAccountSchema().load(response)
+
+    def get_user_subscriptions(
+        self,
+        email: str,
+        marketplaces: List = ["canonical-ua", "blender"],
+        is_in_maintenance: bool = False,
+        is_community_member: bool = False,
+    ) -> List[UserSubscription]:
+        listings = {}
+        product_tags = []
+        for marketplace in marketplaces:
+            marketplace_listings = self.get_product_listings(
+                marketplace,
+                filters={"include-hidden": "true"},
+            )
+            listings.update(marketplace_listings)
+            if marketplace == "canonical-ua":
+                product_tags.extend(["ua", "classic", "pro"])
+            elif marketplace == "blender":
+                product_tags.append("blender")
+        accounts = self.get_accounts(email=email)
+
+        user_summary = []
+        for account in accounts:
+            contracts = self.get_account_contracts(
+                account_id=account.id,
+                product_tags=",".join(product_tags),
+                include_active_machines=True,
+            )
+            subscriptions = []
+            if account.role != "technical":
+                for marketplace in marketplaces:
+                    market_subscriptions = self.get_account_subscriptions(
+                        account_id=account.id,
+                        marketplace=marketplace,
+                    )
+                    subscriptions.extend(market_subscriptions)
+
+            user_summary.append(
+                {
+                    "account": account,
+                    "contracts": contracts,
+                    "subscriptions": subscriptions,
+                }
+            )
+
+        user_subscriptions = build_user_subscriptions(user_summary, listings)
+
+        # overrides
+        for user_subscription in user_subscriptions:
+            is_stripe_sub = user_subscription.type in ["yearly", "monthly"]
+            if is_stripe_sub and is_in_maintenance:
+                user_subscription.statuses["is_upsizeable"] = False
+                user_subscription.statuses["is_downsizeable"] = False
+                user_subscription.statuses["is_cancellable"] = False
+            if is_community_member and user_subscription.type == "free":
+                user_subscription.number_of_machines = 50
+
+        return user_subscriptions
+
+    def get_annotated_subscriptions(
+        self, email: str
+    ) -> List[AnnotatedContractItem]:
+        resp = self.cue_contracts_api.get_annotated_contract_items(email=email)
+        items = AnnotatedContractItemsSchema(many=True).load(resp)
+
+        return items
+
+    def activate_magic_attach(
+        self, user_code: str, contract_id: str, client_ip: int
+    ):
+        headers = {"X-Forwarded-For": client_ip} if client_ip else {}
+        return self.cue_contracts_api.post_magic_attach(
+            request_body={"userCode": user_code, "contractID": contract_id},
+            headers=headers,
+        )

--- a/webapp/shop/api/cue_contracts/api.py
+++ b/webapp/shop/api/cue_contracts/api.py
@@ -1,0 +1,544 @@
+import logging
+from typing import List, Optional
+
+from requests.exceptions import HTTPError
+
+
+class CUEContractsAPI:
+    def __init__(
+        self,
+        session,
+        authentication_token,
+        token_type="Macaroon",
+        api_url="https://cue-contracts.canonical.com",
+        is_for_view=False,
+        remote_addr=None,
+    ):
+        """
+        Expects a Talisker session in most circumstances,
+        from `talisker.requests.get_session()`
+        """
+
+        self.session = session
+        self.authentication_token = authentication_token
+        self.token_type = token_type
+        self.api_url = api_url.rstrip("/")
+        self.is_for_view = is_for_view
+        self.remote_addr = remote_addr
+
+    def set_authentication_token(self, token):
+        self.authentication_token = token
+
+    def set_token_type(self, token_type):
+        self.token_type = token_type
+
+    def set_is_for_view(self, is_for_view):
+        self.is_for_view = is_for_view
+
+    def _request(
+        self,
+        method,
+        path,
+        json=None,
+        params=None,
+        error_rules=None,
+        headers={},
+    ):
+        headers["Authorization"] = (
+            f"{self.token_type} {self.authentication_token}"
+        )
+
+        if self.remote_addr:
+            headers["X-Forwarded-For"] = self.remote_addr
+            logger = logging.getLogger("talisker.requests")
+            logger.info(
+                "remote address", extra={"remote_addr": self.remote_addr}
+            )
+
+        response = self.session.request(
+            method=method,
+            url=f"{self.api_url}/{path}",
+            json=json,
+            headers=headers,
+            params=params,
+        )
+
+        if error_rules:
+            try:
+                response.raise_for_status()
+            except HTTPError as error:
+                self.handle_error(error, error_rules)
+        else:
+            response.raise_for_status()
+
+        return response
+
+    def get_accounts(self, email: str = None) -> dict:
+        return self._request(
+            method="get",
+            path="v1/accounts",
+            params={"email": email} if email else None,
+            error_rules=["default"],
+        ).json()
+
+    def get_account_contracts(
+        self,
+        account_id: str,
+        product_tags: str = "ua,classic,pro,blender",
+        include_active_machines: bool = False,
+    ) -> dict:
+        include_active_machines = str(include_active_machines).lower()
+
+        return self._request(
+            method="get",
+            path=(
+                f"v1/accounts/{account_id}/contracts"
+                f"?productTags={product_tags}"
+                f"&include-active-machines={include_active_machines}"
+            ),
+            error_rules=["default"],
+        ).json()
+
+    def get_contract(self, contract_id: str) -> dict:
+        return self._request(
+            method="get",
+            path=f"v1/contracts/{contract_id}",
+            json={},
+            error_rules=["default"],
+        ).json()
+
+    def get_account_offers(self, account_id: str) -> dict:
+        return self._request(
+            method="get",
+            path=f"v1/accounts/{account_id}/offers",
+            error_rules=["default", "no-found", "user-role"],
+        ).json()
+
+    def get_account_users(self, account_id: str) -> dict:
+        return self._request(
+            method="get",
+            path=f"v1/accounts/{account_id}/users",
+            json={},
+            error_rules=["default"],
+        ).json()
+
+    def put_account_user_role(
+        self,
+        account_id: str,
+        user_role_request: dict,
+    ) -> dict:
+        self._request(
+            method="put",
+            path=f"v1/accounts/{account_id}/user-role",
+            json=user_role_request,
+            error_rules=["default"],
+        )
+
+        return {}
+
+    def get_contract_token(self, contract_id: str) -> Optional[str]:
+        return self._request(
+            method="post",
+            path=f"v1/contracts/{contract_id}/token",
+            json={},
+            error_rules=["default"],
+        ).json()
+
+    def get_customer_info(self, account_id):
+        return self._request(
+            method="get",
+            path=f"v1/accounts/{account_id}/customer-info/stripe",
+            error_rules=["default", "no-found"],
+        ).json()
+
+    def put_customer_info(
+        self, account_id, payment_method_id, address, name, tax_id
+    ) -> dict:
+        return self._request(
+            method="put",
+            path=f"v1/accounts/{account_id}/customer-info/stripe",
+            json={
+                "defaultPaymentMethod": {"Id": payment_method_id},
+                "paymentMethodID": payment_method_id,
+                "address": address,
+                "name": name,
+                "taxID": tax_id,
+            },
+            error_rules=["default"],
+        ).json()
+
+    def put_anonymous_customer_info(
+        self, account_id, name, address, tax_id
+    ) -> dict:
+        return self._request(
+            method="put",
+            path=f"v1/accounts/{account_id}/customer-info/stripe",
+            json={"address": address, "name": name, "taxID": tax_id},
+            error_rules=["default"],
+        ).json()
+
+    def put_payment_method(self, account_id, payment_method_id) -> dict:
+        return self._request(
+            method="put",
+            path=f"v1/accounts/{account_id}/customer-info/stripe",
+            json={
+                "defaultPaymentMethod": {"Id": payment_method_id},
+            },
+            error_rules=["default"],
+        ).json()
+
+    def post_retry_purchase(self, purchase_id) -> dict:
+        self._request(
+            method="post",
+            path=f"v1/purchase/{purchase_id}/retry",
+            error_rules=["default"],
+        )
+
+        return {}
+
+    def get_renewal(self, renewal_id) -> dict:
+        return self._request(
+            method="get",
+            path=f"v1/renewals/{renewal_id}",
+            error_rules=["default"],
+        ).json()
+
+    def accept_renewal(self, renewal_id) -> dict:
+        self._request(
+            method="post",
+            path=f"v1/renewals/{renewal_id}/acceptance",
+            error_rules=["default"],
+        )
+
+        return {}
+
+    def get_product_listings(
+        self, marketplace: str, filters: str = ""
+    ) -> dict:
+        return self._request(
+            method="get",
+            path=f"v1/marketplace/{marketplace}/product-listings{filters}",
+            error_rules=["default"],
+        ).json()
+
+    def get_account_subscriptions(
+        self, account_id: str, marketplace: str, filters: str = ""
+    ) -> dict:
+        return self._request(
+            method="get",
+            path=(
+                f"v1/accounts/{account_id}"
+                f"/marketplace/{marketplace}"
+                f"/subscriptions{filters}"
+            ),
+            error_rules=["default", "auth"],
+        ).json()
+
+    def get_account_purchases(
+        self, account_id: str, filters: str = ""
+    ) -> dict:
+        return self._request(
+            method="get",
+            path=f"v1/accounts/{account_id}/purchases{filters}",
+            error_rules=["default"],
+        ).json()
+
+    def get_purchase(self, purchase_id: str) -> dict:
+        return self._request(
+            method="get",
+            path=f"v1/purchase/{purchase_id}",
+            error_rules=["default"],
+        ).json()
+
+    def ensure_purchase_account(
+        self,
+        marketplace: str = "",
+        email: str = "",
+        account_name: str = "",
+        captcha_value: str = "",
+    ) -> dict:
+        return self._request(
+            method="post",
+            path=f"v1/marketplace/{marketplace}/account",
+            json={
+                "email": email,
+                "accountName": account_name,
+                "recaptchaToken": captcha_value,
+            },
+            error_rules=["default"],
+        ).json()
+
+    def get_purchase_account(self, marketplace: str = "") -> dict:
+        return self._request(
+            method="get",
+            path=f"v1/marketplace/{marketplace}/account",
+            error_rules=["default", "auth", "no-found", "user-role"],
+        ).json()
+
+    def purchase_from_marketplace(
+        self, marketplace: str, purchase_request: dict
+    ) -> dict:
+        return self._request(
+            method="post",
+            path=f"v1/marketplace/{marketplace}/purchase",
+            json=purchase_request,
+            error_rules=["default"],
+        ).json()
+
+    def preview_purchase_from_marketplace(
+        self, marketplace: str, purchase_request: dict
+    ) -> dict:
+        return self._request(
+            method="post",
+            path=f"v1/marketplace/{marketplace}/purchase/preview",
+            json=purchase_request,
+            error_rules=["default"],
+        ).json()
+
+    def cancel_subscription(self, subscription_id: str) -> dict:
+        self._request(
+            method="delete",
+            path=f"v1/subscriptions/{subscription_id}",
+            error_rules=["default"],
+        )
+
+        return {}
+
+    def post_subscription_auto_renewal(
+        self, subscription_id: str, should_auto_renew: bool
+    ) -> dict:
+        self._request(
+            method="post",
+            path=f"v1/subscription/{subscription_id}/auto-renewal",
+            json={"shouldAutoRenew": should_auto_renew},
+            error_rules=["default"],
+        )
+
+        return {}
+
+    def put_contract_entitlements(
+        self,
+        contract_id: str,
+        entitlements_request: dict,
+    ) -> dict:
+        self._request(
+            method="put",
+            path=f"v1/contracts/{contract_id}/defaultEnablement",
+            json=entitlements_request,
+            error_rules=["default"],
+        )
+
+        return {}
+
+    def post_purchase_calculate(
+        self,
+        marketplace: str,
+        request_body: dict,
+    ) -> dict:
+        return self._request(
+            method="post",
+            path=f"v1/marketplace/{marketplace}/purchase/calculate",
+            json=request_body,
+            error_rules=["default"],
+        ).json()
+
+    def web_purchase_from_marketplace(
+        self, marketplace: str, purchase_request: dict
+    ) -> dict:
+        return self._request(
+            method="post",
+            path=f"web/marketplace/{marketplace}/purchase",
+            json=purchase_request,
+            error_rules=["default"],
+        ).json()
+
+    def web_preview_purchase_from_marketplace(
+        self, marketplace: str, purchase_request: dict
+    ) -> dict:
+        return self._request(
+            method="post",
+            path=f"web/marketplace/{marketplace}/purchase/preview",
+            json=purchase_request,
+            error_rules=["default"],
+        ).json()
+
+    def post_assessment_reservation(
+        self,
+        contract_item_id,
+        first_name,
+        last_name,
+        timezone,
+        starts_at,
+        country_code,
+    ) -> dict:
+        req = self._request(
+            method="post",
+            path="v1/cue/schedule",
+            json={
+                "contractItemID": int(contract_item_id),
+                "firstName": first_name,
+                "lastName": last_name,
+                "timezone": timezone,
+                "startsAt": starts_at,
+                "countryCode": country_code,
+            },
+            error_rules=[],
+        ).json()
+        return req
+
+    def delete_assessment_reservation(self, contract_item_id) -> dict:
+        self._request(
+            method="delete",
+            path=f"v1/cue/item/{contract_item_id}",
+            error_rules=["default"],
+        )
+        return {}
+
+    def get_cue_user_bans(self) -> dict:
+        return self._request(
+            method="get",
+            path="v1/cue/user-ban",
+            error_rules=["default"],
+        ).json()
+
+    def put_cue_user_ban(self, user_ban) -> dict:
+        response = self._request(
+            method="put",
+            path="v1/cue/user-ban",
+            json={
+                "email": user_ban["email"],
+                "reason": user_ban["reason"],
+                "expiresAt": user_ban["expiresAt"],
+                "blocked": user_ban["blocked"],
+            },
+            error_rules=["default"],
+        )
+        if response.status_code == 200:
+            return {}
+        return response.json()
+
+    def post_magic_attach(self, request_body: dict, headers: dict) -> dict:
+        self._request(
+            method="post",
+            path="v1/magic-attach/activate",
+            json=request_body,
+            error_rules=["default"],
+            headers=headers,
+        )
+        return {"success": "true"}
+
+    def get_all_account_contracts(self, account_id: str) -> dict:
+        return self._request(
+            method="get",
+            path=f"v1/accounts/{account_id}/contracts",
+            error_rules=["default"],
+        ).json()
+
+    def get_activation_key_contracts(self, account_id: str) -> dict:
+        return self._request(
+            method="get",
+            path=(f"v1/accounts/{account_id}/contracts?productTags=key"),
+            error_rules=["default"],
+        ).json()
+
+    def list_activation_keys(self, contract_id: str) -> dict:
+        return self._request(
+            method="get",
+            path=f"v1/contracts/{contract_id}/keys",
+            error_rules=["default"],
+        ).json()
+
+    def rotate_activation_key(self, request_body: dict) -> dict:
+        return self._request(
+            method="put",
+            path="v1/keys/rotate",
+            json=request_body,
+            error_rules=["default"],
+        ).json()
+
+    def activate_activation_key(self, request_body: dict) -> dict:
+        self._request(
+            method="post",
+            path="v1/keys/activate",
+            json=request_body,
+            error_rules=["default"],
+        )
+
+        return {}
+
+    def get_activation_key_info(self, key_id: str) -> dict:
+        return self._request(
+            method="get",
+            path=f"v1/keys/{key_id}",
+            error_rules=["default"],
+        ).json()
+
+    def get_annotated_contract_items(
+        self, email: str = "", product_tags: List[str] = []
+    ) -> List[dict]:
+        params = {"email": email}
+
+        if product_tags:
+            params["productTags"] = product_tags
+        error_rules = []
+        if "cue" not in product_tags:
+            error_rules = ["default"]
+
+        return self._request(
+            method="get",
+            path="/web/annotated-contract-items",
+            params=params,
+            error_rules=error_rules,
+        ).json()
+
+    def handle_error(self, error, error_rules=None):
+        if not error_rules:
+            return
+
+        status_code = error.response.status_code
+
+        if "user-role" in error_rules and status_code == 403:
+            raise AccessForbiddenError(error)
+
+        if "auth" in error_rules and status_code == 401:
+            if self.is_for_view:
+                raise UnauthorizedErrorView(error)
+            raise UnauthorizedError(error)
+
+        if "no-found" in error_rules and status_code == 404:
+            raise CUEContractsUserHasNoAccount(error)
+
+        if "default" in error_rules:
+            if self.is_for_view:
+                raise CUEContractsAPIErrorView(error)
+            raise CUEContractsAPIError(error)
+
+
+class AccessForbiddenError(HTTPError):
+    def __init__(self, error: HTTPError):
+        super().__init__(request=error.request, response=error.response)
+
+
+class UnauthorizedError(HTTPError):
+    def __init__(self, error: HTTPError):
+        super().__init__(request=error.request, response=error.response)
+
+
+class UnauthorizedErrorView(HTTPError):
+    def __init__(self, error: HTTPError):
+        super().__init__(request=error.request, response=error.response)
+
+
+class CUEContractsAPIError(HTTPError):
+    def __init__(self, error: HTTPError):
+        super().__init__(request=error.request, response=error.response)
+
+
+class CUEContractsAPIErrorView(HTTPError):
+    def __init__(self, error: HTTPError):
+        super().__init__(request=error.request, response=error.response)
+
+
+class CUEContractsUserHasNoAccount(HTTPError):
+    def __init__(self, error: HTTPError):
+        super().__init__(request=error.request, response=error.response)

--- a/webapp/shop/api/cue_contracts/builders.py
+++ b/webapp/shop/api/cue_contracts/builders.py
@@ -1,0 +1,292 @@
+from datetime import datetime
+from typing import List, Dict
+
+import pytz
+from dateutil.parser import parse
+
+from webapp.shop.api.cue_contracts.helpers import (
+    get_items_aggregated_values,
+    get_machine_type,
+    get_user_subscription_statuses,
+    get_price_info,
+    make_user_subscription_id,
+    apply_entitlement_rules,
+    group_shop_items,
+    get_current_number_of_machines,
+)
+from webapp.shop.api.cue_contracts.primitives import (
+    Contract,
+    Account,
+    Subscription,
+    ContractItem,
+)
+from webapp.shop.api.cue_contracts.models import Listing, UserSubscription
+
+
+def build_user_subscriptions(
+    user_summary: List, listings: Dict[str, Listing]
+) -> List[UserSubscription]:
+    grouped_items = build_initial_user_subscriptions(user_summary, listings)
+    user_subscriptions = build_final_user_subscriptions(grouped_items)
+
+    return user_subscriptions
+
+
+def build_initial_user_subscriptions(
+    user_summary: List, listings: Dict[str, Listing]
+) -> List:
+    free_groups = build_free_item_groups(user_summary)
+    trial_groups = build_trial_item_groups(user_summary, listings)
+    shop_groups = build_shop_item_groups(user_summary, listings)
+    legacy_groups = build_legacy_item_groups(user_summary)
+
+    return free_groups + trial_groups + shop_groups + legacy_groups
+
+
+def build_free_item_groups(user_summary: List) -> List:
+    free_item_groups = []
+    for user_details in user_summary:
+        contracts: List[Contract] = user_details.get("contracts")
+
+        for contract in contracts:
+            # skip contracts without items
+            if contract.items is None:
+                continue
+
+            account: Account = user_details.get("account")
+            if account.type == "personal" and contract.product_id == "free":
+                free_item_groups.append(
+                    {
+                        "account": account,
+                        "contract": contract,
+                        "items": contract.items,
+                        "listing": None,
+                        "marketplace": "free",
+                        "subscriptions": user_details.get("subscriptions"),
+                        "type": "free",
+                    }
+                )
+
+    return free_item_groups
+
+
+def build_trial_item_groups(
+    user_summary: List, listings: Dict[str, Listing]
+) -> List:
+    trial_item_groups = []
+    for user_details in user_summary:
+        contracts: List[Contract] = user_details.get("contracts")
+
+        for contract in contracts:
+            # skip free contracts
+            if contract.product_id == "free":
+                continue
+
+            # skip contracts without items
+            if contract.items is None:
+                continue
+
+            for item in contract.items:
+                if item.reason == "trial_started":
+                    listing = listings[item.product_listing_id]
+                    trial_item_groups.append(
+                        {
+                            "account": user_details.get("account"),
+                            "contract": contract,
+                            "items": [item],
+                            "listing": listing,
+                            "marketplace": listing.marketplace,
+                            "subscriptions": user_details.get("subscriptions"),
+                            "subscription_id": item.subscription_id,
+                            "type": "trial",
+                        }
+                    )
+
+    return trial_item_groups
+
+
+def build_shop_item_groups(
+    user_summary: List, listings: Dict[str, Listing]
+) -> List:
+    shop_item_groups = []
+    for user_details in user_summary:
+        contracts: List[Contract] = user_details.get("contracts")
+
+        for contract in contracts:
+            # skip free contracts
+            if contract.product_id == "free":
+                continue
+
+            # skip contracts without items
+            if contract.items is None:
+                continue
+
+            raw_shop_groups = group_shop_items(items=contract.items)
+            for key in raw_shop_groups:
+                key_parts = key.split("||")
+                listing_id = key_parts[0]
+                subscription_id = key_parts[1]
+
+                listing: Listing = listings[listing_id]
+                items: List[ContractItem] = raw_shop_groups[key]
+
+                shop_item_groups.append(
+                    {
+                        "account": user_details.get("account"),
+                        "contract": contract,
+                        "items": items,
+                        "listing": listing,
+                        "subscription_id": subscription_id,
+                        "marketplace": listing.marketplace,
+                        "subscriptions": user_details.get("subscriptions"),
+                        "type": listing.period,
+                    }
+                )
+
+    return shop_item_groups
+
+
+def build_legacy_item_groups(user_summary: List) -> List:
+    legacy_item_groups = []
+    for user_details in user_summary:
+        contracts: List[Contract] = user_details.get("contracts")
+
+        for contract in contracts:
+            # skip free contracts
+            if contract.product_id == "free":
+                continue
+
+            # skip contracts without items
+            if contract.items is None:
+                continue
+
+            for item in contract.items:
+                if (
+                    item.product_listing_id is None
+                    or item.subscription_id is None
+                ):
+                    if item.reason == "key_activated":
+                        legacy_item_groups.append(
+                            {
+                                "account": user_details.get("account"),
+                                "contract": contract,
+                                "items": [item],
+                                "renewal": item.renewal,
+                                "item_id": item.id,
+                                "listing": None,
+                                "marketplace": "canonical-ua",
+                                "subscriptions": user_details.get(
+                                    "subscriptions"
+                                ),
+                                "type": "key_activated",
+                            }
+                        )
+                    else:
+                        legacy_item_groups.append(
+                            {
+                                "account": user_details.get("account"),
+                                "contract": contract,
+                                "items": [item],
+                                "renewal": item.renewal,
+                                "item_id": item.id,
+                                "listing": None,
+                                "marketplace": "canonical-ua",
+                                "subscriptions": user_details.get(
+                                    "subscriptions"
+                                ),
+                                "type": "legacy",
+                            }
+                        )
+
+    return legacy_item_groups
+
+
+def build_final_user_subscriptions(
+    grouped_items: List,
+) -> List[UserSubscription]:
+    user_subscriptions = []
+    for group in grouped_items:
+        account: Account = group.get("account")
+        listing: Listing = group.get("listing")
+        contract: Contract = group.get("contract")
+        subscriptions: List[Subscription] = group.get("subscriptions")
+        items: List[ContractItem] = group.get("items")
+        marketplace = group.get("marketplace")
+        type = group.get("type")
+        renewal = group.get("renewal")
+        item_id = group.get("item_id")
+        subscription_id = group.get("subscription_id")
+        aggregated_values = get_items_aggregated_values(items, type)
+        number_of_machines = aggregated_values.get("number_of_machines")
+        end_date = aggregated_values.get("end_date")
+        current_number_of_machines = (
+            get_current_number_of_machines(
+                subscriptions, subscription_id, listing
+            )
+            if type != "legacy"
+            else (
+                renewal.number_of_machines if renewal else number_of_machines
+            )
+        )
+        price_info = get_price_info(number_of_machines, items, listing)
+        product_name = (
+            contract.name if type != "free" else "Free Personal Token"
+        )
+        statuses = get_user_subscription_statuses(
+            account=account,
+            type=type,
+            current_number_of_machines=current_number_of_machines,
+            end_date=end_date,
+            renewal=renewal,
+            subscription_id=subscription_id,
+            subscriptions=subscriptions or [],
+        )
+
+        id = make_user_subscription_id(
+            account, type, contract, renewal, subscription_id, item_id
+        )
+
+        entitlements = (
+            apply_entitlement_rules(contract.entitlements)
+            if marketplace in ["canonical-ua", "free"]
+            else []
+        )
+
+        user_subscription = UserSubscription(
+            id=id,
+            type=type,
+            account_id=account.id,
+            entitlements=entitlements,
+            start_date=aggregated_values.get("start_date"),
+            end_date=end_date,
+            number_of_machines=number_of_machines,
+            number_of_active_machines=contract.number_of_active_machines,
+            current_number_of_machines=current_number_of_machines,
+            product_name=product_name,
+            marketplace=marketplace,
+            price=price_info.get("price"),
+            currency=price_info.get("currency"),
+            machine_type=get_machine_type(contract.product_id),
+            contract_id=contract.id,
+            subscription_id=subscription_id,
+            listing_id=listing.id if listing else None,
+            period=listing.period if listing else None,
+            renewal_id=renewal.id if renewal else None,
+            statuses=statuses,
+            max_tracking_reached=contract.max_tracking_reached,
+        )
+
+        # Do not return expired user subscriptions after 90 days
+        show_user_subscription = True
+        days_to_show = -90
+        if type != "free":
+            parsed_end_date = parse(user_subscription.end_date)
+            time_now = datetime.utcnow().replace(tzinfo=pytz.utc)
+            delta_till_expiry = parsed_end_date - time_now
+            days_till_expiry = delta_till_expiry.days
+            show_user_subscription = days_till_expiry >= days_to_show
+
+        if show_user_subscription:
+            user_subscriptions.append(user_subscription)
+
+    return user_subscriptions

--- a/webapp/shop/api/cue_contracts/helpers.py
+++ b/webapp/shop/api/cue_contracts/helpers.py
@@ -1,0 +1,626 @@
+from datetime import datetime
+from typing import Dict, List, Optional
+
+import pytz
+from dateutil.parser import parse
+
+from webapp.shop.api.cue_contracts.models import Entitlement, Listing
+from webapp.shop.api.cue_contracts.primitives import (
+    Account,
+    Contract,
+    ContractItem,
+    Renewal,
+    Subscription,
+)
+
+
+def group_shop_items(
+    items: List[ContractItem],
+) -> Dict[str, List[ContractItem]]:
+    item_groups = {}
+    for item in items:
+        listing_id = item.product_listing_id
+        subscription_id = item.subscription_id
+
+        # skip legacy contract items
+        if not listing_id or not subscription_id:
+            continue
+
+        if item.reason == "trial_started":
+            continue
+
+        key = f"{listing_id}||{subscription_id}"
+        item_groups[key] = item_groups.get(key, [])
+        item_groups[key].append(item)
+
+    return item_groups
+
+
+def get_items_aggregated_values(items: List[ContractItem], type: str) -> Dict:
+    start_date = None
+    end_date = None
+    number_of_machines = 0
+    for item in items:
+        number_of_machines = number_of_machines + item.value
+
+        if not start_date:
+            start_date = item.start_date
+
+        if not end_date:
+            end_date = item.end_date
+
+        if start_date and start_date > item.start_date:
+            start_date = item.start_date
+
+        if end_date and end_date < item.end_date:
+            end_date = item.end_date
+
+    # free user subscription end date is None
+    if type == "free":
+        end_date = None
+
+    return {
+        "start_date": start_date,
+        "end_date": end_date,
+        "number_of_machines": number_of_machines,
+    }
+
+
+def get_current_number_of_machines(
+    subscriptions: List[Subscription] = None,
+    subscription_id: str = None,
+    listing: Listing = None,
+) -> int:
+    if not subscriptions or not subscription_id or not listing:
+        return 0
+
+    subscription = [
+        subscription
+        for subscription in subscriptions
+        if subscription.id == subscription_id
+    ]
+
+    if not subscription:
+        return 0
+
+    current_item = [
+        item
+        for item in subscription[0].items
+        if item.product_listing_id == listing.id
+    ]
+
+    if not current_item:
+        return 0
+
+    return current_item[0].value
+
+
+def get_price_info(
+    number_of_machines: int = None,
+    items: List[ContractItem] = None,
+    listing: Listing = None,
+) -> Dict:
+    price_info = {
+        "price": None,
+        "currency": "USD",
+    }
+
+    if listing and number_of_machines:
+        price_info["price"] = number_of_machines * listing.price
+        price_info["currency"] = listing.currency
+
+        return price_info
+
+    if items and len(items) == 1 and items[0].renewal:
+        legacy_item = items[0]
+        price_info["price"] = legacy_item.renewal.price
+        price_info["currency"] = legacy_item.renewal.currency
+
+        return price_info
+
+    return price_info
+
+
+def get_machine_type(product_id: str) -> Optional[str]:
+    if "virtual" in product_id:
+        return "virtual"
+    if "physical" in product_id:
+        return "physical"
+    if "desktop" in product_id:
+        return "desktop"
+
+    # some product ids don't mention the machine type
+    # those products are all "physical", so I set it as default
+    return "physical"
+
+
+def is_trialling_user_subscription(items: List[ContractItem]) -> bool:
+    return len(items) == 1 and items[0].reason == "trial_started"
+
+
+def get_user_subscription_statuses(
+    account: Account,
+    type: str,
+    current_number_of_machines: int,
+    end_date: str = None,
+    renewal: Renewal = None,
+    subscription_id: str = None,
+    subscriptions: List[Subscription] = None,
+) -> dict:
+    # The explanations below use two concepts:
+    # - user subscription: these maps 1:1 with ua-contracts' contract items,
+    #   and these are the cards we present in /pro.
+    # - billing subscription: a bundle of products as billed periodically in
+    #   Stripe. These may lead to the creation of one or more user
+    #   subscriptions over time.
+    statuses = {
+        # is_upsizeable describes whether this user subscription is part of a
+        # billing subscription that allows upselling (that's yearly or
+        # monthly).
+        "is_upsizeable": False,
+        # is_upsizeable describes whether this user subscription is part of a
+        # billing subscription that allows downselling (that's only monthly).
+        "is_downsizeable": False,
+        # is_cancellable describes whether this user subscription is part of a
+        # billing subscription that can be cancelled at the moment or that can
+        # have its items downsold to zero.
+        "is_cancellable": False,
+        # is_cancelled describes whether this user subscription was part of a
+        # billing subscription that was cancelled in the past, or if it was
+        # removed from its billing subscription.
+        "is_cancelled": False,
+        # is_expiring describes whether this user subscription is considered to
+        # be expiring because it's close to its end date and it is part of a
+        # billing subscription that is not set to auto-renew.
+        "is_expiring": False,
+        # is_in_grace_period describes whether this user subscription is in
+        # its grace period, meaning it's past its end, but it still gives
+        # access to the product.
+        "is_in_grace_period": False,
+        # is_expired describes whether this user subscription is completely
+        # expired, past its end date and its grace period.
+        "is_expired": False,
+        # is_trialled describes whether this user subscription was part of a
+        # trial that already ended.
+        "is_trialled": False,
+        # is_renewable describes whether this user subscription can be renewed
+        # via an old-style renewal. Please note that this has nothing to do
+        # with renewals via billing subscriptions.
+        "is_renewable": False,
+        # is_renewal_actionable describes whether a user subscription that
+        # is_renewable belongs to a renewal that can be acted on by the user
+        # via /pro. If this is False, it means the customer should
+        # contact support to renew (because it's a special old-style renewal).
+        "is_renewal_actionable": False,
+        # has_pending_purchases describes whether this user subscription
+        # belongs to a billing subscription that has pending purchases, and
+        # thus it cannot be modified because of that.
+        "has_pending_purchases": False,
+        # is_subscription_active describes whether this user subscription
+        # belongs to a billing subscription that is currently locked (with a
+        # pending purchase) or active.
+        "is_subscription_active": False,
+        # is_subscription_auto_renewing describes whether this user
+        # subscription belongs to a billing subscription that is configured to
+        # auto-renew. Please note that this has nothing to do with
+        # is_renewable above, which applies to old-style, manual renewals.
+        "is_subscription_auto_renewing": False,
+        # should_present_auto_renewal describes whether this user subscription
+        # belongs to a billing subscription that should have its auto-renewal
+        # option displayed to the user at the current time.
+        "should_present_auto_renewal": False,
+        # has_access_to_support describes whether this user subscription
+        # displays the Support portal button. At the moment `billing` users
+        # do not have access
+        "has_access_to_support": False,
+        # has_access_to_token describes whether this user subscription displays
+        # the token or not. At the moment `billing` users do not have access
+        "has_access_to_token": False,
+        # is_renewed describes whether this user subscription has been renewed
+        # already or not
+        "is_renewed": False,
+    }
+
+    if account.role != "billing":
+        statuses["has_access_to_support"] = True
+        statuses["has_access_to_token"] = True
+
+    if type == "free":
+        return statuses
+
+    if renewal is None or (
+        renewal and renewal.status not in ["done", "closed"]
+    ):
+        date_statuses = get_date_statuses(type, end_date)
+        statuses["is_expiring"] = date_statuses["is_expiring"]
+        statuses["is_in_grace_period"] = date_statuses["is_in_grace_period"]
+        statuses["is_expired"] = date_statuses["is_expired"]
+
+    if statuses["is_expired"]:
+        return statuses
+
+    subscriptions = subscriptions or []
+    if has_pending_purchases(subscriptions):
+        statuses["has_pending_purchases"] = True
+        return statuses
+
+    if type == "trial" and account.role != "technical":
+        active_trial = [
+            subscription
+            for subscription in subscriptions
+            if subscription.started_with_trial
+            and subscription.in_trial
+            and subscription.status == "active"
+        ]
+
+        statuses["is_trialled"] = True if active_trial else False
+
+        statuses["is_subscription_auto_renewing"] = (
+            is_billing_subscription_auto_renewing(
+                subscriptions, subscription_id
+            )
+        )
+
+        # If the subscription is set to auto-renew don't expire
+        if statuses["is_subscription_auto_renewing"]:
+            statuses["is_expiring"] = False
+        statuses["is_subscription_active"] = is_billing_subscription_active(
+            subscriptions, subscription_id
+        )
+
+        statuses["is_cancelled"] = not statuses["is_subscription_active"]
+
+        statuses["is_renewed"] = (
+            is_subscription_auto_renewing(subscriptions, subscription_id)
+            and not statuses["is_cancelled"]
+        )
+
+    if type in ["yearly", "monthly"] and account.role != "technical":
+        statuses["is_subscription_active"] = is_billing_subscription_active(
+            subscriptions, subscription_id
+        )
+
+        is_cancelled = (
+            True
+            if not current_number_of_machines
+            or not statuses["is_subscription_active"]
+            else False
+        )
+        statuses["is_cancelled"] = is_cancelled
+        statuses["should_present_auto_renewal"] = (
+            statuses["is_subscription_active"] and not is_cancelled
+        )
+        statuses["is_subscription_auto_renewing"] = (
+            is_billing_subscription_auto_renewing(
+                subscriptions, subscription_id
+            )
+            and not is_cancelled
+        )
+
+        statuses["is_renewed"] = (
+            is_subscription_auto_renewing(subscriptions, subscription_id)
+            and not is_cancelled
+        )
+
+        # If the subscription is set to auto-renew don't expire
+        if statuses["is_subscription_auto_renewing"]:
+            statuses["is_expiring"] = False
+
+        if not is_cancelled:
+            statuses["is_upsizeable"] = True
+            statuses["is_downsizeable"] = True
+            statuses["is_cancellable"] = True
+
+    if type == "legacy" and renewal is None:
+        return statuses
+
+    if type == "legacy":
+        statuses["is_renewal_actionable"] = renewal.actionable or False
+
+        if renewal.actionable and renewal.status == "pending":
+            start = parse(renewal.start_date)
+            end = parse(renewal.end_date)
+            time_now = datetime.utcnow().replace(tzinfo=pytz.utc)
+            if start <= time_now <= end:
+                statuses["is_renewable"] = True
+
+        if renewal.status in ["done", "closed"]:
+            statuses["is_renewed"] = True
+
+    return statuses
+
+
+def get_date_statuses(type: str, end_date: str) -> dict:
+    parsed_end_date = parse(end_date)
+    time_now = datetime.utcnow().replace(tzinfo=pytz.utc)
+    delta_till_expiry = parsed_end_date - time_now
+    days_till_expiry = delta_till_expiry.days
+
+    if type != "legacy":
+        is_expiring_start = 60 if type == "yearly" else 7
+        is_expiring_end = 0
+        grace_period_end = -14
+    else:
+        # legacy purchases can be renewed 90 before and after expiry
+        is_expiring_start = 90
+        is_expiring_end = 0
+        grace_period_end = -90
+
+    is_expiring = is_expiring_start > days_till_expiry >= is_expiring_end
+    is_in_grace_period = is_expiring_end > days_till_expiry >= grace_period_end
+    is_expired = grace_period_end > days_till_expiry
+
+    return {
+        "is_expiring": is_expiring,
+        "is_in_grace_period": is_in_grace_period,
+        "is_expired": is_expired,
+    }
+
+
+def get_pending_purchases(subscriptions: List[Subscription]) -> List:
+    pending_purchases = []
+    for subscription in subscriptions:
+        purchases_ids = subscription.pending_purchases
+        if purchases_ids and len(purchases_ids) > 0:
+            pending_purchases.extend(purchases_ids)
+
+    return pending_purchases
+
+
+def has_pending_purchases(subscriptions: List[Subscription]) -> bool:
+    return len(get_pending_purchases(subscriptions=subscriptions)) > 0
+
+
+def is_user_subscription_cancelled(
+    listing: Listing, subscriptions: List[Subscription], subscription_id: str
+) -> bool:
+    listing_found = False
+    for subscription in subscriptions:
+        allowed_status = subscription.status in ["active", "locked"]
+        if subscription.id != subscription_id or not allowed_status:
+            continue
+
+        for item in subscription.items:
+            if item.product_listing_id == listing.id:
+                listing_found = True
+
+                break
+
+    is_cancelled = True if not listing_found else False
+
+    return is_cancelled
+
+
+def is_billing_subscription_active(
+    subscriptions: List[Subscription], subscription_id: str
+) -> bool:
+    for subscription in subscriptions:
+        if subscription.id == subscription_id and subscription.status in [
+            "active",
+            "locked",
+        ]:
+            return True
+
+    return False
+
+
+def is_subscription_auto_renewing(
+    subscriptions: List[Subscription], subscription_id: str
+) -> bool:
+    subscription = [
+        subscription
+        for subscription in subscriptions
+        if subscription.id == subscription_id
+    ]
+
+    if not subscription:
+        return False
+
+    return subscription[0].is_auto_renewing
+
+
+def is_billing_subscription_auto_renewing(
+    subscriptions: List[Subscription], subscription_id: str
+) -> bool:
+    for subscription in subscriptions:
+        if (
+            subscription.id == subscription_id
+            and subscription.status in ["active", "locked"]
+            and subscription.is_auto_renewing
+        ):
+            return True
+
+    return False
+
+
+def extract_last_purchase_ids(subscriptions: List[Subscription]) -> Dict:
+    last_purchase_ids = {
+        "monthly": "",
+        "yearly": "",
+    }
+
+    for subscription in subscriptions:
+        if subscription.status not in ["active", "locked"]:
+            continue
+
+        last_purchase_ids[subscription.period] = subscription.last_purchase_id
+
+    return last_purchase_ids
+
+
+def set_listings_trial_status(
+    listings: Dict[str, Listing], subscriptions: List[Subscription]
+) -> Dict[str, Listing]:
+    user_can_trial = True
+    for subscription in subscriptions:
+        stated_with_trial = subscription.started_with_trial
+        status = subscription.status
+        if stated_with_trial or status in ["active", "locked"]:
+            user_can_trial = False
+
+            break
+
+    for listing_id, listing in listings.items():
+        listing_can_be_trialled = listing.trial_days and listing.trial_days > 0
+        listing.set_can_be_trialled(listing_can_be_trialled and user_can_trial)
+
+    return listings
+
+
+def make_user_subscription_id(
+    account: Account,
+    type: str,
+    contract: Contract,
+    renewal: Renewal = None,
+    subscription_id: str = None,
+    item_id: id = None,
+) -> str:
+    id_elements = [type, account.id, contract.id]
+    if renewal:
+        id_elements.append(renewal.id)
+
+    if subscription_id:
+        id_elements.append(subscription_id)
+
+    if item_id:
+        id_elements.append(str(item_id))
+
+    return "||".join(id_elements)
+
+
+def apply_entitlement_rules(
+    entitlements: List[Entitlement],
+) -> List[Entitlement]:
+    allowed_entitlements = [
+        "cis",
+        "esm-infra",
+        "esm-apps",
+        "fips",
+        "fips-updates",
+        "livepatch",
+        "support",
+    ]
+
+    allowed_support_level = ["standard", "advanced"]
+
+    final_entitlements = []
+    has_no_esm_apps = True
+    has_livepatch_on = False
+    has_fips_on = False
+    has_fips_updates_on = False
+    support_entitlement = None
+    for entitlement in entitlements:
+        if entitlement.type in allowed_entitlements:
+            if entitlement.type == "esm-apps":
+                has_no_esm_apps = False
+            if entitlement.type == "livepatch":
+                has_livepatch_on = entitlement.enabled_by_default
+            if entitlement.type == "fips-updates":
+                has_fips_updates_on = entitlement.enabled_by_default
+            if entitlement.type == "fips":
+                has_fips_on = entitlement.enabled_by_default
+
+            if entitlement.type != "support":
+                final_entitlements.append(entitlement)
+                continue
+
+            if entitlement.support_level in allowed_support_level:
+                entitlement.enabled_by_default = True
+                support_entitlement = entitlement
+                final_entitlements.append(entitlement)
+
+    if has_no_esm_apps:
+        final_entitlements.append(
+            Entitlement(
+                type="esm-apps",
+                enabled_by_default=False,
+                is_available=False,
+                is_editable=False,
+                is_in_beta=False,
+            )
+        )
+
+    if support_entitlement:
+        final_entitlements.append(
+            Entitlement(
+                type="support",
+                support_level="advanced",
+                enabled_by_default=False,
+                is_available=False,
+                is_editable=False,
+            )
+        )
+
+        if support_entitlement.support_level == "essential":
+            final_entitlements.append(
+                Entitlement(
+                    type="support",
+                    support_level="standard",
+                    enabled_by_default=False,
+                    is_available=False,
+                    is_editable=False,
+                )
+            )
+
+    for entitlement in final_entitlements:
+        if entitlement.type == "support":
+            entitlement.is_editable = False
+
+        if has_fips_on:
+            if entitlement.type == "livepatch":
+                entitlement.is_editable = False
+                entitlement.enabled_by_default = False
+            if entitlement.type == "fips-updates":
+                entitlement.is_editable = False
+                entitlement.enabled_by_default = False
+        elif has_livepatch_on or has_fips_updates_on:
+            if entitlement.type == "fips":
+                entitlement.is_editable = False
+                entitlement.enabled_by_default = False
+
+        if entitlement.is_in_beta:
+            entitlement.is_editable = not entitlement.is_in_beta
+
+    return final_entitlements
+
+
+def to_dict(structure, class_key=None):
+    """Converts structure to dictionary
+
+    Parameters
+    ----------
+    structure: Any
+        Can be a String, Object, List/Dict of Strings or Objects
+    class_key: str
+        Stores the name of the object, used as a key in the dict.
+
+    Returns
+    -------
+    dict
+        If structure is an object
+    Any
+        The same type as structure
+    """
+    if isinstance(structure, list):
+        data = []
+        for value in structure:
+            data.append(to_dict(value))
+        return data
+    elif isinstance(structure, dict):
+        data = {}
+        for key, value in structure.items():
+            data[key] = to_dict(value, class_key)
+        return data
+    elif hasattr(structure, "__dict__"):
+        data = dict(
+            [
+                (key, to_dict(value, class_key))
+                for key, value in structure.__dict__.items()
+                if not callable(value) and not key.startswith("_")
+            ]
+        )
+        if class_key is not None and hasattr(structure, "__class__"):
+            data[class_key] = structure.__class__.__name__
+        return data
+    else:
+        return structure

--- a/webapp/shop/api/cue_contracts/models.py
+++ b/webapp/shop/api/cue_contracts/models.py
@@ -1,0 +1,307 @@
+from typing import List, Optional
+
+from dateutil.parser import parse
+
+
+class Metadata:
+    def __init__(self, key: str, value: str):
+        self.key = key
+        self.value = value
+
+
+class ExternalID:
+    def __init__(self, origin: str, ids: List[str]):
+        self.origin = origin
+        self.ids = ids
+
+
+class Entitlement:
+    def __init__(
+        self,
+        type: str,
+        enabled_by_default: bool,
+        support_level: str = None,
+        is_available: bool = True,
+        is_editable: bool = True,
+        is_in_beta: bool = False,
+    ):
+        self.type = type
+        self.support_level = support_level
+        self.enabled_by_default = enabled_by_default
+        self.is_available = is_available
+        self.is_editable = is_editable
+        self.is_in_beta = is_in_beta
+
+
+class Product:
+    def __init__(
+        self,
+        id: str,
+        name: str,
+    ):
+        self.id = id
+        self.name = name
+
+
+class Listing:
+    def __init__(
+        self,
+        id: str,
+        name: str,
+        marketplace: str,
+        price: int,
+        currency: str,
+        status: str,
+        product: Product = None,
+        trial_days: int = None,
+        period: str = None,
+    ):
+        self.id = id
+        self.name = name
+        self.marketplace = marketplace
+        self.product = product
+        self.price = price
+        self.currency = currency
+        self.status = status
+        self.trial_days = trial_days
+        self.period = period
+        self.can_be_trialled = None
+
+    def set_can_be_trialled(self, can_be_trialled):
+        self.can_be_trialled = can_be_trialled
+
+
+class ChannelListing:
+    def __init__(
+        self,
+        id: str,
+        name: str,
+        marketplace: str,
+        price: int,
+        currency: str,
+        status: str,
+        product: Product = None,
+        metadata: List[Metadata] = None,
+        exclusion_group: str = "",
+        effective_days: int = None,
+    ):
+        self.id = id
+        self.name = name
+        self.marketplace = marketplace
+        self.product = product
+        self.price = price
+        self.currency = currency
+        self.status = status
+        self.metadata = metadata
+        self.exclusion_group = exclusion_group
+        self.effective_days = effective_days
+
+
+class UserSubscription:
+    def __init__(
+        self,
+        id: str,
+        account_id: str,
+        product_name: str,
+        type: str,
+        start_date: str,
+        number_of_machines: int,
+        number_of_active_machines: int,
+        current_number_of_machines: int,
+        machine_type: str,
+        marketplace: str,
+        price: int,
+        currency: str,
+        entitlements: List[Entitlement],
+        statuses: dict,
+        contract_id: str,
+        subscription_id: str = None,
+        end_date: str = None,
+        period: str = None,
+        listing_id: str = None,
+        renewal_id: str = None,
+        max_tracking_reached: bool = False,
+    ):
+        self.id = id
+        self.account_id = account_id
+        self.product_name = product_name
+        self.type = type
+        self.start_date = start_date
+        self.end_date = end_date
+        self.number_of_machines = number_of_machines
+        self.number_of_active_machines = number_of_active_machines
+        self.current_number_of_machines = current_number_of_machines
+        self.machine_type = machine_type
+        self.marketplace = marketplace
+        self.price = price
+        self.currency = currency
+        self.entitlements = entitlements
+        self.statuses = statuses
+        self.period = period
+        self.subscription_id = subscription_id
+        self.contract_id = contract_id
+        self.listing_id = listing_id
+        self.renewal_id = renewal_id
+        self.max_tracking_reached = max_tracking_reached
+
+
+class OfferItem:
+    def __init__(
+        self,
+        id: str,
+        name: str,
+        price: int,
+        allowance: int,
+        effectiveDays: Optional[int] = None,
+        currency: Optional[str] = None,
+        productID: Optional[str] = None,
+        productName: Optional[str] = None,
+    ):
+        self.id = id
+        self.name = name
+        self.price = price
+        self.currency = currency
+        self.allowance = allowance
+        self.effectiveDays = effectiveDays
+        self.productID = productID
+        self.productName = productName
+
+
+class Offer:
+    def __init__(
+        self,
+        id: str,
+        account_id: str,
+        marketplace: str,
+        created_at: str,
+        actionable: bool,
+        total: int,
+        items: List[OfferItem],
+        discount: int = None,
+        can_change_items: Optional[bool] = False,
+        purchase: Optional[bool] = False,
+        external_ids: Optional[List[ExternalID]] = None,
+        activation_account_id: Optional[str] = None,
+        channel_deal_creator_name: Optional[str] = None,
+        distributor_account_name: Optional[str] = None,
+        reseller_account_name: Optional[str] = None,
+        end_user_account_name: Optional[str] = None,
+        technical_contact_email: Optional[str] = None,
+        technical_contact_name: Optional[str] = None,
+        opportunity_number: Optional[str] = None,
+        exclusion_group: Optional[str] = None,
+    ):
+        self.id = id
+        self.account_id = account_id
+        self.total = total
+        self.items = items
+        self.marketplace = marketplace
+        self.created_at = created_at
+        self.actionable = actionable
+        self.discount = discount
+
+        # If activation_account_id exist, it's a channel offer.
+        self.is_channel_offer = activation_account_id is not None
+
+        # Properties below apply only to channel offers.
+        if self.is_channel_offer:
+            self.can_change_items = can_change_items
+            self.purchase = purchase
+            self.external_ids = external_ids
+            self.activation_account_id = activation_account_id
+            self.channel_deal_creator_name = channel_deal_creator_name
+            self.distributor_account_name = distributor_account_name
+            self.reseller_account_name = reseller_account_name
+            self.end_user_account_name = end_user_account_name
+            self.technical_contact_email = technical_contact_email
+            self.technical_contact_name = technical_contact_name
+            self.opportunity_number = opportunity_number
+            self.exclusion_group = exclusion_group
+
+    def check_is_channel_offer(self) -> bool:
+        return self.is_channel_offer
+
+
+class Invoice:
+    def __init__(
+        self,
+        reason: str,
+        currency: str,
+        status: str,
+        id: str = "",
+        total: int = 0,
+        end_of_cycle: str = "",
+        start_of_cycle: str = "",
+        items: dict = None,
+        tax_amount: int = None,
+        payment_status: dict = None,
+        url: str = None,
+    ):
+        self.id = id
+        self.currency = currency
+        self.tax_amount = tax_amount
+        self.total = total
+        self.status = status
+        self.reason = reason
+        self.url = url
+        self.payment_status = payment_status
+        self.end_of_cycle = end_of_cycle
+        self.start_of_cycle = start_of_cycle
+        self.items = items
+
+
+class PurchaseItem:
+    def __init__(
+        self,
+        value: int,
+        listing_id: str,
+        listing: Listing = None,
+    ):
+        self.value = value
+        self.listing = listing
+        self.listing_id = listing_id
+
+
+class Purchase:
+    def __init__(
+        self,
+        account_id: str,
+        created_at: str,
+        id: str,
+        marketplace: str,
+        status: str,
+        items: List[PurchaseItem],
+        subscription_id: str = None,
+        invoice: Invoice = None,
+        coupon: dict = None,
+    ):
+        self.account_id = account_id
+        self.created_at = created_at
+        self.id = id
+        self.invoice = invoice
+        self.items = items
+        self.marketplace = marketplace
+        self.status = status
+        self.subscription_id = subscription_id
+        self.coupon = coupon
+
+    def get_period(self):
+        listing = self.items[0].listing
+        period = listing.period if listing else None
+
+        return "Monthly" if period == "monthly" else "Annual"
+
+    def get_formatted_date(self):
+        return parse(self.created_at).strftime("%d %B, %Y")
+
+    def get_total(self):
+        if self.invoice is None:
+            return None
+
+        if self.invoice.total is not None:
+            cost = self.invoice.total / 100
+            currency = self.invoice.currency
+
+            return f"{cost} {currency}"
+
+        return None

--- a/webapp/shop/api/cue_contracts/parsers.py
+++ b/webapp/shop/api/cue_contracts/parsers.py
@@ -1,0 +1,438 @@
+from typing import List, Dict, Optional
+
+from webapp.shop.api.cue_contracts.primitives import (
+    Contract,
+    ContractItem,
+    Entitlement,
+    Renewal,
+    Subscription,
+    SubscriptionItem,
+    User,
+)
+from webapp.shop.api.cue_contracts.models import (
+    Metadata,
+    ExternalID,
+    Listing,
+    ChannelListing,
+    Product,
+    OfferItem,
+    Offer,
+)
+
+
+def parse_product(raw_product: Dict) -> Product:
+    return Product(
+        id=raw_product.get("id"),
+        name=raw_product.get("name"),
+    )
+
+
+def parse_product_listing(
+    raw_product_listing: Dict, raw_products: List[Dict] = None
+) -> Listing:
+    product = None
+    raw_products = raw_products or []
+    for raw_product in raw_products:
+        if raw_product.get("id") == raw_product_listing.get("productID"):
+            product = parse_product(raw_product)
+            break
+
+    return Listing(
+        id=raw_product_listing.get("id"),
+        name=raw_product_listing.get("name"),
+        marketplace=raw_product_listing.get("marketplace"),
+        product=product,
+        price=raw_product_listing.get("price").get("value"),
+        currency=raw_product_listing.get("price").get("currency"),
+        status=raw_product_listing.get("status"),
+        trial_days=raw_product_listing.get("trialDays"),
+        period=raw_product_listing.get("period"),
+    )
+
+
+def parse_channel_product_listing(
+    raw_product_listing: Dict, raw_products: List[Dict] = None
+) -> ChannelListing:
+    product = None
+    raw_products = raw_products or []
+    for raw_product in raw_products:
+        if raw_product.get("id") == raw_product_listing.get("productID"):
+            product = parse_product(raw_product)
+            break
+
+    return ChannelListing(
+        id=raw_product_listing.get("id"),
+        name=raw_product_listing.get("name"),
+        marketplace=raw_product_listing.get("marketplace"),
+        product=product,
+        price=raw_product_listing.get("price").get("value"),
+        currency=raw_product_listing.get("price").get("currency"),
+        status=raw_product_listing.get("status"),
+        metadata=raw_product_listing.get("metadata"),
+        exclusion_group=raw_product_listing.get("exclusionGroup", ""),
+        effective_days=raw_product_listing.get("effectiveDays"),
+    )
+
+
+def parse_product_listings(
+    raw_product_listings: List[Dict] = None,
+    raw_products: List[Dict] = None,
+) -> Dict[str, Listing]:
+    raw_product_listings = raw_product_listings or {}
+
+    return {
+        product_listing.get("id"): parse_product_listing(
+            product_listing, raw_products
+        )
+        for product_listing in raw_product_listings
+    }
+
+
+def parse_channel_product_listings(
+    raw_product_listings: List[Dict] = None,
+    raw_products: List[Dict] = None,
+) -> Dict[str, ChannelListing]:
+    raw_product_listings = raw_product_listings or {}
+
+    return {
+        product_listing.get("id"): parse_channel_product_listing(
+            product_listing, raw_products
+        )
+        for product_listing in raw_product_listings
+    }
+
+
+def parse_entitlements(
+    raw_entitlements: List[Dict] = None,
+) -> List[Entitlement]:
+    entitlements = []
+    raw_entitlements = raw_entitlements or []
+    for raw_entitlement in raw_entitlements:
+        affordances = raw_entitlement.get("affordances")
+        obligations = raw_entitlement.get("obligations")
+        is_available = raw_entitlement.get("entitled")
+
+        support_level = None
+        if affordances:
+            support_level = affordances.get("supportLevel")
+            is_in_beta = affordances.get("inBeta", False)
+
+        enabled_by_default = (
+            obligations.get("enableByDefault") if obligations else False
+        )
+
+        entitlement = Entitlement(
+            type=raw_entitlement.get("type"),
+            support_level=support_level,
+            enabled_by_default=enabled_by_default,
+            is_available=is_available,
+            is_in_beta=is_in_beta,
+        )
+
+        entitlements.append(entitlement)
+
+    return entitlements
+
+
+def parse_renewal(raw_renewal: Dict = None) -> Renewal:
+    renewal_items = raw_renewal.get("renewalItems")
+    price = 0
+    currency = "usd"
+    number_of_machines = 0
+    for item in renewal_items:
+        price = price + item.get("priceTotal").get("value")
+        currency = item.get("priceTotal").get("currency")
+        number_of_machines = item.get("allowance").get("value")
+
+    return Renewal(
+        id=raw_renewal.get("id"),
+        contract_id=raw_renewal.get("contractID"),
+        actionable=raw_renewal.get("actionable"),
+        status=raw_renewal.get("status"),
+        start_date=raw_renewal.get("start"),
+        end_date=raw_renewal.get("end"),
+        new_contract_start=raw_renewal.get("newContractStart"),
+        price=price,
+        currency=currency,
+        number_of_machines=number_of_machines,
+    )
+
+
+def parse_contract_items(raw_items: List[Dict] = None) -> List[ContractItem]:
+    items = []
+    raw_items = raw_items or []
+    for raw_item in raw_items:
+        raw_renewal = raw_item.get("renewal")
+
+        item = ContractItem(
+            id=raw_item.get("id"),
+            contract_id=raw_item.get("contractID"),
+            created_at=raw_item.get("created"),
+            start_date=raw_item.get("effectiveFrom"),
+            end_date=raw_item.get("effectiveTo"),
+            reason=raw_item.get("reason"),
+            value=raw_item.get("value"),
+            product_listing_id=raw_item.get("productListingID"),
+            purchase_id=raw_item.get("purchaseID"),
+            subscription_id=raw_item.get("subscriptionID"),
+            trial_id=raw_item.get("trialID"),
+            renewal=parse_renewal(raw_renewal) if raw_renewal else None,
+        )
+
+        items.append(item)
+
+    return items
+
+
+def parse_contract(raw_contract: Dict) -> Contract:
+    account_info = raw_contract.get("accountInfo")
+    contract_info = raw_contract.get("contractInfo")
+    raw_entitlements = contract_info.get("resourceEntitlements")
+    entitlements = parse_entitlements(raw_entitlements)
+    raw_items = contract_info.get("items")
+    items = parse_contract_items(raw_items)
+
+    number_of_active_machines = 0
+    max_tracking_reached = False
+    if "activeMachines" in contract_info:
+        active_machines = contract_info["activeMachines"]
+        number_of_active_machines = active_machines["activeMachines"]
+        max_tracking_reached = (
+            active_machines["maximumTrackingReached"]
+            if "maximumTrackingReached" in active_machines
+            else False
+        )
+
+    return Contract(
+        id=contract_info.get("id"),
+        account_id=account_info.get("id"),
+        name=contract_info.get("name"),
+        product_id=contract_info.get("products")[0],
+        entitlements=entitlements,
+        number_of_active_machines=number_of_active_machines,
+        items=items,
+        max_tracking_reached=max_tracking_reached,
+    )
+
+
+def parse_contracts(raw_contracts: Dict) -> List[Contract]:
+    return [parse_contract(raw_contract) for raw_contract in raw_contracts]
+
+
+def parse_subscription_items(
+    subscription_id: str,
+    raw_items: List[Dict] = None,
+) -> List[SubscriptionItem]:
+    subscription_items = []
+    raw_items = raw_items or []
+    for raw_item in raw_items:
+        subscription_item = SubscriptionItem(
+            subscription_id=subscription_id,
+            product_listing_id=raw_item.get("productListing").get("id"),
+            value=raw_item.get("value"),
+        )
+
+        subscription_items.append(subscription_item)
+
+    return subscription_items
+
+
+def parse_subscription(raw_subscription: Dict) -> Subscription:
+    subscription_id = raw_subscription.get("subscription").get("id")
+    raw_items = raw_subscription.get("purchasedProductListings")
+    subscription = raw_subscription.get("subscription")
+
+    return Subscription(
+        id=subscription_id,
+        account_id=subscription.get("accountID"),
+        marketplace=subscription.get("marketplace"),
+        period=subscription.get("period"),
+        status=subscription.get("status"),
+        last_purchase_id=raw_subscription.get("lastPurchaseID"),
+        pending_purchases=raw_subscription.get("pendingPurchases"),
+        is_auto_renewing=subscription.get("autoRenew"),
+        started_with_trial=subscription.get("startedWithTrial"),
+        in_trial=subscription.get("inTrial"),
+        items=parse_subscription_items(subscription_id, raw_items),
+    )
+
+
+def parse_subscriptions(raw_subscriptions: Dict) -> List[Subscription]:
+    return [
+        parse_subscription(raw_subscription)
+        for raw_subscription in raw_subscriptions
+    ]
+
+
+def parse_user(raw_user: Dict) -> User:
+    user = User(
+        display_name=raw_user.get("displayName"),
+        name=raw_user.get("name"),
+        email=raw_user.get("email"),
+        id=raw_user.get("id"),
+        last_login_at=raw_user.get("lastLogin"),
+        first_login_at=raw_user.get("firstLogin"),
+        verified=raw_user.get("verified"),
+    )
+
+    user_role_on_account = raw_user.get("userRoleOnAccount")
+    if user_role_on_account:
+        user.set_user_role_on_account(user_role_on_account)
+
+    return user
+
+
+def parse_users(raw_users: List) -> List[User]:
+    return [parse_user(raw_user) for raw_user in raw_users]
+
+
+def parse_metadata(metadata: List[Dict[str, str]]) -> List[Metadata]:
+    return [Metadata(item["key"], item["value"]) for item in metadata]
+
+
+def parse_external_ids(raw_external_ids: List[Dict]) -> List[ExternalID]:
+    external_ids: List[ExternalID] = []
+    for raw_external_id in raw_external_ids:
+        external_ids.append(
+            ExternalID(
+                origin=raw_external_id["origin"],
+                ids=raw_external_id["IDs"],
+            )
+        )
+    return external_ids
+
+
+def parse_offer_items(
+    raw_offer_items: List, raw_product_listings: List
+) -> List[OfferItem]:
+    offer_items = []
+
+    for raw_offer_item in raw_offer_items:
+        item_listing = raw_offer_item["productListingID"]
+        product_listing = [
+            product_listing
+            for product_listing in raw_product_listings
+            if product_listing.get("id") == item_listing
+        ]
+        allowance = raw_offer_item.get("value")
+        # total price ( price * quantity )
+        price = product_listing[0].get("price").get("value") * allowance
+
+        is_channel_offer = (
+            product_listing[0].get("marketplace") == "canonical-pro-channel"
+        )
+
+        channel_item_fields = {}
+
+        if is_channel_offer:
+            channel_item_fields = {
+                "currency": product_listing[0]
+                .get("price", {})
+                .get("currency"),
+                "effectiveDays": product_listing[0].get("effectiveDays"),
+                "productID": product_listing[0].get("productID"),
+                "productName": product_listing[0].get("productName"),
+            }
+
+        offer_items.append(
+            OfferItem(
+                id=product_listing[0].get("id"),
+                name=product_listing[0].get("name"),
+                price=price,
+                allowance=allowance,
+                **channel_item_fields,
+            )
+        )
+
+    return offer_items
+
+
+def parse_offer(raw_offer: Dict) -> Offer:
+    items = parse_offer_items(
+        raw_offer.get("items", []), raw_offer.get("productListings", [])
+    )
+    external_ids = (
+        parse_external_ids(raw_offer["externalIDs"])
+        if raw_offer.get("activationAccountID") is not None
+        and raw_offer["externalIDs"] is not None
+        else None
+    )
+
+    metadata = (
+        parse_metadata(raw_offer.get("metadata", []))
+        if raw_offer.get("activationAccountID")
+        else None
+    )
+    exclusion_group = raw_offer.get("exclusionGroup", "")
+
+    purchase = "purchase" in raw_offer
+
+    # Always included fields
+    offer_data = {
+        "id": raw_offer["id"],
+        "account_id": raw_offer["accountID"],
+        "marketplace": raw_offer["marketplace"],
+        "created_at": raw_offer["createdAt"],
+        "actionable": raw_offer["actionable"],
+        "purchase": purchase,
+        "total": sum(item.price for item in items),
+        "items": items,
+        "discount": raw_offer.get("discount"),
+    }
+
+    # Conditionally include fields related to activation_account_id
+    if raw_offer.get("activationAccountID"):
+        if metadata:
+            channel_deal_creator_name = get_metadata_value(
+                metadata, "channelDealCreatorName"
+            )
+            distributor_account_name = get_metadata_value(
+                metadata, "distributorAccountName"
+            )
+            end_user_account_name = get_metadata_value(
+                metadata, "endUserAccountName"
+            )
+            reseller_account_name = get_metadata_value(
+                metadata, "resellerAccountName"
+            )
+            technical_contact_email = get_metadata_value(
+                metadata, "technicalContactEmail"
+            )
+            technical_contact_name = get_metadata_value(
+                metadata, "technicalContactName"
+            )
+            opportunity_number = get_metadata_value(
+                metadata, "opportunityNumber"
+            )
+
+        offer_data.update(
+            {
+                "activation_account_id": raw_offer.get("activationAccountID"),
+                "can_change_items": raw_offer.get("canChangeItems"),
+                "external_ids": external_ids,
+                "channel_deal_creator_name": channel_deal_creator_name,
+                "distributor_account_name": distributor_account_name,
+                "reseller_account_name": reseller_account_name,
+                "end_user_account_name": end_user_account_name,
+                "technical_contact_email": technical_contact_email,
+                "technical_contact_name": technical_contact_name,
+                "opportunity_number": opportunity_number,
+                "exclusion_group": exclusion_group,
+            }
+        )
+
+    return Offer(**offer_data)
+
+
+def parse_offers(raw_offers: List) -> List[Offer]:
+    return [parse_offer(raw_offer) for raw_offer in raw_offers]
+
+
+def get_metadata_value(
+    metadata: Optional[List[Metadata]], key: str
+) -> Optional[str]:
+    if metadata is not None:
+        for metadata in metadata:
+            if metadata.key == key:
+                return metadata.value
+    return None

--- a/webapp/shop/api/cue_contracts/primitives.py
+++ b/webapp/shop/api/cue_contracts/primitives.py
@@ -1,0 +1,201 @@
+from typing import List
+from dataclasses import dataclass
+
+from webapp.shop.api.cue_contracts.models import Entitlement
+
+
+class Renewal:
+    def __init__(
+        self,
+        id: str,
+        contract_id: str,
+        actionable: bool,
+        status: str,
+        start_date: str,
+        end_date: str,
+        new_contract_start: str,
+        price: int,
+        currency: str,
+        number_of_machines: int,
+    ):
+        self.id = id
+        self.contract_id = contract_id
+        self.actionable = actionable
+        self.status = status
+        self.start_date = start_date
+        self.end_date = end_date
+        self.price = price
+        self.currency = currency
+        self.new_contract_start = new_contract_start
+        self.number_of_machines = number_of_machines
+
+
+class ContractItem:
+    def __init__(
+        self,
+        id: int,
+        contract_id: str,
+        created_at: str,
+        start_date: str,
+        end_date: str,
+        reason: str,
+        value: int,
+        product_listing_id: str = None,
+        subscription_id: str = None,
+        purchase_id: str = None,
+        trial_id: str = None,
+        renewal: Renewal = None,
+    ):
+        self.id = id
+        self.contract_id = contract_id
+        self.created_at = created_at
+        self.start_date = start_date
+        self.end_date = end_date
+        self.reason = reason
+        self.value = value
+        self.product_listing_id = product_listing_id
+        self.purchase_id = purchase_id
+        self.subscription_id = subscription_id
+        self.trial_id = trial_id
+        self.renewal = renewal
+
+
+class Contract:
+    def __init__(
+        self,
+        id: str,
+        account_id: str,
+        name: str,
+        product_id: str,
+        entitlements: List[Entitlement],
+        number_of_active_machines: int,
+        items: List[ContractItem] = None,
+        max_tracking_reached: bool = False,
+    ):
+        self.id = id
+        self.account_id = account_id
+        self.name = name
+        self.product_id = product_id
+        self.entitlements = entitlements
+        self.number_of_active_machines = number_of_active_machines
+        self.items = items
+        self.max_tracking_reached = max_tracking_reached
+
+
+class SubscriptionItem:
+    def __init__(
+        self,
+        subscription_id: str,
+        product_listing_id: str,
+        value: int,
+    ):
+        self.subscription_id = subscription_id
+        self.product_listing_id = product_listing_id
+        self.value = value
+
+
+class Subscription:
+    def __init__(
+        self,
+        id: str,
+        account_id: str,
+        marketplace: str,
+        status: str,
+        period: str = None,
+        items: List[SubscriptionItem] = None,
+        last_purchase_id: str = None,
+        is_auto_renewing: bool = None,
+        pending_purchases: List[str] = None,
+        started_with_trial: bool = None,
+        in_trial: bool = None,
+    ):
+        self.id = id
+        self.account_id = account_id
+        self.marketplace = marketplace
+        self.period = period
+        self.status = status
+        self.last_purchase_id = last_purchase_id
+        self.pending_purchases = pending_purchases
+        self.is_auto_renewing = is_auto_renewing
+        self.items = items
+        self.started_with_trial = started_with_trial
+        self.in_trial = in_trial
+
+
+class Account:
+    def __init__(
+        self,
+        id: str,
+        name: str = None,
+        type: str = None,
+        role: str = None,
+        token: str = None,
+        hasChannelStoreAccess: bool = False,
+    ):
+        self.id = id
+        self.name = name
+        self.type = type
+        self.role = role
+        self.token = token
+        self.hasChannelStoreAccess = hasChannelStoreAccess
+
+
+class User:
+    def __init__(
+        self,
+        id: str,
+        name: str,
+        display_name: str,
+        email: str,
+        last_login_at: str,
+        first_login_at: str,
+        verified: bool,
+    ):
+        self.first_login_at = first_login_at
+        self.last_login_at = last_login_at
+        self.email = email
+        self.id = id
+        self.name = name
+        self.display_name = display_name
+        self.verified = verified
+        self.user_role_on_account = None
+
+    def set_user_role_on_account(self, user_role_on_account):
+        self.user_role_on_account = user_role_on_account
+
+
+@dataclass
+class AnnotatedContractItem:
+    id: int
+    account_id: str
+    role: str
+    support_level: str
+    product_id: str
+    product_name: str
+    type: str
+    start_date: str
+    number_of_machines: int
+    number_of_active_machines: int
+    current_number_of_machines: int
+    marketplace: str
+    price: int
+    currency: str
+    entitlements: List[Entitlement]
+    contract_id: str = None
+    subscription_id: str = None
+    offer_id: str = None
+    end_date: str = None
+    period: str = None
+    renewal_id: str = None
+    listing_id: str = None
+    token: str = None
+    is_expiring: bool = False
+    is_expired: bool = False
+    should_present_auto_renewal: bool = False
+    in_grace_period: bool = False
+    is_upsizeable: bool = False
+    is_downsizeable: bool = False
+    is_subscription_active: bool = False
+    is_subscription_auto_renewing: bool = False
+    is_renewable: bool = False
+    is_renewal_actionable: bool = False

--- a/webapp/shop/api/cue_contracts/schema.py
+++ b/webapp/shop/api/cue_contracts/schema.py
@@ -1,0 +1,286 @@
+import typing
+from marshmallow import Schema, post_load, validate, EXCLUDE
+from marshmallow.fields import (
+    Function,
+    String,
+    Integer,
+    Nested,
+    List,
+    Boolean,
+)
+
+from webapp.shop.api.cue_contracts.models import (
+    Entitlement,
+    Purchase,
+    PurchaseItem,
+    Invoice,
+)
+from webapp.shop.api.cue_contracts.primitives import (
+    Account,
+    AnnotatedContractItem,
+)
+
+
+class BaseSchema(Schema):
+    class Meta:
+        unknown = EXCLUDE
+
+
+class InvoiceItemSchema(BaseSchema):
+    currency = String()
+    description = String()
+    proRatedAmount = Integer(attribute="pro_rated_amount")
+    quantity = Integer()
+
+
+class PaymentStatusSchema(BaseSchema):
+    status = String()
+    lastPaymentError = String(attribute="error")
+    piClientSecret = String(attribute="pi_client_secret")
+
+
+class InvoiceSchema(BaseSchema):
+    id = Function(deserialize=(lambda id: id.get("IDs")[0]))
+    reason = String(required=True)
+    status = String(required=True)
+    url = String()
+    currency = String(required=True)
+    total = Integer()
+    taxAmount = Integer(attribute="tax_amount")
+    subscriptionStartOfCycle = String(attribute="start_of_cycle")
+    subscriptionEndOfCycle = String(attribute="end_of_cycle")
+    paymentStatus = Nested(PaymentStatusSchema, attribute="payment_status")
+    lineItems = List(Nested(InvoiceItemSchema), attribute="items")
+
+    @post_load
+    def make_invoice(self, data, **kwargs) -> Invoice:
+        return Invoice(**data)
+
+
+class PurchaseItemSchema(BaseSchema):
+    productListingID = String(required=True, attribute="listing_id")
+    value = Integer(required=True)
+
+    @post_load
+    def make_purchase_item(self, data, **kwargs) -> PurchaseItem:
+        return PurchaseItem(**data)
+
+
+class CouponSchema(BaseSchema):
+    origin = String(attribute="origin")
+    IDs = List(String(), attribute="IDs")
+
+
+class PurchaseSchema(BaseSchema):
+    accountID = String(required=True, attribute="account_id")
+    id = String(required=True)
+    createdAt = String(required=True, attribute="created_at")
+    status = String(required=True)
+    subscriptionID = String(attribute="subscription_id")
+    invoice = Nested(InvoiceSchema)
+    purchaseItems = List(
+        Nested(PurchaseItemSchema), required=True, attribute="items"
+    )
+    marketplace = String(
+        validate=validate.OneOf(
+            [
+                "canonical-ua",
+                "canonical-cube",
+                "blender",
+                "canonical-pro-channel",
+            ]
+        ),
+        required=True,
+    )
+    coupon = Nested(CouponSchema)
+
+    @post_load
+    def make_purchase(self, data, **kwargs) -> Purchase:
+        return Purchase(**data)
+
+
+class AccountSchema(BaseSchema):
+    id = String(required=True, attribute="id")
+    name = String(required=True)
+    type = String(required=True)
+    userRoleOnAccount = String(required=True, attribute="role")
+    hasChannelStoreAccess = Boolean(required=True)
+
+    @post_load
+    def make_purchase(self, data, **kwargs) -> Account:
+        return Account(**data)
+
+
+class EnsurePurchaseAccountSchema(BaseSchema):
+    accountID = String(required=True, attribute="id")
+    token = String()
+
+    @post_load
+    def make_purchase(self, data, **kwargs) -> Account:
+        return Account(**data)
+
+
+class EntitlementSchema(BaseSchema):
+    type = String(data_key="resource", required=True)
+    enabled_by_default = Boolean(data_key="enabledByDefault", required=True)
+
+    @post_load
+    def preprocess(self, data, **kwargs) -> Entitlement:
+        return Entitlement(**data)
+
+
+class AnnotatedContractItemsSchema(BaseSchema):
+    id = Function(required=True)
+    account_id = Function(
+        deserialize=(lambda v: v.get("accountID")),
+        data_key="accountContext",
+        required=True,
+    )
+    role = Function(
+        deserialize=(lambda v: v.get("role")),
+        data_key="accountContext",
+        required=True,
+    )
+    product_name = Function(
+        deserialize=(lambda v: v.get("name")),
+        data_key="contractContext",
+        required=True,
+    )
+    type = Function(
+        deserialize=(lambda v: v.get("presentationHint")),
+        data_key="ubuntuProContext",
+        missing="",
+    )
+    start_date = String(
+        required=True,
+        data_key="effectiveFrom",
+    )
+    end_date = String(
+        required=True,
+        data_key="effectiveTo",
+    )
+    number_of_machines = Integer(
+        required=True,
+        data_key="value",
+    )
+    marketplace = Function(
+        deserialize=(lambda v: v["listing"]["marketplace"]),
+        data_key="purchaseContext",
+        missing="canonical-ua",
+    )
+    current_number_of_machines = Function(
+        deserialize=(lambda v: v.get("nextCycleQuantity", 0)),
+        data_key="subscriptionItemContext",
+        missing=0,
+    )
+    number_of_active_machines = Function(
+        deserialize=(lambda v: v.get("activeMachines", 0)),
+        data_key="contractContext",
+        missing=0,
+    )
+    product_id = Function(
+        deserialize=(lambda v: v["products"][0]),
+        data_key="contractContext",
+    )
+    period = Function(
+        deserialize=(lambda v: v["listing"]["period"]),
+        data_key="purchaseContext",
+    )
+    price = Function(
+        deserialize=(lambda v: v["recurringCost"]),
+        data_key="subscriptionItemContext",
+        missing=0,
+    )
+    currency = Function(
+        deserialize=(lambda v: v["recurringCostCurrency"]),
+        data_key="subscriptionItemContext",
+        missing="USD",
+    )
+    token = Function(
+        deserialize=(lambda v: v["token"]),
+        data_key="ubuntuProContext",
+        missing="",
+    )
+    subscription_id = Function(
+        deserialize=(lambda v: v["purchase"].get("subscriptionID")),
+        data_key="purchaseContext",
+        missing="",
+    )
+    offer_id = Function(
+        deserialize=(lambda v: v["purchase"].get("offerID")),
+        data_key="purchaseContext",
+        missing="",
+    )
+    renewal_id = Function(
+        deserialize=(lambda v: v.get("id", "")),
+        data_key="renewalContext",
+        missing="",
+    )
+    listing_id = Function(
+        deserialize=(lambda v: v["listing"]["id"]),
+        data_key="purchaseContext",
+        missing="",
+    )
+    contract_id = String(required=True, data_key="contractID")
+    support_level = Function(
+        deserialize=(lambda v: v.get("supportLevel", "")),
+        data_key="ubuntuProContext",
+        missing="",
+    )
+    entitlements = Function(
+        deserialize=(lambda v: v.get("entitlements", [])),
+        data_key="ubuntuProContext",
+        missing=[],
+    )
+    is_expiring = Function(
+        deserialize=(lambda v: v.get("isExpiring")),
+        data_key="subscriptionContext",
+        missing=False,
+    )
+    is_expired = Function(data_key="expired")
+    in_grace_period = Function(data_key="inGracePeriod")
+    should_present_auto_renewal = Function(
+        deserialize=(lambda v: v.get("shouldAllowAutoRenewalToggle")),
+        data_key="subscriptionContext",
+        missing=False,
+    )
+    is_subscription_active = Function(
+        deserialize=(lambda v: v.get("isActive")),
+        data_key="subscriptionContext",
+        missing=False,
+    )
+    is_upsizeable = Function(
+        deserialize=(lambda v: v.get("canDownsell")),
+        data_key="subscriptionItemContext",
+        missing=False,
+    )
+    is_downsizeable = Function(
+        deserialize=(lambda v: v.get("canUpsell")),
+        data_key="subscriptionItemContext",
+        missing=False,
+    )
+    is_subscription_auto_renewing = Function(
+        deserialize=(lambda v: v.get("willAttemptAutoRenewal")),
+        data_key="subscriptionContext",
+        missing=False,
+    )
+    is_renewal_actionable = Function(
+        deserialize=(lambda v: (v.get("action") == "purchase_manual_renewal")),
+        data_key="renewalContext",
+        missing=False,
+    )
+    is_renewable = Function(
+        deserialize=(lambda v: v.get("status") == "action_needed"),
+        data_key="renewalContext",
+        missing=False,
+    )
+
+    @post_load
+    def preprocess(self, data, **kwargs) -> typing.List[AnnotatedContractItem]:
+        if data["entitlements"]:
+            entitlements = EntitlementSchema(many=True).load(
+                data["entitlements"]
+            )
+            data["entitlements"] = entitlements
+
+        return AnnotatedContractItem(**data)

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -168,7 +168,7 @@ def account_query():
 
     return flask.jsonify(
         {
-            "account": user_info(flask.session),
+            "account": user_info(flask.session, allow_any_token=True),
         }
     )
 


### PR DESCRIPTION
## Done

[Ubuntu.com](http://ubuntu.com/) needs to integrate with the new cue backend. Right now we are using ua-contracts as our backend for authentication but now two backends will be used simultaneously. 

1. `cue-contracts`
2. `ua-contracts`

All the views related to cred will use the cue-contracts backend and will require an SSO login in order to be ungated. Same goes for the views that use ua-contracts

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes

- [ ] Go to `/credentials/shop` and login (should log in)
- [ ] Open account dropdown and click _Invoices & Payments_ (only the invoices created after signing in should show)
- [ ] Navigate to `/desktop` and again click _Invoices & Payments_ (the invoices created in cred should not show, keep in mind that older cred invoices created prior to the new backend will still show)
- [ ] Logout (should log you out of both backends

## Issue / Card

Fixes [WD-21501](https://warthogs.atlassian.net/browse/WD-21501)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-21501]: https://warthogs.atlassian.net/browse/WD-21501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ