### PR TITLE
copy: update contact form emails for /hpe

### DIFF
--- a/templates/shared/forms/interactive/hpe.html
+++ b/templates/shared/forms/interactive/hpe.html
@@ -19,8 +19,8 @@
         <p class="u-no-margin--bottom"><strong>Technology Partner Program</strong>
         <p>tam.vuong@hpe.com</p>
         <p class="u-no-margin--bottom"><strong>Certification Program</strong>
-        <p class="u-no-margin--bottom">nery-gabriela.herrera@hpe.com</p>
-        <p>karen.skweres@hpe.com</p>
+        <p class="u-no-margin--bottom">padilla@hpe.com</p>
+        <p>eddie.campbell@hpe.com</p>
       </div>
     </div>
 


### PR DESCRIPTION
## Done

Update two emails on the contact us modal, triggered from the CTA, on the /hpe page. 

 
Updated according to : https://docs.google.com/document/d/1GtHoXJPGqTaxJxj1d9ul7hZukb_piUdBunXAwx7J28k/edit?tab=t.0#heading=h.47b8yg16cwy2
## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/hpe
    - Be sure to test on mobile, tablet and desktop screen sizes

Or also on the demo @ https://ubuntu-com-15087.demos.haus/hpe#get-in-touch

## Issue / Card

Fixes # https://warthogs.atlassian.net/browse/WD-21954

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
