### PR TITLE
[WD-21541] fix: Kubernetes LTS release chart showing incorrect color order

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -1067,13 +1067,13 @@ export var kubernetesReleasesLTS = [
   {
     startDate: new Date("2024-12-01T00:00:00"),
     endDate: new Date("2034-12-01T00:00:00"),
-    taskName: "Kubernetes 1.32x LTS",
+    taskName: "Kubernetes 1.32.x LTS",
     status: "CANONICAL_KUBERNETES_SUPPORT",
   },
   {
     startDate: new Date("2034-12-01T00:00:00"),
     endDate: new Date("2036-12-01T00:00:00"),
-    taskName: "Kubernetes 1.32x LTS",
+    taskName: "Kubernetes 1.32.x LTS",
     status: "CANONICAL_KUBERNETES_EXPANDED_SECURITY_MAINTENANCE",
   },
 ];


### PR DESCRIPTION
## Done

- Fixed the release name

## QA

- View the site in your web browser at: https://ubuntu-com-15018.demos.haus/about/release-cycle#canonical-kubernetes-release-cycle
- Verify the chart is correct.

## Issue / Card

Fixes #[WD-21541](https://warthogs.atlassian.net/browse/WD-21541)

## Screenshots

Before
![image](https://github.com/user-attachments/assets/631c1e70-e87e-4783-8bf2-85e82cdf485c)

After
![image](https://github.com/user-attachments/assets/4c4b93be-bb07-4947-addd-10ea34329722)




## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-21541]: https://warthogs.atlassian.net/browse/WD-21541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ