### PR TITLE
chore: Remove sec api link

### DIFF
--- a/templates/security/cves/index.html
+++ b/templates/security/cves/index.html
@@ -37,9 +37,6 @@
             <li class="p-inline-list__item">
               <a href="/security/oval">OVAL data</a>
             </li>
-            <li class="p-inline-list__item">
-              <a href="/security/api/docs">Security API</a>
-            </li>
           </ul>
         {% endif %}
       </div>


### PR DESCRIPTION
## Done

- Removed security api link (no copy doc for this page)

## QA

- View the site locally in your web browser at: https://ubuntu-com-15355.demos.haus/security/cves
- See that the "Security API" link has been removed

## Issue / Card

Suggested [here](https://chat.canonical.com/canonical/pl/eioa1apbkig3tk7h9zna5rn19c)
