### PR TITLE
feat(api): Expose endpoint for engage page metadata

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -156,6 +156,7 @@ from webapp.views import (
     build_engage_index,
     build_engage_page,
     build_engage_pages_sitemap,
+    build_engage_pages_metadata,
     build_tutorials_index,
     build_tutorials_query,
     download_server_steps,
@@ -641,6 +642,11 @@ engage_pages = EngagePages(
 app.add_url_rule(
     "/engage/sitemap.xml",
     view_func=build_engage_pages_sitemap(engage_pages),
+)
+
+app.add_url_rule(
+    "/engage/metadata.json",
+    view_func=build_engage_pages_metadata(engage_pages),
 )
 
 app.add_url_rule(

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -566,6 +566,8 @@ def build_engage_pages_metadata(engage_pages):
                                 page.get("author", "")
                             ),  # Author doesn't exist yet
                             "active": str(page.get("active", "")),
+                            "tags": str(page.get("tags", "")),
+                            "type": str(page.get("type", "")),
                         }
                         all_pages.append(sanitized_page)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8118,11 +8118,6 @@ vanilla-framework@4.9.0:
   resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.9.0.tgz#7566b42a22c2394ea1d7ea843d24ec305446cb3e"
   integrity sha512-iTmvqWlsX0ic69VZ1sR9NPQtYRR9+iM679HZCl7SDQhMQSsEeJEQ6Ejjen3JN5a7YxiYmeIhxaLlmC4rExRT1w==
 
-vanilla-framework@^4.24.0:
-  version "4.24.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.24.0.tgz#48a15b4d59c349f418fa0490d4a72b2be9f43b15"
-  integrity sha512-2/BXRB3Aqz1skfBqDD1hn2+PWx6EdF2xGSm8weq5IgIXllbCFgq8nySmfDQOzFSVqIVgyVidWtH3rDDIB0RaIg==
-
 verbalize@^0.1.2:
   version "0.1.2"
   resolved "https://registry.npmjs.org/verbalize/-/verbalize-0.1.2.tgz"


### PR DESCRIPTION
## Done

Exposes the endpoint [/engage/metadata.json](https://ubuntu-com-15235.demos.haus/engage/metadata.json). Which displays the metadata for all engage pages.

Included in the metadata is:
- active
- author (currently not available)
- form_id
- path
- resource_url
- topic_name
- webinar_code
- type
- tags

## QA

- Visit [/engage/metadata.json](https://ubuntu-com-15235.demos.haus/engage/metadata.json) and see if display the aforementioned data

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-22500
