### PR TITLE
armhf added in "Architectures supported with ESM" for 24.04

### DIFF
--- a/templates/security/esm.html
+++ b/templates/security/esm.html
@@ -336,7 +336,7 @@
                 <br />
                 s390x
               </td>
-              <td>amd64, arm64, s390x, ppc64el, RISC-V</td>
+              <td>amd64, arm64, s390x, ppc64el, RISC-V, armhf</td>
             </tr>
           </tbody>
         </table>


### PR DESCRIPTION
## Done

- armhf added in "Architectures supported with ESM" for 24.04

## QA

- naavigate to https://ubuntu-com-15199.demos.haus/security/esm
- find the table "What is covered?", armhf architecture should be there for 24.04
