### PR TITLE
fix(WD-26947): add marketo api url to site.yaml

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -55,6 +55,9 @@ env:
     secretKeyRef:
       key: auth-consumer
       name: launchpad-imagebuild
+  
+  - name: MARKETO_API_URL
+    value: https://066-EOV-335.mktorest.com
 
   - name: MARKETO_API_CLIENT
     secretKeyRef:
@@ -65,9 +68,6 @@ env:
     secretKeyRef:
       key: api_secret
       name: marketo
-  
-  - name: MARKETO_API_URL
-    value: https://066-EOV-335.mktorest.com
 
   - name: GOOGLE_SERVICE_ACCOUNT_EMAIL
     secretKeyRef:
@@ -321,7 +321,10 @@ production:
           secretKeyRef:
             key: app-id
             name: proctor360
-            
+        
+        - name: MARKETO_API_URL
+          value: https://066-EOV-335.mktorest.com
+        
         - name: MARKETO_API_CLIENT
           secretKeyRef:
             key: api_client
@@ -644,6 +647,9 @@ staging:
         key: auth-consumer
         name: launchpad-imagebuild
 
+    - name: MARKETO_API_URL
+      value: https://066-EOV-335.mktorest.com
+
     - name: MARKETO_API_CLIENT
       secretKeyRef:
         key: api_client
@@ -930,6 +936,9 @@ staging:
           secretKeyRef:
             key: organization
             name: credly
+
+        - name: MARKETO_API_URL
+          value: https://066-EOV-335.mktorest.com
 
         - name: MARKETO_API_CLIENT
           secretKeyRef:
@@ -1221,6 +1230,9 @@ demo:
       secretKeyRef:
         key: auth-consumer
         name: launchpad-imagebuild
+    
+    - name: MARKETO_API_URL
+      value: https://066-EOV-335.mktorest.com
 
     - name: MARKETO_API_CLIENT
       secretKeyRef:
@@ -1310,5 +1322,4 @@ demo:
     - name: FLASK_ENV
       value: "demo"    
 
-    - name: MARKETO_API_URL
-      value: https://066-EOV-335.mktorest.com
+    


### PR DESCRIPTION
## Done

- Add `MARKETO_API_URL` to `site.yaml` as it is being used as an env variable (currently production is deployed on PS5 )

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to `/credentials/sign-up` and make sure it is working correctly

## Issue / Card

Fixes [WD-26947](https://warthogs.atlassian.net/browse/WD-26947)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-26947]: https://warthogs.atlassian.net/browse/WD-26947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ