### PR TITLE
fix(pro-subscribe): replace "Buy" with "Get" in page title [WD-27736]

### DIFF
--- a/templates/advantage/subscribe/index.html
+++ b/templates/advantage/subscribe/index.html
@@ -1,4 +1,4 @@
-{% extends "advantage/base_advantage.html" %} {% block title %}Buy Ubuntu Pro{% endblock %} {% block meta_description %}The online shop for getting your Ubuntu Pro subscription.{% endblock %} {% block
+{% extends "advantage/base_advantage.html" %} {% block title %}Get Ubuntu Pro{% endblock %} {% block meta_description %}The online shop for getting your Ubuntu Pro subscription.{% endblock %} {% block
 meta_copydoc
 %}https://docs.google.com/document/d/1UqL8YJH9ywvOXnrt3syY0U8fiOakfAGWmLS9uerwAWk/edit{%
 endblock meta_copydoc %} {% block content %}


### PR DESCRIPTION
## Done

- Updated [/pro/subscribe](https://ubuntu-com-15696.demos.haus/pro/subscribe) page title as per the [copydoc](https://docs.google.com/document/d/1UqL8YJH9ywvOXnrt3syY0U8fiOakfAGWmLS9uerwAWk/edit?tab=t.0)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Open [/pro/subscribe](https://ubuntu-com-15696.demos.haus/pro/subscribe) page
- Check that the page title is "Get Ubuntu Pro"

## Issue / Card

Fixes [WD-27736](https://warthogs.atlassian.net/browse/WD-27736)