### PR TITLE
feat(copy): /robotics/ros-esm.html

### DIFF
--- a/templates/robotics/ros-esm.html
+++ b/templates/robotics/ros-esm.html
@@ -42,6 +42,8 @@ from "_macros/vf_quote-wrapper.jinja" import vf_quote_wrapper %}
          class="js-invoke-modal p-button--positive"
          aria-controls="robotics-modal"
          aria-expanded="false">Get in touch</a>
+      <a href="https://canonical-robotics.readthedocs-hosted.com/en/latest/explanations/security/what-is-ros-esm/"
+        class="p-button">Read the docs</a>
       <a href="https://assets.ubuntu.com/v1/4dedff79-ROS%20ESM%20datasheet.pdf">Read the datasheet&nbsp;&rsaquo;</a>
     {%- endif -%}
     {%- if slot == 'image' -%}
@@ -544,7 +546,8 @@ from "_macros/vf_quote-wrapper.jinja" import vf_quote_wrapper %}
         <h2 class="u-no-margin--bottom">Questions?</h2>
         <p class="p-heading--2">
           Read our
-          <a href="/blog/ros-enterprise-support-15-things-you-need-to-know">FAQ about ROS ESM</a>
+          <a href="/blog/ros-enterprise-support-15-things-you-need-to-know">FAQ about ROS ESM</a>,
+          check out the <a href="https://canonical-robotics.readthedocs-hosted.com/en/latest/explanations/security/what-is-ros-esm/">docs</a>,
           or
           <a class="js-invoke-modal"
              href="/internet-of-things/contact-us?product=robotics"


### PR DESCRIPTION
## Done

-  Updated /robotics/ros-esm.html
  - Added extra docs button
  - Added extra docs link

## QA
- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Visit /robotics/ros-esm.html
  - Ensure the additional links are present as described in the issue below

## Issue / Card

Fixes; https://warthogs.atlassian.net/browse/WD-23489

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
