### PR TITLE
fix(WD-26343): show maintenance window before the window starts

### DIFF
--- a/templates/credentials/base_cred.html
+++ b/templates/credentials/base_cred.html
@@ -9,7 +9,7 @@
 {% endblock body_class %}
 
 {% block outer_content %}
-  {% if show_cred_maintenance_alert and cred_maintenance_start and cred_maintenance_end %}
+  {% if show_cred_maintenance_alert %}
     <div class="p-notification--information" style="margin:1rem">
       <div class="p-notification__content">
         <h5 class="p-notification__title">Maintenance Scheduled</h5>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -924,6 +924,7 @@ app.add_url_rule(
 app.add_url_rule("/credentials", view_func=cred_home)
 app.add_url_rule("/credentials/self-study", view_func=cred_self_study)
 app.add_url_rule("/credentials/exam-content", view_func=cred_syllabus_data)
+app.add_url_rule("/credentials/faq", view_func=cred_syllabus_data)
 app.add_url_rule(
     "/credentials/sign-up", view_func=cred_sign_up, methods=["GET", "POST"]
 )

--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -108,8 +108,18 @@ def cred_home(
 
 
 @shop_decorator(area="cred", response="html")
-def cred_self_study(**_):
-    return flask.render_template("credentials/self-study.html")
+def cred_self_study(
+    show_cred_maintenance_alert,
+    cred_maintenance_start,
+    cred_maintenance_end,
+    **_,
+):
+    return flask.render_template(
+        "credentials/self-study.html",
+        show_cred_maintenance_alert=show_cred_maintenance_alert,
+        cred_maintenance_start=cred_maintenance_start,
+        cred_maintenance_end=cred_maintenance_end,
+    )
 
 
 @shop_decorator(area="cred", permission="user", response="html")
@@ -1335,7 +1345,12 @@ def cred_exam(trueability_api, proctor_api, **_):
 
 
 @shop_decorator(area="cred", response="html")
-def cred_syllabus_data(**_):
+def cred_syllabus_data(
+    show_cred_maintenance_alert,
+    cred_maintenance_start,
+    cred_maintenance_end,
+    **_,
+):
     exam_name = flask.request.args.get("exam")
     syllabus_file = open("webapp/shop/cred/syllabus.json", "r")
     syllabus_data = json.load(syllabus_file)
@@ -1345,6 +1360,24 @@ def cred_syllabus_data(**_):
         "credentials/syllabus.html",
         syllabus_data=syllabus_data,
         exam_name=exam_name,
+        show_cred_maintenance_alert=show_cred_maintenance_alert,
+        cred_maintenance_start=cred_maintenance_start,
+        cred_maintenance_end=cred_maintenance_end,
+    )
+
+
+@shop_decorator(area="cred", response="html")
+def cred_faq(
+    show_cred_maintenance_alert,
+    cred_maintenance_start,
+    cred_maintenance_end,
+    **_,
+):
+    return flask.render_template(
+        "credentials/faq.html",
+        show_cred_maintenance_alert=show_cred_maintenance_alert,
+        cred_maintenance_start=cred_maintenance_start,
+        cred_maintenance_end=cred_maintenance_end,
     )
 
 

--- a/webapp/shop/decorators.py
+++ b/webapp/shop/decorators.py
@@ -118,7 +118,8 @@ def shop_decorator(area=None, permission=None, response="json", redirect=None):
                 is_cred_maintenance_in_timeframe = (
                     _maintenance_start <= _time_now <= _maintenance_end
                 )
-                if _time_now > _maintenance_end:
+                # if maintenance window is in past, then hide the banner
+                if _maintenance_end < _time_now:
                     cred_maintenance = False
 
             is_in_maintenance = (


### PR DESCRIPTION
## Done

- Show maintenance window banner on all the pages of credentials
- Show the banner **before** the window starts so users can know ahead of time about that

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- In your .env.local
    - set `CRED_MAINTENANCE` to true
    - set `CRED_MAINTENANCE_START` to a future datetime
    - set  `CRED_MAINTENANCE_END` to a future datetime
    - make sure you see the maintenance window but can visit /credentials/shop to purchase an exam
    - now set the maintenance window such that the window is in past, the maintenance window should not show up and you should be able to purchase exams
    - now set `CRED_MAINTENANCE` to false
    - you should not see the maintenance banner and should be able to purchase the exam

## Issue / Card

Fixes [WD-26343](https://warthogs.atlassian.net/browse/WD-26343)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-26343]: https://warthogs.atlassian.net/browse/WD-26343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ