### PR TITLE
Add a link to pro free trial on 20.04 page.

### DIFF
--- a/templates/20-04/index.html
+++ b/templates/20-04/index.html
@@ -32,7 +32,7 @@
     {%- endif -%}
     {%- if slot == 'cta' -%}
       <a href="/pro" class="p-button--positive">Get started with Ubuntu Pro for 20.04 LTS</a>
-      <a href="/pro/free-trial">Start a free trial</a>
+      <a href="/pro/free-trial">Start a free trial&nbsp;&rsaquo;</a>
     {%- endif -%}
     {%- if slot == 'image' -%}
       <div class="p-image-container--3-2 is-cover is-highlighted">

--- a/templates/20-04/index.html
+++ b/templates/20-04/index.html
@@ -32,6 +32,7 @@
     {%- endif -%}
     {%- if slot == 'cta' -%}
       <a href="/pro" class="p-button--positive">Get started with Ubuntu Pro for 20.04 LTS</a>
+      <a href="/pro/free-trial">Start a free trial</a>
     {%- endif -%}
     {%- if slot == 'image' -%}
       <div class="p-image-container--3-2 is-cover is-highlighted">


### PR DESCRIPTION
## Done

Add a link to pro free trial on 20.04 page.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/20-04
- Check there is a link to `/pro/free-trial` as per the copydoc

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-26271
