### PR TITLE
fix: image template failing with missing url

### DIFF
--- a/templates/cloud/public-cloud.html
+++ b/templates/cloud/public-cloud.html
@@ -289,7 +289,8 @@
                   <div class="u-crop--16-9">
                     <div class="article-image p-image-container">
                       <a href="/blog/{{ article.slug }}">
-                        {{ image(url=article.image.source_url,
+                        {% set image_url = article.image.source_url if article.image and article.image.source_url else "https://assets.ubuntu.com/v1/94c82a15-blog_fallback_image.png" %}
+                        {{ image(url=image_url,
                                                 alt=article.title.rendered,
                                                 width="400",
                                                 height="400",


### PR DESCRIPTION
## Done

- Fixed cloud/public-cloud page failing

## QA

- View the site locally in your web browser at: https://ubuntu-com-15794.demos.haus/cloud/public-cloud
- Maker sure the page loads correctly, and the blogs are loading fine


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
