### PR TITLE
Fix cover images missing aspect ratios

### DIFF
--- a/templates/about/index.html
+++ b/templates/about/index.html
@@ -35,7 +35,7 @@
       </div>
     </div>
     <div class="u-fixed-width">
-      <div class="p-image-container is-cover">
+      <div class="p-image-container--cinematic is-cover">
         {{ image(url="https://assets.ubuntu.com/v1/1ce22427-hero-img.jpg",
                 alt="",
                 width="2464",

--- a/templates/aws/thank-you.html
+++ b/templates/aws/thank-you.html
@@ -12,7 +12,7 @@
         <h2>A member of our team will be in touch shortly.</h2>
       </div>
       <div class="col">
-        <div class="p-image-container is-cover u-hide--small">
+        <div class="p-image-container--16-9 is-cover u-hide--small">
           <img class="p-image-container__image"
                src="https://assets.ubuntu.com/v1/b0fa63e9-christina-wocintechchat-com-LQ1t-8Ms5PY-unsplash.png"
                alt="" />

--- a/templates/azure/thank-you.html
+++ b/templates/azure/thank-you.html
@@ -16,7 +16,7 @@
         <h2>A member of our team will be in touch shortly.</h2>
       </div>
       <div class="col">
-        <div class="p-image-container is-cover u-hide--small">
+        <div class="p-image-container--16-9 is-cover u-hide--small">
           <img class="p-image-container__image"
                src="https://assets.ubuntu.com/v1/b0fa63e9-christina-wocintechchat-com-LQ1t-8Ms5PY-unsplash.png"
                alt="" />

--- a/templates/ceph/thank-you.html
+++ b/templates/ceph/thank-you.html
@@ -12,7 +12,7 @@
         <h2>We will be in touch shortly.</h2>
       </div>
       <div class="col">
-        <div class="p-image-container is-cover u-hide--small">
+        <div class="p-image-container--16-9 is-cover u-hide--small">
           <img class="p-image-container__image"
               src="https://assets.ubuntu.com/v1/b0fa63e9-christina-wocintechchat-com-LQ1t-8Ms5PY-unsplash.png"
               alt="" />

--- a/templates/community/local-communities.html
+++ b/templates/community/local-communities.html
@@ -138,7 +138,7 @@ meta_copydoc %}
             </div>
             <div class="col">
               <div class="p-section--shallow">
-                <div class="p-image-container is-cover">
+                <div class="p-image-container--3-2 is-cover">
                   {{ image(url="https://assets.ubuntu.com/v1/c71d8fa6-new-community.png",
                                     alt="",
                                     width="566",
@@ -194,7 +194,7 @@ meta_copydoc %}
       </div>
       <div class="col">
         <div class="p-section--shallow">
-          <div class="p-image-container is-cover">
+          <div class="p-image-container--3-2 is-cover">
             {{ image(url="https://assets.ubuntu.com/v1/c71d8fa6-new-community.png",
                         alt="",
                         width="566",

--- a/templates/contact-us/thank-you.html
+++ b/templates/contact-us/thank-you.html
@@ -13,7 +13,7 @@
         <h2>A member of our team will be in touch shortly.</h2>
       </div>
       <div class="col">
-        <div class="p-image-container is-cover u-hide--small">
+        <div class="p-image-container--16-9 is-cover u-hide--small">
           {{ image(url="https://assets.ubuntu.com/v1/934cb30f-thank-you.jpg",
             alt="",
             width="1200",

--- a/templates/core/services/thank-you.html
+++ b/templates/core/services/thank-you.html
@@ -12,7 +12,7 @@
         <h2>A member of our team will be in touch shortly.</h2>
       </div>
       <div class="col">
-        <div class="p-image-container is-cover u-hide--small">
+        <div class="p-image-container--16-9 is-cover u-hide--small">
           <img class="p-image-container__image"
                src="https://assets.ubuntu.com/v1/b0fa63e9-christina-wocintechchat-com-LQ1t-8Ms5PY-unsplash.png"
                alt="" />

--- a/templates/core/thank-you.html
+++ b/templates/core/thank-you.html
@@ -16,7 +16,7 @@
         <h2>We will be in touch shortly.</h2>
       </div>
       <div class="col">
-        <div class="p-image-container is-cover u-hide--small">
+        <div class="p-image-container--16-9 is-cover u-hide--small">
           <img class="p-image-container__image"
                src="https://assets.ubuntu.com/v1/b0fa63e9-christina-wocintechchat-com-LQ1t-8Ms5PY-unsplash.png"
                alt="" />

--- a/templates/desktop/wsl/index.html
+++ b/templates/desktop/wsl/index.html
@@ -54,7 +54,7 @@
       </div>
     {%- endif -%}
     {%- if slot == 'image' -%}
-      <div class="p-image-container is-cover">
+      <div class="p-image-container--16-9 is-cover">
         {{ image(url="https://assets.ubuntu.com/v1/f6c62694-Ubuntu%20on%20WSL%20-%20New%20image%20format.png",
                 alt="",
                 width="1919",

--- a/templates/embedded/index.html
+++ b/templates/embedded/index.html
@@ -280,7 +280,7 @@
         </div>
         <div class="col">
           <div class="p-section--shallow">
-            <div class="p-image-container is-cover is-highlighted">
+            <div class="p-image-container--16-9 is-cover is-highlighted">
               {{ image(url="https://assets.ubuntu.com/v1/ab3a9883-security-matters.png",
                             alt="",
                             width="1800",
@@ -532,7 +532,7 @@
         </div>
         <div class="col">
           <div class="p-section--shallow">
-            <div class="p-image-container is-cover is-highlighted">
+            <div class="p-image-container--16-9 is-cover is-highlighted">
               {{ image(url="https://assets.ubuntu.com/v1/f8f1f33e-devops.png",
                             alt="",
                             width="1800",

--- a/templates/gcp/thank-you.html
+++ b/templates/gcp/thank-you.html
@@ -13,7 +13,7 @@
         <h2>A member of our team will be in touch shortly.</h2>
       </div>
       <div class="col">
-        <div class="p-image-container is-cover u-hide--small">
+        <div class="p-image-container--16-9 is-cover u-hide--small">
           <img class="p-image-container__image"
                src="https://assets.ubuntu.com/v1/b0fa63e9-christina-wocintechchat-com-LQ1t-8Ms5PY-unsplash.png"
                alt="" />

--- a/templates/internet-of-things/smart-city/index.html
+++ b/templates/internet-of-things/smart-city/index.html
@@ -274,7 +274,7 @@
         <h2>IoT over-the-air (OTA) updates</h2>
       </div>
       <div class="col">
-        <div class="p-image-container is-cover is-highlighted">
+        <div class="p-image-container--16-9 is-cover is-highlighted">
           {{ image(url="https://assets.ubuntu.com/v1/fd081fd3-iot-ota-updates.png",
                     alt="",
                     width="1800",
@@ -465,7 +465,7 @@
         <h2>Accelerate data science</h2>
       </div>
       <div class="col">
-        <div class="p-image-container is-cover is-highlighted">
+        <div class="p-image-container--16-9 is-cover is-highlighted">
           {{ image(url="https://assets.ubuntu.com/v1/c65b7605-accelerate-data-science.png",
                     alt="",
                     width="1800",

--- a/templates/internet-of-things/smart-home/index.html
+++ b/templates/internet-of-things/smart-home/index.html
@@ -107,7 +107,7 @@
         <h2>Universal compatibility</h2>
       </div>
       <div class="col">
-        <div class="p-image-container is-cover is-highlighted">
+        <div class="p-image-container--16-9 is-cover is-highlighted">
           {{ image(url="https://assets.ubuntu.com/v1/c8af9315-universal-compatibility.png",
                     alt="",
                     width="1800",

--- a/templates/landscape/managed/index.html
+++ b/templates/landscape/managed/index.html
@@ -207,7 +207,7 @@
             Organizations developing proprietary software on Ubuntu benefit from Managed Landscape's support for private repositories.
           </p>
         </div>
-        <div class="p-image-container is-cover">
+        <div class="p-image-container--3-2 is-cover">
           {{ image(url="https://assets.ubuntu.com/v1/f47e7166-mirror-ubuntu repos.png",
                     alt="",
                     width="1200",

--- a/templates/pricing/thank-you.html
+++ b/templates/pricing/thank-you.html
@@ -20,7 +20,7 @@
         <p class="p-heading--2">We will be in touch shortly.</p>
       </div>
       <div class="col">
-        <div class="p-image-container is-cover u-hide--small">
+        <div class="p-image-container--16-9 is-cover u-hide--small">
           <img class="p-image-container__image"
                src="https://assets.ubuntu.com/v1/b0fa63e9-christina-wocintechchat-com-LQ1t-8Ms5PY-unsplash.png"
                alt="" />

--- a/templates/security/index.html
+++ b/templates/security/index.html
@@ -240,7 +240,7 @@
 
   <div class="p-section">
     <div class="u-fixed-width">
-      <div class="p-image-container is-cover">
+      <div class="p-image-container--cinematic is-cover">
         {{ image(url="https://assets.ubuntu.com/v1/3878c62f-Reliable vulnerability management.png",
                 alt="",
                 width="2464",

--- a/templates/security/osv.html
+++ b/templates/security/osv.html
@@ -72,7 +72,7 @@
       <hr class="p-rule" />
       <div class="col">
         <div class="p-section--shallow">
-          <div class="p-image-container is-cover u-hide--small">
+          <div class="p-image-container--2-3 is-cover u-hide--small">
             {{ image(url="https://assets.ubuntu.com/v1/783924cf-when-to-use-updated.png",
                         alt="",
                         width="1200",

--- a/templates/tests/_thank-you.html
+++ b/templates/tests/_thank-you.html
@@ -16,7 +16,7 @@
         <h2>We will be in touch shortly.</h2>
       </div>
       <div class="col">
-        <div class="p-image-container is-cover u-hide--small">
+        <div class="p-image-container--16-9 is-cover u-hide--small">
           <img class="p-image-container__image"
                src="https://assets.ubuntu.com/v1/b0fa63e9-christina-wocintechchat-com-LQ1t-8Ms5PY-unsplash.png"
                alt="" />


### PR DESCRIPTION
## Done

Fixes several [cover images](https://vanillaframework.io/docs/patterns/images#cover-image) that were missing fixed aspect ratios. After a [safari compatibility fix](https://github.com/canonical/vanilla-framework/pull/5571) for image containers,  covered image containers without aspect ratios stopped being rendered. Covered image containers require a fixed aspect ratio - this needs to be accompanied with a change in language on Vanilla docs from "This can be combined with the aspect ratio modifier to crop the image to a specific aspect ratio" to "This **must** be".

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes https://chat.canonical.com/canonical/pl/7czayisdfid83xkc6758yomrkc

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
