### PR TITLE
Copy update for SLA section on /support

### DIFF
--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -917,10 +917,10 @@
             <th>
               <span class="u-text--muted">Self-Support<sup>1</sup></span>
             </th>
-            <th>
+            <th colspan="2">
               <span class="u-text--muted">Weekday support</span>
             </th>
-            <th>
+            <th colspan="2">
               <span class="u-text--muted">24/7 Support</span>
             </th>
           </tr>
@@ -929,10 +929,10 @@
           <tr>
             <td>Hours of coverage</td>
             <td>N/A</td>
-            <td>
+            <td colspan="2">
               24/5<sup>2</sup>
             </td>
-            <td>
+            <td colspan="2">
               24/7/365<sup>3</sup>
             </td>
           </tr>
@@ -941,22 +941,22 @@
             <td>
               <a href="https://support-portal.canonical.com/">Knowledge Base</a>
             </td>
-            <td>
+            <td colspan="2">
               <a href="https://support-portal.canonical.com/">Support portal</a>, including <a href="https://support-portal.canonical.com/">Knowledge Base</a>, phone, and ticket
             </td>
-            <td>
+            <td colspan="2">
               <a href="https://support-portal.canonical.com/">Support portal</a>, including <a href="https://support-portal.canonical.com/">Knowledge Base</a>, phone, and ticket
             </td>
           </tr>
           <tr>
             <td>Number of cases allowed</td>
             <td>N/A</td>
-            <td>Unlimited</td>
-            <td>Unlimited</td>
+            <td colspan="2">Unlimited</td>
+            <td colspan="2">Unlimited</td>
           </tr>
           <tr>
             <td>
-              <strong>Response times by severity level</strong>
+              <strong>Response times</strong>
             </td>
             <td>
               <strong>First response</strong>
@@ -965,7 +965,13 @@
               <strong>First response</strong>
             </td>
             <td>
+              <strong>Ongoing response<sup>4</sup></strong>
+            </td>
+            <td>
               <strong>First response</strong>
+            </td>
+            <td>
+              <strong>Ongoing response<sup>4</sup></strong>
             </td>
           </tr>
           <tr>
@@ -974,7 +980,9 @@
             </td>
             <td>N/A</td>
             <td>4 hours</td>
+            <td>2 hours</td>
             <td>1 hour</td>
+            <td>2 hours</td>
           </tr>
           <tr>
             <td>
@@ -982,7 +990,9 @@
             </td>
             <td>N/A</td>
             <td>8 hours</td>
+            <td>24 hours</td>
             <td>2 hours</td>
+            <td>24 hours</td>
           </tr>
           <tr>
             <td>
@@ -990,7 +1000,9 @@
             </td>
             <td>N/A</td>
             <td>12 hours</td>
+            <td>Weekly</td>
             <td>6 hours</td>
+            <td>Weekly</td>
           </tr>
           <tr>
             <td>
@@ -998,7 +1010,9 @@
             </td>
             <td>N/A</td>
             <td>24 hours</td>
+            <td>N/A</td>
             <td>12 hours</td>
+            <td>N/A</td>
           </tr>
         </tbody>
       </table>
@@ -1014,6 +1028,9 @@
         </li>
         <li>
           24/7/365 support is intended for Severity 1 issues. Issues at other severity levels will be worked on during standard business hours. In case of a Severity 1 issue, we will work with you until the issue is solved or mitigated with a workaround. As soon as the service or the core functionality is available in production, we will adjust the severity level accordingly. We assume you will be reachable throughout the process as the functionality is being restored.
+        </li>
+        <li>
+          Canonical Support will provide follow-up updates within defined time frames after responding to a customer inquiry. These ongoing response time frames are defined based on the severity level of the issue, and counted from the time of the latest severity update.
         </li>
       </ol>
     </div>

--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -927,7 +927,9 @@
         </thead>
         <tbody>
           <tr>
-            <td>Hours of coverage</td>
+            <td>
+              <strong>Hours of coverage</strong>
+            </td>
             <td>N/A</td>
             <td colspan="2">
               24/5<sup>2</sup>
@@ -937,7 +939,9 @@
             </td>
           </tr>
           <tr>
-            <td>Available channels</td>
+            <td>
+              <strong>Available channels</strong>
+            </td>
             <td>
               <a href="https://support-portal.canonical.com/">Knowledge Base</a>
             </td>
@@ -949,7 +953,9 @@
             </td>
           </tr>
           <tr>
-            <td>Number of cases allowed</td>
+            <td>
+              <strong>Number of cases allowed</strong>
+            </td>
             <td>N/A</td>
             <td colspan="2">Unlimited</td>
             <td colspan="2">Unlimited</td>
@@ -976,7 +982,7 @@
           </tr>
           <tr>
             <td>
-              <strong>Severity 1 -</strong>Production service down. Critical impact on core functionality in a production environment
+              <strong>Severity 1 - </strong>Production service down. Critical impact on core functionality in a production environment
             </td>
             <td>N/A</td>
             <td>4 business hours<sup>2</sup></td>
@@ -986,7 +992,7 @@
           </tr>
           <tr>
             <td>
-              <strong>Severity 2 -</strong>Core functionality severely degraded in a production environment.
+              <strong>Severity 2 - </strong>Core functionality severely degraded in a production environment.
             </td>
             <td>N/A</td>
             <td>8 business hours<sup>2</sup></td>
@@ -996,7 +1002,7 @@
           </tr>
           <tr>
             <td>
-              <strong>Severity 3 -</strong>Issues have a medium to low impact in a production environment.
+              <strong>Severity 3 - </strong>Issues have a medium to low impact in a production environment.
             </td>
             <td>N/A</td>
             <td>12 business hours<sup>2</sup></td>
@@ -1006,7 +1012,7 @@
           </tr>
           <tr>
             <td>
-              <strong>Severity 4 -</strong>Non-urgent requests with low to no impact on production environments.
+              <strong>Severity 4 - </strong>Non-urgent requests with low to no impact on production environments.
             </td>
             <td>N/A</td>
             <td>24 business hours<sup>2</sup></td>

--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -979,8 +979,8 @@
               <strong>Severity 1 -</strong>Production service down. Critical impact on core functionality in a production environment
             </td>
             <td>N/A</td>
-            <td>4 hours</td>
-            <td>2 hours</td>
+            <td>4 business hours<sup>2</sup></td>
+            <td>2 business hours<sup>2</sup></td>
             <td>1 hour</td>
             <td>2 hours</td>
           </tr>
@@ -989,17 +989,17 @@
               <strong>Severity 2 -</strong>Core functionality severely degraded in a production environment.
             </td>
             <td>N/A</td>
-            <td>8 hours</td>
-            <td>24 hours</td>
+            <td>8 business hours<sup>2</sup></td>
+            <td>8 business hours<sup>2</sup></td>
             <td>2 hours</td>
-            <td>24 hours</td>
+            <td>8 business hours<sup>2</sup></td>
           </tr>
           <tr>
             <td>
               <strong>Severity 3 -</strong>Issues have a medium to low impact in a production environment.
             </td>
             <td>N/A</td>
-            <td>12 hours</td>
+            <td>12 business hours<sup>2</sup></td>
             <td>Weekly</td>
             <td>6 hours</td>
             <td>Weekly</td>
@@ -1009,7 +1009,7 @@
               <strong>Severity 4 -</strong>Non-urgent requests with low to no impact on production environments.
             </td>
             <td>N/A</td>
-            <td>24 hours</td>
+            <td>24 business hours<sup>2</sup></td>
             <td>N/A</td>
             <td>12 hours</td>
             <td>N/A</td>
@@ -1024,7 +1024,7 @@
           Included with any <a href="/pro">Ubuntu Pro</a> subscription
         </li>
         <li>
-          24/5 support is intended for Severity 1 issues. Issues at other severity levels will be worked on during standard business hours. Standard business hours are defined as Monday to Friday from 8:00 AM to 6:00 PM at your organisation's headquarters. Weekends and holidays are excluded.
+          Standard business hours are defined as Monday to Friday from 8:00 AM to 6:00 PM at your organization's headquarters. Weekends and holidays are excluded.
         </li>
         <li>
           24/7/365 support is intended for Severity 1 issues. Issues at other severity levels will be worked on during standard business hours. In case of a Severity 1 issue, we will work with you until the issue is solved or mitigated with a workaround. As soon as the service or the core functionality is available in production, we will adjust the severity level accordingly. We assume you will be reachable throughout the process as the functionality is being restored.


### PR DESCRIPTION
## Rationale
The copy update WD-22487 included miscellaneous changes on the page along with specific changes to the SLA section. However, the SLA updates are only applicable from June 30th. It was requested that we omit these changes from the previous PR for this copy update (#15175), and merge everything else. This was completed. This current PR is a separate one specifically for the SLA changes, and **_should not be merged until June 30th_**.

## Done

- Copy update for SLA section on /support

## QA

- Go to https://ubuntu-com-15176.demos.haus/support
- Ensure changes match the [copy doc](https://docs.google.com/document/d/1AU2dwTXpQk2UuEvSuAqRKrbPWYb-LR0ZGvWu6xw95I8/edit?tab=t.0#heading=h.6gxmmp5wr2i8)

## Issue / Card

[WD-22487](https://warthogs.atlassian.net/browse/WD-22487)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

[WD-22487]: https://warthogs.atlassian.net/browse/WD-22487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ