### PR TITLE
WD-23620: add isFree key to check for free products when checking out

### DIFF
--- a/static/js/src/advantage/subscribe/checkout/components/Checkout/Checkout.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Checkout/Checkout.tsx
@@ -125,7 +125,7 @@ const Checkout = ({ products, action, coupon }: Props) => {
                           />
                         ),
                       },
-                      ...(product?.price?.value == 0
+                      ...(product?.price?.value == 0 || product?.isFree
                         ? []
                         : [
                             {

--- a/static/js/src/advantage/subscribe/checkout/utils/types.ts
+++ b/static/js/src/advantage/subscribe/checkout/utils/types.ts
@@ -85,6 +85,7 @@ export interface Product {
   };
   offerId?: string;
   canBeTrialled?: boolean;
+  isFree?: boolean;
 }
 
 export type Coupon = {

--- a/webapp/shop/cred/exams.json
+++ b/webapp/shop/cred/exams.json
@@ -21,7 +21,8 @@
     "openTo": {
       "production": true,
       "staging": true
-    }
+    },
+    "isFree": false
   },
   {
     "id": "cue-02-desktop",
@@ -52,7 +53,8 @@
     "openTo": {
       "production": true,
       "staging": true
-    }
+    },
+    "isFree": true
   },
   {
     "id": "cue-03-server",
@@ -69,6 +71,7 @@
     "openTo": {
       "production": false,
       "staging": false
-    }
+    },
+    "isFree": false
   }
 ]


### PR DESCRIPTION
## Done

- Free products should not ask for CC details
- Add `isFree` key to the `Product` type to check for free products and hide CC element if it is true

## QA

- Go to https://ubuntu-com-15315.demos.haus/credentials/shop and purchase CUE.02 Desktop exam
    - On the Checkout page, you will not be asked to enter CC details

## Issue / Card

Fixes [WD-23620](https://warthogs.atlassian.net/browse/WD-23620)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-23620]: https://warthogs.atlassian.net/browse/WD-23620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ