### PR TITLE
fix: CVE tooltip to include anchor tags

### DIFF
--- a/templates/security/cves/cve.html
+++ b/templates/security/cves/cve.html
@@ -282,10 +282,10 @@
                                 {{ status.name }} {% if status.name == "Fixed" %}<span class="u-text--muted">{{ status.description }} </span> {% endif %}
                                 {% if status.pocket_desc and status.pocket_desc.label == "Ubuntu Pro" %}
                                   <div>
-                                    <a class="p-chip p-tooltip--top-center u-no-margin--bottom" href="/pro" aria-describedby="{{ status.pocket }}-tooltip">
-                                      <p class="p-chip__value">{{ status.pocket_desc.label }}</p>
-                                      <p class="p-tooltip__message cve-chip" role="tooltip" id="{{ status.pocket }}-tooltip">{{ status.pocket_desc.text }}</p>
-                                    </a>
+                                    <button class="p-chip p-tooltip--top-center u-no-margin--bottom" aria-describedby="{{ status.pocket }}-tooltip">
+                                      <span class="p-chip__value">{{ status.pocket_desc.label }}</span>
+                                      <span class="p-tooltip__message cve-chip" role="tooltip" id="{{ status.pocket }}-tooltip">{{ status.pocket_desc.text | safe}}</span>
+                                    </button>
                                   </div>
                                 {% endif %}
                               </div>


### PR DESCRIPTION
## Done

- [List of work items including drive-bys - remember to add the why and what of this work.]

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
