### PR TITLE
chore: Add attribute for maintaing hash on tab selection

### DIFF
--- a/static/js/src/tabbed-content.js
+++ b/static/js/src/tabbed-content.js
@@ -81,13 +81,7 @@
           // if we're adding the ID of the tab to the URL
           // this prevents the page attempting to jump to
           // the section with that ID
-          const url = new URL(window.location.href);
-          url.hash = tab.id;
-          history.pushState({}, "", url);
-
-          // Update the URL again with the same hash, then go back
-          history.pushState({}, "", url);
-          history.back();
+          handleHashChange(tab.id);
         }
 
         setActiveTab(tab, tabs);
@@ -221,6 +215,7 @@
 
   const boards = document.querySelectorAll(`[role=tabpanel]`);
   const dropdownSelect = document.getElementById("boardSelect");
+  const maintainHash = dropdownSelect?.getAttribute("data-maintain-hash");
 
   dropdownSelect?.addEventListener("change", () => {
     selectBoard();
@@ -228,7 +223,15 @@
 
   function selectBoard() {
     boards.forEach((board) => {
-      if (board.id === dropdownSelect.value) {
+      const targetValue = dropdownSelect.value;
+      if (board.id === targetValue) {
+        if (maintainHash) {
+          // Remove '-tab' from the hash
+          const cleanHash = targetValue.endsWith("-tab")
+            ? targetValue.slice(0, -4)
+            : targetValue;
+          handleHashChange(cleanHash);
+        }
         board.classList.remove("u-hide");
         board.focus();
       } else {
@@ -237,3 +240,13 @@
     });
   }
 })();
+
+const handleHashChange = (hash) => {
+  const url = new URL(window.location.href);
+  url.hash = hash;
+  history.pushState({}, "", url);
+
+  // Update the URL again with the same hash, then go back
+  history.pushState({}, "", url);
+  history.back();
+};

--- a/templates/download/mediatek-genio/index.html
+++ b/templates/download/mediatek-genio/index.html
@@ -84,7 +84,7 @@
           </li>
         </ul>
         <form class="u-hide--large u-hide--medium">
-          <select name="boardSelect" id="boardSelect">
+          <select name="boardSelect" id="boardSelect" data-maintain-hash="true">
             <option value="genio-1200-evk-tab" selected="">Genio 1200 EVK</option>
             <option value="genio-700-evk-tab">Genio 700 EVK</option>
             <option value="genio-510-evk-tab">Genio 510 EVK</option>

--- a/templates/download/nvidia-jetson/index.html
+++ b/templates/download/nvidia-jetson/index.html
@@ -86,7 +86,7 @@
           </li>
         </ul>
         <form class="u-hide--large u-hide--medium">
-          <select name="boardSelect" id="boardSelect">
+          <select name="boardSelect" id="boardSelect" data-maintain-hash="true">
             <option value="jetson-agx-orin-tab" selected="">Jetson AGX Orin Series</option>
             <option value="jetson-orin-nano-tab">Jetson Orin Nano Series</option>
             <option value="jetson-orin-nx-tab">Jetson Orin NX Series</option>

--- a/templates/download/renesas-iot/index.html
+++ b/templates/download/renesas-iot/index.html
@@ -87,7 +87,7 @@
         </ul>
         <!-- form dropdown for smaller screens -->
         <form class="u-hide--large u-hide--medium">
-          <select name="boardSelect" id="boardSelect">
+          <select name="boardSelect" id="boardSelect" data-maintain-hash="true">
             <option value="renesas-rz-g2l-tab" selected="">RZ/G2L</option>
             <option value="renesas-rz-g2lc-tab" selected="">RZ/G2LC</option>
             <option value="renesas-rz-g2ul-tab" selected="">RZ/G2UL</option>

--- a/templates/download/risc-v/index.html
+++ b/templates/download/risc-v/index.html
@@ -134,7 +134,7 @@
           </li>
         </ul>
         <form class="u-hide--large u-hide--medium">
-          <select name="boardSelect" id="boardSelect">
+          <select name="boardSelect" id="boardSelect" data-maintain-hash="true">
             <option value="allwinner-nezha-tab" selected="">AllWinner Nezha</option>
             <option value="deepcomputing-fml13v01-tab">DeepComputing FML13V01</option>
             <option value="microchip-curiosity-tab">Microchip PIC64GX1000 Curiosity Kit</option>


### PR DESCRIPTION
## Done

-  Apply the same maintain hash attribute across all download pages with this design (follow up of https://github.com/canonical/ubuntu.com/pull/15733)

## QA

- View the following pages and see that the hash is added to url on click and that it persists: 
  - https://ubuntu-com-15739.demos.haus/download/risc-v
  - https://ubuntu-com-15739.demos.haus/download/renesas-iot
  - https://ubuntu-com-15739.demos.haus/download/nvidia-jetson
  - https://ubuntu-com-15739.demos.haus/download/mediatek-genio

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-29852

