### PR TITLE
WD-21518: check if user is banned on your-exams page

### DIFF
--- a/templates/credentials/your-exams.html
+++ b/templates/credentials/your-exams.html
@@ -13,6 +13,21 @@
 
 {% block content %}
 
+  {% if is_banned %}
+    <div class="row--50-50">
+      <div class="p-strip is-shallow">
+        <div class="p-notification--negative">
+          <div class="p-notification__content">
+            <h5 class="p-notification__title">Error</h5>
+            <p class="p-notification__message" id="error-message">
+              User is banned from Canonical credentialing exams. See our <a href="/credentials/faq">FAQ</a> and <a href="/legal/terms-and-policies/credentials-terms">Terms of Service</a> for details.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  {% endif %}
   <section class="p-suru--50-50">
     <div class="row--50-50">
       <div class="col">

--- a/templates/credentials/your-exams.html
+++ b/templates/credentials/your-exams.html
@@ -26,7 +26,6 @@
         </div>
       </div>
     </div>
-
   {% endif %}
   <section class="p-suru--50-50">
     <div class="row--50-50">

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 import math
 import pytz
 import flask
+from flask.wrappers import Response
 import json
 import os
 import html
@@ -845,8 +846,13 @@ def cred_your_exams(
             cred_maintenance_start=cred_maintenance_start,
             cred_maintenance_end=cred_maintenance_end,
         )
+    cue_products = get_cue_products(type="exam").get_json()
+    productListingID = None
+    if cue_products and len(cue_products) > 0:
+        productListingID = cue_products[0]["longId"]
+    else:
+        flask.abort(404)
 
-    productListingID = "lAG3hRoBLFZc_sbY7KKmsmGzGVYgkmSHtO_xaN1_D82I"
     purchase_request = {
         "accountID": account.id,
         "purchaseItems": [

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -3,7 +3,6 @@ from datetime import datetime, timedelta
 import math
 import pytz
 import flask
-from flask.wrappers import Response
 import json
 import os
 import html

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -981,9 +981,11 @@ def cred_your_exams(
                     ) and not is_banned:
                         proctor_link = None
                         if is_staging:
-                            student_session = proctor_api.get_student_sessions({
+                            student_session = proctor_api.get_student_sessions(
+                                {
                                     "ext_exam_id": r["uuid"],
-                                })
+                                }
+                            )
                             if student_session is not None:
                                 student_session_array = student_session.get(
                                     "data", [{}]


### PR DESCRIPTION
## Done

- Check if user is banned by calling preview purchase API on your-exams page

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Ban a user and make sure they do not see action buttons on your-exams page and an error message

## Issue / Card

Fixes [WD-21518](https://warthogs.atlassian.net/browse/WD-21518)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-21518]: https://warthogs.atlassian.net/browse/WD-21518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ