### PR TITLE
feat: redesigned the confidential computing page

### DIFF
--- a/templates/confidential-computing/index.html
+++ b/templates/confidential-computing/index.html
@@ -18,22 +18,21 @@
 {% block content %}
 
   <div class="is-paper">
-    <section class="p-strip u-no-padding--top">
-      {% call(slot) vf_hero(
-          title_text='Ubuntu for confidential compute',
-          subtitle_text='Protect your data in use, across public and private clouds.',
-          layout='50/50'
-        ) -%}
-        {%- if slot == 'cta' -%}
-          <a href="/contact-us">Contact us to learn more ›</a>
-        {%- endif -%}
-        {%- if slot == 'image' -%}
-          <div class="p-image-container--3-2 is-cover">
-            <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/cf1e2ddb-datacenter-wide-crop.jpeg" alt="">
-          </div>
-        {%- endif -%}
-      {% endcall -%}
-    </section>
+    {% call(slot) vf_hero(
+        title_text='Ubuntu <br/>for confidential compute',
+        subtitle_text='Protect your data in use,<br/> across public and private clouds.',
+        layout='50/50'
+      ) -%}
+      {%- if slot == 'cta' -%}
+        <a href="/contact-us">Contact us to learn more ›</a>
+      {%- endif -%}
+      {%- if slot == 'image' -%}
+        <div class="p-image-container--3-2 is-cover">
+          <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/cf1e2ddb-datacenter-wide-crop.jpeg" alt="">
+        </div>
+      {%- endif -%}
+    {% endcall -%}
+
 
     <section class="p-strip u-no-padding--top">
       <hr class="p-rule--muted is-fixed-width" />
@@ -57,7 +56,7 @@
       <hr class="p-rule--muted is-fixed-width" />
       <div class="row--50-50">
         <div class="col">
-          <h2>Benefits of Ubuntu for confidential computing</h2>
+          <h2>Benefits of Ubuntu<br/> for confidential computing</h2>
         </div>
         <div class="col">
           <ul class="p-list--divided">
@@ -69,31 +68,38 @@
       </div>
     </section>
 
-    <section class="p-section">
+    <section class="p-section is-shallow">
       <hr class="p-rule--muted is-fixed-width" />
-      <div class="row--50-50">
+
+      <div class="row--50-50 u-sv3">
         <div class="col">
           <h2>Intel TDX is available on Ubuntu for both the host and guest</h2>
         </div>
         <div class="col u-sv3">
-          <p>
-            Ubuntu now supports Intel’s latest confidential computing technology. This hardware-based trusted execution environment enables you to add an extra layer of protection to the code and data running within your confidential virtual machines.
-          </p>
-          <div class="p-image__background--3-2 u-align--center u-vertically-center">
-            {{ image(url="https://assets.ubuntu.com/v1/db3fddbb-intel-tdx-is.png",
-              alt="Diagram showing that Ubuntu builds cater to both the host and guest sides, empowering users to launch a confidential TDX virtual machine seamlessly",
-              width="1200",
-              height="1140",
-              hi_def=True,
-              loading="auto|lazy"
-              ) | safe
-            }}
+          <div class="row p-section--shallow">
+            <p>
+              Ubuntu now supports Intel’s latest confidential computing technology. This hardware-based trusted execution environment enables you to add an extra layer of protection to the code and data running within your confidential virtual machines.
+            </p>
+          </div>
+
+          <div class="row">
+            <div class="p-image__background--3-2 u-align--center u-vertically-center">
+              {{ image(url="https://assets.ubuntu.com/v1/db3fddbb-intel-tdx-is.png",
+                alt="Diagram showing that Ubuntu builds cater to both the host and guest sides, empowering users to launch a confidential TDX virtual machine seamlessly",
+                width="1200",
+                height="1140",
+                hi_def=True,
+                loading="auto|lazy"
+                ) | safe
+              }}
+            </div>
           </div>
         </div>
       </div>
+
       <div class="row">
         <div class="col-9 col-start-large-4 col-medium-3 col-start-medium-4">
-          <ol class="p-stepped-list--detailed">
+          <ol class="p-stepped-list--detailed u-no-margin--bottom">
             <li class="p-stepped-list__item">
               <div class="row">
                 <div class="col-3 col-medium-3">
@@ -168,25 +174,20 @@
             </div>
           </div>
           <div class="row">
-            <div class="col-3 col-medium-3">
-              <h3 class="p-heading-icon__title p-heading--5">1. Isolation</h3>
-            </div>
-            <div class="col-6 col-medium-3">
-              <p>
-                Confidential computing capable CPUs are equipped with an AES hardware memory encryption engine, which encrypts data when it is written to system memory, and decrypts it when read. The encryption key itself is stored in the hardware root of trust and is never exposed to the platform’s system software.
-              </p>
-            </div>
-          </div>
-          <hr class="p-rule--muted" />
-          <div class="row">
-            <div class="col-3 col-medium-3">
-              <h3 class="p-heading-icon__title p-heading--5">2. Remote attestation</h3>
-            </div>
-            <div class="col-6 col-medium-3">
-              <p>
-                When a confidential VM is launched, its integrity is verified and its initial code and data are measured by a hardware root of trust. This ensures they have not been tampered with. The measurement is cryptographically signed and can be attested to a remote verifier
-              </p>
-            </div>
+            <ol class="p-list--divided">
+              <li class="p-list__item p-heading-icon__title p-heading--5">Isolation</li>
+              <div class="col-6 col-medium-3 u-sv3">
+                <p>
+                  Confidential computing capable CPUs are equipped with an AES hardware memory encryption engine, which encrypts data when it is written to system memory, and decrypts it when read. The encryption key itself is stored in the hardware root of trust and is never exposed to the platform’s system software.
+                </p>
+              </div>
+              <li class="p-list__item p-heading-icon__title p-heading--5">Remote attestation</li>
+              <div class="col-6 col-medium-3">
+                <p>
+                  When a confidential VM is launched, its integrity is verified and its initial code and data are measured by a hardware root of trust. This ensures they have not been tampered with. The measurement is cryptographically signed and can be attested to a remote verifier
+                </p>
+              </div>
+            </ol>
           </div>
         </div>
       </div>
@@ -198,7 +199,7 @@
         <div class="col-12 u-sv3">
           <h2>Launch enterprise-grade confidential VMs on all major public clouds</h2>
         </div>
-        <div class="col-8 col-start-large-6 col-start-medium-2">
+        <div class="col-10 col-start-large-4 col-start-medium-2">
           <hr class="p-rule--muted" />
           <div class="row">
             <div class="col-2 col-medium-3 col-small-2 u-pad-logo">
@@ -213,7 +214,7 @@
                 }}
               </p>
             </div>
-            <div class="col-6 col-medium-3 col-small-2">
+            <div class="col-8 col-medium-6 col-small-2">
               <ul class="p-list--divided u-no-margin--bottom">
                 <li class="p-list__item">
                   <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.ubuntu-24_04-lts?tab=Overview">Ubuntu 24.04 confidential VMs on Azure</a>
@@ -243,7 +244,7 @@
                 }}
               </p>
             </div>
-            <div class="col-6 col-medium-3 col-small-2">
+            <div class="col-6 col-medium-6 col-small-2">
               <p>
                 <a href="https://canonical.com/blog/start-your-ubuntu-confidential-vm-with-intel-tdx-on-google-cloud">AMD SEV SNP with Ubuntu 22.04 LTS on Google Cloud</a>
               </p>
@@ -262,7 +263,7 @@
                 }}
               </p>
             </div>
-            <div class="col-6 col-medium-3 col-small-2">
+            <div class="col-6 col-medium-6 col-small-2">
               <p>
                 <a href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/sev-snp.html">AMD SEV SNP with Ubuntu 23.10 on AWS</a>
               </p>
@@ -279,7 +280,7 @@
           <h2>How to map security primitives to attacker capabilities</h2>
         </div>
         <div class="col">
-          <div class="u-align--center u-vertically-center u-hide--small">
+          <div class="row p-image-container is-highlighted">
           {{ image(url="https://assets.ubuntu.com/v1/d8d1c7c8-how-to-map.png",
             alt="How to map security primitives to attacker capabilities",
             width="1200",
@@ -288,9 +289,11 @@
             loading="auto|lazy") | safe
           }}
           </div>
-          <p>
-            Uncover the details of Ubuntu’s security solutions and learn how to tailor them to your environment. Equip yourself with the tools to protect your data and stay one step ahead of evolving threats.
-          </p>
+          <div class="row">
+            <p>
+              Uncover the details of Ubuntu’s security solutions and learn how to tailor them to your environment. Equip yourself with the tools to protect your data and stay one step ahead of evolving threats.
+            </p>
+          </div>
           <div class="row">
             <hr class="p-rule--muted" />
             <p>
@@ -323,7 +326,7 @@
       <hr class="p-rule--muted is-fixed-width" />
       <div class="row--50-50 u-sv3">
         <div class="col">
-          <h2>A solid foundation of your zero trust strategy</h2>
+          <h2>A solid foundation of your<br/> zero trust strategy</h2>
         </div>
         <div class="col">
           <p>
@@ -376,7 +379,7 @@
     <section class="p-strip is-deep u-no-padding--top">
       <div class="row--50-50">
         <div class="col">
-          <h2>Learn more about confidential computing</h2>
+          <h2>Learn more about<br/> confidential computing</h2>
         </div>
         <div class="col">
           <ul class="p-list--divided u-no-margin--bottom">
@@ -396,6 +399,7 @@
       </div>
     </section>
     <section class="p-strip is-deep">
+      <hr class="p-rule--muted is-fixed-width" />
       <div class="row">
         <div class="col-12">
           <p class="p-heading--2">

--- a/templates/confidential-computing/index.html
+++ b/templates/confidential-computing/index.html
@@ -35,7 +35,7 @@
 
 
     <section class="p-strip u-no-padding--top">
-      <hr class="p-rule--muted is-fixed-width" />
+      <hr class="p-rule is-fixed-width" />
       <div class="row--50-50">
         <div class="col">
           <h2>What is confidential computing?</h2>
@@ -53,7 +53,7 @@
     </section>
 
     <section class="p-section">
-      <hr class="p-rule--muted is-fixed-width" />
+      <hr class="p-rule is-fixed-width" />
       <div class="row--50-50">
         <div class="col">
           <h2>Benefits of Ubuntu<br/> for confidential computing</h2>
@@ -150,7 +150,7 @@
     </section>
 
     <section class="p-section">
-      <hr class="p-rule--muted is-fixed-width" />
+      <hr class="p-rule is-fixed-width" />
       <div class="row--50-50">
         <div class="col">
           <h2>How confidential VMs work</h2>
@@ -194,7 +194,7 @@
     </section>
 
     <section class="p-strip u-no-padding--top">
-      <hr class="p-rule--muted is-fixed-width" />
+      <hr class="p-rule is-fixed-width" />
       <div class="row">
         <div class="col-12 u-sv3">
           <h2>Launch enterprise-grade confidential VMs on all major public clouds</h2>
@@ -236,7 +236,7 @@
           <div class="row">
             <div class="col-2 col-medium-3 col-small-2 u-pad-logo">
               <p class="u-no-margin--bottom">
-                {{ image(url="https://assets.ubuntu.com/v1/2c479064-cloud-logo%201.svg",
+                {{ image(url="https://assets.ubuntu.com/v1/786c39f9-Google_Cloud_logo.svg",
                                 alt="Google Cloud logo",
                                 height="22",
                                 width="120",
@@ -275,7 +275,7 @@
     </section>
 
     <section class="p-section">
-      <hr class="p-rule--muted is-fixed-width" />
+      <hr class="p-rule is-fixed-width" />
       <div class="row--50-50">
         <div class="col">
           <h2>How to map security primitives<br> to attacker capabilities</h2>
@@ -306,7 +306,7 @@
     </section>
 
     <section class="p-strip u-no-padding--top">
-      <hr class="p-rule--muted is-fixed-width" />
+      <hr class="p-rule is-fixed-width" />
       <div class="row--50-50">
         <div class="col">
           <h2>Use Ubuntu Pro to further harden your confidential VMs</h2>
@@ -324,7 +324,7 @@
     </section>
 
     <section class="p-strip u-no-padding--top">
-      <hr class="p-rule--muted is-fixed-width" />
+      <hr class="p-rule is-fixed-width" />
       <div class="row--50-50 u-sv3">
         <div class="col">
           <h2>A solid foundation of your<br/> zero trust strategy</h2>
@@ -352,8 +352,8 @@
     </section>
 
     <section class="p-strip u-no-padding--top">
-      <hr class="p-rule--muted" />
       <div class="row--50-50">
+        <hr class="p-rule" />
         <div class="col">
           <h2>Confidential computing in your private data center</h2>
         </div>
@@ -375,7 +375,7 @@
       </div>
     </section>
 
-    <hr class="p-rule--muted is-fixed-width" />
+    <hr class="p-rule is-fixed-width" />
 
     <section class="p-strip is-deep u-no-padding--top">
       <div class="row--50-50">

--- a/templates/confidential-computing/index.html
+++ b/templates/confidential-computing/index.html
@@ -351,7 +351,7 @@
       <hr class="p-rule--muted" />
       <div class="row--50-50">
         <div class="col">
-          <h2>Confidential computing in your private data centre</h2>
+          <h2>Confidential computing in your private data center</h2>
         </div>
         <div class="col">
           <p>

--- a/templates/confidential-computing/index.html
+++ b/templates/confidential-computing/index.html
@@ -204,17 +204,18 @@
           <div class="row">
             <div class="col-2 col-medium-3 col-small-2 u-pad-logo">
               <p class="u-no-margin--bottom">
-                {{ image(url="https://assets.ubuntu.com/v1/ea16b84e-microsoft-azure.png",
+                {{ image(url="https://assets.ubuntu.com/v1/aa515363-azure-logo-updated.svg",
                   alt="Azure logo",
                   width="568",
                   height="56",
                   hi_def=True,
+                  attrs={"style": "max-width: 100px;"},
                   loading="auto|lazy"
                   ) | safe
                 }}
               </p>
             </div>
-            <div class="col-8 col-medium-6 col-small-2">
+            <div class="col-7 col-medium-6 col-small-2 col-start-large-4 col-start-medium-2">
               <ul class="p-list--divided u-no-margin--bottom">
                 <li class="p-list__item">
                   <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.ubuntu-24_04-lts?tab=Overview">Ubuntu 24.04 confidential VMs on Azure</a>
@@ -244,7 +245,7 @@
                 }}
               </p>
             </div>
-            <div class="col-6 col-medium-6 col-small-2">
+            <div class="col-6 col-medium-6 col-small-2 col-start-large-4 col-start-medium-2">
               <p>
                 <a href="https://canonical.com/blog/start-your-ubuntu-confidential-vm-with-intel-tdx-on-google-cloud">AMD SEV SNP with Ubuntu 22.04 LTS on Google Cloud</a>
               </p>
@@ -263,7 +264,7 @@
                 }}
               </p>
             </div>
-            <div class="col-6 col-medium-6 col-small-2">
+            <div class="col-6 col-medium-6 col-small-2 col-start-large-4 col-start-medium-2">
               <p>
                 <a href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/sev-snp.html">AMD SEV SNP with Ubuntu 23.10 on AWS</a>
               </p>
@@ -277,7 +278,7 @@
       <hr class="p-rule--muted is-fixed-width" />
       <div class="row--50-50">
         <div class="col">
-          <h2>How to map security primitives to attacker capabilities</h2>
+          <h2>How to map security primitives<br> to attacker capabilities</h2>
         </div>
         <div class="col">
           <div class="row p-image-container is-highlighted">
@@ -398,14 +399,13 @@
         </div>
       </div>
     </section>
+
+    <hr class="p-rule is-fixed-width" />
     <section class="p-strip is-deep">
-      <hr class="p-rule--muted is-fixed-width" />
-      <div class="row">
-        <div class="col-12">
-          <p class="p-heading--2">
-            <a class="js-invoke-modal" href="/contact-us">Contact us to discuss your use case&nbsp;&rsaquo;</a>
-          </p>
-        </div>
+      <div class="u-fixed-width">
+        <p class="p-heading--2">
+          <a class="js-invoke-modal" href="/contact-us">Contact us to discuss your use case&nbsp;&rsaquo;</a>
+        </p>
       </div>
     </section>
   </div>

--- a/templates/confidential-computing/index.html
+++ b/templates/confidential-computing/index.html
@@ -199,7 +199,7 @@
         <div class="col-12 u-sv3">
           <h2>Launch enterprise-grade confidential VMs on all major public clouds</h2>
         </div>
-        <div class="col-10 col-start-large-4 col-start-medium-2">
+        <div class="col-9 col-start-large-4 col-start-medium-2">
           <hr class="p-rule--muted" />
           <div class="row">
             <div class="col-2 col-medium-3 col-small-2 u-pad-logo">
@@ -215,7 +215,7 @@
                 }}
               </p>
             </div>
-            <div class="col-7 col-medium-6 col-small-2 col-start-large-4 col-start-medium-2">
+            <div class="col-6 col-medium-6 col-small-2 col-start-large-4 col-start-medium-2">
               <ul class="p-list--divided u-no-margin--bottom">
                 <li class="p-list__item">
                   <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.ubuntu-24_04-lts?tab=Overview">Ubuntu 24.04 confidential VMs on Azure</a>

--- a/templates/confidential-computing/index.html
+++ b/templates/confidential-computing/index.html
@@ -25,7 +25,7 @@
         layout='50/50'
       ) -%}
       {%- if slot == 'cta' -%}
-        <a href="/contact-us">Contact us to learn more ›</a>
+        <a href="/contact-us" class="js-invoke-modal">Contact us to learn more ›</a>
       {%- endif -%}
       {%- if slot == 'image' -%}
         <div class="p-image-container--3-2 is-cover">
@@ -42,7 +42,7 @@
     {% endcall -%}
 
 
-    <section class="p-strip u-no-padding--top">
+    <section class="p-section">
       <hr class="p-rule is-fixed-width" />
       <div class="row--50-50">
         <div class="col">
@@ -52,9 +52,9 @@
           <p>
             Confidential computing is a new security technique that protects virtual machine workloads from unauthorized access by keeping data encrypted while in system memory. This encryption shields sensitive code and data at runtime from privileged system software and other VMs by operating within a hardware-protected Trusted Execution Environment.
           </p>
-          <p class="p-cta-block">
+          <div class="p-cta-block">
             <a href="/blog/what-is-confidential-computing-a-high-level-explanation-for-cisos">Learn more about confidential computing&nbsp;&rsaquo;</a>
-          </p>
+          </div>
         </div>
       </div>
     </section>
@@ -82,19 +82,21 @@
         {%- endif -%}
 
         {%- if slot == 'description' -%}
-          <div class="col u-sv3">
+          <div class="col">
             <div class="row">
               <p>Ubuntu now supports Intel’s latest confidential computing technology. This hardware-based trusted execution environment enables you to add an extra layer of protection to the code and data running within your confidential virtual machines.</p>
             </div>
-            <div class="p-image-container is-highlighted">
-              {{ image(url="https://assets.ubuntu.com/v1/db3fddbb-intel-tdx-is.png",
-                alt="Diagram showing that Ubuntu builds cater to both the host and guest sides, empowering users to launch a confidential TDX virtual machine seamlessly",
-                width="1200",
-                height="1140",
-                hi_def=True,
-                loading="lazy"
-                ) | safe
-              }}
+            <div class="p-section--shallow">
+              <div class="p-image-container is-highlighted">
+                {{ image(url="https://assets.ubuntu.com/v1/db3fddbb-intel-tdx-is.png",
+                  alt="Diagram showing that Ubuntu builds cater to both the host and guest sides, empowering users to launch a confidential TDX virtual machine seamlessly",
+                  width="1200",
+                  height="1140",
+                  hi_def=True,
+                  loading="lazy"
+                  ) | safe
+                }}
+              </div>
             </div>
           </div>
         {%- endif -%}
@@ -136,10 +138,10 @@
           <h2>How confidential VMs work</h2>
         </div>
         <div class="col">
-          <div class="row u-sv3">
-            <p>
-              Confidential VMs introduce a new trust boundary which only includes the software running within, and the platform’s hardware. All other software outside is no longer part of your trusted computing base. To provide such strong security guarantees, confidential computing relies on two main primitives:
-            </p>
+          <p>
+            Confidential VMs introduce a new trust boundary which only includes the software running within, and the platform’s hardware. All other software outside is no longer part of your trusted computing base. To provide such strong security guarantees, confidential computing relies on two main primitives:
+          </p>
+          <div class="p-section--shallow">
             <div class="p-image-container is-highlighted u-sv3">
               {{ image(url="https://assets.ubuntu.com/v1/480ebd6e-how-confidential-vms.png",
                 alt="",
@@ -151,23 +153,23 @@
               }}
             </div>
           </div>
-          <div class="row">
-            <ol class="p-stepped-list">
-              <li class="p-stepped-list__item">
-                <h5 class="p-stepped-list__title">
-                  Isolation
-                </h5>
-                <p class="p-stepped-list__content">Confidential computing capable CPUs are equipped with an AES hardware memory encryption engine, which encrypts data when it is written to system memory, and decrypts it when read. The encryption key itself is stored in the hardware root of trust and is never exposed to the platform’s system software.</p>
-              </li>
+
+          <ol class="p-stepped-list">
+            <li class="p-stepped-list__item">
+              <h3 class="p-heading--5 p-stepped-list__title">
+                Isolation
+              </h3>
+              <p class="p-stepped-list__content">Confidential computing capable CPUs are equipped with an AES hardware memory encryption engine, which encrypts data when it is written to system memory, and decrypts it when read. The encryption key itself is stored in the hardware root of trust and is never exposed to the platform’s system software.</p>
+            </li>
+            <li class="p-stepped-list__item">
               <hr class="p-rule--muted" />
-              <li class="p-stepped-list__item">
-                <h5 class="p-stepped-list__title">
-                  Remote attestation
-                </h5>
-                <p class="p-stepped-list__content">When a confidential VM is launched, its integrity is verified and its initial code and data are measured by a hardware root of trust. This ensures they have not been tampered with. The measurement is cryptographically signed and can be attested to a remote verifier</p>
-              </li>
-            </ol>
-          </div>
+              <h3 class="p-heading--5 p-stepped-list__title">
+                Remote attestation
+              </h3>
+              <p class="p-stepped-list__content">When a confidential VM is launched, its integrity is verified and its initial code and data are measured by a hardware root of trust. This ensures they have not been tampered with. The measurement is cryptographically signed and can be attested to a remote verifier.</p>
+            </li>
+          </ol>
+
         </div>
       </div>
     </section>
@@ -185,15 +187,15 @@
               <p class="u-no-margin--bottom">
                 {{ image(url="https://assets.ubuntu.com/v1/aa515363-azure-logo-updated.svg",
                   alt="Azure logo",
-                  width="100",
-                  height="56",
+                  width="108",
+                  height="31",
                   hi_def=True,
                   loading="lazy"
                   ) | safe
                 }}
               </p>
             </div>
-            <div class="col-6 col-medium-6 col-small-2 col-start-large-4 col-start-medium-2">
+            <div class="col-6 col-medium-3 col-small-2 col-start-large-4">
               <ul class="p-list--divided u-no-margin--bottom">
                 <li class="p-list__item">
                   <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.ubuntu-24_04-lts?tab=Overview">Ubuntu 24.04 confidential VMs on Azure</a>
@@ -223,7 +225,7 @@
                 }}
               </p>
             </div>
-            <div class="col-6 col-medium-6 col-small-2 col-start-large-4 col-start-medium-2">
+            <div class="col-6 col-medium-3 col-small-2 col-start-large-4">
               <p>
                 <a href="https://canonical.com/blog/start-your-ubuntu-confidential-vm-with-intel-tdx-on-google-cloud">AMD SEV SNP with Ubuntu 22.04 LTS on Google Cloud</a>
               </p>
@@ -242,7 +244,7 @@
                 }}
               </p>
             </div>
-            <div class="col-6 col-medium-6 col-small-2 col-start-large-4 col-start-medium-2">
+            <div class="col-6 col-medium-3 col-small-2 col-start-large-4">
               <p>
                 <a href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/sev-snp.html">AMD SEV SNP with Ubuntu 23.10 on AWS</a>
               </p>
@@ -259,14 +261,16 @@
           <h2>How to map security primitives<br> to attacker capabilities</h2>
         </div>
         <div class="col">
-          <div class="p-image-container is-highlighted">
-            {{ image(url="https://assets.ubuntu.com/v1/d8d1c7c8-how-to-map.png",
-              alt="",
-              width="1200",
-              height="800",
-              hi_def=True,
-              loading="lazy") | safe
-            }}
+          <div class="p-section--shallow">
+            <div class="p-image-container is-highlighted">
+              {{ image(url="https://assets.ubuntu.com/v1/d8d1c7c8-how-to-map.png",
+                alt="",
+                width="1200",
+                height="800",
+                hi_def=True,
+                loading="lazy") | safe
+              }}
+            </div>
           </div>
           <p>
             Uncover the details of Ubuntu’s security solutions and learn how to tailor them to your environment. Equip yourself with the tools to protect your data and stay one step ahead of evolving threats.
@@ -288,10 +292,9 @@
           <p>
             While confidential VMs safeguard your workload from external threats, internal vulnerabilities within their boundaries can still pose risks. This is where Ubuntu Pro proves invaluable, ensuring your guest CVM software stack is continuously patched and up-to-date.
           </p>
-          <hr class="p-rule--muted" />
-          <p>
+          <div class="p-cta-block">
             <a href="/pro">Learn more about Ubuntu Pro&nbsp;&rsaquo;</a>
-          </p>
+          </div>
         </div>
       </div>
     </section>
@@ -311,7 +314,7 @@
           </p>
         </div>
       </div>
-      <div class="row">
+      <div class="u-fixed-width">
         {{ image(url="https://assets.ubuntu.com/v1/e3769453-server-room.png",
           alt="",
           width="2464",

--- a/templates/confidential-computing/index.html
+++ b/templates/confidential-computing/index.html
@@ -34,7 +34,8 @@
             width="1662",
             height="1240",
             hi_def=True,
-            loading="auto"
+            loading="auto",
+            attrs={"class": "p-image-container__image"}
             ) | safe
           }}
         </div>
@@ -83,9 +84,7 @@
 
         {%- if slot == 'description' -%}
           <div class="col">
-            <div class="row">
-              <p>Ubuntu now supports Intel’s latest confidential computing technology. This hardware-based trusted execution environment enables you to add an extra layer of protection to the code and data running within your confidential virtual machines.</p>
-            </div>
+            <p>Ubuntu now supports Intel’s latest confidential computing technology. This hardware-based trusted execution environment enables you to add an extra layer of protection to the code and data running within your confidential virtual machines.</p>
             <div class="p-section--shallow">
               <div class="p-image-container is-highlighted">
                 {{ image(url="https://assets.ubuntu.com/v1/db3fddbb-intel-tdx-is.png",
@@ -93,6 +92,7 @@
                   width="1200",
                   height="1140",
                   hi_def=True,
+                  attrs={"class": "p-image-container__image"},
                   loading="lazy"
                   ) | safe
                 }}
@@ -148,6 +148,7 @@
                 width="1200",
                 height="800",
                 hi_def=True,
+                attrs={"class": "p-image-container__image"},
                 loading="lazy"
                 ) | safe
               }}
@@ -268,6 +269,7 @@
                 width="1200",
                 height="800",
                 hi_def=True,
+                attrs={"class": "p-image-container__image"},
                 loading="lazy") | safe
               }}
             </div>

--- a/templates/confidential-computing/index.html
+++ b/templates/confidential-computing/index.html
@@ -1,5 +1,8 @@
 {% extends "confidential-computing/base_confidential-computing.html" %}
 
+{% from "_macros/vf_hero.jinja" import vf_hero %}
+{% from "_macros/vf_quote-wrapper.jinja" import vf_quote_wrapper %}
+
 {% block title %}Confidential Computing{% endblock %}
 
 {% block meta_description %}
@@ -15,27 +18,38 @@
 {% block content %}
 
   <div class="is-paper">
-    <section class="p-strip is-shallow u-no-padding--bottom">
-      <div class="row">
-        <div class="col-9 col-start-large-4">
-          <div class="p-section--shallow">
-            <h1 class="u-no-margin--bottom">Ubuntu for confidential computing</h1>
-            <p class="p-heading--2">
-              Protect your data in use,
-              <br class="u-hide--small u-hide--medium" />
-              across public and private clouds.
-            </p>
+    <section class="p-strip u-no-padding--top">
+      {% call(slot) vf_hero(
+          title_text='Ubuntu for confidential compute',
+          subtitle_text='Protect your data in use, across public and private clouds.',
+          layout='50/50'
+        ) -%}
+        {%- if slot == 'cta' -%}
+          <a href="/contact-us">Contact us to learn more ›</a>
+        {%- endif -%}
+        {%- if slot == 'image' -%}
+          <div class="p-image-container--3-2 is-cover">
+            <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/cf1e2ddb-datacenter-wide-crop.jpeg" alt="">
           </div>
-          <hr class="p-rule" />
-          <a class="js-invoke-modal p-button--positive" href="/contact-us">Contact us to learn more</a>
-        </div>
-      </div>
+        {%- endif -%}
+      {% endcall -%}
+    </section>
 
-      <div class="u-fixed-width u-no-padding">
-        <img src="https://assets.ubuntu.com/v1/7f34ade9-website_suru_25.jpg"
-             alt=""
-             style="aspect-ratio: 5.177570093457944;
-                    width: 100%" />
+    <section class="p-strip u-no-padding--top">
+      <hr class="p-rule--muted is-fixed-width" />
+      <div class="row--50-50">
+        <div class="col">
+          <h2>What is confidential computing?</h2>
+        </div>
+        <div class="col">
+          <p>
+            Confidential computing is a new security technique that protects virtual machine workloads from unauthorized access by keeping data encrypted while in system memory. This encryption shields sensitive code and data at runtime from privileged system software and other VMs by operating within a hardware-protected Trusted Execution Environment.
+          </p>
+          <hr class="p-rule--muted" />
+          <p>
+            <a href="/engage/introduction-confidential-computing">Learn more about confidential computing ›</a>
+          </p>
+        </div>
       </div>
     </section>
 
@@ -61,63 +75,68 @@
         <div class="col">
           <h2>Intel TDX is available on Ubuntu for both the host and guest</h2>
         </div>
-        <div class="col">
+        <div class="col u-sv3">
           <p>
-            Ubuntu now supports Intel’s latest confidential computing technology. This hardware-based trusted execution
-            environment enables you to add an extra layer of protection to the code and data running within your
-            confidential virtual machines.
+            Ubuntu now supports Intel’s latest confidential computing technology. This hardware-based trusted execution environment enables you to add an extra layer of protection to the code and data running within your confidential virtual machines.
           </p>
-          <div class="u-align--center u-vertically-center u-hide--small">
-            {{ image(url="https://assets.ubuntu.com/v1/c9a80496-Silicon%20-%20Intel%20%20TDX%20and%20Ubuntu%20Figure.png",
-                        alt="Diagram showing that Ubuntu builds cater to both the host and guest sides, empowering users to launch a
-                        confidential TDX virtual machine seamlessly",
-                        width="410",
-                        height="550",
-                        hi_def=True,
-                        loading="lazy") | safe
+          <div class="p-image__background--3-2 u-align--center u-vertically-center">
+            {{ image(url="https://assets.ubuntu.com/v1/db3fddbb-intel-tdx-is.png",
+              alt="Diagram showing that Ubuntu builds cater to both the host and guest sides, empowering users to launch a confidential TDX virtual machine seamlessly",
+              width="1200",
+              height="1140",
+              hi_def=True,
+              loading="auto|lazy"
+              ) | safe
             }}
           </div>
         </div>
       </div>
       <div class="row">
         <div class="col-9 col-start-large-4 col-medium-3 col-start-medium-4">
+          <ol class="p-stepped-list--detailed">
+            <li class="p-stepped-list__item">
+              <div class="row">
+                <div class="col-3 col-medium-3">
+                  <h3 class="p-heading-icon__title p-heading--5">Private preview available on Ubuntu 24.04</h3>
+                </div>
+                <div class="col-6 col-medium-3">
+                  <p>
+                    Canonical’s strategic partnership with Intel gives you a customized Ubuntu build for Intel®TDX, incorporating all the latest necessary end-to-end host-to-guest patches available, even before they make it upstream.
+                  </p>
+                </div>
+              </div>
+            </li>
+            <li class="p-stepped-list__item">
+              <div class="row">
+                <div class="col-3 col-medium-3">
+                  <h3 class="p-heading-icon__title p-heading--5">Host side</h3>
+                </div>
+                <div class="col-6 col-medium-3">
+                  <p>
+                    We support a 6.8 kernel, derived from the 24.04 generic kernel, and offer essential user space components accessible through PPAs, such as Libvirt 9.6, and QEMU 8.0. We also offer a set of user-friendly scripts to simplify the creation of confidential environments with just a few commands.
+                  </p>
+                </div>
+              </div>
+            </li>
+            <li class="p-stepped-list__item">
+              <div class="row">
+                <div class="col-3 col-medium-3">
+                  <h3 class="p-heading-icon__title p-heading--5">Guest side</h3>
+                </div>
+                <div class="col-6 col-medium-3">
+                  <p>
+                    We support a comprehensive package, featuring a 6.8 kernel, Shim, Grub, and TDVF, which serves as an in-guest VM firmware.
+                  </p>
+                </div>
+              </div>
+            </li>
+          </ol>
           <div class="row">
             <div class="col-3 col-medium-3">
-              <h3 class="p-text--small-caps p-heading--5">Private preview available on Ubuntu 24.04</h3>
             </div>
             <div class="col-6 col-medium-3">
-              <p>
-                Canonical’s strategic partnership with Intel gives you a customised Ubuntu
-                build for Intel®TDX, incorporating all the latest necessary end-to-end host-to-guest patches available,
-                even before they make it upstream.
-              </p>
-            </div>
-          </div>
-          <div class="row">
-            <div class="col-3 col-medium-3">
-              <h3 class="p-text--small-caps p-heading--5">Host side</h3>
-            </div>
-            <div class="col-6 col-medium-3">
-              <p>
-                We support a 6.8 kernel, derived from the 24.04 generic kernel, and offer essential user space components accessible through PPAs, such as Libvirt 9.6, and QEMU 8.0. We also offer a set of user-friendly scripts to simplify the creation of confidential environments with just a few commands.
-              </p>
-            </div>
-          </div>
-          <div class="row">
-            <div class="col-3 col-medium-3">
-              <h3 class="p-text--small-caps p-heading--5">Guest side</h3>
-            </div>
-            <div class="col-6 col-medium-3">
-              <p>
-                We support a comprehensive package, featuring a 6.8 kernel, Shim, Grub, and TDVF, which serves as an in-guest VM firmware.
-              </p>
-            </div>
-          </div>
-          <div class="row">
-            <div class="col-6 col-start-large-4">
-              <p>
-                <a href="https://github.com/canonical/tdx">Deploy Intel TDX with Ubuntu 24.04 today&nbsp;&rsaquo;</a>
-              </p>
+              <hr class="p-rule--muted" />
+              <a href="https://github.com/canonical/tdx">Deploy Intel TDX with Ubuntu 24.04 today&nbsp;&rsaquo;</a>
             </div>
           </div>
         </div>
@@ -130,89 +149,71 @@
         <div class="col">
           <h2>How confidential VMs work</h2>
         </div>
-        <div class="col">
-          <p>
-            Confidential VMs introduce a new trust boundary which only includes
-            the software running within, and the platform’s hardware. All other
-            software outside is no longer part of your trusted computing base.
-          </p>
-          <div class="p-image__background--3-2 u-align--center u-vertically-center">
-            {{ image(url="https://assets.ubuntu.com/v1/abd7bccf-Hypervisor%20diagram%203.png",
-                        alt="Diagram showing the hardware is at the base and the CVM can add a layer of protection around the software
-                        it's running",
-                        width="195",
-                        height="282",
-                        hi_def=True,
-                        loading="lazy") | safe
-            }}
+        <div class="col u-sv3">
+          <div class="row">
+            <p>
+              Confidential VMs introduce a new trust boundary which only includes the software running within, and the platform’s hardware. All other software outside is no longer part of your trusted computing base. To provide such strong security guarantees, confidential computing relies on two main primitives:
+            </p>
           </div>
-          <p>
-            To provide such strong security guarantees, confidential computing
-            relies on two main primitives:
-          </p>
-        </div>
-      </div>
-      <div class="row">
-        <div class="col-9 col-start-large-4 col-medium-3 col-start-medium-4">
-          <ol class="p-stepped-list--detailed">
-            <li class="p-stepped-list__item">
-              <div class="row">
-                <div class="col-3 col-medium-3">
-                  <h3 class="p-heading-icon__title p-heading--5">1. Isolation</h3>
-                </div>
-                <div class="col-6 col-medium-3">
-                  <p>
-                    Confidential computing capable CPUs are equipped with an AES
-                    hardware memory encryption engine, which encrypts data when it is
-                    written to system memory, and decrypts it when read. The
-                    encryption key itself is stored in the hardware root of trust and
-                    is never exposed to the platform’s system software.
-                  </p>
-                </div>
-              </div>
-            </li>
-            <li class="p-stepped-list__item">
-              <div class="row">
-                <div class="col-3 col-medium-3">
-                  <h3 class="p-heading-icon__title p-heading--5">2. Remote attestation</h3>
-                </div>
-                <div class="col-6 col-medium-3">
-                  <p>
-                    When a confidential VM is launched, its integrity is verified and
-                    its initial code and data are measured by a hardware root of
-                    trust. This ensures they have not been tampered with. The
-                    measurement is cryptographically signed and can be attested to a
-                    remote verifier.
-                  </p>
-                </div>
-              </div>
-            </li>
-          </ol>
+          <div class="row u-sv3">
+            <div class="p-image__background--3-2 u-align--center u-vertically-center">
+              {{ image(url="https://assets.ubuntu.com/v1/480ebd6e-how-confidential-vms.png",
+                alt="",
+                width="1200",
+                height="800",
+                hi_def=True,
+                loading="auto|lazy"
+                ) | safe
+              }}
+            </div>
+          </div>
+          <div class="row">
+            <div class="col-3 col-medium-3">
+              <h3 class="p-heading-icon__title p-heading--5">1. Isolation</h3>
+            </div>
+            <div class="col-6 col-medium-3">
+              <p>
+                Confidential computing capable CPUs are equipped with an AES hardware memory encryption engine, which encrypts data when it is written to system memory, and decrypts it when read. The encryption key itself is stored in the hardware root of trust and is never exposed to the platform’s system software.
+              </p>
+            </div>
+          </div>
+          <hr class="p-rule--muted" />
+          <div class="row">
+            <div class="col-3 col-medium-3">
+              <h3 class="p-heading-icon__title p-heading--5">2. Remote attestation</h3>
+            </div>
+            <div class="col-6 col-medium-3">
+              <p>
+                When a confidential VM is launched, its integrity is verified and its initial code and data are measured by a hardware root of trust. This ensures they have not been tampered with. The measurement is cryptographically signed and can be attested to a remote verifier
+              </p>
+            </div>
+          </div>
         </div>
       </div>
     </section>
 
-    <hr class="p-rule--muted is-fixed-width" />
-
     <section class="p-strip u-no-padding--top">
+      <hr class="p-rule--muted is-fixed-width" />
       <div class="row">
-        <div class="col-6 col-medium-6">
-          <h2>Enterprise-grade confidential VMs on all major public clouds</h2>
+        <div class="col-12 u-sv3">
+          <h2>Launch enterprise-grade confidential VMs on all major public clouds</h2>
         </div>
-        <div class="col-6 col-medium-6">
+        <div class="col-8 col-start-large-6 col-start-medium-2">
+          <hr class="p-rule--muted" />
           <div class="row">
             <div class="col-2 col-medium-3 col-small-2 u-pad-logo">
               <p class="u-no-margin--bottom">
-                {{ image(url="https://assets.ubuntu.com/v1/dbab00f7-Microsoft_Azure.svg",
-                                alt="Azure logo",
-                                height="22",
-                                width="22",
-                                hi_def=True,
-                                loading="lazy") | safe
+                {{ image(url="https://assets.ubuntu.com/v1/ea16b84e-microsoft-azure.png",
+                  alt="Azure logo",
+                  width="568",
+                  height="56",
+                  hi_def=True,
+                  loading="auto|lazy"
+                  ) | safe
                 }}
               </p>
             </div>
-            <div class="col-4 col-medium-3 col-small-2">
+            <div class="col-6 col-medium-3 col-small-2">
               <ul class="p-list--divided u-no-margin--bottom">
                 <li class="p-list__item">
                   <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.ubuntu-24_04-lts?tab=Overview">Ubuntu 24.04 confidential VMs on Azure</a>
@@ -229,7 +230,7 @@
               </ul>
             </div>
           </div>
-          <hr class="p-rule" />
+          <hr class="p-rule--muted" />
           <div class="row">
             <div class="col-2 col-medium-3 col-small-2 u-pad-logo">
               <p class="u-no-margin--bottom">
@@ -242,13 +243,13 @@
                 }}
               </p>
             </div>
-            <div class="col-4 col-medium-3 col-small-2">
+            <div class="col-6 col-medium-3 col-small-2">
               <p>
                 <a href="https://canonical.com/blog/start-your-ubuntu-confidential-vm-with-intel-tdx-on-google-cloud">AMD SEV SNP with Ubuntu 22.04 LTS on Google Cloud</a>
               </p>
             </div>
           </div>
-          <hr class="p-rule" />
+          <hr class="p-rule--muted" />
           <div class="row">
             <div class="col-2 col-medium-3 col-small-2 u-pad-logo">
               <p class="u-no-margin--bottom">
@@ -261,7 +262,7 @@
                 }}
               </p>
             </div>
-            <div class="col-4 col-medium-3 col-small-2">
+            <div class="col-6 col-medium-3 col-small-2">
               <p>
                 <a href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/sev-snp.html">AMD SEV SNP with Ubuntu 23.10 on AWS</a>
               </p>
@@ -271,22 +272,37 @@
       </div>
     </section>
 
-    <hr class="p-rule--muted is-fixed-width" />
-
-    <section class="p-strip is-deep">
-      <div class="row">
-        <div class="col-12">
-          <p class="p-heading--2">
-            <a href="/engage/introduction-confidential-computing">Download our guide to confidential
-            computing&nbsp;&rsaquo;</a>
+    <section class="p-section">
+      <hr class="p-rule--muted is-fixed-width" />
+      <div class="row--50-50">
+        <div class="col">
+          <h2>How to map security primitives to attacker capabilities</h2>
+        </div>
+        <div class="col">
+          <div class="u-align--center u-vertically-center u-hide--small">
+          {{ image(url="https://assets.ubuntu.com/v1/d8d1c7c8-how-to-map.png",
+            alt="How to map security primitives to attacker capabilities",
+            width="1200",
+            height="800",
+            hi_def=True,
+            loading="auto|lazy") | safe
+          }}
+          </div>
+          <p>
+            Uncover the details of Ubuntu’s security solutions and learn how to tailor them to your environment. Equip yourself with the tools to protect your data and stay one step ahead of evolving threats.
           </p>
+          <div class="row">
+            <hr class="p-rule--muted" />
+            <p>
+              <a href="/engage/security-in-depth">Download the Security in Depth Whitepaper here ›</a>
+            </p>
+          </div>
         </div>
       </div>
     </section>
 
-    <hr class="p-rule--muted is-fixed-width" />
-
     <section class="p-strip u-no-padding--top">
+      <hr class="p-rule--muted is-fixed-width" />
       <div class="row--50-50">
         <div class="col">
           <h2>Use Ubuntu Pro to further harden your confidential VMs</h2>
@@ -295,6 +311,7 @@
           <p>
             While confidential VMs safeguard your workload from external threats, internal vulnerabilities within their boundaries can still pose risks. This is where Ubuntu Pro proves invaluable, ensuring your guest CVM software stack is continuously patched and up-to-date.
           </p>
+          <hr class="p-rule--muted" />
           <p>
             <a href="/pro">Learn more about Ubuntu Pro&nbsp;&rsaquo;</a>
           </p>
@@ -302,31 +319,36 @@
       </div>
     </section>
 
-    <hr class="is-fixed-width" />
-
     <section class="p-strip u-no-padding--top">
-      <div class="row--50-50">
+      <hr class="p-rule--muted is-fixed-width" />
+      <div class="row--50-50 u-sv3">
         <div class="col">
           <h2>A solid foundation of your zero trust strategy</h2>
         </div>
         <div class="col">
           <p>
-            With confidential computing, you can remove the privileged systems
-            software from your trusted computing base, reduce your attack surface,
-            and get a remotely verifiable cryptographic guarantee before trusting
-            any platform with your data.
+            With confidential computing, you can remove the privileged systems software from your trusted computing base, reduce your attack surface, and get a remotely verifiable cryptographic guarantee before trusting any platform with your data.
           </p>
+          <hr class="p-rule--muted" />
           <p>
-            <a href="/blog/build-foundation-zero-trust-strategy-ubuntu-confidential-computing">Learn
-            more about zero trust and confidential computing&nbsp;&rsaquo;</a>
+            <a href="/blog/build-foundation-zero-trust-strategy-ubuntu-confidential-computing">Learn more about zero trust and confidential computing&nbsp;&rsaquo;</a>
           </p>
         </div>
       </div>
+      <div class="row">
+        {{ image(url="https://assets.ubuntu.com/v1/e3769453-server-room.png",
+          alt="Server room with racks of servers",
+          width="2464",
+          height="1027",
+          hi_def=True,
+          loading="auto|lazy"
+          ) | safe
+        }}
+      </div>
     </section>
 
-    <hr class="p-rule--muted is-fixed-width" />
-
     <section class="p-strip u-no-padding--top">
+      <hr class="p-rule--muted" />
       <div class="row--50-50">
         <div class="col">
           <h2>Confidential computing in your private data centre</h2>
@@ -339,9 +361,11 @@
             on-premises servers, using hardware-rooted primitives beyond
             traditional measures.
           </p>
+          <hr class="p-rule--muted" />
           <p>
-            <a href="https://canonical.com/blog/why-do-you-also-need-confidential-computing-for-your-private-datacenter">Why
-            use confidential VMs in your private datacenter?&nbsp;&rsaquo;</a>
+            <a href="/pro/subscribe" class="p-button">Get a free trial for Ubuntu Pro</a>
+            <br />
+            <a href="https://canonical.com/blog/why-do-you-also-need-confidential-computing-for-your-private-datacenter">Why use confidential VMs in your private datacenter?&nbsp;&rsaquo;</a>
           </p>
         </div>
       </div>
@@ -372,16 +396,16 @@
         </div>
       </div>
     </section>
+    <section class="p-strip is-deep">
+      <div class="row">
+        <div class="col-12">
+          <p class="p-heading--2">
+            <a class="js-invoke-modal" href="/contact-us">Contact us to discuss your use case&nbsp;&rsaquo;</a>
+          </p>
+        </div>
+      </div>
+    </section>
   </div>
 
-  <section class="p-strip--white is-deep">
-    <div class="row">
-      <div class="col-12">
-        <p class="p-heading--2">
-          <a class="js-invoke-modal" href="/contact-us">Contact us to discuss your use case&nbsp;&rsaquo;</a>
-        </p>
-      </div>
-    </div>
-  </section>
 
 {% endblock %}

--- a/templates/confidential-computing/index.html
+++ b/templates/confidential-computing/index.html
@@ -2,6 +2,7 @@
 
 {% from "_macros/vf_hero.jinja" import vf_hero %}
 {% from "_macros/vf_quote-wrapper.jinja" import vf_quote_wrapper %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
 {% block title %}Confidential Computing{% endblock %}
 
@@ -28,7 +29,14 @@
       {%- endif -%}
       {%- if slot == 'image' -%}
         <div class="p-image-container--3-2 is-cover">
-          <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/cf1e2ddb-datacenter-wide-crop.jpeg" alt="">
+          {{ image(url="https://assets.ubuntu.com/v1/cf1e2ddb-datacenter-wide-crop.jpeg",
+            alt="",
+            width="1662",
+            height="1240",
+            hi_def=True,
+            loading="auto"
+            ) | safe
+          }}
         </div>
       {%- endif -%}
     {% endcall -%}
@@ -44,9 +52,8 @@
           <p>
             Confidential computing is a new security technique that protects virtual machine workloads from unauthorized access by keeping data encrypted while in system memory. This encryption shields sensitive code and data at runtime from privileged system software and other VMs by operating within a hardware-protected Trusted Execution Environment.
           </p>
-          <hr class="p-rule--muted" />
-          <p>
-            <a href="/engage/introduction-confidential-computing">Learn more about confidential computing ›</a>
+          <p class="p-cta-block">
+            <a href="/blog/what-is-confidential-computing-a-high-level-explanation-for-cisos">Learn more about confidential computing&nbsp;&rsaquo;</a>
           </p>
         </div>
       </div>
@@ -56,7 +63,7 @@
       <hr class="p-rule is-fixed-width" />
       <div class="row--50-50">
         <div class="col">
-          <h2>Benefits of Ubuntu<br/> for confidential computing</h2>
+          <h2>Benefits of Ubuntu<br class="u-hide--medium"/> for confidential computing</h2>
         </div>
         <div class="col">
           <ul class="p-list--divided">
@@ -68,85 +75,58 @@
       </div>
     </section>
 
-    <section class="p-section is-shallow">
-      <hr class="p-rule--muted is-fixed-width" />
-
-      <div class="row--50-50 u-sv3">
-        <div class="col">
+    <section class="p-section">
+      {%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=false, is_list_full_width_on_tablet=true) -%}
+        {%- if slot == 'title' -%}
           <h2>Intel TDX is available on Ubuntu for both the host and guest</h2>
-        </div>
-        <div class="col u-sv3">
-          <div class="row p-section--shallow">
-            <p>
-              Ubuntu now supports Intel’s latest confidential computing technology. This hardware-based trusted execution environment enables you to add an extra layer of protection to the code and data running within your confidential virtual machines.
-            </p>
-          </div>
+        {%- endif -%}
 
-          <div class="row">
-            <div class="p-image__background--3-2 u-align--center u-vertically-center">
+        {%- if slot == 'description' -%}
+          <div class="col u-sv3">
+            <div class="row">
+              <p>Ubuntu now supports Intel’s latest confidential computing technology. This hardware-based trusted execution environment enables you to add an extra layer of protection to the code and data running within your confidential virtual machines.</p>
+            </div>
+            <div class="p-image-container is-highlighted">
               {{ image(url="https://assets.ubuntu.com/v1/db3fddbb-intel-tdx-is.png",
                 alt="Diagram showing that Ubuntu builds cater to both the host and guest sides, empowering users to launch a confidential TDX virtual machine seamlessly",
                 width="1200",
                 height="1140",
                 hi_def=True,
-                loading="auto|lazy"
+                loading="lazy"
                 ) | safe
               }}
             </div>
           </div>
-        </div>
-      </div>
+        {%- endif -%}
 
-      <div class="row">
-        <div class="col-9 col-start-large-4 col-medium-3 col-start-medium-4">
-          <ol class="p-stepped-list--detailed u-no-margin--bottom">
-            <li class="p-stepped-list__item">
-              <div class="row">
-                <div class="col-3 col-medium-3">
-                  <h3 class="p-heading-icon__title p-heading--5">Private preview available on Ubuntu 24.04</h3>
-                </div>
-                <div class="col-6 col-medium-3">
-                  <p>
-                    Canonical’s strategic partnership with Intel gives you a customized Ubuntu build for Intel®TDX, incorporating all the latest necessary end-to-end host-to-guest patches available, even before they make it upstream.
-                  </p>
-                </div>
-              </div>
-            </li>
-            <li class="p-stepped-list__item">
-              <div class="row">
-                <div class="col-3 col-medium-3">
-                  <h3 class="p-heading-icon__title p-heading--5">Host side</h3>
-                </div>
-                <div class="col-6 col-medium-3">
-                  <p>
-                    We support a 6.8 kernel, derived from the 24.04 generic kernel, and offer essential user space components accessible through PPAs, such as Libvirt 9.6, and QEMU 8.0. We also offer a set of user-friendly scripts to simplify the creation of confidential environments with just a few commands.
-                  </p>
-                </div>
-              </div>
-            </li>
-            <li class="p-stepped-list__item">
-              <div class="row">
-                <div class="col-3 col-medium-3">
-                  <h3 class="p-heading-icon__title p-heading--5">Guest side</h3>
-                </div>
-                <div class="col-6 col-medium-3">
-                  <p>
-                    We support a comprehensive package, featuring a 6.8 kernel, Shim, Grub, and TDVF, which serves as an in-guest VM firmware.
-                  </p>
-                </div>
-              </div>
-            </li>
-          </ol>
-          <div class="row">
-            <div class="col-3 col-medium-3">
-            </div>
-            <div class="col-6 col-medium-3">
-              <hr class="p-rule--muted" />
-              <a href="https://github.com/canonical/tdx">Deploy Intel TDX with Ubuntu 24.04 today&nbsp;&rsaquo;</a>
-            </div>
-          </div>
-        </div>
-      </div>
+        {%- if slot == 'list_item_title_1' -%}
+          <h3 class="p-heading--5">Private preview available on Ubuntu 24.04</h3>
+        {%- endif -%}
+
+        {%- if slot == 'list_item_description_1' -%}
+          <p>Canonical’s strategic partnership with Intel gives you a customized Ubuntu build for Intel®TDX, incorporating all the latest necessary end-to-end host-to-guest patches available, even before they make it upstream.</p>
+        {%- endif -%}
+
+        {%- if slot == 'list_item_title_2' -%}
+          <h3 class="p-heading--5">Host side</h3>
+        {%- endif -%}
+
+        {%- if slot == 'list_item_description_2' -%}
+          <p>We support a 6.8 kernel, derived from the 24.04 generic kernel, and offer essential user space components accessible through PPAs, such as Libvirt 9.6, and QEMU 8.0. We also offer a set of user-friendly scripts to simplify the creation of confidential environments with just a few commands.</p>
+        {%- endif -%}
+
+        {%- if slot == 'list_item_title_3' -%}
+          <h3 class="p-heading--5">Guest side</h3>
+        {%- endif -%}
+
+        {%- if slot == 'list_item_description_3' -%}
+          <p>We support a comprehensive package, featuring a 6.8 kernel, Shim, Grub, and TDVF, which serves as an in-guest VM firmware.</p>
+        {%- endif -%}
+
+        {%- if slot == 'cta' -%}
+          <a href="https://github.com/canonical/tdx">Deploy Intel TDX with Ubuntu 24.04 today&nbsp;&rsaquo;</a>
+        {%- endif -%}
+      {%- endcall -%}
     </section>
 
     <section class="p-section">
@@ -155,38 +135,37 @@
         <div class="col">
           <h2>How confidential VMs work</h2>
         </div>
-        <div class="col u-sv3">
-          <div class="row">
+        <div class="col">
+          <div class="row u-sv3">
             <p>
               Confidential VMs introduce a new trust boundary which only includes the software running within, and the platform’s hardware. All other software outside is no longer part of your trusted computing base. To provide such strong security guarantees, confidential computing relies on two main primitives:
             </p>
-          </div>
-          <div class="row u-sv3">
-            <div class="p-image__background--3-2 u-align--center u-vertically-center">
+            <div class="p-image-container is-highlighted u-sv3">
               {{ image(url="https://assets.ubuntu.com/v1/480ebd6e-how-confidential-vms.png",
                 alt="",
                 width="1200",
                 height="800",
                 hi_def=True,
-                loading="auto|lazy"
+                loading="lazy"
                 ) | safe
               }}
             </div>
           </div>
           <div class="row">
-            <ol class="p-list--divided">
-              <li class="p-list__item p-heading-icon__title p-heading--5">Isolation</li>
-              <div class="col-6 col-medium-3 u-sv3">
-                <p>
-                  Confidential computing capable CPUs are equipped with an AES hardware memory encryption engine, which encrypts data when it is written to system memory, and decrypts it when read. The encryption key itself is stored in the hardware root of trust and is never exposed to the platform’s system software.
-                </p>
-              </div>
-              <li class="p-list__item p-heading-icon__title p-heading--5">Remote attestation</li>
-              <div class="col-6 col-medium-3">
-                <p>
-                  When a confidential VM is launched, its integrity is verified and its initial code and data are measured by a hardware root of trust. This ensures they have not been tampered with. The measurement is cryptographically signed and can be attested to a remote verifier
-                </p>
-              </div>
+            <ol class="p-stepped-list">
+              <li class="p-stepped-list__item">
+                <h5 class="p-stepped-list__title">
+                  Isolation
+                </h5>
+                <p class="p-stepped-list__content">Confidential computing capable CPUs are equipped with an AES hardware memory encryption engine, which encrypts data when it is written to system memory, and decrypts it when read. The encryption key itself is stored in the hardware root of trust and is never exposed to the platform’s system software.</p>
+              </li>
+              <hr class="p-rule--muted" />
+              <li class="p-stepped-list__item">
+                <h5 class="p-stepped-list__title">
+                  Remote attestation
+                </h5>
+                <p class="p-stepped-list__content">When a confidential VM is launched, its integrity is verified and its initial code and data are measured by a hardware root of trust. This ensures they have not been tampered with. The measurement is cryptographically signed and can be attested to a remote verifier</p>
+              </li>
             </ol>
           </div>
         </div>
@@ -195,22 +174,21 @@
 
     <section class="p-strip u-no-padding--top">
       <hr class="p-rule is-fixed-width" />
+      <div class="u-fixed-width">
+        <h2>Launch enterprise-grade confidential VMs on all major public clouds</h2>
+      </div>
       <div class="row">
-        <div class="col-12 u-sv3">
-          <h2>Launch enterprise-grade confidential VMs on all major public clouds</h2>
-        </div>
-        <div class="col-9 col-start-large-4 col-start-medium-2">
+        <div class="col-9 col-start-large-4">
           <hr class="p-rule--muted" />
           <div class="row">
             <div class="col-2 col-medium-3 col-small-2 u-pad-logo">
               <p class="u-no-margin--bottom">
                 {{ image(url="https://assets.ubuntu.com/v1/aa515363-azure-logo-updated.svg",
                   alt="Azure logo",
-                  width="568",
+                  width="100",
                   height="56",
                   hi_def=True,
-                  attrs={"style": "max-width: 100px;"},
-                  loading="auto|lazy"
+                  loading="lazy"
                   ) | safe
                 }}
               </p>
@@ -237,11 +215,11 @@
             <div class="col-2 col-medium-3 col-small-2 u-pad-logo">
               <p class="u-no-margin--bottom">
                 {{ image(url="https://assets.ubuntu.com/v1/786c39f9-Google_Cloud_logo.svg",
-                                alt="Google Cloud logo",
-                                height="22",
-                                width="120",
-                                hi_def=True,
-                                loading="lazy") | safe
+                  alt="Google Cloud logo",
+                  height="22",
+                  width="120",
+                  hi_def=True,
+                  loading="lazy") | safe
                 }}
               </p>
             </div>
@@ -281,25 +259,20 @@
           <h2>How to map security primitives<br> to attacker capabilities</h2>
         </div>
         <div class="col">
-          <div class="row p-image-container is-highlighted">
-          {{ image(url="https://assets.ubuntu.com/v1/d8d1c7c8-how-to-map.png",
-            alt="How to map security primitives to attacker capabilities",
-            width="1200",
-            height="800",
-            hi_def=True,
-            loading="auto|lazy") | safe
-          }}
+          <div class="p-image-container is-highlighted">
+            {{ image(url="https://assets.ubuntu.com/v1/d8d1c7c8-how-to-map.png",
+              alt="",
+              width="1200",
+              height="800",
+              hi_def=True,
+              loading="lazy") | safe
+            }}
           </div>
-          <div class="row">
-            <p>
-              Uncover the details of Ubuntu’s security solutions and learn how to tailor them to your environment. Equip yourself with the tools to protect your data and stay one step ahead of evolving threats.
-            </p>
-          </div>
-          <div class="row">
-            <hr class="p-rule--muted" />
-            <p>
-              <a href="/engage/security-in-depth">Download the Security in Depth Whitepaper here ›</a>
-            </p>
+          <p>
+            Uncover the details of Ubuntu’s security solutions and learn how to tailor them to your environment. Equip yourself with the tools to protect your data and stay one step ahead of evolving threats.
+          </p>
+          <div class="p-cta-block">
+            <a href="/engage/security-in-depth">Download the Security in Depth Whitepaper here&nbsp;&rsaquo;</a>
           </div>
         </div>
       </div>
@@ -325,27 +298,26 @@
 
     <section class="p-strip u-no-padding--top">
       <hr class="p-rule is-fixed-width" />
-      <div class="row--50-50 u-sv3">
+      <div class="row--50-50">
         <div class="col">
-          <h2>A solid foundation of your<br/> zero trust strategy</h2>
+          <h2>A solid foundation of your<br class="u-hide--small"/> zero trust strategy</h2>
         </div>
         <div class="col">
           <p>
             With confidential computing, you can remove the privileged systems software from your trusted computing base, reduce your attack surface, and get a remotely verifiable cryptographic guarantee before trusting any platform with your data.
           </p>
-          <hr class="p-rule--muted" />
-          <p>
+          <p class="p-cta-block">
             <a href="/blog/build-foundation-zero-trust-strategy-ubuntu-confidential-computing">Learn more about zero trust and confidential computing&nbsp;&rsaquo;</a>
           </p>
         </div>
       </div>
       <div class="row">
         {{ image(url="https://assets.ubuntu.com/v1/e3769453-server-room.png",
-          alt="Server room with racks of servers",
+          alt="",
           width="2464",
           height="1027",
           hi_def=True,
-          loading="auto|lazy"
+          loading="lazy"
           ) | safe
         }}
       </div>
@@ -365,12 +337,10 @@
             on-premises servers, using hardware-rooted primitives beyond
             traditional measures.
           </p>
-          <hr class="p-rule--muted" />
-          <p>
+          <div class="p-cta-block">
             <a href="/pro/subscribe" class="p-button">Get a free trial for Ubuntu Pro</a>
-            <br />
             <a href="https://canonical.com/blog/why-do-you-also-need-confidential-computing-for-your-private-datacenter">Why use confidential VMs in your private datacenter?&nbsp;&rsaquo;</a>
-          </p>
+          </div>
         </div>
       </div>
     </section>

--- a/templates/confidential-computing/index.html
+++ b/templates/confidential-computing/index.html
@@ -381,8 +381,7 @@
         <div class="col">
           <ul class="p-list--divided u-no-margin--bottom">
             <li class="p-list__item">
-              <a href="/blog/what-is-confidential-computing-a-high-level-explanation-for-cisos">What is
-              confidential computing? A high-level explanation for CISOs</a>
+              <a href="https://canonical.com/blog/tracing-origins-confidential-computing">Learn about the history of confidential computing</a>
             </li>
             <li class="p-list__item">
               <a href="/blog/confidential-computing-in-public-clouds-isolation-and-remote-attestation-explained">Confidential


### PR DESCRIPTION
## Done

Refreshing the confidential computing page for a couple copy changes, adding a couple sections, and adding an image to the hero. 

Design prototype: https://www.figma.com/design/zyG3Iyys2GlxxfqfQQT7bT/23.10-U.com---Confidential-computing?node-id=333-1633&t=vvaIO2f4CieuXvN6-0

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/confidential-computing
    - Be sure to test on mobile, tablet and desktop screen sizes

### Demo

Available at https://ubuntu-com-15026.demos.haus/confidential-computing

## Issue / Card

Fixes # https://warthogs.atlassian.net/browse/WD-20315

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
