### PR TITLE
Refresh: /download/risc-v/canonical-built [WD-29528]

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -890,7 +890,7 @@ release-notes/oneiric-ocelot/?: "https://wiki.ubuntu.com/OneiricOcelot/ReleaseNo
 release-notes/precise-pangolin/?: "https://wiki.ubuntu.com/PrecisePangolin/ReleaseNotes"
 releases/?: "https://releases.ubuntu.com"
 releaseendoflife/?: "/about/release-cycle"
-risc-v/?: "https://wiki.ubuntu.com/RISC-V"
+risc-v/?: /download/risc-v/canonical-built
 robots.txt?: "/static/files/robots.txt"
 robotics/esm/?: "/robotics/ros-esm"
 rss\.xml/?: "/blog/feed"

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -1326,6 +1326,7 @@ $color-link-dark: #69c !default;
   @extend .p-strip--light;
   @extend .u-aspect-ratio--3-2;
 
+  background-color: rgba(0, 0, 0, 0.03);
   margin-top: $spv--small;
   padding-bottom: $spv--large;
   padding-top: $spv--large;

--- a/templates/download/risc-v/allwinner-nezha.html
+++ b/templates/download/risc-v/allwinner-nezha.html
@@ -19,7 +19,7 @@
     </div>
   </div>
   <div class="row p-strip u-no-padding--top">
-    <hr class="p-rule col-9" />
+    <hr class="p-rule is-muted col-9" />
     <div class="col-3">
       <h3 class="p-heading--5 u-no-padding--top">
         Ubuntu Server

--- a/templates/download/risc-v/canonical-built.html
+++ b/templates/download/risc-v/canonical-built.html
@@ -1,6 +1,6 @@
 {% extends "download/_base_download.html" %}
 
-{% block title %}Download Ubuntu for RISC-V Platforms{% endblock %}
+{% block title %}Download Canonical-built Ubuntu for RISC-V Platforms{% endblock %}
 
 {% block meta_description %}
   Use Ubuntu on RISC-V platforms for the familiar developer experience and an accelerated path to production
@@ -10,44 +10,46 @@
   https://docs.google.com/document/d/1kkJeq9HdH3iWV35HwihcJd3CxZw9Jy21W66lJl8VbWs/
 {% endblock meta_copydoc %}
 
+{% from "_macros/vf_hero.jinja" import vf_hero %}
+
 {% block body_class %}
   is-paper
 {% endblock body_class %}
 
 {% block content %}
 
-  <section class="p-strip is-deep">
-    <div class="row">
-      <div class="col-3 col-medium-2">
-        <div class="p-strip is-shallow u-no-padding--top">
-          {{ image(url="https://assets.ubuntu.com/v1/4d5b8d51-riscv-color.svg",
-                    alt="",
-                    width="200",
-                    height="32",
-                    hi_def=True,
-                    loading="auto",
-                    attrs={"style": "padding-top: 1rem"},) | safe
-          }}
-        </div>
-      </div>
-      <div class="col-9 col-medium-4">
-        <h1 class="p-heading--2">
-          <strong>Download Ubuntu for RISC-V Platforms</strong>
-        </h1>
-        <p>
-          Run Ubuntu with your favourite RISC-V boards. Pick the OS image to match your hardware, flash it onto SD/microSD card, load it onto your board and away you go.
-        </p>
-        <p>
-          <strong>
-            We have upgraded the required RISC-V ISA profile to RVA23S64 with the 25.10 release. Hardware that is not RVA23 ready continues to be supported by our 24.04.3 LTS release.
-          </strong>
-        </p>
-        <p>
-          <a href="/download/contact-us" class="js-invoke-modal p-button">Get in touch</a>
-        </p>
-      </div>
-    </div>
-  </section>
+{% call(slot) vf_hero(
+title_text='Download Ubuntu for RISC-V Platforms',
+layout='25/75'
+) -%}
+
+{%- if slot == 'signpost_image' -%}
+  {{ image(url="https://assets.ubuntu.com/v1/4d5b8d51-riscv-color.svg",
+    alt="",
+    width="200",
+    height="32",
+    hi_def=True,
+    loading="auto",
+    attrs={"style": "padding-top: 1rem"},) | safe
+  }}{%- endif -%}
+  {%- if slot == 'description' -%}
+    <p>
+      These Ubuntu images are built and hosted by Canonical, with support and maintenance for Ubuntu components provided under Canonical’s standard SLA. For additional or extended support, please <a href="https://ubuntu.com/download/risc-v#get-in-touch">get in touch</a> with Canonical.
+    </p>
+    <p>
+      Get Ubuntu, running on your favorite RISC-V boards. Choose the right image for your hardware below, flash it onto an SD/microSD card, power up your board, and start building right away.
+    </p>
+    <p>
+      <strong>
+        Note: We have upgraded the required RISC-V ISA profile to RVA23S64 with the 25.10 release. Hardware that is not RVA23-ready continues to be supported by our 24.04 LTS release.
+      </strong>
+    </p>
+  {%- endif -%}
+  {%- if slot == 'cta' -%}
+    <a href="/download/contact-us" class="js-invoke-modal p-button--positive">Contact us</a>
+    <a href="/silicon" class="p-button">Explore our RISC-V program</a>
+  {%- endif -%}
+{%- endcall -%}
 
   <section class="p-strip is-deep u-no-padding--top">
     <hr class="is-fixed-width p-rule" />
@@ -92,17 +94,17 @@
           </li>
           <li>
             <button class="p-tabs__item"
-                    id="pine64-star64"
-                    role="tab"
-                    aria-selected="false"
-                    aria-controls="pine64-star64-tab">Pine64 Star64</button>
-          </li>
-          <li>
-            <button class="p-tabs__item"
                     id="milk-v-mars"
                     role="tab"
                     aria-selected="false"
                     aria-controls="milk-v-mars-tab">Milk-V Mars</button>
+          </li>
+          <li>
+            <button class="p-tabs__item"
+                    id="pine64-star64"
+                    role="tab"
+                    aria-selected="false"
+                    aria-controls="pine64-star64-tab">Pine64 Star64</button>
           </li>
           <li>
             <button class="p-tabs__item"
@@ -139,8 +141,8 @@
             <option value="deepcomputing-fml13v01-tab">DeepComputing FML13V01</option>
             <option value="microchip-curiosity-tab">Microchip PIC64GX1000 Curiosity Kit</option>
             <option value="microchip-polarfire-soc-fpga-icicle-kit-tab">Microchip Polarfire SoC FPGA Icicle</option>
-            <option value="pine64-star64-tab">Pine64 Star64</option>
             <option value="milk-v-mars-tab">Milk-V Mars</option>
+            <option value="pine64-star64-tab">Pine64 Star64</option>
             <option value="qemu-tab">QEMU emulator</option>
             <option value="quemu-sifive-image-tab">SiFive Unmatched</option>
             <option value="sipeed-licheerv-dock-tab">Sipeed LicheeRV Dock</option>
@@ -153,8 +155,8 @@
         {% include "download/risc-v/deepcomputing-fml13v01.html" %}
         {% include "download/risc-v/microchip-curiosity.html" %}
         {% include "download/risc-v/microchip-polarfire.html" %}
-        {% include "download/risc-v/pine64-star64.html" %}
         {% include "download/risc-v/milk-v-mars.html" %}
+        {% include "download/risc-v/pine64-star64.html" %}
         {% include "download/risc-v/qemu-emulator.html" %}
         {% include "download/risc-v/sifive-unmatched.html" %}
         {% include "download/risc-v/sipeed-licheerv.html" %}

--- a/templates/download/risc-v/deepcomputing-fml13v01.html
+++ b/templates/download/risc-v/deepcomputing-fml13v01.html
@@ -15,8 +15,8 @@
       }}
     </div>
   </div>
-  <div class="row p-strip u-no-padding--top">
-    <hr class="p-rule col-9" />
+  <div class="row p-strip is-shallow u-no-padding--top">
+    <hr class="p-rule is-muted col-9" />
     <div class="col-3">
       <h3 class="p-heading--5 u-no-padding--top">
         Ubuntu Server
@@ -26,28 +26,21 @@
     </div>
     <div class="col-6">
       <p>
-        DeepComputing provides a vendor image that fully supports the Framework laptop with the DeepComputing FML13V01
-        motherboard.
-      </p>
-      <p>
-        <a class="p-button--positive"
-          href="https://github.com/DC-DeepComputing/fml13v01/releases">Download
-          DeepComputing image</a>
+        DeepComputing provides a vendor image that fully supports the FrameWork laptop with the DeepComputing FML13V01 motherboard. Please visit our <a href="/download/risc-v/partner-built">partner-built Ubuntu for RISC-V</a> page to download the DeepComputing image.
       </p>
       <p>The Ubuntu images described below only support headless mode (no GPU, no WiFi).</p>
       <p class="p-notification__message">
         <i class="p-icon--information"></i> If you have an eMMC drive, we advise you to use the Ubuntu Server
         live installer.
       </p>
-      <hr class="p-rule--muted is-fixed-width col-6" />
       <p>
         <a class="p-button--positive"
            href="https://cdimage.ubuntu.com/releases/24.04.3/release/ubuntu-24.04.3-preinstalled-server-riscv64+jh7110.img.xz">Download 24.04.3 LTS</a>
       </p>
     </div>
   </div>
-  <div class="row p-strip u-no-padding--top">
-    <hr class="p-rule col-9" />
+  <div class="row p-strip is-shallow u-no-padding--top">
+    <hr class="p-rule is-muted col-9" />
     <div class="col-3">
       <h3 class="p-heading--5 u-no-padding--top">
         Ubuntu Server

--- a/templates/download/risc-v/microchip-curiosity.html
+++ b/templates/download/risc-v/microchip-curiosity.html
@@ -19,7 +19,7 @@
     </div>
   </div>
   <div class="row p-strip u-no-padding--top">
-    <hr class="p-rule col-9" />
+    <hr class="p-rule is-muted col-9" />
     <div class="col-3">
       <h3 class="p-heading--5 u-no-padding--top">
         Ubuntu Server

--- a/templates/download/risc-v/microchip-polarfire.html
+++ b/templates/download/risc-v/microchip-polarfire.html
@@ -23,7 +23,7 @@
     </div>
   </div>
   <div class="row p-strip u-no-padding--top">
-    <hr class="p-rule col-9" />
+    <hr class="p-rule is-muted col-9" />
     <div class="col-3">
       <h3 class="p-heading--5 u-no-padding--top">
         Ubuntu Server

--- a/templates/download/risc-v/milk-v-mars.html
+++ b/templates/download/risc-v/milk-v-mars.html
@@ -20,7 +20,7 @@
     </div>
   </div>
   <div class="row p-strip u-no-padding--top">
-    <hr class="p-rule col-9" />
+    <hr class="p-rule is-muted col-9" />
     <div class="col-3">
       <h3 class="p-heading--5 u-no-padding--top">
         Ubuntu Server
@@ -39,7 +39,7 @@
     </div>
   </div>
   <div class="row p-strip u-no-padding--top">
-    <hr class="p-rule col-9" />
+    <hr class="p-rule is-muted col-9" />
     <div class="col-3">
       <h3 class="p-heading--5 u-no-padding--top">
         Ubuntu Server

--- a/templates/download/risc-v/pine64-star64.html
+++ b/templates/download/risc-v/pine64-star64.html
@@ -20,7 +20,7 @@
     </div>
   </div>
   <div class="row p-strip u-no-padding--top">
-    <hr class="p-rule col-9" />
+    <hr class="p-rule is-muted col-9" />
     <div class="col-3">
       <h3 class="p-heading--5 u-no-padding--top">
         Ubuntu Server
@@ -39,7 +39,7 @@
     </div>
   </div>
   <div class="row p-strip u-no-padding--top">
-    <hr class="p-rule col-9" />
+    <hr class="p-rule is-muted col-9" />
     <div class="col-3">
       <h3 class="p-heading--5 u-no-padding--top">
         Ubuntu Server

--- a/templates/download/risc-v/qemu-emulator.html
+++ b/templates/download/risc-v/qemu-emulator.html
@@ -18,7 +18,7 @@
     </div>
   </div>
   <div class="row p-strip u-no-padding--top">
-    <hr class="p-rule col-9" />
+    <hr class="p-rule is-muted col-9" />
     <div class="col-3">
       <h3 class="p-heading--5 u-no-padding--top">
         Ubuntu Server
@@ -36,7 +36,7 @@
     </div>
   </div>
   <div class="row p-strip u-no-padding--top">
-    <hr class="p-rule is-fixed-width col-9" />
+    <hr class="p-rule is-muted is-fixed-width col-9" />
     <div class="col-3">
       <h3 class="p-heading--5 u-no-padding--top">
         Ubuntu Server

--- a/templates/download/risc-v/sifive-unmatched.html
+++ b/templates/download/risc-v/sifive-unmatched.html
@@ -18,7 +18,7 @@
     </div>
   </div>
   <div class="row p-strip u-no-padding--top">
-    <hr class="p-rule col-9" />
+    <hr class="p-rule is-muted col-9" />
     <div class="col-3">
       <h3 class="p-heading--5 u-no-padding--top">
         Ubuntu Server
@@ -37,7 +37,7 @@
     </div>
   </div>
   <div class="row p-strip u-no-padding--top">
-    <hr class="p-rule col-9" />
+    <hr class="p-rule is-muted col-9" />
     <div class="col-3">
       <h3 class="p-heading--5 u-no-padding--top">
         Ubuntu Server

--- a/templates/download/risc-v/sipeed-licheerv.html
+++ b/templates/download/risc-v/sipeed-licheerv.html
@@ -19,7 +19,7 @@
     </div>
   </div>
   <div class="row p-strip u-no-padding--top">
-    <hr class="p-rule col-9" />
+    <hr class="p-rule is-muted col-9" />
     <div class="col-3">
       <h3 class="p-heading--5 u-no-padding--top">
         Ubuntu Server

--- a/templates/download/risc-v/starfive-visionfive.html
+++ b/templates/download/risc-v/starfive-visionfive.html
@@ -19,7 +19,7 @@
     </div>
   </div>
   <div class="row p-strip u-no-padding--top">
-    <hr class="p-rule col-9" />
+    <hr class="p-rule is-muted col-9" />
     <div class="col-3">
       <h3 class="p-heading--5 u-no-padding--top">
         Ubuntu Server
@@ -38,7 +38,7 @@
     </div>
   </div>
   <div class="row p-strip u-no-padding--top">
-    <hr class="p-rule col-9" />
+    <hr class="p-rule is-muted col-9" />
     <div class="col-3">
       <h3 class="p-heading--5 u-no-padding--top">
         Ubuntu Server


### PR DESCRIPTION
## Done
Page refresh of ubuntu.com/download/risc-v/canonical-built [WD-29528]

Relevant components:

- [Figma](https://www.figma.com/design/cVGimTPHky4h3BPXfrT6GB/ubuntu.com-download---Sites?node-id=3248-2063&p=f&t=KqMM4G5rWrwKhF6I-0)
- [Assets](https://assets.ubuntu.com/manager?tag=download-riscv)
- [Copydoc](https://docs.google.com/document/d/1kkJeq9HdH3iWV35HwihcJd3CxZw9Jy21W66lJl8VbWs/edit?tab=t.9mnusb94wq5p)

**Note: This PR must be merged at the same time as [partner-built](https://warthogs.atlassian.net/browse/WD-29527), by the 23rd October. Please wait for the other PR to be completed.**

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Navigate to `/download/risc-v/canonical-built` and ensure Page refresh is as requested.

## Issue / Card

Fixes #

## Screenshots

N/A


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-29528]: https://warthogs.atlassian.net/browse/WD-29528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ