### PR TITLE
Update link for Qualcomm EVK image installation instructions (WD-29815)

### DIFF
--- a/templates/download/qualcomm-iot/tabs/evaluation-kit-tab.html
+++ b/templates/download/qualcomm-iot/tabs/evaluation-kit-tab.html
@@ -70,7 +70,7 @@
             title="Read more about IQ-9075">IQ-9075</a>
         </li>
         <li class="p-list__item">
-          Ubuntu 24.04 for Qualcomm IQ-9075 Evaluation Kit (EVK) <a href="https://docs.qualcomm.com/bundle/resource/topics/80-90441-252/Integrate-and-flash-software.html?product=1601111740076074&facet=Ubuntu%20quickstart" title="Read image installation instructions of Ubuntu 24.04 for IQ-9075">image installation instructions</a>
+          Ubuntu 24.04 for Qualcomm IQ-9075 Evaluation Kit (EVK) <a href="https://docs.qualcomm.com/bundle/publicresource/topics/80-90441-252/Integrate-and-flash-software.html?product=1601111740076074&facet=Ubuntu%20quickstart" title="Read image installation instructions of Ubuntu 24.04 for IQ-9075">image installation instructions</a>
         </li>
         <li class="p-list__item">
           Ubuntu 24.04 for Qualcomm IQ-9075 Evaluation Kit (EVK) <a href="https://people.canonical.com/~platform/images/qualcomm-iot/ubuntu-24.04/ubuntu-24.04-x05/Ubuntu_24.04_Qualcomm_RB3Gen2_Vision_Development_Kit_and_IQ-9075_Evaluation_Kit_Release_Notes.pdf" title="Read full release notes of Ubuntu 24.04 for IQ-9075">release notes</a>


### PR DESCRIPTION
## Done

- Update link for Qualcomm EVK image installation instructions

## QA

- Go to demo page: https://ubuntu-com-15734.demos.haus/download/qualcomm-iot#evaluation-kit
- Ensure the new link for image installation instructions matches Alex Kaluzhny's comment in the [copy doc](https://docs.google.com/document/d/1BP2T63R6kdnUFQFIZcbXbTIgY-9fQVgVRLsSUU5Rvx8/edit?tab=t.0)

## Issue / Card

[WD-29815](https://warthogs.atlassian.net/browse/WD-29815)


[WD-29815]: https://warthogs.atlassian.net/browse/WD-29815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ