### PR TITLE
Add success message popup for whitepaper download

### DIFF
--- a/templates/engage/shared/_en_engage_form.html
+++ b/templates/engage/shared/_en_engage_form.html
@@ -63,7 +63,7 @@
       <li>
         <button type="submit" class="u-no-margin--bottom {% if cta_class %}{{ cta_class }}{% endif %}" >{% if cta %}{{ cta }}{% else %}Download the whitepaper{% endif %}</button>
         <input name="formid" aria-label="formid" value="{{ id }}" type="hidden" />
-        <input type="hidden" name="returnURL" aria-label="returnURL" value="{{ returnURL }}#contact-form-success" />
+        <input type="hidden" name="returnURL" aria-label="returnURL" value="{{ returnURL }}{% if cta %}#contact-form-success{% else %}#whitepaper-form-success{% endif %}" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="{{ utm_campaign }}" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="{{ utm_medium }}" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="{{ utm_source }}" />

--- a/templates/templates/_notifications.html
+++ b/templates/templates/_notifications.html
@@ -18,6 +18,16 @@
     </div>
   </div>
 </div>
+<div id="whitepaper-form-success" class="p-popup-notification">
+  <div class="p-notification--positive u-no-margin--bottom">
+    <div class="p-notification__content">
+      <p class="p-notification__message">
+        Thank you. You'll receive an email with the whitepaper shortly.
+        <a href="#" onclick="location.href = document.referrer; return false;"><i class="p-notification__close">Close</i></a>
+      </p>
+    </div>
+  </div>
+</div>
 <div id="unsubscribed" class="p-popup-notification">
   <div class="p-notification--positive u-no-margin--bottom">
     <div class="p-notification__content">


### PR DESCRIPTION
## Done

- Add success message popup for whitepaper download

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
