### PR TITLE
Update links on download/qualcomm-iot

### DIFF
--- a/templates/download/qualcomm-iot/tabs/evaluation-kit-tab.html
+++ b/templates/download/qualcomm-iot/tabs/evaluation-kit-tab.html
@@ -81,7 +81,7 @@
       <div class="p-notification--information is-borderless">
         <div class="p-notification__content">
           <p class="p-notification__message">
-            The Ubuntu images are tested on the <a href="https://www.qualcomm.com/developer/hardware/qualcomm-iq-9075-evaluation-kit-evk"
+            The Ubuntu images are tested on the <a href="https://codelinaro.jfrog.io/artifactory/qli-ci/flashable-binaries/ubuntu-fw/QCS9100/QLI.1.4-Ver.1.1/QLI.1.4-Ver.1.1-ubuntu-qcs9100-nhlos-bins.tar.gz"
             title="Read more about Qualcomm IQ-9075 Evaluation Kit (EVK)">Qualcomm IQ-9075 Evaluation Kit (EVK)</a>
           </p>
           <p>(Note: Qualcomm account login is required).</p>

--- a/templates/download/qualcomm-iot/tabs/rb3-gen2-lite-tab.html
+++ b/templates/download/qualcomm-iot/tabs/rb3-gen2-lite-tab.html
@@ -80,7 +80,7 @@
       <div class="p-notification--information is-borderless">
         <div class="p-notification__content">
           <p class="p-notification__message">
-            The Ubuntu images are tested on the <a href="https://www.qualcomm.com/developer/hardware/rb3-gen-2-development-kit"
+            The Ubuntu images are tested on the <a href="https://codelinaro.jfrog.io/artifactory/qli-ci/flashable-binaries/ubuntu-fw/QCM6490/QLI.1.4-Ver.1.1/QLI.1.4-Ver.1.1-ubuntu-QCS6490-nhlos-bins.tar.gz"
     title="Read more about Qualcomm® RB3 Gen 2 Lite dev kit">Qualcomm Dragonwing™ RB3 Gen 2 Lite Vision Development Kit</a>
           </p>
         </div>

--- a/templates/download/qualcomm-iot/tabs/rb3-gen2-tab.html
+++ b/templates/download/qualcomm-iot/tabs/rb3-gen2-tab.html
@@ -80,7 +80,7 @@
       <div class="p-notification--information is-borderless">
         <div class="p-notification__content">
           <p class="p-notification__message">
-            The Ubuntu images are tested on the <a href="https://www.qualcomm.com/developer/hardware/rb3-gen-2-development-kit">Qualcomm Dragonwing™ RB3 Gen 2 Lite Vision Development Kit</a>
+            The Ubuntu images are tested on the <a href="https://codelinaro.jfrog.io/ui/native/qli-ci/flashable-binaries/ubuntu-fw/QCM6490/QLI.1.4-Ver.1.1/QLI.1.4-Ver.1.1-ubuntu-QCS6490-nhlos-bins.tar.gz">Qualcomm Dragonwing™ RB3 Gen 2 Vision Development Kit</a>
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Done

- Update links on download/qualcomm-iot according to the [copydoc](https://docs.google.com/document/d/1BP2T63R6kdnUFQFIZcbXbTIgY-9fQVgVRLsSUU5Rvx8/edit?tab=t.0)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check [download/qualcomm-iot](https://ubuntu-com-15597.demos.haus/download/qualcomm-iot) on the demo server

## Issue / Card

Fixes [WD-26713](https://warthogs.atlassian.net/browse/WD-26713)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-26713]: https://warthogs.atlassian.net/browse/WD-26713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ