### PR TITLE
fix(qualcomm-iot): update download and release note links for RUBIK Pi 3 [WD-30397]

### DIFF
--- a/templates/download/qualcomm-iot/tabs/development-board-tab.html
+++ b/templates/download/qualcomm-iot/tabs/development-board-tab.html
@@ -38,17 +38,27 @@
             <hr class="p-rule--muted" />
           </div>
           <div class="col-3 col-medium-2 col-small-2">
-            <p class="p-heading--5">Download Ubuntu Server 24.04</p>
+            <p class="p-heading--5">Ubuntu Desktop 24.04</p>
           </div>
           <div class="col-3 col-medium-2 col-small-2">
             <a class="p-button--positive"
-               href="https://people.canonical.com/~platform/images/qualcomm-iot/rubikpi3/ubuntu-server-24.04/x00/">Download</a>
+               href="https://people.canonical.com/~platform/images/qualcomm-iot/rubikpi3/ubuntu-desktop-24.04/x01/">Download</a>
           </div>
           <div class="col-6 col-medium-4 col-small-4">
             <hr class="p-rule--muted" />
           </div>
           <div class="col-3 col-medium-2 col-small-2">
-            <p class="p-heading--5">Download boot firmware</p>
+            <p class="p-heading--5">Ubuntu Server 24.04</p>
+          </div>
+          <div class="col-3 col-medium-2 col-small-2">
+            <a class="p-button--positive"
+               href="https://people.canonical.com/~platform/images/qualcomm-iot/rubikpi3/ubuntu-server-24.04/x01/">Download</a>
+          </div>
+          <div class="col-6 col-medium-4 col-small-4">
+            <hr class="p-rule--muted" />
+          </div>
+          <div class="col-3 col-medium-2 col-small-2">
+            <p class="p-heading--5">Boot firmware</p>
           </div>
           <div class="col-3 col-medium-2 col-small-2">
             <a class="p-button"
@@ -67,7 +77,7 @@
     title="Read image installation instructions of Ubuntu 24.04 for Rubik Pi 3">image installation instructions</a>
         </li>
         <li class="p-list__item">
-          Ubuntu 24.04 for Rubik Pi 3 <a href="https://people.canonical.com/~platform/images/qualcomm-iot/rubikpi3/ubuntu-server-24.04/x00/Ubuntu_24.04_Rubik_Pi3_developer_board_Release_Notes.pdf"
+          Ubuntu 24.04 for Rubik Pi 3 <a href="https://people.canonical.com/~platform/images/qualcomm-iot/rubikpi3/ubuntu-desktop-24.04/x01/Ubuntu_24.04_Rubik_Pi3_developer_board_Release_Note.pdf"
     title="Read full release notes of Ubuntu 24.04 for Rubik Pi 3">release notes</a>
         </li>
       </ul>


### PR DESCRIPTION
## Done

- Updated [/download/qualcomm-iot](https://ubuntu-com-15765.demos.haus/download/qualcomm-iot) according to the [copy-doc](https://docs.google.com/document/d/1BP2T63R6kdnUFQFIZcbXbTIgY-9fQVgVRLsSUU5Rvx8/edit?tab=t.0) (comments from Jay Chen only)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Visit [/download/qualcomm-iot](https://ubuntu-com-15765.demos.haus/download/qualcomm-iot)
- Scroll down until you find the "Choose a board" section (with tabs) on the left side of the page
- Select the "RUBIK Pi 3 development board (QCS6490)" tab
- Check that the changes in the [copy-doc](https://docs.google.com/document/d/1BP2T63R6kdnUFQFIZcbXbTIgY-9fQVgVRLsSUU5Rvx8/edit?tab=t.0) (comments from Jay Chen only) have been applied correctly and that links work

## Issue / Card

Fixes [WD-30397](https://warthogs.atlassian.net/browse/WD-30397)

## Screenshots

<img width="725" height="431" alt="image" src="https://github.com/user-attachments/assets/555249a3-0817-4b61-ba65-1aedab0d8d56" />

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

[WD-30397]: https://warthogs.atlassian.net/browse/WD-30397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ