### PR TITLE
Add tracking-api.g2.com to CSP allowlist

### DIFF
--- a/webapp/constants.py
+++ b/webapp/constants.py
@@ -62,6 +62,7 @@ CSP = {
         "cdn.jsdelivr.net",
         "*.g.doubleclick.net",
         "extend.vimeocdn.com",
+        "tracking-api.g2.com",
         "'unsafe-inline'",
     ],
     "font-src": [


### PR DESCRIPTION
## Done

- add tracking-api.g2.com to CSP allowlist

## QA

- Check out the [demo](https://ubuntu-com-15678.demos.haus/)
- Open dev tools
- Check that the console has no errors `Content-Security-Policy: The page’s settings blocked a script` about tracking-api.g2.com

## Issue / Card

Fixes # https://warthogs.atlassian.net/browse/WD-27681

## Screenshots
<img width="1050" height="422" alt="image" src="https://github.com/user-attachments/assets/959cb4fd-7b01-4cf2-9213-b41e602dbcf2" />


[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
