### PR TITLE
Migrate Azure bubble to use form generator

### DIFF
--- a/templates/azure/base_azure.html
+++ b/templates/azure/base_azure.html
@@ -3,7 +3,5 @@
 {% block outer_content %}
   {% block content %}{% endblock %}
 
-  <!-- Set default Marketo information for contact form below-->
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/confidential-computing" data-form-id="5352" data-lp-id="" data-return-url="https://ubuntu.com/azure/thank-you" data-lp-url="https://ubuntu.com/azure/contact-us">
-  </div>
+  {{ load_form("/azure") | safe }}
 {% endblock %}

--- a/templates/azure/confidential-computing/form-data.json
+++ b/templates/azure/confidential-computing/form-data.json
@@ -1,0 +1,32 @@
+{
+  "form": {
+    "/azure/confidential-computing": {
+      "templatePath": "/azure/confidential-computing/index.html",
+      "childrenPaths": [],
+      "isModal": true,
+      "modalId": "azure-confidential-computing-modal",
+      "formData": {
+        "title": "Contact us",
+        "introText": "Discuss your confidential computing use case with our experts",
+        "formId": "5352",
+        "returnUrl": "/azure/confidential-computing#contact-form-success",
+        "lpUrl": "/azure/contact-us",
+        "product": ""
+      },
+      "fieldsets": [
+        {
+          "title": "How should we get in touch?",
+          "id": "about-you",
+          "noCommentsFromLead": true,
+          "fields": [
+            {
+              "type": "tel",
+              "id": "phone",
+              "label": "Mobile/cell phone number"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/templates/azure/confidential-computing/index.html
+++ b/templates/azure/confidential-computing/index.html
@@ -82,7 +82,7 @@
         </ul>
         <hr class="p-rule--muted" />
         <p>
-          <a href="/azure/confidential-computing#get-in-touch">Don’t see what you’re looking for? Contact us to learn more&nbsp;&rsaquo;</a>
+          <a href="/azure/contact-us" class="js-invoke-modal" aria-controls="azure-confidential-computing-modal">Don’t see what you’re looking for? Contact us to learn more&nbsp;&rsaquo;</a>
         </p>
       </div>
     </div>
@@ -181,8 +181,11 @@
   <section class="p-strip is-deep">
     <div class="u-fixed-width">
       <h2>
-        <a href="/azure/confidential-computing#get-in-touch">Contact us to discuss your use case&nbsp;&rsaquo;</a>
+        <a href="/azure/contact-us" class="js-invoke-modal" aria-controls="azure-confidential-computing-modal">Contact us to discuss your use case&nbsp;&rsaquo;</a>
       </h2>
     </div>
   </section>
+
+  {{ load_form("/azure/confidential-computing") | safe }}
+
 {% endblock content %}

--- a/templates/azure/form-data.json
+++ b/templates/azure/form-data.json
@@ -1,0 +1,81 @@
+{
+  "form": {
+    "/azure": {
+      "templatePath": "/azure/index.html",
+      "childrenPaths": ["/azure/pro", "/azure/sql", "/azure/support"],
+      "isModal": true,
+      "modalId": "azure-modal",
+      "formData": {
+        "title": "Canonical - the \"Ubuntu on Azure\" experts",
+        "introText": "Already running Ubuntu on Azure, or planning a migration to the public cloud? Canonical has the expertise to assist you in your project, whether it involves application architecture, optimisation or streamlining operations at scale. Share some details about your project with us and let's get started.",
+        "formId": "3564",
+        "returnUrl": "/azure#contact-form-success",
+        "lpUrl": "/azure/contact-us",
+        "product": "azure"
+      },
+      "fieldsets": [
+        {
+          "title": "How many devices?",
+          "id": "how-many-machines",
+          "inputName": "how-many-machines-do-you-have",
+          "inputType": "radio",
+          "isRequired": true,
+          "fields": [
+            {
+              "type": "radio",
+              "id": "less-5-machines",
+              "value": "less than 5",
+              "label": "< 5 machines"
+            },
+            {
+              "type": "radio",
+              "id": "5-to-15-machines",
+              "value": "5 to 15 machines",
+              "label": "5 - 15 machines"
+            },
+            {
+              "type": "radio",
+              "id": "15-to-50-machines",
+              "value": "15 to 50 machines",
+              "label": "15 - 50 machines"
+            },
+            {
+              "type": "radio",
+              "id": "50-to-100-machines",
+              "value": "50 to 100 machines",
+              "label": "50 - 100 machines"
+            },
+            {
+              "type": "radio",
+              "id": "greater-than-100",
+              "value": "greater than 100",
+              "label": "> 100 machines"
+            }
+          ]
+        },
+        {
+          "title": "What would you like to talk to us about?",
+          "isRequired": true,
+          "fields": [
+            {
+              "type": "long-text",
+              "id": "comments"
+            }
+          ]
+        },
+        {
+          "title": "How should we get in touch?",
+          "id": "about-you",
+          "noCommentsFromLead": true,
+          "fields": [
+            {
+              "type": "tel",
+              "id": "phone",
+              "label": "Mobile/cell phone number"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/templates/azure/index.html
+++ b/templates/azure/index.html
@@ -16,9 +16,7 @@
 
 {% block content %}
   <div class="p-strip is-shallow u-no-padding--bottom">
-    <div class="u-fixed-width">
-      {% include "shared/_azure-banner.html" %}
-    </div>
+    <div class="u-fixed-width">{% include "shared/_azure-banner.html" %}</div>
   </div>
   <section class="p-section--hero">
     <div class="row--50-50">
@@ -27,12 +25,17 @@
           <h1>Ubuntu on Azure</h1>
         </div>
         <div class="p-section--shallow">
-          <p>Canonical produces official Ubuntu images on Microsoft Azure with continuous updates to ensure security and stability from the moment your machines and containers launch.</p>
-          <p>Microsoft works closely with Canonical to optimize Ubuntu images on Microsoft Azure and ensure Ubuntu supports the latest cloud features as these are released. Today, Ubuntu powers a large number of mission-critical workloads on Azure.</p>
+          <p>
+            Canonical produces official Ubuntu images on Microsoft Azure with continuous updates to ensure security and stability from the moment your machines and containers launch.
+          </p>
+          <p>
+            Microsoft works closely with Canonical to optimize Ubuntu images on Microsoft Azure and ensure Ubuntu supports the latest cloud features as these are released. Today, Ubuntu powers a large number of mission-critical workloads on Azure.
+          </p>
           <p>Beyond Ubuntu, Canonical also offers Charmed Apps on Microsoft Azure, enabling hybrid environments.</p>
         </div>
         <div class="p-cta-block">
-          <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.ubuntu-24_04-lts?tab=Overview" class="p-button--positive">Launch Ubuntu 24.04 on Azure</a>
+          <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.ubuntu-24_04-lts?tab=Overview"
+             class="p-button--positive">Launch Ubuntu 24.04 on Azure</a>
           <a href="/azure/contact-us" class="js-invoke-modal">Talk to us about Ubuntu on Azure&nbsp;&rsaquo;</a>
         </div>
       </div>
@@ -111,11 +114,15 @@
         <div class="p-card--overlay u-no-padding--top" style="padding: 1.5rem;">
           <div class="row p-section--shallow">
             <h3>Ubuntu Pro</h3>
-            <p class="p-heading--4">Metered prices available on the <a href="https://azure.microsoft.com/en-us/pricing/calculator/?ef_id=_k_Cj0KCQjw99e4BhDiARIsAISE7P9FZn4N6s9LJYncwceywjOTlWDL1OPGAqO9hUTVXItGgd_P-6pbdlAaAnLHEALw_wcB_k_&ocid=AIDcmmy4pl1olr_SEM__k_Cj0KCQjw99e4BhDiARIsAISE7P9FZn4N6s9LJYncwceywjOTlWDL1OPGAqO9hUTVXItGgd_P-6pbdlAaAnLHEALw_wcB_k_&gad_source=1&gclid=Cj0KCQjw99e4BhDiARIsAISE7P9FZn4N6s9LJYncwceywjOTlWDL1OPGAqO9hUTVXItGgd_P-6pbdlAaAnLHEALw_wcB">Azure Calculator</a></p>
+            <p class="p-heading--4">
+              Metered prices available on the <a href="https://azure.microsoft.com/en-us/pricing/calculator/?ef_id=_k_Cj0KCQjw99e4BhDiARIsAISE7P9FZn4N6s9LJYncwceywjOTlWDL1OPGAqO9hUTVXItGgd_P-6pbdlAaAnLHEALw_wcB_k_&ocid=AIDcmmy4pl1olr_SEM__k_Cj0KCQjw99e4BhDiARIsAISE7P9FZn4N6s9LJYncwceywjOTlWDL1OPGAqO9hUTVXItGgd_P-6pbdlAaAnLHEALw_wcB_k_&gad_source=1&gclid=Cj0KCQjw99e4BhDiARIsAISE7P9FZn4N6s9LJYncwceywjOTlWDL1OPGAqO9hUTVXItGgd_P-6pbdlAaAnLHEALw_wcB">Azure Calculator</a>
+            </p>
           </div>
           <hr class="p-rule--muted" />
           <ul class="p-list--divided">
-            <li class="p-list__item is-ticked">Expanded security patches beyond kernel and key infrastructure to apps and critical vulnerabilities (36,000 packages)</li>
+            <li class="p-list__item is-ticked">
+              Expanded security patches beyond kernel and key infrastructure to apps and critical vulnerabilities (36,000 packages)
+            </li>
             <li class="p-list__item is-ticked">Up to 12-year lifetime support</li>
             <li class="p-list__item is-ticked">
               Automated compliance and hardening tools available
@@ -126,7 +133,9 @@
               </ul>
             </li>
             <li class="p-list__item is-ticked">Kernel live patching for instant security and longer uptimes</li>
-            <li class="p-list__item is-ticked"><strong>Optional</strong> 24/7 enterprise level support for your Ubuntu workloads (<a href="/azure/contact-us" class="js-invoke-modal">contact us</a> to discuss adding this by Azure Marketplace Private Offer)</li>
+            <li class="p-list__item is-ticked">
+              <strong>Optional</strong> 24/7 enterprise level support for your Ubuntu workloads (<a href="/azure/contact-us" class="js-invoke-modal">contact us</a> to discuss adding this by Azure Marketplace Private Offer)
+            </li>
           </ul>
           <hr class="p-rule--muted" />
           <ul class="p-inline-list u-responsive-realign u-no-margin--bottom">
@@ -205,10 +214,14 @@
           <div class="row">
             <hr class="p-rule--muted" />
             <div class="col-6">
-              <p class="p-heading--4"><em>"Thanks to the combination of Microsoft Azure’s infrastructure and Canonical Ubuntu's stability and security, businesses can efficiently deploy agile applications, leverage AI and machine learning, and ensure regulatory compliance. Our collaboration with Canonical underscores a commitment to delivering flexible, innovative solutions via Azure Marketplace that drive digital transformation and operational excellence for organizations."</em></p>
+              <p class="p-heading--4">
+                <em>"Thanks to the combination of Microsoft Azure’s infrastructure and Canonical Ubuntu's stability and security, businesses can efficiently deploy agile applications, leverage AI and machine learning, and ensure regulatory compliance. Our collaboration with Canonical underscores a commitment to delivering flexible, innovative solutions via Azure Marketplace that drive digital transformation and operational excellence for organizations."</em>
+              </p>
             </div>
             <div class="col-3">
-              <p class="u-no-margin--bottom"><strong>Yvonne Muench</strong></p>
+              <p class="u-no-margin--bottom">
+                <strong>Yvonne Muench</strong>
+              </p>
               <p class="u-text--muted">Sr. Director - Marketplace & ISV Journey, Microsoft</p>
             </div>
           </div>
@@ -228,10 +241,14 @@
           <div class="row">
             <hr class="p-rule--muted" />
             <div class="col-6">
-              <p class="p-heading--4"><em>"Canonical has proven to be an exceptional and influential partner in the Linux and open-source community. Our collaborative efforts with their engineering teams are driving innovative advancements in AI, security, and secure software supply chain. This partnership enables customers to seamlessly migrate their legacy on-premises distributions to a more secure environment with Ubuntu on Azure."</em></p>
+              <p class="p-heading--4">
+                <em>"Canonical has proven to be an exceptional and influential partner in the Linux and open-source community. Our collaborative efforts with their engineering teams are driving innovative advancements in AI, security, and secure software supply chain. This partnership enables customers to seamlessly migrate their legacy on-premises distributions to a more secure environment with Ubuntu on Azure."</em>
+              </p>
             </div>
             <div class="col-3">
-              <p class="u-no-margin--bottom"><strong>Ron Abellera</strong></p>
+              <p class="u-no-margin--bottom">
+                <strong>Ron Abellera</strong>
+              </p>
               <p class="u-text--muted">Global Black Belt in Linux at Microsoft</p>
             </div>
           </div>
@@ -247,7 +264,9 @@
         <h2>Secure Data at Run-Time with Confidential Computing on Azure</h2>
       </div>
       <div class="col">
-        <p>If you're running critical workloads and need to process sensitive data, security at system memory is essential. With confidential computing, your workloads are  encrypted at run time, and are thus secure from all software vulnerabilities outside the VM perimeter &ndash; including the hypervisor and from unauthorized cloud admins. Pair confidential VMs with Ubuntu Pro for security in and out of your VM.</p>
+        <p>
+          If you're running critical workloads and need to process sensitive data, security at system memory is essential. With confidential computing, your workloads are  encrypted at run time, and are thus secure from all software vulnerabilities outside the VM perimeter &ndash; including the hypervisor and from unauthorized cloud admins. Pair confidential VMs with Ubuntu Pro for security in and out of your VM.
+        </p>
         <ul class="p-list--divided">
           <li class="p-list__item is-ticked">Secure during compute</li>
           <li class="p-list__item is-ticked">Enables zero trust</li>
@@ -255,9 +274,13 @@
           <li class="p-list__item is-ticked">Available on Ubuntu Pro for added security or the free versions of Ubuntu</li>
         </ul>
         <hr class="p-rule--muted" />
-        <p><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-confidential-vm-jammy?tab=Overview" class="p-button">Launch an Ubuntu Pro CVM now</a></p>
+        <p>
+          <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.0001-com-ubuntu-pro-confidential-vm-jammy?tab=Overview"
+             class="p-button">Launch an Ubuntu Pro CVM now</a>
+        </p>
         <div class="p-cta-block is-borderless">
-          <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.ubuntu-24_04-lts?tab=Overview" style="margin-right: 1rem">Launch an Ubuntu CVM&nbsp;&rsaquo;</a>
+          <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/canonical.ubuntu-24_04-lts?tab=Overview"
+             style="margin-right: 1rem">Launch an Ubuntu CVM&nbsp;&rsaquo;</a>
           <a href="/confidential-computing">Learn more about CVMs&nbsp;&rsaquo;</a>
         </div>
       </div>
@@ -268,7 +291,9 @@
     <div class="row--25-75">
       <hr class="p-rule" />
       <div class="col">
-        <h2 class="p-muted-heading"><a href="/blog/tag/ubuntu-on-azure">Latest from our blog&nbsp;&rsaquo;</a></h2>
+        <h2 class="p-muted-heading">
+          <a href="/blog/tag/ubuntu-on-azure">Latest from our blog&nbsp;&rsaquo;</a>
+        </h2>
       </div>
       <div class="col">
         <div id="blog-posts" class="row"></div>
@@ -284,7 +309,9 @@
         <h2>Optimise your cloud journey with Canonical</h2>
       </div>
       <div class="col">
-        <p>Canonical works with the top enterprises and innovators in the world to define and execute their cloud journeys. Migration, application redesign, support and optimization services are some of the ways in which we have helped customers make the most of Ubuntu and Azure together.</p>
+        <p>
+          Canonical works with the top enterprises and innovators in the world to define and execute their cloud journeys. Migration, application redesign, support and optimization services are some of the ways in which we have helped customers make the most of Ubuntu and Azure together.
+        </p>
         <div class="p-cta-block">
           <a href="/azure/contact-us" class="p-button--positive js-invoke-modal">Talk to us about Ubuntu on Azure</a>
         </div>
@@ -295,7 +322,9 @@
   <template style="display: none" id="articles-template">
     <div class="col-3">
       <div class="article-image"></div>
-      <h3 class="p-heading--5" style="font-weight: normal"><a class="article-link article-title"></a></h3>
+      <h3 class="p-heading--5" style="font-weight: normal">
+        <a class="article-link article-title"></a>
+      </h3>
       <div class="article-excerpt"></div>
     </div>
   </template>
@@ -310,4 +339,7 @@
       linkImage: true,
     })
   </script>
+
+  {{ load_form("/azure") | safe }}
+
 {% endblock content %}

--- a/templates/azure/pro.html
+++ b/templates/azure/pro.html
@@ -78,7 +78,9 @@
            href="https://portal.azure.com/#create/canonical.ubuntu-24_04-ltsubuntu-pro">Launch Ubuntu Pro 24.04 LTS</a>
         <hr class="p-rule--muted" />
         <p>
-          <a href="/azure/get-in-touch" class="js-invoke-modal">Contact us to discuss Ubuntu Pro with support&nbsp;&rsaquo;</a>
+          <a href="/azure/contact-us"
+             class="js-invoke-modal"
+             aria-controls="azure-modal">Contact us to discuss Ubuntu Pro with support&nbsp;&rsaquo;</a>
         </p>
       </div>
     </div>
@@ -272,7 +274,9 @@
       <hr class="p-rule--muted" />
       <div class="col-start-large-7 col-6">
         <p>
-          <a href="/azure/get-in-touch" class="js-invoke-modal">Let's talk Pro&nbsp;&rsaquo;</a>
+          <a href="/azure/contact-us"
+             class="js-invoke-modal"
+             aria-controls="azure-modal">Let's talk Pro&nbsp;&rsaquo;</a>
         </p>
       </div>
     </div>
@@ -288,15 +292,13 @@
         <div class="p-section">
           <div class="p-section--shallow">
             <div class="p-image-container">
-              {{ image (
-              url="https://assets.ubuntu.com/v1/2db99b36-is-ubuntu-pro.png",
-              alt="",
-              width="1800",
-              height="805",
-              hi_def=True,
-              loading="lazy",
-              attrs={"class": "p-image-container__image"}
-              ) | safe
+              {{ image(url="https://assets.ubuntu.com/v1/2db99b36-is-ubuntu-pro.png",
+                            alt="",
+                            width="1800",
+                            height="805",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"class": "p-image-container__image"}) | safe
               }}
             </div>
           </div>

--- a/templates/azure/sql.html
+++ b/templates/azure/sql.html
@@ -31,13 +31,20 @@
         <hr class="is-muted" />
         <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/microsoftsqlserver.sql2019-ubuntupro2004?tab=Overview"
            class="p-button--positive">Launch now</a>
-        <a href="/azure#get-in-touch">Contact us to learn more&nbsp;&rsaquo;</a>
+        <a href="/azure/contact-us"
+           class="js-invoke-modal"
+           aria-controls="azure-modal">Contact us to learn more&nbsp;&rsaquo;</a>
       </div>
       <div class="col-6">
         <div class="p-image-container--3-2 u-hide--small u-hide--medium">
-          <img class="p-image-container__image"
-               src="https://assets.ubuntu.com/v1/a5487809-Image%20container.png"
-               alt="" />
+          {{ image(url="https://assets.ubuntu.com/v1/a5487809-Image container.png",
+                    alt="",
+                    width="600",
+                    height="408",
+                    hi_def=True,
+                    loading="auto",
+                    attrs={"class": "p-image-container__image"}) | safe
+          }}
         </div>
       </div>
     </div>
@@ -56,9 +63,7 @@
             <div class="list-matrix">
               <div class="list-matrix-container">
                 <p class="p-heading--5">24/7 support</p>
-                <p>
-                  Enterprise-grade combined support available via your existing Microsoft support agreement.
-                </p>
+                <p>Enterprise-grade combined support available via your existing Microsoft support agreement.</p>
               </div>
             </div>
           </div>
@@ -67,7 +72,9 @@
             <div class="list-matrix">
               <div class="list-matrix-container">
                 <p class="p-heading--5">The right SQL Server for you</p>
-                <p> Four flavours of SQL Server 2019 are available &ndash; Enterprise, Standard, Web and Developer editions are ready to launch today. </p>
+                <p>
+                  Four flavours of SQL Server 2019 are available &ndash; Enterprise, Standard, Web and Developer editions are ready to launch today.
+                </p>
               </div>
             </div>
           </div>
@@ -115,7 +122,9 @@
             <div class="list-matrix">
               <div class="list-matrix-container">
                 <p class="p-heading--5">CIS STIG</p>
-                <p>For companies looking to leverage industry benchmarks for hardening, Ubuntu Pro makes two leading implementation guides available.</p>
+                <p>
+                  For companies looking to leverage industry benchmarks for hardening, Ubuntu Pro makes two leading implementation guides available.
+                </p>
               </div>
             </div>
           </div>
@@ -150,7 +159,9 @@
             <div class="list-matrix">
               <div class="list-matrix-container">
                 <p class="p-heading--5">Kernel Livepatch</p>
-                <p>Ubuntu kernel updates are regularly issued. With our Livepatch service, kernel patches are delivered immediately, without the need to reboot your VMs.</p>
+                <p>
+                  Ubuntu kernel updates are regularly issued. With our Livepatch service, kernel patches are delivered immediately, without the need to reboot your VMs.
+                </p>
               </div>
             </div>
           </div>

--- a/templates/azure/support.html
+++ b/templates/azure/support.html
@@ -27,7 +27,7 @@
         </div>
         <hr class="is-muted" />
         <p>
-          <a href="/contact-us" class="p-button--positive js-invoke-modal">Contact us</a>
+          <a href="/azure/contact-us" class="p-button--positive js-invoke-modal" aria-controls="azure-modal">Contact us</a>
         </p>
       </div>
       <div class="col">

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -262,10 +262,29 @@ search_engine_id = "adb2397a224a1fe55"
 
 init_handlers(app, sentry)
 
+
 # Prepare forms
-form_template_path = "shared/forms/form-template.html"
-form_loader = FormGenerator(app, form_template_path)
-form_loader.load_forms()
+def init_forms():
+    form_template_path = "shared/forms/form-template.html"
+
+    try:
+        template_full_path = (
+            Path(app.root_path).parent / "templates" / form_template_path
+        )
+        if not template_full_path.exists():
+            raise FileNotFoundError(
+                f"Form template not found: {template_full_path}"
+            )
+
+        form_loader = FormGenerator(app, form_template_path)
+        form_loader.load_forms()
+
+    except Exception as e:
+        print(f"There was an error loading forms: {e}")
+        raise e
+
+
+init_forms()
 
 # Routes
 # ===


### PR DESCRIPTION
## Problem statement

The form being used on all pages in the Azure bubble is a form specific form confidential computing

## Done

- Creates a new modal form to be shared between all Azure bubble pages (except `/azure/confedential-computing`) based on the form found at https://ubuntu.com/azure/contact-us
- Migrates the `confedential-computing` form (which was being used on all the Azure bubble pages) to use the form generator and only use it for `/azure/confedential-computing`

Fly by:
- Adds some basic error handling for the form generator
- Formatting

## QA

For Azure bubble
- Open to the demo to https://ubuntu-com-15491.demos.haus/azure
- Check the form has the same content as the form at https://ubuntu.com/azure/contact-us
- Check it submits successfully and goes through to Marketo. Repeat for the other affected pages: `/azure/pro`, `/azure/sql`, `/azure/support`

For Azure confidential computing
- Open the demo to https://ubuntu-com-15491.demos.haus/azure/confidential-computing
- Check the form has the same content as the form at https://ubuntu.com/azure#get-in-touch
- Check it submits successfully and goes through to Marketo.

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-25595
