### PR TITLE
fix: Remove fallback message in failed form notification

### DIFF
--- a/templates/templates/_notifications.html
+++ b/templates/templates/_notifications.html
@@ -57,9 +57,6 @@
           {% for category, message in messages %}
             {% if category == "contact-form-fail" %}{{ message }}{% endif %}
           {% endfor %}
-          {% if not messages %}
-            An error occurred while submitting your form.
-          {% endif %}
           Please try again or 
           <a href="https://github.com/canonical/ubuntu.com/issues/new?template=ISSUE_TEMPLATE.yaml">file a bug report.</a>
         {% endwith %}


### PR DESCRIPTION
## Done

- Removes the fallback message as this was resolving to true in many cases and causing the failed message to display.

## QA

- Check out this branch locally (demos will not work with marketo right now)
- Go to `http://0.0.0.0:8001/engage/what-is-ubuntu-pro` in incognito mode
- Fill in the form and submit it
- See no 'Failed form' message

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-25744