### PR TITLE
WD-31422-dev-update-training

### DIFF
--- a/templates/training/index.html
+++ b/templates/training/index.html
@@ -222,7 +222,7 @@
               id="openstack-advanced-operations">OpenStack advanced operations</h2>
           <div class="row">
             <div class="col-6" itemscope itemtype="https://schema.org/Product">
-              <h3 class="p-heading--2" itemprop="name">How to operate, manage, and troubleshoot<br class="u-hide--medium u-hide--small"/>Canonical OpenStack</h3>
+              <h3 class="p-heading--2" itemprop="name">How to operate, manage, and troubleshoot <br class="u-hide--medium u-hide--small"/>Canonical OpenStack</h3>
               <p itemprop="description" class="u-sv3">
                 A highly modular training for SRE teams who need to manage Canonical OpenStack. The modules follow different levels, ranging from basics to pro tips, allowing you to tailor the full training program to specific team skills and needs. The peer training sessions are designed to ensure your team acquires experience on specific tasks in a controlled environment and with necessary supervision to correct any errors. Each module spans one to two weeks, depending on the topic.
               </p>


### PR DESCRIPTION
## Done

- Copy update on /training

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Verify copy update from https://docs.google.com/document/d/1gyxy75qXC5Ta08o6Vnm13yK6aeN4qOnsETB2gZ4e0ZY/edit?tab=t.0
 

## Issue / Card

Fixes [#WD-31422](https://warthogs.atlassian.net/browse/WD-31422)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
