### PR TITLE
Add custom download URL for Qualcomm Dragonwing platforms

### DIFF
--- a/webapp/certified/helpers.py
+++ b/webapp/certified/helpers.py
@@ -7,7 +7,6 @@ from markupsafe import Markup
 def get_download_url(model_details):
     """
     Return the appropriate ubuntu models.com/download url for the model
-    :param model: a certifiedmodel resource
     :param model_details: a certifiedmodeldetails resource
     :return: appropriate ubuntu.com/download url
     """


### PR DESCRIPTION
## Done

We recently issued a certificate for a customer project (Qualcomm Dragonwing). This project has a dedicated page with download instructions and release notes, so the Download button on our public certificate page should point to this instead of the generic Ubuntu download page. This PR does this.

This is similar to a fix applied a few months ago:   https://github.com/canonical/ubuntu.com/pull/14876

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes https://warthogs.atlassian.net/browse/C3-1284

## Screenshots

Before applying the patch, https://ubuntu.com/certified/202508-37814 has a download button that points to https://ubuntu.com/download.

After applying the patch, it points to https://ubuntu.com/download/qualcomm-iot#evaluation-kit.


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)
