### PR TITLE
fix size issue on chart

### DIFF
--- a/templates/pro/linux-patch-management-with-pro/bar-chart.html
+++ b/templates/pro/linux-patch-management-with-pro/bar-chart.html
@@ -17,8 +17,6 @@
     margin-left: 32px;
   }
   #myChart {
-    max-width: 100%;
-    height: 400px;
     margin: inherit;
   }
 </style>


### PR DESCRIPTION
## Done

- Fix size issue on Pro CVE chart

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Visit [/pro/linux-patch-management-with-pro](https://ubuntu-com-15409.demos.haus/pro/linux-patch-management-with-pro)

## Issue / Card

Fixes [#WD-24405](https://warthogs.atlassian.net/browse/WD-24405)

## Screenshots

<img width="1761" height="989" alt="image" src="https://github.com/user-attachments/assets/61c393c5-a591-4ca2-8794-b6c9c96a3288" />

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
