### PR TITLE
feat: remove wordpress json redirect

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -564,9 +564,6 @@ production:
     more_set_headers "Link: <https://assets.ubuntu.com>; rel=preconnect; crossorigin, <https://assets.ubuntu.com>; rel=preconnect, <https://res.cloudinary.com>; rel=preconnect";
 
   nginxServerSnippet: |
-    location ^~ /blog/wp-json/wp/v2/ {
-      proxy_pass https://admin.insights.ubuntu.com/wp-json/wp/v2/;
-    }
     location ^~ /wp-content/uploads/ {
       proxy_pass https://admin.insights.ubuntu.com/wp-content/uploads/;
     }
@@ -1109,9 +1106,6 @@ staging:
     more_set_headers "Link: <https://assets.ubuntu.com>; rel=preconnect; crossorigin, <https://assets.ubuntu.com>; rel=preconnect, <https://res.cloudinary.com>; rel=preconnect";
 
   nginxServerSnippet: |
-    location ^~ /blog/wp-json/wp/v2/ {
-      proxy_pass https://admin.insights.ubuntu.com/wp-json/wp/v2/;
-    }
     location ^~ /wp-content/uploads/ {
       proxy_pass https://admin.insights.ubuntu.com/wp-content/uploads/;
     }

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -982,12 +982,6 @@ blog/canonical-announces-ubuntu-22-04-lts-support-for-flexran-reference-software
 blog/intel-compute-stick-now-comes-with-ubuntu: /download/iot/intel-iot
 /blog/cups-remote-code-execution: /blog/cups-remote-code-execution-vulnerability-fix-available
 
-# Copied from https://github.com/canonical-web-and-design/blog.ubuntu.com/blob/master/redirects.yaml
-
-# Wordpress CMS pages & resources
-blog/admin(?P<page>(/.*)?): https://admin.insights.ubuntu.com/admin{page}
-blog/wp-(?P<page>.+): https://admin.insights.ubuntu.com/wp-{page}
-
 # Archive pages
 blog/page/(?P<page>[0-9]+)/?: /blog/archives?page={page}
 


### PR DESCRIPTION
## Problem
We have a security vulnerability due to an exposed wordpress json endpoint that exposes user information.

## Done

- Removed redirects to admin.insights.ubuntu.com, which is only accessible via the VPN.

## QA

- This branch has been deployed to staging. Open the staging url here https://staging.ubuntu.com/
- Open the staging url and check that blogs pages work without issue https://staging.ubuntu.com/blog.

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
