### PR TITLE
chore: bump cookie-policy version

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
   },
   "dependencies": {
     "@axe-core/playwright": "^4.8.5",
-    "@canonical/cookie-policy": "^3.6.4",
+    "@canonical/cookie-policy": "^3.7.3",
     "@canonical/global-nav": "3.8.0",
     "@canonical/latest-news": "2.1.0",
     "@canonical/react-components": "^0.60.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1206,10 +1206,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@canonical/cookie-policy@^3.6.4":
-  version "3.6.5"
-  resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.6.5.tgz#50d82df6da2970b6b5d78d066dd94fcc1317e591"
-  integrity sha512-CQJKSkuLXhSumkIIw4YPSjR7k9561hZ3EEdMPQTkAVTxXURhm3WzJm/uyrvcAuU/a//jzWa8ScltCaHFBdACew==
+"@canonical/cookie-policy@^3.7.3":
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.7.3.tgz#65db73735f7ee565fff37013fd2c2de7bce85648"
+  integrity sha512-6Ycnu0nEgaV5uFplZwHg5mkOQ6HicbXAIb4+I8UH3EXqGCPAuVcfTgd4eunZzmQahVmtNZethNjF/mUoU9Fa6A==
 
 "@canonical/global-nav@3.8.0":
   version "3.8.0"


### PR DESCRIPTION
## Done

- Bump cookie policy version to modernize cookie popup

## QA

- Go to demo link
- See that the cookie notification pops up as a banner
- Click around and ensure that the new cookie policy works as expected
- Scroll down to "Manage your tracker settings"
- See that the notification pops up as expected
- Repeat on medium and small screens 

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
