### PR TITLE
fix(WD-26947): add marketo api url to charmcraft

### DIFF
--- a/charm/charmcraft.yaml
+++ b/charm/charmcraft.yaml
@@ -141,3 +141,7 @@ config:
       type: string
       description: "Canonical login URL for authentication"
       default: "https://login.ubuntu.com/"
+    marketo-api-url:
+      type: string
+      description: "Marketo API URL"
+      default: "https://066-EOV-335.mktorest.com"


### PR DESCRIPTION
## Done

- Add marketo api url to charmcraft

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
