### PR TITLE
feat: Add older blog posts notices/notifications

### DIFF
--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -142,7 +142,7 @@
         {% if 'difference_in_years' in blog_notice %}
           <div class="p-notification--information">
             <div class="p-notification__content">
-              <p class="p-notification__message">
+              <p class="p-notification__message" id="date-notice">
                 {% if blog_notice.updated %}
                   This article was last updated <strong>{{ blog_notice.difference_in_years }} year
                   {% if blog_notice.difference_in_years > 1 %}s{% endif %}


### PR DESCRIPTION
## Done

- Added notices for older blog posts

## QA

- View the site locally in your web browser at: https://ubuntu-com-15261.demos.haus/blog/ubuntu-pro-for-eks-is-now-generally-available
    - Be sure to test on mobile, tablet and desktop screen sizes
- Verify the presence of a notification

## Screenshots
![image](https://github.com/user-attachments/assets/96671f09-dc9e-4ec4-896a-94f1f48f7d77)



## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
