### PR TITLE
fix(qualcomm-iot): update release note link for RUBIK Pi 3 board

### DIFF
--- a/templates/download/qualcomm-iot/tabs/development-board-tab.html
+++ b/templates/download/qualcomm-iot/tabs/development-board-tab.html
@@ -77,7 +77,7 @@
     title="Read image installation instructions of Ubuntu 24.04 for Rubik Pi 3">image installation instructions</a>
         </li>
         <li class="p-list__item">
-          Ubuntu 24.04 for Rubik Pi 3 <a href="https://people.canonical.com/~platform/images/qualcomm-iot/rubikpi3/ubuntu-desktop-24.04/x01/Ubuntu_24.04_Rubik_Pi3_developer_board_Release_Note.pdf"
+          Ubuntu 24.04 for Rubik Pi 3 <a href="https://people.canonical.com/~platform/images/qualcomm-iot/rubikpi3/ubuntu-desktop-24.04/x01/Ubuntu_24.04_Rubik_Pi3_development_board_Release_Note.pdf"
     title="Read full release notes of Ubuntu 24.04 for Rubik Pi 3">release notes</a>
         </li>
       </ul>


### PR DESCRIPTION
## Done

- Updated the "release notes" link in [/download/qualcomm-iot#rubikpi3](https://ubuntu-com-15779.demos.haus/download/qualcomm-iot#rubikpi3)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Go to [/download/qualcomm-iot#rubikpi3](https://ubuntu-com-15779.demos.haus/download/qualcomm-iot#rubikpi3)
- Click the "release notes" link
- Check that the PDF file opens correctly

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
