### PR TITLE
feat: added required fields 

### DIFF
--- a/templates/security/standards/form-data.json
+++ b/templates/security/standards/form-data.json
@@ -23,6 +23,7 @@
           {
             "title": "Tell us about your project and what support you're looking for",
             "id": "about-your-project",
+            "isRequired": true,
             "fields": [
               {
                 "type": "long-text",
@@ -35,6 +36,7 @@
             "title": "If you use Ubuntu, which version(s) are you using?",
             "id": "ubuntu-versions",
             "inputType": "checkbox-visibility",
+            "isRequired": true,
             "fields": [
               {
                 "fieldTitle": "LTS within standard support",


### PR DESCRIPTION
## Done

- Added required fields for copydoc.

## QA

- Open the demo at: https://ubuntu-com-15314.demos.haus/security/standards
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check that the form matches the copydoc
- Submit the form

## Issue / Card

Fixes [WD-23206](https://warthogs.atlassian.net/browse/WD-23206)

## Screenshots
![image](https://github.com/user-attachments/assets/f0883b2a-8544-41b5-9469-16cff3f9a4b7)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-23206]: https://warthogs.atlassian.net/browse/WD-23206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ