### PR TITLE
fix: Ignore www.amd.com links that were failing the linkchecker

### DIFF
--- a/.github/workflows/live-links.yaml
+++ b/.github/workflows/live-links.yaml
@@ -45,6 +45,7 @@ jobs:
             https?://[a-z0-9]*\.example\.com
             https://lenovopress.lenovo.com/*
             https://www.xilinx.com/applications/*
+            https://www.amd.com/*
 
           [output]
           status=0


### PR DESCRIPTION
## Done

- Ignores www.amd.com links

## QA

- Check the linkchecker passes after this PR has been merged

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-23326