### PR TITLE
WD-21375 WD-20560: preserve form values on error for exam scheduling and check expired contracts

### DIFF
--- a/templates/credentials/schedule.html
+++ b/templates/credentials/schedule.html
@@ -21,7 +21,7 @@ meta_copydoc %}
           <div class="p-notification__content">
             <h5 class="p-notification__title">Error</h5>
             <p class="p-notification__message" id="error-message">
-              {% if maintenance_error == 'True' %}
+              {% if maintenance_error == 'True' or maintenance_error == True %}
                 Scheduled time should be outside of the maintenance window. Please schedule the exam before
                 <strong>{{ maintenance_start }}</strong> or after
                 <strong>{{ maintenance_end }}</strong>.
@@ -67,6 +67,7 @@ meta_copydoc %}
                  id="exam-date"
                  name="date"
                  value="{{ date }}"
+                 min="{{ min_date }}"
                  max="{{ max_date }}"
                  required />
           <label class="p-heading--5 u-no-margin" for="exam-time">Select your preferred time</label>
@@ -85,6 +86,7 @@ meta_copydoc %}
                  type="time"
                  id="exam-time"
                  name="time"
+                 value="{{ time }}"
                  required />
           {% if uuid %}<input type="text" id="exam-uuid" name="uuid" value="{{ uuid }}" hidden />{% endif %}
           <div class="u-align--right">
@@ -97,11 +99,16 @@ meta_copydoc %}
 
   {# djlint:off #}
   <script>
+    let selectedTimezone;
     {% if timezone and timezone != "" %}
-    const timezone = "{{ timezone }}";
+    selectedTimezone = "{{ timezone }}";
     {% else %}
-    const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    selectedTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
     {% endif %}
+
+    const serverProvidedMinDate = "{{ min_date }}";
+    const serverProvidedDate = "{{ date }}";
+    const serverProvidedTime = "{{ time }}";
 
     const formatDateTime = (dateTime, locale = 'default') => {
       const date = new Date(dateTime);
@@ -125,13 +132,37 @@ meta_copydoc %}
       const dateInput = document.querySelector("#exam-date");
       const timeInput = document.querySelector("#exam-time");
       const now = new Date();
-      const year = now.getFullYear();
-      const month = now.getMonth() + 1;
-      const day = now.getDate();
-      const dateString = `${year}-${month.toString().padStart(2, "0")}-${day.toString().padStart(2, "0")}`;
-      dateInput.min = dateString;
-      dateInput.value = dateString;
-      timeInput.value = now.toTimeString().split(" ")[0].slice(0, 5);
+
+      // Set min attribute for date input
+      if (serverProvidedMinDate) {
+        dateInput.min = serverProvidedMinDate;
+      } else {
+        const year = now.getFullYear();
+        const month = (now.getMonth() + 1).toString().padStart(2, "0");
+        const day = now.getDate().toString().padStart(2, "0");
+        dateInput.min = `${year}-${month}-${day}`;
+      }
+
+      // Set date value only if not already set by the server or if it's invalid
+      if (dateInput.value && new Date(dateInput.value) >= new Date(dateInput.min)) {
+        // Value is already set by server and is valid, do nothing
+      } else if (serverProvidedDate && new Date(serverProvidedDate) >= new Date(dateInput.min)) {
+        dateInput.value = serverProvidedDate;
+      } else { // Fallback to min_date (today or server min_date)
+        dateInput.value = dateInput.min;
+      }
+
+      // Set time value only if not already set by the server
+      if (timeInput.value && serverProvidedTime) { // If server provided a value, and it's in the input, keep it.
+        timeInput.value = serverProvidedTime;
+      } else if (!timeInput.value && serverProvidedTime) { // If input is empty but server provided one
+        timeInput.value = serverProvidedTime;
+      }
+      else if (!timeInput.value) { // Fallback to current time if still no value
+        const hours = now.getHours().toString().padStart(2, "0");
+        const minutes = now.getMinutes().toString().padStart(2, "0");
+        timeInput.value = `${hours}:${minutes}`;
+      }
     }
 
     const timezoneInput = document.querySelector("#exam-timezone");
@@ -140,7 +171,7 @@ meta_copydoc %}
       optionElement = document.createElement("option");
       optionElement.value = tz;
       optionElement.innerText = tz;
-      if (tz == timezone) {
+      if (tz == selectedTimezone) {
         optionElement.setAttribute("selected", true);
       }
       timezoneInput.appendChild(optionElement);

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -497,9 +497,6 @@ def cred_schedule(
         template_data["time_delay"] = time_delay
         template_data["contract_item_id"] = contract_item_id
         template_data["ta_exam"] = "cue-01-linux"
-        error_start_time = check_cred_exam_start_time(
-            starts_at, timezone, time_buffer, time_delay
-        )
         proc_exam = None
 
         if flask.request.args.get("uuid", default=None, type=str):
@@ -524,7 +521,11 @@ def cred_schedule(
             )
         template_data["ta_exam"] = data["ta_exam"]
         ta_exam_name = EXAM_NAMES[data["ta_exam"]]
+        template_data["ta_exam_name"] = ta_exam_name
 
+        error_start_time = check_cred_exam_start_time(
+            starts_at, timezone, time_buffer, time_delay
+        )
         if error_start_time is not None:
             return flask.render_template(
                 "/credentials/schedule.html",

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -928,6 +928,12 @@ def cred_your_exams(
                 exam_contract.get("id") or exam_contract["contractItem"]["id"]
             )
             contract_long_id = exam_contract["contractItem"]["contractID"]
+            is_contract_expired = (
+                "effectivenessContext" in exam_contract
+                and "status" in exam_contract["effectivenessContext"]
+                and exam_contract["effectivenessContext"]["status"]
+                == "expired"
+            )
 
             # if exam is scheduled
             if "reservation" in exam_contract["cueContext"]:
@@ -1056,6 +1062,7 @@ def cred_your_exams(
                     if (
                         now + timedelta(minutes=30) < starts_at
                         and not is_banned
+                        and not is_contract_expired
                     ):
                         actions.extend(
                             [
@@ -1083,12 +1090,7 @@ def cred_your_exams(
                         }
                     )
             # if exam expires
-            elif (
-                "effectivenessContext" in exam_contract
-                and "status" in exam_contract["effectivenessContext"]
-                and exam_contract["effectivenessContext"]["status"]
-                == "expired"
-            ):
+            elif is_contract_expired:
                 exams_expired.append(
                     {"name": name, "state": "Expired", "actions": []}
                 )
@@ -1096,7 +1098,7 @@ def cred_your_exams(
             # if exam is not used and is not expired
             else:
                 actions = []
-                if not is_banned:
+                if not is_banned and not is_contract_expired:
                     actions = [
                         {
                             "text": "Schedule",


### PR DESCRIPTION
## Done

- On error while exam scheduling, the form values of the scheduling form will now get preserved

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Buy and schedule an exam
    - Choose a date and time which causes error (schedule the exam for within 30 minutes from now to produce)
    - The date, timezone, time values should be preserved upon error

## Issue / Card

Fixes [WD-20560](https://warthogs.atlassian.net/browse/WD-20560), [WD-21375](https://warthogs.atlassian.net/browse/WD-21375)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-21375]: https://warthogs.atlassian.net/browse/WD-21375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[WD-20560]: https://warthogs.atlassian.net/browse/WD-20560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ