### PR TITLE
bug: Fix tab hash persistence

### DIFF
--- a/static/js/src/tabbed-content.js
+++ b/static/js/src/tabbed-content.js
@@ -82,7 +82,7 @@
           // this prevents the page attempting to jump to
           // the section with that ID
           const url = new URL(window.location.href);
-          url.hash = tab.id; // no '#'
+          url.hash = tab.id;
           history.pushState({}, "", url);
 
           // Update the URL again with the same hash, then go back


### PR DESCRIPTION
## Done

- Fixed hash not persisting on tab clicks
 **Note: there are still bugs to be addressed here. When qa-ing across various pages that call this script I noticed that our markup implementation is inconsistent and we have some pages where it is not clear if the hash is indeed supposed to persist. I will open a separate maintenance ticket to review and address these.**

## QA

- View the site locally in your web browser at: https://ubuntu-com-15733.demos.haus/download/qualcomm-iot
- Click through tabs and see that the url is updated with the hash and that it persists on refresh
- Check through a few pages that call this script and observe that the behavior remains unchanged. Eg:
  - https://ubuntu-com-15733.demos.haus/download/risc-v
  - https://ubuntu-com-15733.demos.haus/download/server

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
