### PR TITLE
chore: Update datasheet link for desktop organisations

### DIFF
--- a/templates/desktop/organizations.html
+++ b/templates/desktop/organizations.html
@@ -33,7 +33,7 @@
               <p>
                 <a class="p-button--positive js-invoke-modal" href="/desktop/contact-us">Contact us</a>
                 <a class="p-button"
-                   href="https://assets.ubuntu.com/v1/7e0596c1-Ubuntu%20Desktop%20DS%20Adj%2009.09.24.pdf">Download the datasheet</a>
+                   href="https://assets.ubuntu.com/v1/def33105-ubuntu_desktop_datasheet_2025.pdf">Download the datasheet</a>
                 <a href="/pro">Secure&nbsp;open&nbsp;source&nbsp;with&nbsp;Ubuntu&nbsp;Pro&nbsp;&rsaquo;</a>
               </p>
             </div>


### PR DESCRIPTION
## Done

Updates the datasheet link on /desktop/organizations

## QA

- Go to https://ubuntu-com-15649.demos.haus/desktop/organizations
- Click the "Down load the datasheet" link
- Check that it goes to [the new datasheet](https://assets.ubuntu.com/v1/def33105-ubuntu_desktop_datasheet_2025.pdf) as requested in [the copy doc](https://docs.google.com/document/d/1RuxCA6GYh9UriNv26HCZP9UHo4b4_9fYaaMtGQuH_xc/edit?tab=t.0)

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-27257