### PR TITLE
WD-24193 ubuntu.com/toolchains/dotnet designer review changes applied

### DIFF
--- a/templates/toolchains/dotnet.html
+++ b/templates/toolchains/dotnet.html
@@ -210,7 +210,7 @@
           </a>
           <br>
           <a href="https://ubuntu.com/containers/chiseled/dotnet">
-            Learn about chiselled .NET ›
+            Learn about chiselled .NET&nbsp;&rsaquo;
           </a>
         </div>
       </div>


### PR DESCRIPTION
## Done

Fixes:
1. .NET logo alt changed to ".NET"
2. Removed alt value from Security Patching Maintenance image under Receive up to 12 years of security patching and maintenance section
3. Security Patching Maintenance image is now wrapped in a shallow container div
4. Table "Canonical .NET LTS packages" can now horizontally scroll on smaller screens
5. Download ASP.NET Core Runtime CTA button now has bottom margin. Change is visible on smaller screens.
6. Improved Dev Environment image is now wrapped in a shallow container div under Improved dev environment setup with the .NET snap section

## QA

- Visit https://ubuntu-com-15398.demos.haus/toolchains/dotnet
- Fix 1: Right click on the .NET logo at the top of the page, click inspect and observe alt value being ".NET"
- Fix 2: Scroll to Receive up to 12 years of security patching and maintenance section, right click the image with a laptop in it, click inspect and observe alt value being empty.
- Fix 3: On the same image as Fix 2, please observe there is a space between the image and the text below it. (Check screenshots below in doubt please)
- Fix 4: Scroll to "Canonical .NET LTS packages" table (if you are checking the fixes in given order here, please scroll up) and on a small screen observe that the table can horizontally scroll. Also check screenshots below for what changed. 
- Fix 5: On a small screen, scroll to section Secure, minimal containers for .NET and observe that there is a space between buttons. Difference can be compared from below screenshots.
- Fix 6: Scroll to Improved dev environment setup with the .NET snap section and observe that the image and text below now has a space in between (check screenshots below in doubt please).

Reference url is https://ubuntu.com/toolchains/dotnet

## Issue / Card

Fixes #[WD-24193](https://warthogs.atlassian.net/browse/WD-24193)

## Screenshots

Fix 3 Screenshots:

Before:
<img width="456" height="574" alt="image" src="https://github.com/user-attachments/assets/7ba3792d-5b30-4c0b-8fe9-ec10e3f47d0d" />
After:
<img width="456" height="574" alt="image" src="https://github.com/user-attachments/assets/8912d3e1-e32e-4990-9e66-7c33f900704c" />

Fix 4 Screenshots:

Before:
<img width="456" height="408" alt="image" src="https://github.com/user-attachments/assets/d33d4404-0ba8-4ad3-a354-27575a419502" />
After:
<img width="456" height="408" alt="image" src="https://github.com/user-attachments/assets/59c8d59c-cbd7-4bec-a61a-be896d3fc65e" />

Fix 5 Screenshots:

Before:
<img width="455" height="486" alt="image" src="https://github.com/user-attachments/assets/1dbc6346-0209-4846-adf5-16bd28e0b8b9" />
After:
<img width="455" height="486" alt="image" src="https://github.com/user-attachments/assets/1b44013f-05a0-4d25-90fb-ade213d560eb" />

Fix 6 Screenshots:

Before:
<img width="455" height="486" alt="image" src="https://github.com/user-attachments/assets/5ae4260c-b1cc-427f-a962-6ca415a215a5" />
After:
<img width="455" height="486" alt="image" src="https://github.com/user-attachments/assets/ec75632a-4576-454c-818b-1dc117e61ac2" />


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-24193]: https://warthogs.atlassian.net/browse/WD-24193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ