### PR TITLE
chore: Update broken link /containers/chiselled

### DIFF
--- a/templates/containers/chiseled/index.html
+++ b/templates/containers/chiseled/index.html
@@ -519,7 +519,7 @@
                 a chiseled Ubuntu base image for C/C++, Go and Rust applications</a>
               </li>
               <li class="p-list__item">
-                <a href="https://documentation.ubuntu.com/rockcraft/en/latest/how-to/chisel/install-slice/">Install packages slices into a rock</a>
+                <a href="https://documentation.ubuntu.com/rockcraft/1.8.0/tutorial/chisel.html">Install packages slices into a rock</a>
               </li>
             </ul>
           </div>


### PR DESCRIPTION
## Done

- Updated stale link based on [doc](https://docs.google.com/document/d/1ZkQ-UFTwsPkMnQn8IEEjZOXMy40tkgBscw_-qq9K3nc/edit?disco=AAABswOxyV0)

## QA

- View the site locally in your web browser at: https://ubuntu-com-15774.demos.haus/containers/chiselled and see that the "[Install packages slices into a rock](https://ubuntu-com-15774.demos.haus/containers/chiseled#:~:text=Install%20packages%20slices%20into%20a%20rock)" link matches the doc and no longer throws 404

## Issue / Card

Fixes https://github.com/canonical/ubuntu.com/actions/runs/18833185305
