### PR TITLE
Credit card management updates deux

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -328,7 +328,7 @@ account:
       path: /account
     - title: Invoices
       path: /account/invoices
-    - title: Payment methods
+    - title: Payment method
       path: /account/payment-methods
 
 download:

--- a/static/js/src/advantage/api/contracts.js
+++ b/static/js/src/advantage/api/contracts.js
@@ -340,6 +340,22 @@ export async function setPaymentMethod(accountID, paymentMethodId) {
   return data;
 }
 
+export async function deletePaymentMethod(accountID, paymentMethodId) {
+  const response = await fetch("/account/payment-methods", {
+    method: "DELETE",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      account_id: window.accountId,
+    }),
+  });
+
+  let data = await response.json();
+  return data;
+}
+
 export async function setAutoRenewal(value) {
   const queryString = window.location.search; // Pass arguments to the flask backend
 

--- a/static/js/src/advantage/manage-subscription.js
+++ b/static/js/src/advantage/manage-subscription.js
@@ -14,13 +14,13 @@ const getMessage = (code, default_message) => {
     cancelling_subscription_success:
       "Your subscription was cancelled, the page will reload.",
     resizing_machines_fail:
-      "<strong>Payment method:</strong> There was problem with your payment. Please <a href='/account/payment-methods'>update your payment methods</a> to retry.",
+      "<strong>Payment method:</strong> There was problem with your payment. Please <a href='/account/payment-methods'>update your payment method</a> to retry.",
     subscription_missing:
       "<strong>Could not cancel subscription:</strong> It could be that you have a pending payment that is blocking this action. Contact <a href='https://ubuntu.com/contact-us'>Canonical sales</a> if the problem persists.",
     cancelling_subscription_failed:
       "<strong>Could not cancel subscription:</strong> Contact <a href='https://ubuntu.com/contact-us'>Canonical sales</a> if the problem persists.",
     pending_purchase:
-      "<strong>Error:</strong> You already have a pending purchase. Please go to <a href='/account/payment-methods'>payment methods</a> to retry.",
+      "<strong>Error:</strong> You already have a pending purchase. Please go to <a href='/account/payment-methods'>payment method</a> to retry.",
     unknown_error:
       "<strong>Unknown error:</strong> Contact <a href='https://ubuntu.com/contact-us'>Canonical sales</a> if the problem persists.",
   };

--- a/static/js/src/advantage/react/components/Subscriptions/Notifications/Notifications.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/Notifications/Notifications.test.tsx
@@ -134,3 +134,37 @@ describe("Account users Notification", () => {
     );
   });
 });
+
+describe("Payment method notification", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient();
+    queryClient.setQueryData(["accountUsers"], {
+      accountId: "123",
+      users: [{ name: "blip" }],
+    });
+  });
+
+  it("displays a notification if there is no payment method", () => {
+    queryClient.setQueryData(["hasPaymentMethod", "123"], false);
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <Notifications />
+      </QueryClientProvider>,
+    );
+    expect(wrapper.find("[data-test='no-payment-method']").exists()).toBe(true);
+  });
+
+  it("does not display a notification if there is a payment method", () => {
+    queryClient.setQueryData(["hasPaymentMethod", "123"], true);
+    const wrapper = mount(
+      <QueryClientProvider client={queryClient}>
+        <Notifications />
+      </QueryClientProvider>,
+    );
+    expect(wrapper.find("[data-test='no-payment-method']").exists()).toBe(
+      false,
+    );
+  });
+});

--- a/static/js/src/advantage/react/components/Subscriptions/Notifications/Notifications.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/Notifications/Notifications.tsx
@@ -2,7 +2,10 @@ import { Notification } from "@canonical/react-components";
 import React, { useEffect } from "react";
 
 import { useURLs } from "../../../hooks";
-import { useUserSubscriptions } from "advantage/react/hooks";
+import {
+  useUserSubscriptions,
+  useHasPaymentMethod,
+} from "advantage/react/hooks";
 import { selectStatusesSummary } from "advantage/react/hooks/useUserSubscriptions";
 import ExpiryNotification from "../ExpiryNotification";
 import { ExpiryNotificationSize } from "../ExpiryNotification/ExpiryNotification";
@@ -15,9 +18,10 @@ const Notifications = () => {
     select: selectStatusesSummary,
   });
   const { data: offers } = useGetOffersList();
-
   const { data: accountUsers, isSuccess: isAccountUsersSuccess } =
     useRequestAccountUsers();
+  const { data: hasPaymentMethod, isSuccess: isHasPaymentMethodSuccess } =
+    useHasPaymentMethod(accountUsers?.accountId ?? null);
 
   const [isShowingOnboardingNotification, setIsShowingOnboardingNotification] =
     React.useState(
@@ -36,6 +40,16 @@ const Notifications = () => {
 
   return (
     <>
+      {isHasPaymentMethodSuccess && !hasPaymentMethod ? (
+        <Notification
+          data-test="no-payment-method"
+          severity="caution"
+          title="No payment method saved"
+        >
+          To auto-renew or resize your subscription, add one in{" "}
+          <a href={urls.account.paymentMethods}>Payment method</a>.
+        </Notification>
+      ) : null}
       {statusesSummary?.has_pending_purchases ? (
         <Notification
           data-test="pendingPurchase"
@@ -44,7 +58,7 @@ const Notifications = () => {
           severity="caution"
         >
           You need to{" "}
-          <a href={urls.account.paymentMethods}>update your payment methods</a>{" "}
+          <a href={urls.account.paymentMethods}>update your payment method</a>{" "}
           to ensure there is no interruption to your Ubuntu Pro subscriptions
         </Notification>
       ) : null}

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionEdit/SubscriptionEdit.test.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionEdit/SubscriptionEdit.test.tsx
@@ -46,6 +46,10 @@ describe("SubscriptionEdit", () => {
       ["lastPurchaseIds", subscription.account_id],
       lastPurchaseIds,
     );
+    queryClient.setQueryData(
+      ["hasPaymentMethod", subscription.account_id],
+      true,
+    );
   });
 
   it("shows a cancel link if the subscription is cancellable", async () => {
@@ -315,6 +319,27 @@ describe("SubscriptionEdit", () => {
     });
     wrapper.update();
     expect(wrapper.find("[data-test='payment-error']").exists()).toBe(true);
+  });
+
+  it("cannot be edited if there is no payment method", async () => {
+    queryClient.setQueryData(
+      ["hasPaymentMethod", subscription.account_id],
+      false,
+    );
+    mount(
+      <QueryClientProvider client={queryClient}>
+        <SubscriptionEdit
+          onClose={jest.fn()}
+          selectedId={subscription.id}
+          setNotification={jest.fn()}
+          setShowingCancel={jest.fn()}
+        />
+      </QueryClientProvider>,
+    );
+    await act(async () => {});
+    waitFor(() => {
+      expect(screen.getByTestId("resize-submit-button")).toBeDisabled();
+    });
   });
 
   describe("generateSchema", () => {

--- a/static/js/src/advantage/react/components/Subscriptions/SubscriptionEdit/SubscriptionEdit.tsx
+++ b/static/js/src/advantage/react/components/Subscriptions/SubscriptionEdit/SubscriptionEdit.tsx
@@ -19,6 +19,7 @@ import {
   usePreviewResizeContract,
   useResizeContract,
   useUserSubscriptions,
+  useHasPaymentMethod,
 } from "advantage/react/hooks";
 import { PreviewResizeContractResponse } from "advantage/react/hooks/usePreviewResizeContract";
 import { ResizeContractResponse } from "advantage/react/hooks/useResizeContract";
@@ -75,7 +76,7 @@ const generateError = (error: Error | null) => {
     return (
       <span data-test="has-pending-purchase-error">
         You already have a pending purchase. Please go to{" "}
-        <a href="/account/payment-methods">payment methods</a> to retry.
+        <a href="/account/payment-methods">payment method</a> to retry.
       </span>
     );
   }
@@ -315,7 +316,11 @@ const SubscriptionEdit = ({
     setPreviewQuantityDebounced(e.target.value);
   };
 
+  const { data: hasPaymentMethod } = useHasPaymentMethod(
+    subscription.account_id,
+  );
   const ResizeSchema = generateSchema(subscription, unitName);
+
   return (
     <>
       <Formik
@@ -375,6 +380,7 @@ const SubscriptionEdit = ({
                   name="size"
                   type="number"
                   wrapperClassName="u-sv3"
+                  disabled={!hasPaymentMethod}
                 />
                 <ResizeSummary
                   oldNumberOfMachines={subscription.number_of_machines}

--- a/static/js/src/advantage/react/hooks/index.ts
+++ b/static/js/src/advantage/react/hooks/index.ts
@@ -10,3 +10,4 @@ export { useURLs } from "./useURLs";
 export { useUserSubscriptions } from "./useUserSubscriptions";
 export { useCancelTrial } from "./useCancelTrail";
 export { useUpdateContractEntitlementsMutation } from "./useUpdateContractEntitlementsMutation";
+export { useHasPaymentMethod } from "./useHasPaymentMethod";

--- a/static/js/src/advantage/react/hooks/useHasPaymentMethod.test.tsx
+++ b/static/js/src/advantage/react/hooks/useHasPaymentMethod.test.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import { renderHook } from "@testing-library/react-hooks";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useHasPaymentMethod } from "./useHasPaymentMethod";
+import { getCustomerInfo } from "advantage/api/contracts";
+
+jest.mock("advantage/api/contracts", () => ({
+  getCustomerInfo: jest.fn(),
+}));
+
+const createWrapper = (queryClient: QueryClient) => {
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+describe("useHasPaymentMethod", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient();
+  });
+
+  it("returns true if the user has a payment method", async () => {
+    (getCustomerInfo as jest.Mock).mockResolvedValue({
+      data: {
+        customerInfo: {
+          defaultPaymentMethod: {
+            Id: "123",
+          },
+        },
+      },
+    });
+
+    const wrapper = createWrapper(queryClient);
+    const { result, waitForNextUpdate } = renderHook(
+      () => useHasPaymentMethod("123"),
+      {
+        wrapper,
+      },
+    );
+    await waitForNextUpdate();
+    expect(result.current.data).toBe(true);
+  });
+
+  it("returns false if the user does not have a payment method", async () => {
+    (getCustomerInfo as jest.Mock).mockResolvedValue({
+      data: {
+        customerInfo: {},
+      },
+    });
+
+    const wrapper = createWrapper(queryClient);
+    const { result, waitForNextUpdate } = renderHook(
+      () => useHasPaymentMethod("123"),
+      {
+        wrapper,
+      },
+    );
+    await waitForNextUpdate();
+    expect(result.current.data).toBe(false);
+  });
+});

--- a/static/js/src/advantage/react/hooks/useHasPaymentMethod.ts
+++ b/static/js/src/advantage/react/hooks/useHasPaymentMethod.ts
@@ -1,0 +1,19 @@
+import { getCustomerInfo } from "advantage/api/contracts";
+import { UserSubscription } from "advantage/api/types";
+import { useQuery } from "@tanstack/react-query";
+
+export const useHasPaymentMethod = (
+  accountId: UserSubscription["account_id"] | null,
+) => {
+  const query = useQuery<boolean>({
+    queryKey: ["hasPaymentMethod", accountId],
+    queryFn: async () => {
+      const response = await getCustomerInfo(accountId);
+      const defaultPaymentMethod =
+        response.data?.customerInfo?.defaultPaymentMethod;
+      return Boolean(defaultPaymentMethod);
+    },
+    enabled: Boolean(accountId),
+  });
+  return query;
+};

--- a/static/js/src/advantage/subscribe/checkout/components/Summary/Summary.test.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Summary/Summary.test.tsx
@@ -324,7 +324,7 @@ describe("Summary", () => {
       description: (
         <>
           You already have a pending purchase. Please go to{" "}
-          <a href="/account/payment-methods">payment methods</a> to retry.
+          <a href="/account/payment-methods">payment method</a> to retry.
         </>
       ),
     };

--- a/static/js/src/advantage/subscribe/checkout/components/Summary/Summary.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Summary/Summary.tsx
@@ -117,7 +117,7 @@ function Summary({
         message = (
           <>
             You already have a pending purchase. Please go to{" "}
-            <a href="/account/payment-methods">payment methods</a> to retry.
+            <a href="/account/payment-methods">payment method</a> to retry.
           </>
         );
       } else if (

--- a/static/js/src/advantage/subscribe/checkout/components/UserInfoForm/UserInfoForm.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/UserInfoForm/UserInfoForm.tsx
@@ -385,6 +385,10 @@ const UserInfoForm = ({ setError, isCardSaving, setIsCardSaving }: Props) => {
             validate={validateRequired}
             error={touched?.postalCode && errors?.postalCode}
           />
+          <p>
+            We will save your card information. You can change it in your Ubuntu
+            Pro Dashboard.
+          </p>
         </>
       )}
       <p>

--- a/static/js/src/ua-payment-methods.js
+++ b/static/js/src/ua-payment-methods.js
@@ -2,6 +2,7 @@ import {
   getPurchase,
   retryPurchase,
   setPaymentMethod,
+  deletePaymentMethod,
 } from "./advantage/api/contracts.js";
 
 // initialise Stripe
@@ -38,6 +39,27 @@ const elements = stripe.elements({
 const card = elements.create("card", { style });
 
 const cardElement = document.getElementById("card-element");
+const editSection = document.getElementById("edit-payment-method-section");
+const paymentErrorElement = document.getElementById("payment-errors");
+const paymentWarningElement = document.getElementById("payment-warnings");
+const paymentSuccessElement = document.getElementById("payment-success");
+const emptyPaymentSection = document.getElementById(
+  "no-payment-method-section",
+);
+
+const handleSuccess = (message) => {
+  paymentErrorElement.classList.add("u-hide");
+  paymentWarningElement.classList.add("u-hide");
+  paymentSuccessElement.classList.remove("u-hide");
+  paymentSuccessElement.querySelector(".p-notification__message").innerHTML =
+    `${message}. Reloading page...`;
+};
+
+const handleError = (message) => {
+  paymentErrorElement.querySelector(".p-notification__message").innerHTML =
+    `<strong>${message}</strong> Check the details and try again. Contact <a href='https://ubuntu.com/contact-us'>Canonical sales</a> if the problem persists.`;
+  paymentErrorElement.classList.remove("u-hide");
+};
 
 if (cardElement) {
   card.mount("#card-element");
@@ -64,11 +86,7 @@ if (cardElement) {
   const previewSection = document.getElementById(
     "default-payment-method-section",
   );
-  const editSection = document.getElementById("edit-payment-method-section");
   const cardErrorElement = document.getElementById("card-errors");
-  const paymentErrorElement = document.getElementById("payment-errors");
-  const paymentWarningElement = document.getElementById("payment-warnings");
-  const paymentSuccessElement = document.getElementById("payment-success");
   const tryAgainButton = document.getElementById("try-again-button");
   const tryAgainSpinner = document.getElementById("try-again-spinner");
 
@@ -109,52 +127,43 @@ if (cardElement) {
       })
       .then((result) => {
         if (!result.paymentMethod) {
-          handleError();
+          handleUpdateError();
           return;
         }
 
         handlePaymentMethod(result);
       })
       .catch(() => {
-        handleError();
+        handleUpdateError();
       });
   });
 
   if (cancelButton)
     cancelButton.addEventListener("click", () => {
-      previewSection.classList.remove("u-hide");
       editSection.classList.add("u-hide");
       paymentErrorElement.classList.add("u-hide");
       paymentErrorElement.querySelector(".p-notification__message").innerHTML =
         "";
+
+      if (window.hasPaymentMethod) {
+        previewSection.classList.remove("u-hide");
+      } else {
+        emptyPaymentSection.classList.remove("u-hide");
+      }
     });
 
-  const handleSuccess = (message) => {
-    paymentErrorElement.classList.add("u-hide");
-    paymentWarningElement.classList.add("u-hide");
-    paymentSuccessElement.classList.remove("u-hide");
-    paymentSuccessElement.querySelector(".p-notification__message").innerHTML =
-      `${message}. Reloading page...`;
-  };
-
-  const handleError = () => {
+  const handleUpdateError = () => {
     updateButton.classList.remove("is-processing");
     updateButton.innerHTML = "Update";
     updateButton.disabled = false;
     if (cancelButton) cancelButton.disabled = false;
   };
 
-  const handlePaymentMethodErrors = (message) => {
-    paymentErrorElement.querySelector(".p-notification__message").innerHTML =
-      `<strong>${message}</strong> Check the details and try again. Contact <a href='https://ubuntu.com/contact-us'>Canonical sales</a> if the problem persists.`;
-    paymentErrorElement.classList.remove("u-hide");
-  };
-
   const handlePaymentMethod = (result) => {
     setPaymentMethod(window.accountId, result.paymentMethod.id).then((data) => {
       if (data.errors) {
-        handlePaymentMethodErrors("There was an error with your card.");
-        handleError();
+        handleError("There was an error with your card.");
+        handleUpdateError();
 
         return;
       }
@@ -179,7 +188,7 @@ if (cardElement) {
     resetElement(element);
 
     if (threeDSResponse.error) {
-      handlePaymentMethodErrors("There was an error with the payment.");
+      handleError("There was an error with the payment.");
     } else {
       handleSuccess("Payment successful");
       setTimeout(function () {
@@ -203,14 +212,14 @@ if (cardElement) {
           }
 
           if (!purchase.invoice) {
-            handlePaymentMethodErrors("There was an error with the payment.");
+            handleError("There was an error with the payment.");
             return;
           }
 
           const invoice = purchase.invoice;
 
           if (invoice.paymentStatus.status === "need_another_payment_method") {
-            handlePaymentMethodErrors("There was an error with the payment.");
+            handleError("There was an error with the payment.");
             return;
           }
 
@@ -219,7 +228,7 @@ if (cardElement) {
             return;
           }
 
-          handlePaymentMethodErrors("There was an error with the payment.");
+          handleError("There was an error with the payment.");
         });
       }, 5000);
     });
@@ -227,10 +236,41 @@ if (cardElement) {
 
   const resetElement = (element) => {
     if (element.tagName === "BUTTON") {
-      handleError();
+      handleUpdateError();
       return;
     }
 
     element.classList.add("u-hide");
   };
 }
+
+// Remove payment method
+
+const removePaymentModal = document.getElementById("remove-payment-modal");
+const addPaymentButton = document.getElementById("add-payment-method");
+const confirmRemoveButton = document.getElementById("confirm-remove-payment");
+
+addPaymentButton.addEventListener("click", () => {
+  emptyPaymentSection.classList.add("u-hide");
+  editSection.classList.remove("u-hide");
+});
+
+confirmRemoveButton.addEventListener("click", function () {
+  this.classList.add("is-processing");
+  this.innerHTML = '<i class="p-icon--spinner u-animation--spin is-light"></i>';
+  this.disabled = true;
+  const cancelButton = document.getElementById("cancel-remove-payment");
+  cancelButton.disabled = true;
+
+  deletePaymentMethod(window.accountId)
+    .then((data) => {
+      if (data.errors) {
+        throw new Error();
+      }
+      window.location.reload();
+    })
+    .catch((err) => {
+      removePaymentModal.classList.add("u-hide");
+      handleError("There was an error with your card.");
+    });
+});

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -178,6 +178,7 @@ $color-shadow: rgba(0, 0, 0, 0.5) !default;
 @include vf-p-icon-machines;
 @include vf-p-icon-units;
 @include vf-p-icon-plans;
+@include vf-p-icon-credit-card;
 @include openstack-carousel;
 @include vf-p-equal-height-row;
 

--- a/templates/account/payment-methods/_confirm-remove-modal.html
+++ b/templates/account/payment-methods/_confirm-remove-modal.html
@@ -1,0 +1,13 @@
+<div style="display: none;" class="p-modal" id="remove-payment-modal">
+  <section class="p-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="modal-title" aria-describedby="modal-description">
+    <header class="p-modal__header">
+      <h2 class="p-modal__title" id="modal-title">Remove payment method</h2>
+      <button class="p-modal__close" aria-label="Close active modal" aria-controls="modal">Close</button>
+    </header>
+    <p>Your subscriptions will not renew automatically at the next due date.</p>
+    <footer class="p-modal__footer">
+      <button class="u-no-margin--bottom" id="cancel-remove-payment" aria-controls="remove-payment-modal">Cancel</button>
+      <button class="p-button--negative u-no-margin--bottom" id="confirm-remove-payment">Remove</button>
+    </footer>
+  </section>
+</div>

--- a/templates/account/payment-methods/index.html
+++ b/templates/account/payment-methods/index.html
@@ -1,17 +1,15 @@
 {% extends "advantage/base_advantage.html" %}
 
 {% block title %}Canonical payment method{% endblock %}
+
 {% block meta_description %}Mange your payment method for your Canonical services.{% endblock %}
 
-{% block head_extra %}
-<meta name="robots" content="noindex, nofollow">
-{% endblock %}
+{% block head_extra %}<meta name="robots" content="noindex, nofollow" />{% endblock %}
 
 {% block content %}
 
-<section class="p-strip--suru-topped p-strip-account-page card-management-section">
-  <div class="row">
-    <div class="col-12">
+  <section class="p-strip--suru-topped p-strip-account-page card-management-section">
+    <div class="u-fixed-width">
 
       <div id="payment-success" class="p-notification--positive u-hide">
         <div class="p-notification__content">
@@ -28,53 +26,81 @@
       <div id="payment-warnings" class="p-notification--caution u-hide">
         <div class="p-notification__content">
           <p class="p-notification__message">
-            You have one or more pending payments. Use your saved card to <a id="try-again-button">retry payment</a>. <i id="try-again-spinner" class="p-icon--spinner u-animation--spin is-dark u-hide"></i></p>
+            You have one or more pending payments. Use your saved card to <a id="try-again-button">retry payment</a>. <i id="try-again-spinner"
+    class="p-icon--spinner u-animation--spin is-dark u-hide"></i>
+          </p>
         </div>
       </div>
 
-      <h1>Payment methods</h1>
+      <h1>Payment method</h1>
 
-      <div id="default-payment-method-section" class="row {% if not default_payment_method["id"] %}u-hide{% endif %}" style="margin-top: 2rem;">
+      <div id="default-payment-method-section"
+           class="row {% if not default_payment_method.id %}u-hide{% endif %}"
+           style="margin-top: 2rem">
         <div class="col-4 current-payment-method">
           {% with brand=default_payment_method["brand"] %}
             {% include "account/payment-methods/_card-logo.html" %}
           {% endwith %}
-          <p><span style="text-transform: capitalize;">{{default_payment_method["brand"]}}</span> ending in {{default_payment_method["last4"]}}</p>
-          </div>
+          <p>
+            <span style="text-transform: capitalize;">{{ default_payment_method["brand"] }}</span> ending in {{ default_payment_method["last4"] }}
+          </p>
+        </div>
         <p class="col-4 u-text--muted">Default payment method</p>
         <div class="col-4 u-align--right">
           <button class="p-button" id="edit-payment-details">Edit</button>
+          <button class="p-button--base"
+                  id="remove-payment-details"
+                  aria-controls="remove-payment-modal">Remove</button>
         </div>
       </div>
 
-      {% if default_payment_method %}
-        <div id="edit-payment-method-section" class="row {% if default_payment_method["id"] %}u-hide{% endif %}" style="margin-top: 2rem;">
-          <div class="col-8">
-              <div id="card-element"></div>
-              <span id="card-errors" class="p-form-validation__message u-hide"></span>
+      <div id="edit-payment-method-section"
+           class="row u-hide"
+           style="margin-top: 2rem">
+        <div class="col-8">
+          <div id="card-element"></div>
+          <span id="card-errors" class="p-form-validation__message u-hide"></span>
+        </div>
+        <div class="col-4 u-align--right">
+          <button class="p-button" id="cancel-payment-details">Cancel</button>
+          <button class="p-button--positive" id="update-payment-details" disabled>Save</button>
+        </div>
+      </div>
+      <hr class="{% if not default_payment_method.id %}u-hide{% endif %}" />
+
+      <div id="no-payment-method-section"
+           class="p-strip {% if default_payment_method.id %}u-hide{% endif %}">
+        <div class="row">
+          <div class="u-align--right col-4">
+            <i style="width: 4rem; height: 4rem; margin-top: 0.4rem;" 
+               class="p-icon--credit-card u-hide--medium u-hide--small"></i>
           </div>
-          <div class="col-4 u-align--right">
-            {% if default_payment_method["id"] %}<button class="p-button" id="cancel-payment-details">Cancel</button>{% endif %}
-            <button class="p-button--positive" id="update-payment-details" disabled>Update</button>
-          </div>
-          <div class="col-8">
+          <div class="u-align--left col-8 col-medium-4 col-small-3">
+            <p style="margin-bottom: 0;" class="p-heading--4">You have no payment method saved</p>
+            <p>Add a card to resize and automatically renew your subscriptions.</p>
+            <button class="p-button--positive" id="add-payment-method">Add card</button>
           </div>
         </div>
-        <hr></hr>
-      {% else %}
-        <p>No card added yet.</p>
-      {% endif %}
+      </div>
     </div>
-  </div>
-</section>
+  </section>
 
+  {% include "account/payment-methods/_confirm-remove-modal.html" %}
 
-<script src="https://js.stripe.com/v3/"></script>
-<script>
-  window.stripePublishableKey = "{{ get_stripe_publishable_key }}";
-  window.accountId = "{{ account_id }}";
-  window.pendingPurchaseId = "{{ pending_purchase_id }}";
-</script>
-<script src="{{ versioned_static('js/dist/ua-payment-methods.js') }}" type="module" defer></script>
+  <script src="https://js.stripe.com/v3/"></script>
+  <script>
+    window.stripePublishableKey = "{{ get_stripe_publishable_key }}";
+    window.accountId = "{{ account_id }}";
+    window.pendingPurchaseId = "{{ pending_purchase_id }}";
+    window.hasPaymentMethod = {% if default_payment_method.id %}true{% else %}false{% endif %};
+  </script>
+  <script src="/static/js/src/modal.js"></script>
+  <script>
+    initModals('#remove-payment-modal', '[aria-controls=remove-payment-modal]', false)
+  </script>
+
+  <script src="{{ versioned_static('js/dist/ua-payment-methods.js') }}"
+          type="module"
+          defer></script>
 
 {% endblock content %}

--- a/templates/advantage/index.html
+++ b/templates/advantage/index.html
@@ -58,11 +58,9 @@ endblock meta_copydoc %}
   localStorage.setItem("isInMaintenance", {{ is_in_maintenance|lower }});
 </script>
 
-<script
-  src="{{ versioned_static('js/dist/uaSubscriptions.js') }}"
-  type="module"
-  defer
-></script>
+  <script src="{{ versioned_static('js/dist/uaSubscriptions.js') }}"
+          type="module"
+          defer></script>
 
 {% with first_item="_ua_got_questions", second_item="_ua_legal",
 third_item="_ua_further_reading" %}{% include

--- a/tests/shop/advantage/test_api.py
+++ b/tests/shop/advantage/test_api.py
@@ -550,6 +550,51 @@ class TestPutPaymentMethod(unittest.TestCase):
         self.assertEqual(session.request_kwargs, expected_args)
 
 
+class TestDeletePaymentMethod(unittest.TestCase):
+    def test_errors(self):
+        cases = [
+            (500, False, UAContractsAPIError),
+            (500, True, UAContractsAPIErrorView),
+        ]
+
+        for code, is_for_view, expected_error in cases:
+            session = Session(response=Response(status_code=code, content={}))
+            client = make_client(session, is_for_view=is_for_view)
+
+            with self.assertRaises(expected_error):
+                client.delete_payment_method(
+                    account_id="aAaBbCcDdEeFfGg",
+                    payment_method_id="pm_abcdef",
+                )
+
+    def test_success(self):
+        session = Session(
+            response=Response(
+                status_code=200,
+                content=get_fixture("account"),
+            )
+        )
+        make_client(session).delete_payment_method(
+            account_id="aAaBbCcDdEeFfGg",
+            payment_method_id="pm_abcdef",
+        )
+
+        expected_args = {
+            "headers": {"Authorization": "Macaroon secret-token"},
+            "json": {
+                "deletePaymentMethod": {"Id": "pm_abcdef"},
+            },
+            "method": "put",
+            "params": None,
+            "url": (
+                "https://1.2.3.4/v1"
+                "/accounts/aAaBbCcDdEeFfGg/customer-info/stripe"
+            ),
+        }
+
+        self.assertEqual(session.request_kwargs, expected_args)
+
+
 class TestGetAccountPurchases(unittest.TestCase):
     def test_errors(self):
         cases = [

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -127,6 +127,7 @@ from webapp.shop.cred.views import (
 from webapp.shop.views import (
     account_view,
     checkout,
+    delete_payment_method,
     download_invoice,
     ensure_purchase_account,
     get_customer_info,
@@ -394,6 +395,11 @@ app.add_url_rule(
     "/account/payment-methods",
     view_func=post_payment_methods,
     methods=["POST"],
+)
+app.add_url_rule(
+    "/account/payment-methods",
+    view_func=delete_payment_method,
+    methods=["DELETE"],
 )
 app.add_url_rule(
     "/account/purchase-account",

--- a/webapp/shop/api/ua_contracts/api.py
+++ b/webapp/shop/api/ua_contracts/api.py
@@ -196,6 +196,16 @@ class UAContractsAPI:
             error_rules=["default"],
         ).json()
 
+    def delete_payment_method(self, account_id, payment_method_id) -> dict:
+        return self._request(
+            method="put",
+            path=f"v1/accounts/{account_id}/customer-info/stripe",
+            json={
+                "deletePaymentMethod": {"Id": payment_method_id},
+            },
+            error_rules=["default"],
+        ).json()
+
     def post_retry_purchase(self, purchase_id) -> dict:
         self._request(
             method="post",

--- a/webapp/shop/schemas.py
+++ b/webapp/shop/schemas.py
@@ -145,6 +145,10 @@ post_payment_methods = {
     "payment_method_id": String(required=True),
 }
 
+delete_payment_method = {
+    "account_id": String(required=True),
+}
+
 post_customer_info = {
     "payment_method_id": String(),
     "account_id": String(required=True),

--- a/webapp/shop/views.py
+++ b/webapp/shop/views.py
@@ -24,6 +24,7 @@ from webapp.shop.decorators import SERVICES, shop_decorator
 from webapp.shop.flaskparser import use_kwargs
 from webapp.shop.schemas import (
     PurchaseTotalSchema,
+    delete_payment_method,
     ensure_purchase_account,
     get_purchase_account_status,
     invoice_view,
@@ -192,6 +193,23 @@ def post_payment_methods(ua_contracts_api, **kwargs):
         response = ua_contracts_api.put_customer_info(
             account_id, payment_method_id, None, name, None
         )
+
+    return response
+
+
+@shop_decorator(area="account", permission="user", response="json")
+@use_kwargs(delete_payment_method, location="json")
+def delete_payment_method(ua_contracts_api, **kwargs):
+    account_id = kwargs.get("account_id")
+
+    account_info = ua_contracts_api.get_customer_info(account_id)
+    default_payment_method = account_info["customerInfo"][
+        "defaultPaymentMethod"
+    ]
+
+    response = ua_contracts_api.delete_payment_method(
+        account_id, default_payment_method["id"]
+    )
 
     return response
 


### PR DESCRIPTION
## Done

- Update "payment methods" page to allow removing the payment method
- If removed, show warning notification on Pro dashboard and disable renewal and resize features
- Use singular: "Payment method", as there's only one

## QA

- Open demo or run site locally
- Go to /account/payment-methods
- Remove the credit card
  - [x] The card goes away and it shows an empty state type of page 
- Go to /pro/dashboard
  - [x] There's a warning notification stating there's no payment method
  - [x] You can't change renewal settings
  - [x] You can't edit/resize any subscription
- Compare with [design](https://www.figma.com/design/GXrVXEGISyJVJbGk4V7PoD/25.04-Pro-Dashboard-Updates?node-id=8-3942&p=f&t=f9UtOJUOG1kzNobH-0)

## Issue

https://warthogs.atlassian.net/browse/WD-18327

Note: This PR is copy of https://github.com/canonical/ubuntu.com/pull/14670
Making dup because CLA checks failing 