### PR TITLE
WD-23640: check for contract item's reason for purchase account's existence

### DIFF
--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -847,6 +847,7 @@ def cred_your_exams(
         else:
             exam_contracts = []
 
+    exam_contracts = exam_contracts if exam_contracts is not None else []
     cue_products = get_cue_products(type="exam").get_json()
     productListingID = None
     if cue_products and len(cue_products) > 0:

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -862,7 +862,7 @@ def cred_your_exams(
         "cred_maintenance_start": cred_maintenance_start,
         "cred_maintenance_end": cred_maintenance_end,
     }
-    is_banned = False
+    is_banned = True
     purchased_contracts = list(
         filter(
             lambda c: c["contractItem"]["reason"] == "purchase_made",
@@ -870,7 +870,7 @@ def cred_your_exams(
         )
     )
 
-    if len(purchased_contracts) > 0:
+    if purchased_contracts:
         account_id = purchased_contracts[0]["accountContext"]["accountID"]
         preview_purchase_request = {
             "accountID": account_id,
@@ -901,6 +901,8 @@ def cred_your_exams(
                 error = e.response.json().get("message", "Unknown error")
                 if error != banned_error:
                     is_banned = False
+    else:
+        is_banned = False
 
     exams_in_progress = []
     exams_scheduled = []

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -892,7 +892,7 @@ def cred_your_exams(
         try:
             response = advantage_mapper.purchase_from_marketplace(
                 marketplace="canonical-cube",
-                preview_purchase_request=preview_purchase_request,
+                purchase_request=preview_purchase_request,
                 preview=True,
             )
             is_banned = False

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -7,7 +7,6 @@ import json
 import os
 import html
 from webapp.shop.api.ua_contracts.api import (
-    AccessForbiddenError,
     UAContractsAPIErrorView,
     UAContractsUserHasNoAccount,
 )


### PR DESCRIPTION
## Done

- Check all contract items for reason, if it is `purchase_made`
    - If it is, then get the accountID from that contract item
- If none of the items have the above reason, it is assumed they do not have a purchase account and are since not banned

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- In an account with no purchases in cue marketplace, redeem a key for a CUE exam
    - Navigate to your-exams and you should see that exam

## Issue / Card

Fixes [WD-23640](https://warthogs.atlassian.net/browse/WD-23640)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-23640]: https://warthogs.atlassian.net/browse/WD-23640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ