### PR TITLE
[WD-21500] copy update /download/core

### DIFF
--- a/templates/download/core/index.html
+++ b/templates/download/core/index.html
@@ -49,7 +49,7 @@ meta_copydoc %}
         <div class="p-section--shallow">
           <p>Build your Ubuntu Core image for your application and targeted hardware.</p>
           <p>
-            Ubuntu Core {{ releases.core_lts.version }} is the latest LTS version of Ubuntu for deployment on embedded devices and edge systems. LTS stands for long-term support &mdash; which means 12 years of security and maintenance updates guaranteed until {{ releases.core_lts.eol }}.
+            Ubuntu Core {{ releases.core_lts.version }} is the latest LTS version of Ubuntu for deployment on embedded devices and edge systems. LTS stands for long-term support &mdash; which means 10 years of security and maintenance updates guaranteed until {{ releases.core_lts.eol }}.
           </p>
           <hr class="p-rule" />
           <p>


### PR DESCRIPTION
## Done

- Updated duration

## QA

- View the site locally in your web browser at: 
- Verify the Ubuntu core 24 has EOL 10 years, ending in 2034.
- Find copydoc for verification [here](https://docs.google.com/document/d/1Sxdl5cGGe1wbHmKB2eL2zQLfVW3KBea02a2FIGx3VdQ/edit?tab=t.0)

## Issue / Card

Fixes [WD-21500](https://warthogs.atlassian.net/browse/WD-21500)
Fixes #15008


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-21500]: https://warthogs.atlassian.net/browse/WD-21500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ