### PR TITLE
Use common names for countries in CLA

### DIFF
--- a/static/js/src/canonical-cla/components/ContactDetailsForm/IndividualContactForm.tsx
+++ b/static/js/src/canonical-cla/components/ContactDetailsForm/IndividualContactForm.tsx
@@ -144,11 +144,11 @@ const IndividualContactForm = () => {
             />
             <FormikField
               component={Select}
-              label="Country"
+              label="Country/Region"
               name="country"
               defaultValue={""}
               options={[
-                { label: "Choose a country", value: "", disabled: true },
+                { label: "Choose a country/region", value: "", disabled: true },
                 ...window.COUNTRIES_LIST.map((country) => ({
                   label: country.name,
                   value: country.alpha2,

--- a/static/js/src/canonical-cla/components/ContactDetailsForm/OrganizationContactForm.tsx
+++ b/static/js/src/canonical-cla/components/ContactDetailsForm/OrganizationContactForm.tsx
@@ -177,11 +177,11 @@ const OrganizationContactForm = () => {
             <FormikField
               component={Select}
               required
-              label="Country"
+              label="Country/Region"
               name="country"
               defaultValue={""}
               options={[
-                { label: "Choose a country", value: "", disabled: true },
+                { label: "Choose a country/region", value: "", disabled: true },
                 ...window.COUNTRIES_LIST.map((country) => ({
                   label: country.name,
                   value: country.alpha2,

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -331,7 +331,10 @@ def init_handlers(app, sentry):
         from pycountry import countries
 
         countries = [
-            {"alpha2": country.alpha_2, "name": country.name}
+            {
+                "alpha2": country.alpha_2,
+                "name": getattr(country, "common_name", country.name)
+            }
             for country in list(countries)
         ]
         return sorted(countries, key=lambda x: x["name"])

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -333,7 +333,7 @@ def init_handlers(app, sentry):
         countries = [
             {
                 "alpha2": country.alpha_2,
-                "name": getattr(country, "common_name", country.name)
+                "name": getattr(country, "common_name", country.name),
             }
             for country in list(countries)
         ]


### PR DESCRIPTION
## Done

- Updated the country name retrieval to use the common name when available, enhancing consistency in the country list.
- Updated the country dropdown label to add 'Region'

## QA

- Check out the demo link [here](https://ubuntu-com-15223.demos.haus/legal/contributors/agreement?type=individual)
- Locate the drop-down list option of the "Country" field that check that country name are represented correctly for example `Taiwan` instead of `Taiwan, Province of China`.

## Issue / Card 
Issue: #15221 

Fixes # [23085](https://warthogs.atlassian.net/browse/WD-23085)

## Screenshots



## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
