### PR TITLE
feat: Add 25.10 checksums

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -55,6 +55,7 @@ wsl:
 
 checksums:
   desktop:
+    "25.10": "32e30d72ae4798c633323a2684d94a11582bb03a6ab38d2b0d5ae5eabc5e577b *questing-desktop-amd64.iso"
     "25.04": "b87366b62eddfbecb60e681ba83299c61884a0d97569abe797695c8861f5dea4 *ubuntu-25.04-desktop-amd64.iso"
     "24.10": "489079483487f92ad0d2f3d4b6c88a7b197969eb286b277534047920854a8b03 *ubuntu-24.10-desktop-amd64.iso"
     "24.04.3": "faabcf33ae53976d2b8207a001ff32f4e5daae013505ac7188c9ea63988f8328 *ubuntu-24.04.3-desktop-amd64.iso"
@@ -62,6 +63,7 @@ checksums:
     "21.10": "f8d3ab0faeaecb5d26628ae1aa21c9a13e0a242c381aa08157db8624d574b830 *ubuntu-21.10-desktop-amd64.iso"
     "20.04.6": "510ce77afcb9537f198bc7daa0e5b503b6e67aaed68146943c231baeaab94df1 *ubuntu-20.04.6-desktop-amd64.iso"
   live-server:
+    "25.10": "dc54870e5261c0abad19f74b8146659d10e625971792bd42d7ecde820b60a1d0 *questing-live-server-amd64.iso"
     "25.04": "8b44046211118639c673335a80359f4b3f0d9e52c33fe61c59072b1b61bdecc5 *ubuntu-25.04-live-server-amd64.iso"
     "24.10": "4fce7c02a5e5dbe3426da4aa0f8b7845e9a36aff29c5884d206a08e51b2c4c47 *ubuntu-24.10-live-server-amd64.iso"
     "24.04.3": "c3514bf0056180d09376462a7a1b4f213c1d6e8ea67fae5c25099c6fd3d8274b *ubuntu-24.04.3-live-server-amd64.iso"
@@ -70,6 +72,7 @@ checksums:
     "20.04.6": "b8f31413336b9393ad5d8ef0282717b2ab19f007df2e9ed5196c13d8f9153c8b *ubuntu-20.04.6-live-server-amd64.iso"
     "18.04.6": "6c647b1ab4318e8c560d5748f908e108be654bad1e165f7cf4f3c1fc43995934 *ubuntu-18.04.6-live-server-amd64.iso"
   desktop-arm64+raspi:
+    "25.10": "d35bc2aa6ed256293c4eab4d6066274364ddc790d327bb1ec1bfac117ec89dd3 *questing-preinstalled-desktop-arm64+raspi.img.xz"
     "25.04": "278b1748c783a69edb526e7e29d51b4e55f505a1dcddcc8be3977df5b8d87088 *ubuntu-25.04-preinstalled-desktop-arm64+raspi.img.xz"
     "24.10": "9aaacf14e4d12bd59ac20ba07d34dbe6ad2dee14bc211947915d6b2b845af424 *ubuntu-24.10-preinstalled-desktop-arm64+raspi.img.xz"
     "24.04.3": "04a87330d2dfbe29c29f69d2113d92bbde44daa516054074ff4b96c7ee3c528b *ubuntu-24.04.3-preinstalled-desktop-arm64+raspi.img.xz"
@@ -77,6 +80,7 @@ checksums:
     "21.10": "5187d507099f26bc4d8218085109af498fae5ff93b40c668f83bab5c7574d954 *ubuntu-21.10-preinstalled-desktop-arm64+raspi.img.xz"
     "21.04": "d89ee327a00b98d7166b1a8cc95d17762aaacd3b4d0fc756c5b6b65df1708f48 *ubuntu-21.04-preinstalled-desktop-arm64+raspi.img.xz"
   server-arm64+raspi:
+    "25.10": "b7d8c52fd25e2b6a86f07669769850076a97c2aa1dcbb29cb3038ad5c619cc68 *questing-preinstalled-server-arm64+raspi.img.xz"
     "25.04": "a1439585661b69fd43a29610b443ae460893c5ea88c2036ae979ae6071827ec6 *ubuntu-25.04-preinstalled-server-arm64+raspi.img.xz"
     "24.10": "ef594f0a75f79294b374466c7c49b2d56da223c99fa38d7baefb118ed8a0fb94 *ubuntu-24.10-preinstalled-server-arm64+raspi.img.xz"
     "24.04.3": "9bb1799cee8965e6df0234c1c879dd35be1d87afe39b84951f278b6bd0433e56 *ubuntu-24.04.3-preinstalled-server-arm64+raspi.img.xz"
@@ -89,6 +93,7 @@ checksums:
     "21.10": "341593c9607ed20744cd86941d94d73e3ba4f74e8ef2633eec63ce9b0cfac5a1 *ubuntu-21.10-preinstalled-server-armhf+raspi.img.xz"
     "20.04.5": "065c41846ddf7a1c636a1aac5a7d49ebcee819b141f9d57fd586c5f84b9b7942 *ubuntu-20.04.5-preinstalled-server-armhf+raspi.img.xz"
   server-riscv64:
+    "25.10": "839f0602ead71d8c5a85444164e8cd09af48c348a0ecd729f01531c95f39e00e *questing-live-server-riscv64.iso"
     "25.04": "5c16519f6137a890044c5fb4110264586f5aaddcb9e493bd6ac6bd5fc9934107 *ubuntu-25.04-live-server-riscv64.img.gz"
     "24.10": "a5c932527a48c65713d6c49ef2db258aa00753e910e038571ad09d4fbfa1e9bb *ubuntu-24.10-live-server-riscv64.img.gz"
     "24.04.3": "8e7553f229f5889e8698281404f05d565ae694066215d45df9178d9e865e23fe *ubuntu-24.04.3-preinstalled-server-riscv64.img.xz"


### PR DESCRIPTION
## Done

- Adds checksums for 25.10 release

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
