### PR TITLE
[WD-17831] feat: Rebrand kernel/lifecycle page

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "url-polyfill": "1.1.12",
     "url-search-params-polyfill": "8.2.5",
     "use-query-params": "^2.2.1",
-    "vanilla-framework": "4.23.0",
+    "vanilla-framework": "4.24.0",
     "yup": "1.4.0"
   },
   "resolutions": {

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1619,7 +1619,7 @@ ol.p-list--divided .p-list__item::before {
   row-gap: 0.5rem;
 }
 
-@media screen and (max-width: $breakpoint-large - 1) {
+@media screen and (max-width: #{ $breakpoint-large - 1 }) {
   .u-table-horizontal-scroll {
     overflow-x: hidden;
     .u-table-horizontal-scroll__table {

--- a/templates/kernel/lifecycle.html
+++ b/templates/kernel/lifecycle.html
@@ -38,191 +38,184 @@
         <h2>Installation</h2>
       </div>
       <div class="col">
-        <nav class="p-tabs js-tabbed-content">
-          <ul class="p-tabs__list" role="tablist">
-            <li class="p-tabs__item" role="presentation">
-              <a href="#installation-24-04"
-                 class="p-tabs__link"
-                 id="installation-24-04-tab"
-                 role="tab"
-                 aria-controls="installation-24-04"
-                 aria-selected="true">24.04 LTS</a>
-            </li>
-            <li class="p-tabs__item" role="presentation">
-              <a href="#installation-22-04"
-                 class="p-tabs__link"
-                 id="installation-22-04-tab"
-                 role="tab"
-                 aria-controls="installation-22-04"
-                 aria-selected="true">22.04 LTS</a>
-            </li>
-            <li class="p-tabs__item" role="presentation">
-              <a href="#installation-20-04"
-                 class="p-tabs__link"
-                 id="installation-20-04-tab"
-                 role="tab"
-                 aria-controls="installation-20-04">20.04 LTS</a>
-            </li>
-            <li class="p-tabs__item" role="presentation">
-              <a href="#installation-18-04"
-                 class="p-tabs__link"
-                 id="installation-18-04-tab"
-                 role="tab"
-                 aria-controls="installation-18-04">18.04 LTS</a>
-            </li>
-            <li class="p-tabs__item" role="presentation">
-              <a href="#installation-16-04"
-                 class="p-tabs__link"
-                 id="installation-16-04-tab"
-                 role="tab"
-                 aria-controls="installation-16-04">16.04 LTS</a>
-            </li>
-            <li class="p-tabs__item" role="presentation">
-              <a href="#installation-14-04"
-                 class="p-tabs__link"
-                 id="installation-14-04-tab"
-                 role="tab"
-                 aria-controls="installation-14-04">14.04 LTS</a>
-            </li>
-          </ul>
-        </nav>
+        <div class="p-tabs js-tabbed-content">
+          <div class="p-tabs__list" role="tablist">
+            <div class="p-tabs__item">
+              <button class="p-tabs__link"
+                      id="installation-24-04-tab"
+                      role="tab"
+                      aria-controls="installation-24-04"
+                      aria-selected="true">24.04 LTS</button>
+            </div>
+            <div class="p-tabs__item">
+              <button class="p-tabs__link"
+                      id="installation-22-04-tab"
+                      role="tab"
+                      aria-controls="installation-22-04"
+                      aria-selected="true">22.04 LTS</button>
+            </div>
+            <div class="p-tabs__item">
+              <button class="p-tabs__link"
+                      id="installation-20-04-tab"
+                      role="tab"
+                      aria-controls="installation-20-04">20.04 LTS</button>
+            </div>
+            <div class="p-tabs__item">
+              <button class="p-tabs__link"
+                      id="installation-18-04-tab"
+                      role="tab"
+                      aria-controls="installation-18-04">18.04 LTS</button>
+            </div>
+            <div class="p-tabs__item">
+              <button class="p-tabs__link"
+                      id="installation-16-04-tab"
+                      role="tab"
+                      aria-controls="installation-16-04">16.04 LTS</button>
+            </div>
+            <div class="p-tabs__item">
+              <button class="p-tabs__link"
+                      id="installation-14-04-tab"
+                      role="tab"
+                      aria-controls="installation-14-04">14.04 LTS</button>
+            </div>
+          </div>
+          <div tabindex="0"
+               id="installation-14-04"
+               role="tabpanel"
+               aria-labelledby="installation-14-04-tab">
+            <p>Ubuntu 14.04 LTS &mdash; Trusty Tahr</p>
+            <p>Desktop:</p>
+            <div class="p-code-snippet">
+              <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-lts-xenial xserver-xorg-core-lts-xenial xserver-xorg-lts-xenial xserver-xorg-video-all-lts-xenial xserver-xorg-input-all-lts-xenial libwayland-egl1-mesa-lts-xenial</code></pre>
+            </div>
+            <p>Server:</p>
+            <div class="p-code-snippet">
+              <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-lts-xenial</code></pre>
+            </div>
+            <p>
+              The 14.04.2 and newer point releases ship with an updated kernel and X stack by default. If you have installed with older media, you can use these instructions to install the newer HWE kernel derived from 16.04 (Xenial).
+            </p>
+            <p>
+              If you run a multiarch desktop (for example, i386 and amd64 on amd64, for gaming or Wine), you may find you need a slightly more involved command:
+            </p>
+            <div class="p-code-snippet">
+              <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-lts-xenial xserver-xorg-core-lts-xenial xserver-xorg-lts-xenial xserver-xorg-video-all-lts-xenial xserver-xorg-input-all-lts-xenial libwayland-egl1-mesa-lts-xenial libgl1-mesa-glx-lts-xenial libgl1-mesa-glx-lts-xenial:i386 libglapi-mesa-lts-xenial:i386</code></pre>
+            </div>
+          </div>
 
-        <div class="p-tabs__content"
-             id="installation-14-04"
-             role="tabpanel"
-             aria-labelledby="installation-14-04-tab">
-          <p>Ubuntu 14.04 LTS &mdash; Trusty Tahr</p>
-          <p>Desktop:</p>
-          <div class="p-code-snippet">
-            <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-lts-xenial xserver-xorg-core-lts-xenial xserver-xorg-lts-xenial xserver-xorg-video-all-lts-xenial xserver-xorg-input-all-lts-xenial libwayland-egl1-mesa-lts-xenial</code></pre>
+          <div tabindex="0"
+               id="installation-16-04"
+               role="tabpanel"
+               aria-labelledby="installation-16-04-tab">
+            <p>Ubuntu 16.04 LTS &mdash; Xenial Xerus</p>
+            <p>Desktop:</p>
+            <div class="p-code-snippet">
+              <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-hwe-16.04 xserver-xorg-hwe-16.04</code></pre>
+            </div>
+            <p>Server:</p>
+            <div class="p-code-snippet">
+              <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-hwe-16.04</code></pre>
+            </div>
+            <p>
+              The 16.04.2 and newer point releases ship with an updated kernel and X stack by default for the desktop. Server installations default to the GA kernel and provide the enablement kernel as optional.
+            </p>
+            <p>
+              The 16.04 HWE stacks follow <a href="https://wiki.ubuntu.com/Kernel/RollingLTSEnablementStack">the Rolling Update Model</a>.
+            </p>
           </div>
-          <p>Server:</p>
-          <div class="p-code-snippet">
-            <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-lts-xenial</code></pre>
-          </div>
-          <p>
-            The 14.04.2 and newer point releases ship with an updated kernel and X stack by default. If you have installed with older media, you can use these instructions to install the newer HWE kernel derived from 16.04 (Xenial).
-          </p>
-          <p>
-            If you run a multiarch desktop (for example, i386 and amd64 on amd64, for gaming or Wine), you may find you need a slightly more involved command:
-          </p>
-          <div class="p-code-snippet">
-            <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-lts-xenial xserver-xorg-core-lts-xenial xserver-xorg-lts-xenial xserver-xorg-video-all-lts-xenial xserver-xorg-input-all-lts-xenial libwayland-egl1-mesa-lts-xenial libgl1-mesa-glx-lts-xenial libgl1-mesa-glx-lts-xenial:i386 libglapi-mesa-lts-xenial:i386</code></pre>
-          </div>
-        </div>
 
-        <div class="p-tabs__content"
-             id="installation-16-04"
-             role="tabpanel"
-             aria-labelledby="installation-16-04-tab">
-          <p>Ubuntu 16.04 LTS &mdash; Xenial Xerus</p>
-          <p>Desktop:</p>
-          <div class="p-code-snippet">
-            <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-hwe-16.04 xserver-xorg-hwe-16.04</code></pre>
+          <div tabindex="0"
+               id="installation-18-04"
+               role="tabpanel"
+               aria-labelledby="installation-18-04-tab">
+            <p>Ubuntu 18.04 LTS &mdash; Bionic Beaver</p>
+            <p>Desktop:</p>
+            <div class="p-code-snippet">
+              <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-hwe-18.04 xserver-xorg-hwe-18.04</code></pre>
+            </div>
+            <p>Server:</p>
+            <div class="p-code-snippet">
+              <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-hwe-18.04</code></pre>
+            </div>
+            <p>
+              The 18.04.2 and newer point releases will ship with an updated kernel and X stack by default for the desktop. Server installations will default to the GA kernel and provide the enablement kernel as optional.
+            </p>
+            <p>
+              The 18.04 HWE stacks follow <a href="/about/release-cycle#ubuntu-kernel-release-cycle">the Rolling Update Model</a>.
+            </p>
           </div>
-          <p>Server:</p>
-          <div class="p-code-snippet">
-            <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-hwe-16.04</code></pre>
-          </div>
-          <p>
-            The 16.04.2 and newer point releases ship with an updated kernel and X stack by default for the desktop. Server installations default to the GA kernel and provide the enablement kernel as optional.
-          </p>
-          <p>
-            The 16.04 HWE stacks follow <a href="https://wiki.ubuntu.com/Kernel/RollingLTSEnablementStack">the Rolling Update Model</a>.
-          </p>
-        </div>
 
-        <div class="p-tabs__content"
-             id="installation-18-04"
-             role="tabpanel"
-             aria-labelledby="installation-18-04-tab">
-          <p>Ubuntu 18.04 LTS &mdash; Bionic Beaver</p>
-          <p>Desktop:</p>
-          <div class="p-code-snippet">
-            <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-hwe-18.04 xserver-xorg-hwe-18.04</code></pre>
+          <div tabindex="0"
+               id="installation-20-04"
+               role="tabpanel"
+               aria-labelledby="installation-20-04-tab">
+            <p>Ubuntu 20.04 LTS &mdash; Focal Fossa</p>
+            <p>Desktop:</p>
+            <div class="p-code-snippet">
+              <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-hwe-20.04</code></pre>
+            </div>
+            <p>Server:</p>
+            <div class="p-code-snippet">
+              <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-hwe-20.04</code></pre>
+            </div>
+            <p>
+              Desktop installations of 20.04 default to tracking the HWE stack. Server installations will default to the GA kernel and provide the enablement kernel as optional.
+            </p>
+            <p>
+              Note that certain desktop machines may be on a separate "OEM" track. To determine if the machine is eligible for this, run the command <code>ubuntu-drivers list-oem</code> from a terminal. If this is non-empty, the machine is running the OEM cadence instead of HWE.
+            </p>
+            <p>
+              The 20.04 HWE stack follows <a href="/about/release-cycle#ubuntu-kernel-release-cycle">the Rolling Update Model</a>.
+            </p>
           </div>
-          <p>Server:</p>
-          <div class="p-code-snippet">
-            <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-hwe-18.04</code></pre>
-          </div>
-          <p>
-            The 18.04.2 and newer point releases will ship with an updated kernel and X stack by default for the desktop. Server installations will default to the GA kernel and provide the enablement kernel as optional.
-          </p>
-          <p>
-            The 18.04 HWE stacks follow <a href="/about/release-cycle#ubuntu-kernel-release-cycle">the Rolling Update Model</a>.
-          </p>
-        </div>
 
-        <div class="p-tabs__content"
-             id="installation-20-04"
-             role="tabpanel"
-             aria-labelledby="installation-20-04-tab">
-          <p>Ubuntu 20.04 LTS &mdash; Focal Fossa</p>
-          <p>Desktop:</p>
-          <div class="p-code-snippet">
-            <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-hwe-20.04</code></pre>
+          <div tabindex="0"
+               id="installation-22-04"
+               role="tabpanel"
+               aria-labelledby="installation-22-04-tab">
+            <p>Ubuntu 22.04 LTS &mdash; Jammy Jellyfish</p>
+            <p>Desktop:</p>
+            <div class="p-code-snippet">
+              <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-hwe-22.04</code></pre>
+            </div>
+            <p>Server:</p>
+            <div class="p-code-snippet">
+              <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-hwe-22.04</code></pre>
+            </div>
+            <p>
+              Desktop installations of 22.04 default to tracking the HWE stack. Server installations will default to the GA kernel and provide the enablement kernel as optional.
+            </p>
+            <p>
+              Note that certain desktop machines may be on a separate “OEM” track. To determine if the machine is eligible for this, run the command <code>ubuntu-drivers list-oem</code> from a terminal. If this is non-empty, the machine is running the OEM cadence instead of HWE.
+            </p>
+            <p>
+              The 22.04 HWE stack follows <a href="/about/release-cycle#ubuntu-kernel-release-cycle">the Rolling Update Model</a>.
+            </p>
           </div>
-          <p>Server:</p>
-          <div class="p-code-snippet">
-            <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-hwe-20.04</code></pre>
-          </div>
-          <p>
-            Desktop installations of 20.04 default to tracking the HWE stack. Server installations will default to the GA kernel and provide the enablement kernel as optional.
-          </p>
-          <p>
-            Note that certain desktop machines may be on a separate "OEM" track. To determine if the machine is eligible for this, run the command <code>ubuntu-drivers list-oem</code> from a terminal. If this is non-empty, the machine is running the OEM cadence instead of HWE.
-          </p>
-          <p>
-            The 20.04 HWE stack follows <a href="/about/release-cycle#ubuntu-kernel-release-cycle">the Rolling Update Model</a>.
-          </p>
-        </div>
 
-        <div class="p-tabs__content"
-             id="installation-22-04"
-             role="tabpanel"
-             aria-labelledby="installation-22-04-tab">
-          <p>Ubuntu 22.04 LTS &mdash; Jammy Jellyfish</p>
-          <p>Desktop:</p>
-          <div class="p-code-snippet">
-            <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-hwe-22.04</code></pre>
+          <div tabindex="0"
+               id="installation-24-04"
+               role="tabpanel"
+               aria-labelledby="installation-24-04-tab">
+            <p>Ubuntu 24.04 LTS &mdash; Noble Numbat</p>
+            <p>Desktop:</p>
+            <div class="p-code-snippet">
+              <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-hwe-24.04</code></pre>
+            </div>
+            <p>Server:</p>
+            <div class="p-code-snippet">
+              <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-hwe-24.04</code></pre>
+            </div>
+            <p>
+              Desktop installations of 24.04 default to tracking the HWE stack. Server installations will default to the GA kernel and provide the enablement kernel as optional.
+            </p>
+            <p>
+              Note that certain desktop machines may be on a separate “OEM” track. To determine if the machine is eligible for this, run the command <code>ubuntu-drivers list-oem</code> from a terminal. If this is non-empty, the machine is running the OEM cadence instead of HWE.
+            </p>
+            <p>
+              The 24.04 HWE stack follows <a href="/about/release-cycle#ubuntu-kernel-release-cycle">the Rolling Update Model</a>.
+            </p>
           </div>
-          <p>Server:</p>
-          <div class="p-code-snippet">
-            <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-hwe-22.04</code></pre>
-          </div>
-          <p>
-            Desktop installations of 22.04 default to tracking the HWE stack. Server installations will default to the GA kernel and provide the enablement kernel as optional.
-          </p>
-          <p>
-            Note that certain desktop machines may be on a separate “OEM” track. To determine if the machine is eligible for this, run the command <code>ubuntu-drivers list-oem</code> from a terminal. If this is non-empty, the machine is running the OEM cadence instead of HWE.
-          </p>
-          <p>
-            The 22.04 HWE stack follows <a href="/about/release-cycle#ubuntu-kernel-release-cycle">the Rolling Update Model</a>.
-          </p>
-        </div>
-
-        <div class="p-tabs__content"
-             id="installation-24-04"
-             role="tabpanel"
-             aria-labelledby="installation-24-04-tab">
-          <p>Ubuntu 24.04 LTS &mdash; Noble Numbat</p>
-          <p>Desktop:</p>
-          <div class="p-code-snippet">
-            <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-hwe-24.04</code></pre>
-          </div>
-          <p>Server:</p>
-          <div class="p-code-snippet">
-            <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-hwe-24.04</code></pre>
-          </div>
-          <p>
-            Desktop installations of 24.04 default to tracking the HWE stack. Server installations will default to the GA kernel and provide the enablement kernel as optional.
-          </p>
-          <p>
-            Note that certain desktop machines may be on a separate “OEM” track. To determine if the machine is eligible for this, run the command <code>ubuntu-drivers list-oem</code> from a terminal. If this is non-empty, the machine is running the OEM cadence instead of HWE.
-          </p>
-          <p>
-            The 24.04 HWE stack follows <a href="/about/release-cycle#ubuntu-kernel-release-cycle">the Rolling Update Model</a>.
-          </p>
         </div>
       </div>
     </div>

--- a/templates/kernel/lifecycle.html
+++ b/templates/kernel/lifecycle.html
@@ -1,117 +1,252 @@
 {% extends "kernel/base_kernel.html" %}
 
+{% from "_macros/vf_hero.jinja" import vf_hero %}
+
 {% block title %}Ubuntu kernel lifecycle and enablement stack{% endblock %}
 
-{% block meta_description %}Canonical provides long-term support (LTS) kernels for Ubuntu LTS releases. Canonical also provides interim operating system releases with updated kernels every 6 months. Learn about the lifecycle of each kernel through the lifespan of support.{% endblock meta_description %}
+{% block meta_description %}
+  Canonical provides long-term support (LTS) kernels for Ubuntu LTS releases. Canonical also provides interim operating system releases with updated kernels every 6 months. Learn about the lifecycle of each kernel through the lifespan of support.
+{% endblock meta_description %}
 
-{% block meta_copydoc %}https://docs.google.com/document/d/1d01SFs7c56ge2o92g6Rwr3SjG8rtxm3jNwIyL1N8mQg/edit#heading=h.929qtgja1pr8{% endblock %}
+{% block meta_copydoc %}
+  https://docs.google.com/document/d/1d01SFs7c56ge2o92g6Rwr3SjG8rtxm3jNwIyL1N8mQg/edit#heading=h.929qtgja1pr8
+{% endblock %}
+
+{% block body_class %}
+  is-paper
+{% endblock body_class %}
 
 {% block content %}
-<section class="p-strip--suru-topped is-bordered">
-  <div class="row">
-    <div class="col-8">
-      <h1>Ubuntu kernel lifecycle and enablement stack</h1>
-      <p>The Ubuntu LTS enablement, or Hardware Enablement (HWE), stack provides the newer kernel and X11 display support for existing Ubuntu LTS releases. That stack can be enabled manually, but may also be pre-enabled with an Ubuntu LTS release.</p>
+
+  {% call(slot) vf_hero(
+    title_text='Ubuntu kernel lifecycle<br /> and enablement stack',
+    layout='50/50',
+    is_split_on_medium=true
+    ) -%}
+    {%- if slot == 'description' -%}
+      <p>
+        The Ubuntu LTS enablement, or Hardware Enablement (HWE), stack provides newer kernel and X11 display support for existing Ubuntu LTS releases. That stack can be enabled manually, but may also be pre-enabled with an Ubuntu LTS release.
+      </p>
       <p>The HWE stack can be used by desktop and server systems, as well as cloud or virtual images.</p>
-    </div>
-  </div>
-</section>
+    {%- endif -%}
+  {% endcall -%}
 
-<section class="p-strip--light is-bordered">
-  <div class="row">
-    <div class="col-8">
-      <h2>Installation</h2>
-
+  <section class="p-section">
+    <hr class="p-rule is-fixed-width" />
+    <div class="row--50-50-on-large">
+      <div class="col">
+        <h2>Installation</h2>
+      </div>
+      <div class="col">
         <nav class="p-tabs js-tabbed-content">
           <ul class="p-tabs__list" role="tablist">
             <li class="p-tabs__item" role="presentation">
-              <a href="#installation-22-04" class="p-tabs__link" id="installation-22-04-tab" role="tab" aria-controls="installation-22-04" aria-selected="true">22.04 LTS</a>
+              <a href="#installation-24-04"
+                 class="p-tabs__link"
+                 id="installation-24-04-tab"
+                 role="tab"
+                 aria-controls="installation-24-04"
+                 aria-selected="true">24.04 LTS</a>
             </li>
             <li class="p-tabs__item" role="presentation">
-              <a href="#installation-20-04" class="p-tabs__link" id="installation-20-04-tab" role="tab" aria-controls="installation-20-04">20.04 LTS</a>
+              <a href="#installation-22-04"
+                 class="p-tabs__link"
+                 id="installation-22-04-tab"
+                 role="tab"
+                 aria-controls="installation-22-04"
+                 aria-selected="true">22.04 LTS</a>
             </li>
             <li class="p-tabs__item" role="presentation">
-              <a href="#installation-18-04" class="p-tabs__link" id="installation-18-04-tab" role="tab" aria-controls="installation-18-04">18.04 LTS</a>
+              <a href="#installation-20-04"
+                 class="p-tabs__link"
+                 id="installation-20-04-tab"
+                 role="tab"
+                 aria-controls="installation-20-04">20.04 LTS</a>
             </li>
             <li class="p-tabs__item" role="presentation">
-              <a href="#installation-16-04" class="p-tabs__link" id="installation-16-04-tab" role="tab" aria-controls="installation-16-04">16.04 LTS</a>
+              <a href="#installation-18-04"
+                 class="p-tabs__link"
+                 id="installation-18-04-tab"
+                 role="tab"
+                 aria-controls="installation-18-04">18.04 LTS</a>
             </li>
             <li class="p-tabs__item" role="presentation">
-              <a href="#installation-14-04" class="p-tabs__link" id="installation-14-04-tab" role="tab" aria-controls="installation-14-04">14.04 LTS</a>
+              <a href="#installation-16-04"
+                 class="p-tabs__link"
+                 id="installation-16-04-tab"
+                 role="tab"
+                 aria-controls="installation-16-04">16.04 LTS</a>
+            </li>
+            <li class="p-tabs__item" role="presentation">
+              <a href="#installation-14-04"
+                 class="p-tabs__link"
+                 id="installation-14-04-tab"
+                 role="tab"
+                 aria-controls="installation-14-04">14.04 LTS</a>
             </li>
           </ul>
         </nav>
 
-        <div class="p-tabs__content" id="installation-14-04" role="tabpanel" aria-labelledby="installation-14-04-tab">
+        <div class="p-tabs__content"
+             id="installation-14-04"
+             role="tabpanel"
+             aria-labelledby="installation-14-04-tab">
           <p>Ubuntu 14.04 LTS &mdash; Trusty Tahr</p>
           <p>Desktop:</p>
-          <pre><code>sudo apt-get install --install-recommends linux-generic-lts-xenial xserver-xorg-core-lts-xenial xserver-xorg-lts-xenial xserver-xorg-video-all-lts-xenial xserver-xorg-input-all-lts-xenial libwayland-egl1-mesa-lts-xenial</code></pre>
+          <div class="p-code-snippet">
+            <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-lts-xenial xserver-xorg-core-lts-xenial xserver-xorg-lts-xenial xserver-xorg-video-all-lts-xenial xserver-xorg-input-all-lts-xenial libwayland-egl1-mesa-lts-xenial</code></pre>
+          </div>
           <p>Server:</p>
-          <pre><code>sudo apt-get install --install-recommends linux-generic-lts-xenial</code></pre>
-          <p>The 14.04.2 and newer point releases ship with an updated kernel and X stack by default. If you have installed with older media, you can use these instructions to install the newer HWE kernel derived from 16.04 (Xenial).</p>
-          <p>If you run a multiarch desktop (for example, i386 and amd64 on amd64, for gaming or Wine), you may find you need a slightly more involved command:</p>
-          <pre><code>sudo apt-get install --install-recommends linux-generic-lts-xenial xserver-xorg-core-lts-xenial xserver-xorg-lts-xenial xserver-xorg-video-all-lts-xenial xserver-xorg-input-all-lts-xenial libwayland-egl1-mesa-lts-xenial libgl1-mesa-glx-lts-xenial libgl1-mesa-glx-lts-xenial:i386 libglapi-mesa-lts-xenial:i386</code></pre>
+          <div class="p-code-snippet">
+            <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-lts-xenial</code></pre>
+          </div>
+          <p>
+            The 14.04.2 and newer point releases ship with an updated kernel and X stack by default. If you have installed with older media, you can use these instructions to install the newer HWE kernel derived from 16.04 (Xenial).
+          </p>
+          <p>
+            If you run a multiarch desktop (for example, i386 and amd64 on amd64, for gaming or Wine), you may find you need a slightly more involved command:
+          </p>
+          <div class="p-code-snippet">
+            <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-lts-xenial xserver-xorg-core-lts-xenial xserver-xorg-lts-xenial xserver-xorg-video-all-lts-xenial xserver-xorg-input-all-lts-xenial libwayland-egl1-mesa-lts-xenial libgl1-mesa-glx-lts-xenial libgl1-mesa-glx-lts-xenial:i386 libglapi-mesa-lts-xenial:i386</code></pre>
+          </div>
         </div>
 
-        <div class="p-tabs__content" id="installation-16-04" role="tabpanel" aria-labelledby="installation-16-04-tab">
+        <div class="p-tabs__content"
+             id="installation-16-04"
+             role="tabpanel"
+             aria-labelledby="installation-16-04-tab">
           <p>Ubuntu 16.04 LTS &mdash; Xenial Xerus</p>
           <p>Desktop:</p>
-          <pre><code>sudo apt-get install --install-recommends linux-generic-hwe-16.04 xserver-xorg-hwe-16.04</code></pre>
+          <div class="p-code-snippet">
+            <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-hwe-16.04 xserver-xorg-hwe-16.04</code></pre>
+          </div>
           <p>Server:</p>
-          <pre><code>sudo apt-get install --install-recommends linux-generic-hwe-16.04</code></pre>
-          <p>The 16.04.2 and newer point releases ship with an updated kernel and X stack by default for the desktop. Server installations default to the GA kernel and provide the enablement kernel as optional.The 16.04 HWE stacks follow <a href="https://wiki.ubuntu.com/Kernel/RollingLTSEnablementStack">the Rolling Update Model</a>.</p>
+          <div class="p-code-snippet">
+            <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-hwe-16.04</code></pre>
+          </div>
+          <p>
+            The 16.04.2 and newer point releases ship with an updated kernel and X stack by default for the desktop. Server installations default to the GA kernel and provide the enablement kernel as optional.
+          </p>
+          <p>
+            The 16.04 HWE stacks follow <a href="https://wiki.ubuntu.com/Kernel/RollingLTSEnablementStack">the Rolling Update Model</a>.
+          </p>
         </div>
 
-        <div class="p-tabs__content" id="installation-18-04" role="tabpanel" aria-labelledby="installation-18-04-tab">
+        <div class="p-tabs__content"
+             id="installation-18-04"
+             role="tabpanel"
+             aria-labelledby="installation-18-04-tab">
           <p>Ubuntu 18.04 LTS &mdash; Bionic Beaver</p>
           <p>Desktop:</p>
-          <pre><code>sudo apt-get install --install-recommends linux-generic-hwe-18.04 xserver-xorg-hwe-18.04</code></pre>
+          <div class="p-code-snippet">
+            <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-hwe-18.04 xserver-xorg-hwe-18.04</code></pre>
+          </div>
           <p>Server:</p>
-          <pre><code>sudo apt-get install --install-recommends linux-generic-hwe-18.04</code></pre>
-          <p>The 18.04.2 and newer point releases will ship with an updated kernel and X stack by default for the desktop. Server installations will default to the GA kernel and provide the enablement kernel as optional.</p>
-          <p>The 18.04 HWE stacks follow <a href="/about/release-cycle#ubuntu-kernel-release-cycle">the Rolling Update Model</a>.</p>
+          <div class="p-code-snippet">
+            <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-hwe-18.04</code></pre>
+          </div>
+          <p>
+            The 18.04.2 and newer point releases will ship with an updated kernel and X stack by default for the desktop. Server installations will default to the GA kernel and provide the enablement kernel as optional.
+          </p>
+          <p>
+            The 18.04 HWE stacks follow <a href="/about/release-cycle#ubuntu-kernel-release-cycle">the Rolling Update Model</a>.
+          </p>
         </div>
 
-        <div class="p-tabs__content" id="installation-20-04" role="tabpanel" aria-labelledby="installation-20-04-tab">
+        <div class="p-tabs__content"
+             id="installation-20-04"
+             role="tabpanel"
+             aria-labelledby="installation-20-04-tab">
           <p>Ubuntu 20.04 LTS &mdash; Focal Fossa</p>
           <p>Desktop:</p>
-          <pre><code>sudo apt-get install --install-recommends linux-generic-hwe-20.04</code></pre>
+          <div class="p-code-snippet">
+            <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-hwe-20.04</code></pre>
+          </div>
           <p>Server:</p>
-          <pre><code>sudo apt-get install --install-recommends linux-generic-hwe-20.04</code></pre>
-          <p>Desktop installations of 20.04 default to tracking the HWE stack. Server installations will default to the GA kernel and provide the enablement kernel as optional.</p>
-          <p>Note that certain desktop machines may be on a separate "OEM" track. To determine if the machine is eligible for this, run the command <code>ubuntu-drivers list-oem</code> from a terminal. If this is non-empty, the machine is running the OEM cadence instead of HWE.</p>
-          <p>The 20.04 HWE stack follows <a href="/about/release-cycle#ubuntu-kernel-release-cycle">the Rolling Update Model</a>.</p>
+          <div class="p-code-snippet">
+            <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-hwe-20.04</code></pre>
+          </div>
+          <p>
+            Desktop installations of 20.04 default to tracking the HWE stack. Server installations will default to the GA kernel and provide the enablement kernel as optional.
+          </p>
+          <p>
+            Note that certain desktop machines may be on a separate "OEM" track. To determine if the machine is eligible for this, run the command <code>ubuntu-drivers list-oem</code> from a terminal. If this is non-empty, the machine is running the OEM cadence instead of HWE.
+          </p>
+          <p>
+            The 20.04 HWE stack follows <a href="/about/release-cycle#ubuntu-kernel-release-cycle">the Rolling Update Model</a>.
+          </p>
         </div>
 
-        <div class="p-tabs__content" id="installation-22-04" role="tabpanel" aria-labelledby="installation-22-04-tab">
+        <div class="p-tabs__content"
+             id="installation-22-04"
+             role="tabpanel"
+             aria-labelledby="installation-22-04-tab">
           <p>Ubuntu 22.04 LTS &mdash; Jammy Jellyfish</p>
           <p>Desktop:</p>
-          <pre><code>sudo apt-get install --install-recommends linux-generic-hwe-22.04</code></pre>
+          <div class="p-code-snippet">
+            <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-hwe-22.04</code></pre>
+          </div>
           <p>Server:</p>
-          <pre><code>sudo apt-get install --install-recommends linux-generic-hwe-22.04</code></pre>
-          <p>Desktop installations of 22.04 default to tracking the HWE stack. Server installations will default to the GA kernel and provide the enablement kernel as optional.</p>
-          <p>Note that certain desktop machines may be on a separate “OEM” track. To determine if the machine is eligible for this, run the command <code>ubuntu-drivers list-oem</code> from a terminal. If this is non-empty, the machine is running the OEM cadence instead of HWE. </p>
-          <p>The 22.04 HWE stack follows <a href="/about/release-cycle#ubuntu-kernel-release-cycle">the Rolling Update Model</a>.</p>
+          <div class="p-code-snippet">
+            <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-hwe-22.04</code></pre>
+          </div>
+          <p>
+            Desktop installations of 22.04 default to tracking the HWE stack. Server installations will default to the GA kernel and provide the enablement kernel as optional.
+          </p>
+          <p>
+            Note that certain desktop machines may be on a separate “OEM” track. To determine if the machine is eligible for this, run the command <code>ubuntu-drivers list-oem</code> from a terminal. If this is non-empty, the machine is running the OEM cadence instead of HWE.
+          </p>
+          <p>
+            The 22.04 HWE stack follows <a href="/about/release-cycle#ubuntu-kernel-release-cycle">the Rolling Update Model</a>.
+          </p>
+        </div>
+
+        <div class="p-tabs__content"
+             id="installation-24-04"
+             role="tabpanel"
+             aria-labelledby="installation-24-04-tab">
+          <p>Ubuntu 24.04 LTS &mdash; Noble Numbat</p>
+          <p>Desktop:</p>
+          <div class="p-code-snippet">
+            <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-hwe-24.04</code></pre>
+          </div>
+          <p>Server:</p>
+          <div class="p-code-snippet">
+            <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-hwe-24.04</code></pre>
+          </div>
+          <p>
+            Desktop installations of 24.04 default to tracking the HWE stack. Server installations will default to the GA kernel and provide the enablement kernel as optional.
+          </p>
+          <p>
+            Note that certain desktop machines may be on a separate “OEM” track. To determine if the machine is eligible for this, run the command <code>ubuntu-drivers list-oem</code> from a terminal. If this is non-empty, the machine is running the OEM cadence instead of HWE.
+          </p>
+          <p>
+            The 24.04 HWE stack follows <a href="/about/release-cycle#ubuntu-kernel-release-cycle">the Rolling Update Model</a>.
+          </p>
         </div>
       </div>
     </div>
-  </div>
-</section>
+  </section>
 
-<section class="p-strip is-bordered">
-  <div class="row">
-    <div class="col-8">
-      <h2>Check your support status</h2>
-      <p>To determine if your install is still supported, use this terminal command:</p>
-      <p>
-        <code>hwe-support-status --verbose</code>
-      </p>
+  <section class="p-section">
+    <hr class="p-rule is-fixed-width" />
+    <div class="row--50-50">
+      <div class="col">
+        <h2>Check your support status</h2>
+      </div>
+      <div class="col">
+        <p>
+          To determine if your install is still supported, use hwe-support-status:
+          <div class="p-code-snippet">
+            <pre class="p-code-snippet__block is-wrapped"><code>hwe-support-status --verbose</code></pre>
+          </div>
+        </p>
+      </div>
     </div>
-  </div>
-</section>
+  </section>
 
-{% include "shared/_kernel-support-schedule.html" %}
+  {% include "shared/_kernel-support-schedule.html" %}
 
-<script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
+  <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
 
 {% endblock %}

--- a/templates/shared/_kernel-release-diagram.html
+++ b/templates/shared/_kernel-release-diagram.html
@@ -1,6 +1,8 @@
-<div class="p-section--shallow u-hide--small" id="kernel-eol" style="overflow: hidden;"></div>
-<div class="u-cve-table-horizontal-scroll">
-  <table class="cve-table u-cve-table-horizontal-scroll__table">
+<div class="p-section--shallow u-hide--small"
+     id="kernel-eol"
+     style="overflow: hidden"></div>
+<div class="u-table-horizontal-scroll">
+  <table class="u-table-horizontal-scroll__table">
     <thead>
       <tr>
         <th>Kernel version</th>

--- a/templates/shared/_kernel-release-diagram.html
+++ b/templates/shared/_kernel-release-diagram.html
@@ -1,213 +1,215 @@
-<div class="p-section--shallow u-hide--small" id="kernel-eol"></div>
-<table>
-  <thead>
-    <tr>
-      <th>Kernel version</th>
-      <th>Ubuntu version</th>
-      <th>Released</th>
-      <th>End of Standard Security Maintenance</th>
-      <th>End of Expanded Security Maintenance</th>
-      <th>End of Legacy Support</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <strong>6.14</strong>
-      </td>
-      <td>
-        <strong>25.04</strong>
-      </td>
-      <td>Apr 2025</td>
-      <td>Jan 2026</td>
-    </tr>
-    <tr>
-      <td rowspan="2">
-        <strong>6.11</strong>
-      </td>
-      <td>
-        <strong>24.04.2 LTS (HWE)</strong>
-      </td>
-      <td>Feb 2025</td>
-      <td>Jul 2025</td>
-    </tr>
-    <tr>
-      <td>
-        <strong>24.10</strong>
-      </td>
-      <td>Oct 2024</td>
-      <td>Jul 2025</td>
-    </tr>
-    <tr>
-      <td rowspan="3">
-        <strong>6.8</strong>
-      </td>
-      <td>
-        <strong>22.04.5 LTS (HWE)</strong>
-      </td>
-      <td>Aug 2024</td>
-      <td>Apr 2027</td>
-      <td>Mar 2032</td>
-      <td>Apr 2034</td>
-    </tr>
-    <tr>
-      <td>
-        <strong>24.04.1 LTS</strong>
-      </td>
-      <td>Aug 2024</td>
-      <td>Apr 2029</td>
-      <td>Mar 2034</td>
-      <td>Apr 2036</td>
-    </tr>
-    <tr>
-      <td>
-        <strong>24.04.0 LTS</strong>
-      </td>
-      <td>Apr 2024</td>
-      <td>Apr 2029</td>
-      <td>Mar 2034</td>
-      <td>Apr 2036</td>
-    </tr>
-    <tr>
-      <td rowspan="3">
-        <strong>5.15</strong>
-      </td>
-      <td>
-        <strong>20.04.5 LTS (HWE)</strong>
-      </td>
-      <td>Aug 2022</td>
-      <td>Apr 2025</td>
-      <td>Apr 2030</td>
-      <td>Apr 2032</td>
-    </tr>
-    <tr>
-      <td>
-        <strong>22.04.1 LTS</strong>
-      </td>
-      <td>Aug 2022</td>
-      <td>Apr 2027</td>
-      <td>Mar 2032</td>
-      <td>Apr 2034</td>
-    </tr>
-    <tr>
-      <td>
-        <strong>22.04.0 LTS</strong>
-      </td>
-      <td>Apr 2022</td>
-      <td>Apr 2027</td>
-      <td>Mar 2032</td>
-      <td>Apr 2034</td>
-    </tr>
-    <tr>
-      <td rowspan="3">
-        <strong>5.4</strong>
-      </td>
-      <td>
-        <strong>18.04.5 LTS (HWE)</strong>
-      </td>
-      <td>Aug 2020</td>
-      <td>Apr 2023</td>
-      <td>Apr 2028</td>
-      <td>Apr 2030</td>
-    </tr>
-    <tr>
-      <td>
-        <strong>20.04.1 LTS</strong>
-      </td>
-      <td>Aug 2020</td>
-      <td>Apr 2025</td>
-      <td>Apr 2030</td>
-      <td>Apr 2032</td>
-    </tr>
-    <tr>
-      <td>
-        <strong>20.04.0 LTS</strong>
-      </td>
-      <td>Apr 2020</td>
-      <td>Apr 2025</td>
-      <td>Apr 2030</td>
-      <td>Apr 2032</td>
-    </tr>
-    <tr>
-      <td rowspan="3">
-        <strong>4.15</strong>
-      </td>
-      <td>
-        <strong>16.04.5 LTS (HWE)</strong>
-      </td>
-      <td>Aug 2018</td>
-      <td>Apr 2021</td>
-      <td>Apr 2026</td>
-      <td>Apr 2028</td>
-    </tr>
-    <tr>
-      <td>
-        <strong>18.04.1 LTS</strong>
-      </td>
-      <td>Jul 2018</td>
-      <td>Apr 2023</td>
-      <td>Apr 2028</td>
-      <td>Apr 2030</td>
-    </tr>
-    <tr>
-      <td>
-        <strong>18.04.0 LTS</strong>
-      </td>
-      <td>Apr 2018</td>
-      <td>Apr 2023</td>
-      <td>Apr 2028</td>
-      <td>Apr 2030</td>
-    </tr>
-    <tr>
-      <td rowspan="3">
-        <strong>4.4</strong>
-      </td>
-      <td>
-        <strong>14.04.5 LTS (HWE)</strong>
-      </td>
-      <td>Aug 2016</td>
-      <td>Apr 2019</td>
-      <td>Apr 2024</td>
-      <td>Apr 2026</td>
-    </tr>
-    <tr>
-      <td>
-        <strong>16.04.1 LTS</strong>
-      </td>
-      <td>Jul 2016</td>
-      <td>Apr 2021</td>
-      <td>Apr 2026</td>
-      <td>Apr 2028</td>
-    </tr>
-    <tr>
-      <td>
-        <strong>16.04.0 LTS</strong>
-      </td>
-      <td>Apr 2016</td>
-      <td>Apr 2021</td>
-      <td>Apr 2026</td>
-      <td>Apr 2028</td>
-    </tr>
-    <tr>
-      <td rowspan="3">
-        <strong>3.13</strong>
-      </td>
-      <td>
-        <strong>14.04.1 LTS</strong>
-      </td>
-      <td>Jul 2014</td>
-      <td>Apr 2019</td>
-      <td>Apr 2024</td>
-      <td>Apr 2026</td>
-    </tr>
-    <tr>
-      <td>
-        <strong>14.04.0 LTS</strong>
-      </td>
-      <td>Apr 2014</td>
-      <td>Apr 2019</td>
-      <td>Apr 2024</td>
-      <td>Apr 2026</td>
-    </tr>
-  </tbody>
-</table>
+<div class="p-section--shallow u-hide--small" id="kernel-eol" style="overflow: hidden;"></div>
+<div class="u-cve-table-horizontal-scroll">
+  <table class="cve-table u-cve-table-horizontal-scroll__table">
+    <thead>
+      <tr>
+        <th>Kernel version</th>
+        <th>Ubuntu version</th>
+        <th>Released</th>
+        <th>End of Standard Security Maintenance</th>
+        <th>End of Expanded Security Maintenance</th>
+        <th>End of Legacy Support</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <strong>6.14</strong>
+        </td>
+        <td>
+          <strong>25.04</strong>
+        </td>
+        <td>Apr 2025</td>
+        <td>Jan 2026</td>
+      </tr>
+      <tr>
+        <td rowspan="2">
+          <strong>6.11</strong>
+        </td>
+        <td>
+          <strong>24.04.2 LTS (HWE)</strong>
+        </td>
+        <td>Feb 2025</td>
+        <td>Jul 2025</td>
+      </tr>
+      <tr>
+        <td>
+          <strong>24.10</strong>
+        </td>
+        <td>Oct 2024</td>
+        <td>Jul 2025</td>
+      </tr>
+      <tr>
+        <td rowspan="3">
+          <strong>6.8</strong>
+        </td>
+        <td>
+          <strong>22.04.5 LTS (HWE)</strong>
+        </td>
+        <td>Aug 2024</td>
+        <td>Apr 2027</td>
+        <td>Mar 2032</td>
+        <td>Apr 2034</td>
+      </tr>
+      <tr>
+        <td>
+          <strong>24.04.1 LTS</strong>
+        </td>
+        <td>Aug 2024</td>
+        <td>Apr 2029</td>
+        <td>Mar 2034</td>
+        <td>Apr 2036</td>
+      </tr>
+      <tr>
+        <td>
+          <strong>24.04.0 LTS</strong>
+        </td>
+        <td>Apr 2024</td>
+        <td>Apr 2029</td>
+        <td>Mar 2034</td>
+        <td>Apr 2036</td>
+      </tr>
+      <tr>
+        <td rowspan="3">
+          <strong>5.15</strong>
+        </td>
+        <td>
+          <strong>20.04.5 LTS (HWE)</strong>
+        </td>
+        <td>Aug 2022</td>
+        <td>Apr 2025</td>
+        <td>Apr 2030</td>
+        <td>Apr 2032</td>
+      </tr>
+      <tr>
+        <td>
+          <strong>22.04.1 LTS</strong>
+        </td>
+        <td>Aug 2022</td>
+        <td>Apr 2027</td>
+        <td>Mar 2032</td>
+        <td>Apr 2034</td>
+      </tr>
+      <tr>
+        <td>
+          <strong>22.04.0 LTS</strong>
+        </td>
+        <td>Apr 2022</td>
+        <td>Apr 2027</td>
+        <td>Mar 2032</td>
+        <td>Apr 2034</td>
+      </tr>
+      <tr>
+        <td rowspan="3">
+          <strong>5.4</strong>
+        </td>
+        <td>
+          <strong>18.04.5 LTS (HWE)</strong>
+        </td>
+        <td>Aug 2020</td>
+        <td>Apr 2023</td>
+        <td>Apr 2028</td>
+        <td>Apr 2030</td>
+      </tr>
+      <tr>
+        <td>
+          <strong>20.04.1 LTS</strong>
+        </td>
+        <td>Aug 2020</td>
+        <td>Apr 2025</td>
+        <td>Apr 2030</td>
+        <td>Apr 2032</td>
+      </tr>
+      <tr>
+        <td>
+          <strong>20.04.0 LTS</strong>
+        </td>
+        <td>Apr 2020</td>
+        <td>Apr 2025</td>
+        <td>Apr 2030</td>
+        <td>Apr 2032</td>
+      </tr>
+      <tr>
+        <td rowspan="3">
+          <strong>4.15</strong>
+        </td>
+        <td>
+          <strong>16.04.5 LTS (HWE)</strong>
+        </td>
+        <td>Aug 2018</td>
+        <td>Apr 2021</td>
+        <td>Apr 2026</td>
+        <td>Apr 2028</td>
+      </tr>
+      <tr>
+        <td>
+          <strong>18.04.1 LTS</strong>
+        </td>
+        <td>Jul 2018</td>
+        <td>Apr 2023</td>
+        <td>Apr 2028</td>
+        <td>Apr 2030</td>
+      </tr>
+      <tr>
+        <td>
+          <strong>18.04.0 LTS</strong>
+        </td>
+        <td>Apr 2018</td>
+        <td>Apr 2023</td>
+        <td>Apr 2028</td>
+        <td>Apr 2030</td>
+      </tr>
+      <tr>
+        <td rowspan="3">
+          <strong>4.4</strong>
+        </td>
+        <td>
+          <strong>14.04.5 LTS (HWE)</strong>
+        </td>
+        <td>Aug 2016</td>
+        <td>Apr 2019</td>
+        <td>Apr 2024</td>
+        <td>Apr 2026</td>
+      </tr>
+      <tr>
+        <td>
+          <strong>16.04.1 LTS</strong>
+        </td>
+        <td>Jul 2016</td>
+        <td>Apr 2021</td>
+        <td>Apr 2026</td>
+        <td>Apr 2028</td>
+      </tr>
+      <tr>
+        <td>
+          <strong>16.04.0 LTS</strong>
+        </td>
+        <td>Apr 2016</td>
+        <td>Apr 2021</td>
+        <td>Apr 2026</td>
+        <td>Apr 2028</td>
+      </tr>
+      <tr>
+        <td rowspan="3">
+          <strong>3.13</strong>
+        </td>
+        <td>
+          <strong>14.04.1 LTS</strong>
+        </td>
+        <td>Jul 2014</td>
+        <td>Apr 2019</td>
+        <td>Apr 2024</td>
+        <td>Apr 2026</td>
+      </tr>
+      <tr>
+        <td>
+          <strong>14.04.0 LTS</strong>
+        </td>
+        <td>Apr 2014</td>
+        <td>Apr 2019</td>
+        <td>Apr 2024</td>
+        <td>Apr 2026</td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/templates/shared/_kernel-support-schedule.html
+++ b/templates/shared/_kernel-support-schedule.html
@@ -1,12 +1,14 @@
-<section class="p-strip--light is-bordered">
+<section class="p-section--deep">
   <div class="u-fixed-width">
-    <h2>Kernel release schedule</h2>
+    <hr class="p-rule" />
+    <div class="p-section--shallow">
+      <h2>Kernel release schedule</h2>
+    </div>
   </div>
-  <div class="row">
-    {% include "shared/_kernel-release-diagram.html" %}
-  </div>
+  <div class="row">{% include "shared/_kernel-release-diagram.html" %}</div>
 </section>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.9.0/d3.min.js" defer></script>
-<script src="{{ versioned_static('js/dist/release-chart-manager.js') }}" defer></script>
+<script src="{{ versioned_static('js/dist/release-chart-manager.js') }}"
+        defer></script>
 <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -8102,10 +8102,10 @@ v8-to-istanbul@^9.0.1:
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^2.0.0"
 
-vanilla-framework@4.23.0:
-  version "4.23.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.23.0.tgz#4c2f87743501d88e646de818253a1dcacd2f9c66"
-  integrity sha512-GdlN4PVSanY96IUxQwxv2T1Ls+UgRA+BZqUuGqhO6AlgEet9uKJI7XFSfdieedc0F5P8ySCZA9MkALTGHr6jbA==
+vanilla-framework@4.24.0:
+  version "4.24.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.24.0.tgz#48a15b4d59c349f418fa0490d4a72b2be9f43b15"
+  integrity sha512-2/BXRB3Aqz1skfBqDD1hn2+PWx6EdF2xGSm8weq5IgIXllbCFgq8nySmfDQOzFSVqIVgyVidWtH3rDDIB0RaIg==
 
 vanilla-framework@4.9.0:
   version "4.9.0"


### PR DESCRIPTION
## Done

- Rebranded kernel/lifecycle page

## QA

- View the site in your web browser at: https://ubuntu-com-15115.demos.haus/kernel/lifecycle
    - Be sure to test on mobile, tablet and desktop screen sizes
- Verify the page matches [copydoc](https://docs.google.com/document/d/1d01SFs7c56ge2o92g6Rwr3SjG8rtxm3jNwIyL1N8mQg/edit?tab=t.0) and [figma](https://www.figma.com/design/lIQtR9xJy9gLGIAIcTFAjm/ubuntu.com-kernel?node-id=46-3700)

## Issue / Card

Fixes #[WD-17831](https://warthogs.atlassian.net/browse/WD-17831)

## Screenshots

Before:
![image](https://github.com/user-attachments/assets/52bcfa8f-e354-4101-a345-2c80279b038c)


After:
![image](https://github.com/user-attachments/assets/b2a673ab-c549-4375-a73e-871480ae4cce)




## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-17831]: https://warthogs.atlassian.net/browse/WD-17831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ