### PR TITLE
Bump flask-base to 2.6.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-canonicalwebteam.flask-base==2.5.0
+canonicalwebteam.flask-base==2.6.0
 canonicalwebteam.http==1.0.4
 canonicalwebteam.blog==6.4.6
 canonicalwebteam.search==2.1.2


### PR DESCRIPTION
Bump flask-base to 2.6.0

## Done

- Updated flask base to 2.6.0. This automates loading of prefixed env variables.

## QA

- Check that the demo runs

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
