### PR TITLE
fix: Telco openran page redirect

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -929,7 +929,7 @@ telco/thank-you/?: "https://canonical.com/solutions/telco"
 telco/magma/?: "https://canonical.com/solutions/telco"
 telco/cnf/?: "https://canonical.com/solutions/telco"
 telco/vnf/?: "https://canonical.com/solutions/telco"
-telco/openran/?: "http://canonical.com/solutions/telco/open-ran"
+telco/openran/?: "https://canonical.com/solutions/telco/open-ran"
 telco/osm(/.*)?/?: "https://canonical.com/solutions/telco"
 fan/?: "https://wiki.ubuntu.com/FanNetworking"
 


### PR DESCRIPTION
## Done

- Fixes telco openran redirect route

## QA

- Check out the demo link
- Ensure visiting https://ubuntu-com-15144.demos.haus/telco/openran redirects to https://canonical.com/solutions/telco/open-ran

## Issue / Card

Fixes # [WD-17795](https://warthogs.atlassian.net/browse/WD-17795)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-17795]: https://warthogs.atlassian.net/browse/WD-17795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ