### PR TITLE
Copy update: update spectro cloud logo

### DIFF
--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -365,7 +365,7 @@
               <div class="p-logo-section__item">
                 {{ image(url="https://assets.ubuntu.com/v1/19c3c265-spectrocloud-logo.png",
                                 alt="Spectro Cloud",
-                                width="72",
+                                width="87",
                                 height="96",
                                 hi_def=True,
                                 loading="lazy",
@@ -423,7 +423,7 @@
               <div class="p-logo-section__item">
                 {{ image(url="https://assets.ubuntu.com/v1/19c3c265-spectrocloud-logo.png",
                                 alt="Spectro Cloud",
-                                width="72",
+                                width="87",
                                 height="96",
                                 hi_def=True,
                                 loading="lazy",

--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -363,7 +363,7 @@
                 }}
               </div>
               <div class="p-logo-section__item">
-                {{ image(url="https://assets.ubuntu.com/v1/d0e0b382-spectro-cloud-logo.png",
+                {{ image(url="https://assets.ubuntu.com/v1/19c3c265-spectrocloud-logo.png",
                                 alt="Spectro Cloud",
                                 width="72",
                                 height="96",
@@ -421,7 +421,7 @@
                 }}
               </div>
               <div class="p-logo-section__item">
-                {{ image(url="https://assets.ubuntu.com/v1/d0e0b382-spectro-cloud-logo.png",
+                {{ image(url="https://assets.ubuntu.com/v1/19c3c265-spectrocloud-logo.png",
                                 alt="Spectro Cloud",
                                 width="72",
                                 height="96",


### PR DESCRIPTION
## Done

- Update spectro cloud logo on /kubernetes page

## QA

- Go to[ demo](https://ubuntu-com-15226.demos.haus/kubernetes)
- Scroll down to `Integrated cluster management platforms` section and check the logos and ensure the new logo is shown

## Issue / Card WD-22934
[Copy docs](https://docs.google.com/document/d/1b018GoKMF3abEFJlUkfAEK2JEhXWICKF4V0dGdTvgJs/edit?tab=t.0)

## Screenshots
Before
![image](https://github.com/user-attachments/assets/c75ea2a3-926d-4af1-8aef-a12a698522fa)


After
![image](https://github.com/user-attachments/assets/3567b021-dba2-4285-abef-b4321bf77503)
