### PR TITLE
feat: add wordpress keys to blogs pods

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -217,6 +217,16 @@ production:
 
         - name: SENTRY_DSN
           value: https://0293bb7fc3104e56bafd2422e155790c@sentry.is.canonical.com//13
+        
+        - name: WORDPRESS_APPLICATION_PASSWORD
+          secretKeyRef:
+            key: wordpress-application-password
+            name: wordpress-api
+
+        - name: WORDPRESS_USERNAME
+          secretKeyRef:
+            key: wordpress-username
+            name: wordpress-api
 
     - paths: [/credentials]
       name: ubuntu-com-credentials
@@ -816,6 +826,16 @@ staging:
 
         - name: SENTRY_DSN
           value: https://0293bb7fc3104e56bafd2422e155790c@sentry.is.canonical.com//13
+
+        - name: WORDPRESS_APPLICATION_PASSWORD
+          secretKeyRef:
+            key: wordpress-application-password
+            name: wordpress-api
+
+        - name: WORDPRESS_USERNAME
+          secretKeyRef:
+            key: wordpress-username
+            name: wordpress-api
 
     - paths: [/credentials]
       name: ubuntu-com-credentials


### PR DESCRIPTION
## Done

- Added wordpress keys to `/blog` pods on `PS5`

## QA

- View the demo site in your web browser at: https://ubuntu-com-15758.demos.haus/
    - Be sure to test on mobile, tablet and desktop screen sizes
- After merging to production, check that the https://ubuntu.com/blog/draft-blogs URL returns a list of draft blogs

## Issue / Card

Fixes [WD-30184](https://warthogs.atlassian.net/browse/WD-30184)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-30184]: https://warthogs.atlassian.net/browse/WD-30184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ