### PR TITLE
WD-31106/Update [ubuntu.com/security/esm]

### DIFF
--- a/static/js/src/chart-data.js
+++ b/static/js/src/chart-data.js
@@ -13,7 +13,7 @@ export var serverAndDesktopReleases = [
   },
   {
     startDate: new Date("2024-04-02T00:00:00"),
-    endDate: new Date("2026-04-02T00:00:00"),
+    endDate: new Date("2029-04-02T00:00:00"),
     taskName: "14.04 LTS (Trusty Tahr)",
     status: "PRO_LEGACY_SUPPORT",
   },
@@ -37,7 +37,7 @@ export var serverAndDesktopReleases = [
   },
   {
     startDate: new Date("2026-04-01T00:00:00"),
-    endDate: new Date("2028-04-02T00:00:00"),
+    endDate: new Date("2031-04-02T00:00:00"),
     taskName: "16.04 LTS (Xenial Xerus)",
     status: "PRO_LEGACY_SUPPORT",
   },
@@ -61,7 +61,7 @@ export var serverAndDesktopReleases = [
   },
   {
     startDate: new Date("2028-04-01T00:00:00"),
-    endDate: new Date("2030-04-01T00:00:00"),
+    endDate: new Date("2033-04-01T00:00:00"),
     taskName: "18.04 LTS (Bionic Beaver)",
     status: "PRO_LEGACY_SUPPORT",
   },
@@ -85,7 +85,7 @@ export var serverAndDesktopReleases = [
   },
   {
     startDate: new Date("2030-04-01T00:00:00"),
-    endDate: new Date("2032-04-02T00:00:00"),
+    endDate: new Date("2035-04-02T00:00:00"),
     taskName: "20.04 LTS (Focal Fossa)",
     status: "PRO_LEGACY_SUPPORT",
   },
@@ -109,7 +109,7 @@ export var serverAndDesktopReleases = [
   },
   {
     startDate: new Date("2032-04-01T00:00:00"),
-    endDate: new Date("2034-04-01T00:00:00"),
+    endDate: new Date("2037-04-01T00:00:00"),
     taskName: "22.04 LTS (Jammy Jellyfish)",
     status: "PRO_LEGACY_SUPPORT",
   },
@@ -133,7 +133,7 @@ export var serverAndDesktopReleases = [
   },
   {
     startDate: new Date("2034-04-25T00:00:00"),
-    endDate: new Date("2036-04-25T00:00:00"),
+    endDate: new Date("2039-04-25T00:00:00"),
     taskName: "24.04 LTS (Noble Numbat)",
     status: "PRO_LEGACY_SUPPORT",
   },

--- a/static/js/src/release-chart-old.js
+++ b/static/js/src/release-chart-old.js
@@ -387,7 +387,7 @@ function formatLabel(label, isTooltip = false) {
     case "canonical_kubernetes_support":
       return "Canonical Kubernetes support";
     case "pro_legacy_support":
-      return `Legacy support${!isTooltip ? " (years 11 and 12)" : ""}`;
+      return `Legacy add-on${!isTooltip ? " (years 11 to 15)" : ""}`;
     case "microstack_esm":
       return "Expanded Security Maintenance (ESM)";
     case "pro_support":

--- a/static/js/src/release-chart.js
+++ b/static/js/src/release-chart.js
@@ -472,7 +472,7 @@ function formatKeyLabel(key) {
   );
   formattedKey = formattedKey.replace(
     "Pro legacy support",
-    "Legacy support (years 11 and 12)",
+    "Legacy add-on (years 11 to 15)",
   );
   formattedKey = formattedKey.replace(
     "Microstack esm",

--- a/templates/about/release_cycles/releases-table.html
+++ b/templates/about/release_cycles/releases-table.html
@@ -30,7 +30,7 @@
       <td>Apr 2024</td>
       <td>Apr 2029</td>
       <td>Apr 2034</td>
-      <td>Apr 2036</td>
+      <td>Apr 2039</td>
     </tr>
     <tr>
       <td colspan="2">
@@ -39,7 +39,7 @@
       <td>Apr 2022</td>
       <td>Apr 2027</td>
       <td>Apr 2032</td>
-      <td>Apr 2034</td>
+      <td>Apr 2037</td>
     </tr>
     <tr>
       <td colspan="2">
@@ -48,7 +48,7 @@
       <td>Apr 2020</td>
       <td>May 2025</td>
       <td>Apr 2030</td>
-      <td>Apr 2032</td>
+      <td>Apr 2035</td>
     </tr>
     <tr>
       <td colspan="2">
@@ -57,7 +57,7 @@
       <td>Apr 2018</td>
       <td>May 2023</td>
       <td>Apr 2028</td>
-      <td>Apr 2030</td>
+      <td>Apr 2033</td>
     </tr>
     <tr>
       <td colspan="2">
@@ -66,7 +66,7 @@
       <td>Apr 2016</td>
       <td>Apr 2021</td>
       <td>Apr 2026</td>
-      <td>Apr 2028</td>
+      <td>Apr 2031</td>
     </tr>
     <tr>
       <td colspan="2">
@@ -75,7 +75,7 @@
       <td>Apr 2014</td>
       <td>Apr 2019</td>
       <td>Apr 2024</td>
-      <td>Apr 2026</td>
+      <td>Apr 2029</td>
     </tr>
   </tbody>
 </table>

--- a/templates/security/esm.html
+++ b/templates/security/esm.html
@@ -25,7 +25,7 @@
     ) -%}
     {%- if slot == 'description' -%}
       <p>
-        Extend the lifetime of your favorite Linux and the open source you use on top with reliable security maintenance for up to 12 years.
+        Extend the lifetime of your favorite Linux and the open source you use on top with reliable security maintenance for up to 15 years.
       </p>
     {%- endif -%}
     {%- if slot == 'cta' -%}
@@ -115,7 +115,7 @@
       {%- endif -%}
 
       {%- if slot == 'list_item_title_1' -%}
-        <h3 class="p-heading--5">Up to 12 years of support</h3>
+        <h3 class="p-heading--5">Up to 15 years of support</h3>
       {%- endif -%}
 
       {%- if slot == 'list_item_description_1' -%}
@@ -285,7 +285,7 @@
           <tbody>
             <tr>
               <td>Ubuntu 14.04 LTS (Trusty Tahr)</td>
-              <td>May 2026</td>
+              <td>May 2029</td>
               <td>n/a</td>
               <td>amd64</td>
               <td>amd64</td>
@@ -294,8 +294,8 @@
               <td>
                 <a href="/16-04">Ubuntu 16.04 LTS (Xenial Xerus)</a>
               </td>
-              <td>May 2028</td>
-              <td>May 2028</td>
+              <td>May 2031</td>
+              <td>May 2031</td>
               <td>amd64</td>
               <td>amd64, s390x</td>
             </tr>
@@ -303,8 +303,8 @@
               <td>
                 <a href="/18-04">Ubuntu 18.04 LTS (Bionic Beaver)</a>
               </td>
-              <td>May 2030</td>
-              <td>May 2030</td>
+              <td>May 2033</td>
+              <td>May 2033</td>
               <td>amd64</td>
               <td>amd64, arm64, s390x, ppc64el</td>
             </tr>
@@ -312,15 +312,15 @@
               <td>
                 <a href="/20-04">Ubuntu 20.04 LTS (Focal Fossa)</a>
               </td>
-              <td>May 2032</td>
-              <td>May 2032</td>
+              <td>May 2035</td>
+              <td>May 2035</td>
               <td>amd64</td>
               <td>amd64, arm64, s390x, ppc64el, RISC-V</td>
             </tr>
             <tr>
               <td>Ubuntu 22.04 LTS (Jammy Jellyfish)</td>
-              <td>May 2034</td>
-              <td>May 2034</td>
+              <td>May 2037</td>
+              <td>May 2037</td>
               <td>
                 amd64,
                 <br />
@@ -330,8 +330,8 @@
             </tr>
             <tr>
               <td>Ubuntu 24.04 LTS (Noble Numbat)</td>
-              <td>May 2036</td>
-              <td>May 2036</td>
+              <td>May 2039</td>
+              <td>May 2039</td>
               <td>
                 amd64,
                 <br />


### PR DESCRIPTION
## Done

- Changed "Legacy support" to "Legacy add-on"
- Updated support add-on years from 12 to 15 for all LTS versions 

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/security/esm

## Issue / Card

Addresses [WD-31106](https://warthogs.atlassian.net/browse/WD-31106)
[Copy doc](https://docs.google.com/document/d/1RBZX3PJPvODxRlcnIS10Ii4SkIMH5Fm74EmsMQ0cnic/edit?tab=t.0)

## Screenshots

<img width="2134" height="1528" alt="image" src="https://github.com/user-attachments/assets/4c2bb150-0b97-4c49-a30a-1d21bc7ce370" />

[WD-31106]: https://warthogs.atlassian.net/browse/WD-31106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ