### PR TITLE
[WD-23720] - copydoc: index tense change

### DIFF
--- a/templates/18-04/index.html
+++ b/templates/18-04/index.html
@@ -39,7 +39,7 @@
     <div class="row">
       <hr class="p-rule" />
       <div class="col-6 col-medium-3">
-        <h2>Reaching end of standard support on 31 May 2023</h2>
+        <h2>Reached end of standard support on 31 May 2023</h2>
       </div>
       <div class="col-6 col-medium-3">
         <p>


### PR DESCRIPTION
## Done

- [List of work items including drive-bys - remember to add the why and what of this work.]

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Navigate to 18-04 and observe the tense change of the h2.

## Issue / Card

Fixes copydoc: https://docs.google.com/document/d/1gbygbkkqvWJ-PbkOfTpeL-n8sKlgY-88F_4CNbIPqJA/edit?tab=t.0

## Screenshots
<img width="1396" height="656" alt="image" src="https://github.com/user-attachments/assets/e4c55d01-dfe0-4431-9adc-aaaf7e3b198e" />

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
