### PR TITLE
[WD-29328] update datasheet link on u.com/what-is-enterprise-linux

### DIFF
--- a/templates/what-is-enterprise-linux/index.html
+++ b/templates/what-is-enterprise-linux/index.html
@@ -437,7 +437,7 @@
         "type": "html",
         "content": '<div class="grid-row">
             <p>
-              <a href="https://assets.ubuntu.com/v1/a48fc9cd-Ubuntu%20Desktop%20DS%2021.06.23.pdf?_gl=1*543k35*_gcl_au*NzM0MDU3Njc5LjE3NTMxMDI4MDQ.">
+              <a href="https://assets.ubuntu.com/v1/def33105-ubuntu_desktop_datasheet_2025.pdf">
                 Ubuntu Desktop in the enterprise
               </a>
             </p>


### PR DESCRIPTION
## Done

- Updated the pdf link at the end of the page

## QA

- Visit the demo site at https://ubuntu-com-15723.demos.haus/what-is-enterprise-linux
- Scroll to the almost the bottom of the page (refer to screenshot below)
- Confirm the "Ubuntu Desktop in the enterprise" link has https://assets.ubuntu.com/v1/def33105-ubuntu_desktop_datasheet_2025.pdf as the link.

## Issue / Card

Fixes #[WD-29328](https://warthogs.atlassian.net/browse/WD-29328)

## Screenshots

<img width="1463" height="241" alt="image" src="https://github.com/user-attachments/assets/2af573b6-a8ef-455f-aa21-c3d65679ab49" />


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-29328]: https://warthogs.atlassian.net/browse/WD-29328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ