### PR TITLE
WD-25018 - /server page refresh

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "url-polyfill": "1.1.12",
     "url-search-params-polyfill": "8.2.5",
     "use-query-params": "^2.2.1",
-    "vanilla-framework": "4.30.0",
+    "vanilla-framework": "4.32.0",
     "yup": "1.4.0"
   },
   "resolutions": {

--- a/templates/server/index.html
+++ b/templates/server/index.html
@@ -1,9 +1,15 @@
+{% from "_macros/vf_hero.jinja" import vf_hero %}
+{% from "_macros/vf_tiered-list.jinja" import vf_tiered_list %}
+{% from "_macros/vf_basic-section.jinja" import vf_basic_section %}
+{% from "_macros/vf_equal-heights.jinja" import vf_equal_heights %}
+{% from "_macros/vf_cta-section.jinja" import vf_cta_section %}
+
 {% extends "server/base_server.html" %}
 
 {% block title %}Ubuntu Server - for scale out workloads{% endblock %}
 
 {% block meta_description %}
-  Secure, fast and economically scalable, Ubuntu helps you make the most of your infrastructure. Whether you want to deploy a cloud or a web farm, Ubuntu Server supports the most popular hardware and software.
+  Securely designed, fast and economically scalable, Ubuntu helps you make the most of your infrastructure. Whether you want to deploy a cloud or a web farm, Ubuntu Server supports the most popular hardware and software.
 {% endblock %}
 
 {% block meta_copydoc %}
@@ -16,46 +22,65 @@
 
 {% block content %}
 
-  <section class="p-strip is-shallow u-no-padding--bottom">
-    <div class="row--50-50 p-section">
-      <div class="col">
-        <h1>Scale out with&nbsp;Ubuntu&nbsp;Server</h1>
-      </div>
-      <div class="col">
-        <p>
-          Ubuntu Server brings economic and technical scalability to your data centre, public or private cloud. Whether you want to deploy an OpenStack cloud, a Kubernetes cluster or a 50,000-node render farm, Ubuntu Server delivers the best value scale-out performance available.
-        </p>
-        <a href="/download/server" class="p-button--positive">Download Ubuntu Server</a>
-      </div>
-    </div>
-    <div class="u-fixed-width p-section--shallow u-hide--small">
-      {{ image(url="https://assets.ubuntu.com/v1/e55cc8c0-wide-server.png",
-            alt="",
-            width="4096",
-            height="1377",
-            hi_def=True,
-            loading="auto") | safe
-      }}
-    </div>
-  </section>
+  {% call(slot) vf_hero(
+    title_text='Scale out with Ubuntu Server',
+    layout='50/50'
+  ) -%}
+  {%- if slot == 'description' -%}
+  <p>
+    Ubuntu Server brings economic and technical scalability to your data center, public or private cloud. Whether you want to deploy an OpenStack cloud, a Kubernetes cluster or a 50,000-node render farm, Ubuntu Server delivers the best value scale-out performance available.
+  </p>
+  {%- endif -%}
+  {%- if slot == 'cta' -%}
+  <hr class="p-rule--muted" />
+  <a href="/download/server" class="p-button--positive">Download Ubuntu Server</a>
+  {%- endif -%}
+  {%- if slot == 'image' -%}
+  <div class="p-image-container--3-2 is-cover">
+    <img class="p-image-container__image" src="https://assets.ubuntu.com/v1/a1dd867d-hero.jpg" alt="IT infrastructure - server">
+  </div>
+  {%- endif -%}
+  {% endcall -%}
 
-  <section class="p-section">
-    <div class="row--50-50">
-      <hr class="p-rule" />
-      <div class="col">
-        <h2>Performance and versatility</h2>
-      </div>
-      <div class="col">
-        <p class="p-heading--5">Agile, secure, deploy-anywhere technology for fast-moving companies</p>
-        <p>
-          It doesn't matter whether you want to deploy a NoSQL database, web farm or cloud. Certified by leading hardware OEMs and with comprehensive deployment tools, so you can get the most from your infrastructure.
-        </p>
-        <p>
-          Our regular release cycle means access to the latest and most performant open source. A lean initial installation along with integrated deployment and application modelling technologies make Ubuntu Server a great solution for simple deployment and management at scale.
-        </p>
-      </div>
-    </div>
-  </section>
+  {%- call(slot) vf_tiered_list(is_list_full_width_on_tablet=true) -%}
+  {%- if slot == 'title' -%}
+  <h2>Why choose Ubuntu Server</h2>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_1' -%}
+  <h3 class="p-heading--5">Performance and versatility</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_1' -%}
+  <p>Ubuntu Server is certified by leading hardware OEMs, 
+    carries a lean initial deployment, and includes 
+    integrated deployment and application modeling tools, 
+    so you can get the most from your infrastructure - whether 
+    you're deploying NoSQL databases, web farms, or the cloud.</p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_2' -%}
+  <h3 class="p-heading--5">A release schedule you can rely on</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_2' -%}
+  <p>Long-term support (LTS) releases of Ubuntu Server receive standard security updates 
+    for around 2,500 packages in the Ubuntu Main repository for five years by default. 
+    Interim releases every six months bring new features, while hardware enablement updates 
+    add support for the latest machines to all supported LTS releases. </p>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_title_3' -%}
+  <h3 class="p-heading--5">Most widely used and trusted platform</h3>
+  {%- endif -%}
+
+  {%- if slot == 'list_item_description_3' -%}
+  <p>Ubuntu is the foundation for private cloud implementation and the most-used Linux distribution 
+    in the world (for the third year in a row) according to the 
+    <a href="/about/release-cycle">OpenLogic 2025 State of Open Source report</a>.</p>
+  {%- endif -%}
+  {%- endcall -%}
+
 
   <section class="p-section">
     <div class="row--50-50 p-section--shallow">
@@ -73,83 +98,91 @@
       <div class="p-logo-section">
         <div class="p-logo-section__items">
           <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/a34e318a-lenovo-logo.svg",
+            {{ image(url="https://assets.ubuntu.com/v1/31a3d361-lenovo_logo.svg",
                         alt="Lenovo",
-                        width="105",
-                        height="144",
+                        width="96",
+                        height="104",
                         hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-logo-section__logo"}) | safe
+                        loading="auto|lazy",
+                        fmt="svg"
+                        ) | safe
             }}
           </div>
           <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/43635925-dell-technologies-logo.png",
+            {{ image(url="https://assets.ubuntu.com/v1/c21e1b85-dell_logo.svg",
                         alt="Dell",
-                        width="172",
-                        height="312",
+                        width="184",
+                        height="104",
                         hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-logo-section__logo"}) | safe
+                        loading="auto|lazy",
+                        fmt="svg"
+                        ) | safe
             }}
           </div>
           <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/c8792945-ibm-logo.png",
+            {{ image(url="https://assets.ubuntu.com/v1/17f8776b-ibm_logo.svg",
                         alt="IBM",
-                        width="141",
-                        height="288",
+                        width="50",
+                        height="104",
                         hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-logo-section__logo"}) | safe
+                        loading="auto|lazy",
+                        fmt="svg"
+                        ) | safe
             }}
           </div>
           <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/136e7089-hp-enterprise-logo.svg",
+            {{ image(url="https://assets.ubuntu.com/v1/f953c43c-hp_logo.svg",
                         alt="Hewlett Packard Enterprise",
-                        width="118",
-                        height="144",
+                        width="44",
+                        height="104",
                         hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-logo-section__logo"}) | safe
+                        loading="auto|lazy",
+                        fmt="svg"
+                        ) | safe
             }}
           </div>
           <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/834d57ab-intel-logo.png",
+            {{ image(url="https://assets.ubuntu.com/v1/f591dcf2-intel_new_logo.svg",
                         alt="Intel",
-                        width="149",
-                        height="288",
+                        width="53",
+                        height="104",
                         hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-logo-section__logo"}) | safe
+                        loading="auto|lazy",
+                        fmt="svg"
+                        ) | safe
             }}
           </div>
           <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/3d30864c-cisco-logo.png",
+            {{ image(url="https://assets.ubuntu.com/v1/f9551a38-cisco_logo.svg",
                         alt="Cisco",
-                        width="174",
-                        height="288",
+                        width="77",
+                        height="104",
                         hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-logo-section__logo"}) | safe
+                        loading="auto|lazy",
+                        fmt="svg"
+                        ) | safe
             }}
           </div>
           <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/dac5c9d7-amd-logo.png",
+            {{ image(url="https://assets.ubuntu.com/v1/ab65b397-amd_logo.svg",
                         alt="AMD",
-                        width="186",
-                        height="257",
+                        width="75",
+                        height="104",
                         hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-logo-section__logo"}) | safe
+                        loading="auto|lazy",
+                        fmt="svg"
+                        ) | safe
             }}
           </div>
           <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/d9d05f49-arm-logo.png",
+            {{ image(url="https://assets.ubuntu.com/v1/add5e59c-arm_logo.svg",
                         alt="Arm",
-                        width="183",
-                        height="372",
+                        width="51",
+                        height="104",
                         hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-logo-section__logo"}) | safe
+                        loading="auto|lazy",
+                        fmt="svg"
+                        ) | safe
             }}
           </div>
         </div>
@@ -173,47 +206,65 @@
       <div class="p-logo-section">
         <div class="p-logo-section__items">
           <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/d784fe44-centrify-logo.png",
+            {{ image(url="https://assets.ubuntu.com/v1/b0f72969-centrify_logo.svg",
                         alt="Centrify",
-                        width="288",
-                        height="288",
+                        width="104",
+                        height="104",
                         hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-logo-section__logo"}) | safe
+                        loading="auto|lazy",
+                        fmt="svg"
+                        ) | safe
             }}
           </div>
           <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/4648a4a4-openstack-logo.png",
+            {{ image(url="https://assets.ubuntu.com/v1/98eccc44-openstack_logo.svg",
                         alt="Openstack",
-                        width="509",
-                        height="384",
+                        width="128",
+                        height="104",
                         hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-logo-section__logo"}) | safe
+                        loading="auto|lazy",
+                        fmt="svg"
+                        ) | safe
             }}
           </div>
           <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/ae513503-likewise-logo.png",
+            {{ image(url="https://assets.ubuntu.com/v1/5db71b68-likewise_logo.svg",
                         alt="Likewise",
-                        width="288",
-                        height="288",
+                        width="62",
+                        height="104",
                         hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-logo-section__logo"}) | safe
+                        loading="auto|lazy",
+                        fmt="svg"
+                        ) | safe
             }}
           </div>
           <div class="p-logo-section__item">
-            {{ image(url="https://assets.ubuntu.com/v1/1ebe929e-openbravo-logo.png",
+            {{ image(url="https://assets.ubuntu.com/v1/cb0c8c5e-openbravo_logo.svg",
                         alt="Openbravo",
-                        width="288",
-                        height="288",
+                        width="104",
+                        height="104",
                         hi_def=True,
-                        loading="lazy",
-                        attrs={"class": "p-logo-section__logo"}) | safe
+                        loading="auto|lazy",
+                        fmt="svg"
+                        ) | safe
             }}
           </div>
         </div>
       </div>
+    </div>
+  </section>
+
+  <section class="p-section--shallow u-no-padding--bottom">
+    <div class="u-fixed-width">
+      {{ image(url="https://assets.ubuntu.com/v1/9c29c336-Digital-Light-Theme-Canonical%2520Ubuntu%2520Pro%2520logo.svg",
+        alt="",
+        width="180",
+        height="51",
+        hi_def=True,
+        loading="auto|lazy",
+        fmt="svg"
+        ) | safe
+      }}
     </div>
   </section>
 
@@ -222,19 +273,24 @@
       <hr class="p-rule" />
       <div class="col">
         <h2>
-          A release schedule
-          <br class="u-hide--medium u-hide--small" />
-          you can depend on
+          Get the latest security updates and support
         </h2>
       </div>
       <div class="col">
-        <p class="p-heading--5">Stay up-to-date with regular updates and upgrades</p>
-        <p>
-          Long-term support (LTS) releases of Ubuntu Server receive standard security updates for around 2,500 packages in the Ubuntu Main repository for five years by default. Every six months, interim releases bring new features, while hardware enablement updates add support for the latest machines to all supported LTS releases.
-        </p>
-        <p>
-          <a href="/pro">Ubuntu Pro</a> subscriptions expands security maintenance to over 30,000 packages for 10 years and provides optional, enterprise-grade phone and ticket support by Canonical.
-        </p>
+        <p>Ubuntu Pro is a comprehensive subscription delivering enterprise-grade security, management tooling, and extended support for developers and enterprises.</p>
+        <hr class="p-rule" />
+        <ul class="p-list--divided">
+          <li class="p-list__item has-bullet">Security updates for the <a href="/esm">full open source stack</a></li>
+          <li class="p-list__item has-bullet">Monitoring and management for your entire estate <a href="/landscape">with Landscape</a></li>
+          <li class="p-list__item has-bullet"><a href="/security/certifications">FIPS 140, CIS hardening, STIG, PCI-DSS and more</a></li>
+          <li class="p-list__item has-bullet">Minimize rolling reboots with <a href="/livepatch">Kernel Livepatch</a></li>
+          <li class="p-list__item has-bullet">Optional weekday or 24/7 support tiers</li>
+        </ul>
+        <hr class="p-rule--muted" />
+        <div class="p-cta-block">
+          <a href="/pro" class="p-button--positive">Get Ubuntu Pro</a>
+          <a href="/engage/vulnerability-management" class="p-button">Start a 30-day free trial</a>
+        </div>
       </div>
     </div>
   </section>
@@ -365,156 +421,262 @@
   <script src="https://assets.ubuntu.com/v1/6d64bd2f-d3.min.js"></script>
   <script src="{{ versioned_static('js/dist/release-chart-manager.js') }}"></script>
 
-  <div class="p-section">
+  <section class="p-section--shallow">
     <div class="row--50-50">
       <hr class="p-rule" />
       <div class="col">
-        <h2>
-          Infrastructure
-          <br class="u-hide--medium u-hide--small" />
-          and applications foundation
-        </h2>
+          <h2>Ubuntu Pro in action</h2>
       </div>
       <div class="col">
-        <p class="p-heading--5">From public clouds to data centres to devices</p>
-        <p>
-          Ubuntu is the most popular guest operating system on public clouds, the foundation for private cloud implementation and the platform of choice of developers according to the <a href="https://www.hackerearth.com/recruit/developer-survey">2020 HackerEarth Developer Survey</a>.
-        </p>
+        <nav class="p-tabs js-tabbed-content">
+          <ul class="p-tabs__list u-no-margin--bottom"
+              role="tablist"
+              data-maintain-hash="true">
+            <li class="p-tabs__item">
+              <a class="p-tabs__link"
+                  role="tab"
+                  aria-selected="false"
+                  id="ubuntu-pro-tab-roblox"
+                  href="#ubuntu-pro-roblox"
+                  aria-controls="ubuntu-pro-roblox"
+                  tabindex="-1">Roblox</a>
+            </li>
+            <li class="p-tabs__item">
+              <a class="p-tabs__link"
+                  role="tab"
+                  aria-selected="true"
+                  id="ubuntu-pro-tab-launchdarkly"
+                  href="#ubuntu-pro-launchdarkly"
+                  aria-controls="ubuntu-pro-launchdarkly">LaunchDarkly</a>
+            </li>
+            <li class="p-tabs__item">
+              <a class="p-tabs__link"
+                  role="tab"
+                  aria-selected="false"
+                  id="ubuntu-pro-tab-new-mexico"
+                  href="#ubuntu-pro-new-mexico"
+                  aria-controls="ubuntu-pro-new-mexico"
+                  tabindex="-1">New Mexico State University</a>
+            </li>
+          </ul>
+        </nav>
+        <div id="ubuntu-pro-roblox"
+             class="p-tabs__content"
+             role="tabpanel"
+             aria-labelledby="ubuntu-pro-tab-roblox">
+          <div class="p-strip is-shallow u-no-padding--top u-no-padding--bottom">
+            {{ image(url="https://assets.ubuntu.com/v1/a289e640-roblox_logo_2025_1.svg",
+              alt="Roblox",
+              width="58",
+              height="104",
+              hi_def=True,
+              loading="auto|lazy",
+              fmt="svg"
+              ) | safe
+            }}
+            <h3>Explore how Roblox migrated servers from Windows to Ubuntu in a seven-day timeframe</h3>
+            <div class="u-embedded-media">
+              <iframe
+                width="600"
+                height="337"
+                src="https://www.youtube.com/embed/SwlU4U-BWRo"
+                title="How Roblox went from Windows to Ubuntu in 7 days for edge compute nodes"
+                frameborder="0"
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                referrerpolicy="strict-origin-when-cross-origin"
+                allowfullscreen></iframe>
+            </div>
+            
+          </div>
+        </div>
+        <div id="ubuntu-pro-launchdarkly"
+             class="p-tabs__content"
+             role="tabpanel"
+             aria-labelledby="ubuntu-pro-tab-launchdarkly">
+          <div class="p-strip is-shallow u-no-padding--top">
+            <div class="p-strip is-shallow">
+              {{ image(url="https://assets.ubuntu.com/v1/358661f9-launchdarkly-logo.svg",
+                            alt="LaunchDarkly",
+                            width="201",
+                            height="30",
+                            hi_def=True,
+                            fmt="svg",
+                            loading="lazy"
+                      ) | safe
+              }}
+            </div>
+            <h3>LaunchDarkly becomes the first FedRAMP-authorized feature management platform thanks to Ubuntu Pro</h3>
+            <p>Learn how a SaaS provider achieved effortless FIPS compliance on AWS.</p>
+            <hr class="p-rule--muted" />
+            <a href="https://assets.ubuntu.com/v1/b97b2df6-AWS%20LaunchDarkly%20Case%20Study%20v3%203.6.2024.pdf" aria-label="Read the case study about LaunchDarkly">Read the case study&nbsp;&rsaquo;</a>
+          </div>
+        </div>
+        <div id="ubuntu-pro-new-mexico"
+             class="p-tabs__content"
+             role="tabpanel"
+             aria-labelledby="ubuntu-pro-tab-new-mexico">
+          <div class="p-strip is-shallow u-no-padding--top">
+            <div class="p-strip is-shallow">
+              {{ image(url="https://assets.ubuntu.com/v1/b0ee8fee-nmsu-logo.svg",
+              alt="New Mexico State University",
+              width="45",
+              height="50",
+              hi_def=True,
+              fmt="svg",
+              loading="lazy"
+              ) | safe
+              }}
+            </div>
+            <h3>How New Mexico State University accelerates compliant federal research with Ubuntu</h3>
+            <p>When the stakes are high and national security is on the line, every decision matters. Just ask the team at New Mexico State University's Physical Science Laboratory (PSL).</p>
+            <hr class="p-rule--muted" />
+            <a href="/blog/how-new-mexico-state-university-accelerates-compliant-federal-research-with-ubuntu" aria-label="Read the case study about New Mexico State University">Read the case study&nbsp;&rsaquo;</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  {% call(slot) vf_equal_heights(
+      title_text="Use it with other Canonical products",
+      highlight_images=True,
+      image_aspect_ratio_large="16-9",
+      items=[
+      {
+      "title_text": "Multi-cloud orchestration",
+      "image_html":  image(url="https://assets.ubuntu.com/v1/11b77504-multi_cloud.svg",
+            alt="",
+            width="284",
+            height="161",
+            hi_def=True,
+            loading="auto|lazy",
+            fmt="svg",
+            attrs={"class": "p-image-container__image"}) | safe,
+      "description_html": "<p>With the option of a command line or browser-based interface, Juju enables you to design and deploy entire workloads in just a few clicks. It works on public clouds like AWS and Microsoft Azure, private clouds built on OpenStack and even directly on bare metal, via MAAS.</p>",
+      "cta_html": "<a href='https://jujucharms.com/'>Learn more about Juju&nbsp;&rsaquo;</a>"
+      },
+      {
+      "title_text": "Bare metal provisioning",
+      "image_html":  image(url="https://assets.ubuntu.com/v1/8cb84a41-bare_metal.svg",
+            alt="",
+            width="284",
+            height="161",
+            hi_def=True,
+            loading="auto|lazy",
+            fmt="svg",
+            attrs={"class": "p-image-container__image"}) | safe,
+      "description_html": "<p>MAAS is a time-saving provisioning system that makes it quick and easy to set up the physical hardware needed to deploy complex services, like Ubuntu's OpenStack cloud infrastructure. Just plug in your servers, connect them to the network and let MAAS do the rest.</p>",
+      "cta_html": "<a href='https://maas.io/'>Learn more about MAAS&nbsp;&rsaquo;</a>"
+      },
+      {
+      "title_text": "Machine containers",
+      "image_html":  image(url="https://assets.ubuntu.com/v1/44ac6a9f-machine_containers.svg",
+            alt="",
+            width="284",
+            height="161",
+            hi_def=True,
+            loading="auto|lazy",
+            fmt="svg",
+            attrs={"class": "p-image-container__image"}) | safe,
+      "description_html": "<p>Economics are directly tied to compute density. LXD, the Linux container hypervisor, merges the speed and density of containers with the manageability and security of traditional virtual machines.</p>",
+      "cta_html": "<a href='/lxd'>Learn more about LXD&nbsp;&rsaquo;</a>"
+      }
+      ]
+      ) %}
+  {% endcall %}
+
+  {% call(slot) vf_cta_section(
+          title_text='',
+          variant='default',
+          layout='25-75',
+          ) -%}
+  {%- if slot == 'cta' -%}
+  <a href="https://ubuntu.com/server/contact-us?product=server-overview"> Speak to our technical support team about your support requirements&nbsp;&rsaquo;</a>
+  {%- endif -%}
+  {% endcall -%}
+
+  {{ vf_basic_section(
+    title={"text": "A thriving community"},
+    items=[
+      {
+        "type": "description",
+        "item": {
+          "type": "html",
+          "content": "
+            <p>
+              Exchange expertise and ideas with thousands of other IT professionals.
+            </p>
+            <p>
+              Want to talk to other Ubuntu users straightaway? Share ideas and get advice and help from our large, 
+              active community of IT professionals. As a community, we set high standards for friendliness and tolerance, 
+              we welcome your questions and contributions!
+            </p>
+          "
+        }
+      },
+      {
+        "type": "cta-block",
+        "item": {
+          "link": {
+            "content_html": "Join the community&nbsp;&rsaquo;",
+            "attrs": {
+              "href": "/community"
+            }
+          }
+        }
+      }
+    ]
+  ) }}
+
+  <section class="p-section">
+    <div class="u-fixed-width">
+      <hr class="p-rule" />
+    </div>
+    <div class="grid-row">
+      <div class="grid-col-2">
+        <div class="p-section--shallow">
+          <h2>Get started today</h2>
+        </div>
+      </div>
+      <div class="grid-col-6">
+        <div class="p-section--shallow">
+          <div class="grid-row">
+            <div class="grid-col-2 grid-col-medium-2">
+              <h3 class="p-heading--5">Download</h3>
+            </div>
+            <div class="grid-col-4 grid-col-medium-2">
+              <p>
+                Whether you want to configure a simple file server or build a fifty thousand-node cloud, 
+                you can rely on Ubuntu Server and its five years of guaranteed free upgrades.
+              </p>
+              <a href="/download/server" class="p-button">Get Ubuntu Server</a>
+            </div>
+          </div>
+        </div>
         <hr class="p-rule--muted" />
-        <a href="/engage/from-vmware-to-open-source">Watch a webinar - “From VMware to Open Source”&nbsp;&rsaquo;</a>
-      </div>
-    </div>
-  </div>
-
-  <div class="p-section">
-    <div class="u-fixed-width p-section--shallow">
-      <hr class="p-rule" />
-      <h2>Use it with other Canonical products</h2>
-    </div>
-    <div class="row">
-      <div class="col-9 col-medium-5 col-start-large-4 col-start-medium-2 p-section--shallow">
-        <hr class="p-rule" />
-        <div class="row">
-          <div class="col-3 col-medium-2">
-            {{ image(url="https://assets.ubuntu.com/v1/ef4ac9e1-juju-tagged-logo.png",
-                        alt="Juju",
-                        width="60",
-                        height="32",
-                        hi_def=False,
-                        loading="lazy") | safe
-            }}
-          </div>
-          <div class="col-6 col-medium-3">
-            <p class="p-heading--5">Multi-cloud orchestration</p>
-            <p>
-              With the option of a command line or browser-based interface, Juju enables you to design and deploy entire workloads in just a few clicks. It works on public clouds like AWS and Microsoft Azure, private clouds built on OpenStack and even directly on bare metal, via MAAS.
-            </p>
-            <hr class="p-rule" />
-            <a href="https://jujucharms.com/">Learn more about Juju&nbsp;&rsaquo;</a>
+        <div class="p-section--shallow">
+          <div class="grid-row">
+            <div class="grid-col-2 grid-col-medium-2">
+              <h3 class="p-heading--5">Get Ubuntu Pro</h3>
+            </div>
+            <div class="grid-col-4 grid-col-medium-2">
+              <p>
+                Get the latest security updates and support for Ubuntu Server from Canonical.
+              </p>
+              <a href="/pro" class="p-button">Explore Ubuntu Pro</a>
+              <a href="/server/contact-us?product=contextual-footer-ua">Get in touch&nbsp;&rsaquo;</a>
+            </div>
           </div>
         </div>
       </div>
     </div>
-    <div class="row p-section--shallow">
-      <div class="col-9 col-medium-5 col-start-large-4 col-start-medium-2">
-        <hr class="p-rule" />
-        <div class="row">
-          <div class="col-3 col-medium-2">
-            {{ image(url="https://assets.ubuntu.com/v1/444371de-maas-tagged-logo.png",
-                        alt="Maas",
-                        width="79",
-                        height="32",
-                        hi_def=False,
-                        loading="lazy") | safe
-            }}
-          </div>
-          <div class="col-6 col-medium-3">
-            <p class="p-heading--5">Bare metal provisioning</p>
-            <p>
-              MAAS is a time-saving provisioning system that makes it quick and easy to set up the physical hardware to deploy complex services, like Ubuntu's OpenStack cloud infrastructure. Just plug in your servers, connect them to the network and let MAAS do the rest.
-            </p>
-            <hr class="p-rule" />
-            <a href="https://maas.io/">Learn more about MAAS&nbsp;&rsaquo;</a>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div class="row p-section--shallow">
-      <div class="col-9 col-medium-5 col-start-large-4 col-start-medium-2">
-        <hr class="p-rule" />
-        <div class="row">
-          <div class="col-3 col-medium-2">
-            {{ image(url="https://assets.ubuntu.com/v1/e3805af7-lxd-tagged-logo.png",
-                        alt="LXD",
-                        width="61",
-                        height="32",
-                        hi_def=False,
-                        loading="lazy") | safe
-            }}
-          </div>
-          <div class="col-6 col-medium-3">
-            <p class="p-heading--5">Machine containers</p>
-            <p>
-              Economics are directly tied to compute density. LXD, the Linux container hypervisor, merges the speed and density of containers with the manageability and security of traditional virtual machines.
-            </p>
-            <hr class="p-rule" />
-            <a href="/lxd">Learn more about LXD&nbsp;&rsaquo;</a>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
+  </section>
 
-  <div class="p-section">
-    <div class="row--50-50">
-      <hr class="p-rule" />
-      <div class="col">
-        <h2>Ubuntu Pro</h2>
-      </div>
-      <div class="col">
-        <p>
-          Ubuntu Pro offers a single, per-node packaging of the most comprehensive software, hardening and security in the industry. With the Base OS, OpenStack, Kubernetes and Applications security maintenance included, Ubuntu Pro delivers everything you need to future-proof your data centre.
-        </p>
-        <p>Furthermore, you can add support for the Base OS, Infrastructure and Applications.</p>
-        <hr class="p-rule" />
-        <a href="/pricing/infra">Learn more about Canonical support&nbsp;&rsaquo;</a>
-      </div>
-    </div>
-  </div>
+  {% with title_link="/blog/tag/ubuntu-server", tag_id="1610" %}
+    {% include "server/partial/_latest-blogs-server.html" %}
+  {% endwith %}
 
-  <div class="p-section">
-    <div class="row--50-50">
-      <hr class="p-rule" />
-      <div class="col">
-        <h2>Get in touch</h2>
-      </div>
-      <div class="col">
-        <p>Speak to our technical support team about your support requirements.</p>
-        <hr class="p-rule" />
-        <a href="/server/contact-us?product=server-overview"
-           class="p-button--positive js-invoke-modal">Contact us</a>
-      </div>
-    </div>
-  </div>
-
-  <div class="p-section">
-    <div class="row--50-50">
-      <hr class="p-rule" />
-      <div class="col">
-        <h2>A thriving community</h2>
-      </div>
-      <div class="col">
-        <p>Exchange expertise and ideas with thousands of other IT professionals.</p>
-        <p>
-          Want to talk to other Ubuntu users straightaway? Share ideas and get advice and help from our large, active community of IT professionals. As a community, we set high standards for friendliness and tolerance, we welcome your questions and contributions!
-        </p>
-        <hr class="p-rule" />
-        <a href="/community">Join the community&nbsp;&rsaquo;</a>
-      </div>
-    </div>
-  </div>
-
-  {% include "server/partial/_server-footer.html" %}
+  <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
 
   <!-- Set default Marketo information for contact form below-->
   <div class="u-hide"

--- a/templates/server/partial/_latest-blogs-server.html
+++ b/templates/server/partial/_latest-blogs-server.html
@@ -1,0 +1,48 @@
+<section class="p-section--deep">
+  <div class="u-fixed-width">
+    <hr class="p-rule" />
+    <h2>
+      <a href="{{ title_link }}">Further reading&nbsp;&rsaquo;</a>
+    </h2>
+  </div>
+  <div class="grid-row">
+    <div class="col">
+      <div class="p-section--shallow">
+        <div class="row" id="server-latest"></div>
+      </div>
+    </div>
+  </div>
+
+  <template id="server-latest-template">
+    <div class="col-3 col-medium-2 u-equal-height-items">
+      <div class="u-crop--16-9">
+        <div class="article-image p-image-wrapper"></div>
+      </div>
+      <h3 class="p-text--default">
+        <a class="article-link article-title"></a>
+      </h3>
+      <p class="article-excerpt"></p>
+    </div>
+  </template>
+</section>
+
+<script src="{{ versioned_static('js/dist/latest-news.js') }}"></script>
+{# djlint:off #}
+  <script>
+    canonicalLatestNews.fetchLatestNews(
+      {
+        articlesContainerSelector: "#server-latest",
+        articleTemplateSelector: "#server-latest-template",
+        excerptLength: 200,
+        {% if group_id %}
+          groupId: {{ group_id }},
+        {% endif %}
+        {% if tag_id %}
+          tagId: {{ tag_id }},
+        {% endif %}
+        linkImage: true,
+        limit: 4
+      }
+    )
+</script>
+{# djlint:on #}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8189,10 +8189,10 @@ vanilla-framework@4.26.1:
   resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.26.1.tgz#d076f26a7215cf8b0babae81753ef535e6486257"
   integrity sha512-7m3qX4rm+I+go5mNjzO8gkp2qxr5m4n1jAxTh+bJ8hx/Wrsx3hiWDmJHylZ2GqjeqdtOiidvWgU2ToZJK6ELUg==
 
-vanilla-framework@4.30.0:
-  version "4.30.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.30.0.tgz#165195e32cbfee1506eccb6d550bf1241304a971"
-  integrity sha512-76bFHDNcmRboRD01RcM0CEDcU+gDd8rCMJe2SFF9MJcVeRG/5nla5nBBgT+30dc/ASQOrs3Fiz5kmAT/AQlhFw==
+vanilla-framework@4.32.0:
+  version "4.32.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.32.0.tgz#be0730a25e3fd67b8071a2721cba524da5b531a3"
+  integrity sha512-RdYyNO0zaaZTZ5tw5wLQvuBcSBjmGEN3JYKBf2BJX1/RSnfobpdakl36ftMRkGgjCS7yXnj6toYr+PXiTCYQ+g==
 
 verbalize@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
## Done

- Page refresh for ubuntu.com/server
- [Figma](https://www.figma.com/design/Kw2SwMkH49tN54NbnKs5dt/ubuntu.com-server---Sites?node-id=238-6213&t=ZVX52TCa1jyzCvus-1)
- [Copydoc](https://docs.google.com/document/d/1vxLhtbjgPs9PCNEhr7fbhEoErCPMXYFfU4UTKH7Kbq4/edit?tab=t.0)

## QA

- Check out this feature branch / check demo
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [BAU QA steps](https://webteam.canonical.com/practices/qa-steps)

## Issue / Card

Fixes [WD-25018](https://warthogs.atlassian.net/browse/WD-25018)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
