### PR TITLE
Add tutorial redirects to documentation

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1041,12 +1041,13 @@ tutorials/electron-kiosk/?: https://mir-server.io/docs/make-a-secure-ubuntu-web-
 tutorials/get-started-with-edgex-as-snaps?: /internet-of-things
 tutorials/how-to-install-adguard-home-raspberry-pi/?: /appliance/adguard/raspberry-pi
 tutorials/how-to-use-the-nextcloud-ubuntu-appliance-with-collabora-online-on-intel-nuc/?: /appliance/nextcloud/intel-nuc
-# AWS and Azure tutorials redirects
 tutorials/search-and-launch-ubuntu-22-04-in-aws-using-cli/?: https://documentation.ubuntu.com/aws/aws-how-to/instances/launch-ubuntu-ec2-instance/
 tutorials/build-your-cloudformation-templates-with-the-latest-ubuntu-ami/?: https://documentation.ubuntu.com/aws/aws-how-to/instances/build-cloudformation-templates/
 tutorials/how-to-upgrade-ubuntu-lts-to-ubuntu-pro-on-aws-using-aws-license-manager/?: https://documentation.ubuntu.com/aws/aws-how-to/instances/upgrade-in-place-from-lts-to-pro/
 tutorials/ubuntu-desktop-aws/?: https://documentation.ubuntu.com/aws/aws-how-to/instances/launch-ubuntu-desktop/
 tutorials/provision-an-ubuntu-virtual-machine-running-sql-server-in-azure/?: https://documentation.ubuntu.com/azure/azure-how-to/instances/provision-an-ubuntu-virtual-machine-running-sql-server-in-azure/
+tutorials/install-kubeflow-on-azure-kubernetes-service-aks/?: https://documentation.ubuntu.com/azure/en/latest/azure-how-to/kubernetes/install-kubeflow-on-aks/
+tutorials/deploying-kubeflow-pipelines-with-azure-aks-spot-instances/?: https://documentation.ubuntu.com/azure/en/latest/azure-how-to/kubernetes/deploy-kubeflow-pipelines-with-aks-spot-instances/
 
 # Image builder
 build: /core/build


### PR DESCRIPTION
## Done

- Redirecting some tutorial pages to product docs as the content of these tutorials is now included/duplicated in the product docs

## QA

- Check out the demo branch
- Ensure these redirects work
[search-and-launch-ubuntu-22-04-in-aws-using-cli ](https://ubuntu-com-15259.demos.haus/tutorials/search-and-launch-ubuntu-22-04-in-aws-using-cli)> https://documentation.ubuntu.com/aws/aws-how-to/instances/launch-ubuntu-ec2-instance/
[build-your-cloudformation-templates](https://ubuntu-com-15259.demos.haus/tutorials/build-your-cloudformation-templates-with-the-latest-ubuntu-ami) > https://documentation.ubuntu.com/aws/aws-how-to/instances/build-cloudformation-templates/
[how-to-upgrade-to-ubuntu-pro-on-aws](https://ubuntu-com-15259.demos.haus/tutorials/how-to-upgrade-ubuntu-lts-to-ubuntu-pro-on-aws-using-aws-license-manager) > https://documentation.ubuntu.com/aws/aws-how-to/instances/upgrade-in-place-from-lts-to-pro/
[ubuntu-desktop-aws](https://ubuntu-com-15259.demos.haus/tutorials/ubuntu-desktop-aws) > https://documentation.ubuntu.com/aws/aws-how-to/instances/launch-ubuntu-desktop/
[provision-virtual-machine-sql-azure](https://ubuntu-com-15259.demos.haus/tutorials/provision-an-ubuntu-virtual-machine-running-sql-server-in-azure) > https://documentation.ubuntu.com/azure/azure-how-to/instances/provision-an-ubuntu-virtual-machine-running-sql-server-in-azure/

## Issue / Card

Fixes #
https://warthogs.atlassian.net/browse/WD-22722
https://warthogs.atlassian.net/browse/WD-22723

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
