### PR TITLE
📝 docs: update OpenStack datasheet download link

### DIFF
--- a/templates/openstack/support.html
+++ b/templates/openstack/support.html
@@ -240,7 +240,7 @@
     <div class="row">
       <div class="col-start-large-7 col-6">
         <div class="p-cta-block">
-          <a href="https://assets.ubuntu.com/v1/83834ab4-B%20Ubuntu%20Pro%20DS%2028.10.22%20(1).pdf">Download the Ubuntu Pro datasheet&nbsp;&rsaquo;</a>
+          <a href="https://assets.ubuntu.com/v1/cb9568ea-Datasheet%20-%20Canonical%20OpenStack.pdf">Download Canonical OpenStack datasheet&nbsp;&rsaquo;</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Done

- Updated the openstack support datasheet download link

## QA

- Check out the [demo link here](https://ubuntu-com-15489.demos.haus/openstack/support)
- Check the `What is Ubuntu Pro?` section and check the `Download Canonical OpenStack datasheet` link and ensure it's the same as the [copydoc](https://docs.google.com/document/d/1mHaZQ_VZnISTUEpYKiVK-Ejr5ne8lVevpxEc0LpXYKI/edit?tab=t.0#heading=h.dwgon2w24ruy)

## Issue / Card

Fixes # https://warthogs.atlassian.net/browse/WD-24792

## Screenshots


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
