### PR TITLE
WD-22068: ensure purchase account in canonical-cube marketplace

### DIFF
--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -857,7 +857,7 @@ def cred_your_exams(
 
     account = None
     try:
-        account = advantage_mapper.get_purchase_account("canonical-ua")
+        account = advantage_mapper.ensure_purchase_account("canonical-cube", user["email"])
     except UAContractsUserHasNoAccount:
         flask.current_app.extensions["sentry"].captureException(
             extra={


### PR DESCRIPTION
## Done

- Ensure a purchase account in canonical-cube marketplace which means that account can not be None since the endpoint ensures that if the account does not exist, one is created

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to `/credentials/your-exams` and make sure you do not see a 403 or a 404 error

## Issue / Card

Fixes [WD-22068](https://warthogs.atlassian.net/browse/WD-22068)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
