### PR TITLE
fix: Server CLI Cheatsheet download link not workin on firefox

### DIFF
--- a/templates/download/shared/_server_weekly_news.html
+++ b/templates/download/shared/_server_weekly_news.html
@@ -125,7 +125,7 @@
                  value="" />
           <input type="hidden"
                  name="returnURL"
-                 value="https://assets.ubuntu.com/v1/5809ba46-(Updated)%20Ubuntu%20Server%20CLI%20cheat%20sheet%2002.07.2024%20update.pdf" />
+                 value="https://assets.ubuntu.com/v1/5809ba46-%28Updated%29%2520Ubuntu%2520Server%2520CLI%2520cheat%2520sheet%252002.07.2024%2520update.pdf" />
         </form>
 
       </div>


### PR DESCRIPTION
## Done

- Encodes the download link

## QA

- In firefox browser go to https://ubuntu.com/download/server/thank-you
- Click 'Download the CLI cheat sheet'
- Fill in the form and click 'Download the CLI cheat sheet'
- See you are redirected to the 

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
