### PR TITLE
[WD-17833] feat: Rebrand kernel/variants page

### DIFF
--- a/templates/kernel/variants.html
+++ b/templates/kernel/variants.html
@@ -1,157 +1,236 @@
 {% extends "kernel/base_kernel.html" %}
 
+{% from "_macros/vf_hero.jinja" import vf_hero %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
 {% block title %}Ubuntu kernel variants from Canonical{% endblock %}
+
+{% block meta_description %}
+  Ubuntu is an open source software operating system that runs from the desktop, to the cloud, to all your internet connected things.
+{% endblock %}
+
 {% block meta_copydoc %}https://docs.google.com/document/d/1UVxrF8raNb5Pggj05P0ar_OzV_uwhrTRHv9XRiuM4zs/{% endblock %}
 
+{% block body_class %}
+  is-paper
+{% endblock body_class %}
+
 {% block content %}
-<section class="p-strip--suru-topped is-bordered">
-  <div class="row">
-    <div class="col-8">
-      <h1>Ubuntu kernel variants from Canonical</h1>
-      <p>A kernel variant is a kernel that deviates from the General Availability (GA) kernel by changes to its configuration and/or by having modules added and/or removed. In short, a kernel variant is an Ubuntu kernel that reports a kernel version and flavour other than what is reported with an Ubuntu LTS <code><em>-generic</em></code> kernel when you run the <code>$ uname -a</code> command. It is possible to have kernel variants for multiple releases of a kernel, which is something that will happen naturally over time to a newly-released custom kernel.</p>
-      <p>Canonical's Kernel Team strives to support all use cases from the generic kernel. Only where this is not possible are kernel variants created. Variants fall into four broad categories:</p>
-      <ul class="p-list">
-        <li class="p-list__item is-ticked"><a href="#version-specific-kernels">Version-specific</a>, where the kernel base version differs</li>
-        <li class="p-list__item is-ticked"><a href="#configuration-specific-kernels">Configuration-specific</a>, where desired kernel configurations are incompatible and the underlying features are not runtime selectable</li>
-        <li class="p-list__item is-ticked"><a href="#platform-specific-kernels">Platform-specific</a>, where a specific platform requires patches that are not currently applicable to the primary kernels</li>
-        <li class="p-list__item is-ticked"><a href="#project-specific-kernels">Project-specific</a>, where project deadlines require expedited delivery</li>
-      </ul>
+
+  {% call(slot) vf_hero(
+    title_text='Ubuntu kernel variants from Canonical',
+    subtitle_text='',
+    layout='50/50-full-width-image'
+    ) -%}
+    {%- if slot == 'description' -%}
+      <p>
+        A kernel variant is a kernel that deviates from the General Availability (GA) kernel by changes to its configuration and/or by having modules added and/or removed. In short, a kernel variant is an Ubuntu kernel that reports a kernel version and flavour other than what is reported with an Ubuntu LTS “<code>-generic</code>” kernel when you run the <code>$ uname -a command</code>. It is possible to have kernel variants for multiple releases of a kernel, which is something that will happen naturally over time to a newly-released custom kernel.
+      </p>
+    {%- endif -%}
+    {%- if slot == 'image' -%}
+      <div class="p-image-container--cinematic is-cover is-highlighted">
+        {{ image(url="https://assets.ubuntu.com/v1/7e057da2-Hero.png",
+                alt="",
+                width="2464",
+                height="1176",
+                hi_def=True,
+                loading="auto",
+                attrs={"class":"p-image-container__image"}) | safe
+        }}
+      </div>
+    {% endif -%}
+  {% endcall -%}
+
+  <section class="p-section">
+    {%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=false, is_list_full_width_on_tablet=true) -%}
+      {%- if slot == 'title' -%}
+        <h2>Variant categories</h2>
+      {%- endif -%}
+
+      {%- if slot == 'description' -%}
+        <div class="p-section--shallow">
+          <p>
+            Canonical's Kernel Team strives to support all use cases from the generic kernel. Only where this is not possible are kernel variants created. Variants fall into four broad categories:
+          </p>
+        </div>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_title_1' -%}
+        <h3 class="p-text--small-caps">Version-specific kernels</h3>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_description_1' -%}
+        <h4 class="p-heading--5">Version-specific, where the kernel base version differs</h4>
+        <p>
+          It is not possible to sensibly combine kernels at different upstream versions. For any Ubuntu LTS release  where we carry a General Availability (GA) kernel at one version, and a Hardware Enablement (HWE) kernel at another version, those are delivered as separate kernels. Version-specific kernels provide a consistent operating environment for Application Binary Interface (ABI)-sensitive workloads. It is not possible to combine kernels based on different upstream versions, which means maintaining a version-specific kernel is done through backporting fixes for serious/critical bugs and CVEs, which is the primary differentiator for this kernel variant. Version-specific kernels are just as rigorously maintained by Canonical as our generic kernels but Canonical ensures backport of critical/high CVE mitigation.
+        </p>
+        <p>
+          There is no significant additional technical consideration with a version-specific kernel variant since the work of backporting patches is a well-understood industry practice. However, there are business considerations regarding scope, cost and effort to maintain ABI compatibility over time as a version-specific kernel ages and gets further and further away from the latest upstream stable kernels, which makes backporting critical and high patches increasingly complicated and expensive.
+        </p>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_title_2' -%}
+        <h3 class="p-text--small-caps">Configuration-specific kernels</h3>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_description_2' -%}
+        <h4 class="p-heading--5">
+          Configuration-specific, where desired kernel configurations are incompatible and the underlying features are not runtime selectable
+        </h4>
+        <p>
+          Our primary kernels are targeted to a general-purpose configuration with wide applicability. Where additional configuration combinations are needed, and cannot be runtime selected, we create use-case-specific kernels. For example, some memory management unit (MMU) page table code is build time selectable for performance reasons.
+        </p>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_title_3' -%}
+        <h3 class="p-text--small-caps">Platform-specific kernels</h3>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_description_3' -%}
+        <h4 class="p-heading--5">
+          Platform-specific, where a specific platform requires patches that are not currently applicable to the primary kernels
+        </h4>
+        <p>
+          Some platforms exhibit a very large delta to the primary kernel code base. It is common for this delta to change platform-agnostic code in ways which create risk for other platforms and are not yet accepted upstream. In these cases it is desirable to create a separate kernel for this platform to contain the risk.
+        </p>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_title_4' -%}
+        <h3 class="p-text--small-caps">Project-specific kernels</h3>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_description_4' -%}
+        <h4 class="p-heading--5">Project-specific, where project deadlines require expedited delivery</h4>
+        <p>
+          For some projects it might be required  to release kernels out of sync with the primary kernels, or to release fixes to those projects quicker than is possible to cycle a full suite of testing. In these cases it is desirable to create a separate kernel to release it from those constraints.
+        </p>
+      {%- endif -%}
+    {%- endcall -%}
+  </section>
+
+  <section class="p-section">
+    <div class="u-fixed-width">
+      <hr class="p-rule" />
+      <div class="p-section--shallow">
+        <h2>Current variant kernels</h2>
+      </div>
+      <table class="p-table--mobile-card u-no-margin--bottom" role="grid">
+        <thead>
+          <tr role="row">
+            <th>Name</th>
+            <th>Type</th>
+            <th width="50%;">Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr role="row">
+            <td role="rowheader" data-heading="Name">Generic</td>
+            <td role="gridcell" data-heading="Type">-</td>
+            <td role="gridcell" data-heading="Description">
+              The primary GA kernel, targeting a general-purpose configuration. It is the latest upstream kernel at the time of the release and remains on this version for the life of the release.
+            </td>
+          </tr>
+          <tr role="row">
+            <td role="rowheader" data-heading="Name">lowlatency</td>
+            <td role="gridcell" data-heading="Type">configuration</td>
+            <td role="gridcell" data-heading="Description">Targets latency sensitive applications such as sound processing.</td>
+          </tr>
+          <tr role="row">
+            <td role="rowheader" data-heading="Name">generic-hwe</td>
+            <td role="gridcell" data-heading="Type">version</td>
+            <td role="gridcell" data-heading="Description">
+              Targets a later version of the upstream kernel, and updates with respect to that every 6 months until it matches the GA kernel in the subsequent LTS release.
+            </td>
+          </tr>
+          <tr role="row">
+            <td role="rowheader" data-heading="Name">lowlatency-hwe</td>
+            <td role="gridcell" data-heading="Type">
+              version
+              <br />
+              configuration
+            </td>
+            <td role="gridcell" data-heading="Description">
+              Targets latency-sensitive applications such as sound processing at the same version as the generic-hwe kernel.
+            </td>
+          </tr>
+          <tr role="row">
+            <td role="rowheader" data-heading="Name">generic-hwe-edge</td>
+            <td role="gridcell" data-heading="Type">version</td>
+            <td role="gridcell" data-heading="Description">Provides early access to the next generic-hwe kernel.</td>
+          </tr>
+          <tr role="row">
+            <td role="rowheader" data-heading="Name">lowlatency-hwe-edge</td>
+            <td role="gridcell" data-heading="Type">
+              version
+              <br />
+              configuration
+            </td>
+            <td role="gridcell" data-heading="Description">Provides early access to the next lowlatency-hwe kernel.</td>
+          </tr>
+          <tr role="row">
+            <td role="rowheader" data-heading="Name">kvm</td>
+            <td role="gridcell" data-heading="Type">configuration</td>
+            <td role="gridcell" data-heading="Description">
+              Targeting KVM instance usage. This carries the minimum support required for a guest kernel.
+            </td>
+          </tr>
+          <tr role="row">
+            <td role="rowheader" data-heading="Name">aws</td>
+            <td role="gridcell" data-heading="Type">configuration</td>
+            <td role="gridcell" data-heading="Description">Targeting the AWS cloud.</td>
+          </tr>
+          <tr role="row">
+            <td role="rowheader" data-heading="Name">azure</td>
+            <td role="gridcell" data-heading="Type">
+              configuration
+              <br />
+              version
+            </td>
+            <td role="gridcell" data-heading="Description">Targeting the Azure cloud.</td>
+          </tr>
+          <tr role="row">
+            <td role="rowheader" data-heading="Name">gcp/gke</td>
+            <td role="gridcell" data-heading="Type">configuration</td>
+            <td role="gridcell" data-heading="Description">Targeting the Google Compute Platform/Google Kubernetes Engine.</td>
+          </tr>
+          <tr role="row">
+            <td role="rowheader" data-heading="Name">raspi2</td>
+            <td role="gridcell" data-heading="Type">platform</td>
+            <td role="gridcell" data-heading="Description">For the Raspberry Pi 2 ARM board.</td>
+          </tr>
+          <tr role="row">
+            <td role="rowheader" data-heading="Name">snapdragon</td>
+            <td role="rowheader" data-heading="Type">platform</td>
+            <td role="rowheader" data-heading="Description">For the Qualcomm Snapdragon ARM64 board.</td>
+          </tr>
+          <tr role="row">
+            <td role="rowheader" data-heading="Name">oem</td>
+            <td role="rowheader" data-heading="Type">project</td>
+            <td role="rowheader" data-heading="Description">
+              Targeting various OEM projects. This carries early access drivers for hardware enablement. This kernel is typically used in the early phases of a project release, with a view to "upstreaming" any delta into the GA or HWE kernels and once this delta is incorporated the final platform is moved over to those kernels.
+            </td>
+          </tr>
+        </tbody>
+      </table>
     </div>
-  </div>
-</section>
-<section class="p-strip--light is-bordered">
-  <div class="row">
-    <div class="col-8">
-      <h2 id="version-specific-kernels">Version-specific kernels</h2>
-      <p>It is not possible to sensibly combine kernels at different upstream versions. For any Ubuntu LTS release  where we carry a General Availability (GA) kernel at one version, and a Hardware Enablement (HWE) kernel at another version, those are delivered as separate kernels. Version-specific kernels provide a consistent operating environment for Application Binary Interface (ABI)-sensitive workloads. It is not possible to combine kernels based on different upstream versions, which means maintaining a version-specific kernel is done through backporting fixes for serious/critical bugs and CVEs, which is the primary differentiator for this kernel variant. Version-specific kernels are just as rigorously maintained by Canonical as our generic kernels but Canonical ensures backport of critical/high CVE mitigation.</p>
-      <p>There is no significant additional technical consideration with a version-specific kernel variant since the work of backporting patches is a well-understood industry practice. However, there are business considerations regarding scope, cost and effort to maintain ABI compatibility over time as a version-specific kernel ages and gets further and further away from the latest upstream stable kernels, which makes backporting critical and high patches increasingly complicated and expensive.</p>
+  </section>
+
+  <section class="p-section--deep">
+    <hr class="p-rule is-fixed-width" />
+    <div class="row--50-50">
+      <div class="col">
+        <h2>Additional kernel variants</h2>
+      </div>
+      <div class="col">
+        <p>In addition to those kernel variants, Canonical offers FIPS certified kernels:</p>
+        <hr class="p-rule--muted" />
+        <ul class="p-list--divided u-no-margin--bottom">
+          <li class="p-list__item has-bullet">FIPS - Certified GA kernel for Ubuntu 16.04, 18.04 and 20.04</li>
+          <li class="p-list__item has-bullet">
+            FIPS - compliant GA kernel with critical security and patch updates for Ubuntu 16.04, 18.04 and 20.04
+          </li>
+        </ul>
+      </div>
     </div>
-  </div>
-</section>
-<section class="p-strip is-bordered">
-  <div class="row">
-    <div class="col-8">
-      <h2 id="configuration-specific-kernels">Configuration-specific kernels</h2>
-      <p>Our primary kernels are targeted to a general-purpose configuration with wide applicability. Where additional configuration combinations are needed, and cannot be runtime selected, we create use-case-specific kernels. For example, some memory management unit (MMU) page table code is build time selectable for performance reasons.</p>
-    </div>
-  </div>
-</section>
-<section class="p-strip--light is-bordered">
-  <div class="row">
-    <div class="col-8">
-      <h2 id="platform-specific-kernels">Platform-specific kernels</h2>
-      <p>Some platforms exhibit a very large delta to the primary kernel code base. It is common for this delta to change platform-agnostic code in ways which create risk for other platforms and are not yet accepted upstream. In these cases it is desirable to create a separate kernel for this platform to contain the risk.</p>
-    </div>
-  </div>
-</section>
-<section class="p-strip is-bordered">
-  <div class="row">
-    <div class="col-8">
-      <h2 id="project-specific-kernels">Project-specific kernels</h2>
-      <p>For some projects it might be required  to release kernels out of sync with the primary kernels, or to release fixes to those projects quicker than is possible to cycle a full suite of testing. In these cases it is desirable to create a separate kernel to release it from those constraints.</p>
-    </div>
-  </div>
-</section>
-<section class="p-strip--light is-bordered">
-  <div class="u-fixed-width">
-    <h2 id="current-variant-kernels">Current variant kernels</h2>
-    <table class="p-table--mobile-card" role="grid">
-      <thead>
-        <tr role="row">
-          <th>Name</th>
-          <th>Type</th>
-          <th width="60%;">Description</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr role="row">
-          <td role="rowheader" data-heading="Name">Generic</td>
-          <td role="gridcell" data-heading="Type">-</td>
-          <td role="gridcell" data-heading="Description">The primary GA kernel, targeting a general-purpose configuration. It is the latest upstream kernel at the time of the release and remains on this version for the life of the release.</td>
-        </tr>
-        <tr role="row">
-          <td role="rowheader" data-heading="Name">lowlatency</td>
-          <td role="gridcell" data-heading="Type">configuration</td>
-          <td role="gridcell" data-heading="Description">Targets latency sensitive applications such as sound processing.</td>
-        </tr>
-        <tr role="row">
-          <td role="rowheader" data-heading="Name">generic-hwe</td>
-          <td role="gridcell" data-heading="Type">version</td>
-          <td role="gridcell" data-heading="Description">Targets a later version of the upstream kernel, and updates with respect to that every 6 months until it matches the GA kernel in the subsequent LTS release.</td>
-        </tr>
-        <tr role="row">
-          <td role="rowheader" data-heading="Name">lowlatency-hwe</td>
-          <td role="gridcell" data-heading="Type">
-            version<br>
-            configuration
-          </td>
-          <td role="gridcell" data-heading="Description">Targets latency-sensitive applications such as sound processing at the same version as the generic-hwe kernel.</td>
-        </tr>
-        <tr role="row">
-          <td role="rowheader" data-heading="Name">generic-hwe-edge</td>
-          <td role="gridcell" data-heading="Type">version</td>
-          <td role="gridcell" data-heading="Description">Provides early access to the next generic-hwe kernel.</td>
-        </tr>
-        <tr role="row">
-          <td role="rowheader" data-heading="Name">lowlatency-hwe-edge</td>
-          <td role="gridcell" data-heading="Type">
-            version<br>
-            configuration
-          </td>
-          <td role="gridcell" data-heading="Description">Provides early access to the next lowlatency-hwe kernel.</td>
-        </tr>
-        <tr role="row">
-          <td role="rowheader" data-heading="Name">kvm</td>
-          <td role="gridcell" data-heading="Type">configuration</td>
-          <td role="gridcell" data-heading="Description">Targeting KVM instance usage. This carries the minimum support required for a guest kernel.</td>
-        </tr>
-        <tr role="row">
-          <td role="rowheader" data-heading="Name">aws</td>
-          <td role="gridcell" data-heading="Type">configuration</td>
-          <td role="gridcell" data-heading="Description">Targeting the AWS cloud.</td>
-        </tr>
-        <tr role="row">
-          <td role="rowheader" data-heading="Name">azure</td>
-          <td role="gridcell" data-heading="Type">
-            configuration<br>
-            version
-          </td>
-          <td role="gridcell" data-heading="Description">Targeting the Azure cloud.</td>
-        </tr>
-        <tr role="row">
-          <td role="rowheader" data-heading="Name">gcp/gke</td>
-          <td role="gridcell" data-heading="Type">configuration</td>
-          <td role="gridcell" data-heading="Description">Targeting the Google Compute Platform/Google Kubernetes Engine.</td>
-        </tr>
-        <tr role="row">
-          <td role="rowheader" data-heading="Name">raspi2</td>
-          <td role="gridcell" data-heading="Type">platform</td>
-          <td role="gridcell" data-heading="Description">For the Raspberry Pi 2 ARM board.</td>
-        </tr>
-        <tr role="row">
-          <td role="rowheader" data-heading="Name">snapdragon</td>
-          <td role="rowheader" data-heading="Type">platform</td>
-          <td role="rowheader" data-heading="Description">For the Qualcomm Snapdragon ARM64 board.</td>
-        </tr>
-        <tr role="row">
-          <td role="rowheader" data-heading="Name">oem</td>
-          <td role="rowheader" data-heading="Type">project</td>
-          <td role="rowheader" data-heading="Description">Targeting various OEM projects. This carries early access drivers for hardware enablement. This kernel is typically used in the early phases of a project release, with a view to "upstreaming" any delta into the GA or HWE kernels and once this delta is incorporated the final platform is moved over to those kernels.</td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
-</section>
-<section class="p-strip">
-  <div class="row">
-    <div class="col-8">
-      <h2 id="additional-kernel-variants">Additional kernel variants</h2>
-      <p>In addition to those kernel variants, Canonical offers FIPS certified kernels:</p>
-      <ul>
-        <li>FIPS &mdash; Certified GA kernel for Ubuntu 16.04, 18.04 and 20.04</li>
-        <li>FIPS &mdash; compliant GA kernel with critical security and patch updates for Ubuntu 16.04, 18.04 and 20.04</li>
-      </ul>
-    </div>
-  </div>
-</section>
+  </section>
 {% endblock %}


### PR DESCRIPTION
## Done

- Rebranded kernel/index page

## QA

- View the site in your web browser at: https://ubuntu-com-15109.demos.haus/kernel
    - Be sure to test on mobile, tablet and desktop screen sizes
- Verify the page matches [copydoc](https://docs.google.com/document/d/1UVxrF8raNb5Pggj05P0ar_OzV_uwhrTRHv9XRiuM4zs/edit) and [figma](https://www.figma.com/design/lIQtR9xJy9gLGIAIcTFAjm/ubuntu.com-kernel?node-id=124-5447)

## Issue / Card

Fixes #[WD-17833](https://warthogs.atlassian.net/browse/WD-17833)

## Screenshots

Before:
![image](https://github.com/user-attachments/assets/f6f516aa-f727-4541-a6b6-0775138554b9)


After:
![image](https://github.com/user-attachments/assets/6a8cf235-d22f-4a08-aa2e-f90ccb89005a)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
