### PR TITLE
page update: /security/security-standards

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1173,6 +1173,7 @@ def render_security_standards_blogs():
             4633,
             4749,
         ],
+        excluded_tags=[3184, 3265],
         per_page=4,
         blog_title="Security standards blogs",
     )


### PR DESCRIPTION
## Done

Exclude non-English blogs as requested in the ticket

## QA

- Open [demo](https://ubuntu-com-15248.demos.haus/security/security-standards)
- Scroll down to the "Resources" section
- [x] All showcased blog posts are in English

## Issue

https://warthogs.atlassian.net/browse/WD-23181