### PR TITLE
copy: update /download/risc-v. WD-27365

### DIFF
--- a/templates/download/risc-v/index.html
+++ b/templates/download/risc-v/index.html
@@ -37,7 +37,6 @@
         <p>
           Run Ubuntu with your favourite RISC-V boards. Pick the OS image to match your hardware, flash it onto SD/microSD card, load it onto your board and away you go.
         </p>
-        <p>All images are 64-bit developer preview builds of Ubuntu Server.</p>
         <p>
           <strong>
             We have upgraded the required RISC-V ISA profile to RVA23S64 with the 25.10 release. Hardware that is not RVA23 ready continues to be supported by our 24.04.3 LTS release.


### PR DESCRIPTION
## Done

- Remove "All images are 64-bit developer preview builds of Ubuntu Server." sentence.

[Doc](https://docs.google.com/document/d/1kkJeq9HdH3iWV35HwihcJd3CxZw9Jy21W66lJl8VbWs/edit?tab=t.eaza04uc1o36)
[Demo](https://ubuntu-com-15665.demos.haus/download/risc-v)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes [#WD-27365](https://warthogs.atlassian.net/browse/WD-27365)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
