### PR TITLE
feat: Setup route /blogs/draft-blogs to fetch draft blogs

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -161,6 +161,16 @@ env:
       key: secret
       name: sitemaps
 
+  - name: WORDPRESS_APPLICATION_PASSWORD
+    secretKeyRef:
+      key: wordpress-application-password
+      name: wordpress-api
+
+  - name: WORDPRESS_USERNAME
+    secretKeyRef:
+      key: wordpress-username
+      name: wordpress-api
+
 
 memoryLimit: 512Mi
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 canonicalwebteam.flask-base==2.6.0
 canonicalwebteam.http==1.0.4
-canonicalwebteam.blog==6.5.0
+# canonicalwebteam.blog==6.5.0
+-e git+https://github.com/canonical/canonicalwebteam.blog.git@refs/pull/183/head#egg=canonicalwebteam.blog
 canonicalwebteam.search==2.1.2
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.7.0

--- a/templates/blog/draft-blogs.html
+++ b/templates/blog/draft-blogs.html
@@ -1,0 +1,43 @@
+{% extends "templates/one-column.html" %}
+
+{% block title %}Draft blogs{% endblock %}
+
+{% block content %}
+  <div class="row u-equal-height u-clearfix">
+    {% for article in articles %}
+      {% if (loop.index - 1) % 3 == 0 and loop.index > 1 %}
+      </div>
+      <div class="row u-equal-height u-clearfix">
+      {% endif %}
+      <div class="col-4 col-medium-2 blog-p-card--post">
+        {% include "blog/blog-card-header.html" %}
+
+        <div class="blog-p-card__content">
+
+          {% if article.image and article.image.source_url %}
+            <div class="u-crop--16-9">
+              <a href="/blog/draft-blogs/{{ article.slug }}" aria-hidden="true" tabindex="-1">{{ article.image.rendered|safe }}</a>
+            </div>
+          {% endif %}
+
+          <h3 class="p-heading--4">
+            <a href="/blog/draft-blogs/{{ article.slug }}">{{ article.title.rendered|safe }}</a>
+          </h3>
+
+          <p>
+            <em>by
+              <a href="/blog/author/{{ article.author.slug }}">{{ article.author.name }}</a>
+            on {{ article.date }}</em>
+          </p>
+
+          {% if summary_visible or not article.image.source_url %}
+            <p class="{% if summary_visible %}u-hide--small{% endif %}"
+               style="padding-top:1rem">{{ article.excerpt.raw.replace('[…]', '') |truncate(162) }}</p>
+          {% endif %}
+        </div>
+
+        <p class="blog-p-card__footer">{% include 'blog/singular-category.html' %}</p>
+      </div>
+    {% endfor %}
+  </div>
+{% endblock content %}

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -40,7 +40,8 @@ from webapp.canonical_cla.views import (
 )
 from webapp.certified.views import certified_routes
 from webapp.handlers import init_handlers
-from webapp.login import login_handler, logout
+from webapp.login import login_handler, logout, user_info
+from webapp.decorators import login_required
 from webapp.security.views import (
     cve,
     cve_index,
@@ -1188,6 +1189,37 @@ def render_blogs():
 
 
 app.add_url_rule("/hpe", view_func=render_blogs)
+
+
+draft_blogs = BlogViews(
+    api=BlogAPI(
+        session=session, thumbnail_width=555, thumbnail_height=311
+    ),
+    excluded_tags=[],
+    tag_ids=[4794],
+    per_page=3,
+    blog_title="Daft blogs",
+    status="draft",
+)
+
+# Create draft blogs blueprint with login protection and apply to all routes
+draft_blogs_blueprint = build_blueprint(draft_blogs)
+@draft_blogs_blueprint.before_request
+def require_login():
+    if not user_info(flask.session):
+        return flask.redirect("/login?next=" + flask.request.path)
+
+
+@login_required
+def render_draft_blogs():
+    test_blogs = draft_blogs.get_tag("staging-blogs")
+    return flask.render_template(
+        "/blog/draft-blogs.html", articles=test_blogs["articles"]
+    )
+
+
+app.register_blueprint(draft_blogs_blueprint, url_prefix="/blog/draft-blogs", name="draft_blogs")
+app.add_url_rule("/blog/draft-blogs", view_func=render_draft_blogs)
 
 
 # Public-cloud blog section


### PR DESCRIPTION
## Done

- Adds a new route for listing draft blogs
- Creates new blue print for rendering individual blog articles
- Puts both the routes behind the SSO

## QA

- Open the demo
- See that the blog posts loads
- Confirm it is a [draft blog](https://admin.insights.ubuntu.com/wp-admin/post.php?post=126553&action=edit)

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-24697
