### PR TITLE
WD-21511 WD-21512: show correct exam names when scheduling

### DIFF
--- a/templates/credentials/schedule.html
+++ b/templates/credentials/schedule.html
@@ -53,7 +53,7 @@ meta_copydoc %}
                   id="exam-name"
                   name="name"
                   required>
-            <option value="linux-essentials">CUE.01 Linux</option>
+            <option value="{{ ta_exam }}">{{ ta_exam_name }}</option>
           </select>
           <label class="p-heading--5" for="exam-timezone">Select your timezone</label>
           <select class="spaced-bottom--smaller is-paper--input"

--- a/webapp/shop/cred/constants.py
+++ b/webapp/shop/cred/constants.py
@@ -1,0 +1,8 @@
+TAEXAM_PROC_STATE = {
+    "cue-01-linux": True,
+}
+
+TAEXAM_PROC_EXAM_MAPPING = {
+    "cue-01-linux": 2,
+    "cue-02-desktop": 3,
+}

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -17,6 +17,10 @@ from webapp.shop.api.datastore import (
     handle_confidentiality_agreement_submission,
     has_filed_confidentiality_agreement,
 )
+from webapp.shop.cred.constants import (
+    TAEXAM_PROC_EXAM_MAPPING,
+    TAEXAM_PROC_STATE,
+)
 from webapp.shop.decorators import (
     credentials_group,
     credentials_admin,
@@ -429,18 +433,11 @@ def check_cred_exam_start_time(
 
 
 def get_taexam_to_procexam_mapping(ta_exam: str) -> int | None:
-    mappings = {
-        "cue-01-linux": 2,
-        "cue-02-desktop": 3,
-    }
-    return mappings.get(ta_exam)
+    return TAEXAM_PROC_EXAM_MAPPING.get(ta_exam)
 
 
 def is_proctoring_enabled(ta_exam: str) -> int | None:
-    mappings = {
-        "cue-01-linux": True,
-    }
-    return mappings.get(ta_exam, False)
+    return TAEXAM_PROC_STATE.get(ta_exam, False)
 
 
 @shop_decorator(area="cred", permission="user", response="html")

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -431,8 +431,16 @@ def check_cred_exam_start_time(
 def get_taexam_to_procexam_mapping(ta_exam: str) -> int | None:
     mappings = {
         "cue-01-linux": 2,
+        "cue-02-desktop": 3,
     }
-    return mappings.get(ta_exam, None)
+    return mappings.get(ta_exam)
+
+
+def is_proctoring_enabled(ta_exam: str) -> int | None:
+    mappings = {
+        "cue-01-linux": True,
+    }
+    return mappings.get(ta_exam, False)
 
 
 @shop_decorator(area="cred", permission="user", response="html")
@@ -518,6 +526,7 @@ def cred_schedule(
                 exam_type="cue-01-linux",
             )
         template_data["ta_exam"] = data["ta_exam"]
+        ta_exam_name = EXAM_NAMES[data["ta_exam"]]
 
         if error_start_time is not None:
             return flask.render_template(
@@ -582,7 +591,7 @@ def cred_schedule(
                         error=error,
                         time_delay=time_delay,
                     )
-                if is_staging:
+                if is_staging and is_proctoring_enabled(data["ta_exam"]):
                     student = proctor_api.get_student(user["email"])
                     student_sessions = proctor_api.get_student_sessions(
                         {
@@ -628,7 +637,7 @@ def cred_schedule(
                         )
 
                 exam = {
-                    "name": "CUE.01 Linux",
+                    "name": ta_exam_name,
                     "date": starts_at.strftime("%d %b %Y"),
                     "time": starts_at.strftime("%I:%M %p ") + timezone,
                     "uuid": assessment_reservation_uuid,
@@ -682,7 +691,7 @@ def cred_schedule(
                         time_delay=time_delay,
                     )
                 uuid = ""
-                if is_staging:
+                if is_staging and is_proctoring_enabled(data["ta_exam"]):
                     uuid = response.get("reservation", {}).get("IDs", [])[-1]
                     student_session_data = {
                         "first_name": first_name,
@@ -701,7 +710,7 @@ def cred_schedule(
                     proctor_api.create_student_session(student_session_data)
 
                 exam = {
-                    "name": "CUE.01 Linux",
+                    "name": ta_exam_name,
                     "date": starts_at.strftime("%d %b %Y"),
                     "time": starts_at.strftime("%I:%M %p ") + timezone,
                     "uuid": uuid,
@@ -760,7 +769,7 @@ def cred_schedule(
     ta_exam = flask.request.args.get("ta_exam", "")
     if get_taexam_to_procexam_mapping(ta_exam) is None:
         ta_exam = "cue-01-linux"
-
+    ta_exam_name = EXAM_NAMES[ta_exam]
     return flask.render_template(
         "credentials/schedule.html",
         uuid=assessment_reservation_uuid,
@@ -777,6 +786,7 @@ def cred_schedule(
         cred_maintenance_start=cred_maintenance_start,
         cred_maintenance_end=cred_maintenance_end,
         ta_exam=ta_exam,
+        ta_exam_name=ta_exam_name,
     )
 
 


### PR DESCRIPTION
## Done

- When scheduling CUE.02 Desktop exam, the schedule confirmation showed CUE.01 Linux (incorrect name)
- This PR fixes that & also prevents beta exams from being proctored

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Buy CUE.02 Desktop exam and schedule it
    - You should see CUE.02 Desktop in exam confirmation thank you screen
- Make sure CUE.01 Linux still shows CUE.01 on thank you page 

## Issue / Card

Fixes [WD-21511](https://warthogs.atlassian.net/browse/WD-21511)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-21511]: https://warthogs.atlassian.net/browse/WD-21511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ