### PR TITLE
fix: (WD-27722) Update u.com/download/server/thank-you-s390x for 25.10

### DIFF
--- a/templates/download/server/thank-you-s390x.html
+++ b/templates/download/server/thank-you-s390x.html
@@ -40,22 +40,28 @@
       <div class="col-3">
         <h2 class="p-heading--2">Resources</h2>
       </div>
-      <div class="col-3 col-medium-2">
+      <div class="col-2 col-medium-2">
         <h3 class="p-heading--5">eBook</h3>
         <p>
           <a href="https://pages.ubuntu.com/Forrester_TAP_Report_2016.html">Forrester Research &mdash; get more from the cloud</a>
         </p>
       </div>
-      <div class="col-3 col-medium-2">
+      <div class="col-2 col-medium-2">
         <h3 class="p-heading--5">Whitepaper</h3>
         <p>
           <a href="https://www-01.ibm.com/marketing/iwm/dre/signup?source=stg-web&S_PKG=ov47989&S_TACT=C47305CW">IDC &mdash; next generation applications on Ubuntu for LinuxONE/z</a>
         </p>
       </div>
-      <div class="col-3 col-medium-2">
+      <div class="col-2 col-medium-2">
         <h3 class="p-heading--5">Webinar</h3>
         <p>
           <a href="https://www.youtube.com/watch?v=WxTAd0zqruA">Discover the Cloud and scale out world of Ubuntu on IBM</a>
+        </p>
+      </div>
+      <div class="col-2 col-medium-2">
+        <h3 class="p-heading--5">Webinar</h3>
+        <p>
+          <a href="https://ubuntu.com/engage/webinar-security-ubuntu-ibm-linuxone">Webinar: Security at scale with Canonical and IBM</a>
         </p>
       </div>
     </div>


### PR DESCRIPTION

## Done

- Added a resource link (webinar) to match copytext.
- Changed resources' class to col-2 so all 4 fit neatly on one row.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Navigate to /download/server/thank-you-s390x for 25.10
- Check that a 4th resource is added (Webinar), to match [this copytext](https://docs.google.com/document/d/1GptXtMfbgOjOmqb8DZCCTRwogkiP_cM95U9Z0gFSt7g/edit?tab=t.0)

## Issue / Card

Fixes # [WD-27722](https://warthogs.atlassian.net/browse/WD-27722)

## Screenshots

<img width="1471" height="263" alt="image" src="https://github.com/user-attachments/assets/9a74e4a8-bab8-4f9a-9a31-22fbf98de6ad" />


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-27722]: https://warthogs.atlassian.net/browse/WD-27722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ