### PR TITLE
Add /released/cves endpoint path

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -415,6 +415,8 @@ production:
         [
           /security/cves\.json,
           /security/cves/.*\.json,
+          /security/released/cves\.json,
+          /security/released/cves/.*\.json,
           /security/releases\.json,
           /security/releases/.*\.json,
           /security/api/.*,
@@ -1002,6 +1004,8 @@ staging:
         [
           /security/cves\.json,
           /security/cves/.*\.json,
+          /security/released/cves\.json,
+          /security/released/cves/.*\.json,
           /security/releases\.json,
           /security/releases/.*\.json,
           /security/api/.*,


### PR DESCRIPTION
## Done

- Added path for new sec api endpoint (context [here](https://github.com/canonical/ubuntu-com-security-api/pull/222))

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
