### PR TITLE
feat: Rebrand search page

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 canonicalwebteam.flask-base==2.5.0
 canonicalwebteam.http==1.0.4
 canonicalwebteam.blog==6.4.4
-# canonicalwebteam.search==2.1.1
-canonicalwebteam.search @ git+https://github.com/canonical/canonicalwebteam.search.git@add-featured-search#egg=canonicalwebteam.search
+canonicalwebteam.search==2.1.2
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.5.0
 canonicalwebteam.discourse==6.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 canonicalwebteam.flask-base==2.5.0
 canonicalwebteam.http==1.0.4
 canonicalwebteam.blog==6.4.4
-canonicalwebteam.search==2.1.1
+# canonicalwebteam.search==2.1.1
+canonicalwebteam.search @ git+https://github.com/canonical/canonicalwebteam.search.git@add-featured-search#egg=canonicalwebteam.search
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.5.0
 canonicalwebteam.discourse==6.2.0

--- a/templates/search.html
+++ b/templates/search.html
@@ -8,8 +8,78 @@
 {% endblock %}
 
 {% block content %}
+  <div class="p-section--hero">
+    <div class="p-section--shallow u-fixed-width">
+      {% if query %}
+        <h1>Search results for "{{ query }}"</h1>
+      {% else %}
+        <h1>Search Ubuntu and Canonical sites</h1>
+      {% endif %}
+    </div>
+    {# search form #}
+    <div class="u-fixed-width">
+      <form class="p-search-box" action="/search">
+        <label for="search-input" class="u-off-screen">Search</label>
+        <!-- honeypot search input -->
+        <input type="search"
+              id="search"
+              class="p-search-box__input u-hide "
+              name="search"
+              placeholder="Search our sites"
+              aria-label="Search our sites"
+              value="" />
+        <!-- end of honeypot search input -->
+        <input class="p-search-box__input"
+              name="q"
+              id="search-input"
+              type="search"
+              {% if query %}value="{{ query }}"{% endif %}
+              placeholder="e.g. juju" />
+        {% if siteSearch %}<input name="siteSearch" type="hidden" value="{{ siteSearch }}" />{% endif %}
+        <button type="submit" alt="search" class="p-search-box__button" alt="search">
+          <i class="p-icon--search">Submit</i>
+        </button>
+      </form>
+    </div>
+  </div>
 
-  <div class="p-strip is-shallow">
+  {% if not query %}
+    {% set featured_section = featured["products"]["side_nav_sections"][0] %}
+    {% if featured_section %}
+      <section class="p-section">
+        <div class="p-section--shallow u-fixed-width">
+          <hr class="p-rule" />
+          <h2>{{ featured_section["title"] }}</h2>
+        </div>
+        <div class="p-list--horizontal-section-wrapper">
+          <ul class="p-list--horizontal-section">
+            {% for section in featured_section["primary_links"][0]["links"] %}
+            <li class="p-list__item">
+              <div class="col-3 col-medium-2">
+                <h5 class="u-no-margin--bottom"><a href="{{ section["url"] }}">{{ section["title"] }}</a></h5>
+                <p>{{ section["description"]}}</p>
+              </div>
+            </li>
+          {% endfor %}
+          </ul>
+        </div>
+      </section>
+      <hr class="p-rule is-fixed-width" />
+      <section class="p-strip is-deep">
+        <div class="u-fixed-width">
+          <p class="p-heading--2">
+            <a href="/contact-us">Get in touch&nbsp;&rsaquo;</a>
+          </p>
+        </div>
+      </section>
+    {% endif %}
+  {% else %}
+
+  {% endif %}
+
+
+
+  <div class="p-section">
     <div class="u-fixed-width">
       {% if query %}
         {% if estimatedTotal == 0 %}
@@ -31,32 +101,6 @@
         <h1>Search Ubuntu and Canonical sites</h1>
       {% endif %}
     </div>
-  </div>
-
-  {# search form #}
-  <div class="u-fixed-width">
-    <form class="p-search-box" action="/search">
-      <label for="search-input" class="u-off-screen">Search</label>
-      <!-- honeypot search input -->
-      <input type="search"
-             id="search"
-             class="p-search-box__input u-hide "
-             name="search"
-             placeholder="Search our sites"
-             aria-label="Search our sites"
-             value="" />
-      <!-- end of honeypot search input -->
-      <input class="p-search-box__input"
-             name="q"
-             id="search-input"
-             type="search"
-             {% if query %}value="{{ query }}"{% endif %}
-             placeholder="e.g. juju" />
-      {% if siteSearch %}<input name="siteSearch" type="hidden" value="{{ siteSearch }}" />{% endif %}
-      <button type="submit" alt="search" class="p-search-box__button" alt="search">
-        <i class="p-icon--search">Submit</i>
-      </button>
-    </form>
   </div>
 
   {% if results %}

--- a/templates/search.html
+++ b/templates/search.html
@@ -7,11 +7,27 @@
   {% if query %}for '{{ query }}'{% endif %}
 {% endblock %}
 
+<!-- TODO: What does siteSearch return? -->
+
 {% block content %}
   <div class="p-section--hero">
     <div class="p-section--shallow u-fixed-width">
       {% if query %}
-        <h1>Search results for "{{ query }}"</h1>
+        {% if estimatedTotal == 0 %}
+          <h1>Sorry we couldn't find "{{ query }}"</h1>
+          {% if siteSearch %}
+            <h3>
+              on <a href="https://{{ siteSearch }}">{{ siteSearch }}</a>
+            </h3>
+          {% endif %}
+        {% else %}
+          <h1>Search results for "{{ query }}"</h1>
+          {% if siteSearch %}
+            <h3>
+              on <a href="https://{{ siteSearch }}">{{ siteSearch }}</a>
+            </h3>
+          {% endif %}
+        {% endif %}
       {% else %}
         <h1>Search Ubuntu and Canonical sites</h1>
       {% endif %}
@@ -42,7 +58,6 @@
       </form>
     </div>
   </div>
-
   {% if not query %}
     {% set featured_section = featured["products"]["side_nav_sections"][0] %}
     {% if featured_section %}
@@ -73,35 +88,9 @@
         </div>
       </section>
     {% endif %}
-  {% else %}
-
   {% endif %}
 
 
-
-  <div class="p-section">
-    <div class="u-fixed-width">
-      {% if query %}
-        {% if estimatedTotal == 0 %}
-          <h1 class="p-heading--2">Sorry we couldn't find "{{ query }}"</h1>
-          {% if siteSearch %}
-            <h3>
-              on <a href="https://{{ siteSearch }}">{{ siteSearch }}</a>
-            </h3>
-          {% endif %}
-        {% else %}
-          <h1 class="p-heading--2">Search results for "{{ query }}"</h1>
-          {% if siteSearch %}
-            <h3>
-              on <a href="https://{{ siteSearch }}">{{ siteSearch }}</a>
-            </h3>
-          {% endif %}
-        {% endif %}
-      {% else %}
-        <h1>Search Ubuntu and Canonical sites</h1>
-      {% endif %}
-    </div>
-  </div>
 
   {% if results %}
     {% if results.entries %}
@@ -135,27 +124,42 @@
         </div>
       </div>
     {% else %}
-      <div class="p-strip">
+      <div class="p-section--deep">
         <div class="row">
-          <div class="col-6">
-            <h3>Why not try widening your search?</h3>
-            <p>You can do this by:</p>
+          <div class="p-notification--negative">
+            <div class="p-notification__content">
+              <h5 class="p-notification__title">Your search "{{ query }}" did not match any notices.</h5>
+            </div>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col-4 col-medium-3">
+            <div class="p-heading--4">
+              Why not try widening your search?<br> You can do this by:
+            </div>
+          </div>
+          <div class="col-4 col-medium-3">
             <ul class="p-list">
               <li class="p-list__item is-ticked">Adding alternative words or phrases</li>
               <li class="p-list__item is-ticked">Using individual words instead of phrases</li>
               <li class="p-list__item is-ticked">Trying a different spelling</li>
             </ul>
           </div>
-          <div class="col-6">
-            <h3>Still no luck?</h3>
-            <ul class="p-list">
-              <li class="p-list__item is-ticked">
-                <a href="/">Visit the Ubuntu homepage</a>
-              </li>
-              <li class="p-list__item is-ticked">
-                <a href="/desktop/contact-us?product=search-page">Contact us</a>
-              </li>
-            </ul>
+        </div>
+        <div class="u-fixed-width">
+          <hr>
+        </div>
+        <div class="row">
+          <div class="col-4 col-medium-3">
+            <div class="p-heading--4">Still no luck?</div>
+          </div>
+          <div class="col-6 col-medium-3">
+            <p class="u-no-margin--bottom">
+              <a href="/">Visit the Ubuntu homepage</a>
+            </p>
+            <p class="u-no-margin--bottom">
+              <a href="/desktop/contact-us?product=search-page">Contact us</a>
+            </p>
           </div>
         </div>
       </div>

--- a/templates/search.html
+++ b/templates/search.html
@@ -11,8 +11,6 @@
   {% if query %}for '{{ query }}'{% endif %}
 {% endblock %}
 
-<!-- TODO: What does siteSearch return? -->
-
 {% block content %}
   <div class="p-strip is-shallow">
     <div class="p-section--shallow u-fixed-width">

--- a/templates/search.html
+++ b/templates/search.html
@@ -77,7 +77,7 @@
             {% for section in featured_section["primary_links"][0]["links"] %}
             <li class="p-list__item">
               <div class="col-3 col-medium-2">
-                <h5 class="u-no-margin--bottom"><a href="{{ section["url"] }}">{{ section["title"] }}</a></h5>
+                <h3 class="p-heading--5 u-no-margin--bottom"><a href="{{ section["url"] }}">{{ section["title"] }}</a></h3>
                 <p>{{ section["description"] }}</p>
               </div>
             </li>
@@ -105,9 +105,9 @@
             <hr class="p-rule--muted u-no-margin--bottom" />
             {% endif %}
             <div class="col">
-              <p class="p-heading--3 u-no-margin--bottom">
+              <h2 class="p-heading--3 u-no-margin--bottom">
                 <a href="{{ item.link }}">{{ item.htmlTitle | safe }}</a>
-              </p>
+              </h2>
               <p class="u-no-margin--bottom"><a href="{{ item.link }}" class="u-text--muted">{{ item.htmlFormattedUrl | safe }}</a></p>
               <p>{{ item.htmlSnippet | safe }}</p>
             </div>
@@ -141,9 +141,9 @@
         </div>
         <div class="row">
           <div class="col-4 col-medium-3">
-            <div class="p-heading--4">
-              Why not try widening your search? You can do this by:
-            </div>
+            <h2 class="p-heading--4">
+            Why not try widening your search? You can do this by:
+            </h2>
           </div>
           <div class="col-4 col-medium-3">
             <ul class="p-list">
@@ -158,7 +158,7 @@
         </div>
         <div class="row">
           <div class="col-4 col-medium-3">
-            <div class="p-heading--4">Still no luck?</div>
+            <h2 class="p-heading--4">Still no luck?</h2>
           </div>
           <div class="col-6 col-medium-3">
             <p class="u-no-margin--bottom">

--- a/templates/search.html
+++ b/templates/search.html
@@ -2,6 +2,10 @@
 
 {% block head_extra %}<meta name="robots" content="noindex" />{% endblock %}
 
+{% block body_class %}
+  is-paper
+{% endblock body_class %}
+
 {% block title %}
   Search results
   {% if query %}for '{{ query }}'{% endif %}
@@ -10,7 +14,7 @@
 <!-- TODO: What does siteSearch return? -->
 
 {% block content %}
-  <div class="p-section--hero">
+  <div class="p-strip is-shallow">
     <div class="p-section--shallow u-fixed-width">
       {% if query %}
         {% if estimatedTotal == 0 %}
@@ -33,29 +37,31 @@
       {% endif %}
     </div>
     {# search form #}
-    <div class="u-fixed-width">
-      <form class="p-search-box" action="/search">
-        <label for="search-input" class="u-off-screen">Search</label>
-        <!-- honeypot search input -->
-        <input type="search"
-              id="search"
-              class="p-search-box__input u-hide "
-              name="search"
-              placeholder="Search our sites"
-              aria-label="Search our sites"
-              value="" />
-        <!-- end of honeypot search input -->
-        <input class="p-search-box__input"
-              name="q"
-              id="search-input"
-              type="search"
-              {% if query %}value="{{ query }}"{% endif %}
-              placeholder="e.g. juju" />
-        {% if siteSearch %}<input name="siteSearch" type="hidden" value="{{ siteSearch }}" />{% endif %}
-        <button type="submit" alt="search" class="p-search-box__button" alt="search">
-          <i class="p-icon--search">Submit</i>
-        </button>
-      </form>
+    <div class="p-section--shallow">
+      <div class="u-fixed-width">
+        <form class="p-search-box" action="/search">
+          <label for="search-input" class="u-off-screen">Search</label>
+          <!-- honeypot search input -->
+          <input type="search"
+                id="search"
+                class="p-search-box__input u-hide "
+                name="search"
+                placeholder="Search our sites"
+                aria-label="Search our sites"
+                value="" />
+          <!-- end of honeypot search input -->
+          <input class="p-search-box__input"
+                name="q"
+                id="search-input"
+                type="search"
+                {% if query %}value="{{ query }}"{% endif %}
+                placeholder="e.g. juju" />
+          {% if siteSearch %}<input name="siteSearch" type="hidden" value="{{ siteSearch }}" />{% endif %}
+          <button type="submit" alt="search" class="p-search-box__button" alt="search">
+            <i class="p-icon--search">Submit</i>
+          </button>
+        </form>
+      </div>
     </div>
   </div>
   {% if not query %}
@@ -72,7 +78,7 @@
             <li class="p-list__item">
               <div class="col-3 col-medium-2">
                 <h5 class="u-no-margin--bottom"><a href="{{ section["url"] }}">{{ section["title"] }}</a></h5>
-                <p>{{ section["description"]}}</p>
+                <p>{{ section["description"] }}</p>
               </div>
             </li>
           {% endfor %}
@@ -90,19 +96,20 @@
     {% endif %}
   {% endif %}
 
-
-
   {% if results %}
     {% if results.entries %}
       {% for item in results.entries %}
-        <div class="p-strip is-shallow">
+        <div class="p-section--shallow">
           <div class="row">
-            <div class="col-12">
-              <h5>
-                <a href="{{ item.link }}" class="title-main">{{ item.htmlTitle | safe }}</a>
-              </h5>
+            {% if not loop.first %}
+            <hr class="p-rule--muted u-no-margin--bottom" />
+            {% endif %}
+            <div class="col">
+              <p class="p-heading--3 u-no-margin--bottom">
+                <a href="{{ item.link }}">{{ item.htmlTitle | safe }}</a>
+              </p>
+              <p class="u-no-margin--bottom"><a href="{{ item.link }}" class="u-text--muted">{{ item.htmlFormattedUrl | safe }}</a></p>
               <p>{{ item.htmlSnippet | safe }}</p>
-              <small><a href="{{ item.link }}">{{ item.htmlFormattedUrl | safe }}</a></small>
             </div>
           </div>
         </div>
@@ -135,7 +142,7 @@
         <div class="row">
           <div class="col-4 col-medium-3">
             <div class="p-heading--4">
-              Why not try widening your search?<br> You can do this by:
+              Why not try widening your search? You can do this by:
             </div>
           </div>
           <div class="col-4 col-medium-3">
@@ -147,7 +154,7 @@
           </div>
         </div>
         <div class="u-fixed-width">
-          <hr>
+          <hr class="p-rule" />
         </div>
         <div class="row">
           <div class="col-4 col-medium-3">

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -9,6 +9,7 @@ import flask
 import requests
 import talisker.requests
 from jinja2 import ChoiceLoader, FileSystemLoader
+import yaml
 
 from canonicalwebteam.blog import BlogAPI, BlogViews, build_blueprint
 from canonicalwebteam.discourse import (
@@ -485,6 +486,9 @@ app.add_url_rule(
 )
 
 app.add_url_rule("/getubuntu/releasenotes", view_func=releasenotes_redirect)
+with open("meganav.yaml") as meganav_file:
+    meganav = yaml.load(meganav_file.read(), Loader=yaml.FullLoader)
+
 app.add_url_rule(
     "/search",
     "search",
@@ -493,6 +497,7 @@ app.add_url_rule(
         session=session,
         template_path="search.html",
         search_engine_id=search_engine_id,
+        featured=meganav,
     ),
 )
 


### PR DESCRIPTION
## Done

- Apply rebranding on search page

## QA

- Go to https://ubuntu-com-15216.demos.haus/search
- Check that design matches [Figma](https://www.figma.com/design/RIeBDWnFQVtYOQltavDcXf/Search--ubuntu.com-and-canonical.com-?node-id=1-84&p=f&m=dev)
- Perform searches for no result and result pages

## Issue / Card

Fixes [WD-17811](https://warthogs.atlassian.net/browse/WD-17811)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-17811]: https://warthogs.atlassian.net/browse/WD-17811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ