### PR TITLE
fix: remove merge messages on forms

### DIFF
--- a/templates/shared/contextual_footers/_cloud_newsletter.html
+++ b/templates/shared/contextual_footers/_cloud_newsletter.html
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 <section class="p-section">
   <div class="row--50-50">
     <hr class="p-rule" />
@@ -106,39 +105,3 @@
     </div>
   </div>
 </section>
-=======
-<div class="col-4 p-divider__block">
-  <form action="/marketo/submit" method="post">
-    <h3 class="p-heading--4">Sign up for our monthly Cloud&nbsp;Newsletter</h3>
-    <ul class="p-list u-clearfix">
-      <li class="p-list__item">
-        <label class="u-off-screen" for="email">Your email</label>
-        <input type="email" pattern="^[^ ]+@[^ ]+\.[a-z]{2,26}$" placeholder="Your email" name="email" id="email" required />
-      </li>
-      <li class="p-list__item">
-        <label class="p-checkbox">
-          <input class="p-checkbox__input" name="canonicalUpdatesOptIn" aria-labelledby="canonicalOptIn" value="yes" type="checkbox" />
-          <span class="p-checkbox__label contextual-footer__text--label" id="canonicalOptIn">I agree to receive information about Canonical's products and services.</span>
-        </label>
-      </li>
-      <li class="p-list__item u-no-margin--top">
-        <p>In submitting this form, I confirm that I have read and agree to <a href="https://canonical.com/legal/data-privacy/newsletter">Canonical's Privacy Notice</a> and <a href="https://canonical.com/legal/data-privacy">Privacy Policy</a>.</p>
-      </li>
-      <li class="p-list__item">
-        <span><button type="submit" class="p-button"  onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Contextual footer link', 'eventAction' : 'Cloud newsletter', 'eventLabel' : 'Sign-up for news updates', 'eventValue' : undefined });">Subscribe now</button></span>
-        <input value="1212" name="formid" type="hidden" />
-        <input type="hidden" name="Consent_to_Processing__c" value="yes" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_content" id="utm_content" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_term" id="utm_term" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="GCLID__c" id="GCLID__c" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" name="Facebook_Click_ID__c" id="Facebook_Click_ID__c" value="" />
-        <input type="hidden" aria-hidden="true" aria-label="hidden field" id="preferredLanguage" name="preferredLanguage" maxlength="255" value="" />
-        <input type="hidden" name="returnURL" value="/openstack/newsletter-thank-you" />
-      </li>
-    </ul>
-  </form>
-</div>
->>>>>>> 993906454 (Update legal links across the site)

--- a/templates/shared/forms/form-fields.html
+++ b/templates/shared/forms/form-fields.html
@@ -36,12 +36,8 @@
                           id="firstName"
                           name="firstName"
                           maxlength="255"
-<<<<<<< HEAD
                           autocomplete="given-name"
-                          type="text" />                              
-=======
                           type="text" />
->>>>>>> 993906454 (Update legal links across the site)
                   <label class="is-required"
                           for="lastName">Last name:</label>
                   <input required


### PR DESCRIPTION
## Done

- Removed merge messages on form templates

## QA

- Go to https://ubuntu-com-15505.demos.haus/openstack/consulting
- Scroll to "Sign up for our monthly Cloud Newsletter"
- See that it does not have the merge conflict messages
- Go to https://ubuntu-com-15505.demos.haus/ai/#get-in-touch
- Go to "Last name" field
- See that it does not have the merge conflict messages

## Issue / Card

Fixes [WD-25875](https://warthogs.atlassian.net/browse/WD-25875)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-25875]: https://warthogs.atlassian.net/browse/WD-25875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ