### PR TITLE
docs: add release notes for 1.32 and 1.31 bugfixes

### DIFF
--- a/templates/kubernetes/charmed-k8s/docs/1.31/release-notes.md
+++ b/templates/kubernetes/charmed-k8s/docs/1.31/release-notes.md
@@ -17,6 +17,15 @@ toc: False
 
 ---
 
+# 1.31+ck3
+
+### May 8, 2025 - `charmed-kubernetes --channel 1.31/stable`
+
+## Notable Fixes
+
+### Kubernetes Control Plane Charm
+* [LP#2108934](https://bugs.launchpad.net/bugs/2108934) The CPU usage Prometheus rule now correctly applies to pods running on any node in the cluster.
+
 # 1.31+ck2
 
 ### Mar 31, 2025 - `charmed-kubernetes --channel 1.31/stable`

--- a/templates/kubernetes/charmed-k8s/docs/1.32/release-notes.md
+++ b/templates/kubernetes/charmed-k8s/docs/1.32/release-notes.md
@@ -17,6 +17,16 @@ layout:
 toc: False
 ---
 
+# 1.32+ck2
+
+### May 8, 2025 - `charmed-kubernetes --channel 1.32/stable`
+
+## Notable Fixes
+
+### Kubernetes Control Plane Charm
+* [LP#2108934](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2108934) The CPU usage Prometheus rule now correctly applies to pods running on any node in the cluster.
+* [LP#2097158](https://bugs.launchpad.net/charm-kubernetes-master/+bug/2097158) The `user-create` action ensures `groups` is treated as a list.
+
 # 1.32+ck1
 
 ### Mar 28, 2025 - `charmed-kubernetes --channel 1.32/stable`

--- a/templates/kubernetes/charmed-k8s/docs/release-notes.md
+++ b/templates/kubernetes/charmed-k8s/docs/release-notes.md
@@ -13,6 +13,16 @@ layout: [base, ubuntu-com]
 toc: False
 ---
 
+# 1.32+ck2
+
+### May 8, 2025 - `charmed-kubernetes --channel 1.32/stable`
+
+## Notable Fixes
+
+### Kubernetes Control Plane Charm
+* [LP#2108934](https://bugs.launchpad.net/bugs/2108934) The CPU usage Prometheus rule now correctly applies to pods running on any node in the cluster.
+* [LP#2097158](https://bugs.launchpad.net/bugs/2097158) The `user-create` action ensures `groups` is treated as a list.
+
 # 1.32+ck1
 
 ### Mar 28, 2025 - `charmed-kubernetes --channel 1.32/stable`
@@ -136,6 +146,24 @@ please see the relevant sections of the
 <!--LINKS-->
 
 [rel]: /kubernetes/docs/release-notes
+
+# 1.31+ck3
+
+### May 8, 2025 - `charmed-kubernetes --channel 1.31/stable`
+
+## Notable Fixes
+
+### Kubernetes Control Plane Charm
+* [LP#2108934](https://bugs.launchpad.net/bugs/2108934) The CPU usage Prometheus rule now correctly applies to pods running on any node in the cluster.
+
+# 1.31+ck2
+
+### Mar 31, 2025 - `charmed-kubernetes --channel 1.31/stable`
+
+## Notable Fixes
+
+### Kubernetes Worker Charm
+* [LP#2104056](https://bugs.launchpad.net/bugs/2104056) Update ingress-nginx to 1.11.5 resolving CVE-2025-1974
 
 # 1.31+ck1
 


### PR DESCRIPTION
## Done

Updating release notes for charmed-kubernetes `1.32+ck2` and `1.31+ck3`.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
