### PR TITLE
Separate USN endpoint services

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -413,8 +413,6 @@ production:
 
     - paths:
         [
-          /security/notices\.json,
-          /security/notices/.*\.json,
           /security/cves\.json,
           /security/cves/.*\.json,
           /security/releases\.json,
@@ -423,6 +421,13 @@ production:
           /security/page/.*\.json,
         ]
       service_name: ubuntu-com-security-api
+
+    - paths:
+        [
+          /security/notices\.json,
+          /security/notices/.*\.json,
+        ]
+      service_name: ubuntu-com-security-api-notices
 
     - paths: [/security/updates/.*]
       service_name: ubuntu-com-security-api-updates
@@ -978,8 +983,6 @@ staging:
 
     - paths:
         [
-          /security/notices\.json,
-          /security/notices/.*\.json,
           /security/cves\.json,
           /security/cves/.*\.json,
           /security/releases\.json,
@@ -989,6 +992,13 @@ staging:
           /security/updates/.*,
         ]
       service_name: ubuntu-com-security-api
+    
+    - paths:
+       [
+          /security/notices\.json,
+          /security/notices/.*\.json,
+       ]
+      service_name: ubuntu-com-security-api-notices
 
     - paths: [/security]
       name: ubuntu-com-security


### PR DESCRIPTION
## Done

- Moved the notices endpoints to their own service `ubuntu-com-security-api-notices`

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]
