### PR TITLE
fix(intel-iot): Update form intro text to match copydoc

### DIFF
--- a/templates/download/iot/intel-iot/form-data.json
+++ b/templates/download/iot/intel-iot/form-data.json
@@ -7,7 +7,7 @@
       "formData": {
         "title": "Let's get your project to market faster!",
         "formId": "4205",
-        "introText": "Canonical and Intel have partnered to provide Ubuntu Desktop and Ubuntu Core on Intel's IoT platforms: Atom® X6000E Series, Intel® Pentium® and Celeron® N and J Series and 11th Gen Intel® Core™ processors.",
+        "introText": "Canonical partners with silicon companies, board manufacturers and ODMs to help the industry bring smart device and software capabilities to market faster.\nTell us about your project so we can bring the right Canonical team members to the conversation to help you.",
         "returnUrl": "/download/iot/intel-iot#contact-form-success",
         "product": ""
       },


### PR DESCRIPTION
## Done

- Update `/download/iot/intel-iot` intro text to match copy doc

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: https://ubuntu-com-15747.demos.haus/download/iot/intel-iot#get-in-touch

## Issue / Card

Fixes [WD-29976
](https://warthogs.atlassian.net/browse/WD-29976)
## Screenshots

<img width="980" height="481" alt="image" src="https://github.com/user-attachments/assets/092941dc-93a0-4e29-915f-d0f8099767a4" />


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
