### PR TITLE
WD-31426 /training copy update

### DIFF
--- a/templates/training/index.html
+++ b/templates/training/index.html
@@ -51,6 +51,9 @@
                 <a class="highlight-link" href="#openstack-operations">OpenStack Operations</a>
               </li>
               <li class="p-side-navigation__item">
+                <a class="highlight-link" href="#openstack-advanced-operations">OpenStack Advanced Operations</a>
+              </li>
+              <li class="p-side-navigation__item">
                 <a class="highlight-link" href="#ubuntu-server-administration">Ubuntu Server Administration</a>
               </li>
               <li class="p-side-navigation__item">
@@ -106,7 +109,7 @@
                   <strong>Cost:</strong> USD $23,500 up to 15 attendees, remote delivery
                 </li>
                 <li class="p-list__item">
-                  <strong>Location:</strong> Remote or your premises at extra cost
+                  <strong>Location:</strong> Remote or at your premises at extra cost
                 </li>
                 <li class="p-list__item">
                   <strong>Availability:</strong> Private groups only
@@ -149,7 +152,7 @@
                   <strong>Cost:</strong> USD $23,500 up to 15 attendees, remote delivery
                 </li>
                 <li class="p-list__item">
-                  <strong>Location:</strong> Remote or your premises at extra cost
+                  <strong>Location:</strong> Remote or at your premises at extra cost
                 </li>
                 <li class="p-list__item">
                   <strong>Availability:</strong> Private groups only
@@ -194,7 +197,7 @@
                   <strong>Cost:</strong> USD $35,500 up to 15 attendees, remote delivery
                 </li>
                 <li class="p-list__item">
-                  <strong>Location:</strong> Remote or your premises at extra cost
+                  <strong>Location:</strong> Remote or at your premises at extra cost
                 </li>
                 <li class="p-list__item">
                   <strong>Availability:</strong> Private groups only
@@ -209,6 +212,49 @@
               <p class="training-cta--stacked">
                 <a href="https://assets.ubuntu.com/v1/30545172-Canonical_training-Openstack_operations.pdf">Read the course outline (OpenStack version)&nbsp;&rsaquo;</a>
                 <a href="https://assets.ubuntu.com/v1/70baeb59-training_curriculum_openstack_deployment_and_operations_sunbeam_version.pdf">Read the course outline (Sunbeam version)&nbsp;&rsaquo;</a>
+              </p>
+            </div>
+          </div>
+        </section>
+        <hr class="p-rule" />
+        <section class="p-section">
+          <h2 class="p-text--small-caps section-heading u-no-margin--bottom"
+              id="openstack-advanced-operations">OpenStack advanced operations</h2>
+          <div class="row">
+            <div class="col-6" itemscope itemtype="https://schema.org/Product">
+              <h3 class="p-heading--2" itemprop="name">How to operate, manage, and troubleshoot Canonical OpenStack</h3>
+              <p itemprop="description" class="u-sv3">
+                A highly modular training for SRE teams who need to manage Canonical OpenStack. The modules follow different levels, ranging from basics to pro tips, allowing you to tailor the full training program to specific team skills and needs. The peer training sessions are designed to ensure your team acquires experience on specific tasks in a controlled environment and with necessary supervision to correct any errors. Each module spans one to two weeks, depending on the topic.
+              </p>
+              <a class="p-button--positive"
+                 href="/contact-us">Contact us to book</a>
+              <div class="p-cta-block u-hide--medium u-hide--small">
+                <a href="https://assets.ubuntu.com/v1/61108024-openstackadvancedoperations.pdf">Read the course outline &nbsp;&rsaquo;</a>
+              </div>
+            </div>
+            <div class="col-3">
+              <ul class="p-list">
+                <li class="p-list__item">
+                  <strong>Duration:</strong> 1-2 weeks per module (up to 12 modules over a 15-week total)
+                </li>
+                <li class="p-list__item">
+                  <strong>Cost:</strong> USD $20,000 for 1-week modules, USD $40,000 for 2-week modules; up to 8 attendees, remote delivery
+                </li>
+                <li class="p-list__item">
+                  <strong>Location:</strong> Remote or at your premises at extra cost
+                </li>
+                <li class="p-list__item">
+                  <strong>Availability:</strong> Private groups only
+                </li>
+              </ul>
+            </div>
+          </div>
+          <div class="row u-hide--large">
+            <div class="col-6">
+              <a class="p-button--positive"
+                 href="/contact-us">Contact us to book</a>
+              <p class="training-cta--stacked">
+                <a href="https://assets.ubuntu.com/v1/61108024-openstackadvancedoperations.pdf">Read the course outline &nbsp;&rsaquo;</a>
               </p>
             </div>
           </div>
@@ -317,7 +363,7 @@
                   <strong>Format:</strong> All sessions are a combination of instruction and lab work
                 </li>
                 <li class="p-list__item">
-                  <strong>Location:</strong> Remote, or your premises at extra cost
+                  <strong>Location:</strong> Remote, or at your premises at extra cost
                 </li>
                 <li class="p-list__item">
                   <strong>Availability:</strong> Private groups only
@@ -431,7 +477,7 @@
                   <strong>Format:</strong> All sessions are a combination of instruction and lab work
                 </li>
                 <li class="p-list__item">
-                  <strong>Location:</strong> Remote, or your premises at extra cost
+                  <strong>Location:</strong> Remote, or at your premises at extra cost
                 </li>
                 <li class="p-list__item">
                   <strong>Availability:</strong> Private groups only
@@ -471,7 +517,7 @@
                   <strong>Cost:</strong> USD $23,500 up to 15 attendees, remote delivery
                 </li>
                 <li class="p-list__item">
-                  <strong>Location:</strong> Remote or your premises at extra cost
+                  <strong>Location:</strong> Remote or at your premises at extra cost
                 </li>
                 <li class="p-list__item">
                   <strong>Availability:</strong> Private groups only
@@ -511,7 +557,7 @@
                   <strong>Cost:</strong> USD $8,000 up to 15 attendees, remote delivery
                 </li>
                 <li class="p-list__item">
-                  <strong>Location:</strong> Remote or your premises at extra cost
+                  <strong>Location:</strong> Remote or at your premises at extra cost
                 </li>
               </ul>
             </div>
@@ -548,7 +594,7 @@
                   <strong>Cost:</strong> USD $35,500 up to 15 attendees, remote delivery
                 </li>
                 <li class="p-list__item">
-                  <strong>Location:</strong> Remote or your premises at extra cost
+                  <strong>Location:</strong> Remote or at your premises at extra cost
                 </li>
                 <li class="p-list__item">
                   <strong>Availability:</strong> Private groups only
@@ -591,7 +637,7 @@
                   <strong>Cost:</strong> USD $17,500 up to 15 attendees, remote delivery
                 </li>
                 <li class="p-list__item">
-                  <strong>Location:</strong> Remote or your premises at extra cost
+                  <strong>Location:</strong> Remote or at your premises at extra cost
                 </li>
                 <li class="p-list__item">
                   <strong>Availability:</strong> Private groups only
@@ -634,7 +680,7 @@
                   <strong>Cost:</strong> USD $23,500 up to 15 attendees, remote delivery
                 </li>
                 <li class="p-list__item">
-                  <strong>Location:</strong> Remote or your premises at extra cost
+                  <strong>Location:</strong> Remote or at your premises at extra cost
                 </li>
                 <li class="p-list__item">
                   <strong>Availability:</strong> Private groups only
@@ -677,7 +723,7 @@
                   <strong>Cost:</strong> USD $17,500 up to 15 attendees, remote delivery
                 </li>
                 <li class="p-list__item">
-                  <strong>Location:</strong> Remote or your premises at extra cost
+                  <strong>Location:</strong> Remote or at your premises at extra cost
                 </li>
                 <li class="p-list__item">
                   <strong>Availability:</strong> Private groups only
@@ -718,7 +764,7 @@
                   <strong>Cost:</strong> USD $23,500 up to 15 attendees, remote delivery
                 </li>
                 <li class="p-list__item">
-                  <strong>Location:</strong> Remote or your premises at extra cost
+                  <strong>Location:</strong> Remote or at your premises at extra cost
                 </li>
                 <li class="p-list__item">
                   <strong>Availability:</strong> Private groups only
@@ -759,7 +805,7 @@
                   <strong>Cost:</strong> USD $17,500 up to 15 attendees, remote delivery
                 </li>
                 <li class="p-list__item">
-                  <strong>Location:</strong> Remote or your premises at extra cost
+                  <strong>Location:</strong> Remote or at your premises at extra cost
                 </li>
                 <li class="p-list__item">
                   <strong>Availability:</strong> Private groups only
@@ -800,7 +846,7 @@
                   <strong>Cost:</strong> USD $5,000 up to 15 attendees, remote delivery
                 </li>
                 <li class="p-list__item">
-                  <strong>Location:</strong> Remote or your premises at extra cost
+                  <strong>Location:</strong> Remote or at your premises at extra cost
                 </li>
                 <li class="p-list__item">
                   <strong>Availability:</strong> Private groups only


### PR DESCRIPTION
## Done

- Fix a type all across the page
- Add a new training

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/training or at https://ubuntu-com-15838.demos.haus/training
    - Be sure to test on mobile, tablet and desktop screen sizes
- Check that the changes outlined in the [copy doc](https://docs.google.com/document/d/1gyxy75qXC5Ta08o6Vnm13yK6aeN4qOnsETB2gZ4e0ZY/edit?tab=t.0) were addressed (and accept the suggestions)

## Issue / Card

[WD-31426](https://warthogs.atlassian.net/browse/WD-31426)


[WD-31426]: https://warthogs.atlassian.net/browse/WD-31426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ