### PR TITLE
fix: update /security jobtitle form IDs

### DIFF
--- a/templates/contact-us/form-data.json
+++ b/templates/contact-us/form-data.json
@@ -155,7 +155,7 @@
         {
           "title": "How many devices?",
           "id": "how-many-devices",
-          "inputName": "how-many-devices",
+          "inputName": "how-many-devices-do-you-have",
           "inputType": "radio",
           "isRequired": true,
           "fields": [

--- a/templates/security/cmmc/form-data.json
+++ b/templates/security/cmmc/form-data.json
@@ -331,7 +331,7 @@
               },
               {
                 "type": "text",
-                "id": "jobTitle",
+                "id": "title",
                 "label": "Job title",
                 "isRequired": true
               },

--- a/templates/security/form-data.json
+++ b/templates/security/form-data.json
@@ -338,7 +338,7 @@
               },
               {
                 "type": "text",
-                "id": "jobTitle",
+                "id": "title",
                 "label": "Job title",
                 "isRequired": true
               },

--- a/templates/shared/forms/form-fields.html
+++ b/templates/shared/forms/form-fields.html
@@ -59,7 +59,7 @@
                   {% if field.id %}
                     {% set field_id = field.id %}
                   {% elif field.fieldTitle is not defined %}
-                    {% set field_id = fieldset_id + '-' + field.label %}
+                    {% set field_id = fieldset_id + '-' + field.label|slug %}
                   {% endif %}
 
                   {% if field.value %}


### PR DESCRIPTION
## Done

- update `/security` field IDs from `jobTitle` to `title`
- fly-by work: 
  - update `inputName` for homepage form, fixes [this Sentry error](https://sentry.is.canonical.com/canonical/ubuntu-com/issues/101278/?query=is%3Aunresolved%20marketo)
  - add `slug` to form template field labels

## QA

- Go to /security#get-in-touch
- Submit form, see that there are no error banners and `#contact-form-fail` in the path

## Issue / Card

Fixes [WD-23403](https://warthogs.atlassian.net/browse/WD-23403)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-23403]: https://warthogs.atlassian.net/browse/WD-23403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ