### PR TITLE
feat: Add DeepComputing FML13V01 to risc-v download page

### DIFF
--- a/templates/download/risc-v/deepcompute-fml13v01.html
+++ b/templates/download/risc-v/deepcompute-fml13v01.html
@@ -1,0 +1,69 @@
+<div tabindex="0"
+     role="tabpanel"
+     id="deepcompute-fml13v01-tab"
+     aria-labelledby="deepcompute-fml13v01"
+     aria-hidden="true">
+  <div class="row p-strip is-shallow u-no-padding--top">
+    <div class="col-3">
+      <h2 class="u-hide--small">Deep Computing FML13V01</h2>
+    </div>
+    <div class="col-6 risc-v-container u-vertically-center u-align--center">
+      {{ image(url="https://assets.ubuntu.com/v1/d68a9702-deep-computing.png",
+            alt="",
+            width="400",
+            height="240",
+            hi_def=True,
+            loading="auto",
+            attrs={"class": "risc-v-image"}) | safe
+      }}
+    </div>
+  </div>
+  <div class="row p-strip u-no-padding--top">
+    <hr class="p-rule col-9" />
+    <div class="col-3">
+      <h3 class="p-heading--5 u-no-padding--top">
+        Ubuntu Server
+        <br class="u-hide--small" />
+        preinstalled image
+      </h3>
+    </div>
+    <div class="col-6">
+      <p>
+        DeepComputing provides a vendor image that fully supports the FrameWork laptop with the DeepComputing FML13V01
+        motherboard.
+      </p>
+      <p>The Ubuntu images described below only support headless mode (no GPU, no WiFi).</p>
+      <p class="p-notification__message">
+        <i class="p-icon--information"></i> If you have an eMMC drive, we advise you to use the Ubuntu Server
+        live installer.
+      </p>
+      <hr class="p-rule--muted is-fixed-width col-6" />
+      <p>
+        <a class="p-button--positive"
+           href="https://cdimage.ubuntu.com/releases/25.04/release/ubuntu-25.04-preinstalled-server-riscv64+jh7110.img.xz">Download
+        24.04</a>
+      </p>
+    </div>
+  </div>
+  <div class="row p-strip u-no-padding--top">
+    <hr class="p-rule col-9" />
+    <div class="col-3">
+      <h3 class="p-heading--5 u-no-padding--top">
+        Ubuntu Server
+        <br class="u-hide--small" />
+        live installer
+      </h3>
+    </div>
+    <div class="col-6">
+      <p>
+        <a class="p-button--positive"
+           href="https://cdimage.ubuntu.com/releases/25.04/release/ubuntu-25.04-live-server-riscv64.iso">Download
+        24.04.2 LTS</a>
+      </p>
+      <p>
+        <a href="https://canonical-ubuntu-boards.readthedocs-hosted.com/en/latest/how-to/deepcomputing-fml13v01/">How to
+        install Ubuntu on the DeepComputing FML13V01</a>
+      </p>
+    </div>
+  </div>
+</div>

--- a/templates/download/risc-v/deepcompute-fml13v01.html
+++ b/templates/download/risc-v/deepcompute-fml13v01.html
@@ -26,7 +26,7 @@
     </div>
     <div class="col-6">
       <p>
-        DeepComputing provides a vendor image that fully supports the FrameWork laptop with the DeepComputing FML13V01
+        DeepComputing provides a vendor image that fully supports the Framework laptop with the DeepComputing FML13V01
         motherboard.
       </p>
       <p>The Ubuntu images described below only support headless mode (no GPU, no WiFi).</p>

--- a/templates/download/risc-v/deepcompute-fml13v01.html
+++ b/templates/download/risc-v/deepcompute-fml13v01.html
@@ -9,7 +9,7 @@
     </div>
     <div class="col-6 risc-v-container u-vertically-center u-align--center">
       {{ image(url="https://assets.ubuntu.com/v1/d68a9702-deep-computing.png",
-            alt="",
+            alt="Deep Computing FML13V01 board photo",
             width="400",
             height="240",
             hi_def=True,

--- a/templates/download/risc-v/deepcompute-fml13v01.html
+++ b/templates/download/risc-v/deepcompute-fml13v01.html
@@ -1,20 +1,17 @@
-<div tabindex="0"
-     role="tabpanel"
-     id="deepcompute-fml13v01-tab"
-     aria-labelledby="deepcompute-fml13v01"
-     aria-hidden="true">
+<div tabindex="0" role="tabpanel" id="deepcompute-fml13v01-tab" aria-labelledby="deepcompute-fml13v01"
+  aria-hidden="true">
   <div class="row p-strip is-shallow u-no-padding--top">
     <div class="col-3">
       <h2 class="u-hide--small">Deep Computing FML13V01</h2>
     </div>
     <div class="col-6 risc-v-container u-vertically-center u-align--center">
       {{ image(url="https://assets.ubuntu.com/v1/d68a9702-deep-computing.png",
-            alt="Deep Computing FML13V01 board photo",
-            width="400",
-            height="240",
-            hi_def=True,
-            loading="auto",
-            attrs={"class": "risc-v-image"}) | safe
+      alt="Deep Computing FML13V01 board photo",
+      width="400",
+      height="240",
+      hi_def=True,
+      loading="auto",
+      attrs={"class": "risc-v-image"}) | safe
       }}
     </div>
   </div>
@@ -40,8 +37,8 @@
       <hr class="p-rule--muted is-fixed-width col-6" />
       <p>
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/25.04/release/ubuntu-25.04-preinstalled-server-riscv64+jh7110.img.xz">Download
-        25.04</a>
+          href="https://cdimage.ubuntu.com/releases/25.04/release/ubuntu-25.04-preinstalled-server-riscv64+jh7110.img.xz">Download
+          25.04</a>
       </p>
     </div>
   </div>
@@ -57,12 +54,12 @@
     <div class="col-6">
       <p>
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/25.04/release/ubuntu-25.04-live-server-riscv64.iso">Download
-        25.04</a>
+          href="https://cdimage.ubuntu.com/releases/25.04/release/ubuntu-25.04-live-server-riscv64.iso">Download
+          25.04 live installer</a>
       </p>
       <p>
         <a href="https://canonical-ubuntu-boards.readthedocs-hosted.com/en/latest/how-to/deepcomputing-fml13v01/">How to
-        install Ubuntu on the DeepComputing FML13V01</a>
+          install Ubuntu on the DeepComputing FML13V01</a>
       </p>
     </div>
   </div>

--- a/templates/download/risc-v/deepcompute-fml13v01.html
+++ b/templates/download/risc-v/deepcompute-fml13v01.html
@@ -58,7 +58,7 @@
       <p>
         <a class="p-button--positive"
            href="https://cdimage.ubuntu.com/releases/25.04/release/ubuntu-25.04-live-server-riscv64.iso">Download
-        24.04.2 LTS</a>
+        25.04</a>
       </p>
       <p>
         <a href="https://canonical-ubuntu-boards.readthedocs-hosted.com/en/latest/how-to/deepcomputing-fml13v01/">How to

--- a/templates/download/risc-v/deepcompute-fml13v01.html
+++ b/templates/download/risc-v/deepcompute-fml13v01.html
@@ -41,7 +41,7 @@
       <p>
         <a class="p-button--positive"
            href="https://cdimage.ubuntu.com/releases/25.04/release/ubuntu-25.04-preinstalled-server-riscv64+jh7110.img.xz">Download
-        24.04</a>
+        25.04</a>
       </p>
     </div>
   </div>

--- a/templates/download/risc-v/deepcomputing-fml13v01.html
+++ b/templates/download/risc-v/deepcomputing-fml13v01.html
@@ -2,11 +2,11 @@
   aria-hidden="true">
   <div class="row p-strip is-shallow u-no-padding--top">
     <div class="col-3">
-      <h2 class="u-hide--small">Deep Computing FML13V01</h2>
+      <h2 class="u-hide--small">Deep<wbr />Computing FML13V01</h2>
     </div>
     <div class="col-6 risc-v-container u-vertically-center u-align--center">
       {{ image(url="https://assets.ubuntu.com/v1/d68a9702-deep-computing.png",
-      alt="Deep Computing FML13V01 board photo",
+      alt="DeepComputing FML13V01 board photo",
       width="400",
       height="240",
       hi_def=True,

--- a/templates/download/risc-v/deepcomputing-fml13v01.html
+++ b/templates/download/risc-v/deepcomputing-fml13v01.html
@@ -5,7 +5,7 @@
       <h2 class="u-hide--small">Deep<wbr />Computing FML13V01</h2>
     </div>
     <div class="col-6 risc-v-container u-vertically-center u-align--center">
-      {{ image(url="https://assets.ubuntu.com/v1/d68a9702-deep-computing.png",
+      {{ image(url="https://assets.ubuntu.com/v1/ebf3ab81-deep-computing-updated.png",
       alt="Photo of the DeepComputing FML13V01 board",
       width="400",
       height="240",

--- a/templates/download/risc-v/deepcomputing-fml13v01.html
+++ b/templates/download/risc-v/deepcomputing-fml13v01.html
@@ -1,4 +1,4 @@
-<div tabindex="0" role="tabpanel" id="deepcompute-fml13v01-tab" aria-labelledby="deepcompute-fml13v01"
+<div tabindex="0" role="tabpanel" id="deepcomputing-fml13v01-tab" aria-labelledby="deepcomputing-fml13v01"
   aria-hidden="true">
   <div class="row p-strip is-shallow u-no-padding--top">
     <div class="col-3">

--- a/templates/download/risc-v/index.html
+++ b/templates/download/risc-v/index.html
@@ -137,8 +137,8 @@
           <select name="boardSelect" id="boardSelect">
             <option value="allwinner-nezha-tab" selected="">AllWinner Nezha</option>
             <option value="deepcomputing-fml13v01-tab">DeepComputing FML13V01</option>
-            <option value="microchip-polarfire-soc-fpga-icicle-kit-tab">Microchip Polarfire SoC FPGA Icicle</option>
             <option value="microchip-curiosity-tab">Microchip PIC64GX1000 Curiosity Kit</option>
+            <option value="microchip-polarfire-soc-fpga-icicle-kit-tab">Microchip Polarfire SoC FPGA Icicle</option>
             <option value="pine64-star64-tab">Pine64 Star64</option>
             <option value="milk-v-mars-tab">Milk-V Mars</option>
             <option value="qemu-tab">QEMU emulator</option>

--- a/templates/download/risc-v/index.html
+++ b/templates/download/risc-v/index.html
@@ -136,7 +136,7 @@
         <form class="u-hide--large u-hide--medium">
           <select name="boardSelect" id="boardSelect">
             <option value="allwinner-nezha-tab" selected="">AllWinner Nezha</option>
-            <option value="deepcompute-fml13v01-tab">Deepcomputing FML13V01</option>
+            <option value="deepcompute-fml13v01-tab">DeepComputing FML13V01</option>
             <option value="microchip-polarfire-soc-fpga-icicle-kit-tab">Microchip Polarfire SoC FPGA Icicle</option>
             <option value="microchip-curiosity-tab">Microchip PIC64GX1000 Curiosity Kit</option>
             <option value="pine64-star64-tab">Pine64 Star64</option>

--- a/templates/download/risc-v/index.html
+++ b/templates/download/risc-v/index.html
@@ -69,10 +69,10 @@
           </li>
           <li>
             <button class="p-tabs__item"
-                    id="deepcompute-fml13v01"
+                    id="deepcomputing-fml13v01"
                     role="tab"
                     aria-selected="false"
-                    aria-controls="deepcompute-fml13v01-tab">DeepComputing FML13V01</button>
+                    aria-controls="deepcomputing-fml13v01-tab">DeepComputing FML13V01</button>
           </li>
           <li>
             <button class="p-tabs__item"
@@ -136,7 +136,7 @@
         <form class="u-hide--large u-hide--medium">
           <select name="boardSelect" id="boardSelect">
             <option value="allwinner-nezha-tab" selected="">AllWinner Nezha</option>
-            <option value="deepcompute-fml13v01-tab">DeepComputing FML13V01</option>
+            <option value="deepcomputing-fml13v01-tab">DeepComputing FML13V01</option>
             <option value="microchip-polarfire-soc-fpga-icicle-kit-tab">Microchip Polarfire SoC FPGA Icicle</option>
             <option value="microchip-curiosity-tab">Microchip PIC64GX1000 Curiosity Kit</option>
             <option value="pine64-star64-tab">Pine64 Star64</option>
@@ -150,7 +150,7 @@
       </div>
       <div class="col-9 col-medium-4">
         {% include "download/risc-v/allwinner-nezha.html" %}
-        {% include "download/risc-v/deepcompute-fml13v01.html" %}
+        {% include "download/risc-v/deepcomputing-fml13v01.html" %}
         {% include "download/risc-v/microchip-curiosity.html" %}
         {% include "download/risc-v/microchip-polarfire.html" %}
         {% include "download/risc-v/pine64-star64.html" %}

--- a/templates/download/risc-v/index.html
+++ b/templates/download/risc-v/index.html
@@ -136,7 +136,7 @@
         <form class="u-hide--large u-hide--medium">
           <select name="boardSelect" id="boardSelect">
             <option value="allwinner-nezha-tab" selected="">AllWinner Nezha</option>
-            <option value="deepcompute-fml13v01" selected="">Deepcomputing FML13V01</option>
+            <option value="deepcompute-fml13v01">Deepcomputing FML13V01</option>
             <option value="microchip-polarfire-soc-fpga-icicle-kit-tab">Microchip Polarfire SoC FPGA Icicle</option>
             <option value="microchip-curiosity-tab">Microchip PIC64GX1000 Curiosity Kit</option>
             <option value="pine64-star64-tab">Pine64 Star64</option>

--- a/templates/download/risc-v/index.html
+++ b/templates/download/risc-v/index.html
@@ -136,7 +136,7 @@
         <form class="u-hide--large u-hide--medium">
           <select name="boardSelect" id="boardSelect">
             <option value="allwinner-nezha-tab" selected="">AllWinner Nezha</option>
-            <option value="deepcompute-fml13v01">Deepcomputing FML13V01</option>
+            <option value="deepcompute-fml13v01-tab">Deepcomputing FML13V01</option>
             <option value="microchip-polarfire-soc-fpga-icicle-kit-tab">Microchip Polarfire SoC FPGA Icicle</option>
             <option value="microchip-curiosity-tab">Microchip PIC64GX1000 Curiosity Kit</option>
             <option value="pine64-star64-tab">Pine64 Star64</option>

--- a/templates/download/risc-v/index.html
+++ b/templates/download/risc-v/index.html
@@ -69,12 +69,17 @@
           </li>
           <li>
             <button class="p-tabs__item"
+                    id="deepcompute-fml13v01"
+                    role="tab"
+                    aria-selected="false"
+                    aria-controls="deepcompute-fml13v01-tab">DeepComputing FML13V01</button>
+          </li>
+          <li>
+            <button class="p-tabs__item"
                     id="microchip-curiosity"
                     role="tab"
                     aria-selected="false"
-                    aria-controls="microchip-curiosity-tab">
-              Microchip PIC64GX1000 Curiosity Kit
-            </button>
+                    aria-controls="microchip-curiosity-tab">Microchip PIC64GX1000 Curiosity Kit</button>
           </li>
           <li>
             <button class="p-tabs__item"
@@ -131,6 +136,7 @@
         <form class="u-hide--large u-hide--medium">
           <select name="boardSelect" id="boardSelect">
             <option value="allwinner-nezha-tab" selected="">AllWinner Nezha</option>
+            <option value="deepcompute-fml13v01" selected="">Deepcomputing FML13V01</option>
             <option value="microchip-polarfire-soc-fpga-icicle-kit-tab">Microchip Polarfire SoC FPGA Icicle</option>
             <option value="microchip-curiosity-tab">Microchip PIC64GX1000 Curiosity Kit</option>
             <option value="pine64-star64-tab">Pine64 Star64</option>
@@ -144,6 +150,7 @@
       </div>
       <div class="col-9 col-medium-4">
         {% include "download/risc-v/allwinner-nezha.html" %}
+        {% include "download/risc-v/deepcompute-fml13v01.html" %}
         {% include "download/risc-v/microchip-curiosity.html" %}
         {% include "download/risc-v/microchip-polarfire.html" %}
         {% include "download/risc-v/pine64-star64.html" %}


### PR DESCRIPTION
## Done

- Added DeepComputing FML13V01 board to the risc-v download page.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Visit /download/risc-v
- Ensure the DeepComputing tab works as expected

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-22206

## Screenshots

![image](https://github.com/user-attachments/assets/ea75fc88-e5db-4326-ade5-89614c3fd320)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
