### PR TITLE
Make sure tutorial topics are case-insensitive 

### DIFF
--- a/static/js/src/tutorial-list.js
+++ b/static/js/src/tutorial-list.js
@@ -10,7 +10,23 @@ function handleFilter(key, el, url) {
   }
 
   if (url.searchParams.has(key)) {
-    el.value = url.searchParams.get(key);
+    const urlValue = url.searchParams.get(key);
+    const options = Array.from(el.options);
+    
+    // First try exact match
+    const exactMatch = options.find(({value}) => value === urlValue);
+    if (exactMatch) {
+      el.value = exactMatch.value;
+    } else {
+      // Fall back to case-insensitive match
+      const lowerUrlValue = urlValue.toLowerCase();
+      const caseInsensitiveMatch = options.find(({value}) => 
+        value.toLowerCase() === lowerUrlValue
+      );
+      if (caseInsensitiveMatch) {
+        el.value = caseInsensitiveMatch.value;
+      }
+    }
   }
 
   el.addEventListener("change", (e) => {

--- a/static/js/src/tutorial-list.js
+++ b/static/js/src/tutorial-list.js
@@ -12,16 +12,16 @@ function handleFilter(key, el, url) {
   if (url.searchParams.has(key)) {
     const urlValue = url.searchParams.get(key);
     const options = Array.from(el.options);
-    
+
     // First try exact match
-    const exactMatch = options.find(({value}) => value === urlValue);
+    const exactMatch = options.find(({ value }) => value === urlValue);
     if (exactMatch) {
       el.value = exactMatch.value;
     } else {
       // Fall back to case-insensitive match
       const lowerUrlValue = urlValue.toLowerCase();
-      const caseInsensitiveMatch = options.find(({value}) => 
-        value.toLowerCase() === lowerUrlValue
+      const caseInsensitiveMatch = options.find(
+        ({ value }) => value.toLowerCase() === lowerUrlValue,
       );
       if (caseInsensitiveMatch) {
         el.value = caseInsensitiveMatch.value;

--- a/static/js/src/tutorial-list.test.js
+++ b/static/js/src/tutorial-list.test.js
@@ -11,6 +11,7 @@ describe("handleFilter", () => {
     <select name="tutorials-topic" id="tutorials-topic" class="u-no-margin--bottom">
       <option value="">Any</option>
       <option value="cloud">Cloud</option>
+      <option value="openstack">Openstack</option>
     </select>
   `;
 
@@ -20,6 +21,22 @@ describe("handleFilter", () => {
     const url = new URL("http://localhost?topic=cloud");
     handleFilter("topic", topicEl, url);
     expect(topicEl.value).toBe("cloud");
+  });
+
+  it("sets the option value with case-insensitive matching", () => {
+    document.body.innerHTML = Filters;
+    const topicEl = document.querySelector("#tutorials-topic");
+    const url = new URL("http://localhost?topic=OpenStack");
+    handleFilter("topic", topicEl, url);
+    expect(topicEl.value).toBe("openstack");
+  });
+
+  it("sets the option value with uppercase case-insensitive matching", () => {
+    document.body.innerHTML = Filters;
+    const topicEl = document.querySelector("#tutorials-topic");
+    const url = new URL("http://localhost?topic=OPENSTACK");
+    handleFilter("topic", topicEl, url);
+    expect(topicEl.value).toBe("openstack");
   });
 
   it("removes the page parameter from the URL", () => {

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -254,7 +254,7 @@ def build_tutorials_index(session, tutorials_docs):
             tutorials = [
                 doc
                 for doc in tutorials_docs.parser.tutorials
-                if topic.lower() in doc["categories"].lower()
+                if topic.lower() in doc["categories"]
             ]
 
         # Create list of topics

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -254,7 +254,7 @@ def build_tutorials_index(session, tutorials_docs):
             tutorials = [
                 doc
                 for doc in tutorials_docs.parser.tutorials
-                if topic in doc["categories"]
+                if topic.lower() in doc["categories"].lower()
             ]
 
         # Create list of topics
@@ -305,7 +305,7 @@ def build_tutorials_index(session, tutorials_docs):
             forum_url=tutorials_docs.parser.api.base_url,
             tutorials=tutorials,
             page=page,
-            topic=topic,
+            topic=topic.lower() if topic else topic,
             topics_list=dict(
                 sorted(topics_list.items(), key=lambda key: key[0])
             ),


### PR DESCRIPTION
Topic preselection in tutorials was failing when URL parameters had different casing than the stored category values. For example, ?topic=OpenStack wouldn't preselect the "openstack" option in the dropdown.

## Done

- Fixes a case where the tutorials page have topics with none lowercase text such as Cloud or AWS e.tc
## QA

- Check out the demo and check that [/tutorials?topic=openstack](https://ubuntu-com-15669.demos.haus/tutorials?topic=openstack) and [/tutorials?topic=Openstack](https://ubuntu-com-15669.demos.haus/tutorials?topic=Openstack) works
- Compare that with https://ubuntu.com/tutorials?topic=openstack and https://ubuntu.com/tutorials?topic=Openstack

## Issue / Card

Fixes # https://github.com/canonical/ubuntu.com/issues/11374
https://warthogs.atlassian.net/browse/WD-27640

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
