### PR TITLE
[WD-23819] CVE coverage page copy updates

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -292,16 +292,16 @@ pro:
       path: /pro
     - title: Your subscriptions
       path: /pro/dashboard
-    - title: Security Coverage
+    - title: CVE coverage
       path: /pro/linux-patch-management-with-pro
     - title: Pricing
       path: /pricing/pro
+    - title: Free trial
+      path: /pro/free-trial
     - title: Docs
       path: https://documentation.ubuntu.com/pro
     - title: Discourse
       path: https://discourse.ubuntu.com/c/project/ubuntu-pro/116/
-    - title: CVE Coverage
-      path: /pro/linux-patch-management-with-pro
 
 Distributor:
   title: Ubuntu Pro Distributor

--- a/static/js/src/advantage/linux-patch-management/components/CVESelector.tsx
+++ b/static/js/src/advantage/linux-patch-management/components/CVESelector.tsx
@@ -34,7 +34,7 @@ const CVESelector = ({
           >
             {LTSReleases.map((release) => (
               <option key={release.value} value={release.value}>
-                {release.label}
+                {`${release.label} LTS`}
               </option>
             ))}
           </select>

--- a/static/js/src/advantage/linux-patch-management/components/CVETable.test.tsx
+++ b/static/js/src/advantage/linux-patch-management/components/CVETable.test.tsx
@@ -77,7 +77,7 @@ describe("CVETable", () => {
       "option",
     );
     expect(options).toHaveLength(6); // Only one option for the test data
-    expect(options[0].textContent).toBe("24.04");
+    expect(options[0].textContent).toBe("24.04 LTS");
     expect(getByTestId("table-package-filter")).toHaveValue("");
     const packageOptions = getByTestId("table-package-filter").querySelectorAll(
       "option",

--- a/static/js/src/advantage/linux-patch-management/components/CVETable.tsx
+++ b/static/js/src/advantage/linux-patch-management/components/CVETable.tsx
@@ -23,44 +23,6 @@ const CVETable = () => {
     setSelectedSeverity,
   );
 
-  const headers = [
-    {
-      content: "Packages",
-    },
-    {
-      content: "Severity",
-    },
-    {
-      content: null,
-    },
-    {
-      content: "Coverage Needed",
-    },
-  ];
-
-  const rows = [
-    {
-      columns: [
-        {
-          content: null,
-          role: "columnheader",
-        },
-        {
-          content: <p>High</p>,
-          role: "columnheader",
-        },
-        {
-          content: <p>Critical</p>,
-          role: "columnheader",
-        },
-        {
-          content: null,
-          role: "columnheader",
-        },
-      ],
-    },
-  ];
-
   if (isLoading) {
     return (
       <>
@@ -117,4 +79,42 @@ const CVETable = () => {
     </>
   );
 };
+
+const headers = [
+  {
+    content: "Packages",
+  },
+  {
+    content: "Severity",
+  },
+  {
+    content: null,
+  },
+  {
+    content: "Coverage Needed",
+  },
+];
+
+const rows = [
+  {
+    columns: [
+      {
+        content: null,
+        role: "columnheader",
+      },
+      {
+        content: <p>High</p>,
+        role: "columnheader",
+      },
+      {
+        content: <p>Critical</p>,
+        role: "columnheader",
+      },
+      {
+        content: null,
+        role: "columnheader",
+      },
+    ],
+  },
+];
 export default CVETable;

--- a/static/js/src/advantage/linux-patch-management/components/ProContent.tsx
+++ b/static/js/src/advantage/linux-patch-management/components/ProContent.tsx
@@ -118,7 +118,7 @@ const ProContent = ({
                 >
                   {LTSReleases.map((release) => (
                     <option key={release.value} value={release.value}>
-                      {release.label}
+                      {`${release.label} LTS`}
                     </option>
                   ))}
                 </select>

--- a/templates/pro/linux-patch-management-with-pro/bar-chart.html
+++ b/templates/pro/linux-patch-management-with-pro/bar-chart.html
@@ -63,7 +63,7 @@
         },
         {
           label: 'Packages covered with Ubuntu Pro',
-          data: [18510, 22593, 26217, 27916, 31356, 34387],
+          data: [1627, 25063, 28540, 30287, 33728, 36777],
           backgroundColor: '#e95420',
         }
       ]

--- a/templates/pro/linux-patch-management-with-pro/bar-chart.html
+++ b/templates/pro/linux-patch-management-with-pro/bar-chart.html
@@ -54,7 +54,7 @@
     },
     type: 'bar',
     data: {
-      labels: ['14.04','16.04 LTS', '18.04 LTS', '20.04 LTS', '22.04 LTS', '24.04 LTS'],
+      labels: ['14.04 LTS','16.04 LTS', '18.04 LTS', '20.04 LTS', '22.04 LTS', '24.04 LTS'],
       datasets: [
         {
           label: 'Packages covered with LTS',

--- a/templates/pro/linux-patch-management-with-pro/index.html
+++ b/templates/pro/linux-patch-management-with-pro/index.html
@@ -17,9 +17,15 @@
 
   {% call(slot) vf_hero(
     title_text='Linux patch management, solved',
-    subtitle_text='Use our tool to see which packages Ubuntu Pro supports.',
+    subtitle_text='See which packages Ubuntu Pro supports.',
     layout='50/50'
     ) -%}
+    
+    {%- if slot == 'description' -%}
+      <p>
+        Ubuntu Pro provides comprehensive coverage for the OS and all your open source.
+      </p>
+    {%- endif -%}
     
     {%- if slot == 'cta' -%}
       <a href="/contact-us/form?product=pro" class="p-button--positive">Get in touch</a>

--- a/templates/pro/linux-patch-management-with-pro/index.html
+++ b/templates/pro/linux-patch-management-with-pro/index.html
@@ -17,7 +17,7 @@
 
   {% call(slot) vf_hero(
     title_text='Linux patch management, solved',
-    subtitle_text='See which packages Ubuntu Pro supports.',
+    subtitle_text='See which packages Ubuntu Pro supports',
     layout='50/50'
     ) -%}
     
@@ -28,7 +28,7 @@
     {%- endif -%}
     
     {%- if slot == 'cta' -%}
-      <a href="/contact-us/form?product=pro" class="p-button--positive">Get in touch</a>
+      <a href="/contact-us/form?product=pro" class="p-button--positive u-no-margin--bottom">Get in touch</a>
       <a href="/pro/subscribe">Start a 30-day free trial &rsaquo;</a>
     {%- endif -%}
   {% endcall -%}

--- a/templates/pro/linux-patch-management-with-pro/index.html
+++ b/templates/pro/linux-patch-management-with-pro/index.html
@@ -9,6 +9,10 @@
   See how Ubuntu Pro can help you streamline Linux patch management. Get timely security patches for packages that are important to you.
 {% endblock %}
 
+{% block meta_copydoc %}
+  https://docs.google.com/document/d/1_skjOWBJk_9tehlDW6N5_BVlw-8opAybqDjR7Ya-p1I/edit
+{% endblock meta_copydoc %}
+
 {% block content %}
 
   {% call(slot) vf_hero(

--- a/templates/pro/linux-patch-management-with-pro/index.html
+++ b/templates/pro/linux-patch-management-with-pro/index.html
@@ -22,7 +22,7 @@
     ) -%}
     
     {%- if slot == 'description' -%}
-      <p>
+      <p class="u-no-margin--bottom">
         Ubuntu Pro provides comprehensive coverage for the OS and all your open source.
       </p>
     {%- endif -%}


### PR DESCRIPTION
## Done

- Update navigation items
- Add description to hero section
- Prefix `LTS` to release labels
- Fix copydoc link
- Fix number of packages in bar chart

## QA

- Go to https://ubuntu-com-15348.demos.haus/pro/linux-patch-management-with-pro
- [x] Compare hero section with [copy doc](https://docs.google.com/document/d/1_skjOWBJk_9tehlDW6N5_BVlw-8opAybqDjR7Ya-p1I/edit?tab=t.0#heading=h.6d3m0dei0nxs)
- Install the [Ubuntu Copy Docs](https://chromewebstore.google.com/detail/ubuntu-copy-docs/cmljegnknolilmjdconnapgllmefigfl) extension if you don't have it already
- [x] The copy doc link should take you to the correct document
- [x] The navigation items should be updated according to JIRA ticket
- [x] The options in the **Release** dropdown should end with `LTS`
- [x] The numbers in the **Number of packages covered per release - Pro vs LTS** bar chart should match the ones in the linked JIRA ticket

## Issue / Card

Fixes [WD-23819](https://warthogs.atlassian.net/browse/WD-23819)

## Screenshots

### Navigation before:
<img width="1814" height="139" alt="image" src="https://github.com/user-attachments/assets/b326bf8d-c323-4fb5-8cd9-a49b05a5bb3e" />

### Navigation after:
<img width="1814" height="139" alt="image" src="https://github.com/user-attachments/assets/4f8c7d9c-a0be-4ef0-bdf9-48b163cb74ae" />

### Hero section before:
<img width="1770" height="504" alt="image" src="https://github.com/user-attachments/assets/03db36b8-b13f-41e7-94ee-7d1a3436abf8" />

### Hero section after:
<img width="1770" height="504" alt="image" src="https://github.com/user-attachments/assets/af7eb0e5-489f-4bc9-aecd-d20ce2878ee5" />

### Release dropdown labels before:
<img width="657" height="77" alt="image" src="https://github.com/user-attachments/assets/649ddae4-6225-46b1-be56-9c85f9209b19" />
<img width="910" height="85" alt="image" src="https://github.com/user-attachments/assets/bb080767-99e1-4fe4-b63f-0a0f3e11847b" />

### Release dropdown labels after:
<img width="657" height="77" alt="image" src="https://github.com/user-attachments/assets/553f0e7f-f1e9-48fd-91c2-377ec920e56f" />
<img width="910" height="85" alt="image" src="https://github.com/user-attachments/assets/7b6ec4b5-240b-4374-b361-adb2e1d12a2f" />

### Bar chart before:
<img width="762" height="532" alt="image" src="https://github.com/user-attachments/assets/ad92817d-a45b-41ae-aa96-98b79e29bc13" />

### Bar chart after:
<img width="762" height="532" alt="image" src="https://github.com/user-attachments/assets/fac22a47-2c38-4c8a-8169-d1f7d2146248" />

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-23819]: https://warthogs.atlassian.net/browse/WD-23819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ