### PR TITLE
add link to download deepcomputing image

### DIFF
--- a/templates/download/risc-v/deepcomputing-fml13v01.html
+++ b/templates/download/risc-v/deepcomputing-fml13v01.html
@@ -29,6 +29,11 @@
         DeepComputing provides a vendor image that fully supports the Framework laptop with the DeepComputing FML13V01
         motherboard.
       </p>
+      <p>
+        <a class="p-button--positive"
+          href="https://github.com/DC-DeepComputing/fml13v01/releases">Download
+          DeepComputing image</a>
+      </p>
       <p>The Ubuntu images described below only support headless mode (no GPU, no WiFi).</p>
       <p class="p-notification__message">
         <i class="p-icon--information"></i> If you have an eMMC drive, we advise you to use the Ubuntu Server


### PR DESCRIPTION
## Done

- Adds link to download deepcomputing image at `/download/risc-v`

## QA

- Go to https://ubuntu-com-15327.demos.haus/download/risc-v
- Go to DeepComputing FML13V01 tab
- Check the new `Download` link is there as per [copy doc](https://docs.google.com/document/d/1kkJeq9HdH3iWV35HwihcJd3CxZw9Jy21W66lJl8VbWs/edit?tab=t.jpjwa9vat62f)

## Issue / Card

Fixes [WD-23652](https://warthogs.atlassian.net/browse/WD-23652)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-23652]: https://warthogs.atlassian.net/browse/WD-23652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ