### PR TITLE
fix(WD-24574): update copy for /community page

### DIFF
--- a/templates/community/index.html
+++ b/templates/community/index.html
@@ -66,10 +66,10 @@ meta_copydoc %}
           </div>
         </div>
         <p>
-          The Ubuntu Summit is a showcase for innovation and ambition. It's an invitation to those dissatisfied by the status quo, putting experts, builders, engineers and tinkerers center stage. No compromises; a demonstration of how the best engineering is open engineering.
+          The Ubuntu Summit is a showcase for the innovative and the ambitious. We invite all experts, builders, engineers, tinkerers, designers and dreamers to join us for an unforgettable two days.
         </p>
         <div class="p-cta-block is-borderless">
-          <a href="https://events.canonical.com/event/135/" class="p-button">Find out more</a>
+          <a href="/summit" class="p-button">Find out more</a>
         </div>
       </div>
     </div>
@@ -93,8 +93,7 @@ meta_copydoc %}
             <h3 class="u-clamp--two-lines">{{ event.post.topic.title }}</h3>
           </div>
           <div class="p-equal-height-row__item">
-            <p class="u-text--muted u-no-margin--bottom u-no-padding--top">{{ event.formatted_time }}
-            </p>
+            <p class="u-text--muted u-no-margin--bottom u-no-padding--top">{{ event.formatted_time }}</p>
             <p>
               <a href="https://discourse.ubuntu.com/u/{{ event.creator.username }}">{{ event.creator.name }}</a>
             </p>


### PR DESCRIPTION
## Done

- Update copy
- Update link

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to [/community](https://ubuntu-com-15500.demos.haus/community) and make sure copy matches the copydoc and the link points out to /summit

## Issue / Card

Fixes [WD-24574](https://warthogs.atlassian.net/browse/WD-24574)

## Screenshots
Notice that I am hovering over the button and the link shows up in bottom right corner.

### Before
<img width="1728" height="1117" alt="Screenshot 2025-08-20 at 9 14 49 pm" src="https://github.com/user-attachments/assets/7919efb5-667b-4907-8d34-947185c0b8c3" />

### After
<img width="3456" height="2234" alt="image" src="https://github.com/user-attachments/assets/89f647eb-f780-46ee-a304-bd180a646a02" />


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-24574]: https://warthogs.atlassian.net/browse/WD-24574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ