### PR TITLE
Feat: Added redirect for blog post

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1113,6 +1113,7 @@ blog/kubernetes-1-21-available-from-canonical..*: /blog/kubernetes-1-21-availabl
 blog/what-is-elasticsearch-and-how-are-enterprises-using-it: /blog/what-is-elasticsearch
 blog/managed-postgresql: /blog/what-is-postgresql
 blog/howto-host-your-own-snap-store: /internet-of-things/appstore
+blog/charmed-aether-sd-core-beta-release-announcement: /solutions/telco
 
 # Move snappy topic to snapcraft
 blog/topics/snappy/?: /blog/topics/snapcraft

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1113,7 +1113,7 @@ blog/kubernetes-1-21-available-from-canonical..*: /blog/kubernetes-1-21-availabl
 blog/what-is-elasticsearch-and-how-are-enterprises-using-it: /blog/what-is-elasticsearch
 blog/managed-postgresql: /blog/what-is-postgresql
 blog/howto-host-your-own-snap-store: /internet-of-things/appstore
-blog/charmed-aether-sd-core-beta-release-announcement: /solutions/telco
+blog/charmed-aether-sd-core-beta-release-announcement: https://canonical.com/solutions/telco 
 
 # Move snappy topic to snapcraft
 blog/topics/snappy/?: /blog/topics/snapcraft


### PR DESCRIPTION
## Done

- Added redirect for blog post

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Verify that https://ubuntu-com-15547.demos.haus/blog/charmed-aether-sd-core-beta-release-announcement redirects to  https://canonical.com/solutions/telco 

## Issue / Card

Fixes # https://warthogs.atlassian.net/browse/WD-25993


