### PR TITLE
update links on 24.04 of ubuntu.com download amd

### DIFF
--- a/templates/download/amd/tab-1.html
+++ b/templates/download/amd/tab-1.html
@@ -27,7 +27,7 @@
       <h3>Ubuntu Server 24.04</h3>
     </div>
     <div class="col-6 col-medium-3">
-      <p>The optimised Ubuntu Server 24.04 is beta for now, the certified version is coming soon.</p>
+      <p>The version of Ubuntu with up to 10 years of long term support, until April 2034.</p>
       <p>Works on:</p>
       <ul class="p-list">
         <li class="p-list__item is-ticked">AMD Kria&trade; KD240 Drives Starter Kit</li>
@@ -35,20 +35,13 @@
         <li class="p-list__item is-ticked">AMD Kria&trade; KV260 Vision AI Starter Kit</li>
       </ul>
       <hr class="p-rule" />
-      <div class="p-notification--information is-borderless u-no-margin--bottom">
-        <div class="p-notification__content">
-          <p class="p-notification__message">
-            This Ubuntu version is working on K26 SOMs as well.
-          </p>
-        </div>
-      </div>
       {% include "download/amd/_wiki_notification.html" %}
       <p>
         <a class="p-button--positive"
-           href="https://people.canonical.com/~platform/images/xilinx/kria-ubuntu-24.04/iot-limerick-kria-classic-server-2404-classic-24.04-x05-20241114.img.xz">Download 24.04</a>
+           href="https://people.canonical.com/~platform/images/xilinx/kria-ubuntu-24.04/iot-limerick-kria-classic-server-2404-classic-24.04-x07-20250423.img.xz">Download 24.04</a>
       </p>
       <p>
-        <a href="https://xilinx.github.io/kria-apps-docs/kd240/linux_boot.html">Kria&trade; KD240 Getting Started Guide for Ubuntu</a>
+        <a href="https://xilinx.github.io/kria-apps-docs/kd240/linux_boot.html">Kria&trade; KD240 Getting Started Guide for Ubuntu&nbsp;&rsaquo;</a>
       </p>
     </div>
   </div>
@@ -76,16 +69,16 @@
         <tbody>
           <tr>
             <td>
-              <a href="https://people.canonical.com/~platform/images/xilinx/kria-ubuntu-24.04/iot-limerick-kria-classic-server-2404-classic-24.04-x05-20241114-sysroot.tar.xz">
-                iot-limerick-kria-classic-server-2404-classic-24.04-x05-20241114-sysroot.tar.xz
+              <a href="https://people.canonical.com/~platform/images/xilinx/kria-ubuntu-24.04/iot-limerick-kria-classic-server-2404-classic-24.04-x07-20250423-sysroot.tar.xz">
+                iot-limerick-kria-classic-server-2404-classic-24.04-x07-20250423-sysroot.tar.xz
               </a>
             </td>
             <td>Sysroot for cross-compilation</td>
           </tr>
           <tr>
             <td>
-              <a href="https://people.canonical.com/~platform/images/xilinx/kria-ubuntu-24.04/iot-limerick-kria-classic-server-2404-classic-24.04-x05-20241114-rootfs.tar.gz">
-                iot-limerick-kria-classic-server-2404-classic-24.04-x05-20241114-rootfs.tar.gz
+              <a href="https://people.canonical.com/~platform/images/xilinx/kria-ubuntu-24.04/iot-limerick-kria-classic-server-2404-classic-24.04-x07-20250423-rootfs.tar.gz">
+                iot-limerick-kria-classic-server-2404-classic-24.04-x07-20250423-rootfs.tar.gz
               </a>
             </td>
             <td>Raw Root filesystem</td>

--- a/templates/download/amd/tab-2.html
+++ b/templates/download/amd/tab-2.html
@@ -32,7 +32,7 @@
       <h3>Ubuntu Server 24.04</h3>
     </div>
     <div class="col-6 col-medium-3">
-      <p>The optimised Ubuntu Server 24.04 is beta for now, the certified version is coming soon.</p>
+      <p>The version of Ubuntu with up to 10 years of long term support, until April 2034.</p>
       <p>Works on:</p>
       <ul class="p-list">
         <li class="p-list__item is-ticked">AMD Kria&trade; KR260 Robotics Starter Kit</li>
@@ -40,23 +40,16 @@
         <li class="p-list__item is-ticked">AMD Kria&trade; KD240 Drives Starter Kit</li>
       </ul>
       <hr class="p-rule" />
-      <div class="p-notification--information is-borderless u-no-margin--bottom">
-        <div class="p-notification__content">
-          <p class="p-notification__message">
-            This Ubuntu version is working on K24 SOMs as well.
-          </p>
-        </div>
-      </div>
       {% include "download/amd/_wiki_notification.html" %}
       <p>
         <a class="p-button--positive"
-           href="https://people.canonical.com/~platform/images/xilinx/kria-ubuntu-24.04/iot-limerick-kria-classic-server-2404-classic-24.04-x05-20241114.img.xz">Download 24.04</a>
+           href="https://people.canonical.com/~platform/images/xilinx/kria-ubuntu-24.04/iot-limerick-kria-classic-server-2404-classic-24.04-x07-20250423.img.xz">Download 24.04</a>
       </p>
       <p>
-        <a href="https://xilinx.github.io/kria-apps-docs/kr260/linux_boot.html">Kria&trade; KR260 Getting Started Guide for Ubuntu</a>
+        <a href="https://xilinx.github.io/kria-apps-docs/kr260/linux_boot.html">Kria&trade; KR260 Getting Started Guide for Ubuntu&nbsp;&rsaquo;</a>
       </p>
       <p>
-        <a href="https://xilinx.github.io/kria-apps-docs/kv260/linux_boot.html">Kria&trade; KV260 Getting Started Guide for Ubuntu</a>
+        <a href="https://xilinx.github.io/kria-apps-docs/kv260/linux_boot.html">Kria&trade; KV260 Getting Started Guide for Ubuntu&nbsp;&rsaquo;</a>
       </p>
     </div>
   </div>
@@ -85,16 +78,16 @@
         <tbody>
           <tr>
             <td>
-              <a href="https://people.canonical.com/~platform/images/xilinx/kria-ubuntu-24.04/iot-limerick-kria-classic-server-2404-classic-24.04-x05-20241114-sysroot.tar.xz">
-                iot-limerick-kria-classic-server-2404-classic-24.04-x05-20241114-sysroot.tar.xz
+              <a href="https://people.canonical.com/~platform/images/xilinx/kria-ubuntu-24.04/iot-limerick-kria-classic-server-2404-classic-24.04-x07-20250423-sysroot.tar.xz">
+                iot-limerick-kria-classic-server-2404-classic-24.04-x07-20250423-sysroot.tar.xz
               </a>
             </td>
             <td>Sysroot for cross-compilation</td>
           </tr>
           <tr>
             <td>
-              <a href="https://people.canonical.com/~platform/images/xilinx/kria-ubuntu-24.04/iot-limerick-kria-classic-server-2404-classic-24.04-x05-20241114-rootfs.tar.gz">
-                iot-limerick-kria-classic-server-2404-classic-24.04-x05-20241114-rootfs.tar.gz
+              <a href="https://people.canonical.com/~platform/images/xilinx/kria-ubuntu-24.04/iot-limerick-kria-classic-server-2404-classic-24.04-x07-20250423-rootfs.tar.gz">
+                iot-limerick-kria-classic-server-2404-classic-24.04-x07-20250423-rootfs.tar.gz
               </a>
             </td>
             <td>Raw Root filesystem</td>

--- a/templates/download/amd/tab-3.html
+++ b/templates/download/amd/tab-3.html
@@ -47,7 +47,7 @@
            href="https://people.canonical.com/~platform/images/xilinx/zcu-ubuntu-22.04/iot-limerick-zcu-classic-desktop-2204-x05-2-20221123-58.img.xz">Download 22.04 LTS</a>
       </p>
       <p>
-        <a href="https://xilinx-wiki.atlassian.net/wiki/spaces/A/pages/2363129857/Getting+Started+with+Certified+Ubuntu+22.04+LTS+for+Xilinx+Devices">Getting started with Certified Ubuntu 22.04 LTS for AMD Devices</a>
+        <a href="https://xilinx-wiki.atlassian.net/wiki/spaces/A/pages/2363129857/Getting+Started+with+Certified+Ubuntu+22.04+LTS+for+Xilinx+Devices">Getting started with Certified Ubuntu 22.04 LTS for AMD Devices&nbsp;&rsaquo;</a>
       </p>
     </div>
   </div>
@@ -125,7 +125,7 @@
       </p>
       <p>
         <a href="https://xilinx-wiki.atlassian.net/wiki/spaces/A/pages/2037317633/Getting+Started+with+Certified+Ubuntu+20.04+LTS+for+Xilinx+Devices?utm_source=canonical&utm_medium=referral&utm_campaign=ubuntu&utm_content=download&utm_term=desktop_image">AMD
-        Getting Started Guide for Ubuntu 20.04</a>
+        Getting Started Guide for Ubuntu 20.04&nbsp;&rsaquo;</a>
       </p>
     </div>
   </div>


### PR DESCRIPTION
## Done

- Change links and text in 2 tabs in `download/amd` page

## QA

- Navigate to /download/amd in the demo server. Check that the copy doc matches the page
[Copy doc](https://docs.google.com/document/d/1cxQnEErs8FZ3dZ_IhlfcaJ03gE_vrMJfRC-5me9IDd4/edit?tab=t.0)
[Demo server](https://ubuntu-com-15071.demos.haus/download/amd)

## Issue / Card

Fixes #
[WD-21918 Jira ticket](https://warthogs.atlassian.net/browse/WD-21918)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
