### PR TITLE
fix(WD-26699): prevent pro shop going to maintenance in cred mainteance window

### DIFF
--- a/webapp/shop/decorators.py
+++ b/webapp/shop/decorators.py
@@ -60,6 +60,9 @@ SERVICES = {
 MAINTENANCE_URLS = [
     "/pro/subscribe",
     "/pro/maintenance-check",
+]
+
+CRED_MAINTENANCE_URLS = [
     "/credentials/shop",
 ]
 
@@ -133,7 +136,7 @@ def shop_decorator(area=None, permission=None, response="json", redirect=None):
                 return flask.render_template("advantage/maintenance.html")
 
             if (
-                flask.request.path in MAINTENANCE_URLS
+                flask.request.path in CRED_MAINTENANCE_URLS
                 and cred_is_in_maintenance
             ):
                 return flask.render_template(


### PR DESCRIPTION
## Done

- Prevent /pro/subscribe to go in maintenance when cred is under maintenance

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- In your `.env.local`
    - set CRED_MAINTENANCE=True
    - set CRED_MAINTENANCE_START={past datetime UTC}
    - set CRED_MAINTENANCE_END={future datetime UTC}

## Issue / Card

Fixes [WD-26699](https://warthogs.atlassian.net/browse/WD-26699)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
