### PR TITLE
feat(wsl): add "number 1 choice for organizations" section to /wsl page

### DIFF
--- a/templates/desktop/wsl/index.html
+++ b/templates/desktop/wsl/index.html
@@ -1,5 +1,7 @@
 {% extends "desktop/base_desktop.html" %}
 
+{% from "_macros/vf_basic-section.jinja" import vf_basic_section %}
+
 {% block meta_copydoc %}
   https://docs.google.com/document/d/1M7e2B08GgPA7K6Wx0ThE6s9_xQINM0MSkarfdKUTEYI/edit#
 {% endblock meta_copydoc %}
@@ -142,6 +144,54 @@
         </div>
       </div>
     </section>
+
+    {{ vf_basic_section(
+      title={"text": "Ubuntu is the number 1 choice for organizations using WSL"},
+      items=[
+        {
+          "type": "description",
+          "item": {
+            "type": "html",
+            "content": '
+              <p class="u-sv3">
+                <a href="/pro">Ubuntu Pro</a> brings Expanded Security Maintenance (ESM) for all Ubuntu LTS releases for up to 15 years and optional 24/7 support, including instances on WSL.
+              </p>
+            '
+          }
+        },
+        {
+          "type": "cta-block",
+          "item": {
+            "secondaries": [
+              {
+                "content_html": "Download the Ubuntu Pro for WSL app",
+                "attrs": {
+                  "href": "https://github.com/canonical/ubuntu-pro-for-wsl/releases/latest/download/UbuntuProForWSL.msixbundle"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "description",
+          "item": {
+            "type": "html",
+            "content": '
+              <p>
+                Ubuntu Pro also enables system administrators to manage WSL instances using <a href="/landscape">Landscape, Canonical\'s system management tool for Ubuntu</a>.
+              </p>
+            '
+          }
+        },
+        {
+          "type": "description",
+          "item": {
+            "type": "text",
+            "content": "Monitor your entire estate using the latest Landscape beta features and automatically identify which WSL instances comply with your provisioning and configuration policies in order to keep your environment secure."
+          }
+        },
+      ]
+    ) }}
 
     <section class="p-section">
       <div class="u-fixed-width p-section--shallow">


### PR DESCRIPTION
## Done

- Adds a new section "Ubuntu is the number 1 choice for organizations using WSL" to [/desktop/wsl](https://ubuntu-com-15844.demos.haus/desktop/wsl) ([copy doc](https://docs.google.com/document/d/1M7e2B08GgPA7K6Wx0ThE6s9_xQINM0MSkarfdKUTEYI/edit?tab=t.0#heading=h.vb8d4iili0dv))

**NOTE**: Launch date is December 2nd, so this should not be immediately merged after approval. The CTA link is still non-functional, but should start working on the launch date - as [commented on the copy doc](https://docs.google.com/document/d/1M7e2B08GgPA7K6Wx0ThE6s9_xQINM0MSkarfdKUTEYI/edit?disco=AAABsMy4A5E).

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Open the demo page [/desktop/wsl](https://ubuntu-com-15844.demos.haus/desktop/wsl)
- Check that the new section is added according to the [copy doc](https://docs.google.com/document/d/1M7e2B08GgPA7K6Wx0ThE6s9_xQINM0MSkarfdKUTEYI/edit?tab=t.0#heading=h.vb8d4iili0dv) and the design ([Jira](https://warthogs.atlassian.net/browse/WD-31615?focusedCommentId=959625))

## Issue / Card

Fixes [WD-31615](https://warthogs.atlassian.net/browse/WD-31615)

## Screenshots

<img width="1497" height="696" alt="image" src="https://github.com/user-attachments/assets/41aa7bbc-c2bc-4483-86e4-2847715c84bc" />

## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-31615]: https://warthogs.atlassian.net/browse/WD-31615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ