### PR TITLE
fix(WD-28107): redirect to P360 session when clicking "Take Exam" button

### DIFF
--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -833,9 +833,6 @@ def cred_your_exams(
     user = user_info(flask.session)
     if not email:
         email = user["email"]
-    is_staging = "staging" in get_flask_env(
-        "CONTRACTS_API_URL", "https://contracts.staging.canonical.com/"
-    )
 
     agreement_notification = False
     confidentiality_agreement_enabled = strtobool(
@@ -1038,22 +1035,21 @@ def cred_your_exams(
                         or provisioned_but_not_taken
                     ) and not is_banned:
                         proctor_link = None
-                        if is_staging:
-                            student_session = proctor_api.get_student_sessions(
-                                {
-                                    "ext_exam_id": r["uuid"],
-                                }
+                        student_session = proctor_api.get_student_sessions(
+                            {
+                                "ext_exam_id": r["uuid"],
+                            }
+                        )
+                        if student_session is not None:
+                            student_session_array = student_session.get(
+                                "data", [{}]
                             )
-                            if student_session is not None:
-                                student_session_array = student_session.get(
-                                    "data", [{}]
+                            student_session = None
+                            if len(student_session_array) > 0:
+                                student_session = student_session_array[0]
+                                proctor_link = student_session.get(
+                                    "display_session_link", None
                                 )
-                                student_session = None
-                                if len(student_session_array) > 0:
-                                    student_session = student_session_array[0]
-                                    proctor_link = student_session.get(
-                                        "display_session_link", None
-                                    )
                         action = {
                             "text": (
                                 "Continue exam"


### PR DESCRIPTION
## Done

- Previously, when clicking "Your Exams" button on non-staging environment, it would redirect to the exam page rather than the P360's session check-in page
- This PR checks, regardless of the environment, if a P360 session exists and if it does, it redirects there. If not, it redirects to the exam page

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Purchase an exam using /credentials/shop
- Schedule the exam
- Visit /credentials/your-exams and click the "Take Exam" button when it appears
- This should redirect to P360 check-in session
- Proceed with the check-in and in the end you should be able to take the exam

## Issue / Card

Fixes [WD-28107](https://warthogs.atlassian.net/browse/WD-28107)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-28107]: https://warthogs.atlassian.net/browse/WD-28107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ