### PR TITLE
WD-31493 Added accessibility section for /desktop

### DIFF
--- a/templates/desktop/index.html
+++ b/templates/desktop/index.html
@@ -594,7 +594,7 @@
           </div>
           <div class="col-6 col-medium-3">
             <p>
-              Making linux accessible for people of all ages, languages and physical abilities is at the heart of 
+              Making Linux accessible for people of all ages, languages and physical abilities is at the heart of 
               <a href="/about">Ubuntu’s mission</a> and <a href="/community">our community</a>. 
               Visit the trust center to view our latest <strong>Ubuntu Accessibility Conformance Report, International Edition</strong>.
             </p>


### PR DESCRIPTION
## Done

Updated the "Get started with Ubuntu today" section:
- Added "Accessibility" section.
- Removed bold font from "Professional support" description.

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Visit `/desktop` and check changes in the "Get started with Ubuntu today" section

## Issue / Card

[WD-31493](https://warthogs.atlassian.net/browse/WD-31493)
[Copy-doc](https://docs.google.com/document/d/1ZhMkLlkXcimHTIe1taXy24vbbR9pBkZd49H2sJqeQH0/edit?tab=t.0)

## Screenshots

<img width="2122" height="1246" alt="image" src="https://github.com/user-attachments/assets/21413390-96c9-4611-911a-99f5779eef2b" />



[WD-31493]: https://warthogs.atlassian.net/browse/WD-31493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ