### PR TITLE
fix: broken ceph link on ubuntu.com

### DIFF
--- a/templates/ceph/what-is-ceph.html
+++ b/templates/ceph/what-is-ceph.html
@@ -162,7 +162,7 @@
               Ceph was initially created by Sage Weil as part of his doctoral dissertation at the University of California, Santa Cruz and evolved from a file system prototype to a fully functional open source storage platform.
             </p>
             <p>
-              Ubuntu was an early supporter of Ceph and its community.  That support continues today as Canonical maintains premier member status and serves on the governing board of the <a href="https://ceph.com/foundation/">Ceph Foundation</a>.
+              Ubuntu was an early supporter of Ceph and its community.  That support continues today as Canonical maintains premier member status and serves on the governing board of the <a href="https://ceph.io/foundation/">Ceph Foundation</a>.
             </p>
             <p>Multiple companies contribute to Ceph, with many more playing a part in the broader community.</p>
           </div>


### PR DESCRIPTION
## Done

- Fixed a broken link

## QA

- Verify the updated link works


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
