### PR TITLE
feat: implement single Pricing Block component

### DIFF
--- a/templates/macros/_vf_pricing-block.jinja
+++ b/templates/macros/_vf_pricing-block.jinja
@@ -1,0 +1,95 @@
+# This is a temp fix that can be removed once this issue is resolved: https://github.com/canonical/vanilla-framework/issues/5584
+{#
+  Params
+  - title_text (string) (optional): The text to be displayed as the heading
+  - tiers (Array<{
+      tier_name_text: String,
+      tier_price_text: String,
+      tier_price_explanation: String,
+      tier_description_html?: String,
+      tier_label_text: String,
+      tier_offerings: Array<{
+        list_item_style?: ‘ticked’ | ‘crossed’,
+        list_item_content_html: string
+      }>‘,
+      cta_html?: String
+    }>) (required)
+  Slots
+  - description (optional): paragraph-style content below the title
+#}
+{%- macro vf_pricing_block(
+  title_text="",
+  tiers=[]
+  ) -%}
+  {% set section_description = caller('section_description') %}
+  {% set has_tier_descriptions = (tiers | selectattr("tier_description_html") | list | length) > 0 %}
+  {% if tiers|length == 1 %}
+    {% set base_class_name = "grid-row" %}
+  {% elif tiers|length == 2 %}
+    {% set base_class_name = "p-pricing-block--50-50" %}
+  {% elif tiers|length == 3 %}
+    {% set base_class_name = "p-pricing-block--25-75" %}
+  {% else %}
+    {% set base_class_name = "p-pricing-block" %}
+  {% endif %}
+
+  {%- macro _tier_offerings_list(tier) %}
+    <p class="u-text--muted">What's included</p>
+    <hr class="p-rule--muted u-no-margin--bottom" />
+    <ul class="p-list--divided">
+      {%- for offering in tier.get("tier_offerings") %}
+        {%- set item_style = offering.get('list_item_style', 'undefined') -%}
+        {% if item_style == 'ticked' -%}
+          {% set item_class = "is-ticked" -%}
+        {% elif item_style == 'crossed' -%}
+          {% set item_class = "is-crossed u-text--muted" -%}
+        {% else -%}
+          {% set item_class = "has-bullet" -%}
+        {%- endif -%}
+        <li class="p-list__item {{ item_class }}">{{ offering.list_item_content_html }}</li>
+      {% endfor -%}
+    </ul>
+  {%- endmacro -%}
+
+  <div class="p-section">
+    {% if title_text %}
+      <div class="p-section--shallow">
+        <hr class="p-rule--highlight is-fixed-width" />
+        <div class="grid-row">
+          <div class="grid-col-4 grid-col-medium-4 grid-col-small-4">
+            <h2>{{ title_text }}</h2>
+          </div>
+          {%- if section_description -%}
+            <div class="grid-col-4 grid-col-medium-4 grid-col-small-4">{{ section_description }}</div>
+          {%- endif -%}
+        </div>
+      </div>
+    {% endif %}
+
+    <div class="{{ base_class_name }}">
+      {%- for tier in tiers %}
+        <div class="p-pricing-block__tier">
+          <div class="p-pricing-block__section">
+            <div class="p-section--shallow">
+              <h3 class="p-heading--4">
+                {{ tier.get("tier_name_text") }}
+                <br />
+                <strong>{{ tier.get("tier_price_text") }}</strong>
+                <span class="u-text--muted">{{ tier.get("tier_price_explanation") }}</span>
+              </h3>
+            </div>
+          </div>
+          {%- if has_tier_descriptions -%}
+            {% set description = tier.get("tier_description_html") if tier.get("tier_description_html") else '' %}
+            <div class="p-pricing-block__section"
+                 {% if not description %}role="presentation"{% endif %}>{{ description }}</div>
+          {%- endif %}
+          <div class="p-pricing-block__section">{{ _tier_offerings_list(tier) }}</div>
+          {% if tier.cta_html %}
+            <div class="p-pricing-block__section">{{ tier.cta_html }}</div>
+          {% endif -%}
+        </div>
+      {%- endfor -%}
+    </div>
+  </div>
+{% endmacro -%}

--- a/templates/macros/_vf_pricing-block.jinja
+++ b/templates/macros/_vf_pricing-block.jinja
@@ -52,20 +52,19 @@
       {% endfor -%}
     </ul>
   {%- endmacro -%}
-
+  
   <div class="p-section">
+    {% if include_hr %}
+      <div class="grid-row">
+        <hr class="p-rule--highlight" />
+      </div>
+    {% endif %}
     {% if title_text or section_description %}
       <div class="p-section--shallow">
-        {% if include_hr %}
-          {% if tiers|length == 1 %}
-            <hr class="p-rule--highlight" />
-          {% else %}
-            <hr class="p-rule--highlight is-fixed-width" />
-            <div class="grid-row">
-          {% endif %}
+        {% if tiers|length > 1 %}
+          <div class="grid-row">
         {% endif %}
-
-        {% if title_text  %}
+        {% if title_text %}
           <div class="grid-col-4 grid-col-medium-4 grid-col-small-4">
             <h2>{{ title_text }}</h2>
           </div>

--- a/templates/macros/_vf_pricing-block.jinja
+++ b/templates/macros/_vf_pricing-block.jinja
@@ -2,6 +2,7 @@
 {#
   Params
   - title_text (string) (optional): The text to be displayed as the heading
+  - include_hr (boolean) (optional): Whether to include a horizontal rule above the title
   - tiers (Array<{
       tier_name_text: String,
       tier_price_text: String,
@@ -19,6 +20,7 @@
 #}
 {%- macro vf_pricing_block(
   title_text="",
+  include_hr=true,
   tiers=[]
   ) -%}
   {% set section_description = caller('section_description') %}
@@ -52,17 +54,29 @@
   {%- endmacro -%}
 
   <div class="p-section">
-    {% if title_text %}
+    {% if title_text or section_description %}
       <div class="p-section--shallow">
-        <hr class="p-rule--highlight is-fixed-width" />
-        <div class="grid-row">
+        {% if include_hr %}
+          {% if tiers|length == 1 %}
+            <hr class="p-rule--highlight" />
+          {% else %}
+            <hr class="p-rule--highlight is-fixed-width" />
+            <div class="grid-row">
+          {% endif %}
+        {% endif %}
+
+        {% if title_text  %}
           <div class="grid-col-4 grid-col-medium-4 grid-col-small-4">
             <h2>{{ title_text }}</h2>
           </div>
-          {%- if section_description -%}
-            <div class="grid-col-4 grid-col-medium-4 grid-col-small-4">{{ section_description }}</div>
-          {%- endif -%}
-        </div>
+        {% endif %}
+        
+        {%- if section_description -%}
+          <div class="grid-col-4 grid-col-medium-4 grid-col-small-4">{{ section_description }}</div>
+        {%- endif -%}
+        {% if tiers|length > 1 %}
+          </div>
+        {% endif %}
       </div>
     {% endif %}
 

--- a/templates/openstack/managed.html
+++ b/templates/openstack/managed.html
@@ -39,6 +39,7 @@
   </div>
   <div class="col">
     {% call(slot) vf_pricing_block(
+        include_hr=false,
         tiers=[
         {
           "tier_name_text": 'Managed OpenStack pricing',

--- a/templates/openstack/managed.html
+++ b/templates/openstack/managed.html
@@ -6,6 +6,90 @@
 
 {% block content %}
 
+{% from "macros/_vf_pricing-block.jinja" import vf_pricing_block %}
+
+<section class="p-strip">
+  <div class="u-fixed-width">
+    <h2>Managed OpenStack pricing</h2>
+  </div>
+  <div class="row">
+    <div class="col-6 p-card">
+      <h3 class="p-heading--4">$15 per server per day</h3>
+      <hr class="p-rule--muted" />
+      <p>What's included:</p>
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">Logging, monitoring and alerting</li>
+        <li class="p-list__item is-ticked">24x7 operations with fully staffed NOC</li>
+        <li class="p-list__item is-ticked">Proactive cloud management</li>
+        <li class="p-list__item is-ticked">Incident and problem resolution</li>
+        <li class="p-list__item is-ticked">Software updates and OpenStack upgrades</li>
+        <li class="p-list__item is-ticked">SLA and regular independent audits</li>
+        <li class="p-list__item is-ticked">Most cost-effective approach up to 300 nodes</li>
+        <li class="p-list__item is-ticked">Optional Managed Kubernetes service on top</li>
+        <li class="p-list__item is-ticked">EU and US regulatory compliance options</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<div class="row--50-50">
+  <hr class="p-rule" />
+  <div class="col">
+    <h2>Managed OpenStack pricing</h2>
+  </div>
+  <div class="col">
+    {% call(slot) vf_pricing_block(
+        tiers=[
+        {
+          "tier_name_text": 'Managed OpenStack pricing',
+          "tier_price_text": '$15',
+          "tier_price_explanation": 'per server per day',
+          "tier_label_text": "What\'s included",
+          "tier_offerings": [
+            {
+              "list_item_style": "ticked",
+              "list_item_content_html": "Logging, monitoring and alerting"
+            },
+            {
+              "list_item_style": "ticked",
+              "list_item_content_html": "24x7 operations with fully staffed NOC"
+            },
+            {
+              "list_item_style": "ticked",
+              "list_item_content_html": "Proactive cloud management"
+            },
+            {
+              "list_item_style": "ticked",
+              "list_item_content_html": "Incident and problem resolution"
+            },
+            {
+              "list_item_style": "ticked",
+              "list_item_content_html": "Software updates and OpenStack upgrades"
+            },
+            {
+              "list_item_style": "ticked",
+              "list_item_content_html": "SLA and regular independent audits"
+            },
+            {
+              "list_item_style": "ticked",
+              "list_item_content_html": "Most cost-effective approach up to 300 nodes"
+            },
+            {
+              "list_item_style": "ticked",
+              "list_item_content_html": "Optional Managed Kubernetes service on top"
+            },
+            {
+              "list_item_style": "ticked",
+              "list_item_content_html": "EU and US regulatory compliance options"
+            },
+          ],
+        },
+        ]
+      ) -%}
+    {% endcall %}
+  </div>
+</div>
+
 <section class="p-strip--suru-bottomed">
   <div class="u-fixed-width">
     <h1>Managed private cloud</h1>
@@ -489,29 +573,6 @@
         </div>
       </li>
     </ol>
-  </div>
-</section>
-<section class="p-strip">
-  <div class="u-fixed-width">
-    <h2>Managed OpenStack pricing</h2>
-  </div>
-  <div class="row">
-    <div class="col-6 p-card">
-      <h3 class="p-heading--4">$15 per server per day</h3>
-      <hr class="p-rule--muted" />
-      <p>What's included:</p>
-      <ul class="p-list">
-        <li class="p-list__item is-ticked">Logging, monitoring and alerting</li>
-        <li class="p-list__item is-ticked">24x7 operations with fully staffed NOC</li>
-        <li class="p-list__item is-ticked">Proactive cloud management</li>
-        <li class="p-list__item is-ticked">Incident and problem resolution</li>
-        <li class="p-list__item is-ticked">Software updates and OpenStack upgrades</li>
-        <li class="p-list__item is-ticked">SLA and regular independent audits</li>
-        <li class="p-list__item is-ticked">Most cost-effective approach up to 300 nodes</li>
-        <li class="p-list__item is-ticked">Optional Managed Kubernetes service on top</li>
-        <li class="p-list__item is-ticked">EU and US regulatory compliance options</li>
-      </ul>
-    </div>
   </div>
 </section>
 

--- a/templates/openstack/support.html
+++ b/templates/openstack/support.html
@@ -1,7 +1,6 @@
 {% extends "openstack/_base_openstack.html" %}
 
 {% from "_macros/vf_rich-vertical-list.jinja" import vf_rich_vertical_list %}
-{% from "_macros/vf_rich-horizontal-list.jinja" import vf_rich_horizontal_list %}
 {% from "_macros/vf_quote-wrapper.jinja" import vf_quote_wrapper %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 

--- a/templates/security/cmmc/index.html
+++ b/templates/security/cmmc/index.html
@@ -1,8 +1,6 @@
 {% extends "security/base_security.html" %}
 
 {% from "_macros/vf_hero.jinja" import vf_hero %}
-{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
-{% from "_macros/vf_rich-horizontal-list.jinja" import vf_rich_horizontal_list %}
 {% from "macros/_macros-resource.jinja" import resource_section %}
 
 {% block title %}Enable CMMC compliance with Ubuntu Pro{% endblock %}

--- a/templates/security/vulnerability-management.html
+++ b/templates/security/vulnerability-management.html
@@ -8,7 +8,6 @@
 
 {% from "_macros/vf_hero.jinja" import vf_hero %}
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
-{% from "_macros/vf_rich-horizontal-list.jinja" import vf_rich_horizontal_list %}
 
 {% block body_class %}
   is-paper


### PR DESCRIPTION
## Done

- Implement single Pricing Block component
  - Introduced changes to the pricing block pattern locally, upstream to Vanilla once this is merged
- Changes:
  - Pricing block takes up entire `grid-row` if there is only one component
  - Added `include_hr` param to show/hide `hr` above the title
  - Make `title_text` an optional param
  - Remove shallow section padding if `title_text` or `section_description` is absent

## QA

- Go to https://ubuntu-com-15365.demos.haus/openstack/managed
- Check that the single pricing block matches [Figma](https://www.figma.com/design/vH19y2J2YqwUfksebSUvTW/ubuntu.com-openstack?node-id=817-8294&m=dev)

## Issue / Card

Fixes [WD-23371](https://warthogs.atlassian.net/browse/WD-23371)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-23371]: https://warthogs.atlassian.net/browse/WD-23371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ