### PR TITLE
fix(WD-24543): fix time window calculation and check proctoring on exam

### DIFF
--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -1003,10 +1003,9 @@ def cred_your_exams(
                 # if assessment is provisioned
                 if assessment_id:
                     is_in_window = (
-                        now > starts_at_utc and now < ends_at_utc
-                    ) or (
-                        now < starts_at_utc
-                        and now > starts_at_utc - timedelta(minutes=30)
+                        starts_at_utc - timedelta(minutes=30)
+                        < now
+                        < ends_at_utc
                     )
                     provisioned_but_not_taken = is_in_window and state in [
                         RESERVATION_STATES["notified"],


### PR DESCRIPTION
## Done

- Convert start and end datetime to UTC for checking if the current time is in the exam window
- Fix /credentials/exam endpoint and check if proctoring is enabled and add the exam name to the link

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Purchase and schedule an exam, preferably "Using Linux Terminal"
- Make sure "Take Exam" button shows up when inside the time window

## Issue / Card

Fixes [WD-24543](https://warthogs.atlassian.net/browse/WD-24543)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-24543]: https://warthogs.atlassian.net/browse/WD-24543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ