### PR TITLE
copy: update patching security vulnerabilities text in /security/fedramp

### DIFF
--- a/templates/security/fedramp.html
+++ b/templates/security/fedramp.html
@@ -193,7 +193,7 @@
           </div>
           <div class="col-6 col-medium-3">
             <p>
-              Canonical provides 12 years of security patching for software applications and infrastructure components within the Ubuntu ecosystem. FedRAMP requires you to fix high-risk vulnerabilities within 30 days. Since starting out 20 years ago, Canonical has typically released patches for critical vulnerabilities within 24 hours.
+              Canonical provides up to 12 years of security patching for software applications and infrastructure components within the Ubuntu ecosystem. FedRAMP requires you to fix high-risk vulnerabilities within 30 days. Canonical typically releases patches for critical vulnerabilities within 24 hours on average.
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Done

- Change text in "Patching security vulnerabilities" section of /security/fedramp
## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
- Check that the copy doc matches the page

### or

- Navigate to `/security/fedramp` in the demo server. 
- Check that the copy doc matches the page

[Demo server](https://ubuntu-com-15455.demos.haus/security/fedramp)
[Copy doc](https://docs.google.com/document/d/1eJxGEthPLxG2CjFXTXLk6QF97DNh4VyZZ-AG2yIq8v4/edit?usp=sharing)

## Issue / Card

Fixes #
[WD-24743 Jira ticket](https://warthogs.atlassian.net/browse/WD-24743)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
