### PR TITLE
fix(WD-27250): academy index page copy updates

### DIFF
--- a/secondary-navigation.yaml
+++ b/secondary-navigation.yaml
@@ -478,7 +478,7 @@ robotics:
       path: https://canonical-robotics.readthedocs-hosted.com/en/latest/
 
 credentials:
-  title: University
+  title: Academy
   path: /credentials
 
   children:

--- a/templates/credentials/index.html
+++ b/templates/credentials/index.html
@@ -29,8 +29,8 @@
             </p>
           </div>
           <div class="p-cta-block">
-            <a href="#get-your-openstack" class="p-button--positive">Get your badge</a>
-            <a href="#get-your-openstack" class="p-button">Explore exam content</a>
+            <a href="/credentials/shop" class="p-button--positive">Get your badge</a>
+            <a href="/credentials/exam-content" class="p-button">Explore exam content</a>
           </div>
         </div>
         <div class="p-image-container--cinematic is-cover">
@@ -165,11 +165,11 @@
             </div>
           </div>
           <p class="p-equal-height-row__item">
-            Covers basic operational knowledge of Linux on security, operation and maintenance of basic system resources. View exam content <a href="/internet-of-things/management">here</a>.
+            Covers basic operational knowledge of Linux on security, operation and maintenance of basic system resources. View exam content <a href="credentials/exam-content?exam=Using%20Ubuntu%20Desktop">here</a>.
           </p>
           <div class="p-equal-height-row__item">
             <p>
-              <a href="/internet-of-things/management">Get your badge</a>
+              <a href="/credentials/shop">Get your badge</a>
             </p>
           </div>
         </div>
@@ -191,11 +191,11 @@
             </div>
           </div>
           <p class="p-equal-height-row__item">
-            [Coming soon] Covers administrative essentials for Ubuntu Desktop such as package management, system installation and more. View exam content <a href="/internet-of-things/management">here</a>.
+            [Coming soon] Covers administrative essentials for Ubuntu Desktop such as package management, system installation and more. View exam content <a href="/credentials/exam-content?exam=Using%20Ubuntu%20Desktop">here</a>.
           </p>
           <div class="p-equal-height-row__item">
             <p>
-              <a href="/core/docs/components#heading--confinement">Test beta</a>
+              <a href="/credentials/shop?exam_index=1">Test beta</a>
             </p>
           </div>
         </div>
@@ -217,11 +217,11 @@
             </div>
           </div>
           <p class="p-equal-height-row__item">
-            [Coming soon] Covers common Ubuntu Server administrative tasks like managing and securing services and servers. View exam content <a href="/internet-of-things/management">here</a>.
+            [Coming soon] Covers common Ubuntu Server administrative tasks like managing and securing services and servers. View exam content <a href="/credentials/exam-content?exam=Using%20Ubuntu%20Server">here</a>.
           </p>
           <div class="p-equal-height-row__item">
             <p>
-              <a href="/certified">Test beta</a>
+              <a href="/credentials/sign-up?type=tester">Test beta</a>
             </p>
           </div>
         </div>

--- a/templates/credentials/index.html
+++ b/templates/credentials/index.html
@@ -1,13 +1,9 @@
 {% extends "credentials/base_cred.html" %}
 
-{% block title %}
-  Canonical
-  University
-{% endblock %}
+{% block title %}Canonical Academy{% endblock %}
 
 {% block meta_description %}
-  The Canonical University exams certify knowledge and verify skills in general Linux, Ubuntu
-  Desktop, and Ubuntu Server topics.
+  Get Linux certifications. Take real-world, industry relevant exams from the publisher of Ubuntu.
 {% endblock meta_description %}
 
 {% block
@@ -16,244 +12,294 @@
   endblock meta_copydoc %}
 
   {% block content %}
-    <section class="p-strip--image is-dark is-deep"
-             style="background-image: url(https://assets.ubuntu.com/v1/4a1f9f33-suru-cut.png);
-                    background-position: 100% 60%">
-      <div class="row u-equal-height">
-        <div class="col-6">
-          <h1>Canonical Sys-admin Qualification</h1>
-          <p>
-            We're expanding our exam portfolio to cover multiple job tracks aligned with real-world roles so that you can get skills-based access to top careers.
-            Our sysadmin certification, previously known as CUE, has now evolved into Canonical’s Sysadmin Qualification.
-          </p>
-          <p>
-            Reliable, relevant, and convenient qualifications provide the steps to
-            your professional growth.
-          </p>
-          <p>
-            Develop and certify essential skills on Ubuntu, the world’s most popular
-            Linux OS. You choose the pace.
-          </p>
-          <p>
-            If you have previously taken a CUE exam, please read our FAQ <a href="/credentials/faq">here</a>.
-          </p>
-          <p>
-            <a href="/credentials/shop" class="p-button--positive">Get the exam</a>
-          </p>
+    <section class="p-section--hero">
+      <div class="row--50-50-on-large">
+        <div class="col">
+          <h1 class="u-no-margin--bottom">Canonical Academy</h1>
+          <h2>
+            Self-driven learning.
+            <br />
+            Real-world results.
+          </h2>
         </div>
-        <div class="col-6 u-vertically-center u-align--center u-hide--medium u-hide--small">
-          <!-- <img id="takeover-image"
-      width="400"
-      height="90"
-      alt="Canonical Ubuntu Essentials"
-      src="https://assets.ubuntu.com/v1/c5fa32e4-university-badge.png" /> -->
+        <div class="col">
+          <div class="p-section--shallow">
+            <p>
+              Take control of your professional growth with Linux certifications from Canonical, the publisher of Ubuntu. Each track is built around real-world job roles, helping you develop the hands-on skills that employers need. Learn at your own pace. Gain experience on Ubuntu, the world's most popular Linux OS, and prove your expertise with exams designed by the team behind it.
+            </p>
+          </div>
+          <div class="p-cta-block">
+            <a href="#get-your-openstack" class="p-button--positive">Get your badge</a>
+            <a href="#get-your-openstack" class="p-button">Explore exam content</a>
+          </div>
+        </div>
+        <div class="p-image-container--cinematic is-cover">
+          {{ image(url="https://assets.ubuntu.com/v1/677b11a5-hero.jpg",
+                    alt="",
+                    width="2464",
+                    height="1027",
+                    hi_def=True,
+                    loading="auto",
+                    attrs={"class": "p-image-container__image"}) | safe
+          }}
         </div>
       </div>
     </section>
 
-    <section class="p-strip--light is-deep">
-      <div class="row">
-        <div class="col-3">
-          <h2>Why certify?</h2>
+    <section class="p-section">
+      <div class="row--50-50">
+        <hr class="p-rule--muted" />
+        <div class="col">
+          <h2>Why certify with us?</h2>
         </div>
-        <div class="col-6 col-start-large-6">
+        <div class="col">
           <p>
-            Ubuntu is the world's most popular open source OS for both development and deployment, from the data centre to the cloud to the Internet of things.
+            Ubuntu is the world's most popular open-source OS, powering millions of systems from the data center to the cloud to the edge.
           </p>
           <p>
-            Canonical’s qualifications give you access to top enterprise organisations all over the world - whether you are trying to pave your way into the tech field, looking to upgrade your career or improve your skills.
+            By earning a Canonical Academy badge, you demonstrate proven, practical skills on the platform trusted by leading enterprises worldwide.
+          </p>
+          <p>
+            It's your pathway to the best opportunities - whether you're breaking into tech, advancing your career, or broadening your skills.
           </p>
         </div>
       </div>
     </section>
-    <section class="p-strip">
-      <div class="row">
-        <div class="col-3">
+
+    <section class="p-section">
+      <div class="u-fixed-width">
+        <hr class="p-rule--muted" />
+        <div class="p-section--shallow">
           <h2>What's included?</h2>
         </div>
-        <div class="col-9">
-          <div class="row">
-            <div class="col-2">
-              <h3 class="p-heading--5 u-no-margin--bottom">Industry-vetted exams</h3>
-            </div>
-            <div class="col-7">
-              <p class="u-sv2">
-                Test your knowledge of industry-selected and vetted skills and topics with exams developed using expert feedback and rigorous methodology. Challenge yourself, expand your skill set, and gain access to new career heights. The official Canonical badges will certify your knowledge and recognise you as an industry expert.
-              </p>
-            </div>
-          </div>
-          <hr class="is-fixed-width u-no-margin--bottom" />
-          <div class="row">
-            <div class="col-2">
-              <h3 class="p-heading--5 u-no-margin--bottom">Hands-on testing</h3>
-            </div>
-            <div class="col-7">
-              <p class="u-sv2">
-                Exam questions simulate a real life problem or task that can be part of the day to day of a professional working in an Ubuntu environment. Real-world environments provide a familiar setting to showcase your problem-solving skills.
-              </p>
-            </div>
-          </div>
-          <hr class="is-fixed-width u-no-margin--bottom" />
-          <div class="row">
-            <div class="col-2">
-              <h3 class="p-heading--5 u-no-margin--bottom">Individual pricing</h3>
-            </div>
-            <div class="col-7">
-              <p class="u-sv2">
-                Your career path: now with stepping stones! Take individual exams when they’re most relevant to you, and earn badges that showcase your growing expertise. Stack your achievements by completing all the exams in a track to unlock advanced credentials that reflect both the depth and breadth of your skills.
-              </p>
-            </div>
-          </div>
+      </div>
 
-        </div>
-      </div>
-    </section>
-    <section class="p-strip--light">
       <div class="row">
-        <div class="col-6">
-          <h2 class="u-sv2">Explore the syllabus for the System Administrator track</h2>
-        </div>
-      </div>
-      <div class="row--25-75-on-large">
-        <div class="col"></div>
-        <div class="col">
-          <div class="p-equal-height-row u-sv3">
-            <div class="p-equal-height-row__col">
-              <div class="p-equal-height-row__item u-hide--medium u-hide--small">
-                <div class="is-highlighted">
-                  {{ image(url="https://assets.ubuntu.com/v1/044633cd-exam-linux-terminal.png",
-                                    alt="Using Linux Terminal",
-                                    loading="lazy",
-                                    hi_def=True,
-                                    height="400",
-                                    width="400",
-                                    attrs={"class": "p-image-container__image", "style": "width: 200px"}) | safe
-                  }}
-                </div>
-              </div>
-              <h5 class="p-heading--3 p-equal-height-row__item">
-                <p>Using Linux Terminal</p>
-              </h5>
-              <p class="p-equal-height-row__item">
-                Covers basic operational knowledge of Linux on security, operation and maintenance of basic system resources.
-              </p>
-              <div class="p-equal-height-row__item">
-                <hr class="is-muted" />
-                <p>
-                  <a href="/credentials/shop"
-                     class="p-button--positive u-no-margin--bottom">Get Certification</a>
-                  <a href="/credentials/exam-content?exam=Using%20Linux%20Terminal"
-                     class="p-button--link">Exam Content&nbsp;&rsaquo;</a>
-                </p>
-              </div>
-            </div>
-            <div class="p-equal-height-row__col">
-              <div class="p-equal-height-row__item u-hide--medium u-hide--small">
-                <div class="is-highlighted">
-                  {{ image(url="https://assets.ubuntu.com/v1/6ed52414-exam-ubuntu-desktop.png",
-                                    alt="Using Ubuntu Desktop",
-                                    loading="lazy",
-                                    hi_def=True,
-                                    height="400",
-                                    width="400",
-                                    attrs={"class": "p-image-container__image", "style": "width: 200px"}) | safe
-                  }}
-                </div>
-              </div>
-              <h5 class="p-heading--3 p-equal-height-row__item">
-                <p>Using Ubuntu Desktop</p>
-              </h5>
-              <p class="p-equal-height-row__item">
-                [Coming soon] Covers administrative essentials of Ubuntu Desktop such as package management, system installation and more.
-              </p>
-              <div class="p-equal-height-row__item">
-                <hr class="is-muted" />
-                <p>
-                  <a href="/credentials/shop?exam_index=1"
-                     class="p-button--positive u-no-margin--bottom">Test Beta</a>
-                  <a href="/credentials/exam-content?exam=Using%20Ubuntu%20Desktop"
-                     class="p-button--link">Exam Content&nbsp;&rsaquo;</a>
-                </p>
-              </div>
-            </div>
-            <div class="p-equal-height-row__col">
-              <div class="p-equal-height-row__item u-hide--medium u-hide--small">
-                <div class="is-highlighted">
-                  {{ image(url="https://assets.ubuntu.com/v1/f2d32238-exam-ubuntu-server.png",
-                                    alt="Using Ubuntu Server",
-                                    loading="lazy",
-                                    hi_def=True,
-                                    height="400",
-                                    width="400",
-                                    attrs={"class": "p-image-container__image", "style": "width: 200px"}) | safe
-                  }}
-                </div>
-              </div>
-              <h5 class="p-heading--3 p-equal-height-row__item">
-                <p>Using Ubuntu Server</p>
-              </h5>
-              <p class="p-equal-height-row__item">
-                [Coming soon] Covers common Ubuntu Server administrative tasks like managing and securing services and servers.
-              </p>
-              <div class="p-equal-height-row__item">
-                <hr class="is-muted" />
-                <p>
-                  <a href="/credentials/sign-up?type=tester"
-                     class="p-button--positive u-no-margin--bottom">Test Beta</a>
-                  <a href="/credentials/exam-content?exam=Using%20Ubuntu%20Server"
-                     class="p-button--link">Exam Content&nbsp;&rsaquo;</a>
-                </p>
-              </div>
-            </div>
-          </div>
-          <div class="p-notification--information">
-            <div class="p-notification__content">
-              <p class="p-notification__message">
-                Note: In order to stay current with industry standards, the SysAdmin track is being expanded to include a 4th exam covering more advanced scenarios and skills. Stay tuned for updates on this and future occupational tracks!
-              </p>
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
-    <section class="p-strip is-deep">
-      <div class="row">
-        <div class="col-6">
-          <h2 class="u-sv2">Shape the future of certifications and credentials</h2>
+        <div class="col-3 col-start-large-4">
+          <h3 class="p-heading--5">Industry-vetted exams</h3>
         </div>
         <div class="col-6">
-          <p>Register to be a pre-release tester or subject matter expert.</p>
-          <p class="u-no-margin--bottom">As a tester you will:</p>
-          <ul class="p-list--divided u-no-margin--bottom">
-            <li class="p-list__item is-ticked">
-              <strong>Receive exclusive access to preview, test, and critique exams in development</strong>
-            </li>
-            <li class="p-list__item is-ticked">
-              <strong>Influence exam content and user experience</strong>
-            </li>
-            <li class="p-list__item is-ticked">
-              <strong>Access to full exam at discounted fees</strong>
-            </li>
-          </ul>
-          <p class="u-no-margin--bottom">As a subject matter expert you will:</p>
-          <ul class="p-list--divided u-no-margin--bottom">
-            <li class="p-list__item is-ticked">
-              <strong>Participate in surveys to approve exam topics</strong>
-            </li>
-            <li class="p-list__item is-ticked">
-              <strong>Join advisory panels on the content and direction of future exams</strong>
-            </li>
-            <li class="p-list__item is-ticked">
-              <strong>Contribute to the future of open source skills assessment</strong>
-            </li>
-          </ul>
-          <p>Still have questions? Our team is here to help.</p>
-          <p class="u-sv3">
-            <a href="/credentials/sign-up?type=tester" class="p-button--positive">Sign up as a Tester</a>
-            <a href="/credentials/sign-up?type=sme" class="p-button--positive">Sign up as an SME</a>
-            <a href="mailto:skills@canonical.com" class="p-button">Contact us</a>
+          <p>
+            Test your knowledge of industry-selected and vetted skills with exams developed using expert feedback and rigorous methodology. Challenge yourself, expand your skill set, and gain access to new career opportunities. Each badge you earn builds toward a recognized Linux certification from Canonical Academy, trusted by leading employers.
           </p>
         </div>
+      </div>
+      <div class="row">
+        <div class="col-9 col-start-large-4">
+          <hr class="is-muted" />
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-3 col-start-large-4">
+          <h3 class="p-heading--5">Hands-on testing</h3>
+        </div>
+        <div class="col-6">
+          <p>
+            Exam questions simulate real-life problems and tasks that reflect the day-to-day work of professionals in Ubuntu environments. Real-world testing environments provide a familiar setting to showcase your practical problem-solving skills.
+          </p>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-9 col-start-large-4">
+          <hr class="is-muted" />
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-3 col-start-large-4">
+          <h3 class="p-heading--5">Flexible and convenient</h3>
+        </div>
+        <div class="col-6">
+          <p>
+            Your career path, on your terms. Canonical Academy exams are designed to fit into your schedule, with flexible options that let you learn and test at your own pace. Build your skills step by step, earning badges as you go. Complete an entire track to unlock advanced credentials that demonstrate the depth and breadth of your Linux expertise.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <section class="p-section">
+      <div class="row--50-50 p-section--shallow">
+        <hr class="p-rule--muted" />
+        <div class="u-fixed-width">
+          <h2>Explore the System Administrator track</h2>
+        </div>
+      </div>
+      <div class="p-equal-height-row p-section--shallow">
+        <div class="p-equal-height-row__col">
+          <div class="p-equal-height-row__item">
+            <div class="p-media-container u-darker-background u-hide--small u-hide--medium">
+              {{ image(url="https://assets.ubuntu.com/v1/b49ac756-sys_admin.png",
+                            alt="",
+                            width="568",
+                            height="932",
+                            hi_def=True,
+                            loading="auto",
+                            attrs={"class": "p-image-container__image", "style": "width:320px"}) | safe
+              }}
+            </div>
+            <div class="p-equal-height-row__item">
+              <hr class="p-rule--highlight u-hide--medium u-hide--small" />
+              <h3 class="p-heading--5">Canonical Academy SysAdmin</h3>
+            </div>
+          </div>
+          <p class="p-equal-height-row__item">
+            Build practical, job-ready expertise in Ubuntu system administration. Pass all exams in this track to earn your Canonical Academy SysAdmin qualification.
+          </p>
+        </div>
+        <div class="p-equal-height-row__col">
+          <div class="p-equal-height-row__item">
+            <div class="p-media-container u-darker-background u-hide--small u-hide--medium">
+              {{ image(url="https://assets.ubuntu.com/v1/9949d010-linux_terminal.png",
+                            alt="",
+                            width="568",
+                            height="932",
+                            hi_def=True,
+                            loading="auto",
+                            attrs={"class": "p-image-container__image", "style": "width:320px"}) | safe
+              }}
+            </div>
+            <div class="p-equal-height-row__item">
+              <hr class="p-rule--highlight u-hide--medium u-hide--small" />
+              <h3 class="p-heading--5">Using Linux Terminal</h3>
+            </div>
+          </div>
+          <p class="p-equal-height-row__item">
+            Covers basic operational knowledge of Linux on security, operation and maintenance of basic system resources. View exam content <a href="/internet-of-things/management">here</a>.
+          </p>
+          <div class="p-equal-height-row__item">
+            <p>
+              <a href="/internet-of-things/management">Get your badge</a>
+            </p>
+          </div>
+        </div>
+        <div class="p-equal-height-row__col">
+          <div class="p-equal-height-row__item">
+            <div class="p-media-container u-darker-background u-hide--small u-hide--medium">
+              {{ image(url="https://assets.ubuntu.com/v1/a005177e-ubuntu_desktop.png",
+                            alt="",
+                            width="568",
+                            height="932",
+                            hi_def=True,
+                            loading="auto",
+                            attrs={"class": "p-image-container__image", "style": "width:320px"}) | safe
+              }}
+            </div>
+            <div class="p-equal-height-row__item">
+              <hr class="p-rule--highlight u-hide--medium u-hide--small" />
+              <h3 class="p-heading--5">Using Ubuntu Desktop</h3>
+            </div>
+          </div>
+          <p class="p-equal-height-row__item">
+            [Coming soon] Covers administrative essentials for Ubuntu Desktop such as package management, system installation and more. View exam content <a href="/internet-of-things/management">here</a>.
+          </p>
+          <div class="p-equal-height-row__item">
+            <p>
+              <a href="/core/docs/components#heading--confinement">Test beta</a>
+            </p>
+          </div>
+        </div>
+        <div class="p-equal-height-row__col">
+          <div class="p-equal-height-row__item">
+            <div class="p-media-container u-darker-background u-hide--small u-hide--medium">
+              {{ image(url="https://assets.ubuntu.com/v1/51ef7691-ubuntu_server.png",
+                            alt="",
+                            width="568",
+                            height="932",
+                            hi_def=True,
+                            loading="auto",
+                            attrs={"class": "p-image-container__image", "style": "width:320px"}) | safe
+              }}
+            </div>
+            <div class="p-equal-height-row__item">
+              <hr class="p-rule--highlight u-hide--medium u-hide--small" />
+              <h3 class="p-heading--5">Using Ubuntu Server</h3>
+            </div>
+          </div>
+          <p class="p-equal-height-row__item">
+            [Coming soon] Covers common Ubuntu Server administrative tasks like managing and securing services and servers. View exam content <a href="/internet-of-things/management">here</a>.
+          </p>
+          <div class="p-equal-height-row__item">
+            <p>
+              <a href="/certified">Test beta</a>
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-start-large-4 col-9">
+          <div class="p-equal-height-row p-section--shallow">
+            <div class="p-equal-height-row__col">
+              <div class="p-equal-height-row__item">
+                <div class="p-media-container u-darker-background u-hide--small u-hide--medium">
+                  {{ image(url="https://assets.ubuntu.com/v1/81d5cbca-complex_systems.png",
+                                    alt="",
+                                    width="568",
+                                    height="932",
+                                    hi_def=True,
+                                    loading="auto",
+                                    attrs={"class": "p-image-container__image", "style": "width:320px"}) | safe
+                  }}
+                </div>
+                <div class="p-equal-height-row__item">
+                  <hr class="p-rule--highlight u-hide--medium u-hide--small" />
+                  <h3 class="p-heading--5">Managing Complex Systems</h3>
+                </div>
+              </div>
+              <p class="p-equal-height-row__item">[More details coming soon]</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="p-section">
+      <div class="row--50-50">
+        <hr class="p-rule--muted" />
+        <div class="col">
+          <h2>
+            Shape the future
+            <br />
+            of Canonical University
+          </h2>
+        </div>
+        <div class="col">
+          <p>Register to be a pre-release tester or subject matter expert.</p>
+          <p>
+            As a tester, you will:
+            <ul class="p-list--divided">
+              <li class="p-list__item has-bullet">Receive exclusive access to preview, test, and critique exams in development</li>
+              <li class="p-list__item has-bullet">Influence exam content and user experience</li>
+              <li class="p-list__item has-bullet">Access to full exams at discounted rates</li>
+            </ul>
+          </p>
+          <p>
+            As a subject matter expert you will:
+            <ul class="p-list--divided">
+              <li class="p-list__item has-bullet">Participate in surveys to approve exam topics</li>
+              <li class="p-list__item has-bullet">Join advisory panels on the content and direction of future exams</li>
+              <li class="p-list__item has-bullet">Contribute to the future of open source skills assessment</li>
+            </ul>
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <div class="u-fixed-width">
+      <hr class="p-rule" />
+    </div>
+
+    <section class="p-strip is-deep">
+      <div class="u-fixed-width">
+        <h2>Still have questions? Our team is happy to help.</h2>
+        <p>
+          <a class="p-button--positive js-invoke-modal"
+             href="/credentials/sign-up?type=sme">Apply to be an SME</a>
+          <a class="p-button js-invoke-modal"
+             href="/credentials/sign-up?type=tester">Apply to be a Tester</a>
+          <a href="mailto:skills@canonical.com">Contact us&nbsp;&rsaquo;</a>
+        </p>
       </div>
     </section>
   {% endblock content %}


### PR DESCRIPTION
## Done

- Update index page for canonical academy

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to /credentials and make sure the copy matches the following [copy doc](https://docs.google.com/document/d/1QuhO-9FEOGLrYp8bErS_9snqdljl7d6tFAUoNQxoVDQ/edit?tab=t.0) and [figma design](https://www.figma.com/design/uBwyZbfdiHeVRKx4tqFoY8/Canonical-Academy---Sites?node-id=86-6977&m=dev)

## Issue / Card

Fixes [WD-27250](https://warthogs.atlassian.net/browse/WD-27250)

## Screenshots

### New copy home page
<img width="1728" height="993" alt="Screenshot 2025-09-25 at 5 32 08 pm" src="https://github.com/user-attachments/assets/e89f5a9a-ab3f-4a4f-8ba5-0ebd2b08831b" />


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
