### PR TITLE
fix(WD-27003): Ubuntu Summit copy update

### DIFF
--- a/templates/summit/index.html
+++ b/templates/summit/index.html
@@ -27,7 +27,7 @@
           </p>
           <div class="p-cta-block">
             <a href="https://discourse.ubuntu.com/t/welcome-to-ubuntu-summit-25-10/65270" class="p-button--positive">Register for the Summit</a>
-            <a href="https://discourse.ubuntu.com/t/ubuntu-summit-25-10-timetable/65271/3" class="p-button">View the timetable</a>
+            <a href="https://discourse.ubuntu.com/t/ubuntu-summit-25-10-timetable/65271" class="p-button">View the timetable</a>
           </div>
         </div>
       </div>
@@ -301,7 +301,7 @@
       <hr class="p-rule--highlight" />
       <p>
         <a class="p-text--small-caps"
-           href="https://discourse.ubuntu.com/t/ubuntu-summit-25-10-timetable/65271/3">View the full list of speakers&nbsp;&rsaquo;</a>
+           href="https://discourse.ubuntu.com/t/ubuntu-summit-25-10-timetable/65271">View the full list of speakers&nbsp;&rsaquo;</a>
       </p>
 
       <ul class="p-list--divided row">


### PR DESCRIPTION
## Done

- Removed outdated meta data image (replaced by default Ubuntu one from template)
- Added registration buttons
- Updated list of speakers

Copy doc: https://docs.google.com/document/d/1lj-xPVQjWqo2J_eZ-3ldKhJHj6RQ0Cwmk_Mr4QA4UTY/edit?tab=t.icbvtndfotod
JIRA: https://warthogs.atlassian.net/browse/WD-27003

## QA


- Visit demo: https://ubuntu-com-15627.demos.haus/summit
- Check it agains copy dock
- Verify that new buttons and updated presenters correctly link to discourse

## Issue / Card

Fixes WD-27003

## Screenshots

Updated sections of the page:

<img width="1288" height="463" alt="image" src="https://github.com/user-attachments/assets/d8173412-d22f-4dd8-922e-d9f924170355" />

<img width="1288" height="365" alt="image" src="https://github.com/user-attachments/assets/01a2ecb9-37c0-4cc5-a746-8dcf0279c3d2" />

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
