### PR TITLE
[WD-21391] fix: scrolling issues when closing contact modal and add aria-expanded label to contact button

### DIFF
--- a/static/js/src/dynamic-forms.js
+++ b/static/js/src/dynamic-forms.js
@@ -325,9 +325,6 @@ import { prepareInputFields } from "./prepare-form-inputs.js";
         // clean up event listeners when the modal is closed
         if (contactModal) {
           contactModal.removeEventListener("submit", submitForm);
-          contactModal.removeEventListener("mousedown", submitForm);
-          contactModal.removeEventListener("mouseup", submitForm);
-
           contactModal.removeEventListener("mousedown", handleModalMouseDown);
           contactModal.removeEventListener("mouseup", handleModalMouseUp);
         }

--- a/static/js/src/dynamic-forms.js
+++ b/static/js/src/dynamic-forms.js
@@ -105,6 +105,7 @@ import { prepareInputFields } from "./prepare-form-inputs.js";
 
     // Open the contact us modal
     function open() {
+      modalTrigger.setAttribute("aria-expanded", "true");
       updateHash(triggeringHash);
       dataLayer.push({
         event: "interactive-forms",
@@ -312,6 +313,7 @@ import { prepareInputFields } from "./prepare-form-inputs.js";
       function close() {
         setState(1);
         formContainer.classList.add("u-hide");
+        modalTrigger.setAttribute("aria-expanded", "false");
         modalTrigger.focus();
         updateHash("");
         dataLayer.push({

--- a/static/js/src/dynamic-forms.js
+++ b/static/js/src/dynamic-forms.js
@@ -105,7 +105,8 @@ import { prepareInputFields } from "./prepare-form-inputs.js";
 
     // Open the contact us modal
     function open() {
-      modalTrigger.setAttribute("aria-expanded", "true");
+      if (modalTrigger && modalTrigger !== document.body)
+        modalTrigger.setAttribute("aria-expanded", "true");
       updateHash(triggeringHash);
       dataLayer.push({
         event: "interactive-forms",
@@ -313,7 +314,8 @@ import { prepareInputFields } from "./prepare-form-inputs.js";
       function close() {
         setState(1);
         formContainer.classList.add("u-hide");
-        modalTrigger.setAttribute("aria-expanded", "false");
+        if (modalTrigger && modalTrigger !== document.body)
+          modalTrigger.setAttribute("aria-expanded", "false");
         modalTrigger.focus();
         updateHash("");
         dataLayer.push({


### PR DESCRIPTION
## Done

- Fixed: scroll glitches when closing contact modal
- Chore: add aria-expanded label to button when modal is opened
- drive by: Clear event listeners on closing contact modal

## QA

- Check out this branch
- Run the project using `dotrun`
- View the site in your web browser at: http://0.0.0.0:8001/aws
- Follow the issue reproduction steps outlined [here](https://warthogs.atlassian.net/browse/WD-21391) and verify the bug is resolved and not re-producible.
- Verify the `aria-expanded` attribute is added to contact button when modal is opened
- Try opening/closing/scrolling/submitting the form and make sure everything works as expected.

## Issue / Card

Fixes #[WD-21391](https://warthogs.atlassian.net/browse/WD-21391)
Fixes #[WD-21454](https://warthogs.atlassian.net/browse/WD-21454)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-21391]: https://warthogs.atlassian.net/browse/WD-21391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[WD-21454]: https://warthogs.atlassian.net/browse/WD-21454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ