### PR TITLE
copy update: update pricing nav

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -466,8 +466,6 @@ pricing:
   children:
     - title: Overview
       path: /pricing
-    - title: Consulting
-      path: /pricing/consulting
     - title: Desktops
       path: /pricing/desktop
     - title: Devices


### PR DESCRIPTION
## Done

- Updated pricing navigation to exclude "Consulting" according to the [copy doc](https://docs.google.com/document/d/1DCNvYHfC7AbOcqflTBaVd571iKAP_PaTfnqTENVEDVw/edit?tab=t.0)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Alternatively, view the [demo](https://ubuntu-com-15102.demos.haus/)
    - Navigate to /pricing/pro
    - Check that the navigation bar only contains "Desktops" and "Devices"

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-22067?linkSource=email
