### PR TITLE
Revert adding regional blog endpoints

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -181,7 +181,6 @@ from webapp.views import (
     thank_you,
     unlisted_engage_page,
     build_sitemap_tree,
-    BlogLatestNews,
 )
 
 DISCOURSE_API_KEY = get_flask_env("DISCOURSE_API_KEY")
@@ -574,34 +573,6 @@ app.add_url_rule(
     view_func=BlogRedirects.as_view("blog_redirects", blog_views=blog_views),
 )
 app.register_blueprint(build_blueprint(blog_views), url_prefix="/blog")
-
-cn_blog_views = BlogViews(
-    api=BlogAPI(session=session, thumbnail_width=555, thumbnail_height=311),
-    tag_ids=[3265],
-    per_page=11,
-    blog_title="Ubuntu blog (Chinese)",
-)
-
-app.add_url_rule(
-    "/cn-blog/latest-news",
-    view_func=BlogLatestNews.as_view(
-        "cn_blog_latest_news", blog_views=cn_blog_views
-    ),
-)
-
-jp_blog_views = BlogViews(
-    api=BlogAPI(session=session, thumbnail_width=555, thumbnail_height=311),
-    tag_ids=[3184],
-    per_page=11,
-    blog_title="Ubuntu blog (Japanese)",
-)
-
-app.add_url_rule(
-    "/jp-blog/latest-news",
-    view_func=BlogLatestNews.as_view(
-        "jp_blog_latest_news", blog_views=jp_blog_views
-    ),
-)
 
 # usn section
 app.add_url_rule("/security/notices", view_func=notices)

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -796,16 +796,6 @@ class BlogSitemapPage(BlogView):
         return response
 
 
-class BlogLatestNews(BlogView):
-    def dispatch_request(self):
-        context = self.blog_views.get_latest_news(
-            tag_ids=flask.request.args.getlist("tag-id"),
-            group_ids=flask.request.args.getlist("group-id"),
-            limit=flask.request.args.get("limit", "3"),
-        )
-        return flask.jsonify(context)
-
-
 def sitemap_index():
     xml_sitemap = flask.render_template("sitemap_index.xml")
     response = flask.make_response(xml_sitemap)


### PR DESCRIPTION
## Done

- Revert changes related to adding separate endpoints for fetching regional blog posts. Apparently all websites have their own `/blog` blueprints with their own filtering which is sufficient. 

## QA

- Check that endpoint /cn-blog/latest-news and /jp-blog/latest-news do not exist anymore

## Issue / Card

Related to https://warthogs.atlassian.net/browse/WD-31330
