### PR TITLE
[WD-26079] fix: marketo form failing if `mkt` query param is undefined

### DIFF
--- a/webapp/views.py
+++ b/webapp/views.py
@@ -948,7 +948,7 @@ def marketo_submit():
             {
                 "leadFormFields": form_fields,
                 "visitorData": visitor_data,
-                "cookie": flask.request.args.get("mkt"),
+                "cookie": flask.request.args.get("mkt", None),
             }
         ],
     }
@@ -1030,10 +1030,8 @@ def marketo_submit():
 
     # Redirect to success page only if both submissions were successful
     payload_status = data["result"][0]["status"]
-    if enrichment_submission["success"] is True and payload_status in [
-        "updated",
-        "created",
-    ]:
+
+    if enrichment_submission["success"] is True and data["success"] is True:
         flask.flash(
             "Your form was submitted successfully.", "contact-form-success"
         )


### PR DESCRIPTION
## Done

- Fixed marketo form resulting in failure

## QA

- Open Incognito browser (different browser from everyday usage, if possible)
- Go to https://ubuntu-com-15638.demos.haus/download/server/thank-you?version=24.04.3&architecture=amd64&lts=true
- Click on "Download the CLI cheat sheet" button
- Fill in the form and submit
- Verify the form submission is successful, and cheat sheet is visible

## Issue / Card

Fixes #[WD-26079](https://warthogs.atlassian.net/browse/WD-26079)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-26079]: https://warthogs.atlassian.net/browse/WD-26079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ