### PR TITLE
integrate ta paginated response in your-exams view

### DIFF
--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -897,24 +897,29 @@ def cred_your_exams(
     exams_expired = []
 
     if exam_contracts:
+        reservations_response_pages = []
+        next_page = 1
         # Fetch all reservations in one API call
         try:
-            reservations_response = (
-                trueability_api.get_assessment_reservations(
-                    per_page=500,
-                    email=email,
+            while next_page:
+                reservations_response = (
+                    trueability_api.get_assessment_reservations(
+                        per_page=100,
+                        page=next_page,
+                        email=email,
+                    )
                 )
-            )
-            reservations = {
-                r["uuid"]: r
-                for r in reservations_response.get(
-                    "assessment_reservations", []
+                reservations_response_pages.extend(
+                    reservations_response.get("assessment_reservations", [])
                 )
-            }
-
+                next_page = reservations_response.get("meta", {}).get(
+                    "next_page", None
+                )
+                if next_page:
+                    next_page = int(next_page)
+            reservations = {r["uuid"]: r for r in reservations_response_pages}
         except Exception:
             reservations = {}
-
         for exam_contract in exam_contracts:
             exam_id = exam_contract["cueContext"]["courseID"]
             name = EXAM_NAMES.get(exam_id, exam_id)
@@ -1096,7 +1101,8 @@ def cred_your_exams(
                             "text": "Schedule",
                             "href": "/credentials/schedule?"
                             f"contractItemID={contract_item_id}"
-                            f"&contractLongID={contract_long_id}",
+                            f"&contractLongID={contract_long_id}"
+                            f"&ta_exam={exam_id}",
                             "button_class": "p-button",
                         },
                     ]

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -899,7 +899,7 @@ def cred_your_exams(
     if exam_contracts:
         reservations_response_pages = []
         next_page = 1
-        # Fetch all reservations in one API call
+        # Fetch all reservations for the user over multiple pages
         try:
             while next_page:
                 reservations_response = (


### PR DESCRIPTION
## Done

- Integrate paginated TA response for assessment reservations GET API

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Ensure you can see all your exams on `/credentials/your-exams`

## Issue / Card

Fixes [WD-22009](https://warthogs.atlassian.net/browse/WD-22009)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-22009]: https://warthogs.atlassian.net/browse/WD-22009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ