### PR TITLE
fix: redirect to referrer for failed submissions

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -1087,7 +1087,11 @@ def marketo_submit():
         if return_url:
             # Remove anchor from url
             plain_url = return_url.split("#")[0]
-            return flask.redirect(f"{plain_url}#contact-form-fail")
+            parsed_referrer = urlparse(referrer)
+            return flask.redirect(
+                f"{parsed_referrer.scheme}://"
+                f"{parsed_referrer.netloc}{plain_url}#contact-form-fail"
+            )
         return flask.redirect("/#contact-form-fail")
 
     if referrer:

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -1040,10 +1040,11 @@ def marketo_submit():
                 return flask.redirect(return_url)
 
             if referrer:
-                parsed_referer = urlparse(referrer)
+                parsed_return_url = urlparse(return_url)
+                parsed_referrer = urlparse(referrer)
                 return flask.redirect(
-                    f"{parsed_referer.scheme}://"
-                    f"{parsed_referer.netloc}{return_url}"
+                    f"{parsed_referrer.scheme}://"
+                    f"{parsed_referrer.netloc}{parsed_return_url.path}"
                 )
 
             return flask.redirect(return_url)
@@ -1086,11 +1087,11 @@ def marketo_submit():
 
         if return_url:
             # Remove anchor from url
-            plain_url = return_url.split("#")[0]
+            parsed_return_url = urlparse(return_url)
             parsed_referrer = urlparse(referrer)
             return flask.redirect(
-                f"{parsed_referrer.scheme}://"
-                f"{parsed_referrer.netloc}{plain_url}#contact-form-fail"
+                f"{parsed_referrer.scheme}://{parsed_referrer.netloc}"
+                f"{parsed_return_url.path}#contact-form-fail"
             )
         return flask.redirect("/#contact-form-fail")
 


### PR DESCRIPTION
## Done

- Redirect to referrer URL on failed form submissions

## QA

- Go to https://canonical-com-1845.demos.haus/openstack#get-in-touch 
- Submit form
- See that it redirects to https://canonical-com-1845.demos.haus/openstack#contact-form-fail instead of ubuntu.com

## Issue / Card

Fixes [WD-24539](https://warthogs.atlassian.net/browse/WD-24539)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-24539]: https://warthogs.atlassian.net/browse/WD-24539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ