### PR TITLE
Fix: distinguish unsupported and empty status in Certified components

### DIFF
--- a/templates/certified/model-details/_components-section.html
+++ b/templates/certified/model-details/_components-section.html
@@ -33,6 +33,10 @@
           <td data-heading="18.04 LTS">
             <i class="p-icon--success">Supported</i>
           </td>
+          {% elif component.lts_releases['18.04 LTS'][0].status == 'unsupported' %}
+          <td data-heading="18.04 LTS">
+            <i class="p-icon--error">Unsupported</i>
+          </td>
           {% endif %}
           {% else %}
           <td data-heading="18.04 LTS"></td>
@@ -49,6 +53,10 @@
           {% elif component.lts_releases['20.04 LTS'][0].status == 'certified' %}
           <td data-heading="20.04 LTS">
             <i class="p-icon--success">Supported</i>
+          </td>
+          {% elif component.lts_releases['20.04 LTS'][0].status == 'unsupported' %}
+          <td data-heading="20.04 LTS">
+            <i class="p-icon--error">Unsupported</i>
           </td>
           {% endif %}
           {% else %}
@@ -67,10 +75,13 @@
           <td data-heading="22.04 LTS">
             <i class="p-icon--success">Supported</i>
           </td>
+          {% elif component.lts_releases['22.04 LTS'][0].status == 'unsupported' %}
+          <td data-heading="22.04 LTS">
+            <i class="p-icon--error">Unsupported</i>
+          </td>
           {% endif %}
           {% else %}
           <td data-heading="22.04 LTS">
-            <i class="p-icon--error"></i>
           </td>
           {% endif %}
           {% if '24.04 LTS' in component.lts_releases %}
@@ -86,10 +97,13 @@
           <td data-heading="24.04 LTS">
             <i class="p-icon--success">Supported</i>
           </td>
+          {% elif component.lts_releases['24.04 LTS'][0].status == 'unsupported' %}
+          <td data-heading="24.04 LTS">
+            <i class="p-icon--error">Unsupported</i>
+          </td>
           {% endif %}
           {% else %}
           <td data-heading="24.04 LTS">
-            <i class="p-icon--error"></i>
           </td>
           {% endif %}
           <td data-heading="Comments">{{ component.note }}</td>
@@ -102,11 +116,14 @@
         <i class="p-icon--success"></i> <small class="p-">Supported</small>
       </li>
       <li class="p-inline-list__item">
-        <img src="https://assets.ubuntu.com/v1/8dd0626d-3rd-party-icon.svg" alt="" />
+        <img src="https://assets.ubuntu.com/v1/8dd0626d-3rd-party-icon.svg" alt="May require third-party driver" />
         <small>May require 3rd-party driver</small>
       </li>
       <li class="p-inline-list__item">
         <i class="p-icon--help"></i> <small>In progress</small>
+      </li>
+      <li class="p-inline-list__item">
+        <i class="p-icon--error"></i> <small>Unsupported</small>
       </li>
     </ul>
   </div>


### PR DESCRIPTION
## Done

Updated `templates/certified/model-details/_components-section.html` template:
- Add explicit "Unsupported" status handling for each LTS release: Unsupported status should only be shown when the status is explicitly set in the database. If no status is set, the cell should be blank.
- Add legend for the "Unsupported" marker with an error icon
- Update the alt text to improve accessibility.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes Issue #13106 / Jira CDOC-244

## Screenshots

* Before: (production at https://ubuntu.com/certified/201908-27313)
  <img width="1294" height="287" alt="image" src="https://github.com/user-attachments/assets/25fbbcd7-0670-4989-8e8a-540239e8b4f4" />

* After:  (local at http://127.0.0.1:8001/certified/201908-27313)
  <img width="1294" height="287" alt="image" src="https://github.com/user-attachments/assets/dda70197-aec2-4d3b-b0ca-60aa823a9809" />


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
