### PR TITLE
[WD-23441] feat: add autocomplete attributes to form elements in form-generator template

### DIFF
--- a/templates/shared/forms/form-fields.html
+++ b/templates/shared/forms/form-fields.html
@@ -36,6 +36,7 @@
                           id="firstName"
                           name="firstName"
                           maxlength="255"
+                          autocomplete="given-name"
                           type="text" />                              
                   <label class="is-required"
                           for="lastName">Last name:</label>
@@ -43,6 +44,7 @@
                           id="lastName"
                           name="lastName"
                           maxlength="255"
+                          autocomplete="family-name"
                           type="text" />
                   <label class="is-required"
                             for="email">Email:</label>
@@ -50,6 +52,7 @@
                           id="email"
                           name="email"
                           maxlength="255"
+                          autocomplete="email"
                           type="email"
                           pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$"/>
                   <label class="is-required" 
@@ -58,6 +61,7 @@
                           id="company" 
                           name="company" 
                           maxlength="255"
+                          autocomplete="organization"
                           type="text" />
                   <label class="is-required" 
                           for="title">Job Title:</label>
@@ -65,6 +69,7 @@
                           id="title" 
                           name="title" 
                           maxlength="255" 
+                          autocomplete="organization-title"
                           type="text" />
                   
                   {% with required = true %}
@@ -95,6 +100,7 @@
                               id="{{ field.id }}"
                               name="{{ field.id }}"
                               maxlength="255"
+                              autocomplete="{% if field.type == 'tel' %}tel{% elif field.type == 'email' %}email{% endif %}"
                               type="{{ field.type }}" />
                     {% elif field.type == "long-text" %}
                       <textarea {% if fieldset.isRequired %}required{% endif %}


### PR DESCRIPTION
## Done

- Added `autocomplete` attribute depending on the type of field
  -  First name (given-name)
  -  Last name (family-name)
  - Email (email)
  - Phone number (tel)
  - Company/Company name (organization)
  - Job title (organization-title)

## QA

- Open any form, for example https://ubuntu-com-15378.demos.haus/internet-of-things#get-in-touch
- Verify the autocomplete fields work in personal information section

## Issue / Card

Fixes #[WD-23441](https://warthogs.atlassian.net/browse/WD-23441)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-23441]: https://warthogs.atlassian.net/browse/WD-23441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ