### PR TITLE
[WD-25049] change logo on engage pages thank you page

### DIFF
--- a/templates/engage/shared/_de_thank-you.html
+++ b/templates/engage/shared/_de_thank-you.html
@@ -8,9 +8,9 @@
   <section class="p-section p-engage-banner--grad">
     <div class="grid-row">
       <a href="/">
-        {{ image(url="https://assets.ubuntu.com/v1/3cf74f71-Canonical%20Dark.svg",
-                alt="Ubuntu",
-                width="140",
+        {{ image(url="https://assets.ubuntu.com/v1/b4f695ea-Canonical%20Ubuntu%20copy%202.svg",
+                alt="Canonical Ubuntu",
+                width="220",
                 height="40",
                 hi_def=True,
                 loading="auto",) | safe

--- a/templates/engage/shared/_es_thank-you.html
+++ b/templates/engage/shared/_es_thank-you.html
@@ -8,9 +8,9 @@
   <section class="p-section p-engage-banner--grad">
     <div class="grid-row">
       <a href="/">
-        {{ image(url="https://assets.ubuntu.com/v1/3cf74f71-Canonical%20Dark.svg",
-                alt="Ubuntu",
-                width="140",
+        {{ image(url="https://assets.ubuntu.com/v1/b4f695ea-Canonical%20Ubuntu%20copy%202.svg",
+                alt="Canonical Ubuntu",
+                width="220",
                 height="40",
                 hi_def=True,
                 loading="auto",) | safe

--- a/templates/engage/shared/_fr_thank-you.html
+++ b/templates/engage/shared/_fr_thank-you.html
@@ -8,9 +8,9 @@
   <section class="p-section p-engage-banner--grad">
     <div class="grid-row">
       <a href="/">
-        {{ image(url="https://assets.ubuntu.com/v1/3cf74f71-Canonical%20Dark.svg",
-                alt="Ubuntu",
-                width="140",
+        {{ image(url="https://assets.ubuntu.com/v1/b4f695ea-Canonical%20Ubuntu%20copy%202.svg",
+                alt="Canonical Ubuntu",
+                width="220",
                 height="40",
                 hi_def=True,
                 loading="auto",) | safe

--- a/templates/engage/shared/_it_thank-you.html
+++ b/templates/engage/shared/_it_thank-you.html
@@ -8,9 +8,9 @@
   <section class="p-section p-engage-banner--grad">
     <div class="grid-row">
       <a href="/">
-        {{ image(url="https://assets.ubuntu.com/v1/3cf74f71-Canonical%20Dark.svg",
-                alt="Ubuntu",
-                width="140",
+        {{ image(url="https://assets.ubuntu.com/v1/b4f695ea-Canonical%20Ubuntu%20copy%202.svg",
+                alt="Canonical Ubuntu",
+                width="220",
                 height="40",
                 hi_def=True,
                 loading="auto",) | safe

--- a/templates/engage/shared/_kr_thank-you.html
+++ b/templates/engage/shared/_kr_thank-you.html
@@ -13,9 +13,9 @@
   <section class="p-section p-engage-banner--grad">
     <div class="grid-row">
       <a href="/">
-        {{ image(url="https://assets.ubuntu.com/v1/3cf74f71-Canonical%20Dark.svg",
-                alt="Ubuntu",
-                width="140",
+        {{ image(url="https://assets.ubuntu.com/v1/b4f695ea-Canonical%20Ubuntu%20copy%202.svg",
+                alt="Canonical Ubuntu",
+                width="220",
                 height="40",
                 hi_def=True,
                 loading="auto",) | safe

--- a/templates/engage/shared/_pt_thank-you.html
+++ b/templates/engage/shared/_pt_thank-you.html
@@ -8,9 +8,9 @@
   <section class="p-section p-engage-banner--grad">
     <div class="grid-row">
       <a href="/">
-        {{ image(url="https://assets.ubuntu.com/v1/3cf74f71-Canonical%20Dark.svg",
-                alt="Ubuntu",
-                width="140",
+        {{ image(url="https://assets.ubuntu.com/v1/b4f695ea-Canonical%20Ubuntu%20copy%202.svg",
+                alt="Canonical Ubuntu",
+                width="220",
                 height="40",
                 hi_def=True,
                 loading="auto",) | safe

--- a/templates/engage/shared/_ru_thank-you.html
+++ b/templates/engage/shared/_ru_thank-you.html
@@ -8,9 +8,9 @@
   <section class="p-section p-engage-banner--grad">
     <div class="grid-row">
       <a href="/">
-        {{ image(url="https://assets.ubuntu.com/v1/3cf74f71-Canonical%20Dark.svg",
-                alt="Ubuntu",
-                width="140",
+        {{ image(url="https://assets.ubuntu.com/v1/b4f695ea-Canonical%20Ubuntu%20copy%202.svg",
+                alt="Canonical Ubuntu",
+                width="220",
                 height="40",
                 hi_def=True,
                 loading="auto",) | safe

--- a/templates/engage/shared/_tr_thank-you.html
+++ b/templates/engage/shared/_tr_thank-you.html
@@ -8,9 +8,9 @@
   <section class="p-section p-engage-banner--grad">
     <div class="grid-row">
       <a href="/">
-        {{ image(url="https://assets.ubuntu.com/v1/3cf74f71-Canonical%20Dark.svg",
-                alt="Ubuntu",
-                width="140",
+        {{ image(url="https://assets.ubuntu.com/v1/b4f695ea-Canonical%20Ubuntu%20copy%202.svg",
+                alt="Canonical Ubuntu",
+                width="220",
                 height="40",
                 hi_def=True,
                 loading="auto",) | safe

--- a/templates/engage/shared/_zh-TW_thank-you.html
+++ b/templates/engage/shared/_zh-TW_thank-you.html
@@ -13,9 +13,9 @@
   <section class="p-section p-engage-banner--grad">
     <div class="grid-row">
       <a href="/">
-        {{ image(url="https://assets.ubuntu.com/v1/3cf74f71-Canonical%20Dark.svg",
-                alt="Ubuntu",
-                width="140",
+        {{ image(url="https://assets.ubuntu.com/v1/b4f695ea-Canonical%20Ubuntu%20copy%202.svg",
+                alt="Canonical Ubuntu",
+                width="220",
                 height="40",
                 hi_def=True,
                 loading="auto",) | safe

--- a/templates/engage/thank-you.html
+++ b/templates/engage/thank-you.html
@@ -8,9 +8,9 @@
   <section class="p-section p-engage-banner--grad">
     <div class="grid-row">
       <a href="/">
-        {{ image(url="https://assets.ubuntu.com/v1/3cf74f71-Canonical%20Dark.svg",
-                alt="Ubuntu",
-                width="140",
+        {{ image(url="https://assets.ubuntu.com/v1/b4f695ea-Canonical%20Ubuntu%20copy%202.svg",
+                alt="Canonical Ubuntu",
+                width="220",
                 height="40",
                 hi_def=True,
                 loading="auto",) | safe


### PR DESCRIPTION
## Done

- Changed the logo on Engage pages' Thank You page, in accordance to the request from marketing

## QA

- Open https://ubuntu-com-15517.demos.haus/engage index page
- Select different languages in the "Select language" filter and "Whitepaper" in the "Select resource type" filter, and then click on "Apply filters"
- Click on any engage page card to open it. Make sure that the opened engage page has a form.
- Add "/thank-you" in the URL of an engage page, for example "/engage/zh/vmware-migration-scenarios/thank-you"
- Check that the logo has been updated

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-25049

## Screenshots

Current logo:
<img width="529" height="176" alt="Screenshot From 2025-08-22 17-25-04" src="https://github.com/user-attachments/assets/87f4659b-a4dd-4298-a11c-547d7b30db79" />

New logo:
<img width="529" height="176" alt="Screenshot From 2025-08-22 17-24-26" src="https://github.com/user-attachments/assets/d307795f-a9ab-4ce7-bb88-68cbc54a79c5" />


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
