### PR TITLE
ci: Trigger action error when sitemap build fails

### DIFF
--- a/.github/workflows/sitemap.yaml
+++ b/.github/workflows/sitemap.yaml
@@ -1,10 +1,10 @@
 name: Generate sitemap for static pages
-on:
-  push:
-    branches:
-      - main
-    paths:
-      - "templates/**"
+on: [pull_request]
+  # push:
+  #   branches:
+  #     - main
+  #   paths:
+  #     - "templates/**"
 
 jobs:
   generate-sitemap:
@@ -16,5 +16,5 @@ jobs:
 
       - name: Call sitemap generation endpoint
         run: |
-          curl -X POST "https://ubuntu.com/sitemap_tree.xml" \
-          -H "Authorization: Bearer ${{ secrets.SITEMAP_SECRET }}"
+          curl -f -X POST "https://ubuntu.com/sitemap_tree.xml" \
+          -H "Authorization: Bearer invalid-secret-for-qa"

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -1290,6 +1290,7 @@ def build_sitemap_tree(exclude_paths=None):
                 return xml_sitemap
             else:
                 logging.warning("Sitemap is empty")
+                return {"error:", "Sitemap is empty"}, 500
 
         except Exception as e:
             logging.error(f"Error generating sitemap: {e}")


### PR DESCRIPTION
## Done

- [List of work items including drive-bys - remember to add the why and what of this work.]

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes [WD-21845](https://warthogs.atlassian.net/browse/WD-21845)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
