### PR TITLE
copy: remove "charmed" from openstack datasheet link text

### DIFF
--- a/templates/openstack/what-is-openstack.html
+++ b/templates/openstack/what-is-openstack.html
@@ -780,7 +780,7 @@
           </div>
           <div class="grid-col-3">
             <p>
-              <a href="https://assets.ubuntu.com/v1/cb9568ea-Datasheet%20-%20Canonical%20OpenStack.pdf">Canonical Charmed OpenStack</a>
+              <a href="https://assets.ubuntu.com/v1/cb9568ea-Datasheet%20-%20Canonical%20OpenStack.pdf">Canonical OpenStack</a>
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Done

Removes "Charmed" from the openstack datasheet link on "What Is Openstack" page per [copydoc](https://docs.google.com/document/d/15xrgIq_KUwHaCyFoI7-yS_JmBbsoyXJ4GpRMFAa7_is/edit?tab=t.0#heading=h.sk00jqnhlyyt)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Verify the link text reflects what is in the copydoc exactly

## Issue / Card

Follow-up of #15460 


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
