### PR TITLE
remove space between "year" and "s" in old blog article age notifications

### DIFF
--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -145,11 +145,11 @@
               <p class="p-notification__message" id="date-notice">
                 {% if blog_notice.updated %}
                   This article was last updated <strong>{{ blog_notice.difference_in_years }} year
-                  {% if blog_notice.difference_in_years > 1 %}s{% endif %}
+                  {%- if blog_notice.difference_in_years > 1 -%}s{%- endif -%}
                   ago</strong>.
                 {% else %}
                   This article is more than <strong>{{ blog_notice.difference_in_years }} year
-                  {% if blog_notice.difference_in_years > 1 %}s{% endif %}
+                  {%- if blog_notice.difference_in_years > 1 -%}s{%- endif -%}
                   old</strong>.
                 {% endif %}
               </p>

--- a/templates/blog/article.html
+++ b/templates/blog/article.html
@@ -145,11 +145,11 @@
               <p class="p-notification__message" id="date-notice">
                 {% if blog_notice.updated %}
                   This article was last updated <strong>{{ blog_notice.difference_in_years }} year
-                  {%- if blog_notice.difference_in_years > 1 -%}s{%- endif -%}
+                  {%- if blog_notice.difference_in_years > 1 -%}s{%- endif %}
                   ago</strong>.
                 {% else %}
                   This article is more than <strong>{{ blog_notice.difference_in_years }} year
-                  {%- if blog_notice.difference_in_years > 1 -%}s{%- endif -%}
+                  {%- if blog_notice.difference_in_years > 1 -%}s{%- endif %}
                   old</strong>.
                 {% endif %}
               </p>

--- a/tests/test_blog_notice.py
+++ b/tests/test_blog_notice.py
@@ -68,7 +68,7 @@ class TestBlogNotice(VCRTestCase):
             )
             self.assertTrue(
                 re.search(
-                    r"last\s+updated\s+3\s+year\s+s\s+ago",
+                    r"last\s+updated\s+3\s+years\s+ago",
                     three_years_old_notice.text,
                 )
             )


### PR DESCRIPTION
## Done

- Trims whitespace in the old blogpost notification "year" pluralizer

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Open a blog post >= 2 years old, like [regex basics](https://ubuntu-com-15292.demos.haus/blog/regex-basics)
- Verify that "years" is displayed in the notification at top of the post
- Open a blog post older than 1 year, but less than 2 years old - like [Canonical's recipe for HPC](https://ubuntu-com-15292.demos.haus/blog/canonicals-recipe-for-high-performance-computing)
- Verify that "year" is displayed in the notification at top of the post

## Issue / Card

Fixes #15291 

## Screenshots

![image](https://github.com/user-attachments/assets/c6c1b5b8-256c-48d1-bdfe-53ae9231f548)
![image](https://github.com/user-attachments/assets/19025d69-afda-4424-b27b-7ca807e1344e)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
