### PR TITLE
fix(WD-27335): update SA2 exam id

### DIFF
--- a/webapp/shop/cred/constants.py
+++ b/webapp/shop/cred/constants.py
@@ -11,5 +11,5 @@ TAEXAM_PROC_STATE = {
 
 TAEXAM_PROC_EXAM_MAPPING = {
     "cue-01-linux": 2,
-    "cue-02-desktop": 3,
+    "cue-02-desktop": 4,
 }


### PR DESCRIPTION
## Done

- Update exam id which maps to a proctor exam id from "3" to "4"

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to /credentials/shop
- Purchase "Using Ubuntu Desktop"
- Schedule this exam
- You should receive two emails
    - One from Trueability
    - One from Proctor360
- Now login using a non-canonical account
- Repeat the process
- Now, you should only receive one email from Trueability

## Issue / Card

Fixes [WD-27335](https://warthogs.atlassian.net/browse/WD-27335)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-27335]: https://warthogs.atlassian.net/browse/WD-27335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ