### PR TITLE
[WD-20510] fix: incorrect padding on search and close icon on medium screens

### DIFF
--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -107,14 +107,6 @@ $meganav-height: 3rem;
         }
       }
 
-      .p-navigation__link--search-toggle::after {
-        right: 0.75rem;
-
-        @media (max-width: $breakpoint-navigation-threshold - 1) {
-          right: 0.5rem;
-        }
-      }
-
       @media (max-width: $breakpoint-navigation-threshold - 1) {
         .subsection-active & {
           transform: translateX(-100vw);
@@ -502,22 +494,6 @@ $meganav-height: 3rem;
       }
     }
 
-    .p-navigation__link--search-toggle {
-      padding-bottom: 0.5rem;
-      padding-top: 0.5rem;
-
-      @media (max-width: $breakpoint-large) {
-        padding-right: 3rem;
-        padding-left: 3rem;
-      }
-
-      &::after {
-        color: $color-mid-light;
-        right: 1rem;
-        top: 1rem;
-      }
-    }
-
     @media (min-width: $breakpoint-navigation-threshold) {
       background-color: $color-dark;
       margin-bottom: 0;
@@ -574,23 +550,6 @@ $meganav-height: 3rem;
             opacity: 0.3;
             right: $sph--large - $circle-of-friends-compensation;
           }
-        }
-      }
-
-      .p-navigation__link--search-toggle {
-        color: $color-mid-light;
-        line-height: 1rem;
-        padding: 0.5rem 2rem 0.5rem 1rem;
-
-        &::after {
-          color: $color-mid-light;
-          top: 0.5rem;
-        }
-
-        .p-navigation__search-label {
-          font-size: 0.875rem;
-          font-weight: 300;
-          padding-left: 0.5rem;
         }
       }
 

--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -508,6 +508,7 @@ $meganav-height: 3rem;
 
       @media (max-width: $breakpoint-large) {
         padding-right: 3rem;
+        padding-left: 3rem;
       }
 
       &::after {


### PR DESCRIPTION
## Done

- Removed unused and repetitive styles for navbar search toggle button.

## QA

- View the site locally in your web browser at: https://ubuntu-com-15038.demos.haus/
- Make sure you set the screen size to medium, i.e., < 1250px
- Hover search icon, verify the padding is equal on both sides
- Click search icon, it will toggle the visibility of close icon.
- Hover close icon, verify the padding is equal on both sides.

## Issue / Card

Fixes #[WD-20510](https://warthogs.atlassian.net/browse/WD-20510)
Fixes #14882


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-20510]: https://warthogs.atlassian.net/browse/WD-20510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ