### PR TITLE
 Fix Error Handling in Certified Platform Details Functions

### DIFF
--- a/webapp/certified/api.py
+++ b/webapp/certified/api.py
@@ -1,6 +1,7 @@
 from requests import Session
 
 from webapp.certified.helpers import _get_clean_in_filter
+from webapp.decorators import handle_api_error
 
 
 class CertificationAPI:
@@ -33,6 +34,7 @@ class CertificationAPI:
 
         return response
 
+    @handle_api_error
     def certified_platform_details(
         self,
         platform_id,

--- a/webapp/certified/helpers.py
+++ b/webapp/certified/helpers.py
@@ -1,9 +1,7 @@
 import html
 import bleach
 import markdown
-import requests
 from markupsafe import Markup
-from flask import current_app, abort
 
 
 def get_download_url(model_details):
@@ -122,24 +120,3 @@ def _get_category_pathname(form_factor):
         return "socs"
     else:
         return form_factor.lower() + "s"
-
-
-def handle_api_error(api_call):
-    """
-    Centralized error handling for API calls in certified views.
-
-    :param api_call: A callable that makes the API request
-    :return: The result of the API call if successful
-    :raises: Aborts with appropriate HTTP status codes on error
-    """
-    try:
-        return api_call()
-    except requests.exceptions.HTTPError as error:
-        if error.response.status_code == 404:
-            abort(404)
-        else:
-            current_app.extensions["sentry"].captureException()
-            abort(500)
-    except Exception:
-        current_app.extensions["sentry"].captureException()
-        abort(500)


### PR DESCRIPTION
### Problem
The certified_platform_details and certified_platform_details_by_release functions were incorrectly handling API errors, causing all HTTP errors (including 404s) to be returned as 500 Internal Server Errors instead of the appropriate HTTP status codes. This resulted in poor user experience and incorrect error reporting on Sentry.

Before: When the certified platforms API returned a 404 (platform not found), users would see a generic 500 error page instead of the proper 404 page.

## Done
- Refactored Error Handling Logic : Created a centralized handle_api_error helper function in webapp/certified/helpers.py that properly handles different types of API errors:
  - HTTP 404 errors : Now correctly return abort(404) to show the proper "Not Found" page
  - Other HTTP errors : Return abort(500) with Sentry logging for debugging
  - General exceptions : Return abort(500) with Sentry logging
- Improved User Experience : Users now see appropriate error pages:
  - 404 pages when a platform doesn't exist
  - 500 pages only for actual server errors


## QA

- Check out the links below
  - https://ubuntu-com-15656.demos.haus/certified/platforms/12196/22.04%20LTS
    - It should show a 404 page
  - compare that with production http://ubuntu.com/certified/platforms/12196/22.04%20LTS
  - Check that other pages load correctly
    - https://ubuntu-com-15656.demos.haus/certified/platforms/14169/22.04%20LTS
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
