### PR TITLE
Fix X-Forwarded-For having the incorrect address 

### DIFF
--- a/webapp/shop/decorators.py
+++ b/webapp/shop/decorators.py
@@ -152,7 +152,14 @@ def shop_decorator(area=None, permission=None, response="json", redirect=None):
                     return flask.redirect(f"/login?next={redirect_path}")
 
             ua_contracts_api = get_ua_contracts_api_instance(
-                user_token, response, session, flask.request.remote_addr
+                user_token,
+                response,
+                session,
+                (
+                    flask.request.headers.getlist("X-Forwarded-For")[0]
+                    if flask.request.headers.getlist("X-Forwarded-For")
+                    else flask.request.remote_addr
+                ),
             )
             advantage_mapper = AdvantageMapper(ua_contracts_api)
             is_community_member = False


### PR DESCRIPTION
## Done

- Fix X-Forwarded-For having incorrect client address when sending UA Contracts API call

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
