### PR TITLE
Update live-links.yaml: make the name more specific

### DIFF
--- a/.github/workflows/live-links.yaml
+++ b/.github/workflows/live-links.yaml
@@ -1,4 +1,4 @@
-name: Links on live
+name: Links on ubuntu.com live
 
 on:
   schedule:


### PR DESCRIPTION
## Done

- We are going to add link checkers to more projects and therefore we need a more specific name for the GH action to clarify which project it belongs to.
