### PR TITLE
feat: Update Questing Quokka mascot image with black background version

### DIFF
--- a/templates/download/server/manual.html
+++ b/templates/download/server/manual.html
@@ -196,12 +196,12 @@
           <h2>Ubuntu {{ releases.latest.full_version }}</h2>
         </div>
         <div class="p-image-wrapper u-hide--small">
-          {{ image(url="https://assets.ubuntu.com/v1/7e341c7f-questing-quokka-bg.svg",
-            alt="Questing Quokka",
-            width="182",
-            height="182",
-            hi_def=True,
-            loading="auto") | safe
+          {{ image(url="https://assets.ubuntu.com/v1/fe84bc06-questing_quokka_mascot_circle_bg.svg",
+                    alt="Questing Quokka mascot",
+                    width="182",
+                    height="182",
+                    hi_def=True,
+                    loading="auto") | safe
           }}
         </div>
       </div>


### PR DESCRIPTION
## Done

- Update Questing Quokka mascot image with [new image](https://assets.ubuntu.com/v1/fe84bc06-questing_quokka_mascot_circle_bg.svg)

## QA

- Go to https://ubuntu-com-15707.demos.haus/download/server
- See the mascot image with a black background

