### PR TITLE
chore: Update deprecating snap

### DIFF
--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -205,7 +205,7 @@
         </p>
 
         <p>
-          Ubuntu also supports 'snap' packages which are more suited for third-party applications and tools which evolve at their own speed, independently of Ubuntu. If you want to install a high-profile app like Skype or a toolchain like the latest version of Golang, you probably want the snap because it will give you fresher versions and more control of the specific major versions you want to track.
+          Ubuntu also supports 'snap' packages which are more suited for third-party applications and tools which evolve at their own speed, independently of Ubuntu. If you want to install a high-profile app like Firefox or a toolchain like the latest version of Golang, you probably want the snap because it will give you fresher versions and more control of the specific major versions you want to track.
         </p>
 
         <p>


### PR DESCRIPTION
## Done

- Update "Skype" to "Firefox" as per [copy doc](https://docs.google.com/document/d/1-l3B7AoyDoETaL80UhlfEWCVKmMWPdy3zoF5LpsGcYQ/edit?tab=t.0#heading=h.s6x9gb573nib)

## QA

- Go to /about/release-cycle
- See that "Skype" is replaced with "Firefox"

## Issue / Card

Fixes #15077

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
