### PR TITLE
feat: Implement cross-domain cookie sharing

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -171,6 +171,10 @@ env:
       key: wordpress-username
       name: wordpress-api
 
+  - name: COOKIE_SERVICE_API_KEY
+    secretKeyRef:
+      key: cookies-api-key
+      name: cookies-canonical-com-credentials
 
 memoryLimit: 512Mi
 

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
   },
   "dependencies": {
     "@axe-core/playwright": "^4.8.5",
-    "@canonical/cookie-policy": "^3.7.4",
+    "@canonical/cookie-policy": "3.8.0",
     "@canonical/global-nav": "3.8.0",
     "@canonical/latest-news": "2.1.1",
     "@canonical/react-components": "^0.60.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,8 @@ canonicalwebteam.image-template==1.9.0
 canonicalwebteam.discourse==7.1.0
 canonicalwebteam.form-generator==2.1.0
 canonicalwebteam.directory-parser==1.2.10
+canonicalwebteam.cookie-service==1.0.0
+Flask-Caching==2.1.0
 python-dateutil==2.8.2
 pytz==2022.7.1
 maxminddb-geolite2==2018.703

--- a/yarn.lock
+++ b/yarn.lock
@@ -1206,10 +1206,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@canonical/cookie-policy@^3.7.4":
-  version "3.7.5"
-  resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.7.5.tgz#29dfbc1f6d42dbdcdf6125330083a2ccde7d93d0"
-  integrity sha512-Fi0a8vk9q7L4Em4TiMTYDYnGGnHBfpOwOv7WGWbA/apT6whl33V6HFTTcN+LcY5UnoSNBTZmQn4YBwqLOVdZyQ==
+"@canonical/cookie-policy@3.8.0":
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.8.0.tgz#8f20b5d6d0c2e5553bbe05d1513f7f1af7d0836c"
+  integrity sha512-njUYf10gFmuXr47Aj5jayuFbyq08IkBdr/W6qtvHjZvJ8Dt4ru9ehMacWa4mostfQoXVARusIucOARSgnMoArg==
 
 "@canonical/global-nav@3.8.0":
   version "3.8.0"


### PR DESCRIPTION
## Done

- Implements [cookie service flask extension](https://github.com/canonical/canonicalwebteam.cookie-service) for integration with cookies.canonical.com
- Bumps cookie-policy npm package to 3.8.1
- Implement basic flask-caching to store health status of cookies.canonical.com

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
