### PR TITLE
Feat: Updated nav for /ai

### DIFF
--- a/secondary-navigation.yaml
+++ b/secondary-navigation.yaml
@@ -168,16 +168,10 @@ ai:
   children:
     - title: Overview
       path: /ai
-    - title: MLOps
-      path: /ai/mlops
-    - title: MLflow
-      path: /ai/mlflow
     - title: Consulting
       path: /ai/consulting
     - title: Data Science
       path: /ai/data-science
-    - title: MLOps workshop
-      path: /ai/mlops-workshop
 
 kubernetes:
   title: Canonical Kubernetes


### PR DESCRIPTION
## Done

- updated nav for /ai

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Visit [demo](https://ubuntu-com-15557.demos.haus/ai) and see if it matches
<img width="878" height="855" alt="Screenshot 2025-08-27 at 10 44 15" src="https://github.com/user-attachments/assets/fbf48e49-3e00-47ae-b3be-677cbe8242d1" />

## Issue / Card

Fixes # https://warthogs.atlassian.net/browse/WD-26149

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
