### PR TITLE
remove unexpected hashtag in the tutorials template

### DIFF
--- a/templates/tutorials/tutorial.html
+++ b/templates/tutorials/tutorial.html
@@ -173,7 +173,7 @@
     </div>
   </div>
 
-  <script src="{{ versioned_static('js/dist/prism.js') }}"></script>#
+  <script src="{{ versioned_static('js/dist/prism.js') }}"></script>
 
   <script>
     if (window.location.hash == "#0") {


### PR DESCRIPTION
## Done

- Removes a # that is currently lingering in the tutorials template, causing a random "#" on the page on tutorials, such as [this one](https://ubuntu.com/tutorials/getting-started-with-microk8s-on-ubuntu-core)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Open a tutorial
- Verify the hashtag that is shown on production is no longer there

## Issue / Card

Fixes https://chat.canonical.com/canonical/pl/33686rxeipnn3qhgqfcs9apudc

## Screenshots

### Before
![image](https://github.com/user-attachments/assets/8a611666-1849-45ed-88a6-9b63ce3d4feb)

### After
![image](https://github.com/user-attachments/assets/1c45e736-6b36-42f0-a7ec-2e4f014f2c56)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
