### PR TITLE
Update linkchecker to exclude 401 and 403 status codes in error checks

### DIFF
--- a/.github/workflows/live-links.yaml
+++ b/.github/workflows/live-links.yaml
@@ -50,7 +50,7 @@ jobs:
           status=0
           warnings=0
           ignoreerrors=
-            ^http?s://.* ^.*(471|500|503|504|400)
+            ^http?s://.* ^.*(471|500|503|504|400|403|401)
           EOF
 
       - name: Run linkchecker for 404 errors only

--- a/.github/workflows/performance-check.yaml
+++ b/.github/workflows/performance-check.yaml
@@ -10,6 +10,7 @@ env:
 
 jobs:
   perf-checks:
+    if: github.repository == 'canonical/ubuntu.com'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Done

- Update linkchecker to exclude 401 and 403 status codes in error checks
- Run perf check action on main repo only

## QA

- Check out this feature branch
- Ensure it introduces no additional code other than updating link checker config
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes # [23130](https://warthogs.atlassian.net/browse/WD-23130) [WD-23183](https://warthogs.atlassian.net/browse/WD-23183)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-23183]: https://warthogs.atlassian.net/browse/WD-23183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ