### PR TITLE
fix: change GTM initialization from 'load' to 'DOMContentLoaded`

### DIFF
--- a/templates/templates/_tag_manager.html
+++ b/templates/templates/_tag_manager.html
@@ -1,42 +1,48 @@
-    <script>
-        const userIDCookie = document.cookie.match(new RegExp("(^| )" + "user_id" + "=([^;]+)"));
-        if (userIDCookie !== null) {
-            let idValue = userIDCookie[2];
-            if (idValue) {
-                dataLayer.push({
-                        user_id: idValue,
-                });
-            }
-        }
-    </script>
-    <!-- Google Tag Manager -->
-     <script>
-        document.addEventListener('load', () => {
-          initGTM();
-        });
-        document.addEventListener('scroll', initGTMOnEvent);
-        document.addEventListener('mousemove', initGTMOnEvent);
-        document.addEventListener('touchstart', initGTMOnEvent);
-        document.addEventListener('keydown', initGTMOnEvent); 
+<script>
+  const userIDCookie = document.cookie.match(new RegExp("(^| )" + "user_id" + "=([^;]+)"));
+  if (userIDCookie !== null) {
+    let idValue = userIDCookie[2];
+    if (idValue) {
+      dataLayer.push({
+        user_id: idValue,
+      });
+    }
+  }
+</script>
+<!-- Google Tag Manager -->
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    /** init gtm after 2 seconds - can be adjusted */
+    setTimeout(initGTM, 2000);
+  });
+  document.addEventListener('scroll', initGTMOnEvent);
+  document.addEventListener('mousemove', initGTMOnEvent);
+  document.addEventListener('touchstart', initGTMOnEvent);
+  document.addEventListener('keydown', initGTMOnEvent);
 
-        function initGTMOnEvent(event) {
-          initGTM();
-          event.currentTarget.removeEventListener(event.type, initGTMOnEvent); // remove the event listener that got triggered
-        }
-        function initGTM() {
-          if (window.gtmDidInit) {
-            return false;
-          }
-          window.gtmDidInit = true; // flag to ensure script does not get added to DOM more than once.
-          const script = document.createElement('script');
-          script.type = 'text/javascript';
-          script.async = true;
-          // ensure PageViews is always tracked (on script load)
-          script.onload = () => {
-            dataLayer.push({ event: 'gtm.js', 'gtm.start': new Date().getTime(), 'gtm.uniqueEventId': 0 });
-          };
-          script.src = 'https://www.googletagmanager.com/gtm.js?id=GTM-K92JCQ';
-          document.head.appendChild(script);
-        }
-      </script>
-    <!-- End Google Tag Manager -->
+  function initGTMOnEvent(event) {
+    initGTM();
+    event.currentTarget.removeEventListener(event.type, initGTMOnEvent); // remove the event listener that got triggered
+  }
+
+  function initGTM() {
+    if (window.gtmDidInit) {
+      return false;
+    }
+    window.gtmDidInit = true; // flag to ensure script does not get added to DOM more than once.
+    const script = document.createElement('script');
+    script.type = 'text/javascript';
+    script.async = true;
+    // ensure PageViews is always tracked (on script load)
+    script.onload = () => {
+      dataLayer.push({
+        event: 'gtm.js',
+        'gtm.start': new Date().getTime(),
+        'gtm.uniqueEventId': 0
+      });
+    };
+    script.src = 'https://www.googletagmanager.com/gtm.js?id=GTM-K92JCQ';
+    document.head.appendChild(script);
+  }
+</script>
+<!-- End Google Tag Manager -->


### PR DESCRIPTION
## Done
The event listener was changed from 'load' to 'DOMContentLoaded' to ensure GTM initializes earlier in the page lifecycle. Also added a 2-second delay to prevent potential race conditions.

## QA

- Check out the [demo](https://ubuntu-com-15412.demos.haus/) link
- Check the console and ensure `dataLayer` is present and has the load event in them
  
<img width="1088" height="386" alt="image" src="https://github.com/user-attachments/assets/6bbcfc1f-df6e-4800-95ed-35e20098741a" />


## Issue / Card

Fixes # https://warthogs.atlassian.net/browse/WD-24532

## Screenshots


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
