### PR TITLE
refactor: Migrate /download/contact-us forms to form generator

### DIFF
--- a/templates/download/contact-us.html
+++ b/templates/download/contact-us.html
@@ -6,44 +6,21 @@
 
 {% if product == 'supported-platforms' %}
 
-{% with h1='Contact us about supported platforms',
-  intro_text="Can't find your board of choice? Fill out the form and a member of our team will be in touch",
-  formid="4126",
-  lpId="",
-  returnURL="/download/thank-you?product=supported-platforms" %}
-  {% include "shared/_default-contact-us-form.html" %}
-{% endwith %}
+  {{ load_form("/download/supported-platforms/contact-us") | safe }}
 
 {% elif product == 'qualcomm-iot' %}
 
-{% with h1="Contact us",
-  intro_text="To speak about a specific project requirement or certification, please fill in this form and send us a message",
-  formid="6035",
-  lpId="",
-  returnURL="/download/thank-you?product=qualcomm-iot" %}
-  {% include "shared/forms/interactive/qualcomm-iot.html" %}
-{% endwith %}
+  {{ load_form("/download/qualcomm-iot/contact-us") | safe }}
 
 {% elif product == 'renesas-iot' %}
 
-{% with h1="Contact us",
-  intro_text="To speak about a specific project requirement or certification, please fill in this form and send us a message",
-  formid="6153",
-  lpId="",
-  returnURL="/download/thank-you?product=renesas-iot" %}
-  {% include "shared/forms/interactive/renesas-iot.html" %}
-{% endwith %}
+  {{ load_form("/download/renesas-iot/contact-us") | safe }}
 
 {% else %}
 
-{% with h1="Contact Canonical about downloads",
-  intro_text="",
-  formid="1257",
-  lpId="",
-  returnURL="/download/thank-you" %}
-  {% include "shared/_default-contact-us-form.html" %}
-{% endwith %}
+  {{ load_form("/download/contact-us") | safe }}
 
 {% endif %}
+
 
 {% endblock content %}

--- a/templates/download/form-data.json
+++ b/templates/download/form-data.json
@@ -1,0 +1,771 @@
+{
+  "form": {
+    "/download/contact-us": {
+      "templatePath": "/contact-us.html",
+      "isModal": false,
+      "modalId": "",
+      "formData": {
+        "title": "Contact Canonical about downloads",
+        "formId": "1257",
+        "returnUrl": "/download/thank-you"
+      },
+      "fieldsets": [
+        {
+          "title": "Tell us about your project",
+          "id": "about-your-project",
+          "fields": [
+            {
+              "type": "long-text",
+              "id": "about-your-project",
+              "label": "About your project"
+            }
+          ]
+        },
+        {
+          "title": "If you use Ubuntu, which version(s) are you using?",
+          "id": "ubuntu-versions",
+          "inputType": "checkbox-visibility",
+          "fields": [
+            {
+              "fieldTitle": "LTS within standard support",
+              "options": [
+                {
+                  "type": "checkbox",
+                  "id": "24-04",
+                  "value": "24.04 LTS",
+                  "label": "24.04 LTS"
+                },
+                {
+                  "type": "checkbox",
+                  "id": "22-04",
+                  "value": "22.04 LTS",
+                  "label": "22.04 LTS"
+                },
+                {
+                  "type": "checkbox",
+                  "id": "20-04",
+                  "value": "20.04 LTS",
+                  "label": "20.04 LTS"
+                }
+              ]
+            },
+            {
+              "fieldTitle": "LTS out of standard support",
+              "options": [
+                {
+                  "type": "checkbox",
+                  "id": "18-04",
+                  "value": "18.04 LTS",
+                  "label": "18.04 LTS"
+                },
+                {
+                  "type": "checkbox",
+                  "id": "16-04",
+                  "value": "16.04 LTS",
+                  "label": "16.04 LTS"
+                },
+                {
+                  "type": "checkbox",
+                  "id": "14-04",
+                  "value": "14.04 LTS",
+                  "label": "14.04 LTS"
+                }
+              ]
+            },
+            {
+              "fieldTitle": "Outdated or non-LTS releases non-LTS release",
+              "options": [
+                {
+                  "type": "checkbox",
+                  "id": "22-10",
+                  "value": "22.10",
+                  "label": "non-LTS release"
+                },
+                {
+                  "type": "checkbox",
+                  "id": "12-04",
+                  "value": "12.04 LTS",
+                  "label": "12.04 LTS"
+                }
+              ]
+            },
+            {
+              "fieldTitle": "Other",
+              "options": [
+                {
+                  "type": "checkbox",
+                  "id": "dont-use-ubuntu-today",
+                  "value": "I don't use Ubuntu today",
+                  "label": "I don't use Ubuntu today"
+                },
+                {
+                  "type": "checkbox",
+                  "id": "i-dont-know",
+                  "value": "I don't know",
+                  "label": "I don't know"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "title": "What kind of device are you using?",
+          "id": "kind-of-device",
+          "isRequired": true,
+          "inputType": "checkbox",
+          "fields": [
+            {
+              "type": "checkbox",
+              "id": "desktop-workstation",
+              "value": "desktop/workstation",
+              "label": "Desktop workstation"
+            },
+            {
+              "type": "checkbox",
+              "id": "physical-server",
+              "value": "physical/server",
+              "label": "Physical server"
+            },
+            {
+              "type": "checkbox",
+              "id": "public-cloud",
+              "value": "public/cloud",
+              "label": "Public cloud"
+            },
+            {
+              "type": "checkbox",
+              "id": "virtual-machine",
+              "value": "virtual/machine",
+              "label": "Virtual machine"
+            },
+            {
+              "type": "checkbox",
+              "id": "iot-edge-device",
+              "value": "iot/edge device",
+              "label": "IoT/Edge device"
+            }
+          ]
+        },
+        {
+          "title": "How many devices?",
+          "id": "how-many-machines",
+          "inputName": "how-many-machines-do-you-have",
+          "inputType": "radio",
+          "isRequired": true,
+          "fields": [
+            {
+              "type": "radio",
+              "id": "less-5-machines",
+              "value": "less than 5",
+              "label": "< 5 machines"
+            },
+            {
+              "type": "radio",
+              "id": "5-to-15-machines",
+              "value": "5 to 15 machines",
+              "label": "5 - 15 machines"
+            },
+            {
+              "type": "radio",
+              "id": "15-to-50-machines",
+              "value": "15 to 50 machines",
+              "label": "15 - 50 machines"
+            },
+            {
+              "type": "radio",
+              "id": "50-to-100-machines",
+              "value": "50 to 100 machines",
+              "label": "50 - 100 machines"
+            },
+            {
+              "type": "radio",
+              "id": "greater-than-100",
+              "value": "greater than 100",
+              "label": "> 100 machines"
+            }
+          ]
+        },
+        {
+          "title": "How do you consume open source?",
+          "id": "how-do-you-consume-open-source",
+          "inputType": "checkbox",
+          "fields": [
+            {
+              "type": "checkbox",
+              "id": "ubuntu-repositories",
+              "value": "Ubuntu repositories",
+              "label": "Ubuntu repositories"
+            },
+            {
+              "type": "checkbox",
+              "id": "github-upstream",
+              "value": "GitHub/Upstream",
+              "label": "GitHub/Upstream"
+            },
+            {
+              "type": "checkbox",
+              "id": "internally-approved-repository",
+              "value": "Internally approved repository",
+              "label": "Internally approved repository"
+            },
+            {
+              "type": "checkbox",
+              "id": "i-dont-know",
+              "value": "I don't know",
+              "label": "I don't know"
+            }
+          ]
+        },
+        {
+          "title": "Do you have specific compliance or hardening requirements?",
+          "id": "hardening-requirements",
+          "inputType": "checkbox",
+          "fields": [
+            {
+              "type": "checkbox",
+              "id": "pci",
+              "value": "PCI-DSS",
+              "label": "PCI-DSS"
+            },
+            {
+              "type": "checkbox",
+              "id": "hipaa",
+              "value": "HIPAA",
+              "label": "HIPAA"
+            },
+            {
+              "type": "checkbox",
+              "id": "fisma",
+              "value": "FISMA",
+              "label": "FISMA"
+            },
+            {
+              "type": "checkbox",
+              "id": "fips-140",
+              "value": "FIPS 140",
+              "label": "FIPS 140"
+            },
+            {
+              "type": "checkbox",
+              "id": "ncsc",
+              "value": "NCSC",
+              "label": "NCSC"
+            },
+            {
+              "type": "checkbox",
+              "id": "disa-stig",
+              "value": "DISA-STIG",
+              "label": "DISA-STIG"
+            },
+            {
+              "type": "checkbox",
+              "id": "fedramp",
+              "value": "FedRAMP",
+              "label": "FedRAMP"
+            },
+            {
+              "type": "checkbox",
+              "id": "cis-benchmark",
+              "value": "CIS Benchmark",
+              "label": "CIS Benchmark"
+            }
+          ]
+        },
+        {
+          "title": "Who is responsible for tracking, testing and applying CVE patches in a timely manner?",
+          "id": "responsible-for-tracking",
+          "inputType": "checkbox",
+          "fields": [
+            {
+              "type": "checkbox",
+              "id": "individual-developers",
+              "value": "Individual developers",
+              "label": "Individual developers"
+            },
+            {
+              "type": "checkbox",
+              "id": "project-team",
+              "value": "The project team",
+              "label": "The project team"
+            },
+            {
+              "type": "checkbox",
+              "id": "third-party-vendor",
+              "value": "Third-party vendor",
+              "label": "Third-party vendor"
+            },
+            {
+              "type": "checkbox",
+              "id": "i-dont-know",
+              "value": "I don't know",
+              "label": "I don't know"
+            }
+          ]
+        },
+        {
+          "title": "What advice are you looking for?",
+          "id": "advice",
+          "fields": [
+            {
+              "type": "long-text",
+              "id": "advice",
+              "placeholder": "Tell us about your challenges and your goals"
+            }
+          ]
+        },
+        {
+          "title": "How should we get in touch?",
+          "id": "about-you",
+          "noCommentsFromLead": true,
+          "fields": [
+            {
+              "type": "tel",
+              "id": "phone",
+              "label": "Mobile/cell phone number",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "/download/supported-platforms/contact-us": {
+      "templatePath": "/contact-us.html",
+      "isModal": false,
+      "modalId": "",
+      "formData": {
+        "title": "Contact us about supported platforms",
+        "introText": "Can't find your board of choice? Fill out the form and a member of our team will be in touch",
+        "formId": "4126",
+        "returnUrl": "/download/thank-you?product=supported-platforms",
+        "product": "supported-platforms"
+      },
+      "fieldsets": [
+        {
+          "title": "Tell us about your project",
+          "id": "about-your-project",
+          "fields": [
+            {
+              "type": "long-text",
+              "id": "about-your-project",
+              "label": "About your project"
+            }
+          ]
+        },
+        {
+          "title": "If you use Ubuntu, which version(s) are you using?",
+          "id": "ubuntu-versions",
+          "inputType": "checkbox-visibility",
+          "fields": [
+            {
+              "fieldTitle": "LTS within standard support",
+              "options": [
+                {
+                  "type": "checkbox",
+                  "id": "24-04",
+                  "value": "24.04 LTS",
+                  "label": "24.04 LTS"
+                },
+                {
+                  "type": "checkbox",
+                  "id": "22-04",
+                  "value": "22.04 LTS",
+                  "label": "22.04 LTS"
+                },
+                {
+                  "type": "checkbox",
+                  "id": "20-04",
+                  "value": "20.04 LTS",
+                  "label": "20.04 LTS"
+                }
+              ]
+            },
+            {
+              "fieldTitle": "LTS out of standard support",
+              "options": [
+                {
+                  "type": "checkbox",
+                  "id": "18-04",
+                  "value": "18.04 LTS",
+                  "label": "18.04 LTS"
+                },
+                {
+                  "type": "checkbox",
+                  "id": "16-04",
+                  "value": "16.04 LTS",
+                  "label": "16.04 LTS"
+                },
+                {
+                  "type": "checkbox",
+                  "id": "14-04",
+                  "value": "14.04 LTS",
+                  "label": "14.04 LTS"
+                }
+              ]
+            },
+            {
+              "fieldTitle": "Outdated or non-LTS releases non-LTS release",
+              "options": [
+                {
+                  "type": "checkbox",
+                  "id": "22-10",
+                  "value": "22.10",
+                  "label": "non-LTS release"
+                },
+                {
+                  "type": "checkbox",
+                  "id": "12-04",
+                  "value": "12.04 LTS",
+                  "label": "12.04 LTS"
+                }
+              ]
+            },
+            {
+              "fieldTitle": "Other",
+              "options": [
+                {
+                  "type": "checkbox",
+                  "id": "dont-use-ubuntu-today",
+                  "value": "I don't use Ubuntu today",
+                  "label": "I don't use Ubuntu today"
+                },
+                {
+                  "type": "checkbox",
+                  "id": "i-dont-know",
+                  "value": "I don't know",
+                  "label": "I don't know"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "title": "What kind of device are you using?",
+          "id": "kind-of-device",
+          "isRequired": true,
+          "inputType": "checkbox",
+          "fields": [
+            {
+              "type": "checkbox",
+              "id": "desktop-workstation",
+              "value": "desktop/workstation",
+              "label": "Desktop workstation"
+            },
+            {
+              "type": "checkbox",
+              "id": "physical-server",
+              "value": "physical/server",
+              "label": "Physical server"
+            },
+            {
+              "type": "checkbox",
+              "id": "public-cloud",
+              "value": "public/cloud",
+              "label": "Public cloud"
+            },
+            {
+              "type": "checkbox",
+              "id": "virtual-machine",
+              "value": "virtual/machine",
+              "label": "Virtual machine"
+            },
+            {
+              "type": "checkbox",
+              "id": "iot-edge-device",
+              "value": "iot/edge device",
+              "label": "IoT/Edge device"
+            }
+          ]
+        },
+        {
+          "title": "How many devices?",
+          "id": "how-many-machines",
+          "inputName": "how-many-machines-do-you-have",
+          "inputType": "radio",
+          "isRequired": true,
+          "fields": [
+            {
+              "type": "radio",
+              "id": "less-5-machines",
+              "value": "less than 5",
+              "label": "< 5 machines"
+            },
+            {
+              "type": "radio",
+              "id": "5-to-15-machines",
+              "value": "5 to 15 machines",
+              "label": "5 - 15 machines"
+            },
+            {
+              "type": "radio",
+              "id": "15-to-50-machines",
+              "value": "15 to 50 machines",
+              "label": "15 - 50 machines"
+            },
+            {
+              "type": "radio",
+              "id": "50-to-100-machines",
+              "value": "50 to 100 machines",
+              "label": "50 - 100 machines"
+            },
+            {
+              "type": "radio",
+              "id": "greater-than-100",
+              "value": "greater than 100",
+              "label": "> 100 machines"
+            }
+          ]
+        },
+        {
+          "title": "How do you consume open source?",
+          "id": "how-do-you-consume-open-source",
+          "inputType": "checkbox",
+          "fields": [
+            {
+              "type": "checkbox",
+              "id": "ubuntu-repositories",
+              "value": "Ubuntu repositories",
+              "label": "Ubuntu repositories"
+            },
+            {
+              "type": "checkbox",
+              "id": "github-upstream",
+              "value": "GitHub/Upstream",
+              "label": "GitHub/Upstream"
+            },
+            {
+              "type": "checkbox",
+              "id": "internally-approved-repository",
+              "value": "Internally approved repository",
+              "label": "Internally approved repository"
+            },
+            {
+              "type": "checkbox",
+              "id": "i-dont-know",
+              "value": "I don't know",
+              "label": "I don't know"
+            }
+          ]
+        },
+        {
+          "title": "Do you have specific compliance or hardening requirements?",
+          "id": "hardening-requirements",
+          "inputType": "checkbox",
+          "fields": [
+            {
+              "type": "checkbox",
+              "id": "pci",
+              "value": "PCI-DSS",
+              "label": "PCI-DSS"
+            },
+            {
+              "type": "checkbox",
+              "id": "hipaa",
+              "value": "HIPAA",
+              "label": "HIPAA"
+            },
+            {
+              "type": "checkbox",
+              "id": "fisma",
+              "value": "FISMA",
+              "label": "FISMA"
+            },
+            {
+              "type": "checkbox",
+              "id": "fips-140",
+              "value": "FIPS 140",
+              "label": "FIPS 140"
+            },
+            {
+              "type": "checkbox",
+              "id": "ncsc",
+              "value": "NCSC",
+              "label": "NCSC"
+            },
+            {
+              "type": "checkbox",
+              "id": "disa-stig",
+              "value": "DISA-STIG",
+              "label": "DISA-STIG"
+            },
+            {
+              "type": "checkbox",
+              "id": "fedramp",
+              "value": "FedRAMP",
+              "label": "FedRAMP"
+            },
+            {
+              "type": "checkbox",
+              "id": "cis-benchmark",
+              "value": "CIS Benchmark",
+              "label": "CIS Benchmark"
+            }
+          ]
+        },
+        {
+          "title": "Who is responsible for tracking, testing and applying CVE patches in a timely manner?",
+          "id": "responsible-for-tracking",
+          "inputType": "checkbox",
+          "fields": [
+            {
+              "type": "checkbox",
+              "id": "individual-developers",
+              "value": "Individual developers",
+              "label": "Individual developers"
+            },
+            {
+              "type": "checkbox",
+              "id": "project-team",
+              "value": "The project team",
+              "label": "The project team"
+            },
+            {
+              "type": "checkbox",
+              "id": "third-party-vendor",
+              "value": "Third-party vendor",
+              "label": "Third-party vendor"
+            },
+            {
+              "type": "checkbox",
+              "id": "i-dont-know",
+              "value": "I don't know",
+              "label": "I don't know"
+            }
+          ]
+        },
+        {
+          "title": "What advice are you looking for?",
+          "id": "advice",
+          "fields": [
+            {
+              "type": "long-text",
+              "id": "advice",
+              "placeholder": "Tell us about your challenges and your goals"
+            }
+          ]
+        },
+        {
+          "title": "How should we get in touch?",
+          "id": "about-you",
+          "noCommentsFromLead": true,
+          "fields": [
+            {
+              "type": "tel",
+              "id": "phone",
+              "label": "Mobile/cell phone number",
+              "isRequired": true
+            }
+          ]
+        }
+      ]
+    },
+    "/download/qualcomm-iot/contact-us": {
+      "templatePath": "/contact-us.html",
+      "isModal": false,
+      "modalId": "",
+      "formData": {
+        "title": "Contact us",
+        "introText": "To speak about a specific project requirement or certification, please fill in this form and send us a message",
+        "formId": "6035",
+        "returnUrl": "/download/thank-you?product=qualcomm-iot",
+        "product": "qualcomm-iot"
+      },
+      "fieldsets": [
+        {
+          "title": "How should we get in touch?",
+          "id": "about-you",
+          "noCommentsFromLead": true,
+          "fields": [
+            {
+              "type": "tel",
+              "id": "phone",
+              "label": "Mobile/cell phone number"
+            }
+          ]
+        }
+      ]
+    },
+    "/download/renesas-iot/contact-us": {
+      "templatePath": "/contact-us.html",
+      "isModal": false,
+      "formData": {
+        "title": "Contact us",
+        "introText": "To speak about a specific project requirement or certification, please fill in this form and send us a message",
+        "formId": "6153",
+        "returnUrl": "/download/thank-you?product=renesas-iot",
+        "product": "renesas-iot"
+      },
+      "fieldsets": [
+        {
+          "title": "Your company is?",
+          "inputType": "radio",
+          "inputName": "your-company",
+          "isRequired": true,
+          "fields": [
+            {
+              "type": "radio",
+              "value": "an ODM/OEM",
+              "label": "an ODM/OEM",
+              "id": "your-company-is-odm-oem"
+            },
+            {
+              "type": "radio",
+              "value": "an end customer",
+              "label": "an end customer",
+              "id": "your-company-is-end-customer"
+            }
+          ]
+        },
+        {
+          "title": "Do you have a commercial project?",
+          "inputType": "radio",
+          "inputName": "commercial-project",
+          "isRequired": true,
+          "fields": [
+            {
+              "type": "radio",
+              "value": "Yes",
+              "label": "Yes",
+              "id": "commercial-project-no"
+            },
+            {
+              "type": "radio",
+              "value": "No",
+              "label": "No",
+              "id": "commercial-project-yes"
+            },
+            {
+              "type": "radio",
+              "value": "Not applicable",
+              "label": "Not applicable",
+              "id": "commercial-project-not-applicable"
+            }
+          ]
+        },
+        {
+          "title": "Which Renesas platforms are you interested in?",
+          "id": "renesas-platform",
+          "fields": [
+            {
+              "type": "long-text",
+              "id": "renesas-platform",
+              "label": "renesas-platform"
+            }
+          ]
+        },
+
+        {
+          "title": "How should we get in touch?",
+          "id": "about-you",
+          "noCommentsFromLead": true,
+          "fields": [
+            {
+              "type": "tel",
+              "id": "phone",
+              "label": "Mobile/cell phone number"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/tests/test_marketo.py
+++ b/tests/test_marketo.py
@@ -185,13 +185,11 @@ class TestStaticContactForms(MarketoFormTestCase):
                         self._check_marketo_and_form_fields(
                             form_id, marketo_fields, fields, template_path
                         )
-                    # TODO: Uncomment when resolved
-                    # https://warthogs.atlassian.net/browse/WD-26789
-                    # else:
-                    #     self.fail(
-                    #         "Template not found in "
-                    #         "contact_us_template_fields: " + template,
-                    #     )
+                    else:
+                        self.fail(
+                            "Template not found in "
+                            "contact_us_template_fields: " + template,
+                        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Done

- Migrated all static download forms to form generator
- Uncommented error failure block that was previously thrown by `/download/contact-us.html`

## QA

- Checkout this branch locally
- Run `dotrun test-marketo`, see that all tests pass
- Go to https://ubuntu-com-15687.demos.haus/download/contact-us
- Submit form and see that it goes through Marketo successfully
- Repeat with all other download forms
  - https://ubuntu-com-15687.demos.haus/download/contact-us?product=supported-platforms
  - https://ubuntu-com-15687.demos.haus/download/contact-us?product=qualcomm-iot
  - https://ubuntu-com-15687.demos.haus/download/contact-us?product=renesas-iot

## Issue / Card

Fixes [WD-27755](https://warthogs.atlassian.net/browse/WD-27755) and [WD-26789](https://warthogs.atlassian.net/browse/WD-26789)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-27755]: https://warthogs.atlassian.net/browse/WD-27755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WD-26789]: https://warthogs.atlassian.net/browse/WD-26789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ