### PR TITLE
chore: Update cve chip markup

### DIFF
--- a/templates/security/cves/cve.html
+++ b/templates/security/cves/cve.html
@@ -207,7 +207,7 @@
                       aria-controls="drawer">Toggle table of contents</button>
             </div>
             <ul>
-              {% if cve.description %}
+              {% if cve.description or cve.ubuntu_description%}
                 <li class="p-side-navigation__item">
                   <a class="highlight-link is-active" href="#description">Description</a>
                 </li>
@@ -244,7 +244,10 @@
 
       <main class="col-9">
         <div class="p-section">
-          <h2 id="description" class="section-heading">Description</h2>
+          {% if cve.description or cve.ubuntu_description %}
+            <h2 id="description" class="section-heading">Description</h2>
+          {% endif %}
+
           {% if cve.description %}<p>{{ cve.description }}</p>{% endif %}
 
           {% if cve.ubuntu_description %}


### PR DESCRIPTION
## Done

- ~~Updated CVE chips to be a tags instead of buttons as intented in the [original design ](https://www.figma.com/design/nUJEBpOPTW74RqDRuMQXxB/24.04-ubuntu.com---CVEs---Sites?node-id=949-22691&m=dev)~~  Aligned CVE chip functionality with how it's done on USN pages

## QA

- View the site locally in your web browser at: https://ubuntu-com-15655.demos.haus/security/CVE-2024-44975#status
    - Scroll through the table and see that the chips retain the intended style and that they route to the correct page on click

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-14904
