### PR TITLE
Copy update on /download/iot/intel-iot

### DIFF
--- a/templates/download/iot/intel-iot.html
+++ b/templates/download/iot/intel-iot.html
@@ -170,17 +170,6 @@
           </li>
           <li>
             <button class="p-tabs__item"
-                    id="core-ultra-2"
-                    role="tab"
-                    aria-selected="true"
-                    aria-controls="core-ultra-2-tab">
-              Intel&reg; Core&trade; Ultra (Series 2)
-              <br />
-              <span class="u-text--muted u-no-margin--bottom">Arrow Lake</span>
-            </button>
-          </li>
-          <li>
-            <button class="p-tabs__item"
                     id="core-ultra"
                     role="tab"
                     aria-selected="true"
@@ -260,7 +249,6 @@
         <form class="u-hide--large u-hide--medium">
           <select name="boardSelect" id="boardSelect">
             <option value="atom-x7000-tab" selected="">Intel&reg; Atom&reg; Processor X7000 Series (Amston Lake)</option>
-            <option value="core-ultra-2-tab" selected="">Intel&reg; Core&trade; Ultra (Series 2) (Arrow Lake)</option>
             <option value="core-ultra-tab" selected="">Intel&reg; Core&trade; Ultra (Meteor Lake, Meteor Lake PS)</option>
             <option value="atom-tab">Intel&reg; Atom&reg; X7000E Series (Alder Lake N)</option>
             <option value="thirteen-gen-tab">13th Gen Intel&reg; Core&trade; (Raptor Lake, Raptor Lake PS)</option>
@@ -293,102 +281,6 @@
             <br />
             <a href="https://www.intel.com/content/www/us/en/content-details/820013/intel-atom-processors-x7000c-series-for-networking-product-brief.html?DocID=820013">Read
             about the x7000C Series for Networking&nbsp;&rsaquo;</a>
-          </div>
-          <hr class="p-rule--muted u-hide--medium u-hide--small" />
-          <div class="p-equal-height-row">
-            <div class="p-equal-height-row__col">
-              <div class="p-equal-height-row__item">
-                <h4 class="p-heading--5">Ubuntu Core</h4>
-              </div>
-              <div class="p-equal-height-row__item">
-                <p>Immutable Linux OS optimized for IoT and edge embedded systems.</p>
-                <p>
-                  <a class="p-button--positive"
-                     href="/download/core"
-                     aria-label="Download Ubuntu Desktop Core 24">Download
-                  Core 24</a>
-                </p>
-                <hr class="p-rule--muted u-hide--medium u-hide--small" />
-                <ul class="u-responsive-realign p-inline-list">
-                  <li class="p-inline-list__item">
-                    <a aria-label="Docs for Ubuntu Core"
-                       href="/core/docs/uc24">Docs&nbsp;&rsaquo;</a>
-                  </li>
-                </ul>
-              </div>
-            </div>
-            <div class="p-equal-height-row__col">
-              <div class="p-equal-height-row__item">
-                <h4 class="p-heading--5">Ubuntu Desktop</h4>
-              </div>
-              <div class="p-equal-height-row__item">
-                <p>Modern and performant, with a rich ecosystem of applications.</p>
-                <p>
-                  <a class="p-button--positive"
-                     href="/download/desktop"
-                     aria-label="Download Ubuntu Desktop 24.04 LTS">Download
-                  24.04 LTS</a>
-                </p>
-                <hr class="p-rule--muted u-hide--medium u-hide--small" />
-                <ul class="u-responsive-realign p-inline-list">
-                  <li class="p-inline-list__item">
-                    <a aria-label="Learn more about Ubuntu Desktop"
-                       href="/desktop/developers">Learn
-                    more&nbsp;&rsaquo;</a>
-                  </li>
-                  <li class="p-inline-list__item">
-                    <a href="https://discourse.ubuntu.com/t/ubuntu-24-04-lts-noble-numbat-release-notes/39890">Release notes for 24.04 LTS&nbsp;&rsaquo;</a>
-                  </li>
-                </ul>
-              </div>
-            </div>
-            <div class="p-equal-height-row__col">
-              <div class="p-equal-height-row__item">
-                <h4 class="p-heading--5">Ubuntu Server</h4>
-              </div>
-              <div class="p-equal-height-row__item">
-                <p>Designed and engineered as a backbone for the internet</p>
-                <p>
-                  <a class="p-button--positive"
-                     href="/download/server"
-                     aria-label="Download Ubuntu Server 24.04 LTS">Download
-                  24.04 LTS</a>
-                </p>
-                <hr class="p-rule--muted u-hide--medium u-hide--small" />
-                <ul class="u-responsive-realign p-inline-list">
-                  <li class="p-inline-list__item">
-                    <a aria-label="Docs for Ubuntu Server" href="/server/docs">Docs&nbsp;&rsaquo;</a>
-                  </li>
-                  <li class="p-inline-list__item">
-                    <a href="https://discourse.ubuntu.com/t/ubuntu-24-04-lts-noble-numbat-release-notes/39890">Release
-                      notes for
-                    24.04 LTS&nbsp;&rsaquo;</a>
-                  </li>
-                </ul>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div tabindex="0"
-             role="tabpanel"
-             id="core-ultra-2-tab"
-             aria-labelledby="core-ultra-2"
-             aria-hidden="true">
-          <div class="p-section--shallow">
-            <h3 class="p-heading--2">Intel&reg; Core&trade; Ultra (Series 2)</h3>
-          </div>
-          <hr class="p-rule--muted u-hide--medium u-hide--small" />
-          <div class="col">
-            <p>
-              Intel&reg; Core&trade; Ultra desktop processors (series 2) are the ultimate desktop and entry workstation 
-              platform, engineered to unlock new levels of intelligent performance for the most demanding daily tasks.
-            </p>
-            <a
-              href="https://www.intel.com/content/www/us/en/content-details/843357/intel-core-ultra-200u-and-200h-series-processors-for-the-edge.html?DocID=843357"
-              aria-label="Read the platform brief for Core Ultra Edge Series"
-            >
-              Read the platform brief&nbsp;&rsaquo;
-            </a>
           </div>
           <hr class="p-rule--muted u-hide--medium u-hide--small" />
           <div class="p-equal-height-row">


### PR DESCRIPTION
## Done

- Copy update on `/download/iot/intel-iot` or https://ubuntu-com-15025.demos.haus/download/iot/intel-iot
- Removed Intel core ultra (series 2) 


## QA

- Compare page against [copy doc](https://docs.google.com/document/d/1hxKzPs6e6JQaa9tBqfZ55GAXrVnEryEWBja8HlXy-lc/edit?tab=t.0#heading=h.6fd05dg360az)

## Issue / Card

Fixes #https://warthogs.atlassian.net/browse/WD-21551
