### PR TITLE
Fix TypeError when sorting mixed CVE and URL references in security notices

### DIFF
--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -122,7 +122,7 @@ def notice(notice_id):
             ]
         cves_and_references = sorted(
             cves_and_references,
-            key=lambda x: x["id"],
+            key=lambda x: x["id"] if isinstance(x, dict) and "id" in x else x,
             reverse=True,
         )
 


### PR DESCRIPTION
## Done
Fixes a bug that breaks some individual USN notices page.
the cves_and_references array can have values like this `[https://launchpad.net/bugs/2113924']` or this `[{'id': 'CVE-2019-5427', 'notices_ids': ['USN-5293-1', 'USN-5293-2', 'USN-7571-1']}]` which the sorting function breaks as there are no ids on the array of strings

Related to #15208 #15209 

## QA
Demo links do not have the latest USNs but you can check this out locally to test it out at `/security/notices/USN-7555-3`

- Check out the USN index page on the demo https://ubuntu-com-15210.demos.haus/security/notices
- Open one and check that nothing breaks compared to this on prod: https://ubuntu.com/security/notices/USN-7555-3

## Issue / Card

Fixes # [15210](https://warthogs.atlassian.net/browse/WD-22908)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
