### PR TITLE
fix(WD-24533): add exception handling when initialising proc360

### DIFF
--- a/webapp/shop/decorators.py
+++ b/webapp/shop/decorators.py
@@ -354,7 +354,10 @@ def get_proctor_api_instance(area, proctor_session) -> Proctor360API:
     instance = Proctor360API(
         proctor_session,
     )
-    instance.set_time_zone_ids()
+    try:
+        instance.set_time_zone_ids()
+    except Exception:
+        pass
     return instance
 
 


### PR DESCRIPTION
## Done

- Catch exception when initialising proctor360 and setting timezone ids

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Make sure staging.ubuntu.com/credentials works as well as ubuntu.com/credentials

## Issue / Card

Fixes [WD-24533](https://warthogs.atlassian.net/browse/WD-24533)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-24533]: https://warthogs.atlassian.net/browse/WD-24533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ