### PR TITLE
feat: update risc-v download page for the 24.04.3 point release

### DIFF
--- a/templates/download/risc-v/allwinner-nezha.html
+++ b/templates/download/risc-v/allwinner-nezha.html
@@ -30,7 +30,7 @@
     <div class="col-6">
       <p>
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/24.04.2/release/ubuntu-24.04.2-preinstalled-server-riscv64+nezha.img.xz">Download 24.04.2 LTS</a>
+           href="https://cdimage.ubuntu.com/releases/24.04.3/release/ubuntu-24.04.3-preinstalled-server-riscv64+nezha.img.xz">Download 24.04.3 LTS</a>
         <a class="p-button"
            href="https://cdimage.ubuntu.com/releases/25.04/release/ubuntu-25.04-preinstalled-server-riscv64+nezha.img.xz">Download 25.04</a>
       </p>

--- a/templates/download/risc-v/deepcomputing-fml13v01.html
+++ b/templates/download/risc-v/deepcomputing-fml13v01.html
@@ -42,6 +42,8 @@
       <hr class="p-rule--muted is-fixed-width col-6" />
       <p>
         <a class="p-button--positive"
+           href="https://cdimage.ubuntu.com/releases/24.04.3/release/ubuntu-24.04.3-preinstalled-server-riscv64+jh7110.img.xz">Download 24.04.3 LTS</a>
+        <a class="p-button"
           href="https://cdimage.ubuntu.com/releases/25.04/release/ubuntu-25.04-preinstalled-server-riscv64+jh7110.img.xz">Download
           25.04</a>
       </p>
@@ -59,6 +61,8 @@
     <div class="col-6">
       <p>
         <a class="p-button--positive"
+           href="https://cdimage.ubuntu.com/releases/24.04.3/release/ubuntu-24.04.3-live-server-riscv64.iso">Download 24.04.3 LTS live installer</a>
+        <a class="p-button"
           href="https://cdimage.ubuntu.com/releases/25.04/release/ubuntu-25.04-live-server-riscv64.iso">Download
           25.04 live installer</a>
       </p>

--- a/templates/download/risc-v/index.html
+++ b/templates/download/risc-v/index.html
@@ -40,7 +40,7 @@
         <p>All images are 64-bit developer preview builds of Ubuntu Server.</p>
         <p>
           <strong>
-            We plan to upgrade the ISA level above RVA20 with the 25.10 release. Please, install the 24.04 LTS release if you need long term support for RVA20 hardware.
+            We plan to upgrade the ISA level above RVA20 with the 25.10 release. Please, install the 24.04.3 LTS release if you need long term support for RVA20 hardware.
           </strong>
         </p>
         <p>

--- a/templates/download/risc-v/microchip-curiosity.html
+++ b/templates/download/risc-v/microchip-curiosity.html
@@ -30,7 +30,7 @@
     <div class="col-6">
       <p>
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/24.04.2/release/ubuntu-24.04.2-preinstalled-server-riscv64+pic64gx.img.xz">Download 24.04.2 LTS</a>
+           href="https://cdimage.ubuntu.com/releases/24.04.3/release/ubuntu-24.04.3-preinstalled-server-riscv64+pic64gx.img.xz">Download 24.04.3 LTS</a>
         <a class="p-button"
            href="https://cdimage.ubuntu.com/releases/25.04/release/ubuntu-25.04-preinstalled-server-riscv64+pic64gx.img.xz">Download 25.04</a>
       </p>

--- a/templates/download/risc-v/microchip-polarfire.html
+++ b/templates/download/risc-v/microchip-polarfire.html
@@ -41,7 +41,7 @@
       <hr class="p-rule--muted is-fixed-width col-6" />
       <p>
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/24.04.2/release/ubuntu-24.04.2-preinstalled-server-riscv64+icicle.img.xz">Download 24.04.2 LTS</a>
+           href="https://cdimage.ubuntu.com/releases/24.04.3/release/ubuntu-24.04.3-preinstalled-server-riscv64+icicle.img.xz">Download 24.04.3 LTS</a>
         <a class="p-button"
            href="https://cdimage.ubuntu.com/releases/25.04/release/ubuntu-25.04-preinstalled-server-riscv64+icicle.img.xz">Download 25.04</a>
       </p>

--- a/templates/download/risc-v/milk-v-mars.html
+++ b/templates/download/risc-v/milk-v-mars.html
@@ -34,7 +34,7 @@
       </p>
       <p>
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/24.04.2/release/ubuntu-24.04.2-preinstalled-server-riscv64+milkvmars.img.xz">Download 24.04.2 LTS</a>
+           href="https://cdimage.ubuntu.com/releases/24.04.3/release/ubuntu-24.04.3-preinstalled-server-riscv64+jh7110.img.xz">Download 24.04.3 LTS</a>
         <a class="p-button"
            href="https://cdimage.ubuntu.com/releases/25.04/release/ubuntu-25.04-preinstalled-server-riscv64+jh7110.img.xz">Download 25.04</a>
       </p>
@@ -52,7 +52,7 @@
     <div class="col-6">
       <p>
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/24.04.2/release/ubuntu-24.04.2-live-server-riscv64.img.gz">Download 24.04.2 LTS live installer</a>
+           href="https://cdimage.ubuntu.com/releases/24.04.3/release/ubuntu-24.04.3-live-server-riscv64.iso">Download 24.04.3 LTS live installer</a>
         <a class="p-button"
            href="https://cdimage.ubuntu.com/releases/25.04/release/ubuntu-25.04-live-server-riscv64.iso">Download 25.04 live installer</a>
       </p>

--- a/templates/download/risc-v/pine64-star64.html
+++ b/templates/download/risc-v/pine64-star64.html
@@ -34,6 +34,8 @@
       </p>
       <p>
         <a class="p-button--positive"
+           href="https://cdimage.ubuntu.com/releases/24.04.3/release/ubuntu-24.04.3-preinstalled-server-riscv64+jh7110.img.xz">Download 24.04.3 LTS</a>
+        <a class="p-button"
            href="https://cdimage.ubuntu.com/releases/25.04/release/ubuntu-25.04-preinstalled-server-riscv64+jh7110.img.xz">Download 25.04</a>
       </p>
     </div>
@@ -50,6 +52,8 @@
     <div class="col-6">
       <p>
         <a class="p-button--positive"
+           href="https://cdimage.ubuntu.com/releases/24.04.3/release/ubuntu-24.04.3-live-server-riscv64.iso">Download 24.04.3 LTS live installer</a>
+        <a class="p-button"
            href="https://cdimage.ubuntu.com/releases/25.04/release/ubuntu-25.04-live-server-riscv64.iso">Download 25.04 live installer</a>
       </p>
       <p>

--- a/templates/download/risc-v/qemu-emulator.html
+++ b/templates/download/risc-v/qemu-emulator.html
@@ -29,7 +29,7 @@
     <div class="col-6">
       <p class="u-sv3">
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/24.04.2/release/ubuntu-24.04.2-preinstalled-server-riscv64.img.xz">Download 24.04.2 LTS</a>
+           href="https://cdimage.ubuntu.com/releases/24.04.3/release/ubuntu-24.04.3-preinstalled-server-riscv64.img.xz">Download 24.04.3 LTS</a>
         <a class="p-button--positive"
            href="https://cdimage.ubuntu.com/releases/25.04/release/ubuntu-25.04-preinstalled-server-riscv64.img.xz">Download 25.04</a>
       </p>
@@ -47,7 +47,7 @@
     <div class="col-6">
       <p>
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/24.04.2/release/ubuntu-24.04.2-live-server-riscv64.img.gz">Download 24.04.2 LTS live installer</a>
+           href="https://cdimage.ubuntu.com/releases/24.04.3/release/ubuntu-24.04.3-live-server-riscv64.iso">Download 24.04.3 LTS live installer</a>
         <a class="p-button--positive"
            href="https://cdimage.ubuntu.com/releases/25.04/release/ubuntu-25.04-live-server-riscv64.iso">Download 25.04 live installer</a>
       </p>

--- a/templates/download/risc-v/sifive-unmatched.html
+++ b/templates/download/risc-v/sifive-unmatched.html
@@ -32,7 +32,7 @@
       </p>
       <p class="u-sv3">
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/24.04.2/release/ubuntu-24.04.2-preinstalled-server-riscv64+unmatched.img.xz">Download 24.04.2 LTS</a>
+           href="https://cdimage.ubuntu.com/releases/24.04.3/release/ubuntu-24.04.3-preinstalled-server-riscv64+unmatched.img.xz">Download 24.04.3 LTS</a>
         <a class="p-button"
            href="https://cdimage.ubuntu.com/releases/25.04/release/ubuntu-25.04-preinstalled-server-riscv64+unmatched.img.xz">Download 25.04</a>
       </p>
@@ -50,7 +50,7 @@
     <div class="col-6">
       <p>
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/24.04.2/release/ubuntu-24.04.2-live-server-riscv64.img.gz">Download 24.04.2 LTS live installer</a>
+           href="https://cdimage.ubuntu.com/releases/24.04.3/release/ubuntu-24.04.3-live-server-riscv64.iso">Download 24.04.3 LTS live installer</a>
         <a class="p-button"
            href="https://cdimage.ubuntu.com/releases/25.04/release/ubuntu-25.04-live-server-riscv64.iso">Download 25.04 live installer</a>
       </p>

--- a/templates/download/risc-v/sipeed-licheerv.html
+++ b/templates/download/risc-v/sipeed-licheerv.html
@@ -30,7 +30,7 @@
     <div class="col-6">
       <p>
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/24.04.2/release/ubuntu-24.04.2-preinstalled-server-riscv64+licheerv.img.xz">Download 24.04.2 LTS</a>
+           href="https://cdimage.ubuntu.com/releases/24.04.3/release/ubuntu-24.04.3-preinstalled-server-riscv64+licheerv.img.xz">Download 24.04.3 LTS</a>
         <a class="p-button"
            href="https://cdimage.ubuntu.com/releases/25.04/release/ubuntu-25.04-preinstalled-server-riscv64+licheerv.img.xz">Download 25.04</a>
       </p>

--- a/templates/download/risc-v/starfive-visionfive.html
+++ b/templates/download/risc-v/starfive-visionfive.html
@@ -33,7 +33,7 @@
       </p>
       <p>
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/24.04.2/release/ubuntu-24.04.2-preinstalled-server-riscv64+visionfive2.img.xz">Download 24.04.2 LTS</a>
+           href="https://cdimage.ubuntu.com/releases/24.04.3/release/ubuntu-24.04.3-preinstalled-server-riscv64+jh7110.img.xz">Download 24.04.3 LTS</a>
         <a class="p-button"
            href="https://cdimage.ubuntu.com/releases/25.04/release/ubuntu-25.04-preinstalled-server-riscv64+jh7110.img.xz">Download 25.04</a>
       </p>
@@ -51,7 +51,7 @@
     <div class="col-6">
       <p>
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/24.04.2/release/ubuntu-24.04.2-live-server-riscv64.img.gz">Download 24.04.2 LTS live installer</a>
+           href="https://cdimage.ubuntu.com/releases/24.04.3/release/ubuntu-24.04.3-live-server-riscv64.iso">Download 24.04.3 LTS live installer</a>
         <a class="p-button"
            href="https://cdimage.ubuntu.com/releases/25.04/release/ubuntu-25.04-live-server-riscv64.iso">Download 25.04 live installer</a>
       </p>


### PR DESCRIPTION
## Done

- [Copy doc](https://docs.google.com/document/d/1kkJeq9HdH3iWV35HwihcJd3CxZw9Jy21W66lJl8VbWs/edit?tab=t.eaza04uc1o36#heading=h.66kr608iyr34)
- Updated the links in each of the tabs 

Will merge the PR on 7th August. 

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to https://ubuntu-com-15331.demos.haus/download/risc-v
- Verify if all the changes (including links) in the copy doc are addressed

## Issue / Card

Fixes #[WD-23656](https://warthogs.atlassian.net/browse/WD-23656)

## Screenshots

<img width="1454" height="918" alt="Screenshot 2025-07-11 at 7 43 40 AM" src="https://github.com/user-attachments/assets/4edf679c-6425-42c0-9d5a-bcbc1ffc04c7" />

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-23656]: https://warthogs.atlassian.net/browse/WD-23656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ