### PR TITLE
[Rebrand & Migrate] Ubuntu frame 

### DIFF
--- a/meganav.yaml
+++ b/meganav.yaml
@@ -415,7 +415,7 @@ products:
               url: /certified/devices
             - title: Ubuntu Frame
               description: Embedded graphical displays
-              url: https://mir-server.io/ubuntu-frame
+              url: /frame
             - title: Ubuntu Pro for Devices
               description: Security maintenance for IoT
               url: /pro/devices

--- a/meganav.yaml
+++ b/meganav.yaml
@@ -469,6 +469,9 @@ products:
             - title: JAAS
               description: Auditing and compliance for Juju
               url: https://jaas.ai/
+            - title: Mir
+              description: Display server library
+              url: https://canonical.com/mir
             - title: Toolchains
               description: Build your apps on Ubuntu
               url: /toolchains

--- a/navigation.yaml
+++ b/navigation.yaml
@@ -639,3 +639,11 @@ confidential-ai:
 #   children:
 #     - title: Spring Boot
 #       path: /toolchains/spring
+
+frame:
+  title: Ubuntu Frame
+  path: /frame
+
+  children:
+    - title: Overview
+      path: /frame

--- a/templates/frame/base_frame.html
+++ b/templates/frame/base_frame.html
@@ -1,0 +1,7 @@
+{% extends "templates/base.html" %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1P4xOahtq6VVY6llAAAmQ4cX7ip4zzNXxXciuZ9joxMw/edit#{% endblock meta_copydoc %}
+
+{% block outer_content %}
+  {% block content %}{% endblock %}
+{% endblock %}

--- a/templates/frame/form-data.json
+++ b/templates/frame/form-data.json
@@ -8,7 +8,7 @@
         "title": "Let's get your project to market faster!",
         "introText": "Canonical partners with silicon companies, board manufacturers and ODMs to help the industry bring smart device and software capabilities to market faster. Tell us about your project so we can bring the right Canonical team members to the conversation to help you.",
         "formId": 1670,
-        "returnUrl": "/frame#success",
+        "returnUrl": "/frame#contact-form-success",
         "lpUrl": "https://pages.ubuntu.com/things-contact-us.html",
         "product": ""
       },

--- a/templates/frame/form-data.json
+++ b/templates/frame/form-data.json
@@ -1,0 +1,90 @@
+{
+  "form": {
+    "/frame": {
+      "templatePath": "/frame/index.html",
+      "isModal": true,
+      "modalId": "frame-modal",
+      "formData": {
+        "title": "Let's get your project to market faster!",
+        "introText": "Canonical partners with silicon companies, board manufacturers and ODMs to help the industry bring smart device and software capabilities to market faster. Tell us about your project so we can bring the right Canonical team members to the conversation to help you.",
+        "formId": 1670,
+        "returnUrl": "/frame#success",
+        "lpUrl": "https://pages.ubuntu.com/things-contact-us.html",
+        "product": ""
+      },
+      "fieldsets": [
+        {
+          "title": "Tell us more about your project",
+          "id": "about-project",
+          "fields": [
+            {
+              "type": "long-text",
+              "id": "about-project",
+              "label": "About your project"
+            }
+          ]
+        },
+        {
+          "title": "Do you have a commercial project?",
+          "id": "commercial-project",
+          "inputName": "commercial-project",
+          "inputType": "radio",
+          "isRequired": true,
+          "fields": [
+            {
+              "type": "radio",
+              "label": "Yes",
+              "value": "Yes"
+            },
+            {
+              "type": "radio",
+              "label": "No",
+              "value": "No"
+            }
+          ]
+        },
+        {
+          "title": "When do you need to ship?",
+          "id": "shipping-time",
+          "inputType": "radio",
+          "inputName": "shipping-time",
+          "isRequired": true,
+          "fields": [
+            {
+              "type": "radio",
+              "label": "Next 3 months",
+              "value": "Next 3 months"
+            },
+            {
+              "type": "radio",
+              "label": "Next 3 - 6 months",
+              "value": "Next 3 - 6 months"
+            },
+            {
+              "type": "radio",
+              "label": "Next 6 - 12 months",
+              "value": "Next 6 - 12 months"
+            },
+            {
+              "type": "radio",
+              "label": "No timeline - just researching",
+              "value": "No timeline - just researching"
+            }
+          ]
+        },
+        {
+          "title": "How should we get in touch?",
+          "id": "about-you",
+          "noCommentsFromLead": true,
+          "fields": [
+            {
+              "type": "tel",
+              "id": "phone",
+              "label": "Mobile/cell phone number"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/templates/frame/form-data.json
+++ b/templates/frame/form-data.json
@@ -7,7 +7,7 @@
       "formData": {
         "title": "Let's get your project to market faster!",
         "introText": "Canonical partners with silicon companies, board manufacturers and ODMs to help the industry bring smart device and software capabilities to market faster. Tell us about your project so we can bring the right Canonical team members to the conversation to help you.",
-        "formId": 1670,
+        "formId": 1266,
         "returnUrl": "/frame#contact-form-success",
         "lpUrl": "https://pages.ubuntu.com/things-contact-us.html",
         "product": ""

--- a/templates/frame/index.html
+++ b/templates/frame/index.html
@@ -389,14 +389,14 @@
 
   <section class="p-strip is-deep">
     <div class="row">
-        <h2>
-          Need help? Let’s get your device faster to market
-          <br />
-          <a href="/internet-of-things/smart-displays#get-in-touch"
-             class="js-invoke-modal">Contact us</a>
-        </h2>
+      <h2>
+        Need help? Let’s get your device faster to market
+        <br />
+        <a href="/internet-of-things/smart-displays#get-in-touch"
+           class="js-invoke-modal">Contact us</a>
+      </h2>
     </div>
   </section>
 
-  {{ load_form('/frame') | safe }}
+  {{ load_form("/frame") | safe }}
 {% endblock content %}

--- a/templates/frame/index.html
+++ b/templates/frame/index.html
@@ -392,11 +392,11 @@
         <h2>
           Need help? Let’s get your device faster to market
           <br />
-          <a href="https://ubuntu.com/internet-of-things/digital-signage#get-in-touch"
+          <a href="/internet-of-things/smart-displays#get-in-touch"
              class="js-invoke-modal">Contact us</a>
         </h2>
     </div>
   </section>
 
-  {{ load_form('/internet-of-things', 1670) | safe }}
+  {{ load_form('/frame') | safe }}
 {% endblock content %}

--- a/templates/frame/index.html
+++ b/templates/frame/index.html
@@ -35,10 +35,10 @@
     {%- endif -%}
     {%- if slot == 'image' -%}
       <div class="p-image-container--3-2 is-cover">
-        {{ image(url="https://assets.ubuntu.com/v1/34132d50-ubuntu-frame-hero.png",
+        {{ image(url="https://assets.ubuntu.com/v1/02ab917d-hero.jpg",
                 alt="",
-                width="1234",
-                height="984",
+                width="1200",
+                height="800",
                 hi_def=True,
                 loading="auto",
                 attrs={"class": "p-image-container__image"}) | safe
@@ -67,37 +67,66 @@
       <h2 class="p-text--small-caps">COMPATIBLE WITH POPULAR GRAPHICAL TOOLKITS</h2>
     </div>
     <div class="u-fixed-width">
-      <div class="p-logo-section">
+      <div class="p-logo-section has-misaligned">
         <div class="p-logo-section__items">
           <div class="p-logo-section__item">
-            <img class="p-logo-section__logo"
-                 src="https://assets.ubuntu.com/v1/98d2bf31-144px%20QT%20logo.svg"
-                 alt="Qt logo" />
+            {{ image(url="https://assets.ubuntu.com/v1/971e619b-Qt-logo.png",
+                        alt="Qt logo",
+                        width="156",
+                        height="312",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
           </div>
           <div class="p-logo-section__item">
-            <img class="p-logo-section__logo"
-                 src="https://assets.ubuntu.com/v1/1d3e5eaf-flutter-logo.png"
-                 alt="Flutter logo" />
+            {{ image(url="https://assets.ubuntu.com/v1/3fa92fbd-flutter-logo.png",
+                        alt="Flutter",
+                        width="138",
+                        height="312",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
           </div>
           <div class="p-logo-section__item">
-            <img class="p-logo-section__logo"
-                 src="https://assets.ubuntu.com/v1/d73dbd10-GTK+no+background+%25281%2529.png"
-                 alt="GTK logo" />
+            {{ image(url="https://assets.ubuntu.com/v1/f595e3d7-react-logo.png",
+                        alt="Electron",
+                        width="144",
+                        height="312",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
           </div>
           <div class="p-logo-section__item">
-            <img class="p-logo-section__logo"
-                 src="https://assets.ubuntu.com/v1/9a661d86-html5-logo.png"
-                 alt="HTML5 logo" />
+            {{ image(url="https://assets.ubuntu.com/v1/3bf2462f-GTK-logo.png",
+                        alt="",
+                        width="252",
+                        height="312",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
           </div>
           <div class="p-logo-section__item">
-            <img class="p-logo-section__logo"
-                 src="https://assets.ubuntu.com/v1/82c52642-microsoft-azure.svg"
-                 alt="Microsoft Azure" />
+            {{ image(url="https://assets.ubuntu.com/v1/f2f331ca-html5-logo.png",
+                        alt="HTML5",
+                        width="43",
+                        height="104",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
           </div>
           <div class="p-logo-section__item">
-            <img class="p-logo-section__logo"
-                 src="https://assets.ubuntu.com/v1/086b3df5-sdl-logo.svg"
-                 alt="Simple Directmedia Layer" />
+            {{ image(url="https://assets.ubuntu.com/v1/bcdedc4b-sdl-logo.png",
+                        alt="Simple Directmedia Layer",
+                        width="198",
+                        height="312",
+                        hi_def=True,
+                        attrs={"class": "p-logo-section__logo"}) | safe
+            }}
           </div>
         </div>
       </div>
@@ -170,7 +199,15 @@
         <h2>Learn more about Ubuntu Frame</h2>
       </div>
       <div class="grid-col-small-8 grid-col-medium-4 grid-col-4">
-        <div class="p-image-container--3-2 is-cover is-highlighted"></div>
+        <div class="p-image-container--3-2 is-cover is-highlighted">
+          {{ image(url="https://assets.ubuntu.com/v1/c75ab783-whitepaper.png",
+                    alt="",
+                    width="1200",
+                    height="801",
+                    hi_def=True,
+                    loading="lazy") | safe
+          }}
+        </div>
         <ul class="p-list--divided">
           <li class="p-list__item is-ticked">Detailed product overview</li>
           <li class="p-list__item is-ticked">Tutorials</li>
@@ -259,13 +296,21 @@
         <h2>Designed for enhanced security</h2>
       </div>
       <div class="grid-col-small-8 grid-col-medium-4 grid-col-4">
-        <div class="u-fixed-width u-hide--small">
-          <figure>
-            <img src="https://assets.ubuntu.com/v1/a771b297-Diagram%403x.png"
-                 alt="diagram"
-                 loading="lazy"
-                 width="80%" />
-            <figcaption class="u-text--muted">Architecture that confines shell and app separately</figcaption>
+        <div class="u-fixed-width">
+          <figure class="u-no-margin--bottom">
+            <div class="p-image-container is-highlighted">
+              {{ image(url="https://assets.ubuntu.com/v1/9de2c517-designed-for-security.png",
+                            alt="",
+                            width="1200",
+                            height="676",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"class": "p-image-container__image",}) | safe
+              }}
+            </div>
+            <figcaption>
+              <p class="u-text--muted">Architecture that confines shell and app separately</p>
+            </figcaption>
           </figure>
         </div>
         <p>

--- a/templates/frame/index.html
+++ b/templates/frame/index.html
@@ -4,7 +4,7 @@
 {% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
 
 {% block title %}
-  Ubuntu frame
+  Ubuntu Frame
 {% endblock title %}
 
 {% block meta_copydoc %}

--- a/templates/frame/index.html
+++ b/templates/frame/index.html
@@ -170,9 +170,7 @@
       <div class="grid-col-small-8 grid-col-medium-4 grid-col-4">
         <ol class="p-stepped-list u-no-margin--bottom">
           <li class="p-stepped-list__item u-no-padding--bottom">
-            <p class="p-stepped-list__title p-heading--5">
-              Setup your device
-            </p>
+            <p class="p-stepped-list__title p-heading--5">Setup your device</p>
             <p>
               You need either <a href="/core">Ubuntu Core</a> or a version of Linux supporting snaps
             </p>
@@ -203,15 +201,20 @@
         <h2>Learn more about Ubuntu Frame</h2>
       </div>
       <div class="grid-col-small-8 grid-col-medium-4 grid-col-4">
-        <div class="p-image-container--3-2 is-cover is-highlighted">
-          {{ image(url="https://assets.ubuntu.com/v1/c75ab783-whitepaper.png",
-                    alt="",
-                    width="1200",
-                    height="801",
-                    hi_def=True,
-                    loading="lazy") | safe
-          }}
+        <div class="p-section--shallow">
+          <div class="p-image-container--3-2 is-cover is-highlighted">
+            {{ image(url="https://assets.ubuntu.com/v1/c75ab783-whitepaper.png",
+                        alt="",
+                        width="1200",
+                        height="801",
+                        hi_def=True,
+                        loading="lazy") | safe
+            }}
+          </div>
         </div>
+        <p>
+          <b>What&apos;s included in our datasheet:</b>
+        </p>
         <ul class="p-list--divided">
           <li class="p-list__item is-ticked">Detailed product overview</li>
           <li class="p-list__item is-ticked">Tutorials</li>
@@ -355,9 +358,7 @@
               <hr class="p-rule--muted" />
             </div>
             <div class="p-equal-height-row__item">
-              <h3 class="p-heading--5">
-                Raspberry Pi
-              </h3>
+              <h3 class="p-heading--5">Raspberry Pi</h3>
               <div class="u-hide--large p-cta-block">
                 <a href="/download/raspberry-pi-core">Install Ubuntu Frame on Raspberry Pi&nbsp;&rsaquo;</a>
               </div>
@@ -378,9 +379,7 @@
               <hr class="p-rule--muted" />
             </div>
             <div class="p-equal-height-row__item">
-              <h3 class="p-heading--5">
-                Intel NUC
-              </h3>
+              <h3 class="p-heading--5">Intel NUC</h3>
               <div class="u-hide--large p-cta-block">
                 <a href="/download/intel-nuc">Install Ubuntu Frame on Intel NUC&nbsp;&rsaquo;</a>
               </div>
@@ -401,9 +400,7 @@
               <hr class="p-rule--muted" />
             </div>
             <div class="p-equal-height-row__item">
-              <h3 class="p-heading--5">
-                Dragonboard
-              </h3>
+              <h3 class="p-heading--5">Dragonboard</h3>
               <div class="u-hide--large p-cta-block">
                 <a href="/download/qualcomm-dragonboard-410c">Install Ubuntu Frame on Dragonboard&nbsp;&rsaquo;</a>
               </div>

--- a/templates/frame/index.html
+++ b/templates/frame/index.html
@@ -441,7 +441,7 @@
       <h2>
         Need help? Let’s get your device faster to market
         <br />
-        <a href="/internet-of-things/smart-displays#get-in-touch"
+        <a href="/internet-of-things/contact-us"
            aria-controls="frame-modal"
            class="js-invoke-modal">Contact us</a>
       </h2>

--- a/templates/frame/index.html
+++ b/templates/frame/index.html
@@ -19,9 +19,9 @@
 
 {% block content %}
   {% call(slot) vf_hero(
-    title_text='Simplify the development of embedded displays',
+    title_text='Simplify the development <br class="u-hide--small" /> of embedded displays',
     layout='50/50',
-    is_split_on_medium=true
+    is_split_on_medium=false
     ) -%}
     {%- if slot == 'description' -%}
       <p>
@@ -101,7 +101,7 @@
           </div>
           <div class="p-logo-section__item">
             {{ image(url="https://assets.ubuntu.com/v1/3bf2462f-GTK-logo.png",
-                        alt="",
+                        alt="GTK",
                         width="252",
                         height="312",
                         hi_def=True,
@@ -198,7 +198,7 @@
     <hr class="p-rule is-fixed-width" />
     <div class="grid-row">
       <div class="grid-col-small-8 grid-col-medium-4 grid-col-4">
-        <h2>Learn more about Ubuntu Frame</h2>
+        <h2>Learn more about <br class="u-hide--small u-hide--medium" /> Ubuntu Frame</h2>
       </div>
       <div class="grid-col-small-8 grid-col-medium-4 grid-col-4">
         <div class="p-section--shallow">
@@ -303,7 +303,7 @@
         <h2>Designed for enhanced security</h2>
       </div>
       <div class="grid-col-small-8 grid-col-medium-4 grid-col-4">
-        <div class="u-fixed-width">
+        <div class="u-fixed-width u-hide--small">
           <figure class="u-no-margin--bottom">
             <div class="p-image-container is-highlighted">
               {{ image(url="https://assets.ubuntu.com/v1/9de2c517-designed-for-security.png",
@@ -337,7 +337,7 @@
         <h2>Ready for all boards, frameworks and applications</h2>
       </div>
       <div class="grid-col-small-8 grid-col-medium-4 grid-col-4">
-        <p>Minimise your costs and time to market: Ubuntu Frame is compatible with the most popular frameworks and silicon.</p>
+        <p>Minimize your costs and time to market: Ubuntu Frame is compatible with the most popular frameworks and silicon.</p>
       </div>
     </div>
     <div class="row p-section--shallow">

--- a/templates/frame/index.html
+++ b/templates/frame/index.html
@@ -168,23 +168,27 @@
         </h2>
       </div>
       <div class="grid-col-small-8 grid-col-medium-4 grid-col-4">
-        <ol class="p-list--divided">
-          <li class="p-list__item u-no-padding--bottom">
-            <p class="p-heading--5 u-no-padding--top">Setup your device</p>
+        <ol class="p-stepped-list u-no-margin--bottom">
+          <li class="p-stepped-list__item u-no-padding--bottom">
+            <p class="p-stepped-list__title p-heading--5">
+              Setup your device
+            </p>
             <p>
               You need either <a href="/core">Ubuntu Core</a> or a version of Linux supporting snaps
             </p>
+            <hr class="p-rule--muted" />
           </li>
-          <li class="p-list__item u-no-padding--bottom">
-            <p class="p-heading--5 u-no-padding--top">Install Ubuntu Frame</p>
-            <div class="p-section--shallow">
-              <pre class="u-no-margin--bottom"><code>$ sudo snap install ubuntu-frame</code></pre>
+          <li class="p-stepped-list__item u-no-padding--bottom">
+            <p class="p-heading--5 p-stepped-list__title">Install Ubuntu Frame</p>
+            <div class="p-code-snippet u-no-margin--bottom p-section--shallow">
+              <pre class="p-code-snippet__block--icon"><code>sudo snap install ubuntu-frame</code></pre>
             </div>
+            <hr class="p-rule--muted" />
           </li>
-          <li class="p-list__item u-no-padding--bottom">
-            <p class="p-heading--5 u-no-padding--top">Install your application</p>
-            <div>
-              <pre class="u-no-margin--bottom"><code>$ sudo snap install [your-app]</code></pre>
+          <li class="p-stepped-list__item u-no-padding--bottom">
+            <p class="p-heading--5 p-stepped-list__title">Install your application</p>
+            <div class="p-code-snippet u-no-margin--bottom">
+              <pre class="p-code-snippet__block--icon"><code>sudo snap install [your-app]</code></pre>
             </div>
           </li>
         </ol>
@@ -352,7 +356,7 @@
             </div>
             <div class="p-equal-height-row__item">
               <h3 class="p-heading--5">
-                <a href="/download/raspberry-pi-core">Raspberry Pi</a>
+                Raspberry Pi
               </h3>
               <div class="u-hide--large p-cta-block">
                 <a href="/download/raspberry-pi-core">Install Ubuntu Frame on Raspberry Pi&nbsp;&rsaquo;</a>
@@ -375,7 +379,7 @@
             </div>
             <div class="p-equal-height-row__item">
               <h3 class="p-heading--5">
-                <a href="/download/intel-nuc">Intel NUC</a>
+                Intel NUC
               </h3>
               <div class="u-hide--large p-cta-block">
                 <a href="/download/intel-nuc">Install Ubuntu Frame on Intel NUC&nbsp;&rsaquo;</a>
@@ -398,7 +402,7 @@
             </div>
             <div class="p-equal-height-row__item">
               <h3 class="p-heading--5">
-                <a href="/download/qualcomm-dragonboard-410c">Dragonboard</a>
+                Dragonboard
               </h3>
               <div class="u-hide--large p-cta-block">
                 <a href="/download/qualcomm-dragonboard-410c">Install Ubuntu Frame on Dragonboard&nbsp;&rsaquo;</a>

--- a/templates/frame/index.html
+++ b/templates/frame/index.html
@@ -1,0 +1,402 @@
+{% extends "frame/base_frame.html" %}
+
+{% from "_macros/vf_hero.jinja" import vf_hero %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+
+{% block title %}
+  Ubuntu frame
+{% endblock title %}
+
+{% block meta_copydoc %}
+  https://docs.google.com/document/d/1P4xOahtq6VVY6llAAAmQ4cX7ip4zzNXxXciuZ9joxMw/edit#
+{% endblock meta_copydoc %}
+
+{% block meta_description %}
+  Ubuntu Frame is the foundation for any embedded graphical display implementation. Secured by design, tested in the field and long term supported by Canonical.
+{% endblock %}
+
+{% block body_class %}is-paper{% endblock %}
+
+{% block content %}
+  {% call(slot) vf_hero(
+    title_text='Simplify the development of embedded displays',
+    layout='50/50',
+    is_split_on_medium=true
+    ) -%}
+    {%- if slot == 'description' -%}
+      <p>
+        Ubuntu Frame is a reliable and secure display server for embedded Linux devices with long term support. Simple to configure, simple to deploy.
+      </p>
+    {%- endif -%}
+    {%- if slot == 'cta' -%}
+      <a href="https://assets.ubuntu.com/v1/713b9224-Ubuntu.Frame.Datasheet.pdf"
+         class="p-button--positive">Get the Ubuntu Frame datasheet</a>
+      <a href="/engage/Embedding_IoT_GUI_with_Ubuntu_Frame">Learn how to develop GUIs for IoT with our developer guide&nbsp;&rsaquo;</a>
+    {%- endif -%}
+    {%- if slot == 'image' -%}
+      <div class="p-image-container--3-2 is-cover">
+        {{ image(url="https://assets.ubuntu.com/v1/34132d50-ubuntu-frame-hero.png",
+                alt="",
+                width="1234",
+                height="984",
+                hi_def=True,
+                loading="auto",
+                attrs={"class": "p-image-container__image"}) | safe
+        }}
+      </div>
+    {%- endif -%}
+  {% endcall -%}
+
+  <section class="p-section">
+    <hr class="p-rule is-fixed-width" />
+    <div class="grid-row">
+      <div class="grid-col-small-8 grid-col-medium-4 grid-col-4">
+        <h2>The foundation for embedded graphical display implementations</h2>
+      </div>
+      <div class="grid-col-small-8 grid-col-medium-4 grid-col-4">
+        <p>
+          Ubuntu Frame streamlines the building and development of products that need graphical output. Ubuntu Frame bundles communication protocols, input protocols, and security policies into a single kit, which can then be used in embedded devices. Whether you are building an interactive kiosk, a digital signage solution or any other product that requires a graphical output, Ubuntu Frame instantly allows your device to run your fullscreen application.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <hr class="is-fixed-width p-rule" />
+    <div class="row">
+      <h2 class="p-text--small-caps">COMPATIBLE WITH POPULAR GRAPHICAL TOOLKITS</h2>
+    </div>
+    <div class="u-fixed-width">
+      <div class="p-logo-section">
+        <div class="p-logo-section__items">
+          <div class="p-logo-section__item">
+            <img class="p-logo-section__logo"
+                 src="https://assets.ubuntu.com/v1/98d2bf31-144px%20QT%20logo.svg"
+                 alt="Qt logo" />
+          </div>
+          <div class="p-logo-section__item">
+            <img class="p-logo-section__logo"
+                 src="https://assets.ubuntu.com/v1/1d3e5eaf-flutter-logo.png"
+                 alt="Flutter logo" />
+          </div>
+          <div class="p-logo-section__item">
+            <img class="p-logo-section__logo"
+                 src="https://assets.ubuntu.com/v1/d73dbd10-GTK+no+background+%25281%2529.png"
+                 alt="GTK logo" />
+          </div>
+          <div class="p-logo-section__item">
+            <img class="p-logo-section__logo"
+                 src="https://assets.ubuntu.com/v1/9a661d86-html5-logo.png"
+                 alt="HTML5 logo" />
+          </div>
+          <div class="p-logo-section__item">
+            <img class="p-logo-section__logo"
+                 src="https://assets.ubuntu.com/v1/82c52642-microsoft-azure.svg"
+                 alt="Microsoft Azure" />
+          </div>
+          <div class="p-logo-section__item">
+            <img class="p-logo-section__logo"
+                 src="https://assets.ubuntu.com/v1/086b3df5-sdl-logo.svg"
+                 alt="Simple Directmedia Layer" />
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <hr class="p-rule is-fixed-width" />
+    <div class="grid-row">
+      <div class="grid-col-small-8 grid-col-medium-4 grid-col-4">
+        <h2>
+          One tool,
+          <br class="u-hide--small" />
+          all key interaction functionalities
+        </h2>
+      </div>
+      <div class="grid-col-small-8 grid-col-medium-4 grid-col-4">
+        <video autoplay=""
+               loop=""
+               muted=""
+               class="p-section--shallow u-no-margin--bottom">
+          <source src="https://images.zenhubusercontent.com/138038838/29ab4d93-f46f-4d7a-a71a-bb57d6480cc8/ubuntu_all_animations_v5.mp4" />
+        </video>
+        <p>
+          Besides keyboard and mouse input, Ubuntu Frame also automatically enables all the functionality that end-users expect while interacting with digital displays. This includes a wide range of touch gestures such as: multi-finger support, swipe, zoom in and out, touch to focus, and more. It also comes with its own on-screen keyboard.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <hr class="p-rule is-fixed-width" />
+    <div class="grid-row">
+      <div class="grid-col-small-8 grid-col-medium-4 grid-col-4">
+        <h2>
+          How to get started with
+          <br class="u-hide--small" />
+          Ubuntu Frame
+        </h2>
+      </div>
+      <div class="grid-col-small-8 grid-col-medium-4 grid-col-4">
+        <ol class="p-list--divided">
+          <li class="p-list__item u-no-padding--bottom">
+            <p class="p-heading--5 u-no-padding--top">Setup your device</p>
+            <p>
+              You need either <a href="/core">Ubuntu Core</a> or a version of Linux supporting snaps
+            </p>
+          </li>
+          <li class="p-list__item u-no-padding--bottom">
+            <p class="p-heading--5 u-no-padding--top">Install Ubuntu Frame</p>
+            <div class="p-section--shallow">
+              <pre class="u-no-margin--bottom"><code>$ sudo snap install ubuntu-frame</code></pre>
+            </div>
+          </li>
+          <li class="p-list__item u-no-padding--bottom">
+            <p class="p-heading--5 u-no-padding--top">Install your application</p>
+            <div>
+              <pre class="u-no-margin--bottom"><code>$ sudo snap install [your-app]</code></pre>
+            </div>
+          </li>
+        </ol>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <hr class="p-rule is-fixed-width" />
+    <div class="grid-row">
+      <div class="grid-col-small-8 grid-col-medium-4 grid-col-4">
+        <h2>Learn more about Ubuntu Frame</h2>
+      </div>
+      <div class="grid-col-small-8 grid-col-medium-4 grid-col-4">
+        <div class="p-image-container--3-2 is-cover is-highlighted"></div>
+        <ul class="p-list--divided">
+          <li class="p-list__item is-ticked">Detailed product overview</li>
+          <li class="p-list__item is-ticked">Tutorials</li>
+          <li class="p-list__item is-ticked">Answers to frequently asked questions</li>
+        </ul>
+        <div class="p-cta-block">
+          <a href="/engage/Embedding_IoT_GUI_with_Ubuntu_Frame"
+             class="p-button--positive">Download the Developer Guide</a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <div>
+    {%- call(slot) vf_tiered_list(is_list_full_width_on_tablet=false) -%}
+      {%- if slot == 'title' -%}
+        <h2>
+          Ubuntu Frame: Focus on
+          <br class="u-hide--small" />
+          Innovation, Not Integration
+        </h2>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_title_1' -%}
+        <h3 class="p-heading--5">More time for innovation</h3>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_description_1' -%}
+        <p>
+          Out-of-the-box, Ubuntu Frame automatically enables all that you need to deploy embedded graphical applications, including input modalities, window behaviours and dynamics, and secure client-server communication. Less integration and maintenance challenges, more time to work on your graphical application.
+        </p>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_title_2' -%}
+        <h3 class="p-heading--5">Simplified development</h3>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_description_2' -%}
+        <p>
+          Stop adding a dedicated board and mobile OS just for your display. Reduce integration complexity, costs and security vulnerabilities with a solution that perfectly matches your underlying architecture. With Ubuntu Frame, installing the full graphical stack in your embedded Linux device is as simple as one single command.
+        </p>
+        <div class="p-cta-block">
+          <a href="/engage/Embedding_IoT_GUI_with_Ubuntu_Frame">Learn how to develop GUIs for IoT with our developer guide&nbsp;&rsaquo;</a>
+        </div>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_title_3' -%}
+        <h3 class="p-heading--5">A reliable graphical server</h3>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_description_3' -%}
+        <p>
+          Ubuntu Frame reliability has been widely tested in the field. Its technology has been in development for over 7 years and in production for 5 years. As such, Ubuntu Frame is one of the most mature graphical servers available today for embedded devices.
+        </p>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_title_4' -%}
+        <h3 class="p-heading--5">Based on Mir</h3>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_description_4' -%}
+        <p>
+          <a href="https://canonical.com/Mir">Mir</a> is an open source system-level library that can be used to create high-performing display servers for IoT devices and traditional Desktops. It replaces the X window server system, commonly used on Linux desktop devices. Mir allows device makers and desktop users to have a well-defined, efficient, flexible, and secure platform for their graphical environment.
+        </p>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_title_5' -%}
+        <h3 class="p-heading--5">Supported for your device lifetime</h3>
+      {%- endif -%}
+
+      {%- if slot == 'list_item_description_5' -%}
+        <p>
+          When used in conjunction with Ubuntu Core, the OS tailored for IoT, Ubuntu Frame comes with 10 years of security updates.
+        </p>
+        <div class="p-cta-block">
+          <a href="/core">Learn more about Ubuntu Core&nbsp;&rsaquo;</a>
+        </div>
+      {%- endif -%}
+    {%- endcall -%}
+  </div>
+
+  <section class="p-section">
+    <hr class="p-rule is-fixed-width" />
+    <div class="grid-row">
+      <div class="grid-col-small-8 grid-col-medium-4 grid-col-4">
+        <h2>Designed for enhanced security</h2>
+      </div>
+      <div class="grid-col-small-8 grid-col-medium-4 grid-col-4">
+        <div class="u-fixed-width u-hide--small">
+          <figure>
+            <img src="https://assets.ubuntu.com/v1/a771b297-Diagram%403x.png"
+                 alt="diagram"
+                 loading="lazy"
+                 width="80%" />
+            <figcaption class="u-text--muted">Architecture that confines shell and app separately</figcaption>
+          </figure>
+        </div>
+        <p>
+          Thanks to Ubuntu Frame's own secure socket, applications can only talk exclusively to the Ubuntu Frame server. This reduces attack vectors since there is no inter-process communication to be snooped on by malicious code.
+        </p>
+        <div class="p-cta-block">
+          <a href="/engage/ubuntu-core-security-audit">Learn more about snaps security in this independent cybersecurity evaluation&nbsp;&rsaquo;</a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="p-section">
+    <hr class="p-rule is-fixed-width" />
+    <div class="grid-row">
+      <div class="grid-col-small-8 grid-col-medium-4 grid-col-4">
+        <h2>Ready for all boards, frameworks and applications</h2>
+      </div>
+      <div class="grid-col-small-8 grid-col-medium-4 grid-col-4">
+        <p>Minimise your costs and time to market: Ubuntu Frame is compatible with the most popular frameworks and silicon.</p>
+      </div>
+    </div>
+    <div class="row p-section--shallow">
+      <div class="col-9 col-start-large-4">
+        <div class="p-equal-height-row--wrap">
+          <div class="p-equal-height-row__col is-borderless">
+            <div class="p-equal-height-row__item">
+              <div class="p-image-container">
+                {{ image(url="https://assets.ubuntu.com/v1/cae6a3ba-pi-4.png",
+                                alt="",
+                                width="852",
+                                height="569",
+                                hi_def=True,
+                                loading="lazy",
+                                attrs={"class": "p-image-container__image",}) | safe
+                }}
+              </div>
+              <hr class="p-rule--muted" />
+            </div>
+            <div class="p-equal-height-row__item">
+              <h3 class="p-heading--5">
+                <a href="/download/raspberry-pi-core">Raspberry Pi</a>
+              </h3>
+              <div class="u-hide--large p-cta-block">
+                <a href="/download/raspberry-pi-core">Install Ubuntu Frame on Raspberry Pi&nbsp;&rsaquo;</a>
+              </div>
+            </div>
+          </div>
+          <div class="p-equal-height-row__col is-borderless">
+            <div class="p-equal-height-row__item">
+              <div class="p-image-container is-highlighted p-image-container--3-2">
+                {{ image(url="https://assets.ubuntu.com/v1/195fca60-NUC-board.png",
+                                alt="",
+                                width="198",
+                                height="140",
+                                hi_def=True,
+                                loading="lazy",
+                                attrs={"class": "p-image-container__image",}) | safe
+                }}
+              </div>
+              <hr class="p-rule--muted" />
+            </div>
+            <div class="p-equal-height-row__item">
+              <h3 class="p-heading--5">
+                <a href="/download/intel-nuc">Intel NUC</a>
+              </h3>
+              <div class="u-hide--large p-cta-block">
+                <a href="/download/intel-nuc">Install Ubuntu Frame on Intel NUC&nbsp;&rsaquo;</a>
+              </div>
+            </div>
+          </div>
+          <div class="p-equal-height-row__col is-borderless">
+            <div class="p-equal-height-row__item">
+              <div class="p-image-container">
+                {{ image(url="https://assets.ubuntu.com/v1/ef894f14-dragonboard.png",
+                                alt="",
+                                width="852",
+                                height="569",
+                                hi_def=True,
+                                loading="lazy",
+                                attrs={"class": "p-image-container__image"}) | safe
+                }}
+              </div>
+              <hr class="p-rule--muted" />
+            </div>
+            <div class="p-equal-height-row__item">
+              <h3 class="p-heading--5">
+                <a href="/download/qualcomm-dragonboard-410c">Dragonboard</a>
+              </h3>
+              <div class="u-hide--large p-cta-block">
+                <a href="/download/qualcomm-dragonboard-410c">Install Ubuntu Frame on Dragonboard&nbsp;&rsaquo;</a>
+              </div>
+            </div>
+          </div>
+        </div>
+        <hr class="p-rule--muted u-hide--small u-hide--medium" />
+      </div>
+      <div class="grid-row u-hide--small u-hide--medium">
+        <div class="grid-col-2 grid-col-start-large-3">
+          <a href="/download/raspberry-pi-core">Install Ubuntu Frame on Raspberry Pi&nbsp;&rsaquo;</a>
+        </div>
+        <div class="grid-col-2">
+          <a href="/download/intel-nuc">Install Ubuntu Frame on Intel NUC&nbsp;&rsaquo;</a>
+        </div>
+        <div class="grid-col-2">
+          <a href="/download/qualcomm-dragonboard-410c">Install Ubuntu Frame on Dragonboard&nbsp;&rsaquo;</a>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-start-large-7 col-6">
+        <div class="p-cta-block">
+          <a href="https://discourse.ubuntu.com/t/where-does-ubuntu-frame-work/23193"
+             aria-label="Learn more information about Ubuntu Frame graphic support">More information about Ubuntu Frame graphic support&nbsp;&rsaquo;</a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <hr class="p-rule is-fixed-width" />
+
+  <section class="p-strip is-deep">
+    <div class="row">
+        <h2>
+          Need help? Let’s get your device faster to market
+          <br />
+          <a href="https://ubuntu.com/internet-of-things/digital-signage#get-in-touch"
+             class="js-invoke-modal">Contact us</a>
+        </h2>
+    </div>
+  </section>
+
+  {{ load_form('/internet-of-things', 1670) | safe }}
+{% endblock content %}

--- a/templates/frame/index.html
+++ b/templates/frame/index.html
@@ -198,7 +198,11 @@
     <hr class="p-rule is-fixed-width" />
     <div class="grid-row">
       <div class="grid-col-small-8 grid-col-medium-4 grid-col-4">
-        <h2>Learn more about <br class="u-hide--small u-hide--medium" /> Ubuntu Frame</h2>
+        <h2>
+          Learn more about
+          <br class="u-hide--small u-hide--medium" />
+          Ubuntu Frame
+        </h2>
       </div>
       <div class="grid-col-small-8 grid-col-medium-4 grid-col-4">
         <div class="p-section--shallow">
@@ -307,7 +311,7 @@
           <figure class="u-no-margin--bottom">
             <div class="p-image-container is-highlighted">
               {{ image(url="https://assets.ubuntu.com/v1/9de2c517-designed-for-security.png",
-                            alt="",
+                            alt="A figure showing how input events and screen contents are protected in the Ubuntu Frame ecosystem. A graphical application (example: a web app) only has access to the network and to Ubuntu Frame over a Wayland protocol socket, provided the operator grants those permissions by connecting the respective Snap interfaces. Only Ubuntu Frame has access to input and output hardware (Keyboard, Mouse, Screen) and mediates applications' access to sensitive data.",
                             width="1200",
                             height="676",
                             hi_def=True,

--- a/templates/frame/index.html
+++ b/templates/frame/index.html
@@ -144,12 +144,11 @@
         </h2>
       </div>
       <div class="grid-col-small-8 grid-col-medium-4 grid-col-4">
-        <video autoplay=""
-               loop=""
-               muted=""
-               class="p-section--shallow u-no-margin--bottom">
-          <source src="https://images.zenhubusercontent.com/138038838/29ab4d93-f46f-4d7a-a71a-bb57d6480cc8/ubuntu_all_animations_v5.mp4" />
-        </video>
+        <div class="p-section--shallow">
+          <video autoplay="" loop="" muted="" class="u-no-margin--bottom">
+            <source src="https://images.zenhubusercontent.com/138038838/29ab4d93-f46f-4d7a-a71a-bb57d6480cc8/ubuntu_all_animations_v5.mp4" />
+          </video>
+        </div>
         <p>
           Besides keyboard and mouse input, Ubuntu Frame also automatically enables all the functionality that end-users expect while interacting with digital displays. This includes a wide range of touch gestures such as: multi-finger support, swipe, zoom in and out, touch to focus, and more. It also comes with its own on-screen keyboard.
         </p>
@@ -224,7 +223,7 @@
           <li class="p-list__item is-ticked">Tutorials</li>
           <li class="p-list__item is-ticked">Answers to frequently asked questions</li>
         </ul>
-        <div class="p-cta-block">
+        <div class="p-cta-block u-no-padding--bottom">
           <a href="/engage/Embedding_IoT_GUI_with_Ubuntu_Frame"
              class="p-button--positive">Download the Developer Guide</a>
         </div>
@@ -281,7 +280,7 @@
 
       {%- if slot == 'list_item_description_4' -%}
         <p>
-          <a href="https://canonical.com/Mir">Mir</a> is an open source system-level library that can be used to create high-performing display servers for IoT devices and traditional Desktops. It replaces the X window server system, commonly used on Linux desktop devices. Mir allows device makers and desktop users to have a well-defined, efficient, flexible, and secure platform for their graphical environment.
+          <a href="https://canonical.com/mir">Mir</a> is an open source system-level library that can be used to create high-performing display servers for IoT devices and traditional Desktops. It replaces the X window server system, commonly used on Linux desktop devices. Mir allows device makers and desktop users to have a well-defined, efficient, flexible, and secure platform for their graphical environment.
         </p>
       {%- endif -%}
 
@@ -336,7 +335,7 @@
 
   <section class="p-section">
     <hr class="p-rule is-fixed-width" />
-    <div class="grid-row">
+    <div class="grid-row p-section--shallow">
       <div class="grid-col-small-8 grid-col-medium-4 grid-col-4">
         <h2>Ready for all boards, frameworks and applications</h2>
       </div>
@@ -443,6 +442,7 @@
         Need help? Let’s get your device faster to market
         <br />
         <a href="/internet-of-things/smart-displays#get-in-touch"
+           aria-controls="frame-modal"
            class="js-invoke-modal">Contact us</a>
       </h2>
     </div>

--- a/templates/internet-of-things/smart-displays.html
+++ b/templates/internet-of-things/smart-displays.html
@@ -259,7 +259,7 @@
             <div class="col">
               <div class="p-section--shallow">
                 <p>
-                  <a href="https://mir-server.io/ubuntu-frame/">Ubuntu Frame</a> unlocks a kiosk mode that helps you create a dedicated and locked-down user experience.
+                  <a href="/frame">Ubuntu Frame</a> unlocks a kiosk mode that helps you create a dedicated and locked-down user experience.
                   Your graphical application will instantly run in full screen with all input modalities seamlessly on all hardware.
                 </p>
                 <p>
@@ -267,7 +267,7 @@
                 </p>
               </div>
               <div class="p-cta-block">
-                <a href="https://mir-server.io/ubuntu-frame/">Learn more about Ubuntu Frame&nbsp;&rsaquo;</a>
+                <a href="/frame">Learn more about Ubuntu Frame&nbsp;&rsaquo;</a>
               </div>
             </div>
           </div>

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -161,6 +161,8 @@ CSP = {
         "cdn.livechatinc.com",
         "secure.livechatinc.com",
         "cdn.livechat-static.com",
+        "images.zenhubusercontent.com",
+        "assets.ubuntu.com",
     ],
     "child-src": [
         "api.livechatinc.com",


### PR DESCRIPTION
Blocked by https://github.com/canonical/canonical.com/pull/1823

## Done

- Migrated and Rebranded the Mir Server Ubuntu Frame page from mir-server.io/ubuntu-frame to /frame

## QA

- Check out the [demo page](https://ubuntu-com-15395.demos.haus/frame)
- Cross-check implementation against
  - [Figma](https://www.figma.com/design/daTnm6OGHWmBFc0FZ67IYP/ubuntu.com-frame?node-id=12-4102&m=dev)
  - [Copydocs](https://docs.google.com/document/d/1P4xOahtq6VVY6llAAAmQ4cX7ip4zzNXxXciuZ9joxMw/edit?tab=t.0)
- Check against
  - Mobile
  - Tablet
  - Desktop

PR is also related to [#1813](https://github.com/canonical/canonical.com/pull/1823)

## Issue / Card

Fixes # [WD-18820](https://warthogs.atlassian.net/browse/WD-18820)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-18820]: https://warthogs.atlassian.net/browse/WD-18820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ