### PR TITLE
fix(WD-29521): update time buffer for scheduling exam on staging

### DIFF
--- a/webapp/shop/cred/views.py
+++ b/webapp/shop/cred/views.py
@@ -499,8 +499,8 @@ def cred_schedule(
     is_staging = "staging" in get_flask_env(
         "CONTRACTS_API_URL", "https://contracts.staging.canonical.com/"
     )
-    time_buffer = 0.5 if is_staging else 3
-    time_delay = "30 minutes" if is_staging else "3 hours"
+    time_buffer = 1 if is_staging else 3
+    time_delay = "1 hour" if is_staging else "3 hours"
 
     if flask.request.method == "POST":
         data = flask.request.form


### PR DESCRIPTION
## Done

- Update scheduling time from 30 minutes to 1 hour for staging

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
