### PR TITLE
perf: Load fronts from vanilla-framework

### DIFF
--- a/templates/templates/base.html
+++ b/templates/templates/base.html
@@ -1,13 +1,15 @@
 <!DOCTYPE html>
 
-<html prefix="og: http://ogp.me/ns#" class="
-  {% block extra_html_class %}{% endblock %}"
-  lang="{% block meta_lang %}en{% endblock %}" dir="ltr">
+<html prefix="og: http://ogp.me/ns#" class=" 
+  {% block extra_html_class %}{% endblock %}" lang="
+  {% block meta_lang %}en{% endblock %}" dir="ltr">
   <head>
-    <meta charset="UTF-8">
-    <meta name="keywords" content="index, follow">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{% block title %}{% endblock %} | Ubuntu</title>
+    <meta charset="UTF-8" />
+    <meta name="keywords" content="index, follow" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>
+      {% block title %}{% endblock %}
+    | Ubuntu</title>
     <link rel="preconnect" href="https://res.cloudinary.com" />
     <link rel="preconnect" href="https://assets.ubuntu.com" crossorigin />
 
@@ -15,162 +17,167 @@
     <link rel="dns-prefetch" href="https://www.googletagmanager.com" />
     <link rel="preconnect" href="https://pagead2.googlesyndication.com" />
     <link rel="dns-prefetch" href="https://pagead2.googlesyndication.com" />
-    
-    <script src="https://assets.ubuntu.com/v1/703e23c9-lazysizes+noscript+native-loading.5.1.2.min.js" defer></script>
+
+    <script src="https://assets.ubuntu.com/v1/703e23c9-lazysizes+noscript+native-loading.5.1.2.min.js"
+            defer></script>
     <script src="{{ versioned_static('js/src/navigation.js') }}" defer></script>
     <script src="{{ versioned_static('js/dist/main.js') }}" defer></script>
-    <script src="{{ versioned_static('js/src/infer-preferred-language.js')}}" defer></script>
+    <script src="{{ versioned_static('js/src/infer-preferred-language.js')}}"
+            defer></script>
 
-    <link rel="stylesheet" type="text/css" media="screen" href="{{ versioned_static("css/styles.css") }}" />
-    <link rel="stylesheet" type="text/css" media="print" href="{{ versioned_static("css/print.css") }}" />
+    <link rel="stylesheet"
+          type="text/css"
+          media="screen"
+          href="{{ versioned_static('css/styles.css') }}" />
+    <link rel="stylesheet"
+          type="text/css"
+          media="print"
+          href="{{ versioned_static('css/print.css') }}" />
     <script>
       performance.mark("Stylesheets finished");
     </script>
-    
-    <link rel="canonical" href="{% block canonical_url %}{{ request.url }}{% endblock %}" />
 
-    <link rel="apple-touch-icon"
-          sizes="180x180"
-          href="https://assets.ubuntu.com/v1/f38b9c7e-COF%20apple-touch-icon.png" />
-    <link rel="icon"
-          type="image/png"
-          sizes="32x32"
-          href="https://assets.ubuntu.com/v1/be7e4cc6-COF-favicon-32x32.png" />
-    <link rel="icon"
-          type="image/png"
-          sizes="16x16"
-          href="https://assets.ubuntu.com/v1/16c27f81-COF%20favicon-16x16.png" />
-    <link rel="manifest" href="{{ versioned_static("files/site.webmanifest") }}" />
-    <!-- Serving favicon for search engines locally -->
-    <link rel="icon" type="image/png" sizes="48x48" href="{{ versioned_static("favicons/COF-favicon-48x48.png") }}" />
-    {%- block head_extra %}{% endblock %}
-    <link rel="preload"
-          as="font"
-          type="font/woff2"
-          href="https://assets.ubuntu.com/v1/f1ea362b-Ubuntu%5Bwdth,wght%5D-latin-v0.896a.woff2"
-          crossorigin />
-    <link rel="preload"
-          as="font"
-          type="font/woff2"
-          href="https://assets.ubuntu.com/v1/90b59210-Ubuntu-Italic%5Bwdth,wght%5D-latin-v0.896a.woff2"
-          crossorigin />
-    <link rel="preload"
-          as="font"
-          type="font/woff2"
-          href="https://assets.ubuntu.com/v1/d5fc1819-UbuntuMono%5Bwght%5D-latin-v0.869.woff2"
-          crossorigin />
-    <link rel="preload"
-          as="font"
-          type="font/woff2"
-          href="https://assets.ubuntu.com/v1/77cd6650-Ubuntu%5Bwdth,wght%5D-cyrillic-extended-v0.896a.woff2"
-          crossorigin />
-    <link rel="preload"
-          as="font"
-          type="font/woff2"
-          href="https://assets.ubuntu.com/v1/2702fce5-Ubuntu%5Bwdth,wght%5D-cyrillic-v0.896a.woff2"
-          crossorigin />
-    <link rel="preload"
-          as="font"
-          type="font/woff2"
-          href="https://assets.ubuntu.com/v1/5c108b7d-Ubuntu%5Bwdth,wght%5D-greek-extended-v0.896a.woff2"
-          crossorigin />
-    <link rel="preload"
-          as="font"
-          type="font/woff2"
-          href="https://assets.ubuntu.com/v1/0a14c405-Ubuntu%5Bwdth,wght%5D-greek-v0.896a.woff2"
-          crossorigin />
-    <link rel="preload"
-          as="font"
-          type="font/woff2"
-          href="https://assets.ubuntu.com/v1/19f68eeb-Ubuntu%5Bwdth,wght%5D-latin-extended-v0.896a.woff2"
-          crossorigin />
+    <link rel="canonical" href="
+      {% block canonical_url %}{{ request.url }}{% endblock %}" />
 
-    <meta name="description" content="{% block meta_description %}Ubuntu is an open source software operating system that runs from the desktop, to the cloud, to all your internet connected things.{% endblock %}">
-    <meta name="facebook-domain-verification"
-          content="zxp9j79g1gy2xenbu9ll964pttk5hu">
-    <meta name="twitter:account_id" content="4503599627481511">
-    <meta name="twitter:site" content="@ubuntu">
-    <meta property="og:type" content="website">
-    <meta property="og:url" content="{{ request.url }}">
-    <meta property="og:site_name" content="Ubuntu">
-    <meta name="copydoc" content="{% block meta_copydoc %}https://drive.google.com/drive/folders/0B4s80tIYQW4BMjNiMGFmNzQtNDkxZC00YmQ0LWJiZWUtNTk2YThlY2MzZmJh{% endblock %}">
-    <meta name="google-site-verification"
-          content="ddh2iq7ZuKf1LpkL_gtM_T7DkKDVD7ibq6Ceue4a_3M">
+      <link rel="apple-touch-icon"
+            sizes="180x180"
+            href="https://assets.ubuntu.com/v1/f38b9c7e-COF%20apple-touch-icon.png" />
+      <link rel="icon"
+            type="image/png"
+            sizes="32x32"
+            href="https://assets.ubuntu.com/v1/be7e4cc6-COF-favicon-32x32.png" />
+      <link rel="icon"
+            type="image/png"
+            sizes="16x16"
+            href="https://assets.ubuntu.com/v1/16c27f81-COF%20favicon-16x16.png" />
+      <link rel="manifest"
+            href="{{ versioned_static('files/site.webmanifest') }}" />
+      <!-- Serving favicon for search engines locally -->
+      <link rel="icon"
+            type="image/png"
+            sizes="48x48"
+            href="{{ versioned_static('favicons/COF-favicon-48x48.png') }}" />
+      
+      <!-- Preload core fonts to reduce FOUT -->
+      <link rel="preload"
+            as="font"
+            type="font/woff2"
+            href="https://assets.ubuntu.com/v1/f1ea362b-Ubuntu%5Bwdth,wght%5D-latin-v0.896a.woff2"
+            crossorigin />
+      <link rel="preload"
+            as="font"
+            type="font/woff2"
+            href="https://assets.ubuntu.com/v1/90b59210-Ubuntu-Italic%5Bwdth,wght%5D-latin-v0.896a.woff2"
+            crossorigin />
+      <link rel="preload"
+            as="font"
+            type="font/woff2"
+            href="https://assets.ubuntu.com/v1/0df3f53f-UbuntuMono%5Bwght%5D-latin-v0.896a.woff2"
+            crossorigin />
+      
+      {%- block head_extra %}{% endblock %}
 
-    {% if self.title() %}
-    <meta name="twitter:title" content="{{ self.title() }} | Ubuntu">
-    <meta property="og:title" content="{{ self.title() }} | Ubuntu">
-    {% endif %}
+      <meta name="description" content="
+        {% block meta_description %}Ubuntu is an open source software operating system that runs from the desktop, to the cloud, to all your internet connected things.{% endblock %}" />
+        <meta name="facebook-domain-verification"
+              content="zxp9j79g1gy2xenbu9ll964pttk5hu" />
+        <meta name="twitter:account_id" content="4503599627481511" />
+        <meta name="twitter:site" content="@ubuntu" />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="{{ request.url }}" />
+        <meta property="og:site_name" content="Ubuntu" />
+        <meta name="copydoc" content="
+          {% block meta_copydoc %}https://drive.google.com/drive/folders/0B4s80tIYQW4BMjNiMGFmNzQtNDkxZC00YmQ0LWJiZWUtNTk2YThlY2MzZmJh{% endblock %}" />
+          <meta name="google-site-verification"
+                content="ddh2iq7ZuKf1LpkL_gtM_T7DkKDVD7ibq6Ceue4a_3M" />
 
-    {% if self.meta_description() %}
-    <meta name="twitter:description" content="{{ self.meta_description() }}">
-    <meta property="og:description" content="{{ self.meta_description() }}">
-    {% endif %}
-    {# Define the required meta_image block #}
-    <!-- Meta image: {% block meta_image %}{% endblock %} -->
-    {%- if self.meta_image() %}
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:image"
-          content="{% if 'http' not in self.meta_image() %}https://assets.ubuntu.com/v1/{% endif %}{{ self.meta_image() }}">
-    <meta property="og:image"
-          content="{% if 'http' not in self.meta_image() %}https://assets.ubuntu.com/v1/{% endif %}{{ self.meta_image() }}">
-    {% else %}
-      <meta name="twitter:card" content="summary_large_image" />
-      <meta name="twitter:image"
-            content="https://assets.ubuntu.com/v1/47f12466-og_%20ubuntu.png" />
-      <meta property="og:image"
-            content="https://assets.ubuntu.com/v1/47f12466-og_%20ubuntu.png" />
-    {% endif %}
-    {% block extra_metatags %}{% endblock %}
-    <style>#rememberMe {display: none;}</style>
+          {% if self.title() %}
+            <meta name="twitter:title" content="{{ self.title() }} | Ubuntu" />
+            <meta property="og:title" content="{{ self.title() }} | Ubuntu" />
+          {% endif %}
 
-    <!-- Cookie policy -->
-    <link rel="stylesheet" href="{{ versioned_static('css/cookie-policy.css') }}">
-    <script src="{{ versioned_static('js/dist/cookie-policy.js') }}"></script>
-    <script src="{{ versioned_static('js/src/cookie-policy-with-callback.js') }}" type="module"></script>
-  </head>
+          {% if self.meta_description() %}
+            <meta name="twitter:description" content="{{ self.meta_description() }}" />
+            <meta property="og:description" content="{{ self.meta_description() }}" />
+          {% endif %}
+          {# Define the required meta_image block #}
+          <!-- Meta image: {% block meta_image %}{% endblock %} -->
+          {%- if self.meta_image() %}
+            <meta name="twitter:card" content="summary_large_image" />
+            <meta name="twitter:image"
+                  content="{% if 'http' not in self.meta_image() %}https://assets.ubuntu.com/v1/{% endif %}{{ self.meta_image() }}" />
+            <meta property="og:image"
+                  content="{% if 'http' not in self.meta_image() %}https://assets.ubuntu.com/v1/{% endif %}{{ self.meta_image() }}" />
+          {% else %}
+            <meta name="twitter:card" content="summary_large_image" />
+            <meta name="twitter:image"
+                  content="https://assets.ubuntu.com/v1/47f12466-og_%20ubuntu.png" />
+            <meta property="og:image"
+                  content="https://assets.ubuntu.com/v1/47f12466-og_%20ubuntu.png" />
+          {% endif %}
 
-  <body class="{% block body_class %}{% endblock %}">
-    <!-- google tag manager -->
-    <noscript>
-      <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K92JCQ"
-              height="0"
-              width="0"
-              style="display: none;
-                      visibility: hidden"
-              title="Google Tag Manager"></iframe>
-    </noscript>
-    <!-- end google tag manager -->
+          {% block extra_metatags %}{% endblock %}
+          <style>
+            #rememberMe {
+              display: none;
+            }
+          </style>
 
-    {% include "templates/_getfeedback.html" %}
-    {% include "templates/_notifications.html" %}
+          <!-- Cookie policy -->
+          <link rel="stylesheet"
+                href="{{ versioned_static('css/cookie-policy.css') }}" />
+          <script src="{{ versioned_static('js/dist/cookie-policy.js') }}"></script>
+          <script src="{{ versioned_static('js/src/cookie-policy-with-callback.js') }}"
+                  type="module"></script>
+        </head>
 
-    {% if not(hide_nav == True) %}
-      {% include "templates/_navigation.html" %}
-    {% endif %}
+        <body class="
+          {% block body_class %}{% endblock %}">
+          <!-- google tag manager -->
+          <noscript>
+            <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K92JCQ"
+                    height="0"
+                    width="0"
+                    style="display: none;
+                           visibility: hidden"
+                    title="Google Tag Manager"></iframe>
+          </noscript>
+          <!-- end google tag manager -->
 
-    <div class="wrapper u-no-margin--top">
-      <main id="main-content" class="inner-wrapper">
-        {% block content_head %}{% endblock %}
-        {% block content_container %}
-          {% block outer_content %}{% endblock outer_content %}
-        {% endblock content_container %}
-      </main>
-    </div>
+          {% include "templates/_getfeedback.html" %}
+          {% include "templates/_notifications.html" %}
 
-    <!-- footer content goes here -->
-    {% if not(hide_footer == True) %}
-      {% if small_footer %}
-        {% include "templates/small-footer.html" %}
-      {% else %}
-        {% include "templates/footer.html" %}
-        {% if "/whitepapers" not in
-          request.path %}
-        {% endif %}
-        {% block footer_extra %}{% endblock %}
-      {% endif %}
-    {% endif %}
+          {% if not(hide_nav == True) %}
+            {% include "templates/_navigation.html" %}
+          {% endif %}
 
-    {%- include "templates/_tag_manager.html" %}
-  </body>
-</html>
+          <div class="wrapper u-no-margin--top">
+            <main id="main-content" class="inner-wrapper">
+
+              {% block content_head %}{% endblock %}
+
+              {% block content_container %}
+                {% block outer_content %}
+                {% endblock outer_content %}
+              {% endblock content_container %}
+            </main>
+          </div>
+
+          <!-- footer content goes here -->
+          {% if not(hide_footer == True) %}
+            {% if small_footer %}
+              {% include "templates/small-footer.html" %}
+            {% else %}
+              {% include "templates/footer.html" %}
+              {% if "/whitepapers" not in
+                request.path %}
+              {% endif %}
+
+              {% block footer_extra %}{% endblock %}
+            {% endif %}
+          {% endif %}
+
+          {%- include "templates/_tag_manager.html" %}
+        </body>
+      </html>


### PR DESCRIPTION
## Done

- Removes non-core font references from header and rely on [vanilla-framework dynamic loading of fonts](https://github.com/canonical/vanilla-framework/blob/2d55b074a685e2f222fdf353682f8b616683274b/scss/_base_fontfaces.scss#L18)

## QA

- Open [the demo](https://ubuntu-com-15850.demos.haus/), check that the page loads as normal and the fonts match those on [https://ubuntu.com](ubuntu.com)

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-31757
