### PR TITLE
feat: replaced ubuntuforums with discourse

### DIFF
--- a/meganav.yaml
+++ b/meganav.yaml
@@ -614,7 +614,7 @@ support:
               url: /about
             - title: Ubuntu Discourse
               description: Discuss Ubuntu with other users
-              url: /about
+              url: https://discourse.ubuntu.com/
 
       secondary_links:
         - title: Quick links
@@ -778,7 +778,6 @@ community:
             - title: Ubuntu Summit
               description: Showcasing open source innovation
               url: /summit
-            
 
       secondary_links:
         - title: Quick links

--- a/meganav.yaml
+++ b/meganav.yaml
@@ -612,9 +612,6 @@ support:
             - title: About Ubuntu
               description: Introduction to the OS
               url: /about
-            - title: Ubuntu forums
-              description: Discuss Ubuntu with other users
-              url: https://ubuntuforums.org/
 
       secondary_links:
         - title: Quick links
@@ -650,9 +647,6 @@ community:
             - title: Ask Ubuntu
               description: Q&A for users and developers
               url: https://askubuntu.com/
-            - title: Forums
-              description: Discuss Ubuntu with other users
-              url: https://ubuntuforums.org/
             - title: Ubuntu Masters
               description: Get inspired by IT practitioners
               url: /masters-conference
@@ -675,9 +669,6 @@ community:
             - title: Ask Ubuntu
               description: Q&A for users and developers
               url: https://askubuntu.com/
-            - title: Forums
-              description: Discuss Ubuntu with other users
-              url: https://ubuntuforums.org/
             - title: Chat on IRC
               description: Speak to Ubuntu users
               url: https://help.ubuntu.com/community/InternetRelayChat
@@ -689,11 +680,11 @@ community:
         - title: Quick links
           links:
             - title: "Forum: New to Ubuntu"
-              url: https://ubuntuforums.org/forumdisplay.php?f=125
+              url: https://discourse.ubuntu.com/c/intro/101
             - title: "Forum: Ubuntu Official Flavors Support"
-              url: https://ubuntuforums.org/forumdisplay.php?f=327
+              url: https://discourse.ubuntu.com/c/flavors/22
             - title: "Forum: Ubuntu, Linux and OS Chat"
-              url: https://ubuntuforums.org/forumdisplay.php?f=434
+              url: https://discourse.ubuntu.com/c/project/307
             - title: Ubuntu Community on Discourse
               url: https://discourse.ubuntu.com/c/community/78
 

--- a/meganav.yaml
+++ b/meganav.yaml
@@ -650,6 +650,9 @@ community:
             - title: Ask Ubuntu
               description: Q&A for users and developers
               url: https://askubuntu.com/
+            - title: Forums
+              description: Discuss Ubuntu with other users
+              url: https://discourse.ubuntu.com/
             - title: Ubuntu Masters
               description: Get inspired by IT practitioners
               url: /masters-conference

--- a/meganav.yaml
+++ b/meganav.yaml
@@ -612,6 +612,9 @@ support:
             - title: About Ubuntu
               description: Introduction to the OS
               url: /about
+            - title: Ubuntu Discourse
+              description: Discuss Ubuntu with other users
+              url: /about
 
       secondary_links:
         - title: Quick links

--- a/templates/hpc/_hpc-contact-us-form.html
+++ b/templates/hpc/_hpc-contact-us-form.html
@@ -193,7 +193,7 @@
             <a href="https://askubuntu.com/">Ask Ubuntu</a>
           </li>
           <li class="p-list__item">
-            <a href="https://ubuntuforums.org/">The Ubuntu forum</a>
+            <a href="https://discourse.ubuntu.com/">Ubuntu Community on Discourse</a>
           </li>
           <li class="p-list__item">
             <a href="https://help.ubuntu.com/">Help docs</a>

--- a/templates/shared/_default-contact-us-form.html
+++ b/templates/shared/_default-contact-us-form.html
@@ -579,13 +579,17 @@
       <h2>Need help with Ubuntu?</h2>
     </div>
     <div class="col">
-      <p>If you are just looking for some free support for yourself, you can try:</p>
+      <p>
+        If you are just looking for some free support for yourself, you can try:
+      </p>
       <ul class="p-list">
         <li class="p-list__item">
           <a href="https://askubuntu.com/">Ask Ubuntu</a>
         </li>
         <li class="p-list__item">
-          <a href="https://ubuntuforums.org/">The Ubuntu forum</a>
+          <a href="https://discourse.ubuntu.com/">
+            Ubuntu Community on Discourse
+          </a>
         </li>
         <li class="p-list__item">
           <a href="https://help.ubuntu.com/">Help docs</a>

--- a/templates/shared/_openstack_contact_us.html
+++ b/templates/shared/_openstack_contact_us.html
@@ -486,13 +486,17 @@
       <h2>Need help with Ubuntu?</h2>
     </div>
     <div class="col">
-      <p>If you are just looking for some free support for yourself, you can try:</p>
+      <p>
+        If you are just looking for some free support for yourself, you can try:
+      </p>
       <ul class="p-list">
         <li class="p-list__item">
           <a href="https://askubuntu.com/">Ask Ubuntu</a>
         </li>
         <li class="p-list__item">
-          <a href="https://ubuntuforums.org/">The Ubuntu forum</a>
+          <a href="https://discourse.ubuntu.com/">
+            Ubuntu Community on Discourse
+          </a>
         </li>
         <li class="p-list__item">
           <a href="https://help.ubuntu.com/">Help docs</a>

--- a/templates/shared/forms/_desktop_help.html
+++ b/templates/shared/forms/_desktop_help.html
@@ -5,11 +5,21 @@
       <h2 class="p-card__title">Need help with Ubuntu?</h2>
     </div>
     <div class="col">
-      <p>If you are just looking for some free support for yourself, you can try:</p>
+      <p>
+        If you are just looking for some free support for yourself, you can try:
+      </p>
       <ul class="p-list">
-        <li class="p-list__item"><a href="https://askubuntu.com/">Ask Ubuntu</a></li>
-        <li class="p-list__item"><a href="https://ubuntuforums.org/">The Ubuntu forum</a></li>
-        <li class="p-list__item"><a href="https://help.ubuntu.com/">Help docs</a></li>
+        <li class="p-list__item">
+          <a href="https://askubuntu.com/">Ask Ubuntu</a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://discourse.ubuntu.com/">
+            Ubuntu Community on Discourse
+          </a>
+        </li>
+        <li class="p-list__item">
+          <a href="https://help.ubuntu.com/">Help docs</a>
+        </li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
## Done

- Replaced https://ubuntuforums.org links with https://discourse.ubuntu.com.
- Updated the links in the meganav.

## QA

- View the site locally in your web browser at: https://ubuntu-com-15153.demos.haus/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check that the support links are working, 

## Issue / Card

Fixes https://github.com/canonical/ubuntu.com/issues/15096

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
