### PR TITLE
docs: add release notes for 1.33, 1.32, and 1.31 Charmed K8s bugfixes

### DIFF
--- a/templates/kubernetes/charmed-k8s/docs/1.31/release-notes.md
+++ b/templates/kubernetes/charmed-k8s/docs/1.31/release-notes.md
@@ -1,3 +1,4 @@
+
 ---
 wrapper_template: templates/docs/markdown.html
 markdown_includes:
@@ -16,6 +17,20 @@ layout:
 toc: False
 
 ---
+
+# 1.31+ck4
+
+### August 6, 2025 - `charmed-kubernetes --channel 1.31/stable`
+
+## Notable Fixes
+
+### Kubernetes Control Plane Charm
+* [LP#2109614](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/2109614) Fetch `kube-control` address bindings
+and include them in the Subject Alternative Names (SANs).
+
+### Kubernetes Worker Charm
+* [LP#2109614](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/2109614) Fetch `kube-control` address bindings
+and include them in the Subject Alternative Names (SANs).
 
 # 1.31+ck3
 

--- a/templates/kubernetes/charmed-k8s/docs/1.32/release-notes.md
+++ b/templates/kubernetes/charmed-k8s/docs/1.32/release-notes.md
@@ -17,6 +17,20 @@ layout:
 toc: False
 ---
 
+# 1.32+ck3
+
+### August 6, 2025 - `charmed-kubernetes --channel 1.32/stable`
+
+## Notable Fixes
+
+### Kubernetes Control Plane Charm
+* [LP#2109614](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/2109614) Fetch `kube-control` address bindings
+and include them in the Subject Alternative Names (SANs).
+
+### Kubernetes Worker Charm
+* [LP#2109614](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/2109614) Fetch `kube-control` address bindings
+and include them in the Subject Alternative Names (SANs).
+
 # 1.32+ck2
 
 ### May 8, 2025 - `charmed-kubernetes --channel 1.32/stable`

--- a/templates/kubernetes/charmed-k8s/docs/1.33/release-notes.md
+++ b/templates/kubernetes/charmed-k8s/docs/1.33/release-notes.md
@@ -18,6 +18,20 @@ toc: False
 
 ---
 
+# 1.33+ck2
+
+### August 6, 2025 - `charmed-kubernetes --channel 1.33/stable`
+
+## Notable Fixes
+
+### Kubernetes Control Plane Charm
+* [LP#2109614](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/2109614) Fetch `kube-control` address bindings
+and include them in the Subject Alternative Names (SANs).
+
+### Kubernetes Worker Charm
+* [LP#2109614](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/2109614) Fetch `kube-control` address bindings
+and include them in the Subject Alternative Names (SANs).
+
 # 1.33+ck1
 
 ### July 8, 2025 - `charmed-kubernetes --channel 1.33/stable`

--- a/templates/kubernetes/charmed-k8s/docs/release-notes.md
+++ b/templates/kubernetes/charmed-k8s/docs/release-notes.md
@@ -13,6 +13,20 @@ layout: [base, ubuntu-com]
 toc: False
 ---
 
+# 1.33+ck2
+
+### August 6, 2025 - `charmed-kubernetes --channel 1.33/stable`
+
+## Notable Fixes
+
+### Kubernetes Control Plane Charm
+* [LP#2109614](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/2109614) Fetch `kube-control` address bindings
+and include them in the Subject Alternative Names (SANs).
+
+### Kubernetes Worker Charm
+* [LP#2109614](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/2109614) Fetch `kube-control` address bindings
+and include them in the Subject Alternative Names (SANs).
+
 # 1.33+ck1
 
 ### July 8, 2025 - `charmed-kubernetes --channel 1.33/stable`
@@ -114,6 +128,19 @@ relevant sections of the [upstream release notes][upstream-changelog-1.33].
 
 [upstream-changelog-1.33]: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.33.md#deprecation
 
+# 1.32+ck3
+
+### August 6, 2025 - `charmed-kubernetes --channel 1.32/stable`
+
+## Notable Fixes
+
+### Kubernetes Control Plane Charm
+* [LP#2109614](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/2109614) Fetch `kube-control` address bindings
+and include them in the Subject Alternative Names (SANs).
+
+### Kubernetes Worker Charm
+* [LP#2109614](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/2109614) Fetch `kube-control` address bindings
+and include them in the Subject Alternative Names (SANs).
 
 # 1.32+ck2
 
@@ -248,6 +275,20 @@ please see the relevant sections of the
 <!--LINKS-->
 
 [rel]: /kubernetes/docs/release-notes
+
+# 1.31+ck4
+
+### August 6, 2025 - `charmed-kubernetes --channel 1.31/stable`
+
+## Notable Fixes
+
+### Kubernetes Control Plane Charm
+* [LP#2109614](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/2109614) Fetch `kube-control` address bindings
+and include them in the Subject Alternative Names (SANs).
+
+### Kubernetes Worker Charm
+* [LP#2109614](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/2109614) Fetch `kube-control` address bindings
+and include them in the Subject Alternative Names (SANs).
 
 # 1.31+ck3
 


### PR DESCRIPTION
## Done

Add release notes for `1.33+ck2`, `1.32+ck3`, and `1.31+ck4`.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
