### PR TITLE
fix numbers in chart at /

### DIFF
--- a/templates/pro/linux-patch-management-with-pro/bar-chart.html
+++ b/templates/pro/linux-patch-management-with-pro/bar-chart.html
@@ -58,7 +58,7 @@
       datasets: [
         {
           label: 'Packages covered with LTS',
-          data: [3171, 2470, 2323, 2371, 2372, 2390],
+          data: [0, 0, 0, 0, 2372, 2390],
           backgroundColor: '#656565',
         },
         {


### PR DESCRIPTION
## Done

- Fix numbers in packages chart in /pro/linux-patch-management-with-pro

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Visit [/pro/linux-patch-management-with-pro](https://ubuntu-com-15340.demos.haus/pro/linux-patch-management-with-pro)

## Issue / Card

Fixes [#WD-23792](https://warthogs.atlassian.net/browse/WD-23792)

## Screenshots

Before:
<img width="675" height="337" alt="image" src="https://github.com/user-attachments/assets/eba3437b-2cd4-4a23-b323-3c7ef54a62e0" />

After:
<img width="675" height="337" alt="image" src="https://github.com/user-attachments/assets/fac8f9ea-9dae-4757-a594-153475da4acb" />



## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
