### PR TITLE
WD-21716 - Copy Update - Add missing legacy date for kernel releases

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -188,6 +188,13 @@ export var kernelReleases = [
     status: "ESM",
   },
   {
+    startDate: new Date("2032-03-31T00:00:00"),
+    endDate: new Date("2034-04-29T00:00:00"),
+    taskName: "22.04.5 LTS (HWE)",
+    taskVersion: "6.8 kernel",
+    status: "PRO_LEGACY_SUPPORT",
+  },
+  {
     startDate: new Date("2024-08-01T00:00:00"),
     endDate: new Date("2029-04-01T00:00:00"),
     taskName: "24.04.1 LTS",
@@ -200,6 +207,13 @@ export var kernelReleases = [
     taskName: "24.04.1 LTS",
     taskVersion: "6.8 kernel",
     status: "ESM",
+  },
+  {
+    startDate: new Date("2034-03-31T00:00:00"),
+    endDate: new Date("2036-04-29T00:00:00"),
+    taskName: "24.04.1 LTS",
+    taskVersion: "6.8 kernel",
+    status: "PRO_LEGACY_SUPPORT",
   },
   {
     startDate: new Date("2024-04-01T00:00:00"),
@@ -216,6 +230,13 @@ export var kernelReleases = [
     status: "ESM",
   },
   {
+    startDate: new Date("2034-03-31T00:00:00"),
+    endDate: new Date("2036-04-29T00:00:00"),
+    taskName: "24.04.0 LTS",
+    taskVersion: "6.8 kernel",
+    status: "PRO_LEGACY_SUPPORT",
+  },
+  {
     startDate: new Date("2022-08-01T00:00:00"),
     endDate: new Date("2027-04-01T00:00:00"),
     taskName: "22.04.1 LTS",
@@ -230,6 +251,13 @@ export var kernelReleases = [
     status: "ESM",
   },
   {
+    startDate: new Date("2032-03-01T00:00:00"),
+    endDate: new Date("2034-04-29T00:00:00"),
+    taskName: "22.04.1 LTS",
+    taskVersion: "5.15 kernel",
+    status: "PRO_LEGACY_SUPPORT",
+  },
+  {
     startDate: new Date("2022-08-01T00:00:00"),
     endDate: new Date("2025-04-30T00:00:00"),
     taskName: "20.04.5 LTS (HWE)",
@@ -242,6 +270,13 @@ export var kernelReleases = [
     taskName: "20.04.5 LTS (HWE)",
     taskVersion: "",
     status: "ESM",
+  },
+  {
+    startDate: new Date("2030-04-29T00:00:00"),
+    endDate: new Date("2032-04-29T00:00:00"),
+    taskName: "20.04.5 LTS (HWE)",
+    taskVersion: "",
+    status: "PRO_LEGACY_SUPPORT",
   },
   {
     startDate: new Date("2022-04-01T00:00:00"),
@@ -258,6 +293,13 @@ export var kernelReleases = [
     status: "ESM",
   },
   {
+    startDate: new Date("2032-03-30T00:00:00"),
+    endDate: new Date("2034-04-30T00:00:00"),
+    taskName: "22.04.0 LTS",
+    taskVersion: "",
+    status: "PRO_LEGACY_SUPPORT",
+  },
+  {
     startDate: new Date("2020-08-13T00:00:00"),
     endDate: new Date("2023-04-30T00:00:00"),
     taskName: "18.04.5 LTS (HWE)",
@@ -270,6 +312,13 @@ export var kernelReleases = [
     taskName: "18.04.5 LTS (HWE)",
     taskVersion: "5.4 kernel",
     status: "ESM",
+  },
+  {
+    startDate: new Date("2028-04-28T00:00:00"),
+    endDate: new Date("2030-04-28T00:00:00"),
+    taskName: "18.04.5 LTS (HWE)",
+    taskVersion: "5.4 kernel",
+    status: "PRO_LEGACY_SUPPORT",
   },
   {
     startDate: new Date("2020-08-06T00:00:00"),
@@ -286,6 +335,13 @@ export var kernelReleases = [
     status: "ESM",
   },
   {
+    startDate: new Date("2030-04-29T00:00:00"),
+    endDate: new Date("2032-04-29T00:00:00"),
+    taskName: "20.04.1 LTS",
+    taskVersion: "",
+    status: "PRO_LEGACY_SUPPORT",
+  },
+  {
     startDate: new Date("2020-04-23T00:00:00"),
     endDate: new Date("2025-04-30T00:00:00"),
     taskName: "20.04.0 LTS",
@@ -298,6 +354,13 @@ export var kernelReleases = [
     taskName: "20.04.0 LTS",
     taskVersion: "",
     status: "ESM",
+  },
+  {
+    startDate: new Date("2030-04-29T00:00:00"),
+    endDate: new Date("2032-04-29T00:00:00"),
+    taskName: "20.04.0 LTS",
+    taskVersion: "",
+    status: "PRO_LEGACY_SUPPORT",
   },
   {
     startDate: new Date("2018-08-02T00:00:00"),
@@ -314,6 +377,13 @@ export var kernelReleases = [
     status: "ESM",
   },
   {
+    startDate: new Date("2026-04-29T00:00:00"),
+    endDate: new Date("2028-04-29T00:00:00"),
+    taskName: "16.04.5 LTS (HWE)",
+    taskVersion: "4.15 kernel",
+    status: "PRO_LEGACY_SUPPORT",
+  },
+  {
     startDate: new Date("2018-07-26T00:00:00"),
     endDate: new Date("2023-04-30T00:00:00"),
     taskName: "18.04.1 LTS",
@@ -326,6 +396,13 @@ export var kernelReleases = [
     taskName: "18.04.1 LTS",
     taskVersion: "",
     status: "ESM",
+  },
+  {
+    startDate: new Date("2028-04-28T00:00:00"),
+    endDate: new Date("2030-04-28T00:00:00"),
+    taskName: "18.04.1 LTS",
+    taskVersion: "",
+    status: "PRO_LEGACY_SUPPORT",
   },
   {
     startDate: new Date("2018-04-26T00:00:00"),
@@ -342,6 +419,13 @@ export var kernelReleases = [
     status: "ESM",
   },
   {
+    startDate: new Date("2028-04-28T00:00:00"),
+    endDate: new Date("2030-04-28T00:00:00"),
+    taskName: "18.04.0 LTS",
+    taskVersion: "",
+    status: "PRO_LEGACY_SUPPORT",
+  },
+  {
     startDate: new Date("2016-08-04T00:00:00"),
     endDate: new Date("2019-04-30T00:00:00"),
     taskName: "14.04.5 LTS (HWE)",
@@ -354,6 +438,13 @@ export var kernelReleases = [
     taskName: "14.04.5 LTS (HWE)",
     taskVersion: "4.4 kernel",
     status: "ESM",
+  },
+  {
+    startDate: new Date("2024-04-29T00:00:00"),
+    endDate: new Date("2026-04-29T00:00:00"),
+    taskName: "14.04.5 LTS (HWE)",
+    taskVersion: "4.4 kernel",
+    status: "PRO_LEGACY_SUPPORT",
   },
   {
     startDate: new Date("2016-07-21T00:00:00"),
@@ -370,6 +461,13 @@ export var kernelReleases = [
     status: "ESM",
   },
   {
+    startDate: new Date("2026-04-29T00:00:00"),
+    endDate: new Date("2028-04-29T00:00:00"),
+    taskName: "16.04.1 LTS",
+    taskVersion: "",
+    status: "PRO_LEGACY_SUPPORT",
+  },
+  {
     startDate: new Date("2016-04-21T00:00:00"),
     endDate: new Date("2021-04-30T00:00:00"),
     taskName: "16.04.0 LTS",
@@ -382,6 +480,13 @@ export var kernelReleases = [
     taskName: "16.04.0 LTS",
     taskVersion: "",
     status: "ESM",
+  },
+  {
+    startDate: new Date("2026-04-29T00:00:00"),
+    endDate: new Date("2028-04-29T00:00:00"),
+    taskName: "16.04.0 LTS",
+    taskVersion: "",
+    status: "PRO_LEGACY_SUPPORT",
   },
 ];
 
@@ -1187,9 +1292,10 @@ export var desktopServerStatus = {
 };
 
 export var kernelStatus = {
-  LTS: "chart__bar--black",
+  LTS: "chart__bar--orange",
   ESM: "chart__bar--aubergine-light",
   INTERIM_RELEASE: "chart__bar--grey",
+  PRO_LEGACY_SUPPORT: "chart__bar--black",
 };
 
 export var kernelReleaseScheduleStatus = {
@@ -1250,8 +1356,8 @@ export var kernelReleaseNames = [
   "22.04.5 LTS (HWE)",
   "24.04.1 LTS",
   "24.04.0 LTS",
-  "22.04.1 LTS",
   "20.04.5 LTS (HWE)",
+  "22.04.1 LTS",
   "22.04.0 LTS",
   "18.04.5 LTS (HWE)",
   "20.04.1 LTS",

--- a/static/js/src/release-chart-old.js
+++ b/static/js/src/release-chart-old.js
@@ -34,7 +34,15 @@ function sortTasks(tasks) {
  *
  * Add bars to chart using supplied data
  */
-function addBarsToChart(svg, tasks, taskStatus, x, y, highlightVersion) {
+function addBarsToChart(
+  svg,
+  tasks,
+  taskStatus,
+  x,
+  y,
+  highlightVersion,
+  chartSelector,
+) {
   svg
     .selectAll(".chart")
     .data(tasks, function (d) {
@@ -62,7 +70,8 @@ function addBarsToChart(svg, tasks, taskStatus, x, y, highlightVersion) {
         d.status === "MAIN_UNIVERSE" ||
         d.status === "PRO_SUPPORT" ||
         (d.status === "PRO_LEGACY_SUPPORT" &&
-          d.taskName !== "14.04 LTS (Trusty Tahr)")
+          d.taskName !== "14.04 LTS (Trusty Tahr)" &&
+          chartSelector !== "#kernel-eol")
       ) {
         return (
           "translate(" +
@@ -77,7 +86,8 @@ function addBarsToChart(svg, tasks, taskStatus, x, y, highlightVersion) {
     .attr("height", function (d) {
       if (
         d.status === "PRO_LEGACY_SUPPORT" &&
-        d.taskName !== "14.04 LTS (Trusty Tahr)"
+        d.taskName !== "14.04 LTS (Trusty Tahr)" &&
+        chartSelector !== "#kernel-eol"
       ) {
         return y.bandwidth() * 2;
       }
@@ -518,7 +528,7 @@ export function createReleaseChartOld(
   addYAxis(svg, yAxis, taskVersions);
   addYAxisVerticalLines(svg, width);
 
-  addBarsToChart(svg, tasks, taskStatus, x, y, highlightVersion);
+  addBarsToChart(svg, tasks, taskStatus, x, y, highlightVersion, chartSelector);
   addTooltipToBars(svg);
 
   emboldenLTSLabels(svg, y);

--- a/templates/shared/_kernel-release-diagram.html
+++ b/templates/shared/_kernel-release-diagram.html
@@ -5,8 +5,9 @@
       <th>Kernel version</th>
       <th>Ubuntu version</th>
       <th>Released</th>
-      <th>End of life</th>
-      <th>Expanded security maintenance</th>
+      <th>End of Standard Security Maintenance</th>
+      <th>End of Expanded Security Maintenance</th>
+      <th>End of Legacy Support</th>
     </tr>
   </thead>
   <tbody>
@@ -47,6 +48,7 @@
       <td>Aug 2024</td>
       <td>Apr 2027</td>
       <td>Mar 2032</td>
+      <td>Apr 2034</td>
     </tr>
     <tr>
       <td>
@@ -55,6 +57,7 @@
       <td>Aug 2024</td>
       <td>Apr 2029</td>
       <td>Mar 2034</td>
+      <td>Apr 2036</td>
     </tr>
     <tr>
       <td>
@@ -63,25 +66,28 @@
       <td>Apr 2024</td>
       <td>Apr 2029</td>
       <td>Mar 2034</td>
+      <td>Apr 2036</td>
     </tr>
     <tr>
       <td rowspan="3">
         <strong>5.15</strong>
       </td>
       <td>
-        <strong>22.04.1 LTS</strong>
-      </td>
-      <td>Aug 2022</td>
-      <td>Apr 2027</td>
-      <td>Mar 2032</td>
-    </tr>
-    <tr>
-      <td>
         <strong>20.04.5 LTS (HWE)</strong>
       </td>
       <td>Aug 2022</td>
       <td>Apr 2025</td>
       <td>Apr 2030</td>
+      <td>Apr 2032</td>
+    </tr>
+    <tr>
+      <td>
+        <strong>22.04.1 LTS</strong>
+      </td>
+      <td>Aug 2022</td>
+      <td>Apr 2027</td>
+      <td>Mar 2032</td>
+      <td>Apr 2034</td>
     </tr>
     <tr>
       <td>
@@ -90,6 +96,7 @@
       <td>Apr 2022</td>
       <td>Apr 2027</td>
       <td>Mar 2032</td>
+      <td>Apr 2034</td>
     </tr>
     <tr>
       <td rowspan="3">
@@ -101,6 +108,7 @@
       <td>Aug 2020</td>
       <td>Apr 2023</td>
       <td>Apr 2028</td>
+      <td>Apr 2030</td>
     </tr>
     <tr>
       <td>
@@ -109,6 +117,7 @@
       <td>Aug 2020</td>
       <td>Apr 2025</td>
       <td>Apr 2030</td>
+      <td>Apr 2032</td>
     </tr>
     <tr>
       <td>
@@ -117,6 +126,7 @@
       <td>Apr 2020</td>
       <td>Apr 2025</td>
       <td>Apr 2030</td>
+      <td>Apr 2032</td>
     </tr>
     <tr>
       <td rowspan="3">
@@ -128,6 +138,7 @@
       <td>Aug 2018</td>
       <td>Apr 2021</td>
       <td>Apr 2026</td>
+      <td>Apr 2028</td>
     </tr>
     <tr>
       <td>
@@ -136,6 +147,7 @@
       <td>Jul 2018</td>
       <td>Apr 2023</td>
       <td>Apr 2028</td>
+      <td>Apr 2030</td>
     </tr>
     <tr>
       <td>
@@ -144,6 +156,7 @@
       <td>Apr 2018</td>
       <td>Apr 2023</td>
       <td>Apr 2028</td>
+      <td>Apr 2030</td>
     </tr>
     <tr>
       <td rowspan="3">
@@ -155,6 +168,7 @@
       <td>Aug 2016</td>
       <td>Apr 2019</td>
       <td>Apr 2024</td>
+      <td>Apr 2026</td>
     </tr>
     <tr>
       <td>
@@ -163,6 +177,7 @@
       <td>Jul 2016</td>
       <td>Apr 2021</td>
       <td>Apr 2026</td>
+      <td>Apr 2028</td>
     </tr>
     <tr>
       <td>
@@ -171,6 +186,7 @@
       <td>Apr 2016</td>
       <td>Apr 2021</td>
       <td>Apr 2026</td>
+      <td>Apr 2028</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
## Done

- Add missing legacy dates for kernel release graph and table

## QA

- Check out the [kernel release graph and table here](https://ubuntu-com-15061.demos.haus/about/release-cycle#ubuntu-kernel-release-cycle).
- Make sure the date for the Legacy Support on the kernel release graph and table matches [what is in the copy doc](https://docs.google.com/document/d/1ozdBTb7M5TJExdETYjWWpKn-_hdANXCKxjL6GzobnxE/edit?tab=t.0).

## Issue / Card

- [WD-21716](https://warthogs.atlassian.net/browse/WD-21716)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-21716]: https://warthogs.atlassian.net/browse/WD-21716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ