### PR TITLE
fix: robotics page image container class

### DIFF
--- a/templates/robotics/index.html
+++ b/templates/robotics/index.html
@@ -40,8 +40,7 @@
                 height="1200",
                 hi_def=True,
                 loading="auto",
-                attrs={"class": "p-image-container__image", "id":"robotics-image",
-                "class":"u-hide",}) | safe
+                attrs={"class": "p-image-container__image u-hide", "id":"robotics-image"}) | safe
         }}
       </div>
     {% endif -%}


### PR DESCRIPTION
## Done

- Updated the Hero image classname

## QA

- Check [/robotics](https://ubuntu-com-15676.demos.haus/robotics)
- Compare that to prod https://ubuntu.com/robotics
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots
### Before
<img width="3000" height="1756" alt="image" src="https://github.com/user-attachments/assets/87af01cb-6192-4eca-b5e3-a6cd41c2a7a4" />
### After
<img width="2504" height="1046" alt="image" src="https://github.com/user-attachments/assets/96ebeae2-c8bb-4539-9ba9-9a7a6ba557de" />

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
