### PR TITLE
chore: Add toolchains link to meganav

### DIFF
--- a/meganav.yaml
+++ b/meganav.yaml
@@ -469,6 +469,9 @@ products:
             - title: JAAS
               description: Auditing and compliance for Juju
               url: https://jaas.ai/
+            - title: Toolchains
+              description: Build your apps on Ubuntu
+              url: /toolchains
 
       secondary_links:
         - title: Quick links


### PR DESCRIPTION
## Done
Adds link to toolchains in meganav

## QA
- Go to https://ubuntu-com-15247.demos.haus/
- Click "Products" in the navigation
- Click "Developer tools"
- There should be a "Toolchains" link to https://ubuntu-com-15247.demos.haus/toolchains underneath "JAAS"

## Issue / Card
Fixes https://warthogs.atlassian.net/browse/WD-22993