### PR TITLE
feat: added konf config for flat notices

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -419,7 +419,6 @@ production:
           /security/releases/.*\.json,
           /security/api/.*,
           /security/page/.*\.json,
-          /security/flat/notices\.json,
         ]
       service_name: ubuntu-com-security-api
 
@@ -435,7 +434,7 @@ production:
           /security/flat/notices\.json,
           /security/flat/notices/.*\.json,
         ]
-      service_name: ubuntu-security-api-flat-notices
+      service_name: ubuntu-com-security-api-flat-notices
 
     - paths: [/security/updates/.*]
       service_name: ubuntu-com-security-api-updates
@@ -1008,7 +1007,6 @@ staging:
           /security/api/.*,
           /security/page/.*\.json,
           /security/updates/.*,
-          /security/flat/notices\.json,
         ]
       service_name: ubuntu-com-security-api
     

--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -435,7 +435,7 @@ production:
           /security/flat/notices\.json,
           /security/flat/notices/.*\.json,
         ]
-      service_name: ubuntu-com-security-api-notices
+      service_name: ubuntu-security-api-flat-notices
 
     - paths: [/security/updates/.*]
       service_name: ubuntu-com-security-api-updates

--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -1017,7 +1017,7 @@ staging:
           /security/notices\.json,
           /security/notices/.*\.json,
        ]
-      service_name: ubuntu-com-security-api-flat-notices
+      service_name: ubuntu-com-security-api-notices
 
     - paths:
         [

--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -1024,7 +1024,7 @@ staging:
           /security/flat/notices\.json,
           /security/flat/notices/.*\.json,
         ]
-      service_name: ubuntu-com-security-api-notices
+      service_name: ubuntu-com-security-api-flat-notices
 
     - paths: [/security]
       name: ubuntu-com-security

--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -1017,6 +1017,13 @@ staging:
           /security/notices\.json,
           /security/notices/.*\.json,
        ]
+      service_name: ubuntu-com-security-api-flat-notices
+
+    - paths:
+        [
+          /security/flat/notices\.json,
+          /security/flat/notices/.*\.json,
+        ]
       service_name: ubuntu-com-security-api-notices
 
     - paths: [/security]

--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -430,6 +430,13 @@ production:
         ]
       service_name: ubuntu-com-security-api-notices
 
+    - paths:
+        [
+          /security/flat/notices\.json,
+          /security/flat/notices/.*\.json,
+        ]
+      service_name: ubuntu-com-security-api-notices
+
     - paths: [/security/updates/.*]
       service_name: ubuntu-com-security-api-updates
       replicas: 2


### PR DESCRIPTION
## Done

- This PR redirects traffic to specific flat/notices pods in the security api.
- To be merged after https://github.com/canonical/ubuntu-com-security-api/pull/221

## QA

- Staging has been deployed, test it at https://staging.ubuntu.com/security/flat/notices.json

## Issue / Card

Fixes [WD-24490](https://warthogs.atlassian.net/browse/WD-24490)

[WD-24490]: https://warthogs.atlassian.net/browse/WD-24490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ