### PR TITLE
Update codebase with pre-existing releases.yaml values

### DIFF
--- a/templates/download/core/index.html
+++ b/templates/download/core/index.html
@@ -94,7 +94,7 @@ meta_copydoc %}
           </ul>
           <hr class="p-rule is-muted" />
           <p>
-            <a href="/core/docs/uc24">Core 24 release notes&nbsp;&rsaquo;</a>
+            <a href="https://documentation.ubuntu.com/core/reference/release-notes/index.html">Core {{ releases.core_lts.version }} release notes&nbsp;&rsaquo;</a>
           </p>
         </div>
         <!-- tab 2 -->

--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -128,7 +128,7 @@
                  aria-label="{{ releases.lts.full_version }} LTS deep dive">Deep dive&nbsp;&rsaquo;</a>
             </li>
             <li class="p-inline-list__item">
-              <a href="https://discourse.ubuntu.com/t/noble-numbat-release-notes/39890"
+              <a href="{{ releases.lts.release_notes_url }}"
                  aria-label="{{ releases.lts.full_version }} LTS release notes">Release notes&nbsp;&rsaquo;</a>
             </li>
           </ul>
@@ -187,7 +187,7 @@
       <div class="col">
         <div class="p-section--shallow">
           <p>
-            The latest version of the Ubuntu operating system for desktop PCs and laptops, Ubuntu 25.04 comes with nine months of security and maintenance updates, until January 2026.
+            The latest version of the Ubuntu operating system for desktop PCs and laptops, Ubuntu {{ releases.latest.full_version }} comes with nine months of security and maintenance updates, until {{ releases.latest.eol }}.
           </p>
           <hr class="p-rule--muted" />
 
@@ -198,10 +198,10 @@
             <div class="col-3">
               <a class="p-button--positive"
                  href="/download/desktop/thank-you?version={{ releases.latest.full_version }}&amp;architecture=amd64"
-                 onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });"
-                 aria-label="Download Ubuntu 25.04 amd64">Download</a>
-              {% if releases.lts.iso_download_size %}
-                <span class="u-text--muted">{{ releases.lts.iso_download_size }}</span>
+                 onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });"
+                 aria-label="Download Ubuntu {{ releases.latest.full_version }} amd64">Download</a>
+              {% if releases.latest.iso_download_size %}
+                <span class="u-text--muted">{{ releases.latest.iso_download_size }}</span>
               {% endif %}
 
               <script>
@@ -217,8 +217,8 @@
             <div class="col-3">
               <a class="p-button"
                  href="https://cdimage.ubuntu.com/releases/{{ releases.latest.full_version }}/release/ubuntu-{{ releases.latest.full_version }}-desktop-arm64.iso"
-                 onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{ releases.lts.short_version }}', 'eventValue' : undefined });"
-                 aria-label="Download Ubuntu 25.04 arm64">Download</a>
+                 onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Download', 'eventAction' : 'Desktop', 'eventLabel' : '{{ releases.latest.short_version }}', 'eventValue' : undefined });"
+                 aria-label="Download Ubuntu {{ releases.latest.full_version }} arm64">Download</a>
               {% if releases.latest.arm_iso_download_size %}
                 <span class="u-text--muted">{{ releases.latest.arm_iso_download_size }}</span>
               {% endif %}
@@ -287,7 +287,7 @@
                  aria-label="{{ releases.lts.full_version }} LTS deep dive">Press release&nbsp;&rsaquo;</a>
             </li>
             <li class="p-inline-list__item">
-              <a href="https://discourse.ubuntu.com/t/plucky-puffin-release-notes/48687"
+              <a href="{{ releases.latest.release_notes_url }}"
                  aria-label="{{ releases.latest.full_version }} release notes">Release notes&nbsp;&rsaquo;</a>
             </li>
           </ul>

--- a/templates/download/raspberry-pi/thank-you.html
+++ b/templates/download/raspberry-pi/thank-you.html
@@ -80,7 +80,7 @@
           {% if version == releases.latest.core_version %}
             <div class="col-4 col-medium-2">
               <h3 class="p-heading--5">
-                <a href="/core/docs/uc20/install-raspberry-pi">Installing Ubuntu Core 20 on a Raspberry Pi</a>
+                <a href="https://documentation.ubuntu.com/core/tutorials/try-pre-built-images/use-raspberry-pi-imager/index.html">Installing Ubuntu Core {{ releases.core_lts.version }} on a Raspberry Pi</a>
               </h3>
               <p>A complete guide to installing Ubuntu Core on a Raspberry Pi 4 (4GB or 8GB).</p>
             </div>

--- a/templates/download/risc-v/allwinner-nezha.html
+++ b/templates/download/risc-v/allwinner-nezha.html
@@ -32,7 +32,7 @@
         <a class="p-button--positive"
            href="https://cdimage.ubuntu.com/releases/24.04.3/release/ubuntu-24.04.3-preinstalled-server-riscv64+nezha.img.xz">Download 24.04.3 LTS</a>
         <a class="p-button"
-           href="https://cdimage.ubuntu.com/releases/25.04/release/ubuntu-25.04-preinstalled-server-riscv64+nezha.img.xz">Download 25.04</a>
+           href="https://cdimage.ubuntu.com/releases/{{ releases.latest.full_version }}/release/ubuntu-{{ releases.latest.full_version }}-preinstalled-server-riscv64+nezha.img.xz">Download {{ releases.latest.full_version }}</a>
       </p>
       <p>
         <a href="https://canonical-ubuntu-boards.readthedocs-hosted.com/en/latest/how-to/allwinner-nezha-d1/">How to install Ubuntu on the Allwinner Nezha D1</a>

--- a/templates/download/shared/_verify-checksums.html
+++ b/templates/download/shared/_verify-checksums.html
@@ -1,15 +1,25 @@
-You can <button class="p-button--link" onclick="verifyDownloadContent()">verify your download</button>{% if not 'raspi' in system %}, or get <a href="/tutorials/tutorial-install-ubuntu-{% if system == 'live-server'%}server{% else %}{{ system }}{% endif %}?backURL=https://ubuntu.com/download/{% if system == 'live-server'%}server{% else %}{{ system }}{% endif %}/thank-you">help on installing</a>{% endif %}.
+You can
+<button class="p-button--link" onclick="verifyDownloadContent()">verify your download</button>
+{%- if not 'raspi' in system -%}, or get <a href="/tutorials/tutorial-install-ubuntu-{% if system == 'live-server' %}server{% else %}{{ system }}{% endif %}?backURL=https://ubuntu.com/download/{% if system == 'live-server' %}server{% else %}{{ system }}{% endif %}/thank-you">help on installing</a>
+{%- endif -%}
+.
 
-
-<div class="u-hide" id="menu-4" aria-hidden="true" aria-label="Verification instructions:">
+<div class="u-hide"
+     id="menu-4"
+     aria-hidden="true"
+     aria-label="Verification instructions:">
   {% if releases.checksums[system] and releases.checksums[system][version] %}
     <p>Run this command in your terminal in the directory the iso was downloaded to verify the SHA256 checksum:</p>
     <pre>echo "{{ releases.checksums[system][version] }}" | shasum -a 256 --check</pre>
     <p>You should get the following output:</p>
     <pre>ubuntu-{{ version }}-{% if system != architecture %}{{ system }}-{% else %}preinstalled-server-{% endif %}{{ architecture }}.iso: OK</pre>
-    <p>Or follow this tutorial to learn <a href="/tutorials/tutorial-how-to-verify-ubuntu">how to verify downloads</a>.</p>
+    <p>
+      Or follow this tutorial to learn <a href="/tutorials/tutorial-how-to-verify-ubuntu">how to verify downloads</a>.
+    </p>
   {% else %}
-    <p>Please check the <a href="https://cdimage.ubuntu.com/releases/{{ version }}/release/SHA256SUMS">SHA256SUMS page</a> for the checksum numbers.</p>
+    <p>
+      Please check the <a href="https://cdimage.ubuntu.com/releases/{{ version }}/release/SHA256SUMS">SHA256SUMS page</a> for the checksum numbers.
+    </p>
   {% endif %}
 </div>
 


### PR DESCRIPTION
## Done

- Finds places where the values from [releases.yaml](https://github.com/canonical/ubuntu.com/blob/main/releases.yaml) could be used and updates them
- Tracked in this [spreadsheet](https://docs.google.com/spreadsheets/d/1faYkCW0aNgqro3kC7mp51qoOuAA2de7uwLVHeb4Ut7U/edit?gid=21472837#gid=21472837) under the tab 'Places old keys could be used'

## QA

- Open the demo and the spreadsheet
- Visit each of the pages that a variable has been applied and check there are no errors and that the links match those on live _and_ work
- Check that the places that have been updated are logical (ie. if it says something about lts but then a key for latest is used, this would be bad)

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-24271
