### PR TITLE
Update Qualcomm tabs content for 24.04 public beta

### DIFF
--- a/templates/download/qualcomm-iot/index.html
+++ b/templates/download/qualcomm-iot/index.html
@@ -56,6 +56,7 @@
         </div>
         <ul class="js-tabbed-content p-tabs--vertical is-black u-hide--small"
             role="tablist"
+            data-maintain-hash="true"
             aria-label="Qualcomm IoT Boards">
           <li>
             <button class="p-tabs__item"

--- a/templates/download/qualcomm-iot/tabs/rb3-gen2-lite-tab.html
+++ b/templates/download/qualcomm-iot/tabs/rb3-gen2-lite-tab.html
@@ -69,7 +69,8 @@
 
       <ul class="p-list--divided">
         <li class="p-list__item">
-          Get started with Ubuntu 22.04 for <a href="https://www.qualcomm.com/products/internet-of-things/industrial/industrial-automation/qcs5430">QCS5430</a>
+          Get started with Ubuntu 22.04 for <a href="https://www.qualcomm.com/products/internet-of-things/industrial/industrial-automation/qcs5430"
+    aria-label="Read more about QCS5430">QCS5430</a>
         </li>
         <li class="p-list__item">
           Ubuntu 24.04 for QCS5430 <a href="https://docs.qualcomm.com/bundle/publicresource/topics/80-90441-1/Integrate_and_flash_software_2.html?product=1601111740057201">image installation instructions</a>
@@ -82,7 +83,8 @@
       <div class="p-notification--information is-borderless">
         <div class="p-notification__content">
           <p class="p-notification__message">
-            The Ubuntu images are tested on the <a href="https://www.qualcomm.com/developer/hardware/rb3-gen-2-development-kit">Qualcomm® RB3 Gen 2 Lite dev kit</a>
+            The Ubuntu images are tested on the <a href="https://www.qualcomm.com/developer/hardware/rb3-gen-2-development-kit"
+    aria-label="Read more about Qualcomm® RB3 Gen 2 Lite dev kit">Qualcomm® RB3 Gen 2 Lite dev kit</a>
           </p>
         </div>
       </div>
@@ -125,7 +127,8 @@
 
       <ul class="p-list--divided">
         <li class="p-list__item">
-          Get started with Ubuntu Server 22.04 for <a href="https://www.qualcomm.com/products/internet-of-things/industrial/industrial-automation/qcs5430">QCS5430</a>
+          Get started with Ubuntu Server 22.04 for <a href="https://www.qualcomm.com/products/internet-of-things/industrial/industrial-automation/qcs5430"
+    aria-label="Read more about QCS5430">QCS5430</a>
         </li>
         <li class="p-list__item">
           Ubuntu Server 22.04 for QCS5430 <a href="https://docs.qualcomm.com/bundle/publicresource/topics/80-82645-1/Integrate_and_flash_software_2.html?product=1601111740057201">image installation instructions</a>
@@ -138,7 +141,8 @@
       <div class="p-notification--information is-borderless">
         <div class="p-notification__content">
           <p class="p-notification__message">
-            The Ubuntu images are tested on the <a href="https://www.qualcomm.com/developer/hardware/rb3-gen-2-development-kit">Qualcomm® RB3 Gen 2 Lite dev kit</a>
+            The Ubuntu images are tested on the <a href="https://www.qualcomm.com/developer/hardware/rb3-gen-2-development-kit"
+    aria-label="Read more about Qualcomm® RB3 Gen 2 Lite dev kit">Qualcomm® RB3 Gen 2 Lite dev kit</a>
           </p>
         </div>
       </div>

--- a/templates/download/qualcomm-iot/tabs/rb3-gen2-lite-tab.html
+++ b/templates/download/qualcomm-iot/tabs/rb3-gen2-lite-tab.html
@@ -73,7 +73,7 @@
     aria-label="Read more about QCS5430">QCS5430</a>
         </li>
         <li class="p-list__item">
-          Ubuntu 24.04 for QCS5430 <a href="https://docs.qualcomm.com/bundle/publicresource/topics/80-90441-1/Integrate_and_flash_software_2.html?product=1601111740057201">image installation instructions</a>
+          Ubuntu 24.04 for QCS5430 <a href="https://docs.qualcomm.com/bundle/publicresource/topics/80-90441-1/Integrate_and_flash_software_2.html?product=1601111740057201&facet=RB3%20Gen%202%20Dev%20Kit%20Quick%20Start%2024.04">image installation instructions</a>
         </li>
         <li class="p-list__item">
           Ubuntu 24.04 for QCS5430 <a href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x03/Ubuntu_24.04_for_Qualcomm_Dragonwing_RB3_Gen2_Vision_Development_Kit_Release_Notes.pdf">release notes</a>
@@ -131,7 +131,7 @@
     aria-label="Read more about QCS5430">QCS5430</a>
         </li>
         <li class="p-list__item">
-          Ubuntu Server 22.04 for QCS5430 <a href="https://docs.qualcomm.com/bundle/publicresource/topics/80-82645-1/Integrate_and_flash_software_2.html?product=1601111740057201">image installation instructions</a>
+          Ubuntu Server 22.04 for QCS5430 <a href="https://docs.qualcomm.com/bundle/publicresource/topics/80-82645-1/Integrate_and_flash_software_2.html?product=1601111740057201&facet=RB3%20Gen%202%20Dev%20Kit%20Quick%20Start%2022.04">image installation instructions</a>
         </li>
         <li class="p-list__item">
           Ubuntu Server 22.04 for QCS5430 <a href="https://people.canonical.com/~platform/images/qualcomm-iot/rb3-22.04/rb3-server-22.04-x08/Ubuntu%2022.04%20for%20Qualcomm%C2%AE%20RB3%20Gen%202%20Vision%20Development%20Kit%20Release%20Notes.pdf">release notes</a>

--- a/templates/download/qualcomm-iot/tabs/rb3-gen2-lite-tab.html
+++ b/templates/download/qualcomm-iot/tabs/rb3-gen2-lite-tab.html
@@ -70,13 +70,13 @@
       <ul class="p-list--divided">
         <li class="p-list__item">
           Get started with Ubuntu 22.04 for <a href="https://www.qualcomm.com/products/internet-of-things/industrial/industrial-automation/qcs5430"
-    aria-label="Read more about QCS5430">QCS5430</a>
+    title="Read more about QCS5430">QCS5430</a>
         </li>
         <li class="p-list__item">
-          Ubuntu 24.04 for QCS5430 <a href="https://docs.qualcomm.com/bundle/publicresource/topics/80-90441-1/Integrate_and_flash_software_2.html?product=1601111740057201&facet=RB3%20Gen%202%20Dev%20Kit%20Quick%20Start%2024.04">image installation instructions</a>
+          Ubuntu 24.04 for QCS5430 <a href="https://docs.qualcomm.com/bundle/publicresource/topics/80-90441-1/Integrate_and_flash_software_2.html?product=1601111740057201&facet=RB3%20Gen%202%20Dev%20Kit%20Quick%20Start%2024.04" title="Read image installation instructions of Ubuntu 24.04 for QCS5430">image installation instructions</a>
         </li>
         <li class="p-list__item">
-          Ubuntu 24.04 for QCS5430 <a href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x03/Ubuntu_24.04_for_Qualcomm_Dragonwing_RB3_Gen2_Vision_Development_Kit_Release_Notes.pdf">release notes</a>
+          Ubuntu 24.04 for QCS5430 <a href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x03/Ubuntu_24.04_for_Qualcomm_Dragonwing_RB3_Gen2_Vision_Development_Kit_Release_Notes.pdf" title="Read full release notes of Ubuntu 24.04 for QCS5430">release notes</a>
         </li>
       </ul>
       <hr class="p-rule--muted" />
@@ -84,7 +84,7 @@
         <div class="p-notification__content">
           <p class="p-notification__message">
             The Ubuntu images are tested on the <a href="https://www.qualcomm.com/developer/hardware/rb3-gen-2-development-kit"
-    aria-label="Read more about Qualcomm® RB3 Gen 2 Lite dev kit">Qualcomm® RB3 Gen 2 Lite dev kit</a>
+    title="Read more about Qualcomm® RB3 Gen 2 Lite dev kit">Qualcomm® RB3 Gen 2 Lite dev kit</a>
           </p>
         </div>
       </div>
@@ -128,13 +128,13 @@
       <ul class="p-list--divided">
         <li class="p-list__item">
           Get started with Ubuntu Server 22.04 for <a href="https://www.qualcomm.com/products/internet-of-things/industrial/industrial-automation/qcs5430"
-    aria-label="Read more about QCS5430">QCS5430</a>
+    title="Read more about QCS5430">QCS5430</a>
         </li>
         <li class="p-list__item">
-          Ubuntu Server 22.04 for QCS5430 <a href="https://docs.qualcomm.com/bundle/publicresource/topics/80-82645-1/Integrate_and_flash_software_2.html?product=1601111740057201&facet=RB3%20Gen%202%20Dev%20Kit%20Quick%20Start%2022.04">image installation instructions</a>
+          Ubuntu Server 22.04 for QCS5430 <a href="https://docs.qualcomm.com/bundle/publicresource/topics/80-82645-1/Integrate_and_flash_software_2.html?product=1601111740057201&facet=RB3%20Gen%202%20Dev%20Kit%20Quick%20Start%2022.04" title="Read image installation instructions of Ubuntu Server 22.04 for QCS5430">image installation instructions</a>
         </li>
         <li class="p-list__item">
-          Ubuntu Server 22.04 for QCS5430 <a href="https://people.canonical.com/~platform/images/qualcomm-iot/rb3-22.04/rb3-server-22.04-x08/Ubuntu%2022.04%20for%20Qualcomm%C2%AE%20RB3%20Gen%202%20Vision%20Development%20Kit%20Release%20Notes.pdf">release notes</a>
+          Ubuntu Server 22.04 for QCS5430 <a href="https://people.canonical.com/~platform/images/qualcomm-iot/rb3-22.04/rb3-server-22.04-x08/Ubuntu%2022.04%20for%20Qualcomm%C2%AE%20RB3%20Gen%202%20Vision%20Development%20Kit%20Release%20Notes.pdf" title="Read full release notes of Ubuntu Server 22.04 for QCS5430">release notes</a>
         </li>
       </ul>
       <hr class="p-rule--muted" />
@@ -142,7 +142,7 @@
         <div class="p-notification__content">
           <p class="p-notification__message">
             The Ubuntu images are tested on the <a href="https://www.qualcomm.com/developer/hardware/rb3-gen-2-development-kit"
-    aria-label="Read more about Qualcomm® RB3 Gen 2 Lite dev kit">Qualcomm® RB3 Gen 2 Lite dev kit</a>
+    title="Read more about Qualcomm® RB3 Gen 2 Lite dev kit">Qualcomm® RB3 Gen 2 Lite dev kit</a>
           </p>
         </div>
       </div>

--- a/templates/download/qualcomm-iot/tabs/rb3-gen2-lite-tab.html
+++ b/templates/download/qualcomm-iot/tabs/rb3-gen2-lite-tab.html
@@ -39,8 +39,8 @@
           </div>
           <div class="col-3 col-medium-2 col-small-2">
             <a class="p-button--positive"
-               href=""
-               title="Download Ubuntu Desktop 24.04 for QCS5430">Download [TODO href]</a>
+               href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x03/ubuntu-desktop-24.04"
+               title="Download Ubuntu Desktop 24.04 for QCS5430">Download</a>
           </div>
           <div class="col-6 col-medium-4 col-small-4">
             <hr class="p-rule--muted" />
@@ -50,8 +50,8 @@
           </div>
           <div class="col-3 col-medium-2 col-small-2">
             <a class="p-button--positive"
-               href=""
-               title="Download Ubuntu Server 24.04 for QCS5430">Download [TODO href]</a>
+               href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x03/ubuntu-server-24.04"
+               title="Download Ubuntu Server 24.04 for QCS5430">Download</a>
           </div>
           <div class="col-6 col-medium-4 col-small-4">
             <hr class="p-rule--muted" />
@@ -60,7 +60,9 @@
             <p class="p-heading--5">Boot firmware</p>
           </div>
           <div class="col-3 col-medium-2 col-small-2">
-            <a class="p-button" href="" title="Download boot firmware">Download [TODO href]</a>
+            <a class="p-button"
+               href="https://artifacts.codelinaro.org/ui/native/qli-ci/flashable-binaries/ubuntu-fw/QLI.1.4-Ver.1.1-ubuntu-nhlos-bins.tar.gz"
+               title="Download boot firmware">Download</a>
           </div>
         </div>
       </div>

--- a/templates/download/qualcomm-iot/tabs/rb3-gen2-lite-tab.html
+++ b/templates/download/qualcomm-iot/tabs/rb3-gen2-lite-tab.html
@@ -25,24 +25,102 @@
   <hr class="p-rule--muted" />
   <div class="row">
     <div class="col-3">
-      <h3 class="p-heading--5">Ubuntu Server 22.04</h3>
+      <h3 class="p-heading--5">Ubuntu 24.04</h3>
     </div>
     <div class="col-6">
-      <p>This is the Beta 2 release of Ubuntu on Qualcomm IoT Platforms for QCS5430. The certified version is coming soon.</p>
-      <div class="p-cta-block">
-        <a class="p-button--positive"
-           href="https://people.canonical.com/~platform/images/qualcomm-iot/rb3-22.04/rb3-server-22.04-x08/">Download Ubuntu Server 22.04 for QCS5430</a>
-        <a class="p-button"
-           href="https://artifacts.codelinaro.org/artifactory/qli-ci/flashable-binaries/ubuntu-fw/QLI.1.2-Ver.1.1-ubuntu-nhlos-bins.tar.gz">Download boot firmware</a>
+      <p>This is the Beta release of Ubuntu on Qualcomm IoT Platforms for QCS5430.  The certified version is coming soon.</p>
+      <div class="p-section--shallow">
+        <div class="row">
+          <div class="col-6 col-medium-4 col-small-4">
+            <hr class="p-rule--muted" />
+          </div>
+          <div class="col-3 col-medium-2 col-small-2">
+            <p class="p-heading--5">Ubuntu Desktop 24.04 for QCS5430</p>
+          </div>
+          <div class="col-3 col-medium-2 col-small-2">
+            <a class="p-button--positive"
+               href=""
+               title="Download Ubuntu Desktop 24.04 for QCS5430">Download [TODO href]</a>
+          </div>
+          <div class="col-6 col-medium-4 col-small-4">
+            <hr class="p-rule--muted" />
+          </div>
+          <div class="col-3 col-medium-2 col-small-2">
+            <p class="p-heading--5">Ubuntu Server 24.04 for QCS5430</p>
+          </div>
+          <div class="col-3 col-medium-2 col-small-2">
+            <a class="p-button--positive"
+               href=""
+               title="Download Ubuntu Server 24.04 for QCS5430">Download [TODO href]</a>
+          </div>
+          <div class="col-6 col-medium-4 col-small-4">
+            <hr class="p-rule--muted" />
+          </div>
+          <div class="col-3 col-medium-2 col-small-2">
+            <p class="p-heading--5">Boot firmware</p>
+          </div>
+          <div class="col-3 col-medium-2 col-small-2">
+            <a class="p-button" href="" title="Download boot firmware">Download [TODO href]</a>
+          </div>
+        </div>
+      </div>
+
+      <ul class="p-list--divided">
+        <li class="p-list__item">
+          Get started with Ubuntu 22.04 for <a href="https://www.qualcomm.com/products/internet-of-things/industrial/industrial-automation/qcs5430">QCS5430</a>
+        </li>
+        <li class="p-list__item">
+          Ubuntu 24.04 for QCS5430 <a href="">image installation instructions [TODO href]</a>
+        </li>
+        <li class="p-list__item">
+          Ubuntu 24.04 for QCS5430 <a href="">release notes [TODO href]</a>
+        </li>
+      </ul>
+      <hr class="p-rule--muted" />
+      <div class="p-notification--information is-borderless">
+        <div class="p-notification__content">
+          <p class="p-notification__message">
+            The Ubuntu images are tested on the <a href="https://www.qualcomm.com/products/internet-of-things/industrial/industrial-automation/qcs5430#featuredhardwaresection">Qualcomm® RB3 Gen 2 Lite dev kit</a>
+          </p>
+        </div>
       </div>
     </div>
   </div>
+
   <hr class="p-rule--muted" />
   <div class="row">
     <div class="col-3">
-      <h3 class="p-heading--5">Get started</h3>
+      <h3 class="p-heading--5">Ubuntu Server 22.04</h3>
     </div>
     <div class="col-6">
+      <p>This is the Beta 2 release of Ubuntu on Qualcomm IoT Platforms for QCS5430.</p>
+      <div class="p-section--shallow">
+        <div class="row">
+          <div class="col-6 col-medium-4 col-small-4">
+            <hr class="p-rule--muted" />
+          </div>
+          <div class="col-3 col-medium-2 col-small-2">
+            <p class="p-heading--5">Ubuntu Server 22.04 for QCS5430</p>
+          </div>
+          <div class="col-3 col-medium-2 col-small-2">
+            <a class="p-button--positive"
+               href="https://people.canonical.com/~platform/images/qualcomm-iot/rb3-22.04/rb3-server-22.04-x08/"
+               title="Download Ubuntu Server 22.04 for QCS5430">Download</a>
+          </div>
+          <div class="col-6 col-medium-4 col-small-4">
+            <hr class="p-rule--muted" />
+          </div>
+          <div class="col-3 col-medium-2 col-small-2">
+            <p class="p-heading--5">Boot firmware</p>
+          </div>
+          <div class="col-3 col-medium-2 col-small-2">
+            <a class="p-button"
+               href="https://artifacts.codelinaro.org/artifactory/qli-ci/flashable-binaries/ubuntu-fw/QLI.1.2-Ver.1.1-ubuntu-nhlos-bins.tar.gz"
+               title="Download boot firmware">Download</a>
+          </div>
+        </div>
+      </div>
+
       <ul class="p-list--divided">
         <li class="p-list__item">
           Get started with Ubuntu Server 22.04 for <a href="https://www.qualcomm.com/products/internet-of-things/industrial/industrial-automation/qcs5430">QCS5430</a>

--- a/templates/download/qualcomm-iot/tabs/rb3-gen2-lite-tab.html
+++ b/templates/download/qualcomm-iot/tabs/rb3-gen2-lite-tab.html
@@ -72,17 +72,17 @@
           Get started with Ubuntu 22.04 for <a href="https://www.qualcomm.com/products/internet-of-things/industrial/industrial-automation/qcs5430">QCS5430</a>
         </li>
         <li class="p-list__item">
-          Ubuntu 24.04 for QCS5430 <a href="">image installation instructions [TODO href]</a>
+          Ubuntu 24.04 for QCS5430 <a href="https://docs.qualcomm.com/bundle/publicresource/topics/80-90441-1/Integrate_and_flash_software_2.html?product=1601111740057201">image installation instructions</a>
         </li>
         <li class="p-list__item">
-          Ubuntu 24.04 for QCS5430 <a href="">release notes [TODO href]</a>
+          Ubuntu 24.04 for QCS5430 <a href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x03/Ubuntu_24.04_for_Qualcomm_Dragonwing_RB3_Gen2_Vision_Development_Kit_Release_Notes.pdf">release notes</a>
         </li>
       </ul>
       <hr class="p-rule--muted" />
       <div class="p-notification--information is-borderless">
         <div class="p-notification__content">
           <p class="p-notification__message">
-            The Ubuntu images are tested on the <a href="https://www.qualcomm.com/products/internet-of-things/industrial/industrial-automation/qcs5430#featuredhardwaresection">Qualcomm® RB3 Gen 2 Lite dev kit</a>
+            The Ubuntu images are tested on the <a href="https://www.qualcomm.com/developer/hardware/rb3-gen-2-development-kit">Qualcomm® RB3 Gen 2 Lite dev kit</a>
           </p>
         </div>
       </div>
@@ -138,7 +138,7 @@
       <div class="p-notification--information is-borderless">
         <div class="p-notification__content">
           <p class="p-notification__message">
-            The Ubuntu images are tested on the <a href="https://www.qualcomm.com/products/internet-of-things/industrial/industrial-automation/qcs5430#featuredhardwaresection">Qualcomm® RB3 Gen 2 Lite dev kit</a>
+            The Ubuntu images are tested on the <a href="https://www.qualcomm.com/developer/hardware/rb3-gen-2-development-kit">Qualcomm® RB3 Gen 2 Lite dev kit</a>
           </p>
         </div>
       </div>

--- a/templates/download/qualcomm-iot/tabs/rb3-gen2-tab.html
+++ b/templates/download/qualcomm-iot/tabs/rb3-gen2-tab.html
@@ -70,13 +70,13 @@
       <ul class="p-list--divided">
         <li class="p-list__item">
           Get started with Ubuntu 24.04 for <a href="https://www.qualcomm.com/products/internet-of-things/industrial/building-enterprise/qcs6490#overview"
-    aria-label="Read more about QCS6490">QCS6490</a>
+    title="Read more about QCS6490">QCS6490</a>
         </li>
         <li class="p-list__item">
-          Ubuntu 24.04 for QCS6490 <a href="https://docs.qualcomm.com/bundle/publicresource/topics/80-90441-1/Integrate_and_flash_software_2.html?product=1601111740057201&facet=RB3%20Gen%202%20Dev%20Kit%20Quick%20Start%2024.04">image installation instructions</a>
+          Ubuntu 24.04 for QCS6490 <a href="https://docs.qualcomm.com/bundle/publicresource/topics/80-90441-1/Integrate_and_flash_software_2.html?product=1601111740057201&facet=RB3%20Gen%202%20Dev%20Kit%20Quick%20Start%2024.04" title="Read image installation instructions of Ubuntu 24.04 for QCS6490">image installation instructions</a>
         </li>
         <li class="p-list__item">
-          Ubuntu 24.04 for QCS6490 <a href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x03/Ubuntu_24.04_for_Qualcomm_Dragonwing_RB3_Gen2_Vision_Development_Kit_Release_Notes.pdf">release notes</a>
+          Ubuntu 24.04 for QCS6490 <a href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x03/Ubuntu_24.04_for_Qualcomm_Dragonwing_RB3_Gen2_Vision_Development_Kit_Release_Notes.pdf" title="Read full release notes of Ubuntu 24.04 for QCS6490">release notes</a>
         </li>
       </ul>
       <hr class="p-rule--muted" />
@@ -84,7 +84,7 @@
         <div class="p-notification__content">
           <p class="p-notification__message">
             The Ubuntu images are tested on the <a href="https://www.qualcomm.com/developer/hardware/rb3-gen-2-development-kit"
-    aria-label="Read more about Qualcomm® RB3 Gen 2 dev kit">Qualcomm® RB3 Gen 2 dev kit</a>
+    title="Read more about Qualcomm® RB3 Gen 2 dev kit">Qualcomm® RB3 Gen 2 dev kit</a>
           </p>
         </div>
       </div>
@@ -128,13 +128,13 @@
       <ul class="p-list--divided">
         <li class="p-list__item">
           Get started with Ubuntu Server 22.04 for <a href="https://www.qualcomm.com/products/internet-of-things/industrial/building-enterprise/qcs6490#overview"
-    aria-label="Read more about QCS6490">QCS6490</a>
+    title="Read more about QCS6490">QCS6490</a>
         </li>
         <li class="p-list__item">
-          Ubuntu Server 22.04 for QCS6490 <a href="https://docs.qualcomm.com/bundle/publicresource/topics/80-82645-1/Integrate_and_flash_software_2.html?product=1601111740057201&facet=RB3%20Gen%202%20Dev%20Kit%20Quick%20Start%2022.04">image installation instructions</a>
+          Ubuntu Server 22.04 for QCS6490 <a href="https://docs.qualcomm.com/bundle/publicresource/topics/80-82645-1/Integrate_and_flash_software_2.html?product=1601111740057201&facet=RB3%20Gen%202%20Dev%20Kit%20Quick%20Start%2022.04" title="Read image installation instructions of Ubuntu Server 22.04 for QCS6490">image installation instructions</a>
         </li>
         <li class="p-list__item">
-          Ubuntu Server 22.04 for QCS6490 <a href="https://people.canonical.com/~platform/images/qualcomm-iot/rb3-22.04/rb3-server-22.04-x08/Ubuntu%2022.04%20for%20Qualcomm%C2%AE%20RB3%20Gen%202%20Vision%20Development%20Kit%20Release%20Notes.pdf">release notes</a>
+          Ubuntu Server 22.04 for QCS6490 <a href="https://people.canonical.com/~platform/images/qualcomm-iot/rb3-22.04/rb3-server-22.04-x08/Ubuntu%2022.04%20for%20Qualcomm%C2%AE%20RB3%20Gen%202%20Vision%20Development%20Kit%20Release%20Notes.pdf" title="Read full release notes of Ubuntu Server 22.04 for QCS6490">release notes</a>
         </li>
       </ul>
       <hr class="p-rule--muted" />
@@ -142,7 +142,7 @@
         <div class="p-notification__content">
           <p class="p-notification__message">
             The Ubuntu images are tested on the <a href="https://www.qualcomm.com/developer/hardware/rb3-gen-2-development-kit"
-    aria-label="Read more about Qualcomm® RB3 Gen 2 dev kit">Qualcomm® RB3 Gen 2 dev kit</a>
+    title="Read more about Qualcomm® RB3 Gen 2 dev kit">Qualcomm® RB3 Gen 2 dev kit</a>
           </p>
         </div>
       </div>

--- a/templates/download/qualcomm-iot/tabs/rb3-gen2-tab.html
+++ b/templates/download/qualcomm-iot/tabs/rb3-gen2-tab.html
@@ -69,7 +69,8 @@
 
       <ul class="p-list--divided">
         <li class="p-list__item">
-          Get started with Ubuntu 24.04 for <a href="https://www.qualcomm.com/products/internet-of-things/industrial/building-enterprise/qcs6490#overview">QCS6490</a>
+          Get started with Ubuntu 24.04 for <a href="https://www.qualcomm.com/products/internet-of-things/industrial/building-enterprise/qcs6490#overview"
+    aria-label="Read more about QCS6490">QCS6490</a>
         </li>
         <li class="p-list__item">
           Ubuntu 24.04 for QCS6490 <a href="https://docs.qualcomm.com/bundle/publicresource/topics/80-90441-1/Integrate_and_flash_software_2.html?product=1601111740057201">image installation instructions</a>
@@ -82,7 +83,8 @@
       <div class="p-notification--information is-borderless">
         <div class="p-notification__content">
           <p class="p-notification__message">
-            The Ubuntu images are tested on the <a href="https://www.qualcomm.com/developer/hardware/rb3-gen-2-development-kit">Qualcomm® RB3 Gen 2 dev kit</a>
+            The Ubuntu images are tested on the <a href="https://www.qualcomm.com/developer/hardware/rb3-gen-2-development-kit"
+    aria-label="Read more about Qualcomm® RB3 Gen 2 dev kit">Qualcomm® RB3 Gen 2 dev kit</a>
           </p>
         </div>
       </div>
@@ -125,7 +127,8 @@
 
       <ul class="p-list--divided">
         <li class="p-list__item">
-          Get started with Ubuntu Server 22.04 for <a href="https://www.qualcomm.com/products/internet-of-things/industrial/building-enterprise/qcs6490#overview">QCS6490</a>
+          Get started with Ubuntu Server 22.04 for <a href="https://www.qualcomm.com/products/internet-of-things/industrial/building-enterprise/qcs6490#overview"
+    aria-label="Read more about QCS6490">QCS6490</a>
         </li>
         <li class="p-list__item">
           Ubuntu Server 22.04 for QCS6490 <a href="https://docs.qualcomm.com/bundle/publicresource/topics/80-82645-1/Integrate_and_flash_software_2.html?product=1601111740057201">image installation instructions</a>
@@ -138,7 +141,8 @@
       <div class="p-notification--information is-borderless">
         <div class="p-notification__content">
           <p class="p-notification__message">
-            The Ubuntu images are tested on the <a href="https://www.qualcomm.com/developer/hardware/rb3-gen-2-development-kit">Qualcomm® RB3 Gen 2 dev kit</a>
+            The Ubuntu images are tested on the <a href="https://www.qualcomm.com/developer/hardware/rb3-gen-2-development-kit"
+    aria-label="Read more about Qualcomm® RB3 Gen 2 dev kit">Qualcomm® RB3 Gen 2 dev kit</a>
           </p>
         </div>
       </div>

--- a/templates/download/qualcomm-iot/tabs/rb3-gen2-tab.html
+++ b/templates/download/qualcomm-iot/tabs/rb3-gen2-tab.html
@@ -73,7 +73,7 @@
     aria-label="Read more about QCS6490">QCS6490</a>
         </li>
         <li class="p-list__item">
-          Ubuntu 24.04 for QCS6490 <a href="https://docs.qualcomm.com/bundle/publicresource/topics/80-90441-1/Integrate_and_flash_software_2.html?product=1601111740057201">image installation instructions</a>
+          Ubuntu 24.04 for QCS6490 <a href="https://docs.qualcomm.com/bundle/publicresource/topics/80-90441-1/Integrate_and_flash_software_2.html?product=1601111740057201&facet=RB3%20Gen%202%20Dev%20Kit%20Quick%20Start%2024.04">image installation instructions</a>
         </li>
         <li class="p-list__item">
           Ubuntu 24.04 for QCS6490 <a href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x03/Ubuntu_24.04_for_Qualcomm_Dragonwing_RB3_Gen2_Vision_Development_Kit_Release_Notes.pdf">release notes</a>
@@ -131,7 +131,7 @@
     aria-label="Read more about QCS6490">QCS6490</a>
         </li>
         <li class="p-list__item">
-          Ubuntu Server 22.04 for QCS6490 <a href="https://docs.qualcomm.com/bundle/publicresource/topics/80-82645-1/Integrate_and_flash_software_2.html?product=1601111740057201">image installation instructions</a>
+          Ubuntu Server 22.04 for QCS6490 <a href="https://docs.qualcomm.com/bundle/publicresource/topics/80-82645-1/Integrate_and_flash_software_2.html?product=1601111740057201&facet=RB3%20Gen%202%20Dev%20Kit%20Quick%20Start%2022.04">image installation instructions</a>
         </li>
         <li class="p-list__item">
           Ubuntu Server 22.04 for QCS6490 <a href="https://people.canonical.com/~platform/images/qualcomm-iot/rb3-22.04/rb3-server-22.04-x08/Ubuntu%2022.04%20for%20Qualcomm%C2%AE%20RB3%20Gen%202%20Vision%20Development%20Kit%20Release%20Notes.pdf">release notes</a>

--- a/templates/download/qualcomm-iot/tabs/rb3-gen2-tab.html
+++ b/templates/download/qualcomm-iot/tabs/rb3-gen2-tab.html
@@ -25,26 +25,102 @@
   <hr class="p-rule--muted" />
   <div class="row">
     <div class="col-3">
-      <h3 class="p-heading--5">Ubuntu Server 22.04</h3>
+      <h3 class="p-heading--5">Ubuntu 24.04</h3>
     </div>
     <div class="col-6">
-      <p>
-        This is the Beta 2 release of Ubuntu on Qualcomm IoT Platforms for QCS6490. The certified version is coming soon.
-      </p>
-      <div class="p-cta-block">
-        <a class="p-button--positive"
-           href="https://people.canonical.com/~platform/images/qualcomm-iot/rb3-22.04/rb3-server-22.04-x08/">Download Ubuntu Server 22.04 for QCS6490</a>
-        <a class="p-button"
-           href="https://artifacts.codelinaro.org/artifactory/qli-ci/flashable-binaries/ubuntu-fw/QLI.1.2-Ver.1.1-ubuntu-nhlos-bins.tar.gz">Download boot firmware</a>
+      <p>This is the Beta release of Ubuntu on Qualcomm IoT Platforms for QCS6490. The certified version is coming soon.</p>
+      <div class="p-section--shallow">
+        <div class="row">
+          <div class="col-6 col-medium-4 col-small-4">
+            <hr class="p-rule--muted" />
+          </div>
+          <div class="col-3 col-medium-2 col-small-2">
+            <p class="p-heading--5">Ubuntu Desktop 24.04 for QCS6490</p>
+          </div>
+          <div class="col-3 col-medium-2 col-small-2">
+            <a class="p-button--positive"
+               href=""
+               title="Download Ubuntu Desktop 24.04 for QCS6490">Download [TODO href]</a>
+          </div>
+          <div class="col-6 col-medium-4 col-small-4">
+            <hr class="p-rule--muted" />
+          </div>
+          <div class="col-3 col-medium-2 col-small-2">
+            <p class="p-heading--5">Ubuntu Server 24.04 for QCS6490</p>
+          </div>
+          <div class="col-3 col-medium-2 col-small-2">
+            <a class="p-button--positive"
+               href=""
+               title="Download Ubuntu Server 24.04 for QCS6490">Download [TODO href]</a>
+          </div>
+          <div class="col-6 col-medium-4 col-small-4">
+            <hr class="p-rule--muted" />
+          </div>
+          <div class="col-3 col-medium-2 col-small-2">
+            <p class="p-heading--5">Boot firmware</p>
+          </div>
+          <div class="col-3 col-medium-2 col-small-2">
+            <a class="p-button" href="" title="Download boot firmware">Download [TODO href]</a>
+          </div>
+        </div>
+      </div>
+
+      <ul class="p-list--divided">
+        <li class="p-list__item">
+          Get started with Ubuntu 24.04 for <a href="https://www.qualcomm.com/products/internet-of-things/industrial/building-enterprise/qcs6490#overview">QCS6490</a>
+        </li>
+        <li class="p-list__item">
+          Ubuntu 24.04 for QCS6490 <a href="">image installation instructions [TODO href]</a>
+        </li>
+        <li class="p-list__item">
+          Ubuntu 24.04 for QCS6490 <a href="">release notes [TODO href]</a>
+        </li>
+      </ul>
+      <hr class="p-rule--muted" />
+      <div class="p-notification--information is-borderless">
+        <div class="p-notification__content">
+          <p class="p-notification__message">
+            The Ubuntu images are tested on the <a href="https://www.qualcomm.com/products/internet-of-things/industrial/building-enterprise/qcs6490#featuredhardwaresection">Qualcomm® RB3 Gen 2 dev kit</a>
+          </p>
+        </div>
       </div>
     </div>
   </div>
+
   <hr class="p-rule--muted" />
   <div class="row">
     <div class="col-3">
-      <h3 class="p-heading--5">Get started</h3>
+      <h3 class="p-heading--5">Ubuntu Server 22.04</h3>
     </div>
     <div class="col-6">
+      <p>This is the Beta 2 release of Ubuntu on Qualcomm IoT Platforms for QCS6490.</p>
+      <div class="p-section--shallow">
+        <div class="row">
+          <div class="col-6 col-medium-4 col-small-4">
+            <hr class="p-rule--muted" />
+          </div>
+          <div class="col-3 col-medium-2 col-small-2">
+            <p class="p-heading--5">Ubuntu Server 22.04 for QCS6490</p>
+          </div>
+          <div class="col-3 col-medium-2 col-small-2">
+            <a class="p-button--positive"
+               href="https://people.canonical.com/~platform/images/qualcomm-iot/rb3-22.04/rb3-server-22.04-x08/"
+               title="Download Ubuntu Server 22.04 for QCS6490">Download</a>
+          </div>
+          <div class="col-6 col-medium-4 col-small-4">
+            <hr class="p-rule--muted" />
+          </div>
+          <div class="col-3 col-medium-2 col-small-2">
+            <p class="p-heading--5">Boot firmware</p>
+          </div>
+          <div class="col-3 col-medium-2 col-small-2">
+            <a class="p-button"
+               href="https://artifacts.codelinaro.org/artifactory/qli-ci/flashable-binaries/ubuntu-fw/QLI.1.2-Ver.1.1-ubuntu-nhlos-bins.tar.gz"
+               title="Download boot firmware">Download</a>
+          </div>
+        </div>
+      </div>
+
       <ul class="p-list--divided">
         <li class="p-list__item">
           Get started with Ubuntu Server 22.04 for <a href="https://www.qualcomm.com/products/internet-of-things/industrial/building-enterprise/qcs6490#overview">QCS6490</a>

--- a/templates/download/qualcomm-iot/tabs/rb3-gen2-tab.html
+++ b/templates/download/qualcomm-iot/tabs/rb3-gen2-tab.html
@@ -39,8 +39,8 @@
           </div>
           <div class="col-3 col-medium-2 col-small-2">
             <a class="p-button--positive"
-               href=""
-               title="Download Ubuntu Desktop 24.04 for QCS6490">Download [TODO href]</a>
+               href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x03/ubuntu-desktop-24.04"
+               title="Download Ubuntu Desktop 24.04 for QCS6490">Download</a>
           </div>
           <div class="col-6 col-medium-4 col-small-4">
             <hr class="p-rule--muted" />
@@ -50,8 +50,8 @@
           </div>
           <div class="col-3 col-medium-2 col-small-2">
             <a class="p-button--positive"
-               href=""
-               title="Download Ubuntu Server 24.04 for QCS6490">Download [TODO href]</a>
+               href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x03/ubuntu-server-24.04"
+               title="Download Ubuntu Server 24.04 for QCS6490">Download</a>
           </div>
           <div class="col-6 col-medium-4 col-small-4">
             <hr class="p-rule--muted" />
@@ -60,7 +60,7 @@
             <p class="p-heading--5">Boot firmware</p>
           </div>
           <div class="col-3 col-medium-2 col-small-2">
-            <a class="p-button" href="" title="Download boot firmware">Download [TODO href]</a>
+            <a class="p-button" href="https://artifacts.codelinaro.org/ui/native/qli-ci/flashable-binaries/ubuntu-fw/QLI.1.4-Ver.1.1-ubuntu-nhlos-bins.tar.gz" title="Download boot firmware">Download</a>
           </div>
         </div>
       </div>

--- a/templates/download/qualcomm-iot/tabs/rb3-gen2-tab.html
+++ b/templates/download/qualcomm-iot/tabs/rb3-gen2-tab.html
@@ -60,7 +60,9 @@
             <p class="p-heading--5">Boot firmware</p>
           </div>
           <div class="col-3 col-medium-2 col-small-2">
-            <a class="p-button" href="https://artifacts.codelinaro.org/ui/native/qli-ci/flashable-binaries/ubuntu-fw/QLI.1.4-Ver.1.1-ubuntu-nhlos-bins.tar.gz" title="Download boot firmware">Download</a>
+            <a class="p-button"
+               href="https://artifacts.codelinaro.org/ui/native/qli-ci/flashable-binaries/ubuntu-fw/QLI.1.4-Ver.1.1-ubuntu-nhlos-bins.tar.gz"
+               title="Download boot firmware">Download</a>
           </div>
         </div>
       </div>
@@ -70,17 +72,17 @@
           Get started with Ubuntu 24.04 for <a href="https://www.qualcomm.com/products/internet-of-things/industrial/building-enterprise/qcs6490#overview">QCS6490</a>
         </li>
         <li class="p-list__item">
-          Ubuntu 24.04 for QCS6490 <a href="">image installation instructions [TODO href]</a>
+          Ubuntu 24.04 for QCS6490 <a href="https://docs.qualcomm.com/bundle/publicresource/topics/80-90441-1/Integrate_and_flash_software_2.html?product=1601111740057201">image installation instructions</a>
         </li>
         <li class="p-list__item">
-          Ubuntu 24.04 for QCS6490 <a href="">release notes [TODO href]</a>
+          Ubuntu 24.04 for QCS6490 <a href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x03/Ubuntu_24.04_for_Qualcomm_Dragonwing_RB3_Gen2_Vision_Development_Kit_Release_Notes.pdf">release notes</a>
         </li>
       </ul>
       <hr class="p-rule--muted" />
       <div class="p-notification--information is-borderless">
         <div class="p-notification__content">
           <p class="p-notification__message">
-            The Ubuntu images are tested on the <a href="https://www.qualcomm.com/products/internet-of-things/industrial/building-enterprise/qcs6490#featuredhardwaresection">Qualcomm® RB3 Gen 2 dev kit</a>
+            The Ubuntu images are tested on the <a href="https://www.qualcomm.com/developer/hardware/rb3-gen-2-development-kit">Qualcomm® RB3 Gen 2 dev kit</a>
           </p>
         </div>
       </div>
@@ -126,17 +128,17 @@
           Get started with Ubuntu Server 22.04 for <a href="https://www.qualcomm.com/products/internet-of-things/industrial/building-enterprise/qcs6490#overview">QCS6490</a>
         </li>
         <li class="p-list__item">
-          Ubuntu Server 22.04 for QCS6490 <a href="https://docs.qualcomm.com/bundle/publicresource/topics/80-82645-1/Integrate_and_flash_software_2.html?product=1601111740057201">image installation instructions</a>
+          Ubuntu Server 22.04 for QCS6490 <a href="https://docs.qualcomm.com/bundle/publicresource/topics/80-90441-1/Integrate_and_flash_software_2.html?product=1601111740057201">image installation instructions</a>
         </li>
         <li class="p-list__item">
-          Ubuntu Server 22.04 for QCS6490 <a href="https://people.canonical.com/~platform/images/qualcomm-iot/rb3-22.04/rb3-server-22.04-x08/Ubuntu%2022.04%20for%20Qualcomm%C2%AE%20RB3%20Gen%202%20Vision%20Development%20Kit%20Release%20Notes.pdf">release notes</a>
+          Ubuntu Server 22.04 for QCS6490 <a href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x03/Ubuntu_24.04_for_Qualcomm_Dragonwing_RB3_Gen2_Vision_Development_Kit_Release_Notes.pdf">release notes</a>
         </li>
       </ul>
       <hr class="p-rule--muted" />
       <div class="p-notification--information is-borderless">
         <div class="p-notification__content">
           <p class="p-notification__message">
-            The Ubuntu images are tested on the <a href="https://www.qualcomm.com/products/internet-of-things/industrial/building-enterprise/qcs6490#featuredhardwaresection">Qualcomm® RB3 Gen 2 dev kit</a>
+            The Ubuntu images are tested on the <a href="https://www.qualcomm.com/developer/hardware/rb3-gen-2-development-kit">Qualcomm® RB3 Gen 2 dev kit</a>
           </p>
         </div>
       </div>

--- a/templates/download/qualcomm-iot/tabs/rb3-gen2-tab.html
+++ b/templates/download/qualcomm-iot/tabs/rb3-gen2-tab.html
@@ -128,10 +128,10 @@
           Get started with Ubuntu Server 22.04 for <a href="https://www.qualcomm.com/products/internet-of-things/industrial/building-enterprise/qcs6490#overview">QCS6490</a>
         </li>
         <li class="p-list__item">
-          Ubuntu Server 22.04 for QCS6490 <a href="https://docs.qualcomm.com/bundle/publicresource/topics/80-90441-1/Integrate_and_flash_software_2.html?product=1601111740057201">image installation instructions</a>
+          Ubuntu Server 22.04 for QCS6490 <a href="https://docs.qualcomm.com/bundle/publicresource/topics/80-82645-1/Integrate_and_flash_software_2.html?product=1601111740057201">image installation instructions</a>
         </li>
         <li class="p-list__item">
-          Ubuntu Server 22.04 for QCS6490 <a href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x03/Ubuntu_24.04_for_Qualcomm_Dragonwing_RB3_Gen2_Vision_Development_Kit_Release_Notes.pdf">release notes</a>
+          Ubuntu Server 22.04 for QCS6490 <a href="https://people.canonical.com/~platform/images/qualcomm-iot/rb3-22.04/rb3-server-22.04-x08/Ubuntu%2022.04%20for%20Qualcomm%C2%AE%20RB3%20Gen%202%20Vision%20Development%20Kit%20Release%20Notes.pdf">release notes</a>
         </li>
       </ul>
       <hr class="p-rule--muted" />


### PR DESCRIPTION
## Done

- Updated the contents of the Qualcomm tabs for the new release

Copy doc: https://docs.google.com/document/d/1BP2T63R6kdnUFQFIZcbXbTIgY-9fQVgVRLsSUU5Rvx8/edit?tab=t.0
Figma: https://www.figma.com/design/cVGimTPHky4h3BPXfrT6GB/Ubuntu.com-download?node-id=1990-17189&m=dev

## QA

- Demo: https://ubuntu-com-15033.demos.haus/download/qualcomm-iot
- Review the contents of the tabs agains copydoc and Figma design (design only shows one of them, but they only differ in device name)

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-21405

## Screenshots

<img width="1311" alt="image" src="https://github.com/user-attachments/assets/8ce94ab7-f816-48c1-82eb-110129d097ff" />



## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
