### PR TITLE
Update ISSUE_TEMPLATE.yaml, add a note about security advisory

### DIFF
--- a/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.yaml
+++ b/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.yaml
@@ -9,6 +9,10 @@ body:
   attributes:
     value: |
       *Please provide as many details as possible in order to provide maintainers more context about the issue. Don't skip/remove any of the sections below. If there is no data to provide in one of the sections, please specify it by typing "N/A" or similar. That will help maintainers reproduce the issue and be able to help quickly. Thanks.*
+- type: markdown
+  attributes:
+    value: |
+      *If you want to report a vulnerability, please don't use this form and report it [here](https://github.com/canonical/ubuntu.com/security/advisories/new) instead.*
 - type: textarea
   id: summary
   attributes:


### PR DESCRIPTION
## Done

- Since we utilize a security advisory for reporting vulnerabilities, it's worth pointing external contributors to it as well

