### PR TITLE
chore: Remove templates from sitemap

### DIFF
--- a/templates/security/vulnerabilities/vulnerability-detailed.html
+++ b/templates/security/vulnerabilities/vulnerability-detailed.html
@@ -8,6 +8,8 @@
   is-paper
 {% endblock body_class %}
 
+{% block head_extra %}<meta name="robots" content="noindex" />{% endblock %}
+
 {% block content %}
 
   {% set breadcrumbs = [{"name": "Vulnerability knowledge base", "href": "/security/vulnerabilities"}, {"name": "View all", "href": "/security/vulnerabilities/view-all"}, {"name": document.title}] %}

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -187,6 +187,7 @@ CHARMHUB_DISCOURSE_API_USERNAME = os.getenv("CHARMHUB_DISCOURSE_API_USERNAME")
 # Sitemaps that are already generated and don't need to be updated.
 # Can be seen on sitemap_index.xml
 DYNAMIC_SITEMAPS = [
+    "templates",
     "tutorials",
     "engage",
     "ceph/docs",


### PR DESCRIPTION
## Done

- Remove `/templates/templates/...` directory from sitemap
- Remove `/security/vulnerabilities/vulnerability-detailed.html` from sitemap

## QA

- Go to https://ubuntu-com-15086.demos.haus/sitemap_tree.xml
- Search for `/templates`, see that they are not indexed
- Repeat step 2 with `/security/vulnerabilities/vulnerability-detailed`

## Issue / Card

Fixes [WD-21815](https://warthogs.atlassian.net/browse/WD-21815)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-21815]: https://warthogs.atlassian.net/browse/WD-21815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ