### PR TITLE
feat: Update /security to references 15 years of support

### DIFF
--- a/templates/security/index.html
+++ b/templates/security/index.html
@@ -191,7 +191,7 @@
 
     {%- if slot == 'description' -%}
       <p>
-        Ubuntu is a Linux-based OS based on Unix. It inherits Discretionary Access Control and includes Mandatory Access Control via AppArmor. Since 2004, Ubuntu has provided a robust security foundation to protect your open source ecosystem, with up to 12 years of security maintenance and support to let you build with confidence.
+        Ubuntu is a Linux-based OS based on Unix. It inherits Discretionary Access Control and includes Mandatory Access Control via AppArmor. Since 2004, Ubuntu has provided a robust security foundation to protect your open source ecosystem, with up to 15 years of security maintenance and support to let you build with confidence.
       </p>
       <div class="p-cta-block">
         <a href="/about/release-cycle">Check out the Ubuntu release cadence&nbsp;&rsaquo;</a>
@@ -230,7 +230,7 @@
 
     {%- if slot == 'list_item_description_3' -%}
       <p>
-        Every Long Term Support (LTS) release of Ubuntu comes with five years of standard security and maintenance updates for the main OS. Expand that to up to 12 years with Ubuntu Pro &ndash; not just for the main OS but for all the open source packages you consume from Ubuntu.
+        Every Long Term Support (LTS) release of Ubuntu comes with five years of standard security and maintenance updates for the main OS. Expand that to up to 15 years with Ubuntu Pro &ndash; not just for the main OS but for all the open source packages you consume from Ubuntu.
       </p>
       <div class="p-cta-block is-borderless">
         <a href="/security/vulnerability-management">Read more about vulnerability management&nbsp;&rsaquo;</a>
@@ -316,7 +316,7 @@
         <h3 class="p-heading--4">Ubuntu Pro</h3>
         <ul class="p-list--divided">
           <li class="p-list__item is-ticked">
-            <a href="/security/esm">Expanded Security Maintenance (ESM)</a> for up to 12 years for the Operating System as well as Infrastructure and Applications.
+            <a href="/security/esm">Expanded Security Maintenance (ESM)</a> for up to 15 years for the Operating System as well as Infrastructure and Applications.
           </li>
           <li class="p-list__item is-ticked">
             <a href="/security/livepatch">Kernel Livepatch</a> to minimize downtime without reboots.


### PR DESCRIPTION
## Done

- Update based on changes in [copydoc](https://docs.google.com/document/d/1yEocR1WXQvN_B1L1yBYrG_0D7ikS6QhcOz27sYs-teI/edit?tab=t.0) (updates '12 years' to '15 years') 

## QA

- Open [demo](https://ubuntu-com-15805.demos.haus/security)
- Compare against [copydoc](https://docs.google.com/document/d/1yEocR1WXQvN_B1L1yBYrG_0D7ikS6QhcOz27sYs-teI/edit?tab=t.0)

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-31167

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
