### PR TITLE
update /about/release-cycle#ubuntu-kernel-release-cycle

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -488,6 +488,48 @@ export var kernelReleases = [
     taskVersion: "",
     status: "PRO_LEGACY_SUPPORT",
   },
+  {
+    startDate: new Date("2014-07-25T00:00:00"),
+    endDate: new Date("2019-04-30T00:00:00"),
+    taskName: "14.04.1 LTS",
+    taskVersion: "",
+    status: "LTS",
+  },
+  {
+    startDate: new Date("2019-04-30T00:00:00"),
+    endDate: new Date("2024-04-30T00:00:00"),
+    taskName: "14.04.1 LTS",
+    taskVersion: "",
+    status: "ESM",
+  },
+  {
+    startDate: new Date("2024-04-30T00:00:00"),
+    endDate: new Date("2026-04-30T00:00:00"),
+    taskName: "14.04.1 LTS",
+    taskVersion: "",
+    status: "PRO_LEGACY_SUPPORT",
+  },
+  {
+    startDate: new Date("2014-04-17T00:00:00"),
+    endDate: new Date("2019-04-30T00:00:00"),
+    taskName: "14.04.0 LTS",
+    taskVersion: "",
+    status: "LTS",
+  },
+  {
+    startDate: new Date("2019-04-30T00:00:00"),
+    endDate: new Date("2024-04-30T00:00:00"),
+    taskName: "14.04.0 LTS",
+    taskVersion: "",
+    status: "ESM",
+  },
+  {
+    startDate: new Date("2024-04-30T00:00:00"),
+    endDate: new Date("2026-04-30T00:00:00"),
+    taskName: "14.04.0 LTS",
+    taskVersion: "",
+    status: "PRO_LEGACY_SUPPORT",
+  },
 ];
 
 export var kernelReleases2204 = [
@@ -1368,6 +1410,8 @@ export var kernelReleaseNames = [
   "14.04.5 LTS (HWE)",
   "16.04.1 LTS",
   "16.04.0 LTS",
+  "14.04.1 LTS",
+  "14.04.0 LTS",
 ];
 
 export var kernelVersionNames = [
@@ -1388,6 +1432,8 @@ export var kernelVersionNames = [
   "",
   "4.4",
   "",
+  "",
+  "3.13",
   "",
 ];
 

--- a/static/sass/_pattern_chart.scss
+++ b/static/sass/_pattern_chart.scss
@@ -90,6 +90,7 @@
 
 .chart-key text {
   font-size: 14px;
+  font-family: Ubuntu, sans-serif;
 }
 
 .x.axis text {
@@ -103,6 +104,10 @@
 
 .chart-key__row {
   display: block;
+}
+
+.chart text {
+  font-family: Ubuntu, sans-serif;
 }
 
 .horizontal-bar-chart {

--- a/static/sass/_pattern_chart.scss
+++ b/static/sass/_pattern_chart.scss
@@ -93,6 +93,10 @@
   font-family: Ubuntu, sans-serif;
 }
 
+.chart text {
+  font-family: Ubuntu, sans-serif;
+}
+
 .x.axis text {
   font-size: 12px;
   text-anchor: start !important;
@@ -104,10 +108,6 @@
 
 .chart-key__row {
   display: block;
-}
-
-.chart text {
-  font-family: Ubuntu, sans-serif;
 }
 
 .horizontal-bar-chart {

--- a/templates/shared/_kernel-release-diagram.html
+++ b/templates/shared/_kernel-release-diagram.html
@@ -188,5 +188,26 @@
       <td>Apr 2026</td>
       <td>Apr 2028</td>
     </tr>
+    <tr>
+      <td rowspan="3">
+        <strong>3.13</strong>
+      </td>
+      <td>
+        <strong>14.04.1 LTS</strong>
+      </td>
+      <td>Jul 2014</td>
+      <td>Apr 2019</td>
+      <td>Apr 2024</td>
+      <td>Apr 2026</td>
+    </tr>
+    <tr>
+      <td>
+        <strong>14.04.0 LTS</strong>
+      </td>
+      <td>Apr 2014</td>
+      <td>Apr 2019</td>
+      <td>Apr 2024</td>
+      <td>Apr 2026</td>
+    </tr>
   </tbody>
 </table>


### PR DESCRIPTION
## Done

- Updates kernel release cycle to include 3.13 version
- Changes font in graph to Ubuntu
- [Copydoc here](https://docs.google.com/document/d/1-l3B7AoyDoETaL80UhlfEWCVKmMWPdy3zoF5LpsGcYQ/edit?tab=t.hit0f47o27pk)

## QA

- Go to [demo](https://ubuntu-com-15068.demos.haus/about/release-cycle#ubuntu-kernel-release-cycle)
- Make sure 3.13 kernel version is in the graph and the table
- Check the dates correspond to the [copydoc](https://docs.google.com/document/d/1-l3B7AoyDoETaL80UhlfEWCVKmMWPdy3zoF5LpsGcYQ/edit?tab=t.hit0f47o27pk)

## Issue / Card

Fixes [WD-21827](https://warthogs.atlassian.net/browse/WD-21827)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-21827]: https://warthogs.atlassian.net/browse/WD-21827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ