### PR TITLE
WD-22491: disable buy button on checkout page based on form states

### DIFF
--- a/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
@@ -30,6 +30,7 @@ type Props = {
   action: Action;
   coupon?: Coupon;
   errorType: string;
+  isDisabled: boolean;
 };
 
 const BuyButton = ({
@@ -38,12 +39,13 @@ const BuyButton = ({
   action,
   coupon,
   errorType,
+  isDisabled,
 }: Props) => {
   const [isLoading, setIsLoading] = useState(false);
 
   const isBuyButtonDisabled = useMemo(() => {
-    return isLoading || errorType === "cue-banned";
-  }, [isLoading, errorType]);
+    return isLoading || errorType === "cue-banned" || isDisabled;
+  }, [isLoading, errorType, isDisabled]);
 
   const {
     values,

--- a/static/js/src/advantage/subscribe/checkout/components/Checkout/Checkout.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Checkout/Checkout.tsx
@@ -36,6 +36,8 @@ type Props = {
 const Checkout = ({ products, action, coupon }: Props) => {
   const [error, setError] = useState<DisplayError | null>(null);
   const [errorType, setErrorType] = useState<string>("");
+  const [isTotalLoading, setIsTotalLoading] = useState<boolean>(true);
+
   const { data: userInfo, isLoading: isUserInfoLoading } = useCustomerInfo();
   const userCanTrial = window.canTrial;
   const marketplace = products[0].product.marketplace;
@@ -95,85 +97,101 @@ const Checkout = ({ products, action, coupon }: Props) => {
                   action === "purchase")
               }
             >
-              <>
-                <Col emptyLarge={7} size={6}>
-                  <p>* indicates a mandatory field</p>
-                </Col>
-                <List
-                  stepped
-                  detailed
-                  items={[
-                    {
-                      title: "Region and taxes",
-                      content: (
-                        <Taxes products={products} setError={setError} />
-                      ),
-                    },
-                    {
-                      title: "Your purchase",
-                      content: (
-                        <Summary
-                          products={products}
-                          action={action}
-                          coupon={coupon}
-                          setError={setError}
-                          setErrorType={setErrorType}
-                        />
-                      ),
-                    },
-                    ...(product?.price?.value == 0
-                      ? []
-                      : [
-                          {
-                            title: "Your information",
-                            content: <UserInfoForm setError={setError} />,
-                          },
-                        ]),
-                    ...(canTrial
-                      ? [
-                          {
-                            title: "Free trial",
-                            content: (
-                              <FreeTrial products={products} action={action} />
-                            ),
-                          },
-                        ]
-                      : []),
-                    ...(marketplace ===
-                    UserSubscriptionMarketplace.CanonicalProChannel
-                      ? [
-                          {
-                            title: "Additional notes",
-                            content: (
-                              <Strip className="u-no-padding--top">
-                                <AdditionalNotes />
-                              </Strip>
-                            ),
-                          },
-                        ]
-                      : []),
-                    {
-                      title: "Confirm and buy",
-                      content: (
-                        <>
-                          <ConfirmAndBuy products={products} action={action} />
-                          <Row>
-                            <Col emptyLarge={7} size={6}>
-                              <BuyButton
-                                products={products}
-                                action={action}
-                                setError={setError}
-                                coupon={coupon}
-                                errorType={errorType}
-                              />
-                            </Col>
-                          </Row>
-                        </>
-                      ),
-                    },
-                  ]}
-                />
-              </>
+              {({ values }) => (
+                <>
+                  <Col emptyLarge={7} size={6}>
+                    <p>* indicates a mandatory field</p>
+                  </Col>
+                  <List
+                    stepped
+                    detailed
+                    items={[
+                      {
+                        title: "Region and taxes",
+                        content: (
+                          <Taxes products={products} setError={setError} />
+                        ),
+                      },
+                      {
+                        title: "Your purchase",
+                        content: (
+                          <Summary
+                            products={products}
+                            action={action}
+                            coupon={coupon}
+                            setError={setError}
+                            setErrorType={setErrorType}
+                            setIsTotalLoading={setIsTotalLoading}
+                          />
+                        ),
+                      },
+                      ...(product?.price?.value == 0
+                        ? []
+                        : [
+                            {
+                              title: "Your information",
+                              content: <UserInfoForm setError={setError} />,
+                            },
+                          ]),
+                      ...(canTrial
+                        ? [
+                            {
+                              title: "Free trial",
+                              content: (
+                                <FreeTrial
+                                  products={products}
+                                  action={action}
+                                />
+                              ),
+                            },
+                          ]
+                        : []),
+                      ...(marketplace ===
+                      UserSubscriptionMarketplace.CanonicalProChannel
+                        ? [
+                            {
+                              title: "Additional notes",
+                              content: (
+                                <Strip className="u-no-padding--top">
+                                  <AdditionalNotes />
+                                </Strip>
+                              ),
+                            },
+                          ]
+                        : []),
+                      {
+                        title: "Confirm and buy",
+                        content: (
+                          <>
+                            <ConfirmAndBuy
+                              products={products}
+                              action={action}
+                            />
+                            <Row>
+                              <Col emptyLarge={7} size={6}>
+                                <BuyButton
+                                  products={products}
+                                  action={action}
+                                  setError={setError}
+                                  coupon={coupon}
+                                  errorType={errorType}
+                                  isDisabled={
+                                    !(
+                                      values.TermsAndConditions &&
+                                      values.Description &&
+                                      values.captchaValue
+                                    ) || isTotalLoading
+                                  }
+                                />
+                              </Col>
+                            </Row>
+                          </>
+                        ),
+                      },
+                    ]}
+                  />
+                </>
+              )}
             </Formik>
           )}
         </Row>

--- a/static/js/src/advantage/subscribe/checkout/components/Summary/Summary.test.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Summary/Summary.test.tsx
@@ -72,6 +72,7 @@ describe("Summary", () => {
               action={"purchase"}
               setError={jest.fn()}
               setErrorType={jest.fn()}
+              setIsTotalLoading={jest.fn()}
               coupon={{ origin: "", IDs: [] }}
             />
           </Elements>
@@ -126,6 +127,7 @@ describe("Summary", () => {
               action={"purchase"}
               setError={jest.fn()}
               setErrorType={jest.fn()}
+              setIsTotalLoading={jest.fn()}
               coupon={{ origin: "", IDs: [] }}
             />
           </Elements>
@@ -168,6 +170,7 @@ describe("Summary", () => {
               action={"purchase"}
               setError={jest.fn()}
               setErrorType={jest.fn()}
+              setIsTotalLoading={jest.fn()}
               coupon={{ origin: "", IDs: [] }}
             />
           </Elements>
@@ -212,6 +215,7 @@ describe("Summary", () => {
               action={"purchase"}
               setError={jest.fn()}
               setErrorType={jest.fn()}
+              setIsTotalLoading={jest.fn()}
               coupon={{ origin: "", IDs: [] }}
             />
           </Elements>
@@ -256,6 +260,7 @@ describe("Summary", () => {
               action={"purchase"}
               setError={setError}
               setErrorType={jest.fn()}
+              setIsTotalLoading={jest.fn()}
               coupon={{ origin: "", IDs: [] }}
             />
           </Elements>
@@ -307,6 +312,7 @@ describe("Summary", () => {
               action={"purchase"}
               setError={setError}
               setErrorType={jest.fn()}
+              setIsTotalLoading={jest.fn()}
               coupon={{ origin: "", IDs: [] }}
             />
           </Elements>
@@ -360,6 +366,7 @@ describe("Summary", () => {
               action={"purchase"}
               setError={setError}
               setErrorType={jest.fn()}
+              setIsTotalLoading={jest.fn()}
               coupon={{ origin: "", IDs: [] }}
             />
           </Elements>
@@ -411,6 +418,7 @@ describe("Summary", () => {
               action={"purchase"}
               setError={setError}
               setErrorType={jest.fn()}
+              setIsTotalLoading={jest.fn()}
               coupon={{ origin: "", IDs: [] }}
             />
           </Elements>

--- a/static/js/src/advantage/subscribe/checkout/components/Summary/Summary.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Summary/Summary.tsx
@@ -25,9 +25,17 @@ type Props = {
   setError: React.Dispatch<React.SetStateAction<DisplayError | null>>;
   setErrorType: React.Dispatch<React.SetStateAction<string>>;
   coupon: Coupon;
+  setIsTotalLoading: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
-function Summary({ products, action, coupon, setError, setErrorType }: Props) {
+function Summary({
+  products,
+  action,
+  coupon,
+  setError,
+  setErrorType,
+  setIsTotalLoading,
+}: Props) {
   const { values } = useFormikContext<FormValues>();
 
   const { data: calculate, isFetching: isCalculateFetching } = useCalculate({
@@ -158,6 +166,10 @@ function Summary({ products, action, coupon, setError, setErrorType }: Props) {
       return;
     }
   }, [error]);
+
+  useEffect(() => {
+    setIsTotalLoading?.(isSummaryLoading);
+  }, [isSummaryLoading]);
 
   let totalSection = (
     <>


### PR DESCRIPTION
## Done

- Disable BuyButton if user has not checked mandatory checkboxes or if the total is loading

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to checkout and ensure buy button is disabled if you don't check the mandatory checkboxes or if the total is loading

## Issue / Card

Fixes [WD-22491](https://warthogs.atlassian.net/browse/WD-22491)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
