### PR TITLE
Chart update

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -149,6 +149,12 @@ export var serverAndDesktopReleases = [
     taskName: "25.04 (Plucky Puffin)",
     status: "INTERIM_RELEASE",
   },
+  {
+    startDate: new Date("2025-10-01T00:00:00"),
+    endDate: new Date("2026-07-07T00:00:00"),
+    taskName: "25.10 (Questing Quokka)",
+    status: "INTERIM_RELEASE"
+  },
 ];
 
 export var kernelReleases = [
@@ -1255,6 +1261,7 @@ export var microStackStatus = {
 };
 
 export var desktopServerReleaseNames = [
+  "25.10 (Questing Quokka)",
   "25.04 (Plucky Puffin)",
   "24.10 (Oracular Oriole)",
   "24.04 LTS (Noble Numbat)",

--- a/templates/about/release_cycles/releases-table.html
+++ b/templates/about/release_cycles/releases-table.html
@@ -1,65 +1,83 @@
 <table>
-    <thead>
-        <tr>
-            <td colspan="2">&nbsp;</td>
-            <th scope="col">Released</th>
-            <th scope="col">End of Standard Support</th>
-            <th scope="col">End of Ubuntu Pro Support</th>
-            <th scope="col">End of Legacy Support</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td colspan="2">25.04 (Plucky Puffin)</td>
-            <td>Apr 2025</td>
-            <td>Jan 2026</td>
-        </tr>
-        <tr>
-            <td colspan="2">24.10 (Oracular Oriole)</td>
-            <td>Oct 2024</td>
-            <td>Jul 2025</td>
-        </tr>
-        <tr>
-            <td colspan="2"><strong>24.04 LTS (Noble Numbat)</strong></td>
-            <td>Apr 2024</td>
-            <td>Apr 2029</td>
-            <td>Apr 2034</td>
-            <td>Apr 2036</td>
-        </tr>
-        <tr>
-            <td colspan="2"><strong>22.04 LTS (Jammy Jellyfish)</strong></td>
-            <td>Apr 2022</td>
-            <td>Apr 2027</td>
-            <td>Apr 2032</td>
-            <td>Apr 2034</td>
-        </tr>
-        <tr>
-            <td colspan="2"><strong>20.04 LTS (Focal Fossa)</strong></td>
-            <td>Apr 2020</td>
-            <td>May 2025</td>
-            <td>Apr 2030</td>
-            <td>Apr 2032</td>
-        </tr>
-        <tr>
-            <td colspan="2"><strong>18.04 LTS (Bionic Beaver)</strong></td>
-            <td>Apr 2018</td>
-            <td>May 2023</td>
-            <td>Apr 2028</td>
-            <td>Apr 2030</td>
-        </tr>
-        <tr>
-            <td colspan="2"><strong>16.04 LTS (Xenial Xerus)</strong></td>
-            <td>Apr 2016</td>
-            <td>Apr 2021</td>
-            <td>Apr 2026</td>
-            <td>Apr 2028</td>
-        </tr>
-        <tr>
-            <td colspan="2"><strong>14.04 LTS (Trusty Tahr)</strong></td>
-            <td>Apr 2014</td>
-            <td>Apr 2019</td>
-            <td>Apr 2024</td>
-            <td>Apr 2026</td>
-        </tr>
-    </tbody>
+  <thead>
+    <tr>
+      <td colspan="2">&nbsp;</td>
+      <th scope="col">Released</th>
+      <th scope="col">End of Standard Support</th>
+      <th scope="col">End of Ubuntu Pro Support</th>
+      <th scope="col">End of Legacy Support</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td colspan="2">25.10 (Questing Quokka)</td>
+      <td>Oct 2025</td>
+      <td>Jul 2026</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td colspan="2">25.04 (Plucky Puffin)</td>
+      <td>Apr 2025</td>
+      <td>Jan 2026</td>
+    </tr>
+    <tr>
+      <td colspan="2">24.10 (Oracular Oriole)</td>
+      <td>Oct 2024</td>
+      <td>Jul 2025</td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <strong>24.04 LTS (Noble Numbat)</strong>
+      </td>
+      <td>Apr 2024</td>
+      <td>Apr 2029</td>
+      <td>Apr 2034</td>
+      <td>Apr 2036</td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <strong>22.04 LTS (Jammy Jellyfish)</strong>
+      </td>
+      <td>Apr 2022</td>
+      <td>Apr 2027</td>
+      <td>Apr 2032</td>
+      <td>Apr 2034</td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <strong>20.04 LTS (Focal Fossa)</strong>
+      </td>
+      <td>Apr 2020</td>
+      <td>May 2025</td>
+      <td>Apr 2030</td>
+      <td>Apr 2032</td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <strong>18.04 LTS (Bionic Beaver)</strong>
+      </td>
+      <td>Apr 2018</td>
+      <td>May 2023</td>
+      <td>Apr 2028</td>
+      <td>Apr 2030</td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <strong>16.04 LTS (Xenial Xerus)</strong>
+      </td>
+      <td>Apr 2016</td>
+      <td>Apr 2021</td>
+      <td>Apr 2026</td>
+      <td>Apr 2028</td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <strong>14.04 LTS (Trusty Tahr)</strong>
+      </td>
+      <td>Apr 2014</td>
+      <td>Apr 2019</td>
+      <td>Apr 2024</td>
+      <td>Apr 2026</td>
+    </tr>
+  </tbody>
 </table>

--- a/templates/download/desktop/index.html
+++ b/templates/download/desktop/index.html
@@ -175,12 +175,12 @@
           <h2>Ubuntu {{ releases.latest.full_version }}</h2>
         </div>
         <div class="p-image-wrapper u-hide--small">
-          {{ image(url="https://assets.ubuntu.com/v1/7e341c7f-questing-quokka-bg.svg",
-                    alt="Plucky Puffin",
-                    width="200",
-                    height="200",
+          {{ image(url="https://assets.ubuntu.com/v1/fe84bc06-questing_quokka_mascot_circle_bg.svg",
+                    alt="Questing Quokka mascot",
+                    width="182",
+                    height="182",
                     hi_def=True,
-                    loading="lazy") | safe
+                    loading="auto") | safe
           }}
         </div>
       </div>
@@ -273,7 +273,9 @@
              aria-labelledby="release-notes-tab-{{ releases.latest.slug }}">
           <ul class="p-list--divided">
             <li class="p-list__item is-ticked">Linux Kernel 6.17 with support for the latest hardware</li>
-            <li class="p-list__item is-ticked">GNOME 49 desktop environment with new accessibility menu, lock screen media control and reboot/shutdown, HDR brightness controls</li>
+            <li class="p-list__item is-ticked">
+              GNOME 49 desktop environment with new accessibility menu, lock screen media control and reboot/shutdown, HDR brightness controls
+            </li>
             <li class="p-list__item is-ticked">Loupe, a modern image viewer</li>
             <li class="p-list__item is-ticked">Ptyxis, a new terminal emulator</li>
             <li class="p-list__item is-ticked">Major enhancements to TPM-Backed full disk encryption</li>
@@ -392,5 +394,5 @@
   {% endwith %}
 
   <script src="{{ versioned_static('js/dist/tabbedContent.js') }}"></script>
-  
+
 {% endblock content %}

--- a/templates/download/raspberry-pi/index.html
+++ b/templates/download/raspberry-pi/index.html
@@ -117,13 +117,12 @@
       <div class="col u-image-position">
         <h2>Ubuntu {{ releases.latest.full_version }}</h2>
         <div class="p-image-wrapper u-hide--small">
-          {{ image(url="https://assets.ubuntu.com/v1/7e341c7f-questing-quokka-bg.svg",
-                    alt="Questing Quokka",
-                    width="180",
-                    height="180",
+          {{ image(url="https://assets.ubuntu.com/v1/fe84bc06-questing_quokka_mascot_circle_bg.svg",
+                    alt="Questing Quokka mascot",
+                    width="182",
+                    height="182",
                     hi_def=True,
-                    loading="lazy"
-                    ) | safe
+                    loading="auto") | safe
           }}
         </div>
       </div>


### PR DESCRIPTION
## Done

- Update the chart on `/about/release-cycle` (and all other charts, as they share data) to show 25.10 data
- Updates `/download/raspberry-pi` and `/server` to use the [latest mascot](https://assets.ubuntu.com/v1/fe84bc06-questing_quokka_mascot_circle_bg.svg) 

## QA

- Go to 

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
