### PR TITLE
[WD-17822] feat: rebrand kernel bubble

### DIFF
--- a/meganav.yaml
+++ b/meganav.yaml
@@ -425,6 +425,9 @@ products:
             - title: IoT Professional Services
               description: Bring IoT devices to market
               url: /core/services
+            - title: Kernel
+              description: Ubuntu kernel on certified hardware
+              url: /kernel
 
       secondary_links:
         - title: Quick links

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "url-polyfill": "1.1.12",
     "url-search-params-polyfill": "8.2.5",
     "use-query-params": "^2.2.1",
-    "vanilla-framework": "4.23.0",
+    "vanilla-framework": "4.24.0",
     "yup": "1.4.0"
   },
   "resolutions": {

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1619,7 +1619,7 @@ ol.p-list--divided .p-list__item::before {
   row-gap: 0.5rem;
 }
 
-@media screen and (max-width: $breakpoint-large - 1) {
+@media screen and (max-width: #{ $breakpoint-large - 1 }) {
   .u-table-horizontal-scroll {
     overflow-x: hidden;
     .u-table-horizontal-scroll__table {

--- a/templates/kernel/form-data.json
+++ b/templates/kernel/form-data.json
@@ -1,0 +1,435 @@
+{
+  "form": {
+    "/kernel": {
+      "templatePath": "/kernel/index.html",
+      "childrenPaths": ["/kernel/lifecycle", "/kernel/variants"],
+      "isModal": true,
+      "modalId": "kernel-modal",
+      "formData": {
+        "title": "Contact us about Ubuntu kernels",
+        "formId": 6269,
+        "returnUrl": "/kernel#contact-form-success",
+        "lpUrl": "https://pages.ubuntu.com/things-contact-us.html",
+        "product": ""
+      },
+      "fieldsets": [
+        {
+          "title": "Tell us about your project",
+          "id": "about-your-project",
+          "fields": [
+            {
+              "type": "long-text",
+              "id": "about-your-project",
+              "label": "About your project"
+            }
+          ]
+        },
+        {
+          "title": "In which industry do you operate?",
+          "id": "industry",
+          "inputType": "checkbox",
+          "isRequired": true,
+          "fields": [
+            {
+              "type": "checkbox",
+              "id": "industrial",
+              "value": "Industrial",
+              "label": "Industrial"
+            },
+            {
+              "type": "checkbox",
+              "id": "automotive",
+              "value": "Automotive",
+              "label": "Automotive"
+            },
+            {
+              "type": "checkbox",
+              "id": "telco",
+              "value": "Telco",
+              "label": "Telco"
+            },
+            {
+              "type": "checkbox",
+              "id": "public-sector",
+              "value": "Public Sector",
+              "label": "Public Sector"
+            },
+            {
+              "type": "checkbox",
+              "id": "other-industry",
+              "label": "Other",
+              "value": "Other",
+              "hasTextarea": true
+            }
+          ]
+        },
+        {
+          "title": "Which architecture are you using?",
+          "id": "architecture",
+          "inputType": "checkbox",
+          "isRequired": true,
+          "fields": [
+            {
+              "type": "checkbox",
+              "id": "arm",
+              "value": "ARM",
+              "label": "ARM"
+            },
+            {
+              "type": "checkbox",
+              "id": "x86",
+              "value": "x86",
+              "label": "x86"
+            },
+            {
+              "type": "checkbox",
+              "id": "risc-v",
+              "value": "RISC-V",
+              "label": "RISC-V"
+            },
+            {
+              "type": "checkbox",
+              "id": "other-architecture",
+              "label": "Other",
+              "value": "Other",
+              "hasTextarea": true
+            }
+          ]
+        },
+        {
+          "title": "Which hardware are you using?",
+          "id": "hardware",
+          "inputType": "checkbox",
+          "isRequired": true,
+          "fields": [
+            {
+              "type": "checkbox",
+              "id": "intel",
+              "value": "Intel",
+              "label": "Intel"
+            },
+            {
+              "type": "checkbox",
+              "id": "amd",
+              "value": "AMD",
+              "label": "AMD"
+            },
+            {
+              "type": "checkbox",
+              "id": "nvidia",
+              "value": "Nvidia",
+              "label": "Nvidia"
+            },
+            {
+              "type": "checkbox",
+              "id": "mediatek",
+              "value": "Mediatek",
+              "label": "Mediatek"
+            },
+            {
+              "type": "checkbox",
+              "id": "nxp",
+              "value": "NXP",
+              "label": "NXP"
+            },
+            {
+              "type": "checkbox",
+              "id": "raspberry-pi",
+              "value": "Raspberry Pi",
+              "label": "Raspberry Pi"
+            },
+            {
+              "type": "checkbox",
+              "id": "renesas",
+              "value": "Renesas",
+              "label": "Renesas"
+            },
+            {
+              "type": "checkbox",
+              "id": "xilinx",
+              "value": "Xilinx",
+              "label": "Xilinx"
+            },
+            {
+              "type": "checkbox",
+              "id": "ibm",
+              "value": "IBM",
+              "label": "IBM"
+            },
+            {
+              "type": "checkbox",
+              "id": "other-hardware",
+              "label": "Other",
+              "value": "Other",
+              "hasTextarea": true
+            }
+          ]
+        },
+        {
+          "title": "If you use Ubuntu, which version(s) are you using?",
+          "id": "ubuntu-versions",
+          "inputType": "checkbox-visibility",
+          "fields": [
+            {
+              "fieldTitle": "LTS within standard support",
+              "options": [
+                {
+                  "type": "checkbox",
+                  "id": "24-04",
+                  "value": "24.04 LTS",
+                  "label": "24.04 LTS"
+                },
+                {
+                  "type": "checkbox",
+                  "id": "22-04",
+                  "value": "22.04 LTS",
+                  "label": "22.04 LTS"
+                },
+                {
+                  "type": "checkbox",
+                  "id": "20-04",
+                  "value": "20.04 LTS",
+                  "label": "20.04 LTS"
+                }
+              ]
+            },
+            {
+              "fieldTitle": "LTS out of standard support",
+              "options": [
+                {
+                  "type": "checkbox",
+                  "id": "18-04",
+                  "value": "18.04 LTS",
+                  "label": "18.04 LTS"
+                },
+                {
+                  "type": "checkbox",
+                  "id": "16-04",
+                  "value": "16.04 LTS",
+                  "label": "16.04 LTS"
+                },
+                {
+                  "type": "checkbox",
+                  "id": "14-04",
+                  "value": "14.04 LTS",
+                  "label": "14.04 LTS"
+                }
+              ]
+            },
+            {
+              "fieldTitle": "Other",
+              "options": [
+                {
+                  "type": "checkbox",
+                  "id": "outdated-lts-release",
+                  "value": "Outdated LTS release",
+                  "label": "Outdated LTS release"
+                },
+                {
+                  "type": "checkbox",
+                  "id": "non-lts-release",
+                  "value": "Non-LTS release",
+                  "label": "Non-LTS release"
+                },
+                {
+                  "type": "checkbox",
+                  "id": "dont-use-ubuntu-today",
+                  "value": "I don't use Ubuntu today",
+                  "label": "I don't use Ubuntu today"
+                },
+                {
+                  "type": "checkbox",
+                  "id": "i-dont-know",
+                  "value": "I don't know",
+                  "label": "I don't know"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "title": "Which kernel variant are you interested in?",
+          "id": "kernel-variant",
+          "isRequired": true,
+          "inputType": "checkbox",
+          "fields": [
+            {
+              "type": "checkbox",
+              "id": "generic",
+              "value": "Generic",
+              "label": "Generic"
+            },
+            {
+              "type": "checkbox",
+              "id": "fips",
+              "value": "FIPS",
+              "label": "FIPS"
+            },
+            {
+              "type": "checkbox",
+              "id": "realtime",
+              "value": "Real-time (PREEMPT_RT)",
+              "label": "Real-time (PREEMPT_RT)"
+            },
+            {
+              "type": "checkbox",
+              "id": "other-variant",
+              "label": "Other",
+              "value": "Other",
+              "hasTextarea": true
+            }
+          ]
+        },
+        {
+          "title": "What kind of device are you using?",
+          "id": "kind-of-device",
+          "isRequired": true,
+          "inputType": "checkbox",
+          "fields": [
+            {
+              "type": "checkbox",
+              "id": "desktop-workstation",
+              "value": "desktop/workstation",
+              "label": "Desktop/Workstation"
+            },
+            {
+              "type": "checkbox",
+              "id": "physical-server",
+              "value": "physical/server",
+              "label": "Physical server"
+            },
+            {
+              "type": "checkbox",
+              "id": "public-cloud",
+              "value": "public/cloud",
+              "label": "Public cloud"
+            },
+            {
+              "type": "checkbox",
+              "id": "virtual-machine",
+              "value": "virtual/machine",
+              "label": "Virtual machine"
+            },
+            {
+              "type": "checkbox",
+              "id": "iot-edge-device",
+              "value": "iot/edge device",
+              "label": "IoT/Edge device"
+            }
+          ]
+        },
+        {
+          "title": "How many devices?",
+          "id": "how-many-machines",
+          "inputName": "how-many-machines-do-you-have",
+          "inputType": "radio",
+          "isRequired": true,
+          "fields": [
+            {
+              "type": "radio",
+              "id": "less-5-machines",
+              "value": "less than 5",
+              "label": "< 5 machines"
+            },
+            {
+              "type": "radio",
+              "id": "5-to-15-machines",
+              "value": "5 to 15 machines",
+              "label": "5 - 15 machines"
+            },
+            {
+              "type": "radio",
+              "id": "15-to-50-machines",
+              "value": "15 to 50 machines",
+              "label": "15 - 50 machines"
+            },
+            {
+              "type": "radio",
+              "id": "50-to-100-machines",
+              "value": "50 to 100 machines",
+              "label": "50 - 100 machines"
+            },
+            {
+              "type": "radio",
+              "id": "greater-than-100",
+              "value": "greater than 100",
+              "label": "> 100 machines"
+            }
+          ]
+        },
+        {
+          "title": "Who is responsible for tracking, testing and applying CVE patches in a timely manner?",
+          "id": "who-is-responsible-for-tracking",
+          "isRequired": true,
+          "inputType": "checkbox",
+          "fields": [
+            {
+              "type": "checkbox",
+              "id": "individual-developers",
+              "value": "Individual developers",
+              "label": "Individual developers"
+            },
+            {
+              "type": "checkbox",
+              "id": "the-project-team",
+              "value": "The project team",
+              "label": "The project team"
+            },
+            {
+              "type": "checkbox",
+              "id": "third-party-vendor",
+              "value": "Third-party vendor",
+              "label": "Third-party vendor"
+            },
+            {
+              "type": "checkbox",
+              "id": "i-dont-know",
+              "value": "I don't know",
+              "label": "I don't know"
+            }
+          ]
+        },
+        {
+          "title": "What advice are you looking for?",
+          "id": "advice",
+          "fields": [
+            {
+              "type": "long-text",
+              "id": "advice",
+              "label": "Tell us about your challenges and your goals"
+            }
+          ]
+        },
+        {
+          "title": "How should we get in touch?",
+          "id": "about-you",
+          "noCommentsFromLead": true,
+          "fields": [
+            {
+              "type": "text",
+              "id": "company",
+              "label": "Company name",
+              "isRequired": true
+            },
+            {
+              "type": "text",
+              "id": "title",
+              "label": "Job title",
+              "isRequired": true
+            },
+            {
+              "type": "tel",
+              "id": "phone",
+              "label": "Mobile/cell phone number"
+            },
+            {
+              "type": "country",
+              "label": "Country",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/templates/kernel/index.html
+++ b/templates/kernel/index.html
@@ -1,5 +1,7 @@
 {% extends "kernel/base_kernel.html" %}
 
+{% from "_macros/vf_hero.jinja" import vf_hero %}
+
 {% block title %}Ubuntu kernels from Canonical{% endblock %}
 
 {% block meta_description %}
@@ -8,157 +10,190 @@
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1XLdk2Slh4vi4AjGnatcK1BmJGmMNKIjN27KwbTwG5iI/{% endblock %}
 
+{% block body_class %}
+  is-paper
+{% endblock body_class %}
+
 {% block content %}
-  <section class="p-strip--suru is-dark">
-    <div class="row u-equal-height">
-      <div class="col-7">
-        <h1>Ubuntu kernels from Canonical</h1>
-        <p>
-          At the core of the Ubuntu operating system is the Linux kernel, which manages and controls the hardware resources like I/O (networking, storage, graphics and various user interface devices, etc.), memory and CPU for your device or computer. It is one of the first software programs a booting device loads and runs on the central processing unit (CPU). The Linux kernel manages the system's hardware environment so other programs like the operating system's user space programs and application software programs can run well without modification on a variety of different platforms and without needing to know very much about that underlying system.
-        </p>
-        <p>
-          <a class="p-link--inverted"
-             href="https://www.brighttalk.com/webcast/6793/398353/ubuntu-20-04-lts-whats-new-in-server">
-            Watch the webinar - "Ubuntu 20.04 LTS: What's new in server?"
-          </a>
-        </p>
+
+  {% call(slot) vf_hero(
+    title_text='Ubuntu kernels from Canonical',
+    subtitle_text='',
+    layout='50/50'
+    ) -%}
+    {%- if slot == 'description' -%}
+      <p>
+        At the core of the Ubuntu operating system is the Linux kernel, which manages and controls the hardware resources like I/O (networking, storage, graphics and various user interface devices, etc.), memory and CPU for your device or computer. It is one of the first software programs a booting device loads and runs on the central processing unit (CPU).
+      </p>
+      <p>
+        The Linux kernel manages the system's hardware environment so other programs like the operating system's user space programs and application software programs can run well without modification on a variety of different platforms and without needing to know very much about that underlying system.
+      </p>
+    {%- endif -%}
+  {% endcall -%}
+
+  <section class="p-section">
+    <hr class="p-rule is-fixed-width" />
+    <div class="row--50-50">
+      <div class="col">
+        <h2>Identifying a kernel</h2>
       </div>
-      <div class="col-5 u-align--center u-vertically-center u-hide--medium u-hide--small">
-        {{ image(url="https://assets.ubuntu.com/v1/3b5dc41b-Kernel_white.svg",
+      <div class="col">
+        <p>The easiest way to determine the kernel you're running is to type</p>
+        <div class="p-code-snippet">
+          <pre class="p-code-snippet__block--icon is-wrapped"><code>cat /proc/version_signature</code></pre>
+        </div>
+        <p>on the terminal. For example:</p>
+        <div class="p-code-snippet">
+          <pre class="p-code-snippet__block--icon is-wrapped"><code>cat /proc/version_signature</code><br /><code>Ubuntu 5.4.0-12.15-generic 5.4.8</code></pre>
+        </div>
+        <p>This output provides important information about the kernel:</p>
+        <hr class="p-rule--muted" />
+        <ul class="p-list--divided u-no-margin--bottom">
+          <li class="p-list__item has-bullet">
+            Canonical adds “<code>Ubuntu</code>” to the build number to indicate that this is an official build from the Ubuntu archive
+          </li>
+          <li class="p-list__item has-bullet">
+            Ubuntu kernel-release = <code>5.4.0-12.15-generic</code>
+            <ul class="p-list--divided u-no-margin--bottom">
+              <li class="p-list__item has-bullet">
+                kernel version is <code>5.4</code>, which is identical to upstream stable kernel version
+              </li>
+              <li class="p-list__item has-bullet">
+                <code>.0</code> is an obsolete parameter left over from older upstream kernel version naming practices
+              </li>
+              <li class="p-list__item has-bullet">
+                <code>-12</code> application binary interface (ABI) bump for this kernel
+              </li>
+              <li class="p-list__item has-bullet">
+                <code>.15</code> upload number for this kernel
+              </li>
+              <li class="p-list__item has-bullet">
+                <code>-generic</code> is kernel flavor parameter, where <code>-generic</code> is the default Ubuntu kernel flavor
+              </li>
+              <li class="p-list__item has-bullet">
+                Mainline kernel-version = <code>5.4.8</code>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </div>
+
+    </div>
+  </section>
+
+  <section class="p-section">
+    <hr class="p-rule is-fixed-width" />
+    <div class="row--50-50">
+      <div class="col">
+        <h2>Kernel and OS releases</h2>
+      </div>
+      <div class="col">
+        <p>
+          Canonical provides long-term support (LTS) kernels for <a href="/about/release-cycle">Ubuntu LTS releases</a>. Canonical also provides interim operating system releases with updated kernels every 6 months.
+        </p>
+        <p>
+          For customers and business partners that don't have specialized bleeding-edge workloads or latest hardware needs, the latest  LTS release “-generic” kernel is the best option for them such as the 4.15 default kernel in Ubuntu 18.04 LTS. Customers who need the latest hardware support capability can install the latest HWE kernel such as the ones contained in interim releases, keeping in mind the shorter support lifespan associated with these kernels (9 months). HWE kernel customers are recommended to upgrade to a newer LTS release that supports their hardware and/or software needs as soon as it is available. Another option for customers is to use point releases. For example, there is an 18.04.4 point release as of February 2020, which includes an updated 5.3.x kernel but is also considered LTS, exactly like the original GA 4.15 kernel in 18.04.
+        </p>
+        <div class="p-cta-block">
+          <a href="/kernel/lifecycle">Learn more about the Ubuntu kernel support lifecycle&nbsp;&rsaquo;</a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <hr class="p-rule is-fixed-width" />
+    <div class="p-section--shallow">
+      <div class="row--50-50">
+        <div class="col">
+          <h2>Kernel security</h2>
+        </div>
+        <div class="col">
+          <p>
+            The Canonical Kernel Team's primary focus is the careful maintenance of kernels and their variants for regular delivery via the <a href="https://wiki.ubuntu.com/StableReleaseUpdates">Ubuntu SRU process</a>, and the Canonical <a href="/security/livepatch">livepatch service</a>. This includes rigorous management of Common Vulnerabilities and Exposures (CVEs) assigned to the Linux kernel and application of relevant patches for all critical and serious kernel defects and then rigorously testing newly updated kernels end-to-end each SRU cycle.
+          </p>
+        </div>
+      </div>
+    </div>
+    <div class="u-fixed-width">
+      <div class="p-image-container--cinematic is-cover">
+        {{ image(url="https://assets.ubuntu.com/v1/11de01ee-Kernel security.png",
                 alt="",
-                height="248",
-                width="280",
+                width="2464",
+                height="1027",
                 hi_def=True,
-                loading="auto",) | safe
+                loading="lazy",
+                attrs={"class": "p-image-container__image"}) | safe
         }}
       </div>
     </div>
   </section>
 
-  <section class="p-strip is-bordered">
-    <div class="row">
-      <div class="col-7">
-        <h2 id="identifying-a-kernel">Identifying a kernel</h2>
-        <p>
-          The easiest way to determine the kernel you're running is to type <code>cat /proc/version_signature</code> on the terminal. For example:
-        </p>
-      </div>
-    </div>
-    <div class="u-fixed-width">
-      <p>
-        <code>$ cat /proc/version_signature</code>
-      </p>
-      <p>
-        <code><em>Ubuntu 5.4.0-12.15-generic 5.4.8</em></code>
-      </p>
-    </div>
-    <div class="row">
-      <div class="col-7">
-        <p>This output provides important information about the kernel:</p>
-        <ul>
-          <li>
-            Canonical adds "<code><em>Ubuntu</em></code>"
-          </li>
-          <li>
-            Ubuntu kernel-release = <code><em>5.4.0-12.15-generic</em></code>
-            <ul>
-              <li>
-                kernel version is <code><em>5.4</em></code>, which is identical to upstream stable kernel version
-              </li>
-              <li>
-                <code><em>.0</em></code> is an obsolete parameter left over from older upstream kernel version naming practices
-              </li>
-              <li>
-                <code><em>-12</em></code> application binary interface (ABI) bump for this kernel
-              </li>
-              <li>
-                <code><em>.15</em></code> upload number for this kernel
-              </li>
-              <li>
-                <code><em>-generic</em></code> is kernel flavour parameter, where <code><em>-generic</em></code> is the default Ubuntu kernel flavour
-              </li>
-            </ul>
-          </li>
-          <li>
-            Mainline kernel-version = <code><em>5.4.8</em></code>
-          </li>
-        </ul>
-      </div>
-    </div>
-  </section>
-
-  <section class="p-strip is-bordered">
-    <div class="u-fixed-width">
-      <h2 id="kernel-os-and-releases">Kernel and OS releases</h2>
-      <p>
-        Canonical provides long-term support (LTS) kernels for <a href="/about/release-cycle">Ubuntu LTS releases</a>. Canonical also provides interim operating system releases with updated kernels every 6 months.
-      </p>
-      <p>
-        For customers and business partners that don't have specialised bleeding-edge workloads or latest hardware needs, the latest  LTS release "-generic" kernel is the best option for them such as the 4.15 default kernel in Ubuntu 18.04 LTS. Customers who need the latest hardware support capability can install the latest HWE kernel such as the ones contained in interim releases, keeping in mind the shorter support lifespan associated with these kernels (9 months). HWE kernel customers are recommended to upgrade to a newer LTS release that supports their hardware and/or software needs as soon as it is available. Another option for customers is to use point releases. For example, there is an 18.04.4 point release as of February 2020, which includes an updated 5.3.x kernel but is also considered LTS, exactly like the original GA 4.15 kernel in 18.04.
-      </p>
-      <p>
-        <a href="/kernel/lifecycle">More details on the Ubuntu kernel support lifecycle&nbsp;&rsaquo;</a>
-      </p>
-    </div>
-  </section>
-
-  <section class="p-strip--light is-bordered">
-    <div class="u-fixed-width">
-      <h2 id="kernel-security">Kernel security</h2>
-      <p>
-        The Canonical Kernel Team's primary focus is the careful maintenance of kernels and their variants for regular delivery via the <a href="https://wiki.ubuntu.com/StableReleaseUpdates">Ubuntu SRU process</a> and the Canonical <a href="/security/livepatch">livepatch service</a>. This includes rigorous management of all Linux kernel Common Vulnerabilities and Exposures (CVE) lists (with a focus on patching  all <a href="/security/cves/about#priority">high and critical</a> CVEs) review and application of all relevant patches for all critical and serious kernel defects in the mailing lists and then rigorously testing newly updated kernels end-to-end each SRU cycle.
-      </p>
-    </div>
-  </section>
-
-  <section class="p-strip is-bordered">
-    <div class="u-fixed-width">
-      <h2 id="general-availability-and-variant-ubuntu-kernels">General Availability (GA) and variant Ubuntu kernels</h2>
-      <p>
-        The complete functionality of any given kernel is determined by the included modules and the kernel configuration for both hardware and the expected workloads that are run on it.
-      </p>
-      <p>
-        Kernel modules are binary programs that extend a kernel's ability to control the computing system's hardware or add additional system capabilities like high-performance networking or non-standard graphics, etc. The GA kernel that is shipped by default, with the Canonical Ubuntu Long Term Support (LTS) and Hardware Enablement (HWE) releases, are tuned for stable, reliable, secure, high-performance operation over a wide variety of hardware platforms and workloads.
-      </p>
-      <p>
-        A kernel variant is a kernel that deviates from the generic GA kernel by changes to its configuration, and/or by having modules added and/or removed.
-      </p>
-      <p>
-        <a href="/kernel/variants">Should my organisation use a variant kernel?&nbsp;&rsaquo;</a>
-      </p>
-    </div>
-  </section>
-
-  <section class="p-strip--light">
-    <div class="u-fixed-width">
-      <h2 id="custom-kernels">Optimised kernels</h2>
-      <p>
-        Canonical advocates for customers to use the GA kernel shipped with Ubuntu as the best and most cost-effective option in their business environment. We also offer the option for customers to customize their own Ubuntu kernels. Several of our enterprise, Telco and cloud provider customers have systems and workload needs, which justify both the time investment to optimise their kernels and the pay to develop and maintain those optimised kernels over time.
-      </p>
-    </div>
-  </section>
-
-  <section class="is-active p-takeover--dark js-takeover is-dark">
-    <div class="row u-equal-height">
-      <div class="col-6 col-medium-3 u-vertically-center">
-        <p class="p-text--small-caps">Whitepaper</p>
-        <h2 class="p-heading--1 u-no-padding--top">
-          A CTO's guide to real-time kernel
+  <section class="p-section">
+    <hr class="p-rule is-fixed-width" />
+    <div class="row--50-50">
+      <div class="col">
+        <h2>
+          General Availability (GA) and
+          <br class="u-hide--small" />
+          variant Ubuntu kernels
         </h2>
-        <h3 class="p-heading--4">Understanding real-time systems, their cases and inner workings</h3>
+      </div>
+      <div class="col">
         <p>
-          <a href="/engage/cto-guide-real-time-kernel?utm_source=kernelpage"
-              class="p-button--positive u-no-margin--bottom">Download <span class="u-off-screen">the RTF guide</span> now</a>
+          The complete functionality of any given kernel is determined by the included modules and the kernel configuration for both hardware and the expected workloads that are run on it.
+        </p>
+        <p>
+          Kernel modules are binary programs that extend a kernel’s ability to control the computing system’s hardware or add additional system capabilities like high-performance networking or non-standard graphics, etc.   The GA kernel that is shipped by default, with the Canonical Ubuntu Long Term Support (LTS) and Hardware Enablement (HWE) releases, are tuned for stable, reliable, secure, high-performance operation over a wide variety of hardware platforms and workloads.
+        </p>
+        <p>
+          A kernel variant is a kernel that deviates from the generic GA kernel by changes to its configuration, and/or by having modules added and/or removed.
+        </p>
+        <div class="p-cta-block">
+          <a href="/kernel/variants">Learn more about Ubuntu kernel variants from Canonical&nbsp;&rsaquo;</a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <hr class="p-rule is-fixed-width" />
+    <div class="row--50-50">
+      <div class="col">
+        <h2>Optimized kernels</h2>
+      </div>
+      <div class="col">
+        <p>
+          Canonical advocates for customers to use the GA kernel shipped with Ubuntu as the best and most cost-effective option in their business environment. We also offer the option for customers to customize their own Ubuntu kernels. Several of our enterprise, Telco and cloud provider customers have systems and workload needs, which justify both the time investment to optimize their kernels and the pay to develop and maintain those optimized kernels over time.
         </p>
       </div>
-      <div class="col-6 col-medium-3 u-vertically-center u-align--center u-align--left-medium u-hide--small">
-        <a href="/engage/cto-guide-real-time-kernel?utm_source=kernelpage"
-           aria-label="Download the RTF guide now">
-          <img src="https://assets.ubuntu.com/v1/3fa3e0f0-RTK-wp-cover.png"
-               width="250"
-               height="354" 
-               alt=""/>
-        </a>
+    </div>
+  </section>
+
+  <section class="p-section--deep">
+    <hr class="p-rule is-fixed-width" />
+    <div class="row--50-50">
+      <div class="col">
+        <h2>A CTO's guide to real-time kernel</h2>
+      </div>
+      <div class="col">
+        <div class="p-section--shallow">
+          <div class="p-image-container--3-2 is-cover is-highlighted">
+            {{ image(url="https://assets.ubuntu.com/v1/8b433860-Whitepaper.png",
+                        alt="",
+                        width="1800",
+                        height="1014",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-image-container__image"}) | safe
+            }}
+          </div>
+        </div>
+        <p>Understanding real-time systems, their use cases and inner workings</p>
+        <div class="p-cta-block">
+          <a href="/engage/cto-guide-real-time-kernel?utm_source=kernelpage"
+             class="p-button--positive">Get the whitepaper</a>
+        </div>
       </div>
     </div>
   </section>

--- a/templates/kernel/lifecycle.html
+++ b/templates/kernel/lifecycle.html
@@ -1,117 +1,245 @@
 {% extends "kernel/base_kernel.html" %}
 
+{% from "_macros/vf_hero.jinja" import vf_hero %}
+
 {% block title %}Ubuntu kernel lifecycle and enablement stack{% endblock %}
 
-{% block meta_description %}Canonical provides long-term support (LTS) kernels for Ubuntu LTS releases. Canonical also provides interim operating system releases with updated kernels every 6 months. Learn about the lifecycle of each kernel through the lifespan of support.{% endblock meta_description %}
+{% block meta_description %}
+  Canonical provides long-term support (LTS) kernels for Ubuntu LTS releases. Canonical also provides interim operating system releases with updated kernels every 6 months. Learn about the lifecycle of each kernel through the lifespan of support.
+{% endblock meta_description %}
 
-{% block meta_copydoc %}https://docs.google.com/document/d/1d01SFs7c56ge2o92g6Rwr3SjG8rtxm3jNwIyL1N8mQg/edit#heading=h.929qtgja1pr8{% endblock %}
+{% block meta_copydoc %}
+  https://docs.google.com/document/d/1d01SFs7c56ge2o92g6Rwr3SjG8rtxm3jNwIyL1N8mQg/edit#heading=h.929qtgja1pr8
+{% endblock %}
+
+{% block body_class %}
+  is-paper
+{% endblock body_class %}
 
 {% block content %}
-<section class="p-strip--suru-topped is-bordered">
-  <div class="row">
-    <div class="col-8">
-      <h1>Ubuntu kernel lifecycle and enablement stack</h1>
-      <p>The Ubuntu LTS enablement, or Hardware Enablement (HWE), stack provides the newer kernel and X11 display support for existing Ubuntu LTS releases. That stack can be enabled manually, but may also be pre-enabled with an Ubuntu LTS release.</p>
+
+  {% call(slot) vf_hero(
+    title_text='Ubuntu kernel lifecycle<br /> and enablement stack',
+    layout='50/50',
+    is_split_on_medium=true
+    ) -%}
+    {%- if slot == 'description' -%}
+      <p>
+        The Ubuntu LTS enablement, or Hardware Enablement (HWE), stack provides newer kernel and X11 display support for existing Ubuntu LTS releases. That stack can be enabled manually, but may also be pre-enabled with an Ubuntu LTS release.
+      </p>
       <p>The HWE stack can be used by desktop and server systems, as well as cloud or virtual images.</p>
-    </div>
-  </div>
-</section>
+    {%- endif -%}
+  {% endcall -%}
 
-<section class="p-strip--light is-bordered">
-  <div class="row">
-    <div class="col-8">
-      <h2>Installation</h2>
+  <section class="p-section">
+    <hr class="p-rule is-fixed-width" />
+    <div class="row--50-50-on-large">
+      <div class="col">
+        <h2>Installation</h2>
+      </div>
+      <div class="col">
+        <div class="p-tabs js-tabbed-content">
+          <div class="p-tabs__list" role="tablist">
+            <div class="p-tabs__item">
+              <button class="p-tabs__link"
+                      id="installation-24-04-tab"
+                      role="tab"
+                      aria-controls="installation-24-04"
+                      aria-selected="true">24.04 LTS</button>
+            </div>
+            <div class="p-tabs__item">
+              <button class="p-tabs__link"
+                      id="installation-22-04-tab"
+                      role="tab"
+                      aria-controls="installation-22-04"
+                      aria-selected="true">22.04 LTS</button>
+            </div>
+            <div class="p-tabs__item">
+              <button class="p-tabs__link"
+                      id="installation-20-04-tab"
+                      role="tab"
+                      aria-controls="installation-20-04">20.04 LTS</button>
+            </div>
+            <div class="p-tabs__item">
+              <button class="p-tabs__link"
+                      id="installation-18-04-tab"
+                      role="tab"
+                      aria-controls="installation-18-04">18.04 LTS</button>
+            </div>
+            <div class="p-tabs__item">
+              <button class="p-tabs__link"
+                      id="installation-16-04-tab"
+                      role="tab"
+                      aria-controls="installation-16-04">16.04 LTS</button>
+            </div>
+            <div class="p-tabs__item">
+              <button class="p-tabs__link"
+                      id="installation-14-04-tab"
+                      role="tab"
+                      aria-controls="installation-14-04">14.04 LTS</button>
+            </div>
+          </div>
+          <div tabindex="0"
+               id="installation-14-04"
+               role="tabpanel"
+               aria-labelledby="installation-14-04-tab">
+            <p>Ubuntu 14.04 LTS &mdash; Trusty Tahr</p>
+            <p>Desktop:</p>
+            <div class="p-code-snippet">
+              <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-lts-xenial xserver-xorg-core-lts-xenial xserver-xorg-lts-xenial xserver-xorg-video-all-lts-xenial xserver-xorg-input-all-lts-xenial libwayland-egl1-mesa-lts-xenial</code></pre>
+            </div>
+            <p>Server:</p>
+            <div class="p-code-snippet">
+              <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-lts-xenial</code></pre>
+            </div>
+            <p>
+              The 14.04.2 and newer point releases ship with an updated kernel and X stack by default. If you have installed with older media, you can use these instructions to install the newer HWE kernel derived from 16.04 (Xenial).
+            </p>
+            <p>
+              If you run a multiarch desktop (for example, i386 and amd64 on amd64, for gaming or Wine), you may find you need a slightly more involved command:
+            </p>
+            <div class="p-code-snippet">
+              <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-lts-xenial xserver-xorg-core-lts-xenial xserver-xorg-lts-xenial xserver-xorg-video-all-lts-xenial xserver-xorg-input-all-lts-xenial libwayland-egl1-mesa-lts-xenial libgl1-mesa-glx-lts-xenial libgl1-mesa-glx-lts-xenial:i386 libglapi-mesa-lts-xenial:i386</code></pre>
+            </div>
+          </div>
 
-        <nav class="p-tabs js-tabbed-content">
-          <ul class="p-tabs__list" role="tablist">
-            <li class="p-tabs__item" role="presentation">
-              <a href="#installation-22-04" class="p-tabs__link" id="installation-22-04-tab" role="tab" aria-controls="installation-22-04" aria-selected="true">22.04 LTS</a>
-            </li>
-            <li class="p-tabs__item" role="presentation">
-              <a href="#installation-20-04" class="p-tabs__link" id="installation-20-04-tab" role="tab" aria-controls="installation-20-04">20.04 LTS</a>
-            </li>
-            <li class="p-tabs__item" role="presentation">
-              <a href="#installation-18-04" class="p-tabs__link" id="installation-18-04-tab" role="tab" aria-controls="installation-18-04">18.04 LTS</a>
-            </li>
-            <li class="p-tabs__item" role="presentation">
-              <a href="#installation-16-04" class="p-tabs__link" id="installation-16-04-tab" role="tab" aria-controls="installation-16-04">16.04 LTS</a>
-            </li>
-            <li class="p-tabs__item" role="presentation">
-              <a href="#installation-14-04" class="p-tabs__link" id="installation-14-04-tab" role="tab" aria-controls="installation-14-04">14.04 LTS</a>
-            </li>
-          </ul>
-        </nav>
+          <div tabindex="0"
+               id="installation-16-04"
+               role="tabpanel"
+               aria-labelledby="installation-16-04-tab">
+            <p>Ubuntu 16.04 LTS &mdash; Xenial Xerus</p>
+            <p>Desktop:</p>
+            <div class="p-code-snippet">
+              <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-hwe-16.04 xserver-xorg-hwe-16.04</code></pre>
+            </div>
+            <p>Server:</p>
+            <div class="p-code-snippet">
+              <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-hwe-16.04</code></pre>
+            </div>
+            <p>
+              The 16.04.2 and newer point releases ship with an updated kernel and X stack by default for the desktop. Server installations default to the GA kernel and provide the enablement kernel as optional.
+            </p>
+            <p>
+              The 16.04 HWE stacks follow <a href="https://wiki.ubuntu.com/Kernel/RollingLTSEnablementStack">the Rolling Update Model</a>.
+            </p>
+          </div>
 
-        <div class="p-tabs__content" id="installation-14-04" role="tabpanel" aria-labelledby="installation-14-04-tab">
-          <p>Ubuntu 14.04 LTS &mdash; Trusty Tahr</p>
-          <p>Desktop:</p>
-          <pre><code>sudo apt-get install --install-recommends linux-generic-lts-xenial xserver-xorg-core-lts-xenial xserver-xorg-lts-xenial xserver-xorg-video-all-lts-xenial xserver-xorg-input-all-lts-xenial libwayland-egl1-mesa-lts-xenial</code></pre>
-          <p>Server:</p>
-          <pre><code>sudo apt-get install --install-recommends linux-generic-lts-xenial</code></pre>
-          <p>The 14.04.2 and newer point releases ship with an updated kernel and X stack by default. If you have installed with older media, you can use these instructions to install the newer HWE kernel derived from 16.04 (Xenial).</p>
-          <p>If you run a multiarch desktop (for example, i386 and amd64 on amd64, for gaming or Wine), you may find you need a slightly more involved command:</p>
-          <pre><code>sudo apt-get install --install-recommends linux-generic-lts-xenial xserver-xorg-core-lts-xenial xserver-xorg-lts-xenial xserver-xorg-video-all-lts-xenial xserver-xorg-input-all-lts-xenial libwayland-egl1-mesa-lts-xenial libgl1-mesa-glx-lts-xenial libgl1-mesa-glx-lts-xenial:i386 libglapi-mesa-lts-xenial:i386</code></pre>
-        </div>
+          <div tabindex="0"
+               id="installation-18-04"
+               role="tabpanel"
+               aria-labelledby="installation-18-04-tab">
+            <p>Ubuntu 18.04 LTS &mdash; Bionic Beaver</p>
+            <p>Desktop:</p>
+            <div class="p-code-snippet">
+              <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-hwe-18.04 xserver-xorg-hwe-18.04</code></pre>
+            </div>
+            <p>Server:</p>
+            <div class="p-code-snippet">
+              <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-hwe-18.04</code></pre>
+            </div>
+            <p>
+              The 18.04.2 and newer point releases will ship with an updated kernel and X stack by default for the desktop. Server installations will default to the GA kernel and provide the enablement kernel as optional.
+            </p>
+            <p>
+              The 18.04 HWE stacks follow <a href="/about/release-cycle#ubuntu-kernel-release-cycle">the Rolling Update Model</a>.
+            </p>
+          </div>
 
-        <div class="p-tabs__content" id="installation-16-04" role="tabpanel" aria-labelledby="installation-16-04-tab">
-          <p>Ubuntu 16.04 LTS &mdash; Xenial Xerus</p>
-          <p>Desktop:</p>
-          <pre><code>sudo apt-get install --install-recommends linux-generic-hwe-16.04 xserver-xorg-hwe-16.04</code></pre>
-          <p>Server:</p>
-          <pre><code>sudo apt-get install --install-recommends linux-generic-hwe-16.04</code></pre>
-          <p>The 16.04.2 and newer point releases ship with an updated kernel and X stack by default for the desktop. Server installations default to the GA kernel and provide the enablement kernel as optional.The 16.04 HWE stacks follow <a href="https://wiki.ubuntu.com/Kernel/RollingLTSEnablementStack">the Rolling Update Model</a>.</p>
-        </div>
+          <div tabindex="0"
+               id="installation-20-04"
+               role="tabpanel"
+               aria-labelledby="installation-20-04-tab">
+            <p>Ubuntu 20.04 LTS &mdash; Focal Fossa</p>
+            <p>Desktop:</p>
+            <div class="p-code-snippet">
+              <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-hwe-20.04</code></pre>
+            </div>
+            <p>Server:</p>
+            <div class="p-code-snippet">
+              <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-hwe-20.04</code></pre>
+            </div>
+            <p>
+              Desktop installations of 20.04 default to tracking the HWE stack. Server installations will default to the GA kernel and provide the enablement kernel as optional.
+            </p>
+            <p>
+              Note that certain desktop machines may be on a separate "OEM" track. To determine if the machine is eligible for this, run the command <code>ubuntu-drivers list-oem</code> from a terminal. If this is non-empty, the machine is running the OEM cadence instead of HWE.
+            </p>
+            <p>
+              The 20.04 HWE stack follows <a href="/about/release-cycle#ubuntu-kernel-release-cycle">the Rolling Update Model</a>.
+            </p>
+          </div>
 
-        <div class="p-tabs__content" id="installation-18-04" role="tabpanel" aria-labelledby="installation-18-04-tab">
-          <p>Ubuntu 18.04 LTS &mdash; Bionic Beaver</p>
-          <p>Desktop:</p>
-          <pre><code>sudo apt-get install --install-recommends linux-generic-hwe-18.04 xserver-xorg-hwe-18.04</code></pre>
-          <p>Server:</p>
-          <pre><code>sudo apt-get install --install-recommends linux-generic-hwe-18.04</code></pre>
-          <p>The 18.04.2 and newer point releases will ship with an updated kernel and X stack by default for the desktop. Server installations will default to the GA kernel and provide the enablement kernel as optional.</p>
-          <p>The 18.04 HWE stacks follow <a href="/about/release-cycle#ubuntu-kernel-release-cycle">the Rolling Update Model</a>.</p>
-        </div>
+          <div tabindex="0"
+               id="installation-22-04"
+               role="tabpanel"
+               aria-labelledby="installation-22-04-tab">
+            <p>Ubuntu 22.04 LTS &mdash; Jammy Jellyfish</p>
+            <p>Desktop:</p>
+            <div class="p-code-snippet">
+              <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-hwe-22.04</code></pre>
+            </div>
+            <p>Server:</p>
+            <div class="p-code-snippet">
+              <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-hwe-22.04</code></pre>
+            </div>
+            <p>
+              Desktop installations of 22.04 default to tracking the HWE stack. Server installations will default to the GA kernel and provide the enablement kernel as optional.
+            </p>
+            <p>
+              Note that certain desktop machines may be on a separate “OEM” track. To determine if the machine is eligible for this, run the command <code>ubuntu-drivers list-oem</code> from a terminal. If this is non-empty, the machine is running the OEM cadence instead of HWE.
+            </p>
+            <p>
+              The 22.04 HWE stack follows <a href="/about/release-cycle#ubuntu-kernel-release-cycle">the Rolling Update Model</a>.
+            </p>
+          </div>
 
-        <div class="p-tabs__content" id="installation-20-04" role="tabpanel" aria-labelledby="installation-20-04-tab">
-          <p>Ubuntu 20.04 LTS &mdash; Focal Fossa</p>
-          <p>Desktop:</p>
-          <pre><code>sudo apt-get install --install-recommends linux-generic-hwe-20.04</code></pre>
-          <p>Server:</p>
-          <pre><code>sudo apt-get install --install-recommends linux-generic-hwe-20.04</code></pre>
-          <p>Desktop installations of 20.04 default to tracking the HWE stack. Server installations will default to the GA kernel and provide the enablement kernel as optional.</p>
-          <p>Note that certain desktop machines may be on a separate "OEM" track. To determine if the machine is eligible for this, run the command <code>ubuntu-drivers list-oem</code> from a terminal. If this is non-empty, the machine is running the OEM cadence instead of HWE.</p>
-          <p>The 20.04 HWE stack follows <a href="/about/release-cycle#ubuntu-kernel-release-cycle">the Rolling Update Model</a>.</p>
-        </div>
-
-        <div class="p-tabs__content" id="installation-22-04" role="tabpanel" aria-labelledby="installation-22-04-tab">
-          <p>Ubuntu 22.04 LTS &mdash; Jammy Jellyfish</p>
-          <p>Desktop:</p>
-          <pre><code>sudo apt-get install --install-recommends linux-generic-hwe-22.04</code></pre>
-          <p>Server:</p>
-          <pre><code>sudo apt-get install --install-recommends linux-generic-hwe-22.04</code></pre>
-          <p>Desktop installations of 22.04 default to tracking the HWE stack. Server installations will default to the GA kernel and provide the enablement kernel as optional.</p>
-          <p>Note that certain desktop machines may be on a separate “OEM” track. To determine if the machine is eligible for this, run the command <code>ubuntu-drivers list-oem</code> from a terminal. If this is non-empty, the machine is running the OEM cadence instead of HWE. </p>
-          <p>The 22.04 HWE stack follows <a href="/about/release-cycle#ubuntu-kernel-release-cycle">the Rolling Update Model</a>.</p>
+          <div tabindex="0"
+               id="installation-24-04"
+               role="tabpanel"
+               aria-labelledby="installation-24-04-tab">
+            <p>Ubuntu 24.04 LTS &mdash; Noble Numbat</p>
+            <p>Desktop:</p>
+            <div class="p-code-snippet">
+              <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-hwe-24.04</code></pre>
+            </div>
+            <p>Server:</p>
+            <div class="p-code-snippet">
+              <pre class="p-code-snippet__block is-wrapped"><code>sudo apt-get install --install-recommends linux-generic-hwe-24.04</code></pre>
+            </div>
+            <p>
+              Desktop installations of 24.04 default to tracking the HWE stack. Server installations will default to the GA kernel and provide the enablement kernel as optional.
+            </p>
+            <p>
+              Note that certain desktop machines may be on a separate “OEM” track. To determine if the machine is eligible for this, run the command <code>ubuntu-drivers list-oem</code> from a terminal. If this is non-empty, the machine is running the OEM cadence instead of HWE.
+            </p>
+            <p>
+              The 24.04 HWE stack follows <a href="/about/release-cycle#ubuntu-kernel-release-cycle">the Rolling Update Model</a>.
+            </p>
+          </div>
         </div>
       </div>
     </div>
-  </div>
-</section>
+  </section>
 
-<section class="p-strip is-bordered">
-  <div class="row">
-    <div class="col-8">
-      <h2>Check your support status</h2>
-      <p>To determine if your install is still supported, use this terminal command:</p>
-      <p>
-        <code>hwe-support-status --verbose</code>
-      </p>
+  <section class="p-section">
+    <hr class="p-rule is-fixed-width" />
+    <div class="row--50-50">
+      <div class="col">
+        <h2>Check your support status</h2>
+      </div>
+      <div class="col">
+        <p>
+          To determine if your install is still supported, use hwe-support-status:
+          <div class="p-code-snippet">
+            <pre class="p-code-snippet__block is-wrapped"><code>hwe-support-status --verbose</code></pre>
+          </div>
+        </p>
+      </div>
     </div>
-  </div>
-</section>
+  </section>
 
-{% include "shared/_kernel-support-schedule.html" %}
+  {% include "shared/_kernel-support-schedule.html" %}
 
-<script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
+  <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
 
 {% endblock %}

--- a/templates/kernel/variants.html
+++ b/templates/kernel/variants.html
@@ -1,157 +1,239 @@
 {% extends "kernel/base_kernel.html" %}
 
+{% from "_macros/vf_hero.jinja" import vf_hero %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
 {% block title %}Ubuntu kernel variants from Canonical{% endblock %}
+
+{% block meta_description %}
+  Ubuntu is an open source software operating system that runs from the desktop, to the cloud, to all your internet connected things.
+{% endblock %}
+
 {% block meta_copydoc %}https://docs.google.com/document/d/1UVxrF8raNb5Pggj05P0ar_OzV_uwhrTRHv9XRiuM4zs/{% endblock %}
 
+{% block body_class %}
+  is-paper
+{% endblock body_class %}
+
 {% block content %}
-<section class="p-strip--suru-topped is-bordered">
-  <div class="row">
-    <div class="col-8">
-      <h1>Ubuntu kernel variants from Canonical</h1>
-      <p>A kernel variant is a kernel that deviates from the General Availability (GA) kernel by changes to its configuration and/or by having modules added and/or removed. In short, a kernel variant is an Ubuntu kernel that reports a kernel version and flavour other than what is reported with an Ubuntu LTS <code><em>-generic</em></code> kernel when you run the <code>$ uname -a</code> command. It is possible to have kernel variants for multiple releases of a kernel, which is something that will happen naturally over time to a newly-released custom kernel.</p>
-      <p>Canonical's Kernel Team strives to support all use cases from the generic kernel. Only where this is not possible are kernel variants created. Variants fall into four broad categories:</p>
-      <ul class="p-list">
-        <li class="p-list__item is-ticked"><a href="#version-specific-kernels">Version-specific</a>, where the kernel base version differs</li>
-        <li class="p-list__item is-ticked"><a href="#configuration-specific-kernels">Configuration-specific</a>, where desired kernel configurations are incompatible and the underlying features are not runtime selectable</li>
-        <li class="p-list__item is-ticked"><a href="#platform-specific-kernels">Platform-specific</a>, where a specific platform requires patches that are not currently applicable to the primary kernels</li>
-        <li class="p-list__item is-ticked"><a href="#project-specific-kernels">Project-specific</a>, where project deadlines require expedited delivery</li>
-      </ul>
+
+  {% call(slot) vf_hero(
+    title_text='Ubuntu kernel variants from Canonical',
+    subtitle_text='',
+    layout='50/50-full-width-image'
+    ) -%}
+    {%- if slot == 'description' -%}
+      <p>
+        A kernel variant is a kernel that deviates from the General Availability (GA) kernel by changes to its configuration and/or by having modules added and/or removed. In short, a kernel variant is an Ubuntu kernel that reports a kernel version and flavour other than what is reported with an Ubuntu LTS “<code>-generic</code>” kernel when you run the <code>$ uname -a command</code>. It is possible to have kernel variants for multiple releases of a kernel, which is something that will happen naturally over time to a newly-released custom kernel.
+      </p>
+    {%- endif -%}
+
+    {%- if slot == 'cta' -%}
+      <a href="/kernel/real-time/contact-us"
+         class="p-button--positive js-invoke-modal"
+         aria-controls="kernel-modal">Get in touch</a>
+    {%- endif -%}
+
+    {%- if slot == 'image' -%}
+      <div class="p-image-container--cinematic is-cover is-highlighted">
+        {{ image(url="https://assets.ubuntu.com/v1/7e057da2-Hero.png",
+                alt="",
+                width="2464",
+                height="1176",
+                hi_def=True,
+                loading="auto",
+                attrs={"class":"p-image-container__image"}) | safe
+        }}
+      </div>
+    {% endif -%}
+  {% endcall -%}
+
+  <section class="p-section">
+    {%- call(slot) vf_tiered_list(is_description_full_width_on_desktop=false, is_list_full_width_on_tablet=true) -%}
+      {%- if slot == 'title' -%}
+        <h2>Variant categories</h2>
+      {%- endif -%}
+
+      {%- if slot == 'description' -%}
+        <div class="p-section--shallow">
+          <p>
+            Canonical's Kernel Team strives to support all use cases from the generic kernel. Only where this is not possible are kernel variants created. Variants fall into four broad categories:
+          </p>
+        </div>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_title_1' -%}
+        <h3 class="p-text--small-caps">Version-specific kernels</h3>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_description_1' -%}
+        <p class="p-heading--5">Version-specific, where the kernel base version differs</p>
+        <p>
+          It is not possible to sensibly combine kernels at different upstream versions. For any Ubuntu LTS release  where we carry a General Availability (GA) kernel at one version, and a Hardware Enablement (HWE) kernel at another version, those are delivered as separate kernels. Version-specific kernels provide a consistent operating environment for Application Binary Interface (ABI)-sensitive workloads. It is not possible to combine kernels based on different upstream versions, which means maintaining a version-specific kernel is done through backporting fixes for serious/critical bugs and CVEs, which is the primary differentiator for this kernel variant. Version-specific kernels are just as rigorously maintained by Canonical as our generic kernels but Canonical ensures backport of critical/high CVE mitigation.
+        </p>
+        <p>
+          There is no significant additional technical consideration with a version-specific kernel variant since the work of backporting patches is a well-understood industry practice. However, there are business considerations regarding scope, cost and effort to maintain ABI compatibility over time as a version-specific kernel ages and gets further and further away from the latest upstream stable kernels, which makes backporting critical and high patches increasingly complicated and expensive.
+        </p>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_title_2' -%}
+        <h3 class="p-text--small-caps">Configuration-specific kernels</h3>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_description_2' -%}
+        <p class="p-heading--5">
+          Configuration-specific, where desired kernel configurations are incompatible and the underlying features are not runtime selectable
+        </p>
+        <p>
+          Our primary kernels are targeted to a general-purpose configuration with wide applicability. Where additional configuration combinations are needed, and cannot be runtime selected, we create use-case-specific kernels. For example, some memory management unit (MMU) page table code is build time selectable for performance reasons.
+        </p>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_title_3' -%}
+        <h3 class="p-text--small-caps">Platform-specific kernels</h3>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_description_3' -%}
+        <p class="p-heading--5">
+          Platform-specific, where a specific platform requires patches that are not currently applicable to the primary kernels
+        </p>
+        <p>
+          Some platforms exhibit a very large delta to the primary kernel code base. It is common for this delta to change platform-agnostic code in ways which create risk for other platforms and are not yet accepted upstream. In these cases it is desirable to create a separate kernel for this platform to contain the risk.
+        </p>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_title_4' -%}
+        <h3 class="p-text--small-caps">Project-specific kernels</h3>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_description_4' -%}
+        <p class="p-heading--5">Project-specific, where project deadlines require expedited delivery</p>
+        <p>
+          For some projects it might be required  to release kernels out of sync with the primary kernels, or to release fixes to those projects quicker than is possible to cycle a full suite of testing. In these cases it is desirable to create a separate kernel to release it from those constraints.
+        </p>
+      {%- endif -%}
+    {%- endcall -%}
+  </section>
+
+  <section class="p-section">
+    <div class="u-fixed-width">
+      <hr class="p-rule" />
+      <div class="p-section--shallow">
+        <h2>Current variant kernels</h2>
+      </div>
+      <table class="p-table--mobile-card u-no-margin--bottom" role="grid">
+        <thead>
+          <tr role="row">
+            <th>Name</th>
+            <th>Type</th>
+            <th width="50%;">Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr role="row">
+            <td role="rowheader" data-heading="Name">Generic</td>
+            <td role="gridcell" data-heading="Type">-</td>
+            <td role="gridcell" data-heading="Description">
+              The primary GA kernel, targeting a general-purpose configuration. It is the latest upstream kernel at the time of the release and remains on this version for the life of the release.
+            </td>
+          </tr>
+          <tr role="row">
+            <td role="rowheader" data-heading="Name">lowlatency</td>
+            <td role="gridcell" data-heading="Type">configuration</td>
+            <td role="gridcell" data-heading="Description">Targets latency sensitive applications such as sound processing.</td>
+          </tr>
+          <tr role="row">
+            <td role="rowheader" data-heading="Name">generic-hwe</td>
+            <td role="gridcell" data-heading="Type">version</td>
+            <td role="gridcell" data-heading="Description">
+              Targets a later version of the upstream kernel, and updates with respect to that every 6 months until it matches the GA kernel in the subsequent LTS release.
+            </td>
+          </tr>
+          <tr role="row">
+            <td role="rowheader" data-heading="Name">lowlatency-hwe</td>
+            <td role="gridcell" data-heading="Type">
+              version
+              <br />
+              configuration
+            </td>
+            <td role="gridcell" data-heading="Description">
+              Targets latency-sensitive applications such as sound processing at the same version as the generic-hwe kernel.
+            </td>
+          </tr>
+          <tr role="row">
+            <td role="rowheader" data-heading="Name">generic-hwe-edge</td>
+            <td role="gridcell" data-heading="Type">version</td>
+            <td role="gridcell" data-heading="Description">Provides early access to the next generic-hwe kernel.</td>
+          </tr>
+          <tr role="row">
+            <td role="rowheader" data-heading="Name">lowlatency-hwe-edge</td>
+            <td role="gridcell" data-heading="Type">
+              version
+              <br />
+              configuration
+            </td>
+            <td role="gridcell" data-heading="Description">Provides early access to the next lowlatency-hwe kernel.</td>
+          </tr>
+          <tr role="row">
+            <td role="rowheader" data-heading="Name">aws</td>
+            <td role="gridcell" data-heading="Type">configuration</td>
+            <td role="gridcell" data-heading="Description">Targeting the AWS cloud.</td>
+          </tr>
+          <tr role="row">
+            <td role="rowheader" data-heading="Name">azure</td>
+            <td role="gridcell" data-heading="Type">
+              configuration
+              <br />
+              version
+            </td>
+            <td role="gridcell" data-heading="Description">Targeting the Azure cloud.</td>
+          </tr>
+          <tr role="row">
+            <td role="rowheader" data-heading="Name">gcp/gke</td>
+            <td role="gridcell" data-heading="Type">configuration</td>
+            <td role="gridcell" data-heading="Description">Targeting the Google Compute Platform/Google Kubernetes Engine.</td>
+          </tr>
+          <tr role="row">
+            <td role="rowheader" data-heading="Name">raspi</td>
+            <td role="gridcell" data-heading="Type">platform</td>
+            <td role="gridcell" data-heading="Description">For the Raspberry Pi ARM board.</td>
+          </tr>
+          <tr role="row">
+            <td role="rowheader" data-heading="Name">snapdragon</td>
+            <td role="rowheader" data-heading="Type">platform</td>
+            <td role="rowheader" data-heading="Description">For the Qualcomm Snapdragon ARM64 board.</td>
+          </tr>
+          <tr role="row">
+            <td role="rowheader" data-heading="Name">oem</td>
+            <td role="rowheader" data-heading="Type">project</td>
+            <td role="rowheader" data-heading="Description">
+              Targeting various OEM projects. This carries early access drivers for hardware enablement. This kernel is typically used in the early phases of a project release, with a view to "upstreaming" any delta into the GA or HWE kernels and once this delta is incorporated the final platform is moved over to those kernels.
+            </td>
+          </tr>
+        </tbody>
+      </table>
     </div>
-  </div>
-</section>
-<section class="p-strip--light is-bordered">
-  <div class="row">
-    <div class="col-8">
-      <h2 id="version-specific-kernels">Version-specific kernels</h2>
-      <p>It is not possible to sensibly combine kernels at different upstream versions. For any Ubuntu LTS release  where we carry a General Availability (GA) kernel at one version, and a Hardware Enablement (HWE) kernel at another version, those are delivered as separate kernels. Version-specific kernels provide a consistent operating environment for Application Binary Interface (ABI)-sensitive workloads. It is not possible to combine kernels based on different upstream versions, which means maintaining a version-specific kernel is done through backporting fixes for serious/critical bugs and CVEs, which is the primary differentiator for this kernel variant. Version-specific kernels are just as rigorously maintained by Canonical as our generic kernels but Canonical ensures backport of critical/high CVE mitigation.</p>
-      <p>There is no significant additional technical consideration with a version-specific kernel variant since the work of backporting patches is a well-understood industry practice. However, there are business considerations regarding scope, cost and effort to maintain ABI compatibility over time as a version-specific kernel ages and gets further and further away from the latest upstream stable kernels, which makes backporting critical and high patches increasingly complicated and expensive.</p>
+  </section>
+
+  <section class="p-section--deep">
+    <hr class="p-rule is-fixed-width" />
+    <div class="row--50-50">
+      <div class="col">
+        <h2>Additional kernel variants</h2>
+      </div>
+      <div class="col">
+        <p>In addition to those kernel variants, Canonical offers FIPS certified kernels:</p>
+        <hr class="p-rule--muted" />
+        <ul class="p-list--divided u-no-margin--bottom">
+          <li class="p-list__item has-bullet">FIPS - Certified GA kernel for Ubuntu 16.04, 18.04 and 20.04</li>
+          <li class="p-list__item has-bullet">
+            FIPS - compliant GA kernel with critical security and patch updates for Ubuntu 16.04, 18.04 and 20.04
+          </li>
+        </ul>
+      </div>
     </div>
-  </div>
-</section>
-<section class="p-strip is-bordered">
-  <div class="row">
-    <div class="col-8">
-      <h2 id="configuration-specific-kernels">Configuration-specific kernels</h2>
-      <p>Our primary kernels are targeted to a general-purpose configuration with wide applicability. Where additional configuration combinations are needed, and cannot be runtime selected, we create use-case-specific kernels. For example, some memory management unit (MMU) page table code is build time selectable for performance reasons.</p>
-    </div>
-  </div>
-</section>
-<section class="p-strip--light is-bordered">
-  <div class="row">
-    <div class="col-8">
-      <h2 id="platform-specific-kernels">Platform-specific kernels</h2>
-      <p>Some platforms exhibit a very large delta to the primary kernel code base. It is common for this delta to change platform-agnostic code in ways which create risk for other platforms and are not yet accepted upstream. In these cases it is desirable to create a separate kernel for this platform to contain the risk.</p>
-    </div>
-  </div>
-</section>
-<section class="p-strip is-bordered">
-  <div class="row">
-    <div class="col-8">
-      <h2 id="project-specific-kernels">Project-specific kernels</h2>
-      <p>For some projects it might be required  to release kernels out of sync with the primary kernels, or to release fixes to those projects quicker than is possible to cycle a full suite of testing. In these cases it is desirable to create a separate kernel to release it from those constraints.</p>
-    </div>
-  </div>
-</section>
-<section class="p-strip--light is-bordered">
-  <div class="u-fixed-width">
-    <h2 id="current-variant-kernels">Current variant kernels</h2>
-    <table class="p-table--mobile-card" role="grid">
-      <thead>
-        <tr role="row">
-          <th>Name</th>
-          <th>Type</th>
-          <th width="60%;">Description</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr role="row">
-          <td role="rowheader" data-heading="Name">Generic</td>
-          <td role="gridcell" data-heading="Type">-</td>
-          <td role="gridcell" data-heading="Description">The primary GA kernel, targeting a general-purpose configuration. It is the latest upstream kernel at the time of the release and remains on this version for the life of the release.</td>
-        </tr>
-        <tr role="row">
-          <td role="rowheader" data-heading="Name">lowlatency</td>
-          <td role="gridcell" data-heading="Type">configuration</td>
-          <td role="gridcell" data-heading="Description">Targets latency sensitive applications such as sound processing.</td>
-        </tr>
-        <tr role="row">
-          <td role="rowheader" data-heading="Name">generic-hwe</td>
-          <td role="gridcell" data-heading="Type">version</td>
-          <td role="gridcell" data-heading="Description">Targets a later version of the upstream kernel, and updates with respect to that every 6 months until it matches the GA kernel in the subsequent LTS release.</td>
-        </tr>
-        <tr role="row">
-          <td role="rowheader" data-heading="Name">lowlatency-hwe</td>
-          <td role="gridcell" data-heading="Type">
-            version<br>
-            configuration
-          </td>
-          <td role="gridcell" data-heading="Description">Targets latency-sensitive applications such as sound processing at the same version as the generic-hwe kernel.</td>
-        </tr>
-        <tr role="row">
-          <td role="rowheader" data-heading="Name">generic-hwe-edge</td>
-          <td role="gridcell" data-heading="Type">version</td>
-          <td role="gridcell" data-heading="Description">Provides early access to the next generic-hwe kernel.</td>
-        </tr>
-        <tr role="row">
-          <td role="rowheader" data-heading="Name">lowlatency-hwe-edge</td>
-          <td role="gridcell" data-heading="Type">
-            version<br>
-            configuration
-          </td>
-          <td role="gridcell" data-heading="Description">Provides early access to the next lowlatency-hwe kernel.</td>
-        </tr>
-        <tr role="row">
-          <td role="rowheader" data-heading="Name">kvm</td>
-          <td role="gridcell" data-heading="Type">configuration</td>
-          <td role="gridcell" data-heading="Description">Targeting KVM instance usage. This carries the minimum support required for a guest kernel.</td>
-        </tr>
-        <tr role="row">
-          <td role="rowheader" data-heading="Name">aws</td>
-          <td role="gridcell" data-heading="Type">configuration</td>
-          <td role="gridcell" data-heading="Description">Targeting the AWS cloud.</td>
-        </tr>
-        <tr role="row">
-          <td role="rowheader" data-heading="Name">azure</td>
-          <td role="gridcell" data-heading="Type">
-            configuration<br>
-            version
-          </td>
-          <td role="gridcell" data-heading="Description">Targeting the Azure cloud.</td>
-        </tr>
-        <tr role="row">
-          <td role="rowheader" data-heading="Name">gcp/gke</td>
-          <td role="gridcell" data-heading="Type">configuration</td>
-          <td role="gridcell" data-heading="Description">Targeting the Google Compute Platform/Google Kubernetes Engine.</td>
-        </tr>
-        <tr role="row">
-          <td role="rowheader" data-heading="Name">raspi2</td>
-          <td role="gridcell" data-heading="Type">platform</td>
-          <td role="gridcell" data-heading="Description">For the Raspberry Pi 2 ARM board.</td>
-        </tr>
-        <tr role="row">
-          <td role="rowheader" data-heading="Name">snapdragon</td>
-          <td role="rowheader" data-heading="Type">platform</td>
-          <td role="rowheader" data-heading="Description">For the Qualcomm Snapdragon ARM64 board.</td>
-        </tr>
-        <tr role="row">
-          <td role="rowheader" data-heading="Name">oem</td>
-          <td role="rowheader" data-heading="Type">project</td>
-          <td role="rowheader" data-heading="Description">Targeting various OEM projects. This carries early access drivers for hardware enablement. This kernel is typically used in the early phases of a project release, with a view to "upstreaming" any delta into the GA or HWE kernels and once this delta is incorporated the final platform is moved over to those kernels.</td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
-</section>
-<section class="p-strip">
-  <div class="row">
-    <div class="col-8">
-      <h2 id="additional-kernel-variants">Additional kernel variants</h2>
-      <p>In addition to those kernel variants, Canonical offers FIPS certified kernels:</p>
-      <ul>
-        <li>FIPS &mdash; Certified GA kernel for Ubuntu 16.04, 18.04 and 20.04</li>
-        <li>FIPS &mdash; compliant GA kernel with critical security and patch updates for Ubuntu 16.04, 18.04 and 20.04</li>
-      </ul>
-    </div>
-  </div>
-</section>
+  </section>
+
+  {{ load_form("/kernel") | safe }}
+
 {% endblock %}

--- a/templates/shared/_kernel-release-diagram.html
+++ b/templates/shared/_kernel-release-diagram.html
@@ -1,213 +1,217 @@
-<div class="p-section--shallow u-hide--small" id="kernel-eol"></div>
-<table>
-  <thead>
-    <tr>
-      <th>Kernel version</th>
-      <th>Ubuntu version</th>
-      <th>Released</th>
-      <th>End of Standard Security Maintenance</th>
-      <th>End of Expanded Security Maintenance</th>
-      <th>End of Legacy Support</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>
-        <strong>6.14</strong>
-      </td>
-      <td>
-        <strong>25.04</strong>
-      </td>
-      <td>Apr 2025</td>
-      <td>Jan 2026</td>
-    </tr>
-    <tr>
-      <td rowspan="2">
-        <strong>6.11</strong>
-      </td>
-      <td>
-        <strong>24.04.2 LTS (HWE)</strong>
-      </td>
-      <td>Feb 2025</td>
-      <td>Jul 2025</td>
-    </tr>
-    <tr>
-      <td>
-        <strong>24.10</strong>
-      </td>
-      <td>Oct 2024</td>
-      <td>Jul 2025</td>
-    </tr>
-    <tr>
-      <td rowspan="3">
-        <strong>6.8</strong>
-      </td>
-      <td>
-        <strong>22.04.5 LTS (HWE)</strong>
-      </td>
-      <td>Aug 2024</td>
-      <td>Apr 2027</td>
-      <td>Mar 2032</td>
-      <td>Apr 2034</td>
-    </tr>
-    <tr>
-      <td>
-        <strong>24.04.1 LTS</strong>
-      </td>
-      <td>Aug 2024</td>
-      <td>Apr 2029</td>
-      <td>Mar 2034</td>
-      <td>Apr 2036</td>
-    </tr>
-    <tr>
-      <td>
-        <strong>24.04.0 LTS</strong>
-      </td>
-      <td>Apr 2024</td>
-      <td>Apr 2029</td>
-      <td>Mar 2034</td>
-      <td>Apr 2036</td>
-    </tr>
-    <tr>
-      <td rowspan="3">
-        <strong>5.15</strong>
-      </td>
-      <td>
-        <strong>20.04.5 LTS (HWE)</strong>
-      </td>
-      <td>Aug 2022</td>
-      <td>Apr 2025</td>
-      <td>Apr 2030</td>
-      <td>Apr 2032</td>
-    </tr>
-    <tr>
-      <td>
-        <strong>22.04.1 LTS</strong>
-      </td>
-      <td>Aug 2022</td>
-      <td>Apr 2027</td>
-      <td>Mar 2032</td>
-      <td>Apr 2034</td>
-    </tr>
-    <tr>
-      <td>
-        <strong>22.04.0 LTS</strong>
-      </td>
-      <td>Apr 2022</td>
-      <td>Apr 2027</td>
-      <td>Mar 2032</td>
-      <td>Apr 2034</td>
-    </tr>
-    <tr>
-      <td rowspan="3">
-        <strong>5.4</strong>
-      </td>
-      <td>
-        <strong>18.04.5 LTS (HWE)</strong>
-      </td>
-      <td>Aug 2020</td>
-      <td>Apr 2023</td>
-      <td>Apr 2028</td>
-      <td>Apr 2030</td>
-    </tr>
-    <tr>
-      <td>
-        <strong>20.04.1 LTS</strong>
-      </td>
-      <td>Aug 2020</td>
-      <td>Apr 2025</td>
-      <td>Apr 2030</td>
-      <td>Apr 2032</td>
-    </tr>
-    <tr>
-      <td>
-        <strong>20.04.0 LTS</strong>
-      </td>
-      <td>Apr 2020</td>
-      <td>Apr 2025</td>
-      <td>Apr 2030</td>
-      <td>Apr 2032</td>
-    </tr>
-    <tr>
-      <td rowspan="3">
-        <strong>4.15</strong>
-      </td>
-      <td>
-        <strong>16.04.5 LTS (HWE)</strong>
-      </td>
-      <td>Aug 2018</td>
-      <td>Apr 2021</td>
-      <td>Apr 2026</td>
-      <td>Apr 2028</td>
-    </tr>
-    <tr>
-      <td>
-        <strong>18.04.1 LTS</strong>
-      </td>
-      <td>Jul 2018</td>
-      <td>Apr 2023</td>
-      <td>Apr 2028</td>
-      <td>Apr 2030</td>
-    </tr>
-    <tr>
-      <td>
-        <strong>18.04.0 LTS</strong>
-      </td>
-      <td>Apr 2018</td>
-      <td>Apr 2023</td>
-      <td>Apr 2028</td>
-      <td>Apr 2030</td>
-    </tr>
-    <tr>
-      <td rowspan="3">
-        <strong>4.4</strong>
-      </td>
-      <td>
-        <strong>14.04.5 LTS (HWE)</strong>
-      </td>
-      <td>Aug 2016</td>
-      <td>Apr 2019</td>
-      <td>Apr 2024</td>
-      <td>Apr 2026</td>
-    </tr>
-    <tr>
-      <td>
-        <strong>16.04.1 LTS</strong>
-      </td>
-      <td>Jul 2016</td>
-      <td>Apr 2021</td>
-      <td>Apr 2026</td>
-      <td>Apr 2028</td>
-    </tr>
-    <tr>
-      <td>
-        <strong>16.04.0 LTS</strong>
-      </td>
-      <td>Apr 2016</td>
-      <td>Apr 2021</td>
-      <td>Apr 2026</td>
-      <td>Apr 2028</td>
-    </tr>
-    <tr>
-      <td rowspan="3">
-        <strong>3.13</strong>
-      </td>
-      <td>
-        <strong>14.04.1 LTS</strong>
-      </td>
-      <td>Jul 2014</td>
-      <td>Apr 2019</td>
-      <td>Apr 2024</td>
-      <td>Apr 2026</td>
-    </tr>
-    <tr>
-      <td>
-        <strong>14.04.0 LTS</strong>
-      </td>
-      <td>Apr 2014</td>
-      <td>Apr 2019</td>
-      <td>Apr 2024</td>
-      <td>Apr 2026</td>
-    </tr>
-  </tbody>
-</table>
+<div class="p-section--shallow u-hide--small"
+     id="kernel-eol"
+     style="overflow: hidden"></div>
+<div class="u-table-horizontal-scroll">
+  <table class="u-table-horizontal-scroll__table">
+    <thead>
+      <tr>
+        <th>Kernel version</th>
+        <th>Ubuntu version</th>
+        <th>Released</th>
+        <th>End of Standard Security Maintenance</th>
+        <th>End of Expanded Security Maintenance</th>
+        <th>End of Legacy Support</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <strong>6.14</strong>
+        </td>
+        <td>
+          <strong>25.04</strong>
+        </td>
+        <td>Apr 2025</td>
+        <td>Jan 2026</td>
+      </tr>
+      <tr>
+        <td rowspan="2">
+          <strong>6.11</strong>
+        </td>
+        <td>
+          <strong>24.04.2 LTS (HWE)</strong>
+        </td>
+        <td>Feb 2025</td>
+        <td>Jul 2025</td>
+      </tr>
+      <tr>
+        <td>
+          <strong>24.10</strong>
+        </td>
+        <td>Oct 2024</td>
+        <td>Jul 2025</td>
+      </tr>
+      <tr>
+        <td rowspan="3">
+          <strong>6.8</strong>
+        </td>
+        <td>
+          <strong>22.04.5 LTS (HWE)</strong>
+        </td>
+        <td>Aug 2024</td>
+        <td>Apr 2027</td>
+        <td>Mar 2032</td>
+        <td>Apr 2034</td>
+      </tr>
+      <tr>
+        <td>
+          <strong>24.04.1 LTS</strong>
+        </td>
+        <td>Aug 2024</td>
+        <td>Apr 2029</td>
+        <td>Mar 2034</td>
+        <td>Apr 2036</td>
+      </tr>
+      <tr>
+        <td>
+          <strong>24.04.0 LTS</strong>
+        </td>
+        <td>Apr 2024</td>
+        <td>Apr 2029</td>
+        <td>Mar 2034</td>
+        <td>Apr 2036</td>
+      </tr>
+      <tr>
+        <td rowspan="3">
+          <strong>5.15</strong>
+        </td>
+        <td>
+          <strong>20.04.5 LTS (HWE)</strong>
+        </td>
+        <td>Aug 2022</td>
+        <td>Apr 2025</td>
+        <td>Apr 2030</td>
+        <td>Apr 2032</td>
+      </tr>
+      <tr>
+        <td>
+          <strong>22.04.1 LTS</strong>
+        </td>
+        <td>Aug 2022</td>
+        <td>Apr 2027</td>
+        <td>Mar 2032</td>
+        <td>Apr 2034</td>
+      </tr>
+      <tr>
+        <td>
+          <strong>22.04.0 LTS</strong>
+        </td>
+        <td>Apr 2022</td>
+        <td>Apr 2027</td>
+        <td>Mar 2032</td>
+        <td>Apr 2034</td>
+      </tr>
+      <tr>
+        <td rowspan="3">
+          <strong>5.4</strong>
+        </td>
+        <td>
+          <strong>18.04.5 LTS (HWE)</strong>
+        </td>
+        <td>Aug 2020</td>
+        <td>Apr 2023</td>
+        <td>Apr 2028</td>
+        <td>Apr 2030</td>
+      </tr>
+      <tr>
+        <td>
+          <strong>20.04.1 LTS</strong>
+        </td>
+        <td>Aug 2020</td>
+        <td>Apr 2025</td>
+        <td>Apr 2030</td>
+        <td>Apr 2032</td>
+      </tr>
+      <tr>
+        <td>
+          <strong>20.04.0 LTS</strong>
+        </td>
+        <td>Apr 2020</td>
+        <td>Apr 2025</td>
+        <td>Apr 2030</td>
+        <td>Apr 2032</td>
+      </tr>
+      <tr>
+        <td rowspan="3">
+          <strong>4.15</strong>
+        </td>
+        <td>
+          <strong>16.04.5 LTS (HWE)</strong>
+        </td>
+        <td>Aug 2018</td>
+        <td>Apr 2021</td>
+        <td>Apr 2026</td>
+        <td>Apr 2028</td>
+      </tr>
+      <tr>
+        <td>
+          <strong>18.04.1 LTS</strong>
+        </td>
+        <td>Jul 2018</td>
+        <td>Apr 2023</td>
+        <td>Apr 2028</td>
+        <td>Apr 2030</td>
+      </tr>
+      <tr>
+        <td>
+          <strong>18.04.0 LTS</strong>
+        </td>
+        <td>Apr 2018</td>
+        <td>Apr 2023</td>
+        <td>Apr 2028</td>
+        <td>Apr 2030</td>
+      </tr>
+      <tr>
+        <td rowspan="3">
+          <strong>4.4</strong>
+        </td>
+        <td>
+          <strong>14.04.5 LTS (HWE)</strong>
+        </td>
+        <td>Aug 2016</td>
+        <td>Apr 2019</td>
+        <td>Apr 2024</td>
+        <td>Apr 2026</td>
+      </tr>
+      <tr>
+        <td>
+          <strong>16.04.1 LTS</strong>
+        </td>
+        <td>Jul 2016</td>
+        <td>Apr 2021</td>
+        <td>Apr 2026</td>
+        <td>Apr 2028</td>
+      </tr>
+      <tr>
+        <td>
+          <strong>16.04.0 LTS</strong>
+        </td>
+        <td>Apr 2016</td>
+        <td>Apr 2021</td>
+        <td>Apr 2026</td>
+        <td>Apr 2028</td>
+      </tr>
+      <tr>
+        <td rowspan="3">
+          <strong>3.13</strong>
+        </td>
+        <td>
+          <strong>14.04.1 LTS</strong>
+        </td>
+        <td>Jul 2014</td>
+        <td>Apr 2019</td>
+        <td>Apr 2024</td>
+        <td>Apr 2026</td>
+      </tr>
+      <tr>
+        <td>
+          <strong>14.04.0 LTS</strong>
+        </td>
+        <td>Apr 2014</td>
+        <td>Apr 2019</td>
+        <td>Apr 2024</td>
+        <td>Apr 2026</td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/templates/shared/_kernel-support-schedule.html
+++ b/templates/shared/_kernel-support-schedule.html
@@ -1,12 +1,14 @@
-<section class="p-strip--light is-bordered">
+<section class="p-section--deep">
   <div class="u-fixed-width">
-    <h2>Kernel release schedule</h2>
+    <hr class="p-rule" />
+    <div class="p-section--shallow">
+      <h2>Kernel release schedule</h2>
+    </div>
   </div>
-  <div class="row">
-    {% include "shared/_kernel-release-diagram.html" %}
-  </div>
+  <div class="row">{% include "shared/_kernel-release-diagram.html" %}</div>
 </section>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.9.0/d3.min.js" defer></script>
-<script src="{{ versioned_static('js/dist/release-chart-manager.js') }}" defer></script>
+<script src="{{ versioned_static('js/dist/release-chart-manager.js') }}"
+        defer></script>
 <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -8102,10 +8102,10 @@ v8-to-istanbul@^9.0.1:
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^2.0.0"
 
-vanilla-framework@4.23.0:
-  version "4.23.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.23.0.tgz#4c2f87743501d88e646de818253a1dcacd2f9c66"
-  integrity sha512-GdlN4PVSanY96IUxQwxv2T1Ls+UgRA+BZqUuGqhO6AlgEet9uKJI7XFSfdieedc0F5P8ySCZA9MkALTGHr6jbA==
+vanilla-framework@4.24.0:
+  version "4.24.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.24.0.tgz#48a15b4d59c349f418fa0490d4a72b2be9f43b15"
+  integrity sha512-2/BXRB3Aqz1skfBqDD1hn2+PWx6EdF2xGSm8weq5IgIXllbCFgq8nySmfDQOzFSVqIVgyVidWtH3rDDIB0RaIg==
 
 vanilla-framework@4.9.0:
   version "4.9.0"


### PR DESCRIPTION
## Done

- This is the feature branch for kernel bubble rebranding
- Following pages are included in this rebrand
  - index
  - lifecycle (and a modal form)
  - variants

## QA

- View the site  in your web browser at: https://ubuntu-com-15174.demos.haus/kernel
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go through all the pages, make sure all the links work and everything looks good.

## Issue / Card

Fixes #[WD-17822](https://warthogs.atlassian.net/browse/WD-17822)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-17822]: https://warthogs.atlassian.net/browse/WD-17822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ