### PR TITLE
Remove headings in "Resources" section

### DIFF
--- a/templates/what-is-enterprise-linux/index.html
+++ b/templates/what-is-enterprise-linux/index.html
@@ -436,32 +436,23 @@
       "item": {
         "type": "html",
         "content": '<div class="grid-row">
-            <div class="grid-col-1">
-              <h3 class="p-heading--5">Datasheet</h3>
-            </div>
-            <div class="grid-col-3">
-              <p>
-                <a href="https://assets.ubuntu.com/v1/a48fc9cd-Ubuntu%20Desktop%20DS%2021.06.23.pdf?_gl=1*543k35*_gcl_au*NzM0MDU3Njc5LjE3NTMxMDI4MDQ.">
-                  Ubuntu Desktop in the enterprise
-                </a>
-              </p>
-              
-            </div>
+            <p>
+              <a href="https://assets.ubuntu.com/v1/a48fc9cd-Ubuntu%20Desktop%20DS%2021.06.23.pdf?_gl=1*543k35*_gcl_au*NzM0MDU3Njc5LjE3NTMxMDI4MDQ.">
+                Ubuntu Desktop in the enterprise
+              </a>
+            </p>
           </div>
           <hr class="p-rule--muted">
           <div class="grid-row">
-            <div class="grid-col-1">
-              <h3 class="p-heading--5">Webpage</h3>
-            </div>
-            <div class="grid-col-3">
-              <p>
-                <a href="https://ubuntu.com/cloud/public-cloud">Ubuntu on public clouds</a>
-              </p>
-              <hr class="p-rule--muted">
-              <p>
-                <a href="https://ubuntu.com/pro">Ubuntu Pro</a>
-              </p>
-            </div>
+            <p>
+              <a href="https://ubuntu.com/cloud/public-cloud">Ubuntu on public clouds</a>
+            </p>
+          </div>
+          <hr class="p-rule--muted">
+          <div class="grid-row">
+            <p>
+              <a href="https://ubuntu.com/pro">Ubuntu Pro</a>
+            </p>
           </div>'
       }
     }


### PR DESCRIPTION
## Done

- removed headings in the "Resources" section of /what-is-enterprise-linux page

## QA

- goto https://ubuntu-com-15718.demos.haus/what-is-enterprise-linux
- check the links at the bottom "Resources" section.

## Issue / Card

https://warthogs.atlassian.net/browse/WD-29301

## Copydoc

https://docs.google.com/document/d/1Z6iBXfd9lOoQHcuyzaiSUtJ2nzP6SKcc1hnUB-SajyA/edit?tab=t.0

