### PR TITLE
Remove Oracular Oriole

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -138,12 +138,6 @@ export var serverAndDesktopReleases = [
     status: "PRO_LEGACY_SUPPORT",
   },
   {
-    startDate: new Date("2024-10-01T00:00:00"),
-    endDate: new Date("2025-07-01T00:00:00"),
-    taskName: "24.10 (Oracular Oriole)",
-    status: "INTERIM_RELEASE",
-  },
-  {
     startDate: new Date("2025-04-01T00:00:00"),
     endDate: new Date("2026-01-05T00:00:00"),
     taskName: "25.04 (Plucky Puffin)",
@@ -1287,7 +1281,6 @@ export var microStackStatus = {
 export var desktopServerReleaseNames = [
   "25.10 (Questing Quokka)",
   "25.04 (Plucky Puffin)",
-  "24.10 (Oracular Oriole)",
   "24.04 LTS (Noble Numbat)",
   "22.04 LTS (Jammy Jellyfish)",
   "20.04 LTS (Focal Fossa)",

--- a/templates/about/release_cycles/releases-table.html
+++ b/templates/about/release_cycles/releases-table.html
@@ -24,13 +24,6 @@
       <td aria-label="Not applicable">-</td>
     </tr>
     <tr>
-      <td colspan="2">24.10 (Oracular Oriole)</td>
-      <td>Oct 2024</td>
-      <td>Jul 2025</td>
-      <td aria-label="Not applicable">-</td>
-      <td aria-label="Not applicable">-</td>
-    </tr>
-    <tr>
       <td colspan="2">
         <strong>24.04 LTS (Noble Numbat)</strong>
       </td>


### PR DESCRIPTION
## Done

- Remove Oracular Oriole

## QA

- Go to https://ubuntu-com-15751.demos.haus/about/release-cycle
- Check that Oracular Oriole has been removed from the chart 
- Double check that [the issue](https://warthogs.atlassian.net/browse/WD-30029) has been addressed

## Issue / Card

Fixes #https://warthogs.atlassian.net/browse/WD-30029


