### PR TITLE
feat: add country field to /kernel/real-time/contact-us form

### DIFF
--- a/templates/kernel/real-time/contact-us.html
+++ b/templates/kernel/real-time/contact-us.html
@@ -633,6 +633,9 @@
                   <label for="phone">Mobile/cell phone number:</label>
                   <input id="phone" name="phone" maxlength="255" type="tel" />
                 </li>
+
+                {% include "shared/forms/_country.html" %}
+
               </ul>
               <ul class="p-list">
                 <li class="p-list__item">


### PR DESCRIPTION
## Done

- Add missing country field

## QA

- Go to https://ubuntu-com-15614.demos.haus/kernel/real-time/contact-us
- See that country field is present in the form
- Fill up form and see that it goes through as expected

## Issue / Card

Fixes [WD-26958](https://warthogs.atlassian.net/browse/WD-26958)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-26958]: https://warthogs.atlassian.net/browse/WD-26958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ