### PR TITLE
feat: Add missing /legal redirect

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -759,6 +759,7 @@ legal/terms-and-policies/font-licence/ofl-1.1-ufl-1.0.diff/?: "https://canonical
 legal/terms-and-policies/font-licence/faq/?: "https://canonical.com/legal/font-licence/faq"
 legal/terms-and-policies/privacy-policy/?: "https://canonical.com/legal/data-privacy"
 legal/(?P<path>.*)/?: "https://canonical.com/legal/{path}"
+legal/?: "https://canonical.com/legal"
 licensing/?: "https://canonical.com/legal/intellectual-property-policy"
 livepatch/?: "/security/livepatch"
 lotus/?: "/ibm"


### PR DESCRIPTION
## Done

- Redirect /legal to canonical.com/legal

## QA

- Open https://ubuntu-com-15515.demos.haus/legal
- See you are redirect to https://canonical.com/legal

## Issue / Card

https://warthogs.atlassian.net/browse/WD-26006
