### PR TITLE
[WD-21953] Update CTA label on /pro/subscribe

### DIFF
--- a/static/js/src/advantage/subscribe/react/components/PaymentButton/PaymentButton.tsx
+++ b/static/js/src/advantage/subscribe/react/components/PaymentButton/PaymentButton.tsx
@@ -40,7 +40,7 @@ export default function PaymentButton() {
             location.href = "/account/checkout";
           }}
         >
-          Buy now
+          Continue to checkout
         </Button>
       )}
     </>

--- a/static/js/src/advantage/subscribe/react/components/ProductSummary/ProductSummary.test.tsx
+++ b/static/js/src/advantage/subscribe/react/components/ProductSummary/ProductSummary.test.tsx
@@ -32,7 +32,7 @@ test("Should show Buy now button and full service description link when 'organis
   expect(
     screen.getAllByText("See full service description")[0],
   ).toHaveAttribute("href", "/legal/ubuntu-pro-description");
-  expect(screen.getAllByText("Buy now")[0]).toBeInTheDocument();
+  expect(screen.getAllByText("Continue to checkout")[0]).toBeInTheDocument();
 });
 
 test("Should show Ubuntu Pro Desktop when 'Desktops' is selected ", async () => {
@@ -51,7 +51,7 @@ test("Should show Ubuntu Pro Desktop when 'Desktops' is selected ", async () => 
   expect(
     screen.getAllByText("See full service description")[0],
   ).toHaveAttribute("href", "/legal/ubuntu-pro-description");
-  expect(screen.getAllByText("Buy now")[0]).toBeInTheDocument();
+  expect(screen.getAllByText("Continue to checkout")[0]).toBeInTheDocument();
 });
 test("Should show register button and person subscription terms of service when 'myself' is selected ", async () => {
   render(


### PR DESCRIPTION
## Done

- Updated label on /pro/subscribe buy button

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Visit /pro/subscribe
    - The CTA button label should have changed
    - pressing the button should still redirect to /account/checkout

## Issue / Card

Fixes [#WD-21953](https://warthogs.atlassian.net/browse/WD-21953)

## Screenshots

![image](https://github.com/user-attachments/assets/b89d5067-f175-4b2e-9ec4-5a19a4180e84)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
