### PR TITLE
copy: update /download/risc-v for Ubuntu 25.10 release

### DIFF
--- a/templates/download/risc-v/allwinner-nezha.html
+++ b/templates/download/risc-v/allwinner-nezha.html
@@ -31,8 +31,6 @@
       <p>
         <a class="p-button--positive"
            href="https://cdimage.ubuntu.com/releases/24.04.3/release/ubuntu-24.04.3-preinstalled-server-riscv64+nezha.img.xz">Download 24.04.3 LTS</a>
-        <a class="p-button"
-           href="https://cdimage.ubuntu.com/releases/{{ releases.latest.full_version }}/release/ubuntu-{{ releases.latest.full_version }}-preinstalled-server-riscv64+nezha.img.xz">Download {{ releases.latest.full_version }}</a>
       </p>
       <p>
         <a href="https://canonical-ubuntu-boards.readthedocs-hosted.com/en/latest/how-to/allwinner-nezha-d1/">How to install Ubuntu on the Allwinner Nezha D1</a>

--- a/templates/download/risc-v/deepcomputing-fml13v01.html
+++ b/templates/download/risc-v/deepcomputing-fml13v01.html
@@ -43,9 +43,6 @@
       <p>
         <a class="p-button--positive"
            href="https://cdimage.ubuntu.com/releases/24.04.3/release/ubuntu-24.04.3-preinstalled-server-riscv64+jh7110.img.xz">Download 24.04.3 LTS</a>
-        <a class="p-button"
-          href="https://cdimage.ubuntu.com/releases/25.04/release/ubuntu-25.04-preinstalled-server-riscv64+jh7110.img.xz">Download
-          25.04</a>
       </p>
     </div>
   </div>
@@ -62,9 +59,6 @@
       <p>
         <a class="p-button--positive"
            href="https://cdimage.ubuntu.com/releases/24.04.3/release/ubuntu-24.04.3-live-server-riscv64.iso">Download 24.04.3 LTS live installer</a>
-        <a class="p-button"
-          href="https://cdimage.ubuntu.com/releases/25.04/release/ubuntu-25.04-live-server-riscv64.iso">Download
-          25.04 live installer</a>
       </p>
       <p>
         <a href="https://canonical-ubuntu-boards.readthedocs-hosted.com/en/latest/how-to/deepcomputing-fml13v01/">How to

--- a/templates/download/risc-v/index.html
+++ b/templates/download/risc-v/index.html
@@ -40,7 +40,7 @@
         <p>All images are 64-bit developer preview builds of Ubuntu Server.</p>
         <p>
           <strong>
-            We plan to upgrade the ISA level above RVA20 with the 25.10 release. Please, install the 24.04.3 LTS release if you need long term support for RVA20 hardware.
+            We have upgraded the required RISC-V ISA profile to RVA23S64 with the 25.10 release. Hardware that is not RVA23 ready continues to be supported by our 24.04.3 LTS release.
           </strong>
         </p>
         <p>

--- a/templates/download/risc-v/microchip-curiosity.html
+++ b/templates/download/risc-v/microchip-curiosity.html
@@ -31,8 +31,6 @@
       <p>
         <a class="p-button--positive"
            href="https://cdimage.ubuntu.com/releases/24.04.3/release/ubuntu-24.04.3-preinstalled-server-riscv64+pic64gx.img.xz">Download 24.04.3 LTS</a>
-        <a class="p-button"
-           href="https://cdimage.ubuntu.com/releases/25.04/release/ubuntu-25.04-preinstalled-server-riscv64+pic64gx.img.xz">Download 25.04</a>
       </p>
       <p>
         <a href="https://canonical-ubuntu-boards.readthedocs-hosted.com/en/latest/how-to/microchip-pic64gx1000-discovery/">How to install Ubuntu on the Microchip PIC64GX1000 Curiosity Kit</a>

--- a/templates/download/risc-v/microchip-polarfire.html
+++ b/templates/download/risc-v/microchip-polarfire.html
@@ -42,8 +42,6 @@
       <p>
         <a class="p-button--positive"
            href="https://cdimage.ubuntu.com/releases/24.04.3/release/ubuntu-24.04.3-preinstalled-server-riscv64+icicle.img.xz">Download 24.04.3 LTS</a>
-        <a class="p-button"
-           href="https://cdimage.ubuntu.com/releases/25.04/release/ubuntu-25.04-preinstalled-server-riscv64+icicle.img.xz">Download 25.04</a>
       </p>
       <p>
         <a href="https://canonical-ubuntu-boards.readthedocs-hosted.com/en/latest/how-to/microchip-polarfire-icicle/">How to install Ubuntu on the Microchip Polarfire SoC FPGA Icicle Kit</a>

--- a/templates/download/risc-v/milk-v-mars.html
+++ b/templates/download/risc-v/milk-v-mars.html
@@ -35,8 +35,6 @@
       <p>
         <a class="p-button--positive"
            href="https://cdimage.ubuntu.com/releases/24.04.3/release/ubuntu-24.04.3-preinstalled-server-riscv64+jh7110.img.xz">Download 24.04.3 LTS</a>
-        <a class="p-button"
-           href="https://cdimage.ubuntu.com/releases/25.04/release/ubuntu-25.04-preinstalled-server-riscv64+jh7110.img.xz">Download 25.04</a>
       </p>
     </div>
   </div>
@@ -53,8 +51,6 @@
       <p>
         <a class="p-button--positive"
            href="https://cdimage.ubuntu.com/releases/24.04.3/release/ubuntu-24.04.3-live-server-riscv64.iso">Download 24.04.3 LTS live installer</a>
-        <a class="p-button"
-           href="https://cdimage.ubuntu.com/releases/25.04/release/ubuntu-25.04-live-server-riscv64.iso">Download 25.04 live installer</a>
       </p>
       <p>
         <a href="https://canonical-ubuntu-boards.readthedocs-hosted.com/en/latest/how-to/milk-v-mars/">How to install Ubuntu on the Milk-V Mars</a>

--- a/templates/download/risc-v/pine64-star64.html
+++ b/templates/download/risc-v/pine64-star64.html
@@ -35,8 +35,6 @@
       <p>
         <a class="p-button--positive"
            href="https://cdimage.ubuntu.com/releases/24.04.3/release/ubuntu-24.04.3-preinstalled-server-riscv64+jh7110.img.xz">Download 24.04.3 LTS</a>
-        <a class="p-button"
-           href="https://cdimage.ubuntu.com/releases/25.04/release/ubuntu-25.04-preinstalled-server-riscv64+jh7110.img.xz">Download 25.04</a>
       </p>
     </div>
   </div>
@@ -53,8 +51,6 @@
       <p>
         <a class="p-button--positive"
            href="https://cdimage.ubuntu.com/releases/24.04.3/release/ubuntu-24.04.3-live-server-riscv64.iso">Download 24.04.3 LTS live installer</a>
-        <a class="p-button"
-           href="https://cdimage.ubuntu.com/releases/25.04/release/ubuntu-25.04-live-server-riscv64.iso">Download 25.04 live installer</a>
       </p>
       <p>
         <a href="https://canonical-ubuntu-boards.readthedocs-hosted.com/en/latest/how-to/pine64-star64/">How to install Ubuntu on the Pine64 Star64</a>

--- a/templates/download/risc-v/qemu-emulator.html
+++ b/templates/download/risc-v/qemu-emulator.html
@@ -31,7 +31,7 @@
         <a class="p-button--positive"
            href="https://cdimage.ubuntu.com/releases/24.04.3/release/ubuntu-24.04.3-preinstalled-server-riscv64.img.xz">Download 24.04.3 LTS</a>
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/25.04/release/ubuntu-25.04-preinstalled-server-riscv64.img.xz">Download 25.04</a>
+           href="https://cdimage.ubuntu.com/releases/25.10/release/ubuntu-25.10-preinstalled-server-riscv64.img.xz">Download 25.10</a>
       </p>
     </div>
   </div>
@@ -49,7 +49,7 @@
         <a class="p-button--positive"
            href="https://cdimage.ubuntu.com/releases/24.04.3/release/ubuntu-24.04.3-live-server-riscv64.iso">Download 24.04.3 LTS live installer</a>
         <a class="p-button--positive"
-           href="https://cdimage.ubuntu.com/releases/25.04/release/ubuntu-25.04-live-server-riscv64.iso">Download 25.04 live installer</a>
+           href="https://cdimage.ubuntu.com/releases/25.10/release/ubuntu-25.10-live-server-riscv64.iso">Download 25.10 live installer</a>
       </p>
       <p>
         <a href="https://canonical-ubuntu-boards.readthedocs-hosted.com/en/latest/how-to/qemu-riscv/">How to install Ubuntu on QEMU RISC-V</a>

--- a/templates/download/risc-v/sifive-unmatched.html
+++ b/templates/download/risc-v/sifive-unmatched.html
@@ -33,8 +33,6 @@
       <p class="u-sv3">
         <a class="p-button--positive"
            href="https://cdimage.ubuntu.com/releases/24.04.3/release/ubuntu-24.04.3-preinstalled-server-riscv64+unmatched.img.xz">Download 24.04.3 LTS</a>
-        <a class="p-button"
-           href="https://cdimage.ubuntu.com/releases/25.04/release/ubuntu-25.04-preinstalled-server-riscv64+unmatched.img.xz">Download 25.04</a>
       </p>
     </div>
   </div>
@@ -51,8 +49,6 @@
       <p>
         <a class="p-button--positive"
            href="https://cdimage.ubuntu.com/releases/24.04.3/release/ubuntu-24.04.3-live-server-riscv64.iso">Download 24.04.3 LTS live installer</a>
-        <a class="p-button"
-           href="https://cdimage.ubuntu.com/releases/25.04/release/ubuntu-25.04-live-server-riscv64.iso">Download 25.04 live installer</a>
       </p>
       <p>
         <a href="https://canonical-ubuntu-boards.readthedocs-hosted.com/en/latest/how-to/sifive-hifive-unmatched/">How to install Ubuntu on SiFive HiFive Unmatched</a>

--- a/templates/download/risc-v/sipeed-licheerv.html
+++ b/templates/download/risc-v/sipeed-licheerv.html
@@ -31,8 +31,6 @@
       <p>
         <a class="p-button--positive"
            href="https://cdimage.ubuntu.com/releases/24.04.3/release/ubuntu-24.04.3-preinstalled-server-riscv64+licheerv.img.xz">Download 24.04.3 LTS</a>
-        <a class="p-button"
-           href="https://cdimage.ubuntu.com/releases/25.04/release/ubuntu-25.04-preinstalled-server-riscv64+licheerv.img.xz">Download 25.04</a>
       </p>
       <p>
         <a href="https://canonical-ubuntu-boards.readthedocs-hosted.com/en/latest/how-to/sipeed-licheerv-dock/">How to install Ubuntu on the LicheeRV Dock</a>

--- a/templates/download/risc-v/starfive-visionfive.html
+++ b/templates/download/risc-v/starfive-visionfive.html
@@ -34,8 +34,6 @@
       <p>
         <a class="p-button--positive"
            href="https://cdimage.ubuntu.com/releases/24.04.3/release/ubuntu-24.04.3-preinstalled-server-riscv64+jh7110.img.xz">Download 24.04.3 LTS</a>
-        <a class="p-button"
-           href="https://cdimage.ubuntu.com/releases/25.04/release/ubuntu-25.04-preinstalled-server-riscv64+jh7110.img.xz">Download 25.04</a>
       </p>
     </div>
   </div>
@@ -52,8 +50,6 @@
       <p>
         <a class="p-button--positive"
            href="https://cdimage.ubuntu.com/releases/24.04.3/release/ubuntu-24.04.3-live-server-riscv64.iso">Download 24.04.3 LTS live installer</a>
-        <a class="p-button"
-           href="https://cdimage.ubuntu.com/releases/25.04/release/ubuntu-25.04-live-server-riscv64.iso">Download 25.04 live installer</a>
       </p>
       <p>
         <a href="https://canonical-ubuntu-boards.readthedocs-hosted.com/en/latest/how-to/starfive-visionfive-2/">How to install Ubuntu on the StarFive VisionFive 2</a>


### PR DESCRIPTION
## Done

- Remove the 25.04 download links from the RISC-V download page.

[Doc](https://docs.google.com/document/d/1kkJeq9HdH3iWV35HwihcJd3CxZw9Jy21W66lJl8VbWs/edit?tab=t.eaza04uc1o36#heading=h.kmwms8mtcb3m)
[Demo](https://ubuntu-com-15615.demos.haus/download/risc-v)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes [#WD-26752](https://warthogs.atlassian.net/browse/WD-26752)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
