### PR TITLE
test: implement playwright tests for static contact forms

### DIFF
--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -51,4 +51,5 @@ jobs:
       env:
         PLAYWRIGHT_USER_ID: ${{ secrets.PLAYWRIGHT_USER_ID }}
         PLAYWRIGHT_USER_PASSWORD : ${{ secrets.PLAYWRIGHT_USER_PASSWORD }}
-      run: yarn playwright test --grep "should return success response"
+        TESTING: true
+      run: yarn playwright test

--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -51,4 +51,4 @@ jobs:
       env:
         PLAYWRIGHT_USER_ID: ${{ secrets.PLAYWRIGHT_USER_ID }}
         PLAYWRIGHT_USER_PASSWORD : ${{ secrets.PLAYWRIGHT_USER_PASSWORD }}
-      run: yarn playwright test
+      run: yarn playwright test --grep "should return success response"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,7 +11,7 @@ dotenv.config({
  */
 export default defineConfig({
   testDir: path.join(__dirname, "tests/playwright/tests"),
-  testIgnore: '**\/pro/**',
+  testIgnore: ['**\/pro/**', '**/certified.spec.ts'],
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,7 +11,7 @@ dotenv.config({
  */
 export default defineConfig({
   testDir: path.join(__dirname, "tests/playwright/tests"),
-  testIgnore: ['**\/pro/**', '**/certified.spec.ts'], // TODO: remove certified from ignore list when ready
+  testIgnore: '**\/pro/**',
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,7 +11,7 @@ dotenv.config({
  */
 export default defineConfig({
   testDir: path.join(__dirname, "tests/playwright/tests"),
-  testIgnore: ['**\/pro/**', '**/certified.spec.ts'],
+  testIgnore: ['**\/pro/**', '**/certified.spec.ts'], // TODO: remove certified from ignore list when ready
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */

--- a/static/js/src/dynamic-forms.js
+++ b/static/js/src/dynamic-forms.js
@@ -587,7 +587,7 @@ import { prepareInputFields } from "./prepare-form-inputs.js";
       );
       if (requiredFieldsets.length) {
         submitButton.disabled = true;
-      };      
+      }
 
       // Add event listeners to toggle checkbox visibility
       const ubuntuVersionCheckboxes = document.querySelector(

--- a/static/js/src/dynamic-forms.js
+++ b/static/js/src/dynamic-forms.js
@@ -581,6 +581,14 @@ import { prepareInputFields } from "./prepare-form-inputs.js";
 
       fireLoadedEvent();
 
+      // Disable submit button if there are required checkboxes
+      const requiredFieldsets = document.querySelectorAll(
+        "fieldset.js-required-checkbox",
+      );
+      if (requiredFieldsets.length) {
+        submitButton.disabled = true;
+      };      
+
       // Add event listeners to toggle checkbox visibility
       const ubuntuVersionCheckboxes = document.querySelector(
         "fieldset.js-toggle-checkbox-visibility",
@@ -589,11 +597,7 @@ import { prepareInputFields } from "./prepare-form-inputs.js";
         toggleCheckboxVisibility(ubuntuVersionCheckboxes, event.target);
       });
 
-      // Add event listeners to required fieldsets
-      const requiredFieldsets = document.querySelectorAll(
-        "fieldset.js-required-checkbox",
-      );
-      // Check if there are any required fieldsets
+      // Add event listeners if there are required fieldsets present
       if (requiredFieldsets.length > 0) {
         const submitButton = document.querySelector(".js-submit-button");
         submitButton.disabled = true;

--- a/static/js/src/static-forms.js
+++ b/static/js/src/static-forms.js
@@ -200,6 +200,14 @@ function setUpStaticForms(form, formId) {
     form.addEventListener("submit", () => attachLoadingSpinner(submitButton));
   }
 
+  // Disable submit button if there are required checkboxes
+  const requiredCheckboxes = document.querySelectorAll(
+    "fieldset.js-required-checkbox",
+  );
+  if (requiredCheckboxes.length) {
+    submitButton.disabled = true;
+  };
+
   form.addEventListener("submit", function (e) {
     setDataLayerConsentInfo();
   });

--- a/static/js/src/static-forms.js
+++ b/static/js/src/static-forms.js
@@ -206,7 +206,7 @@ function setUpStaticForms(form, formId) {
   );
   if (requiredCheckboxes.length) {
     submitButton.disabled = true;
-  };
+  }
 
   form.addEventListener("submit", function (e) {
     setDataLayerConsentInfo();

--- a/templates/kernel/real-time/contact-us.html
+++ b/templates/kernel/real-time/contact-us.html
@@ -547,10 +547,10 @@
             <div class="col">
               <label class="p-checkbox">
                 <input type="checkbox"
-                       aria-labelledby="pindividual-developers"
+                       aria-labelledby="individual-developers"
                        class="p-checkbox__input"
                        value="Individual developers" />
-                <span class="p-checkbox__label" id="pindividual-developers">Individual developers</span>
+                <span class="p-checkbox__label" id="individual-developers">Individual developers</span>
               </label>
               <label class="p-checkbox">
                 <input type="checkbox"

--- a/templates/shared/_default-contact-us-form.html
+++ b/templates/shared/_default-contact-us-form.html
@@ -195,7 +195,7 @@
                      class="p-radio__input"
                      type="radio"
                      aria-labelledby="less-5-machines"
-                     name="how-many-machines-do-you-have"
+                     name="_radio_how-many-machines-do-you-have"
                      value="less than 5" />
               <span class="p-radio__label" id="less-5-machines">&lt;&nbsp;5 machines</span>
 
@@ -204,7 +204,7 @@
               <input type="radio"
                      aria-labelledby="15-to-15-machines"
                      class="p-radio__input"
-                     name="how-many-machines-do-you-have"
+                     name="_radio_how-many-machines-do-you-have"
                      value="5 to 15 machines" />
               <span class="p-radio__label" id="15-to-15-machines">5&nbsp;&ndash;&nbsp;15 machines</span>
             </label>
@@ -212,7 +212,7 @@
               <input type="radio"
                      aria-labelledby="15-to-50-machines"
                      class="p-radio__input"
-                     name="how-many-machines-do-you-have"
+                     name="_radio_how-many-machines-do-you-have"
                      value="15 to 50 machines" />
               <span class="p-radio__label" id="15-to-50-machines">15&nbsp;&ndash;&nbsp;50 machines</span>
             </label>
@@ -220,7 +220,7 @@
               <input type="radio"
                      aria-labelledby="50-to-100-machines"
                      class="p-radio__input"
-                     name="how-many-machines-do-you-have"
+                     name="_radio_how-many-machines-do-you-have"
                      value="50 to 100 machines" />
               <span class="p-radio__label" id="50-to-100-machines">50&nbsp;&ndash;&nbsp;100 machines</span>
             </label>
@@ -228,7 +228,7 @@
               <input type="radio"
                      aria-labelledby="greater-than-100"
                      class="p-radio__input"
-                     name="how-many-machines-do-you-have"
+                     name="_radio_how-many-machines-do-you-have"
                      value="greater than 100" />
               <span class="p-radio__label" id="greater-than-100">&gt;&nbsp;100 machines</span>
             </label>

--- a/templates/shared/_default-contact-us-form.html
+++ b/templates/shared/_default-contact-us-form.html
@@ -364,10 +364,10 @@
           <div class="col">
             <label class="p-checkbox">
               <input type="checkbox"
-                     aria-labelledby="pindividual-developers"
+                     aria-labelledby="individual-developers"
                      class="p-checkbox__input"
                      value="Individual developers" />
-              <span class="p-checkbox__label" id="pindividual-developers">Individual developers</span>
+              <span class="p-checkbox__label" id="individual-developers">Individual developers</span>
             </label>
             <label class="p-checkbox">
               <input type="checkbox"

--- a/templates/shared/_pro-contact-us-form.html
+++ b/templates/shared/_pro-contact-us-form.html
@@ -379,10 +379,10 @@
           <div class="col">
             <label class="p-checkbox">
               <input type="checkbox"
-                     aria-labelledby="pindividual-developers"
+                     aria-labelledby="individual-developers"
                      class="p-checkbox__input"
                      value="Individual developers" />
-              <span class="p-checkbox__label" id="pindividual-developers">Individual developers</span>
+              <span class="p-checkbox__label" id="individual-developers">Individual developers</span>
             </label>
             <label class="p-checkbox">
               <input type="checkbox"

--- a/templates/shared/forms/interactive/aws.html
+++ b/templates/shared/forms/interactive/aws.html
@@ -372,10 +372,10 @@
               <div class="col">
                 <label class="p-checkbox">
                   <input type="checkbox"
-                         aria-labelledby="pindividual-developers"
+                         aria-labelledby="individual-developers"
                          class="p-checkbox__input"
                          value="Individual developers" />
-                  <span class="p-checkbox__label" id="pindividual-developers">Individual developers</span>
+                  <span class="p-checkbox__label" id="individual-developers">Individual developers</span>
                 </label>
                 <label class="p-checkbox">
                   <input type="checkbox"

--- a/templates/shared/forms/interactive/esm.html
+++ b/templates/shared/forms/interactive/esm.html
@@ -361,10 +361,10 @@
               <div class="col">
                 <label class="p-checkbox">
                   <input type="checkbox"
-                         aria-labelledby="pindividual-developers"
+                         aria-labelledby="individual-developers"
                          class="p-checkbox__input"
                          value="Individual developers" />
-                  <span class="p-checkbox__label" id="pindividual-developers">Individual developers</span>
+                  <span class="p-checkbox__label" id="individual-developers">Individual developers</span>
                 </label>
                 <label class="p-checkbox">
                   <input type="checkbox"

--- a/templates/shared/forms/interactive/general.html
+++ b/templates/shared/forms/interactive/general.html
@@ -370,10 +370,10 @@
               <div class="col">
                 <label class="p-checkbox">
                   <input type="checkbox"
-                         aria-labelledby="pindividual-developers"
+                         aria-labelledby="individual-developers"
                          class="p-checkbox__input"
                          value="Individual developers" />
-                  <span class="p-checkbox__label" id="pindividual-developers">Individual developers</span>
+                  <span class="p-checkbox__label" id="individual-developers">Individual developers</span>
                 </label>
                 <label class="p-checkbox">
                   <input type="checkbox"

--- a/templates/shared/forms/interactive/landscape.html
+++ b/templates/shared/forms/interactive/landscape.html
@@ -370,10 +370,10 @@
               <div class="col">
                 <label class="p-checkbox">
                   <input type="checkbox"
-                         aria-labelledby="pindividual-developers"
+                         aria-labelledby="individual-developers"
                          class="p-checkbox__input"
                          value="Individual developers" />
-                  <span class="p-checkbox__label" id="pindividual-developers">Individual developers</span>
+                  <span class="p-checkbox__label" id="individual-developers">Individual developers</span>
                 </label>
                 <label class="p-checkbox">
                   <input type="checkbox"

--- a/templates/shared/forms/interactive/pricing-infra.html
+++ b/templates/shared/forms/interactive/pricing-infra.html
@@ -372,10 +372,10 @@
               <div class="col">
                 <label class="p-checkbox">
                   <input type="checkbox"
-                         aria-labelledby="pindividual-developers"
+                         aria-labelledby="individual-developers"
                          class="p-checkbox__input"
                          value="Individual developers" />
-                  <span class="p-checkbox__label" id="pindividual-developers">Individual developers</span>
+                  <span class="p-checkbox__label" id="individual-developers">Individual developers</span>
                 </label>
                 <label class="p-checkbox">
                   <input type="checkbox"

--- a/templates/shared/forms/interactive/storage.html
+++ b/templates/shared/forms/interactive/storage.html
@@ -370,10 +370,10 @@
               <div class="col">
                 <label class="p-checkbox">
                   <input type="checkbox"
-                         aria-labelledby="pindividual-developers"
+                         aria-labelledby="individual-developers"
                          class="p-checkbox__input"
                          value="Individual developers" />
-                  <span class="p-checkbox__label" id="pindividual-developers">Individual developers</span>
+                  <span class="p-checkbox__label" id="individual-developers">Individual developers</span>
                 </label>
                 <label class="p-checkbox">
                   <input type="checkbox"

--- a/templates/tests/_static-client-form.html
+++ b/templates/tests/_static-client-form.html
@@ -1,0 +1,19 @@
+{% extends "base_index.html" %}
+
+{% block body_class %}
+  is-paper
+{% endblock body_class %}
+
+{% block title %}Test _client-contact-us.html static form template{% endblock %}
+
+{% block content %}
+
+{% with h1="Test Static Contact Form",
+  intro_text="This is a test form for _client-contact-us.html static form template.",
+  formid="9999",
+  lpId="9999",
+  returnURL="/tests/_thank-you" %}
+  {% include "shared/_client-contact-us-form.html" %}
+{% endwith %}
+
+{% endblock content %}

--- a/templates/tests/_static-default-form.html
+++ b/templates/tests/_static-default-form.html
@@ -1,0 +1,18 @@
+{% extends "base_index.html" %}
+
+{% block body_class %}
+  is-paper
+{% endblock body_class %}
+{% block title %}Test _default-contact-us.html static form template{% endblock %}
+
+{% block content %}
+  {% with h1="Test Static Contact Form",
+    intro_text="This is a test form for _default-contact-us.html static form template.",
+    formid="9999",
+    lpId="9999",
+    returnURL="/tests/_thank-you",
+    howManyVM=True %}
+    {% include "shared/_default-contact-us-form.html" %}
+  {% endwith %}
+
+{% endblock content %}

--- a/templates/tests/_thank-you.html
+++ b/templates/tests/_thank-you.html
@@ -1,0 +1,55 @@
+{% extends "core/base_core.html" %}
+
+{% block title %}Thank you | Ubuntu core{% endblock %}
+
+{% block head_extra %}<meta name="robots" content="noindex" />{% endblock %}
+
+{% block body_class %}
+  is-paper
+{% endblock body_class %}
+
+{% block content %}
+  <div class="p-section--hero">
+    <div class="row--50-50">
+      <div class="col">
+        <h1 class="u-no-margin--bottom">Thank you for contacting our team.</h1>
+        <h2>We will be in touch shortly.</h2>
+      </div>
+      <div class="col">
+        <div class="p-image-container is-cover u-hide--small">
+          <img class="p-image-container__image"
+               src="https://assets.ubuntu.com/v1/b0fa63e9-christina-wocintechchat-com-LQ1t-8Ms5PY-unsplash.png"
+               alt="" />
+        </div>
+      </div>
+    </div>
+  </div>
+
+  {% include "shared/_thank_you_footer.html" %}
+
+{% endblock content %}
+
+{% block footer_extra %}
+  <!-- Google Code for Services Canonical &mdash; contact us Conversion Page -->
+  <script>
+    /* <![CDATA[ */
+    var google_conversion_id = 1012391776;
+    var google_conversion_language = "en";
+    var google_conversion_format = "3";
+    var google_conversion_color = "ffffff";
+    var google_conversion_label = "-mBBCIC5vwMQ4L7f4gM";
+    var google_conversion_value = 0;
+    /* ]]> */
+  </script>
+  <script type="text/javascript"
+          src="https://www.googleadservices.com/pagead/conversion.js"></script>
+  <noscript>
+    <div style="display:inline;">
+      <img height="1"
+           width="1"
+           style="border-style:none"
+           alt=""
+           src="https://www.googleadservices.com/pagead/conversion/1012391776/?value=0&amp;label=-mBBCIC5vwMQ4L7f4gM&amp;guid=ON&amp;script=0" />
+    </div>
+  </noscript>
+{% endblock footer_extra %}

--- a/tests/playwright/helpers/commands.ts
+++ b/tests/playwright/helpers/commands.ts
@@ -1,5 +1,10 @@
 import { Page } from "@playwright/test";
 
+export const isExistingField = async (page, fieldName) => {
+  const field = page.locator(fieldName);
+  return await field.count() > 0;
+};
+
 export const login = async (page: Page) => {
   // TODO: mocking Login (To intercept "https://login.ubuntu.com/*/+login", proper mock responses are needed)
   
@@ -29,7 +34,9 @@ export const selectProducts = async (
 export const acceptCookiePolicy = async (
   page: Page,
 ) => {
-  await page.locator('#cookie-policy-button-accept').click();
+  if (await isExistingField(page, '#cookie-policy-button-accept')) {
+    await page.locator('#cookie-policy-button-accept').click();
+  }
 };
 
 export const acceptTerms = async (page: Page) => {
@@ -39,4 +46,21 @@ export const acceptTerms = async (page: Page) => {
 
 export const clickRecaptcha = async (page: Page) => {
   await page.frameLocator('[title="reCAPTCHA"]').getByRole('checkbox', { name: 'I\'m not a robot' }).click({force: true});
+}
+
+// Forms testing helpers
+export const fillExistingFields = async (page, testTextFields, testCheckboxFields) => {
+  // Fill text fields
+  for (const { field, value } of testTextFields) {
+    if (await isExistingField(page, field)) {
+      await page.fill(field, value);
+    }
+  }
+
+  // Fill radio fields
+  for (const { field, value } of testCheckboxFields) {
+    if (await isExistingField(page, field)) {
+      await page.getByLabel(value).check({ force: true });
+    }
+  }
 }

--- a/tests/playwright/helpers/form-fields.ts
+++ b/tests/playwright/helpers/form-fields.ts
@@ -1,0 +1,20 @@
+export const formTextFields = [
+  { field: 'input[name="company"]', value: 'Test Company' },
+  { field: 'input[name="title"]', value: 'Test Title' },
+  { field: 'textarea[id="comments"]', value: 'Test comments' },
+  { field: 'input[name="firstName"]', value: 'Test first name' },
+  { field: 'input[name="lastName"]', value: 'Test last name' },
+  { field: 'input[name="email"]', value: 'test@test.com' },
+  { field: 'textarea[id="about-your-project"]', value: 'Test project description' },
+  { field: 'textarea[id="advice"]', value: 'Test advice' },
+]
+
+export const formCheckboxFields = [
+  { field: 'input[name="_radio_how-many-machines-do-you-have"]', value: '< 5 machines' },
+  { field: 'input[aria-labelledby="24-04"]', value: '24.04 LTS' },
+  { field: 'input[aria-labelledby="physical-server"]', value: 'Physical server' },
+  { field: 'input[aria-labelledby="ubuntu-repositories"]', value: 'Ubuntu repositories' },
+  { field: 'input[aria-labelledby="pci"]', value: 'PCI-DSS' },
+  { field: 'input[aria-labelledby="individual-developers"]', value: 'Individual developers' },
+  { field: 'input[name="canonicalUpdatesOptIn"]', value: 'I agree to receive information' }
+]

--- a/tests/playwright/helpers/mockData.ts
+++ b/tests/playwright/helpers/mockData.ts
@@ -59,429 +59,429 @@ export const customerInfoResponse = {
 }
 
 // post /account/customer-info${queryString}`
-  export const customerInfoPost = {
-    "createdAt": "2023-12-06T18:48:42Z",
-    "externalAccountIDs": [
-        {
-            "IDs": [
-                "cus_P8hYsgkn9vMYbx"
-            ],
-            "origin": "Stripe"
-        }
-    ],
-    "id": "aAINI96WQv-l2yAHBv68YxhhL-dDsJ0H1poiQe8Ee-1A",
-    "lastModifiedAt": "0001-01-01T00:00:00Z",
-    "name": "abcde",
-    "type": "paid"
-  }
-  
-  // post /pro/purchase/preview${window.location.search}`,
-  export const postPurchasePreview = {
-    "currency": "usd",
-    "end_of_cycle": "",
-    "id": "",
-    "items": null,
-    "payment_status": null,
-    "reason": "subscription_create",
-    "start_of_cycle": "",
-    "status": "done",
-    "tax_amount": null,
-    "total": 50000,
-    "url": null
-  }
-  
-  // post /pro/purchase${window.location.search}
-  export const postPurchase = {
-      "accountID": "aAaBbCcDdEeFfGg",
-      "createdAt": "2020-01-01T10:00:00Z",
-      "createdBy": "abcdef",
-      "id": "pAaBbCcDdEeFfGg",
-      "invoice": {
-        "amountDue": 1000,
-        "amountPaid": 1000,
-        "currency": "usd",
-        "id": {
-          "IDs": [
-            "invoice_id"
-          ],
-          "origin": "Stripe"
-        },
-        "reason": "subscription_update",
-        "status": "paid",
-        "subscriptionID": {
-          "IDs": [
-            "randomId4"
-          ],
-          "origin": "Stripe"
-        },
-        "taxAmount": 200,
-        "total": 1000
-      },
-      "lastModified": "2021-07-21T12:18:43.057Z",
-      "marketplace": "canonical-ua",
-      "purchaseItems": [
-        {
-          "productListingID": "lAaBbCcDdEeFfGg",
-          "value": 1
-        }
-      ],
-      "status": "done",
-      "stripeInvoices": [
-        {
-          "id": "invoice_id",
-          "last_update": "2020-01-01T10:00:00Z",
-          "pi_status": "succeeded",
-          "subscription_status": "active"
-        }
-      ],
-      "subscriptionID": "sAaBbCcDdEeFfGg"
-  }
-  
-  // /account/purchases/${purchaseID}${queryString}
-  export const getPurchaseResponse = {
-    "accountID": "aAINI96WQv-l2yAHBv68YxhhL-dDsJ0H1poiQe8Ee-1A",
-    "createdAt": "2023-12-06T18:48:47.585Z",
-    "createdBy": "L4zm3xn",
-    "id": "pAIUWWqMhL0NPk48dbylA8nxfjDh1lhC28jtJnUXzebA",
-    "lastModified": "2023-12-06T18:48:50.343Z",
-    "marketplace": "canonical-ua",
-    "purchaseItems": [
-        {
-            "paidForInCycle": 2,
-            "productListingID": "lADzGbq4gpOUmb-mT6U8k-H-J7VFZYBbFaQJZHmAQSLs",
-            "value": 2
-        }
-    ],
-    "status": "done",
-    "subscriptionID": "sALNCX77nsuXYVZDZG_k6IpCR81lRKoiS-fDb4ZwKKfE"
-  }
-
-  export const postInvoiceResponse = {
-    "accountID": "aAINI96WQv-l2yAHBv68YxhhL-dDsJ0H1poiQe8Ee-1A",
-    "createdAt": "2023-12-06T18:48:47.585Z",
-    "createdBy": "L4zm3xn",
-    "end": "2024-12-06T18:48:48Z",
-    "id": "pAIUWWqMhL0NPk48dbylA8nxfjDh1lhC28jtJnUXzebA",
-    "invoice": {
-        "amountDue": 54000,
-        "amountPaid": 54000,
-        "currency": "usd",
-        "customerAddress": {
-            "city": "abcd",
-            "country": "FR",
-            "line1": "abcd",
-            "line2": "",
-            "postal_code": "abcd",
-            "state": ""
-        },
-        "customerEmail": "min.kim+new@canonical.com",
-        "customerName": "abcde",
-        "id": {
-            "IDs": [
-                "in_1OKQ9MCzjFajHovdrVmszv6Q"
-            ],
-            "origin": "Stripe"
-        },
-        "identifier": "C41F3A29-0001",
-        "lineItems": [
-            {
-                "currency": "usd",
-                "description": "2 x Ubuntu Pro (Infra-only) (at $225.00 / year)",
-                "planID": {
-                    "IDs": [
-                        "CO4VF1902"
-                    ],
-                    "origin": "Stripe"
-                },
-                "proRatedAmount": 45000,
-                "quantity": 2
-            }
+export const customerInfoPost = {
+"createdAt": "2023-12-06T18:48:42Z",
+"externalAccountIDs": [
+    {
+        "IDs": [
+            "cus_P8hYsgkn9vMYbx"
         ],
-        "paid": true,
-        "paidAt": "2023-12-06T18:48:48Z",
-        "paymentStatus": {
-            "status": "paid"
-        },
-        "reason": "subscription_create",
-        "status": "paid",
-        "subscriptionID": {
-            "IDs": [
-                "sub_1OKQ9MCzjFajHovdICAATNUg"
-            ],
-            "origin": "Stripe"
-        },
-        "taxAmount": 9000,
-        "total": 54000,
-        "url": "https://pay.stripe.com/invoice/acct_1GH9uHCzjFajHovd/test_YWNjdF8xR0g5dUhDempGYWpIb3ZkLF9QOGhZbnJMTEtmTnJRZ1ZxNmdtblRTYkFpSTI5MThwLDkyNDI5MzQw02007D7sWxQg/pdf?s=ap"
+        "origin": "Stripe"
+    }
+],
+"id": "aAINI96WQv-l2yAHBv68YxhhL-dDsJ0H1poiQe8Ee-1A",
+"lastModifiedAt": "0001-01-01T00:00:00Z",
+"name": "abcde",
+"type": "paid"
+}
+
+// post /pro/purchase/preview${window.location.search}`,
+export const postPurchasePreview = {
+"currency": "usd",
+"end_of_cycle": "",
+"id": "",
+"items": null,
+"payment_status": null,
+"reason": "subscription_create",
+"start_of_cycle": "",
+"status": "done",
+"tax_amount": null,
+"total": 50000,
+"url": null
+}
+
+// post /pro/purchase${window.location.search}
+export const postPurchase = {
+    "accountID": "aAaBbCcDdEeFfGg",
+    "createdAt": "2020-01-01T10:00:00Z",
+    "createdBy": "abcdef",
+    "id": "pAaBbCcDdEeFfGg",
+    "invoice": {
+    "amountDue": 1000,
+    "amountPaid": 1000,
+    "currency": "usd",
+    "id": {
+        "IDs": [
+        "invoice_id"
+        ],
+        "origin": "Stripe"
     },
-    "lastModified": "2023-12-06T18:48:55.511Z",
+    "reason": "subscription_update",
+    "status": "paid",
+    "subscriptionID": {
+        "IDs": [
+        "randomId4"
+        ],
+        "origin": "Stripe"
+    },
+    "taxAmount": 200,
+    "total": 1000
+    },
+    "lastModified": "2021-07-21T12:18:43.057Z",
     "marketplace": "canonical-ua",
     "purchaseItems": [
-        {
-            "paidForInCycle": 2,
-            "productListingID": "lADzGbq4gpOUmb-mT6U8k-H-J7VFZYBbFaQJZHmAQSLs",
-            "value": 2
-        }
+    {
+        "productListingID": "lAaBbCcDdEeFfGg",
+        "value": 1
+    }
     ],
-    "start": "2023-12-06T18:48:48Z",
     "status": "done",
     "stripeInvoices": [
+    {
+        "id": "invoice_id",
+        "last_update": "2020-01-01T10:00:00Z",
+        "pi_status": "succeeded",
+        "subscription_status": "active"
+    }
+    ],
+    "subscriptionID": "sAaBbCcDdEeFfGg"
+}
+
+// /account/purchases/${purchaseID}${queryString}
+export const getPurchaseResponse = {
+"accountID": "aAINI96WQv-l2yAHBv68YxhhL-dDsJ0H1poiQe8Ee-1A",
+"createdAt": "2023-12-06T18:48:47.585Z",
+"createdBy": "L4zm3xn",
+"id": "pAIUWWqMhL0NPk48dbylA8nxfjDh1lhC28jtJnUXzebA",
+"lastModified": "2023-12-06T18:48:50.343Z",
+"marketplace": "canonical-ua",
+"purchaseItems": [
+    {
+        "paidForInCycle": 2,
+        "productListingID": "lADzGbq4gpOUmb-mT6U8k-H-J7VFZYBbFaQJZHmAQSLs",
+        "value": 2
+    }
+],
+"status": "done",
+"subscriptionID": "sALNCX77nsuXYVZDZG_k6IpCR81lRKoiS-fDb4ZwKKfE"
+}
+
+export const postInvoiceResponse = {
+"accountID": "aAINI96WQv-l2yAHBv68YxhhL-dDsJ0H1poiQe8Ee-1A",
+"createdAt": "2023-12-06T18:48:47.585Z",
+"createdBy": "L4zm3xn",
+"end": "2024-12-06T18:48:48Z",
+"id": "pAIUWWqMhL0NPk48dbylA8nxfjDh1lhC28jtJnUXzebA",
+"invoice": {
+    "amountDue": 54000,
+    "amountPaid": 54000,
+    "currency": "usd",
+    "customerAddress": {
+        "city": "abcd",
+        "country": "FR",
+        "line1": "abcd",
+        "line2": "",
+        "postal_code": "abcd",
+        "state": ""
+    },
+    "customerEmail": "min.kim+new@canonical.com",
+    "customerName": "abcde",
+    "id": {
+        "IDs": [
+            "in_1OKQ9MCzjFajHovdrVmszv6Q"
+        ],
+        "origin": "Stripe"
+    },
+    "identifier": "C41F3A29-0001",
+    "lineItems": [
         {
-            "id": "in_1OKQ9MCzjFajHovdrVmszv6Q",
-            "last_update": "2023-12-06T18:48:53.67Z",
-            "pi_status": "succeeded",
-            "subscription_status": "active"
+            "currency": "usd",
+            "description": "2 x Ubuntu Pro (Infra-only) (at $225.00 / year)",
+            "planID": {
+                "IDs": [
+                    "CO4VF1902"
+                ],
+                "origin": "Stripe"
+            },
+            "proRatedAmount": 45000,
+            "quantity": 2
         }
     ],
-    "subscriptionID": "sALNCX77nsuXYVZDZG_k6IpCR81lRKoiS-fDb4ZwKKfE"
-  }
-
-  // post_calculate 
-  export const postCalculate = {
-    "currency": "USD",
-    "subtotal": 450000,
-    "tax": 0,
-    "total": 450000
-  }
-  
-  export const postCalculateWithTax = {
-    "currency": "USD",
-    "subtotal": 45000,
-    "tax": 9000,
-    "total": 54000
-  }
-  
-  export const postEnsureResponse = {
-    "id": "aAINI96WQv-l2yAHBv68YxhhL-dDsJ0H1poiQe8Ee-1A",
-    "name": null,
-    "role": null,
-    "token": null,
-    "type": null
-  }
-  
-  export const paymentMethodResponse = {
-    "id": "pm_1OKQ9GCzjFajHovdLN8THd3p",
-    "object": "payment_method",
-    "billing_details": {
-        "address": {
-            "city": "abcd",
-            "country": "FR",
-            "line1": "abcd",
-            "line2": null,
-            "postal_code": "42424",
-            "state": ""
-        },
-        "email": "min.kim+new@canonical.com",
-        "name": "new",
-        "phone": null
+    "paid": true,
+    "paidAt": "2023-12-06T18:48:48Z",
+    "paymentStatus": {
+        "status": "paid"
     },
-    "card": {
-        "brand": "visa",
-        "checks": {
-            "address_line1_check": null,
-            "address_postal_code_check": null,
-            "cvc_check": null
-        },
-        "country": "US",
-        "exp_month": 4,
-        "exp_year": 2024,
-        "funding": "credit",
-        "generated_from": null,
-        "last4": "4242",
-        "networks": {
-            "available": [
-                "visa"
-            ],
-            "preferred": null
-        },
-        "three_d_secure_usage": {
-            "supported": true
-        },
-        "wallet": null
-    },
-    "created": 1701888522,
-    "customer": null,
-    "livemode": false,
-    "type": "card"
-  }
-  
-  export const subscriptions = [
-    {
-        "account_id": "aAHrg0aPSEy6XuvHk4wYpUKfiZ9gvMvrFJX87CgGLxoI",
-        "contract_id": "cAcRekzmrHZG5PXkd0Is4QAcQigPNhrbNpAnSuX8koQY",
-        "currency": "USD",
-        "current_number_of_machines": 0,
-        "end_date": null,
-        "entitlements": [
-            {
-                "enabled_by_default": false,
-                "is_available": true,
-                "is_editable": true,
-                "is_in_beta": false,
-                "support_level": null,
-                "type": "cis"
-            },
-            {
-                "enabled_by_default": true,
-                "is_available": true,
-                "is_editable": true,
-                "is_in_beta": false,
-                "support_level": null,
-                "type": "esm-apps"
-            },
-            {
-                "enabled_by_default": true,
-                "is_available": true,
-                "is_editable": true,
-                "is_in_beta": false,
-                "support_level": null,
-                "type": "esm-infra"
-            },
-            {
-                "enabled_by_default": false,
-                "is_available": true,
-                "is_editable": false,
-                "is_in_beta": false,
-                "support_level": null,
-                "type": "fips"
-            },
-            {
-                "enabled_by_default": false,
-                "is_available": true,
-                "is_editable": true,
-                "is_in_beta": false,
-                "support_level": null,
-                "type": "fips-updates"
-            },
-            {
-                "enabled_by_default": true,
-                "is_available": true,
-                "is_editable": true,
-                "is_in_beta": false,
-                "support_level": null,
-                "type": "livepatch"
-            }
+    "reason": "subscription_create",
+    "status": "paid",
+    "subscriptionID": {
+        "IDs": [
+            "sub_1OKQ9MCzjFajHovdICAATNUg"
         ],
-        "id": "free||aAHrg0aPSEy6XuvHk4wYpUKfiZ9gvMvrFJX87CgGLxoI||cAcRekzmrHZG5PXkd0Is4QAcQigPNhrbNpAnSuX8koQY",
-        "listing_id": null,
-        "machine_type": "physical",
-        "marketplace": "free",
-        "number_of_active_machines": 0,
-        "number_of_machines": 5,
-        "period": null,
-        "price": null,
-        "product_name": "Free Personal Token",
-        "renewal_id": null,
-        "start_date": "2023-12-06T20:29:10Z",
-        "statuses": {
-            "has_access_to_support": true,
-            "has_access_to_token": true,
-            "has_pending_purchases": false,
-            "is_cancellable": false,
-            "is_cancelled": false,
-            "is_downsizeable": false,
-            "is_expired": false,
-            "is_expiring": false,
-            "is_in_grace_period": false,
-            "is_renewable": false,
-            "is_renewal_actionable": false,
-            "is_renewed": false,
-            "is_subscription_active": false,
-            "is_subscription_auto_renewing": false,
-            "is_trialled": false,
-            "is_upsizeable": false,
-            "should_present_auto_renewal": false
-        },
-        "subscription_id": null,
-        "type": "free"
+        "origin": "Stripe"
     },
+    "taxAmount": 9000,
+    "total": 54000,
+    "url": "https://pay.stripe.com/invoice/acct_1GH9uHCzjFajHovd/test_YWNjdF8xR0g5dUhDempGYWpIb3ZkLF9QOGhZbnJMTEtmTnJRZ1ZxNmdtblRTYkFpSTI5MThwLDkyNDI5MzQw02007D7sWxQg/pdf?s=ap"
+},
+"lastModified": "2023-12-06T18:48:55.511Z",
+"marketplace": "canonical-ua",
+"purchaseItems": [
     {
-        "account_id": "aAINI96WQv-l2yAHBv68YxhhL-dDsJ0H1poiQe8Ee-1A",
-        "contract_id": "cAHt29tU3ckpALgOOaZ5HR0girJMQPIWqrXdxm7s3pas",
-        "currency": "USD",
-        "current_number_of_machines": 2,
-        "end_date": "2024-12-06T18:48:48Z",
-        "entitlements": [
-            {
-                "enabled_by_default": false,
-                "is_available": true,
-                "is_editable": true,
-                "is_in_beta": false,
-                "support_level": null,
-                "type": "cis"
-            },
-            {
-                "enabled_by_default": true,
-                "is_available": true,
-                "is_editable": true,
-                "is_in_beta": false,
-                "support_level": null,
-                "type": "esm-infra"
-            },
-            {
-                "enabled_by_default": false,
-                "is_available": true,
-                "is_editable": false,
-                "is_in_beta": false,
-                "support_level": null,
-                "type": "fips"
-            },
-            {
-                "enabled_by_default": false,
-                "is_available": true,
-                "is_editable": true,
-                "is_in_beta": false,
-                "support_level": null,
-                "type": "fips-updates"
-            },
-            {
-                "enabled_by_default": true,
-                "is_available": true,
-                "is_editable": true,
-                "is_in_beta": false,
-                "support_level": null,
-                "type": "livepatch"
-            },
-            {
-                "enabled_by_default": false,
-                "is_available": false,
-                "is_editable": false,
-                "is_in_beta": false,
-                "support_level": null,
-                "type": "esm-apps"
-            }
-        ],
-        "id": "yearly||aAINI96WQv-l2yAHBv68YxhhL-dDsJ0H1poiQe8Ee-1A||cAHt29tU3ckpALgOOaZ5HR0girJMQPIWqrXdxm7s3pas||sALNCX77nsuXYVZDZG_k6IpCR81lRKoiS-fDb4ZwKKfE",
-        "listing_id": "lADzGbq4gpOUmb-mT6U8k-H-J7VFZYBbFaQJZHmAQSLs",
-        "machine_type": "physical",
-        "marketplace": "canonical-ua",
-        "number_of_active_machines": 0,
-        "number_of_machines": 2,
-        "period": "yearly",
-        "price": 45000,
-        "product_name": "Ubuntu Pro (Infra-only)",
-        "renewal_id": null,
-        "start_date": "2023-12-06T18:48:48Z",
-        "statuses": {
-            "has_access_to_support": true,
-            "has_access_to_token": true,
-            "has_pending_purchases": false,
-            "is_cancellable": true,
-            "is_cancelled": false,
-            "is_downsizeable": true,
-            "is_expired": false,
-            "is_expiring": false,
-            "is_in_grace_period": false,
-            "is_renewable": false,
-            "is_renewal_actionable": false,
-            "is_renewed": true,
-            "is_subscription_active": true,
-            "is_subscription_auto_renewing": true,
-            "is_trialled": false,
-            "is_upsizeable": true,
-            "should_present_auto_renewal": true
-        },
-        "subscription_id": "sALNCX77nsuXYVZDZG_k6IpCR81lRKoiS-fDb4ZwKKfE",
-        "type": "yearly"
+        "paidForInCycle": 2,
+        "productListingID": "lADzGbq4gpOUmb-mT6U8k-H-J7VFZYBbFaQJZHmAQSLs",
+        "value": 2
     }
-  ]
+],
+"start": "2023-12-06T18:48:48Z",
+"status": "done",
+"stripeInvoices": [
+    {
+        "id": "in_1OKQ9MCzjFajHovdrVmszv6Q",
+        "last_update": "2023-12-06T18:48:53.67Z",
+        "pi_status": "succeeded",
+        "subscription_status": "active"
+    }
+],
+"subscriptionID": "sALNCX77nsuXYVZDZG_k6IpCR81lRKoiS-fDb4ZwKKfE"
+}
+
+// post_calculate 
+export const postCalculate = {
+"currency": "USD",
+"subtotal": 450000,
+"tax": 0,
+"total": 450000
+}
+
+export const postCalculateWithTax = {
+"currency": "USD",
+"subtotal": 45000,
+"tax": 9000,
+"total": 54000
+}
+
+export const postEnsureResponse = {
+"id": "aAINI96WQv-l2yAHBv68YxhhL-dDsJ0H1poiQe8Ee-1A",
+"name": null,
+"role": null,
+"token": null,
+"type": null
+}
+
+export const paymentMethodResponse = {
+"id": "pm_1OKQ9GCzjFajHovdLN8THd3p",
+"object": "payment_method",
+"billing_details": {
+    "address": {
+        "city": "abcd",
+        "country": "FR",
+        "line1": "abcd",
+        "line2": null,
+        "postal_code": "42424",
+        "state": ""
+    },
+    "email": "min.kim+new@canonical.com",
+    "name": "new",
+    "phone": null
+},
+"card": {
+    "brand": "visa",
+    "checks": {
+        "address_line1_check": null,
+        "address_postal_code_check": null,
+        "cvc_check": null
+    },
+    "country": "US",
+    "exp_month": 4,
+    "exp_year": 2024,
+    "funding": "credit",
+    "generated_from": null,
+    "last4": "4242",
+    "networks": {
+        "available": [
+            "visa"
+        ],
+        "preferred": null
+    },
+    "three_d_secure_usage": {
+        "supported": true
+    },
+    "wallet": null
+},
+"created": 1701888522,
+"customer": null,
+"livemode": false,
+"type": "card"
+}
+
+export const subscriptions = [
+{
+    "account_id": "aAHrg0aPSEy6XuvHk4wYpUKfiZ9gvMvrFJX87CgGLxoI",
+    "contract_id": "cAcRekzmrHZG5PXkd0Is4QAcQigPNhrbNpAnSuX8koQY",
+    "currency": "USD",
+    "current_number_of_machines": 0,
+    "end_date": null,
+    "entitlements": [
+        {
+            "enabled_by_default": false,
+            "is_available": true,
+            "is_editable": true,
+            "is_in_beta": false,
+            "support_level": null,
+            "type": "cis"
+        },
+        {
+            "enabled_by_default": true,
+            "is_available": true,
+            "is_editable": true,
+            "is_in_beta": false,
+            "support_level": null,
+            "type": "esm-apps"
+        },
+        {
+            "enabled_by_default": true,
+            "is_available": true,
+            "is_editable": true,
+            "is_in_beta": false,
+            "support_level": null,
+            "type": "esm-infra"
+        },
+        {
+            "enabled_by_default": false,
+            "is_available": true,
+            "is_editable": false,
+            "is_in_beta": false,
+            "support_level": null,
+            "type": "fips"
+        },
+        {
+            "enabled_by_default": false,
+            "is_available": true,
+            "is_editable": true,
+            "is_in_beta": false,
+            "support_level": null,
+            "type": "fips-updates"
+        },
+        {
+            "enabled_by_default": true,
+            "is_available": true,
+            "is_editable": true,
+            "is_in_beta": false,
+            "support_level": null,
+            "type": "livepatch"
+        }
+    ],
+    "id": "free||aAHrg0aPSEy6XuvHk4wYpUKfiZ9gvMvrFJX87CgGLxoI||cAcRekzmrHZG5PXkd0Is4QAcQigPNhrbNpAnSuX8koQY",
+    "listing_id": null,
+    "machine_type": "physical",
+    "marketplace": "free",
+    "number_of_active_machines": 0,
+    "number_of_machines": 5,
+    "period": null,
+    "price": null,
+    "product_name": "Free Personal Token",
+    "renewal_id": null,
+    "start_date": "2023-12-06T20:29:10Z",
+    "statuses": {
+        "has_access_to_support": true,
+        "has_access_to_token": true,
+        "has_pending_purchases": false,
+        "is_cancellable": false,
+        "is_cancelled": false,
+        "is_downsizeable": false,
+        "is_expired": false,
+        "is_expiring": false,
+        "is_in_grace_period": false,
+        "is_renewable": false,
+        "is_renewal_actionable": false,
+        "is_renewed": false,
+        "is_subscription_active": false,
+        "is_subscription_auto_renewing": false,
+        "is_trialled": false,
+        "is_upsizeable": false,
+        "should_present_auto_renewal": false
+    },
+    "subscription_id": null,
+    "type": "free"
+},
+{
+    "account_id": "aAINI96WQv-l2yAHBv68YxhhL-dDsJ0H1poiQe8Ee-1A",
+    "contract_id": "cAHt29tU3ckpALgOOaZ5HR0girJMQPIWqrXdxm7s3pas",
+    "currency": "USD",
+    "current_number_of_machines": 2,
+    "end_date": "2024-12-06T18:48:48Z",
+    "entitlements": [
+        {
+            "enabled_by_default": false,
+            "is_available": true,
+            "is_editable": true,
+            "is_in_beta": false,
+            "support_level": null,
+            "type": "cis"
+        },
+        {
+            "enabled_by_default": true,
+            "is_available": true,
+            "is_editable": true,
+            "is_in_beta": false,
+            "support_level": null,
+            "type": "esm-infra"
+        },
+        {
+            "enabled_by_default": false,
+            "is_available": true,
+            "is_editable": false,
+            "is_in_beta": false,
+            "support_level": null,
+            "type": "fips"
+        },
+        {
+            "enabled_by_default": false,
+            "is_available": true,
+            "is_editable": true,
+            "is_in_beta": false,
+            "support_level": null,
+            "type": "fips-updates"
+        },
+        {
+            "enabled_by_default": true,
+            "is_available": true,
+            "is_editable": true,
+            "is_in_beta": false,
+            "support_level": null,
+            "type": "livepatch"
+        },
+        {
+            "enabled_by_default": false,
+            "is_available": false,
+            "is_editable": false,
+            "is_in_beta": false,
+            "support_level": null,
+            "type": "esm-apps"
+        }
+    ],
+    "id": "yearly||aAINI96WQv-l2yAHBv68YxhhL-dDsJ0H1poiQe8Ee-1A||cAHt29tU3ckpALgOOaZ5HR0girJMQPIWqrXdxm7s3pas||sALNCX77nsuXYVZDZG_k6IpCR81lRKoiS-fDb4ZwKKfE",
+    "listing_id": "lADzGbq4gpOUmb-mT6U8k-H-J7VFZYBbFaQJZHmAQSLs",
+    "machine_type": "physical",
+    "marketplace": "canonical-ua",
+    "number_of_active_machines": 0,
+    "number_of_machines": 2,
+    "period": "yearly",
+    "price": 45000,
+    "product_name": "Ubuntu Pro (Infra-only)",
+    "renewal_id": null,
+    "start_date": "2023-12-06T18:48:48Z",
+    "statuses": {
+        "has_access_to_support": true,
+        "has_access_to_token": true,
+        "has_pending_purchases": false,
+        "is_cancellable": true,
+        "is_cancelled": false,
+        "is_downsizeable": true,
+        "is_expired": false,
+        "is_expiring": false,
+        "is_in_grace_period": false,
+        "is_renewable": false,
+        "is_renewal_actionable": false,
+        "is_renewed": true,
+        "is_subscription_active": true,
+        "is_subscription_auto_renewing": true,
+        "is_trialled": false,
+        "is_upsizeable": true,
+        "should_present_auto_renewal": true
+    },
+    "subscription_id": "sALNCX77nsuXYVZDZG_k6IpCR81lRKoiS-fDb4ZwKKfE",
+    "type": "yearly"
+}
+]

--- a/tests/playwright/tests/forms.spec.ts
+++ b/tests/playwright/tests/forms.spec.ts
@@ -1,0 +1,196 @@
+import { test, expect } from "@playwright/test";
+import { acceptCookiePolicy } from "../helpers/commands";
+
+test.describe("Form ID validation", () => {
+  /**
+   * Discover all static contact us pages from the sitemap
+   * @param page The Playwright page object
+   * @returns An array of contact us page URLs
+   */
+  async function discoverContactUsPages(page) {
+    const contactUsPages: string[] = [];
+    await page.goto('https://ubuntu.com/sitemap_tree.xml');
+    const sitemapContent = await page.textContent('body');
+    const contactUsRegex = /<loc>([^<]+\/contact-us[^<]*)<\/loc>/g;
+    let match;
+
+    while ((match = contactUsRegex.exec(sitemapContent)) !== null) {
+      const fullPath = match[1];
+
+      const path = new URL(fullPath);
+      const pathname = path.pathname;
+      if (pathname != '/contact-us') {
+        contactUsPages.push(pathname);
+      }
+    }
+
+    return contactUsPages.length > 0 ? contactUsPages : [];
+  }
+
+  test("should discover and validate all static /contact-us pages", async ({ page }) => {
+    const contactUsPages = await discoverContactUsPages(page);
+    for (const url of contactUsPages) {
+      await test.step(`Validating form on ${url}`, async () => {
+        await page.goto(url);
+
+        // Only accept cookie policy if it exists
+        if (await page.locator('#cookie-policy-button-accept').isVisible()) {
+          await acceptCookiePolicy(page);
+        }
+
+        // Check that formid and mktoForm input fields are present
+        const formIdInput = page.locator('input[name="formid"]');
+        await expect(formIdInput).not.toBeEmpty();        
+        const form = page.locator('form[id^="mktoForm_"]');
+        await expect(form).toBeVisible();
+
+        await page.waitForTimeout(1000);        
+      
+      });
+    }
+  });
+});
+
+test.describe("Form submission validation", () => {
+  test("should redirect to thank you page when form is submitted successfully", async ({ page }) => {
+    const responsePromise = page.waitForResponse(response => 
+      response.url().includes('/marketo/submit') && response.status() === 302
+    );
+
+    await page.goto("/core/contact-us");
+    await acceptCookiePolicy(page);
+    
+    // Fill required fields
+    await page.fill('input[name="company"]', 'Test Company');
+    await page.fill('input[name="title"]', 'Test Title');
+    await page.fill('textarea[id="comments"]', 'Test comments');
+    await page.getByLabel("< 5 machines").check({ force: true });
+    await page.fill('input[name="firstName"]', 'Test first name');
+    await page.fill('input[name="lastName"]', 'Test last name');
+    await page.fill('input[name="email"]', 'test@test.com');
+    await page.getByLabel('I agree to receive information').check({ force: true });
+
+    await page.getByRole("button", { name: /Submit/ }).click();
+
+    // Wait for 302 response
+    const response = await responsePromise;
+    expect(response.status()).toBe(302);
+  });
+
+  test("should return 400 error when honeypot is triggered", async ({ page }) => {
+     const responsePromise = page.waitForResponse(response => 
+      response.url().includes('/marketo/submit') && response.status() === 400
+    );
+    await page.goto("/core/contact-us");
+    await acceptCookiePolicy(page);    
+
+    await page.fill('input[name="company"]', 'Test Company');
+    await page.fill('input[name="title"]', 'Test Title');
+    await page.fill('textarea[id="comments"]', 'Test comments');
+    await page.getByLabel("< 5 machines").check({ force: true });
+    await page.fill('input[name="firstName"]', 'Test first name');
+    await page.fill('input[name="lastName"]', 'Test last name');
+    await page.fill('input[name="email"]', 'test@test.com');
+    await page.getByLabel('I agree to receive information').check({ force: true });
+
+    // Honeypot fields
+    await page.fill('input[name="website"]', 'test');
+    await page.fill('input[name="name"]', 'test');
+    await page.getByRole("button", { name: /Submit/ }).click();
+
+    // Wait for 400 response
+    const response = await responsePromise;
+    expect(response.status()).toBe(400);
+  });
+
+  test("should focus to required field if missing required fields", async ({ page }) => {
+    await page.goto("/core/contact-us");
+    await acceptCookiePolicy(page);    
+    await page.getByRole("button", { name: /Submit/ }).click();
+
+    // Check if the first required field is focused
+    const firstRequiredField = page.locator('input[name="company"]');
+    await expect(firstRequiredField).toBeFocused();
+  });
+});
+
+test.describe("Email validation", () => {
+  const invalidEmails = [
+    { email: 'invalid-email', expectedMessage: "Please include an '@'" },
+    { email: 'test@', expectedMessage: "Please enter a part following '@'" },
+    { email: 'test@invalid', expectedMessage: "Please match the requested format" },
+    { email: '@invalid.com', expectedMessage: "Please enter a part followed by '@'" }
+  ];
+
+  invalidEmails.forEach(({ email, expectedMessage }) => {
+    test(`should show validation message for ${email}`, async ({ page }) => {
+      await page.goto("/core/contact-us");
+      await acceptCookiePolicy(page);
+
+      // Fill required fields
+      await page.fill('input[name="company"]', 'Test Company');
+      await page.fill('input[name="title"]', 'Test Title');
+      await page.fill('textarea[id="comments"]', 'Test comments');
+      await page.getByLabel("< 5 machines").check({ force: true });
+      await page.fill('input[name="firstName"]', 'John');
+      await page.fill('input[name="lastName"]', 'Doe');
+      
+      // Fill invalid email
+      await page.fill('input[name="email"]', email);
+
+      // Check validation message
+      await page.getByRole("button", { name: /Submit/ }).click();
+      const emailField = page.locator('input[name="email"]');
+      const validationMessage = await emailField.evaluate(el => {
+        if (el instanceof HTMLInputElement) {
+          return el.validationMessage;
+        }
+        return '';
+      });
+      
+      expect(validationMessage).toContain(expectedMessage);
+      await expect(emailField).toHaveJSProperty("validity.valid", false);
+    });
+  });
+});
+
+test.describe("Radio field handling", () => {
+  test("radio fields should have appropriate js hooks classnames", async ({ page }) => {
+    await page.goto("/core/contact-us");
+    await acceptCookiePolicy(page);
+
+    // Check that radio has js hooks classnames
+    const radioFieldset = page.locator('fieldset.js-remove-radio-names');
+    await expect(radioFieldset).toBeVisible();
+
+    // Check that radio buttons are present
+    const radioButtons = radioFieldset.locator('input[type="radio"]');
+    await expect(radioButtons.first()).toBeVisible();
+    
+    // Check that radio buttons have names starting with _radio_
+    const radioName = await radioButtons.first().getAttribute('name');
+    expect(radioName).toMatch(/^_radio_/);
+  });
+});
+
+test.describe("Required checkbox validation", () => {
+  test("should disable submit button when required checkbox is not checked", async ({ page }) => {
+    await page.goto("/ai/contact-us");
+    await acceptCookiePolicy(page);
+
+    // Check that submit button is disabled
+    const submitButton = page.getByRole("button", { name: /Submit/ });
+    await expect(submitButton).toBeDisabled();
+  });
+
+  test("should enable submit button when required checkbox is checked", async ({ page }) => {
+    await page.goto("/ai/contact-us");
+    await acceptCookiePolicy(page);
+
+    // Check the required checkbox
+    await page.getByLabel('Physical server').check({ force: true });
+
+    const submitButton = page.getByRole("button", { name: /Submit/ });
+    await expect(submitButton).toBeEnabled();
+  });
+});

--- a/tests/playwright/tests/pro/checkout.spec.ts
+++ b/tests/playwright/tests/pro/checkout.spec.ts
@@ -178,7 +178,7 @@ test.describe("Checkout - Region and taxes", () => {
   });
 });
 
-test.describe("Checkout - Your inforamtion", () => {
+test.describe("Checkout - Your information", () => {
   test("Click cancel should reset field", async ({ page }) => {
     await page.goto("/pro/subscribe");
     await acceptCookiePolicy(page);

--- a/tests/playwright/tests/static-forms.spec.ts
+++ b/tests/playwright/tests/static-forms.spec.ts
@@ -103,46 +103,6 @@ test.describe("Form submission validation", () => {
   });
 });
 
-test.describe("Email validation", () => {
-  const invalidEmails = [
-    { email: 'invalid-email', expectedMessage: "Please include an '@'" },
-    { email: 'test@', expectedMessage: "Please enter a part following '@'" },
-    { email: 'test@invalid', expectedMessage: "Please match the requested format" },
-    { email: '@invalid.com', expectedMessage: "Please enter a part followed by '@'" }
-  ];
-
-  invalidEmails.forEach(({ email, expectedMessage }) => {
-    test(`should show validation message for ${email}`, async ({ page }) => {
-      await page.goto("/core/contact-us");
-      await acceptCookiePolicy(page);
-
-      // Fill required fields
-      await page.fill('input[name="company"]', 'Test Company');
-      await page.fill('input[name="title"]', 'Test Title');
-      await page.fill('textarea[id="comments"]', 'Test comments');
-      await page.getByLabel("< 5 machines").check({ force: true });
-      await page.fill('input[name="firstName"]', 'John');
-      await page.fill('input[name="lastName"]', 'Doe');
-      
-      // Fill invalid email
-      await page.fill('input[name="email"]', email);
-
-      // Check validation message
-      await page.getByRole("button", { name: /Submit/ }).click();
-      const emailField = page.locator('input[name="email"]');
-      const validationMessage = await emailField.evaluate(el => {
-        if (el instanceof HTMLInputElement) {
-          return el.validationMessage;
-        }
-        return '';
-      });
-      
-      expect(validationMessage).toContain(expectedMessage);
-      await expect(emailField).toHaveJSProperty("validity.valid", false);
-    });
-  });
-});
-
 test.describe("Radio field handling", () => {
   test("radio fields should have appropriate js hooks classnames", async ({ page }) => {
     for (const url of staticContactUsPages) {

--- a/tests/playwright/tests/static-forms.spec.ts
+++ b/tests/playwright/tests/static-forms.spec.ts
@@ -52,11 +52,10 @@ test.describe("Form ID validation", () => {
 });
 
 test.describe("Form submission validation", () => {
-  test("should redirect to thank you page when form is submitted successfully", async ({ page }) => {
+  test("should return success response code when form is submitted successfully", async ({ page }) => {
     const responsePromise = page.waitForResponse(response => 
-      response.url().includes('/marketo/submit') && response.status() === 302
+      response.url().includes('/marketo/submit') && response.status() !== 400
     );
-
     await page.goto("/core/contact-us");
     await acceptCookiePolicy(page);
     
@@ -69,16 +68,17 @@ test.describe("Form submission validation", () => {
     await page.fill('input[name="lastName"]', 'Test last name');
     await page.fill('input[name="email"]', 'test@test.com');
     await page.getByLabel('I agree to receive information').check({ force: true });
-
+    
     await page.getByRole("button", { name: /Submit/ }).click();
 
-    // Wait for 302 response
+    // Wait for successful/redirect responses
     const response = await responsePromise;
-    expect(response.status()).toBe(302);
+    expect([200, 302]).toContain(response.status());
+    
   });
 
   test("should return 400 error when honeypot is triggered", async ({ page }) => {
-     const responsePromise = page.waitForResponse(response => 
+    const responsePromise = page.waitForResponse(response => 
       response.url().includes('/marketo/submit') && response.status() === 400
     );
     await page.goto("/core/contact-us");

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1278,23 +1278,7 @@ app.add_url_rule(
 
 
 # Create endpoints for testing environment only
-if app.config.get('TESTING') or os.getenv('TESTING') or app.debug:
-    @app.route('/marketo/submit', methods=['POST'])
-    def mock_marketo_submit():
-        print("Mock Marketo submission received")
-        if flask.request.form.get('website') or flask.request.form.get('name'):
-            print("Honeypot triggered!")
-            return flask.jsonify({'error': 'Invalid submission'}), 400
-
-        # Simulate validation errors
-        required_fields = ['firstName', 'lastName', 'email']
-        for field in required_fields:
-            if not flask.request.form.get(field):
-                return flask.jsonify({'error': f'Missing {field}'}), 400
-
-        # Simulate successful submission
-        return_url = flask.request.form.get('returnURL', '/tests/_thank-you')
-        return flask.redirect(return_url)
+if app.config.get("TESTING") or os.getenv("TESTING") or app.debug:
 
     @app.route("/tests/<path:subpath>")
     def tests(subpath):


### PR DESCRIPTION
Note: Re-include certified tests before merging

## Done

- Implement testing for static contact forms
- Added dedicated forms for testing, using static form templates: `_client-contact-us.html`, `_default-contact-us.html`
- Implemented reusable helper functions to fill up form fields, can be reused when testing modals/form generator forms
- Tests included:
  - Form ID validation
  - Form submission validation
  - ~Email validation~
  - Radio field handling
  - Required checkbox validation
- Fly-by: 
  - Disable submit button on static & dynamic form initialisation if `js-required-checkbox` is present in the form
  - Fix typo from `pindividual-developers` -> `individual-developers`
  - Add `_radio_` prefix to fields on `_default-contact-us.html`

## QA

- See that [run-playwright](https://github.com/canonical/ubuntu.com/actions/runs/16341269462/job/46164229635?pr=15341) action passes

## Issue / Card

Fixes [WD-22315](https://warthogs.atlassian.net/browse/WD-22315)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-22315]: https://warthogs.atlassian.net/browse/WD-22315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ