### PR TITLE
[WD-22279] chore: Replace all instances of /digital-signage with /smart-displays

### DIFF
--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -315,7 +315,7 @@ meta_copydoc %}
         <hr class="u-hide--small p-rule" />
         <div class="row">
           <div class="col-3 col-medium-2">
-            <a href="/internet-of-things/digital-signage">
+            <a href="/internet-of-things/smart-displays">
               <h3 class="p-heading--5">Signage</h3>
               <div class="p-image-container">
                 <img class="p-image-container__image"

--- a/templates/core/stories.html
+++ b/templates/core/stories.html
@@ -375,7 +375,7 @@
           </div>
           <hr class="p-rule--muted" />
           <p>
-            <a href="/internet-of-things/digital-signage">Learn more about Ubuntu Core in digital signage&nbsp;&rsaquo;</a>
+            <a href="/internet-of-things/smart-displays">Learn more about Ubuntu Core in digital signage&nbsp;&rsaquo;</a>
           </p>
         </div>
         <!-- tab 4 -->

--- a/templates/internet-of-things/form-data.json
+++ b/templates/internet-of-things/form-data.json
@@ -4,7 +4,7 @@
       "templatePath": "/internet-of-things/index.html",
       "childrenPaths": [
         "/internet-of-things/appstore",
-        "/internet-of-things/digital-signage",
+        "/internet-of-things/smart-displays",
         "/internet-of-things/gateways",
         "/internet-of-things/management",
         "/internet-of-things/networking",

--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -155,7 +155,7 @@
 
               <div class="p-equal-height-row__item">
                 <h3 class="p-heading--5">
-                  <a href="/internet-of-things/digital-signage">Digital signage</a>
+                  <a href="/internet-of-things/smart-displays">Digital signage</a>
                 </h3>
               </div>
 

--- a/templates/internet-of-things/smart-city/index.html
+++ b/templates/internet-of-things/smart-city/index.html
@@ -155,7 +155,7 @@
           </p>
 
           <div class="p-cta-block row--r-gap3">
-            <a href="/internet-of-things/digital-signage">Our smart display solutions&nbsp;&rsaquo;</a>
+            <a href="/internet-of-things/smart-displays">Our smart display solutions&nbsp;&rsaquo;</a>
             <a href="/automotive">Our automotive solutions&nbsp;&rsaquo;</a>
           </div>
         </div>


### PR DESCRIPTION
## Done

- Replaced all instances of /digital-signage to /smart-displays

## QA

- View the site locally in your web browser at: https://ubuntu-com-15125.demos.haus/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Make sure the following links work and redirect to https://ubuntu-com-15125.demos.haus/internet-of-things/smart-displays
  - https://ubuntu-com-15125.demos.haus/internet-of-things/digital-signage
  - https://ubuntu-com-15125.demos.haus/internet-of-things/digital-signage#get-in-touch

## Issue / Card

Fixes #[WD-22279](https://warthogs.atlassian.net/browse/WD-22279)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-22279]: https://warthogs.atlassian.net/browse/WD-22279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ