### PR TITLE
use image template on /20years & /appliance

### DIFF
--- a/templates/20years/index.html
+++ b/templates/20years/index.html
@@ -77,11 +77,14 @@
         <hr class="p-rule--muted" />
         <div class="row">
           <div class="col-1 col-medium-1 u-hide--small">
-            <img src="https://assets.ubuntu.com/v1/db939bdb-Frame%203611.png"
-                 alt="Warty warthog logo"
-                 width="57"
-                 height="40"
-                 style="margin-top:0.65rem" />
+            {{ image(url="https://assets.ubuntu.com/v1/db939bdb-Frame 3611.png",
+                        alt="Warty warthog logo",
+                        width="456",
+                        height="320",
+                        hi_def=True,
+                        loading="auto",
+                        attrs={"style": "margin-top:0.65rem; width:57px"},) | safe
+            }}
           </div>
           <div class="col-2 col-medium-2 col-small-2 u-align--right">
             <div class="p-tube-line">
@@ -215,11 +218,14 @@
         </div>
         <div class="row">
           <div class="col-1 col-medium-1 u-hide--small">
-            <img src="https://assets.ubuntu.com/v1/e1af7468-wubi.png"
-                 alt="Wubi logo"
-                 width="57"
-                 height="40"
-                 style="margin-top:0.65rem" />
+            {{ image(url="https://assets.ubuntu.com/v1/e1af7468-wubi.png",
+                        alt="Wubi logo",
+                        width="456",
+                        height="320",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"style": "margin-top:0.65rem; width:57px"},) | safe
+            }}
           </div>
           <div class="col-2 col-medium-2 col-small-2 col-start-large-2 col-start-medium-2 u-align--right">
             <div class="p-tube-line">
@@ -272,11 +278,14 @@
         <hr class="p-rule--muted" />
         <div class="row">
           <div class="col-1 col-medium-1 u-hide--small">
-            <img src="https://assets.ubuntu.com/v1/86744995-pangolin.png"
-                 alt="Precise Pangolin logo"
-                 width="57"
-                 height="40"
-                 style="margin-top:0.65rem" />
+            {{ image(url="https://assets.ubuntu.com/v1/86744995-pangolin.png",
+                        alt="Precise Pangolin logo",
+                        width="456",
+                        height="320",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"style": "margin-top:0.65rem; width:57px"}) | safe
+            }}
           </div>
           <div class="col-2 col-medium-2 col-small-2 u-align--right">
             <div class="p-tube-line">
@@ -313,11 +322,14 @@
         <hr class="p-rule--muted" />
         <div class="row">
           <div class="col-1 col-medium-1 u-hide--small">
-            <img src="https://assets.ubuntu.com/v1/f9b5d5f2-unicorn.png"
-                 alt="Utopic Unicorn logo"
-                 width="57"
-                 height="40"
-                 style="margin-top:0.65rem" />
+            {{ image(url="https://assets.ubuntu.com/v1/f9b5d5f2-unicorn.png",
+                        alt="Utopic Unicorn logo",
+                        width="456",
+                        height="320",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"style": "margin-top:0.65rem; width:57px"}) | safe
+            }}
           </div>
           <div class="col-2 col-medium-2 col-small-2 u-align--right">
             <div class="p-tube-line">
@@ -337,11 +349,14 @@
         <hr class="p-rule--muted" />
         <div class="row">
           <div class="col-1 col-medium-1 u-hide--small">
-            <img src="https://assets.ubuntu.com/v1/714c5293-ubuntu-mate-circle-icon.png"
-                 alt="Ubuntu Mate logo"
-                 width="40"
-                 height="40"
-                 style="margin-top:0.65rem" />
+            {{ image(url="https://assets.ubuntu.com/v1/714c5293-ubuntu-mate-circle-icon.png",
+                        alt="Ubuntu Mate logo",
+                        width="80",
+                        height="80",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"style": "margin-top:0.65rem; width:40px"}) | safe
+            }}
           </div>
           <div class="col-2 col-medium-2 col-small-2 u-align--right">
             <div class="p-tube-line">
@@ -361,11 +376,14 @@
         <hr class="p-rule--muted" />
         <div class="row">
           <div class="col-1 col-medium-1 u-hide--small">
-            <img src="https://assets.ubuntu.com/v1/3a434514-ubuntu-core.png"
-                 alt="Old Circle of friends logo"
-                 width="40"
-                 height="40"
-                 style="margin-top:0.65rem" />
+            {{ image(url="https://assets.ubuntu.com/v1/3a434514-ubuntu-core.png",
+                        alt="Old Circle of friends logo",
+                        width="120",
+                        height="120",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"style": "margin-top:0.65rem; width:40px"}) | safe
+            }}
           </div>
           <div class="col-2 col-medium-2 col-small-2 u-align--right">
             <div class="p-tube-line">
@@ -384,11 +402,14 @@
         </div>
         <div class="row">
           <div class="col-1 col-medium-1 u-hide--small">
-            <img src="https://assets.ubuntu.com/v1/f2b0a195-snapcraft.png"
-                 alt="Snap store logo"
-                 width="57"
-                 height="40"
-                 style="margin-top:0.65rem" />
+            {{ image(url="https://assets.ubuntu.com/v1/f2b0a195-snapcraft.png",
+                        alt="Snap store logo",
+                        width="456",
+                        height="320",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"style": "margin-top:0.65rem; width:57px"}) | safe
+            }}
           </div>
           <div class="col-2 col-medium-2 col-small-2 u-align--right">
             <div class="p-tube-line">
@@ -442,11 +463,14 @@
         <hr class="p-rule--muted" />
         <div class="row">
           <div class="col-1 col-medium-1 u-hide--small">
-            <img src="https://assets.ubuntu.com/v1/1edfdad3-CoF%20larger.png"
-                 alt="Circle of Friends tag"
-                 width="57"
-                 height="61"
-                 style="margin-top:0.65rem" />
+            {{ image(url="https://assets.ubuntu.com/v1/1edfdad3-CoF%20larger.png",
+                        alt="Circle of Friends tag",
+                        width="456",
+                        height="408",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"style": "margin-top:0.65rem; width:57px"}) | safe
+            }}
           </div>
           <div class="col-2 col-medium-2 col-small-2 u-align--right">
             <div class="p-tube-line">
@@ -483,11 +507,14 @@
         <hr class="p-rule--muted" />
         <div class="row">
           <div class="col-1 col-medium-1 u-hide--small">
-            <img src="https://assets.ubuntu.com/v1/8d056333-numbat.png"
-                 alt="Noble Numbat logo"
-                 width="57"
-                 height="40"
-                 style="margin-top:0.65rem" />
+            {{ image(url="https://assets.ubuntu.com/v1/8d056333-numbat.png",
+                        alt="Noble Numbat logo",
+                        width="456",
+                        height="320",
+                        hi_def=True,
+                        loading="lazy",
+                        attrs={"style": "margin-top:0.65rem; width:57px"}) | safe
+            }}
           </div>
           <div class="col-2 col-medium-2 col-small-2 u-align--right">
             <div class="p-tube-line">
@@ -526,7 +553,8 @@
               <div class="p-tube-line__circle"></div>
               <img class="p-tube-line__image"
                    src="https://assets.ubuntu.com/v1/a73ced17-bday-cake-no-bg.png"
-                   alt="Birthday cake emoji" />
+                   alt="Birthday cake emoji"
+                   loading="lazy" />
             </div>
           </div>
           <div class="col-6 col-medium-3 col-small-2">
@@ -632,7 +660,8 @@
             <div class="p-heading-icon__header">
               <img class="p-heading-icon__img"
                    src="https://assets.ubuntu.com/v1/9a62ef78-@shaakunthala.png"
-                   alt="" />
+                   alt=""
+                   loading="lazy" />
               <p class="p-heading-icon__title">
                 <strong><small>Tweet by @shaakunthala</small></strong>
               </p>
@@ -658,7 +687,8 @@
             <div class="p-heading-icon__header">
               <img class="p-heading-icon__img"
                    src="https://assets.ubuntu.com/v1/0da07e88-X%20Logo%20-%20Updated%202.png"
-                   alt="X logo" />
+                   alt="X logo"
+                   loading="lazy" />
               <p class="p-heading-icon__title">
                 <a href="https://x.com/shaakunthala/status/1819043688753889436?ref_src=twsrc%5Etfw">See post&nbsp;&rsaquo;</a>
               </p>
@@ -670,7 +700,8 @@
             <div class="p-heading-icon__header">
               <img class="p-heading-icon__img"
                    src="https://assets.ubuntu.com/v1/41d6d2ab-keegan%20turner.jpeg"
-                   alt="Keegan Turner portrait" />
+                   alt="Keegan Turner portrait"
+                   loading="lazy" />
               <p class="p-heading-icon__title">
                 <strong><small>LinkedIn post by Keegan Turner</small></strong>
               </p>
@@ -684,7 +715,8 @@
             <div class="p-heading-icon__header">
               <img class="p-heading-icon__img"
                    src="https://assets.ubuntu.com/v1/965ec1de-LinkedIn%20Logo%20-%20Updated%202.png"
-                   alt="LinkedIn logo" />
+                   alt="LinkedIn logo"
+                   loading="lazy" />
               <p class="p-heading-icon__title">
                 <a href="https://www.linkedin.com/posts/keegan-turner-20716615b_20-years-of-ubuntu-activity-7245407163685191680-qR7S?utm_source=share&utm_medium=member_desktop">See post&nbsp;&rsaquo;</a>
               </p>
@@ -717,7 +749,8 @@
             <div class="p-heading-icon__header">
               <img class="p-heading-icon__img"
                    src="https://assets.ubuntu.com/v1/965ec1de-LinkedIn%20Logo%20-%20Updated%202.png"
-                   alt="LinkedIn logo" />
+                   alt="LinkedIn logo"
+                   loading="lazy" />
               <p class="p-heading-icon__title">
                 <a href="https://www.linkedin.com/posts/activity-7235633404451377153-VX9X?utm_source=share&utm_medium=member_desktop">See post&nbsp;&rsaquo;</a>
               </p>
@@ -727,9 +760,14 @@
         <div class="p-card--social-media">
           <div class="p-heading-icon">
             <div class="p-heading-icon__header">
-              <img class="p-heading-icon__img"
-                   src="https://assets.ubuntu.com/v1/3da1e420-@ken%20vandine.png"
-                   alt="" />
+              {{ image(url="https://assets.ubuntu.com/v1/3da1e420-@ken%20vandine.png",
+                            alt="",
+                            width="193",
+                            height="193",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"class": "p-heading-icon__img"}) | safe
+              }}
               <p class="p-heading-icon__title">
                 <strong><small>LinkedIn post by Ken VanDine</small></strong>
               </p>
@@ -752,7 +790,8 @@
             <div class="p-heading-icon__header">
               <img class="p-heading-icon__img"
                    src="https://assets.ubuntu.com/v1/965ec1de-LinkedIn%20Logo%20-%20Updated%202.png"
-                   alt="LinkedIn logo" />
+                   alt="LinkedIn logo"
+                   loading="lazy" />
               <p class="p-heading-icon__title">
                 <a href="https://www.linkedin.com/posts/kenvandine_ubuntu-activity-7177007812047183872-Wz-9">See post&nbsp;&rsaquo;</a>
               </p>
@@ -766,7 +805,8 @@
             <div class="p-heading-icon__header">
               <img class="p-heading-icon__img"
                    src="https://assets.ubuntu.com/v1/5bbc95e4-Jono.jpeg"
-                   alt="Jono Bacon portrait" />
+                   alt="Jono Bacon portrait"
+                   loading="lazy" />
               <p class="p-heading-icon__title">
                 <strong><small>LinkedIn post by Jono Bacon</small></strong>
               </p>
@@ -784,7 +824,8 @@
             <div class="p-heading-icon__header">
               <img class="p-heading-icon__img"
                    src="https://assets.ubuntu.com/v1/965ec1de-LinkedIn%20Logo%20-%20Updated%202.png"
-                   alt="LinkedIn logo" />
+                   alt="LinkedIn logo"
+                   loading="lazy" />
               <p class="p-heading-icon__title">
                 <a href="https://www.linkedin.com/pulse/holy-smokes-20-years-canonical-ubuntu-jono-bacon-el1dc/?trackingId=U6%2BX7%2Fa9anAAFVzgEfG7UQ%3D%3D">See post&nbsp;&rsaquo;</a>
               </p>
@@ -796,7 +837,8 @@
             <div class="p-heading-icon__header">
               <img class="p-heading-icon__img"
                    src="https://assets.ubuntu.com/v1/883761af-brandon%20lichtenwalner.jpeg"
-                   alt="Brandon Lichtenwalner portrait" />
+                   alt="Brandon Lichtenwalner portrait"
+                   loading="lazy" />
               <p class="p-heading-icon__title">
                 <strong><small>LinkedIn post by Brandon Lichtenwalner</small></strong>
               </p>
@@ -820,7 +862,8 @@
             <div class="p-heading-icon__header">
               <img class="p-heading-icon__img"
                    src="https://assets.ubuntu.com/v1/965ec1de-LinkedIn%20Logo%20-%20Updated%202.png"
-                   alt="LinkedIn logo" />
+                   alt="LinkedIn logo"
+                   loading="lazy" />
               <p class="p-heading-icon__title">
                 <a href="https://www.linkedin.com/posts/brandonlichtenwalner_ubuntults-opensource-activity-7190780387613122560-3WVe?utm_source=share&utm_medium=member_desktop">See post&nbsp;&rsaquo;</a>
               </p>
@@ -830,9 +873,14 @@
         <div class="p-card--social-media">
           <div class="p-heading-icon">
             <div class="p-heading-icon__header">
-              <img class="p-heading-icon__img"
-                   src="https://assets.ubuntu.com/v1/3aa35ae4-@nebojsa%20tomic.png"
-                   alt="" />
+              {{ image(url="https://assets.ubuntu.com/v1/3aa35ae4-@nebojsa%20tomic.png",
+                            alt="",
+                            width="192",
+                            height="193",
+                            hi_def=True,
+                            loading="lazy",
+                            attrs={"class": "p-heading-icon__img"}) | safe
+              }}
               <p class="p-heading-icon__title">
                 <strong><small>LinkedIn post by
                 Nebojsa Tomic</small></strong>
@@ -859,7 +907,8 @@
             <div class="p-heading-icon__header">
               <img class="p-heading-icon__img"
                    src="https://assets.ubuntu.com/v1/965ec1de-LinkedIn%20Logo%20-%20Updated%202.png"
-                   alt="LinkedIn logo" />
+                   alt="LinkedIn logo"
+                   loading="lazy" />
               <p class="p-heading-icon__title">
                 <a href="https://www.linkedin.com/posts/nebojsatomic_almost-20-years-ago-when-very-few-people-activity-7189918964301381632-bzSd">See post&nbsp;&rsaquo;</a>
               </p>
@@ -895,7 +944,8 @@
             <div class="p-heading-icon__header">
               <img class="p-heading-icon__img"
                    src="https://assets.ubuntu.com/v1/965ec1de-LinkedIn%20Logo%20-%20Updated%202.png"
-                   alt="LinkedIn logo" />
+                   alt="LinkedIn logo"
+                   loading="lazy" />
               <p class="p-heading-icon__title">
                 <a href="https://www.linkedin.com/posts/jokar_linux-ubuntu-desktop-activity-7246555578204909569-pZXR/?utm_source=share&utm_medium=member_desktop">See post&nbsp;&rsaquo;</a>
               </p>
@@ -907,7 +957,8 @@
             <div class="p-heading-icon__header">
               <img class="p-heading-icon__img"
                    src="https://assets.ubuntu.com/v1/a07b08f2-mathew%20thornton.jpeg"
-                   alt="Matthew Thornton portrait" />
+                   alt="Matthew Thornton portrait"
+                   loading="lazy" />
               <p class="p-heading-icon__title">
                 <strong><small>LinkedIn post by Matthew Thornton</small></strong>
               </p>
@@ -922,7 +973,8 @@
             <div class="p-heading-icon__header">
               <img class="p-heading-icon__img"
                    src="https://assets.ubuntu.com/v1/965ec1de-LinkedIn%20Logo%20-%20Updated%202.png"
-                   alt="LinkedIn logo" />
+                   alt="LinkedIn logo"
+                   loading="lazy" />
               <p class="p-heading-icon__title">
                 <a href="https://www.linkedin.com/posts/mattcthornton_when-i-was-in-my-early-teens-my-friend-nate-activity-7235596007210643456-rY7Y?utm_source=share&utm_medium=member_desktop">See post&nbsp;&rsaquo;</a>
               </p>
@@ -954,7 +1006,8 @@
             <div class="p-heading-icon__header">
               <img class="p-heading-icon__img"
                    src="https://assets.ubuntu.com/v1/965ec1de-LinkedIn%20Logo%20-%20Updated%202.png"
-                   alt="LinkedIn logo" />
+                   alt="LinkedIn logo"
+                   loading="lazy" />
               <p class="p-heading-icon__title">
                 <a href="https://www.linkedin.com/posts/shinglyu_found-this-old-photo-of-ubuntu-606-lts-activity-7206958851890315265-wjZ4?utm_source=share&utm_medium=member_desktop">See post&nbsp;&rsaquo;</a>
               </p>
@@ -966,7 +1019,8 @@
             <div class="p-heading-icon__header">
               <img class="p-heading-icon__img"
                    src="https://assets.ubuntu.com/v1/523f779c-Shannon%20smith.jpeg"
-                   alt="Shannon Smith portrait" />
+                   alt="Shannon Smith portrait"
+                   loading="lazy" />
               <p class="p-heading-icon__title">
                 <strong><small>LinkedIn post by Shannon Smith</small></strong>
               </p>
@@ -978,7 +1032,8 @@
             <div class="p-heading-icon__header">
               <img class="p-heading-icon__img"
                    src="https://assets.ubuntu.com/v1/965ec1de-LinkedIn%20Logo%20-%20Updated%202.png"
-                   alt="LinkedIn logo" />
+                   alt="LinkedIn logo"
+                   loading="lazy" />
               <p class="p-heading-icon__title">
                 <a href="https://www.linkedin.com/posts/shannonandriansmith_ubuntults-opensource-activity-7191994640412151808-KUQW?utm_source=share&utm_medium=member_desktop">See post&nbsp;&rsaquo;</a>
               </p>
@@ -1241,11 +1296,14 @@
     <div class="p-section">
       <div class="row--25-75">
         <div class="col u-hide--small">
-          <img src="https://assets.ubuntu.com/v1/f08a4123-Qualcomm-Logo.png"
-               width="126"
-               height="50"
-               alt="Qualcomm logo"
-               style="margin-top:1rem" />
+          {{ image(url="https://assets.ubuntu.com/v1/f08a4123-Qualcomm-Logo.png",
+                    alt="Qualcomm logo",
+                    width="756",
+                    height="300",
+                    hi_def=True,
+                    loading="lazy",
+                    attrs={"style":"margin-top:1rem; width: 126px"}) | safe
+          }}
         </div>
         <div class="col">
           <hr class="p-rule--muted" />
@@ -1268,11 +1326,14 @@
     <div class="p-section">
       <div class="row--25-75">
         <div class="col u-hide--small">
-          <img src="https://assets.ubuntu.com/v1/48056c37-DFI-Logo.png"
-               alt="DFI logo"
-               width="126"
-               height="50"
-               style="margin-top:1rem" />
+          {{ image(url="https://assets.ubuntu.com/v1/48056c37-DFI-Logo.png",
+                    alt="DFI logo",
+                    width="756",
+                    height="300",
+                    hi_def=True,
+                    loading="lazy",
+                    attrs={"style":"margin-top:1rem; width: 126px"}) | safe
+          }}
         </div>
         <div class="col">
           <hr class="p-rule--muted" />
@@ -1295,11 +1356,14 @@
     <div class="p-section">
       <div class="row--25-75">
         <div class="col u-hide--small">
-          <img src="https://assets.ubuntu.com/v1/8a9c6ca4-Advantech%20Logo.png"
-               alt="Advantech logo"
-               width="126"
-               height="50"
-               style="margin-top:1rem" />
+          {{ image(url="https://assets.ubuntu.com/v1/8a9c6ca4-Advantech-Logo.png",
+                    alt="Advantech logo",
+                    width="756",
+                    height="300",
+                    hi_def=True,
+                    loading="lazy",
+                    attrs={"style":"margin-top:1rem; width: 126px"}) | safe
+          }}
         </div>
         <div class="col">
           <hr class="p-rule--muted" />
@@ -1322,11 +1386,14 @@
     <div class="p-section">
       <div class="row--25-75">
         <div class="col u-hide--small">
-          <img src="https://assets.ubuntu.com/v1/3afe5e82-ADLINK%20Logo.png"
-               alt="Adlink logo"
-               width="126"
-               height="50"
-               style="margin-top:1rem" />
+          {{ image(url="https://assets.ubuntu.com/v1/3afe5e82-Adlink-Logo.png",
+                    alt="Adlink logo",
+                    width="756",
+                    height="300",
+                    hi_def=True,
+                    loading="lazy",
+                    attrs={"style":"margin-top:1rem; width: 126px"}) | safe
+          }}
         </div>
         <div class="col">
           <hr class="p-rule--muted" />
@@ -1349,11 +1416,14 @@
     <div class="p-section">
       <div class="row--25-75">
         <div class="col u-hide--small">
-          <img src="https://assets.ubuntu.com/v1/ff6f1197-ASRock%20Logo.png"
-               alt="ASRock logo"
-               width="126"
-               height="50"
-               style="margin-top:1rem" />
+          {{ image(url="https://assets.ubuntu.com/v1/ff6f1197-ASRock-Logo.png",
+                    alt="ASRock logo",
+                    width="756",
+                    height="300",
+                    hi_def=True,
+                    loading="lazy",
+                    attrs={"style":"margin-top:1rem; width: 126px"}) | safe
+          }}
         </div>
         <div class="col">
           <hr class="p-rule--muted" />
@@ -1376,11 +1446,14 @@
     <div class="p-section">
       <div class="row--25-75">
         <div class="col u-hide--small">
-          <img src="https://assets.ubuntu.com/v1/b645dd23-ASUS%20IoT%20Logo.png"
-               alt="Asus IOT logo"
-               width="126"
-               height="50"
-               style="margin-top:1rem" />
+          {{ image(url="https://assets.ubuntu.com/v1/b645dd23-ASUS%20IoT%20Logo.png",
+                    alt="Asus IOT logo",
+                    width="756",
+                    height="300",
+                    hi_def=True,
+                    loading="lazy",
+                    attrs={"style":"margin-top:1rem; width: 126px"}) | safe
+          }}
         </div>
         <div class="col">
           <hr class="p-rule--muted" />
@@ -1403,11 +1476,14 @@
     <div class="p-section">
       <div class="row--25-75">
         <div class="col u-hide--small">
-          <img src="https://assets.ubuntu.com/v1/021e8610-A24%20Logo.png"
-               alt="A24 logo"
-               width="126"
-               height="50"
-               style="margin-top:1rem" />
+          {{ image(url="https://assets.ubuntu.com/v1/021e8610-A24%20Logo.png",
+                    alt="A24 logo",
+                    width="756",
+                    height="300",
+                    hi_def=True,
+                    loading="lazy",
+                    attrs={"style":"margin-top:1rem; width: 126px"}) | safe
+          }}
         </div>
         <div class="col">
           <hr class="p-rule--muted" />
@@ -1430,11 +1506,14 @@
     <div class="p-section">
       <div class="row--25-75">
         <div class="col u-hide--small">
-          <img src="https://assets.ubuntu.com/v1/55a19d67-Nvidia%20Logo.png"
-               alt="NVidia logo"
-               width="126"
-               height="50"
-               style="margin-top:1rem" />
+          {{ image(url="https://assets.ubuntu.com/v1/55a19d67-Nvidia%20Logo.png",
+                    alt="NVidia logo",
+                    width="756",
+                    height="300",
+                    hi_def=True,
+                    loading="lazy",
+                    attrs={"style":"margin-top:1rem; width: 126px"}) | safe
+          }}
         </div>
         <div class="col">
           <hr class="p-rule--muted" />
@@ -1457,11 +1536,14 @@
     <div class="p-section">
       <div class="row--25-75">
         <div class="col u-hide--small">
-          <img src="https://assets.ubuntu.com/v1/62f81bcb-arm%20Logo.png"
-               alt="ARM logo"
-               width="126"
-               height="50"
-               style="margin-top:1rem" />
+          {{ image(url="https://assets.ubuntu.com/v1/62f81bcb-arm%20Logo.png",
+                    alt="ARM logo",
+                    width="756",
+                    height="300",
+                    hi_def=True,
+                    loading="lazy",
+                    attrs={"style":"margin-top:1rem; width: 126px"}) | safe
+          }}
         </div>
         <div class="col">
           <hr class="p-rule--muted" />
@@ -1484,11 +1566,14 @@
     <div class="p-section">
       <div class="row--25-75">
         <div class="col u-hide--small">
-          <img src="https://assets.ubuntu.com/v1/b93ffef5-Dell%20Technologies%20Logo.png"
-               alt="Dell logo"
-               width="126"
-               height="50"
-               style="margin-top:1rem" />
+          {{ image(url="https://assets.ubuntu.com/v1/b93ffef5-Dell%20Technologies%20Logo.png",
+                    alt="Dell logo",
+                    width="756",
+                    height="300",
+                    hi_def=True,
+                    loading="lazy",
+                    attrs={"style":"margin-top:1rem; width: 126px"}) | safe
+          }}
         </div>
         <div class="col">
           <hr class="p-rule--muted" />
@@ -1511,11 +1596,14 @@
     <div class="p-section">
       <div class="row--25-75">
         <div class="col u-hide--small">
-          <img src="https://assets.ubuntu.com/v1/0600e0fa-Hewlett%20Packard%20Enterprise%20Logo.png"
-               alt="HP Enterprise logo"
-               width="126"
-               height="50"
-               style="margin-top:1rem" />
+          {{ image(url="https://assets.ubuntu.com/v1/0600e0fa-Hewlett%20Packard%20Enterprise%20Logo.png",
+                    alt="HP Enterprise logo",
+                    width="756",
+                    height="300",
+                    hi_def=True,
+                    loading="lazy",
+                    attrs={"style":"margin-top:1rem; width: 126px"}) | safe
+          }}
         </div>
         <div class="col">
           <hr class="p-rule--muted" />

--- a/templates/20years/index.html
+++ b/templates/20years/index.html
@@ -1356,7 +1356,7 @@
     <div class="p-section">
       <div class="row--25-75">
         <div class="col u-hide--small">
-          {{ image(url="https://assets.ubuntu.com/v1/8a9c6ca4-Advantech-Logo.png",
+          {{ image(url="https://assets.ubuntu.com/v1/8a9c6ca4-Advantech Logo.png",
                     alt="Advantech logo",
                     width="756",
                     height="300",
@@ -1386,7 +1386,7 @@
     <div class="p-section">
       <div class="row--25-75">
         <div class="col u-hide--small">
-          {{ image(url="https://assets.ubuntu.com/v1/3afe5e82-Adlink-Logo.png",
+          {{ image(url="https://assets.ubuntu.com/v1/3afe5e82-ADLINK%20Logo.png",
                     alt="Adlink logo",
                     width="756",
                     height="300",
@@ -1416,7 +1416,7 @@
     <div class="p-section">
       <div class="row--25-75">
         <div class="col u-hide--small">
-          {{ image(url="https://assets.ubuntu.com/v1/ff6f1197-ASRock-Logo.png",
+          {{ image(url="https://assets.ubuntu.com/v1/ff6f1197-ASRock%20Logo.png",
                     alt="ASRock logo",
                     width="756",
                     height="300",

--- a/templates/advantage/_table.html
+++ b/templates/advantage/_table.html
@@ -24,25 +24,25 @@
             </p>
           </td>
           <td data-heading="Personal use" class="u-align--center">
-            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg"
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" loading="lazy"
                  alt="Yes"
                  width="16"
                  height="16" />
           </td>
           <td data-heading="Essential" class="u-align--center">
-            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg"
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" loading="lazy"
                  alt="Yes"
                  width="16"
                  height="16" />
           </td>
           <td data-heading="Standard" class="u-align--center">
-            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg"
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" loading="lazy"
                  alt="Yes"
                  width="16"
                  height="16" />
           </td>
           <td data-heading="Yes" class="u-align--center">
-            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg"
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" loading="lazy"
                  alt="Yes"
                  width="16"
                  height="16" />
@@ -53,25 +53,25 @@
             <a href="/livepatch">Kernel Livepatch</a> service to avoid reboots
           </td>
           <td data-heading="Personal use" class="u-align--center">
-            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg"
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" loading="lazy"
                  alt="Yes"
                  width="16"
                  height="16" />
           </td>
           <td data-heading="Essential" class="u-align--center">
-            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg"
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" loading="lazy"
                  alt="Yes"
                  width="16"
                  height="16" />
           </td>
           <td data-heading="Standard" class="u-align--center">
-            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg"
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" loading="lazy"
                  alt="Yes"
                  width="16"
                  height="16" />
           </td>
           <td data-heading="Advanced" class="u-align--center">
-            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg"
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" loading="lazy"
                  alt="Yes"
                  width="16"
                  height="16" />
@@ -83,25 +83,25 @@
             certified crypto modules
           </td>
           <td data-heading="Personal use" class="u-align--center">
-            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg"
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" loading="lazy"
                  alt="Yes"
                  width="16"
                  height="16" />
           </td>
           <td data-heading="Essential" class="u-align--center">
-            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg"
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" loading="lazy"
                  alt="Yes"
                  width="16"
                  height="16" />
           </td>
           <td data-heading="Standard" class="u-align--center">
-            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg"
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" loading="lazy"
                  alt="Yes"
                  width="16"
                  height="16" />
           </td>
           <td data-heading="Advanced" class="u-align--center">
-            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg"
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" loading="lazy"
                  alt="Yes"
                  width="16"
                  height="16" />
@@ -112,25 +112,25 @@
             <a href="/security/cc">Common Criteria EAL2</a>
           </td>
           <td data-heading="Personal use" class="u-align--center">
-            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg"
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" loading="lazy"
                  alt="Yes"
                  width="16"
                  height="16" />
           </td>
           <td data-heading="Essential" class="u-align--center">
-            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg"
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" loading="lazy"
                  alt="Yes"
                  width="16"
                  height="16" />
           </td>
           <td data-heading="Standard" class="u-align--center">
-            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg"
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" loading="lazy"
                  alt="Yes"
                  width="16"
                  height="16" />
           </td>
           <td data-heading="Advanced" class="u-align--center">
-            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg"
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" loading="lazy"
                  alt="Yes"
                  width="16"
                  height="16" />
@@ -139,25 +139,25 @@
         <tr id="kvm-guests">
           <td data-heading="">Certified Windows drivers for KVM guests</td>
           <td data-heading="Personal use" class="u-align--center">
-            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg"
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" loading="lazy"
                  alt="Yes"
                  width="16"
                  height="16" />
           </td>
           <td data-heading="Essential" class="u-align--center">
-            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg"
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" loading="lazy"
                  alt="Yes"
                  width="16"
                  height="16" />
           </td>
           <td data-heading="Standard" class="u-align--center">
-            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg"
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" loading="lazy"
                  alt="Yes"
                  width="16"
                  height="16" />
           </td>
           <td data-heading="Advanced" class="u-align--center">
-            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg"
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" loading="lazy"
                  alt="Yes"
                  width="16"
                  height="16" />
@@ -168,25 +168,25 @@
             <a href="https://documentation.ubuntu.com/landscape/how-to-guides/landscape-installation-and-set-up/quickstart-installation/">Landscape On-Prem</a> management dashboard
           </td>
           <td data-heading="Personal use" class="u-align--center">
-            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg"
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" loading="lazy"
                  alt="Yes"
                  width="16"
                  height="16" />
           </td>
           <td data-heading="Essential" class="u-align--center">
-            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg"
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" loading="lazy"
                  alt="Yes"
                  width="16"
                  height="16" />
           </td>
           <td data-heading="Standard" class="u-align--center">
-            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg"
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" loading="lazy"
                  alt="Yes"
                  width="16"
                  height="16" />
           </td>
           <td data-heading="Advanced" class="u-align--center">
-            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg"
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" loading="lazy"
                  alt="Yes"
                  width="16"
                  height="16" />
@@ -198,19 +198,19 @@
           </td>
           <td data-heading="Personal use" class="u-align--center">-</td>
           <td data-heading="Essential" class="u-align--center">
-            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg"
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" loading="lazy"
                  alt="Yes"
                  width="16"
                  height="16" />
           </td>
           <td data-heading="Standard" class="u-align--center">
-            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg"
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" loading="lazy"
                  alt="Yes"
                  width="16"
                  height="16" />
           </td>
           <td data-heading="Advanced" class="u-align--center">
-            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg"
+            <img src="https://assets.ubuntu.com/v1/f1a7515d-tick-darkaubergine.svg" loading="lazy"
                  alt="Yes"
                  width="16"
                  height="16" />

--- a/templates/advantage/blender/index.html
+++ b/templates/advantage/blender/index.html
@@ -58,7 +58,7 @@
     <div class="col-4">
       <p class="u-no-padding--top">
         <span data-prop="user-count">0</span> &times;
-        <img src="https://assets.ubuntu.com/v1/786ed546-blender.svg" width="30" height="24" style="position: relative; top: 3px;">
+        <img src="https://assets.ubuntu.com/v1/786ed546-blender.svg" width="30" height="24" style="position: relative; top: 3px;" loading="lazy">
         <span data-prop="selected-package">Blender Support Standard</span>
       </p>
     </div>

--- a/templates/appliance/shared/_base_appliance_index.html
+++ b/templates/appliance/shared/_base_appliance_index.html
@@ -207,7 +207,14 @@
           <div class="grid-col-2">
             {% if downloads.raspberrypi %}
               <div class="p-image-container is-highlighted">
-                <img src="https://assets.ubuntu.com/v1/2560d6f8-pi-4-updated.png" alt="" />
+                {{ image(url="https://assets.ubuntu.com/v1/2560d6f8-pi-4-updated.png",
+                                alt="",
+                                width="852",
+                                height="480",
+                                hi_def=True,
+                                loading="lazy",
+                                attrs={"class":"p-image-container__image"}) | safe
+                }}
               </div>
               {% if downloads.pi2 %}
                 <p>
@@ -233,7 +240,14 @@
           <div class="grid-col-2">
             {% if downloads.intelnuc %}
               <div class="p-image-container is-highlighted">
-                <img src="https://assets.ubuntu.com/v1/abb2df0f-intel-nuc.png" alt="" />
+                {{ image(url="https://assets.ubuntu.com/v1/abb2df0f-intel-nuc.png",
+                                alt="",
+                                width="852",
+                                height="481",
+                                hi_def=True,
+                                loading="lazy",
+                                attrs={"class":"p-image-container__image"}) | safe
+                }}
               </div>
               <h3 class="p-heading--5">
                 <a href="/appliance/{{ short_name }}/intel-nuc">Install on an Intel NUC</a>


### PR DESCRIPTION
## Done

- Replace static image tags with image template function for better image loading and optimisation.

## QA

- Check out the demo links
- https://ubuntu-com-15539.demos.haus/20years
- https://ubuntu-com-15539.demos.haus/appliance/lxd
- https://ubuntu-com-15539.demos.haus/blender

## Issue / Card

Fixes # https://warthogs.atlassian.net/browse/WD-25999

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
