### PR TITLE
copy update: update download NVIDIA Jetson page

### DIFF
--- a/templates/download/nvidia-jetson/index.html
+++ b/templates/download/nvidia-jetson/index.html
@@ -30,7 +30,7 @@
       <div class="col">
         <h1>Install Ubuntu on NVIDIA Jetson</h1>
         <p>
-          Run Ubuntu on your NVIDIA&reg; Jetson&trade; Orin platforms to create breakthrough AI solutions across all industries, being available for all the enthusiasts for hands-on AI learning and making amazing projects and for enterprises delivering commercial solutions.
+          Run Ubuntu on your NVIDIA&reg; Jetson&trade; platforms to create breakthrough AI solutions across all industries, being available for all the enthusiasts for hands-on AI learning and making amazing projects and for enterprises delivering commercial solutions. Ubuntu images are now available for both the latest Jetson Thor and Jetson Orin platforms.
         </p>
         <p>
           Pick the OS image to match your hardware, flash it onto a USB or NVMe disk, load it onto your board and away you go.
@@ -76,12 +76,20 @@
                     aria-selected="false"
                     aria-controls="jetson-orin-nx-tab">Jetson Orin NX Series</button>
           </li>
+          <li>
+            <button class="p-tabs__item"
+                    id="jetson-agx-thor"
+                    role="tab"
+                    aria-selected="false"
+                    aria-controls="jetson-agx-thor-tab">Jetson AGX Thor Series</button>
+          </li>
         </ul>
         <form class="u-hide--large u-hide--medium">
           <select name="boardSelect" id="boardSelect">
             <option value="jetson-agx-orin-tab" selected="">Jetson AGX Orin Series</option>
             <option value="jetson-orin-nano-tab">Jetson Orin Nano Series</option>
             <option value="jetson-orin-nx-tab">Jetson Orin NX Series</option>
+            <option value="jetson-agx-thor-tab">Jetson AGX Thor Series</option>
           </select>
         </form>
       </div>
@@ -89,6 +97,7 @@
         {% include "download/nvidia-jetson/tab-1-jetson-agx-orin.html" %}
         {% include "download/nvidia-jetson/tab-2-jetson-orin-nano.html" %}
         {% include "download/nvidia-jetson/tab-3-jetson-orin-nx.html" %}
+        {% include "download/nvidia-jetson/tab-4-jetson-agx-thor.html" %}
       </div>
     </div>
   </section>

--- a/templates/download/nvidia-jetson/tab-4-jetson-agx-thor.html
+++ b/templates/download/nvidia-jetson/tab-4-jetson-agx-thor.html
@@ -1,0 +1,69 @@
+<div tabindex="0"
+     role="tabpanel"
+     id="jetson-agx-thor-tab"
+     aria-labelledby="jetson-agx-thor"
+     aria-hidden="true">
+  <div class="row p-strip is-shallow u-no-padding--top">
+    <div class="col-3">
+      <h2 class="u-hide--small">Jetson AGX Thor</h2>
+    </div>
+    <div class="col-6 u-vertically-center u-align--center">
+      {{ image (
+      url="https://assets.ubuntu.com/v1/c9301d06-Jetson_product_tiles_Module_pages-Jetson_AGX_Orin-ftont-v002.jpg",
+      alt="",
+      width="500",
+      height="375",
+      hi_def=True,
+      loading="auto"
+      ) | safe
+      }}
+    </div>
+  </div>
+  <div class="row p-strip u-no-padding--top">
+    <hr class="p-rule col-9" />
+    <div class="col-3">
+      <h3 class="p-heading--5 u-no-padding--top">Ubuntu Server 24.04</h3>
+    </div>
+    <div class="col-6">
+      <p class="u-no-padding--top">This is a beta version of Ubuntu Server 24.04. The certified version is coming soon.</p>
+      <hr class="p-rule--muted" />
+      <div class="p-notification--information is-borderless">
+        <div class="p-notification__content">
+          <p class="p-notification__message">Please download boot firmware before you start your installation.</p>
+        </div>
+      </div>
+      <p>
+        <a class="p-button--positive"
+           href="https://people.canonical.com/~platform/images/nvidia-tegra/ubuntu-24.04-preinstalled-server-thor-arm64+jetson.img.xz">
+          Download <span class="u-off-screen">Ubuntu Server</span> 24.04 for Jetson AGX Thor
+        </a>
+        <a class="p-button"
+           href="https://developer.nvidia.com/downloads/embedded/L4T/r38_Release_v2.0/release/Jetson_Linux_R38.2.0_aarch64.tbz2">Download Jetson AGX Thor boot firmware</a>
+      </p>
+    </div>
+  </div>
+  <div class="row u-no-padding--top">
+    <hr class="p-rule col-9" />
+    <div class="col-3">
+      <h3 class="p-heading--5 u-no-padding--top">Get started</h3>
+    </div>
+    <div class="col-6">
+      <p class="u-no-padding--top">
+        Get started with Ubuntu 24.04 for <a href="https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-thor/">Jetson AGX Thor</a>
+      </p>
+      <p>
+        <a href="https://canonical-ubuntu-for-jetson.readthedocs-hosted.com/classic/release-note-noble-thor-beta/">Ubuntu 24.04 for NVIDIA Jetson Thor Beta Release Notes v1.0</a>
+        <br />
+        <a href="https://canonical-ubuntu-for-jetson.readthedocs-hosted.com/how-to/flash/">Program an Ubuntu on NVIDIA Jetson Thor AGX</a>
+      </p>
+      <hr class="p-rule--muted" />
+      <div class="p-notification--information is-borderless">
+        <div class="p-notification__content">
+          <p class="p-notification__message">
+            The Ubuntu images are tested on the <a href="https://developer.nvidia.com/embedded/jetson-developer-kits">Jetson AGX Thor Developer Kit</a>
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: https://ubuntu-com-15611.demos.haus/download/nvidia-jetson
    - Be sure to test on mobile, tablet and desktop screen sizes
- Make sure the changes in the [copy doc](https://docs.google.com/document/d/1DHLqBbo6xIHDp-Uc8ngo1t5-GJgeTdTVwBvZRIKyZ0Y/edit?tab=t.0) are applied

## Issue / Card

Fixes [WD-26697](https://warthogs.atlassian.net/browse/WD-26697)



## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-26697]: https://warthogs.atlassian.net/browse/WD-26697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ