### PR TITLE
fix(Nav): Fix misaligned search icon in navigation

### DIFF
--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -107,6 +107,14 @@ $meganav-height: 3rem;
         }
       }
 
+      .p-navigation__link--search-toggle::after {
+        right: 0.75rem;
+
+        @media (max-width: $breakpoint-navigation-threshold - 1) {
+          right: 0.5rem;
+        }
+      }
+
       @media (max-width: $breakpoint-navigation-threshold - 1) {
         .subsection-active & {
           transform: translateX(-100vw);
@@ -494,6 +502,21 @@ $meganav-height: 3rem;
       }
     }
 
+    .p-navigation__link--search-toggle {
+      padding-bottom: 0.5rem;
+      padding-top: 0.5rem;
+
+      @media (max-width: $breakpoint-large) {
+        padding-right: 3rem;
+      }
+
+      &::after {
+        color: $color-mid-light;
+        right: 1rem;
+        top: 1rem;
+      }
+    }
+
     @media (min-width: $breakpoint-navigation-threshold) {
       background-color: $color-dark;
       margin-bottom: 0;
@@ -550,6 +573,23 @@ $meganav-height: 3rem;
             opacity: 0.3;
             right: $sph--large - $circle-of-friends-compensation;
           }
+        }
+      }
+
+      .p-navigation__link--search-toggle {
+        color: $color-mid-light;
+        line-height: 1rem;
+        padding: 0.5rem 2rem 0.5rem 1rem;
+
+        &::after {
+          color: $color-mid-light;
+          top: 0.5rem;
+        }
+
+        .p-navigation__search-label {
+          font-size: 0.875rem;
+          font-weight: 300;
+          padding-left: 0.5rem;
         }
       }
 


### PR DESCRIPTION
## Done

Reverts https://github.com/canonical/ubuntu.com/pull/15038, which introduced a search icon misalignment issue on the [Ubuntu desktop page](https://ubuntu.com/desktop). 

This will re-open [this issue](https://github.com/canonical/ubuntu.com/issues/14882) with the search icon hover padding, but I think it's better in the short term for the hover padding to be off than for the icon alignment to be off, and I don't have the time myself to fix the underlying issue in u.com. 

## QA

- Open demo
- Verify that the search icon is properly aligned on all screen sizes. Be sure to check the [homepage](https://ubuntu-com-15060.demos.haus/), [desktop](https://ubuntu-com-15060.demos.haus/desktop), and [server](https://ubuntu-com-15060.demos.haus/server) pages. 

## Issue / Card

Fixes https://chat.canonical.com/canonical/pl/ohzwhdkhqtn63j4maecipt36fw
Fixes https://chat.canonical.com/canonical/pl/o5w8ko4irpbn7rbg7z1ppuhs4a

## Screenshots

Before

![Screenshot from 2025-04-29 13-55-31](https://github.com/user-attachments/assets/8e7e3fa1-b67f-488a-8167-ce85fa4eeb72)


After
![Screenshot from 2025-04-29 13-55-35](https://github.com/user-attachments/assets/921e0bc0-116b-412d-a7c3-1d83da3d841b)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
