### PR TITLE
Fix SA taxID

### DIFF
--- a/static/js/src/account-billing.js
+++ b/static/js/src/account-billing.js
@@ -201,7 +201,7 @@ function createModal({ modalSelector, triggerButton }) {
       name: data.get("name"),
       taxID: {
         value: data.get("vat"),
-        type: country === "ZA" ? "za_vat" : "eu_vat",
+        type: findCountryCode(country) === "ZA" ? "za_vat" : "eu_vat",
       },
     };
 


### PR DESCRIPTION
## Done

- Fix SA taxID

## QA

- Login and browse to the Ubuntu Pro Dashboard
- Click 'Billing and users', Invoices
- Click 'Edit billing details'
- Select 'South Africa', enter a valid South African VAT number and click Save

## Issue / Card

Fixes #https://github.com/canonical/ubuntu.com/issues/15342

