### PR TITLE
WD-31116: Copy update to pricing devices

### DIFF
--- a/templates/pricing/devices.html
+++ b/templates/pricing/devices.html
@@ -81,7 +81,7 @@
           <h4 class="p-heading--5">
             Snap creation service
             <br />
-            $25,000
+            $21,600
           </h4>
           <p>
             Get three critical apps containerised as snaps by Canonical experts, using best practices and focused on your business and technical needs.
@@ -93,7 +93,7 @@
           <h4 class="p-heading--5">
             Snapcraft 101 training
             <br />
-            $5,000
+            $8,400
           </h4>
           <p>
             Learn about snap design and security, and how to package your existing apps as snaps. Set up continuous integration, testing and delivery pipelines to your fleet. Two days of training over four sessions.
@@ -157,7 +157,7 @@
         <div class="p-cta-block">
           <a href="/internet-of-things/appstore"
              class="p-button"
-             aria-label="Learn more about our IoT App Store">Learn more&nbsp;&rsaquo;</a>
+             aria-label="Learn more about our IoT App Store">Learn more</a>
         </div>
       </div>
     </div>
@@ -340,14 +340,14 @@
     <div class="row--50-50">
       <hr class="p-rule" />
       <div class="col">
-        <h2>Canonical Embedding programme</h2>
+        <h2>Ubuntu Pro for devices</h2>
       </div>
       <div class="col">
         <p>
           <strong>Are your devices running Ubuntu Desktop or Server?</strong>
         </p>
         <p>
-          Treat every device on your fleet as a first-class server-grade managed asset, with monitoring, security, role-based access controls, and application lifecycle management. The Embedding programme includes:
+          Treat every device on your fleet as a first-class server-grade managed asset, with monitoring, security, role-based access controls, and application lifecycle management. Ubuntu Pro includes:
         </p>
         <ul class="p-list--divided">
           <li class="p-list__item is-ticked">Security maintenance for Ubuntu Universe and Main</li>
@@ -368,7 +368,7 @@
           </li>
         </ul>
         <div class="p-cta-block">
-          <a href="/embedding">Learn more about the Embedding programme</a>
+          <a href="/pro/devices">Learn more about Ubuntu Pro&nbsp;&rsaquo;</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Done

- Updated the pricing and naming of the products on the pricing/devices page as per [the copy doc](https://docs.google.com/document/d/1uiKNaT59tk2rvjuM24vpqVblcNO90PmE4wUlq9A9Rsk/edit?tab=t.0)
- Drive by, removal of a button with a `>`

## QA

- Open the demo
- Go to /pricing/devices
- Check the suggestions in the copy doc are correct

## Issue / Card

Fixes WD-31116
