### PR TITLE
copy: update download links as suggestion mode on /download/renesas-iot. WD-31543

### DIFF
--- a/templates/download/renesas-iot/tab-1-renesas-rz-g2l.html
+++ b/templates/download/renesas-iot/tab-1-renesas-rz-g2l.html
@@ -15,12 +15,12 @@
         </div>
         <div class="col-6">
           <p>
-            This is an early access release of Ubuntu on Renesas IoT Platforms for the Renesas RZ family. The certified version is coming soon.
+            This is a Beta release of Ubuntu on Renesas IoT Platforms for the Renesas RZ family. The certified version is coming soon.
           </p>
           <div class="p-cta-block">
-            <a href="https://people.canonical.com/~platform/images/renesas-iot/ubuntu-24.04/ubuntu-24.04-preinstalled-desktop-arm64.img.xz"
+            <a href="https://people.canonical.com/~platform/images/renesas-iot/ubuntu-24.04/x04/iot-renesas-rzg2l-lc-ul-classic-desktop-2404-release-20251026.img.xz"
                class="p-button--positive">Download Ubuntu 24.04</a>
-            <a href="https://people.canonical.com/~platform/images/renesas-iot/ubuntu-24.04/bootassets_classic_rzg2l.zip"
+            <a href="https://people.canonical.com/~platform/images/renesas-iot/ubuntu-24.04/x04/bootassets-rzg2l.tar.gz"
                class="p-button">Download boot assets</a>
           </div>
         </div>
@@ -32,12 +32,12 @@
         </div>
         <div class="col-6">
           <p>
-            This is an early access release of Ubuntu on Renesas IoT Platforms for the Renesas RZ family. The certified version is coming soon.
+            This is a Beta release of Ubuntu on Renesas IoT Platforms for the Renesas RZ family. The certified version is coming soon.
           </p>
           <div class="p-cta-block">
-            <a href="https://people.canonical.com/~platform/images/renesas-iot/ubuntu-24.04/ubuntu-24.04-preinstalled-server-arm64.img.xz"
+            <a href="https://people.canonical.com/~platform/images/renesas-iot/ubuntu-24.04/x04/iot-renesas-rzg2l-lc-ul-classic-server-2404-release-20251026.img.xz"
                class="p-button--positive">Download Ubuntu 24.04</a>
-            <a href="https://people.canonical.com/~platform/images/renesas-iot/ubuntu-24.04/bootassets_classic_rzg2l.zip"
+            <a href="https://people.canonical.com/~platform/images/renesas-iot/ubuntu-24.04/x04/bootassets-rzg2l.tar.gz"
                class="p-button">Download boot assets</a>
           </div>
         </div>
@@ -74,11 +74,11 @@
         </li>
         <li class="p-list__item">
           Ubuntu 24.04 for RZ/G2L
-          <a href="https://people.canonical.com/~platform/images/renesas-iot/Documentation/UbuntuQuickStartGuide_rzg2l_x02.pdf">image installation instructions</a>
+          <a href="https://people.canonical.com/~platform/images/renesas-iot/Documentation/Quick%20start%20guide%20to%20RZ_G2L%20with%20classic%20Ubuntu%20images_x04.pdf">image installation instructions</a>
         </li>
         <li class="p-list__item">
           Ubuntu for RZ/G2L
-          <a href="https://people.canonical.com/~platform/images/renesas-iot/Documentation/ReleaseNote_ubuntu_core_rzg2_x02.pdf">release notes</a>
+          <a href="https://people.canonical.com/~platform/images/renesas-iot/Documentation/Ubuntu%20for%20Renesas%20RZ_G2L-G2UL-G2LC%20Release%20Notes%20-%20x04.pdf">release notes</a>
         </li>
       </ul>
       <hr class="p-rule--muted" />

--- a/templates/download/renesas-iot/tab-2-renesas-rz-g2lc.html
+++ b/templates/download/renesas-iot/tab-2-renesas-rz-g2lc.html
@@ -15,12 +15,12 @@
         </div>
         <div class="col-6">
           <p>
-            This is an early access release of Ubuntu on Renesas IoT Platforms for the Renesas RZ family. The certified version is coming soon.
+            This is a Beta release of Ubuntu on Renesas IoT Platforms for the Renesas RZ family. The certified version is coming soon.
           </p>
           <div class="p-cta-block">
-            <a href="https://people.canonical.com/~platform/images/renesas-iot/ubuntu-24.04/x02/ubuntu-noble-server-rzg2l.img.xz"
+            <a href="https://people.canonical.com/~platform/images/renesas-iot/ubuntu-24.04/x04/iot-renesas-rzg2l-lc-ul-classic-server-2404-release-20251026.img.xz"
                class="p-button--positive">Download Ubuntu 24.04</a>
-            <a href="https://people.canonical.com/~platform/images/renesas-iot/ubuntu-24.04/x02/bootassets.tar.gz"
+            <a href="https://people.canonical.com/~platform/images/renesas-iot/ubuntu-24.04/x04/bootassets-rzg2lc.tar.gz"
                class="p-button">Download boot assets</a>
           </div>
         </div>
@@ -56,11 +56,11 @@
         </li>
         <li class="p-list__item">
           Ubuntu 24.04 for RZ/G2LC
-          <a href="https://people.canonical.com/~platform/images/renesas-iot/Documentation/UbuntuQuickStartGuide_rzg2l_x02.pdf">image installation instructions</a>
+          <a href="https://people.canonical.com/~platform/images/renesas-iot/Documentation/Quick%20start%20guide%20to%20RZ_G2L%20with%20classic%20Ubuntu%20images_x04.pdf">image installation instructions</a>
         </li>
         <li class="p-list__item">
           Ubuntu for RZ/G2LC
-          <a href="https://people.canonical.com/~platform/images/renesas-iot/Documentation/ReleaseNote_ubuntu_core_rzg2_x02.pdf">release notes</a>
+          <a href="https://people.canonical.com/~platform/images/renesas-iot/Documentation/Ubuntu%20for%20Renesas%20RZ_G2L-G2UL-G2LC%20Release%20Notes%20-%20x04.pdf">release notes</a>
         </li>
       </ul>
       <hr class="p-rule--muted" />

--- a/templates/download/renesas-iot/tab-3-renesas-rz-g2ul.html
+++ b/templates/download/renesas-iot/tab-3-renesas-rz-g2ul.html
@@ -15,12 +15,12 @@
         </div>
         <div class="col-6">
           <p>
-            This is an early access release of Ubuntu on Renesas IoT Platforms for the Renesas RZ family. The certified version is coming soon.
+            This is a Beta release of Ubuntu on Renesas IoT Platforms for the Renesas RZ family. The certified version is coming soon.
           </p>
           <div class="p-cta-block">
-            <a href="https://people.canonical.com/~platform/images/renesas-iot/ubuntu-24.04/x02/ubuntu-noble-server-rzg2l.img.xz"
+            <a href="https://people.canonical.com/~platform/images/renesas-iot/ubuntu-24.04/x04/iot-renesas-rzg2l-lc-ul-classic-server-2404-release-20251026.img.xz"
                class="p-button--positive">Download Ubuntu 24.04</a>
-            <a href="https://people.canonical.com/~platform/images/renesas-iot/ubuntu-24.04/x02/bootassets.tar.gz"
+            <a href="https://people.canonical.com/~platform/images/renesas-iot/ubuntu-24.04/x04/bootassets-rzg2ul.tar.gz"
                class="p-button">Download boot assets</a>
           </div>
         </div>
@@ -56,11 +56,11 @@
         </li>
         <li class="p-list__item">
           Ubuntu 24.04 for RZ/G2UL
-          <a href="https://people.canonical.com/~platform/images/renesas-iot/Documentation/UbuntuQuickStartGuide_rzg2l_x02.pdf">image installation instructions</a>
+          <a href="https://people.canonical.com/~platform/images/renesas-iot/Documentation/Quick%20start%20guide%20to%20RZ_G2L%20with%20classic%20Ubuntu%20images_x04.pdf">image installation instructions</a>
         </li>
         <li class="p-list__item">
           Ubuntu for RZ/G2UL
-          <a href="https://people.canonical.com/~platform/images/renesas-iot/Documentation/ReleaseNote_ubuntu_core_rzg2_x02.pdf">release notes</a>
+          <a href="https://people.canonical.com/~platform/images/renesas-iot/Documentation/Ubuntu%20for%20Renesas%20RZ_G2L-G2UL-G2LC%20Release%20Notes%20-%20x04.pdf">release notes</a>
         </li>
       </ul>
       <hr class="p-rule--muted" />


### PR DESCRIPTION
## Done

Update the download links to be in the `suggestion mode` on [/download/renesas-iot](https://ubuntu.com/download/renesas-iot).

[Doc](https://docs.google.com/document/d/1-S_loqM0YLcaMR4WG7Tal0765cBoIa_0ssOI3NAtw4E/edit?tab=t.0)
[Demo](https://ubuntu-com-15845.demos.haus/download/renesas-iot)

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes [#WD-31543](https://warthogs.atlassian.net/browse/WD-31543)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
