### PR TITLE
[WD-27816]: copy update for `download/qualcomm-iot` tabs

### DIFF
--- a/templates/download/qualcomm-iot/tabs/evaluation-kit-tab.html
+++ b/templates/download/qualcomm-iot/tabs/evaluation-kit-tab.html
@@ -28,7 +28,7 @@
       <h3 class="p-heading--5">Ubuntu 24.04 LTS</h3>
     </div>
     <div class="col-6">
-      <p>This is an early release of Ubuntu 24.04 image on the Qualcomm Dragonwing™ IQ-9075 Evaluation Kit (EVK). The certified version is coming soon.</p>
+      <p>This is the Beta release of Ubuntu 24.04 image on the Qualcomm Dragonwing™ IQ-9075 Evaluation Kit (EVK). The certified version is coming soon.</p>
       <div class="p-section--shallow">
         <div class="row">
           <div class="col-6 col-medium-4 col-small-4">
@@ -38,7 +38,7 @@
             <p class="p-heading--5">Ubuntu Desktop 24.04</p>
           </div>
           <div class="col-3 col-medium-2 col-small-2">
-            <a class="p-button--positive" href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x04/ubuntu-desktop-24.04/"
+            <a class="p-button--positive" href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x05/ubuntu-desktop-24.04/"
             title="Download Ubuntu Desktop 24.04">Download</a>
           </div>
           <div class="col-6 col-medium-4 col-small-4">
@@ -48,7 +48,7 @@
             <p class="p-heading--5">Ubuntu Server 24.04</p>
           </div>
           <div class="col-3 col-medium-2 col-small-2">
-            <a class="p-button--positive" href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x04/ubuntu-server-24.04/"
+            <a class="p-button--positive" href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x05/ubuntu-server-24.04/"
             title="Download Ubuntu Server 24.04">Download</a>
           </div>
           <div class="col-6 col-medium-4 col-small-4">
@@ -58,7 +58,7 @@
             <p class="p-heading--5">Boot firmware</p>
           </div>
           <div class="col-3 col-medium-2 col-small-2">
-            <a class="p-button" href="https://codelinaro.jfrog.io/artifactory/qli-ci/flashable-binaries/ubuntu-fw/QCS9100/QLI.1.4-Ver.1.1/QLI.1.4-Ver.1.1-ubuntu-qcs9100-nhlos-bins.tar.gz"
+            <a class="p-button" href="https://artifacts.codelinaro.org/artifactory/qli-ci/flashable-binaries/ubuntu-fw/QCS9100/QLI.1.5-Ver.1.1/QLI.1.5-Ver.1.1-ubuntu-nhlos-bins.tar.gz"
             title=" Download boot firmware">Download</a>
           </div>
         </div>
@@ -71,10 +71,9 @@
         </li>
         <li class="p-list__item">
           Ubuntu 24.04 for Qualcomm IQ-9075 Evaluation Kit (EVK) <a href="https://docs.qualcomm.com/bundle/resource/topics/80-90441-252/Integrate-and-flash-software.html?product=1601111740076074&facet=Ubuntu%20quickstart" title="Read image installation instructions of Ubuntu 24.04 for IQ-9075">image installation instructions</a>
-          <p>(Note: Qualcomm account login is required).</p>
         </li>
         <li class="p-list__item">
-          Ubuntu 24.04 for Qualcomm IQ-9075 Evaluation Kit (EVK) <a href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x04/Ubuntu_24.04_Qualcomm_RB3Gen2_Vision_Development_Kit_and_IQ-9075_Evaluation_Kit_Release_Notes.pdf" title="Read full release notes of Ubuntu 24.04 for IQ-9075">release notes</a>
+          Ubuntu 24.04 for Qualcomm IQ-9075 Evaluation Kit (EVK) <a href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x05/Ubuntu_24.04_Qualcomm_RB3Gen2_Vision_Development_Kit_and_IQ-9075_Evaluation_Kit_Release_Notes.pdf" title="Read full release notes of Ubuntu 24.04 for IQ-9075">release notes</a>
         </li>
       </ul>
       <hr class="p-rule--muted" />
@@ -84,7 +83,6 @@
             The Ubuntu images are tested on the <a href="https://www.qualcomm.com/developer/hardware/qualcomm-iq-9075-evaluation-kit-evk"
             title="Read more about Qualcomm IQ-9075 Evaluation Kit (EVK)">Qualcomm IQ-9075 Evaluation Kit (EVK)</a>
           </p>
-          <p>(Note: Qualcomm account login is required).</p>
         </div>
       </div>
     </div>

--- a/templates/download/qualcomm-iot/tabs/rb3-gen2-lite-tab.html
+++ b/templates/download/qualcomm-iot/tabs/rb3-gen2-lite-tab.html
@@ -38,7 +38,7 @@
             <p class="p-heading--5">Ubuntu Desktop 24.04 for QCS5430</p>
           </div>
           <div class="col-3 col-medium-2 col-small-2">
-            <a class="p-button--positive" href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x04/ubuntu-desktop-24.04/"
+            <a class="p-button--positive" href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x05/ubuntu-desktop-24.04/"
             title=" Download boot firmware"> Download</a>
           </div>
           <div class="col-6 col-medium-4 col-small-4">
@@ -48,7 +48,7 @@
             <p class="p-heading--5">Ubuntu Server 24.04 for QCS5430</p>
           </div>
           <div class="col-3 col-medium-2 col-small-2">
-            <a class="p-button--positive" href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x04/ubuntu-server-24.04/"
+            <a class="p-button--positive" href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x05/ubuntu-server-24.04/"
             title=" Download Ubuntu Server 24.04 for QCS5430">Download</a>
           </div>
           <div class="col-6 col-medium-4 col-small-4">
@@ -58,7 +58,7 @@
             <p class="p-heading--5">Boot firmware</p>
           </div>
           <div class="col-3 col-medium-2 col-small-2">
-            <a class="p-button" href="https://codelinaro.jfrog.io/artifactory/qli-ci/flashable-binaries/ubuntu-fw/QCM6490/QLI.1.4-Ver.1.1/QLI.1.4-Ver.1.1-ubuntu-QCS6490-nhlos-bins.tar.gz"
+            <a class="p-button" href="https://artifacts.codelinaro.org/artifactory/qli-ci/flashable-binaries/ubuntu-fw/QCM6490/QLI.1.5-Ver.1.1/QLI.1.5-Ver.1.1-ubuntu-nhlos-bins.tar.gz"
             title=" Download boot firmware">Download</a>
           </div>
         </div>
@@ -73,7 +73,7 @@
           Ubuntu 24.04 for QCS5430 <a href="https://docs.qualcomm.com/bundle/publicresource/topics/80-90441-1/Integrate_and_flash_software_2.html?product=1601111740013077&facet=Ubuntu%20quickstart" title="Read image installation instructions of Ubuntu 24.04 for QCS5430">image installation instructions</a>
         </li>
         <li class="p-list__item">
-          Ubuntu 24.04 for QCS5430 <a href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x04/Ubuntu_24.04_Qualcomm_RB3Gen2_Vision_Development_Kit_and_IQ-9075_Evaluation_Kit_Release_Notes.pdf" title="Read full release notes of Ubuntu 24.04 for QCS5430">release notes</a>
+          Ubuntu 24.04 for QCS5430 <a href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x05/Ubuntu_24.04_Qualcomm_RB3Gen2_Vision_Development_Kit_and_IQ-9075_Evaluation_Kit_Release_Notes.pdf" title="Read full release notes of Ubuntu 24.04 for QCS5430">release notes</a>
         </li>
       </ul>
       <hr class="p-rule--muted" />

--- a/templates/download/qualcomm-iot/tabs/rb3-gen2-tab.html
+++ b/templates/download/qualcomm-iot/tabs/rb3-gen2-tab.html
@@ -38,7 +38,7 @@
             <p class="p-heading--5">Ubuntu Desktop 24.04 for QCS6490</p>
           </div>
           <div class="col-3 col-medium-2 col-small-2">
-            <a class="p-button--positive" href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x04/ubuntu-desktop-24.04/"
+            <a class="p-button--positive" href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x05/ubuntu-desktop-24.04/"
             title=" Download Ubuntu Desktop 24.04 for QCS6490">Download</a>
           </div>
           <div class="col-6 col-medium-4 col-small-4">
@@ -48,7 +48,7 @@
             <p class="p-heading--5">Ubuntu Server 24.04 for QCS6490</p>
           </div>
           <div class="col-3 col-medium-2 col-small-2">
-            <a class="p-button--positive" href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x04/ubuntu-server-24.04/"
+            <a class="p-button--positive" href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x05/ubuntu-server-24.04/"
             title=" Download Ubuntu Server 24.04 for QCS6490">Download</a>
           </div>
           <div class="col-6 col-medium-4 col-small-4">
@@ -58,7 +58,7 @@
             <p class="p-heading--5">Boot firmware</p>
           </div>
           <div class="col-3 col-medium-2 col-small-2">
-            <a class="p-button" href="https://codelinaro.jfrog.io/ui/native/qli-ci/flashable-binaries/ubuntu-fw/QCM6490/QLI.1.4-Ver.1.1/QLI.1.4-Ver.1.1-ubuntu-QCS6490-nhlos-bins.tar.gz"
+            <a class="p-button" href="https://artifacts.codelinaro.org/artifactory/qli-ci/flashable-binaries/ubuntu-fw/QCM6490/QLI.1.5-Ver.1.1/QLI.1.5-Ver.1.1-ubuntu-nhlos-bins.tar.gz"
             title=" Download boot firmware">Download</a>
           </div>
         </div>
@@ -73,7 +73,7 @@
           Ubuntu 24.04 for QCS6490 <a href="https://docs.qualcomm.com/bundle/publicresource/topics/80-90441-1/Integrate_and_flash_software_2.html?product=1601111740013077&facet=Ubuntu%20quickstart" title="Read image installation instructions of Ubuntu 24.04 for QCS6490">image installation instructions</a>
         </li>
         <li class="p-list__item">
-          Ubuntu 24.04 for QCS6490 <a href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x04/Ubuntu_24.04_Qualcomm_RB3Gen2_Vision_Development_Kit_and_IQ-9075_Evaluation_Kit_Release_Notes.pdf" title="Read full release notes of Ubuntu 24.04 for QCS6490">release notes</a>
+          Ubuntu 24.04 for QCS6490 <a href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x05/Ubuntu_24.04_Qualcomm_RB3Gen2_Vision_Development_Kit_and_IQ-9075_Evaluation_Kit_Release_Notes.pdf" title="Read full release notes of Ubuntu 24.04 for QCS6490">release notes</a>
         </li>
       </ul>
       <hr class="p-rule--muted" />


### PR DESCRIPTION
## Done

- Updates `download/qualcomm-iot` tabs per [copydoc](https://docs.google.com/document/d/1BP2T63R6kdnUFQFIZcbXbTIgY-9fQVgVRLsSUU5Rvx8/edit?tab=t.0)
- The tabs for "Qualcomm Dragonwing™ RB3 Gen 2 Vision Development Kit (QCS6490)", "Qualcomm Dragonwing™ RB3 Gen 2 Lite Vision Development Kit (QCS5430)", and "Qualcomm Dragonwing™ Evaluation Kit IQ-9075 (EVK)" have been updated. 

## QA

- Open [`/download/qualcomm-iot`](https://ubuntu-com-15697.demos.haus/download/qualcomm-iot)
- Check that all of the updated links now point to the expected pages
- Check that the changes match with the [copydoc](https://docs.google.com/document/d/1BP2T63R6kdnUFQFIZcbXbTIgY-9fQVgVRLsSUU5Rvx8/edit?tab=t.0)

## Issue / Card

Fixes [WD-27816](https://warthogs.atlassian.net/browse/WD-27816)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-27816]: https://warthogs.atlassian.net/browse/WD-27816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ