### PR TITLE
[WD-27000] feat: dynamically generated vulnerabilities sitemap

### DIFF
--- a/templates/sitemap_index.xml
+++ b/templates/sitemap_index.xml
@@ -19,6 +19,9 @@
     <loc>https://ubuntu.com/security/notices/sitemap.xml</loc>
   </sitemap>
   <sitemap>
+    <loc>https://ubuntu.com/security/vulnerabilities/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
     <loc>https://ubuntu.com/security/cves/sitemap.xml</loc>
   </sitemap>
   <sitemap>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -45,6 +45,7 @@ from webapp.security.views import (
     notices_sitemap,
     single_cves_sitemap,
     single_notices_sitemap,
+    vulnerabilities_sitemap,
 )
 from webapp.shop.advantage.views import (
     accept_renewal,
@@ -198,6 +199,7 @@ DYNAMIC_SITEMAPS = [
     "blog",
     "security/notices",
     "security/cves",
+    "security/vulnerabilities",
     "security/livepatch/docs",
     "robotics/docs",
 ]
@@ -611,6 +613,12 @@ security_vulnerabilities = Category(
     ),
     category_id=308,
 )
+
+app.add_url_rule(
+    "/security/vulnerabilities/sitemap.xml",
+    view_func=vulnerabilities_sitemap(security_vulnerabilities),
+)
+
 
 app.add_url_rule(
     "/security",

--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -816,25 +816,22 @@ def vulnerabilities_sitemap(security_vulnerabilities):
                 vuln["slug"] = topics[vuln_id]
             # Add year
             dt = datetime.strptime(vuln["published"], "%d/%m/%Y")
+            vuln["published_dt"] = dt  # Store parsed date
             vuln["year"] = dt.year
 
         # Make sure they are in order of published date
-        vulnerabilities.sort(
-            key=lambda item: datetime.strptime(item["published"], "%d/%m/%Y"),
-            reverse=True,
-        )
+        vulnerabilities.sort(key=lambda v: v["published_dt"], reverse=True)
 
         # Build links for the XML template
-        links = []
-        for vulnerability in vulnerabilities:
-            links.append(
-                {
-                    "url": f"https://ubuntu.com/security/{vulnerability['slug']}",
-                    "last_updated": (
-                        vulnerability.get("published") or ""
-                    ),
-                }
-            )
+        links = [
+            {
+                "url": (
+                    f"https://ubuntu.com/security/vulnerabilities/{v['slug']}"
+                ),
+                "last_updated": v["published_dt"].strftime("%Y/%m/%d"),
+            }
+            for v in vulnerabilities
+        ]
 
         xml_sitemap = flask.render_template("sitemap.xml", links=links)
 


### PR DESCRIPTION
## Done

- Dynamically generate sitemap for /security/vulnerabilities

## QA

- Verify vulnerabilities sitemap at https://ubuntu-com-15621.demos.haus/security/vulnerabilities/sitemap.xml

## Issue / Card

Fixes #[WD-27000](https://warthogs.atlassian.net/browse/WD-27000)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-27000]: https://warthogs.atlassian.net/browse/WD-27000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ