### PR TITLE
ci: report failing forms action to MM

### DIFF
--- a/.github/workflows/forms.yaml
+++ b/.github/workflows/forms.yaml
@@ -77,3 +77,9 @@ jobs:
           MARKETO_API_SECRET: ${{ secrets.MARKETO_API_SECRET }}
         run: |
           python -m unittest tests.test_marketo
+
+      - name: Send message on failure
+        env:
+          BOT_URL: ${{ secrets.BOT_URL }}
+        if: failure()
+        run: curl -X POST -F "workflow=${GITHUB_WORKFLOW}" -F "repo_name=${GITHUB_REPOSITORY}" -F "action_id=${GITHUB_RUN_ID}" $BOT_URL?room=webge-forms


### PR DESCRIPTION
## Done

- Note: remove QA steps and failing test before merging
- Added a failing test to test integration workflow
- Report failing form action to webge-forms channel


## QA

- See that `test-marketo` action fails
- See that the action failure is reported on ~webge-forms channel

## Issue / Card

Fixes [WD-26857](https://warthogs.atlassian.net/browse/WD-26857)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-26857]: https://warthogs.atlassian.net/browse/WD-26857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ