### PR TITLE
Missing fallback OG Image tags

### DIFF
--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -117,9 +117,9 @@
     {% else %}
       <meta name="twitter:card" content="summary_large_image" />
       <meta name="twitter:image"
-            content="https://assets.ubuntu.com/v1/b4ba06f2-Ubuntu%20logo.svg" />
+            content="https://assets.ubuntu.com/v1/47f12466-og_%20ubuntu.png" />
       <meta property="og:image"
-            content="https://assets.ubuntu.com/v1/b4ba06f2-Ubuntu%20logo.svg" />
+            content="https://assets.ubuntu.com/v1/47f12466-og_%20ubuntu.png" />
     {% endif %}
     {% block extra_metatags %}{% endblock %}
     <style>#rememberMe {display: none;}</style>


### PR DESCRIPTION
## Done

Added a fallback OG Image tag for URLs that do not specify an og image

## QA

- Check out [the demo](https://canonical-com-1708.demos.haus/) and preview the link to see that it now has a fallback og image

You can check [here](https://www.opengraph.xyz/url/https%3A%2F%2Fubuntu-com-15116.demos.haus%2F) for how the preview looks like 

## Issue / Card

Fixes # [WD-22224](https://warthogs.atlassian.net/browse/WD-22224)
Parent issue [WD-22215](https://warthogs.atlassian.net/browse/WD-22215)

## Screenshots

### Before
![image](https://github.com/user-attachments/assets/ff9c8cb5-a9c6-4511-bcc8-00e851bec163)

### After
![image](https://github.com/user-attachments/assets/613ef3fc-d316-4c2a-bb58-72b58c3cfecf)
![image](https://github.com/user-attachments/assets/155e6181-9338-4ccb-ad96-61f063f34476)


[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-22224]: https://warthogs.atlassian.net/browse/WD-22224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[WD-22215]: https://warthogs.atlassian.net/browse/WD-22215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ