### PR TITLE
Fix: width for severity base score icon to match height

### DIFF
--- a/static/sass/_pattern_cve.scss
+++ b/static/sass/_pattern_cve.scss
@@ -195,6 +195,7 @@
 
     .p-heading-icon__img {
       height: 1.5rem;
+      width: 1.5rem;
       margin-left: -0.5rem;
       margin-right: 0;
     }


### PR DESCRIPTION
## Done
- Ensure the image maintains aspect ratio by setting explicit width of 1.5rem to match the existing height of 1.5rem for .p-heading-icon__img

## QA
- Go to any CVE page. e.g. http://localhost:8001/security/CVE-2025-32463 (Demo is currently down for the CVE pages)
  - Scroll down to the Severity score breakdown section
- View the site in your web browser
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes # #15642 

## Screenshots
### Before
<img width="1514" height="670" alt="image" src="https://github.com/user-attachments/assets/01565ee5-6d32-45f6-a2ef-3d6d813a2041" />

### After
<img width="1942" height="1234" alt="image" src="https://github.com/user-attachments/assets/d0c31afe-30bf-4cb6-b11b-563cb3edd267" />


[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
