### PR TITLE
chore: update k8s LTS support timelines

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -1066,15 +1066,21 @@ export var kubernetesReleases = [
 export var kubernetesReleasesLTS = [
   {
     startDate: new Date("2024-12-01T00:00:00"),
-    endDate: new Date("2034-12-01T00:00:00"),
+    endDate: new Date("2025-12-01T00:00:00"),
     taskName: "Kubernetes 1.32.x LTS",
     status: "CANONICAL_KUBERNETES_SUPPORT",
+  },
+  {
+    startDate: new Date("2025-12-01T00:00:00"),
+    endDate: new Date("2034-12-01T00:00:00"),
+    taskName: "Kubernetes 1.32.x LTS",
+    status: "CANONICAL_KUBERNETES_EXPANDED_SECURITY_MAINTENANCE",
   },
   {
     startDate: new Date("2034-12-01T00:00:00"),
     endDate: new Date("2036-12-01T00:00:00"),
     taskName: "Kubernetes 1.32.x LTS",
-    status: "CANONICAL_KUBERNETES_EXPANDED_SECURITY_MAINTENANCE",
+    status: "CANONICAL_KUBERNETES_LEGACY_SUPPORT",
   },
 ];
 
@@ -1212,6 +1218,12 @@ export var openStackStatus = {
 export var kubernetesStatus = {
   CANONICAL_KUBERNETES_SUPPORT: "chart__bar--black",
   CANONICAL_KUBERNETES_EXPANDED_SECURITY_MAINTENANCE: "chart__bar--aubergine",
+};
+
+export var kubernetesStatusLTS = {
+  CANONICAL_KUBERNETES_SUPPORT: "chart__bar--black",
+  CANONICAL_KUBERNETES_EXPANDED_SECURITY_MAINTENANCE: "chart__bar--aubergine",
+  CANONICAL_KUBERNETES_LEGACY_SUPPORT: "chart__bar--orange",
 };
 
 export var microStackStatus = {

--- a/static/js/src/release-chart-manager.js
+++ b/static/js/src/release-chart-manager.js
@@ -23,6 +23,7 @@ import {
   kernelStatusALL,
   openStackStatus,
   kubernetesStatus,
+  kubernetesStatusLTS,
   microStackStatus,
   desktopServerReleaseNames,
   kernelReleaseNames,
@@ -160,7 +161,7 @@ function buildCharts() {
     createReleaseChartOld(
       "#kubernetes-lts",
       kubernetesReleaseNamesLTS,
-      kubernetesStatus,
+      kubernetesStatusLTS,
       kubernetesReleasesLTS,
     );
   }

--- a/static/js/src/release-chart-old.js
+++ b/static/js/src/release-chart-old.js
@@ -382,6 +382,8 @@ function formatLabel(label, isTooltip = false) {
       return "Expanded Security Maintenance (ESM)";
     case "pro_support":
       return "Ubuntu Pro + Support coverage";
+    case "canonical_kubernetes_legacy_support":
+      return "Canonical Kubernetes Legacy Support";
 
     default:
       return null;


### PR DESCRIPTION
## Done

- Updated k8s LTS support charts

## QA

- View the site in your web browser at: https://ubuntu-com-15020.demos.haus/about/release-cycle#canonical-kubernetes-release-cycle
- Verify the chart is correct and up-to-date with this [discussion](https://chat.canonical.com/canonical/pl/8h6pi6tt4bgkux7oeq4qfe7a6h) and this [copydoc](https://docs.google.com/document/d/1-l3B7AoyDoETaL80UhlfEWCVKmMWPdy3zoF5LpsGcYQ/edit?tab=t.0)

Quote: 
> It should be one year for the black line, and 9 years for the red line, and then we can add the legacy support with 2 years

## Screenshots

![image](https://github.com/user-attachments/assets/4ddd15d3-f302-4281-b211-8ec8b05a3cab)



## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
