### PR TITLE
copy: toolchains/java wording on ubuntu pro and support period

### DIFF
--- a/templates/toolchains/java.html
+++ b/templates/toolchains/java.html
@@ -38,7 +38,7 @@
       <p>
         Innovate with Java and run your preferred build of OpenJDK on Ubuntu. Bring
         stability to your Java environment with up to 12 years of long-term support
-        for all OpenJDK LTS releases, through Ubuntu Pro. Put stability and
+        for all OpenJDK LTS releases, through Ubuntu Pro and Ubuntu Pro + Support. Put stability and
         compliance at the heart of your applications with rigorous TCK validation,
         minimal runtime containers and FIPS-certified cryptographic modules.
       </p>
@@ -72,25 +72,25 @@
               <td>8 (LTS)</td>
               <td>2014</td>
               <td>24.04, 22.04, 20.04, 18.04</td>
-              <td>At least 2034</td>
+              <td>Up to 2034</td>
             </tr>
             <tr>
               <td>11 (LTS)</td>
               <td>2018</td>
               <td>24.04, 22.04, 20.04, 18.04</td>
-              <td>At least 2034</td>
+              <td>Up to 2034</td>
             </tr>
             <tr>
               <td>17 (LTS)</td>
               <td>2021</td>
               <td>24.04, 22.04, 20.04, 18.04</td>
-              <td>At least 2034</td>
+              <td>Up to 2034</td>
             </tr>
             <tr>
               <td>21 (LTS)</td>
               <td>2023</td>
               <td>24.04, 22.04, 20.04</td>
-              <td>At least 2034</td>
+              <td>Up to 2034</td>
             </tr>
           </tbody>
         </table>
@@ -161,7 +161,7 @@
           Using OpenJDK on Ubuntu gives developers the freedom to focus on
           making impactful applications that deliver for customers with
           expanded security maintenance for the latest OpenJDK LTS releases
-          running until 2034.
+          running up to 2034.
         </p>
         <div class="p-cta-block">
           <a class="p-button" href="https://ubuntu.com/pricing/pro">Get support with Ubuntu Pro</a>


### PR DESCRIPTION
## Done

- copy: toolchains/java wording on ubuntu pro and support period
- [copydoc](https://docs.google.com/document/d/1ShgZyjn6pBG-L5iVd-MEIwc1JRVhaSeUFoImo5iWO-k/edit?tab=t.0)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- check the page on [toolchains/java in the demo server](https://ubuntu-com-15693.demos.haus/toolchains/java)

## Issue / Card

Fixes [WD-27261](https://warthogs.atlassian.net/browse/WD-27261)

## Screenshots

<img width="1919" height="957" alt="image" src="https://github.com/user-attachments/assets/1fc4bb82-62f4-4618-8490-8cb0c7c076f5" />



## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-27261]: https://warthogs.atlassian.net/browse/WD-27261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ