### PR TITLE
update: openstack/managed: include link to new datasheet [WD-24790]

### DIFF
--- a/templates/openstack/managed.html
+++ b/templates/openstack/managed.html
@@ -30,7 +30,7 @@
           <p>Offload from your operations team and accelerate your time-to-market with Canonical’s Managed OpenStack.</p>
         </div>
         <div class="p-cta-block">
-          <a href="/openstack/managed#get-in-touch"
+          <a href="/openstack/contact-us"
              class="p-button--positive js-invoke-modal"
              aria-controls="openstack-modal">Get Managed OpenStack</a>
           <a href="https://www.brighttalk.com/webcast/6793/387966?utm_source=brighttalk-portal&utm_medium=web&utm_content=hosted%20private%20cloud%20infrastructure&utm_campaign=webcasts-search-results-feed"> Watch the webinar - "Hosted private cloud infrastructure: a cost analysis"</a>


### PR DESCRIPTION
## Done

- Made [copy doc](https://docs.google.com/document/d/1g38PPPhEP0Z66eM_gezfUyUwAr5e9vGfTHJDWV8gZlE/edit?tab=t.0) changes
- [Demo](https://ubuntu-com-15458.demos.haus/openstack/managed)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/openstack/managed
    - Be sure to test on mobile, tablet and desktop screen sizes


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
