### PR TITLE
WD-22437: use different form id for staging and production for marketo sign ups

### DIFF
--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -203,8 +203,7 @@ def cred_sign_up(**_):
                     ),
                     400,
                 )
-    except Exception as e:
-        print(e)
+    except Exception:
         flask.current_app.extensions["sentry"].captureException(
             extra={"payload": payload}
         )

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -115,6 +115,9 @@ def cred_self_study(**_):
 @shop_decorator(area="cred", permission="user", response="html")
 def cred_sign_up(**_):
     search_type = flask.request.args.get("type")
+    if not search_type or (search_type not in ["tester", "sme"]):
+        return flask.redirect("/credentials/sign-up?type=tester")
+
     if flask.request.method == "GET":
         sign_up_open = True
         return flask.render_template(
@@ -171,12 +174,14 @@ def cred_sign_up(**_):
     is_staging = "staging" in os.getenv(
         "CONTRACTS_API_URL", "https://contracts.staging.canonical.com/"
     )
-    form_fields["enviornment"] = "staging" if is_staging else "production"
+    marketo_form_id = "6254" if is_staging else "3801"
     payload = {
-        "formId": form_fields.pop("formid"),
+        "formId": marketo_form_id,
         "input": [
             {
-                "leadFormFields": form_fields,
+                "leadFormFields": form_fields.update(
+                    {"formid": marketo_form_id}
+                ),
                 "visitorData": visitor_data,
                 "cookie": flask.request.args.get("mkt"),
             }

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -175,13 +175,12 @@ def cred_sign_up(**_):
         "CONTRACTS_API_URL", "https://contracts.staging.canonical.com/"
     )
     marketo_form_id = "6254" if is_staging else "3801"
+    form_fields.update({"formid": marketo_form_id})
     payload = {
         "formId": marketo_form_id,
         "input": [
             {
-                "leadFormFields": form_fields.update(
-                    {"formid": marketo_form_id}
-                ),
+                "leadFormFields": form_fields,
                 "visitorData": visitor_data,
                 "cookie": flask.request.args.get("mkt"),
             }

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -174,8 +174,8 @@ def cred_sign_up(**_):
     is_staging = "staging" in os.getenv(
         "CONTRACTS_API_URL", "https://contracts.staging.canonical.com/"
     )
-    marketo_form_id = "6254" if is_staging else "3801"
-    form_fields.update({"formid": marketo_form_id})
+    marketo_form_id = 6254 if is_staging else 3801
+    form_fields.pop("formid")
     payload = {
         "formId": marketo_form_id,
         "input": [
@@ -203,7 +203,8 @@ def cred_sign_up(**_):
                     ),
                     400,
                 )
-    except Exception:
+    except Exception as e:
+        print(e)
         flask.current_app.extensions["sentry"].captureException(
             extra={"payload": payload}
         )


### PR DESCRIPTION
## Done

- Use form id 6254 is on staging and 3801 if on production for sending data to Marketo

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to `/credentials/sign-up?type=tester` or `/credentials/sign-up?type=sme`
    - Fill the form and submit
    - It should submit without error

## Issue / Card

Fixes [WD-22437](https://warthogs.atlassian.net/browse/WD-22437)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-22437]: https://warthogs.atlassian.net/browse/WD-22437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ