### PR TITLE
feat: Link and copy update for pro/free-trial

### DIFF
--- a/templates/pro/free-trial.html
+++ b/templates/pro/free-trial.html
@@ -56,7 +56,7 @@ meta_copydoc %}
         </p>
       {%- endif -%}
       {%- if slot == 'cta' -%}
-        <a href="/pro" class="p-button--positive">Discover Ubuntu Pro</a>
+        <a href="/pro/subscribe" class="p-button--positive">Try Ubuntu Pro now</a>
       {%- endif -%}
       {%- if slot == 'image' -%}
         {{ image(url="https://assets.ubuntu.com/v1/dcae3633-hero-image.jpg",


### PR DESCRIPTION
## Done

- feat: Link and copy update for pro/free-trial

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- check the page at https://ubuntu-com-15021.demos.haus/pro/free-trial for the new CTA label and link target

## Issue / Card

Fixes [WD-21538](https://warthogs.atlassian.net/browse/WD-21538?linkSource=email)
[Copy doc](https://docs.google.com/document/d/1USgQJcUKNz3iZYeNVeICVqGz879rlG5ztEtVxPWm8bc/edit?tab=t.0)

## Screenshots

![image](https://github.com/user-attachments/assets/dd7f71ce-5cd5-44d5-8fe8-fcc129b3637b)

[WD-21538]: https://warthogs.atlassian.net/browse/WD-21538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ