### PR TITLE
fix: add theming support for dropdown tel input

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -202,6 +202,15 @@ $color-shadow: rgba(0, 0, 0, 0.5) !default;
   }
 }
 
+// Override dropdown background colours to match theme
+.iti__dropdown-content {
+  background-color: $colors--theme--background-default;
+}
+
+.iti__country.iti__highlight {
+  background-color: $colors--theme--background-hover;
+}
+
 // Make sure the phone input has the same margin as other inputs
 .iti {
   margin-bottom: $input-margin-bottom;


### PR DESCRIPTION
## Done

- Override styles for `intl-tel-input` dropdown to allow theming inheritance

## QA

- Go to #get-in-touch
- Go to the mobile/phone number input, click on the dropdown and see that the colour themes are reflected
- Repeat on another page with light/paper theme such as /aws/contact-us

## Issue / Card

Fixes [WD-31635](https://warthogs.atlassian.net/browse/WD-31635)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-31635]: https://warthogs.atlassian.net/browse/WD-31635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ