### PR TITLE
Revert "copy: update GA release"

### DIFF
--- a/templates/download/qualcomm-iot/tabs/evaluation-kit-tab.html
+++ b/templates/download/qualcomm-iot/tabs/evaluation-kit-tab.html
@@ -28,7 +28,7 @@
       <h3 class="p-heading--5">Ubuntu 24.04 LTS</h3>
     </div>
     <div class="col-6">
-      <p>This is the GA release of Ubuntu 24.04 image on the Qualcomm Dragonwing™ IQ-9075 Evaluation Kit (EVK).</p>
+      <p>This is the Beta release of Ubuntu 24.04 image on the Qualcomm Dragonwing™ IQ-9075 Evaluation Kit (EVK). The certified version is coming soon.</p>
       <div class="p-section--shallow">
         <div class="row">
           <div class="col-6 col-medium-4 col-small-4">


### PR DESCRIPTION
Reverts canonical/ubuntu.com#15828

Go-live date is the 26th of November (https://warthogs.atlassian.net/browse/WD-31323)