### PR TITLE
[WD-23251] fix: CTA link overflow on u.com homepage

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -471,7 +471,7 @@
 
       <div class="row">
         <hr class="p-rule--muted" />
-        <div class="col-3 col-start-large-7 col-medium-2 col-medium-start-3">
+        <div class="col-6 col-start-large-7">
           <p>
             <a href="/cloud/public-cloud"
                aria-label="Learn more about public cloud optimisation"


### PR DESCRIPTION
## Done

- Fixed the overflowing CTA

## QA

- View the site locally in your web browser at: https://ubuntu-com-15384.demos.haus/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Verify the affected CTA (Learn more about cloud optimization) is not overflowing on medium/smaller screen sizes

## Issue / Card

Fixes #[WD-23251](https://warthogs.atlassian.net/browse/WD-23251)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-23251]: https://warthogs.atlassian.net/browse/WD-23251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ