### PR TITLE
Update toolchain links to point to correct pages

### DIFF
--- a/templates/toolchains/index.html
+++ b/templates/toolchains/index.html
@@ -68,7 +68,7 @@
           }
         },
         {
-          "href": "https://documentation.ubuntu.com/ubuntu-for-developers",
+          "href": "https://documentation.ubuntu.com/ubuntu-for-developers/howto/python-setup/",
           "text": "Learn more &rsaquo;",
           "label": "Learn more about Python",
           "image_attrs": {
@@ -79,7 +79,7 @@
           }
         },
         {
-          "href": "https://documentation.ubuntu.com/ubuntu-for-developers",
+          "href": "https://documentation.ubuntu.com/ubuntu-for-developers/howto/go-setup/",
           "text": "Learn more &rsaquo;",
           "label": "Learn more about Go",
           "image_attrs": {
@@ -90,7 +90,7 @@
           }
         },
         {
-          "href": "https://documentation.ubuntu.com/ubuntu-for-developers",
+          "href": "https://documentation.ubuntu.com/ubuntu-for-developers/howto/rust-setup/",
           "text": "Learn more &rsaquo;",
           "label": "Learn more about Rust",
           "image_attrs": {
@@ -101,7 +101,7 @@
           }
         },
         {
-          "href": "https://documentation.ubuntu.com/ubuntu-for-developers",
+          "href": "/toolchains/dotnet",
           "text": "Learn more &rsaquo;",
           "label": "Learn more about .NET",
           "image_attrs": {


### PR DESCRIPTION
## Done

Updated links to toolchains:

- .NET to the existing page at [toolchains/dotnet](https://ubuntu.com/toolchains/dotnet)
- Python, Go, and Rust to resp. setup articles within [Ubuntu for developers docs](https://documentation.ubuntu.com/ubuntu-for-developers/)

## Issue / Card

Fixes # [FR-11757](https://warthogs.atlassian.net/browse/FR-11757)


[FR-11757]: https://warthogs.atlassian.net/browse/FR-11757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ