### PR TITLE
fix: newsletter data privacy link

### DIFF
--- a/templates/blog/newsletter-form.html
+++ b/templates/blog/newsletter-form.html
@@ -20,7 +20,7 @@
               products and services.</span>
           </label>
           <p>By submitting this form, I confirm that I have read and agree to <a
-              href="https://canonical.com/legal/dataprivacy" target="_blank">Canonical's Privacy Policy</a>.</p>
+              href="https://canonical.com/legal/data-privacy" target="_blank">Canonical's Privacy Policy</a>.</p>
         </div>
 
         {# These are honey pot fields to catch bots #}


### PR DESCRIPTION
## Done

- Update the link from the blog newsletter to the correct data privacy page

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to [/blog](https://ubuntu-com-15646.demos.haus/blog).
- Click on the "Canonical’s Privacy Policy" link in the newsletter signup box.
- The link should take you to https://canonical.com/legal/data-privacy instead of a 404.

## Issue / Card

https://warthogs.atlassian.net/browse/WD-27220?focusedCommentId=913949&sourceType=mention


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
