### PR TITLE
chore(qualcomm-iot): adapted two links on the Rubik Pi3 tab

### DIFF
--- a/templates/download/qualcomm-iot/tabs/development-board-tab.html
+++ b/templates/download/qualcomm-iot/tabs/development-board-tab.html
@@ -59,11 +59,11 @@
 
       <ul class="p-list--divided">
         <li class="p-list__item">
-          Get started with Ubuntu 24.04 for <a href="https://www.thundercomm.com/rubik-pi-3/en/docs/rubik-pi-3-user-manual/1.0.0-u/quick-start/"
+          Get started with Ubuntu 24.04 for <a href="https://www.thundercomm.com/rubik-pi-3/en/docs/category/quick-start"
     title="Read more about RUBIK Pi 3">RUBIK Pi 3 Development Board</a>
         </li>
         <li class="p-list__item">
-          Ubuntu 24.04 for Rubik Pi 3 <a href="https://www.thundercomm.com/rubik-pi-3/en/docs/rubik-pi-3-user-manual/1.0.0-u/quick-start/update-software"
+          Ubuntu 24.04 for Rubik Pi 3 <a href="https://www.thundercomm.com/rubik-pi-3/en/docs/category/update-software"
     title="Read image installation instructions of Ubuntu 24.04 for Rubik Pi 3">image installation instructions</a>
         </li>
         <li class="p-list__item">


### PR DESCRIPTION
## Done

Updated two links under the "RUBIK Pi 3 development board" tab.

(copy doc: https://docs.google.com/document/d/1BP2T63R6kdnUFQFIZcbXbTIgY-9fQVgVRLsSUU5Rvx8/edit?tab=t.0)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/download/qualcomm-iot
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

https://warthogs.atlassian.net/browse/WD-27903

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
