### PR TITLE
fix(WD-27045): update academy maintenance window

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -19,7 +19,7 @@ env:
     value: 2025-09-05T00:00:00Z
 
   - name: CRED_MAINTENANCE_END
-    value: 2025-09-19T23:59:59Z
+    value: 2025-09-24T23:59:59Z
 
   - name: SEARCH_API_KEY
     secretKeyRef:
@@ -355,7 +355,7 @@ production:
           value: 2025-09-05T00:00:00Z
 
         - name: CRED_MAINTENANCE_END
-          value: 2025-09-19T23:59:59Z
+          value: 2025-09-24T23:59:59Z
 
     - paths: [/tutorials]
       name: ubuntu-com-tutorials
@@ -610,7 +610,7 @@ staging:
       value: 2025-09-05T00:00:00Z
 
     - name: CRED_MAINTENANCE_END
-      value: 2025-09-19T23:59:59Z
+      value: 2025-09-24T23:59:59Z
 
     - name: SEARCH_API_KEY
       secretKeyRef:
@@ -957,7 +957,7 @@ staging:
           value: 2025-09-05T00:00:00Z
 
         - name: CRED_MAINTENANCE_END
-          value: 2025-09-19T23:59:59Z
+          value: 2025-09-24T23:59:59Z
 
     - paths: [/tutorials]
       name: ubuntu-com-tutorials
@@ -1194,7 +1194,7 @@ demo:
       value: 2025-09-05T00:00:00Z
 
     - name: CRED_MAINTENANCE_END
-      value: 2025-09-19T23:59:59Z
+      value: 2025-09-24T23:59:59Z
 
     - name: SEARCH_API_KEY
       secretKeyRef:


### PR DESCRIPTION
## Done

- Update academy's maintenance window's end time

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to /credentials and make sure the banner says that maintenance window ends on 24th Sep 23:59 (UTC)
    - Note that the time on the banner shown is in your local timezone so adjust accordingly 

## Issue / Card

Fixes [WD-27045](https://warthogs.atlassian.net/browse/WD-27045)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-27045]: https://warthogs.atlassian.net/browse/WD-27045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ