### PR TITLE
Use global MARKETO_API_URL env

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -332,9 +332,6 @@ production:
             key: api_secret
             name: marketo
       
-        - name: MARKETO_API_URL
-          value: https://066-EOV-335.mktorest.com
-
         - name: CREDLY_URL
           value: https://api.credly.com/v1
 
@@ -656,9 +653,6 @@ staging:
       secretKeyRef:
         key: api_secret
         name: marketo
-  
-    - name: MARKETO_API_URL
-      value: https://066-EOV-335.mktorest.com
 
     - name: GOOGLE_SERVICE_ACCOUNT_EMAIL
       secretKeyRef:
@@ -946,9 +940,6 @@ staging:
           secretKeyRef:
             key: api_secret
             name: marketo
-
-        - name: MARKETO_API_URL
-          value: https://066-EOV-335.mktorest.com
 
         - name: CRED_MAINTENANCE
           value: true
@@ -1240,9 +1231,6 @@ demo:
       secretKeyRef:
         key: api_secret
         name: marketo
-
-    - name: MARKETO_API_URL
-      value: https://066-EOV-335.mktorest.com
 
     - name: SENTRY_DSN
       value: https://0293bb7fc3104e56bafd2422e155790c@sentry.is.canonical.com//13


### PR DESCRIPTION
## Problem
Deployments seem to be failing due to a [key mismatch](https://jenkins.canonical.com/webteam/job/ubuntu.com/1774/consoleFull) on kubernetes

## Done

- Use single global env variable for marketo, as they are the same. This should also help prevent any duplicate key references in the final deployment yaml.

## QA

- Check that the demo deployment succeeded
- View the demo locally in your web browser at: https://ubuntu-com-15571.demos.haus/
    - Be sure to test on mobile, tablet and desktop screen sizes

## Issue / Card

Fixes [WD-26402](https://warthogs.atlassian.net/browse/WD-26402)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-26402]: https://warthogs.atlassian.net/browse/WD-26402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ