### PR TITLE
chore: Add release support tag to usn table

### DIFF
--- a/templates/security/notices/usn.html
+++ b/templates/security/notices/usn.html
@@ -168,7 +168,7 @@
                           <th rowspan={{ notice.release_packages[version].items() | length }}>
                             {{ version }}
                             {% for release in notice.releases %}
-                              {% if release.version == version %}<span class="u-text--muted">{{ release.codename }}</span>{% endif %}
+                              {% if release.version == version %}{% if release.support_tag %}LTS{% endif %} <span class="u-text--muted">{{ release.codename }}</span>{% endif %}
                             {% endfor %}
                           </th>
                         {% endif %}


### PR DESCRIPTION
## Done

- Added missing support tag to table

## QA

- View the site locally in your web browser at: http://0.0.0.0:8001security/notices/USN-6895-1
- See that the supported release (Jammy) has the LTS mention whereas the unsupported release (Mantic) does not

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-29364
