### PR TITLE
Setup redirects for outdated tutorials

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1033,6 +1033,8 @@ tutorials/microstack-get-started? : /openstack/tutorials
 tutorials/install-openstack-with-conjure-up? : /openstack/tutorials
 tutorials/electron-kiosk/?: https://mir-server.io/docs/make-a-secure-ubuntu-web-kiosk
 tutorials/get-started-with-edgex-as-snaps?: /internet-of-things
+tutorials/how-to-install-adguard-home-raspberry-pi/?: /appliance/adguard/raspberry-pi
+tutorials/how-to-use-the-nextcloud-ubuntu-appliance-with-collabora-online-on-intel-nuc/?: /appliance/nextcloud/intel-nuc
 
 # Image builder
 build: /core/build


### PR DESCRIPTION
## Done

- Setup redirect for stated outdated tutorial links per task request.

## QA

- Check the demo
- Ensure:
  - /tutorials/how-to-install-adguard-home-raspberry-pi -> /appliance/adguard/raspberry-pi
  - /tutorials/how-to-use-the-nextcloud-ubuntu-appliance-with-collabora-online-on-intel-nuc
 -> /appliance/nextcloud/intel-nuc

## Issue / Card

Fixes # [22333](https://warthogs.atlassian.net/browse/WD-22333)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
