### PR TITLE
Update kernel life cycle chart & table WD-23333

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -153,6 +153,13 @@ export var serverAndDesktopReleases = [
 
 export var kernelReleases = [
   {
+    startDate: new Date("2025-08-01T00:00:00"),
+    endDate: new Date("2026-01-01T00:00:00"),
+    taskName: "24.04.3 LTS (HWE)",
+    taskVersion: "6.14 kernel",
+    status: "INTERIM_RELEASE",
+  },
+  {
     startDate: new Date("2025-04-01T00:00:00"),
     endDate: new Date("2026-01-01T00:00:00"),
     taskName: "25.04",
@@ -1266,6 +1273,7 @@ export var desktopServerReleaseNames = [
 ];
 
 export var kernelReleaseNames = [
+  "24.04.3 LTS (HWE)",
   "25.04",
   "24.04.2 LTS (HWE)",
   "24.10",
@@ -1284,6 +1292,7 @@ export var kernelReleaseNames = [
 
 export var kernelVersionNames = [
   "6.14",
+  "",
   "6.11",
   "",
   "6.8",

--- a/templates/shared/_kernel-release-diagram.html
+++ b/templates/shared/_kernel-release-diagram.html
@@ -15,9 +15,16 @@
     </thead>
     <tbody>
       <tr>
-        <td>
+        <td rowspan="2">
           <strong>6.14</strong>
         </td>
+        <td>
+          <strong>24.04.3 LTS (HWE)</strong>
+        </td>
+        <td>Aug 2025</td>
+        <td>Jan 2026</td>
+      </tr>
+      <tr>
         <td>
           <strong>25.04</strong>
         </td>


### PR DESCRIPTION
## Done

- Update kernel life cycle to include the newest 6.14 `24.04.3 LTS (HWE)` kernel

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- go to `https://ubuntu-com-15302.demos.haus//about/release-cycle#ubuntu-kernel-release-cycle` and check that the new entry for `24.04.3 LTS (HWE)` has been added to both the graph and the table
- go to `https://ubuntu-com-15302.demos.haus//kernel/lifecycle` and check the same version is updated

## Issue / Card

https://warthogs.atlassian.net/browse/WD-23333

## Screenshots

<img width="836" alt="image" src="https://github.com/user-attachments/assets/9b81ce9c-7913-437f-8e63-810f9f5041a9" />

<img width="811" alt="image" src="https://github.com/user-attachments/assets/0c213b37-8dc4-4ee6-ac23-701f772f366e" />


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
