### PR TITLE
fix(/robotics): Fix broken links

### DIFF
--- a/templates/robotics/index.html
+++ b/templates/robotics/index.html
@@ -299,7 +299,7 @@
 
           <p>
             <a class="p-button--positive"
-               href="https://canonical-robotics.readthedocs-hosted.com/how-to-guides/">Explore documentation</a>
+               href="https://canonical-robotics.readthedocs-hosted.com/en/latest/how-to-guides/">Explore documentation</a>
             <a href="https://canonical-robotics.readthedocs-hosted.com/">Learn more about Snapcraft&nbsp;&rsaquo;</a>
           </p>
         </div>


### PR DESCRIPTION
## Done

- Fixes the broken links reported in this [failing link check report](https://github.com/canonical/ubuntu.com/actions/runs/15341587525/job/43168688212)
- The new correct links have been added to the [copydoc](https://docs.google.com/document/d/1JNFk2C0shH3DapKuJM8X0QfAiD1RzHvXoydn8P9mEMg/edit?tab=t.0#)

## QA

- Open [the demo](https://ubuntu-com-15154.demos.haus/robotics)
- Check the links reported in the [link check report](https://github.com/canonical/ubuntu.com/actions/runs/15341587525/job/43168688212) are now working and match those in the [copydoc](https://docs.google.com/document/d/1JNFk2C0shH3DapKuJM8X0QfAiD1RzHvXoydn8P9mEMg/edit?tab=t.0#)

