### PR TITLE
feat(certified): update components table layout and styling

### DIFF
--- a/templates/certified/model-details/_components-section.html
+++ b/templates/certified/model-details/_components-section.html
@@ -72,13 +72,5 @@
       <hr class="p-rule" />
       <p class="u-text--muted">*Releases with a blank status have not been tested</p>
     </div>
-    <!-- <ul class="p-inline-list u-hide--medium u-hide--large">
-      <li class="p-inline-list__item">
-        <i class="p-icon--success"></i> <small class="p-">Supported</small>
-      </li>
-      <li class="p-inline-list__item">
-        <i class="p-icon--help"></i> <small>In progress</small>
-      </li>
-    </ul> -->
   </div>
 </section>

--- a/webapp/certified/views.py
+++ b/webapp/certified/views.py
@@ -622,16 +622,6 @@ def certified_model_details(canonical_id):
         "form_factor", model_release["category"]
     )
 
-    # TODO remove (this is for demo)
-    component_summaries[0]["lts_releases"] = {
-        '20.04 LTS': [{'release': '20.04 LTS', 'third_party_driver': True, 'status': 'certified'}],
-        '22.04 LTS': [{'release': '22.04 LTS', 'third_party_driver': False, 'status': 'inprogress'}],
-        '18.04 LTS': [{'release': '18.04 LTS', 'third_party_driver': False, 'status': 'certified'}],
-        'Core 18': [{'release': 'Core 18', 'third_party_driver': True, 'status': 'unsupported'}],
-        'Core 24': [{'release': 'Core 24', 'third_party_driver': False, 'status': 'unsupported'}],
-        'Core 20': [{'release': 'Core 20', 'third_party_driver': True, 'status': 'inprogress'}]
-    }
-
     return render_template(
         "certified/model-details.html",
         canonical_id=canonical_id,


### PR DESCRIPTION
## Done
- Restructure components table to show releases vertically
- Simplify table styling and remove redundant columns
- Add demo data for testing purposes
- Add explicit "Unsupported" status handling for each LTS release: Unsupported status should only be shown when the status is explicitly set in the database. If no status is set, the cell should be blank.


[Figma](https://www.figma.com/design/1gDRefkvA5TnZGWI9tdkZB/ubuntu.com-certified?node-id=675-11535) 
[Demo](https://ubuntu-com-15456.demos.haus/certified/202412-36076)

## QA

- Check out the [Demo](https://ubuntu-com-15456.demos.haus/certified/202412-36076)
- Check that it follows the design on [Figma](https://www.figma.com/design/1gDRefkvA5TnZGWI9tdkZB/ubuntu.com-certified?node-id=675-11535) 
- Check that statuses show on the table correctly

## Issue / Card

Fixes # https://warthogs.atlassian.net/browse/WD-18361
#13106 

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
