### PR TITLE
copy: update datasheet link on `openstack/what-is-openstack`

### DIFF
--- a/templates/openstack/what-is-openstack.html
+++ b/templates/openstack/what-is-openstack.html
@@ -769,7 +769,7 @@
           </div>
           <div class="grid-col-3">
             <p>
-              <a href="https://assets.ubuntu.com/v1/92fe24b8-Charmed.OpenStack_19.01.22.pdf">Canonical&rsquo;s Charmed OpenStack</a>
+              <a href="https://assets.ubuntu.com/v1/cb9568ea-Datasheet%20-%20Canonical%20OpenStack.pdf">Canonical Charmed OpenStack</a>
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Done

- Updates link for the OpenStack datasheet on openstack/what-is-openstack.
- Minor copy change to the text of the link to remove the "'s" from "Canonical's Charmed OpenStack"

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Open [`/openstack/what-is-openstack`]() and ensure the datasheet link address and text have been updated as requested in the [copydoc](https://docs.google.com/document/d/15xrgIq_KUwHaCyFoI7-yS_JmBbsoyXJ4GpRMFAa7_is/edit?tab=t.0#heading=h.sk00jqnhlyyt)

## Issue / Card

Fixes [WD-24789](https://warthogs.atlassian.net/browse/WD-24789)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
