### PR TITLE
build: move css build

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint-js": "eslint static/js/src/**/*.{js,jsx,ts,tsx}",
     "lint-ts": "tsc --noEmit",
     "test-js": "TZ=UTC NODE_ICU_DATA=node_modules/full-icu jest",
-    "build-css": "sass static/sass:static/css --load-path=node_modules --style=compressed --quiet-deps && postcss --replace 'static/css/**/*.css' --no-map",
+    "build-css": "sass static/sass:static/css --load-path=node_modules --style=compressed --quiet-deps && postcss --replace 'static/css/**/*.css' --no-map && cp node_modules/@canonical/cookie-policy/build/css/cookie-policy.css static/css/",
     "build-js": "node build.js && ./scripts/build-modules.sh",
     "build-vanilla-framework": "mkdir -p static/js/modules/vanilla-framework && cp -r node_modules/vanilla-framework/templates/_macros/ static/js/modules/vanilla-framework",
     "build": "yarn run build-css && yarn run build-js",

--- a/scripts/build-modules.sh
+++ b/scripts/build-modules.sh
@@ -3,7 +3,6 @@
 
 # Build cookie policy
 cp node_modules/@canonical/cookie-policy/build/js/cookie-policy.js static/js/dist/
-cp node_modules/@canonical/cookie-policy/build/css/cookie-policy.css static/css/
 
 # Build flickity
 cp node_modules/flickity/dist/flickity.pkgd.min.js static/js/dist/


### PR DESCRIPTION
## Done

- Move css build to `build-css`

## QA

- Open demo
- See that cookie popup has a white border around it which indicates that the new package is installed
- Go to Dev Tools > Sources > ubuntu-com > static > css
- See that `cookie-policy.css` file is built in the static css file

## Issue / Card

Fixes #

## Screenshots
<img width="577" height="414" alt="Screenshot 2025-11-27 at 1 38 09 PM" src="https://github.com/user-attachments/assets/9329a2c2-64cb-4f29-b843-5b75e9f4b104" />




## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
