### PR TITLE
WD-23223: disable cue.02 exam in production

### DIFF
--- a/webapp/shop/cred/exams.json
+++ b/webapp/shop/cred/exams.json
@@ -50,7 +50,7 @@
       }
     ],
     "openTo": {
-      "production": true,
+      "production": false,
       "staging": true
     }
   },


### PR DESCRIPTION
## Done

- Disable CUE.02 exam in production for all users (internal and external)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to [ubuntu-com-15257.demos.haus/credentials/shop](https://ubuntu-com-15257.demos.haus/credentials/shop) and make sure you only see CUE.01 exam enabled

## Issue / Card

Fixes [WD-23223](https://warthogs.atlassian.net/browse/WD-23223)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-23223]: https://warthogs.atlassian.net/browse/WD-23223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ