### PR TITLE
WD-23710: checkout error for zero price value products

### DIFF
--- a/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
@@ -140,7 +140,7 @@ const BuyButton = ({
 
     // Update customer information
     const hasZeroPriceValue = products.some(
-      (item) => item.product.price.value === 0,
+      (item) => item.product.price.value === 0 || item.product.isFree,
     );
     if (!values.defaultPaymentMethod && !hasZeroPriceValue) {
       await postCustomerInfoMutation.mutateAsync(


### PR DESCRIPTION
## Done

- Check if product is free while making purchase

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Create a new account without a CC
- Purchase CUE.02 exam
- It should not throw any error

## Issue / Card

Fixes [WD-23710](https://warthogs.atlassian.net/browse/WD-23710)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-23710]: https://warthogs.atlassian.net/browse/WD-23710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ