### PR TITLE
fix: Auto slide function on ubuntu.com/summit

### DIFF
--- a/templates/summit/index.html
+++ b/templates/summit/index.html
@@ -578,10 +578,10 @@
       }
 
       [previousButton, nextButton].forEach(button => {
-        button.addEventListener('mouseenter', () => {
+        button.addEventListener('mouseover', () => {
           carousel.pausePlayer();
         });
-        button.addEventListener('mouseleave', () => {
+        button.addEventListener('mouseout', () => {
           carousel.playPlayer();
         });
       });


### PR DESCRIPTION
## Done

- Fixed the carousel functionality on the summit page that skips an image when arrow buttons are clicked when the auto play flag is turned on. The timer does not reset when arrow next/prev buttons are clicked

## QA

- Navigate to [/summit](https://ubuntu-com-15113.demos.haus/summit)
- Click the arrow next button on the slider and see that the slider pauses for 3s before moving to the next image

## Issue / Card

Fixes # [WD-22183](https://warthogs.atlassian.net/browse/WD-22183)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-22183]: https://warthogs.atlassian.net/browse/WD-22183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ