### PR TITLE
WD-22351: redirect on exam schedule page if contractLongID not present

### DIFF
--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -457,6 +457,10 @@ def cred_schedule(
     error = None
 
     contract_long_id = flask.request.args.get("contractLongID")
+
+    if not contract_long_id:
+        return flask.redirect("/credentials/your-exams")
+
     contract_detail = ua_contracts_api.get_contract(contract_long_id)
 
     now = datetime.utcnow()


### PR DESCRIPTION
## Done

- Redirect on schedule exam page if `contractLongID` is not present
- Without `contractLongID`, we can not proceed

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to `/credentials/schedule` or `/credentials/schedule?contractLongID=`
    - You should be redirected to `/credentials/your-exams`

## Issue / Card

Fixes [WD-22351](https://warthogs.atlassian.net/browse/WD-22351)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-22351]: https://warthogs.atlassian.net/browse/WD-22351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ