### PR TITLE
WD-24292: Update ubuntu.com/credentials/exam-content

### DIFF
--- a/webapp/shop/cred/syllabus.json
+++ b/webapp/shop/cred/syllabus.json
@@ -80,13 +80,6 @@
           "Connect to an Active Directory realm",
           "Assign permissions to directories using ACL attributes"
         ]
-      },
-      {
-        "chapter_title": "Configure Networking Capabilities",
-        "chapter_sections": [
-          "Configure a Wifi Network Connection",
-          "Interact with basic L2 and L3 network configuration"
-        ]
       }
     ]
   },


### PR DESCRIPTION
## Done

- Updated content of /credentials/exam-content to match [copy doc](https://docs.google.com/document/d/1bnA-f5m2zvZLh8NB2eR51s--7DarJTmWLXjWShK6378/edit?tab=t.0#heading=h.jz78yovdsvhq)

## QA

- Visit https://ubuntu-com-15400.demos.haus/credentials/exam-content
- Navigate to "Using Ubuntu Desktop" tab
- Compare the content of the page with the [copy doc](https://docs.google.com/document/d/1bnA-f5m2zvZLh8NB2eR51s--7DarJTmWLXjWShK6378/edit?tab=t.0#heading=h.jz78yovdsvhq)

## Issue / Card

Fixes #[WD-24292](https://warthogs.atlassian.net/browse/WD-24292)

## Screenshots

Before:
<img width="741" height="1034" alt="image" src="https://github.com/user-attachments/assets/9cd07d48-7dc4-47cd-87ed-2a4ef269ea82" />

After:
<img width="741" height="1034" alt="image" src="https://github.com/user-attachments/assets/65efc6c9-6fe7-4a71-8988-501eff3b99d5" />


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-24292]: https://warthogs.atlassian.net/browse/WD-24292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ