### PR TITLE
feat: Implement endpoint validation for CLA API proxy

### DIFF
--- a/tests/cla/test_routes.py
+++ b/tests/cla/test_routes.py
@@ -22,7 +22,8 @@ class TestCLARoutes(unittest.TestCase):
             "utf-8"
         )
         response = self.client.get(
-            f"/legal/contributors/agreement/api?request_url={github_profile_endpoint}"
+            f"/legal/contributors/agreement/api"
+            f"?request_url={github_profile_endpoint}"
         )
 
         self.assertEqual(response.status_code, 200)
@@ -50,7 +51,8 @@ class TestCLARoutes(unittest.TestCase):
             "utf-8"
         )
         response = self.client.get(
-            f"/legal/contributors/agreement/api?request_url={github_profile_endpoint}"
+            f"/legal/contributors/agreement/api"
+            f"?request_url={github_profile_endpoint}"
         )
 
         self.assertEqual(response.status_code, 500)
@@ -70,7 +72,8 @@ class TestCLARoutes(unittest.TestCase):
             "utf-8"
         )
         response = self.client.get(
-            f"/legal/contributors/agreement/api?request_url={malicious_endpoint}"
+            f"/legal/contributors/agreement/api"
+            f"?request_url={malicious_endpoint}"
         )
 
         self.assertEqual(response.status_code, 403)

--- a/webapp/canonical_cla/views.py
+++ b/webapp/canonical_cla/views.py
@@ -42,8 +42,10 @@ def update_query_params(url: str, **params) -> str:
 
 def validate_agreement_url(url: str) -> str:
     """
-    Validate and sanitize agreement_url to prevent open redirect vulnerabilities.
-    Only allow relative URLs or URLs with the same hostname as the current request.
+    Validate and sanitize agreement_url to prevent open redirect
+    vulnerabilities.
+    Only allow relative URLs or URLs with the same hostname as
+    the current request.
     Returns the validated URL or defaults to "/legal/contributors/agreement".
     """
     fallback_url = "/legal/contributors/agreement"
@@ -159,7 +161,8 @@ def canonical_cla_api_proxy():
         return flask.abort(400)
     request_url = base64.b64decode(encoded_request_url).decode("utf-8")
 
-    # Security check: Validate that the request_url is in the allowed endpoints list
+    # Security check: Validate that the request_url
+    # is in the allowed endpoints list
     # Parse the URL to extract just the path for validation
     parsed_url = urlparse.urlparse(request_url)
     request_path = parsed_url.path


### PR DESCRIPTION
## Done

- Added a list of allowed endpoints to restrict access in the canonical CLA API proxy.
- Introduced a new test case to verify that disallowed endpoints return a 403 status with an appropriate error message.
- Updated existing tests to use base64 encoding for the GitHub profile endpoint in requests.

## Issue / Card

Fixes https://github.com/canonical/ubuntu.com/security/code-scanning/50



## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
