### PR TITLE
feat: add translations for "Additional Resources" heading

### DIFF
--- a/templates/engage/base.html
+++ b/templates/engage/base.html
@@ -149,7 +149,7 @@
   <section class="p-strip--light is-shallow">
     <div class="row">
       <div class="col-8">
-        <h2 class="p-heading--3">Additional Resources</h2>
+        <h2 class="p-heading--3">{% if metadata['language'] == 'es' %}Recursos adicionales{% elif metadata['language'] == 'fr' %}Ressources supplémentaires{% elif metadata['language'] == 'pt' %}Recursos adicionais{% elif metadata['language'] == 'de' %}Zusätzliche Ressourcen{% else %}Additional Resources{% endif %}</h2>
       </div>
     </div>
 


### PR DESCRIPTION
Support multiple languages by adding conditional rendering for the "Additional Resources" heading based on the metadata language. Currently supports Spanish, French, Portuguese, and German.

## Done

- [List of work items including drive-bys - remember to add the why and what of this work.]

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
