### PR TITLE
feat: updated jira sync key to 22403

### DIFF
--- a/.github/.jira_sync_config.yaml
+++ b/.github/.jira_sync_config.yaml
@@ -22,4 +22,4 @@ settings:
   sync_comments: true
 
   # (Optional) (Default: None) Parent Epic key to link the issue to
-  epic_key: "WD-17176"
+  epic_key: "WD-22403"


### PR DESCRIPTION
## Done

- Updated the epic key for  github issues to [22403](https://warthogs.atlassian.net/browse/WD-22403)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
