### PR TITLE
Update link to Ubuntu images documentation for Oracle Cloud

### DIFF
--- a/templates/download/cloud/tabs/_oracle-cloud.html
+++ b/templates/download/cloud/tabs/_oracle-cloud.html
@@ -18,7 +18,7 @@
     </p>
     <ul class="p-list--divided">
       <li class="p-list__item">
-        <a href="https://canonical-oracle.readthedocs-hosted.com/en/latest/oracle-how-to/find-ubuntu-images/">Find Ubuntu images on Oracle Cloud</a>
+        <a href="https://documentation.ubuntu.com/oracle/oracle-how-to/find-ubuntu-images/">Find Ubuntu images on Oracle Cloud</a>
       </li>
       <li class="p-list__item">
         <a href="https://canonical-oracle.readthedocs-hosted.com/">Documentation</a>


### PR DESCRIPTION
## Done

- Updated link 
https://documentation.ubuntu.com/oracle/en/latest/oracle-how-to/find-ubuntu-images/ -> https://documentation.ubuntu.com/oracle/oracle-how-to/find-ubuntu-images/

## QA

- View the demo in your web browser at: http://0.0.0.0:8001/cloud/public-cloud
- Select the oracle tab and click `Find Ubuntu images on Oracle Cloud`
- You should be redirected to https://documentation.ubuntu.com/oracle/oracle-how-to/find-ubuntu-images/
    - Be sure to test on mobile, tablet and desktop screen sizes

## Issue / Card

Fixes [WD-26333](https://warthogs.atlassian.net/browse/WD-26333)

## Screenshots
<img width="1671" height="604" alt="image" src="https://github.com/user-attachments/assets/86be155b-559e-45f5-8108-4527ff5bc11a" />

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
