### PR TITLE
[WD-23405] feat: show error page if marketo ID is invalid

### DIFF
--- a/templates/400.html
+++ b/templates/400.html
@@ -17,7 +17,7 @@
       <div class="col-6 u-vertically-center">
         <div>
           <h1>400: Bad request</h1>
-          <p class="p-heading--4">The server didn't understand the request.</p>
+          <p class="p-heading--4">{{ error_msg if error_msg else "The server didn't understand the request." }}</p>
         </div>
       </div>
     </div>

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -983,6 +983,12 @@ def marketo_submit():
         r = marketo_api.submit_form(payload)
         data = r.json()
 
+        if "errors" in data and data["errors"][0]["code"] == "609":
+            return flask.render_template(
+                "/400.html",
+                error_msg="Please ensure the form exists and try again.",
+            )
+
         if "result" not in data:
             flask.current_app.extensions["sentry"].captureMessage(
                 "Marketo form API Issue",


### PR DESCRIPTION
## Done

- Display error page with message for invalid marketo ID submission

## QA

- View the site  in your web browser at: https://ubuntu-com-15613.demos.haus/internet-of-things/appstore
- Scroll down to newsletter signup
- Enter your email and submit the form
- Verify it displays 400 error page, with custom message

## Issue / Card

Fixes #[WD-23405](https://warthogs.atlassian.net/browse/WD-23405)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-23405]: https://warthogs.atlassian.net/browse/WD-23405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ