### PR TITLE
Wd 22327 vat error message formatting

### DIFF
--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionCancel/SubscriptionCancel.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionCancel/SubscriptionCancel.tsx
@@ -51,7 +51,7 @@ const generateError = (error: CancelError | null) => {
           action.{" "}
         </>
       ) : null}
-      Contact <a href="/contact-us">Canonical sales</a> if the problem persists.
+      Contact{" "}<a href="/contact-us">Canonical sales</a>{" "}if the problem persists.
     </>
   );
 };

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionCancel/SubscriptionCancel.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionCancel/SubscriptionCancel.tsx
@@ -51,7 +51,7 @@ const generateError = (error: CancelError | null) => {
           action.{" "}
         </>
       ) : null}
-      Contact{" "}<a href="/contact-us">Canonical sales</a>{" "}if the problem persists.
+      Contact <a href="/contact-us">Canonical sales</a> if the problem persists.
     </>
   );
 };

--- a/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
@@ -225,9 +225,7 @@ const BuyButton = ({
           <>
             VAT number could not be validated at this time, please try again
             later or contact{" "}
-            <a href="mailto:customersuccess@canonical.com">
-              customer success
-            </a>{" "}
+            <a href="mailto:customersuccess@canonical.com">customer success</a>{" "}
             if the problem persists.
           </>
         ),

--- a/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
@@ -224,7 +224,7 @@ const BuyButton = ({
         description: (
           <>
             VAT number could not be validated at this time, please try again
-            later or contact
+            later or contact{" "}
             <a href="mailto:customersuccess@canonical.com">
               customer success
             </a>{" "}

--- a/static/js/src/advantage/subscribe/checkout/components/Taxes/Taxes.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Taxes/Taxes.tsx
@@ -107,7 +107,7 @@ const Taxes = ({ products, setError }: TaxesProps) => {
                   description: (
                     <>
                       VAT number could not be validated at this time, please try
-                      again later or contact
+                      again later or contact{" "}
                       <a href="mailto:customersuccess@canonical.com">
                         customer success
                       </a>{" "}


### PR DESCRIPTION
## Done

- Fix spacing on error messages in /account/checkout

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
