### PR TITLE
Fix cover image with no aspect ratio on IoT page

### DIFF
--- a/templates/internet-of-things/index.html
+++ b/templates/internet-of-things/index.html
@@ -36,7 +36,7 @@
       <a href="/download/iot" class="p-button">Download Ubuntu for IoT</a>
     {%- endif -%}
     {%- if slot == "image" -%}
-      <div class="p-image-container is-highlighted is-cover u-hide--small">
+      <div class="p-image-container--cinematic is-highlighted is-cover u-hide--small">
         {{ image(url="https://assets.ubuntu.com/v1/7b0d858b-hero-img-iot-2.png",
                 alt="",
                 width="3696",


### PR DESCRIPTION
## Done

Follow up to #15431 , one case of a cover image with a missing aspect ratio was not initially caught by my IDE search. Fixing it now.



## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to [internet-of-things](https://ubuntu-com-xxxxx.demos.haus/internet-of-things) and verify the cover image is rendered as expected
  - Side note: is the [source image](https://assets.ubuntu.com/v1/7b0d858b-hero-img-iot-2.png) cropped correctly? It looks like it has content cut off at the bottom, but this is coming from the source image itself, not any of our CSS. Maybe for another issue.

## Issue / Card

Fixes https://chat.canonical.com/canonical/pl/7czayisdfid83xkc6758yomrkc

## Screenshots

Before
<img width="1157" height="282" alt="image" src="https://github.com/user-attachments/assets/b00f7644-52d4-4bf4-9fa3-c2313f45267a" />

After
<img width="1482" height="851" alt="image" src="https://github.com/user-attachments/assets/12fb1f42-1ddd-4455-acc2-33f806192fc6" />



## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
