### PR TITLE
feat: update core section links

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -756,7 +756,7 @@
           <div class="p-section--shallow">
             <h2 class="p-heading--1 u-no-margin--bottom">Ultra secure things</h2>
             <p class="p-heading--2">
-              <a href="/appliance">Ubuntu Core Appliances</a> with transactional updates <a href="/embedded">for a better embedded Linux</a>.
+              <a href="/core">Ubuntu Core</a> with transactional updates for a better embedded Linux.
             </p>
             <div class="p-logo-section--dense">
               <div class="p-logo-section__items landing-logos u-no-padding">


### PR DESCRIPTION
## Done

- Update two links in the core section.

## QA

- Go to https://ubuntu-com-15053.demos.haus/
- Scroll down to to the "Ultra secure things" section.
- Check that the subheading matches the copy doc: https://docs.google.com/document/d/1ySJxQbqVdeH4Tra0zwBm2Tn0s56kFGnEF7d8xDRTxwU/edit?tab=t.0#heading=h.mfi239m5io9u.

## Issue / Card

https://warthogs.atlassian.net/browse/WD-21770?linkSource=email

## Screenshots

<img width="1506" alt="Screenshot 2025-04-29 at 10 25 29 am" src="https://github.com/user-attachments/assets/a6c78a8f-9f32-4397-ad67-585fdc26e603" />

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
