### PR TITLE
Update discourse dependency to 7.1.0 🔧

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ canonicalwebteam.blog==6.7.0
 canonicalwebteam.search==2.1.2
 canonicalwebteam.templatefinder==1.0.0
 canonicalwebteam.image-template==1.9.0
-canonicalwebteam.discourse==7.0.0
+canonicalwebteam.discourse==7.1.0
 canonicalwebteam.form-generator==2.0.1
 canonicalwebteam.directory-parser==1.2.10
 python-dateutil==2.8.2


### PR DESCRIPTION
## Done
- Bump DIscourse module version
- Fix list of tags on /case-study so that the list of tags that appear are only related to `case study`
- Fix filtering on engage pages: When you select a tag and apply filter, it fetches posts related to that tag. The filtering does not work well as some posts with that tag do not appear.

## QA

- Check out [/engage](https://ubuntu-com-15819.demos.haus/engage)
- Select Anjuna from the tags and apply filter (https://ubuntu-com-15819.demos.haus/engage?tag=anjuna)
- Check that posts appear
- Add resource filter https://ubuntu-com-15819.demos.haus/engage?tag=anjuna&resource=case+study
- Check that posts appear
- Select security from the tags and apply the filter
- Check that posts appear

Compare that to production
- Check out [/engage](https://ubuntu.com/engage)
- Apply `anjuna` tag  and `case study` resource filter (https://ubuntu.com/engage?tag=anjuna&resource=case+study)
- See that no posts appear
- Select `case study` from the resource filter while having `anjuna` tag applied and English and see that posts appear (https://ubuntu.com/engage?tag=anjuna&resource=case+study&language=en)

## Screenshots
### Before
<img width="2918" height="1250" alt="image" src="https://github.com/user-attachments/assets/755ad0d3-a0a9-4b2f-a328-105da657146b" />


### After
<img width="3110" height="1686" alt="image" src="https://github.com/user-attachments/assets/de750135-6812-44bf-8127-31aa6f91edb5" />

Fixes #
https://warthogs.atlassian.net/browse/WD-31245

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
