### PR TITLE
update: kernel release cycle graphs for 25.10

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -153,6 +153,13 @@ export var serverAndDesktopReleases = [
 
 export var kernelReleases = [
   {
+    startDate: new Date("2025-10-01T00:00:00"),
+    endDate: new Date("2026-07-01T00:00:00"),
+    taskName: "25.10",
+    taskVersion: "6.17 kernel",
+    status: "INTERIM_RELEASE",
+  },
+  {
     startDate: new Date("2025-08-01T00:00:00"),
     endDate: new Date("2026-01-01T00:00:00"),
     taskName: "24.04.3 LTS (HWE)",
@@ -164,20 +171,6 @@ export var kernelReleases = [
     endDate: new Date("2026-01-01T00:00:00"),
     taskName: "25.04",
     taskVersion: "6.14 kernel",
-    status: "INTERIM_RELEASE",
-  },
-  {
-    startDate: new Date("2025-02-01T00:00:00"),
-    endDate: new Date("2025-07-01T00:00:00"),
-    taskName: "24.04.2 LTS (HWE)",
-    taskVersion: "6.11 kernel",
-    status: "INTERIM_RELEASE",
-  },
-  {
-    startDate: new Date("2024-10-01T00:00:00"),
-    endDate: new Date("2025-07-01T00:00:00"),
-    taskName: "24.10",
-    taskVersion: "6.11 kernel",
     status: "INTERIM_RELEASE",
   },
   {
@@ -1273,10 +1266,9 @@ export var desktopServerReleaseNames = [
 ];
 
 export var kernelReleaseNames = [
+  "25.10",
   "24.04.3 LTS (HWE)",
   "25.04",
-  "24.04.2 LTS (HWE)",
-  "24.10",
   "22.04.5 LTS (HWE)",
   "24.04.[0 or 1] LTS",
   "20.04.5 LTS (HWE)",
@@ -1291,9 +1283,8 @@ export var kernelReleaseNames = [
 ];
 
 export var kernelVersionNames = [
+  "6.17",
   "6.14",
-  "",
-  "6.11",
   "",
   "6.8",
   "",

--- a/templates/shared/_kernel-release-diagram.html
+++ b/templates/shared/_kernel-release-diagram.html
@@ -15,6 +15,16 @@
     </thead>
     <tbody>
       <tr>
+        <td>
+          <strong>6.17</strong>
+        </td>
+        <td>
+          <strong>25.10</strong>
+        </td>
+        <td>Oct 2025</td>
+        <td>Jul 2026</td>
+      </tr>
+      <tr>
         <td rowspan="2">
           <strong>6.14</strong>
         </td>
@@ -30,23 +40,6 @@
         </td>
         <td>Apr 2025</td>
         <td>Jan 2026</td>
-      </tr>
-      <tr>
-        <td rowspan="2">
-          <strong>6.11</strong>
-        </td>
-        <td>
-          <strong>24.04.2 LTS (HWE)</strong>
-        </td>
-        <td>Feb 2025</td>
-        <td>Jul 2025</td>
-      </tr>
-      <tr>
-        <td>
-          <strong>24.10</strong>
-        </td>
-        <td>Oct 2024</td>
-        <td>Jul 2025</td>
       </tr>
       <tr>
         <td rowspan="2">


### PR DESCRIPTION
## Done

The kernel release cycle graphs are updated for 25.10, and unsupported releases are removed.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to http://0.0.0.0:8001/about/release-cycle and http://0.0.0.0:8001/kernel/lifecycle


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
