### PR TITLE
add Resources section to /support page

### DIFF
--- a/templates/support/index.html
+++ b/templates/support/index.html
@@ -1192,7 +1192,7 @@
           "render_images": false,
           "categories": [
             {
-              "title": "Datasheets",
+              "title": "Datasheet",
               "items": [
                 {
                   "title": {


### PR DESCRIPTION
## Done

- Add new section called "Resources" at the bottom of the /support page according to the [copy doc](https://docs.google.com/document/d/1AU2dwTXpQk2UuEvSuAqRKrbPWYb-LR0ZGvWu6xw95I8/edit?tab=t.0) and [Figma design](https://www.figma.com/design/YdmmtZxcCdEVJE4JmSqfeD/ubuntu.com-support---Sites?node-id=96-2268&t=cEqnpm8jq3KYoMLi-0)

## QA

- Open the page at https://ubuntu-com-15811.demos.haus/support
- Scroll down and check the "Resources" section

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-31087
