### PR TITLE
legal/ubuntu-pro-service-terms: update from copy doc. fixes 

### DIFF
--- a/templates/legal/ubuntu-pro-service-terms/2024-12-10.md
+++ b/templates/legal/ubuntu-pro-service-terms/2024-12-10.md
@@ -1,9 +1,10 @@
 ---
 wrapper_template: "legal/_base_legal_markdown.html"
 context:
-  title: "Ubuntu Pro service terms"
+  title: "Ubuntu Pro service terms | 2024-12-10"
   description: "Ubuntu and Canonical Legal - Ubuntu Pro service terms"
-  update_date: "16 Jun 2025"
+  latest_version: "/legal/ubuntu-advantage-service-terms"
+  update_date: "10 December 2024"
   copydoc: https://docs.google.com/document/d/1aeqs6k-jgTf8xu3bOcloYpRgvIy7DuGjwyk7TLeTcqw/edit
 ---
 
@@ -52,7 +53,7 @@ When used in this Agreement, the following terms mean:
    2. Online purchases require Customer to have an Ubuntu One account.
 
 <h2>3. Services</h2>
-   1.  Unless otherwise specified in the Order, Canonical will make the Services available to Customer within 5 days of any of the following events: (i) Canonical receives a purchase order from Customer for the fees, (ii) Customer pays the fees to Canonical, or (iii) Canonical's reseller orders the Services with respect to Customer. Subject to this Agreement, including Customer's payment of the fees, Canonical will provide the Services using reasonable skill and care and through suitably qualified employees and contractors. Ubuntu Pro Services apply to all Ubuntu systems within the covered cloud or cluster. If the applicable Order does not specify a process to cover Ubuntu systems added to the cloud or cluster after the Order date, Customer will place additional Orders as Ubuntu systems are added to the cloud or cluster.
+   1.  Unless otherwise specified in the Order, Canonical will make the Services available to Customer within 5 days of any of the following events: (i) Canonical receives a purchase order from Customer for the fees, (ii) Customer pays the fees to Canonical, or (iii) Canonical's reseller orders the Services with respect to Customer. Subject to this Agreement, including Customer's payment of the fees, Canonical will provide the Services using reasonable skill and care and through suitably qualified employees and contractors.
    2.  Canonical is not obligated to perform (i) any service or function except as expressly identified in the Order; or (ii) any Services to the extent its performance is limited by Customer's failure to meet any reasonable dependency.
 
 <h2>4. Intellectual Property Rights</h2>
@@ -79,7 +80,7 @@ When used in this Agreement, the following terms mean:
 <h2>7. Fees and payment</h2>
    1.  Unless an Order expressly sets out an invoicing schedule or payment details, if Customer is purchasing Services directly from Canonical, Canonical will invoice Customer for the fees associated with each Order at the time of Customer's Order or immediately following a "free use" service period where the service is not cancelled. Fees will be due within 30 days from the date of invoice.
    2.  Customer will not be charged for "free use" service periods. Where identified in an Order the Services will automatically renew at the end of the free use service period and Customer will be charged.
-   3.  For credit card payments, payment is handled by a third party. Customer's credit card statement may identify payments as made to "Canonical" or "Stripe". You authorize us or our authorized vendor(s) to store your payment method and use it in connection with your use of the Services. You may have the option to manually update the card on file. Customer is responsible for any foreign transaction fees incurred by Customer's bank. Customer will abide by any relevant terms and conditions or other legal agreement, whether with Canonical or a third party, that governs Customer use of a given payment processing method. Canonical may add or remove payment processing methods at its sole discretion and without notice to Customer.  Once an Order is placed, Canonical or its third party  payment processor will charge Customer's credit card or other form of payment, along with any additional applicable amounts (including any taxes). Customer is solely responsible for all amounts payable associated with purchases made in accordance with an Order. Customer will be charged at the rate applicable at the time of use. If the fees payable for the Service change later, Canonical will notify Customer via email or at the time of Customer's renewal. The increase will apply to the next payment due from Customer after the notice is placed on an account page or as otherwise stated.
+   3.  For credit card payments, payment is handled by a third party. Customer's credit card statement may identify payments as made to "Canonical" or "Stripe". Customer is responsible for any foreign transaction fees incurred by Customer's bank. Customer will abide by any relevant terms and conditions or other legal agreement, whether with Canonical or a third party, that governs Customer use of a given payment processing method. Canonical may add or remove payment processing methods at its sole discretion and without notice to Customer.  Once an Order is placed, Canonical or its third party  payment processor will charge Customer's credit card or other form of payment, along with any additional applicable amounts (including any taxes). Customer is solely responsible for all amounts payable associated with purchases made in accordance with an Order. Customer will be charged at the rate applicable at the time of use. If the fees payable for the Service change later, Canonical will notify Customer via email or at the time of Customer's renewal. The increase will apply to the next payment due from Customer after the notice is placed on an account page or as otherwise stated.
    4.  If an Order specifies an amount due for travel expenses, Customer will pay such amount on a fixed fee basis. If Customer requests a change to the timing of Canonical's performance of the Services after the timing is agreed, Customer will also be responsible for reimbursing Canonical any non-recoverable travel expenses incurred by Canonical (or Canonical's partner) with respect to the originally agreed performance timing.
    5.  The fees are exclusive of all applicable taxes and tariffs, which Customer will pay in addition to the fees at the rate prevailing on the date of the invoice. Any sums payable by Customer to Canonical will be paid clear of any deductions or withholdings. In the event that Customer is required by applicable law to withhold or deduct any amounts from the fees, Customer will pay any additional amounts necessary to ensure that Canonical is in the same position as it would have been, had no deductions or withholdings been required.
    6.  During the term of this Agreement, Canonical may request Customer's confirmation of its compliance with this Agreement or, if Canonical reasonably suspects that Customer is not in compliance with this Agreement, audit Customer's use of the Services to confirm compliance. If any audit reveals that Customer was not in compliance with the Agreement, Customer will immediately come into compliance. If Customer's confirmation or an audit reveals that additional fees are due, Customer will pay such fees and interest (at the rate applicable to past due amounts), within 30 days of the date of Canonical's invoice. If the additional fees exceed the fees originally invoiced for the period covered by the audit by 5%, Customer will reimburse Canonical for the costs of the audit.
@@ -124,20 +125,3 @@ When used in this Agreement, the following terms mean:
    1.  If Customer is an entity registered in the United States of America, Canada, or Mexico, this Agreement, each Order, and any non-contractual obligations arising from this Agreement will be governed by and construed in accordance with the laws of the State of New York (USA) and any the parties submit to the exclusive jurisdiction of the Federal and State courts located in the State of New York (USA). In all other cases, this Agreement and any non-contractual obligations arising from this Agreement will be governed by and construed in accordance with the laws of England, and the parties submit to the exclusive jurisdiction of the courts of England.
    2.  The preceding exclusive jurisdiction requirement does not apply to the extent a party seeks immediate injunctive relief (for example, in connection with a breach or impending breach of confidentiality obligations) that would not be reasonably effective unless obtained in the jurisdiction of the conduct at issue.
    3.  The provisions of the United Nations Convention on Contracts for the International Sale of Goods will not apply to this Agreement.
-
----
-
-### Older versions
-
-- [10 December 2024 ›](/legal/ubuntu-pro-service-terms/2024-12-10)
-- [16 February 2024 ›](/legal/ubuntu-pro-service-terms/2024-02-16)
-- [25 January 2023 ›](/legal/ubuntu-pro-service-terms/2023-01-25)
-- [11 February 2019 ›](/legal/ubuntu-pro-service-terms/2019-02-11)
-- [24 June 2016 ›](/legal/ubuntu-pro-service-terms/2016-06-24)
-- [20 May 2016 ›](/legal/ubuntu-pro-service-terms/2016-05-20)
-- [09 September 2015 ›](/legal/ubuntu-pro-service-terms/2015-09-09)
-- [24 June 2015 ›](/legal/ubuntu-pro-service-terms/2015-06-24)
-
-### Japanese translation
-
-- [略式サービス契約 ›](/legal/ubuntu-pro-service-terms/ja)


### PR DESCRIPTION
## Done

- legal/ubuntu-pro-service-terms: update from copy doc

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- check [legal/ubuntu-pro-service-terms](https://ubuntu-com-15202.demos.haus/legal/ubuntu-pro-service-terms) was updated in regard to the update from [copy doc](https://docs.google.com/document/d/1aeqs6k-jgTf8xu3bOcloYpRgvIy7DuGjwyk7TLeTcqw/edit?tab=t.0)
- check the older version from December 2024

## Issue / Card

Fixes [WD-22812](https://warthogs.atlassian.net/browse/WD-22812)

## Screenshots

![image](https://github.com/user-attachments/assets/4dc67044-f618-4295-a320-48d3603012d0)



## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-22812]: https://warthogs.atlassian.net/browse/WD-22812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ