### PR TITLE
[WD-24333] feat: Deploy or refresh charm if needed

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -114,7 +114,14 @@ jobs:
         run: |
           export JUJU_MODEL=admin/${{ vars.JUJU_MODEL_NAME }}
           export CHARM_NAME=${{ vars.CHARM_NAME }}
-          juju refresh $CHARM_NAME --path ./*.charm --resource flask-app-image=${{ needs.publish-image.outputs.image_url }}
+
+          if juju status --color --relations | grep -q "^$CHARM_NAME\\s"; then
+            echo "Application '$CHARM_NAME' exists. Running juju refresh..."
+            juju refresh $CHARM_NAME --path ./*.charm --resource flask-app-image=${{ needs.publish-image.outputs.image_url }}
+          else
+            echo "Application '$CHARM_NAME' not found. Running juju deploy..."
+            juju deploy ./*.charm $CHARM_NAME --resource flask-app-image=${{ needs.publish-image.outputs.image_url }}
+          fi
           juju wait-for application $CHARM_NAME --query="name=='$CHARM_NAME' && (status=='active' || status=='idle')"
 
   deploy-production:
@@ -157,5 +164,12 @@ jobs:
         run: |
           export JUJU_MODEL=admin/${{ vars.JUJU_MODEL_NAME }}
           export CHARM_NAME=${{ vars.CHARM_NAME }}
-          juju refresh $CHARM_NAME --path ./*.charm --resource flask-app-image=${{ needs.publish-image.outputs.image_url }}
+
+          if juju status --color --relations | grep -q "^$CHARM_NAME\\s"; then
+            echo "Application '$CHARM_NAME' exists. Running juju refresh..."
+            juju refresh $CHARM_NAME --path ./*.charm --resource flask-app-image=${{ needs.publish-image.outputs.image_url }}
+          else
+            echo "Application '$CHARM_NAME' not found. Running juju deploy..."
+            juju deploy ./*.charm $CHARM_NAME --resource flask-app-image=${{ needs.publish-image.outputs.image_url }}
+          fi
           juju wait-for application $CHARM_NAME --query="name=='$CHARM_NAME' && (status=='active' || status=='idle')"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - feat-ps6-migration
-      - fix-pack-charm
+      - deploy-or-refresh-charm
       # - main
 
 env:


### PR DESCRIPTION
## Problem Statement

The current deployment script expects a charmed application to be already deployed in a model. If the charm is not already deployed, the script is going to fail.
We need to be able to deploy the charm if it doesn't exist, or refresh it if it does.

## Done

- Deploy charmed app if it doesn't exist

## QA

- Verify the `Pack and Deploy` action succeeds.

## Issue / Card

Fixes #[WD-24333](https://warthogs.atlassian.net/browse/WD-24333)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
