### PR TITLE
Copy update to /security/esm diagram legend

### DIFF
--- a/static/js/src/release-chart-old.js
+++ b/static/js/src/release-chart-old.js
@@ -361,8 +361,8 @@ function formatLabel(label, isTooltip = false) {
     case "kub":
       return "Kub";
     case "esm":
-      return `Expanded Security Maintenance${
-        !isTooltip ? " (extra 5 years)" : ""
+      return `LTS Expanded Security Maintenance for Ubuntu Main${
+        !isTooltip ? " (additional 5 years)" : ""
       }`;
     case "interim_release":
       return `Interim release standard security maintenance${
@@ -373,11 +373,11 @@ function formatLabel(label, isTooltip = false) {
     case "cve":
       return "CVE/Critical fixes only";
     case "main_universe":
-      return `LTS Expanded Security Maintenance (ESM) for Ubuntu Universe${
-        !isTooltip ? " (initial 5 years)" : ""
+      return `Expanded Security Maintenance (ESM) for Ubuntu Universe${
+        !isTooltip ? " (10 years)" : ""
       }`;
     case "hardware_and_maintenance_updates":
-      return "LTS standard security maintenance for Ubuntu Main";
+      return `LTS standard security maintenance for Ubuntu Main${!isTooltip ? " (initial 5 years)" : ""}`;
     case "matching_openstack_release_support":
       return "Matching OpenStack release support";
     case "extended_support_for_customers":


### PR DESCRIPTION
## Done
Updated release cycle diagram legend at `/security/esm` according to:
  - [WD-28062](https://warthogs.atlassian.net/browse/WD-28062)
  - [Copy doc](https://docs.google.com/document/d/1RBZX3PJPvODxRlcnIS10Ii4SkIMH5Fm74EmsMQ0cnic/edit?tab=t.0)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/esm
    - Be sure to test on mobile, tablet and desktop screen sizes

## Screenshots

<img width="1254" height="513" alt="image" src="https://github.com/user-attachments/assets/8cda0766-2560-43d8-9ebe-31ab50eeaff2" />

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-28062]: https://warthogs.atlassian.net/browse/WD-28062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ