### PR TITLE
WD-23382 Apply copy updates to the download desktop thank you

### DIFF
--- a/templates/download/shared/_downloads-resources.html
+++ b/templates/download/shared/_downloads-resources.html
@@ -23,9 +23,9 @@
         </div>
         <div class="col-3 col-medium-2">
           <h3 class="p-heading--5">
-            <a href="/download/raspberry-pi">Install Ubuntu Desktop on Raspberry&nbsp;Pi</a>
+            <a href="/pro/subscribe">Try Ubuntu Pro for free</a>
           </h3>
-          <p>Use the Raspberry Pi Imager or install Ubuntu manually. Ubuntu LTS releases are certified on select Raspberry Pi hardware.</p>
+          <p>Anyone can <a href="/pro/subscribe">use Ubuntu Pro for free</a> on up to 5 machines. <a href="/pro/free-trial">Enterprises can try it for free</a> for 30 days. </p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Done

- Updated the copy on the resources section of the download desktop thank you page

## QA

- Open the demo
- Go to /download/desktop/thank-you?version=24.04.2&architecture=amd64&lts=true
- Scroll to the Resources section and see the content for Raspberry Pi have been replaced with Pro as suggested in [the copy doc](https://docs.google.com/document/d/187Vg9I0Jjlp1_yAjYtHdoEwFCJeVOaz9Kzeb6kptMpA/edit?tab=t.0).

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-23382?atlOrigin=eyJpIjoiZjBjMTQzNzg4NmYzNDliMzg1YzQzNmI5Yzk0M2UwYzYiLCJwIjoiaiJ9
