### PR TITLE
[WD-27636] - update /download/server for 25.10

### DIFF
--- a/templates/download/server/manual.html
+++ b/templates/download/server/manual.html
@@ -196,12 +196,12 @@
           <h2>Ubuntu {{ releases.latest.full_version }}</h2>
         </div>
         <div class="p-image-wrapper u-hide--small">
-          {{ image(url="https://assets.ubuntu.com/v1/ce1666ec-pp-master-orange-hex.svg",
-                    alt="Plucky Puffin",
-                    width="182",
-                    height="192",
-                    hi_def=True,
-                    loading="auto") | safe
+          {{ image(url="https://assets.ubuntu.com/v1/7e341c7f-questing-quokka-bg.svg",
+            alt="Questing Quokka",
+            width="182",
+            height="182",
+            hi_def=True,
+            loading="auto") | safe
           }}
         </div>
       </div>
@@ -260,10 +260,8 @@
              role="tabpanel"
              aria-labelledby="release-notes-tab-latest">
           <ul class="p-list--divided">
-            <li class="p-list__item is-ticked">Linux 6.14 kernel</li>
-            <li class="p-list__item is-ticked">Updates to new Database versions including MySQL 8.4 and Postgresql 17</li>
-            <li class="p-list__item is-ticked">Updated Virtualization stack based on QEMU 9.2 and libvirt 11.0</li>
-            <li class="p-list__item is-ticked">Chrony as NTP client using the secure NTS by default</li>
+            <li class="p-list__item is-ticked">Linux 6.17 kernel</li>
+            <li class="p-list__item is-ticked">Updated Virtualization stack based on QEMU 10.1 and libvirt 11.6</li>
           </ul>
           <hr class="p-rule" />
           <ul class="u-responsive-realign p-inline-list">


### PR DESCRIPTION
## Done

- update mascot, version and maintenance update deadline for latest release in ubuntu server page

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- You can also check the [demo](https://ubuntu-com-15680.demos.haus/download/server) directly
## Issue / Card
Google doc - [Document](https://docs.google.com/document/d/1Qob4Ni_y1ffIdSWqaw2xH0dxiHZQmkRGP5nuoBhIfyM/edit?tab=t.0)
Jira ticket - [WD-27636](https://warthogs.atlassian.net/browse/WD-27636)

## Screenshots
Before:
<img width="1358" height="589" alt="image" src="https://github.com/user-attachments/assets/046fb5b0-322a-4c8e-a017-457eefc61674" />
After:
<img width="1353" height="558" alt="image" src="https://github.com/user-attachments/assets/83586115-8f83-4fa8-87af-4cca87e2de7e" />


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-27636]: https://warthogs.atlassian.net/browse/WD-27636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ