### PR TITLE
[WD-22310] chore: Update meganav link

### DIFF
--- a/meganav.yaml
+++ b/meganav.yaml
@@ -149,7 +149,7 @@ products:
               url: /ceph
             - title: Anbox Cloud
               description: Virtualized Android on demand
-              url: https://anbox-cloud.io/
+              url: https://canonical.com/anbox-cloud
             - title: Juju
               description: Orchestrator engine for operators
               url: https://juju.is/


### PR DESCRIPTION
## Done

- Updated meganav link for anbox cloud

## QA

- View the site in your web browser at: http://0.0.0.0:8001/
- In the meganav, select Products > Private Cloud > Anbox Cloud
- Verify it redirects to canonical.com/anbox-cloud

## Issue / Card

Fixes #[WD-22310](https://warthogs.atlassian.net/browse/WD-22310)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
