### PR TITLE
chore: Update community help link

### DIFF
--- a/templates/support/community-support.html
+++ b/templates/support/community-support.html
@@ -34,7 +34,7 @@
           <a href="/community/support">Find community support</a>
         </h2>
         <p>
-          <a href="https://askubuntu.com/">Ask Ubuntu</a> and <a href="https://ubuntuforums.org/">Ubuntu Forums</a> are great sources of answers to common questions about installing, troubleshooting and optimising Ubuntu. For more info on support forums, including IRC channels, see <a href="/community/support">our community docs</a>.
+          <a href="https://askubuntu.com/">Ask Ubuntu</a> and <a href="https://discourse.ubuntu.com">the Ubuntu Discourse</a> are great sources of answers to common questions about installing, troubleshooting and optimising Ubuntu. For more info on support forums, including IRC channels, see <a href="/community/support">our community docs</a>.
         </p>
       </div>
       <div class="col-6 p-card">


### PR DESCRIPTION
## Done

- Update deprecated Ubuntu Forums link to Ubuntu Discourse
- [Copy doc](https://docs.google.com/document/d/1vrnljXUx71ZZhz3cQ6NupUNw6yNqW2OWkyY8Ozx2bqw/edit?tab=t.0)

## QA

- Go to /support/community-support
- Click on "Ubuntu Discourse" and see that it links to Discourse as expected

## Issue / Card

Fixes [WD-21943](https://warthogs.atlassian.net/browse/WD-21943) https://github.com/canonical/ubuntu.com/issues/15027 [WD-21552](https://warthogs.atlassian.net/browse/WD-21552)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-21943]: https://warthogs.atlassian.net/browse/WD-21943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[WD-21552]: https://warthogs.atlassian.net/browse/WD-21552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ