### PR TITLE
test: Add Marketo form integration tests

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -162,9 +162,8 @@ jobs:
           coverage run --source=. -m unittest discover tests
         env:
           SEARCH_API_KEY: fake-key
-          MARKETO_API_CLIENT: $${{ secrets.MARKETO_API_CLIENT }}
-          MARKETO_API_SECRET: $${{ secrets.MARKETO_API_SECRET }}
-          SITEMAP_SECRET: $${{ secrets.SITEMAP_SECRET }}
+          MARKETO_API_CLIENT: ${{ secrets.MARKETO_API_CLIENT }}
+          MARKETO_API_SECRET: ${{ secrets.MARKETO_API_SECRET }}
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -162,6 +162,9 @@ jobs:
           coverage run --source=. -m unittest discover tests
         env:
           SEARCH_API_KEY: fake-key
+          MARKETO_API_CLIENT: $${{ secrets.MARKETO_API_CLIENT }}
+          MARKETO_API_SECRET: $${{ secrets.MARKETO_API_SECRET }}
+          SITEMAP_SECRET: $${{ secrets.SITEMAP_SECRET }}
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -164,6 +164,7 @@ jobs:
           SEARCH_API_KEY: fake-key
           MARKETO_API_CLIENT: ${{ secrets.MARKETO_API_CLIENT }}
           MARKETO_API_SECRET: ${{ secrets.MARKETO_API_SECRET }}
+          SITEMAP_SECRET: ${{ secrets.SITEMAP_SECRET }}
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/templates/advantage/subscribe/form-data.json
+++ b/templates/advantage/subscribe/form-data.json
@@ -16,12 +16,11 @@
         {
           "title": "Tell us about your project",
           "id": "about-your-project",
-          "noCommentsFromLead": true,
           "fields": [
             {
               "type": "long-text",
               "id": "about-your-project",
-              "label": "Abour your project"
+              "label": "About your project"
             }
           ]
         },
@@ -115,13 +114,12 @@
         {
           "title": "*What is the name of your cloud provider?",
           "id": "cloud-provider",
-          "noCommentsFromLead": true,
+          "isRequired": true,
           "fields": [
             {
               "type": "long-text",
               "id": "cloud-provider-name",
-              "label": "Cloud provider name",
-              "isRequired": true
+              "label": "Cloud provider name"
             }
           ]
         },
@@ -302,7 +300,6 @@
         {
           "title": "What advice are you looking for?",
           "id": "advice",
-          "noCommentsFromLead": true,
           "fields": [
             {
               "type": "long-text",

--- a/templates/aws/form-data.json
+++ b/templates/aws/form-data.json
@@ -21,7 +21,7 @@
             {
               "type": "long-text",
               "id": "about-your-project",
-              "label": "Abour your project"
+              "label": "About your project"
             }
           ]
         },

--- a/templates/aws/form-data.json
+++ b/templates/aws/form-data.json
@@ -17,7 +17,6 @@
         {
           "title": "Tell us about your project",
           "id": "about-your-project",
-          "noCommentsFromLead": true,
           "fields": [
             {
               "type": "long-text",
@@ -310,7 +309,6 @@
         {
           "title": "What advice are you looking for?",
           "id": "advice",
-          "noCommentsFromLead": true,
           "fields": [
             {
               "type": "long-text",

--- a/templates/contact-us/form-data.json
+++ b/templates/contact-us/form-data.json
@@ -18,7 +18,6 @@
         {
           "title": "Tell us about your project",
           "id": "about-your-project",
-          "noCommentsFromLead": true,
           "fields": [
             {
               "type": "long-text",
@@ -311,7 +310,6 @@
         {
           "title": "What advice are you looking for?",
           "id": "advice",
-          "noCommentsFromLead": true,
           "fields": [
             {
               "type": "long-text",

--- a/templates/containers/form-data.json
+++ b/templates/containers/form-data.json
@@ -48,21 +48,6 @@
           "noCommentsFromLead": true,
           "fields": [
             {
-              "type": "text",
-              "id": "company",
-              "label": "Company name"
-            },
-            {
-              "type": "text",
-              "id": "title",
-              "label": "Job title"
-            },
-            {
-              "type": "country",
-              "label": "Country",
-              "isRequired": true
-            },
-            {
               "type": "tel",
               "id": "phone",
               "label": "Mobile/cell phone number",

--- a/templates/internet-of-things/form-data.json
+++ b/templates/internet-of-things/form-data.json
@@ -28,7 +28,7 @@
             {
               "type": "long-text",
               "id": "about-project",
-              "label": "Abour your project"
+              "label": "About your project"
             }
           ]
         },

--- a/templates/security/form-data.json
+++ b/templates/security/form-data.json
@@ -19,7 +19,6 @@
           {
             "title": "Tell us about your project",
             "id": "about-your-project",
-            "noCommentsFromLead": true,
             "fields": [
               {
                 "type": "long-text",
@@ -312,7 +311,6 @@
           {
             "title": "What advice are you looking for?",
             "id": "advice",
-            "noCommentsFromLead": true,
             "fields": [
               {
                 "type": "long-text",

--- a/templates/toolchains/form-data.json
+++ b/templates/toolchains/form-data.json
@@ -90,12 +90,11 @@
         {
           "title": "Tell us about your project",
           "id": "about-your-project",
-          "noCommentsFromLead": true,
           "fields": [
             {
               "type": "long-text",
               "id": "about-your-project",
-              "label": "Abour your project"
+              "label": "About your project"
             }
           ]
         },

--- a/tests/test_marketo.py
+++ b/tests/test_marketo.py
@@ -1,6 +1,7 @@
 import unittest
 import talisker.requests
 import json
+import os
 from requests import Session
 from pathlib import Path
 
@@ -19,12 +20,12 @@ SET_FIELDS = set(
         "title",
         "country",
         "phone",
-        "comments_from_lead__c"
+        "comments_from_lead__c",
     }
 )
-# All form-data.json forms exluding test files
 form_files = [
-    f for f in Path("templates").rglob("form-data.json")
+    f
+    for f in Path("templates").rglob("form-data.json")
     if "templates/tests" not in str(f)
 ]
 
@@ -37,6 +38,9 @@ class TestMarketo(unittest.TestCase):
 
         app.testing = True
         self.client = app.test_client()
+
+        assert get_flask_env("MARKETO_API_CLIENT") is not None
+        assert get_flask_env("MARKETO_API_SECRET") is not None
 
         marketo_session = Session()
         talisker.requests.configure(marketo_session)
@@ -59,9 +63,9 @@ class TestMarketo(unittest.TestCase):
     def _check_form_with_marketo(self, form_path):
         # Function to check form fields and Marketo fields against one another
         def _check_form_fields(field_id, check_form):
-            assert field_id is not None, (
-                f"Field ID is none for {check_form} fields"
-            )
+            assert (
+                field_id is not None
+            ), f"Field ID is none for {check_form} fields"
 
             field_id = field_id.lower()
             if check_form == "marketo":
@@ -85,9 +89,9 @@ class TestMarketo(unittest.TestCase):
 
         with open(form_path, "r") as f:
             forms = json.load(f).get("form", {})
-            assert forms is not None, (
-                f"Form data could not be loaded from {form_path}"
-            )
+            assert (
+                forms is not None
+            ), f"Form data could not be loaded from {form_path}"
 
         # form-data.json may have multiple forms
         for form_data in forms.values():
@@ -125,6 +129,9 @@ class TestMarketo(unittest.TestCase):
                 required = marketo_field.get("required")
                 if required:
                     _check_form_fields(id, "form-data")
+
+    def test_submit_form(self):
+        return
 
 
 if __name__ == "__main__":

--- a/tests/test_marketo.py
+++ b/tests/test_marketo.py
@@ -39,8 +39,8 @@ class TestMarketo(unittest.TestCase):
         app.testing = True
         self.client = app.test_client()
 
-        marketo_client = get_flask_env("MARKETO_API_CLIENT")
-        marketo_secret = get_flask_env("MARKETO_API_SECRET")
+        marketo_client = os.getenv("MARKETO_API_CLIENT")
+        marketo_secret = os.getenv("MARKETO_API_SECRET")
         assert marketo_client is not None
         assert marketo_secret is not None
         assert len(marketo_client) > 10, "MARKETO_API_CLIENT is not valid"
@@ -50,8 +50,8 @@ class TestMarketo(unittest.TestCase):
         talisker.requests.configure(marketo_session)
         self.marketo_api = MarketoAPI(
             "https://066-EOV-335.mktorest.com",
-            get_flask_env("MARKETO_API_CLIENT"),
-            get_flask_env("MARKETO_API_SECRET"),
+            os.getenv("MARKETO_API_CLIENT"),
+            os.getenv("MARKETO_API_SECRET"),
             marketo_session,
         )
         self.marketo_api._authenticate()

--- a/tests/test_marketo.py
+++ b/tests/test_marketo.py
@@ -39,8 +39,12 @@ class TestMarketo(unittest.TestCase):
         app.testing = True
         self.client = app.test_client()
 
-        assert get_flask_env("MARKETO_API_CLIENT") is not None
-        assert get_flask_env("MARKETO_API_SECRET") is not None
+        marketo_client = get_flask_env("MARKETO_API_CLIENT")
+        marketo_secret = get_flask_env("MARKETO_API_SECRET")
+        assert marketo_client is not None
+        assert marketo_secret is not None
+        assert len(marketo_client) > 10, "MARKETO_API_CLIENT is not valid"
+        assert len(marketo_secret) > 10, "MARKETO_API_SECRET is not valid"
 
         marketo_session = Session()
         talisker.requests.configure(marketo_session)

--- a/tests/test_marketo.py
+++ b/tests/test_marketo.py
@@ -1,0 +1,131 @@
+import unittest
+import talisker.requests
+import json
+from requests import Session
+from pathlib import Path
+
+from canonicalwebteam.flask_base.env import get_flask_env
+
+from webapp.app import app
+from webapp.marketo import MarketoAPI
+
+# Fields that are already hardcoded into form-fields.html
+SET_FIELDS = set(
+    {
+        "firstname",
+        "lastname",
+        "email",
+        "company",
+        "title",
+        "country",
+        "phone",
+        "comments_from_lead__c"
+    }
+)
+# All form-data.json forms exluding test files
+form_files = [
+    f for f in Path("templates").rglob("form-data.json")
+    if "templates/tests" not in str(f)
+]
+
+
+class TestMarketo(unittest.TestCase):
+    def setUp(self):
+        """
+        Set up Flask app for testing
+        """
+
+        app.testing = True
+        self.client = app.test_client()
+
+        marketo_session = Session()
+        talisker.requests.configure(marketo_session)
+        self.marketo_api = MarketoAPI(
+            "https://066-EOV-335.mktorest.com",
+            get_flask_env("MARKETO_API_CLIENT"),
+            get_flask_env("MARKETO_API_SECRET"),
+            marketo_session,
+        )
+        self.marketo_api._authenticate()
+        return super().setUp()
+
+    def test_marketo_api(self):
+        assert self.marketo_api.token is not None
+
+    def test_forms_with_marketo(self):
+        for form in form_files:
+            self._check_form_with_marketo(form)
+
+    def _check_form_with_marketo(self, form_path):
+        # Function to check form fields and Marketo fields against one another
+        def _check_form_fields(field_id, check_form):
+            assert field_id is not None, (
+                f"Field ID is none for {check_form} fields"
+            )
+
+            field_id = field_id.lower()
+            if check_form == "marketo":
+                assert field_id in [
+                    f.get("id").lower() for f in marketo_fields
+                ], (
+                    f"Field {field_id} is not present in "
+                    f"{check_form} fields"
+                    f" for form {form_path}"
+                )
+
+            elif check_form == "form-data":
+                if field_id not in SET_FIELDS:
+                    assert field_id in [
+                        f.get("id").lower() for f in form_fields
+                    ], (
+                        f"Field {field_id} is not present in "
+                        f"{check_form} fields"
+                        f" for form {form_path}"
+                    )
+
+        with open(form_path, "r") as f:
+            forms = json.load(f).get("form", {})
+            assert forms is not None, (
+                f"Form data could not be loaded from {form_path}"
+            )
+
+        # form-data.json may have multiple forms
+        for form_data in forms.values():
+            form_id = form_data.get("formData").get("formId")
+
+            # Check that marketo form exists
+            marketo_response = self.marketo_api.get_form_fields(form_id)
+            assert marketo_response.status_code == 200
+            assert (
+                marketo_response is not None
+            ), "Marketo fields should not be None"
+            marketo_fields = marketo_response.json().get("result", [])
+
+            # Check that form fields match Marketo fields
+            form_fields = form_data.get("fieldsets", [])
+            for field in form_fields:
+                field_id = field.get("id")
+
+                # Check that individual fields are all expected
+                # in the Marketo fields
+                if field.get("noCommentsFromLead"):
+                    if field_id != "about-you":
+                        _check_form_fields(field_id, "marketo")
+                    else:
+                        # Check enrichment fields separately
+                        contact_fields = field.get("fields", [])
+                        for contact_field in contact_fields:
+                            _check_form_fields(
+                                contact_field.get("id"), "marketo"
+                            )
+
+            # Check that Marketo required fields are included in form
+            for marketo_field in marketo_fields:
+                id = marketo_field.get("id")
+                required = marketo_field.get("required")
+                if required:
+                    _check_form_fields(id, "form-data")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sitemap.py
+++ b/tests/test_sitemap.py
@@ -1,9 +1,8 @@
-# Packages
 import unittest
-from unittest.mock import patch
-import logging
 import re
 import os
+import logging
+from unittest.mock import patch
 import xml.etree.ElementTree as ET
 from webapp.app import app
 from webapp.views import build_sitemap_tree

--- a/webapp/marketo.py
+++ b/webapp/marketo.py
@@ -52,12 +52,6 @@ class MarketoAPI:
             "POST", "/rest/v1/leads/submitForm.json", json=data
         )
 
-    def describe_leads(self):
-        return self.request("GET", "/rest/v1/leads/describe.json")
-
-    def get_lead(self, id_):
-        return self.request("GET", f"/rest/v1/leads/{id_}.json")
-
     def update_leads(self, leads=None):
         data = {
             "action": "createOrUpdate",

--- a/webapp/marketo.py
+++ b/webapp/marketo.py
@@ -23,6 +23,9 @@ class MarketoAPI:
             f"client_id={self.client_id}&client_secret={self.client_secret}"
         )
         request = self.session.get(auth_url)
+        response = request.json()
+        if "access_token" not in response:
+            raise ValueError(f"No access_token in response: {response}")
         self.token = request.json()["access_token"]
 
     def request(self, method, url, url_args={}, json=None):

--- a/webapp/marketo.py
+++ b/webapp/marketo.py
@@ -65,3 +65,6 @@ class MarketoAPI:
             "input": leads,
         }
         return self.request("POST", "/rest/v1/leads.json", json=data)
+
+    def get_form_fields(self, id):
+        return self.request("GET", f"/rest/asset/v1/form/{id}/fields.json")


### PR DESCRIPTION
## Done

- This test only checks for forms generated using the form generator `form-data.json`
- Check that fields from the forms are expected in Marketo
- Check that Marketo required fields are included in form fields
- Fly-by work:
  - Fix typo for `Abour your project`
  - Remove `noCommentsFromLead: true` from fields that should be concatenated to the `Comments_from_lead__c`
    - A good way to check this is to submit the form on prod, see that the field is was previously nowhere to be found in the payload
    - Remove unused functions in `marketo.py`

## QA

- See that [`test-python`](https://github.com/canonical/ubuntu.com/actions/runs/17125647235/job/48576573412?pr=15507) action passes

## Issue / Card

Fixes [WD-23892](https://warthogs.atlassian.net/browse/WD-23892)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-23892]: https://warthogs.atlassian.net/browse/WD-23892?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ