### PR TITLE
Center search toggle icon in navigation dropdown

### DIFF
--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -583,6 +583,14 @@ $meganav-height: 3rem;
       .p-navigation__dropdown--right {
         top: 2rem;
       }
+
+      .p-navigation__link--search-toggle {
+        &::after {
+          top: 50%;
+          left: 50%;
+          transform: translate(-50%, -50%);
+        }
+      }
     }
 
     & ~ .global-nav-dropdown {


### PR DESCRIPTION
## Done

- Fixed the styling of the navbar search & close icon positioning.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes.

## Issue / Card

Fixes https://chat.canonical.com/canonical/pl/o5w8ko4irpbn7rbg7z1ppuhs4a
Fixes https://chat.canonical.com/canonical/pl/ohzwhdkhqtn63j4maecipt36fw

## Screenshots
### Before
![image](https://github.com/user-attachments/assets/7cdeb2da-119d-48c8-ac63-d59a40cfadbe)
![image](https://github.com/user-attachments/assets/1b474760-9493-4c6f-b269-709272534611)

### After
![image](https://github.com/user-attachments/assets/80447f17-60d5-4300-b3a5-829312e5f2fa)
![image](https://github.com/user-attachments/assets/b98466e8-377e-45b3-ae82-897e63b3f14e)




## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
