### PR TITLE
fix(WD-24788): update link for downloading openstack datasheet

### DIFF
--- a/templates/openstack/index.html
+++ b/templates/openstack/index.html
@@ -294,7 +294,7 @@
       <div class="grid-row">
         <div class="grid-col-4 grid-col-start-large-5">
           <hr class="p-rule--muted" />
-          <a href="https://assets.ubuntu.com/v1/117a9275-Charmed%20OpenStack.pdf"
+          <a href="https://assets.ubuntu.com/v1/cb9568ea-Datasheet%20-%20Canonical%20OpenStack.pdf"
              class="p-button u-no-margin--bottom">Download the datasheet</a>
         </div>
       </div>


### PR DESCRIPTION
## Done

- Update link for downloading openstack datasheet

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to /openstack, click "Download the datasheet", the link should be https://assets.ubuntu.com/v1/cb9568ea-Datasheet%20-%20Canonical%20OpenStack.pdf

## Issue / Card

Fixes [WD-24788](https://warthogs.atlassian.net/browse/WD-24788)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
