### PR TITLE
fix: broken images on blog articles

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ canonicalwebteam.http==1.0.4
 canonicalwebteam.blog==6.4.4
 canonicalwebteam.search==2.1.2
 canonicalwebteam.templatefinder==1.0.0
-git+https://github.com/canonical/canonicalwebteam.image-template.git@fix-wordpress-images#egg=canonicalwebteam.image-template
+canonicalwebteam.image-template==1.7.0
 canonicalwebteam.discourse==6.3.0
 canonicalwebteam.form-generator==2.0.1
 canonicalwebteam.directory-parser==1.2.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ canonicalwebteam.http==1.0.4
 canonicalwebteam.blog==6.4.4
 canonicalwebteam.search==2.1.2
 canonicalwebteam.templatefinder==1.0.0
-canonicalwebteam.image-template==1.5.0
+git+https://github.com/canonical/canonicalwebteam.image-template.git@fix-wordpress-images#egg=canonicalwebteam.image-template
 canonicalwebteam.discourse==6.3.0
 canonicalwebteam.form-generator==2.0.1
 canonicalwebteam.directory-parser==1.2.10


### PR DESCRIPTION
## Done

- Bump version for image template module

## QA

- View the site locally in your web browser at: https://ubuntu-com-15391.demos.haus/blog/linux-foundation-openstack
    - Be sure to test on mobile, tablet and desktop screen sizes
- Make sure the images are loading fine
- Check different random pages on https://ubuntu-com-15391.demos.haus and make sure the image-template module is working fine and the images are loading successfully.

## Fixes

 - Fixes #[WD-24160](https://warthogs.atlassian.net/browse/WD-24160)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-24160]: https://warthogs.atlassian.net/browse/WD-24160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ