### PR TITLE
WD-29304 (remove "cloud native operations report" from meganav)

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -306,8 +306,6 @@ products:
               url: /kubernetes/charmed-k8s/docs/quickstart
             - title: Distributions comparison
               url: /kubernetes/compare
-            - title: Cloud native operations report
-              url: https://juju.is/cloud-native-kubernetes-usage-report-2022
             - title: Getting started with MicroK8s
               url: http://microk8s.io/docs/getting-started
             - title: Kubeflow installation tutorial


### PR DESCRIPTION
## Done

- Removed "cloud native operations report" from meganav

## QA

- View demo: https://ubuntu-com-15710.demos.haus/
- Click on "Products" in the top nav, then click on "Kubernetes" subsection, then ensure that there are only 5 secondary links and that "Cloud native operations report" is not one of them
- Copy doc here: https://docs.google.com/document/d/1Y0dxbuar0UAPSCfILtP7fsEX-83yDh7Ha637FA9Wbik/edit?disco=AAABr6Uiqcg

## Issue / Card

[WD-29304](https://warthogs.atlassian.net/browse/WD-29304)

[WD-29304]: https://warthogs.atlassian.net/browse/WD-29304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ