### PR TITLE
ci: add explicit env variable

### DIFF
--- a/.github/workflows/sitemap.yaml
+++ b/.github/workflows/sitemap.yaml
@@ -16,10 +16,14 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Call sitemap generation endpoint
+        env:
+          SITEMAP_SECRET: ${{ secrets.SITEMAP_SECRET }}
         run: |
           curl --fail-with-body -X POST "https://ubuntu.com/sitemap_tree.xml" \
-          -H "Authorization: Bearer ${{ secrets.SITEMAP_SECRET }}"
+          -H "Authorization: Bearer $SITEMAP_SECRET"
 
       - name: Send message on failure
+        env:
+          BOT_URL: ${{ secrets.BOT_URL }}
         if: failure()
-        run: curl -X POST -F "workflow=${GITHUB_WORKFLOW}" -F "repo_name=${GITHUB_REPOSITORY}" -F "action_id=${GITHUB_RUN_ID}" ${{ secrets.BOT_URL }}?room=web-design
+        run: curl -X POST -F "workflow=${GITHUB_WORKFLOW}" -F "repo_name=${GITHUB_REPOSITORY}" -F "action_id=${GITHUB_RUN_ID}" $BOT_URL?room=web-design


### PR DESCRIPTION
## Done

- Updated sitemap secrets on the repository
- Explicitly declare env variables on GH actions

## QA

- See that [`generate sitemap action`](https://github.com/canonical/ubuntu.com/actions/runs/17259504351/job/48977674188?pr=15533) passes

## Issue / Card

Fixes [WD-26152](https://warthogs.atlassian.net/browse/WD-26152)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-26152]: https://warthogs.atlassian.net/browse/WD-26152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ