### PR TITLE
Add new endpoint path

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -419,6 +419,7 @@ production:
           /security/releases/.*\.json,
           /security/api/.*,
           /security/page/.*\.json,
+          /security/flat/notices\.json,
         ]
       service_name: ubuntu-com-security-api
 
@@ -1000,6 +1001,7 @@ staging:
           /security/api/.*,
           /security/page/.*\.json,
           /security/updates/.*,
+          /security/flat/notices\.json,
         ]
       service_name: ubuntu-com-security-api
     


### PR DESCRIPTION
## Done

- Added paths to the new /security/flat/notices.json endpoint

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
