### PR TITLE
chore: Added example demo for Vanilla ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "url-polyfill": "1.1.12",
     "url-search-params-polyfill": "8.2.5",
     "use-query-params": "^2.2.1",
-    "vanilla-framework": "4.34.1",
+    "vanilla-framework": "git+https://github.com/canonical/vanilla-framework.git#export-js",
     "yup": "1.4.0"
   },
   "resolutions": {

--- a/static/js/src/main.js
+++ b/static/js/src/main.js
@@ -10,3 +10,4 @@ import "./core.js";
 import "./smart-quotes.js";
 import "./prepare-form-inputs.js";
 import "./search.js";
+import { tabs } from "vanilla-framework/js";

--- a/templates/vanilla-demo.html
+++ b/templates/vanilla-demo.html
@@ -1,0 +1,60 @@
+{% extends "templates/base.html" %}
+
+{% block body_class %}
+  is-paper
+{% endblock body_class %}
+
+{% block outer_content %}
+
+  {% block content %}
+    <div class="p-tabs">
+      <div class="p-tabs__list" role="tablist" aria-label="Juju technology">
+        <div class="p-tabs__item">
+          <button class="p-tabs__link"
+                  role="tab"
+                  aria-selected="true"
+                  aria-controls="olm-tab"
+                  id="olm">Charmed Operator Lifecycle Manager</button>
+        </div>
+        <div class="p-tabs__item">
+          <button class="p-tabs__link"
+                  role="tab"
+                  aria-selected="false"
+                  aria-controls="operator-tab"
+                  id="operator"
+                  tabindex="-1">Charmed Operator SDK</button>
+        </div>
+        <div class="p-tabs__item">
+          <button class="p-tabs__link"
+                  role="tab"
+                  aria-selected="false"
+                  aria-controls="charmhub-tab"
+                  id="charmhub"
+                  tabindex="-1">Charmhub</button>
+        </div>
+      </div>
+
+      <div tabindex="0" role="tabpanel" id="olm-tab" aria-labelledby="olm">
+        <p>
+          A system to help you move from configuration management to application management across your hybrid cloud estate - through sharable, reusable, tiny applications called Charmed Operators.
+        </p>
+      </div>
+
+      <div tabindex="0"
+           role="tabpanel"
+           id="operator-tab"
+           aria-labelledby="operator"
+           hidden="hidden">
+        <p>A set of tools to help you write Charmed Operators and to package them as Charms.</p>
+      </div>
+
+      <div tabindex="0"
+           role="tabpanel"
+           id="charmhub-tab"
+           aria-labelledby="charmhub"
+           hidden="hidden">
+        <p>A repository for charms - from Observability to Data to Identity and more.</p>
+      </div>
+    </div>
+  {% endblock %}
+{% endblock %}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8168,10 +8168,9 @@ vanilla-framework@4.26.1:
   resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.26.1.tgz#d076f26a7215cf8b0babae81753ef535e6486257"
   integrity sha512-7m3qX4rm+I+go5mNjzO8gkp2qxr5m4n1jAxTh+bJ8hx/Wrsx3hiWDmJHylZ2GqjeqdtOiidvWgU2ToZJK6ELUg==
 
-vanilla-framework@4.34.1:
+"vanilla-framework@git+https://github.com/canonical/vanilla-framework.git#export-js":
   version "4.34.1"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.34.1.tgz#99da5661c10fa1539b263b87df9b455cc09761f6"
-  integrity sha512-ycuVdn0yYsDuRbMD7mTbGPQ2r8y0FtL601Sa0id5ozHS24wzBd7Yp1w1TLYprvP5q7dCO5r6fne/k/bw08e0tg==
+  resolved "git+https://github.com/canonical/vanilla-framework.git#8939788f52a1ad97e5618ed9f4b4f001d4896de6"
 
 verbalize@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
## Done

- Added a demo page on ubuntu, which utilizes JS from vanilla
- Mocked an example of a project using bundler, like esbuild

## QA

- View the site in your web browser at: https://ubuntu-com-15713.demos.haus/vanilla-demo
- Click through the tabs
- Make sure the tabs are working as expected

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
