### PR TITLE
[WD-26079] fix: marketo forms failing for new creations

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -1030,10 +1030,10 @@ def marketo_submit():
 
     # Redirect to success page only if both submissions were successful
     payload_status = data["result"][0]["status"]
-    if (
-        enrichment_submission["success"] is True
-        and payload_status == "updated"
-    ):
+    if enrichment_submission["success"] is True and payload_status in [
+        "updated",
+        "created",
+    ]:
         flask.flash(
             "Your form was submitted successfully.", "contact-form-success"
         )


### PR DESCRIPTION
## Done

- Fixed marketo form submissions failing for new lead creations

## QA

- Open Incognito browser (different browser from everyday usage, if possible)
- Go to https://ubuntu-com-15637.demos.haus/download/server/thank-you?version=24.04.3&architecture=amd64&lts=true
- Click on "Download the CLI cheat sheet" button
- Fill in the form and submit
- Verify the form submission is successful, and cheat sheet is visible

## Issue / Card

Fixes #[WD-26079](https://warthogs.atlassian.net/browse/WD-26079)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-26079]: https://warthogs.atlassian.net/browse/WD-26079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ