### PR TITLE
fix(WD-25022): add exam variant to exam results cred dashboard

### DIFF
--- a/static/js/src/advantage/credentials/dashboard/components/ExamResults/ExamResults.tsx
+++ b/static/js/src/advantage/credentials/dashboard/components/ExamResults/ExamResults.tsx
@@ -96,6 +96,12 @@ const ExamResults = () => {
                 href={props.row.original.result_url}
                 target="_blank"
                 rel="noopener noreferrer"
+                style={{
+                  color:
+                    props.row.original.score > props.row.original.cutOff
+                      ? "#fff"
+                      : "",
+                }}
               >
                 {props.value}
               </a>
@@ -106,6 +112,7 @@ const ExamResults = () => {
         Header: "First Name",
         accessor: "user.first_name",
         sortType: "basic",
+        Cell: (props: any) => <small>{props.value}</small>,
       },
       {
         Header: "User Email",
@@ -117,6 +124,11 @@ const ExamResults = () => {
           ) : (
             <small>{props.value}</small>
           ),
+      },
+      {
+        Header: "Variant",
+        accessor: "ability_screen_variant.name",
+        sortType: "basic",
       },
       {
         Header: "Score (%)",


### PR DESCRIPTION
## Done

- Add exam variant to exam results dashboard

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to /credentials/dashboard/exams/results and make sure you see exam variant in the table as a column

## Issue / Card

Fixes [WD-25022](https://warthogs.atlassian.net/browse/WD-25022)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-25022]: https://warthogs.atlassian.net/browse/WD-25022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ