### PR TITLE
WD22786: open desktop exam for production for internal users

### DIFF
--- a/templates/credentials/shop/index.html
+++ b/templates/credentials/shop/index.html
@@ -16,7 +16,7 @@
       <div class="row u-hide--small">
         {% for exam in exams %}
           {% set metadata_length = exam.metadata|length %}
-          {% set is_disabled = metadata_length == 1 %}
+          {% set is_disabled = exam.disabled == True %}
           {% set is_discounted = True if metadata_length > 1 and exam.metadata[1].discountPrice else False %}
           <div class="col-4">
             <div id="price-card-{{ loop.index0 }}"
@@ -65,7 +65,7 @@
       <!-- Smaller cards for minimised window -->
       {% for exam in exams %}
         {% set metadata_length = exam.metadata|length %}
-        {% set is_disabled = metadata_length == 1 %}
+        {% set is_disabled = exam.disabled == True %}
         {% set is_discounted = True if metadata_length > 1 and exam.metadata[1].discountPrice else False %}
         <div class="col-12 u-hide u-show--small">
           <div id="price-card-{{ loop.index0 }}"
@@ -160,7 +160,8 @@
     const handleSubmit = () => {
       event.preventDefault();
       const index = document.querySelector('input[name="exam-radio"]:checked').value;
-      if (index == 1 && !isStaging) {
+      const isExamDisabled = exams[index].disabled;
+      if (isExamDisabled) {
         return;
       }
       const shopCheckoutData = {

--- a/webapp/shop/cred/exams.json
+++ b/webapp/shop/cred/exams.json
@@ -17,7 +17,11 @@
         "originalPrice": "100.00",
         "currency": "$"
       }
-    ]
+    ],
+    "openTo": {
+      "production": true,
+      "staging": true
+    }
   },
   {
     "id": "cue-02-desktop",
@@ -44,7 +48,11 @@
         "discountPrice": "0.00",
         "currency": "$"
       }
-    ]
+    ],
+    "openTo": {
+      "production": true,
+      "staging": true
+    }
   },
   {
     "id": "cue-03-server",
@@ -55,7 +63,12 @@
         "key": "description",
         "value":
           "Illustrate your knowledge of common Ubuntu Server administrative tasks and troubleshooting. Topics include job control, performance tuning, services management, and Bash scripting."
-      }
-    ]
+      },
+      {}
+    ],
+    "openTo": {
+      "production": false,
+      "staging": false
+    }
   }
 ]

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -1463,9 +1463,6 @@ def cred_submit_form(**_):
 
 @shop_decorator(area="cube", permission="user", response="html")
 def cred_shop(ua_contracts_api, advantage_mapper, **kwargs):
-    is_staging = "staging" in os.getenv(
-        "CONTRACTS_API_URL", "https://contracts.staging.canonical.com/"
-    )
     exam_index = 0
     try:
         exam_index = int(flask.request.args.get("exam_index", 0))
@@ -1482,12 +1479,26 @@ def cred_shop(ua_contracts_api, advantage_mapper, **kwargs):
             "account/forbidden.html", reason="channel_account"
         )
 
+    is_staging = "staging" in os.getenv(
+        "CONTRACTS_API_URL", "https://contracts.staging.canonical.com/"
+    )
+    is_production = not is_staging
     exams_file = open("webapp/shop/cred/exams.json", "r")
     exams = json.load(exams_file)
-    if not is_staging:
-        old_metadata = exams[1]["metadata"]
-        exams[1]["metadata"] = [old_metadata[0]]
     cue_products = get_cue_products(type="exam").json
+    user = user_info(flask.session)
+    for exam in exams:
+        exam_open_to = exam.get(
+            "openTo", {"production": False, "staging": False}
+        )
+        is_disabled = (is_staging and not exam_open_to["staging"]) or (
+            is_production and not exam_open_to["production"]
+        )
+        is_internal_user = user.get("email", "").endswith("@canonical.com")
+        exam["disabled"] = is_disabled
+        if exam["id"] == "cue-02-desktop" and not is_internal_user:
+            exam["disabled"] = True
+
     for product in cue_products:
         for exam in exams:
             if product["id"] == exam["id"]:
@@ -1499,8 +1510,6 @@ def cred_shop(ua_contracts_api, advantage_mapper, **kwargs):
                 exam["marketplace"] = product["marketplace"]
                 exam["name"] = product["name"]
                 exam["periodQuantity"] = product["effectiveDays"]
-
-    # purchase account required for purchasing from marketplace
 
     return flask.render_template(
         "credentials/shop/index.html",

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -1496,7 +1496,11 @@ def cred_shop(ua_contracts_api, advantage_mapper, **kwargs):
         )
         is_internal_user = user.get("email", "").endswith("@canonical.com")
         exam["disabled"] = is_disabled
-        if exam["id"] == "cue-02-desktop" and not is_internal_user:
+        if (
+            exam["id"] == "cue-02-desktop"
+            and not is_internal_user
+            and is_production
+        ):
             exam["disabled"] = True
 
     for product in cue_products:

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -1496,11 +1496,7 @@ def cred_shop(ua_contracts_api, advantage_mapper, **kwargs):
         )
         is_internal_user = user.get("email", "").endswith("@canonical.com")
         exam["disabled"] = is_disabled
-        if (
-            exam["id"] == "cue-02-desktop"
-            and not is_internal_user
-            and is_production
-        ):
+        if exam["id"] == "cue-02-desktop" and not is_internal_user:
             exam["disabled"] = True
 
     for product in cue_products:


### PR DESCRIPTION
## Done

- Open desktop exam for internal users

## Drive-by

- Refactor the logic for disabling exam for prod and staging environment for better readability

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to `staging.ubuntu.com/credentials/shop` or `ubuntu.com/credentials/shop` as internal user and you will see two enabled exams
- Go to above as non-internal user, for production you will see only one exam (cue.01) and for staging you will see two exams

## Issue / Card

Fixes [WD-22786](https://warthogs.atlassian.net/browse/WD-22786)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-22786]: https://warthogs.atlassian.net/browse/WD-22786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ