### PR TITLE
[WD-24186] feat: Blog images can now pull their width and height from css styles

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 canonicalwebteam.flask-base==2.6.0
 canonicalwebteam.http==1.0.4
-canonicalwebteam.blog==6.4.4
+git+https://github.com/canonical/canonicalwebteam.blog.git@WD-24186#egg=canonicalwebteam.blog
 canonicalwebteam.search==2.1.2
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.7.0


### PR DESCRIPTION
## Done

- Bump version for blog module

## QA

- View the site locally in your web browser at: https://ubuntu-com-15391.demos.haus/blog/linux-foundation-openstack
    - Be sure to test on mobile, tablet and desktop screen sizes
- Make sure the images are loading fine
- Check different random pages on https://ubuntu-com-15391.demos.haus and make sure the image-template module is working fine and the images are loading successfully.

## Issue / Card

Fixes #[WD-24186](https://warthogs.atlassian.net/browse/WD-24186)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
