### PR TITLE
fix: update country from IP address if not provided in form field

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -898,6 +898,15 @@ def marketo_submit():
     if "country" in form_fields:
         enrichment_fields["country"] = form_fields["country"]
         form_fields.pop("country")
+    else:
+        try:
+            ip_location = ip_reader.get(client_ip)
+            if ip_location and "country" in ip_location:
+                enrichment_fields["country"] = ip_location["country"][
+                    "iso_code"
+                ]
+        except Exception:
+            pass
 
     user_id = flask.request.cookies.get("user_id")
     if user_id:
@@ -948,13 +957,6 @@ def marketo_submit():
                 if k == "utm_content":
                     k = "utmcontent"
                 enrichment_fields[k] = v
-
-    try:
-        ip_location = ip_reader.get(client_ip)
-        if ip_location and "country" in ip_location:
-            enrichment_fields["country"] = ip_location["country"]["iso_code"]
-    except Exception:
-        pass
 
     enriched_payload = {
         "formId": "4198",


### PR DESCRIPTION
## Done

- Only overwrite the country field on enrichment forms with IP address if the form does not have a Country formfield

## QA

- Go to any form that has Country field, e.g https://ubuntu-com-15269.demos.haus#get-in-touch
- Select a different country from the pre-selected dropdown
- Submit form, check payload
- See that country code reflects the chosen country
- Check that the same country code is submitted to Marketo successfully
- Repeat with a form that does not have Country field, e.g https://ubuntu-com-15269.demos.haus/download/mediatek-genio/contact-us
- Check on Marketo that the Country field is submitted as the country of IP address

## Issue / Card

Fixes [WD-23224](https://warthogs.atlassian.net/browse/WD-23224)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-23224]: https://warthogs.atlassian.net/browse/WD-23224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ