### PR TITLE
fix: enable production access for CUE.02 desktop exam

### DIFF
--- a/webapp/shop/cred/exams.json
+++ b/webapp/shop/cred/exams.json
@@ -50,7 +50,7 @@
       }
     ],
     "openTo": {
-      "production": false,
+      "production": true,
       "staging": true
     }
   },


### PR DESCRIPTION
## Done

- Enable CUE.02 Desktop exam for production access

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to [ubuntu.com/credentials/shop](ubuntu.com/credentials/shop) and you should see CUE.01 and CUE.02 exams with CUE.02 at a discounted price of zero dollars (only internal users should be able to buy CUE.02)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
