### PR TITLE
fix: Radio buttons wont have their name attr removed when JS is disabled

### DIFF
--- a/templates/desktop/thank-you.html
+++ b/templates/desktop/thank-you.html
@@ -9,7 +9,7 @@
 {% block head_extra %}<meta name="robots" content="noindex" />{% endblock %}
 
 {% block content %}
-  {% with thanks_context="contacting our team." thanks_message="We will be in touch shortly.". %}
+  {% with thanks_context="contacting our team.", thanks_message="We will be in touch shortly." %}
     {% include "shared/_thank_you.html" %}
   {% endwith %}
 {% endblock content %}

--- a/templates/shared/_client-contact-us-form.html
+++ b/templates/shared/_client-contact-us-form.html
@@ -53,7 +53,7 @@
                      class="p-radio__input"
                      type="radio"
                      aria-labelledby="less-5-machines"
-                     name="how-many-machines-do-you-have"
+                     name="_radio_how-many-machines-do-you-have"
                      value="less than 5" />
               <span class="p-radio__label" id="less-5-machines">&lt;&nbsp;5 machines</span>
 
@@ -62,7 +62,7 @@
               <input type="radio"
                      aria-labelledby="15-to-15-machines"
                      class="p-radio__input"
-                     name="how-many-machines-do-you-have"
+                     name="_radio_how-many-machines-do-you-have"
                      value="5 to 15 machines" />
               <span class="p-radio__label" id="15-to-15-machines">5&nbsp;&ndash;&nbsp;15 machines</span>
             </label>
@@ -70,7 +70,7 @@
               <input type="radio"
                      aria-labelledby="15-to-50-machines"
                      class="p-radio__input"
-                     name="how-many-machines-do-you-have"
+                     name="_radio_how-many-machines-do-you-have"
                      value="15 to 50 machines" />
               <span class="p-radio__label" id="15-to-50-machines">15&nbsp;&ndash;&nbsp;50 machines</span>
             </label>
@@ -78,7 +78,7 @@
               <input type="radio"
                      aria-labelledby="50-to-100-machines"
                      class="p-radio__input"
-                     name="how-many-machines-do-you-have"
+                     name="_radio_how-many-machines-do-you-have"
                      value="50 to 100 machines" />
               <span class="p-radio__label" id="50-to-100-machines">50&nbsp;&ndash;&nbsp;100 machines</span>
             </label>
@@ -86,7 +86,7 @@
               <input type="radio"
                      aria-labelledby="greater-than-100"
                      class="p-radio__input"
-                     name="how-many-machines-do-you-have"
+                     name="_radio_how-many-machines-do-you-have"
                      value="greater than 100" />
               <span class="p-radio__label" id="greater-than-100">&gt;&nbsp;100 machines</span>
             </label>

--- a/templates/shared/forms/form-fields.html
+++ b/templates/shared/forms/form-fields.html
@@ -99,7 +99,7 @@
                                  id="{{ field_id }}"
                                  type="radio"
                                  id="{{ field.id }}"
-                                 name="{{ fieldset_inputName }}"
+                                 name="_radio_{{ fieldset_inputName }}"
                                  aria-labelledby="{{ field.id }}"
                                  value="{{ field.value }}"
                                  {% if field.isSelected %}checked{% endif %} />

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -881,6 +881,9 @@ def shorten_acquisition_url(acquisition_url):
 def marketo_submit():
     form_fields = {}
     for key in flask.request.form:
+        # Skip keys that start with '_radio_' to avoid marketo errors
+        if key.startswith("_radio_"):
+            continue
         values = flask.request.form.getlist(key)
         value = ", ".join(values)
         if value:


### PR DESCRIPTION
## Done

- Adds a check in the marketo_submit function for names starting with '_radio_' and removed them from the payload

## QA

- Open the form /desktop/contact-us
- Disable JS
- Fill in and submit the form
- See that it successfully submits
- Check the payload makes it to Marketo

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-23427
