### PR TITLE
remove notification bar after submitting an engage page form

### DIFF
--- a/templates/engage/shared/_en_engage_form.html
+++ b/templates/engage/shared/_en_engage_form.html
@@ -63,7 +63,7 @@
       <li>
         <button type="submit" class="u-no-margin--bottom {% if cta_class %}{{ cta_class }}{% endif %}" >{% if cta %}{{ cta }}{% else %}Download the whitepaper{% endif %}</button>
         <input name="formid" aria-label="formid" value="{{ id }}" type="hidden" />
-        <input type="hidden" name="returnURL" aria-label="returnURL" value="{{ returnURL }}#contact-form-success" />
+        <input type="hidden" name="returnURL" aria-label="returnURL" value="{{ returnURL }}" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_campaign" id="utm_campaign" value="{{ utm_campaign }}" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_medium" id="utm_medium" value="{{ utm_medium }}" />
         <input type="hidden" aria-hidden="true" aria-label="hidden field" name="utm_source" id="utm_source" value="{{ utm_source }}" />


### PR DESCRIPTION
## Done

- Currently after submitting the form on an engage page that is in English, a user is redirected to the Thank You page and there is also a notification bar shown at the top. The notification bar is redundant as it duplicates the message on the Thank You page and therefore it was removed in this PR.

## QA

- Open any engage page that has a form (like a whitepaper) at https://ubuntu-com-15728.demos.haus/engage
- Fill out the form and click the submit button
- The Thank You page should open without the notification bar at the top

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-29344

## Screenshots

Before:
<img width="1782" height="1060" alt="Screenshot 2025-10-09 at 17 24 28" src="https://github.com/user-attachments/assets/21f7340a-d05f-4086-9943-7c835f3ddec5" />

After:
<img width="1908" height="1062" alt="Screenshot 2025-10-09 at 17 25 04" src="https://github.com/user-attachments/assets/00807d96-301a-47ba-9133-c6a73265794f" />


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
