### PR TITLE
fix(WD-27250): fix typography on academy homepage

### DIFF
--- a/templates/credentials/index.html
+++ b/templates/credentials/index.html
@@ -262,7 +262,7 @@
           <h2>
             Shape the future
             <br />
-            of Canonical University
+            of Canonical Academy
           </h2>
         </div>
         <div class="col">


### PR DESCRIPTION
## Done

- Fix a typo in academy homepage

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
