### PR TITLE
fix(WD-30439): change EL to GR in tax list 

### DIFF
--- a/static/js/src/advantage/countries-and-states.js
+++ b/static/js/src/advantage/countries-and-states.js
@@ -11,7 +11,7 @@ export const vatCountries = [
   "FI",
   "FR",
   "DE",
-  "EL",
+  "GR",
   "HU",
   "IE",
   "IT",


### PR DESCRIPTION
## Done

- Added Greece to VAT list

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Create a new SSO account
- Select a product from /pro/subscribe
- Proceed to checkout
- In checkout select Greece as country and add a fake VAT like `EL996763330`
- Fill in the other details and use a stripe test card to pay
- Purchase should go through and the VAT should be verified

## Issue / Card

Fixes [#WD-30439](https://warthogs.atlassian.net/browse/WD-30439)

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
