### PR TITLE
copy update: add notification to `/gcp`

### DIFF
--- a/templates/gcp/index.html
+++ b/templates/gcp/index.html
@@ -37,6 +37,21 @@
   </section>
 
   <section class="p-section">
+    <div class="row">
+      <div class="p-notification--information u-no-margin--bottom">
+        <div class="p-notification__content">
+          <p class="p-notification__title p-heading--5">Discover the top open source security challenges facing 500+ organizations</p>
+          <p class="p-notification__message">
+            <a href="/engage/2025-state-of-software-supply-chain?utm_source=webbanner&utm_medium=organic&utm_campaign=701N100000UcKSjIAN">
+              Download the full report from IDC to learn more
+            </a>
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
     <div class="row--50-50 p-section--shallow">
       <hr class="p-rule--muted" />
       <div class="col">


### PR DESCRIPTION
## Done

- Adds notification banner to `/gcp`

## QA

- Go to https://ubuntu-com-15163.demos.haus/gcp
- Check that the notification banner is there and matches the [design](https://www.figma.com/design/vz3yAG1nYI7r5gc3SpTUOw/ubuntu.com-gcp--Google-Cloud-?node-id=53-1776&m=dev&t=T583MUoZcidEucEH-1)
  - [Link in copydoc](https://docs.google.com/document/d/1Gvt9tNFDZkqkBcP0k79C6ueTJCmNZvwoXQoU19WEa8E/edit?disco=AAABjwUKGyg)

## Issue / Card

Fixes [WD-22232](https://warthogs.atlassian.net/browse/WD-22232)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-22232]: https://warthogs.atlassian.net/browse/WD-22232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ