### PR TITLE
feat: allow indexing for detailed vulnerability pages

### DIFF
--- a/templates/security/vulnerabilities/vulnerability-detailed.html
+++ b/templates/security/vulnerabilities/vulnerability-detailed.html
@@ -8,8 +8,6 @@
   is-paper vulnerability-details
 {% endblock body_class %}
 
-{% block head_extra %}<meta name="robots" content="noindex" />{% endblock %}
-
 {% block content %}
 
   {% set breadcrumbs = [{"name": "Vulnerability knowledge base", "href": "/security/vulnerabilities"}, {"name": "View all", "href": "/security/vulnerabilities/view-all"}, {"name": document.title}] %}


### PR DESCRIPTION
## Done

- Remove `noindex` meta tag for detailed vulnerability pages

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
