### PR TITLE
[WD-21294] Pro shop - add referral links for sales

### DIFF
--- a/static/js/src/advantage/subscribe/checkout/app.tsx
+++ b/static/js/src/advantage/subscribe/checkout/app.tsx
@@ -50,6 +50,7 @@ declare global {
 
 const checkoutData = localStorage.getItem("shop-checkout-data") || "";
 const parsedCheckoutData = JSON.parse(checkoutData);
+console.log(parsedCheckoutData);
 const stripePromise = loadStripe(window.stripePublishableKey || "");
 const parsedCheckoutProducts: CheckoutProducts[] = parsedCheckoutData?.products;
 
@@ -63,6 +64,7 @@ const products = parsedCheckoutProducts.map((product) => {
 const action: Action = parsedCheckoutData?.action;
 const coupon: Coupon = parsedCheckoutData?.coupon || undefined;
 const marketplace = products[0].product.marketplace;
+const referral_id = parsedCheckoutData?.metadata?.find((item) => item.key === "referralID")?.value;
 
 window.marketplace = marketplace;
 window.canTrial = undefined;
@@ -95,7 +97,7 @@ const App = () => {
     <Sentry.ErrorBoundary>
       <QueryClientProvider client={queryClient}>
         <Elements stripe={stripePromise}>
-          <Checkout products={products} action={action} coupon={coupon} />
+          <Checkout products={products} action={action} coupon={coupon} referral_id={referral_id} />
         </Elements>
         <ReactQueryDevtools initialIsOpen={false} />
       </QueryClientProvider>

--- a/static/js/src/advantage/subscribe/checkout/app.tsx
+++ b/static/js/src/advantage/subscribe/checkout/app.tsx
@@ -96,7 +96,12 @@ const App = () => {
     <Sentry.ErrorBoundary>
       <QueryClientProvider client={queryClient}>
         <Elements stripe={stripePromise}>
-          <Checkout products={products} action={action} coupon={coupon} referral_id={referral_id} />
+          <Checkout
+            products={products}
+            action={action}
+            coupon={coupon}
+            referral_id={referral_id}
+          />
         </Elements>
         <ReactQueryDevtools initialIsOpen={false} />
       </QueryClientProvider>

--- a/static/js/src/advantage/subscribe/checkout/app.tsx
+++ b/static/js/src/advantage/subscribe/checkout/app.tsx
@@ -50,7 +50,6 @@ declare global {
 
 const checkoutData = localStorage.getItem("shop-checkout-data") || "";
 const parsedCheckoutData = JSON.parse(checkoutData);
-console.log(parsedCheckoutData);
 const stripePromise = loadStripe(window.stripePublishableKey || "");
 const parsedCheckoutProducts: CheckoutProducts[] = parsedCheckoutData?.products;
 
@@ -64,7 +63,7 @@ const products = parsedCheckoutProducts.map((product) => {
 const action: Action = parsedCheckoutData?.action;
 const coupon: Coupon = parsedCheckoutData?.coupon || undefined;
 const marketplace = products[0].product.marketplace;
-const referral_id = parsedCheckoutData?.metadata?.find((item) => item.key === "referralID")?.value;
+const referral_id = localStorage.getItem("referral_id") || undefined;
 
 window.marketplace = marketplace;
 window.canTrial = undefined;

--- a/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/BuyButton/BuyButton.tsx
@@ -29,6 +29,7 @@ type Props = {
   products: CheckoutProducts[];
   action: Action;
   coupon?: Coupon;
+  referral_id: string | undefined;
   errorType: string;
   isDisabled: boolean;
 };
@@ -38,6 +39,7 @@ const BuyButton = ({
   products,
   action,
   coupon,
+  referral_id,
   errorType,
   isDisabled,
 }: Props) => {
@@ -160,6 +162,7 @@ const BuyButton = ({
         action: buyAction,
         coupon,
         poNumber,
+        referral_id,
       },
       {
         onSuccess: (purchaseId: string) => {

--- a/static/js/src/advantage/subscribe/checkout/components/Checkout/Checkout.tsx
+++ b/static/js/src/advantage/subscribe/checkout/components/Checkout/Checkout.tsx
@@ -31,9 +31,10 @@ type Props = {
   products: CheckoutProducts[];
   action: Action;
   coupon: Coupon;
+  referral_id: string | undefined;
 };
 
-const Checkout = ({ products, action, coupon }: Props) => {
+const Checkout = ({ products, action, coupon, referral_id }: Props) => {
   const [error, setError] = useState<DisplayError | null>(null);
   const [errorType, setErrorType] = useState<string>("");
   const [isTotalLoading, setIsTotalLoading] = useState<boolean>(true);
@@ -182,6 +183,7 @@ const Checkout = ({ products, action, coupon }: Props) => {
                                   action={action}
                                   setError={setError}
                                   coupon={coupon}
+                                  referral_id={referral_id}
                                   errorType={errorType}
                                   isDisabled={
                                     !(

--- a/static/js/src/advantage/subscribe/checkout/hooks/postPurchase.tsx
+++ b/static/js/src/advantage/subscribe/checkout/hooks/postPurchase.tsx
@@ -37,13 +37,11 @@ const postPurchase = () => {
 
       if (marketplace !== UserSubscriptionMarketplace.CanonicalProChannel) {
         const product = products[0].product;
-        const metadata = localStorage.getItem("metadata") || "";
         payload = {
           account_id: window.accountId,
           marketplace: marketplace,
           action: action,
           coupon: coupon,
-          metadata: JSON.parse(metadata),
         };
 
         if (window.previousPurchaseIds !== undefined && product.period) {

--- a/static/js/src/advantage/subscribe/checkout/hooks/postPurchase.tsx
+++ b/static/js/src/advantage/subscribe/checkout/hooks/postPurchase.tsx
@@ -37,12 +37,13 @@ const postPurchase = () => {
 
       if (marketplace !== UserSubscriptionMarketplace.CanonicalProChannel) {
         const product = products[0].product;
-
+        const metadata = localStorage.getItem("metadata") || "";
         payload = {
           account_id: window.accountId,
           marketplace: marketplace,
           action: action,
           coupon: coupon,
+          metadata: JSON.parse(metadata),
         };
 
         if (window.previousPurchaseIds !== undefined && product.period) {

--- a/static/js/src/advantage/subscribe/checkout/hooks/postPurchase.tsx
+++ b/static/js/src/advantage/subscribe/checkout/hooks/postPurchase.tsx
@@ -19,7 +19,13 @@ type Props = {
 
 const postPurchase = () => {
   const mutation = useMutation<any, Error, Props>({
-    mutationFn: async ({ products, action, coupon, referral_id, poNumber }: Props) => {
+    mutationFn: async ({
+      products,
+      action,
+      coupon,
+      referral_id,
+      poNumber,
+    }: Props) => {
       if (window.currentPaymentId) {
         await retryPurchase(window.currentPaymentId);
 

--- a/static/js/src/advantage/subscribe/checkout/hooks/postPurchase.tsx
+++ b/static/js/src/advantage/subscribe/checkout/hooks/postPurchase.tsx
@@ -14,11 +14,12 @@ type Props = {
   action: Action;
   coupon?: Coupon;
   poNumber?: string | null;
+  referral_id?: string;
 };
 
 const postPurchase = () => {
   const mutation = useMutation<any, Error, Props>({
-    mutationFn: async ({ products, action, coupon, poNumber }: Props) => {
+    mutationFn: async ({ products, action, coupon, referral_id, poNumber }: Props) => {
       if (window.currentPaymentId) {
         await retryPurchase(window.currentPaymentId);
 
@@ -43,6 +44,12 @@ const postPurchase = () => {
           action: action,
           coupon: coupon,
         };
+        if (referral_id) {
+          payload.metadata = [{
+            "key": "referralID",
+            "value": referral_id
+          }];
+        }
 
         if (window.previousPurchaseIds !== undefined && product.period) {
           payload.previous_purchase_id =

--- a/static/js/src/advantage/subscribe/checkout/hooks/postPurchase.tsx
+++ b/static/js/src/advantage/subscribe/checkout/hooks/postPurchase.tsx
@@ -43,13 +43,8 @@ const postPurchase = () => {
           marketplace: marketplace,
           action: action,
           coupon: coupon,
+          referral_id: referral_id,
         };
-        if (referral_id) {
-          payload.metadata = [{
-            "key": "referralID",
-            "value": referral_id
-          }];
-        }
 
         if (window.previousPurchaseIds !== undefined && product.period) {
           payload.previous_purchase_id =

--- a/static/js/src/advantage/subscribe/checkout/hooks/usePreview.tsx
+++ b/static/js/src/advantage/subscribe/checkout/hooks/usePreview.tsx
@@ -32,7 +32,6 @@ const usePreview = ({ products, action, coupon }: Props) => {
 
       if (marketplace !== UserSubscriptionMarketplace.CanonicalProChannel) {
         const product = products[0].product;
-
         payload = {
           account_id: window.accountId,
           marketplace: marketplace,

--- a/static/js/src/advantage/subscribe/checkout/utils/types.ts
+++ b/static/js/src/advantage/subscribe/checkout/utils/types.ts
@@ -120,6 +120,7 @@ export type PaymentPayload = {
   offer_id?: string;
   coupon?: Coupon;
   metadata?: Array<{ key: string; value: string }>;
+  referral_id?: string;
 };
 
 export type TaxInfo = {

--- a/static/js/src/advantage/subscribe/react/components/PaymentButton/PaymentButton.tsx
+++ b/static/js/src/advantage/subscribe/react/components/PaymentButton/PaymentButton.tsx
@@ -5,7 +5,8 @@ import { ProductUsers } from "../../utils/utils";
 
 export default function PaymentButton() {
   const { quantity, product, productUser } = useContext(FormContext);
-
+  let params = new URLSearchParams(document.location.search);
+  let referral_id =  params.get("referral_id") || "";
   const shopCheckoutData = {
     products: [
       {
@@ -13,6 +14,7 @@ export default function PaymentButton() {
         quantity: Number(quantity) ?? 0,
       },
     ],
+    metadata: [{"key": "referralID", "value": referral_id}],
     action: "purchase",
   };
 

--- a/static/js/src/advantage/subscribe/react/components/PaymentButton/PaymentButton.tsx
+++ b/static/js/src/advantage/subscribe/react/components/PaymentButton/PaymentButton.tsx
@@ -14,8 +14,8 @@ export default function PaymentButton() {
         quantity: Number(quantity) ?? 0,
       },
     ],
-    metadata: [{"key": "referralID", "value": referral_id}],
     action: "purchase",
+    metadata: [{"key": "referralID", "value": referral_id}],
   };
 
   return (

--- a/static/js/src/advantage/subscribe/react/components/PaymentButton/PaymentButton.tsx
+++ b/static/js/src/advantage/subscribe/react/components/PaymentButton/PaymentButton.tsx
@@ -15,7 +15,6 @@ export default function PaymentButton() {
       },
     ],
     action: "purchase",
-    metadata: [{"key": "referralID", "value": referral_id}],
   };
 
   return (
@@ -39,6 +38,7 @@ export default function PaymentButton() {
               "shop-checkout-data",
               JSON.stringify(shopCheckoutData),
             );
+            localStorage.setItem("referral_id", referral_id);
             location.href = "/account/checkout";
           }}
         >

--- a/static/js/src/advantage/subscribe/react/components/PaymentButton/PaymentButton.tsx
+++ b/static/js/src/advantage/subscribe/react/components/PaymentButton/PaymentButton.tsx
@@ -6,7 +6,7 @@ import { ProductUsers } from "../../utils/utils";
 export default function PaymentButton() {
   const { quantity, product, productUser } = useContext(FormContext);
   let params = new URLSearchParams(document.location.search);
-  let referral_id =  params.get("referral_id") || "";
+  let referral_id = params.get("referral_id") || "";
   const shopCheckoutData = {
     products: [
       {

--- a/webapp/shop/advantage/views.py
+++ b/webapp/shop/advantage/views.py
@@ -3,6 +3,7 @@ import json
 from typing import List
 
 import flask
+from webargs.fields import String
 
 from webapp.login import user_info
 from webapp.shop.api.ua_contracts.advantage_mapper import AdvantageMapper

--- a/webapp/shop/advantage/views.py
+++ b/webapp/shop/advantage/views.py
@@ -3,7 +3,6 @@ import json
 from typing import List
 
 import flask
-from webargs.fields import String
 
 from webapp.login import user_info
 from webapp.shop.api.ua_contracts.advantage_mapper import AdvantageMapper
@@ -274,7 +273,6 @@ def post_advantage_purchase(advantage_mapper: AdvantageMapper, **kwargs):
     action = kwargs.get("action", "purchase")
     coupon = kwargs.get("coupon")
     referral_id = kwargs.get("referral_id")
-    print(referral_id)
 
     subscribed_quantities = {}
     if action == "purchase":
@@ -341,10 +339,7 @@ def post_advantage_purchase(advantage_mapper: AdvantageMapper, **kwargs):
         if flask.session.get(metadata_key)
     ]
     if referral_id:
-        metadata.append({
-            "key": "referralID",
-            "value": referral_id
-        })
+        metadata.append({"key": "referralID", "value": referral_id})
 
     if marketplace == "canonical-pro-channel":
         channel_metadata = kwargs.get("metadata")

--- a/webapp/shop/advantage/views.py
+++ b/webapp/shop/advantage/views.py
@@ -273,6 +273,8 @@ def post_advantage_purchase(advantage_mapper: AdvantageMapper, **kwargs):
     marketplace = kwargs.get("marketplace")
     action = kwargs.get("action", "purchase")
     coupon = kwargs.get("coupon")
+    referral_id = kwargs.get("referral_id")
+    print(referral_id)
 
     subscribed_quantities = {}
     if action == "purchase":
@@ -338,6 +340,11 @@ def post_advantage_purchase(advantage_mapper: AdvantageMapper, **kwargs):
         for metadata_key in metadata_keys
         if flask.session.get(metadata_key)
     ]
+    if referral_id:
+        metadata.append({
+            "key": "referralID",
+            "value": referral_id
+        })
 
     if marketplace == "canonical-pro-channel":
         channel_metadata = kwargs.get("metadata")

--- a/webapp/shop/api/ua_contracts/advantage_mapper.py
+++ b/webapp/shop/api/ua_contracts/advantage_mapper.py
@@ -183,7 +183,6 @@ class AdvantageMapper:
     def purchase_from_marketplace(
         self, marketplace: str, purchase_request: dict, preview=True
     ) -> Union[Invoice, Purchase]:
-        print(purchase_request)
         if preview:
             invoice = self.ua_contracts_api.preview_purchase_from_marketplace(
                 marketplace=marketplace, purchase_request=purchase_request

--- a/webapp/shop/api/ua_contracts/advantage_mapper.py
+++ b/webapp/shop/api/ua_contracts/advantage_mapper.py
@@ -183,6 +183,7 @@ class AdvantageMapper:
     def purchase_from_marketplace(
         self, marketplace: str, purchase_request: dict, preview=True
     ) -> Union[Invoice, Purchase]:
+        print(purchase_request)
         if preview:
             invoice = self.ua_contracts_api.preview_purchase_from_marketplace(
                 marketplace=marketplace, purchase_request=purchase_request

--- a/webapp/shop/schemas.py
+++ b/webapp/shop/schemas.py
@@ -88,6 +88,7 @@ account_purhcase = {
     ),
     "coupon": Nested(CouponSchema),
     "metadata": List(Nested(Metadata), allow_none=True),
+    "referral_id": String(allow_none=True),
 }
 
 


### PR DESCRIPTION
## Done

- Add referral links for Pro shop

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Visit /pro/subscribe?referral_id=1234
    - Click on buy button 
    - Check the localStorage which should have the referral_id stored in the product metadata
- In the checkout proceed to pay
    - Check the purchase request
    - Should have referral Id in the request body  
- To verify that the purchase has the metadata stored correctly. visit 
https://contracts.staging.canonical.com/v1/purchases/{{purchaseID}}/details and search for `1234`. PurchaseID can be seen from the backoffice or the /account/invoices page


## Issue / Card

Fixes [#WD-21294](https://warthogs.atlassian.net/browse/WD-21294)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
