### PR TITLE
Fix download link

### DIFF
--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -201,7 +201,7 @@
             </div>
             <div class="col-3">
               <a class="p-button--positive"
-                 href="/download/desktop/thank-you?version={{ releases.lts.full_version }}&amp;architecture=amd64"
+                 href="/download/desktop/thank-you?version={{ releases.latest.full_version }}&amp;architecture=amd64"
                  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });"
                  aria-label="Download Ubuntu 25.04 amd64"
                  >Download


### PR DESCRIPTION
## Done

- Fix download link version

## QA

- View the site locally in your web browser at: https://ubuntu-com-15011.demos.haus/download/desktop
  - Click on the amd version of 25.04 and see that the correct version is download

## Issue / Card

Fixes #15010