### PR TITLE
fix: ubuntu/frame image & mir-server.io links

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -974,7 +974,7 @@ tour/?: "/desktop"
 tour/en/?: "/desktop"
 tour/zh-CN/?: "/desktop"
 trademark-policy/?: "/legal/intellectual-property-policy"
-tutorials/secure-ubuntu-kiosk: "https://mir-server.io/docs/make-a-secure-ubuntu-web-kiosk"
+tutorials/secure-ubuntu-kiosk: "https://canonical.com/mir/docs/make-a-secure-ubuntu-web-kiosk"
 tuxaward/?: "/blog/ubuntu-wins-tux-award/"
 ua/?: "/support"
 ua-assurance-terms/?: "/legal/ubuntu-advantage-assurance"
@@ -1123,7 +1123,7 @@ t/(?P<path>.*)/?: /tutorials/{path}
 tutorial/(?P<path>.*)/?: /tutorials/{path}
 tutorials/microstack-get-started? : https://canonical-openstack.readthedocs-hosted.com/en/latest/tutorial/
 tutorials/install-openstack-with-conjure-up? : https://canonical-openstack.readthedocs-hosted.com/en/latest/tutorial/
-tutorials/electron-kiosk/?: https://mir-server.io/docs/make-a-secure-ubuntu-web-kiosk
+tutorials/electron-kiosk/?: https://canonical.com/mir/docs/make-a-secure-ubuntu-web-kiosk
 tutorials/get-started-with-edgex-as-snaps?: /internet-of-things
 tutorials/how-to-install-adguard-home-raspberry-pi/?: /appliance/adguard/raspberry-pi
 tutorials/how-to-use-the-nextcloud-ubuntu-appliance-with-collabora-online-on-intel-nuc/?: /appliance/nextcloud/intel-nuc

--- a/templates/frame/index.html
+++ b/templates/frame/index.html
@@ -211,7 +211,8 @@
                         width="1200",
                         height="801",
                         hi_def=True,
-                        loading="lazy") | safe
+                        loading="lazy",
+                        attrs={"class": "p-image-container__image"}) | safe
             }}
           </div>
         </div>


### PR DESCRIPTION
## Done

- Fix mir-server link redirects
- Fix image on Ubuntu/frame

## QA

- Check out [demo](https://ubuntu-com-15438.demos.haus/frame) link image displays well compared to https://ubuntu.com/frame
- Check [tutorials/secure-ubuntu-kiosk](https://ubuntu-com-15438.demos.haus/tutorials/secure-ubuntu-kiosk) redirects to https://canonical.com/mir/docs/make-a-secure-ubuntu-web-kiosk
- Check [tutorials/electron-kiosk/](https://ubuntu-com-15438.demos.haus/tutorials/electron-kiosk/) redirects to https://canonical.com/mir/docs/make-a-secure-ubuntu-web-kiosk

## Issue / Card

Fixes #

## Screenshots
### before
<img width="1227" height="840" alt="image" src="https://github.com/user-attachments/assets/956362b4-90fd-4434-879a-654aa3335391" />

### after
<img width="1218" height="724" alt="image" src="https://github.com/user-attachments/assets/706bfe57-b9f3-4d20-bbdf-05ab334da8ea" />



## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
