### PR TITLE
fix: Fix icon placement

### DIFF
--- a/static/sass/_pattern_cve.scss
+++ b/static/sass/_pattern_cve.scss
@@ -70,7 +70,7 @@
       padding-top: 0;
     }
 
-    #priority-icon {
+    .priority-icon {
       float: inline-end;
     }
   }

--- a/templates/security/cves/_cve-card.html
+++ b/templates/security/cves/_cve-card.html
@@ -8,7 +8,7 @@
           <h2 class="p-heading--5">
             <a href="/security/{{ cve.id }}">{{ cve.id }}</a>
           </h2>
-          <span id="priority-icon">
+          <span class="priority-icon">
             {% if cve.priority == 'unknown' %}
               <i class="p-icon--placeholder"></i>
             {% elif cve.priority == 'negligible' %}


### PR DESCRIPTION
## Done

- Fixed icon alignment 

## QA

- View the site locally in your web browser at: https://ubuntu-com-15117.demos.haus/security/cves
- See that icon is right-aligned 

## Issue / Card

Fixes #https://warthogs.atlassian.net/browse/WD-22225

## Screenshots
before:
![Screenshot from 2025-05-21 17-29-39](https://github.com/user-attachments/assets/6d7068c0-fea4-4e61-84bd-2d0a14a5825e)
after:
![Screenshot from 2025-05-21 17-29-15](https://github.com/user-attachments/assets/bf1630c9-3d48-44cb-b426-a675a7c96414)
