### PR TITLE
[WD-27023] Copy update: /kubernetes

### DIFF
--- a/templates/kubernetes/index.html
+++ b/templates/kubernetes/index.html
@@ -353,16 +353,6 @@
                 }}
               </div>
               <div class="p-logo-section__item">
-                {{ image(url="https://assets.ubuntu.com/v1/eb826d4d-portainer-io-logo.png",
-                                alt="Portainer.io",
-                                width="144",
-                                height="96",
-                                hi_def=True,
-                                loading="lazy",
-                                attrs={"class": "p-logo-section__logo"}) | safe
-                }}
-              </div>
-              <div class="p-logo-section__item">
                 {{ image(url="https://assets.ubuntu.com/v1/19c3c265-spectrocloud-logo.png",
                                 alt="Spectro Cloud",
                                 width="87",


### PR DESCRIPTION
## Done

Remove logo as requested in the [ticket](https://warthogs.atlassian.net/browse/WD-27023).

## QA

- Check [demo](https://ubuntu-com-15625.demos.haus/kubernetes#:~:text=public%20cloud%20to-,edge,-Bootstrap%0Ayour%20Kubernetes)
- The logo is not there 

## Issue

https://warthogs.atlassian.net/browse/WD-27023