### PR TITLE
build: update @canonical/latest-news dependency to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@axe-core/playwright": "^4.8.5",
     "@canonical/cookie-policy": "^3.6.4",
     "@canonical/global-nav": "3.7.3",
-    "@canonical/latest-news": "1.6.0",
+    "@canonical/latest-news": "2.0.0",
     "@canonical/react-components": "^0.60.0",
     "@fullhuman/postcss-purgecss": "6",
     "@percy/cli": "^1.30.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1218,10 +1218,10 @@
   dependencies:
     vanilla-framework "4.26.1"
 
-"@canonical/latest-news@1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@canonical/latest-news/-/latest-news-1.6.0.tgz#a484da6f96c73d658564e90f282e6b9a4320b37a"
-  integrity sha512-XKV9BttYHYBkmknQ/xQvskomv4anXxb2PvtmBQ6i8s/RfZD9XcmmpN5Ar7dkikcVU7GO5XjdH4xszPuhLcdtMg==
+"@canonical/latest-news@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@canonical/latest-news/-/latest-news-2.0.0.tgz#45635fdc72d0ea1e1b5f36f3a58e414bec95f257"
+  integrity sha512-GDDtRxoN1zQU7H8yoaMYAaxF1Z8ZxGEAHLRqw+QvdDRRTt1SK6MziilAoJmbyMV0UKvDKIh5doZ1EpE5VtRVnQ==
 
 "@canonical/react-components@^0.60.0":
   version "0.60.0"


### PR DESCRIPTION
## Done

- update @canonical/latest-news dependency to 2.0.0 which added Cloudinary CDN support for images and Implements image lazy loading option

## QA

- Check out this page with latest news: https://ubuntu-com-15668.demos.haus/desktop/developers
  - [/16-04](https://ubuntu-com-15668.demos.haus/16-04#:~:text=Latest%20from%20our%20blog%C2%A0%E2%80%BA)
  - [/azure](https://ubuntu-com-15668.demos.haus/azure#:~:text=Latest%20from%20our%20blog%C2%A0%E2%80%BA)
- Scroll to the bottom (section before the footer)
- Check that news load
- Check that the package upgrade features are present by inspecting the cards and seeing that
  - the image have `loading="lazy"`
  - the image use cloudinary to route the assets URL
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes # https://warthogs.atlassian.net/browse/WD-27669

## Screenshots
<img width="2512" height="900" alt="image" src="https://github.com/user-attachments/assets/6a512a42-a0df-4e80-9ea7-45d5e0bdb80c" />


[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
