### PR TITLE
[K8s Docs] Update k8s doc links

### DIFF
--- a/templates/kubernetes/charmed-k8s/docs/1.30/upgrading.md
+++ b/templates/kubernetes/charmed-k8s/docs/1.30/upgrading.md
@@ -16,7 +16,7 @@ toc: False
 <div class="p-notification--caution is-inline">
   <div markdown="1" class="p-notification__content">
     <span class="p-notification__title">Caution:</span>
-    <p class="p-notification__message">This release includes topology changes and new best practices for integrating <strong>Charmed Kubernetes</strong> with other Juju ecosystem solutions. Be sure to read and understand the *What's new* section of the <a href="/kubernetes/charmed-k8s/docs/1.30/release-notes">1.30 release notes</a> prior to upgrading your cluster.<br/>
+    <p class="p-notification__message">This release includes topology changes and new best practices for integrating <strong>Charmed Kubernetes</strong> with other Juju ecosystem solutions. Be sure to read and understand the What's new section of the <a href="/kubernetes/charmed-k8s/docs/1.30/release-notes">1.30 release notes</a> prior to upgrading your cluster.<br/>
     <br/>
     Additionally, some features from previous <strong>Charmed Kubernetes</strong> releases are not yet available in this release. If you rely on a component identified as an *Integration gap* in the <a href="/kubernetes/charmed-k8s/docs/1.30/release-notes#notes-issues">Notes and Known Issues</a> section of the release notes, remain on release 1.28 (or earlier) and do not upgrade to 1.30 at this time.</p>
   </div>
@@ -48,7 +48,7 @@ The 'App' section of the output lists each application and its version number. N
 <div class="p-notification--warning is-inline">
   <div markdown="1" class="p-notification__content">
     <span class="p-notification__title">Warning!:</span>
-    <p class="p-notification__message"><strong>Juju compatibility</strong>: Juju version 3.1 or better is required to deploy Charmed Kubernetes 1.30. See the <a href="https://juju.is/docs/juju/upgrade-your-juju-deployment-from-2-9-to-3-x">Juju documentation</a> for information on upgrading controllers and models to Juju 3.x.</p>
+    <p class="p-notification__message"><strong>Juju compatibility</strong>: Juju version 3.1 or better is required to deploy Charmed Kubernetes 1.30. See the <a href="https://documentation.ubuntu.com/juju/3.6/howto/manage-controllers/#upgrade-a-controller">Juju documentation</a> for information on upgrading controllers and models to Juju 3.x.</p>
   </div>
 </div>
 
@@ -79,7 +79,7 @@ deprecated APIs.
 
 ## Upgrading the series (required for machines currently running Ubuntu 18.04)
 
-All of the charms support [upgrading machine series via Juju](https://juju.is/docs/juju/manage-machines#heading--upgrade-a-machine).
+All of the charms support [upgrading machine series via Juju](https://documentation.ubuntu.com/juju/3.6/howto/manage-machines).
 As each machine is upgraded, the applications on that machine will be stopped and the unit will
 go into a `blocked` state until the upgrade is complete. For the worker units, pods will be drained
 from the node and onto one of the other nodes at the start of the upgrade, and the node will be removed
@@ -380,6 +380,7 @@ It is recommended that you run a [cluster validation][validation] to ensure that
 [blue-green]: https://martinfowler.com/bliki/BlueGreenDeployment.html
 [validation]: /kubernetes/charmed-k8s/docs/validation
 [supported-versions]: /kubernetes/charmed-k8s/docs/supported-versions
+[juju-controller-upgrade]: https://documentation.ubuntu.com/juju/3.6/howto/manage-controllers/#upgrade-a-controller
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">

--- a/templates/kubernetes/charmed-k8s/docs/1.31/upgrading.md
+++ b/templates/kubernetes/charmed-k8s/docs/1.31/upgrading.md
@@ -47,7 +47,7 @@ The 'App' section of the output lists each application and its version number. N
 <div class="p-notification--warning is-inline">
   <div markdown="1" class="p-notification__content">
     <span class="p-notification__title">Warning!:</span>
-    <p class="p-notification__message"><strong>Juju compatibility</strong>  The latest current version of Juju (as of the time of the Charmed Kubernetes 1.31 release) is <strong>3.5</strong>. This new major release introduces some breaking changes with previous versions. It is recommended that you upgrade to this new version of Juju, but also be aware of the changes. See the <a href="https://juju.is/docs/juju/upgrade-your-juju-deployment-from-2-9-to-3-x"> Juju documentation</a> for more information.</p>
+    <p class="p-notification__message"><strong>Juju compatibility</strong>  The latest current version of Juju (as of the time of the Charmed Kubernetes 1.31 release) is <strong>3.5</strong>. This new major release introduces some breaking changes with previous versions. It is recommended that you upgrade to this new version of Juju, but also be aware of the changes. See the <a href="https://documentation.ubuntu.com/juju/3.6/howto/manage-controllers/#upgrade-a-controller"> Juju documentation</a> for more information.</p>
   </div>
 </div>
 
@@ -62,7 +62,7 @@ You should also make sure:
 -   Your Juju client and controller/models are running the same, stable version of Juju (see the [Juju docs][juju-controller-upgrade]).
 -   You read the [Upgrade notes][notes] to see if any caveats apply to the versions you are upgrading to/from.
 -   You read the [Release notes][release-notes] for the version you are upgrading to, which will alert you to any important changes to the operation of your cluster.
--   You read the [Upstream release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.31.md#deprecation) for details of deprecation notices and API changes for Kubernetes 1.27 which may impact your workloads.
+-   You read the [Upstream release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.31.md#deprecation) for details of deprecation notices and API changes for Kubernetes 1.31 which may impact your workloads.
 
 It is also important to understand that **Charmed Kubernetes** will only upgrade
 and if necessary migrate, components relating specifically to elements of
@@ -81,7 +81,7 @@ deprecated APIs.
 
 ## Upgrading the Machine's Series (required for machines currently running 18.04(Bionic))
 
-All of the charms support [upgrading the machine's series via Juju](https://juju.is/docs/juju/manage-machines#heading--upgrade-a-machine).
+All of the charms support [upgrading the machine's series via Juju](https://documentation.ubuntu.com/juju/3.6/howto/manage-machines).
 As each machine is upgraded, the applications on that machine will be stopped and the unit will
 go into a `blocked` status until the upgrade is complete. For the worker units, pods will be drained
 from the node and onto one of the other nodes at the start of the upgrade, and the node will be removed
@@ -392,6 +392,7 @@ It is recommended that you run a [cluster validation][validation] to ensure that
 [blue-green]: https://martinfowler.com/bliki/BlueGreenDeployment.html
 [validation]: /kubernetes/charmed-k8s/docs/validation
 [supported-versions]: /kubernetes/charmed-k8s/docs/supported-versions
+[juju-controller-upgrade]:https://documentation.ubuntu.com/juju/3.6/howto/manage-controllers/#upgrade-a-controller
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">

--- a/templates/kubernetes/charmed-k8s/docs/1.32/upgrading.md
+++ b/templates/kubernetes/charmed-k8s/docs/1.32/upgrading.md
@@ -54,7 +54,7 @@ You should also make sure:
 -   Your Juju client and controller/models are running the same, stable version of Juju (see the [Juju docs][juju-controller-upgrade]).
 -   You read the [Upgrade notes][notes] to see if any caveats apply to the versions you are upgrading to/from.
 -   You read the [Release notes][release-notes] for the version you are upgrading to, which will alert you to any important changes to the operation of your cluster.
--   You read the [Upstream release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.27.md#deprecation) for details of deprecation notices and API changes for Kubernetes 1.27 which may impact your workloads.
+-   You read the [Upstream release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.32.md#deprecation) for details of deprecation notices and API changes for Kubernetes 1.32 which may impact your workloads.
 
 It is also important to understand that **Charmed Kubernetes** will only upgrade
 and if necessary migrate, components relating specifically to elements of
@@ -366,6 +366,7 @@ It is recommended that you run a [cluster validation][validation] to ensure that
 [blue-green]: https://martinfowler.com/bliki/BlueGreenDeployment.html
 [validation]: /kubernetes/docs/validation
 [supported-versions]: /kubernetes/docs/supported-versions
+[juju-controller-upgrade]:https://documentation.ubuntu.com/juju/3.6/howto/manage-controllers/#upgrade-a-controller
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">

--- a/templates/kubernetes/charmed-k8s/docs/ceph.md
+++ b/templates/kubernetes/charmed-k8s/docs/ceph.md
@@ -58,7 +58,7 @@ juju integrate ceph-osd ceph-mon
   <div markdown="1" class="p-notification__content">
     <span class="p-notification__title">Note:</span>
     <p class="p-notification__message">For more on how Juju makes use of storage, please see the relevant
-<a href="https://juju.is/docs/juju/manage-storage">Juju documentation</a></p>
+<a href="https://documentation.ubuntu.com/juju/3.6/howto/manage-storage/">Juju documentation</a></p>
   </div>
 </div>
 

--- a/templates/kubernetes/charmed-k8s/docs/certs-and-trust.md
+++ b/templates/kubernetes/charmed-k8s/docs/certs-and-trust.md
@@ -42,7 +42,7 @@ Unfortunately, the **Juju** controller does not provide any mechanisms for
 generating or distributing additional certificates to be used by the
 applications on the machines, so they must be managed by the charms via the
 secure relation data channel. This is done using the [tls-certificates][]
-[interface protocol][interface] and a relation to an application providing a
+interface protocol and a relation to an application providing a
 Certificate Authority.  (This CA could be either a root CA, or an intermediary
 CA authorised by some other root CA to issue certificates.)
 
@@ -71,7 +71,7 @@ identifying and validating it to any clients that wish to connect.
 The primary address at which the service can be reached will be its [common
 name][CN]; ideally, this will be a fully-qualified domain name (FQDN) which
 will not change, but for internal service communication, it is often just the
-[ingress address][network primitives] for the unit. Any additional names or
+ingress address for the unit. Any additional names or
 addresses by which the service can be reached will be its [subject alternative
 names (SANs)][SANs].
 
@@ -120,13 +120,12 @@ See the [operations documentation][vault-cdk] for details on how to deploy Vault
 [PKI]: https://github.com/OpenVPN/easy-rsa/blob/master/doc/Intro-To-PKI.md
 [chain of trust]: https://en.wikipedia.org/wiki/Chain_of_trust
 [CA]: https://en.wikipedia.org/wiki/Certificate_authority
-[Juju units]: https://juju.is/docs/juju/quick-reference
-[Juju controller]: https://juju.is/docs/juju/quick-reference
+[Juju units]: https://documentation.ubuntu.com/juju/3.6/reference/unit/
+[Juju controller]: https://documentation.ubuntu.com/juju/3.6/reference/controller/
 [tls-certificates]: https://github.com/juju-solutions/interface-tls-certificates
-[interface]: https://juju.is/docs/juju/quick-reference
 [websockets]: https://en.wikipedia.org/wiki/WebSocket
 [cloud-init]: https://cloud-init.io/
-[relation]: https://juju.is/docs/juju/quick-reference
+[relation]: https://documentation.ubuntu.com/juju/3.6/reference/relation/
 [vault-charm]: https://charmhub.io/vault
 [vault]: https://www.vaultproject.io
 [easyrsa-charm]: https://charmhub.io/containers-easyrsa
@@ -139,7 +138,6 @@ See the [operations documentation][vault-cdk] for details on how to deploy Vault
 [client certificate]: https://en.wikipedia.org/wiki/Public_key_certificate#TLS/SSL_client_certificate
 [CN]: https://knowledge.digicert.com/solution/SO7239.html
 [SANs]: https://en.wikipedia.org/wiki/Subject_Alternative_Name
-[network primitives]: https://juju.is/docs/juju/quick-reference
 [kubernetes-control-plane]: https://charmhub.io/kubernetes-control-plane
 [`extra_sans`]:  https://charmhub.io/kubernetes-control-plane/configure
 [HA]: https://en.wikipedia.org/wiki/High_availability

--- a/templates/kubernetes/charmed-k8s/docs/cni-cilium.md
+++ b/templates/kubernetes/charmed-k8s/docs/cni-cilium.md
@@ -318,7 +318,7 @@ For additional troubleshooting pointers, please see the
 [hubble-introduction]: https://docs.cilium.io/en/stable/gettingstarted/hubble_intro/
 [hubble-client]: https://docs.cilium.io/en/stable/gettingstarted/hubble_cli/#hubble-cli
 [hubble-metrics]: https://docs.cilium.io/en/stable/observability/metrics/#hubble-metrics
-[juju-cmi]: https://juju.is/docs/juju/cross-model-integration
+[juju-cmi]: https://documentation.ubuntu.com/juju/3.6/howto/manage-relations/#add-a-cross-model-relation
 [troubleshooting]: /kubernetes/charmed-k8s/docs/troubleshooting
 
 <!-- FEEDBACK -->

--- a/templates/kubernetes/charmed-k8s/docs/encryption-at-rest.md
+++ b/templates/kubernetes/charmed-k8s/docs/encryption-at-rest.md
@@ -112,7 +112,7 @@ storage pool, or even full-disk-encryption on the host machine.
 [HashiCorp's Vault]: https://www.vaultproject.io/
 [VaultLocker]: https://github.com/openstack-charmers/vaultlocker
 [Vault charm]: https://charmhub.io/vault
-[expose]: https://juju.is/docs/juju/expose-a-deployed-application
+[expose]: https://documentation.ubuntu.com/juju/3.6/howto/manage-applications/#manage-an-applications-public-availability-over-the-network
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">

--- a/templates/kubernetes/charmed-k8s/docs/equinix.md
+++ b/templates/kubernetes/charmed-k8s/docs/equinix.md
@@ -439,7 +439,7 @@ Hello Kubernetes!
 [bugs]: https://bugs.launchpad.net/charmed-kubernetes
 [install]: /kubernetes/charmed-k8s/docs/install-manual
 [Equinix Cloud Controller Manager]: https://github.com/equinix/cloud-provider-equinix-metal/
-[Juju documentation]: https://juju.is/docs/juju/installing-juju
+[Juju documentation]: https://documentation.ubuntu.com/juju/3.6/tutorial/
 [Equinix Metal]: https://metal.equinix.com/
 
 <!-- FEEDBACK -->

--- a/templates/kubernetes/charmed-k8s/docs/gatekeeper.md
+++ b/templates/kubernetes/charmed-k8s/docs/gatekeeper.md
@@ -181,7 +181,7 @@ ns-must-have-gk                                6
 [gatekeeper-controller-manager]: https://charmhub.io/gatekeeper-controller-manager
 [prometheus-k8s]: https://charmhub.io/prometheus-k8s
 [grafana-agent-k8s]: https://charmhub.io/grafana-agent-k8s
-[storage-pools]: https://juju.is/docs/juju/defining-and-using-persistent-storage
+[storage-pools]: https://documentation.ubuntu.com/juju/3.6/howto/manage-storage/
 [quickstart]: https://ubuntu.com/kubernetes/charmed-k8s/docs/quickstart
 
 <!-- FEEDBACK -->
@@ -194,3 +194,4 @@ ns-must-have-gk                                6
     <p>See the guide to <a href="/kubernetes/charmed-k8s/docs/how-to-contribute"> contributing </a> or discuss these docs in our <a href="https://chat.charmhub.io/charmhub/channels/kubernetes"> public Mattermost channel</a>.</p>
   </div>
 </div>
+

--- a/templates/kubernetes/charmed-k8s/docs/how-to-cos-lite.md
+++ b/templates/kubernetes/charmed-k8s/docs/how-to-cos-lite.md
@@ -149,11 +149,11 @@ you can head over to the [COS Lite documentation][cos-lite-docs].
 
 [how-to-install]: /kubernetes/charmed-k8s/docs/how-to-install
 [how-to-install-microk8s]: https://microk8s.io/docs/getting-started
-[add-k8s]: https://juju.is/docs/juju/juju-add-k8s
+[add-k8s]: https://documentation.ubuntu.com/juju/3.6/reference/juju-cli/list-of-juju-cli-commands/add-k8s/
 [cos-lite-docs]: https://charmhub.io/topics/canonical-observability-stack
-[juju-models]: https://juju.is/docs/juju/model
-[juju-debug-log]: https://juju.is/docs/juju/juju-debug-log
-[cross-model-integration]: https://juju.is/docs/juju/relation#heading--cross-model
+[juju-models]: https://documentation.ubuntu.com/juju/3.6/reference/model
+[juju-debug-log]: https://documentation.ubuntu.com/juju/3.6/reference/juju-cli/list-of-juju-cli-commands/debug-log/
+[cross-model-integration]: https://documentation.ubuntu.com/juju/3.6/reference/relation
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">

--- a/templates/kubernetes/charmed-k8s/docs/install-existing.md
+++ b/templates/kubernetes/charmed-k8s/docs/install-existing.md
@@ -16,7 +16,7 @@ toc: False
 Machines that are provisioned without Juju can still be used for Juju deployments.
 This is known as a *manual cloud* and is described in the following Juju documentation:
 
-[https://juju.is/docs/juju/manual][juju-manual]
+[The manual cloud and Juju][juju-manual]
 
 In this guide, we will create a manual cloud with 3 existing machines. We will then
 deploy a minimal installation of **Charmed Kubernetes** to this cloud using the
@@ -85,7 +85,7 @@ juju deploy kubernetes-core --map-machines=existing
 <div class="p-notification--positive is-inline">
   <div markdown="1" class="p-notification__content">
     <span class="p-notification__title">Note:</span>
-    <p class="p-notification__message">The "--map-machines" flag instructs Juju to use existing machines to satisfy placement directives defined in the bundle. Without this, Juju would attempt to provision new machines for this deployment. More information about machine mapping can be found in the <a href="https://juju.is/docs/juju/juju-deploy">Juju deploy</a> documentation.</p>
+    <p class="p-notification__message">The "--map-machines" flag instructs Juju to use existing machines to satisfy placement directives defined in the bundle. Without this, Juju would attempt to provision new machines for this deployment. More information about machine mapping can be found in the <a href="https://documentation.ubuntu.com/juju/3.6/reference/juju-cli/list-of-juju-cli-commands/deploy">Juju deploy</a> documentation.</p>
   </div>
 </div>
 
@@ -102,7 +102,7 @@ Now that you have a **Charmed Kubernetes** cluster up and running, check out the
 
 <!-- LINKS -->
 
-[juju-manual]: https://juju.is/docs/juju/manual
+[juju-manual]: https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-manual-cloud-and-juju/
 [kubernetes-core]: https://charmhub.io/kubernetes-core
 [operations]: /kubernetes/charmed-k8s/docs/operations
 

--- a/templates/kubernetes/charmed-k8s/docs/install-local.md
+++ b/templates/kubernetes/charmed-k8s/docs/install-local.md
@@ -304,7 +304,7 @@ sudo sysctl fs.inotify.max_user_watches=1048576
 If the CNI pods fail to start, see notes on the specific CNI page.
 
 CNIs like [Cilium][cilium] and [Calico][calico] need access to `/sys/fs/bpf`, but that
-mountpoint is not supported by the Juju [validation check][juju-validation-check]
+mountpoint is not supported by the Juju validation check
 for the charm-specific `lxd-profile.yaml`. See [CNI Overview][cni-overview] for more
 details.
 
@@ -326,11 +326,10 @@ juju config calico ignore-loose-rpf=true
 <!-- LINKS -->
 
 [lxd-home]: https://ubuntu.com/lxd
-[lxd-profile]: https://juju.is/docs/sdk/lxd-profile-yaml
+[lxd-profile]: https://canonical-charmcraft.readthedocs-hosted.com/en/stable/reference/files/lxd-profile-yaml-file
 [calico]: /kubernetes/charmed-k8s/docs/cni-calico
 [cilium]: /kubernetes/charmed-k8s/docs/cni-cilium
 [cni-overview]: /kubernetes/charmed-k8s/docs/cni-overview
-[juju-validation-check]: https://juju.is/docs/juju/use-lxd-profiles
 [Juju]: https://jaas.ai
 [snap]: https://snapcraft.io/docs/installing-snapd
 [install]: /kubernetes/charmed-k8s/docs/install-manual

--- a/templates/kubernetes/charmed-k8s/docs/install-manual.md
+++ b/templates/kubernetes/charmed-k8s/docs/install-manual.md
@@ -457,13 +457,12 @@ Now you have a cluster up and running, check out the
 
 [latest-bundle-file]: https://charmhub.io/charmed-kubernetes
 [jaas]: https://jaas.ai/
-[juju-docs]: https://juju.is/docs/juju/installing-juju
-[controller-config]: https://juju.is/docs/juju/create-controllers
-[credentials]: https://juju.is/docs/juju/credentials
+[juju-docs]: https://documentation.ubuntu.com/juju/3.6/tutorial/
+[credentials]: https://documentation.ubuntu.com/juju/3.6/reference/juju-cli/list-of-juju-cli-commands/credentials/
 [quickstart]: /kubernetes/charmed-k8s/docs/quickstart
-[juju-bundle]: https://juju.is/docs/sdk/bundles
+[juju-bundle]: https://documentation.ubuntu.com/juju/3.6/reference/bundle/
 [juju-gui]: https://juju.is/docs/juju/manage-the-juju-dashboard
-[juju-constraints]: https://juju.is/docs/juju/constraints
+[juju-constraints]: https://documentation.ubuntu.com/juju/3.6/reference/juju-cli/list-of-juju-cli-commands/constraints/
 [asset-aws-overlay]: https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/overlays/aws-overlay.yaml
 [charm-kworker]: https://charmhub.io/containers-kubernetes-worker
 [snaps]: https://docs.snapcraft.io/snap-documentation

--- a/templates/kubernetes/charmed-k8s/docs/install-offline.md
+++ b/templates/kubernetes/charmed-k8s/docs/install-offline.md
@@ -261,19 +261,12 @@ is covered in the [proxy documentation][].
 [LXD]: https://ubuntu.com/lxd
 [LXD-image]: https://documentation.ubuntu.com/lxd/en/latest/images/
 [maas-images]: https://maas.io/docs/how-to-use-standard-images
-[simplestreams]: https://juju.is/docs/juju/cloud-image-metadata
+[simplestreams]: https://documentation.ubuntu.com/juju/3.6/howto/manage-metadata/
 [bundles]: /kubernetes/charmed-k8s/docs/supported-versions
 [1.23-components]: /kubernetes/charmed-k8s/docs/1.23/components#snaps
 [cdk-shrinkwrap]: https://github.com/charmed-kubernetes/cdk-shrinkwrap
-[controller-config]: https://juju.is/docs/juju/controllers
-[credentials]: https://juju.is/docs/juju/credentials
-[customize-bundle]: /kubernetes/charmed-k8s/docs/install-manual#customising-the-bundle-install
 [container images]: https://github.com/charmed-kubernetes/bundle/tree/master/container-images
-[juju-bundle]: https://juju.is/docs/sdk/bundles
-[juju-constraints]: https://juju.is/docs/juju/constraints
-[juju-docs]: https://juju.is/docs/juju/installing-juju
-[juju-gui]: https://juju.is/docs/juju/accessing-the-dashboard
-[offline-mode]: https://juju.is/docs/juju/configure-juju-for-offline-usage
+[offline-mode]: https://documentation.ubuntu.com/juju/3.6/howto/manage-your-deployment/take-your-deployment-offline/
 [on-prem-livepatch]: https://ubuntu.com/security/livepatch/docs/on_prem
 [overlays]: /kubernetes/charmed-k8s/docs/install-manual#overlay
 [quickstart]: /kubernetes/charmed-k8s/docs/quickstart

--- a/templates/kubernetes/charmed-k8s/docs/keepalived.md
+++ b/templates/kubernetes/charmed-k8s/docs/keepalived.md
@@ -92,7 +92,7 @@ balancer.
 [keepalived-home]: http://www.keepalived.org/
 [SANs]: https://www.openssl.org/docs/manmaster/man5/x509v3_config.html#Subject-Alternative-Name
 [logging-doc]: /kubernetes/charmed-k8s/docs/logging
-[subordinate-charm]: https://juju.is/docs/sdk#heading--subordinate-charms
+[subordinate-charm]: https://documentation.ubuntu.com/juju/3.6/howto/manage-charms
 [openstack-vip]: https://medium.com/jexia/virtual-ip-with-openstack-neutron-dd9378a48bdf
 
 <!-- FEEDBACK -->

--- a/templates/kubernetes/charmed-k8s/docs/logging.md
+++ b/templates/kubernetes/charmed-k8s/docs/logging.md
@@ -281,7 +281,7 @@ view.
 
 <!--LINKS -->
 
-[juju-logging]: https://juju.is/docs/juju/juju-logs
+[juju-logging]: https://documentation.ubuntu.com/juju/3.6/howto/manage-logs/
 [k8-logs]: https://kubernetes.io/docs/concepts/cluster-administration/logging/
 [ck8s-audit-logs]: /kubernetes/charmed-k8s/docs/audit-logging
 [logging-egf-overlay]: https://raw.githubusercontent.com/charmed-kubernetes/bundle/main/overlays/logging-egf-overlay.yaml

--- a/templates/kubernetes/charmed-k8s/docs/metallb.md
+++ b/templates/kubernetes/charmed-k8s/docs/metallb.md
@@ -144,7 +144,7 @@ metallb/0*  active    idle   192.168.0.15
 
 To exit the screen with `juju status --watch 1s`, enter `Ctrl+c`.
 If you want to further inspect Juju logs, can watch for logs with `juju debug-log`.
-More info on logging at [juju logs](https://juju.is/docs/juju/juju-logs).
+More info on logging at [juju logs](https://documentation.ubuntu.com/juju/3.6/howto/manage-logs/).
 
 #### Configuration
 

--- a/templates/kubernetes/charmed-k8s/docs/multiple-networks.md
+++ b/templates/kubernetes/charmed-k8s/docs/multiple-networks.md
@@ -118,7 +118,7 @@ The following endpoints are available for use in bindings:
 | kubernetes-worker | kube-control | Traffic to kubelet, from kube-apiserver (health checks) |
 
 You can read more about bindings in the Juju documentation here:
-[Binding endpoints within a bundle](https://juju.is/docs/sdk/bind-endpoints-within-a-bundle)
+[Binding endpoints within a bundle](https://documentation.ubuntu.com/juju/3.6/reference/juju-cli/list-of-juju-cli-commands/bind/)
 
 
 <!-- FEEDBACK -->

--- a/templates/kubernetes/charmed-k8s/docs/proxies.md
+++ b/templates/kubernetes/charmed-k8s/docs/proxies.md
@@ -91,7 +91,7 @@ also be configured for offline use (see the
 
 <!-- LINKS -->
 
-[Juju proxy documentation]: https://juju.is/docs/juju/working-offline
+[Juju proxy documentation]: https://documentation.ubuntu.com/juju/3.6/howto/manage-your-deployment/take-your-deployment-offline/
 [1.23-components]: 1.23/components#snaps
 [offline]: install-offline
 [snap]: https://snapcraft.io

--- a/templates/kubernetes/charmed-k8s/docs/quickstart.md
+++ b/templates/kubernetes/charmed-k8s/docs/quickstart.md
@@ -68,7 +68,7 @@ Google. You can see which ones are ready to use by running this command:
           </div>
           <script id="asciicast-254740" src="https://asciinema.org/a/254740.js" async data-rows="18" ></script>
 
-          <p><a href="https://juju.is/docs/juju/clouds">Find out more about Clouds in Juju</a></p>
+          <p><a href="https://documentation.ubuntu.com/juju/3.6/reference/juju-cli/list-of-juju-cli-commands/clouds/">Find out more about Clouds in Juju</a></p>
         </div>
       </li>
 

--- a/templates/kubernetes/charmed-k8s/docs/scaling.md
+++ b/templates/kubernetes/charmed-k8s/docs/scaling.md
@@ -182,8 +182,8 @@ For a more detailed guide, please refer to the [Juju high availability documenta
 
 <!-- LINKS -->
 
-[juju-ha]: https://juju.is/docs/juju/high-availability-juju-controller
-[juju-constraints]: https://juju.is/docs/juju/constraints
+[juju-ha]: https://documentation.ubuntu.com/juju/3.6/reference/high-availability/
+[juju-constraints]: https://documentation.ubuntu.com/juju/3.6/reference/juju-cli/list-of-juju-cli-commands/constraints/
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">

--- a/templates/kubernetes/charmed-k8s/docs/security.md
+++ b/templates/kubernetes/charmed-k8s/docs/security.md
@@ -100,9 +100,9 @@ To test your cluster, please see the
 
 [cis-benchmark]: https://www.cisecurity.org/benchmark/kubernetes/
 [Kubernetes Security documentation]: https://kubernetes.io/docs/concepts/security/overview/
-[Machine auth]: https://juju.is/docs/juju/accessing-individual-machines-with-ssh
-[juju-users]: https://juju.is/docs/juju/manage-users
-[juju-user-types]: https://juju.is/docs/juju/user
+[Machine auth]: https://documentation.ubuntu.com/juju/3.6/howto/manage-ssh-keys/
+[juju-users]: https://documentation.ubuntu.com/juju/3.6/howto/manage-users/
+[juju-user-types]: https://documentation.ubuntu.com/juju/3.6/reference/user/
 [CIS compliance]: /kubernetes/charmed-k8s/docs/cis-compliance
 [k8s-auth]: /kubernetes/charmed-k8s/docs/auth
 [k8s-aws-iam]: /kubernetes/charmed-k8s/docs/aws-iam-auth

--- a/templates/kubernetes/charmed-k8s/docs/storage.md
+++ b/templates/kubernetes/charmed-k8s/docs/storage.md
@@ -58,7 +58,7 @@ So, for example, to deploy three `ceph-osd` storage nodes, using the default sto
 <div class="p-notification--positive is-inline">
   <div markdown="1" class="p-notification__content">
     <span class="p-notification__title">Note:</span>
-    <p class="p-notification__message">For a more detailed explanation of Juju's storage pools and options, please see the relevant <a href="https://juju.is/docs/juju/defining-and-using-persistent-storage">Juju documentation</a>.</p>
+    <p class="p-notification__message">For a more detailed explanation of Juju's storage pools and options, please see the relevant <a href="https://documentation.ubuntu.com/juju/3.6/howto/manage-storage/">Juju documentation</a>.</p>
   </div>
 </div>
 
@@ -290,8 +290,7 @@ There is no requirement that these additional units should have the same amount 
 [kubernetes-storage-docs]: https://kubernetes.io/docs/concepts/storage/
 [ceph-home]: https://ceph.com/
 [ceph-charm]: https://charmhub.io/ceph-osd
-[juju-storage]: https://juju.is/docs/juju/defining-and-using-persistent-storage
-[juju-cmr]: https://juju.is/docs/juju/cross-model-relations
+[juju-cmr]: https://documentation.ubuntu.com/juju/3.6/howto/manage-relations/#add-a-cross-model-relation
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">

--- a/templates/kubernetes/charmed-k8s/docs/upgrading.md
+++ b/templates/kubernetes/charmed-k8s/docs/upgrading.md
@@ -125,7 +125,7 @@ It is recommended that you run a [cluster validation][validation] to ensure that
 [validation]: /kubernetes/charmed-k8s/docs/validation
 [supported-versions]: /kubernetes/charmed-k8s/docs/supported-versions
 [inclusive-naming]: /kubernetes/charmed-k8s/docs/inclusive-naming
-[juju-controller-upgrade]: https://juju.is/docs/juju/upgrade-models
+[juju-controller-upgrade]: https://documentation.ubuntu.com/juju/3.6/howto/manage-models/#upgrade-a-model
 
 <!-- FEEDBACK -->
 <div class="p-notification--information">

--- a/templates/kubernetes/charmed-k8s/docs/using-vault.md
+++ b/templates/kubernetes/charmed-k8s/docs/using-vault.md
@@ -276,7 +276,7 @@ juju status vault
 [certs-doc]: /kubernetes/charmed-k8s/docs/certs-and-trust
 [encryption-doc]: /kubernetes/charmed-k8s/docs/encryption-at-rest
 [vault]: https://www.vaultproject.io
-[expose]: https://juju.is/docs/juju/expose-a-deployed-application
+[expose]: https://documentation.ubuntu.com/juju/3.6/reference/juju-cli/list-of-juju-cli-commands/expose/
 [hacluster]: https://charmhub.io/hacluster/
 [vault-guide-csr]: https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/app-certificate-management.html
 [vault-charm-unseal]: https://opendev.org/openstack/charm-vault/src/branch/master/src/README.md#post-deployment-tasks

--- a/templates/kubernetes/charmed-k8s/docs/vsphere-integration.md
+++ b/templates/kubernetes/charmed-k8s/docs/vsphere-integration.md
@@ -20,7 +20,7 @@ to directly use native vSphere features such as storage.
 <div class="p-notification--information is-inline">
   <div class="p-notification__content">
     <span class="p-notification__title">Note:</span>
-    <p class="p-notification__message">These instructions for deploying Charmed Kubernetes with the vSphere Cloud Provider assume that Juju has been configured appropriately for your vSphere server. For reference, the configuration options may be found in the <a href="https://juju.is/docs/juju/vmware-vsphere" >Juju documentation</a>.</p>
+    <p class="p-notification__message">These instructions for deploying Charmed Kubernetes with the vSphere Cloud Provider assume that Juju has been configured appropriately for your vSphere server. For reference, the configuration options may be found in the <a href="https://documentation.ubuntu.com/juju/3.6/reference/cloud/list-of-supported-clouds/the-vmware-vsphere-cloud-and-juju/" >Juju documentation</a>.</p>
   </div>
 </div>
 


### PR DESCRIPTION
## Done

After the rework of the Juju docs, there were many broken links in Charmed Kuberentes. This PR updates those links.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
