### PR TITLE
chore: Bump canonicalwebteam.discourse to 6.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ canonicalwebteam.blog==6.4.4
 canonicalwebteam.search==2.1.1
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.5.0
-canonicalwebteam.discourse @ git+https://github.com/canonical/canonicalwebteam.discourse@wd-20353
+canonicalwebteam.discourse==6.2.0
 canonicalwebteam.form-generator==2.0.0
 canonicalwebteam.directory-parser==1.2.10
 python-dateutil==2.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ canonicalwebteam.blog==6.4.4
 canonicalwebteam.search==2.1.1
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.5.0
-canonicalwebteam.discourse==6.0.0
+canonicalwebteam.discourse @ git+https://github.com/canonical/canonicalwebteam.discourse@wd-20353
 canonicalwebteam.form-generator==2.0.0
 canonicalwebteam.directory-parser==1.2.10
 python-dateutil==2.8.2

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1833,7 +1833,8 @@ ol.p-stepped-list.no-full-stop
   table {
     width: auto;
 
-    td, th {
+    td,
+    th {
       white-space: nowrap;
     }
   }

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1823,3 +1823,18 @@ ol.p-stepped-list.no-full-stop
     scroll-margin-top: 100px;
   }
 }
+
+// Custom styling for the vulnerability details page
+// that allows large complex tables to be scrollable
+.vulnerability-details .p-table--wide-table {
+  width: 100%;
+  overflow-x: auto;
+
+  table {
+    width: auto;
+
+    td, th {
+      white-space: nowrap;
+    }
+  }
+}

--- a/templates/security/vulnerabilities/vulnerability-detailed.html
+++ b/templates/security/vulnerabilities/vulnerability-detailed.html
@@ -5,7 +5,7 @@
 {% block meta_description %}{{ document.sections[0].title }}{% endblock %}
 
 {% block body_class %}
-  is-paper
+  is-paper vulnerability-details
 {% endblock body_class %}
 
 {% block content %}

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -1257,6 +1257,9 @@ def build_vulnerabilities(security_vulnerabilities):
                 if str(item["id"]) == str(document["topic_id"]):
                     document_metadata = item
                     break
+                
+            # TEMP HACK TO DISPLAY TOPICS WHICH AREN'T INDEXED
+            document_metadata = {'name': 'Native BHI (Branch History Injection 2) (CVE-2024-2201)', 'description': 'A new variant of the previously-disclosed BHI (also known as Spectre v2) vulnerabilities was discovered to affected certain Intel CPUs. The new publication shows that attacks are possible using vectors other than eBPF, leading to information disclosure.', 'status': 'Fixed', 'published': '24/04/2024', 'display-until': '01/01/2024', 'id': '53198', 'slug': 'native-bhi', 'year': 2024}
 
             return flask.render_template(
                 "security/vulnerabilities/vulnerability-detailed.html",

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -1257,7 +1257,7 @@ def build_vulnerabilities(security_vulnerabilities):
                 if str(item["id"]) == str(document["topic_id"]):
                     document_metadata = item
                     break
-                
+
             # TEMP HACK TO DISPLAY TOPICS WHICH AREN'T INDEXED
             document_metadata = {'name': 'Native BHI (Branch History Injection 2) (CVE-2024-2201)', 'description': 'A new variant of the previously-disclosed BHI (also known as Spectre v2) vulnerabilities was discovered to affected certain Intel CPUs. The new publication shows that attacks are possible using vectors other than eBPF, leading to information disclosure.', 'status': 'Fixed', 'published': '24/04/2024', 'display-until': '01/01/2024', 'id': '53198', 'slug': 'native-bhi', 'year': 2024}
 

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -1258,9 +1258,6 @@ def build_vulnerabilities(security_vulnerabilities):
                     document_metadata = item
                     break
 
-            # TEMP HACK TO DISPLAY TOPICS WHICH AREN'T INDEXED
-            document_metadata = {'name': 'Native BHI (Branch History Injection 2) (CVE-2024-2201)', 'description': 'A new variant of the previously-disclosed BHI (also known as Spectre v2) vulnerabilities was discovered to affected certain Intel CPUs. The new publication shows that attacks are possible using vectors other than eBPF, leading to information disclosure.', 'status': 'Fixed', 'published': '24/04/2024', 'display-until': '01/01/2024', 'id': '53198', 'slug': 'native-bhi', 'year': 2024}
-
             return flask.render_template(
                 "security/vulnerabilities/vulnerability-detailed.html",
                 metadata=document_metadata,


### PR DESCRIPTION
## Done

- Bump canonicalwebteam.discourse to 6.2.0
- Introduces a class 'p-table--wide-table' to make tables horizontally scroll able (this can be reviewed later, once the discourse work is merged) 
- Adds a body class the vulnerabilities pages 'vulnerabilities-details'

## QA

- Go to this [Discourse post](https://discourse.ubuntu.com/t/test-topic/59821) and find the table with the string '[style=p-table--wide-table]' above it
- Find the corresponding table in [the demo](https://ubuntu-com-15050.demos.haus/security/vulnerabilities/test-topic). See the string, '[style=p-table--wide-table]', has been removed
- Inspect the table element and see it is wrapped in a div with the class 'p-table--wide-table'

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-20353
