### PR TITLE
[WD-26500] make top menu items accessible by defining their role correctly

### DIFF
--- a/static/js/src/navigation.js
+++ b/static/js/src/navigation.js
@@ -788,10 +788,10 @@ if (accountContainer) {
     .then((response) => response.json())
     .then((data) => {
       if (data.account === null) {
-        accountContainer.innerHTML = `<a href="/login" class="p-navigation__link" style="padding-right: 1rem;" tabindex="0" onclick="event.stopPropagation()">Sign in</a>`;
+        accountContainer.innerHTML = `<a href="/login" class="p-navigation__link" style="padding-right: 1rem;" tabindex="0" role="button" onclick="event.stopPropagation()">Sign in</a>`;
       } else {
         window.accountJSONRes = data.account;
-        accountContainer.innerHTML = `<button href="#" class="p-navigation__link is-signed-in" aria-controls="canonical-login-content-mobile" aria-expanded="false" aria-haspopup="true">Account</button>
+        accountContainer.innerHTML = `<button href="#" class="p-navigation__link is-signed-in" role="menuitem" aria-controls="canonical-login-content-mobile" aria-expanded="false" aria-haspopup="true">Account</button>
           <ul class="p-navigation__dropdown" id="canonical-login-content-mobile" aria-hidden="true">
             <li class="p-navigation__item--dropdown-close" id="canonical-login-back">
               <button class="p-navigation__link js-back" href="canonical-login-content-mobile" aria-controls="canonical-login-content-mobile" tabindex="-1"">

--- a/templates/templates/_navigation.html
+++ b/templates/templates/_navigation.html
@@ -35,50 +35,50 @@
       <nav class="p-navigation__nav js-show-nav" aria-label="Categories">
         <ul class="p-navigation__items" role="menu">
           <li class="p-navigation__item--dropdown-toggle"
-              role="menuitem"
               id="products"
               onmouseenter="fetchDropdown('/templates/navigation/products', 'products', event); this.onmouseenter = null;">
             <a class="p-navigation__link"
+               role="menuitem"
                href="/navigation#products-navigation"
                aria-controls="products-content"
                tabindex="0"
                onfocus="fetchDropdown('/templates/navigation/products', 'products');">Products</a>
           </li>
           <li class="p-navigation__item--dropdown-toggle"
-              role="menuitem"
               id="use-case"
               onmouseenter="fetchDropdown('/templates/navigation/use-case', 'use-case', event); this.onmouseenter = null;">
             <a class="p-navigation__link"
+               role="menuitem"
                href="/navigation#use-case-navigation"
                aria-controls="use-case-content"
                tabindex="0"
                onfocus="fetchDropdown('/templates/navigation/use-case', 'use-case');">Use cases</a>
           </li>
           <li class="p-navigation__item--dropdown-toggle"
-              role="menuitem"
               id="support"
               onmouseenter="fetchDropdown('/templates/navigation/support', 'support', event); this.onmouseenter = null;">
             <a class="p-navigation__link"
+               role="menuitem"
                href="/navigation#support-navigation"
                aria-controls="support-content"
                tabindex="0"
                onfocus="fetchDropdown('/templates/navigation/support', 'support');">Support</a>
           </li>
           <li class="p-navigation__item--dropdown-toggle"
-              role="menuitem"
               id="community"
               onmouseenter="fetchDropdown('/templates/navigation/community', 'community', event); this.onmouseenter = null;">
             <a class="p-navigation__link"
+               role="menuitem"
                href="/navigation#community-navigation"
                aria-controls="community-content"
                tabindex="0"
                onfocus="fetchDropdown('/templates/navigation/community', 'community');">Community</a>
           </li>
           <li class="p-navigation__item--dropdown-toggle"
-              role="menuitem"
               id="download-ubuntu"
               onmouseenter="fetchDropdown('/templates/navigation/download-ubuntu', 'download-ubuntu', event); this.onmouseenter = null;">
             <a class="p-navigation__link"
+               role="menuitem"
                href="/navigation#download-ubuntu-navigation"
                aria-controls="download-ubuntu-content"
                tabindex="0"
@@ -88,7 +88,6 @@
               role="menuitem"
               id="all-canonical"></li>
           <li class="p-navigation__item--dropdown-toggle js-account"
-              role="menuitem"
               id="canonical-login"></li>
           <li class="p-navigation__item">
             <a href="/search"


### PR DESCRIPTION
## Done

- Correctly define the "role" tag on the top menu items for a voiceover, which includes:
   - Products
   - Use Cases
   - Support
   - Community
   - Download Ubuntu
   - All Canonical
   - Sign in/Account

Previously these menu items were pronounced as just "Menu Item" by the voiceover on Apple OS-es (see the linked GitHub issue below).

## QA

- Open the demo link on any browser
- Turn on the voiceover
- Click through the menu items in top navigation
- Check that the voiceover correctly pronounces the menu items
- Check on different screen resolutions, as for tablet and mobile screen navigation looks slightly different
- Preferrably check on MacOS and iOS as well, because that's where this issue was reported

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-26500
Addresses https://github.com/canonical/ubuntu.com/issues/15576
