### PR TITLE
WD-15705: add 24.10 exam to badge issue menu in dashboard

### DIFF
--- a/static/js/src/advantage/credentials/dashboard/constants.ts
+++ b/static/js/src/advantage/credentials/dashboard/constants.ts
@@ -9,9 +9,9 @@ export const CREDLY_BADGE_TEMPLATES = [
     badgeTitle: "[Beta] CUE.01 Linux Quick Certification",
     shortTitle: "[Beta] CUE.01 Linux",
   },
-  // {
-  //   templateId: "a81d475c-e534-45d2-b60c-01eab5e53f42",
-  //   badgeTitle: "CUE.01 Linux Quick Certification (24.10 exam edition)",
-  //   shortTitle: "CUE.01 Linux (24.10)",
-  // },
+  {
+    templateId: "a81d475c-e534-45d2-b60c-01eab5e53f42",
+    badgeTitle: "CUE.01 Linux Quick Certification (24.10 exam edition)",
+    shortTitle: "CUE.01 Linux (24.10)",
+  },
 ];

--- a/webapp/shop/decorators.py
+++ b/webapp/shop/decorators.py
@@ -324,7 +324,7 @@ def get_credly_api_instance(area, credly_session) -> CredlyAPI:
         base_url=os.getenv("CREDLY_URL", "https://sandbox-api.credly.com/v1"),
         auth_token=os.getenv("CREDLY_TOKEN", ""),
         org_id=os.getenv(
-            "CREDLY_ORGANIZATION_ID", "069adc37-b51e-45ee-8c9d-4a2c89ce6622"
+            "CREDLY_ORGANIZATION_ID", "30dfd771-5079-4000-9865-8c3aeb4545b6"
         ),
         session=credly_session,
     )


### PR DESCRIPTION
## Done

- Add 24.10 credly badge to dashboard for issuance

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to `/credentials/dashboard/exams/results`
    - In the column **Issue Badge** you should be able to see CUE.01 Linux 24.10

## Issue / Card

Fixes [WD-15705](https://warthogs.atlassian.net/browse/WD-15705)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-15705]: https://warthogs.atlassian.net/browse/WD-15705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ