### PR TITLE
copy: change FIPS notification link for /security/security-standards

### DIFF
--- a/templates/security/security-standards.html
+++ b/templates/security/security-standards.html
@@ -54,7 +54,7 @@
       <div class="p-notification--information is-light">
         <div class="p-notification__content">
           <div class="p-notification__message">
-            FIPS 140-3 is now available for Ubuntu 22.04 LTS. <a href="/blog/ubuntu-22-04-fips-140-3-modules-available-for-preview" aria-label="Learn more about FIPS 140-3 for Ubuntu 22.04 LTS">Learn more</a>
+            FIPS 140-3 is now available for Ubuntu 22.04 LTS. <a href="/blog/fips-140-3-for-ubuntu-22-04lts" aria-label="Learn more about FIPS 140-3 for Ubuntu 22.04 LTS">Learn more.</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Done

Change FIPS notification link for /security/security-standards according to [this comment](https://warthogs.atlassian.net/browse/WD-19955?focusedCommentId=741745)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
