### PR TITLE
WD-27088 - Copy update: Upgrade navigation link from 18.04 upgrade to 20.04 upgrade

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -594,8 +594,8 @@ support:
       secondary_links:
         - title: Quick links
           links:
-            - title: Upgrade from 18.04
-              url: /18-04
+            - title: Upgrade from 20.04 LTS
+              url: /20-04
             - title: Why Ubuntu Pro?
               url: /pro/why-pro
             - title: Expanded Security Maintenance


### PR DESCRIPTION
## Done

- Upgrade navigation link from 18.04 upgrade to 20.04 upgrade

## QA

- Check out the support section on the meganav in the [demo](https://ubuntu-com-15681.demos.haus/) (under quick links).
- Make sure the link and text are updated per this [comment in the copy doc](https://docs.google.com/document/d/1DCNvYHfC7AbOcqflTBaVd571iKAP_PaTfnqTENVEDVw/edit?disco=AAABrUkkx-E).

## Issue / Card

- [WD-27088](https://warthogs.atlassian.net/browse/WD-27088)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-27088]: https://warthogs.atlassian.net/browse/WD-27088?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ