### PR TITLE
fix: update lastmod format to match gsc requirements

### DIFF
--- a/webapp/security/views.py
+++ b/webapp/security/views.py
@@ -830,7 +830,8 @@ def vulnerabilities_sitemap(security_vulnerabilities):
                 ),
                 "last_updated": (
                     v["published_dt"].strftime("%Y-%m-%d")
-                    if v["published_dt"] else ""
+                    if v["published_dt"]
+                    else ""
                 ),
             }
             for v in vulnerabilities


### PR DESCRIPTION
## Done

- Update `lastmod` format from `YYYY/MM/DD` to `YYYY-MM-DD`
- Added ubuntu.com/security/vulnerabilities/sitemap.xml to Google Search Console index
- After this is pushed, resubmit the sitemap and see that it passes


## QA

- Go to https://ubuntu-com-15778.demos.haus/security/vulnerabilities/sitemap.xml
- See that the date format matches `YYYY-MM-DD`

## Issue / Card

Fixes [WD-22027](https://warthogs.atlassian.net/browse/WD-22027)

## Screenshots

<img width="1540" height="850" alt="Screenshot 2025-10-28 at 5 08 19 PM" src="https://github.com/user-attachments/assets/2d9405f9-093b-4d5a-865a-68d44e2d9dfc" />



## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-22027]: https://warthogs.atlassian.net/browse/WD-22027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ