### PR TITLE
fix: replace developer pdf links that were 404ing

### DIFF
--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -453,7 +453,7 @@
         <div class="u-hide--large">
           <hr class="p-rule--muted" />
           <p>
-            Source: <a href="https://recruit-c7ff.kxcdn.com/recruit/wp-content/uploads/2020/05/he-developer-survey-2020.pdf">The 2020
+            Source: <a href="https://media.hackerearth.com/recruit/wp-content/uploads/2020/05/he-developer-survey-2020.pdf">The 2020
           HackerEarth Developer Survey</a>
         </p>
       </div>
@@ -467,7 +467,7 @@
       <div class="u-hide--large">
         <hr class="p-rule--muted" />
         <p>
-          Source: <a href="https://www.openlogic.com/system/files/ebook-openlogic-the-2022-state-of-open-source-report.pdf">The
+          Source: <a href="https://ospo.co/documents/9/ebook-openlogic-the-2022-state-of-open-source-report.pdf">The
         2022 State of Open Source Report &ndash; OpenLogic</a>
       </p>
     </div>

--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -477,14 +477,14 @@
   <div class="col">
     <hr class="p-rule--muted" />
     <p>
-      Source: <a href="https://recruit-c7ff.kxcdn.com/recruit/wp-content/uploads/2020/05/he-developer-survey-2020.pdf">The 2020
+      Source: <a href="https://media.hackerearth.com/recruit/wp-content/uploads/2020/05/he-developer-survey-2020.pdf">The 2020
     HackerEarth Developer Survey</a>
   </p>
 </div>
 <div class="col">
   <hr class="p-rule--muted" />
   <p>
-    Source: <a href="https://www.openlogic.com/system/files/ebook-openlogic-the-2022-state-of-open-source-report.pdf">The
+    Source: <a href="https://ospo.co/documents/9/ebook-openlogic-the-2022-state-of-open-source-report.pdf">The
   2022 State of Open Source Report &ndash; OpenLogic</a>
 </p>
 </div>


### PR DESCRIPTION
## Done

- Update the developer page links to pdfs that were giving a 404.

Copy doc: https://docs.google.com/document/d/1VJ3xT2ViC-CvL0UmsAUzpYFmvpuqUP4AbpnlPm8tqOA/edit?tab=t.0

## QA

- Go to [/desktop/developers](https://ubuntu-com-15101.demos.haus/desktop/developers)
- Scroll down to "Developers love Ubuntu, organisations trust it".
- Click on the two "Source: ..." links below the charts and they should take you to pdfs.

## Issue / Card

https://warthogs.atlassian.net/browse/WD-22122?linkSource=email