### PR TITLE
fix: exclude non-english blog post

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1322,7 +1322,7 @@ def render_cmmc_blogs():
             4633,
             4749,
         ],
-        excluded_tags=[3265],
+        excluded_tags=[3184, 3265],
         per_page=4,
         blog_title="CMMC blogs",
     )


### PR DESCRIPTION
## Done

-  exclude non-english blog post 

## QA

- Go to https://ubuntu-com-15466.demos.haus/security/cmmc
- scroll to "Resources" sections
- Verify no Japanese text exists

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-24866


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
