### PR TITLE
  add redirects from /pro/tutorial page to new page

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1182,7 +1182,7 @@ advantage/attach: "/pro/attach"
 advantage: "/pro"
 advantage/(?P<path>.*): "/pro/{path}"
 pro/get-in-touch: "/pro#get-in-touch"
-pro/beta: "/pro/tutorial"
+pro/beta: https://documentation.ubuntu.com/pro/
 /pro/tutorial: https://documentation.ubuntu.com/pro/
 
 # USN redirects


### PR DESCRIPTION
## Done

- Redirect /pro/tutorials to new documentation website

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Visit [/pro/tutorial](https://ubuntu-com-15622.demos.haus/pro/tutorial)
- Should be redirected to the new documentation site.

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
