### PR TITLE
copy update: update security text

### DIFF
--- a/templates/security/cmmc/index.html
+++ b/templates/security/cmmc/index.html
@@ -70,7 +70,7 @@
             Ubuntu Pro supports the CMMC requirement to remediate software vulnerabilities in a timely manner.
             </p>
             <p>
-              For over 20 years, Canonical has provided security fixes for all the open source applications and infrastructure components available within the Ubuntu ecosystem.
+              For over 20 years, Canonical has provided critical security fixes for all the open source applications and infrastructure components available within the Ubuntu ecosystem.
             </p>
         </div>
         <hr class="p-rule--muted" />


### PR DESCRIPTION
## Done

- Updated text under "Easy and automated security patching” according to the [copy doc](https://docs.google.com/document/d/1IbVBPtZZ0zLtT1C5j70cUrSx2bvP1KWtvSJObQKqFb8/edit?tab=t.0)

## QA

- Check out this feature branch
- Run the site using the command ./run serve or dotrun
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Be sure to test on mobile, tablet and desktop screen sizes
- Alternatively, view the [demo](https://ubuntu-com-15102.demos.haus/)
    - Navigate to /security/cmmc
    - Check that the text under "Easy and automated security patching” says "For over 20 years, Canonical has provided critical security fixes" instead of "For over 20 years, Canonical has provided security fixes"
    
## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-22496
