### PR TITLE
Replacing duplicate reference link with the correct one

### DIFF
--- a/templates/desktop/developers.html
+++ b/templates/desktop/developers.html
@@ -485,7 +485,7 @@
       <div class="col">
         <hr class="p-rule--muted" />
         <p>
-          Source: <a href="https://www.openlogic.com/resources/state-of-open-source-report">2025 State of Open Source Report, Perforce OpenLogic</a>
+          Source: <a href="https://5413615.fs1.hubspotusercontent-na1.net/hubfs/5413615/Eclipse%20IoT%20White%20Papers%20and%20Case%20Studies/IoT%20and%20Embedded%20Survey%20Report%202024.pdf">2024 IoT & Embedded Developer Survey Report, Eclipse Foundation</a>
         </p>
       </div>
     </div>


### PR DESCRIPTION
For the "Developers love Ubuntu, organizations trust it" graphs, the previous changes were based on a white paper that contained an error itself: the same 'State of Open Source Report' was quoted as a source for both graphs.

This commit replaces that duplicate report link with the correct one, an IoT & Embedded Developer Survey Report.