### PR TITLE
chore: add the Renesas logo to iot page

### DIFF
--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -585,6 +585,16 @@
                         attrs={"class": "p-logo-section__logo"},) | safe
             }}
           </div>
+          <div class="p-logo-section__item">
+            {{ image(url="https://assets.ubuntu.com/v1/6e12ae75-renesas-logo.png",
+                        alt="Renesas",
+                        width="285",
+                        height="313",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"},) | safe
+            }}
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Done

- add the Renesas logo to iot section on /internet-of-things page

## QA

- View update via https://ubuntu-com-15104.demos.haus/internet-of-things
  - Be sure to test on mobile, tablet and desktop screen sizes 
 - Check against [doc](https://docs.google.com/document/d/1nBx1SP3Y10gXX0rZPDaz1Gudy-hWP4XRMUcETyPBldI/edit?tab=t.0) and [jira ticket](https://warthogs.atlassian.net/browse/WD-21940#icft=WD-21940)

## Issue / Card
[jira ticket](https://warthogs.atlassian.net/browse/WD-21940#icft=WD-21940)

## Screenshots
![Screenshot from 2025-05-16 11-53-09](https://github.com/user-attachments/assets/03148fe9-84e8-45c8-9e12-cedf2f98f9cb)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
