### PR TITLE
Copy update: Update RISC-V in the meganav

### DIFF
--- a/navigation.yaml
+++ b/navigation.yaml
@@ -879,8 +879,6 @@ download_ubuntu:
               url: /download/server/power
             - title: s390x
               url: /download/server/s390x
-            - title: RISC-V
-              url: /download/risc-v
     - title: Raspberry Pi
       primary_links:
         - links:
@@ -949,7 +947,7 @@ download_ubuntu:
             - title: Raspberry Pi
               url: /raspberry-pi
     - title: Ubuntu for RISC-V
-      primary_links: 
+      primary_links:
         - links:
             - title: Canonical-built images
               description: RISC-V images from Canonical
@@ -962,6 +960,8 @@ download_ubuntu:
           links:
             - title: RISC-V Cookbook for partners to build Ubuntu images
               url: https://canonical-risc-v-cookbook.readthedocs-hosted.com/en/latest/
+            - title: Introduction to Canonical's RISC-V programs
+              url: https://canonical.com/partners/silicon#risc-v
     - title: Develop on Ubuntu
       primary_links:
         - links:


### PR DESCRIPTION
## Done
Updated RISC-V in the meganav in line with the [doc](https://docs.google.com/document/d/1DCNvYHfC7AbOcqflTBaVd571iKAP_PaTfnqTENVEDVw/edit?tab=t.0#heading=h.wgubbpfalsgo).

## QA
Compare with copy doc.

## Issue / Card
https://warthogs.atlassian.net/browse/WD-30522