### PR TITLE
Add Pro trial link on extended coverage section.

### DIFF
--- a/templates/security/cves/cve.html
+++ b/templates/security/cves/cve.html
@@ -329,6 +329,7 @@
               Reduce your average CVE exposure time from 98 days to 1 day with expanded CVE patching, ten-years security maintenance and optional support for the full stack of open-source applications. Free for personal use.
             </p>
             <a class="p-button--positive" href="/pro">Get Ubuntu Pro</a>
+            <a href="/pro/free-trial">30-day free trial</a>
           </div>
         {% endif %}
 


### PR DESCRIPTION
## Done

Add Pro trial link on extended coverage section.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://localhost:8001/security/CVE-2023-1436
- Check the expanded security coverage as a link to the pro trial page with text `30-day free trial`

## Issue / Card

Fixes #WD-23786
