### PR TITLE
fix(WD-26284): add maintenance window

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -16,10 +16,10 @@ env:
     value: true
 
   - name: CRED_MAINTENANCE_START
-    value: 2024-09-28T11:00:00Z
+    value: 2025-09-05T00:00:00Z
 
   - name: CRED_MAINTENANCE_END
-    value: 2024-09-28T15:00:00Z
+    value: 2025-09-19T23:59:59Z
 
   - name: SEARCH_API_KEY
     secretKeyRef:
@@ -352,10 +352,10 @@ production:
           value: true
 
         - name: CRED_MAINTENANCE_START
-          value: 2024-09-28T11:00:00Z
+          value: 2025-09-05T00:00:00Z
 
         - name: CRED_MAINTENANCE_END
-          value: 2024-09-28T15:00:00Z
+          value: 2025-09-19T23:59:59Z
 
     - paths: [/tutorials]
       name: ubuntu-com-tutorials
@@ -605,10 +605,10 @@ staging:
       value: true
 
     - name: CRED_MAINTENANCE_START
-      value: 2024-09-28T11:00:00Z
+      value: 2025-09-05T00:00:00Z
 
     - name: CRED_MAINTENANCE_END
-      value: 2024-09-28T15:00:00Z
+      value: 2025-09-19T23:59:59Z
 
     - name: SEARCH_API_KEY
       secretKeyRef:
@@ -952,10 +952,10 @@ staging:
           value: true
 
         - name: CRED_MAINTENANCE_START
-          value: 2024-09-28T11:00:00Z
+          value: 2025-09-05T00:00:00Z
 
         - name: CRED_MAINTENANCE_END
-          value: 2024-09-28T15:00:00Z
+          value: 2025-09-19T23:59:59Z
 
     - paths: [/tutorials]
       name: ubuntu-com-tutorials
@@ -1187,10 +1187,10 @@ demo:
       value: true
 
     - name: CRED_MAINTENANCE_START
-      value: 2024-09-28T11:00:00Z
+      value: 2025-09-05T00:00:00Z
 
     - name: CRED_MAINTENANCE_END
-      value: 2024-09-28T15:00:00Z
+      value: 2025-09-19T23:59:59Z
 
     - name: SEARCH_API_KEY
       secretKeyRef:

--- a/templates/credentials/base_cred.html
+++ b/templates/credentials/base_cred.html
@@ -54,7 +54,7 @@
         const maintenanceEndFormatted = dateTimeFormatter(maintenanceEnd, navigator.language);
         const elem = document.getElementById("cred-maintenance-message");
         if (elem) {
-          elem.innerHTML = `Our system will be under maintenance starting from <strong>${maintenanceStartFormatted}</strong> to <strong>${maintenanceEndFormatted}</strong>`;
+          elem.innerHTML = `We have scheduled maintenance planned from <strong>${maintenanceStartFormatted}</strong> to <strong>${maintenanceEndFormatted}</strong>. You would not be able to purchase new exams, schedule new exams or access existing exams. Thank you for your cooperation. We regret any inconvenience caused.`;
         }
       }
 


### PR DESCRIPTION
## Done

- Add maintenance window to credentials
- Update maintenance window message

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Locally, update the CRED_MAINTENANCE = true and set CRED_MAINTENANCE_START and CRED_MAINTENANCE_END so that current time falls in the window
- Take a look at credentials pages, you should see a banner notifying the maintenance window

## Issue / Card

Fixes [WD-26284](https://warthogs.atlassian.net/browse/WD-26284)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-26284]: https://warthogs.atlassian.net/browse/WD-26284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ