### PR TITLE
Disable robots index on staging

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -189,7 +189,9 @@ extraHosts:
 # Overrides for production
 production:
   replicas: 9
-
+  env:
+    - name: FLASK_ENV
+      value: "production"
   routes:
     - paths: [/blog]
       name: ubuntu-com-blog
@@ -776,6 +778,9 @@ staging:
         key: maas-api-username
         name: discourse-api
 
+    - name: FLASK_ENV
+      value: "staging"
+
   routes:
     - paths: [/blog]
       name: ubuntu-com-blog
@@ -1296,3 +1301,6 @@ demo:
 
     - name: CANONICAL_CLA_API_URL
       value: https://cla.staging.canonical.com
+
+    - name: FLASK_ENV
+      value: "demo"

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -236,14 +236,17 @@ class TestRoutes(VCRTestCase):
             response.json, {"country": "India", "country_code": "IN"}
         )
 
-    def test_staging_no_robots_txt(self):
-        """Test that only production returns X-Robots-Tag header"""
+    def test_staging_no_robots_header(self):
+        """Test that staging does not return a X-Robots-Tag header"""
         os.environ["FLASK_ENV"] = "staging"
         response = self.client.get("/robots.txt")
         self.assertTrue(response.headers["X-Robots-Tag"] == "none")
+
+    def test_production_robots_header(self):
+        """Test only production returns X-Robots-Tag header"""
         os.environ["FLASK_ENV"] = "production"
         response = self.client.get("/robots.txt")
-        self.assertTrue(response.headers["X-Robots-Tag"] == "none")
+        self.assertTrue(response.headers.get("X-Robots-Tag") != "none")
 
 
 if __name__ == "__main__":

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,6 +1,7 @@
 # Standard library
-import unittest
 import logging
+import os
+import unittest
 
 # Packages
 from bs4 import BeautifulSoup
@@ -8,7 +9,6 @@ from vcr_unittest import VCRTestCase
 
 # Local
 from webapp.app import app
-
 
 # Suppress talisker warnings, that get annoying
 logging.getLogger("talisker.context").disabled = True
@@ -235,6 +235,13 @@ class TestRoutes(VCRTestCase):
         self.assertEqual(
             response.json, {"country": "India", "country_code": "IN"}
         )
+
+    def test_staging_no_robots_txt(self):
+        """Test that the staging environment does not serve a robots.txt file"""
+        os.environ["FLASK_ENV"] = "staging"
+        response = self.client.get("/robots.txt")
+        self.assertTrue(response.headers["X-Robots-Tag"] == "none")
+        self.assertNotIn(b"User-agent", response.data)
 
 
 if __name__ == "__main__":

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -237,11 +237,13 @@ class TestRoutes(VCRTestCase):
         )
 
     def test_staging_no_robots_txt(self):
-        """Test that the staging environment does not serve a robots.txt file"""
+        """Test that only production returns X-Robots-Tag header"""
         os.environ["FLASK_ENV"] = "staging"
         response = self.client.get("/robots.txt")
         self.assertTrue(response.headers["X-Robots-Tag"] == "none")
-        self.assertNotIn(b"User-agent", response.data)
+        os.environ["FLASK_ENV"] = "production"
+        response = self.client.get("/robots.txt")
+        self.assertTrue(response.headers["X-Robots-Tag"] == "none")
 
 
 if __name__ == "__main__":

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -397,7 +397,7 @@ def init_handlers(app, sentry):
         )
         response.headers["Cross-Origin-Resource-Policy"] = "cross-origin"
         response.headers["X-Permitted-Cross-Domain-Policies"] = "none"
-        if get_flask_env("FLASK_ENV", "production") == "staging":
+        if get_flask_env("FLASK_ENV", "production") != "production":
             response.headers["X-Robots-Tag"] = "none"
         return response
 

--- a/webapp/handlers.py
+++ b/webapp/handlers.py
@@ -378,6 +378,7 @@ def init_handlers(app, sentry):
         access the resource
         - X-Permitted-Cross-Domain-Policies: disallows cross-domain access to
         resources.
+        - X-Robots-Tag: prevents search engines from indexing the page
         """
 
         def get_csp_as_str(csp={}):
@@ -396,6 +397,8 @@ def init_handlers(app, sentry):
         )
         response.headers["Cross-Origin-Resource-Policy"] = "cross-origin"
         response.headers["X-Permitted-Cross-Domain-Policies"] = "none"
+        if get_flask_env("FLASK_ENV", "production") == "staging":
+            response.headers["X-Robots-Tag"] = "none"
         return response
 
     app.add_template_filter(date_has_passed)


### PR DESCRIPTION
## Problem
Staging pages, especially security CVEs are being indexed by google ahead of the main website.

## Done

- Added env variable `FLASK_ENV` to distinguish between production and other environments. This env variable is automatically injected into the charm config so it seemed like a good candidate for this use.
- Returned [`X-Robots-Tag`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Robots-Tag) header as `none` when not on production.

## QA

- Open the [demo](https://ubuntu-com-15467.demos.haus/), and with developer tools open, in the network tab check for the `X-Robots-Tag` header and see that it is set to `none`

## Issue / Card
Fixes [WD-25019](https://warthogs.atlassian.net/browse/WD-25019)
## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

## Screenshots
<img width="367" height="573" alt="image" src="https://github.com/user-attachments/assets/59cba751-e319-4f53-9ec9-fe0963ec9d4a" />

[WD-25019]: https://warthogs.atlassian.net/browse/WD-25019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ