### PR TITLE
WD-27723: update release chart and table for 25.10 cycle

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -138,15 +138,15 @@ export var serverAndDesktopReleases = [
     status: "PRO_LEGACY_SUPPORT",
   },
   {
-    startDate: new Date("2024-10-01T00:00:00"),
-    endDate: new Date("2025-07-01T00:00:00"),
-    taskName: "24.10 (Oracular Oriole)",
-    status: "INTERIM_RELEASE",
-  },
-  {
     startDate: new Date("2025-04-01T00:00:00"),
     endDate: new Date("2026-01-05T00:00:00"),
     taskName: "25.04 (Plucky Puffin)",
+    status: "INTERIM_RELEASE",
+  },
+  {
+    startDate: new Date("2025-10-01T00:00:00"),
+    endDate: new Date("2026-07-01T00:00:00"),
+    taskName: "25.10 (Questing Quokka)",
     status: "INTERIM_RELEASE",
   },
 ];
@@ -1262,8 +1262,8 @@ export var microStackStatus = {
 };
 
 export var desktopServerReleaseNames = [
+  "25.10 (Questing Quokka)",
   "25.04 (Plucky Puffin)",
-  "24.10 (Oracular Oriole)",
   "24.04 LTS (Noble Numbat)",
   "22.04 LTS (Jammy Jellyfish)",
   "20.04 LTS (Focal Fossa)",

--- a/templates/about/release_cycles/releases-table.html
+++ b/templates/about/release_cycles/releases-table.html
@@ -10,14 +10,14 @@
     </thead>
     <tbody>
         <tr>
+            <td colspan="2">25.10 (Questing Quokka)</td>
+            <td>Oct 2025</td>
+            <td>Jul 2026</td>
+        </tr>
+        <tr>
             <td colspan="2">25.04 (Plucky Puffin)</td>
             <td>Apr 2025</td>
             <td>Jan 2026</td>
-        </tr>
-        <tr>
-            <td colspan="2">24.10 (Oracular Oriole)</td>
-            <td>Oct 2024</td>
-            <td>Jul 2025</td>
         </tr>
         <tr>
             <td colspan="2"><strong>24.04 LTS (Noble Numbat)</strong></td>


### PR DESCRIPTION
## Done

updated release chart and accompanying table for 25.10 cycle:
- add Questing Quokka
- remove Oracular Oriole

## QA

check https://ubuntu-com-15695.demos.haus/desktop/developers

## Issue / Card

https://warthogs.atlassian.net/browse/WD-27723