### PR TITLE
fix link to data sheet

### DIFF
--- a/static/js/src/advantage/linux-patch-management/utils/helpers.ts
+++ b/static/js/src/advantage/linux-patch-management/utils/helpers.ts
@@ -5,7 +5,7 @@ export const useFetchCVEData = (release: string) => {
     queryKey: ["cveData", release],
     queryFn: async () => {
       const response = await fetch(
-        `https://raw.githubusercontent.com/canonical/pro-cve-aggregator/refs/heads/master/${release}.json`,
+        `https://raw.githubusercontent.com/canonical/pro-cve-aggregator/refs/heads/main/${release}.json`,
       );
       if (!response.ok) {
         throw new Error("Network response was not ok");


### PR DESCRIPTION
## Done

- Fix the missing datasheet in /pro/linux-patch-management-with-pro

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Visit [Pro CVE page](https://ubuntu-com-15423.demos.haus/pro/linux-patch-management-with-pro)
- Table of CVEs should be visible
- The section with the search and filtering of packages is also visible

## Issue / Card

Fixes [#WD-24562](https://warthogs.atlassian.net/browse/WD-24562)

## Screenshots

<img width="2485" height="1288" alt="image" src="https://github.com/user-attachments/assets/ffd020f3-2b0a-43e6-8ac8-1c2ca5aa07ca" />
<img width="2485" height="1288" alt="image" src="https://github.com/user-attachments/assets/d708690f-3b25-4c03-8698-8a719ff4a0b2" />


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
