### PR TITLE
Wd 24133 avoid users from pressing the buy button when cc details are being updated

### DIFF
--- a/static/js/src/advantage/subscribe/checkout/components/Checkout/Checkout.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Checkout/Checkout.tsx
@@ -37,6 +37,7 @@ const Checkout = ({ products, action, coupon }: Props) => {
   const [error, setError] = useState<DisplayError | null>(null);
   const [errorType, setErrorType] = useState<string>("");
   const [isTotalLoading, setIsTotalLoading] = useState<boolean>(true);
+  const [isCardSaving, setIsCardSaving] = useState<boolean>(false);
 
   const { data: userInfo, isLoading: isUserInfoLoading } = useCustomerInfo();
   const userCanTrial = window.canTrial;
@@ -130,7 +131,7 @@ const Checkout = ({ products, action, coupon }: Props) => {
                         : [
                             {
                               title: "Your information",
-                              content: <UserInfoForm setError={setError} />,
+                              content: <UserInfoForm setError={setError} isCardSaving={isCardSaving} setIsCardSaving={setIsCardSaving} />,
                             },
                           ]),
                       ...(canTrial
@@ -180,7 +181,7 @@ const Checkout = ({ products, action, coupon }: Props) => {
                                       values.TermsAndConditions &&
                                       values.Description &&
                                       values.captchaValue
-                                    ) || isTotalLoading
+                                    ) || isTotalLoading || isCardSaving
                                   }
                                 />
                               </Col>

--- a/static/js/src/advantage/subscribe/checkout/components/Checkout/Checkout.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Checkout/Checkout.tsx
@@ -38,6 +38,7 @@ const Checkout = ({ products, action, coupon }: Props) => {
   const [errorType, setErrorType] = useState<string>("");
   const [isTotalLoading, setIsTotalLoading] = useState<boolean>(true);
   const [isCardSaving, setIsCardSaving] = useState<boolean>(false);
+  const isBuyButtonDisabled = isCardSaving || isTotalLoading;
 
   const { data: userInfo, isLoading: isUserInfoLoading } = useCustomerInfo();
   const userCanTrial = window.canTrial;
@@ -181,7 +182,7 @@ const Checkout = ({ products, action, coupon }: Props) => {
                                       values.TermsAndConditions &&
                                       values.Description &&
                                       values.captchaValue
-                                    ) || isTotalLoading || isCardSaving
+                                    ) || isBuyButtonDisabled
                                   }
                                 />
                               </Col>

--- a/static/js/src/advantage/subscribe/checkout/components/Checkout/Checkout.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Checkout/Checkout.tsx
@@ -132,7 +132,13 @@ const Checkout = ({ products, action, coupon }: Props) => {
                         : [
                             {
                               title: "Your information",
-                              content: <UserInfoForm setError={setError} isCardSaving={isCardSaving} setIsCardSaving={setIsCardSaving} />,
+                              content: (
+                                <UserInfoForm
+                                  setError={setError}
+                                  isCardSaving={isCardSaving}
+                                  setIsCardSaving={setIsCardSaving}
+                                />
+                              ),
                             },
                           ]),
                       ...(canTrial

--- a/static/js/src/advantage/subscribe/checkout/components/UserInfoForm/UserInfoForm.test.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/UserInfoForm/UserInfoForm.test.tsx
@@ -39,7 +39,7 @@ describe("UserInfoFormTests", () => {
       <QueryClientProvider client={queryClient}>
         <Formik initialValues={initialValues} onSubmit={jest.fn()}>
           <Elements stripe={stripePromise}>
-            <UserInfoForm setError={jest.fn()} />
+            <UserInfoForm setError={jest.fn()} isCardSaving={false} setIsCardSaving={jest.fn()} />
           </Elements>
         </Formik>
       </QueryClientProvider>,
@@ -103,7 +103,7 @@ describe("UserInfoFormTests", () => {
       <QueryClientProvider client={queryClient}>
         <Formik initialValues={initialValues} onSubmit={jest.fn()}>
           <Elements stripe={stripePromise}>
-            <UserInfoForm setError={jest.fn()} />
+            <UserInfoForm setError={jest.fn()} isCardSaving={false} setIsCardSaving={jest.fn()} />
           </Elements>
         </Formik>
       </QueryClientProvider>,
@@ -146,7 +146,7 @@ describe("UserInfoFormTests", () => {
       <QueryClientProvider client={queryClient}>
         <Formik initialValues={initialValues} onSubmit={jest.fn()}>
           <Elements stripe={stripePromise}>
-            <UserInfoForm setError={jest.fn()} />
+            <UserInfoForm setError={jest.fn()} isCardSaving={false} setIsCardSaving={jest.fn()} />
           </Elements>
         </Formik>
       </QueryClientProvider>,

--- a/static/js/src/advantage/subscribe/checkout/components/UserInfoForm/UserInfoForm.test.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/UserInfoForm/UserInfoForm.test.tsx
@@ -39,7 +39,11 @@ describe("UserInfoFormTests", () => {
       <QueryClientProvider client={queryClient}>
         <Formik initialValues={initialValues} onSubmit={jest.fn()}>
           <Elements stripe={stripePromise}>
-            <UserInfoForm setError={jest.fn()} isCardSaving={false} setIsCardSaving={jest.fn()} />
+            <UserInfoForm
+              setError={jest.fn()}
+              isCardSaving={false}
+              setIsCardSaving={jest.fn()}
+            />
           </Elements>
         </Formik>
       </QueryClientProvider>,
@@ -103,7 +107,11 @@ describe("UserInfoFormTests", () => {
       <QueryClientProvider client={queryClient}>
         <Formik initialValues={initialValues} onSubmit={jest.fn()}>
           <Elements stripe={stripePromise}>
-            <UserInfoForm setError={jest.fn()} isCardSaving={false} setIsCardSaving={jest.fn()} />
+            <UserInfoForm
+              setError={jest.fn()}
+              isCardSaving={false}
+              setIsCardSaving={jest.fn()}
+            />
           </Elements>
         </Formik>
       </QueryClientProvider>,
@@ -146,7 +154,11 @@ describe("UserInfoFormTests", () => {
       <QueryClientProvider client={queryClient}>
         <Formik initialValues={initialValues} onSubmit={jest.fn()}>
           <Elements stripe={stripePromise}>
-            <UserInfoForm setError={jest.fn()} isCardSaving={false} setIsCardSaving={jest.fn()} />
+            <UserInfoForm
+              setError={jest.fn()}
+              isCardSaving={false}
+              setIsCardSaving={jest.fn()}
+            />
           </Elements>
         </Formik>
       </QueryClientProvider>,

--- a/static/js/src/advantage/subscribe/checkout/components/UserInfoForm/UserInfoForm.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/UserInfoForm/UserInfoForm.tsx
@@ -387,7 +387,10 @@ const UserInfoForm = ({ setError, isCardSaving, setIsCardSaving }: Props) => {
           />
         </>
       )}
-      <p>We will save your card information. You can change it in your Ubuntu account </p>
+      <p>
+        We will save your card information. You can change it in your Ubuntu
+        account{" "}
+      </p>
     </>
   );
 

--- a/static/js/src/advantage/subscribe/checkout/components/UserInfoForm/UserInfoForm.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/UserInfoForm/UserInfoForm.tsx
@@ -25,9 +25,11 @@ import { UserSubscriptionMarketplace } from "advantage/api/enum";
 
 type Props = {
   setError: React.Dispatch<React.SetStateAction<DisplayError | null>>;
+  isCardSaving: boolean;
+  setIsCardSaving: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
-const UserInfoForm = ({ setError }: Props) => {
+const UserInfoForm = ({ setError, isCardSaving, setIsCardSaving }: Props) => {
   const {
     errors,
     touched,
@@ -35,7 +37,6 @@ const UserInfoForm = ({ setError }: Props) => {
     initialValues,
     setFieldTouched,
     setFieldValue,
-    isSubmitting,
   } = useFormikContext<FormValues>();
   const queryClient = useQueryClient();
   const paymentMethodMutation = registerPaymentMethod();
@@ -85,6 +86,7 @@ const UserInfoForm = ({ setError }: Props) => {
     setFieldTouched("isInfoSaved", false);
     setIsButtonDisabled(true);
     setFieldValue("isInfoSaved", true);
+    setIsCardSaving(true);
 
     paymentMethodMutation.mutate(
       { formData: values },
@@ -94,11 +96,13 @@ const UserInfoForm = ({ setError }: Props) => {
           queryClient.invalidateQueries({ queryKey: ["preview"] });
           setIsButtonDisabled(false);
           setIsEditing(false);
+          setIsCardSaving(false);
         },
         onError: (error) => {
           setFieldValue("Description", false);
           setFieldValue("TermsAndConditions", false);
           setIsButtonDisabled(false);
+          setIsCardSaving(false);
           document.querySelector("h1")?.scrollIntoView();
 
           if (error instanceof Error) {
@@ -435,7 +439,7 @@ const UserInfoForm = ({ setError }: Props) => {
             )}
             <ActionButton
               onClick={toggleEditing}
-              loading={isSubmitting}
+              loading={isCardSaving}
               disabled={isButtonDisabled}
               data-testid="user-info-save-button"
             >

--- a/static/js/src/advantage/subscribe/checkout/components/UserInfoForm/UserInfoForm.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/UserInfoForm/UserInfoForm.tsx
@@ -387,6 +387,7 @@ const UserInfoForm = ({ setError, isCardSaving, setIsCardSaving }: Props) => {
           />
         </>
       )}
+      <p>We will save your card information. You can change it in your Ubuntu account </p>
     </>
   );
 


### PR DESCRIPTION
## Done

- Avoid users from pressing the buy button when cc details are being updated
- Also add label to cc about the ability to delete it later

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Login using an account which already has a 
- Select a product at /pro/subscribe
- Proceed to checkout
- Fill out the form
- Change the network speed to 3g to exaggerate the effects
- Click on edit to edit the credit card details
    - Could also  
    - Click on save
    - Save button should go into loading state
-  While the cc is being saved, submit the form after completing the necessary details
   - The submit button should be disabled till the cc is saving
   - After cc is saved, buy button should be enabled again

## Issue / Card

Fixes [#WD-24133](https://warthogs.atlassian.net/browse/WD-24133) and [#WD-24194](https://warthogs.atlassian.net/browse/WD-24194)

## Screenshots

<img width="881" height="885" alt="image" src="https://github.com/user-attachments/assets/b3310302-82ef-4178-b3c4-37ded442037c" />


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
