### PR TITLE
refactor: move /azure forms to form gen

### DIFF
--- a/templates/advantage/subscribe/form-data.json
+++ b/templates/advantage/subscribe/form-data.json
@@ -16,12 +16,11 @@
         {
           "title": "Tell us about your project",
           "id": "about-your-project",
-          "noCommentsFromLead": true,
           "fields": [
             {
               "type": "long-text",
               "id": "about-your-project",
-              "label": "Abour your project"
+              "label": "About your project"
             }
           ]
         },
@@ -115,13 +114,12 @@
         {
           "title": "*What is the name of your cloud provider?",
           "id": "cloud-provider",
-          "noCommentsFromLead": true,
+          "isRequired": true,
           "fields": [
             {
               "type": "long-text",
               "id": "cloud-provider-name",
-              "label": "Cloud provider name",
-              "isRequired": true
+              "label": "Cloud provider name"
             }
           ]
         },
@@ -302,7 +300,6 @@
         {
           "title": "What advice are you looking for?",
           "id": "advice",
-          "noCommentsFromLead": true,
           "fields": [
             {
               "type": "long-text",

--- a/templates/aws/form-data.json
+++ b/templates/aws/form-data.json
@@ -21,7 +21,7 @@
             {
               "type": "long-text",
               "id": "about-your-project",
-              "label": "Abour your project"
+              "label": "About your project"
             }
           ]
         },

--- a/templates/aws/form-data.json
+++ b/templates/aws/form-data.json
@@ -17,7 +17,6 @@
         {
           "title": "Tell us about your project",
           "id": "about-your-project",
-          "noCommentsFromLead": true,
           "fields": [
             {
               "type": "long-text",
@@ -310,7 +309,6 @@
         {
           "title": "What advice are you looking for?",
           "id": "advice",
-          "noCommentsFromLead": true,
           "fields": [
             {
               "type": "long-text",

--- a/templates/azure/base_azure.html
+++ b/templates/azure/base_azure.html
@@ -2,8 +2,4 @@
 
 {% block outer_content %}
   {% block content %}{% endblock %}
-
-  <!-- Set default Marketo information for contact form below-->
-  <div class="u-hide" id="contact-form-container" data-form-location="/shared/forms/interactive/confidential-computing" data-form-id="5352" data-lp-id="" data-return-url="https://ubuntu.com/azure/thank-you" data-lp-url="https://ubuntu.com/azure/contact-us">
-  </div>
 {% endblock %}

--- a/templates/azure/confidential-computing.html
+++ b/templates/azure/confidential-computing.html
@@ -185,4 +185,6 @@
       </h2>
     </div>
   </section>
+
+  {{ load_form("/azure") | safe }}
 {% endblock content %}

--- a/templates/azure/form-data.json
+++ b/templates/azure/form-data.json
@@ -1,0 +1,38 @@
+{
+    "form": {
+      "/azure": {
+        "templatePath": "/azure/index.html",
+        "childrenPaths": [
+          "/azure/confidential-computing",
+          "/azure/pro",
+          "/azure/sql",
+          "/azure/support"
+        ],
+        "isModal": true,
+        "modalId": "azure-modal",
+        "formData": {
+          "title": "Contact us",
+          "introText": "Discuss your confidential computing use case with our experts",
+          "formId": 5352,
+          "returnUrl": "/azure/thank-you#contact-form-success",
+          "lpUrl": "https://ubuntu.com/azure/contact-us",
+          "product": ""
+        },
+        "fieldsets": [
+          {
+            "title": "How should we get in touch?",
+            "id": "about-you",
+            "noCommentsFromLead": true,
+            "fields": [
+              {
+                "type": "tel",
+                "id": "phone",
+                "label": "Phone number",
+                "isRequired": true
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }

--- a/templates/azure/index.html
+++ b/templates/azure/index.html
@@ -300,6 +300,8 @@
     </div>
   </template>
 
+  {{ load_form("/azure") | safe }}
+
   <script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
   <script>
     canonicalLatestNews.fetchLatestNews({

--- a/templates/azure/private-offer.html
+++ b/templates/azure/private-offer.html
@@ -121,4 +121,6 @@
       </p>
     </div>
   </div>
+
+  {{ load_form("/azure") | safe }}
 {% endblock %}

--- a/templates/azure/pro.html
+++ b/templates/azure/pro.html
@@ -78,7 +78,7 @@
            href="https://portal.azure.com/#create/canonical.ubuntu-24_04-ltsubuntu-pro">Launch Ubuntu Pro 24.04 LTS</a>
         <hr class="p-rule--muted" />
         <p>
-          <a href="/azure/get-in-touch" class="js-invoke-modal">Contact us to discuss Ubuntu Pro with support&nbsp;&rsaquo;</a>
+          <a href="/azure/contact-us" class="js-invoke-modal">Contact us to discuss Ubuntu Pro with support&nbsp;&rsaquo;</a>
         </p>
       </div>
     </div>
@@ -315,5 +315,7 @@
   {% endwith %}
 
   <script src="{{ versioned_static('js/dist/utmInheritance.js') }}"></script>
+
+  {{ load_form("/azure") | safe }}
 
 {% endblock content %}

--- a/templates/azure/sql.html
+++ b/templates/azure/sql.html
@@ -31,7 +31,7 @@
         <hr class="is-muted" />
         <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/microsoftsqlserver.sql2019-ubuntupro2004?tab=Overview"
            class="p-button--positive">Launch now</a>
-        <a href="/azure#get-in-touch">Contact us to learn more&nbsp;&rsaquo;</a>
+        <a class="js-invoke-modal" href="/azure/contact-us">Contact us to learn more&nbsp;&rsaquo;</a>
       </div>
       <div class="col-6">
         <div class="p-image-container--3-2 u-hide--small u-hide--medium">
@@ -245,4 +245,6 @@
       </div>
     </div>
   </section>
+
+  {{ load_form("/azure") | safe }}
 {% endblock content %}

--- a/templates/azure/support.html
+++ b/templates/azure/support.html
@@ -161,4 +161,6 @@
       </div>
     </section>
 
+    {{ load_form("/azure") | safe }}
+
   {% endblock content %}

--- a/templates/contact-us/form-data.json
+++ b/templates/contact-us/form-data.json
@@ -18,7 +18,6 @@
         {
           "title": "Tell us about your project",
           "id": "about-your-project",
-          "noCommentsFromLead": true,
           "fields": [
             {
               "type": "long-text",
@@ -311,7 +310,6 @@
         {
           "title": "What advice are you looking for?",
           "id": "advice",
-          "noCommentsFromLead": true,
           "fields": [
             {
               "type": "long-text",

--- a/templates/containers/form-data.json
+++ b/templates/containers/form-data.json
@@ -48,21 +48,6 @@
           "noCommentsFromLead": true,
           "fields": [
             {
-              "type": "text",
-              "id": "company",
-              "label": "Company name"
-            },
-            {
-              "type": "text",
-              "id": "title",
-              "label": "Job title"
-            },
-            {
-              "type": "country",
-              "label": "Country",
-              "isRequired": true
-            },
-            {
               "type": "tel",
               "id": "phone",
               "label": "Mobile/cell phone number",

--- a/templates/internet-of-things/form-data.json
+++ b/templates/internet-of-things/form-data.json
@@ -28,7 +28,7 @@
             {
               "type": "long-text",
               "id": "about-project",
-              "label": "Abour your project"
+              "label": "About your project"
             }
           ]
         },

--- a/templates/security/form-data.json
+++ b/templates/security/form-data.json
@@ -19,7 +19,6 @@
           {
             "title": "Tell us about your project",
             "id": "about-your-project",
-            "noCommentsFromLead": true,
             "fields": [
               {
                 "type": "long-text",
@@ -312,7 +311,6 @@
           {
             "title": "What advice are you looking for?",
             "id": "advice",
-            "noCommentsFromLead": true,
             "fields": [
               {
                 "type": "long-text",

--- a/templates/shared/forms/form-fields.html
+++ b/templates/shared/forms/form-fields.html
@@ -37,7 +37,7 @@
                           name="firstName"
                           maxlength="255"
                           autocomplete="given-name"
-                          type="text" />                              
+                          type="text" />
                   <label class="is-required"
                           for="lastName">Last name:</label>
                   <input required

--- a/templates/toolchains/form-data.json
+++ b/templates/toolchains/form-data.json
@@ -90,12 +90,11 @@
         {
           "title": "Tell us about your project",
           "id": "about-your-project",
-          "noCommentsFromLead": true,
           "fields": [
             {
               "type": "long-text",
               "id": "about-your-project",
-              "label": "Abour your project"
+              "label": "About your project"
             }
           ]
         },

--- a/tests/test_marketo.py
+++ b/tests/test_marketo.py
@@ -19,12 +19,12 @@ SET_FIELDS = set(
         "title",
         "country",
         "phone",
-        "comments_from_lead__c"
+        "comments_from_lead__c",
     }
 )
-# All form-data.json forms exluding test files
 form_files = [
-    f for f in Path("templates").rglob("form-data.json")
+    f
+    for f in Path("templates").rglob("form-data.json")
     if "templates/tests" not in str(f)
 ]
 
@@ -59,9 +59,9 @@ class TestMarketo(unittest.TestCase):
     def _check_form_with_marketo(self, form_path):
         # Function to check form fields and Marketo fields against one another
         def _check_form_fields(field_id, check_form):
-            assert field_id is not None, (
-                f"Field ID is none for {check_form} fields"
-            )
+            assert (
+                field_id is not None
+            ), f"Field ID is none for {check_form} fields"
 
             field_id = field_id.lower()
             if check_form == "marketo":
@@ -85,9 +85,9 @@ class TestMarketo(unittest.TestCase):
 
         with open(form_path, "r") as f:
             forms = json.load(f).get("form", {})
-            assert forms is not None, (
-                f"Form data could not be loaded from {form_path}"
-            )
+            assert (
+                forms is not None
+            ), f"Form data could not be loaded from {form_path}"
 
         # form-data.json may have multiple forms
         for form_data in forms.values():
@@ -125,6 +125,9 @@ class TestMarketo(unittest.TestCase):
                 required = marketo_field.get("required")
                 if required:
                     _check_form_fields(id, "form-data")
+
+    def test_submit_form(self):
+        return
 
 
 if __name__ == "__main__":

--- a/tests/test_marketo.py
+++ b/tests/test_marketo.py
@@ -1,0 +1,131 @@
+import unittest
+import talisker.requests
+import json
+from requests import Session
+from pathlib import Path
+
+from canonicalwebteam.flask_base.env import get_flask_env
+
+from webapp.app import app
+from webapp.marketo import MarketoAPI
+
+# Fields that are already hardcoded into form-fields.html
+SET_FIELDS = set(
+    {
+        "firstname",
+        "lastname",
+        "email",
+        "company",
+        "title",
+        "country",
+        "phone",
+        "comments_from_lead__c"
+    }
+)
+# All form-data.json forms exluding test files
+form_files = [
+    f for f in Path("templates").rglob("form-data.json")
+    if "templates/tests" not in str(f)
+]
+
+
+class TestMarketo(unittest.TestCase):
+    def setUp(self):
+        """
+        Set up Flask app for testing
+        """
+
+        app.testing = True
+        self.client = app.test_client()
+
+        marketo_session = Session()
+        talisker.requests.configure(marketo_session)
+        self.marketo_api = MarketoAPI(
+            "https://066-EOV-335.mktorest.com",
+            get_flask_env("MARKETO_API_CLIENT"),
+            get_flask_env("MARKETO_API_SECRET"),
+            marketo_session,
+        )
+        self.marketo_api._authenticate()
+        return super().setUp()
+
+    def test_marketo_api(self):
+        assert self.marketo_api.token is not None
+
+    def test_forms_with_marketo(self):
+        for form in form_files:
+            self._check_form_with_marketo(form)
+
+    def _check_form_with_marketo(self, form_path):
+        # Function to check form fields and Marketo fields against one another
+        def _check_form_fields(field_id, check_form):
+            assert field_id is not None, (
+                f"Field ID is none for {check_form} fields"
+            )
+
+            field_id = field_id.lower()
+            if check_form == "marketo":
+                assert field_id in [
+                    f.get("id").lower() for f in marketo_fields
+                ], (
+                    f"Field {field_id} is not present in "
+                    f"{check_form} fields"
+                    f" for form {form_path}"
+                )
+
+            elif check_form == "form-data":
+                if field_id not in SET_FIELDS:
+                    assert field_id in [
+                        f.get("id").lower() for f in form_fields
+                    ], (
+                        f"Field {field_id} is not present in "
+                        f"{check_form} fields"
+                        f" for form {form_path}"
+                    )
+
+        with open(form_path, "r") as f:
+            forms = json.load(f).get("form", {})
+            assert forms is not None, (
+                f"Form data could not be loaded from {form_path}"
+            )
+
+        # form-data.json may have multiple forms
+        for form_data in forms.values():
+            form_id = form_data.get("formData").get("formId")
+
+            # Check that marketo form exists
+            marketo_response = self.marketo_api.get_form_fields(form_id)
+            assert marketo_response.status_code == 200
+            assert (
+                marketo_response is not None
+            ), "Marketo fields should not be None"
+            marketo_fields = marketo_response.json().get("result", [])
+
+            # Check that form fields match Marketo fields
+            form_fields = form_data.get("fieldsets", [])
+            for field in form_fields:
+                field_id = field.get("id")
+
+                # Check that individual fields are all expected
+                # in the Marketo fields
+                if field.get("noCommentsFromLead"):
+                    if field_id != "about-you":
+                        _check_form_fields(field_id, "marketo")
+                    else:
+                        # Check enrichment fields separately
+                        contact_fields = field.get("fields", [])
+                        for contact_field in contact_fields:
+                            _check_form_fields(
+                                contact_field.get("id"), "marketo"
+                            )
+
+            # Check that Marketo required fields are included in form
+            for marketo_field in marketo_fields:
+                id = marketo_field.get("id")
+                required = marketo_field.get("required")
+                if required:
+                    _check_form_fields(id, "form-data")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sitemap.py
+++ b/tests/test_sitemap.py
@@ -1,9 +1,8 @@
-# Packages
 import unittest
-from unittest.mock import patch
-import logging
 import re
 import os
+import logging
+from unittest.mock import patch
 import xml.etree.ElementTree as ET
 from webapp.app import app
 from webapp.views import build_sitemap_tree

--- a/webapp/marketo.py
+++ b/webapp/marketo.py
@@ -52,12 +52,6 @@ class MarketoAPI:
             "POST", "/rest/v1/leads/submitForm.json", json=data
         )
 
-    def describe_leads(self):
-        return self.request("GET", "/rest/v1/leads/describe.json")
-
-    def get_lead(self, id_):
-        return self.request("GET", f"/rest/v1/leads/{id_}.json")
-
     def update_leads(self, leads=None):
         data = {
             "action": "createOrUpdate",

--- a/webapp/marketo.py
+++ b/webapp/marketo.py
@@ -65,3 +65,6 @@ class MarketoAPI:
             "input": leads,
         }
         return self.request("POST", "/rest/v1/leads.json", json=data)
+
+    def get_form_fields(self, id):
+        return self.request("GET", f"/rest/asset/v1/form/{id}/fields.json")


### PR DESCRIPTION
## Done

- Move `/azure` modal forms to form generator
- Update CTA href to `/azure/contact-us` and add appropriate JS hooks to trigger modal popup
- Move `/azure/contact-us` static form to form generator

## QA

- Go to /azure
- Click on CTA, see that modal pops up
- Submit and check that it goes through Marketo
- Repeat for all affected /azure files and /azure/contact-us static form

## Issue / Card

Fixes [WD-25988](https://warthogs.atlassian.net/browse/WD-25988)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-25988]: https://warthogs.atlassian.net/browse/WD-25988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ