### PR TITLE
fix(WD-31417): Contact Us page, move 20.04 LTS to “LTS out of standard support“

### DIFF
--- a/templates/contact-us/form/form-data.json
+++ b/templates/contact-us/form/form-data.json
@@ -41,18 +41,18 @@
                   "id": "22-04",
                   "value": "22.04 LTS",
                   "label": "22.04 LTS"
-                },
-                {
-                  "type": "checkbox",
-                  "id": "20-04",
-                  "value": "20.04 LTS",
-                  "label": "20.04 LTS"
                 }
               ]
             },
             {
               "fieldTitle": "LTS out of standard support",
               "options": [
+                {
+                  "type": "checkbox",
+                  "id": "20-04",
+                  "value": "20.04 LTS",
+                  "label": "20.04 LTS"
+                },
                 {
                   "type": "checkbox",
                   "id": "18-04",


### PR DESCRIPTION
## Done

- Moved the 20.04 LTS option from field 1 to field 2

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8001/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Navigate to `/contact-us/form?product=pro`.
- Check that 20.04 is now under LTS out of standard support.

## Issue / Card

Fixes # [WD-31417](https://warthogs.atlassian.net/browse/WD-31417)


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)


[WD-31417]: https://warthogs.atlassian.net/browse/WD-31417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ