### PR TITLE
chore: Update copy on the release cycle page

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -13,7 +13,7 @@ export var serverAndDesktopReleases = [
   },
   {
     startDate: new Date("2024-04-02T00:00:00"),
-    endDate: new Date("2026-04-02T00:00:00"),
+    endDate: new Date("2029-04-02T00:00:00"),
     taskName: "14.04 LTS (Trusty Tahr)",
     status: "PRO_LEGACY_SUPPORT",
   },
@@ -37,7 +37,7 @@ export var serverAndDesktopReleases = [
   },
   {
     startDate: new Date("2026-04-01T00:00:00"),
-    endDate: new Date("2028-04-02T00:00:00"),
+    endDate: new Date("2031-04-02T00:00:00"),
     taskName: "16.04 LTS (Xenial Xerus)",
     status: "PRO_LEGACY_SUPPORT",
   },
@@ -61,7 +61,7 @@ export var serverAndDesktopReleases = [
   },
   {
     startDate: new Date("2028-04-01T00:00:00"),
-    endDate: new Date("2030-04-01T00:00:00"),
+    endDate: new Date("2033-04-01T00:00:00"),
     taskName: "18.04 LTS (Bionic Beaver)",
     status: "PRO_LEGACY_SUPPORT",
   },
@@ -85,7 +85,7 @@ export var serverAndDesktopReleases = [
   },
   {
     startDate: new Date("2030-04-01T00:00:00"),
-    endDate: new Date("2032-04-02T00:00:00"),
+    endDate: new Date("2035-04-02T00:00:00"),
     taskName: "20.04 LTS (Focal Fossa)",
     status: "PRO_LEGACY_SUPPORT",
   },
@@ -109,7 +109,7 @@ export var serverAndDesktopReleases = [
   },
   {
     startDate: new Date("2032-04-01T00:00:00"),
-    endDate: new Date("2034-04-01T00:00:00"),
+    endDate: new Date("2037-04-01T00:00:00"),
     taskName: "22.04 LTS (Jammy Jellyfish)",
     status: "PRO_LEGACY_SUPPORT",
   },
@@ -133,7 +133,7 @@ export var serverAndDesktopReleases = [
   },
   {
     startDate: new Date("2034-04-25T00:00:00"),
-    endDate: new Date("2036-04-25T00:00:00"),
+    endDate: new Date("2039-04-25T00:00:00"),
     taskName: "24.04 LTS (Noble Numbat)",
     status: "PRO_LEGACY_SUPPORT",
   },
@@ -152,13 +152,6 @@ export var serverAndDesktopReleases = [
 ];
 
 export var kernelReleases = [
-  {
-    startDate: new Date("2025-10-01T00:00:00"),
-    endDate: new Date("2026-07-01T00:00:00"),
-    taskName: "25.10",
-    taskVersion: "6.17 kernel",
-    status: "INTERIM_RELEASE",
-  },
   {
     startDate: new Date("2025-08-01T00:00:00"),
     endDate: new Date("2026-01-01T00:00:00"),
@@ -189,7 +182,7 @@ export var kernelReleases = [
   },
   {
     startDate: new Date("2032-03-31T00:00:00"),
-    endDate: new Date("2034-04-29T00:00:00"),
+    endDate: new Date("2037-04-29T00:00:00"),
     taskName: "22.04.5 LTS (HWE)",
     taskVersion: "6.8 kernel",
     status: "PRO_LEGACY_SUPPORT",
@@ -210,7 +203,7 @@ export var kernelReleases = [
   },
   {
     startDate: new Date("2034-03-31T00:00:00"),
-    endDate: new Date("2036-04-29T00:00:00"),
+    endDate: new Date("2039-04-29T00:00:00"),
     taskName: "24.04.[0 or 1] LTS",
     taskVersion: "6.8 kernel",
     status: "PRO_LEGACY_SUPPORT",
@@ -231,7 +224,7 @@ export var kernelReleases = [
   },
   {
     startDate: new Date("2032-03-01T00:00:00"),
-    endDate: new Date("2034-04-29T00:00:00"),
+    endDate: new Date("2037-04-29T00:00:00"),
     taskName: "22.04.[0 or 1] LTS",
     taskVersion: "5.15 kernel",
     status: "PRO_LEGACY_SUPPORT",
@@ -252,7 +245,7 @@ export var kernelReleases = [
   },
   {
     startDate: new Date("2030-04-29T00:00:00"),
-    endDate: new Date("2032-04-29T00:00:00"),
+    endDate: new Date("2035-04-29T00:00:00"),
     taskName: "20.04.5 LTS (HWE)",
     taskVersion: "",
     status: "PRO_LEGACY_SUPPORT",
@@ -273,7 +266,7 @@ export var kernelReleases = [
   },
   {
     startDate: new Date("2028-04-28T00:00:00"),
-    endDate: new Date("2030-04-28T00:00:00"),
+    endDate: new Date("2033-04-28T00:00:00"),
     taskName: "18.04.5 LTS (HWE)",
     taskVersion: "5.4 kernel",
     status: "PRO_LEGACY_SUPPORT",
@@ -294,7 +287,7 @@ export var kernelReleases = [
   },
   {
     startDate: new Date("2030-04-29T00:00:00"),
-    endDate: new Date("2032-04-29T00:00:00"),
+    endDate: new Date("2035-04-29T00:00:00"),
     taskName: "20.04.[0 or 1] LTS",
     taskVersion: "",
     status: "PRO_LEGACY_SUPPORT",
@@ -315,7 +308,7 @@ export var kernelReleases = [
   },
   {
     startDate: new Date("2026-04-29T00:00:00"),
-    endDate: new Date("2028-04-29T00:00:00"),
+    endDate: new Date("2031-04-29T00:00:00"),
     taskName: "16.04.5 LTS (HWE)",
     taskVersion: "4.15 kernel",
     status: "PRO_LEGACY_SUPPORT",
@@ -336,7 +329,7 @@ export var kernelReleases = [
   },
   {
     startDate: new Date("2028-04-28T00:00:00"),
-    endDate: new Date("2030-04-28T00:00:00"),
+    endDate: new Date("2033-04-28T00:00:00"),
     taskName: "18.04.[0 or 1] LTS",
     taskVersion: "",
     status: "PRO_LEGACY_SUPPORT",
@@ -357,7 +350,7 @@ export var kernelReleases = [
   },
   {
     startDate: new Date("2024-04-29T00:00:00"),
-    endDate: new Date("2026-04-29T00:00:00"),
+    endDate: new Date("2029-04-29T00:00:00"),
     taskName: "14.04.5 LTS (HWE)",
     taskVersion: "4.4 kernel",
     status: "PRO_LEGACY_SUPPORT",
@@ -378,7 +371,7 @@ export var kernelReleases = [
   },
   {
     startDate: new Date("2026-04-29T00:00:00"),
-    endDate: new Date("2028-04-29T00:00:00"),
+    endDate: new Date("2031-04-29T00:00:00"),
     taskName: "16.04.[0 or 1] LTS",
     taskVersion: "",
     status: "PRO_LEGACY_SUPPORT",
@@ -399,7 +392,7 @@ export var kernelReleases = [
   },
   {
     startDate: new Date("2024-04-30T00:00:00"),
-    endDate: new Date("2026-04-30T00:00:00"),
+    endDate: new Date("2029-04-30T00:00:00"),
     taskName: "14.04.[0 or 1] LTS",
     taskVersion: "",
     status: "PRO_LEGACY_SUPPORT",
@@ -1087,7 +1080,7 @@ export var kubernetesReleasesLTS = [
   },
   {
     startDate: new Date("2034-12-01T00:00:00"),
-    endDate: new Date("2036-12-01T00:00:00"),
+    endDate: new Date("2039-12-01T00:00:00"),
     taskName: "Kubernetes 1.32.x LTS",
     status: "CANONICAL_KUBERNETES_LEGACY_SUPPORT",
   },
@@ -1290,7 +1283,6 @@ export var desktopServerReleaseNames = [
 ];
 
 export var kernelReleaseNames = [
-  "25.10",
   "24.04.3 LTS (HWE)",
   "25.04",
   "22.04.5 LTS (HWE)",
@@ -1307,7 +1299,6 @@ export var kernelReleaseNames = [
 ];
 
 export var kernelVersionNames = [
-  "6.17",
   "6.14",
   "",
   "6.8",

--- a/static/js/src/release-chart-old.js
+++ b/static/js/src/release-chart-old.js
@@ -387,13 +387,13 @@ function formatLabel(label, isTooltip = false) {
     case "canonical_kubernetes_support":
       return "Canonical Kubernetes support";
     case "pro_legacy_support":
-      return `Legacy support${!isTooltip ? " (years 11 and 12)" : ""}`;
+      return `Legacy add-on${!isTooltip ? " (years 11 to 15)" : ""}`;
     case "microstack_esm":
       return "Expanded Security Maintenance (ESM)";
     case "pro_support":
       return "Ubuntu Pro + Support coverage";
     case "canonical_kubernetes_legacy_support":
-      return "Canonical Kubernetes Legacy Support";
+      return "Canonical Kubernetes Legacy add-on";
 
     default:
       return null;

--- a/static/js/src/release-chart.js
+++ b/static/js/src/release-chart.js
@@ -472,7 +472,7 @@ function formatKeyLabel(key) {
   );
   formattedKey = formattedKey.replace(
     "Pro legacy support",
-    "Legacy support (years 11 and 12)",
+    "Legacy add-on (years 11 to 15)",
   );
   formattedKey = formattedKey.replace(
     "Microstack esm",

--- a/templates/about/release-cycle.html
+++ b/templates/about/release-cycle.html
@@ -103,7 +103,7 @@
         </p>
 
         <p>
-          Add on optional Legacy Support to Ubuntu Pro and expand security maintenance and support for an additional 2 years, resulting in 12 years of coverage overall.
+          The optional Legacy add-on to Ubuntu Pro expands security maintenance and support for an additional 5 years, resulting in 15 years of coverage overall.
         </p>
 
         <p>
@@ -163,19 +163,9 @@
           Furthermore ESM also covers 10 years of security maintenance for the Universe repository, which is not provided outside
           of Ubuntu Pro subscription. The full 10 year Ubuntu LTS lifecycle is available with an <a href="/pro">Ubuntu Pro
           subscription</a> (free for personal use on up to 5 machines). Technical phone and ticket support is only available as an
-          add-on to an Ubuntu Pro subscription. At the end of the 10 year Ubuntu Pro period, a Legacy support add-on can be purchased
-          to cover additional 2 years of the lifetime of Ubuntu LTS, giving a total of 12 years support and maintenance.
+          add-on to an Ubuntu Pro subscription. At the end of the 10 year Ubuntu Pro period, a Legacy add-on can be purchased
+          to cover additional 5 years of the lifetime of Ubuntu LTS, giving a total of 15 years support and maintenance.
         </p>
-
-        <div class="u-fixed-width u-hide--small">
-          {{ image(url="https://assets.ubuntu.com/v1/07c82176-Ubuntu%20LTS%20Releases%20-%20Updated.png",
-                    alt="",
-                    width="737",
-                    height="544",
-                    hi_def=True,
-                    loading="lazy") | safe
-          }}
-        </div>
 
         <p>To check the subscription status of your system, use this command:</p>
 
@@ -291,7 +281,7 @@
         <h3>Canonical Kubernetes</h3>
 
         <p>
-          Canonical now offers 12 years of security maintenance and support for Kubernetes with an <a href="/support">Ubuntu Pro</a> subscription, starting with Kubernetes 1.32.
+          Canonical now offers 15 years of security maintenance and support for Kubernetes with an <a href="/support">Ubuntu Pro</a> subscription, starting with Kubernetes 1.32.
         </p>
 
         <p>
@@ -303,7 +293,7 @@
         </p>
 
         <p>
-          The optional Legacy Support add-on on top of Ubuntu Pro extends the security maintenance and support for an additional 2 years, resulting in 12 years coverage overall.
+          The optional Legacy add-on on top of Ubuntu Pro extends the security maintenance and support for an additional 5 years, resulting in 15 years coverage overall.
         </p>
 
         <p>The Canonical Kubernetes support lifecycle can be represented this way:</p>

--- a/templates/about/release_cycles/k8s-lts.html
+++ b/templates/about/release_cycles/k8s-lts.html
@@ -7,7 +7,7 @@
           <th>Release</th>
           <th>Released</th>
           <th>End of Ubuntu Pro support</th>
-          <th>End of Legacy support</th>
+          <th>End of Legacy add-on coverage</th>
         </tr>
       </thead>
       <tbody>
@@ -25,7 +25,7 @@
           <td><strong>1.32.x LTS</strong></td>
           <td>Dec 2024</td>
           <td>Dec 2034</td>
-          <td>Dec 2036</td>
+          <td>Dec 2039</td>
         </tr>
       </tbody>
     </table>

--- a/templates/about/release_cycles/releases-table.html
+++ b/templates/about/release_cycles/releases-table.html
@@ -5,7 +5,7 @@
       <th scope="col">Released</th>
       <th scope="col">End of Standard Support</th>
       <th scope="col">End of Ubuntu Pro Support</th>
-      <th scope="col">End of Legacy Support</th>
+      <th scope="col">End of Legacy add-on coverage</th>
     </tr>
   </thead>
   <tbody>
@@ -30,7 +30,7 @@
       <td>Apr 2024</td>
       <td>Apr 2029</td>
       <td>Apr 2034</td>
-      <td>Apr 2036</td>
+      <td>Apr 2039</td>
     </tr>
     <tr>
       <td colspan="2">
@@ -39,7 +39,7 @@
       <td>Apr 2022</td>
       <td>Apr 2027</td>
       <td>Apr 2032</td>
-      <td>Apr 2034</td>
+      <td>Apr 2037</td>
     </tr>
     <tr>
       <td colspan="2">
@@ -48,7 +48,7 @@
       <td>Apr 2020</td>
       <td>May 2025</td>
       <td>Apr 2030</td>
-      <td>Apr 2032</td>
+      <td>Apr 2035</td>
     </tr>
     <tr>
       <td colspan="2">
@@ -57,7 +57,7 @@
       <td>Apr 2018</td>
       <td>May 2023</td>
       <td>Apr 2028</td>
-      <td>Apr 2030</td>
+      <td>Apr 2033</td>
     </tr>
     <tr>
       <td colspan="2">
@@ -66,7 +66,7 @@
       <td>Apr 2016</td>
       <td>Apr 2021</td>
       <td>Apr 2026</td>
-      <td>Apr 2028</td>
+      <td>Apr 2031</td>
     </tr>
     <tr>
       <td colspan="2">
@@ -75,7 +75,7 @@
       <td>Apr 2014</td>
       <td>Apr 2019</td>
       <td>Apr 2024</td>
-      <td>Apr 2026</td>
+      <td>Apr 2029</td>
     </tr>
   </tbody>
 </table>

--- a/templates/shared/_kernel-release-diagram.html
+++ b/templates/shared/_kernel-release-diagram.html
@@ -10,20 +10,10 @@
         <th>Released</th>
         <th>End of Standard Security Maintenance</th>
         <th>End of Expanded Security Maintenance</th>
-        <th>End of Legacy Support</th>
+        <th>End of Legacy add-on coverage</th>
       </tr>
     </thead>
     <tbody>
-      <tr>
-        <td>
-          <strong>6.17</strong>
-        </td>
-        <td>
-          <strong>25.10</strong>
-        </td>
-        <td>Oct 2025</td>
-        <td>Jul 2026</td>
-      </tr>
       <tr>
         <td rowspan="2">
           <strong>6.14</strong>
@@ -51,7 +41,7 @@
         <td>Aug 2024</td>
         <td>Apr 2027</td>
         <td>Mar 2032</td>
-        <td>Apr 2034</td>
+        <td>Apr 2037</td>
       </tr>
       <tr>
         <td>
@@ -60,7 +50,7 @@
         <td>Apr 2024</td>
         <td>Apr 2029</td>
         <td>Mar 2034</td>
-        <td>Apr 2036</td>
+        <td>Apr 2039</td>
       </tr>
       <tr>
         <td rowspan="2">
@@ -72,7 +62,7 @@
         <td>Aug 2022</td>
         <td>Apr 2025</td>
         <td>Apr 2030</td>
-        <td>Apr 2032</td>
+        <td>Apr 2035</td>
       </tr>
       <tr>
         <td>
@@ -81,7 +71,7 @@
         <td>Apr 2022</td>
         <td>Apr 2027</td>
         <td>Mar 2032</td>
-        <td>Apr 2034</td>
+        <td>Apr 2037</td>
       </tr>
       <tr>
         <td rowspan="2">
@@ -93,7 +83,7 @@
         <td>Aug 2020</td>
         <td>Apr 2023</td>
         <td>Apr 2028</td>
-        <td>Apr 2030</td>
+        <td>Apr 2033</td>
       </tr>
       <tr>
         <td>
@@ -102,7 +92,7 @@
         <td>Apr 2020</td>
         <td>Apr 2025</td>
         <td>Apr 2030</td>
-        <td>Apr 2032</td>
+        <td>Apr 2035</td>
       </tr>
       <tr>
         <td rowspan="2">
@@ -114,7 +104,7 @@
         <td>Aug 2018</td>
         <td>Apr 2021</td>
         <td>Apr 2026</td>
-        <td>Apr 2028</td>
+        <td>Apr 2031</td>
       </tr>
       <tr>
         <td>
@@ -123,7 +113,7 @@
         <td>Apr 2018</td>
         <td>Apr 2023</td>
         <td>Apr 2028</td>
-        <td>Apr 2030</td>
+        <td>Apr 2033</td>
       </tr>
       <tr>
         <td rowspan="2">
@@ -135,7 +125,7 @@
         <td>Aug 2016</td>
         <td>Apr 2019</td>
         <td>Apr 2024</td>
-        <td>Apr 2026</td>
+        <td>Apr 2029</td>
       </tr>
       <tr>
         <td>
@@ -144,7 +134,7 @@
         <td>Apr 2016</td>
         <td>Apr 2021</td>
         <td>Apr 2026</td>
-        <td>Apr 2028</td>
+        <td>Apr 2031</td>
       </tr>
       <tr>
         <td rowspan="3">
@@ -156,7 +146,7 @@
         <td>Apr 2014</td>
         <td>Apr 2019</td>
         <td>Apr 2024</td>
-        <td>Apr 2026</td>
+        <td>Apr 2029</td>
       </tr>
     </tbody>
   </table>


### PR DESCRIPTION
## Done

Updates the copy on /about/release-cycle

## QA

- Go to https://ubuntu-com-15795.demos.haus/about/release-cycle
- Check that the [copy doc updates from Lidia](https://docs.google.com/document/d/1-l3B7AoyDoETaL80UhlfEWCVKmMWPdy3zoF5LpsGcYQ/edit?tab=t.0) have been made
- For each update, resolve the comment in the copy doc
- Check that 3 years has been added to each value for LTS releases in the "End of add-on coverage" column of the table in the "Ubuntu releases" section

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-31110