### PR TITLE
security: add frame-ancestors to CSP to prevent clickjacking

### DIFF
--- a/templates/test.html
+++ b/templates/test.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Iframe Test</title>
+</head>
+<body>
+    <h1>Testing if Ubuntu.com can be embedded</h1>
+    <iframe src="https://ubuntu.com" width="800" height="600"></iframe>
+</body>
+</html>

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -166,6 +166,7 @@ CSP = {
         "'self'",
         "blob:",
     ],
+    "frame-ancestors": ["'none'"],
 }
 
 


### PR DESCRIPTION
## Done

- Add `frame-ancestors` to prevent clickjacking
- Added https://ubuntu-com-15263.demos.haus/test route to QA blank iframe
- Fixes `X-Frame-Options` vulnerability [here](https://securityheaders.com/?q=ubuntu.com&followRedirects=on)

## QA

- Go to any page e.g https://ubuntu-com-15263.demos.haus/
- Go to **Network** tab, reload page
- Click on the first main request of the page
- Look into **Response Headers** section and check `Content-Security-Policy: ...frame-ancestors 'none'` is present
- Go to https://ubuntu-com-15263.demos.haus/test
- Check that there is a errored blank iframe

## Issue / Card

Fixes [WD-23225](https://warthogs.atlassian.net/browse/WD-23225)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-23225]: https://warthogs.atlassian.net/browse/WD-23225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ