### PR TITLE
feat: added nginx rate limiting to marketo

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -1241,12 +1241,12 @@ demo:
     - name: CANONICAL_CLA_API_URL
       value: https://cla.staging.canonical.com
 
-    nginxConfigurationSnippet: |
-      limit_req_zone $binary_remote_addr zone=marketo:50m rate=1r/s;
+  nginxConfigurationSnippet: |
+    limit_req_zone $binary_remote_addr zone=marketo:50m rate=1r/s;
 
-    nginxServerSnippet: |
-      location ^~ /marketo/submit/ {
-        limit_req zone=marketo burst=20;
-        limit_req_status 429;
-        limit_req_log_level warn;
-      }
+  nginxServerSnippet: |
+    location ^~ /marketo/submit/ {
+      limit_req zone=marketo burst=20;
+      limit_req_status 429;
+      limit_req_log_level warn;
+    }


### PR DESCRIPTION
## Done

- Added rate limiting config for the `/marketo/submit` endpoint.
  - Limited to 1req/s
  - Allow a queue of 20 requests before returning 429 

## QA

- Open the [demo](https://ubuntu-com-15035.demos.haus/)
- Attempt to hit the rate limit using the handy [hey tool](https://github.com/rakyll/hey?tab=readme-ov-file) by running
```bash
./hey_linux_amd64 -m POST -H "Content-Type: application/x-www-form-urlencoded" -d "formid=testratelimit&email=email@example.com&company=canonical" https://ubuntu-com-15035.demos.haus/marketo/submit
```
- Once QA is done, I'll add the same limit to staging and production nginx configs as well

## Issue / Card

Fixes [WD-15861](https://warthogs.atlassian.net/browse/WD-15861)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-15861]: https://warthogs.atlassian.net/browse/WD-15861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ