### PR TITLE
fix: exclude non-english blog post

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1322,7 +1322,7 @@ def render_cmmc_blogs():
             4633,
             4749,
         ],
-        excluded_tags=[3265],
+        excluded_tags=[3184, 3265],
         per_page=4,
         blog_title="CMMC blogs",
     )


### PR DESCRIPTION
## Done

- [List of work items including drive-bys - remember to add the why and what of this work.]

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
